### PR TITLE
feat(r4g1): enforce pinned quality floor in the deployed gate (#110)

### DIFF
--- a/features/suites/r4g1_compile_quality.feature
+++ b/features/suites/r4g1_compile_quality.feature
@@ -12,7 +12,22 @@ Feature: R4G1 compilation quality gates
     When the R4G1 quality gate validates the report
     Then the quality gate rejects the graph below baseline
 
-  Scenario: accept a graph at the TLA baseline
+  Scenario: reject a graph at the TLA baseline but below the pinned floor
     Given a graph quality report at or above the TLA baseline
     When the R4G1 quality gate validates the report
+    Then the quality gate rejects the graph for digression
+
+  Scenario: accept a graph at the pinned quality anchors
+    Given a graph quality report at the pinned quality anchors
+    When the R4G1 quality gate validates the report
     Then the quality gate accepts the graph
+
+  Scenario: reject a graph that digresses in bits per token
+    Given a graph quality report with digressed bits per token
+    When the R4G1 quality gate validates the report
+    Then the quality gate rejects the graph for digression
+
+  Scenario: reject a graph that digresses in top-1 agreement
+    Given a graph quality report with digressed top-1 agreement
+    When the R4G1 quality gate validates the report
+    Then the quality gate rejects the graph for digression

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -612,12 +612,26 @@ impl R4g1State {
     }
 }
 
-/// Validate the graph's Rule 1+2 top-1 agreement against the TLA baseline.
-/// Missing metrics remain compatible with older reports; when both metrics
-/// exist, the deployed graph must not be worse than the baseline.
+/// Pinned quality floor (issue #110, era: #65-chain anchors). The deployed
+/// graph must not digress from the Rule 1+2 anchors the quality chain
+/// measured (31.7086% top-1, 9.8612 bits/token) beyond the margins the CI
+/// trend alarm allows. Keep these constants in sync with
+/// `scripts/check_gate_c_regression.py`; when a compiler redesign
+/// legitimately moves the anchors, update both sites in the same commit with
+/// an era note.
+const QUALITY_FLOOR_TOP1_AGREEMENT: f64 = 0.317 - 0.02;
+const QUALITY_FLOOR_BITS_PER_TOKEN: f64 = 9.86 + 0.10;
+
+/// Validate the graph's Rule 1+2 quality against the TLA baseline and the
+/// pinned absolute floor. Missing metrics remain compatible with older
+/// reports; when present, the deployed graph must not be worse than the
+/// baseline and must not digress below the #65-chain anchors.
 pub fn validate_quality_report(report: &serde_json::Value) -> Result<(), String> {
     let graph_agreement = report
         .pointer("/gate_c/rule12_precedence/top1_agreement")
+        .and_then(serde_json::Value::as_f64);
+    let graph_bits = report
+        .pointer("/gate_c/rule12_precedence/bits_per_token")
         .and_then(serde_json::Value::as_f64);
     let baseline_agreement = report
         .pointer("/gate_c/tla3_baseline/top1_agreement")
@@ -628,6 +642,23 @@ pub fn validate_quality_report(report: &serde_json::Value) -> Result<(), String>
                 "R4G1 quality gate failed: graph runtime top-1 {:.2}% is below TLA baseline {:.2}%",
                 graph * 100.0,
                 baseline * 100.0
+            ));
+        }
+    }
+    if let Some(graph) = graph_agreement {
+        if graph < QUALITY_FLOOR_TOP1_AGREEMENT {
+            return Err(format!(
+                "R4G1 quality gate failed: graph runtime top-1 {:.2}% digresses below the pinned floor {:.2}%",
+                graph * 100.0,
+                QUALITY_FLOOR_TOP1_AGREEMENT * 100.0
+            ));
+        }
+    }
+    if let Some(bits) = graph_bits {
+        if bits > QUALITY_FLOOR_BITS_PER_TOKEN {
+            return Err(format!(
+                "R4G1 quality gate failed: graph runtime {:.4} bits/token digresses above the pinned ceiling {:.4}",
+                bits, QUALITY_FLOOR_BITS_PER_TOKEN
             ));
         }
     }

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -184,6 +184,49 @@ fn quality_gate_accepts(w: &mut R4g1World) {
     assert!(w.quality_error.is_none());
 }
 
+#[given("a graph quality report at the pinned quality anchors")]
+fn pinned_anchors_report(w: &mut R4g1World) {
+    // #65-chain anchors: 31.7086% top-1, 9.8612 bits/token (era note in
+    // src/r4g1.rs QUALITY_FLOOR_*).
+    w.quality_report = Some(serde_json::json!({
+        "gate_c": {
+            "rule12_precedence": {"top1_agreement": 0.3171, "bits_per_token": 9.8612},
+            "tla3_baseline": {"top1_agreement": 0.1811, "bits_per_token": 11.8781}
+        }
+    }));
+}
+
+#[given("a graph quality report with digressed bits per token")]
+fn digressed_bits_report(w: &mut R4g1World) {
+    // Agreement still clears the baseline, so only the absolute floor can fire.
+    w.quality_report = Some(serde_json::json!({
+        "gate_c": {
+            "rule12_precedence": {"top1_agreement": 0.3171, "bits_per_token": 10.5},
+            "tla3_baseline": {"top1_agreement": 0.1811, "bits_per_token": 11.8781}
+        }
+    }));
+}
+
+#[given("a graph quality report with digressed top-1 agreement")]
+fn digressed_agreement_report(w: &mut R4g1World) {
+    // Agreement still clears the baseline, so only the absolute floor can fire.
+    w.quality_report = Some(serde_json::json!({
+        "gate_c": {
+            "rule12_precedence": {"top1_agreement": 0.25, "bits_per_token": 9.8612},
+            "tla3_baseline": {"top1_agreement": 0.1811, "bits_per_token": 11.8781}
+        }
+    }));
+}
+
+#[then("the quality gate rejects the graph for digression")]
+fn quality_gate_rejects_digression(w: &mut R4g1World) {
+    assert!(w
+        .quality_error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("digresses"));
+}
+
 #[tokio::main]
 async fn main() {
     R4g1World::cucumber()


### PR DESCRIPTION
Closes #110

## What

The deployed quality gate (`validate_quality_report`) previously enforced only a *relative* check: Rule 1+2 top-1 ≥ TLA3 baseline. A change that degraded graph and baseline together — or degraded bits/token, which was never inspected — would pass silently. This PR pins the absolute quality floor the #65 chain achieved, enforced at artifact load time and covered by BDD:

- Rule 1+2 top-1 agreement ≥ **0.297** (pin 0.317 − 0.02)
- Rule 1+2 bits/token ≤ **9.96** (pin 9.86 + 0.10)

Constants carry an era note tying them to `scripts/check_gate_c_regression.py` (same numbers, one definition of digression); both sites move together when a compiler redesign legitimately shifts the anchors. Missing metrics remain compatible with older reports, as before.

## BDD coverage (features/suites/r4g1_compile_quality.feature)

- accept a graph at the pinned anchors (31.71% / 9.8612 bits)
- reject on bits/token digression (10.5 bits; relative check still passes, so only the floor can fire)
- reject on top-1 digression (25%; same isolation)
- the pre-existing "accept a graph at the TLA baseline" scenario is updated: at-baseline quality (18.11%) is now *below the floor* and must be rejected — that expectation change is the point of the gate, and the relative-baseline reject scenario remains for the teacher-side regression case

## Verification

- `cargo test --test bdd`: 16/16 scenarios pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo test --workspace --offline`: green
- κ reproduction: unaffected (gate-side change, not compiler), verified

Refs #65 (anchors), #77 (trend alarm)
