### PR TITLE
feat(compiler): implement bounded future-state optimization and planning over graph transitions (#131)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/future_state_planner.rs
+++ b/crates/uor-r4-graph-compiler/src/future_state_planner.rs
@@ -1,0 +1,398 @@
+//! Bounded Future-State Optimization & Planning Over Graph Transitions
+//!
+//! Specification & Source: `docs/hologram_formal_analysis_direction.md` PDF §§3, 10, 12, 17;
+//! `docs/formal_vocabulary.md` §5; GitHub Issue #131.
+//!
+//! This module replaces overloaded intent framing with an explicit bounded future-state optimizer:
+//! - Finite action trajectory search $s_0 \xrightarrow{a_1} s_1 \xrightarrow{a_2} \dots \xrightarrow{a_k} s_k \in G$.
+//! - Enforces forbidden region constraints $s_i \notin C$ at every intermediate step.
+//! - Bounded planning horizon $H_{\max}$, frontier size $K_{\max}$, and deterministic tie-breaking.
+//! - Emits `PlanWitness` recording selected transitions and rejected counterfactual alternatives.
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::fmt;
+
+/// Errors arising during trajectory planning or constraint evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlannerError {
+    /// Initial state violates forbidden region constraint.
+    InitialStateForbidden { state_id: String },
+    /// No valid plan reaches the goal region within the horizon bound.
+    HorizonExceeded { max_horizon: usize },
+    /// Search frontier exhausted without finding goal region.
+    FrontierExhausted { nodes_expanded: usize },
+    /// Transition confidence below uncertainty threshold.
+    UncertainTransition {
+        src_id: String,
+        action: String,
+        confidence: f32,
+    },
+    /// Transition enters forbidden constraint region.
+    ForbiddenStateViolation { state_id: String, region_id: String },
+}
+
+impl fmt::Display for PlannerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InitialStateForbidden { state_id } => {
+                write!(
+                    f,
+                    "Initial state '{state_id}' is inside a forbidden constraint region"
+                )
+            }
+            Self::HorizonExceeded { max_horizon } => {
+                write!(
+                    f,
+                    "Goal not reached within maximum planning horizon of {max_horizon} steps"
+                )
+            }
+            Self::FrontierExhausted { nodes_expanded } => {
+                write!(
+                    f,
+                    "Search frontier exhausted after expanding {nodes_expanded} nodes"
+                )
+            }
+            Self::UncertainTransition {
+                src_id,
+                action,
+                confidence,
+            } => write!(
+                f,
+                "Uncertain transition from '{src_id}' under action '{action}' (confidence = {confidence:.2})"
+            ),
+            Self::ForbiddenStateViolation {
+                state_id,
+                region_id,
+            } => write!(
+                f,
+                "State '{state_id}' violates forbidden constraint region '{region_id}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PlannerError {}
+
+/// Graph state node for graph transitions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannerStateNode {
+    pub id: String,
+    pub is_goal: bool,
+    pub is_forbidden: bool,
+    pub forbidden_region_id: Option<String>,
+}
+
+/// Typed graph edge transition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannerEdgeTransition {
+    pub src_id: String,
+    pub action: String,
+    pub dst_id: String,
+    pub cost: f32,
+    pub confidence: f32,
+}
+
+/// Planning configuration and resource bounds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannerConfig {
+    pub max_horizon: usize,
+    pub max_frontier_size: usize,
+    pub min_confidence_threshold: f32,
+}
+
+impl PlannerConfig {
+    pub fn default_v1() -> Self {
+        Self {
+            max_horizon: 10,
+            max_frontier_size: 100,
+            min_confidence_threshold: 0.5,
+        }
+    }
+}
+
+impl Default for PlannerConfig {
+    fn default() -> Self {
+        Self::default_v1()
+    }
+}
+
+/// Plan trajectory result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlanTrajectory {
+    pub state_sequence: Vec<String>,
+    pub action_sequence: Vec<String>,
+    pub total_cost: f32,
+    pub horizon_steps: usize,
+    pub nodes_expanded: usize,
+    pub witness: PlanWitness,
+}
+
+/// Audit witness recording selected transitions and rejected alternatives.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlanWitness {
+    pub plan_cid: String,
+    pub accepted_edges: Vec<(String, String, String)>, // (src, action, dst)
+    pub rejected_alternatives_count: usize,
+}
+
+#[derive(Clone, PartialEq)]
+struct SearchNode {
+    state_id: String,
+    g_cost: f32,
+    h_cost: f32,
+    f_cost: f32,
+    depth: usize,
+    state_path: Vec<String>,
+    action_path: Vec<String>,
+}
+
+impl Eq for SearchNode {}
+
+impl Ord for SearchNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Min-heap based on f_cost with deterministic tie-breaking on state_id
+        other
+            .f_cost
+            .partial_cmp(&self.f_cost)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| self.state_id.cmp(&other.state_id))
+    }
+}
+
+impl PartialOrd for SearchNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Bounded Future-State Graph Planner.
+pub struct BoundedGraphPlanner;
+
+impl BoundedGraphPlanner {
+    /// Plan finite action trajectory from start state to goal region avoiding forbidden states.
+    pub fn plan(
+        start_state_id: &str,
+        nodes: &[PlannerStateNode],
+        edges: &[PlannerEdgeTransition],
+        config: &PlannerConfig,
+    ) -> Result<PlanTrajectory, PlannerError> {
+        let node_map: HashMap<&str, &PlannerStateNode> =
+            nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+        let start_node =
+            node_map
+                .get(start_state_id)
+                .ok_or_else(|| PlannerError::InitialStateForbidden {
+                    state_id: start_state_id.to_string(),
+                })?;
+
+        if start_node.is_forbidden {
+            return Err(PlannerError::InitialStateForbidden {
+                state_id: start_state_id.to_string(),
+            });
+        }
+
+        let mut open_set = BinaryHeap::new();
+        let mut visited = HashSet::new();
+        let mut rejected_count = 0;
+        let mut nodes_expanded = 0;
+
+        open_set.push(SearchNode {
+            state_id: start_state_id.to_string(),
+            g_cost: 0.0,
+            h_cost: 0.0,
+            f_cost: 0.0,
+            depth: 0,
+            state_path: vec![start_state_id.to_string()],
+            action_path: Vec::new(),
+        });
+
+        while let Some(current) = open_set.pop() {
+            nodes_expanded += 1;
+
+            let curr_node = node_map.get(current.state_id.as_str()).unwrap();
+            if curr_node.is_goal {
+                let mut accepted_edges = Vec::new();
+                for i in 0..current.action_path.len() {
+                    accepted_edges.push((
+                        current.state_path[i].clone(),
+                        current.action_path[i].clone(),
+                        current.state_path[i + 1].clone(),
+                    ));
+                }
+
+                let plan_cid = format!("plan_{:08x}", simple_cid(&current.state_path.join("->")));
+                return Ok(PlanTrajectory {
+                    state_sequence: current.state_path,
+                    action_sequence: current.action_path,
+                    total_cost: current.g_cost,
+                    horizon_steps: current.depth,
+                    nodes_expanded,
+                    witness: PlanWitness {
+                        plan_cid,
+                        accepted_edges,
+                        rejected_alternatives_count: rejected_count,
+                    },
+                });
+            }
+
+            if current.depth >= config.max_horizon {
+                continue;
+            }
+
+            if visited.contains(&current.state_id) {
+                continue;
+            }
+            visited.insert(current.state_id.clone());
+
+            let outgoing: Vec<&PlannerEdgeTransition> = edges
+                .iter()
+                .filter(|e| e.src_id == current.state_id)
+                .collect();
+
+            for edge in outgoing {
+                if edge.confidence < config.min_confidence_threshold {
+                    rejected_count += 1;
+                    continue;
+                }
+
+                let dst_node = match node_map.get(edge.dst_id.as_str()) {
+                    Some(n) => n,
+                    None => {
+                        rejected_count += 1;
+                        continue;
+                    }
+                };
+
+                if dst_node.is_forbidden {
+                    rejected_count += 1;
+                    continue;
+                }
+
+                let new_g = current.g_cost + edge.cost;
+                let new_h = if dst_node.is_goal { 0.0 } else { 1.0 };
+                let new_f = new_g + new_h;
+
+                let mut new_state_path = current.state_path.clone();
+                new_state_path.push(edge.dst_id.clone());
+
+                let mut new_action_path = current.action_path.clone();
+                new_action_path.push(edge.action.clone());
+
+                open_set.push(SearchNode {
+                    state_id: edge.dst_id.clone(),
+                    g_cost: new_g,
+                    h_cost: new_h,
+                    f_cost: new_f,
+                    depth: current.depth + 1,
+                    state_path: new_state_path,
+                    action_path: new_action_path,
+                });
+            }
+
+            if open_set.len() > config.max_frontier_size {
+                return Err(PlannerError::FrontierExhausted { nodes_expanded });
+            }
+        }
+
+        Err(PlannerError::FrontierExhausted { nodes_expanded })
+    }
+}
+
+fn simple_cid(input: &str) -> u32 {
+    let mut h = 0x811c9dc5u32;
+    for b in input.bytes() {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x01000193);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bounded_planner_successful_goal_reaching() {
+        let nodes = vec![
+            PlannerStateNode {
+                id: "s0".to_string(),
+                is_goal: false,
+                is_forbidden: false,
+                forbidden_region_id: None,
+            },
+            PlannerStateNode {
+                id: "s1".to_string(),
+                is_goal: false,
+                is_forbidden: false,
+                forbidden_region_id: None,
+            },
+            PlannerStateNode {
+                id: "s2".to_string(),
+                is_goal: true,
+                is_forbidden: false,
+                forbidden_region_id: None,
+            },
+        ];
+        let edges = vec![
+            PlannerEdgeTransition {
+                src_id: "s0".to_string(),
+                action: "step1".to_string(),
+                dst_id: "s1".to_string(),
+                cost: 1.0,
+                confidence: 0.9,
+            },
+            PlannerEdgeTransition {
+                src_id: "s1".to_string(),
+                action: "step2".to_string(),
+                dst_id: "s2".to_string(),
+                cost: 1.0,
+                confidence: 0.95,
+            },
+        ];
+
+        let config = PlannerConfig::default_v1();
+        let plan = BoundedGraphPlanner::plan("s0", &nodes, &edges, &config).unwrap();
+
+        assert_eq!(plan.state_sequence, vec!["s0", "s1", "s2"]);
+        assert_eq!(plan.action_sequence, vec!["step1", "step2"]);
+        assert_eq!(plan.horizon_steps, 2);
+        assert!(plan.witness.plan_cid.starts_with("plan_"));
+    }
+
+    #[test]
+    fn test_bounded_planner_forbidden_constraint_rejection() {
+        let nodes = vec![
+            PlannerStateNode {
+                id: "s0".to_string(),
+                is_goal: false,
+                is_forbidden: false,
+                forbidden_region_id: None,
+            },
+            PlannerStateNode {
+                id: "s1".to_string(),
+                is_goal: false,
+                is_forbidden: true,
+                forbidden_region_id: Some("C_hazard".to_string()),
+            },
+            PlannerStateNode {
+                id: "s2".to_string(),
+                is_goal: true,
+                is_forbidden: false,
+                forbidden_region_id: None,
+            },
+        ];
+        let edges = vec![PlannerEdgeTransition {
+            src_id: "s0".to_string(),
+            action: "step1".to_string(),
+            dst_id: "s1".to_string(),
+            cost: 1.0,
+            confidence: 0.9,
+        }];
+
+        let config = PlannerConfig::default_v1();
+        let err = BoundedGraphPlanner::plan("s0", &nodes, &edges, &config).unwrap_err();
+        assert!(matches!(err, PlannerError::FrontierExhausted { .. }));
+    }
+}

--- a/crates/uor-r4-graph-compiler/src/future_state_planner.rs
+++ b/crates/uor-r4-graph-compiler/src/future_state_planner.rs
@@ -213,6 +213,9 @@ impl BoundedGraphPlanner {
         let mut rejected_count = 0;
         let mut nodes_expanded = 0;
         let mut forbidden_states_entered = 0;
+        // Set when any node's expansion is dropped for hitting `max_horizon`; used to
+        // report `HorizonExceeded` rather than a misleading `FrontierExhausted` when the
+        // search would otherwise have continued past the bound.
         let mut horizon_capped = false;
 
         open_set.push(SearchNode {

--- a/crates/uor-r4-graph-compiler/src/future_state_planner.rs
+++ b/crates/uor-r4-graph-compiler/src/future_state_planner.rs
@@ -159,7 +159,7 @@ struct SearchNode {
 
 impl PartialEq for SearchNode {
     fn eq(&self, other: &Self) -> bool {
-        self.state_id == other.state_id && self.f_cost.total_cmp(&other.f_cost) == Ordering::Equal
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -227,7 +227,10 @@ impl BoundedGraphPlanner {
         while let Some(current) = open_set.pop() {
             nodes_expanded += 1;
 
-            let curr_node = node_map.get(current.state_id.as_str()).unwrap();
+            let curr_node = match node_map.get(current.state_id.as_str()) {
+                Some(n) => n,
+                None => continue,
+            };
             if curr_node.is_forbidden {
                 forbidden_states_entered += 1;
                 continue;

--- a/crates/uor-r4-graph-compiler/src/future_state_planner.rs
+++ b/crates/uor-r4-graph-compiler/src/future_state_planner.rs
@@ -18,10 +18,15 @@ use std::fmt;
 pub enum PlannerError {
     /// Initial state violates forbidden region constraint.
     InitialStateForbidden { state_id: String },
+    /// The requested state does not exist in the state graph.
+    UnknownState { state_id: String },
     /// No valid plan reaches the goal region within the horizon bound.
     HorizonExceeded { max_horizon: usize },
     /// Search frontier exhausted without finding goal region.
-    FrontierExhausted { nodes_expanded: usize },
+    FrontierExhausted {
+        nodes_expanded: usize,
+        forbidden_states_entered: usize,
+    },
     /// Transition confidence below uncertainty threshold.
     UncertainTransition {
         src_id: String,
@@ -41,16 +46,22 @@ impl fmt::Display for PlannerError {
                     "Initial state '{state_id}' is inside a forbidden constraint region"
                 )
             }
+            Self::UnknownState { state_id } => {
+                write!(f, "State '{state_id}' does not exist in the state graph")
+            }
             Self::HorizonExceeded { max_horizon } => {
                 write!(
                     f,
                     "Goal not reached within maximum planning horizon of {max_horizon} steps"
                 )
             }
-            Self::FrontierExhausted { nodes_expanded } => {
+            Self::FrontierExhausted {
+                nodes_expanded,
+                forbidden_states_entered,
+            } => {
                 write!(
                     f,
-                    "Search frontier exhausted after expanding {nodes_expanded} nodes"
+                    "Search frontier exhausted after expanding {nodes_expanded} nodes ({forbidden_states_entered} forbidden states entered)"
                 )
             }
             Self::UncertainTransition {
@@ -136,15 +147,20 @@ pub struct PlanWitness {
     pub rejected_alternatives_count: usize,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 struct SearchNode {
     state_id: String,
     g_cost: f32,
-    h_cost: f32,
     f_cost: f32,
     depth: usize,
     state_path: Vec<String>,
     action_path: Vec<String>,
+}
+
+impl PartialEq for SearchNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.state_id == other.state_id && self.f_cost.total_cmp(&other.f_cost) == Ordering::Equal
+    }
 }
 
 impl Eq for SearchNode {}
@@ -154,8 +170,7 @@ impl Ord for SearchNode {
         // Min-heap based on f_cost with deterministic tie-breaking on state_id
         other
             .f_cost
-            .partial_cmp(&self.f_cost)
-            .unwrap_or(Ordering::Equal)
+            .total_cmp(&self.f_cost)
             .then_with(|| self.state_id.cmp(&other.state_id))
     }
 }
@@ -183,7 +198,7 @@ impl BoundedGraphPlanner {
         let start_node =
             node_map
                 .get(start_state_id)
-                .ok_or_else(|| PlannerError::InitialStateForbidden {
+                .ok_or_else(|| PlannerError::UnknownState {
                     state_id: start_state_id.to_string(),
                 })?;
 
@@ -197,11 +212,12 @@ impl BoundedGraphPlanner {
         let mut visited = HashSet::new();
         let mut rejected_count = 0;
         let mut nodes_expanded = 0;
+        let mut forbidden_states_entered = 0;
+        let mut horizon_capped = false;
 
         open_set.push(SearchNode {
             state_id: start_state_id.to_string(),
             g_cost: 0.0,
-            h_cost: 0.0,
             f_cost: 0.0,
             depth: 0,
             state_path: vec![start_state_id.to_string()],
@@ -212,6 +228,10 @@ impl BoundedGraphPlanner {
             nodes_expanded += 1;
 
             let curr_node = node_map.get(current.state_id.as_str()).unwrap();
+            if curr_node.is_forbidden {
+                forbidden_states_entered += 1;
+                continue;
+            }
             if curr_node.is_goal {
                 let mut accepted_edges = Vec::new();
                 for i in 0..current.action_path.len() {
@@ -222,7 +242,10 @@ impl BoundedGraphPlanner {
                     ));
                 }
 
-                let plan_cid = format!("plan_{:08x}", simple_cid(&current.state_path.join("->")));
+                let plan_cid = format!(
+                    "blake3:plan_{}",
+                    blake3::hash(current.state_path.join("->").as_bytes()).to_hex()
+                );
                 return Ok(PlanTrajectory {
                     state_sequence: current.state_path,
                     action_sequence: current.action_path,
@@ -238,6 +261,7 @@ impl BoundedGraphPlanner {
             }
 
             if current.depth >= config.max_horizon {
+                horizon_capped = true;
                 continue;
             }
 
@@ -283,7 +307,6 @@ impl BoundedGraphPlanner {
                 open_set.push(SearchNode {
                     state_id: edge.dst_id.clone(),
                     g_cost: new_g,
-                    h_cost: new_h,
                     f_cost: new_f,
                     depth: current.depth + 1,
                     state_path: new_state_path,
@@ -292,21 +315,24 @@ impl BoundedGraphPlanner {
             }
 
             if open_set.len() > config.max_frontier_size {
-                return Err(PlannerError::FrontierExhausted { nodes_expanded });
+                return Err(PlannerError::FrontierExhausted {
+                    nodes_expanded,
+                    forbidden_states_entered,
+                });
             }
         }
 
-        Err(PlannerError::FrontierExhausted { nodes_expanded })
-    }
-}
+        if horizon_capped {
+            return Err(PlannerError::HorizonExceeded {
+                max_horizon: config.max_horizon,
+            });
+        }
 
-fn simple_cid(input: &str) -> u32 {
-    let mut h = 0x811c9dc5u32;
-    for b in input.bytes() {
-        h ^= b as u32;
-        h = h.wrapping_mul(0x01000193);
+        Err(PlannerError::FrontierExhausted {
+            nodes_expanded,
+            forbidden_states_entered,
+        })
     }
-    h
 }
 
 #[cfg(test)]
@@ -358,7 +384,7 @@ mod tests {
         assert_eq!(plan.state_sequence, vec!["s0", "s1", "s2"]);
         assert_eq!(plan.action_sequence, vec!["step1", "step2"]);
         assert_eq!(plan.horizon_steps, 2);
-        assert!(plan.witness.plan_cid.starts_with("plan_"));
+        assert!(plan.witness.plan_cid.starts_with("blake3:plan_"));
     }
 
     #[test]
@@ -393,6 +419,12 @@ mod tests {
 
         let config = PlannerConfig::default_v1();
         let err = BoundedGraphPlanner::plan("s0", &nodes, &edges, &config).unwrap_err();
-        assert!(matches!(err, PlannerError::FrontierExhausted { .. }));
+        match err {
+            PlannerError::FrontierExhausted {
+                forbidden_states_entered,
+                ..
+            } => assert_eq!(forbidden_states_entered, 0),
+            other => panic!("expected FrontierExhausted, got {other:?}"),
+        }
     }
 }

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod future_state_planner;
 pub mod graph;
 pub mod induction;
 pub mod observation;

--- a/features/suites/future_state_planner.feature
+++ b/features/suites/future_state_planner.feature
@@ -1,0 +1,19 @@
+@status:enforced
+Feature: Bounded future-state optimization and planning over graph transitions
+  The future-state optimizer must search finite action trajectories reaching goal regions while avoiding forbidden constraint states and enforcing horizon bounds.
+
+  Scenario: Plan a 2-step trajectory to a goal region avoiding hazards
+    Given a start state "s0", intermediate state "s1", and goal state "s2"
+    When the bounded graph planner computes a trajectory
+    Then the action sequence ["step1", "step2"] reaches "s2" in 2 steps
+    And a PlanWitness recording accepted transitions and plan CID is emitted
+
+  Scenario: Reject trajectories that enter forbidden constraint states
+    Given an intermediate state "s1" marked as forbidden
+    When the bounded graph planner attempts to plan a trajectory through "s1"
+    Then planning fails with a frontier exhausted error and zero forbidden states entered
+
+  Scenario: Reject initial state inside a forbidden region
+    Given a start state "s0" marked as forbidden
+    When planning is initiated from "s0"
+    Then planning fails immediately with an initial state forbidden error

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -545,7 +545,7 @@ fn bdd_planner_trajectory_check(w: &mut R4g1World) {
 #[then("a PlanWitness recording accepted transitions and plan CID is emitted")]
 fn bdd_planner_witness_check(w: &mut R4g1World) {
     let plan = w.plan_result.as_ref().expect("plan");
-    assert!(plan.witness.plan_cid.starts_with("plan_"));
+    assert!(plan.witness.plan_cid.starts_with("blake3:plan_"));
     assert_eq!(plan.witness.accepted_edges.len(), 2);
 }
 
@@ -591,7 +591,13 @@ fn bdd_planner_attempt_forbidden_plan(w: &mut R4g1World) {
 #[then("planning fails with a frontier exhausted error and zero forbidden states entered")]
 fn bdd_planner_frontier_exhausted_check(w: &mut R4g1World) {
     let err = w.plan_error.as_ref().expect("plan error");
-    assert!(matches!(err, PlannerError::FrontierExhausted { .. }));
+    match err {
+        PlannerError::FrontierExhausted {
+            forbidden_states_entered,
+            ..
+        } => assert_eq!(*forbidden_states_entered, 0),
+        other => panic!("expected FrontierExhausted, got {other:?}"),
+    }
 }
 
 #[given("a start state \"s0\" marked as forbidden")]

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -50,6 +50,11 @@ struct R4g1World {
     u8_a: u8,
     u8_b: u8,
     u8_res: u8,
+    // Future State Planner fields (#131)
+    plan_nodes: Vec<uor_r4_graph_compiler::future_state_planner::PlannerStateNode>,
+    plan_edges: Vec<uor_r4_graph_compiler::future_state_planner::PlannerEdgeTransition>,
+    plan_result: Option<uor_r4_graph_compiler::future_state_planner::PlanTrajectory>,
+    plan_error: Option<uor_r4_graph_compiler::future_state_planner::PlannerError>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -470,6 +475,148 @@ fn u8_kernel_zero_floats(_w: &mut R4g1World) {
     let kernel_code = &source[kernel_start..];
     assert!(!kernel_code.contains("f32") && !kernel_code.contains("f64"));
     assert!(!kernel_code.contains(" * ") && !kernel_code.contains(" / "));
+}
+
+// =========================================================================
+// Future State Planner BDD Steps (#131)
+// =========================================================================
+use uor_r4_graph_compiler::future_state_planner::{
+    BoundedGraphPlanner, PlannerConfig, PlannerEdgeTransition, PlannerError, PlannerStateNode,
+};
+
+#[given("a start state \"s0\", intermediate state \"s1\", and goal state \"s2\"")]
+fn bdd_planner_setup_valid_graph(w: &mut R4g1World) {
+    w.plan_nodes = vec![
+        PlannerStateNode {
+            id: "s0".to_string(),
+            is_goal: false,
+            is_forbidden: false,
+            forbidden_region_id: None,
+        },
+        PlannerStateNode {
+            id: "s1".to_string(),
+            is_goal: false,
+            is_forbidden: false,
+            forbidden_region_id: None,
+        },
+        PlannerStateNode {
+            id: "s2".to_string(),
+            is_goal: true,
+            is_forbidden: false,
+            forbidden_region_id: None,
+        },
+    ];
+    w.plan_edges = vec![
+        PlannerEdgeTransition {
+            src_id: "s0".to_string(),
+            action: "step1".to_string(),
+            dst_id: "s1".to_string(),
+            cost: 1.0,
+            confidence: 0.9,
+        },
+        PlannerEdgeTransition {
+            src_id: "s1".to_string(),
+            action: "step2".to_string(),
+            dst_id: "s2".to_string(),
+            cost: 1.0,
+            confidence: 0.95,
+        },
+    ];
+}
+
+#[when("the bounded graph planner computes a trajectory")]
+fn bdd_planner_compute_trajectory(w: &mut R4g1World) {
+    let config = PlannerConfig::default_v1();
+    let res = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config);
+    match res {
+        Ok(t) => w.plan_result = Some(t),
+        Err(e) => w.plan_error = Some(e),
+    }
+}
+
+#[then("the action sequence [\"step1\", \"step2\"] reaches \"s2\" in 2 steps")]
+fn bdd_planner_trajectory_check(w: &mut R4g1World) {
+    let plan = w.plan_result.as_ref().expect("plan");
+    assert_eq!(plan.action_sequence, vec!["step1", "step2"]);
+    assert_eq!(plan.state_sequence, vec!["s0", "s1", "s2"]);
+    assert_eq!(plan.horizon_steps, 2);
+}
+
+#[then("a PlanWitness recording accepted transitions and plan CID is emitted")]
+fn bdd_planner_witness_check(w: &mut R4g1World) {
+    let plan = w.plan_result.as_ref().expect("plan");
+    assert!(plan.witness.plan_cid.starts_with("plan_"));
+    assert_eq!(plan.witness.accepted_edges.len(), 2);
+}
+
+#[given("an intermediate state \"s1\" marked as forbidden")]
+fn bdd_planner_setup_forbidden_intermediate(w: &mut R4g1World) {
+    w.plan_nodes = vec![
+        PlannerStateNode {
+            id: "s0".to_string(),
+            is_goal: false,
+            is_forbidden: false,
+            forbidden_region_id: None,
+        },
+        PlannerStateNode {
+            id: "s1".to_string(),
+            is_goal: false,
+            is_forbidden: true,
+            forbidden_region_id: Some("hazard_0".to_string()),
+        },
+        PlannerStateNode {
+            id: "s2".to_string(),
+            is_goal: true,
+            is_forbidden: false,
+            forbidden_region_id: None,
+        },
+    ];
+    w.plan_edges = vec![PlannerEdgeTransition {
+        src_id: "s0".to_string(),
+        action: "step1".to_string(),
+        dst_id: "s1".to_string(),
+        cost: 1.0,
+        confidence: 0.9,
+    }];
+}
+
+#[when("the bounded graph planner attempts to plan a trajectory through \"s1\"")]
+fn bdd_planner_attempt_forbidden_plan(w: &mut R4g1World) {
+    let config = PlannerConfig::default_v1();
+    if let Err(e) = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config) {
+        w.plan_error = Some(e);
+    }
+}
+
+#[then("planning fails with a frontier exhausted error and zero forbidden states entered")]
+fn bdd_planner_frontier_exhausted_check(w: &mut R4g1World) {
+    let err = w.plan_error.as_ref().expect("plan error");
+    assert!(matches!(err, PlannerError::FrontierExhausted { .. }));
+}
+
+#[given("a start state \"s0\" marked as forbidden")]
+fn bdd_planner_setup_forbidden_start(w: &mut R4g1World) {
+    w.plan_nodes = vec![PlannerStateNode {
+        id: "s0".to_string(),
+        is_goal: false,
+        is_forbidden: true,
+        forbidden_region_id: Some("start_hazard".to_string()),
+    }];
+    w.plan_edges = Vec::new();
+}
+
+#[when("planning is initiated from \"s0\"")]
+fn bdd_planner_initiate_forbidden_start(w: &mut R4g1World) {
+    let config = PlannerConfig::default_v1();
+    if let Err(e) = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config) {
+        w.plan_error = Some(e);
+    }
+}
+
+#[then("planning fails immediately with an initial state forbidden error")]
+fn bdd_planner_initial_forbidden_check(w: &mut R4g1World) {
+    let err = w.plan_error.as_ref().expect("plan error");
+    assert!(matches!(err, PlannerError::InitialStateForbidden { .. }));
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Overview & Purpose
Resolves #131. Implementation follows PDF §§3, 10, 12, 17 and `docs/formal_vocabulary.md` §5.

## Key Changes
1. **Bounded Future-State Planner**: Implemented `BoundedGraphPlanner` searching finite action trajectories $s_0 \xrightarrow{a_1} s_1 \dots \xrightarrow{a_k} s_k \in G$ while enforcing forbidden region constraints ($s_i \notin C$) at every step.
2. **Explicit Bounds & Tie-Breaking**: Enforced planning horizon bound $H_{\max}$, candidate queue limit $K_{\max}$, and deterministic A* search tie-breaking.
3. **Audit Plan Witness**: Implemented `PlanWitness` recording content-addressed plan CIDs, accepted edge steps, and rejected counterfactual alternatives count.
4. **Explicit Planning Failures**: Added `PlannerError` variants for `InitialStateForbidden`, `HorizonExceeded`, `FrontierExhausted`, `UncertainTransition`, and `ForbiddenStateViolation`.
5. **Cucumber BDD Suite**: Added `features/suites/future_state_planner.feature` with 3 scenarios and step definitions in `tests/bdd.rs`.

## Verification
- `cargo fmt --check`: Clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`: Clean
- `cargo test --workspace --offline`: All unit tests passed
- `cargo test --test bdd --offline`: All 28 BDD scenarios passed (88 steps)
- `cargo check -p uor-r4-graph-format --no-default-features`: Clean
- `python3 scripts/check_claim_wording.py`: Wording gate passed