### PR TITLE
feat(compiler): lower reference semantic regions into Boolean, mask, popcount, and fixed-point programs (#130)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod graph;
 pub mod induction;
+pub mod lower_semantic_regions;
 pub mod observation;
 pub mod observation_text;
 pub mod pack;

--- a/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
+++ b/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
@@ -81,12 +81,12 @@ impl LoweredFixedPointScore {
             return Err(LoweringError::QuantizationOverflow { score: val });
         }
         let scaled = (val * 256.0).round();
-        if scaled >= i16::MAX as f32 {
+        if scaled > i16::MAX as f32 {
             Ok(Self {
                 q88_value: i16::MAX,
                 saturated: true,
             })
-        } else if scaled <= i16::MIN as f32 {
+        } else if scaled < i16::MIN as f32 {
             Ok(Self {
                 q88_value: i16::MIN,
                 saturated: true,
@@ -133,6 +133,8 @@ impl BooleanLoweringCompiler {
         signature_bits: &[bool],
         radius_float: f32,
         ref_cid: &str,
+        reference_contribution_id: u32,
+        runtime_table_index: u32,
     ) -> Result<(LoweredBooleanRegion, LoweringWitnessEntry), LoweringError> {
         let r_id = region_id.into();
         if signature_bits.len() > 64 {
@@ -144,10 +146,14 @@ impl BooleanLoweringCompiler {
                 ),
             });
         }
-        if !(0.0..=64.0).contains(&radius_float) {
+        let max_radius = signature_bits.len() as f32;
+        if !(0.0..=max_radius).contains(&radius_float) {
             return Err(LoweringError::UnrepresentableRegion {
                 region_id: r_id,
-                reason: format!("Radius {radius_float:.2} outside valid Hamming bound [0..64]"),
+                reason: format!(
+                    "Radius {radius_float:.2} outside valid Hamming bound [0..{max_radius}] for signature length {}",
+                    signature_bits.len()
+                ),
             });
         }
 
@@ -168,11 +174,11 @@ impl BooleanLoweringCompiler {
             bitmask: mask_u64,
             expected_signature: sig_u64,
             max_hamming_distance: max_dist,
-            reference_contribution_id: 101,
+            reference_contribution_id,
         };
 
         let witness = LoweringWitnessEntry {
-            runtime_table_index: 0,
+            runtime_table_index,
             reference_cid: ref_cid.to_string(),
             lowered_type: "LoweredBooleanRegion".to_string(),
             quantization_delta: (radius_float - max_dist as f32).abs(),
@@ -193,6 +199,8 @@ mod tests {
             &[true, false, true, true], // sig = 0b1101 = 13
             1.0,
             "cid_test_123",
+            101,
+            0,
         )
         .unwrap();
 
@@ -226,8 +234,15 @@ mod tests {
     #[test]
     fn test_unrepresentable_region_rejection() {
         let long_sig = vec![true; 100];
-        let err = BooleanLoweringCompiler::lower_region("reg_overflow", &long_sig, 1.0, "cid_err")
-            .unwrap_err();
+        let err = BooleanLoweringCompiler::lower_region(
+            "reg_overflow",
+            &long_sig,
+            1.0,
+            "cid_err",
+            101,
+            0,
+        )
+        .unwrap_err();
 
         assert!(matches!(err, LoweringError::UnrepresentableRegion { .. }));
     }

--- a/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
+++ b/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
@@ -246,4 +246,27 @@ mod tests {
 
         assert!(matches!(err, LoweringError::UnrepresentableRegion { .. }));
     }
+
+    #[test]
+    fn test_radius_exceeding_signature_width_rejected() {
+        let sig = vec![true, false, true, true]; // 4-bit signature
+        let err =
+            BooleanLoweringCompiler::lower_region("reg_wide_radius", &sig, 5.0, "cid_err", 101, 0)
+                .unwrap_err();
+
+        assert!(matches!(err, LoweringError::UnrepresentableRegion { .. }));
+    }
+
+    #[test]
+    fn test_saturation_boundary_not_flagged_when_exactly_representable() {
+        // i16::MAX / 256.0 is exactly representable and should not be marked saturated.
+        let q_exact_max = LoweredFixedPointScore::quantize_q88(i16::MAX as f32 / 256.0).unwrap();
+        assert_eq!(q_exact_max.q88_value, i16::MAX);
+        assert!(!q_exact_max.saturated);
+
+        // i16::MIN / 256.0 is exactly representable and should not be marked saturated.
+        let q_exact_min = LoweredFixedPointScore::quantize_q88(i16::MIN as f32 / 256.0).unwrap();
+        assert_eq!(q_exact_min.q88_value, i16::MIN);
+        assert!(!q_exact_min.saturated);
+    }
 }

--- a/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
+++ b/crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs
@@ -1,0 +1,234 @@
+//! Lowering Reference Semantic Regions into Boolean, Mask, Popcount, and Fixed-Point Programs
+//!
+//! Specification & Source: `docs/hologram_formal_analysis_direction.md` PDF §§5, 7, 17;
+//! `docs/formal_vocabulary.md` §6; GitHub Issue #130.
+//!
+//! This module implements the lowering boundary from the reference floating-point graph
+//! to the normative transformerless runtime representation:
+//! - Lowering region predicates into Boolean bitmasks, bit signatures, and Hamming/popcount thresholds.
+//! - Quantizing transition scores into fixed-width ScoreQ (Q8.8 i16) tables with explicit saturation.
+//! - Emitting traceable `LoweringWitness` linking runtime binary layout to reference IR CIDs.
+//! - Enforcing runtime transformerless invariants (XOR/AND/OR/shift/rotate/popcount/add/sub only).
+
+use std::fmt;
+
+/// Errors arising during semantic region lowering or fixed-point quantization.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoweringError {
+    /// Reference region center/boundary exceeds bounded integer representation.
+    UnrepresentableRegion { region_id: String, reason: String },
+    /// Score quantization overflow or invalid range.
+    QuantizationOverflow { score: f32 },
+    /// Reference IR state missing during lowering.
+    MissingReferenceState { state_id: String },
+}
+
+impl fmt::Display for LoweringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnrepresentableRegion { region_id, reason } => write!(
+                f,
+                "Reference region '{region_id}' unrepresentable in integer runtime: {reason}"
+            ),
+            Self::QuantizationOverflow { score } => {
+                write!(
+                    f,
+                    "Fixed-point score quantization overflow for value: {score:.4}"
+                )
+            }
+            Self::MissingReferenceState { state_id } => {
+                write!(f, "Missing reference state during lowering: {state_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LoweringError {}
+
+/// Lowered Boolean region predicate evaluated via bitwise XOR and POPCOUNT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoweredBooleanRegion {
+    pub region_id: String,
+    pub bitmask: u64,
+    pub expected_signature: u64,
+    pub max_hamming_distance: u32,
+    pub reference_contribution_id: u32,
+}
+
+impl LoweredBooleanRegion {
+    /// Runtime integer-only predicate evaluation (XOR + POPCOUNT).
+    /// Returns true if Hamming distance between input signature and region signature <= max threshold.
+    #[inline]
+    pub fn evaluate_runtime_integer(&self, input_signature: u64) -> bool {
+        let diff = (input_signature & self.bitmask) ^ (self.expected_signature & self.bitmask);
+        let hamming = diff.count_ones();
+        hamming <= self.max_hamming_distance
+    }
+}
+
+/// Quantized Q8.8 fixed-point ScoreQ program entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoweredFixedPointScore {
+    /// Q8.8 fixed-point representation (scaled by 256.0).
+    pub q88_value: i16,
+    pub saturated: bool,
+}
+
+impl LoweredFixedPointScore {
+    /// Quantize f32 float into Q8.8 i16 with explicit saturation.
+    pub fn quantize_q88(val: f32) -> Result<Self, LoweringError> {
+        if val.is_nan() {
+            return Err(LoweringError::QuantizationOverflow { score: val });
+        }
+        let scaled = (val * 256.0).round();
+        if scaled >= i16::MAX as f32 {
+            Ok(Self {
+                q88_value: i16::MAX,
+                saturated: true,
+            })
+        } else if scaled <= i16::MIN as f32 {
+            Ok(Self {
+                q88_value: i16::MIN,
+                saturated: true,
+            })
+        } else {
+            Ok(Self {
+                q88_value: scaled as i16,
+                saturated: false,
+            })
+        }
+    }
+
+    /// Dequantize back to f32 float for reference comparison testing.
+    pub fn dequantize(&self) -> f32 {
+        self.q88_value as f32 / 256.0
+    }
+}
+
+/// Traceable witness linking runtime integer table indices back to reference IR CIDs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoweringWitnessEntry {
+    pub runtime_table_index: u32,
+    pub reference_cid: String,
+    pub lowered_type: String,
+    pub quantization_delta: f32,
+}
+
+/// Complete Lowering Witness emitted alongside binary packed artifacts.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoweringWitness {
+    pub compiler_version: String,
+    pub total_lowered_regions: usize,
+    pub total_lowered_scores: usize,
+    pub entries: Vec<LoweringWitnessEntry>,
+}
+
+/// Lowering Compiler engine.
+pub struct BooleanLoweringCompiler;
+
+impl BooleanLoweringCompiler {
+    /// Lower a set of boolean signatures and radiuses into `LoweredBooleanRegion` predicates.
+    pub fn lower_region(
+        region_id: impl Into<String>,
+        signature_bits: &[bool],
+        radius_float: f32,
+        ref_cid: &str,
+    ) -> Result<(LoweredBooleanRegion, LoweringWitnessEntry), LoweringError> {
+        let r_id = region_id.into();
+        if signature_bits.len() > 64 {
+            return Err(LoweringError::UnrepresentableRegion {
+                region_id: r_id,
+                reason: format!(
+                    "Signature length {} exceeds 64-bit mask limit",
+                    signature_bits.len()
+                ),
+            });
+        }
+        if !(0.0..=64.0).contains(&radius_float) {
+            return Err(LoweringError::UnrepresentableRegion {
+                region_id: r_id,
+                reason: format!("Radius {radius_float:.2} outside valid Hamming bound [0..64]"),
+            });
+        }
+
+        let mut sig_u64 = 0u64;
+        let mut mask_u64 = 0u64;
+
+        for (idx, &bit) in signature_bits.iter().enumerate() {
+            mask_u64 |= 1u64 << idx;
+            if bit {
+                sig_u64 |= 1u64 << idx;
+            }
+        }
+
+        let max_dist = radius_float.floor() as u32;
+
+        let region = LoweredBooleanRegion {
+            region_id: r_id.clone(),
+            bitmask: mask_u64,
+            expected_signature: sig_u64,
+            max_hamming_distance: max_dist,
+            reference_contribution_id: 101,
+        };
+
+        let witness = LoweringWitnessEntry {
+            runtime_table_index: 0,
+            reference_cid: ref_cid.to_string(),
+            lowered_type: "LoweredBooleanRegion".to_string(),
+            quantization_delta: (radius_float - max_dist as f32).abs(),
+        };
+
+        Ok((region, witness))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lowered_boolean_region_runtime_integer_evaluation() {
+        let (region, witness) = BooleanLoweringCompiler::lower_region(
+            "reg_1",
+            &[true, false, true, true], // sig = 0b1101 = 13
+            1.0,
+            "cid_test_123",
+        )
+        .unwrap();
+
+        assert_eq!(witness.reference_cid, "cid_test_123");
+
+        // Exact match -> distance 0 <= 1 -> true
+        assert!(region.evaluate_runtime_integer(0b1101));
+        // 1 bit difference -> distance 1 <= 1 -> true
+        assert!(region.evaluate_runtime_integer(0b1100));
+        // 2 bits difference -> distance 2 > 1 -> false
+        assert!(!region.evaluate_runtime_integer(0b0000));
+    }
+
+    #[test]
+    fn test_q88_fixed_point_quantization_and_saturation() {
+        let q_normal = LoweredFixedPointScore::quantize_q88(1.5).unwrap();
+        assert_eq!(q_normal.q88_value, 384); // 1.5 * 256
+        assert!(!q_normal.saturated);
+        assert!((q_normal.dequantize() - 1.5).abs() < 1e-4);
+
+        // Saturation test
+        let q_max = LoweredFixedPointScore::quantize_q88(500.0).unwrap();
+        assert_eq!(q_max.q88_value, i16::MAX);
+        assert!(q_max.saturated);
+
+        let q_min = LoweredFixedPointScore::quantize_q88(-500.0).unwrap();
+        assert_eq!(q_min.q88_value, i16::MIN);
+        assert!(q_min.saturated);
+    }
+
+    #[test]
+    fn test_unrepresentable_region_rejection() {
+        let long_sig = vec![true; 100];
+        let err = BooleanLoweringCompiler::lower_region("reg_overflow", &long_sig, 1.0, "cid_err")
+            .unwrap_err();
+
+        assert!(matches!(err, LoweringError::UnrepresentableRegion { .. }));
+    }
+}

--- a/features/suites/lower_semantic_regions.feature
+++ b/features/suites/lower_semantic_regions.feature
@@ -1,0 +1,21 @@
+@status:enforced
+Feature: Lowering reference semantic regions into Boolean, mask, popcount, and fixed-point programs
+  Reference floating-point semantic regions and transition scores must lower into integer-only bitmask, popcount, and Q8.8 fixed-point ScoreQ programs with traceable lowering witnesses.
+
+  Scenario: Lower a reference semantic region into integer bitmask and popcount predicate
+    Given a reference semantic region with signature [true, false, true, true] and Hamming radius 1.0
+    When the region is lowered into a LoweredBooleanRegion
+    Then the integer predicate evaluates to true for signatures within Hamming distance 1
+    And evaluates to false for signatures outside Hamming distance 1
+    And a LoweringWitnessEntry is recorded
+
+  Scenario: Quantize reference transition scores into Q8.8 fixed-point ScoreQ values with saturation
+    Given floating-point scores 1.5, 500.0, and -500.0
+    When scores are quantized into Q8.8 fixed-point representation
+    Then 1.5 quantizes to 384 without saturation
+    And extreme scores saturate at i16 MAX and i16 MIN
+
+  Scenario: Reject reference regions exceeding maximum bitmask capacity
+    Given a reference region with a 100-bit signature
+    When region lowering is attempted
+    Then lowering fails with an unrepresentable region error

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -50,6 +50,13 @@ struct R4g1World {
     u8_a: u8,
     u8_b: u8,
     u8_res: u8,
+    // Lower Semantic Regions fields (#130)
+    lower_bool_region: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweredBooleanRegion>,
+    lower_witness: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweringWitnessEntry>,
+    lower_q_normal: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweredFixedPointScore>,
+    lower_q_max: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweredFixedPointScore>,
+    lower_q_min: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweredFixedPointScore>,
+    lower_error: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweringError>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -470,6 +477,99 @@ fn u8_kernel_zero_floats(_w: &mut R4g1World) {
     let kernel_code = &source[kernel_start..];
     assert!(!kernel_code.contains("f32") && !kernel_code.contains("f64"));
     assert!(!kernel_code.contains(" * ") && !kernel_code.contains(" / "));
+}
+
+// =========================================================================
+// Lower Semantic Regions BDD Steps (#130)
+// =========================================================================
+use uor_r4_graph_compiler::lower_semantic_regions::{
+    BooleanLoweringCompiler, LoweredFixedPointScore, LoweringError,
+};
+
+#[given(
+    "a reference semantic region with signature [true, false, true, true] and Hamming radius 1.0"
+)]
+fn bdd_given_ref_region(_w: &mut R4g1World) {}
+
+#[when("the region is lowered into a LoweredBooleanRegion")]
+fn bdd_lower_region_step(w: &mut R4g1World) {
+    let (region, witness) = BooleanLoweringCompiler::lower_region(
+        "reg_bdd_1",
+        &[true, false, true, true],
+        1.0,
+        "cid_bdd_ref_101",
+    )
+    .unwrap();
+    w.lower_bool_region = Some(region);
+    w.lower_witness = Some(witness);
+}
+
+#[then("the integer predicate evaluates to true for signatures within Hamming distance 1")]
+fn bdd_integer_predicate_within_distance(w: &mut R4g1World) {
+    let region = w.lower_bool_region.as_ref().expect("region");
+    // Exact 0b1101 = 13 (distance 0)
+    assert!(region.evaluate_runtime_integer(0b1101));
+    // Distance 1 (0b1100)
+    assert!(region.evaluate_runtime_integer(0b1100));
+}
+
+#[then("evaluates to false for signatures outside Hamming distance 1")]
+fn bdd_integer_predicate_outside_distance(w: &mut R4g1World) {
+    let region = w.lower_bool_region.as_ref().expect("region");
+    // Distance 2 (0b0000)
+    assert!(!region.evaluate_runtime_integer(0b0000));
+}
+
+#[then("a LoweringWitnessEntry is recorded")]
+fn bdd_witness_recorded_check(w: &mut R4g1World) {
+    let witness = w.lower_witness.as_ref().expect("witness");
+    assert_eq!(witness.reference_cid, "cid_bdd_ref_101");
+}
+
+#[given("floating-point scores 1.5, 500.0, and -500.0")]
+fn bdd_given_float_scores(_w: &mut R4g1World) {}
+
+#[when("scores are quantized into Q8.8 fixed-point representation")]
+fn bdd_quantize_scores_step(w: &mut R4g1World) {
+    w.lower_q_normal = Some(LoweredFixedPointScore::quantize_q88(1.5).unwrap());
+    w.lower_q_max = Some(LoweredFixedPointScore::quantize_q88(500.0).unwrap());
+    w.lower_q_min = Some(LoweredFixedPointScore::quantize_q88(-500.0).unwrap());
+}
+
+#[then("1.5 quantizes to 384 without saturation")]
+fn bdd_quantize_1_5_check(w: &mut R4g1World) {
+    let q = w.lower_q_normal.as_ref().expect("normal q");
+    assert_eq!(q.q88_value, 384);
+    assert!(!q.saturated);
+}
+
+#[then("extreme scores saturate at i16 MAX and i16 MIN")]
+fn bdd_quantize_extreme_check(w: &mut R4g1World) {
+    let q_max = w.lower_q_max.as_ref().expect("max q");
+    assert_eq!(q_max.q88_value, i16::MAX);
+    assert!(q_max.saturated);
+
+    let q_min = w.lower_q_min.as_ref().expect("min q");
+    assert_eq!(q_min.q88_value, i16::MIN);
+    assert!(q_min.saturated);
+}
+
+#[given("a reference region with a 100-bit signature")]
+fn bdd_given_100bit_sig(_w: &mut R4g1World) {}
+
+#[when("region lowering is attempted")]
+fn bdd_attempt_100bit_lowering(w: &mut R4g1World) {
+    let long_sig = vec![true; 100];
+    if let Err(e) = BooleanLoweringCompiler::lower_region("reg_overflow", &long_sig, 1.0, "cid_err")
+    {
+        w.lower_error = Some(e);
+    }
+}
+
+#[then("lowering fails with an unrepresentable region error")]
+fn bdd_unrepresentable_error_check(w: &mut R4g1World) {
+    let err = w.lower_error.as_ref().expect("lower error");
+    assert!(matches!(err, LoweringError::UnrepresentableRegion { .. }));
 }
 
 #[tokio::main]

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -498,6 +498,8 @@ fn bdd_lower_region_step(w: &mut R4g1World) {
         &[true, false, true, true],
         1.0,
         "cid_bdd_ref_101",
+        101,
+        0,
     )
     .unwrap();
     w.lower_bool_region = Some(region);
@@ -560,7 +562,8 @@ fn bdd_given_100bit_sig(_w: &mut R4g1World) {}
 #[when("region lowering is attempted")]
 fn bdd_attempt_100bit_lowering(w: &mut R4g1World) {
     let long_sig = vec![true; 100];
-    if let Err(e) = BooleanLoweringCompiler::lower_region("reg_overflow", &long_sig, 1.0, "cid_err")
+    if let Err(e) =
+        BooleanLoweringCompiler::lower_region("reg_overflow", &long_sig, 1.0, "cid_err", 101, 0)
     {
         w.lower_error = Some(e);
     }


### PR DESCRIPTION
## Overview & Purpose
Resolves #130. Implementation follows PDF §§5, 7, 17 and `docs/formal_vocabulary.md` §6.

## Key Changes
1. **Boolean & Popcount Region Lowering**: Implemented `LoweredBooleanRegion` lowering reference floating-point region center vectors and Hamming radiuses into 64-bit bitmasks, expected signatures, and integer-only predicate evaluation via `XOR` and `POPCOUNT`.
2. **Fixed-Point Q8.8 ScoreQ Quantization**: Implemented `LoweredFixedPointScore` quantizing floating-point transition and emission scores into Q8.8 (`i16`) representation with explicit saturation boundaries (`i16::MIN`..`i16::MAX`).
3. **Traceable Lowering Witness**: Implemented `LoweringWitness` tracking `LoweringWitnessEntry` items to map each runtime table index/bit back to a reference IR CID and record quantization deltas.
4. **Unrepresentable Region Guard**: Implemented explicit `LoweringError::UnrepresentableRegion` for signatures exceeding 64 bits or invalid Hamming bounds.
5. **Cucumber BDD Suite**: Added `features/suites/lower_semantic_regions.feature` with 3 scenarios and step definitions in `tests/bdd.rs`.

## Verification
- `cargo fmt --check`: Clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`: Clean
- `cargo test --workspace --offline`: All unit tests passed
- `cargo test --test bdd --offline`: All 28 BDD scenarios passed (90 steps)
- `cargo check -p uor-r4-graph-format --no-default-features`: Clean
- `python3 scripts/check_claim_wording.py`: Wording gate passed