### PR TITLE
D3 natural-corpus observation run (issue #72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,13 @@
 node_modules/
 dist/
 manifold_cache_rust.json
-.uor-models/
+# Local model/corpus store; keep only the CID-pinned corpus manifests
+# tracked (issue #72: the D3 natural partition's provenance is versioned,
+# the bulk data stays local).
+.uor-models/*
+!.uor-models/corpora/
+.uor-models/corpora/*/*
+!.uor-models/corpora/*/manifest.json
 uor_standards/
 crates/uor-r4-graph-format/fuzz/target/
 pkg/

--- a/.uor-models/corpora/simple-wiki-20231101/manifest.json
+++ b/.uor-models/corpora/simple-wiki-20231101/manifest.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "simple-wiki-20231101-sample",
+  "role": "D3 natural partition (docs/transformerless/BASELINE.md \u00a72)",
+  "source": {
+    "dataset": "wikimedia/wikipedia",
+    "config": "20231101.simple",
+    "split": "train",
+    "rows": "0..2999 via datasets-server.huggingface.co/rows",
+    "fetched_at": "2026-07-22"
+  },
+  "license": {
+    "spdx": "CC-BY-SA-4.0",
+    "attribution": "Wikimedia contributors (Simple English Wikipedia)",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+  },
+  "article_count": 3000,
+  "text_bytes": 11972624,
+  "corpus_cid": "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf",
+  "split_rule": "held-out partition = articles where blake3(id as utf-8)[0] % 5 == 0 (deterministic, content-addressed, ~20%); remainder is construction",
+  "files": [
+    "articles.jsonl (one JSON object per article: id, url, title, text)"
+  ]
+}

--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -331,11 +331,22 @@ pub fn observe_text_command(args: &[String]) -> Result<(), String> {
             report.articles_truncated
         );
     }
+    if report.characters_replaced != 0 {
+        println!(
+            "note: {} characters unencodable in the teacher vocab replaced with spaces",
+            report.characters_replaced
+        );
+    }
     if report.done {
+        // Persist the merged record stream: Gate C consumes it as
+        // --corpus-recs with state.bin as --corpus-meta (issue #72).
+        let merged = observe::merge_shards(&options.output).map_err(|error| error.to_string())?;
+        let merged_path = options.output.join("merged.bin");
+        std::fs::write(&merged_path, &merged).map_err(|error| error.to_string())?;
         println!(
             "observe-text complete: merged κ {} at {}",
             report.merged_kappa.expect("done reports merged κ"),
-            options.output.display()
+            merged_path.display()
         );
     } else {
         println!(
@@ -601,6 +612,7 @@ struct ScoreOptions {
     corpus_recs: PathBuf,
     artifacts: PathBuf,
     cover: Option<PathBuf>,
+    stories: Option<PathBuf>,
     transition_out_degree: usize,
     emission_entries: usize,
     root_top_b: usize,
@@ -617,6 +629,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         corpus_recs: PathBuf::from(default_recs),
         artifacts: PathBuf::from(compiler::ART_PATH),
         cover: None,
+        stories: None,
         transition_out_degree: score::DEFAULT_TRANSITION_OUT_DEGREE,
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
         root_top_b: score::DEFAULT_ROOT_TOP_B,
@@ -636,6 +649,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
             "--corpus-recs" => options.corpus_recs = PathBuf::from(value),
             "--artifacts" => options.artifacts = PathBuf::from(value),
             "--cover" => options.cover = Some(PathBuf::from(value)),
+            "--stories" => options.stories = Some(PathBuf::from(value)),
             "--transition-out-degree" => {
                 options.transition_out_degree = value
                     .parse()
@@ -738,7 +752,38 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
     };
-    let (train_positions, held_out_positions) = cover::split_positions(&corpus);
+    let (train_positions, held_out_positions) = match &options.stories {
+        // D3 natural partition (issue #72): the observation pass records
+        // the construction/held-out decision per story (article) in the
+        // stories index; honor it instead of the ordinal train cut.
+        Some(path) => {
+            let index = observe_text::StoryIndex::load(path)?
+                .ok_or_else(|| format!("stories index not found at {}", path.display()))?;
+            let mut train = Vec::new();
+            let mut held_out = Vec::new();
+            for i in 0..corpus.n {
+                let story = corpus.story[i];
+                match index.partition_of(story) {
+                    Some(observe::RecordPartition::Construction) => train.push(i),
+                    Some(observe::RecordPartition::HeldOut) => held_out.push(i),
+                    None => {
+                        return Err(format!(
+                            "story {story} missing from stories index {}",
+                            path.display()
+                        ))
+                    }
+                }
+            }
+            eprintln!(
+                "score: D3 partition split from {} ({} construction / {} held-out positions)",
+                path.display(),
+                train.len(),
+                held_out.len()
+            );
+            (train, held_out)
+        }
+        None => cover::split_positions(&corpus),
+    };
     let train = cover::build_observations(&artifacts, &corpus, &train_positions);
     let held_out = cover::build_observations(&artifacts, &corpus, &held_out_positions);
 

--- a/crates/uor-r4-core/src/transformerless/observe.rs
+++ b/crates/uor-r4-core/src/transformerless/observe.rs
@@ -165,6 +165,11 @@ pub struct ObservationManifest {
     /// producing pipeline has one (from-text driver; absent otherwise).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partition_rule: Option<String>,
+    /// CID of the exact input the observations were derived from (the
+    /// from-text driver records the articles-file κ, i.e. the corpus CID
+    /// of the D3 manifest; absent for teacher-generated streams).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_cid: Option<String>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -177,6 +182,7 @@ impl ObservationManifest {
             schema: 1,
             shard_bits,
             partition_rule: None,
+            input_cid: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -280,6 +286,15 @@ impl ObservationShardWriter {
     pub fn set_partition_rule(&mut self, rule: &str) -> io::Result<()> {
         if self.manifest.partition_rule.as_deref() != Some(rule) {
             self.manifest.partition_rule = Some(rule.to_owned());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Record the input CID in the manifest (idempotent, atomic store).
+    pub fn set_input_cid(&mut self, cid: &str) -> io::Result<()> {
+        if self.manifest.input_cid.as_deref() != Some(cid) {
+            self.manifest.input_cid = Some(cid.to_owned());
             self.manifest.store(&self.dir)?;
         }
         Ok(())

--- a/crates/uor-r4-core/src/transformerless/observe_text.rs
+++ b/crates/uor-r4-core/src/transformerless/observe_text.rs
@@ -549,6 +549,11 @@ pub fn observe_text_corpus(
     writer
         .set_partition_rule(PARTITION_RULE)
         .map_err(|error| error.to_string())?;
+    // The PROV link from produced artifacts back to the sealed corpus
+    // (issue #72): the input κ is the corpus CID of the D3 manifest.
+    writer
+        .set_input_cid(&format!("blake3:{}", blake3::Hash::from(kappa).to_hex()))
+        .map_err(|error| error.to_string())?;
 
     let mut checkpoint = match read_checkpoint(out_dir, shard_count)? {
         Some(checkpoint) => {

--- a/crates/uor-r4-core/src/transformerless/observe_text.rs
+++ b/crates/uor-r4-core/src/transformerless/observe_text.rs
@@ -426,6 +426,10 @@ pub struct ObservationReport {
     /// Articles truncated at the teacher sequence length during this
     /// invocation.
     pub articles_truncated: u64,
+    /// Characters replaced by the lossy tokenizer fallback during this
+    /// invocation (unencodable in the teacher vocab; substituted with a
+    /// space — deterministic, see [`scenarios::Tokenizer::encode_lossy`]).
+    pub characters_replaced: u64,
     /// Records committed so far (all invocations).
     pub records: u64,
     /// Records written during this invocation.
@@ -456,6 +460,7 @@ fn build_report(
     writer: &ObservationShardWriter,
     articles_total: u64,
     articles_truncated: u64,
+    characters_replaced: u64,
     written: u64,
 ) -> Result<ObservationReport, String> {
     let stories_path = out_dir.join(STORIES_FILE);
@@ -483,6 +488,7 @@ fn build_report(
         articles_total,
         articles_completed: checkpoint.stories,
         articles_truncated,
+        characters_replaced,
         records: checkpoint.n,
         written,
         construction_records,
@@ -609,7 +615,7 @@ pub fn observe_text_corpus(
             "text observation corpus already complete: {} records",
             checkpoint.n
         );
-        return build_report(out_dir, &checkpoint, &writer, articles_total, 0, 0);
+        return build_report(out_dir, &checkpoint, &writer, articles_total, 0, 0, 0);
     }
 
     let vocab = oracle.vocab();
@@ -620,6 +626,7 @@ pub fn observe_text_corpus(
     progress.set(checkpoint.stories as usize);
     let mut written = 0u64;
     let mut truncated = 0u64;
+    let mut replaced = 0u64;
     let t0 = std::time::Instant::now();
 
     let file = fs::File::open(articles_path)
@@ -645,7 +652,8 @@ pub fn observe_text_corpus(
         let story = u32::try_from(ordinal)
             .map_err(|_| "article ordinal exceeds the u32 story field".to_owned())?;
         let partition = partition_of(&article.id);
-        let tokens = tokenizer.encode(&article.text);
+        let (tokens, article_replaced) = tokenizer.encode_lossy(&article.text);
+        replaced += article_replaced;
         let positions = tokens.len().saturating_sub(1).min(seq_len);
         if positions < tokens.len().saturating_sub(1) {
             truncated += 1;
@@ -734,6 +742,7 @@ pub fn observe_text_corpus(
         &writer,
         articles_total,
         truncated,
+        replaced,
         written,
     )?;
     println!(
@@ -803,6 +812,21 @@ mod tests {
             bytes.extend_from_slice(line.as_bytes());
         }
         fs::write(path, bytes).expect("write articles fixture");
+    }
+
+    #[test]
+    fn encode_lossy_replaces_unencodable_characters_with_spaces() {
+        let tokenizer = fixture_tokenizer();
+        // 'Ɔ' (U+0186) is neither a whole token nor byte-encodable in the
+        // fixture vocab (a..d and space only): the legacy llama2.c teacher
+        // has exactly this gap for non-ASCII text (issue #72).
+        let (tokens, replaced) = tokenizer.encode_lossy("abƆd");
+        assert_eq!(replaced, 1);
+        assert_eq!(tokens, tokenizer.encode("ab d"));
+        // Fully encodable text is untouched.
+        let (tokens, replaced) = tokenizer.encode_lossy("abcd");
+        assert_eq!(replaced, 0);
+        assert_eq!(tokens, tokenizer.encode("abcd"));
     }
 
     /// Deterministic few-token oracle: logits depend only on (token, pos),

--- a/crates/uor-r4-core/src/transformerless/scenarios.rs
+++ b/crates/uor-r4-core/src/transformerless/scenarios.rs
@@ -196,6 +196,41 @@ impl Tokenizer {
         toks
     }
 
+    /// Whether `ch` encodes — as a whole token or via byte fallback.
+    fn char_encodable(&self, ch: char) -> bool {
+        let mut utf8 = [0u8; 4];
+        let bytes = ch.encode_utf8(&mut utf8).as_bytes();
+        self.map.contains_key(bytes) || bytes.iter().all(|byte| self.map.contains_key(&[*byte][..]))
+    }
+
+    /// Lossy variant of [`encode`] for natural corpora (issue #72): a
+    /// character the tokenizer cannot represent at all (neither a whole
+    /// token nor byte fallback — the legacy llama2.c vocab covers ASCII
+    /// bytes only) is replaced with a space, or dropped when even space is
+    /// unencodable. Returns the token stream and the number of replaced
+    /// characters. The substitution is deterministic, so a resumed
+    /// observation pass reproduces identical records.
+    pub fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64) {
+        let substitute = if self.char_encodable(' ') {
+            Some(' ')
+        } else {
+            None
+        };
+        let mut sanitized = String::with_capacity(text.len());
+        let mut replaced = 0u64;
+        for ch in text.chars() {
+            if self.char_encodable(ch) {
+                sanitized.push(ch);
+            } else {
+                if let Some(substitute) = substitute {
+                    sanitized.push(substitute);
+                }
+                replaced += 1;
+            }
+        }
+        (self.encode(&sanitized), replaced)
+    }
+
     /// Encode into caller-owned storage without allocating.
     pub fn encode_into(&self, text: &str, out: &mut [u32]) -> io::Result<usize> {
         let capacity_error = || io::Error::new(io::ErrorKind::InvalidInput, "token buffer full");


### PR DESCRIPTION
## What

Completes the D3 natural-corpus observation run (issue #72): the sealed Simple English Wikipedia sample (3000 articles, CC BY-SA 4.0) is now observed, manifested, and measured.

- **`Tokenizer::encode_lossy`**: the legacy llama2.c vocab has ASCII-only byte fallback and panicked on 61/3000 articles; unencodable characters are deterministically replaced with spaces (736 total) and counted in the observation report.
- **`score --stories PATH`**: Gate C honors the D3 partition (`blake3(article id)[0] % 5 == 0`, 2404/596 articles construction/held-out) from the observation stories index instead of the ordinal train cut.
- **`input_cid`** in the observation manifest: PROV reference to the corpus CID, verified byte-identical (`blake3:194db0ee…`) against `committed.bin` and the corpus manifest.
- **Corpus manifest committed** under `.uor-models/corpora/` (gitignore exception; bulk data stays local): CID, SPDX `CC-BY-SA-4.0`, article count, split rule.
- **`merged.bin`** written on completion (Gate C `--corpus-recs`; `state.bin` is `--corpus-meta`).

## Measured (posted in full to #72)

Observation: 667,942 records, 16/16 shards κ-pinned, merged κ `blake3:212bfdd4…`. Gate C on the 133,417-position held-out natural partition: **Rule 1+2 top-1 47.9% / 18.25 bits/token vs TLA3 baseline 47.9% / 35.55** — all held-out predictions resolved via ExactContext (0 Graph, 0 Novel), so the natural-partition judge currently measures exact-context memory; caveat noted in the issue for #75.

## Gates

- [x] local: fmt, clippy, nextest (289/289), bdd (13/13), doc tests
- [x] observation run complete (3000/3000 articles, resumable-sharded, content-addressed)
- [x] natural-partition Gate C 4-way table → https://github.com/UOR-Foundation/uor-r4/issues/72#issuecomment-5055665554
- [x] corpus manifest committed with CID + SPDX + split rule