### PR TITLE
docs(readme): align legacy benchmark workflow with the current CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,21 @@ and same-machine performance comparison.
 cargo run --release -- setup
 cargo run --release -- gen 300 150000
 # repeat gen until it reports done=1
-cargo run --release -- compile
-cargo run --release -- store
 cargo run --release -- certify
 cargo run --release -- compare
+cargo run --release -- compare-report
 cargo run --release -- scenarios
 ```
+
+`certify` performs the compile, store, certificate, and census steps
+internally. The bare `compile` and `store` subcommands belong to the HF
+graph-compiler path — `compile` requires `--model` or `--source`, and `store`
+depends on a prior graph compile — and are not part of the legacy chain.
+
+`gen` output is not byte-reproducible across machines or eras: story and
+held-out counts can differ slightly from the certified stream (e.g. 754
+stories / 30,036 held-out against the certified 757 / 30,192), which bounds
+how exactly downstream figures reproduce.
 
 Its default files are:
 


### PR DESCRIPTION
Closes #233.

Docs-only. Updates the "Legacy benchmark and certification workflow" section of README.md to match the CLI at HEAD:

- Removes `compile` and `store` from the legacy chain — bare `compile` resolves to the HF graph-compiler path and fails without `--model`/`--source`; bare `store` panics (`crates/uor-r4-graph-cli/src/lib.rs:1710`, "run compile first"). A note now says both belong to the graph-compiler path.
- Documents the current chain (`gen → certify → compare → compare-report`), with `certify` performing compile, store, certificate, and census internally — matching the repo's own `setup` output.
- Records that `gen` output is not byte-reproducible across machines/eras (e.g. 754 stories / 30,036 held-out vs the certified 757 / 30,192), which bounds exact reproduction of downstream figures.

Local gates per AGENTS.md, all clean at `df4facd` on macOS 26.5.1 arm64 / rustc 1.95.0: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (0 failures), and both no_std ladder checks for `uor-r4-graph-format`.

Process note: filed from a fork — outside contributors can't self-assign, so the AGENTS.md self-assign step is covered by this PR reference instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
