### PR TITLE
feat: predictive-sufficiency and rate-distortion reports by graph depth (closes #24)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -154,6 +154,8 @@ pub mod compare;
 pub mod compiler;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod progress;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod predictive_sufficiency;
 pub mod reference_state;
 pub mod runtime;
 pub mod score_q;

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -1,0 +1,142 @@
+//! Predictive-sufficiency divergence measurement and rate-distortion reporting across
+//! graph depths (Phase 3 / Plan §9.14).
+
+use crate::transformerless::runtime::OpKernel;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphDepth {
+    BroadCloud,
+    IntermediateCloud,
+    FullCloud,
+    ResidualAugmented,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DivergencePoint {
+    pub depth: GraphDepth,
+    pub kl_divergence: f64,
+    pub cross_entropy: f64,
+    pub top1_accuracy: f64,
+    pub top5_recall: f64,
+    pub bytes_footprint: usize,
+    pub op_budget: OpKernel,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct RateDistortionReport {
+    pub points: Vec<DivergencePoint>,
+}
+
+impl RateDistortionReport {
+    pub fn new(points: Vec<DivergencePoint>) -> Self {
+        RateDistortionReport { points }
+    }
+
+    /// Returns list of (Rate in bytes+ops, Distortion in KL-divergence bits).
+    pub fn compute_rate_distortion_curve(&self) -> Vec<(f64, f64)> {
+        self.points
+            .iter()
+            .map(|p| {
+                let total_ops = (p.op_budget.adds
+                    + p.op_budget.xors
+                    + p.op_budget.shifts
+                    + p.op_budget.compares
+                    + p.op_budget.table_reads
+                    + p.op_budget.candidate_scans) as f64;
+                let rate = (p.bytes_footprint as f64) + 0.1 * total_ops;
+                let distortion = p.kl_divergence;
+                (rate, distortion)
+            })
+            .collect()
+    }
+
+    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
+        Ok(buf)
+    }
+
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
+        ciborium::from_reader(bytes).map_err(|e| e.to_string())
+    }
+}
+
+pub struct PredictiveSufficiencyEvaluator;
+
+impl PredictiveSufficiencyEvaluator {
+    /// Compute KL-divergence D_KL(P || Q) = sum(P(i) * log(P(i) / Q(i)))
+    pub fn compute_kl_divergence(p: &[f64], q: &[f64]) -> f64 {
+        if p.len() != q.len() || p.is_empty() {
+            return 0.0;
+        }
+        let eps = 1e-12;
+        p.iter()
+            .zip(q.iter())
+            .map(|(&pi, &qi)| {
+                let pi_c = pi.max(eps);
+                let qi_c = qi.max(eps);
+                pi_c * (pi_c / qi_c).ln()
+            })
+            .sum::<f64>()
+    }
+
+    /// Compute Cross-Entropy H(P, Q) = -sum(P(i) * log(Q(i)))
+    pub fn compute_cross_entropy(p: &[f64], q: &[f64]) -> f64 {
+        if p.len() != q.len() || p.is_empty() {
+            return 0.0;
+        }
+        let eps = 1e-12;
+        -p.iter()
+            .zip(q.iter())
+            .map(|(&pi, &qi)| {
+                let pi_c = pi.max(eps);
+                let qi_c = qi.max(eps);
+                pi_c * qi_c.ln()
+            })
+            .sum::<f64>()
+    }
+
+    pub fn evaluate_depth(
+        teacher_probs: &[f64],
+        graph_probs: &[f64],
+        depth: GraphDepth,
+        bytes: usize,
+        ops: OpKernel,
+    ) -> DivergencePoint {
+        let kl = Self::compute_kl_divergence(teacher_probs, graph_probs);
+        let ce = Self::compute_cross_entropy(teacher_probs, graph_probs);
+
+        let top1_acc = if !teacher_probs.is_empty() && !graph_probs.is_empty() {
+            let max_t = teacher_probs
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .map(|x| x.0)
+                .unwrap_or(0);
+            let max_g = graph_probs
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .map(|x| x.0)
+                .unwrap_or(0);
+            if max_t == max_g {
+                1.0
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        DivergencePoint {
+            depth,
+            kl_divergence: kl,
+            cross_entropy: ce,
+            top1_accuracy: top1_acc,
+            top5_recall: 1.0,
+            bytes_footprint: bytes,
+            op_budget: ops,
+        }
+    }
+}

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -149,11 +149,16 @@ impl PredictiveSufficiencyEvaluator {
             graph_top5.sort_by(|a, b| b.1.total_cmp(a.1));
 
             teacher_top
-                .map(|teacher_top| {
-                    graph_top5
+                .map(|teacher_idx| {
+                    if graph_top5
                         .iter()
                         .take(5)
-                        .any(|(index, _)| *index == teacher_top) as u8 as f64
+                        .any(|(index, _)| *index == teacher_idx)
+                    {
+                        1.0
+                    } else {
+                        0.0
+                    }
                 })
                 .unwrap_or(0.0)
         } else {

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -35,6 +35,8 @@ impl RateDistortionReport {
 
     /// Returns list of (Rate in bytes+ops, Distortion in KL-divergence bits).
     pub fn compute_rate_distortion_curve(&self) -> Vec<(f64, f64)> {
+        const OPS_TO_BYTES_WEIGHT: f64 = 0.1;
+
         self.points
             .iter()
             .map(|p| {
@@ -44,7 +46,7 @@ impl RateDistortionReport {
                     + p.op_budget.compares
                     + p.op_budget.table_reads
                     + p.op_budget.candidate_scans) as f64;
-                let rate = (p.bytes_footprint as f64) + 0.1 * total_ops;
+                let rate = (p.bytes_footprint as f64) + OPS_TO_BYTES_WEIGHT * total_ops;
                 let distortion = p.kl_divergence;
                 (rate, distortion)
             })

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -18,6 +18,7 @@ pub struct DivergencePoint {
     pub kl_divergence: f64,
     pub cross_entropy: f64,
     pub top1_accuracy: f64,
+    /// Whether the teacher's most likely class is among the graph's five most likely classes.
     pub top5_recall: f64,
     pub bytes_footprint: usize,
     pub op_budget: OpKernel,
@@ -133,13 +134,38 @@ impl PredictiveSufficiencyEvaluator {
         } else {
             0.0
         };
+        let top5_recall = if !teacher_probs.is_empty() && !graph_probs.is_empty() {
+            let teacher_top = teacher_probs
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| v.is_finite())
+                .max_by(|a, b| a.1.total_cmp(b.1))
+                .map(|(i, _)| i);
+            let mut graph_top5 = graph_probs
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| v.is_finite())
+                .collect::<Vec<_>>();
+            graph_top5.sort_by(|a, b| b.1.total_cmp(a.1));
+
+            teacher_top
+                .map(|teacher_top| {
+                    graph_top5
+                        .iter()
+                        .take(5)
+                        .any(|(index, _)| *index == teacher_top) as u8 as f64
+                })
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
 
         DivergencePoint {
             depth,
             kl_divergence: kl,
             cross_entropy: ce,
             top1_accuracy: top1_acc,
-            top5_recall: 1.0,
+            top5_recall,
             bytes_footprint: bytes,
             op_budget: ops,
         }

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -83,18 +83,20 @@ impl PredictiveSufficiencyEvaluator {
             .sum::<f64>()
     }
 
-    /// Compute Cross-Entropy H(P, Q) = -sum(P(i) * log(Q(i)))
+    /// Compute Cross-Entropy H(P, Q) = -sum(P(i) * log2(Q(i)))
     pub fn compute_cross_entropy(p: &[f64], q: &[f64]) -> f64 {
         if p.len() != q.len() || p.is_empty() {
-            return 0.0;
+            return f64::NAN;
         }
         let eps = 1e-12;
-        -p.iter()
+        p.iter()
             .zip(q.iter())
             .map(|(&pi, &qi)| {
-                let pi_c = pi.max(eps);
+                if pi <= 0.0 {
+                    return 0.0;
+                }
                 let qi_c = qi.max(eps);
-                pi_c * qi_c.ln()
+                -pi * qi_c.log2()
             })
             .sum::<f64>()
     }

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -65,18 +65,20 @@ impl RateDistortionReport {
 pub struct PredictiveSufficiencyEvaluator;
 
 impl PredictiveSufficiencyEvaluator {
-    /// Compute KL-divergence D_KL(P || Q) = sum(P(i) * log(P(i) / Q(i)))
+    /// Compute KL-divergence D_KL(P || Q) = sum(P(i) * log2(P(i) / Q(i)))
     pub fn compute_kl_divergence(p: &[f64], q: &[f64]) -> f64 {
         if p.len() != q.len() || p.is_empty() {
-            return 0.0;
+            return f64::NAN;
         }
         let eps = 1e-12;
         p.iter()
             .zip(q.iter())
             .map(|(&pi, &qi)| {
-                let pi_c = pi.max(eps);
+                if pi <= 0.0 {
+                    return 0.0;
+                }
                 let qi_c = qi.max(eps);
-                pi_c * (pi_c / qi_c).ln()
+                pi * (pi / qi_c).log2()
             })
             .sum::<f64>()
     }

--- a/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
+++ b/crates/uor-r4-core/src/transformerless/predictive_sufficiency.rs
@@ -114,18 +114,17 @@ impl PredictiveSufficiencyEvaluator {
         let ce = Self::compute_cross_entropy(teacher_probs, graph_probs);
 
         let top1_acc = if !teacher_probs.is_empty() && !graph_probs.is_empty() {
-            let max_t = teacher_probs
-                .iter()
-                .enumerate()
-                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-                .map(|x| x.0)
-                .unwrap_or(0);
-            let max_g = graph_probs
-                .iter()
-                .enumerate()
-                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-                .map(|x| x.0)
-                .unwrap_or(0);
+            let argmax = |xs: &[f64]| -> usize {
+                xs.iter()
+                    .enumerate()
+                    .filter(|(_, v)| v.is_finite())
+                    .max_by(|a, b| a.1.total_cmp(b.1))
+                    .map(|(i, _)| i)
+                    .unwrap_or(0)
+            };
+
+            let max_t = argmax(teacher_probs);
+            let max_g = argmax(graph_probs);
             if max_t == max_g {
                 1.0
             } else {

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -26,7 +26,7 @@ const TOP_M_MEMBERSHIPS: usize = 3;
 /// Complete arithmetic interface of the runtime, with an operation census.
 /// There is no multiplication method; the census has no multiplication
 /// field. Both absences are the point.
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub struct OpKernel {
     pub adds: u64,
     pub xors: u64,

--- a/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
@@ -28,8 +28,8 @@ fn test_kl_divergence_and_cross_entropy() {
 fn test_predictive_sufficiency_evaluator_depths() {
     let teacher = vec![0.7, 0.2, 0.1];
     let broad = vec![0.33, 0.33, 0.34];
-    let intermediate = vec![0.5, 0.3, 0.2];
-    let full = vec![0.65, 0.25, 0.1];
+    let _intermediate = vec![0.5, 0.3, 0.2];
+    let _full = vec![0.65, 0.25, 0.1];
     let residual = vec![0.7, 0.2, 0.1];
 
     let ops = OpKernel::default();

--- a/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
@@ -16,6 +16,17 @@ fn test_kl_divergence_and_cross_entropy() {
         "KL divergence of distribution with itself must be ~0"
     );
 
+    // Edge case: zeros in the distribution should not introduce spurious mass.
+    let pz = vec![1.0, 0.0, 0.0];
+    let qz = vec![1.0, 0.0, 0.0];
+    let kl_zeros = PredictiveSufficiencyEvaluator::compute_kl_divergence(&pz, &qz);
+    assert!(
+        kl_zeros.abs() < 1e-12,
+        "KL divergence must be ~0 when P contains zeros and P==Q"
+    );
+    let ce_zeros = PredictiveSufficiencyEvaluator::compute_cross_entropy(&pz, &qz);
+    assert!(ce_zeros.abs() < 1e-12);
+
     let q2 = vec![0.8, 0.1, 0.1];
     let kl_diff = PredictiveSufficiencyEvaluator::compute_kl_divergence(&p, &q2);
     assert!(kl_diff > 0.0, "KL divergence must be positive for distinct distributions");

--- a/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
@@ -65,6 +65,16 @@ fn test_predictive_sufficiency_evaluator_depths() {
         pt_residual.kl_divergence < pt_broad.kl_divergence,
         "Residual depth KL divergence must be strictly less than BroadCloud depth"
     );
+    assert_eq!(pt_residual.top5_recall, 1.0);
+
+    let top5_miss = PredictiveSufficiencyEvaluator::evaluate_depth(
+        &[0.9, 0.02, 0.02, 0.02, 0.02, 0.02],
+        &[0.01, 0.2, 0.2, 0.2, 0.2, 0.19],
+        GraphDepth::BroadCloud,
+        1000,
+        OpKernel::default(),
+    );
+    assert_eq!(top5_miss.top5_recall, 0.0);
 }
 
 #[test]

--- a/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-core/tests/predictive_sufficiency_test.rs
@@ -1,0 +1,90 @@
+use uor_r4_core::transformerless::{
+    predictive_sufficiency::{
+        DivergencePoint, GraphDepth, PredictiveSufficiencyEvaluator, RateDistortionReport,
+    },
+    runtime::OpKernel,
+};
+
+#[test]
+fn test_kl_divergence_and_cross_entropy() {
+    let p = vec![0.5, 0.25, 0.25];
+    let q = vec![0.5, 0.25, 0.25];
+
+    let kl_self = PredictiveSufficiencyEvaluator::compute_kl_divergence(&p, &q);
+    assert!(
+        kl_self.abs() < 1e-6,
+        "KL divergence of distribution with itself must be ~0"
+    );
+
+    let q2 = vec![0.8, 0.1, 0.1];
+    let kl_diff = PredictiveSufficiencyEvaluator::compute_kl_divergence(&p, &q2);
+    assert!(kl_diff > 0.0, "KL divergence must be positive for distinct distributions");
+
+    let ce = PredictiveSufficiencyEvaluator::compute_cross_entropy(&p, &q2);
+    assert!(ce > 0.0);
+}
+
+#[test]
+fn test_predictive_sufficiency_evaluator_depths() {
+    let teacher = vec![0.7, 0.2, 0.1];
+    let broad = vec![0.33, 0.33, 0.34];
+    let intermediate = vec![0.5, 0.3, 0.2];
+    let full = vec![0.65, 0.25, 0.1];
+    let residual = vec![0.7, 0.2, 0.1];
+
+    let ops = OpKernel::default();
+
+    let pt_broad = PredictiveSufficiencyEvaluator::evaluate_depth(
+        &teacher,
+        &broad,
+        GraphDepth::BroadCloud,
+        1000,
+        ops.clone(),
+    );
+
+    let pt_residual = PredictiveSufficiencyEvaluator::evaluate_depth(
+        &teacher,
+        &residual,
+        GraphDepth::ResidualAugmented,
+        5000,
+        ops,
+    );
+
+    assert!(
+        pt_residual.kl_divergence < pt_broad.kl_divergence,
+        "Residual depth KL divergence must be strictly less than BroadCloud depth"
+    );
+}
+
+#[test]
+fn test_rate_distortion_report_cbor_roundtrip() {
+    let p1 = DivergencePoint {
+        depth: GraphDepth::BroadCloud,
+        kl_divergence: 1.25,
+        cross_entropy: 2.10,
+        top1_accuracy: 0.60,
+        top5_recall: 0.85,
+        bytes_footprint: 1024,
+        op_budget: OpKernel::default(),
+    };
+
+    let p2 = DivergencePoint {
+        depth: GraphDepth::ResidualAugmented,
+        kl_divergence: 0.05,
+        cross_entropy: 1.15,
+        top1_accuracy: 0.98,
+        top5_recall: 1.00,
+        bytes_footprint: 8192,
+        op_budget: OpKernel::default(),
+    };
+
+    let report = RateDistortionReport::new(vec![p1, p2]);
+    let curve = report.compute_rate_distortion_curve();
+    assert_eq!(curve.len(), 2);
+    assert_eq!(curve[0].1, 1.25);
+    assert_eq!(curve[1].1, 0.05);
+
+    let cbor_bytes = report.to_cbor_bytes().expect("serialize CBOR");
+    let decoded = RateDistortionReport::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
+    assert_eq!(report, decoded);
+}


### PR DESCRIPTION
Implements Issue #24: Divergence D_KL(T(.|c) || T(.|R_d(c))) across graph depths (BroadCloud, IntermediateCloud, FullCloud, ResidualAugmented), operational rate-distortion curves (bytes+ops vs bits retained), and CBOR RateDistortionReport serialization.