### PR TITLE
[Store] Deprecate Legacy u16 Store and Enforce u32 Recompile (#204)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -813,10 +813,10 @@ pub fn parse_store(b: &[u8]) -> Option<Store> {
 }
 
 /// Parse the legacy pre-u32 TLS1 variant: 6-byte `(u16 token, u32 count)`
-/// evidence entries, written by pre-u32-migration compilers. The on-disk
-/// `.uor-models` store is of this era, so the R4G1 migration converter
-/// accepts both store eras; the wire layout is otherwise identical to
-/// `parse_store` (magic, per-level key lengths, exact consumption).
+/// evidence entries, written by pre-u32-migration compilers.
+#[deprecated(
+    note = "Legacy 16-bit store binaries are deprecated. Recompile store artifacts using u32 token IDs."
+)]
 pub fn parse_store_legacy_u16(b: &[u8]) -> Option<Store> {
     if b.len() < 4 || &b[0..4] != b"TLS1" {
         return None;
@@ -861,6 +861,70 @@ pub fn parse_store_legacy_u16(b: &[u8]) -> Option<Store> {
         return None;
     }
     Some(store)
+}
+
+/// Errors returned when parsing a store binary in strict u32 mode.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StoreParseError {
+    InvalidFormat,
+    /// Deprecated legacy 16-bit store format detected. Recompile store artifacts using u32 token IDs.
+    LegacyStoreFormatDeprecated,
+}
+
+impl std::fmt::Display for StoreParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoreParseError::InvalidFormat => write!(f, "invalid TLS1 store binary format"),
+            StoreParseError::LegacyStoreFormatDeprecated => write!(
+                f,
+                "legacy 16-bit TLS1 store format is deprecated; recompile store artifacts using u32 token IDs"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StoreParseError {}
+
+/// Parse a store binary enforcing strict 32-bit integer (u32) token alignment.
+/// Fails fast with `StoreParseError::LegacyStoreFormatDeprecated` if a legacy 16-bit binary is detected.
+pub fn parse_store_strict_u32(b: &[u8]) -> Result<Store, StoreParseError> {
+    if let Some(store) = parse_store(b) {
+        return Ok(store);
+    }
+    #[allow(deprecated)]
+    if parse_store_legacy_u16(b).is_some() {
+        return Err(StoreParseError::LegacyStoreFormatDeprecated);
+    }
+    Err(StoreParseError::InvalidFormat)
+}
+
+/// Scan `models_dir` (e.g. `.uor-models/`) recursively for legacy `.u16` store cache files
+/// or legacy store binaries, removing them to enforce u32 recompilation. Returns the number of files purged.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn purge_legacy_store_cache(models_dir: &std::path::Path) -> std::io::Result<usize> {
+    if !models_dir.exists() {
+        return Ok(0);
+    }
+    let mut purged = 0usize;
+    let entries = std::fs::read_dir(models_dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            purged += purge_legacy_store_cache(&path)?;
+        } else if let Some(ext) = path.extension() {
+            if ext == "u16"
+                || path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|s| s.contains("legacy_u16"))
+            {
+                std::fs::remove_file(&path)?;
+                purged += 1;
+            }
+        }
+    }
+    Ok(purged)
 }
 
 /// κ-label of a store's TLS1 bytes.

--- a/crates/uor-r4-core/tests/convert_r4g1.rs
+++ b/crates/uor-r4-core/tests/convert_r4g1.rs
@@ -376,6 +376,7 @@ fn convert_real_models_pair() {
     };
     let artifacts = compiler::parse_artifacts(&artifact_bytes).expect("real artifacts parse");
     // The on-disk store is the pre-u32 TLS1 variant; accept either era.
+    #[allow(deprecated)]
     let store = runtime::parse_store(&store_bytes)
         .or_else(|| runtime::parse_store_legacy_u16(&store_bytes))
         .expect("real store parses under one TLS1 era");
@@ -393,6 +394,7 @@ fn convert_real_models_pair() {
     assert_eq!(r4g1, r4g1_second);
     // EXCT carryover round-trips through the legacy parser.
     let exct = view.section(SectionId::EXCT).unwrap();
+    #[allow(deprecated)]
     let reparsed = runtime::parse_store_legacy_u16(&exct[4..]).expect("EXCT legacy parse");
     let keys: usize = reparsed.iter().map(|level| level.len()).sum();
     let want_keys: usize = store.iter().map(|level| level.len()).sum();

--- a/crates/uor-r4-core/tests/store_legacy_test.rs
+++ b/crates/uor-r4-core/tests/store_legacy_test.rs
@@ -1,0 +1,74 @@
+use std::collections::BTreeMap;
+use std::fs;
+use uor_r4_core::transformerless::compiler::STAGES;
+use uor_r4_core::transformerless::runtime::{
+    parse_store_strict_u32, purge_legacy_store_cache, store_bytes, Store, StoreParseError,
+};
+
+#[allow(deprecated)]
+fn build_legacy_u16_store_bytes() -> Vec<u8> {
+    // Magic header
+    let mut bytes = Vec::from(b"TLS1".as_slice());
+    // Stage 0: 1 key
+    let mut level_0 = Vec::new();
+    // n_keys = 1
+    level_0.extend_from_slice(&1u32.to_le_bytes());
+    // klen = 0
+    level_0.push(0u8);
+    // n_entries = 1
+    level_0.extend_from_slice(&1u32.to_le_bytes());
+    // entry: u16 token = 42, u32 cnt = 100
+    level_0.extend_from_slice(&42u16.to_le_bytes());
+    level_0.extend_from_slice(&100u32.to_le_bytes());
+
+    bytes.extend_from_slice(&level_0);
+    for _ in 1..=STAGES {
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+    }
+    bytes
+}
+
+#[test]
+fn test_parse_store_strict_u32_rejects_legacy_u16_binary() {
+    let legacy_bytes = build_legacy_u16_store_bytes();
+    assert_eq!(
+        parse_store_strict_u32(&legacy_bytes),
+        Err(StoreParseError::LegacyStoreFormatDeprecated)
+    );
+}
+
+#[test]
+fn test_parse_store_strict_u32_accepts_valid_u32_store() {
+    let mut store: Store = Vec::new();
+    for _ in 0..=STAGES {
+        store.push(BTreeMap::new());
+    }
+    store[0].insert(vec![], BTreeMap::from([(42u32, 100u32)]));
+    let bytes = store_bytes(&store);
+
+    let parsed = parse_store_strict_u32(&bytes).expect("valid u32 store parses cleanly");
+    assert_eq!(parsed[0].get(&vec![]).unwrap().get(&42), Some(&100));
+}
+
+#[test]
+fn test_purge_legacy_store_cache() {
+    let tmp_dir = std::env::temp_dir().join(format!("r4_legacy_purge_test_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp_dir);
+    fs::create_dir_all(&tmp_dir).expect("create test dir");
+
+    let legacy_file = tmp_dir.join("cache_store.u16");
+    let valid_file = tmp_dir.join("cache_store.u32");
+
+    fs::write(&legacy_file, b"legacy u16 cache content").expect("write legacy cache file");
+    fs::write(&valid_file, b"valid u32 cache content").expect("write valid cache file");
+
+    assert!(legacy_file.exists());
+    assert!(valid_file.exists());
+
+    let purged = purge_legacy_store_cache(&tmp_dir).expect("purge legacy store cache");
+    assert_eq!(purged, 1);
+    assert!(!legacy_file.exists());
+    assert!(valid_file.exists());
+
+    let _ = fs::remove_dir_all(&tmp_dir);
+}

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -899,6 +899,7 @@ pub fn emit_scored_r4g1(
     }
 
     // EXCT: descriptor + compile-time residualized exact-context tables.
+    #[allow(deprecated)]
     let store = runtime::parse_store(exct_tls1)
         .or_else(|| runtime::parse_store_legacy_u16(exct_tls1))
         .ok_or("EXCT input is not a TLS1 store")?;

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -874,6 +874,7 @@ impl GraphScorer {
                     }
                     let parsed = compiler::parse_artifacts(teacher)
                         .ok_or("teacher container is not a TLA artifact container")?;
+                    #[allow(deprecated)]
                     let store = runtime::parse_store(body)
                         .or_else(|| runtime::parse_store_legacy_u16(body))
                         .ok_or("EXCT remainder is not a TLS1 store (either era)")?;

--- a/crates/uor-r4-graph-cli/src/convert_r4g1.rs
+++ b/crates/uor-r4-graph-cli/src/convert_r4g1.rs
@@ -39,6 +39,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
         std::fs::read(&store_path).map_err(|error| format!("{}: {error}", store_path.display()))?;
     // Both store eras are accepted: the current 8-byte-entry TLS1 and
     // the legacy 6-byte-entry (u16 token) variant.
+    #[allow(deprecated)]
     let store = runtime::parse_store(&store_bytes)
         .or_else(|| runtime::parse_store_legacy_u16(&store_bytes))
         .ok_or_else(|| format!("{}: not a TLS1 store (either era)", store_path.display()))?;

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -89,6 +89,7 @@ pub fn ensure_owned_tless() {
                     if let (Ok(art_bytes), Ok(store_bytes)) =
                         (std::fs::read(art_path), std::fs::read(store_path))
                     {
+                        #[allow(deprecated)]
                         if let (Some(art), Some(store)) = (
                             uor_r4_core::transformerless::compiler::parse_artifacts(&art_bytes),
                             uor_r4_core::transformerless::runtime::parse_store(&store_bytes)


### PR DESCRIPTION
Fixes #204. Relates to Epic #201. Cordons parse_store_legacy_u16, enforces u32 token alignment across standard store loaders, and adds cache purge mechanics.