### PR TITLE
From-text observation driver (issue #72)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -26,8 +26,8 @@
 //! and qwen/phi-class sources differ only in that adapter.
 
 use super::{
-    certify, compare, compiler, convert_r4g1, cover, cover_sweep, observe, runtime, scenarios,
-    score,
+    certify, compare, compiler, convert_r4g1, cover, cover_sweep, observe, observe_text, runtime,
+    scenarios, score,
     teacher::{BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, TeacherOracle},
 };
 use serde::Serialize;
@@ -36,10 +36,12 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
+const DEFAULT_TOKENIZER: &str = "/tmp/ref/tokenizer.bin";
 const STORE_PATH: &str = "/tmp/tless_store.bin";
 const DEFAULT_HF_SOURCE_PATH: &str = ".uor-models/sources/smollm2-135m-instruct";
 const DEFAULT_HF_COMPILED_PATH: &str = ".uor-models/compiled/smollm2-135m-instruct";
 const DEFAULT_HF_EVALUATION_REPORT: &str = "instruction-eval.json";
+const DEFAULT_TEXT_CORPUS: &str = ".uor-models/corpora/simple-wiki-20231101/articles.jsonl";
 
 #[derive(Debug, PartialEq, Eq)]
 struct CompileOptions {
@@ -180,6 +182,166 @@ pub fn observe_command(args: &[String]) -> Result<(), String> {
     } else {
         println!(
             "observation corpus is not complete; rerun the same command to resume {}",
+            options.output.display()
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ObserveTextOptions {
+    input: PathBuf,
+    source: PathBuf,
+    checkpoint: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
+    output: PathBuf,
+    seconds: u64,
+    shards: u8,
+    sequence_length: usize,
+}
+
+fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, String> {
+    let mut options = ObserveTextOptions {
+        input: PathBuf::from(DEFAULT_TEXT_CORPUS),
+        source: PathBuf::from(DEFAULT_HF_SOURCE_PATH),
+        checkpoint: None,
+        tokenizer: None,
+        output: PathBuf::from("obs-text"),
+        seconds: 300,
+        shards: 4,
+        sequence_length: 128,
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--input" => options.input = PathBuf::from(value),
+            "--source" => options.source = PathBuf::from(value),
+            "--checkpoint" => options.checkpoint = Some(PathBuf::from(value)),
+            "--tokenizer" => options.tokenizer = Some(PathBuf::from(value)),
+            "--out" => options.output = PathBuf::from(value),
+            "--seconds" => {
+                options.seconds = value
+                    .parse()
+                    .map_err(|_| format!("invalid --seconds value: {value}"))?;
+            }
+            "--shards" => {
+                options.shards = value
+                    .parse()
+                    .map_err(|_| format!("invalid --shards value: {value}"))?;
+                if options.shards > observe::MAX_SHARD_BITS {
+                    return Err(format!(
+                        "--shards must be at most {} (2^N shard files)",
+                        observe::MAX_SHARD_BITS
+                    ));
+                }
+            }
+            "--sequence-length" => {
+                options.sequence_length = value
+                    .parse()
+                    .map_err(|_| format!("invalid --sequence-length value: {value}"))?;
+                if options.sequence_length == 0 {
+                    return Err("--sequence-length must be greater than zero".to_owned());
+                }
+            }
+            _ => return Err(format!("unknown observe-text option: {flag}")),
+        }
+        index += 2;
+    }
+    Ok(options)
+}
+
+/// From-text observation driver (issue #72): feed the sealed natural-text
+/// corpus (D3) through the teacher, recording the same v3 observation
+/// records the autoregressive `observe` path produces, with the corpus
+/// split rule applied at write time and recorded per shard.
+pub fn observe_text_command(args: &[String]) -> Result<(), String> {
+    #[cfg(debug_assertions)]
+    eprintln!(
+        "warning: debug builds make teacher generation much slower; use `cargo run --release -- observe-text ...`"
+    );
+    let options = parse_observe_text_options(args)?;
+    std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
+    let token_byte_lengths: Vec<u32>;
+    let tokenizer: scenarios::Tokenizer;
+    let mut oracle: Box<dyn TeacherOracle> = if let Some(checkpoint) = &options.checkpoint {
+        // Legacy llama2.c checkpoint: the companion tokenizer is the
+        // scoreless tokenizer.bin fetched by `setup` (overridable with
+        // --tokenizer); its piece byte lengths anchor records into the
+        // article text.
+        let tokenizer_path = options
+            .tokenizer
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_TOKENIZER));
+        tokenizer = scenarios::Tokenizer::try_load(&tokenizer_path)
+            .map_err(|error| format!("{}: {error}", tokenizer_path.display()))?;
+        token_byte_lengths = tokenizer
+            .vocab
+            .iter()
+            .map(|piece| piece.len() as u32)
+            .collect();
+        let path = checkpoint
+            .to_str()
+            .ok_or_else(|| "checkpoint path is not UTF-8".to_owned())?;
+        Box::new(LlamaOracle::load(path))
+    } else {
+        let oracle = HuggingFaceLlamaOracle::load_with_sequence_length(
+            &options.source,
+            options.sequence_length,
+        )
+        .map_err(|error| format!("failed to load Hugging Face model: {error}"))?;
+        eprintln!("exporting tokenizer...");
+        token_byte_lengths = scenarios::export_hf_bytelevel_tokenizer_with_lengths(
+            options.source.join("tokenizer.json"),
+            options.output.join("tokenizer.bin"),
+        )
+        .map_err(|error| error.to_string())?;
+        tokenizer = scenarios::Tokenizer::try_load(options.output.join("tokenizer.bin"))
+            .map_err(|error| error.to_string())?;
+        Box::new(oracle)
+    };
+    let report = observe_text::observe_text_corpus(
+        oracle.as_mut(),
+        options.seconds,
+        &tokenizer,
+        Some(&token_byte_lengths),
+        &options.input,
+        &options.output,
+        options.shards,
+        true,
+    )?;
+    println!(
+        "observe-text: {} records across {}/{} shards ({} written this run)",
+        report.records, report.shards_completed, report.shard_count, report.written
+    );
+    println!(
+        "partition: {} construction / {} held-out records ({} / {} articles of {})",
+        report.construction_records,
+        report.held_out_records,
+        report.construction_articles,
+        report.held_out_articles,
+        report.articles_total
+    );
+    if report.articles_truncated != 0 {
+        println!(
+            "note: {} articles truncated at the teacher sequence length",
+            report.articles_truncated
+        );
+    }
+    if report.done {
+        println!(
+            "observe-text complete: merged κ {} at {}",
+            report.merged_kappa.expect("done reports merged κ"),
+            options.output.display()
+        );
+    } else {
+        println!(
+            "text observation corpus is not complete ({}/{} articles); rerun the same command to resume {}",
+            report.articles_completed,
+            report.articles_total,
             options.output.display()
         );
     }
@@ -1431,6 +1593,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
         Some("compare-report") => compare::report(),
         Some("evaluate-report") => evaluate_report(&args[1..])?,
         Some("observe") => observe_command(&args[1..])?,
+        Some("observe-text") => observe_text_command(&args[1..])?,
         Some("scenarios") => {
             let mut oracle = LlamaOracle::load(DEFAULT_CHECKPOINT);
             scenarios::scenarios(&mut oracle);
@@ -1452,6 +1615,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 "R4 transformerless — cross-compile a transformer into a mul-free table artifact\n\
                  commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | certify | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
                  observation pipeline: observe [--source DIR | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
+                 text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR | --checkpoint BIN] [--tokenizer PATH] [--sequence-length N]\n\
                  cover induction: cover [--corpus-meta P --corpus-recs P] [--artifacts P] [--depths N] [--k0 N] [--regions-budget N] [--memory-budget MB] [--min-support N] [--entropy-gain BITS] [--radius-quantile PCT] [--out DIR]\n\
                  score (phase 4): score [--corpus-meta P --corpus-recs P] [--artifacts P] [--cover P] [--transition-out-degree N] [--emission-entries N] [--root-top-b N] [--exct-top-x N] [--witness-sample N] [--smoothing RULE] [--out DIR]\n\
                  cover sweep (issue 70): cover-sweep [--corpus-meta P --corpus-recs P] [--artifacts P] [--out DIR]\n\
@@ -1591,6 +1755,71 @@ mod tests {
     fn observe_rejects_excessive_shard_fanout() {
         let args = ["--shards", "9"].map(str::to_owned);
         assert!(parse_observe_options(&args).is_err());
+    }
+
+    #[test]
+    fn observe_text_defaults_and_overrides() {
+        let options = parse_observe_text_options(&[]).expect("defaults");
+        assert_eq!(options.input, PathBuf::from(DEFAULT_TEXT_CORPUS));
+        assert_eq!(options.source, PathBuf::from(DEFAULT_HF_SOURCE_PATH));
+        assert_eq!(options.checkpoint, None);
+        assert_eq!(options.tokenizer, None);
+        assert_eq!(options.output, PathBuf::from("obs-text"));
+        assert_eq!(options.seconds, 300);
+        assert_eq!(options.shards, 4);
+        assert_eq!(options.sequence_length, 128);
+
+        let args = [
+            "--input",
+            "/tmp/articles.jsonl",
+            "--checkpoint",
+            "/tmp/ref/out/model.bin",
+            "--tokenizer",
+            "/tmp/ref/tokenizer.bin",
+            "--out",
+            "/tmp/obs-text",
+            "--seconds",
+            "5",
+            "--shards",
+            "3",
+            "--sequence-length",
+            "64",
+        ]
+        .map(str::to_owned);
+        let options = parse_observe_text_options(&args).expect("valid options");
+        assert_eq!(options.input, PathBuf::from("/tmp/articles.jsonl"));
+        assert_eq!(
+            options.checkpoint,
+            Some(PathBuf::from("/tmp/ref/out/model.bin"))
+        );
+        assert_eq!(
+            options.tokenizer,
+            Some(PathBuf::from("/tmp/ref/tokenizer.bin"))
+        );
+        assert_eq!(options.output, PathBuf::from("/tmp/obs-text"));
+        assert_eq!(options.seconds, 5);
+        assert_eq!(options.shards, 3);
+        assert_eq!(options.sequence_length, 64);
+    }
+
+    #[test]
+    fn observe_text_rejects_invalid_options() {
+        for args in [
+            vec!["--shards", "9"],
+            vec!["--shards", "x"],
+            vec!["--seconds", "-1"],
+            vec!["--sequence-length", "0"],
+            vec!["--target", "10"],
+            vec!["--bogus", "1"],
+        ] {
+            let args: Vec<String> = args.iter().map(|arg| (*arg).to_owned()).collect();
+            assert!(
+                parse_observe_text_options(&args).is_err(),
+                "{args:?} rejected"
+            );
+        }
+        let missing = ["--out"].map(str::to_owned);
+        assert!(parse_observe_text_options(&missing).is_err());
     }
 
     #[test]

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -172,6 +172,8 @@ pub mod graph_patch;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod observe;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod observe_text;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod performance_certificate;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod predictive_sufficiency;

--- a/crates/uor-r4-core/src/transformerless/observe.rs
+++ b/crates/uor-r4-core/src/transformerless/observe.rs
@@ -109,6 +109,37 @@ fn file_kappa(path: &Path) -> io::Result<String> {
     Ok(format!("blake3:{}", hasher.finalize().to_hex()))
 }
 
+/// Document-level partition of one observation record, recorded per shard
+/// so downstream consumers can split a merged observation corpus exactly
+/// (the from-text driver of `super::observe_text` tags every record with
+/// its article's partition at write time).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RecordPartition {
+    Construction,
+    HeldOut,
+}
+
+/// Per-partition record counts of one shard.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartitionCounts {
+    pub construction: u64,
+    pub held_out: u64,
+}
+
+impl PartitionCounts {
+    fn add(&mut self, partition: RecordPartition) {
+        match partition {
+            RecordPartition::Construction => self.construction += 1,
+            RecordPartition::HeldOut => self.held_out += 1,
+        }
+    }
+
+    /// Total records across both partitions.
+    pub fn total(&self) -> u64 {
+        self.construction + self.held_out
+    }
+}
+
 /// One completed shard's entry in the observation manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardEntry {
@@ -116,6 +147,11 @@ pub struct ShardEntry {
     pub records: u64,
     /// Content κ of the shard file bytes.
     pub kappa: String,
+    /// Per-partition record counts, when the producing pipeline tags
+    /// records with a document-level partition (absent for the generation
+    /// path, so its manifest bytes are unchanged).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partitions: Option<PartitionCounts>,
 }
 
 /// Manifest of an observation shard directory: the fan-out, the completed
@@ -125,6 +161,10 @@ pub struct ShardEntry {
 pub struct ObservationManifest {
     pub schema: u32,
     pub shard_bits: u8,
+    /// The document-level partition rule records are tagged with, when the
+    /// producing pipeline has one (from-text driver; absent otherwise).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partition_rule: Option<String>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -136,6 +176,7 @@ impl ObservationManifest {
         Self {
             schema: 1,
             shard_bits,
+            partition_rule: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -184,6 +225,8 @@ pub struct ObservationShardWriter {
     dir: PathBuf,
     manifest: ObservationManifest,
     handles: Vec<Option<ShardHandle>>,
+    partition_counts: Vec<PartitionCounts>,
+    partitions_active: bool,
 }
 
 impl ObservationShardWriter {
@@ -211,10 +254,15 @@ impl ObservationShardWriter {
             None => ObservationManifest::new(shard_bits),
         };
         let handles = (0..manifest.shard_count()).map(|_| None).collect();
+        let partition_counts = (0..manifest.shard_count())
+            .map(|_| PartitionCounts::default())
+            .collect();
         Ok(Self {
             dir,
             manifest,
             handles,
+            partition_counts,
+            partitions_active: false,
         })
     }
 
@@ -224,6 +272,40 @@ impl ObservationShardWriter {
 
     pub fn is_complete(&self, shard: u32) -> bool {
         self.manifest.completed.contains_key(&shard)
+    }
+
+    /// Record the document-level partition rule in the manifest (persisted
+    /// atomically). Idempotent: storing the already-recorded rule is a
+    /// no-op and does not rewrite the manifest.
+    pub fn set_partition_rule(&mut self, rule: &str) -> io::Result<()> {
+        if self.manifest.partition_rule.as_deref() != Some(rule) {
+            self.manifest.partition_rule = Some(rule.to_owned());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Pending per-shard partition counts (records written so far via
+    /// [`ObservationShardWriter::write_record_in_partition`] plus any
+    /// counts restored by [`ObservationShardWriter::restore_partition_counts`]).
+    pub fn partition_counts(&self, shard: u32) -> Option<PartitionCounts> {
+        self.partition_counts.get(shard as usize).copied()
+    }
+
+    /// Restore per-shard partition counts from an earlier pass's
+    /// checkpoint, so counts accumulated across a resume cover the whole
+    /// shard rather than only this invocation's writes.
+    pub fn restore_partition_counts(&mut self, counts: &[PartitionCounts]) -> io::Result<()> {
+        if counts.len() != self.partition_counts.len() {
+            return Err(invalid_input(format!(
+                "partition count table has {} shards, expected {}",
+                counts.len(),
+                self.partition_counts.len()
+            )));
+        }
+        self.partition_counts.copy_from_slice(counts);
+        self.partitions_active = counts.iter().any(|count| count.total() != 0);
+        Ok(())
     }
 
     fn shard_path(&self, shard: u32) -> PathBuf {
@@ -272,6 +354,24 @@ impl ObservationShardWriter {
         Ok(true)
     }
 
+    /// Append one partitioned record to `shard`: identical write semantics
+    /// to [`ObservationShardWriter::write_record`], additionally counting
+    /// the record under its document-level partition so the finalized
+    /// shard entry lists construction vs held-out counts.
+    pub fn write_record_in_partition(
+        &mut self,
+        record: &[u8; RECORD_SIZE],
+        shard: u32,
+        partition: RecordPartition,
+    ) -> io::Result<bool> {
+        let written = self.write_record(record, shard)?;
+        if written {
+            self.partition_counts[shard as usize].add(partition);
+            self.partitions_active = true;
+        }
+        Ok(written)
+    }
+
     /// Flush every open shard handle. Called at whole-story checkpoints so
     /// the on-disk shard bytes always cover exactly the completed stories
     /// of the deterministic stream.
@@ -313,6 +413,9 @@ impl ObservationShardWriter {
         let entry = ShardEntry {
             records: length / RECORD_SIZE as u64,
             kappa: file_kappa(&path)?,
+            partitions: self
+                .partitions_active
+                .then_some(self.partition_counts[shard as usize]),
         };
         self.manifest.total_records = self.manifest.total_records.saturating_add(entry.records);
         self.manifest.completed.insert(shard, entry);

--- a/crates/uor-r4-core/src/transformerless/observe_text.rs
+++ b/crates/uor-r4-core/src/transformerless/observe_text.rs
@@ -1,0 +1,1472 @@
+//! From-text observation driver (issue #72): feed natural text through the
+//! teacher and record the SAME v3 observation records the autoregressive
+//! `observe` path produces, so the sealed D3 natural partition corpus
+//! (Simple English Wikipedia, `.uor-models/corpora/simple-wiki-20231101`)
+//! becomes a real observation corpus.
+//!
+//! Record semantics are the generation path's, teacher-forced:
+//!
+//! - per article, the text is tokenized BOS-prefixed and the oracle steps
+//!   over the stream; at each position the v3 48-byte record for
+//!   (8-token context window → next text token) is emitted through the
+//!   SHARED [`compiler::encode_v3_record`] / [`compiler::softmax_top3_sample`]
+//!   / [`compiler::byte_anchors`] helpers, so bytes are format-identical to
+//!   the autoregressive path (the sampled token is discarded; the record's
+//!   `next` is the actual next text token);
+//! - sharding is the generation path's scheme: [`observe::sample_id`] over
+//!   the context window → [`observe::shard_of`] — content-addressed, so
+//!   shard bytes are independent of article completion order (T-invariance);
+//! - `story` is the article ordinal (u32, dense, in jsonl order); the
+//!   story → article mapping is written to `stories.jsonl` (one JSON object
+//!   per line: story, id, url, title, partition).
+//!
+//! Partition semantics (D3): the split rule of the corpus manifest —
+//! held-out = `blake3(article id as utf-8)[0] % 5 == 0` — is applied AT
+//! WRITE TIME by [`partition_of`]: every record is tagged with its
+//! article's partition, each shard's manifest entry lists the
+//! construction/held-out record counts, and the observation manifest
+//! records the rule itself, so downstream consumers can split a merged
+//! corpus exactly (`stories.jsonl` carries the per-story partition).
+//!
+//! Resume contract: per-article checkpointing. `committed.bin` is the
+//! authoritative checkpoint (the 25-byte corpus-meta header — n, stories,
+//! rng, done — plus the input κ and per-shard committed byte lengths and
+//! partition counts, atomically renamed); `state.bin` mirrors the header
+//! in the exact 25-byte corpus-meta layout for readers shared with the
+//! generation path. A rerun skips completed shards (manifest) and
+//! completed articles (the dense ordinal prefix). Byte-level resume within
+//! an article is not needed: an interrupted article is restarted, its
+//! records are content-stable, and incomplete shards/story lines are
+//! trimmed back to the committed checkpoint on open, so a resumed run
+//! converges to the exact shard κ of a single-pass run.
+
+use super::compiler;
+use super::observe::{self, ObservationShardWriter, PartitionCounts, RecordPartition, RECORD_SIZE};
+use super::progress::Progress;
+use super::scenarios::Tokenizer;
+use super::teacher::TeacherOracle;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+/// Authoritative per-article checkpoint file name within an observation
+/// directory.
+pub const COMMITTED_FILE: &str = "committed.bin";
+
+/// Story → article mapping file name within an observation directory.
+pub const STORIES_FILE: &str = "stories.jsonl";
+
+/// The document-level partition rule, recorded in the observation manifest
+/// verbatim from the sealed corpus manifest (`manifest.json` split_rule).
+pub const PARTITION_RULE: &str =
+    "held-out = blake3(article id as utf-8)[0] % 5 == 0; remainder is construction";
+
+/// rng seed of the observation stream, identical to the corpus and
+/// autoregressive observation streams.
+const RNG_SEED: u64 = 0x5EED;
+
+/// Checkpoint header width: the corpus-meta layout (n u64 | stories u64 |
+/// rng u64 | done u8), mirrored verbatim into `state.bin`.
+const HEADER_SIZE: usize = 25;
+
+/// Per-shard checkpoint row width: committed byte length u64 |
+/// construction records u64 | held-out records u64.
+const SHARD_ROW_SIZE: usize = 24;
+
+/// Input-pin width: blake3 digest of the articles file.
+const INPUT_KAPPA_SIZE: usize = 32;
+
+/// Document-level partition of one article, keyed by its article id:
+/// held-out when `blake3(id as utf-8)[0] % 5 == 0` (the D3 split rule).
+pub fn partition_of(article_id: &str) -> RecordPartition {
+    if blake3::hash(article_id.as_bytes()).as_bytes()[0].is_multiple_of(5) {
+        RecordPartition::HeldOut
+    } else {
+        RecordPartition::Construction
+    }
+}
+
+/// One article of the sealed text corpus (one JSON object per line).
+#[derive(Debug, Deserialize)]
+struct Article {
+    id: String,
+    url: String,
+    title: String,
+    text: String,
+}
+
+/// One line of `stories.jsonl`: the story ordinal → article mapping with
+/// the article's partition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoryEntry {
+    pub story: u32,
+    pub id: String,
+    pub url: String,
+    pub title: String,
+    pub partition: RecordPartition,
+}
+
+/// The loaded story → article mapping of an observation directory.
+#[derive(Debug, Clone)]
+pub struct StoryIndex {
+    entries: Vec<StoryEntry>,
+}
+
+impl StoryIndex {
+    /// Load `stories.jsonl`, validating dense ordinals (line i must map
+    /// story i). Returns `Ok(None)` when the file does not exist.
+    pub fn load(path: &Path) -> Result<Option<Self>, String> {
+        let bytes = match fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(format!("{}: {error}", path.display())),
+        };
+        let mut entries = Vec::new();
+        for (index, line) in bytes.split(|&byte| byte == b'\n').enumerate() {
+            if line.is_empty() {
+                continue;
+            }
+            let entry: StoryEntry = serde_json::from_slice(line).map_err(|error| {
+                format!(
+                    "{} line {}: invalid story entry: {error}",
+                    path.display(),
+                    index + 1
+                )
+            })?;
+            if entry.story as usize != entries.len() {
+                return Err(format!(
+                    "{} line {}: story ordinals are not dense (got {}, expected {})",
+                    path.display(),
+                    index + 1,
+                    entry.story,
+                    entries.len()
+                ));
+            }
+            entries.push(entry);
+        }
+        Ok(Some(Self { entries }))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The mapping entry of one story ordinal.
+    pub fn get(&self, story: u32) -> Option<&StoryEntry> {
+        self.entries.get(story as usize)
+    }
+
+    /// The document-level partition of one story ordinal.
+    pub fn partition_of(&self, story: u32) -> Option<RecordPartition> {
+        self.get(story).map(|entry| entry.partition)
+    }
+
+    /// (construction, held-out) article counts across the mapping.
+    pub fn partition_counts(&self) -> (u64, u64) {
+        let mut counts = (0u64, 0u64);
+        for entry in &self.entries {
+            match entry.partition {
+                RecordPartition::Construction => counts.0 += 1,
+                RecordPartition::HeldOut => counts.1 += 1,
+            }
+        }
+        counts
+    }
+}
+
+/// Per-shard committed state: byte length of the shard file covered by the
+/// checkpoint plus the partition counts of the records in it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ShardCheckpoint {
+    bytes: u64,
+    partitions: PartitionCounts,
+}
+
+/// The authoritative checkpoint: the corpus-meta header (n, stories, rng,
+/// done), the input κ pinning the articles file across resumes, and the
+/// per-shard committed state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Checkpoint {
+    n: u64,
+    stories: u64,
+    rng: u64,
+    done: bool,
+    input_kappa: [u8; INPUT_KAPPA_SIZE],
+    shards: Vec<ShardCheckpoint>,
+}
+
+impl Checkpoint {
+    fn fresh(shard_count: u32, input_kappa: [u8; INPUT_KAPPA_SIZE]) -> Self {
+        Self {
+            n: 0,
+            stories: 0,
+            rng: RNG_SEED,
+            done: false,
+            input_kappa,
+            shards: vec![ShardCheckpoint::default(); shard_count as usize],
+        }
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        let mut bytes =
+            Vec::with_capacity(HEADER_SIZE + INPUT_KAPPA_SIZE + self.shards.len() * SHARD_ROW_SIZE);
+        bytes.extend_from_slice(&self.header());
+        bytes.extend_from_slice(&self.input_kappa);
+        for shard in &self.shards {
+            bytes.extend_from_slice(&shard.bytes.to_le_bytes());
+            bytes.extend_from_slice(&shard.partitions.construction.to_le_bytes());
+            bytes.extend_from_slice(&shard.partitions.held_out.to_le_bytes());
+        }
+        bytes
+    }
+
+    /// The 25-byte corpus-meta header: n u64 | stories u64 | rng u64 |
+    /// done u8 — the `state.bin` mirror layout.
+    fn header(&self) -> [u8; HEADER_SIZE] {
+        let mut header = [0u8; HEADER_SIZE];
+        header[0..8].copy_from_slice(&self.n.to_le_bytes());
+        header[8..16].copy_from_slice(&self.stories.to_le_bytes());
+        header[16..24].copy_from_slice(&self.rng.to_le_bytes());
+        header[24] = u8::from(self.done);
+        header
+    }
+
+    fn decode(bytes: &[u8], shard_count: u32) -> Result<Self, String> {
+        let expected = HEADER_SIZE + INPUT_KAPPA_SIZE + shard_count as usize * SHARD_ROW_SIZE;
+        if bytes.len() != expected {
+            return Err(format!(
+                "committed checkpoint has {} bytes, expected {expected}",
+                bytes.len()
+            ));
+        }
+        let at = |offset: usize| {
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().expect("8-byte slice"))
+        };
+        let mut shards = Vec::with_capacity(shard_count as usize);
+        let mut offset = HEADER_SIZE + INPUT_KAPPA_SIZE;
+        for _ in 0..shard_count {
+            let shard = ShardCheckpoint {
+                bytes: at(offset),
+                partitions: PartitionCounts {
+                    construction: at(offset + 8),
+                    held_out: at(offset + 16),
+                },
+            };
+            if !shard.bytes.is_multiple_of(RECORD_SIZE as u64) {
+                return Err("committed checkpoint has a torn shard length".to_owned());
+            }
+            shards.push(shard);
+            offset += SHARD_ROW_SIZE;
+        }
+        let checkpoint = Self {
+            n: at(0),
+            stories: at(8),
+            rng: at(16),
+            done: bytes[24] != 0,
+            input_kappa: bytes[HEADER_SIZE..HEADER_SIZE + INPUT_KAPPA_SIZE]
+                .try_into()
+                .expect("32-byte slice"),
+            shards,
+        };
+        let committed_records: u64 = checkpoint
+            .shards
+            .iter()
+            .map(|shard| shard.bytes / RECORD_SIZE as u64)
+            .sum();
+        if checkpoint.n != committed_records {
+            return Err(format!(
+                "committed checkpoint records {} do not match the shard lengths {committed_records}",
+                checkpoint.n
+            ));
+        }
+        Ok(checkpoint)
+    }
+}
+
+fn input_kappa(path: &Path) -> Result<[u8; INPUT_KAPPA_SIZE], String> {
+    let bytes = fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    Ok(*blake3::hash(&bytes).as_bytes())
+}
+
+fn read_checkpoint(dir: &Path, shard_count: u32) -> Result<Option<Checkpoint>, String> {
+    let path = dir.join(COMMITTED_FILE);
+    match fs::read(&path) {
+        Ok(bytes) => Checkpoint::decode(&bytes, shard_count)
+            .map(Some)
+            .map_err(|error| format!("{}: {error}", path.display())),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("{}: {error}", path.display())),
+    }
+}
+
+/// Persist the checkpoint: `committed.bin` atomically (write-then-rename),
+/// then the `state.bin` mirror in the 25-byte corpus-meta layout.
+fn write_checkpoint(dir: &Path, checkpoint: &Checkpoint) -> Result<(), String> {
+    let tmp = dir.join(".committed.bin.tmp");
+    fs::write(&tmp, checkpoint.encode()).map_err(|error| format!("{}: {error}", tmp.display()))?;
+    fs::rename(&tmp, dir.join(COMMITTED_FILE))
+        .map_err(|error| format!("committed checkpoint rename: {error}"))?;
+    let state_path = dir.join(observe::STATE_FILE);
+    fs::write(&state_path, checkpoint.header())
+        .map_err(|error| format!("{}: {error}", state_path.display()))?;
+    Ok(())
+}
+
+/// Trim one incomplete shard file back to its committed length, so a
+/// restarted article never duplicates its records. A file longer than the
+/// checkpoint holds the content-stable tail of an interrupted article and
+/// is truncated; a file shorter than the checkpoint means data loss.
+fn reconcile_shard(dir: &Path, shard_bits: u8, shard: u32, committed: u64) -> Result<(), String> {
+    let path = dir.join(observe::shard_file_name(shard_bits, shard));
+    let length = match fs::metadata(&path) {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if committed == 0 {
+                return Ok(());
+            }
+            return Err(format!(
+                "{} is missing but the checkpoint commits {committed} bytes; delete the observation directory and rerun",
+                path.display()
+            ));
+        }
+        Err(error) => return Err(format!("{}: {error}", path.display())),
+    };
+    if length % RECORD_SIZE as u64 != 0 {
+        return Err(format!(
+            "shard file {} has a torn record ({length} bytes); delete it and rerun",
+            path.display()
+        ));
+    }
+    if length < committed {
+        return Err(format!(
+            "{} is shorter ({length} bytes) than the committed checkpoint ({committed} bytes); delete the observation directory and rerun",
+            path.display()
+        ));
+    }
+    if length > committed {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        file.set_len(committed)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Trim `stories.jsonl` back to the committed story count (crash window:
+/// a story line appended just before the checkpoint rename failed).
+fn reconcile_stories(path: &Path, stories: u64) -> Result<(), String> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if stories == 0 {
+                return Ok(());
+            }
+            return Err(format!(
+                "{} is missing but the checkpoint commits {stories} stories; delete the observation directory and rerun",
+                path.display()
+            ));
+        }
+        Err(error) => return Err(format!("{}: {error}", path.display())),
+    };
+    let mut lines: Vec<&[u8]> = bytes.split(|&byte| byte == b'\n').collect();
+    if lines.last() == Some(&b"".as_slice()) {
+        lines.pop();
+    }
+    if (lines.len() as u64) < stories {
+        return Err(format!(
+            "{} has {} story lines but the checkpoint commits {stories}; delete the observation directory and rerun",
+            path.display(),
+            lines.len()
+        ));
+    }
+    if lines.len() as u64 == stories {
+        return Ok(());
+    }
+    let mut trimmed = Vec::new();
+    for line in &lines[..stories as usize] {
+        trimmed.extend_from_slice(line);
+        trimmed.push(b'\n');
+    }
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, &trimmed).map_err(|error| format!("{}: {error}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .map_err(|error| format!("{}: story mapping rename: {error}", path.display()))?;
+    Ok(())
+}
+
+/// Append one story mapping line to `stories.jsonl`.
+fn append_story(path: &Path, entry: &StoryEntry) -> Result<(), String> {
+    let mut line = serde_json::to_vec(entry).map_err(|error| error.to_string())?;
+    line.push(b'\n');
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    file.write_all(&line)
+        .and_then(|()| file.flush())
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    Ok(())
+}
+
+/// Outcome of one [`observe_text_corpus`] invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservationReport {
+    /// Articles in the input file.
+    pub articles_total: u64,
+    /// Articles committed so far (= the next article ordinal to process).
+    pub articles_completed: u64,
+    /// Articles truncated at the teacher sequence length during this
+    /// invocation.
+    pub articles_truncated: u64,
+    /// Records committed so far (all invocations).
+    pub records: u64,
+    /// Records written during this invocation.
+    pub written: u64,
+    /// Committed construction records (all shards).
+    pub construction_records: u64,
+    /// Committed held-out records (all shards).
+    pub held_out_records: u64,
+    /// Construction articles in the committed story mapping.
+    pub construction_articles: u64,
+    /// Held-out articles in the committed story mapping.
+    pub held_out_articles: u64,
+    /// Shards κ-pinned in the manifest.
+    pub shards_completed: u32,
+    /// Shards in the configured fan-out.
+    pub shard_count: u32,
+    /// κ of the merged shard bytes, once the corpus is complete.
+    pub merged_kappa: Option<String>,
+    /// Path of the story → article mapping file.
+    pub stories_file: PathBuf,
+    /// Whether every article is committed and every shard is κ-pinned.
+    pub done: bool,
+}
+
+fn build_report(
+    out_dir: &Path,
+    checkpoint: &Checkpoint,
+    writer: &ObservationShardWriter,
+    articles_total: u64,
+    articles_truncated: u64,
+    written: u64,
+) -> Result<ObservationReport, String> {
+    let stories_path = out_dir.join(STORIES_FILE);
+    let (construction_articles, held_out_articles) = match StoryIndex::load(&stories_path)? {
+        Some(index) => index.partition_counts(),
+        None => (0, 0),
+    };
+    let (construction_records, held_out_records) =
+        checkpoint
+            .shards
+            .iter()
+            .fold((0u64, 0u64), |(construction, held_out), shard| {
+                (
+                    construction + shard.partitions.construction,
+                    held_out + shard.partitions.held_out,
+                )
+            });
+    let merged_kappa = if checkpoint.done {
+        let merged = observe::merge_shards(out_dir).map_err(|error| error.to_string())?;
+        Some(format!("blake3:{}", blake3::hash(&merged).to_hex()))
+    } else {
+        None
+    };
+    Ok(ObservationReport {
+        articles_total,
+        articles_completed: checkpoint.stories,
+        articles_truncated,
+        records: checkpoint.n,
+        written,
+        construction_records,
+        held_out_records,
+        construction_articles,
+        held_out_articles,
+        shards_completed: writer.manifest().completed.len() as u32,
+        shard_count: writer.manifest().shard_count(),
+        merged_kappa,
+        stories_file: stories_path,
+        done: checkpoint.done,
+    })
+}
+
+/// Run the from-text observation pass over `articles_path` (one JSON
+/// object per line: id, url, title, text), spilling v3 records into
+/// content-addressed shards under `out_dir`.
+///
+/// The teacher stream is teacher-forced: per article the BOS-prefixed
+/// token stream is stepped through the oracle and each position records
+/// (context window → actual next token). Positions are capped at the
+/// oracle's sequence length (longer articles are truncated). The pass
+/// checkpoints per article and stops when `budget_s` elapses; rerunning
+/// resumes from the checkpoint. With `resume` set, an existing observation
+/// directory continues from its checkpoint; without it, a non-empty
+/// directory is an error.
+#[allow(clippy::too_many_arguments)] // mirrors the observe_sharded driver signature
+pub fn observe_text_corpus(
+    oracle: &mut dyn TeacherOracle,
+    budget_s: u64,
+    tokenizer: &Tokenizer,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+) -> Result<ObservationReport, String> {
+    let kappa = input_kappa(articles_path)?;
+    let mut writer =
+        ObservationShardWriter::open(out_dir, shard_bits).map_err(|error| error.to_string())?;
+    let shard_count = writer.manifest().shard_count();
+    let stories_path = out_dir.join(STORIES_FILE);
+    let has_prior_state = out_dir.join(COMMITTED_FILE).exists()
+        || out_dir.join(observe::STATE_FILE).exists()
+        || stories_path.exists()
+        || !writer.manifest().completed.is_empty()
+        || (0..shard_count).any(|shard| {
+            out_dir
+                .join(observe::shard_file_name(shard_bits, shard))
+                .exists()
+        });
+    if !resume && has_prior_state {
+        return Err(format!(
+            "{} already contains an observation corpus; pass resume to continue it",
+            out_dir.display()
+        ));
+    }
+    writer
+        .set_partition_rule(PARTITION_RULE)
+        .map_err(|error| error.to_string())?;
+
+    let mut checkpoint = match read_checkpoint(out_dir, shard_count)? {
+        Some(checkpoint) => {
+            if checkpoint.input_kappa != kappa {
+                return Err(format!(
+                    "{} does not match the observation checkpoint's input; pass the same articles file or a fresh output directory",
+                    articles_path.display()
+                ));
+            }
+            checkpoint
+        }
+        None => Checkpoint::fresh(shard_count, kappa),
+    };
+    if !checkpoint.done && !writer.manifest().completed.is_empty() {
+        return Err(format!(
+            "{} has finalized shards but an unfinished checkpoint; delete the observation directory and rerun",
+            out_dir.display()
+        ));
+    }
+    // Reconcile on-disk bytes to the committed checkpoint before writing:
+    // interrupted articles leave content-stable tails that are trimmed, so
+    // the restarted article's records are appended exactly once.
+    for shard in 0..shard_count {
+        if writer.is_complete(shard) {
+            continue;
+        }
+        reconcile_shard(
+            out_dir,
+            shard_bits,
+            shard,
+            checkpoint.shards[shard as usize].bytes,
+        )?;
+    }
+    reconcile_stories(&stories_path, checkpoint.stories)?;
+    let counts: Vec<PartitionCounts> = checkpoint
+        .shards
+        .iter()
+        .map(|shard| shard.partitions)
+        .collect();
+    writer
+        .restore_partition_counts(&counts)
+        .map_err(|error| error.to_string())?;
+
+    // The article stream is processed in jsonl order; count it up front
+    // for progress and the report.
+    let articles_total = {
+        let file = fs::File::open(articles_path)
+            .map_err(|error| format!("{}: {error}", articles_path.display()))?;
+        let mut lines = BufReader::new(file).lines();
+        let mut total = 0u64;
+        for line in &mut lines {
+            line.map_err(|error| format!("{}: {error}", articles_path.display()))?;
+            total += 1;
+        }
+        total
+    };
+
+    if checkpoint.done {
+        // A crash between the done checkpoint and finalization can leave
+        // shards unpinned; finalize (idempotent) and stop without touching
+        // completed shard files.
+        writer.finalize_all().map_err(|error| error.to_string())?;
+        println!(
+            "text observation corpus already complete: {} records",
+            checkpoint.n
+        );
+        return build_report(out_dir, &checkpoint, &writer, articles_total, 0, 0);
+    }
+
+    let vocab = oracle.vocab();
+    let seq_len = oracle.seq_len();
+    let mut logits = vec![0f32; vocab];
+    let mut window: Vec<u32> = Vec::with_capacity(compiler::WINDOW);
+    let mut progress = Progress::new("text observations", articles_total as usize);
+    progress.set(checkpoint.stories as usize);
+    let mut written = 0u64;
+    let mut truncated = 0u64;
+    let t0 = std::time::Instant::now();
+
+    let file = fs::File::open(articles_path)
+        .map_err(|error| format!("{}: {error}", articles_path.display()))?;
+    let mut ordinal = 0u64;
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| format!("{}: {error}", articles_path.display()))?;
+        if ordinal < checkpoint.stories {
+            // Completed article: skip without re-deriving its records.
+            ordinal += 1;
+            continue;
+        }
+        if t0.elapsed().as_secs() >= budget_s {
+            break;
+        }
+        let article: Article = serde_json::from_str(&line).map_err(|error| {
+            format!(
+                "{} line {}: invalid article: {error}",
+                articles_path.display(),
+                ordinal + 1
+            )
+        })?;
+        let story = u32::try_from(ordinal)
+            .map_err(|_| "article ordinal exceeds the u32 story field".to_owned())?;
+        let partition = partition_of(&article.id);
+        let tokens = tokenizer.encode(&article.text);
+        let positions = tokens.len().saturating_sub(1).min(seq_len);
+        if positions < tokens.len().saturating_sub(1) {
+            truncated += 1;
+        }
+        // Teacher-forced record stream for this article, buffered until
+        // the per-article checkpoint so an interrupted article leaves no
+        // partial records behind.
+        let mut records: Vec<(u32, [u8; RECORD_SIZE])> = Vec::with_capacity(positions);
+        oracle.reset();
+        window.clear();
+        let mut story_byte_offset = 0u32;
+        for pos in 0..positions {
+            let token = tokens[pos];
+            oracle.step(token as usize, pos, &mut logits);
+            let (_sampled, top_tokens, top_weights) =
+                compiler::softmax_top3_sample(&mut logits, &mut checkpoint.rng);
+            let next = tokens[pos + 1];
+            window.push(token);
+            if window.len() > compiler::WINDOW {
+                window.remove(0);
+            }
+            let id = observe::sample_id(&window);
+            let shard = observe::shard_of(&id, shard_bits);
+            let span_start = pos as u32;
+            let span_end = span_start.saturating_add(1);
+            let (byte_start, byte_end) =
+                compiler::byte_anchors(token_byte_lengths, story_byte_offset, next as usize);
+            let record = compiler::encode_v3_record(
+                story,
+                next,
+                &top_tokens,
+                &top_weights,
+                (span_start, span_end),
+                (byte_start, byte_end),
+            );
+            records.push((shard, record));
+            if token_byte_lengths.is_some() {
+                story_byte_offset = byte_end;
+            }
+            checkpoint.n += 1;
+        }
+        // Per-article checkpoint: shard bytes first (flush), then the
+        // story mapping line, then the atomic committed checkpoint and its
+        // state.bin mirror.
+        for (shard, record) in &records {
+            if writer
+                .write_record_in_partition(record, *shard, partition)
+                .map_err(|error| error.to_string())?
+            {
+                written += 1;
+                checkpoint.shards[*shard as usize].bytes += RECORD_SIZE as u64;
+            }
+        }
+        writer.flush().map_err(|error| error.to_string())?;
+        for (slot, shard_checkpoint) in checkpoint.shards.iter_mut().enumerate() {
+            shard_checkpoint.partitions = writer.partition_counts(slot as u32).unwrap_or_default();
+        }
+        append_story(
+            &stories_path,
+            &StoryEntry {
+                story,
+                id: article.id,
+                url: article.url,
+                title: article.title,
+                partition,
+            },
+        )?;
+        ordinal += 1;
+        checkpoint.stories = ordinal;
+        checkpoint.done = ordinal == articles_total;
+        write_checkpoint(out_dir, &checkpoint)?;
+        progress.set(ordinal as usize);
+    }
+    if !checkpoint.done && ordinal == articles_total {
+        // Empty input file: nothing to do, the corpus is trivially complete.
+        checkpoint.done = true;
+        write_checkpoint(out_dir, &checkpoint)?;
+    }
+    if checkpoint.done {
+        writer.finalize_all().map_err(|error| error.to_string())?;
+        progress.finish();
+    }
+    let report = build_report(
+        out_dir,
+        &checkpoint,
+        &writer,
+        articles_total,
+        truncated,
+        written,
+    )?;
+    println!(
+        "text observations: {} / {} articles, {} records ({} written), {}/{} shards complete, done={}",
+        report.articles_completed,
+        report.articles_total,
+        report.records,
+        report.written,
+        report.shards_completed,
+        report.shard_count,
+        report.done
+    );
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transformerless::observe::{
+        merge_shards, sample_id, shard_file_name, shard_of, ObservationManifest,
+    };
+    use crate::transformerless::teacher::{BehaviorSource, RepresentationSource};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const SHARD_BITS: u8 = 2;
+    const SHARD_COUNT: u32 = 1 << SHARD_BITS;
+    const FAKE_VOCAB: usize = 32;
+    const FAKE_SEQ_LEN: usize = 16;
+
+    // Tokenizer fixture pieces: byte fallback for ' ' and a..d plus four
+    // merges; ids 1/2 stay the BOS/EOS convention.
+    const PIECES: [&[u8]; 12] = [
+        b"<unk>", b"<s>", b"</s>", b" ", b"a", b"b", b"c", b"d", b" a", b"ab", b"bc", b"cd",
+    ];
+
+    fn unique_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("uor-r4-observe-text-{name}-{nanos}"))
+    }
+
+    fn fixture_tokenizer() -> Tokenizer {
+        let path = unique_path("tokenizer.bin");
+        let mut bytes = Vec::new();
+        for piece in PIECES {
+            bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+            bytes.extend_from_slice(piece);
+        }
+        fs::write(&path, bytes).expect("write tokenizer fixture");
+        let tokenizer = Tokenizer::try_load(&path).expect("load tokenizer fixture");
+        let _ = fs::remove_file(&path);
+        tokenizer
+    }
+
+    fn fixture_token_byte_lengths() -> Vec<u32> {
+        PIECES.iter().map(|piece| piece.len() as u32).collect()
+    }
+
+    fn write_articles(path: &Path, articles: &[(&str, &str)]) {
+        let mut bytes = Vec::new();
+        for (id, text) in articles {
+            let line = format!(
+                "{{\"id\":\"{id}\",\"url\":\"https://example.test/{id}\",\"title\":\"Title {id}\",\"text\":\"{text}\"}}\n"
+            );
+            bytes.extend_from_slice(line.as_bytes());
+        }
+        fs::write(path, bytes).expect("write articles fixture");
+    }
+
+    /// Deterministic few-token oracle: logits depend only on (token, pos),
+    /// so teacher-forced records are content-stable across restarts.
+    struct FakeOracle;
+
+    impl RepresentationSource for FakeOracle {
+        fn vocab_size(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn source_dimension(&self) -> usize {
+            4
+        }
+        fn tokenizer_address(&self) -> &str {
+            "fake-tokenizer"
+        }
+        fn read_embedding_rows(
+            &self,
+            _range: std::ops::Range<usize>,
+            output: &mut [f32],
+        ) -> Result<(), String> {
+            output.fill(0.0);
+            Ok(())
+        }
+    }
+
+    impl BehaviorSource for FakeOracle {
+        fn reset(&mut self) {}
+        fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]) {
+            for (index, logit) in logits.iter_mut().enumerate() {
+                let value = (token as u64 * 31 + pos as u64 * 7 + index as u64 * 13) % 29;
+                *logit = value as f32 * 0.25 - 3.0;
+            }
+        }
+    }
+
+    impl TeacherOracle for FakeOracle {
+        fn vocab(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn dim(&self) -> usize {
+            4
+        }
+        fn seq_len(&self) -> usize {
+            FAKE_SEQ_LEN
+        }
+        fn kappa(&self) -> String {
+            "blake3:fake".to_owned()
+        }
+        fn source_bytes(&self) -> usize {
+            0
+        }
+        fn embedding(&self, _token: usize, out: &mut [f32]) {
+            out.fill(0.0);
+        }
+    }
+
+    /// Independent replication of the driver loop over the first `up_to`
+    /// articles, built ONLY from the shared encoder helpers: the expected
+    /// per-shard record runs plus the rng state after them. This is the
+    /// cross-check that the driver emits format-identical v3 bytes.
+    fn expected_shards(
+        articles: &[(&str, &str)],
+        tokenizer: &Tokenizer,
+        token_byte_lengths: Option<&[u32]>,
+        up_to: usize,
+    ) -> (Vec<Vec<[u8; RECORD_SIZE]>>, u64) {
+        let mut oracle = FakeOracle;
+        let mut rng = RNG_SEED;
+        let mut logits = vec![0f32; FAKE_VOCAB];
+        let mut shards: Vec<Vec<[u8; RECORD_SIZE]>> =
+            (0..SHARD_COUNT).map(|_| Vec::new()).collect();
+        let mut window: Vec<u32> = Vec::new();
+        for (ordinal, (_, text)) in articles.iter().enumerate().take(up_to) {
+            let tokens = tokenizer.encode(text);
+            let positions = tokens.len().saturating_sub(1).min(FAKE_SEQ_LEN);
+            oracle.reset();
+            window.clear();
+            let mut offset = 0u32;
+            for pos in 0..positions {
+                let token = tokens[pos];
+                oracle.step(token as usize, pos, &mut logits);
+                let (_sampled, top_tokens, top_weights) =
+                    compiler::softmax_top3_sample(&mut logits, &mut rng);
+                let next = tokens[pos + 1];
+                window.push(token);
+                if window.len() > compiler::WINDOW {
+                    window.remove(0);
+                }
+                let shard = shard_of(&sample_id(&window), SHARD_BITS);
+                let (byte_start, byte_end) =
+                    compiler::byte_anchors(token_byte_lengths, offset, next as usize);
+                let record = compiler::encode_v3_record(
+                    ordinal as u32,
+                    next,
+                    &top_tokens,
+                    &top_weights,
+                    (pos as u32, (pos as u32).saturating_add(1)),
+                    (byte_start, byte_end),
+                );
+                shards[shard as usize].push(record);
+                if token_byte_lengths.is_some() {
+                    offset = byte_end;
+                }
+            }
+        }
+        (shards, rng)
+    }
+
+    fn expected_merged(
+        articles: &[(&str, &str)],
+        tokenizer: &Tokenizer,
+        token_byte_lengths: Option<&[u32]>,
+    ) -> Vec<u8> {
+        let (shards, _) = expected_shards(articles, tokenizer, token_byte_lengths, articles.len());
+        shards.concat().concat()
+    }
+
+    /// Partition of each record in a shard file, via the story mapping.
+    fn recount_partitions(dir: &Path, shard: u32, index: &StoryIndex) -> (u64, u64) {
+        let bytes =
+            fs::read(dir.join(shard_file_name(SHARD_BITS, shard))).expect("shard file bytes");
+        let mut counts = (0u64, 0u64);
+        for record in bytes.chunks_exact(RECORD_SIZE) {
+            let story = u32::from_le_bytes(record[0..4].try_into().expect("story field"));
+            match index.partition_of(story) {
+                Some(RecordPartition::Construction) => counts.0 += 1,
+                Some(RecordPartition::HeldOut) => counts.1 += 1,
+                None => panic!("record story {story} missing from the story mapping"),
+            }
+        }
+        counts
+    }
+
+    fn directory_fingerprint(dir: &Path) -> String {
+        let mut hasher = blake3::Hasher::new();
+        let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+            .expect("read dir")
+            .map(|entry| entry.expect("dir entry").path())
+            .collect();
+        entries.sort();
+        for entry in entries {
+            if entry.is_dir() {
+                continue;
+            }
+            hasher.update(entry.file_name().expect("file name").as_encoded_bytes());
+            hasher.update(&fs::read(&entry).expect("file bytes"));
+        }
+        hasher.finalize().to_hex().to_string()
+    }
+
+    /// Six few-token articles with deterministic coverage of both
+    /// partitions: the first four construction ids and the first two
+    /// held-out ids found among "1".."=20".
+    fn test_articles() -> Vec<(String, String)> {
+        let texts = ["ab", "bc", "abcd", "ab bc", "", "cd ab"];
+        let mut construction = Vec::new();
+        let mut held_out = Vec::new();
+        for ordinal in 1..=20u32 {
+            let id = ordinal.to_string();
+            match partition_of(&id) {
+                RecordPartition::Construction if construction.len() < 4 => construction.push(id),
+                RecordPartition::HeldOut if held_out.len() < 2 => held_out.push(id),
+                _ => {}
+            }
+            if construction.len() == 4 && held_out.len() == 2 {
+                break;
+            }
+        }
+        assert_eq!(
+            (construction.len(), held_out.len()),
+            (4, 2),
+            "partition fixture ids exhausted"
+        );
+        construction
+            .into_iter()
+            .chain(held_out)
+            .zip(texts)
+            .map(|(id, text)| (id, text.to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn partition_rule_is_blake3_first_byte_mod_5() {
+        let mut held_out = 0usize;
+        for ordinal in 1..=200u32 {
+            let id = ordinal.to_string();
+            let digest = blake3::hash(id.as_bytes());
+            let expected = if digest.as_bytes()[0].is_multiple_of(5) {
+                RecordPartition::HeldOut
+            } else {
+                RecordPartition::Construction
+            };
+            assert_eq!(partition_of(&id), expected, "article id {id}");
+            if expected == RecordPartition::HeldOut {
+                held_out += 1;
+            }
+        }
+        assert!(held_out > 0 && held_out < 200, "both partitions populated");
+    }
+
+    #[test]
+    fn checkpoint_roundtrip_and_state_layout() {
+        let dir = unique_path("checkpoint");
+        fs::create_dir_all(&dir).expect("mkdir");
+        let kappa = *blake3::hash(b"articles").as_bytes();
+        let mut checkpoint = Checkpoint::fresh(SHARD_COUNT, kappa);
+        checkpoint.n = 3;
+        checkpoint.stories = 2;
+        checkpoint.rng = 0xABCD;
+        checkpoint.shards[0].bytes = 2 * RECORD_SIZE as u64;
+        checkpoint.shards[0].partitions = PartitionCounts {
+            construction: 1,
+            held_out: 1,
+        };
+        checkpoint.shards[3].bytes = RECORD_SIZE as u64;
+        checkpoint.shards[3].partitions = PartitionCounts {
+            construction: 0,
+            held_out: 1,
+        };
+        write_checkpoint(&dir, &checkpoint).expect("write checkpoint");
+
+        let committed = fs::read(dir.join(COMMITTED_FILE)).expect("committed.bin bytes");
+        assert_eq!(
+            committed.len(),
+            HEADER_SIZE + INPUT_KAPPA_SIZE + SHARD_COUNT as usize * SHARD_ROW_SIZE
+        );
+        let decoded = Checkpoint::decode(&committed, SHARD_COUNT).expect("decode");
+        assert_eq!(decoded, checkpoint);
+
+        // state.bin mirrors the header in the exact 25-byte corpus-meta
+        // layout: n u64 | stories u64 | rng u64 | done u8.
+        let state = fs::read(dir.join(observe::STATE_FILE)).expect("state.bin bytes");
+        assert_eq!(state.len(), 25);
+        assert_eq!(u64::from_le_bytes(state[0..8].try_into().unwrap()), 3);
+        assert_eq!(u64::from_le_bytes(state[8..16].try_into().unwrap()), 2);
+        assert_eq!(
+            u64::from_le_bytes(state[16..24].try_into().unwrap()),
+            0xABCD
+        );
+        assert_eq!(state[24], 0);
+
+        // A checkpoint whose record count disagrees with the shard lengths
+        // is rejected.
+        let mut torn = committed.clone();
+        torn[0] = torn[0].wrapping_add(1);
+        assert!(Checkpoint::decode(&torn, SHARD_COUNT).is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn text_pipeline_records_shards_partitions_and_resume() {
+        let articles = test_articles();
+        let articles_ref: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("articles.jsonl");
+        write_articles(&input, &articles_ref);
+
+        // Run A: single pass to completion.
+        let dir_a = unique_path("run-a");
+        let mut oracle = FakeOracle;
+        let report = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_a,
+            SHARD_BITS,
+            false,
+        )
+        .expect("single pass");
+        assert!(report.done);
+        assert_eq!(report.articles_total, articles.len() as u64);
+        assert_eq!(report.articles_completed, articles.len() as u64);
+        assert_eq!(report.shards_completed, SHARD_COUNT);
+        assert_eq!(report.written, report.records);
+        assert!(report.merged_kappa.is_some());
+        assert_eq!(
+            report.construction_records + report.held_out_records,
+            report.records
+        );
+        assert_eq!(
+            report.construction_articles + report.held_out_articles,
+            articles.len() as u64
+        );
+
+        // Record bytes cross-checked against the shared encoder: the
+        // merged stream is exactly the per-shard ascending concatenation
+        // of the independently replicated records.
+        let expected = expected_merged(&articles_ref, &tokenizer, Some(&lengths));
+        let merged = merge_shards(&dir_a).expect("merge a");
+        assert_eq!(merged, expected, "driver bytes diverge from shared encoder");
+        assert_eq!(merged.len() as u64, report.records * RECORD_SIZE as u64);
+        let want_kappa = format!("blake3:{}", blake3::hash(&merged).to_hex());
+        assert_eq!(report.merged_kappa.as_deref(), Some(want_kappa.as_str()));
+
+        // Manifest: the rule is recorded and every shard entry's partition
+        // counts match the rule applied to stories.jsonl.
+        let manifest = ObservationManifest::load(&dir_a)
+            .expect("manifest io")
+            .expect("manifest");
+        assert_eq!(manifest.partition_rule.as_deref(), Some(PARTITION_RULE));
+        assert_eq!(manifest.total_records, report.records);
+        let index = StoryIndex::load(&report.stories_file)
+            .expect("story mapping io")
+            .expect("story mapping");
+        assert_eq!(index.len(), articles.len());
+        for (ordinal, (id, _)) in articles.iter().enumerate() {
+            let entry = index.get(ordinal as u32).expect("story entry");
+            assert_eq!(entry.id, *id);
+            assert_eq!(entry.partition, partition_of(id));
+        }
+        let (mut construction, mut held_out) = (0u64, 0u64);
+        for shard in 0..SHARD_COUNT {
+            let entry = manifest.completed.get(&shard).expect("shard entry");
+            let partitions = entry.partitions.expect("partition counts");
+            let (want_construction, want_held_out) = recount_partitions(&dir_a, shard, &index);
+            assert_eq!(partitions.construction, want_construction, "shard {shard}");
+            assert_eq!(partitions.held_out, want_held_out, "shard {shard}");
+            assert_eq!(partitions.total(), entry.records, "shard {shard}");
+            construction += partitions.construction;
+            held_out += partitions.held_out;
+        }
+        assert_eq!(construction, report.construction_records);
+        assert_eq!(held_out, report.held_out_records);
+        // The fixture must actually exercise both partitions.
+        assert!(construction > 0 && held_out > 0);
+
+        // state.bin is the 25-byte corpus-meta header with done=1.
+        let state = fs::read(dir_a.join(observe::STATE_FILE)).expect("state.bin");
+        assert_eq!(state.len(), 25);
+        assert_eq!(state[24], 1);
+        assert_eq!(
+            u64::from_le_bytes(state[8..16].try_into().unwrap()),
+            articles.len() as u64
+        );
+
+        // A held-out-only merge contains exactly the records whose story
+        // ids the rule marks held-out.
+        let held_out_merged: Vec<&[u8]> = merged
+            .chunks_exact(RECORD_SIZE)
+            .filter(|record| {
+                let story = u32::from_le_bytes(record[0..4].try_into().expect("story"));
+                index.partition_of(story) == Some(RecordPartition::HeldOut)
+            })
+            .collect();
+        assert_eq!(held_out_merged.len() as u64, held_out);
+
+        // Rerun: fully resumed, no byte changes anywhere.
+        let fingerprint = directory_fingerprint(&dir_a);
+        let rerun = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_a,
+            SHARD_BITS,
+            true,
+        )
+        .expect("idempotent rerun");
+        assert!(rerun.done);
+        assert_eq!(rerun.written, 0);
+        assert_eq!(rerun.records, report.records);
+        assert_eq!(rerun.merged_kappa, report.merged_kappa);
+        assert_eq!(
+            directory_fingerprint(&dir_a),
+            fingerprint,
+            "completed observation directory changed on rerun"
+        );
+        // resume=false refuses a non-empty directory.
+        assert!(observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_a,
+            SHARD_BITS,
+            false,
+        )
+        .is_err());
+
+        // Run B: budget-starved first invocation, then resumed — merged
+        // bytes are identical to the single-pass run (T-invariance across
+        // article completion order).
+        let dir_b = unique_path("run-b");
+        let starved = observe_text_corpus(
+            &mut oracle,
+            0,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_b,
+            SHARD_BITS,
+            true,
+        )
+        .expect("budget-starved pass");
+        assert!(!starved.done);
+        assert_eq!(starved.written, 0);
+        let resumed = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_b,
+            SHARD_BITS,
+            true,
+        )
+        .expect("resumed pass");
+        assert!(resumed.done);
+        assert_eq!(merge_shards(&dir_b).expect("merge b"), expected);
+
+        for dir in [&dir_a, &dir_b] {
+            let _ = fs::remove_dir_all(dir);
+        }
+        let _ = fs::remove_file(&input);
+    }
+
+    #[test]
+    fn crash_trims_converge_to_single_pass_kappa() {
+        let articles = test_articles();
+        let articles_ref: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("articles.jsonl");
+        write_articles(&input, &articles_ref);
+        let expected = expected_merged(&articles_ref, &tokenizer, Some(&lengths));
+        let (expected_shards_all, _) =
+            expected_shards(&articles_ref, &tokenizer, Some(&lengths), articles.len());
+        let (article0_shards, rng_after_0) =
+            expected_shards(&articles_ref, &tokenizer, Some(&lengths), 1);
+
+        // Craft A: a crash before the first checkpoint — shard files hold
+        // a partial article-0 tail and one story line, no committed.bin.
+        // Open must trim everything and recompute from scratch.
+        let dir_a = unique_path("crash-pre");
+        fs::create_dir_all(&dir_a).expect("mkdir a");
+        let index_path = dir_a.join(STORIES_FILE);
+        for shard in 0..SHARD_COUNT {
+            let records = &article0_shards[shard as usize];
+            let partial: Vec<u8> = records[..records.len() / 2].concat();
+            fs::write(dir_a.join(shard_file_name(SHARD_BITS, shard)), partial)
+                .expect("craft shard tail");
+        }
+        append_story(
+            &index_path,
+            &StoryEntry {
+                story: 0,
+                id: articles[0].0.clone(),
+                url: format!("https://example.test/{}", articles[0].0),
+                title: format!("Title {}", articles[0].0),
+                partition: partition_of(&articles[0].0),
+            },
+        )
+        .expect("craft story line");
+        let mut oracle = FakeOracle;
+        let report_a = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_a,
+            SHARD_BITS,
+            true,
+        )
+        .expect("pre-checkpoint crash recovery");
+        assert!(report_a.done);
+        assert_eq!(merge_shards(&dir_a).expect("merge a"), expected);
+
+        // Craft B: a crash after the article-0 checkpoint — committed.bin
+        // pins article 0 but shard files and stories.jsonl already hold
+        // later articles' content. Open must trim both back to the
+        // checkpoint and recompute the trimmed articles exactly once.
+        let dir_b = unique_path("crash-post");
+        fs::create_dir_all(&dir_b).expect("mkdir b");
+        {
+            // Manifest with the partition rule, as a real first pass
+            // leaves it; no shards finalized.
+            let mut writer =
+                ObservationShardWriter::open(&dir_b, SHARD_BITS).expect("open craft writer");
+            writer.set_partition_rule(PARTITION_RULE).expect("rule");
+        }
+        for shard in 0..SHARD_COUNT {
+            let mut bytes = article0_shards[shard as usize].concat();
+            // The tail: every later article's records for this shard.
+            let tail: Vec<[u8; RECORD_SIZE]> = expected_shards_all[shard as usize]
+                [article0_shards[shard as usize].len()..]
+                .to_vec();
+            bytes.extend_from_slice(&tail.concat());
+            fs::write(dir_b.join(shard_file_name(SHARD_BITS, shard)), bytes)
+                .expect("craft shard bytes");
+        }
+        let mut committed =
+            Checkpoint::fresh(SHARD_COUNT, input_kappa(&input).expect("input kappa"));
+        committed.n = article0_shards.iter().map(Vec::len).sum::<usize>() as u64;
+        committed.stories = 1;
+        committed.rng = rng_after_0;
+        for shard in 0..SHARD_COUNT {
+            let records = &article0_shards[shard as usize];
+            let partition = partition_of(&articles[0].0);
+            let mut counts = PartitionCounts::default();
+            for _ in records {
+                match partition {
+                    RecordPartition::Construction => counts.construction += 1,
+                    RecordPartition::HeldOut => counts.held_out += 1,
+                }
+            }
+            committed.shards[shard as usize] = ShardCheckpoint {
+                bytes: (records.len() * RECORD_SIZE) as u64,
+                partitions: counts,
+            };
+        }
+        write_checkpoint(&dir_b, &committed).expect("craft checkpoint");
+        // stories.jsonl holds both committed story 0 and uncommitted
+        // story 1.
+        for (ordinal, (id, _)) in articles.iter().enumerate().take(2) {
+            append_story(
+                &dir_b.join(STORIES_FILE),
+                &StoryEntry {
+                    story: ordinal as u32,
+                    id: id.clone(),
+                    url: format!("https://example.test/{id}"),
+                    title: format!("Title {id}"),
+                    partition: partition_of(id),
+                },
+            )
+            .expect("craft story line");
+        }
+        let report_b = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_b,
+            SHARD_BITS,
+            true,
+        )
+        .expect("post-checkpoint crash recovery");
+        assert!(report_b.done);
+        assert_eq!(merge_shards(&dir_b).expect("merge b"), expected);
+        let index = StoryIndex::load(&report_b.stories_file)
+            .expect("story mapping io")
+            .expect("story mapping");
+        assert_eq!(index.len(), articles.len());
+
+        for dir in [&dir_a, &dir_b] {
+            let _ = fs::remove_dir_all(dir);
+        }
+        let _ = fs::remove_file(&input);
+    }
+
+    #[test]
+    fn unknown_byte_anchors_and_sequence_length_truncation() {
+        let tokenizer = fixture_tokenizer();
+        let input = unique_path("articles.jsonl");
+        // One long article with no mergeable pairs (41 tokens, exceeding
+        // the 16-position teacher window) and one short one; no token
+        // byte lengths → v3 "unknown" anchors.
+        const LONG_TEXT: &str = "adadadadadadadadadadadadadadadadadadadad";
+        write_articles(&input, &[("9", LONG_TEXT), ("10", "ab")]);
+        let dir = unique_path("anchors");
+        let mut oracle = FakeOracle;
+        let report = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            None,
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("pass");
+        assert!(report.done);
+        assert_eq!(report.articles_truncated, 1);
+        // The long article contributes exactly seq_len records.
+        let long_tokens = tokenizer.encode(LONG_TEXT);
+        assert!(long_tokens.len() - 1 > FAKE_SEQ_LEN);
+        let merged = merge_shards(&dir).expect("merge");
+        let long_records = merged
+            .chunks_exact(RECORD_SIZE)
+            .filter(|record| record[0..4] == 0u32.to_le_bytes())
+            .count();
+        assert_eq!(long_records, FAKE_SEQ_LEN);
+        for record in merged.chunks_exact(RECORD_SIZE) {
+            assert_eq!(&record[40..44], &u32::MAX.to_le_bytes());
+            assert_eq!(&record[44..48], &u32::MAX.to_le_bytes());
+        }
+        // The same replication check holds on the unknown-anchor path.
+        let expected = expected_merged(&[("9", LONG_TEXT), ("10", "ab")], &tokenizer, None);
+        assert_eq!(merged, expected);
+        let _ = fs::remove_dir_all(&dir);
+        let _ = fs::remove_file(&input);
+    }
+
+    #[test]
+    fn merged_records_load_as_v3_corpus() {
+        let articles = test_articles();
+        let articles_ref: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("articles.jsonl");
+        write_articles(&input, &articles_ref);
+        let dir = unique_path("corpus-load");
+        let mut oracle = FakeOracle;
+        let report = observe_text_corpus(
+            &mut oracle,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("pass");
+        assert!(report.done);
+
+        let merged = merge_shards(&dir).expect("merge");
+        let meta = unique_path("corpus.meta");
+        let recs = unique_path("corpus.records");
+        let mut header = [0u8; 25];
+        header[0..8].copy_from_slice(&report.records.to_le_bytes());
+        header[8..16].copy_from_slice(&(articles.len() as u64).to_le_bytes());
+        header[16..24].copy_from_slice(&RNG_SEED.to_le_bytes());
+        header[24] = 1;
+        fs::write(&meta, header).expect("meta");
+        fs::write(&recs, &merged).expect("recs");
+        let corpus = compiler::load_corpus_from(
+            meta.to_str().expect("meta utf-8"),
+            recs.to_str().expect("recs utf-8"),
+        )
+        .expect("merged observation records must parse as a v3 corpus");
+        assert_eq!(corpus.n, report.records as usize);
+        // Cross-check story/span/anchor fields against the replication.
+        let (shards, _) =
+            expected_shards(&articles_ref, &tokenizer, Some(&lengths), articles.len());
+        let expected = shards.concat();
+        for (index, record) in expected.concat().chunks_exact(RECORD_SIZE).enumerate() {
+            let story = u32::from_le_bytes(record[0..4].try_into().unwrap());
+            let next = u32::from_le_bytes(record[4..8].try_into().unwrap());
+            let byte_start = u32::from_le_bytes(record[40..44].try_into().unwrap());
+            assert_eq!(corpus.story[index], story);
+            assert_eq!(corpus.next[index], next);
+            assert_eq!(corpus.byte_start[index], byte_start);
+        }
+        let _ = fs::remove_dir_all(&dir);
+        let _ = fs::remove_file(&input);
+        let _ = fs::remove_file(&meta);
+        let _ = fs::remove_file(&recs);
+    }
+}

--- a/crates/uor-r4-core/tests/observe_text.rs
+++ b/crates/uor-r4-core/tests/observe_text.rs
@@ -1,0 +1,341 @@
+//! From-text observation driver tests (issue #72): the observation
+//! manifest stays byte-compatible with the generation path, and the
+//! `observe-text` CLI turns the sealed natural-text corpus (or a small
+//! synthesized stand-in) into sharded v3 observation records with the D3
+//! split rule applied at write time. The CLI smoke runs against the
+//! legacy llama2.c fixture checkpoint when present and skips with a note
+//! otherwise.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uor_r4_core::transformerless::command;
+use uor_r4_core::transformerless::compiler::load_corpus_from;
+use uor_r4_core::transformerless::observe::{
+    merge_shards, shard_file_name, ObservationManifest, PartitionCounts, RecordPartition,
+    ShardEntry, RECORD_SIZE,
+};
+use uor_r4_core::transformerless::observe_text::{
+    partition_of, StoryIndex, PARTITION_RULE, STORIES_FILE,
+};
+
+const LEGACY_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
+const LEGACY_TOKENIZER: &str = "/tmp/ref/tokenizer.bin";
+const SEALED_CORPUS: &str = ".uor-models/corpora/simple-wiki-20231101/articles.jsonl";
+
+fn unique_path(name: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("uor-r4-observe-text-cli-{name}-{nanos}"))
+}
+
+// ------------------------------------------------- manifest byte-compat --
+
+/// The partition extension is additive: a manifest without partition
+/// information serializes exactly as the generation path always has, and
+/// the legacy bytes parse into the extended struct.
+#[test]
+fn manifest_without_partitions_is_byte_compatible() {
+    let mut manifest = ObservationManifest::new(3);
+    manifest.completed.insert(
+        2,
+        ShardEntry {
+            records: 2,
+            kappa: "blake3:x".to_owned(),
+            partitions: None,
+        },
+    );
+    manifest.total_records = 2;
+    let bytes = serde_json::to_vec_pretty(&manifest).expect("serialize");
+    let expected = r#"{
+  "schema": 1,
+  "shard_bits": 3,
+  "completed": {
+    "2": {
+      "records": 2,
+      "kappa": "blake3:x"
+    }
+  },
+  "total_records": 2
+}"#;
+    assert_eq!(
+        String::from_utf8(bytes).expect("utf-8"),
+        expected,
+        "generation-path manifest bytes changed"
+    );
+
+    let parsed: ObservationManifest =
+        serde_json::from_str(expected).expect("legacy manifest parses");
+    assert_eq!(parsed.partition_rule, None);
+    assert_eq!(parsed.completed[&2].partitions, None);
+
+    // The partitioned form round-trips with the rule and per-shard counts.
+    let mut partitioned = ObservationManifest::new(3);
+    partitioned.partition_rule = Some(PARTITION_RULE.to_owned());
+    partitioned.completed.insert(
+        5,
+        ShardEntry {
+            records: 3,
+            kappa: "blake3:y".to_owned(),
+            partitions: Some(PartitionCounts {
+                construction: 2,
+                held_out: 1,
+            }),
+        },
+    );
+    partitioned.total_records = 3;
+    let bytes = serde_json::to_vec_pretty(&partitioned).expect("serialize partitioned");
+    let parsed: ObservationManifest =
+        serde_json::from_slice(&bytes).expect("partitioned manifest parses");
+    assert_eq!(parsed, partitioned);
+    let text = String::from_utf8(bytes).expect("utf-8");
+    assert!(text.contains("partition_rule"));
+    assert!(text.contains("\"construction\": 2"));
+    assert!(text.contains("\"held_out\": 1"));
+}
+
+// ------------------------------------------------------------- CLI smoke --
+
+/// Ten short articles: a char-safe prefix of the sealed D3 corpus when
+/// present, otherwise a synthesized stand-in. Short texts keep the debug
+/// teacher fast; the release smoke run uses full articles.
+fn smoke_articles() -> Option<Vec<String>> {
+    if let Ok(corpus) = std::fs::read_to_string(SEALED_CORPUS) {
+        let mut lines = Vec::new();
+        for line in corpus.lines().take(10) {
+            let mut article: serde_json::Value = serde_json::from_str(line).expect("article json");
+            let text = article["text"].as_str().expect("article text");
+            let prefix: String = text.chars().take(120).collect();
+            article["text"] = serde_json::Value::String(prefix);
+            lines.push(serde_json::to_string(&article).expect("article line"));
+        }
+        return Some(lines);
+    }
+    let texts = [
+        "The cat sat on the mat and looked at the dog with great care.",
+        "A little dog ran across the park chasing a red ball all day.",
+        "Mary had a small lamb whose fleece was white as the new snow.",
+        "The sun rises in the east and sets in the west every single day.",
+        "One day a bird found a shiny key hidden under the garden bench.",
+        "Tom saw a big truck outside his house early in the morning.",
+        "Water is made of hydrogen and oxygen in every small drop we drink.",
+        "The school opens at eight and the children arrive by the big gate.",
+        "A farmer grows wheat and corn in the field behind the old barn.",
+        "The library has many books about ships and the sea on the shelf.",
+    ];
+    let lines = texts
+        .iter()
+        .enumerate()
+        .map(|(index, text)| {
+            format!(
+                "{{\"id\":\"smoke-{index}\",\"url\":\"https://example.test/{index}\",\"title\":\"Smoke {index}\",\"text\":{}}}",
+                serde_json::to_string(text).expect("text json")
+            )
+        })
+        .collect();
+    Some(lines)
+}
+
+fn directory_fingerprint(dir: &Path) -> String {
+    let mut hasher = blake3::Hasher::new();
+    let mut entries: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
+        .expect("read dir")
+        .map(|entry| entry.expect("dir entry").path())
+        .collect();
+    entries.sort();
+    for entry in entries {
+        if entry.is_dir() {
+            continue;
+        }
+        hasher.update(entry.file_name().expect("file name").as_encoded_bytes());
+        hasher.update(&std::fs::read(&entry).expect("file bytes"));
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+#[test]
+fn observe_text_cli_smoke_with_legacy_checkpoint() {
+    if std::fs::metadata(LEGACY_CHECKPOINT).is_err() || std::fs::metadata(LEGACY_TOKENIZER).is_err()
+    {
+        eprintln!(
+            "skipping: legacy checkpoint or tokenizer not found at {LEGACY_CHECKPOINT} / {LEGACY_TOKENIZER}"
+        );
+        return;
+    }
+    let Some(lines) = smoke_articles() else {
+        eprintln!("skipping: no smoke articles available");
+        return;
+    };
+    let input = unique_path("articles.jsonl");
+    std::fs::write(&input, lines.join("\n") + "\n").expect("write smoke articles");
+    let article_ids: Vec<String> = lines
+        .iter()
+        .map(|line| {
+            let article: serde_json::Value = serde_json::from_str(line).expect("article json");
+            article["id"].as_str().expect("article id").to_owned()
+        })
+        .collect();
+    let dir = unique_path("smoke");
+    let args: Vec<String> = [
+        "observe-text",
+        "--input",
+        input.to_str().expect("utf-8 input path"),
+        "--checkpoint",
+        LEGACY_CHECKPOINT,
+        "--tokenizer",
+        LEGACY_TOKENIZER,
+        "--out",
+        dir.to_str().expect("utf-8 temp path"),
+        "--shards",
+        "3",
+        "--seconds",
+        "120",
+    ]
+    .iter()
+    .map(|arg| (*arg).to_string())
+    .collect();
+    command::run(&args).expect("observe-text run 1");
+
+    // Shards + manifest produced; the rule is recorded.
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.shard_bits, 3);
+    assert_eq!(manifest.completed.len(), 8, "all shards finalized");
+    assert_eq!(manifest.partition_rule.as_deref(), Some(PARTITION_RULE));
+    assert!(manifest.total_records > 0);
+
+    // The story mapping covers every article with the rule's partition.
+    let index = StoryIndex::load(&dir.join(STORIES_FILE))
+        .expect("story mapping io")
+        .expect("story mapping");
+    assert_eq!(index.len(), article_ids.len());
+    let (mut construction_articles, mut held_out_articles) = (0u64, 0u64);
+    for (ordinal, id) in article_ids.iter().enumerate() {
+        let entry = index.get(ordinal as u32).expect("story entry");
+        assert_eq!(entry.id, *id);
+        assert_eq!(entry.partition, partition_of(id));
+        if entry.partition == RecordPartition::Construction {
+            construction_articles += 1;
+        } else {
+            held_out_articles += 1;
+        }
+    }
+    assert!(
+        held_out_articles > 0,
+        "smoke must exercise held-out articles"
+    );
+    assert!(construction_articles > 0);
+
+    // Partition counts in each shard entry match the rule applied to
+    // stories.jsonl, recounted record by record.
+    let (mut construction_records, mut held_out_records) = (0u64, 0u64);
+    for shard in 0..8u32 {
+        let bytes = std::fs::read(dir.join(shard_file_name(3, shard))).expect("shard file bytes");
+        assert_eq!(bytes.len() % RECORD_SIZE, 0);
+        let (mut shard_construction, mut shard_held_out) = (0u64, 0u64);
+        for record in bytes.chunks_exact(RECORD_SIZE) {
+            let story = u32::from_le_bytes(record[0..4].try_into().expect("story field"));
+            match index.partition_of(story) {
+                Some(RecordPartition::Construction) => shard_construction += 1,
+                Some(RecordPartition::HeldOut) => shard_held_out += 1,
+                None => panic!("record story {story} missing from the story mapping"),
+            }
+        }
+        let entry = manifest.completed.get(&shard).expect("shard entry");
+        let partitions = entry.partitions.expect("partition counts recorded");
+        assert_eq!(
+            (partitions.construction, partitions.held_out),
+            (shard_construction, shard_held_out),
+            "shard {shard} partition counts"
+        );
+        assert_eq!(partitions.total(), entry.records);
+        construction_records += partitions.construction;
+        held_out_records += partitions.held_out;
+    }
+    assert_eq!(
+        construction_records + held_out_records,
+        manifest.total_records
+    );
+
+    // Records parse via the shared v3 corpus loader.
+    let merged = merge_shards(&dir).expect("merge");
+    assert_eq!(
+        merged.len() as u64,
+        manifest.total_records * RECORD_SIZE as u64
+    );
+    let meta = unique_path("corpus.meta");
+    let recs = unique_path("corpus.records");
+    let mut header = [0u8; 25];
+    header[0..8].copy_from_slice(&manifest.total_records.to_le_bytes());
+    header[8..16].copy_from_slice(&(article_ids.len() as u64).to_le_bytes());
+    header[24] = 1;
+    std::fs::write(&meta, header).expect("meta");
+    std::fs::write(&recs, &merged).expect("recs");
+    let corpus = load_corpus_from(
+        meta.to_str().expect("meta utf-8"),
+        recs.to_str().expect("recs utf-8"),
+    )
+    .expect("observation records parse as a v3 corpus");
+    assert_eq!(corpus.n, manifest.total_records as usize);
+    assert_eq!(corpus.stories, article_ids.len() as u64);
+
+    // Byte anchors chain within each story: dense spans from 0 and
+    // contiguous byte ranges (real token byte lengths, not u32::MAX).
+    let mut stories: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+    for position in 0..corpus.n {
+        stories
+            .entry(corpus.story[position])
+            .or_default()
+            .push(position);
+    }
+    for (story, positions) in &stories {
+        let mut positions = positions.clone();
+        positions.sort_by_key(|&position| corpus.span_start[position]);
+        for (rank, &position) in positions.iter().enumerate() {
+            assert_eq!(corpus.span_start[position] as usize, rank, "story {story}");
+            assert_ne!(corpus.byte_start[position], u32::MAX, "story {story}");
+            if rank > 0 {
+                let previous = positions[rank - 1];
+                assert_eq!(
+                    corpus.byte_start[position], corpus.byte_end[previous],
+                    "story {story} byte anchors must chain"
+                );
+            } else {
+                assert_eq!(corpus.byte_start[position], 0, "story {story}");
+            }
+        }
+    }
+
+    // Rerun is idempotent: no byte changes anywhere in the directory.
+    let fingerprint = directory_fingerprint(&dir);
+    command::run(&args).expect("observe-text run 2");
+    assert_eq!(
+        directory_fingerprint(&dir),
+        fingerprint,
+        "completed observation directory changed on rerun"
+    );
+
+    // A held-out-only merge contains only records whose story ids the
+    // rule marks held-out.
+    let held_out_merged: Vec<&[u8]> = merged
+        .chunks_exact(RECORD_SIZE)
+        .filter(|record| {
+            let story = u32::from_le_bytes(record[0..4].try_into().expect("story field"));
+            index.partition_of(story) == Some(RecordPartition::HeldOut)
+        })
+        .collect();
+    assert_eq!(held_out_merged.len() as u64, held_out_records);
+    for record in &held_out_merged {
+        let story = u32::from_le_bytes(record[0..4].try_into().expect("story field"));
+        let entry = index.get(story).expect("story entry");
+        assert_eq!(partition_of(&entry.id), RecordPartition::HeldOut);
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_file(&input);
+    let _ = std::fs::remove_file(&meta);
+    let _ = std::fs::remove_file(&recs);
+}


### PR DESCRIPTION
Teacher-forced encoding of natural text into v3 observation records, completing the D3 Simple English Wikipedia partition as a real observation corpus.

- observe_text.rs: per-article tokenize + teacher step, records via the shared encode_v3_record/softmax_top3_sample/byte_anchors helpers (no second encoder), sample-id content-addressed sharding identical to the generation path, atomic per-article checkpoints converging to the exact single-pass merged κ on resume
- Partition semantics: story = article ordinal; stories.jsonl maps story → {id,url,title,partition}; per-shard {construction, held_out} counts written at write time per the sealed corpus's D3 rule (blake3(id)[0] % 5 == 0)
- observe.rs: optional partition fields (skip_serializing_if=None — generation-path manifest bytes unchanged, pinned by a compat test)
- CLI: r4 transformerless observe-text [--input] [--out] [--shards] [--seconds] [--checkpoint|--source]

Smoke (10 sealed-corpus articles, legacy fixture checkpoint): 2331 records, 16 shards, 1819 construction / 512 held-out records (8/2 articles ≈ 20% held-out, matching the rule; independent recount matched), merged κ blake3:7ba60de6..., rerun writes 0 bytes (idempotent).

Verified in a clean detached worktree (no in-flight edits from other sessions): 47 test suites green, clippy -D warnings clean, cargo fmt --check clean. Unblocks #75 (HF-path full Gate C on the D3 distribution) and #73 (larger-teacher ceiling).