### PR TITLE
feat(compiler): introduce unsupervised intervention and counterfactual behavioral probes (#128)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
+++ b/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
@@ -12,6 +12,7 @@
 //!   `Sensitive` (causal interventions must alter output).
 //! - Probe harness evaluating sensitivity and invariance scores with anti-memorization guards.
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Errors arising during behavioral probe creation or evaluation.
@@ -73,7 +74,7 @@ impl fmt::Display for BehavioralProbeError {
 impl std::error::Error for BehavioralProbeError {}
 
 /// Controlled intervention kind applied to observation context $x$.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum InterventionKind {
     /// Ablating specific context text spans.
     ContextAblation,
@@ -88,7 +89,7 @@ pub enum InterventionKind {
 }
 
 /// Declared expectation relation under intervention.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ExpectedRelation {
     /// Output MUST remain invariant ($\Delta \le \epsilon$).
     Invariant,
@@ -99,7 +100,7 @@ pub enum ExpectedRelation {
 }
 
 /// A content-addressed intervention record describing a counterfactual probe.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InterventionRecord {
     /// Content-addressed ID derived from observation and intervention payload.
     pub id: String,
@@ -143,15 +144,22 @@ impl InterventionRecord {
             });
         }
 
-        // Content-addressed ID simulation
-        let id_raw = format!(
-            "{}:{}:{:?}:{}",
-            obs,
-            kind as u8,
-            affected_span,
-            baseline_output.len()
-        );
-        let id = format!("probe_{:08x}", simple_hash(&id_raw));
+        // Content-addressed ID: blake3 over the observation, intervention
+        // kind/span, expected relation, and both output vectors, so any
+        // difference in inputs or outputs yields a distinct id.
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(obs.as_bytes());
+        hasher.update(&[kind as u8]);
+        hasher.update(&(start as u64).to_le_bytes());
+        hasher.update(&(end as u64).to_le_bytes());
+        hasher.update(&[expected_relation as u8]);
+        for value in &baseline_output {
+            hasher.update(&value.to_le_bytes());
+        }
+        for value in &intervention_output {
+            hasher.update(&value.to_le_bytes());
+        }
+        let id = format!("probe_blake3:{}", hasher.finalize().to_hex());
 
         Ok(Self {
             id,
@@ -175,7 +183,7 @@ impl InterventionRecord {
 }
 
 /// Evaluation result metrics for a probe suite.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BehavioralProbeReport {
     pub total_probes: usize,
     pub invariant_passed: usize,
@@ -242,13 +250,28 @@ impl BehavioralProbeHarness {
             1.0
         };
 
-        // Anti-memorization guard check: if sensitivity under GoalChange or ContextAblation is 0,
-        // the model is memorizing surface form without understanding state dynamics.
-        let memorization_passed = sensitivity_score > 0.0 || sens_count == 0;
+        // Anti-memorization guard check: any Sensitive GoalChange/ContextAblation probe
+        // whose divergence falls below the sensitivity threshold indicates the model is
+        // memorizing surface form without understanding state dynamics.
+        let mut memorization_passed = true;
+        let mut failing_probe_id = None;
+        for probe in probes {
+            if probe.expected_relation == ExpectedRelation::Sensitive
+                && matches!(
+                    probe.kind,
+                    InterventionKind::GoalChange | InterventionKind::ContextAblation
+                )
+                && probe.output_divergence() < sensitivity_threshold
+            {
+                memorization_passed = false;
+                failing_probe_id = Some(probe.id.clone());
+                break;
+            }
+        }
 
         if !memorization_passed {
             return Err(BehavioralProbeError::MemorizationDetected {
-                probe_id: "suite_guard".to_string(),
+                probe_id: failing_probe_id.unwrap_or_else(|| "suite_guard".to_string()),
             });
         }
 
@@ -261,16 +284,6 @@ impl BehavioralProbeHarness {
             memorization_check_passed: memorization_passed,
         })
     }
-}
-
-/// Simple non-cryptographic hash helper for content-addressed IDs.
-fn simple_hash(input: &str) -> u32 {
-    let mut h = 0x811c9dc5u32;
-    for b in input.bytes() {
-        h ^= b as u32;
-        h = h.wrapping_mul(0x01000193);
-    }
-    h
 }
 
 #[cfg(test)]

--- a/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
+++ b/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
@@ -1,0 +1,345 @@
+//! Unsupervised Intervention and Counterfactual Behavioral Probes
+//!
+//! Specification & Source: `docs/hologram_formal_analysis_direction.md` PDF §§7, 11, 17;
+//! `docs/formal_vocabulary.md` §3; GitHub Issue #128.
+//!
+//! This module provides the behavioral-probing layer needed to distinguish reusable
+//! predictive structure from surface association:
+//! - Content-addressed `InterventionRecord` defining baseline vs perturbed observations.
+//! - Supported intervention kinds: `ContextAblation`, `SurfaceVariation`, `EntitySubstitution`,
+//!   `TemporalChange`, and `GoalChange`.
+//! - Declarative expectations: `Invariant` (nuisance variations must preserve output) vs
+//!   `Sensitive` (causal interventions must alter output).
+//! - Probe harness evaluating sensitivity and invariance scores with anti-memorization guards.
+
+use std::fmt;
+
+/// Errors arising during behavioral probe creation or evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BehavioralProbeError {
+    /// Affected span range is out of bounds for the source observation string.
+    SpanOutOfBounds {
+        start: usize,
+        end: usize,
+        len: usize,
+    },
+    /// Invalid probe outputs (empty or dimension mismatch).
+    InvalidOutputDimensions {
+        baseline_len: usize,
+        intervention_len: usize,
+    },
+    /// Surface memorization guard detected non-generalizing table lookup.
+    MemorizationDetected { probe_id: String },
+    /// Probe execution failed expected relation assertion.
+    AssertionFailed {
+        probe_id: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+impl fmt::Display for BehavioralProbeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SpanOutOfBounds { start, end, len } => {
+                write!(
+                    f,
+                    "Probe span [{start}..{end}] out of bounds for observation length {len}"
+                )
+            }
+            Self::InvalidOutputDimensions {
+                baseline_len,
+                intervention_len,
+            } => write!(
+                f,
+                "Output dimension mismatch: baseline {baseline_len}, intervention {intervention_len}"
+            ),
+            Self::MemorizationDetected { probe_id } => write!(
+                f,
+                "Anti-memorization guard failed for probe '{probe_id}': surface lookup detected"
+            ),
+            Self::AssertionFailed {
+                probe_id,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "Probe '{probe_id}' assertion failed: expected {expected}, actual {actual}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BehavioralProbeError {}
+
+/// Controlled intervention kind applied to observation context $x$.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InterventionKind {
+    /// Ablating specific context text spans.
+    ContextAblation,
+    /// Paraphrase or surface-preserving variation (nuisance parameter).
+    SurfaceVariation,
+    /// Value or entity substitution.
+    EntitySubstitution,
+    /// Temporal sequence shift.
+    TemporalChange,
+    /// Action or goal specification change.
+    GoalChange,
+}
+
+/// Declared expectation relation under intervention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExpectedRelation {
+    /// Output MUST remain invariant ($\Delta \le \epsilon$).
+    Invariant,
+    /// Output MUST be sensitive / change ($\Delta \ge \delta$).
+    Sensitive,
+    /// Relationship is unknown / unconstrained.
+    Unknown,
+}
+
+/// A content-addressed intervention record describing a counterfactual probe.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InterventionRecord {
+    /// Content-addressed ID derived from observation and intervention payload.
+    pub id: String,
+    /// Baseline source observation text ($x$).
+    pub source_observation: String,
+    /// Type of controlled intervention applied.
+    pub kind: InterventionKind,
+    /// Character/byte span affected by intervention $(start, end)$.
+    pub affected_span: (usize, usize),
+    /// Declared expected behavior relation.
+    pub expected_relation: ExpectedRelation,
+    /// Baseline teacher output probabilities $P_\theta(\cdot | x)$.
+    pub baseline_output: Vec<f32>,
+    /// Counterfactual teacher output probabilities $P_\theta(\cdot | x_{\text{intervened}})$.
+    pub intervention_output: Vec<f32>,
+}
+
+impl InterventionRecord {
+    /// Create and validate a new intervention record.
+    pub fn new(
+        source_observation: impl Into<String>,
+        kind: InterventionKind,
+        affected_span: (usize, usize),
+        expected_relation: ExpectedRelation,
+        baseline_output: Vec<f32>,
+        intervention_output: Vec<f32>,
+    ) -> Result<Self, BehavioralProbeError> {
+        let obs = source_observation.into();
+        let (start, end) = affected_span;
+        if start > end || end > obs.len() {
+            return Err(BehavioralProbeError::SpanOutOfBounds {
+                start,
+                end,
+                len: obs.len(),
+            });
+        }
+        if baseline_output.len() != intervention_output.len() || baseline_output.is_empty() {
+            return Err(BehavioralProbeError::InvalidOutputDimensions {
+                baseline_len: baseline_output.len(),
+                intervention_len: intervention_output.len(),
+            });
+        }
+
+        // Content-addressed ID simulation
+        let id_raw = format!(
+            "{}:{}:{:?}:{}",
+            obs,
+            kind as u8,
+            affected_span,
+            baseline_output.len()
+        );
+        let id = format!("probe_{:08x}", simple_hash(&id_raw));
+
+        Ok(Self {
+            id,
+            source_observation: obs,
+            kind,
+            affected_span,
+            expected_relation,
+            baseline_output,
+            intervention_output,
+        })
+    }
+
+    /// Compute L1 divergence between baseline and intervention outputs.
+    pub fn output_divergence(&self) -> f32 {
+        self.baseline_output
+            .iter()
+            .zip(self.intervention_output.iter())
+            .map(|(b, i)| (b - i).abs())
+            .sum::<f32>()
+    }
+}
+
+/// Evaluation result metrics for a probe suite.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BehavioralProbeReport {
+    pub total_probes: usize,
+    pub invariant_passed: usize,
+    pub sensitive_passed: usize,
+    pub invariance_score: f32,
+    pub sensitivity_score: f32,
+    pub memorization_check_passed: bool,
+}
+
+/// Harness executing and auditing counterfactual behavioral probes.
+pub struct BehavioralProbeHarness;
+
+impl BehavioralProbeHarness {
+    /// Evaluate a set of intervention records against expectation relations.
+    pub fn evaluate_suite(
+        probes: &[InterventionRecord],
+        invariance_tolerance: f32,
+        sensitivity_threshold: f32,
+    ) -> Result<BehavioralProbeReport, BehavioralProbeError> {
+        if probes.is_empty() {
+            return Ok(BehavioralProbeReport {
+                total_probes: 0,
+                invariant_passed: 0,
+                sensitive_passed: 0,
+                invariance_score: 1.0,
+                sensitivity_score: 1.0,
+                memorization_check_passed: true,
+            });
+        }
+
+        let mut inv_count = 0;
+        let mut inv_passed = 0;
+        let mut sens_count = 0;
+        let mut sens_passed = 0;
+
+        for probe in probes {
+            let div = probe.output_divergence();
+            match probe.expected_relation {
+                ExpectedRelation::Invariant => {
+                    inv_count += 1;
+                    if div <= invariance_tolerance {
+                        inv_passed += 1;
+                    }
+                }
+                ExpectedRelation::Sensitive => {
+                    sens_count += 1;
+                    if div >= sensitivity_threshold {
+                        sens_passed += 1;
+                    }
+                }
+                ExpectedRelation::Unknown => {}
+            }
+        }
+
+        let invariance_score = if inv_count > 0 {
+            inv_passed as f32 / inv_count as f32
+        } else {
+            1.0
+        };
+
+        let sensitivity_score = if sens_count > 0 {
+            sens_passed as f32 / sens_count as f32
+        } else {
+            1.0
+        };
+
+        // Anti-memorization guard check: if sensitivity under GoalChange or ContextAblation is 0,
+        // the model is memorizing surface form without understanding state dynamics.
+        let memorization_passed = sensitivity_score > 0.0 || sens_count == 0;
+
+        if !memorization_passed {
+            return Err(BehavioralProbeError::MemorizationDetected {
+                probe_id: "suite_guard".to_string(),
+            });
+        }
+
+        Ok(BehavioralProbeReport {
+            total_probes: probes.len(),
+            invariant_passed: inv_passed,
+            sensitive_passed: sens_passed,
+            invariance_score,
+            sensitivity_score,
+            memorization_check_passed: memorization_passed,
+        })
+    }
+}
+
+/// Simple non-cryptographic hash helper for content-addressed IDs.
+fn simple_hash(input: &str) -> u32 {
+    let mut h = 0x811c9dc5u32;
+    for b in input.bytes() {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x01000193);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intervention_record_creation_and_divergence() {
+        let rec = InterventionRecord::new(
+            "The temperature is 20C.",
+            InterventionKind::SurfaceVariation,
+            (0, 15),
+            ExpectedRelation::Invariant,
+            vec![0.8, 0.2],
+            vec![0.81, 0.19],
+        )
+        .unwrap();
+
+        assert!(rec.id.starts_with("probe_"));
+        assert!((rec.output_divergence() - 0.02).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_probe_harness_evaluation() {
+        let p_inv = InterventionRecord::new(
+            "Context text sample",
+            InterventionKind::SurfaceVariation,
+            (0, 7),
+            ExpectedRelation::Invariant,
+            vec![0.9, 0.1],
+            vec![0.905, 0.095], // div = 0.01
+        )
+        .unwrap();
+
+        let p_sens = InterventionRecord::new(
+            "Context text sample",
+            InterventionKind::GoalChange,
+            (0, 7),
+            ExpectedRelation::Sensitive,
+            vec![0.9, 0.1],
+            vec![0.1, 0.9], // div = 1.6
+        )
+        .unwrap();
+
+        let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5).unwrap();
+
+        assert_eq!(report.total_probes, 2);
+        assert_eq!(report.invariance_score, 1.0);
+        assert_eq!(report.sensitivity_score, 1.0);
+        assert!(report.memorization_check_passed);
+    }
+
+    #[test]
+    fn test_anti_memorization_guard_rejection() {
+        // Sensitive goal change resulted in 0 divergence -> memorization failure!
+        let p_mem = InterventionRecord::new(
+            "Context text sample",
+            InterventionKind::GoalChange,
+            (0, 7),
+            ExpectedRelation::Sensitive,
+            vec![0.9, 0.1],
+            vec![0.9, 0.1], // div = 0.0
+        )
+        .unwrap();
+
+        let err = BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5).unwrap_err();
+        assert!(matches!(
+            err,
+            BehavioralProbeError::MemorizationDetected { .. }
+        ));
+    }
+}

--- a/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
+++ b/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
@@ -253,25 +253,16 @@ impl BehavioralProbeHarness {
         // Anti-memorization guard check: any Sensitive GoalChange/ContextAblation probe
         // whose divergence falls below the sensitivity threshold indicates the model is
         // memorizing surface form without understanding state dynamics.
-        let mut memorization_passed = true;
-        let mut failing_probe_id = None;
-        for probe in probes {
-            if probe.expected_relation == ExpectedRelation::Sensitive
+        if let Some(probe) = probes.iter().find(|probe| {
+            probe.expected_relation == ExpectedRelation::Sensitive
                 && matches!(
                     probe.kind,
                     InterventionKind::GoalChange | InterventionKind::ContextAblation
                 )
                 && probe.output_divergence() < sensitivity_threshold
-            {
-                memorization_passed = false;
-                failing_probe_id = Some(probe.id.clone());
-                break;
-            }
-        }
-
-        if !memorization_passed {
+        }) {
             return Err(BehavioralProbeError::MemorizationDetected {
-                probe_id: failing_probe_id.unwrap_or_else(|| "suite_guard".to_string()),
+                probe_id: probe.id.clone(),
             });
         }
 
@@ -281,7 +272,7 @@ impl BehavioralProbeHarness {
             sensitive_passed: sens_passed,
             invariance_score,
             sensitivity_score,
-            memorization_check_passed: memorization_passed,
+            memorization_check_passed: true,
         })
     }
 }

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod behavioral_probes;
 pub mod graph;
 pub mod induction;
 pub mod observation;

--- a/features/suites/behavioral_probes.feature
+++ b/features/suites/behavioral_probes.feature
@@ -1,0 +1,19 @@
+@status:enforced
+Feature: Unsupervised intervention and counterfactual behavioral probes
+  Behavioral probes must evaluate sensitivity to causal interventions, invariance under nuisance variation, and enforce anti-memorization guards.
+
+  Scenario: Evaluate invariance under surface variation and sensitivity under goal changes
+    Given a baseline observation "Context text sample"
+    When an invariant surface variation probe and a sensitive goal change probe are evaluated
+    Then both invariance and sensitivity expectations pass cleanly
+    And the anti-memorization guard succeeds
+
+  Scenario: Reject surface-memorizing tables under goal change intervention
+    Given a sensitive goal change probe that produces zero output divergence
+    When the probe suite is evaluated by the behavioral harness
+    Then evaluation fails with a memorization detected error
+
+  Scenario: Reject out-of-bound affected span ranges
+    Given an observation of length 15
+    When an intervention record is created with span [0..20]
+    Then record creation fails with a span out of bounds error

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -50,6 +50,11 @@ struct R4g1World {
     u8_a: u8,
     u8_b: u8,
     u8_res: u8,
+    // Behavioral Probe fields (#128)
+    probe_baseline_obs: String,
+    probe_suite_report: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeReport>,
+    probe_suite_error: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeError>,
+    probe_record_error: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeError>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -470,6 +475,111 @@ fn u8_kernel_zero_floats(_w: &mut R4g1World) {
     let kernel_code = &source[kernel_start..];
     assert!(!kernel_code.contains("f32") && !kernel_code.contains("f64"));
     assert!(!kernel_code.contains(" * ") && !kernel_code.contains(" / "));
+}
+
+// =========================================================================
+// Behavioral Probes BDD Steps (#128)
+// =========================================================================
+use uor_r4_graph_compiler::behavioral_probes::{
+    BehavioralProbeError, BehavioralProbeHarness, ExpectedRelation, InterventionKind,
+    InterventionRecord,
+};
+
+#[given("a baseline observation \"Context text sample\"")]
+fn bdd_baseline_observation(w: &mut R4g1World) {
+    w.probe_baseline_obs = "Context text sample".to_string();
+}
+
+#[when("an invariant surface variation probe and a sensitive goal change probe are evaluated")]
+fn bdd_evaluate_probes(w: &mut R4g1World) {
+    let obs = &w.probe_baseline_obs;
+    let p_inv = InterventionRecord::new(
+        obs,
+        InterventionKind::SurfaceVariation,
+        (0, 7),
+        ExpectedRelation::Invariant,
+        vec![0.9, 0.1],
+        vec![0.905, 0.095],
+    )
+    .unwrap();
+
+    let p_sens = InterventionRecord::new(
+        obs,
+        InterventionKind::GoalChange,
+        (0, 7),
+        ExpectedRelation::Sensitive,
+        vec![0.9, 0.1],
+        vec![0.1, 0.9],
+    )
+    .unwrap();
+
+    let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5).unwrap();
+    w.probe_suite_report = Some(report);
+}
+
+#[then("both invariance and sensitivity expectations pass cleanly")]
+fn bdd_invariance_sensitivity_pass(w: &mut R4g1World) {
+    let report = w.probe_suite_report.as_ref().expect("report");
+    assert_eq!(report.invariance_score, 1.0);
+    assert_eq!(report.sensitivity_score, 1.0);
+}
+
+#[then("the anti-memorization guard succeeds")]
+fn bdd_memorization_guard_succeeds(w: &mut R4g1World) {
+    let report = w.probe_suite_report.as_ref().expect("report");
+    assert!(report.memorization_check_passed);
+}
+
+#[given("a sensitive goal change probe that produces zero output divergence")]
+fn bdd_zero_divergence_sensitive_probe(w: &mut R4g1World) {
+    let p_mem = InterventionRecord::new(
+        "Context text sample",
+        InterventionKind::GoalChange,
+        (0, 7),
+        ExpectedRelation::Sensitive,
+        vec![0.9, 0.1],
+        vec![0.9, 0.1], // div = 0.0 -> memorization!
+    )
+    .unwrap();
+
+    if let Err(e) = BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5) {
+        w.probe_suite_error = Some(e);
+    }
+}
+
+#[when("the probe suite is evaluated by the behavioral harness")]
+fn bdd_harness_eval_step(_w: &mut R4g1World) {}
+
+#[then("evaluation fails with a memorization detected error")]
+fn bdd_memorization_error_check(w: &mut R4g1World) {
+    let err = w.probe_suite_error.as_ref().expect("suite error");
+    assert!(matches!(
+        err,
+        BehavioralProbeError::MemorizationDetected { .. }
+    ));
+}
+
+#[given("an observation of length 15")]
+fn bdd_observation_len_15(_w: &mut R4g1World) {}
+
+#[when("an intervention record is created with span [0..20]")]
+fn bdd_create_out_of_bounds_span(w: &mut R4g1World) {
+    if let Err(e) = InterventionRecord::new(
+        "Short 15 char!!",
+        InterventionKind::ContextAblation,
+        (0, 20),
+        ExpectedRelation::Invariant,
+        vec![1.0],
+        vec![1.0],
+    ) {
+        w.probe_record_error = Some(e);
+    }
+}
+
+#[then("record creation fails with a span out of bounds error")]
+fn bdd_span_out_of_bounds_check(w: &mut R4g1World) {
+    let err = w.probe_record_error.as_ref().expect("record error");
+    assert!(matches!(err, BehavioralProbeError::SpanOutOfBounds { .. }));
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Overview & Purpose
Resolves #128. Implementation follows PDF §§7, 11, 17 and `docs/formal_vocabulary.md` §3.

## Key Changes
1. **Intervention Record**: Implemented content-addressed `InterventionRecord` tracking baseline observation, affected span $(start, end)$, and expected relation (`Invariant` vs `Sensitive`).
2. **Behavioral Probe Harness**: Implemented `BehavioralProbeHarness` evaluating `invariance_score` and `sensitivity_score` under 5 intervention kinds (`ContextAblation`, `SurfaceVariation`, `EntitySubstitution`, `TemporalChange`, `GoalChange`).
3. **Anti-Memorization Guard**: Added `memorization_check_passed` rejecting non-generalizing surface lookup tables that exhibit zero sensitivity under goal/context interventions.
4. **Cucumber BDD Suite**: Added `features/suites/behavioral_probes.feature` with 3 scenarios and step definitions in `tests/bdd.rs`.

## Verification
- `cargo fmt --check`: Clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`: Clean
- `cargo test --workspace --offline`: All unit tests passed
- `cargo test --test bdd --offline`: All 28 BDD scenarios passed (88 steps)
- `cargo check -p uor-r4-graph-format --no-default-features`: Clean
- `python3 scripts/check_claim_wording.py`: Wording gate passed