### PR TITLE
Document the PR-based merge workflow (ruleset protects main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
         uses: taiki-e/install-action@cargo-nextest
 
       - name: cargo nextest run --workspace
-        run: cargo nextest run --workspace
+        run: cargo nextest run --workspace -E 'not binary(bdd)'
+
+      - name: cucumber BDD suite (own runner, not nextest-compatible)
+        run: cargo test --test bdd
 
       - name: cargo test --doc
         run: cargo test --doc --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: wasm-pack build --target web
 
   gate-c-trend:
-    name: Gate C trend alarm (issue #77)
+    name: Gate C trend alarm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,18 @@ audit, and nightly fuzz smoke — keep it green.
 
 ## Process conventions
 
-- **Issues**: assignment = work-in-progress signal (convention documented in
-  `uor_standards/prism/AGENTS.md` §5.4). Assign yourself when starting; close
-  with the commit reference. Milestones mirror plan phases.
+- **Merge workflow (since 2026-07-22): NO direct pushes to `main`.** A ruleset
+  ("main: required checks", id 19597522) protects `main`: all changes land via
+  PR, and the five CI checks (`fmt / clippy / tests / no_std / κ`,
+  `cargo audit`, `fuzz smoke`, `wasm-pack build`, `Gate C trend alarm`) must
+  pass with the branch up to date (strict policy). GitHub's merge-queue rule
+  type was unavailable via the API when this was set up — if the Settings UI
+  toggle gets enabled later, PRs go through the merge queue instead of plain
+  merge; the workflow below is identical either way.
+- **Per issue**: assign yourself (WIP signal) → branch `issue-<n>-<slug>` →
+  work + verify the four gates locally → open PR → merge when checks are
+  green → close the issue with the DoD evidence and the merge commit
+  reference. Milestones mirror plan phases.
 - **PR review** (incl. Copilot-generated): never merge unverified. Run the
   four gates + κ-reproduction on a merge preview first; resolve conflicts
   hunk-by-hunk — whole-file `checkout --theirs/--ours` has silently dropped

--- a/scripts/gate_c_trend.sh
+++ b/scripts/gate_c_trend.sh
@@ -13,7 +13,7 @@ OUT_DIR="${TREND_DIR:-/tmp/gate_c_trend}"
 TREND_OUT="${TREND_OUT:-/tmp/gate_c_trend.jsonl}"
 
 rm -rf "$OUT_DIR"
-cargo run -q --release --offline --bin r4 -- transformerless score \
+cargo run -q --release --bin r4 -- transformerless score \
   --corpus-meta "$FIXTURE_META" --corpus-recs "$FIXTURE_RECS" \
   --artifacts "$FIXTURE_ART" --out "$OUT_DIR" >/dev/null
 


### PR DESCRIPTION
Process change companion to the ruleset: main is now protected (ruleset id 19597522) — no direct pushes, five CI checks required with strict up-to-date policy. AGENTS.md gains the per-issue flow: assign -> branch -> PR -> checks -> merge -> close with DoD evidence. The merge-queue rule type was rejected by the API twice (plan/instance limitation); if the Settings UI toggle gets enabled, PRs route through the merge queue with the same workflow. This PR is itself the first change through the new protected path.