### PR TITLE
HF-path (SmolLM2) full Gate C on the D3 distribution (issue #75)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -175,10 +175,16 @@ pub fn observe_command(args: &[String]) -> Result<(), String> {
         token_byte_lengths.as_deref(),
     )?;
     if summary.done {
+        // Persist the merged record stream so Gate C can consume it as
+        // --corpus-recs with state.bin as --corpus-meta (same convention
+        // as the from-text driver, issue #75).
+        let merged = observe::merge_shards(&options.output).map_err(|error| error.to_string())?;
+        let merged_path = options.output.join("merged.bin");
+        std::fs::write(&merged_path, &merged).map_err(|error| error.to_string())?;
         println!(
             "observe complete: {} records at {}",
             summary.records,
-            options.output.display()
+            merged_path.display()
         );
     } else {
         println!(

--- a/crates/uor-r4-core/src/transformerless/observe_text.rs
+++ b/crates/uor-r4-core/src/transformerless/observe_text.rs
@@ -834,6 +834,28 @@ mod tests {
         assert_eq!(tokens, tokenizer.encode("abcd"));
     }
 
+    #[test]
+    fn encode_byte_fallback_cannot_overflow_char_sized_buffer() {
+        // Byte-level tokenizer (the HF path): a multi-byte character
+        // decomposes into one token per byte, so a char-sized buffer
+        // overflows — BOS + space + 4 byte tokens = 6 > 2 chars + 2
+        // (issue #75). The buffer is sized by bytes.
+        let pieces: [&[u8]; 6] = [b"<unk>", b"<s>", b"</s>", b" ", &[0xC6], &[0x86]];
+        let path = unique_path("tokenizer-bytes.bin");
+        let mut bytes = Vec::new();
+        for piece in pieces {
+            bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+            bytes.extend_from_slice(piece);
+        }
+        fs::write(&path, bytes).expect("write tokenizer fixture");
+        let tokenizer = Tokenizer::try_load(&path).expect("load tokenizer fixture");
+        let _ = fs::remove_file(&path);
+        // 'Ɔ' = U+0186 = bytes 0xC6 0x86; two of them decompose to four
+        // byte tokens (no merge pieces here to recombine them).
+        let tokens = tokenizer.encode("ƆƆ");
+        assert_eq!(tokens.len(), 6);
+    }
+
     /// Deterministic few-token oracle: logits depend only on (token, pos),
     /// so teacher-forced records are content-stable across restarts.
     struct FakeOracle;

--- a/docs/transformerless/BASELINE.md
+++ b/docs/transformerless/BASELINE.md
@@ -146,6 +146,22 @@ residuals transfer poorly while exact-context store coverage stays total (ExactC
 both partitions — the Rule 1+2 rows are entirely EXCT-driven, hence argmax-identical to the
 baseline).
 
+**Full-corpus confirmation (issue #75, 2026-07-23).** The first pass above scored a 400-article
+prefix slice of the natural partition; the declared natural partition is the full sealed corpus
+(3000 articles, #72). Re-run at n=3000 (361,232 records, 72,131 held-out by the same §2 rule;
+observation merged κ `blake3:a646421d…`, teacher-forced at sequence length 128 with 2545/3000
+articles truncated): Rule 1+2 **28.1% / 11.3565** vs TLA3 baseline **28.1% / 11.2481**
+(argmax-identical, ExactContext 100%; scored artifact κ `blake3:3c99b707…`). The larger corpus
+shifts the target-2 natural verdict: the baseline's bits/token improves from 18.76 (n=400) to
+11.25 (n=3000) as exact-context coverage grows, while the graph's bits stay ~flat — so on the
+full declared corpus the natural row reads **target 1: stretch FAIL / floor PASS (equal)**,
+**target 2: FAIL** (11.3565 > 11.2481 − 0.3 threshold would need ≤ 10.95). The slice verdicts
+above are retained as the n=400 record; the n=3000 rows are the declared-corpus measurement.
+Continuity corroboration: an independently regenerated 150,000-record SmolLM2 continuity corpus
+(same recipe as the declared 200k one) scored Rule 1+2 4.7% / 15.37 vs baseline 4.7% / 18.11 —
+same shape as the declared-corpus row (floor PASS, target-2 PASS), lower absolute agreement,
+i.e. generation-stream sensitive. §4.1 carries the consolidated target table.
+
 ### 3.2 Artifact sizes (fresh, 2026-07-21, `.uor-models/compiled/smollm2-135m-instruct/`)
 
 | File | Bytes | Note |
@@ -210,6 +226,26 @@ Pass conditions for the Phase-5 minimum viable graph, all on the declared distri
 6. Novel/Contradictory fallback rate measured and reported; on-distribution rate < 20%.
 
 Missing target 1–2 or 4 ⇒ stop or redesign. Missing 3/5/6 ⇒ redesign discussion.
+
+### 4.1 Measured values (2026-07-23, issue #75)
+
+Cover + score + Gate C for the SmolLM2-135M compile on both D3 partitions; per-partition
+4-way tables and run details in §3.1 (declared corpora; natural at the full sealed n=3000)
+and issue #75.
+
+| target | continuity (declared 200k corpus) | natural (full sealed corpus, n=3000) | verdict |
+|---|---|---|---|
+| 1. agreement ≥ baseline + 5pts | 14.76% vs 14.76% (+0.0) | 28.1% vs 28.1% (+0.0) | stretch **FAIL** both; floor ("not worse") **PASS** both (argmax-identical prediction sets) |
+| 2. bits/token ≤ baseline − 0.3 | 14.62 ≤ 20.33 (−6.01) | 11.3565 > 10.9481 (+0.11 over baseline) | **PASS** continuity, **FAIL** natural |
+
+Structural caveat, material to the verdict: on both partitions every held-out prediction
+resolved via exact context (ExactContext 100%, Graph 0, Novel 0), so rows 1–2 currently
+compare EXCT-table scoring against the store baseline, not graph generalization. The
+natural target-2 verdict is corpus-size sensitive (PASS at the n=400 slice, FAIL at the
+declared n=3000) because exact-context coverage improves the baseline faster than the
+graph with more data. Until an EXCT-free evaluation exists, the stop-or-redesign signal
+from missing targets 1–2 should be read as "the current judge measures exact-context
+memory" — the Phase-5 review decision input is here and in issue #75.
 
 ## 5. Threat-model note (backlog #22)
 


### PR DESCRIPTION
## What

Runs cover + score + Gate C for the SmolLM2-135M compile on both D3 partitions (teacher-generated continuity + Simple Wiki natural) and fills the M.V.G. target rows 1–2 in `docs/transformerless/BASELINE.md` §4 with measured values and plain pass/fail verdicts.

So far: fixes `Tokenizer::encode` buffer sizing (byte-level tokenizers decompose multi-byte chars into up to 4 tokens; the char-sized buffer panicked on the Simple Wiki corpus via the SmolLM2 tokenizer).

## Status

- [x] encode buffer fix + regression test
- [ ] HF natural-partition observation (3000 articles, in progress)
- [ ] SmolLM2 continuity corpus generation (150k target)
- [ ] score_report.json per partition posted to #75
- [ ] BASELINE.md §4 rows 1–2 measured with verdicts
- [ ] fixture-vs-D3 gap analysis

Do not enqueue until the measurement is in.