### PR TITLE
feat: instrument per-token operation and candidate-scan counts (closes #14)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -31,9 +31,14 @@ pub struct OpKernel {
     pub shifts: u64,
     pub compares: u64,
     pub table_reads: u64,
+    pub candidate_scans: u64,
 }
 
 impl OpKernel {
+    #[inline]
+    pub fn candidate_scan(&mut self) {
+        self.candidate_scans += 1;
+    }
     #[inline]
     pub fn add(&mut self, a: i64, b: i64) -> i64 {
         self.adds += 1;
@@ -74,8 +79,8 @@ impl OpKernel {
 
     pub fn report(&self) -> String {
         format!(
-            "op census: add {} | xor {} | shift {} | compare {} | table-read {} | multiply — no such operation exists in the kernel",
-            self.adds, self.xors, self.shifts, self.compares, self.table_reads
+            "op census: add {} | xor {} | shift {} | compare {} | table-read {} | candidate-scan {} | multiply — no such operation exists in the kernel",
+            self.adds, self.xors, self.shifts, self.compares, self.table_reads, self.candidate_scans
         )
     }
 }
@@ -449,7 +454,7 @@ impl<'a> Runtime<'a> {
             rot: derive_rotations(),
             pop: derive_popcount_table(),
             kernel: OpKernel::default(),
-            recent: Vec::new(),
+            recent: Vec::with_capacity(36),
         }
     }
 
@@ -478,6 +483,7 @@ impl<'a> Runtime<'a> {
             let mut best_d = i64::MAX;
             let mut best_k = 0u8;
             for (kk, cs) in sigs.chunks_exact(SIG_BYTES).enumerate() {
+                self.kernel.candidate_scan();
                 let mut d = 0i64;
                 for (&a, &bb) in sig.iter().zip(cs) {
                     let x = self.kernel.xor(a, bb);
@@ -508,6 +514,7 @@ impl<'a> Runtime<'a> {
                 let mut best_c = -1000000i64;
                 let mut best_n = 0u32;
                 for (&t, &cnt) in dist {
+                    self.kernel.candidate_scan();
                     let mut score = cnt as i64;
                     let occurrences = self.recent.iter().filter(|&&r| r == t).count();
                     if occurrences > 0 {
@@ -547,6 +554,7 @@ impl<'a> Runtime<'a> {
                 let mut best_c = -1000000i64;
                 let mut best_n = 0u32;
                 for (&t, &cnt) in dist {
+                    self.kernel.candidate_scan();
                     let mut score = cnt as i64;
                     let occurrences = self.recent.iter().filter(|&&r| r == t).count();
                     if occurrences > 0 {

--- a/crates/uor-r4-core/tests/allocation_census.rs
+++ b/crates/uor-r4-core/tests/allocation_census.rs
@@ -84,7 +84,7 @@ fn measure<T>(f: impl FnOnce() -> T) -> (T, Census) {
 // ------------------------------------------------------------ op census --
 
 /// Snapshot of the runtime's `OpKernel` counters (the kernel itself is not
-/// `Clone`, so copy the five public fields).
+/// `Clone`, so copy the public fields).
 #[derive(Clone, Copy)]
 struct Ops {
     adds: u64,
@@ -92,6 +92,7 @@ struct Ops {
     shifts: u64,
     compares: u64,
     table_reads: u64,
+    candidate_scans: u64,
 }
 
 impl Ops {
@@ -102,6 +103,7 @@ impl Ops {
             shifts: k.shifts,
             compares: k.compares,
             table_reads: k.table_reads,
+            candidate_scans: k.candidate_scans,
         }
     }
     fn since(self, before: Ops) -> Ops {
@@ -111,6 +113,7 @@ impl Ops {
             shifts: self.shifts - before.shifts,
             compares: self.compares - before.compares,
             table_reads: self.table_reads - before.table_reads,
+            candidate_scans: self.candidate_scans - before.candidate_scans,
         }
     }
 }
@@ -122,7 +125,7 @@ const GEN_TOKENS: usize = 32;
 /// Fixed seed window: deterministic, and every id is below the smallest
 /// supported vocabulary (TLA3, V = 32000), so the same seed drives both the
 /// fixture and the real smollm2 artifacts.
-const SEED: [u16; WINDOW] = [1, 40, 416, 1024, 2048, 4096, 8192, 16384];
+const SEED: [u32; WINDOW] = [1, 40, 416, 1024, 2048, 4096, 8192, 16384];
 
 fn real_path(name: &str) -> String {
     let dir = env!("CARGO_MANIFEST_DIR");
@@ -186,7 +189,7 @@ fn parse_store_measured() -> (Store, String) {
     let mut store: Store = (0..=STAGES).map(|_| Default::default()).collect();
     for i in 0..64u16 {
         let code = [(i % 251) as u8, (i / 2) as u8, 0, 0];
-        runtime::add_evidence(&mut store, &code, i);
+        runtime::add_evidence(&mut store, &code, i as u32, 1);
     }
     (store, "synthetic (add_evidence, gate closed)".to_string())
 }
@@ -214,6 +217,7 @@ fn allocation_census() {
     let ((code, wit, n, gen_ops), gen_cen) = measure(|| {
         let code = rt.assign_window(&SEED);
         let tok = rt.predict(&store, &code);
+        rt.recent.clear();
         let wit = rt.predict_witness(&store, &code);
         assert_eq!(tok, wit.token, "predict and predict_witness agree");
         let before = Ops::of(&rt.kernel);
@@ -240,20 +244,21 @@ fn allocation_census() {
     let t = GEN_TOKENS as f64;
     println!(
         "[kernel] ops over {GEN_TOKENS} generated tokens: adds {} | xors {} | \
-         shifts {} | compares {} | table-reads {}",
-        gen_ops.adds, gen_ops.xors, gen_ops.shifts, gen_ops.compares, gen_ops.table_reads
+         shifts {} | compares {} | table-reads {} | candidate-scans {}",
+        gen_ops.adds, gen_ops.xors, gen_ops.shifts, gen_ops.compares, gen_ops.table_reads, gen_ops.candidate_scans
     );
     println!(
         "[kernel] per generated token (avg): adds {:.1} | xors {:.1} | \
-         shifts {:.1} | compares {:.1} | table-reads {:.1}",
+         shifts {:.1} | compares {:.1} | table-reads {:.1} | candidate-scans {:.1}",
         gen_ops.adds as f64 / t,
         gen_ops.xors as f64 / t,
         gen_ops.shifts as f64 / t,
         gen_ops.compares as f64 / t,
-        gen_ops.table_reads as f64 / t
+        gen_ops.table_reads as f64 / t,
+        gen_ops.candidate_scans as f64 / t
     );
     println!("[kernel] cumulative {}", rt.kernel.report());
-    let tokens: Vec<u16> = out.iter().map(|p| p.token).collect();
+    let tokens: Vec<u32> = out.iter().map(|p| p.token).collect();
     let depths: Vec<usize> = out.iter().map(|p| p.depth).collect();
     println!("[gen] tokens {tokens:?}");
     println!("[gen] depths {depths:?}");
@@ -264,7 +269,7 @@ fn allocation_census() {
     let (_, ev_cen) = measure(|| {
         for i in 0..64u16 {
             let code = [(i % 251) as u8, ((i / 4) % 256) as u8, (i % 17) as u8, 0];
-            runtime::add_evidence(&mut scratch, &code, i.wrapping_mul(7));
+            runtime::add_evidence(&mut scratch, &code, (i.wrapping_mul(7)) as u32, 1);
         }
     });
     println!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -891,7 +891,7 @@ fn handle_connection(
             match tless_uor::UorTlessModel::forward(input) {
                 Ok(grounded) => {
                     // the deterministic record again via the axis, for the JSON fields
-                    let mut out = [0u8; 36];
+                    let mut out = [0u8; 40];
                     let _ = tless_uor::TlessAxisImpl::predict(&buf, &mut out);
                     let token = u32::from_be_bytes([out[0], out[1], out[2], out[3]]);
                     let depth = out[4];

--- a/src/server.rs
+++ b/src/server.rs
@@ -935,6 +935,7 @@ fn handle_connection(
                             "shifts": census(19),
                             "compares": census(23),
                             "table_reads": census(27),
+                            "candidate_scans": census(31),
                             "multiply": 0,
                         },
                         "artifact": {

--- a/src/server.rs
+++ b/src/server.rs
@@ -891,8 +891,10 @@ fn handle_connection(
             match tless_uor::UorTlessModel::forward(input) {
                 Ok(grounded) => {
                     // the deterministic record again via the axis, for the JSON fields
-                    let mut out = [0u8; 40];
-                    let _ = tless_uor::TlessAxisImpl::predict(&buf, &mut out);
+                    let mut out = [0u8; tless_uor::TLESS_OUTPUT_BYTES];
+                    if let Err(e) = tless_uor::TlessAxisImpl::predict(&buf, &mut out) {
+                        return (500, format!("{{\"error\":\"axis predict failed: {:?}\"}}", e));
+                    }
                     let token = u32::from_be_bytes([out[0], out[1], out[2], out[3]]);
                     let depth = out[4];
                     let code: Vec<u8> = out[5..9].to_vec();

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -413,9 +413,9 @@ impl TlessAxis for TlessAxisImpl {
     const MAX_OUTPUT_BYTES: usize = 40;
 
     /// input: WINDOW u32 token ids, little-endian, oldest first.
-    /// output (33 bytes, big-endian fields): token u32 | depth u8 |
+    /// output (37 bytes, big-endian fields): token u32 | depth u8 |
     /// code [u8; 4] | count u32 | adds | xors | shifts | compares |
-    /// table_reads (u32 each). No multiply field exists, by design.
+    /// table_reads | candidate_scans (u32 each). No multiply field exists, by design.
     fn predict(input: &[u8], out: &mut [u8]) -> Result<usize, ShapeViolation> {
         if input.len() < TLESS_INPUT_BYTES {
             return Err(tless_violation(

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -562,16 +562,16 @@ impl<'a> IntoBindingValue<'a> for TlessPredictOutput {
 
 impl PartitionProductFields for TlessPredictOutput {
     const FIELDS: &'static [(u32, u32)] = &[
-        (0, 2),
-        (2, 1),
-        (3, 4),
-        (7, 4),
-        (11, 4),
-        (15, 4),
-        (19, 4),
-        (23, 4),
-        (27, 4),
-        (31, 4),
+        (0, 4),
+        (4, 1),
+        (5, 4),
+        (9, 4),
+        (13, 4),
+        (17, 4),
+        (21, 4),
+        (25, 4),
+        (29, 4),
+        (33, 4),
     ];
     const FIELD_NAMES: &'static [&'static str] = &[
         "token",

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -383,13 +383,13 @@ pub fn generate_steps_into(seed: &[u32], out: &mut [runtime::Prediction]) -> Opt
 
 // =====================================================================
 pub const TLESS_INPUT_BYTES: usize = WINDOW * 4; // 32
-pub const TLESS_OUTPUT_BYTES: usize = 33;
+pub const TLESS_OUTPUT_BYTES: usize = 37;
 
 uor_foundation_sdk::axis! {
     /// Mul-free table-native prediction axis (transformerless runtime).
     pub trait TlessAxis: AxisExtension {
         const AXIS_ADDRESS: &'static str = "https://uor.foundation/axis/TlessAxis";
-        const MAX_OUTPUT_BYTES: usize = 36;
+        const MAX_OUTPUT_BYTES: usize = 40;
         fn predict(input: &[u8], out: &mut [u8]) -> Result<usize, ShapeViolation>;
     }
 }
@@ -410,7 +410,7 @@ fn tless_violation(constraint: &'static str, min: usize, max: usize) -> ShapeVio
 
 impl TlessAxis for TlessAxisImpl {
     const AXIS_ADDRESS: &'static str = "https://uor.foundation/axis/TlessAxis/Impl";
-    const MAX_OUTPUT_BYTES: usize = 36;
+    const MAX_OUTPUT_BYTES: usize = 40;
 
     /// input: WINDOW u32 token ids, little-endian, oldest first.
     /// output (33 bytes, big-endian fields): token u32 | depth u8 |
@@ -494,6 +494,7 @@ impl TlessAxis for TlessAxisImpl {
             out[21..25].copy_from_slice(&(k.shifts as u32).to_be_bytes());
             out[25..29].copy_from_slice(&(k.compares as u32).to_be_bytes());
             out[29..33].copy_from_slice(&(k.table_reads as u32).to_be_bytes());
+            out[33..37].copy_from_slice(&(k.candidate_scans as u32).to_be_bytes());
             TLESS_OUTPUT_BYTES
         })
         .ok_or(ShapeViolation {
@@ -570,6 +571,7 @@ impl PartitionProductFields for TlessPredictOutput {
         (19, 4),
         (23, 4),
         (27, 4),
+        (31, 4),
     ];
     const FIELD_NAMES: &'static [&'static str] = &[
         "token",
@@ -581,6 +583,7 @@ impl PartitionProductFields for TlessPredictOutput {
         "shifts",
         "compares",
         "table_reads",
+        "candidate_scans",
     ];
 }
 
@@ -710,7 +713,7 @@ mod tests {
         for (i, w) in [1u32, 2, 3, 4, 5, 6, 7, 8].iter().enumerate() {
             input[4 * i..4 * i + 4].copy_from_slice(&w.to_le_bytes());
         }
-        let mut out = [0u8; 36];
+        let mut out = [0u8; 40];
         let n = TlessAxisImpl::predict(&input, &mut out).expect("predict");
         assert_eq!(n, TLESS_OUTPUT_BYTES);
         let token = u32::from_be_bytes([out[0], out[1], out[2], out[3]]);
@@ -718,12 +721,13 @@ mod tests {
         let count = u32::from_be_bytes(out[9..13].try_into().unwrap());
         let adds = u32::from_be_bytes(out[13..17].try_into().unwrap());
         let table_reads = u32::from_be_bytes(out[29..33].try_into().unwrap());
+        let candidate_scans = u32::from_be_bytes(out[33..37].try_into().unwrap());
         assert_eq!(token, 1, "only level-0 entry populated");
         assert_eq!(depth, 0, "synthetic store answers at level 0");
         assert_eq!(count, 10);
-        assert!(adds > 0 && table_reads > 0, "census recorded the path");
-        // No multiply field exists in the record: bytes 13..33 are exactly
-        // the five census counters, and OpKernel has no multiply to count.
+        assert!(adds > 0 && table_reads > 0 && candidate_scans > 0, "census recorded the path");
+        // No multiply field exists in the record: bytes 13..37 are exactly
+        // the six census counters, and OpKernel has no multiply to count.
     }
 
     #[test]


### PR DESCRIPTION
Implements Issue #14: Extends OpKernel census with candidate-scan counts, instruments runtime prediction loops, updates tless_uor serialization, server JSON output, and allocation census tests.