### PR TITLE
feat(quantum): Bott periodic Fock space O(1) context store (#107)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/bott_fock.rs
+++ b/crates/uor-r4-core/src/transformerless/bott_fock.rs
@@ -1,0 +1,244 @@
+//! Bott periodic Fock space context abstraction (issue #107; spec:
+//! `docs/r4_furey_quantum_geometric_plan.md` §Phase 4).
+//!
+//! Folds an arbitrary N-token context window into one fixed 16x16 integer
+//! state matrix. The construction is O(1) in space and update time **by
+//! construction**: the state is a fixed `[i16; 256]` array, every append
+//! performs the same fixed sweep of 256 integer operations, and nothing
+//! is allocated — there is no KV cache to grow.
+//!
+//! The update is the integer-kernel form of the 8-periodicity tensor
+//! contraction Cl(s,t) ≅ Cl(s0,t0) ⊗ M16(R)^⊗n: a contractive decay
+//! (each entry sheds a fixed fraction) plus a token-mixing injection
+//! (the embedding folded across every matrix cell with position-sensitive
+//! rotations). Contraction keeps the state bounded for unbounded N; the
+//! fold is lossy — an abstraction of the context, not a reversible
+//! encoding.
+//!
+//! Operator discipline (P-4 spirit): XOR, rotate, arithmetic shift, and
+//! saturating add/sub only — no multiply, divide, modulo, or float in
+//! the update path. Machine-checked by the self-scan test in this file.
+
+/// Token embedding width folded into the state (one M16(R) axis).
+pub const CONTEXT_DIM: usize = 16;
+/// Folded state entries: the 16x16 M16(R) context matrix, row-major.
+pub const STATE_ENTRIES: usize = 256;
+
+/// Fixed-size O(1) context store: the folded M16(R) state matrix plus a
+/// monotone token counter. No heap, no growable state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BottFockContextStore {
+    state: [i16; STATE_ENTRIES],
+    token_count: u64,
+}
+
+impl Default for BottFockContextStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BottFockContextStore {
+    /// Zero state, no tokens folded.
+    pub fn new() -> Self {
+        Self {
+            state: [0; STATE_ENTRIES],
+            token_count: 0,
+        }
+    }
+
+    /// Fold one 16-wide integer token embedding into the context state.
+    ///
+    /// Fixed work per call: one sweep of the 256 state cells. Decay keeps
+    /// the state contractive (each cell sheds a quarter of its value) and
+    /// the injection is saturated, so the state stays bounded for
+    /// unbounded token counts.
+    pub fn append_token(&mut self, token: &[i16; CONTEXT_DIM]) {
+        let mut idx = 0usize;
+        let mut row = 0usize;
+        while row < CONTEXT_DIM {
+            let row_embedding = token[row];
+            let mut col = 0usize;
+            while col < CONTEXT_DIM {
+                // Position-sensitive injection: the row embedding rotated
+                // by the column index, XOR-mixed with the column
+                // embedding. Row index folds into the cell address via
+                // shift (the matrix is 16 = 2^4 wide).
+                let rotated = row_embedding.rotate_left((col & 15) as u32);
+                let injection = rotated ^ token[col];
+                // Contractive decay: cell <- cell - cell/4 (arithmetic
+                // shift), then inject a quarter of the mix, saturated.
+                let decayed = self.state[idx] - (self.state[idx] >> 2);
+                self.state[idx] = decayed.saturating_add(injection >> 2);
+                idx += 1;
+                col += 1;
+            }
+            row += 1;
+        }
+        self.token_count += 1;
+    }
+
+    /// Number of tokens folded into the state so far.
+    pub fn token_count(&self) -> u64 {
+        self.token_count
+    }
+
+    /// The folded 16x16 context state matrix (row-major).
+    pub fn state(&self) -> &[i16; STATE_ENTRIES] {
+        &self.state
+    }
+
+    /// Order- and content-sensitive checksum of the folded state, for
+    /// determinism checks. XOR/rotate fold; no allocation.
+    pub fn checksum(&self) -> u64 {
+        let mut acc = self.token_count;
+        let mut idx = 0usize;
+        while idx < STATE_ENTRIES {
+            let cell = self.state[idx] as u16 as u64;
+            acc = acc.rotate_left(7) ^ cell;
+            idx += 1;
+        }
+        acc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_embedding(seed: u64, out: &mut [i16; CONTEXT_DIM]) {
+        // Deterministic xorshift fill; no RNG state outside the caller.
+        let mut x = seed | 1;
+        let mut i = 0usize;
+        while i < CONTEXT_DIM {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            out[i] = x as i16;
+            i += 1;
+        }
+    }
+
+    #[test]
+    fn append_is_deterministic_and_counts_tokens() {
+        let mut a = BottFockContextStore::new();
+        let mut b = BottFockContextStore::new();
+        let mut token = [0i16; CONTEXT_DIM];
+        let mut n = 0u64;
+        while n < 1_000 {
+            sample_embedding(n, &mut token);
+            a.append_token(&token);
+            b.append_token(&token);
+            n += 1;
+        }
+        assert_eq!(a, b, "same token stream folds to the same state");
+        assert_eq!(a.token_count(), 1_000);
+        assert_eq!(a.checksum(), b.checksum());
+        assert_ne!(a.checksum(), BottFockContextStore::new().checksum());
+    }
+
+    #[test]
+    fn state_converges_under_repeated_embedding() {
+        let mut store = BottFockContextStore::new();
+        let extremes = [
+            i16::MIN,
+            i16::MAX,
+            i16::MIN,
+            i16::MAX,
+            0,
+            -1,
+            1,
+            0,
+            i16::MAX,
+            i16::MIN,
+            0,
+            -1,
+            1,
+            0,
+            i16::MAX,
+            i16::MIN,
+        ];
+        let mut n = 0u64;
+        while n < 100_000 {
+            store.append_token(&extremes);
+            n += 1;
+        }
+        // Contractive decay plus bounded injection reaches a fixed point:
+        // folding the same embedding further no longer moves the state.
+        let converged = store.state().to_owned();
+        let mut n = 0u64;
+        while n < 1_000 {
+            store.append_token(&extremes);
+            n += 1;
+        }
+        assert_eq!(store.state(), &converged, "state reaches a fixed point");
+    }
+
+    #[test]
+    fn order_changes_the_fold() {
+        let mut first = BottFockContextStore::new();
+        let mut second = BottFockContextStore::new();
+        let mut t0 = [0i16; CONTEXT_DIM];
+        let mut t1 = [0i16; CONTEXT_DIM];
+        sample_embedding(11, &mut t0);
+        sample_embedding(22, &mut t1);
+        first.append_token(&t0);
+        first.append_token(&t1);
+        second.append_token(&t1);
+        second.append_token(&t0);
+        assert_ne!(first.checksum(), second.checksum());
+    }
+
+    /// P-4-style self scan: the update path uses no multiplication,
+    /// division, or modulo operator on values. Doc/comment lines are
+    /// stripped; dereference `*x` (star not preceded by an operand) is
+    /// not an arithmetic operator and does not match.
+    #[test]
+    fn p4_update_source_scan() {
+        let src = include_str!("bott_fock.rs");
+        let mut offenders = Vec::new();
+        for (ln, line) in src.lines().enumerate() {
+            let code = line.trim_start();
+            if code.starts_with("//") {
+                continue;
+            }
+            let b = code.as_bytes();
+            for (i, &ch) in b.iter().enumerate() {
+                if ch != b'*' && ch != b'/' && ch != b'%' {
+                    continue;
+                }
+                if ch == b'/'
+                    && ((i + 1 < b.len() && b[i + 1] == b'/') || (i >= 1 && b[i - 1] == b'/'))
+                {
+                    continue; // comment slashes
+                }
+                let prev = if i >= 2 && b[i - 1] == b' ' {
+                    b[i - 2]
+                } else if i >= 1 {
+                    b[i - 1]
+                } else {
+                    b' '
+                };
+                let next = if i + 2 < b.len() && b[i + 1] == b' ' {
+                    b[i + 2]
+                } else if i + 1 < b.len() {
+                    b[i + 1]
+                } else {
+                    b' '
+                };
+                let operand_l =
+                    |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b')' || c == b']';
+                let operand_r = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'(';
+                if operand_l(prev) && operand_r(next) {
+                    offenders.push(format!("line {}: {}", ln + 1, code));
+                    break;
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "arithmetic operators in the update path:\n{}",
+            offenders.join("\n")
+        );
+    }
+}

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -21,6 +21,7 @@
 
 // teacher/compiler are portable (math, types, containers); only their
 // fs-dependent functions are cfg-gated per item (see those files).
+pub mod bott_fock;
 pub mod cd_space;
 pub mod endomorphism;
 pub mod teacher;

--- a/crates/uor-r4-core/tests/bott_fock_scaling.rs
+++ b/crates/uor-r4-core/tests/bott_fock_scaling.rs
@@ -1,0 +1,94 @@
+//! Bott Fock context scaling benchmark (issue #107, Gate F).
+//!
+//! Proves the O(1) claims of `BottFockContextStore`:
+//!
+//! - **Space**: the store is a fixed-size value (256 `i16` cells + one
+//!   counter); folding more tokens never grows it — no KV cache.
+//! - **Time**: every append performs the same fixed 256-cell integer
+//!   sweep, so per-append latency is independent of how many tokens were
+//!   folded before. The full N = 10^3 .. 10^6 wall-clock table runs in
+//!   the release-mode ignored test:
+//!
+//! ```text
+//! cargo test -p uor-r4-core --release --test bott_fock_scaling -- --ignored --nocapture
+//! ```
+
+use std::time::Instant;
+use uor_r4_core::transformerless::bott_fock::{BottFockContextStore, CONTEXT_DIM};
+
+/// Deterministic xorshift embedding stream — no RNG state outside the
+/// caller, identical token sequences across runs.
+struct TokenStream(u64);
+
+impl TokenStream {
+    fn next(&mut self, out: &mut [i16; CONTEXT_DIM]) {
+        let mut i = 0usize;
+        while i < CONTEXT_DIM {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            out[i] = self.0 as i16;
+            i += 1;
+        }
+    }
+}
+
+#[test]
+fn store_size_is_independent_of_token_count() {
+    let fixed_size = std::mem::size_of::<BottFockContextStore>();
+    let mut store = BottFockContextStore::new();
+    let mut stream = TokenStream(0x9e3779b97f4a7c15);
+    let mut token = [0i16; CONTEXT_DIM];
+    let mut n = 0u64;
+    while n < 100_000 {
+        stream.next(&mut token);
+        store.append_token(&token);
+        n += 1;
+        assert_eq!(
+            std::mem::size_of_val(&store),
+            fixed_size,
+            "store grew after {n} appends"
+        );
+    }
+    assert_eq!(store.token_count(), 100_000);
+    assert_eq!(store.state().len(), 256);
+}
+
+/// Wall-clock O(1) proof across the DoD range N = 10^3 .. 10^6. Timing
+/// belongs in release mode; ignored by default so debug-mode CI never
+/// sees a flaky clock assertion.
+#[test]
+#[ignore = "release-mode wall-clock benchmark"]
+fn append_latency_is_constant_across_context_lengths() {
+    let sizes = [1_000u64, 10_000, 100_000, 1_000_000];
+    let mut per_append_ns = Vec::new();
+    for &n in &sizes {
+        let mut store = BottFockContextStore::new();
+        let mut stream = TokenStream(0x243f6a8885a308d3);
+        let mut token = [0i16; CONTEXT_DIM];
+        let start = Instant::now();
+        let mut i = 0u64;
+        while i < n {
+            stream.next(&mut token);
+            store.append_token(&token);
+            i += 1;
+        }
+        let elapsed = start.elapsed().as_nanos();
+        let per_append = elapsed / (n as u128);
+        per_append_ns.push(per_append);
+        println!(
+            "N = {n:>9}: total {:?}, {per_append} ns/append",
+            start.elapsed()
+        );
+    }
+    let min = *per_append_ns.iter().min().expect("sizes non-empty");
+    let max = *per_append_ns.iter().max().expect("sizes non-empty");
+    println!("per-append spread: min {min} ns, max {max} ns");
+    // Strict O(1) would be ratio 1.0; wall clocks jitter, so fail only
+    // when the slowest batch is more than 3x the fastest — a bound that
+    // still catches any accidental O(N) work (10^3 x spread at N = 10^6).
+    assert!(
+        max <= min.saturating_mul(3),
+        "per-append latency grew with context length: min {min} ns, max {max} ns"
+    );
+}


### PR DESCRIPTION
Closes #107

## What

`crates/uor-r4-core/src/transformerless/bott_fock.rs` — Bott periodic Fock space context store per `docs/r4_furey_quantum_geometric_plan.md` §Phase 4. Folds an arbitrary N-token context window into a fixed `[i16; 256]` state matrix: O(1) space and O(1) update time **by construction** (fixed array, one fixed 256-cell integer sweep per append, no KV cache, no allocation).

Update rule: contractive decay (each cell sheds a quarter) + position-sensitive injection (row embedding rotated by column index, XOR-mixed with the column embedding, quarter-strength, saturating). XOR/rotate/arithmetic-shift/saturating-add only — no mul/div/mod/float in the update path, machine-checked by a P-4-style self-scan test in the module.

Honesty note: the fold is lossy — an abstraction of the context, not a reversible encoding. Documented as such in the module.

## Gate F evidence (release benchmark, `tests/bott_fock_scaling.rs`)

| N (context tokens) | total | ns/append |
| ---: | ---: | ---: |
| 1,000 | 157.6 µs | 157 |
| 10,000 | 1.63 ms | 162 |
| 100,000 | 14.80 ms | 148 |
| 1,000,000 | 146.89 ms | 146 |

Per-append spread 146–162 ns (ratio ≈ 1.1) — flat across three orders of magnitude; the test asserts max ≤ 3× min, which still catches any accidental O(N) work. Always-on half of the test asserts store size never grows across 100k appends.

## Tests

- append determinism + token counting; fixed-point convergence under repeated embedding; order sensitivity; P-4 source self-scan
- `store_size_is_independent_of_token_count` (always-on), `append_latency_is_constant_across_context_lengths` (release, ignored by default)

Run: `cargo test -p uor-r4-core --release --test bott_fock_scaling -- --ignored --nocapture`

## Verification

- `cargo test --workspace --offline`: green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean

Refs #103 (tracker), #105 (operator store conventions)
