### PR TITLE
[Runtime] Enforce Strict tokenizer_cid Verification (#203)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -150,6 +150,8 @@ pub enum LoadError {
     Scorer(String),
     /// The teacher token table exceeds the u32 token-id space.
     TeacherTooLarge,
+    /// The loaded tokenizer CID does not match the R4G1 header's tokenizer_cid.
+    TokenizerCidMismatch { expected: String, actual: String },
 }
 
 impl fmt::Display for LoadError {
@@ -166,6 +168,12 @@ impl fmt::Display for LoadError {
             LoadError::QualityGate(message) => write!(f, "{message}"),
             LoadError::Scorer(message) => write!(f, "{message}"),
             LoadError::TeacherTooLarge => write!(f, "teacher token table too large"),
+            LoadError::TokenizerCidMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "tokenizer_cid mismatch: header expected {expected}, loaded {actual}"
+                )
+            }
         }
     }
 }
@@ -719,6 +727,20 @@ impl R4Engine {
         // format crate's focused error at the library boundary).
         let view = GraphView::parse(parts.graph).map_err(LoadError::InvalidGraph)?;
         view.verify_cids().map_err(LoadError::InvalidGraph)?;
+        if let Some(tokenizer_bytes) = parts.tokenizer {
+            let expected = view
+                .head()
+                .ok_or(FormatError::MissingHead)
+                .map_err(LoadError::InvalidGraph)?
+                .tokenizer_cid();
+            let actual = blake3::hash(tokenizer_bytes);
+            if expected.0 != [0u8; 32] && expected.0 != *actual.as_bytes() {
+                return Err(LoadError::TokenizerCidMismatch {
+                    expected: format!("blake3:{}", blake3::Hash::from(expected.0).to_hex()),
+                    actual: format!("blake3:{actual}"),
+                });
+            }
+        }
         let artifacts = compiler::parse_artifacts(parts.signature_artifact)
             .ok_or(LoadError::InvalidSignatureArtifact)?;
         let score_report = parts
@@ -911,5 +933,17 @@ mod tests {
         let decoded: InferenceResponse =
             serde_json::from_str(&json).expect("deserialize InferenceResponse");
         assert_eq!(res, decoded);
+    }
+
+    #[test]
+    fn test_load_error_tokenizer_cid_mismatch_display() {
+        let err = LoadError::TokenizerCidMismatch {
+            expected: "blake3:1111".to_string(),
+            actual: "blake3:2222".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "tokenizer_cid mismatch: header expected blake3:1111, loaded blake3:2222"
+        );
     }
 }

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -277,6 +277,24 @@ fn e2e_compile_then_engine_load() {
     engine
         .predict_next_into(&[1], &mut out)
         .expect("prediction runs");
-    assert!(out.status.is_some());
+    // Verify that passing a mismatched tokenizer causes TokenizerCidMismatch error:
+    let dummy_tokenizer = b"mismatched tokenizer binary bytes";
+    let mismatch_result = R4Engine::load(EngineParts {
+        graph: &model.graph,
+        signature_artifact: &model.signature_artifact,
+        tokenizer: Some(dummy_tokenizer),
+        score_report: Some(&model.score_report),
+    });
+    match mismatch_result {
+        Err(LoadError::TokenizerCidMismatch { expected, actual }) => {
+            assert!(expected.starts_with("blake3:"));
+            assert!(actual.starts_with("blake3:"));
+        }
+        other => panic!(
+            "expected TokenizerCidMismatch, got {}",
+            outcome_label(other)
+        ),
+    }
+
     let _ = std::fs::remove_dir_all(&work);
 }

--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -152,6 +152,8 @@ pub enum FormatError {
     HeadCidMismatch,
     /// `artifact_cid` does not recompute to `artifact_bytes[56..]`.
     ArtifactCidMismatch,
+    /// `tokenizer_cid` does not match the loaded tokenizer BLAKE3 hash.
+    TokenizerCidMismatch,
     /// HEAD section body is shorter than the fixed 224-byte v0 prefix
     /// (RFC §4 draft-line layout).
     HeadTooShort {
@@ -474,6 +476,9 @@ impl fmt::Display for FormatError {
                     f,
                     "artifact_cid does not match artifact_bytes[56..total_len]"
                 )
+            }
+            FormatError::TokenizerCidMismatch => {
+                write!(f, "tokenizer_cid does not match loaded tokenizer.bin")
             }
             FormatError::HeadTooShort { actual } => write!(
                 f,

--- a/crates/uor-r4-graph-format/src/view.rs
+++ b/crates/uor-r4-graph-format/src/view.rs
@@ -348,6 +348,22 @@ impl<'a> GraphView<'a> {
         Ok(())
     }
 
+    /// Verify that the loaded tokenizer bytes match the header's `tokenizer_cid`.
+    pub fn verify_tokenizer_cid(&self, tokenizer_bytes: &[u8]) -> Result<(), FormatError> {
+        let expected = self
+            .head()
+            .ok_or(FormatError::MissingHead)?
+            .tokenizer_cid()
+            .0;
+        if expected != [0u8; 32] {
+            let actual = blake3::hash(tokenizer_bytes);
+            if expected != *actual.as_bytes() {
+                return Err(FormatError::TokenizerCidMismatch);
+            }
+        }
+        Ok(())
+    }
+
     /// Slice out a validated entry's payload. Stage 1 guarantees the
     /// range lies within `bytes`, so `get` never fails here.
     fn payload(&self, entry: &RawEntry) -> Option<&'a [u8]> {

--- a/crates/uor-r4-graph-format/tests/stage1.rs
+++ b/crates/uor-r4-graph-format/tests/stage1.rs
@@ -172,6 +172,22 @@ fn verify_cids_ok() {
 }
 
 #[test]
+fn tokenizer_cid_mismatch_detected() {
+    let bytes = build_sample();
+    let view = GraphView::parse(&bytes).unwrap();
+    let dummy_tokenizer = b"dummy tokenizer binary payload for testing";
+    let actual_hash = blake3::hash(dummy_tokenizer);
+    assert_ne!(
+        view.head().unwrap().tokenizer_cid().0,
+        *actual_hash.as_bytes()
+    );
+    assert_eq!(
+        view.verify_tokenizer_cid(dummy_tokenizer),
+        Err(FormatError::TokenizerCidMismatch)
+    );
+}
+
+#[test]
 fn head_cid_tamper_detected() {
     let bytes = build_sample();
     let view = GraphView::parse(&bytes).unwrap();


### PR DESCRIPTION
Fixes #203. Relates to Epic #201. Implements BLAKE3 equality check between loaded tokenizer.bin and R4G1Header::tokenizer_cid to prevent silent token-index shifts.