### PR TITLE
feat: compile forward transitions and reverse indexes from teacher corpus (closes #18)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -149,3 +149,5 @@ pub mod progress;
 pub mod runtime;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scenarios;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod transitions;

--- a/crates/uor-r4-core/src/transformerless/transitions.rs
+++ b/crates/uor-r4-core/src/transformerless/transitions.rs
@@ -136,7 +136,8 @@ where
     }
 
     // Group transitions by src node
-    let mut transitions_by_src: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
+    let mut transitions_by_src: std::collections::BTreeMap<u32, Vec<(u32, u32)>> =
+        std::collections::BTreeMap::new();
     for ((src, dst), weight) in transition_counts {
         transitions_by_src.entry(src).or_default().push((dst, weight));
     }

--- a/crates/uor-r4-core/src/transformerless/transitions.rs
+++ b/crates/uor-r4-core/src/transformerless/transitions.rs
@@ -88,16 +88,35 @@ impl TransitionGraph {
     /// For every dst node, all reverse index entries in its slice MUST refer to
     /// valid canonical edge IDs whose destination equals dst.
     pub fn verify_theorem_7(&self) -> Result<(), &'static str> {
+        if self.edges.is_empty() {
+            return Ok(());
+        }
+        if self.reverse_index.len() != self.edges.len() {
+            return Err("Theorem 7 violation: reverse index does not cover all edges");
+        }
+        let total_count: usize = self.reverse_offsets.values().map(|&(_, c)| c).sum();
+        if total_count != self.reverse_index.len() {
+            return Err("Theorem 7 violation: reverse offsets do not cover reverse index");
+        }
+        for &edge_id in &self.reverse_index {
+            if edge_id as usize >= self.edges.len() {
+                return Err("Theorem 7 violation: invalid canonical edge ID in reverse index");
+            }
+        }
+        for i in 1..self.reverse_index.len() {
+            let prev_dst = self.edges[self.reverse_index[i - 1] as usize].dst;
+            let cur_dst = self.edges[self.reverse_index[i] as usize].dst;
+            if prev_dst > cur_dst {
+                return Err("Theorem 7 violation: reverse index not sorted by dst");
+            }
+        }
         for (&dst, &(start, count)) in &self.reverse_offsets {
             if start + count > self.reverse_index.len() {
                 return Err("Theorem 7 violation: reverse index range out of bounds");
             }
             for i in start..start + count {
                 let edge_id = self.reverse_index[i];
-                let edge = self
-                    .edges
-                    .get(edge_id as usize)
-                    .ok_or("Theorem 7 violation: invalid canonical edge ID in reverse index")?;
+                let edge = &self.edges[edge_id as usize];
                 if edge.dst != dst {
                     return Err("Theorem 7 violation: reverse index target mismatched edge dst");
                 }

--- a/crates/uor-r4-core/src/transformerless/transitions.rs
+++ b/crates/uor-r4-core/src/transformerless/transitions.rs
@@ -1,0 +1,159 @@
+//! Forward transition edges ($E_f$) and reverse edge indexes ($E_b$) compiled
+//! from teacher corpus streams.
+//!
+//! Enforces Theorem 7: Reverse edge indexes ($E_b$) reference exact canonical
+//! edge IDs in $E_f$ sorted by destination region.
+
+use super::compiler::Corpus;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum EdgeKind {
+    Refinement = 0,
+    Overlap = 1,
+    Forward = 2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Edge {
+    pub id: u32,
+    pub src: u32,
+    pub dst: u32,
+    pub weight: u32,
+    pub kind: EdgeKind,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TransitionGraph {
+    /// Canonical edge array (E_f + E_r + E_o). Canonical Edge ID = index.
+    pub edges: Vec<Edge>,
+    /// Map from src node ID to list of canonical edge IDs originating from src.
+    pub forward_map: HashMap<u32, Vec<u32>>,
+    /// Reverse index array E_b: canonical edge IDs sorted by dst node ID.
+    pub reverse_index: Vec<u32>,
+    /// Map from dst node ID to (start_offset, count) in `reverse_index`.
+    pub reverse_offsets: HashMap<u32, (usize, usize)>,
+}
+
+impl TransitionGraph {
+    pub fn new() -> Self {
+        TransitionGraph::default()
+    }
+
+    /// Add a canonical edge to the graph.
+    pub fn add_edge(&mut self, src: u32, dst: u32, weight: u32, kind: EdgeKind) -> u32 {
+        let id = self.edges.len() as u32;
+        let edge = Edge {
+            id,
+            src,
+            dst,
+            weight,
+            kind,
+        };
+        self.edges.push(edge);
+        self.forward_map.entry(src).or_default().push(id);
+        id
+    }
+
+    /// Build and sort the reverse edge index $E_b$, validating Theorem 7 consistency.
+    pub fn build_reverse_index(&mut self) -> Result<(), &'static str> {
+        let mut edge_ids: Vec<u32> = (0..self.edges.len() as u32).collect();
+        // Sort edge IDs by (dst, src, kind, id)
+        edge_ids.sort_by_key(|&id| {
+            let e = &self.edges[id as usize];
+            (e.dst, e.src, e.kind as u8, e.id)
+        });
+
+        let mut reverse_offsets = HashMap::new();
+        let total = edge_ids.len();
+        let mut idx = 0;
+        while idx < total {
+            let dst = self.edges[edge_ids[idx] as usize].dst;
+            let start = idx;
+            while idx < total && self.edges[edge_ids[idx] as usize].dst == dst {
+                idx += 1;
+            }
+            let count = idx - start;
+            reverse_offsets.insert(dst, (start, count));
+        }
+
+        self.reverse_index = edge_ids;
+        self.reverse_offsets = reverse_offsets;
+
+        self.verify_theorem_7()
+    }
+
+    /// Verify Theorem 7 consistency:
+    /// For every dst node, all reverse index entries in its slice MUST refer to
+    /// valid canonical edge IDs whose destination equals dst.
+    pub fn verify_theorem_7(&self) -> Result<(), &'static str> {
+        for (&dst, &(start, count)) in &self.reverse_offsets {
+            if start + count > self.reverse_index.len() {
+                return Err("Theorem 7 violation: reverse index range out of bounds");
+            }
+            for i in start..start + count {
+                let edge_id = self.reverse_index[i];
+                let edge = self
+                    .edges
+                    .get(edge_id as usize)
+                    .ok_or("Theorem 7 violation: invalid canonical edge ID in reverse index")?;
+                if edge.dst != dst {
+                    return Err("Theorem 7 violation: reverse index target mismatched edge dst");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Compile forward region transitions ($E_f$) and reverse edge indexes ($E_b$)
+/// from a teacher corpus.
+///
+/// `region_assigner`: maps a token ID / context index to a region ID.
+/// `max_transitions_per_node`: maximum forward transitions to keep per region node.
+pub fn compile_transitions_from_corpus<F>(
+    corpus: &Corpus,
+    region_assigner: F,
+    max_transitions_per_node: usize,
+) -> Result<TransitionGraph, &'static str>
+where
+    F: Fn(u32) -> u32,
+{
+    let mut transition_counts: HashMap<(u32, u32), u32> = HashMap::new();
+
+    // Iterate over sequential positions in the corpus
+    let n = corpus.n;
+    if n > 1 {
+        for i in 0..(n - 1) {
+            // Keep transitions within the same story sequence
+            if corpus.story[i] == corpus.story[i + 1] {
+                let src_node = region_assigner(corpus.input[i]);
+                let dst_node = region_assigner(corpus.next[i]);
+                *transition_counts.entry((src_node, dst_node)).or_default() += 1;
+            }
+        }
+    }
+
+    // Group transitions by src node
+    let mut transitions_by_src: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
+    for ((src, dst), weight) in transition_counts {
+        transitions_by_src.entry(src).or_default().push((dst, weight));
+    }
+
+    let mut graph = TransitionGraph::new();
+
+    // Add forward edges bounded to top `max_transitions_per_node` per src node
+    for (src, mut dsts) in transitions_by_src {
+        // Sort descending by transition weight, then ascending by dst node ID
+        dsts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        let limit = dsts.len().min(max_transitions_per_node);
+        for &(dst, weight) in &dsts[..limit] {
+            graph.add_edge(src, dst, weight, EdgeKind::Forward);
+        }
+    }
+
+    // Build and verify Theorem 7 reverse index
+    graph.build_reverse_index()?;
+    Ok(graph)
+}

--- a/crates/uor-r4-core/tests/transitions_test.rs
+++ b/crates/uor-r4-core/tests/transitions_test.rs
@@ -1,0 +1,89 @@
+use uor_r4_core::transformerless::compiler::Corpus;
+use uor_r4_core::transformerless::transitions::{
+    compile_transitions_from_corpus, EdgeKind, TransitionGraph,
+};
+
+#[test]
+fn test_transition_graph_manual_edges_and_theorem_7() {
+    let mut graph = TransitionGraph::new();
+    let e0 = graph.add_edge(10, 20, 5, EdgeKind::Forward);
+    let e1 = graph.add_edge(30, 20, 8, EdgeKind::Forward);
+    let e2 = graph.add_edge(10, 40, 3, EdgeKind::Forward);
+
+    assert_eq!(e0, 0);
+    assert_eq!(e1, 1);
+    assert_eq!(e2, 2);
+
+    graph.build_reverse_index().expect("build reverse index");
+
+    // Theorem 7 verification
+    assert!(graph.verify_theorem_7().is_ok());
+
+    // Verify reverse index for dst = 20
+    let &(start, count) = graph.reverse_offsets.get(&20).expect("dst 20 in reverse map");
+    assert_eq!(count, 2);
+    let rev_slice = &graph.reverse_index[start..start + count];
+    for &edge_id in rev_slice {
+        assert_eq!(graph.edges[edge_id as usize].dst, 20);
+    }
+}
+
+#[test]
+fn test_compile_transitions_from_synthetic_corpus() {
+    let corpus = Corpus {
+        n: 6,
+        stories: 1,
+        story: vec![1, 1, 1, 1, 1, 1],
+        input: vec![100, 200, 100, 200, 100, 300],
+        next: vec![200, 100, 200, 100, 300, 400],
+        t_argmax: vec![200, 100, 200, 100, 300, 400],
+        top_tokens: vec![[200, 0, 0]; 6],
+        top_weights: vec![[100, 0, 0]; 6],
+    };
+
+    // Simple region assigner mapping token_id -> region_id
+    let region_assigner = |tok: u32| tok / 10; // 100->10, 200->20, 300->30, 400->40
+
+    let graph = compile_transitions_from_corpus(&corpus, region_assigner, 10)
+        .expect("compile transitions");
+
+    // Verify Theorem 7
+    assert!(graph.verify_theorem_7().is_ok());
+
+    // Check transition counts
+    // 100 -> 200 appears twice => region 10 -> region 20 weight 2
+    // 200 -> 100 appears twice => region 20 -> region 10 weight 2
+    // 100 -> 300 appears once => region 10 -> region 30 weight 1
+    // 300 -> 400 appears once => region 30 -> region 40 weight 1
+
+    let edges_from_10 = graph.forward_map.get(&10).expect("edges from 10");
+    assert_eq!(edges_from_10.len(), 2);
+    let edge_10_20 = &graph.edges[edges_from_10[0] as usize];
+    assert_eq!(edge_10_20.src, 10);
+    assert_eq!(edge_10_20.dst, 20);
+    assert_eq!(edge_10_20.weight, 2);
+}
+
+#[test]
+fn test_bounded_transitions_per_node() {
+    let corpus = Corpus {
+        n: 4,
+        stories: 1,
+        story: vec![1, 1, 1, 1],
+        input: vec![10, 10, 10, 10],
+        next: vec![20, 30, 40, 50],
+        t_argmax: vec![20, 30, 40, 50],
+        top_tokens: vec![[0; 3]; 4],
+        top_weights: vec![[0; 3]; 4],
+    };
+
+    let region_assigner = |tok: u32| tok;
+    let max_transitions = 2;
+
+    let graph = compile_transitions_from_corpus(&corpus, region_assigner, max_transitions)
+        .expect("compile bounded transitions");
+
+    let edges_from_10 = graph.forward_map.get(&10).expect("edges from 10");
+    assert_eq!(edges_from_10.len(), 2, "bounded to max 2 transitions per node");
+    assert!(graph.verify_theorem_7().is_ok());
+}


### PR DESCRIPTION
Implements Issue #18: Compiles forward region transition edges (E_f) and reverse edge indexes (E_b) from teacher corpus stream, enforcing Theorem 7 consistency by construction.