### PR TITLE
Hidden-state trace lane for cover induction (issue #71)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -29,6 +29,7 @@ use super::{
     certify, compare, compiler, convert_r4g1, cover, cover_sweep, observe, observe_text, runtime,
     scenarios, score,
     teacher::{BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, TeacherOracle},
+    trace_lane,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -1610,6 +1611,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
         Some("cover") => cover_command(&args[1..])?,
         Some("score") => score_command(&args[1..])?,
         Some("cover-sweep") => cover_sweep::cover_sweep_command(&args[1..])?,
+        Some("lane-compare") => trace_lane::lane_compare_command(&args[1..])?,
         _ => {
             println!(
                 "R4 transformerless — cross-compile a transformer into a mul-free table artifact\n\
@@ -1619,6 +1621,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                  cover induction: cover [--corpus-meta P --corpus-recs P] [--artifacts P] [--depths N] [--k0 N] [--regions-budget N] [--memory-budget MB] [--min-support N] [--entropy-gain BITS] [--radius-quantile PCT] [--out DIR]\n\
                  score (phase 4): score [--corpus-meta P --corpus-recs P] [--artifacts P] [--cover P] [--transition-out-degree N] [--emission-entries N] [--root-top-b N] [--exct-top-x N] [--witness-sample N] [--smoothing RULE] [--out DIR]\n\
                  cover sweep (issue 70): cover-sweep [--corpus-meta P --corpus-recs P] [--artifacts P] [--out DIR]\n\
+                 lane compare (issue 71): lane-compare [--corpus-meta P --corpus-recs P] [--artifacts P] [--checkpoint BIN] [--out DIR]\n\
                  hf evaluation: evaluate-report [--source DIR] [--compiled DIR] [--report PATH] [--sequence-length N]\n\
                  docs: docs/TRANSFORMERLESS.md (extrapolation), docs/PROOF.md (proof + certificate)"
             );

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -54,6 +54,7 @@ pub fn xorshift(s: &mut u64) -> u64 {
 ///   | span_start u32 | span_end u32 | byte_start u32 | byte_end u32
 /// legacy record sizes are still accepted on load:
 ///   v1=12 bytes (story,next,argmax,logprob) and v2=32 bytes (no anchors).
+#[derive(Clone)]
 pub struct Corpus {
     pub n: usize,
     pub stories: u64,
@@ -613,6 +614,7 @@ pub fn train_cut(c: &Corpus) -> u32 {
 
 pub const ART_PATH: &str = "/tmp/tless_artifacts.bin";
 
+#[derive(Clone)]
 pub struct Compiled {
     /// COMPRESSED token representation: STAGES code bytes per token [V × STAGES]
     /// plus i8 stage books [STAGES × (K × D)]. The runtime decodes rows on

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -192,5 +192,7 @@ pub mod score_q;
 pub mod score_runtime;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod shortlist_evaluator;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod trace_lane;
 // Transitions are portable (pure graph math, no fs).
 pub mod transitions;

--- a/crates/uor-r4-core/src/transformerless/trace_lane.rs
+++ b/crates/uor-r4-core/src/transformerless/trace_lane.rs
@@ -1,0 +1,656 @@
+//! Hidden-state trace lane for cover induction (graph-compiler plan §5
+//! Phase 2, issue #71): a second observation lane beside the deterministic
+//! context-bundle lane of [`cover::build_observations`], sourced from the
+//! [`TeacherOracle::hidden_state`] trace surface, plus the lane-comparison
+//! driver that measures both lanes at one fixed region budget and records
+//! an adoption decision.
+//!
+//! # The lane
+//!
+//! [`build_trace_observations`] replays the corpus through the oracle in
+//! story order — `reset` at each story boundary, then
+//! `step(input[i], pos_in_story)` per position — and reads the final
+//! hidden state (post-final-rmsnorm, pre-classifier activation) after each
+//! step. The replay is strictly sequential in corpus position order, so it
+//! is bit-reproducible on the same machine by construction (no
+//! parallelism, no RNG, no clock; the κ-baseline macOS-pinned caveat
+//! below applies to the f32 values themselves).
+//!
+//! The produced [`Observation`] rows keep `position`, `sample`
+//! ([`observe::sample_id`] of the same context window), and `next`
+//! **identical to the bundle lane**, so [`cover::split_positions`],
+//! entropy gating, reference recall, and Gate C align 1:1 across lanes —
+//! only the vector and signature change:
+//!
+//! - `vector`: the L2-normalized hidden state (the k-means input).
+//! - `sig`: sign bits of the raw hidden state, bit `d` set iff coordinate
+//!   `d > 0.0` — exactly the [`cover::binarize_prototype`] convention.
+//!   Unlike the bundle lane there is no per-dimension thresholds
+//!   centering: for hidden states, **sign vs 0.0 IS the centering** (the
+//!   final rmsnorm removes the scale/offset freedom the thresholds
+//!   calibrate in the bundle lane). L2 normalization divides by a positive
+//!   scalar, so the sign bits are identical taken before or after
+//!   normalization.
+//!
+//! **Dimension gate (v1):** the lane requires
+//! `oracle.source_dimension() == compiler::D` (the legacy stories15M
+//! teacher, dim 288) so the hidden-state signature drops straight into
+//! the same 288-bit Hamming membership path as the bundle lane. Oracles
+//! with any other width (e.g. the raw 576-dim Hugging Face teacher) are
+//! rejected with a plain error — no silent truncation or projection.
+//!
+//! Everything downstream is reused untouched: [`cover::induce_cover`],
+//! [`cover::ReferenceClassifier`], [`cover::evaluate_held_out`],
+//! [`cover::build_edges`], the score compiler, and
+//! [`cover_sweep::run_point`] are all lane-agnostic given observations —
+//! Gate C for each lane routes with that lane's own sigs because
+//! `run_point` feeds the lane's observation rows into
+//! `score::evaluate_gate_c` (the `score --cover` CLI is bundle-hardcoded
+//! and is NOT used here).
+//!
+//! # The comparison
+//!
+//! [`run_compare`] builds the hidden-lane observations over one fixed
+//! observation sample (the CLI uses the full pinned fixture corpus: every
+//! position in file order, split into train/held-out by the usual 80/20
+//! story cut) and runs ONE fixed region-budget point — the confirmed
+//! default operating point `k0 = 8`, entropy gain 0.25 bits, regions
+//! budget 256 (the 42-region default row of the issue-#70 sweep) — on
+//! both lanes through [`cover_sweep::run_point`]. The report holds, per
+//! lane, the per-depth reference top-1/top-M recall and frontier width,
+//! the scored artifact bytes, and the Gate C Rule 1+2 top-1 agreement and
+//! bits/token, plus the TLA3 store baseline row. The baseline is
+//! inherently bundle-lane (it routes `runtime::assign_plain` class codes,
+//! not cover regions); it is recorded once as a shared reference row and
+//! labeled as such.
+//!
+//! # The recorded lane choice
+//!
+//! The adoption rule is deterministic and stated in the report:
+//!
+//! > adopt the hidden lane iff its Gate C Rule 1+2 top-1 agreement
+//! > STRICTLY exceeds the bundle lane's at the same fixed point; ties and
+//! > regressions keep the deterministic bundle lane.
+//!
+//! [`LaneChoice`] records the decision, the rule, the justifying deltas
+//! (top-1 agreement, bits/token, deepest-depth reference recall), and a
+//! written rationale. On "adopted", plan §4.1 requires an i8/sign
+//! quantized spill for the hidden-state vectors (per-vector max-abs
+//! scale, ~0.3 KB/obs) before the lane ships; on "rejected", the
+//! comparison table itself is the rejection evidence and no spill is
+//! built.
+//!
+//! # Report schema (`lane_compare.json`, schema = 1)
+//!
+//! ```text
+//! schema:          1
+//! inputs:          {artifact_kappa, corpus_kappa, teacher_kappa, sample,
+//!                   stories, positions, train_observations,
+//!                   held_out_observations}
+//! point:           {label, k0, depths, entropy_gain_bits, regions_budget,
+//!                   min_support, memory_budget_bytes}
+//! tla3_baseline:   {positions, top1_agreement, bits_per_token}
+//!                   (shared reference row — inherently bundle-lane)
+//! lanes:           [{lane: "bundle" | "hidden", <SweepRow fields>}]
+//! choice:          {decision, lane, rule, delta_rule12_top1,
+//!                   delta_bits_per_token, delta_reference_top1_deepest,
+//!                   rationale}
+//! determinism:     note string
+//! ```
+//!
+//! # Determinism
+//!
+//! Same-machine double runs are byte-identical (asserted in
+//! `tests/trace_lane.rs`): the replay is sequential in fixed story order
+//! and every consumed compiler is deterministic by construction. The f32
+//! hidden states are libm-sensitive cross-platform — the macOS-pinned
+//! status of the κ baseline, inherited here exactly as
+//! `cover_sweep.rs:643-649` records it; cross-platform byte equality
+//! awaits the D2 canonical deterministic compile mode. This module is
+//! compiler-side ONLY: nothing here touches `runtime.rs` (the
+//! machine-checked P-4 source scan enforces the mul-free kernel there).
+
+use serde::Serialize;
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use super::compiler::{self, D, SIG_BYTES};
+use super::cover::{self, Observation};
+use super::cover_sweep::{self, SweepInputs, SweepPoint, SweepRow, SweepRowConfig};
+use super::observe;
+use super::score::{GateCMetrics, ScoreConfig};
+use super::teacher::{LlamaOracle, TeacherOracle};
+
+/// The `lane_compare.json` schema version (module docs).
+pub const LANE_COMPARE_SCHEMA: u32 = 1;
+
+/// Lane label of the deterministic context-bundle lane.
+pub const LANE_BUNDLE: &str = "bundle";
+/// Lane label of the teacher hidden-state trace lane.
+pub const LANE_HIDDEN: &str = "hidden";
+
+/// Default source checkpoint for the trace replay (the legacy stories15M
+/// teacher — the only in-tree oracle with `source_dimension() == D`).
+pub const DEFAULT_TRACE_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
+
+/// The adoption rule, recorded verbatim in every report (module docs).
+pub const ADOPTION_RULE: &str = "adopt the hidden lane iff its Gate C Rule 1+2 top-1 agreement \
+                                 strictly exceeds the bundle lane's at the same fixed point; \
+                                 ties and regressions keep the deterministic bundle lane";
+
+/// The fixed observation sample the CLI compares over (module docs).
+pub const SAMPLE_NOTE: &str =
+    "the full pinned corpus: every position in file order, train/held-out split by the \
+     compiler::train_cut 80/20 story cut (same sample on both lanes)";
+
+/// Build the hidden-state trace observations of the given corpus
+/// positions (module docs: the lane). `positions` must be ascending and
+/// in range; the replay walks the corpus once in position order, resets
+/// at story boundaries, and stops after the last wanted position. The
+/// returned rows align 1:1 with [`cover::build_observations`] on
+/// `position`, `sample`, and `next` for the same `positions`.
+pub fn build_trace_observations(
+    oracle: &mut dyn TeacherOracle,
+    corpus: &compiler::Corpus,
+    positions: &[usize],
+) -> Result<Vec<Observation>, String> {
+    if oracle.source_dimension() != D {
+        return Err(format!(
+            "trace lane v1 requires source dimension {D} (compiler::D); this oracle exposes {} \
+             — no silent truncation or projection",
+            oracle.source_dimension()
+        ));
+    }
+    for (k, &p) in positions.iter().enumerate() {
+        if p >= corpus.n {
+            return Err(format!(
+                "position {p} is out of range (corpus has {})",
+                corpus.n
+            ));
+        }
+        if k > 0 && p <= positions[k - 1] {
+            return Err("positions must be strictly ascending".to_owned());
+        }
+    }
+    let mut logits = vec![0f32; oracle.vocab()];
+    let mut observations = Vec::with_capacity(positions.len());
+    let mut wanted = positions.iter().peekable();
+    let mut pos_in_story = 0usize;
+    oracle.reset();
+    for i in 0..corpus.n {
+        if i > 0 && corpus.story[i] != corpus.story[i - 1] {
+            oracle.reset();
+            pos_in_story = 0;
+        }
+        oracle.step(corpus.input[i] as usize, pos_in_story, &mut logits);
+        pos_in_story += 1;
+        if wanted.peek() == Some(&&i) {
+            wanted.next();
+            let hidden = oracle
+                .hidden_state()
+                .ok_or_else(|| "oracle exposes no hidden_state trace surface".to_owned())?;
+            if hidden.len() != D {
+                return Err(format!(
+                    "hidden_state length {} != compiler::D {D}",
+                    hidden.len()
+                ));
+            }
+            let mut sig = [0u8; SIG_BYTES];
+            let mut vector = vec![0f32; D];
+            let mut nn = 0f32;
+            for (d, &x) in hidden.iter().enumerate() {
+                if x > 0.0 {
+                    sig[d / 8] |= 1 << (d % 8);
+                }
+                vector[d] = x;
+                nn += x * x;
+            }
+            let nn = nn.sqrt().max(1e-9);
+            for x in vector.iter_mut() {
+                *x /= nn;
+            }
+            observations.push(Observation {
+                position: i as u32,
+                sample: observe::sample_id(&cover::context_window(corpus, i)),
+                vector,
+                sig,
+                next: corpus.next[i],
+            });
+            if wanted.peek().is_none() {
+                break;
+            }
+        }
+    }
+    if observations.len() != positions.len() {
+        return Err(format!(
+            "replay produced {} of {} wanted observations",
+            observations.len(),
+            positions.len()
+        ));
+    }
+    Ok(observations)
+}
+
+/// One lane's comparison row: its label plus the full sweep-point row.
+#[derive(Debug, Clone, Serialize)]
+pub struct LaneRow {
+    /// `bundle` or `hidden`.
+    pub lane: String,
+    /// The lane's regions × bytes × agreement row (cover_sweep schema).
+    #[serde(flatten)]
+    pub row: SweepRow,
+}
+
+/// The recorded lane choice (module docs for the rule).
+#[derive(Debug, Clone, Serialize)]
+pub struct LaneChoice {
+    /// `adopted` or `rejected`.
+    pub decision: String,
+    /// The lane the decision keeps in the compiler path.
+    pub lane: String,
+    /// The adoption rule applied ([`ADOPTION_RULE`]).
+    pub rule: String,
+    /// hidden − bundle Gate C Rule 1+2 top-1 agreement.
+    pub delta_rule12_top1: f64,
+    /// hidden − bundle Gate C bits/token (negative is better).
+    pub delta_bits_per_token: f64,
+    /// hidden − bundle reference top-1 recall at the deepest depth.
+    pub delta_reference_top1_deepest: f64,
+    /// The written justification (numbers + the rule's application).
+    pub rationale: String,
+}
+
+/// Shared-input provenance of the comparison.
+#[derive(Debug, Clone, Serialize)]
+pub struct LaneCompareInputs {
+    pub artifact_kappa: String,
+    pub corpus_kappa: String,
+    /// κ of the teacher checkpoint the hidden lane replayed.
+    pub teacher_kappa: String,
+    /// The fixed observation sample ([`SAMPLE_NOTE`]).
+    pub sample: String,
+    pub stories: u64,
+    pub positions: usize,
+    pub train_observations: usize,
+    pub held_out_observations: usize,
+}
+
+/// The fixed point's cover configuration columns.
+#[derive(Debug, Clone, Serialize)]
+pub struct LaneComparePoint {
+    pub label: String,
+    #[serde(flatten)]
+    pub config: SweepRowConfig,
+}
+
+/// The `lane_compare.json` document (schema in the module docs).
+#[derive(Debug, Clone, Serialize)]
+pub struct LaneCompareReport {
+    pub schema: u32,
+    pub inputs: LaneCompareInputs,
+    /// The single fixed region-budget point both lanes ran.
+    pub point: LaneComparePoint,
+    /// The cover-independent TLA3 store baseline — a shared reference row,
+    /// inherently bundle-lane (`assign_plain` class codes), recorded once.
+    pub tla3_baseline: GateCMetrics,
+    /// One row per lane, bundle first.
+    pub lanes: Vec<LaneRow>,
+    /// The recorded adoption decision.
+    pub choice: LaneChoice,
+    /// Determinism status note.
+    pub determinism: String,
+}
+
+/// The single fixed comparison point: the confirmed default operating
+/// point (module docs; the 42-region baseline row of the #70 sweep).
+pub fn compare_point() -> SweepPoint {
+    let config = cover::CoverConfig::default();
+    SweepPoint {
+        label: format!(
+            "k0={}/gain={}/budget={} (default)",
+            config.k0, config.entropy_gain_bits, config.regions_budget
+        ),
+        baseline: true,
+        config,
+    }
+}
+
+/// Apply the adoption rule ([`ADOPTION_RULE`]) to the two lane rows.
+pub fn choose_lane(bundle: &SweepRow, hidden: &SweepRow) -> LaneChoice {
+    let delta_top1 = hidden.gate_c_rule12.top1_agreement - bundle.gate_c_rule12.top1_agreement;
+    let delta_bits = hidden.gate_c_rule12.bits_per_token - bundle.gate_c_rule12.bits_per_token;
+    let deepest = |row: &SweepRow| row.recall.last().map_or(0.0, |d| d.reference_top1);
+    let delta_recall = deepest(hidden) - deepest(bundle);
+    let adopted = delta_top1 > 0.0;
+    let decision = if adopted { "adopted" } else { "rejected" };
+    let lane = if adopted { LANE_HIDDEN } else { LANE_BUNDLE };
+    let mut rationale = format!(
+        "hidden lane Rule 1+2 top-1 {:.4} vs bundle {:.4} (Δ {:+.4}), bits/token Δ {:+.4}, \
+         deepest-depth reference top-1 Δ {:+.4}",
+        hidden.gate_c_rule12.top1_agreement,
+        bundle.gate_c_rule12.top1_agreement,
+        delta_top1,
+        delta_bits,
+        delta_recall
+    );
+    if adopted {
+        rationale.push_str(
+            " — the hidden lane strictly beats the bundle lane on the distortion axis at the \
+             same region budget: adopted; plan §4.1 i8/sign spill of the hidden-state vectors \
+             is now owed before the lane ships",
+        );
+    } else {
+        rationale.push_str(
+            " — no strict top-1 gain over the deterministic bundle lane: rejected; the \
+             comparison table in this report is the rejection evidence and no i8 spill is built",
+        );
+    }
+    LaneChoice {
+        decision: decision.to_owned(),
+        lane: lane.to_owned(),
+        rule: ADOPTION_RULE.to_owned(),
+        delta_rule12_top1: delta_top1,
+        delta_bits_per_token: delta_bits,
+        delta_reference_top1_deepest: delta_recall,
+        rationale,
+    }
+}
+
+/// Run both lanes at the fixed point over two already-loaded input sets
+/// (identical except for the observation rows) and assemble the report.
+/// `teacher_kappa` identifies the hidden lane's oracle. Deterministic:
+/// two calls with the same inputs produce byte-identical JSON.
+pub fn compare_lanes(
+    bundle: &SweepInputs,
+    hidden: &SweepInputs,
+    point: &SweepPoint,
+    score_config: &ScoreConfig,
+    teacher_kappa: &str,
+    sample_note: &str,
+) -> Result<LaneCompareReport, String> {
+    // 1:1 alignment is the lane contract (module docs): same positions,
+    // samples, and next tokens on both lanes.
+    for (b, h) in bundle.train.iter().zip(hidden.train.iter()) {
+        if b.position != h.position || b.sample != h.sample || b.next != h.next {
+            return Err(
+                "lane misalignment: train observations differ in position/sample/next".to_owned(),
+            );
+        }
+    }
+    for (b, h) in bundle.held_out.iter().zip(hidden.held_out.iter()) {
+        if b.position != h.position || b.sample != h.sample || b.next != h.next {
+            return Err(
+                "lane misalignment: held-out observations differ in position/sample/next"
+                    .to_owned(),
+            );
+        }
+    }
+    let (bundle_row, tla3_baseline, _bytes) = cover_sweep::run_point(bundle, point, score_config)?;
+    let (hidden_row, _tla3_again, _bytes) = cover_sweep::run_point(hidden, point, score_config)?;
+    let choice = choose_lane(&bundle_row, &hidden_row);
+    Ok(LaneCompareReport {
+        schema: LANE_COMPARE_SCHEMA,
+        inputs: LaneCompareInputs {
+            artifact_kappa: bundle.artifact_kappa.clone(),
+            corpus_kappa: bundle.corpus_kappa.clone(),
+            teacher_kappa: teacher_kappa.to_owned(),
+            sample: sample_note.to_owned(),
+            stories: bundle.corpus.stories,
+            positions: bundle.corpus.n,
+            train_observations: bundle.train.len(),
+            held_out_observations: bundle.held_out.len(),
+        },
+        point: LaneComparePoint {
+            label: point.label.clone(),
+            config: SweepRowConfig {
+                k0: point.config.k0,
+                depths: point.config.depths,
+                entropy_gain_bits: point.config.entropy_gain_bits,
+                regions_budget: point.config.regions_budget,
+                min_support: point.config.min_support,
+                memory_budget_bytes: point.config.memory_budget_bytes,
+            },
+        },
+        tla3_baseline,
+        lanes: vec![
+            LaneRow {
+                lane: LANE_BUNDLE.to_owned(),
+                row: bundle_row,
+            },
+            LaneRow {
+                lane: LANE_HIDDEN.to_owned(),
+                row: hidden_row,
+            },
+        ],
+        choice,
+        determinism: "same-machine double runs are byte-identical (sequential story-order replay, \
+                      content-addressed seeds, ordered reductions; asserted in \
+                      tests/trace_lane.rs); the f32 hidden states are macOS-pinned and \
+                      libm-sensitive cross-platform — the inherited status of the κ baseline \
+                      (D2 resolves cross-platform byte equality later)"
+            .to_owned(),
+    })
+}
+
+/// The full driver: replay the corpus through `oracle` to build the
+/// hidden lane over the same positions as the bundle-lane `inputs`, then
+/// compare both lanes at the fixed point.
+pub fn run_compare(
+    inputs: &SweepInputs,
+    oracle: &mut dyn TeacherOracle,
+    score_config: &ScoreConfig,
+) -> Result<LaneCompareReport, String> {
+    let corpus = &inputs.corpus;
+    let positions: Vec<usize> = (0..corpus.n).collect();
+    eprintln!(
+        "lane-compare: replaying {} positions through the teacher (hidden-state lane)...",
+        corpus.n
+    );
+    let all = build_trace_observations(oracle, corpus, &positions)?;
+    let cut = compiler::train_cut(corpus);
+    let (trace_train, trace_held_out): (Vec<Observation>, Vec<Observation>) = all
+        .into_iter()
+        .partition(|o| corpus.story[o.position as usize] < cut);
+    let trace_inputs = SweepInputs {
+        artifact_container: inputs.artifact_container.clone(),
+        artifacts: inputs.artifacts.clone(),
+        corpus: inputs.corpus.clone(),
+        meta_bytes: inputs.meta_bytes.clone(),
+        recs_bytes: inputs.recs_bytes.clone(),
+        train: trace_train,
+        held_out: trace_held_out,
+        store: inputs.store.clone(),
+        tls1: inputs.tls1.clone(),
+        artifact_kappa: inputs.artifact_kappa.clone(),
+        corpus_kappa: inputs.corpus_kappa.clone(),
+    };
+    let teacher_kappa = oracle.kappa();
+    compare_lanes(
+        inputs,
+        &trace_inputs,
+        &compare_point(),
+        score_config,
+        &teacher_kappa,
+        SAMPLE_NOTE,
+    )
+}
+
+/// The console comparison table (module docs): per-depth reference recall
+/// and frontier width per lane, then the Gate C rows plus the shared TLA3
+/// baseline row, then the recorded lane choice.
+pub fn render_table(report: &LaneCompareReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "lane comparison at {} — {} train / {} held-out observations:",
+        report.point.label, report.inputs.train_observations, report.inputs.held_out_observations
+    );
+    let _ = writeln!(
+        out,
+        "per-depth reference recall and frontier width (held-out):"
+    );
+    let _ = writeln!(
+        out,
+        "  {:<8} {:>5} {:>9} {:>9} {:>9} {:>9}",
+        "lane", "depth", "evaluated", "ref-top1", "ref-topM", "frontier"
+    );
+    for lane in &report.lanes {
+        for d in &lane.row.recall {
+            let _ = writeln!(
+                out,
+                "  {:<8} {:>5} {:>9} {:>8.1}% {:>8.1}% {:>4.2}/{}",
+                lane.lane,
+                d.depth,
+                d.evaluated,
+                100.0 * d.reference_top1,
+                100.0 * d.reference_topm,
+                d.frontier_mean,
+                d.frontier_max
+            );
+        }
+    }
+    let _ = writeln!(out, "Gate C (held-out, Rule 1+2 precedence):");
+    let _ = writeln!(
+        out,
+        "  {:<8} {:>7} {:>10} {:>10} {:>10}",
+        "lane", "regions", "bytes", "R1+2 top1", "bits/token"
+    );
+    for lane in &report.lanes {
+        let _ = writeln!(
+            out,
+            "  {:<8} {:>7} {:>10} {:>9.1}% {:>10.4}",
+            lane.lane,
+            lane.row.regions.total,
+            lane.row.artifact_bytes,
+            100.0 * lane.row.gate_c_rule12.top1_agreement,
+            lane.row.gate_c_rule12.bits_per_token
+        );
+    }
+    let _ = writeln!(
+        out,
+        "  {:<8} {:>7} {:>10} {:>9.1}% {:>10.4}   (TLA3 store baseline — bundle-lane class codes; shared reference row)",
+        "tla3",
+        "-",
+        "-",
+        100.0 * report.tla3_baseline.top1_agreement,
+        report.tla3_baseline.bits_per_token
+    );
+    let _ = writeln!(
+        out,
+        "lane choice: {} — keep the {} lane ({})",
+        report.choice.decision, report.choice.lane, report.choice.rationale
+    );
+    out
+}
+
+// ------------------------------------------------------------ CLI --------
+
+#[derive(Debug, PartialEq, Eq)]
+struct LaneCompareOptions {
+    corpus_meta: PathBuf,
+    corpus_recs: PathBuf,
+    artifacts: PathBuf,
+    checkpoint: PathBuf,
+    output: PathBuf,
+}
+
+fn parse_lane_compare_options(args: &[String]) -> Result<LaneCompareOptions, String> {
+    let (default_meta, default_recs) = compiler::corpus_paths();
+    let mut options = LaneCompareOptions {
+        corpus_meta: PathBuf::from(default_meta),
+        corpus_recs: PathBuf::from(default_recs),
+        artifacts: PathBuf::from(compiler::ART_PATH),
+        checkpoint: PathBuf::from(DEFAULT_TRACE_CHECKPOINT),
+        output: PathBuf::from("lane_compare"),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--corpus-meta" => options.corpus_meta = PathBuf::from(value),
+            "--corpus-recs" => options.corpus_recs = PathBuf::from(value),
+            "--artifacts" => options.artifacts = PathBuf::from(value),
+            "--checkpoint" => options.checkpoint = PathBuf::from(value),
+            "--out" => options.output = PathBuf::from(value),
+            _ => return Err(format!("unknown lane-compare option: {flag}")),
+        }
+        index += 2;
+    }
+    Ok(options)
+}
+
+/// Hidden-state trace lane comparison (issue #71, module docs): run both
+/// observation lanes at the fixed default point, write
+/// `lane_compare.json`, and print the comparison table. Release-mode
+/// workload on the fixture corpus (the replay is one forward per corpus
+/// position).
+pub fn lane_compare_command(args: &[String]) -> Result<(), String> {
+    #[cfg(debug_assertions)]
+    eprintln!(
+        "warning: debug builds make the replay much slower; use `cargo run --release -- transformerless lane-compare ...`"
+    );
+    let options = parse_lane_compare_options(args)?;
+    let inputs = cover_sweep::load_inputs(
+        &options.corpus_meta,
+        &options.corpus_recs,
+        &options.artifacts,
+    )?;
+    let checkpoint = options
+        .checkpoint
+        .to_str()
+        .ok_or_else(|| "checkpoint path is not UTF-8".to_owned())?;
+    let mut oracle = LlamaOracle::load(checkpoint);
+    let report = run_compare(&inputs, &mut oracle, &ScoreConfig::default())?;
+
+    std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
+    let report_json = serde_json::to_string_pretty(&report).map_err(|error| error.to_string())?;
+    let report_path = options.output.join("lane_compare.json");
+    std::fs::write(&report_path, &report_json)
+        .map_err(|error| format!("{}: {error}", report_path.display()))?;
+
+    print!("{}", render_table(&report));
+    println!("  report: {}", report_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_defaults_and_overrides() {
+        let options = parse_lane_compare_options(&[]).expect("defaults");
+        let (default_meta, default_recs) = compiler::corpus_paths();
+        assert_eq!(options.corpus_meta, PathBuf::from(default_meta));
+        assert_eq!(options.corpus_recs, PathBuf::from(default_recs));
+        assert_eq!(options.artifacts, PathBuf::from(compiler::ART_PATH));
+        assert_eq!(options.checkpoint, PathBuf::from(DEFAULT_TRACE_CHECKPOINT));
+        assert_eq!(options.output, PathBuf::from("lane_compare"));
+
+        let args = [
+            "--corpus-meta",
+            "/tmp/m.bin",
+            "--corpus-recs",
+            "/tmp/r.bin",
+            "--artifacts",
+            "/tmp/a.bin",
+            "--checkpoint",
+            "/tmp/model.bin",
+            "--out",
+            "/tmp/lc",
+        ]
+        .map(str::to_owned);
+        let options = parse_lane_compare_options(&args).expect("valid options");
+        assert_eq!(options.corpus_meta, PathBuf::from("/tmp/m.bin"));
+        assert_eq!(options.checkpoint, PathBuf::from("/tmp/model.bin"));
+        assert_eq!(options.output, PathBuf::from("/tmp/lc"));
+
+        let bad = ["--k0", "16"].map(str::to_owned);
+        assert!(parse_lane_compare_options(&bad).is_err());
+        let missing = ["--out"].map(str::to_owned);
+        assert!(parse_lane_compare_options(&missing).is_err());
+    }
+}

--- a/crates/uor-r4-core/tests/trace_lane.rs
+++ b/crates/uor-r4-core/tests/trace_lane.rs
@@ -1,0 +1,577 @@
+//! Hidden-state trace lane tests (graph-compiler plan §5 Phase 2, issue
+//! #71): a FakeOracle with planted hidden-state geometry proves
+//! `build_trace_observations` aligns 1:1 with the bundle lane and that
+//! `induce_cover` recovers the planted regions from trace observations;
+//! the dimension gate rejects non-288 oracles; the two-lane comparison is
+//! byte-identical across a double run; the adoption rule's edges are unit
+//! tested. The fixture-corpus comparison (150k-position teacher replay)
+//! is a release-only workload and is `#[ignore]`d by default, mirroring
+//! the κ-reproduction convention: run it with
+//! `cargo test -p uor-r4-core --release --offline --test trace_lane -- --ignored --nocapture`.
+
+use uor_r4_core::transformerless::compiler::{self, Corpus, D, K, SIG_BYTES, STAGES};
+use uor_r4_core::transformerless::cover::{self, CoverConfig, Observation};
+use uor_r4_core::transformerless::cover_sweep::{self, SweepInputs};
+use uor_r4_core::transformerless::runtime;
+use uor_r4_core::transformerless::score::{GateCMetrics, ScoreConfig};
+use uor_r4_core::transformerless::teacher::{
+    BehaviorSource, LlamaOracle, RepresentationSource, TeacherOracle,
+};
+use uor_r4_core::transformerless::trace_lane;
+
+const LEGACY_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
+
+// ------------------------------------------------------- synthetic data --
+// Mirrors tests/cover_sweep.rs: five planted groups on the 288-dim sphere
+// over 10 stories of 42 positions; the trace lane's FakeOracle plants the
+// same geometry as hidden states.
+
+const GROUP_SIZES: [usize; 5] = [100, 100, 60, 60, 100];
+const COARSE: [usize; 5] = [0, 1, 2, 2, 3];
+const STORY_LEN: u32 = 42;
+const RECOVERY_RECALL_FLOOR: f64 = 0.95;
+
+fn xorshift(s: &mut u64) -> u64 {
+    let mut x = *s;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *s = x;
+    x
+}
+
+fn planted_center(coarse: usize) -> Vec<f32> {
+    let mut center = vec![0f32; D];
+    for d in 0..72 {
+        center[coarse * 72 + d] = 1.0 / (72f32).sqrt();
+    }
+    center
+}
+
+fn planted_center_g2(sub_b: bool) -> Vec<f32> {
+    let mut center = vec![0f32; D];
+    for d in 0..36 {
+        center[144 + d] = if sub_b { 0.8 } else { 1.2 };
+        center[180 + d] = if sub_b { 1.2 } else { 0.8 };
+    }
+    center
+}
+
+/// Group of a corpus position under the planted layout.
+fn group_of(position: usize) -> usize {
+    let mut rest = position;
+    for (group, &size) in GROUP_SIZES.iter().enumerate() {
+        if rest < size {
+            return group;
+        }
+        rest -= size;
+    }
+    panic!("position {position} past the planted corpus");
+}
+
+/// The planted hidden state of a corpus position: the group center plus
+/// deterministic sign-independent jitter (the tests/cover.rs pattern).
+fn planted_hidden(position: usize) -> Vec<f32> {
+    let group = group_of(position);
+    let mut vector = match group {
+        2 => planted_center_g2(false),
+        3 => planted_center_g2(true),
+        _ => planted_center(COARSE[group]),
+    };
+    let mut rng = (position as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    for x in vector.iter_mut() {
+        let draw = xorshift(&mut rng);
+        let magnitude = ((draw >> 9) % 1000) as f32 * 1e-5;
+        *x += if draw & 1 == 1 { magnitude } else { -magnitude };
+    }
+    vector
+}
+
+fn synthetic_corpus() -> Corpus {
+    let mut story = Vec::new();
+    let mut input = Vec::new();
+    let mut next = Vec::new();
+    let mut t_argmax = Vec::new();
+    let mut top_tokens = Vec::new();
+    let mut top_weights = Vec::new();
+    let mut position = 0u32;
+    for (group, &size) in GROUP_SIZES.iter().enumerate() {
+        for i in 0..size {
+            let next_token = match group {
+                0 => 30,
+                1 => 40 + (i % 4) as u32,
+                2 => 10,
+                3 => 20,
+                _ => 50 + (i % 4) as u32,
+            };
+            story.push(position / STORY_LEN);
+            input.push(if position.is_multiple_of(STORY_LEN) {
+                1
+            } else {
+                *next.last().expect("previous next token")
+            });
+            next.push(next_token);
+            t_argmax.push(next_token);
+            top_tokens.push([next_token, 0, 0, 0, 0, 0, 0, 0]);
+            top_weights.push([100, 0, 0, 0, 0, 0, 0, 0]);
+            position += 1;
+        }
+    }
+    let n = story.len();
+    Corpus {
+        n,
+        stories: u64::from(position / STORY_LEN),
+        story,
+        input,
+        next,
+        t_argmax,
+        top_tokens,
+        top_weights,
+        span_start: (0..n as u32).collect(),
+        span_end: (1..=n as u32).collect(),
+        byte_start: vec![u32::MAX; n],
+        byte_end: vec![u32::MAX; n],
+    }
+}
+
+/// A minimal Compiled (random-but-deterministic tables; mirrors
+/// tests/cover_sweep.rs).
+fn synthetic_compiled() -> compiler::Compiled {
+    let vocab = 64usize;
+    let mut rng = 0xC0DE42u64;
+    let mut rand_bytes =
+        |n: usize| -> Vec<u8> { (0..n).map(|_| (xorshift(&mut rng) & 0xff) as u8).collect() };
+    compiler::Compiled {
+        token_codes: rand_bytes(vocab * STAGES),
+        stage_books: (0..STAGES)
+            .map(|_| rand_bytes(K * D).iter().map(|&b| b as i8).collect())
+            .collect(),
+        stage_shifts: vec![0; STAGES],
+        thresholds: vec![0; D],
+        class_sigs: (0..STAGES).map(|_| rand_bytes(K * SIG_BYTES)).collect(),
+        ctx_cb: Vec::new(),
+        token_stage_kappas: Vec::new(),
+    }
+}
+
+// -------------------------------------------------------- planted oracle --
+
+/// FakeOracle planting the five-group hidden-state geometry: step number
+/// (counted across resets, matching the lane's sequential story-order
+/// replay) maps to the corpus position of the same index.
+struct PlantedOracle {
+    calls: usize,
+    hidden: Vec<f32>,
+    dim: usize,
+}
+
+impl PlantedOracle {
+    fn new() -> Self {
+        PlantedOracle {
+            calls: 0,
+            hidden: vec![0f32; D],
+            dim: D,
+        }
+    }
+}
+
+impl RepresentationSource for PlantedOracle {
+    fn vocab_size(&self) -> usize {
+        64
+    }
+    fn source_dimension(&self) -> usize {
+        self.dim
+    }
+    fn tokenizer_address(&self) -> &str {
+        "planted-tokenizer"
+    }
+    fn read_embedding_rows(
+        &self,
+        _range: std::ops::Range<usize>,
+        output: &mut [f32],
+    ) -> Result<(), String> {
+        output.fill(0.0);
+        Ok(())
+    }
+}
+
+impl BehaviorSource for PlantedOracle {
+    fn reset(&mut self) {}
+    fn step(&mut self, _token: usize, _pos: usize, logits: &mut [f32]) {
+        self.hidden = planted_hidden(self.calls);
+        self.calls += 1;
+        for (i, logit) in logits.iter_mut().enumerate() {
+            *logit = i as f32;
+        }
+    }
+}
+
+impl TeacherOracle for PlantedOracle {
+    fn vocab(&self) -> usize {
+        64
+    }
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn seq_len(&self) -> usize {
+        64
+    }
+    fn kappa(&self) -> String {
+        "blake3:planted-oracle".to_owned()
+    }
+    fn source_bytes(&self) -> usize {
+        0
+    }
+    fn embedding(&self, _token: usize, out: &mut [f32]) {
+        out.fill(0.0);
+    }
+    fn hidden_state(&self) -> Option<&[f32]> {
+        Some(&self.hidden)
+    }
+}
+
+// ------------------------------------------------------------- the lane --
+
+#[test]
+fn trace_observations_align_with_the_bundle_lane() {
+    let corpus = synthetic_corpus();
+    let artifacts = synthetic_compiled();
+    let positions: Vec<usize> = (0..corpus.n).collect();
+    let mut oracle = PlantedOracle::new();
+    let trace = trace_lane::build_trace_observations(&mut oracle, &corpus, &positions)
+        .expect("trace observations");
+    let bundle = cover::build_observations(&artifacts, &corpus, &positions);
+
+    assert_eq!(trace.len(), corpus.n);
+    assert_eq!(oracle.calls, corpus.n, "one forward per corpus position");
+    let mut vectors_differ = 0usize;
+    for (t, b) in trace.iter().zip(bundle.iter()) {
+        // The lane contract: position, sample, and next are identical to
+        // the bundle lane; only the vector and sig change.
+        assert_eq!(t.position, b.position);
+        assert_eq!(t.sample, b.sample);
+        assert_eq!(t.next, b.next);
+        // Unit-normalized vector, sign-bit signature vs 0.0.
+        let norm = t.vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "unit vector, got norm {norm}");
+        for (d, &x) in t.vector.iter().enumerate() {
+            let bit = t.sig[d / 8] >> (d % 8) & 1;
+            assert_eq!(bit == 1, x > 0.0, "sig bit {d} matches the sign");
+        }
+        if t.vector != b.vector {
+            vectors_differ += 1;
+        }
+    }
+    assert!(
+        vectors_differ > corpus.n / 2,
+        "the hidden lane is a genuinely different geometry ({vectors_differ} differing vectors)"
+    );
+}
+
+#[test]
+fn replay_stops_after_the_last_wanted_position() {
+    let corpus = synthetic_corpus();
+    let positions: Vec<usize> = (0..corpus.n).step_by(7).collect();
+    let last = *positions.last().expect("nonempty");
+    let mut oracle = PlantedOracle::new();
+    let trace = trace_lane::build_trace_observations(&mut oracle, &corpus, &positions)
+        .expect("trace observations");
+    assert_eq!(trace.len(), positions.len());
+    assert_eq!(
+        oracle.calls,
+        last + 1,
+        "no forwards past the last wanted position"
+    );
+    for (obs, &p) in trace.iter().zip(positions.iter()) {
+        assert_eq!(obs.position, p as u32);
+    }
+}
+
+#[test]
+fn dimension_gate_rejects_non_d_oracles() {
+    let corpus = synthetic_corpus();
+    let mut oracle = PlantedOracle {
+        calls: 0,
+        hidden: vec![0f32; 576],
+        dim: 576, // the raw Hugging Face teacher width
+    };
+    let positions: Vec<usize> = (0..4).collect();
+    let error = trace_lane::build_trace_observations(&mut oracle, &corpus, &positions)
+        .expect_err("576-dim oracle is rejected, not truncated");
+    assert!(error.contains("288"), "names the required width: {error}");
+    assert!(error.contains("576"), "names the actual width: {error}");
+}
+
+#[test]
+fn induce_cover_recovers_planted_regions_from_trace_observations() {
+    let corpus = synthetic_corpus();
+    let positions: Vec<usize> = (0..corpus.n).collect();
+    let mut oracle = PlantedOracle::new();
+    let trace = trace_lane::build_trace_observations(&mut oracle, &corpus, &positions)
+        .expect("trace observations");
+    let labels: Vec<usize> = (0..corpus.n).map(|p| COARSE[group_of(p)]).collect();
+    let config = CoverConfig {
+        depths: 3,
+        k0: 4,
+        min_support: 64,
+        entropy_gain_bits: 0.25,
+        ..CoverConfig::default()
+    };
+    let induced = cover::induce_cover(
+        &trace,
+        &config,
+        "blake3:planted-artifact",
+        "blake3:planted-corpus",
+    )
+    .expect("induction succeeds");
+    let cover = &induced.cover;
+
+    // Same planted geometry as tests/cover.rs: 4 depth-1 regions, the G2
+    // region splits into 2 token-pure children, nothing deeper.
+    assert_eq!(cover.regions.len(), 6, "4 depth-1 regions + 2 G2 children");
+    assert_eq!(cover.regions_at_depth(1).len(), 4);
+    assert_eq!(cover.regions_at_depth(2).len(), 2);
+    for group in 0..4 {
+        let group_members: Vec<usize> = (0..trace.len()).filter(|&i| labels[i] == group).collect();
+        let best = cover
+            .regions_at_depth(1)
+            .iter()
+            .map(|&r| {
+                group_members
+                    .iter()
+                    .filter(|i| cover.members[r as usize].contains(i))
+                    .count()
+            })
+            .max()
+            .unwrap();
+        let recall = best as f64 / group_members.len() as f64;
+        assert!(
+            recall >= RECOVERY_RECALL_FLOOR,
+            "planted coarse group {group} recovered from the hidden lane with recall {recall:.3}"
+        );
+    }
+}
+
+// --------------------------------------------------- the comparison ------
+
+/// The shared inputs of both lanes over the synthetic corpus: the bundle
+/// lane from `cover::build_observations`, the hidden lane from the
+/// PlantedOracle replay — everything else identical.
+fn synthetic_lane_inputs() -> (SweepInputs, SweepInputs) {
+    let corpus = synthetic_corpus();
+    let artifacts = synthetic_compiled();
+    let artifact_container = compiler::artifact_bytes(&artifacts);
+    let (train_pos, held_pos) = cover::split_positions(&corpus);
+    let bundle_train = cover::build_observations(&artifacts, &corpus, &train_pos);
+    let bundle_held = cover::build_observations(&artifacts, &corpus, &held_pos);
+    let all_positions: Vec<usize> = (0..corpus.n).collect();
+    let mut oracle = PlantedOracle::new();
+    let trace_all = trace_lane::build_trace_observations(&mut oracle, &corpus, &all_positions)
+        .expect("trace observations");
+    let cut = compiler::train_cut(&corpus);
+    let (trace_train, trace_held): (Vec<Observation>, Vec<Observation>) = trace_all
+        .into_iter()
+        .partition(|o| corpus.story[o.position as usize] < cut);
+    let (store, _) = runtime::build_store(&artifacts, &corpus);
+    let tls1 = runtime::store_bytes(&store);
+    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let corpus_kappa = "blake3:synthetic-corpus".to_owned();
+    let bundle = SweepInputs {
+        artifact_kappa: artifact_kappa.clone(),
+        corpus_kappa: corpus_kappa.clone(),
+        artifact_container: artifact_container.clone(),
+        artifacts: artifacts.clone(),
+        corpus: corpus.clone(),
+        meta_bytes: b"synthetic-meta".to_vec(),
+        recs_bytes: b"synthetic-recs".to_vec(),
+        train: bundle_train,
+        held_out: bundle_held,
+        store: store.clone(),
+        tls1: tls1.clone(),
+    };
+    let trace = SweepInputs {
+        artifact_kappa,
+        corpus_kappa,
+        artifact_container,
+        artifacts,
+        corpus,
+        meta_bytes: b"synthetic-meta".to_vec(),
+        recs_bytes: b"synthetic-recs".to_vec(),
+        train: trace_train,
+        held_out: trace_held,
+        store,
+        tls1,
+    };
+    (bundle, trace)
+}
+
+#[test]
+fn comparison_runs_both_lanes_with_honest_counts() {
+    let (bundle, trace) = synthetic_lane_inputs();
+    let point = trace_lane::compare_point();
+    let report = trace_lane::compare_lanes(
+        &bundle,
+        &trace,
+        &point,
+        &ScoreConfig::default(),
+        "blake3:planted-oracle",
+        trace_lane::SAMPLE_NOTE,
+    )
+    .expect("comparison runs");
+
+    assert_eq!(report.schema, trace_lane::LANE_COMPARE_SCHEMA);
+    assert_eq!(report.lanes.len(), 2);
+    assert_eq!(report.lanes[0].lane, trace_lane::LANE_BUNDLE);
+    assert_eq!(report.lanes[1].lane, trace_lane::LANE_HIDDEN);
+    assert_eq!(report.inputs.train_observations, bundle.train.len());
+    assert_eq!(report.inputs.held_out_observations, bundle.held_out.len());
+    assert_eq!(report.tla3_baseline.positions, bundle.held_out.len());
+    assert_eq!(report.point.config.k0, CoverConfig::default().k0);
+    for lane in &report.lanes {
+        assert!(lane.row.regions.total >= 1);
+        assert!(lane.row.regions.total <= lane.row.config.regions_budget);
+        assert_eq!(lane.row.gate_c_rule12.positions, bundle.held_out.len());
+        assert!((0.0..=1.0).contains(&lane.row.gate_c_rule12.top1_agreement));
+        assert!(lane.row.gate_c_rule12.bits_per_token.is_finite());
+        for d in &lane.row.recall {
+            assert_eq!(d.evaluated, bundle.held_out.len());
+            assert!((0.0..=1.0).contains(&d.reference_top1));
+            assert!((0.0..=1.0).contains(&d.reference_topm));
+        }
+    }
+    // The recorded choice names a lane, quotes the rule, and justifies
+    // itself with the two lanes' numbers.
+    assert!(
+        report.choice.decision == "adopted" || report.choice.decision == "rejected",
+        "decision recorded: {}",
+        report.choice.decision
+    );
+    assert_eq!(report.choice.rule, trace_lane::ADOPTION_RULE);
+    assert!(!report.choice.rationale.is_empty());
+    let bundle_top1 = report.lanes[0].row.gate_c_rule12.top1_agreement;
+    let hidden_top1 = report.lanes[1].row.gate_c_rule12.top1_agreement;
+    assert_eq!(report.choice.delta_rule12_top1, hidden_top1 - bundle_top1);
+    assert_eq!(
+        report.choice.decision == "adopted",
+        hidden_top1 > bundle_top1,
+        "the decision follows the recorded rule"
+    );
+}
+
+#[test]
+fn comparison_double_run_is_byte_identical() {
+    let (bundle, trace) = synthetic_lane_inputs();
+    let point = trace_lane::compare_point();
+    let config = ScoreConfig::default();
+    let report1 = trace_lane::compare_lanes(
+        &bundle,
+        &trace,
+        &point,
+        &config,
+        "blake3:planted-oracle",
+        "s",
+    )
+    .expect("first run");
+    let report2 = trace_lane::compare_lanes(
+        &bundle,
+        &trace,
+        &point,
+        &config,
+        "blake3:planted-oracle",
+        "s",
+    )
+    .expect("second run");
+    let ser1 = serde_json::to_string_pretty(&report1).expect("serializes");
+    let ser2 = serde_json::to_string_pretty(&report2).expect("serializes");
+    assert_eq!(ser1, ser2, "byte-identical lane_compare.json");
+}
+
+#[test]
+fn adoption_rule_edges() {
+    let row = |top1: f64, bits: f64, recall: f64| cover_sweep::SweepRow {
+        label: "x".to_owned(),
+        baseline: false,
+        config: cover_sweep::SweepRowConfig {
+            k0: 8,
+            depths: 3,
+            entropy_gain_bits: 0.25,
+            regions_budget: 256,
+            min_support: 64,
+            memory_budget_bytes: 0,
+        },
+        regions: cover_sweep::SweepRegions {
+            total: 1,
+            per_depth: vec![1],
+            splits: 0,
+            max_depth: 1,
+        },
+        recall: vec![cover_sweep::SweepDepthRecall {
+            depth: 1,
+            evaluated: 10,
+            reference_top1: recall,
+            reference_topm: recall,
+            frontier_mean: 1.0,
+            frontier_max: 1,
+        }],
+        artifact_bytes: 100,
+        graph_kappa: "blake3:x".to_owned(),
+        gate_c_rule12: GateCMetrics {
+            positions: 10,
+            top1_agreement: top1,
+            bits_per_token: bits,
+        },
+    };
+    // Strict gain → adopted.
+    let choice = trace_lane::choose_lane(&row(0.50, 8.0, 0.9), &row(0.51, 8.1, 0.9));
+    assert_eq!(choice.decision, "adopted");
+    assert_eq!(choice.lane, trace_lane::LANE_HIDDEN);
+    // Exact tie → rejected (the rule requires a STRICT gain).
+    let choice = trace_lane::choose_lane(&row(0.50, 8.0, 0.9), &row(0.50, 7.9, 1.0));
+    assert_eq!(choice.decision, "rejected");
+    assert_eq!(choice.lane, trace_lane::LANE_BUNDLE);
+    // Regression → rejected even with better recall and bits/token.
+    let choice = trace_lane::choose_lane(&row(0.50, 8.0, 0.9), &row(0.49, 7.0, 1.0));
+    assert_eq!(choice.decision, "rejected");
+    assert!(choice.rationale.contains("rejection evidence"));
+}
+
+// ------------------------------------------------- fixture end-to-end ----
+
+#[test]
+#[ignore = "release-only fixture workload (150k-position teacher replay)"]
+fn fixture_corpus_lane_compare_end_to_end() {
+    if std::fs::metadata(LEGACY_CHECKPOINT).is_err() {
+        eprintln!("skipping: source checkpoint not found at {LEGACY_CHECKPOINT}");
+        return;
+    }
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let inputs = cover_sweep::load_inputs(
+        std::path::Path::new(&format!("{dir}/tests/fixtures/c_meta.bin")),
+        std::path::Path::new(&format!("{dir}/tests/fixtures/c_recs.bin")),
+        std::path::Path::new(&format!("{dir}/tests/fixtures/tless_artifacts.bin")),
+    )
+    .expect("fixture inputs load");
+    let mut oracle = LlamaOracle::load(LEGACY_CHECKPOINT);
+    let report = trace_lane::run_compare(&inputs, &mut oracle, &ScoreConfig::default())
+        .expect("fixture comparison");
+    print!("{}", trace_lane::render_table(&report));
+
+    assert_eq!(report.lanes.len(), 2);
+    assert_eq!(
+        report.inputs.train_observations + report.inputs.held_out_observations,
+        report.inputs.positions
+    );
+    for lane in &report.lanes {
+        assert!(lane.row.regions.total >= 1);
+        for d in &lane.row.recall {
+            assert!((0.0..=1.0).contains(&d.reference_top1));
+            assert!((0.0..=1.0).contains(&d.reference_topm));
+        }
+        assert!((0.0..=1.0).contains(&lane.row.gate_c_rule12.top1_agreement));
+    }
+    assert!(
+        report.choice.decision == "adopted" || report.choice.decision == "rejected",
+        "decision recorded: {}",
+        report.choice.decision
+    );
+}


### PR DESCRIPTION
## What was built

Issue #71: the `TeacherOracle::hidden_state()` trace surface is wired as a second cover-induction observation lane beside the deterministic context-bundle lane.

- **`crates/uor-r4-core/src/transformerless/trace_lane.rs`** (new, compiler-side only, `#[cfg(not(target_arch = "wasm32"))]` like its neighbors — nothing touches `runtime.rs`; the P-4 machine-checked scan still passes):
  - `build_trace_observations`: replays the corpus through the oracle in story order (`reset` at story boundaries, one `step` per position) and builds `Observation` rows whose `position` / `sample` / `next` are **identical** to `cover::build_observations` (split, entropy gating, recall, and Gate C align 1:1 across lanes). `vector` = L2-normalized final hidden state; `sig` = sign bits vs 0.0 (the `binarize_prototype` convention — for hidden states there is no thresholds centering; sign vs 0.0 IS the centering; documented in the module docs). **Dimension gate**: v1 requires `source_dimension() == compiler::D` (288, the legacy stories15M teacher); other widths (e.g. the raw 576-dim HF teacher) get a plain error — no silent truncation.
  - `compare_lanes` / `run_compare`: runs ONE fixed region-budget point — the confirmed default `k0=8 / entropy-gain 0.25 / budget 256` (the 42-region #70 default) — on **both** lanes through the lane-agnostic `cover_sweep::run_point` (Gate C routes with each lane's own sigs; the bundle-hardcoded `score --cover` CLI is not used). Writes `lane_compare.json` (schema documented in the module docs) with per-lane rows, the shared TLA3 baseline row (labeled inherently bundle-lane), a recorded lane choice with the adoption rule and justifying deltas, and the macOS-pinned libm-sensitive determinism note.
  - `lane-compare` CLI subcommand (registered in `command.rs` dispatch + usage text).
- **`crates/uor-r4-core/tests/trace_lane.rs`** (new): FakeOracle with planted hidden-state geometry (the 5-group 288-dim sphere pattern) — `induce_cover` recovers the planted regions from trace observations (4 depth-1 regions + the G2 split, ≥0.95 per-group recall); 1:1 alignment with the bundle lane asserted; dimension-gate rejection; byte-identical double-run of the comparison report; adoption-rule edge cases; a checkpoint-gated `#[ignore]` fixture end-to-end test (skip-if-absent convention).
- Minimal supporting change: `#[derive(Clone)]` on `compiler::Corpus` and `compiler::Compiled` (the trace lane's `SweepInputs` shares the loaded inputs).

## The measurement (release binary, fixture corpus, 150k positions / 754 stories, 119,964 train / 30,036 held-out)

Command: `cargo run --release --offline --bin r4 -- transformerless lane-compare --corpus-meta crates/uor-r4-core/tests/fixtures/c_meta.bin --corpus-recs crates/uor-r4-core/tests/fixtures/c_recs.bin --artifacts crates/uor-r4-core/tests/fixtures/tless_artifacts.bin --out /tmp/lane-compare-71` (~10 min under CPU contention).

Per-depth reference recall and frontier width (held-out):

| lane | depth | evaluated | ref-top1 | ref-topM | frontier |
|---|---|---|---|---|---|
| bundle | 1 | 30036 | 78.9% | 93.7% | 2.41/3 |
| bundle | 2 | 30036 | 69.8% | 82.8% | 2.39/3 |
| bundle | 3 | 30036 | 58.9% | 72.4% | 2.44/3 |
| hidden | 1 | 30036 | 80.4% | 92.8% | 2.52/3 |
| hidden | 2 | 30036 | 66.9% | 82.8% | 2.64/3 |
| hidden | 3 | 30036 | 60.5% | 76.2% | 2.54/3 |

Gate C (held-out, Rule 1+2 precedence):

| lane | regions | bytes | R1+2 top1 | bits/token |
|---|---|---|---|---|
| bundle | 42 | 10,867,179 | 31.7% | 9.8612 |
| hidden | 42 | 10,868,395 | **2.8%** | **16.3302** |
| tla3 (shared baseline, bundle-lane class codes) | - | - | 31.7% | 11.8781 |

## Recorded lane choice: **rejected — no gain**

Rule (recorded in `lane_compare.json`): adopt the hidden lane iff its Gate C Rule 1+2 top-1 agreement strictly exceeds the bundle lane's at the same fixed point. The hidden lane's region *geometry* is comparable (deepest-depth reference top-1 +1.6 pts), but its Gate C distortion collapses (top-1 2.8% vs 31.7%, Δ −28.9 pts; bits/token +6.47) — the hidden-state sign codes route the scored graph far worse than the bundle codes. The comparison table above is the rejection evidence.

## Acceptance boxes

- [x] Cover induction runs end-to-end over final hidden states for a fixed observation sample (full pinned fixture corpus, both lanes, same sample).
- [x] Per-lane reference recall and Gate C numbers compared in one table (console table + `lane_compare.json`).
- [ ] Quantized i8 spill for hidden-state vectors — **intentionally unticked**: the lane was rejected by the measurement, so no spill is built (per the issue: "If rejected: the comparison table showing no gain is attached").
- [x] Rejection: the comparison table showing no gain is attached (above, and recorded in the report JSON).

## Gates (all run in the worktree)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` — clean
- `cargo nextest run --workspace -E 'not binary(bdd)'` — 289 passed, 11 skipped
- `cargo test --test bdd` — 13 scenarios passed
- `cargo test --doc --workspace` — clean

Determinism note: same-machine double runs are byte-identical (asserted synthetically in `tests/trace_lane.rs`); the f32 hidden states are macOS-pinned / libm-sensitive cross-platform — the inherited status of the κ baseline (D2 resolves cross-platform byte equality later).
