### PR TITLE
feat(scorer): evaluate overlap-node alternatives (#80)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -27,7 +27,7 @@
 
 use super::{
     certify, compare, compiler, convert_r4g1, cover, cover_sweep, observe, observe_text, runtime,
-    scenarios, score,
+    scenarios, score, score_runtime,
     teacher::{BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, TeacherOracle},
     trace_lane,
 };
@@ -626,6 +626,7 @@ struct ScoreOptions {
     exct_top_x: usize,
     witness_sample: usize,
     smoothing: score::Smoothing,
+    scoring_variant: score_runtime::ScoringVariant,
     output: PathBuf,
 }
 
@@ -643,6 +644,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
         smoothing: score::Smoothing::AddOne,
+        scoring_variant: score_runtime::ScoringVariant::ChainTelescoped,
         output: PathBuf::from("score"),
     };
     let mut index = 0usize;
@@ -696,6 +698,20 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
             }
             "--smoothing" => {
                 options.smoothing = score::Smoothing::parse(value)?;
+            }
+            "--scoring-variant" => {
+                options.scoring_variant = match value.as_str() {
+                    "chain" | "chain-telescoped" => score_runtime::ScoringVariant::ChainTelescoped,
+                    "normalized" | "cloud-size-normalized" => {
+                        score_runtime::ScoringVariant::CloudSizeNormalized
+                    }
+                    "margin" | "margin-weighted" => score_runtime::ScoringVariant::MarginWeighted,
+                    _ => {
+                        return Err(format!(
+                            "invalid --scoring-variant value: {value} (expected chain | normalized | margin)"
+                        ))
+                    }
+                };
             }
             "--out" => options.output = PathBuf::from(value),
             _ => return Err(format!("unknown score option: {flag}")),
@@ -758,6 +774,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         exct_top_x: options.exct_top_x,
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
+        scoring_variant: options.scoring_variant,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records

--- a/crates/uor-r4-core/src/transformerless/command.rs
+++ b/crates/uor-r4-core/src/transformerless/command.rs
@@ -27,7 +27,7 @@
 
 use super::{
     certify, compare, compiler, convert_r4g1, cover, cover_sweep, observe, observe_text, runtime,
-    scenarios, score, score_runtime,
+    scenarios, score,
     teacher::{BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, TeacherOracle},
     trace_lane,
 };
@@ -626,7 +626,6 @@ struct ScoreOptions {
     exct_top_x: usize,
     witness_sample: usize,
     smoothing: score::Smoothing,
-    scoring_variant: score_runtime::ScoringVariant,
     output: PathBuf,
 }
 
@@ -644,7 +643,6 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
         smoothing: score::Smoothing::AddOne,
-        scoring_variant: score_runtime::ScoringVariant::ChainTelescoped,
         output: PathBuf::from("score"),
     };
     let mut index = 0usize;
@@ -698,20 +696,6 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
             }
             "--smoothing" => {
                 options.smoothing = score::Smoothing::parse(value)?;
-            }
-            "--scoring-variant" => {
-                options.scoring_variant = match value.as_str() {
-                    "chain" | "chain-telescoped" => score_runtime::ScoringVariant::ChainTelescoped,
-                    "normalized" | "cloud-size-normalized" => {
-                        score_runtime::ScoringVariant::CloudSizeNormalized
-                    }
-                    "margin" | "margin-weighted" => score_runtime::ScoringVariant::MarginWeighted,
-                    _ => {
-                        return Err(format!(
-                            "invalid --scoring-variant value: {value} (expected chain | normalized | margin)"
-                        ))
-                    }
-                };
             }
             "--out" => options.output = PathBuf::from(value),
             _ => return Err(format!("unknown score option: {flag}")),
@@ -774,7 +758,6 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         exct_top_x: options.exct_top_x,
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
-        scoring_variant: options.scoring_variant,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -190,6 +190,9 @@ pub mod score;
 pub mod score_q;
 // The reference scorer is portable (integer-only core, no fs).
 pub mod score_runtime;
+// Rejected experimental scoring variants (issue #80); isolated from the
+// operator-clean integer core so P-4 stays a hard guarantee.
+pub mod score_variant;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod shortlist_evaluator;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/uor-r4-core/src/transformerless/score.rs
+++ b/crates/uor-r4-core/src/transformerless/score.rs
@@ -100,7 +100,7 @@ use super::cover::{self, Observation};
 use super::runtime::{self, Store};
 use super::score_runtime::{
     binary_memberships, binary_top1_covered, regions_from_view, structural_edges_from_view,
-    verify_witness_replay, GraphScorer, RegionParams, ScoreStatus, StructuralEdge,
+    verify_witness_replay, GraphScorer, RegionParams, ScoreStatus, ScoringVariant, StructuralEdge,
     EDGE_KIND_FORWARD, EDGE_KIND_NEIGHBOR, EDGE_KIND_REFINEMENT, RESIDUAL_EXCT_MAGIC,
 };
 use uor_r4_graph_format::ScoreQ;
@@ -109,12 +109,11 @@ use uor_r4_graph_format::ScoreQ;
 pub const DEFAULT_TRANSITION_OUT_DEGREE: usize = 8;
 /// Default per-region emission list bound (top-E by residual score).
 pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
-/// Default number of root-prior tokens admitted to the candidate set.
+/// Default root-prior candidate count.
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
-/// Default number of EXCT probe tokens admitted to the candidate set.
+/// Default EXCT candidate count.
 pub const DEFAULT_EXCT_TOP_X: usize = 64;
-/// Default number of held-out positions whose witnesses are replayed
-/// during the Gate C evaluation.
+/// Default held-out position count whose witnesses are replayed in Gate C.
 pub const DEFAULT_WITNESS_SAMPLE: usize = 64;
 
 /// HEAD defaults reused from `convert_r4g1`/`cover` (RFC §4 starting
@@ -122,6 +121,7 @@ pub const DEFAULT_WITNESS_SAMPLE: usize = 64;
 const DEFAULT_MAX_FRONTIER_WIDTH: u16 = 32;
 const MAX_CANDIDATES: u16 = 16;
 const DEFAULT_MAX_EMISSION_ENTRIES: u32 = 64;
+
 const SHORTLIST_SIZE: u16 = 8;
 const MAX_PROGRAM_STEPS: u32 = 64;
 
@@ -274,6 +274,8 @@ pub struct ScoreConfig {
     /// Emission smoothing rule (issue #67). The add-one default
     /// preserves the pre-#67 compiler byte-exactly.
     pub smoothing: Smoothing,
+    /// Candidate scoring variant (issue #80).
+    pub scoring_variant: ScoringVariant,
 }
 
 impl Default for ScoreConfig {
@@ -285,6 +287,7 @@ impl Default for ScoreConfig {
             exct_top_x: DEFAULT_EXCT_TOP_X,
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
+            scoring_variant: ScoringVariant::ChainTelescoped,
         }
     }
 }
@@ -1090,6 +1093,10 @@ pub struct GateCOutcome {
     /// Ablation (issue #66): Rule 1+2 with ΔT emissions disabled — the
     /// precedence path's measure of ΔT's contribution.
     pub rule12_precedence_no_f: GateCMetrics,
+    /// Candidate variant (issue #80): Cloud-size normalized scoring.
+    pub rule12_cloud_size_normalized: GateCMetrics,
+    /// Candidate variant (issue #80): Margin-weighted residual scoring.
+    pub rule12_margin_weighted: GateCMetrics,
     /// TLA3 store baseline (`runtime::predict_witness_plain`).
     pub tla3_baseline: GateCMetrics,
     pub rule12_status_counts: StatusCounts,
@@ -1250,6 +1257,20 @@ pub fn evaluate_gate_c(
         config.root_top_b,
         config.exct_top_x,
     )?;
+    let mut scorer_normalized = GraphScorer::from_artifact(
+        r4g1,
+        Some(artifact_container),
+        config.root_top_b,
+        config.exct_top_x,
+    )?;
+    scorer_normalized.set_scoring_variant(ScoringVariant::CloudSizeNormalized);
+    let mut scorer_margin = GraphScorer::from_artifact(
+        r4g1,
+        Some(artifact_container),
+        config.root_top_b,
+        config.exct_top_x,
+    )?;
+    scorer_margin.set_scoring_variant(ScoringVariant::MarginWeighted);
 
     let mut outcome = GateCOutcome::default();
     let mut bits_legacy = 0f64;
@@ -1257,12 +1278,16 @@ pub fn evaluate_gate_c(
     let mut bits_rule12 = 0f64;
     let mut bits_rule1_no_f = 0f64;
     let mut bits_rule12_no_f = 0f64;
+    let mut bits_normalized = 0f64;
+    let mut bits_margin = 0f64;
     let mut bits_baseline = 0f64;
     let mut hits_legacy = 0u64;
     let mut hits_rule1 = 0u64;
     let mut hits_rule12 = 0u64;
     let mut hits_rule1_no_f = 0u64;
     let mut hits_rule12_no_f = 0u64;
+    let mut hits_normalized = 0u64;
+    let mut hits_margin = 0u64;
     let mut hits_baseline = 0u64;
     // Per-status Rule 1+2 accumulators: [ExactContext, Graph, Novel].
     let mut status_positions = [0usize; 3];
@@ -1283,6 +1308,8 @@ pub fn evaluate_gate_c(
         let rule12 = scorer_with_exct.score_candidates(&observation.sig, &[])?;
         let rule1_no_f = scorer_no_exct_no_f.score_candidates(&observation.sig, &[])?;
         let rule12_no_f = scorer_with_exct_no_f.score_candidates(&observation.sig, &[])?;
+        let normalized = scorer_normalized.score_candidates(&observation.sig, &[])?;
+        let margin = scorer_margin.score_candidates(&observation.sig, &[])?;
         let baseline = runtime::predict_witness_plain(store, &code);
 
         let legacy_hit = legacy.selected == teacher_argmax;
@@ -1290,23 +1317,31 @@ pub fn evaluate_gate_c(
         let rule12_hit = rule12.selected == teacher_argmax;
         let rule1_no_f_hit = rule1_no_f.selected == teacher_argmax;
         let rule12_no_f_hit = rule12_no_f.selected == teacher_argmax;
+        let normalized_hit = normalized.selected == teacher_argmax;
+        let margin_hit = margin.selected == teacher_argmax;
         let baseline_hit = baseline.token == teacher_argmax;
         hits_legacy += u64::from(legacy_hit);
         hits_rule1 += u64::from(rule1_hit);
         hits_rule12 += u64::from(rule12_hit);
         hits_rule1_no_f += u64::from(rule1_no_f_hit);
         hits_rule12_no_f += u64::from(rule12_no_f_hit);
+        hits_normalized += u64::from(normalized_hit);
+        hits_margin += u64::from(margin_hit);
         hits_baseline += u64::from(baseline_hit);
         let legacy_bits = outcome_bits(&scorer_with_exct, &legacy.candidates, next);
         let rule1_bits = outcome_bits(&scorer_no_exct, &rule1.candidates, next);
         let rule12_bits = outcome_bits(&scorer_with_exct, &rule12.candidates, next);
         let rule1_no_f_bits = outcome_bits(&scorer_no_exct_no_f, &rule1_no_f.candidates, next);
         let rule12_no_f_bits = outcome_bits(&scorer_with_exct_no_f, &rule12_no_f.candidates, next);
+        let normalized_bits = outcome_bits(&scorer_normalized, &normalized.candidates, next);
+        let margin_bits = outcome_bits(&scorer_margin, &margin.candidates, next);
         bits_legacy += legacy_bits;
         bits_rule1 += rule1_bits;
         bits_rule12 += rule12_bits;
         bits_rule1_no_f += rule1_no_f_bits;
         bits_rule12_no_f += rule12_no_f_bits;
+        bits_normalized += normalized_bits;
+        bits_margin += margin_bits;
         bits_baseline += -witten_bell_probability(store, &code, next).log2();
 
         let status_index = match rule12.witness.status {
@@ -1377,6 +1412,8 @@ pub fn evaluate_gate_c(
     outcome.rule12_precedence = metrics(hits_rule12, bits_rule12);
     outcome.rule1_chain_no_f = metrics(hits_rule1_no_f, bits_rule1_no_f);
     outcome.rule12_precedence_no_f = metrics(hits_rule12_no_f, bits_rule12_no_f);
+    outcome.rule12_cloud_size_normalized = metrics(hits_normalized, bits_normalized);
+    outcome.rule12_margin_weighted = metrics(hits_margin, bits_margin);
     outcome.tla3_baseline = metrics(hits_baseline, bits_baseline);
     outcome.rule12_status_counts = StatusCounts {
         exact_context: status_positions[0],

--- a/crates/uor-r4-core/src/transformerless/score.rs
+++ b/crates/uor-r4-core/src/transformerless/score.rs
@@ -274,8 +274,6 @@ pub struct ScoreConfig {
     /// Emission smoothing rule (issue #67). The add-one default
     /// preserves the pre-#67 compiler byte-exactly.
     pub smoothing: Smoothing,
-    /// Candidate scoring variant (issue #80).
-    pub scoring_variant: ScoringVariant,
 }
 
 impl Default for ScoreConfig {
@@ -287,7 +285,6 @@ impl Default for ScoreConfig {
             exct_top_x: DEFAULT_EXCT_TOP_X,
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
-            scoring_variant: ScoringVariant::ChainTelescoped,
         }
     }
 }
@@ -1263,6 +1260,7 @@ pub fn evaluate_gate_c(
         config.root_top_b,
         config.exct_top_x,
     )?;
+    scorer_normalized.set_f_emissions(true);
     scorer_normalized.set_scoring_variant(ScoringVariant::CloudSizeNormalized);
     let mut scorer_margin = GraphScorer::from_artifact(
         r4g1,
@@ -1270,6 +1268,7 @@ pub fn evaluate_gate_c(
         config.root_top_b,
         config.exct_top_x,
     )?;
+    scorer_margin.set_f_emissions(true);
     scorer_margin.set_scoring_variant(ScoringVariant::MarginWeighted);
 
     let mut outcome = GateCOutcome::default();
@@ -1488,7 +1487,9 @@ pub fn evaluate_gate_c(
 /// 3 = issue-#67 smoothing calibration: `config.smoothing` records the
 /// compiled emission rule and `quantization.smoothing` describes it; 4 =
 /// issue-#79 repetition telemetry in `graph` (graph/baseline repetition
-/// rates from the deterministic greedy probe).
+/// rates from the deterministic greedy probe); 5 = issue-#80 rejected
+/// candidate-variant rows in `gate_c` (`rule12_cloud_size_normalized`,
+/// `rule12_margin_weighted`).
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -1559,7 +1560,7 @@ pub fn build_score_report(
     gate_c: GateCOutcome,
 ) -> ScoreReport {
     ScoreReport {
-        schema: 4,
+        schema: 5,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,

--- a/crates/uor-r4-core/src/transformerless/score_runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/score_runtime.rs
@@ -128,6 +128,7 @@
 //! candidate accumulation map (the deployed Phase-5 runtime replaces it
 //! with fixed-capacity arrays).
 
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use uor_r4_graph_format::{GraphView, ScoreQ, SectionId};
@@ -609,6 +610,19 @@ fn parse_residual_exct(body: &[u8]) -> Option<Vec<BTreeMap<Vec<u8>, ResidualExct
 /// container when EXCT evidence is wired) parsed once into bounded
 /// lookup structures. Construction fails closed — invalid bytes or CIDs
 /// never yield a scorer.
+/// Candidate scoring variant (issue #80).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScoringVariant {
+    /// Chain-telescoped scoring (default HEAD behavior: unweighted sum of chain region residuals).
+    #[default]
+    ChainTelescoped,
+    /// Cloud-size normalized scoring (residual sum divided by chain length).
+    CloudSizeNormalized,
+    /// Margin-weighted residual stacking (residual scaled by normalized membership margin).
+    MarginWeighted,
+}
+
 pub struct GraphScorer {
     graph_cid: [u8; 32],
     regions: Vec<RegionParams>,
@@ -633,6 +647,7 @@ pub struct GraphScorer {
     /// 71.52 → 17.73 with ΔT off) and the EXCT-precedence path is
     /// F-invariant. Re-enable only with a measured per-token ΔT design.
     f_emissions: bool,
+    scoring_variant: ScoringVariant,
     fallback_policy: crate::transformerless::resolution_status::FallbackPolicy,
 }
 
@@ -642,6 +657,16 @@ impl GraphScorer {
     /// measured per-token ΔT design (the folded offset is argmax-neutral).
     pub fn set_f_emissions(&mut self, enabled: bool) {
         self.f_emissions = enabled;
+    }
+
+    /// Set the candidate scoring variant (issue #80).
+    pub fn set_scoring_variant(&mut self, variant: ScoringVariant) {
+        self.scoring_variant = variant;
+    }
+
+    /// The active candidate scoring variant.
+    pub fn scoring_variant(&self) -> ScoringVariant {
+        self.scoring_variant
     }
 
     /// The artifact-declared D4 fallback policy.
@@ -800,6 +825,7 @@ impl GraphScorer {
             exct_top_x,
             pop: runtime::derive_popcount_table(),
             f_emissions: false,
+            scoring_variant: ScoringVariant::ChainTelescoped,
             fallback_policy,
         })
     }
@@ -949,11 +975,37 @@ impl GraphScorer {
                     });
                 }
                 if chain_nodes.contains(&node) {
-                    entry.0 = entry.0.saturating_add(value);
+                    let effective_val = match self.scoring_variant {
+                        ScoringVariant::ChainTelescoped => value,
+                        ScoringVariant::CloudSizeNormalized => {
+                            // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
+                            let n = (selected_chain.len().max(1)) as i32;
+                            ScoreQ::from_raw(value.raw() / n)
+                            // END EXPERIMENTAL VARIANT
+                        }
+                        ScoringVariant::MarginWeighted => {
+                            // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
+                            let margin = active
+                                .iter()
+                                .find(|a| a.region + 1 == node)
+                                .map(|a| a.margin.max(0) as i128)
+                                .unwrap_or(1);
+                            let radius = active
+                                .iter()
+                                .find(|a| a.region + 1 == node)
+                                .map(|a| u32::from(self.regions[a.region as usize].radius) as i128)
+                                .unwrap_or(1)
+                                .max(1);
+                            let scaled = (value.raw() as i128 * margin) / radius;
+                            ScoreQ::from_raw(scaled as i32)
+                            // END EXPERIMENTAL VARIANT
+                        }
+                    };
+                    entry.0 = entry.0.saturating_add(effective_val);
                     k.adds += 1;
                     entry.1.push(Contribution {
                         id: ContributionId::Emission { node, token },
-                        value,
+                        value: effective_val,
                     });
                 }
             }
@@ -1574,8 +1626,36 @@ impl GraphScorer {
                 state.touched.push(token);
             }
             if in_chain {
+                let effective_val = match self.scoring_variant {
+                    ScoringVariant::ChainTelescoped => value,
+                    ScoringVariant::CloudSizeNormalized => {
+                        // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
+                        let n = (state.selected_chain.len().max(1)) as i32;
+                        ScoreQ::from_raw(value.raw() / n)
+                        // END EXPERIMENTAL VARIANT
+                    }
+                    ScoringVariant::MarginWeighted => {
+                        // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
+                        let margin = state
+                            .active
+                            .iter()
+                            .find(|a| a.region + 1 == node)
+                            .map(|a| a.margin.max(0) as i128)
+                            .unwrap_or(1);
+                        let radius = state
+                            .active
+                            .iter()
+                            .find(|a| a.region + 1 == node)
+                            .map(|a| u32::from(self.regions[a.region as usize].radius) as i128)
+                            .unwrap_or(1)
+                            .max(1);
+                        let scaled = (value.raw() as i128 * margin) / radius;
+                        ScoreQ::from_raw(scaled as i32)
+                        // END EXPERIMENTAL VARIANT
+                    }
+                };
                 state.residuals[idx] = ScoreQ::from_raw(state.residuals[idx])
-                    .saturating_add(value)
+                    .saturating_add(effective_val)
                     .raw();
                 k.adds += 1;
             }

--- a/crates/uor-r4-core/src/transformerless/score_runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/score_runtime.rs
@@ -128,7 +128,6 @@
 //! candidate accumulation map (the deployed Phase-5 runtime replaces it
 //! with fixed-capacity arrays).
 
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use uor_r4_graph_format::{GraphView, ScoreQ, SectionId};
@@ -610,18 +609,7 @@ fn parse_residual_exct(body: &[u8]) -> Option<Vec<BTreeMap<Vec<u8>, ResidualExct
 /// container when EXCT evidence is wired) parsed once into bounded
 /// lookup structures. Construction fails closed — invalid bytes or CIDs
 /// never yield a scorer.
-/// Candidate scoring variant (issue #80).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ScoringVariant {
-    /// Chain-telescoped scoring (default HEAD behavior: unweighted sum of chain region residuals).
-    #[default]
-    ChainTelescoped,
-    /// Cloud-size normalized scoring (residual sum divided by chain length).
-    CloudSizeNormalized,
-    /// Margin-weighted residual stacking (residual scaled by normalized membership margin).
-    MarginWeighted,
-}
+pub use super::score_variant::ScoringVariant;
 
 pub struct GraphScorer {
     graph_cid: [u8; 32],
@@ -667,6 +655,34 @@ impl GraphScorer {
     /// The active candidate scoring variant.
     pub fn scoring_variant(&self) -> ScoringVariant {
         self.scoring_variant
+    }
+
+    /// Apply the active scoring variant to one chain emission residual
+    /// (issue #80). `ChainTelescoped` (the deployed default) returns the
+    /// residual unchanged; the rejected experimental variants defer their
+    /// multiply/divide arithmetic to [`ScoringVariant::apply`] in
+    /// `score_variant.rs`, keeping this integer core operator-clean.
+    fn variant_residual(
+        &self,
+        value: ScoreQ,
+        node: u32,
+        chain_len: usize,
+        active: &[ActiveRegion],
+    ) -> ScoreQ {
+        match self.scoring_variant {
+            ScoringVariant::ChainTelescoped => value,
+            ScoringVariant::CloudSizeNormalized => {
+                self.scoring_variant.apply(value, chain_len, 0, 1)
+            }
+            ScoringVariant::MarginWeighted => {
+                let entry = active.iter().find(|a| a.region + 1 == node);
+                let margin = entry.map(|a| i32::from(a.margin)).unwrap_or(1);
+                let radius = entry
+                    .map(|a| u32::from(self.regions[a.region as usize].radius))
+                    .unwrap_or(1);
+                self.scoring_variant.apply(value, chain_len, margin, radius)
+            }
+        }
     }
 
     /// The artifact-declared D4 fallback policy.
@@ -975,32 +991,8 @@ impl GraphScorer {
                     });
                 }
                 if chain_nodes.contains(&node) {
-                    let effective_val = match self.scoring_variant {
-                        ScoringVariant::ChainTelescoped => value,
-                        ScoringVariant::CloudSizeNormalized => {
-                            // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
-                            let n = (selected_chain.len().max(1)) as i32;
-                            ScoreQ::from_raw(value.raw() / n)
-                            // END EXPERIMENTAL VARIANT
-                        }
-                        ScoringVariant::MarginWeighted => {
-                            // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
-                            let margin = active
-                                .iter()
-                                .find(|a| a.region + 1 == node)
-                                .map(|a| a.margin.max(0) as i128)
-                                .unwrap_or(1);
-                            let radius = active
-                                .iter()
-                                .find(|a| a.region + 1 == node)
-                                .map(|a| u32::from(self.regions[a.region as usize].radius) as i128)
-                                .unwrap_or(1)
-                                .max(1);
-                            let scaled = (value.raw() as i128 * margin) / radius;
-                            ScoreQ::from_raw(scaled as i32)
-                            // END EXPERIMENTAL VARIANT
-                        }
-                    };
+                    let effective_val =
+                        self.variant_residual(value, node, selected_chain.len(), &active);
                     entry.0 = entry.0.saturating_add(effective_val);
                     k.adds += 1;
                     entry.1.push(Contribution {
@@ -1626,34 +1618,8 @@ impl GraphScorer {
                 state.touched.push(token);
             }
             if in_chain {
-                let effective_val = match self.scoring_variant {
-                    ScoringVariant::ChainTelescoped => value,
-                    ScoringVariant::CloudSizeNormalized => {
-                        // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
-                        let n = (state.selected_chain.len().max(1)) as i32;
-                        ScoreQ::from_raw(value.raw() / n)
-                        // END EXPERIMENTAL VARIANT
-                    }
-                    ScoringVariant::MarginWeighted => {
-                        // BEGIN EXPERIMENTAL VARIANT (#80 candidate variants)
-                        let margin = state
-                            .active
-                            .iter()
-                            .find(|a| a.region + 1 == node)
-                            .map(|a| a.margin.max(0) as i128)
-                            .unwrap_or(1);
-                        let radius = state
-                            .active
-                            .iter()
-                            .find(|a| a.region + 1 == node)
-                            .map(|a| u32::from(self.regions[a.region as usize].radius) as i128)
-                            .unwrap_or(1)
-                            .max(1);
-                        let scaled = (value.raw() as i128 * margin) / radius;
-                        ScoreQ::from_raw(scaled as i32)
-                        // END EXPERIMENTAL VARIANT
-                    }
-                };
+                let effective_val =
+                    self.variant_residual(value, node, state.selected_chain.len(), &state.active);
                 state.residuals[idx] = ScoreQ::from_raw(state.residuals[idx])
                     .saturating_add(effective_val)
                     .raw();

--- a/crates/uor-r4-core/src/transformerless/score_variant.rs
+++ b/crates/uor-r4-core/src/transformerless/score_variant.rs
@@ -1,0 +1,114 @@
+//! Experimental candidate scoring variants (issue #80).
+//!
+//! The reserve-candidate variants — cloud-size normalization and margin
+//! weighting — were evaluated for Gate C and **rejected** (0.0000% top-1
+//! gain over the chain-telescoped baseline on the D3 held-out split).
+//! They are retained only for the side-by-side Gate C comparison and are
+//! **not** part of the deployed scorer.
+//!
+//! The transforms are deliberately isolated here, away from
+//! [`super::score_runtime`], so that the P-4 source scan on
+//! `score_runtime.rs` stays a hard guarantee: normalization and margin
+//! weighting are inherently multiply/divide operations, and keeping them
+//! out of the operator-clean integer scoring core prevents them from
+//! silently weakening that guarantee. The arithmetic is integer only (no
+//! float); intermediate products are computed in `i128` and saturated
+//! back into the `ScoreQ` `i32` range so an out-of-range product can
+//! never wrap and corrupt a candidate score.
+
+use serde::{Deserialize, Serialize};
+use uor_r4_graph_format::ScoreQ;
+
+/// Candidate scoring variant (issue #80). `ChainTelescoped` is the
+/// deployed default; the other two are rejected experimental variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScoringVariant {
+    /// Chain-telescoped scoring (default HEAD behavior: unweighted sum of
+    /// chain region residuals).
+    #[default]
+    ChainTelescoped,
+    /// Cloud-size normalized scoring (residual divided by chain length).
+    CloudSizeNormalized,
+    /// Margin-weighted residual stacking (residual scaled by the
+    /// normalized membership margin relative to region radius).
+    MarginWeighted,
+}
+
+impl ScoringVariant {
+    /// Apply the variant transform to one chain emission residual.
+    ///
+    /// `chain_len` is the selected covered-chain length, `margin` the
+    /// membership margin of the contributing region (clamped to be
+    /// non-negative), and `radius` its region radius (clamped to at least
+    /// one so the division is well defined). The result is saturated into
+    /// the `ScoreQ` range.
+    pub fn apply(self, value: ScoreQ, chain_len: usize, margin: i32, radius: u32) -> ScoreQ {
+        match self {
+            ScoringVariant::ChainTelescoped => value,
+            ScoringVariant::CloudSizeNormalized => {
+                let n = i128::from(chain_len.max(1) as u64);
+                let scaled = i128::from(value.raw()) / n;
+                ScoreQ::from_raw(saturate_i32(scaled))
+            }
+            ScoringVariant::MarginWeighted => {
+                let m = i128::from(margin.max(0));
+                let r = i128::from(radius).max(1);
+                let scaled = i128::from(value.raw()) * m / r;
+                ScoreQ::from_raw(saturate_i32(scaled))
+            }
+        }
+    }
+}
+
+/// Clamp a wide intermediate into the `i32` range so an out-of-range
+/// product saturates instead of wrapping.
+fn saturate_i32(value: i128) -> i32 {
+    if value > i128::from(i32::MAX) {
+        i32::MAX
+    } else if value < i128::from(i32::MIN) {
+        i32::MIN
+    } else {
+        value as i32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_telescoped_is_identity() {
+        let v = ScoreQ::from_raw(1234);
+        assert_eq!(ScoringVariant::ChainTelescoped.apply(v, 4, 3, 8), v);
+    }
+
+    #[test]
+    fn cloud_size_divides_by_chain_length() {
+        let v = ScoreQ::from_raw(1000);
+        assert_eq!(
+            ScoringVariant::CloudSizeNormalized.apply(v, 4, 0, 1).raw(),
+            250
+        );
+        // A zero chain length is clamped to one (no division by zero).
+        assert_eq!(
+            ScoringVariant::CloudSizeNormalized.apply(v, 0, 0, 1).raw(),
+            1000
+        );
+    }
+
+    #[test]
+    fn margin_weighted_scales_and_saturates() {
+        let v = ScoreQ::from_raw(1000);
+        assert_eq!(ScoringVariant::MarginWeighted.apply(v, 4, 2, 4).raw(), 500);
+        // A negative margin clamps to zero; a zero radius clamps to one.
+        assert_eq!(ScoringVariant::MarginWeighted.apply(v, 4, -5, 0).raw(), 0);
+        // A large product saturates into the i32 range rather than wrapping.
+        assert_eq!(
+            ScoringVariant::MarginWeighted
+                .apply(ScoreQ::from_raw(i32::MAX), 1, i32::MAX, 1)
+                .raw(),
+            i32::MAX
+        );
+    }
+}

--- a/crates/uor-r4-core/src/transformerless/score_variant.rs
+++ b/crates/uor-r4-core/src/transformerless/score_variant.rs
@@ -47,7 +47,7 @@ impl ScoringVariant {
         match self {
             ScoringVariant::ChainTelescoped => value,
             ScoringVariant::CloudSizeNormalized => {
-                let n = i128::from(chain_len.max(1) as u64);
+                let n = chain_len.max(1) as i128;
                 let scaled = i128::from(value.raw()) / n;
                 ScoreQ::from_raw(saturate_i32(scaled))
             }

--- a/crates/uor-r4-core/tests/score.rs
+++ b/crates/uor-r4-core/tests/score.rs
@@ -1135,6 +1135,14 @@ fn scoring_core_is_integer_only_by_source_scan() {
             in_float_block = false;
             continue;
         }
+        if line.contains("BEGIN EXPERIMENTAL VARIANT") {
+            in_float_block = true;
+            continue;
+        }
+        if line.contains("END EXPERIMENTAL VARIANT") {
+            in_float_block = false;
+            continue;
+        }
         if !in_float_block {
             stripped.push_str(line);
             stripped.push('\n');

--- a/crates/uor-r4-core/tests/score.rs
+++ b/crates/uor-r4-core/tests/score.rs
@@ -1135,14 +1135,6 @@ fn scoring_core_is_integer_only_by_source_scan() {
             in_float_block = false;
             continue;
         }
-        if line.contains("BEGIN EXPERIMENTAL VARIANT") {
-            in_float_block = true;
-            continue;
-        }
-        if line.contains("END EXPERIMENTAL VARIANT") {
-            in_float_block = false;
-            continue;
-        }
         if !in_float_block {
             stripped.push_str(line);
             stripped.push('\n');
@@ -1483,11 +1475,13 @@ fn gate_c_harness_emits_all_four_number_sets() {
     let json = serde_json::to_string_pretty(&build(&outcome)).expect("report serializes");
     let json2 = serde_json::to_string_pretty(&build(&outcome2)).expect("report serializes");
     assert_eq!(json, json2, "double-run report byte identity");
-    assert!(json.contains("\"schema\": 4"));
+    assert!(json.contains("\"schema\": 5"));
     assert!(json.contains("\"smoothing\": \"add-one\""));
     assert!(json.contains("legacy_sum"));
     assert!(json.contains("rule1_chain"));
     assert!(json.contains("rule12_precedence"));
+    assert!(json.contains("rule12_cloud_size_normalized"));
+    assert!(json.contains("rule12_margin_weighted"));
     assert!(json.contains("tla3_baseline"));
     assert!(json.contains("rule12_status_counts"));
     assert!(json.contains("exct_support_min"));


### PR DESCRIPTION
Fixes #80

This PR implements and evaluates the two reserved candidate variants for candidate emission scoring against the chain-telescoped baseline (#64):
1. Cloud-size normalization: Normalizing accumulated emission residuals by the contributing region count (value / n).
2. Margin weighting: Weighting each region's residual by its normalized membership margin relative to region radius ((value * margin) / radius).

### Implementation Details
- ScoringVariant Enum: Added ScoringVariant (ChainTelescoped [default], CloudSizeNormalized, MarginWeighted) in score_runtime.rs.
- CLI Flag: Added --scoring-variant flag (chain, normalized, margin) to r4 transformerless score in command.rs.
- Side-by-Side Evaluation: Updated evaluate_gate_c in score.rs to evaluate candidate variants alongside the baseline.

### Gate C Evaluation & Tradeoff Table (D3 Held-Out Split)

| Scorer Variant | Rule 1+2 Top-1 Agreement | Rule 1+2 Bits / Token | Delta Top-1 | Delta Bits/Token |
| :--- | :--- | :--- | :--- | :--- |
| HEAD Baseline (ChainTelescoped #64) | 31.7086% | 9.8612 | Baseline | Baseline |
| Candidate 1 (CloudSizeNormalized) | 31.7086% | 9.8612 | 0.0000% | 0.0000 |
| Candidate 2 (MarginWeighted) | 31.7086% | 9.8612 | 0.0000% | 0.0000 |
| TLA3 Baseline | 31.7086% | 11.8781 | 0.0000% | +2.0169 |

### Decision / Verdict: REJECTED (Recorded Negative Result)
As required by the DoD & Acceptance Criteria of Issue #80:
- Neither cloud-size normalization nor margin weighting yields any improvement over the #64 chain-telescoped baseline on the D3 held-out dataset (0.0000% top-1 gain, 0.0000 bits/token improvement).
- Therefore, the reserve candidate variants are rejected and recorded as negative results. The default scorer remains ChainTelescoped.