### PR TITLE
fix(certify): guard R4G1 evaluation behind a readiness probe, skip vacuous runs (#232)

### DIFF
--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -287,27 +287,72 @@ pub fn certify(oracle: &dyn TeacherOracle) {
     .expect("r4g1 conversion");
     let r4g1 = uor_r4_graph_runtime::R4G1Runtime::parse(&r4g1_bytes).expect("r4g1 parse");
 
-    let (mut top1, mut agree) = (0u64, 0u64);
-    for &i in &test {
-        let mut node_scores =
-            vec![uor_r4_core::transformerless::score_q::ScoreQ::MIN; r4g1.node_count() as usize];
+    // One reusable score buffer for probe + evaluation (issue #232): the
+    // previous code allocated a node_count-sized vec on every held-out
+    // position for a parameter the runtime does not read.
+    let mut node_scores =
+        vec![uor_r4_core::transformerless::score_q::ScoreQ::MIN; r4g1.node_count() as usize];
+
+    let hist_at = |i: usize| {
         let mut hist = [0u32; WINDOW + 1];
         for (idx, w) in rot.iter().enumerate().take(WINDOW) {
             hist[idx] = c.input[i.saturating_sub(*w)];
         }
-        let pred = r4g1.predict_token(&hist, None, &mut node_scores);
-        if pred == c.next[i] {
-            top1 += 1;
+        hist
+    };
+
+    // Readiness probe (issue #232): bounded and deterministic (first
+    // PROBE_POSITIONS held-out positions, in order). An untrained or
+    // unscored graph would otherwise spend hours on a full evaluation that
+    // terminates in an all-zero row — output that reads as a measured
+    // failure when it is an absent measurement.
+    let probe_hists: Vec<[u32; WINDOW + 1]> = test
+        .iter()
+        .take(crate::r4g1_readiness::PROBE_POSITIONS)
+        .map(|&i| hist_at(i))
+        .collect();
+    let readiness = crate::r4g1_readiness::r4g1_eval_readiness(
+        &r4g1,
+        probe_hists.iter().map(|h| &h[..]),
+        &mut node_scores,
+    );
+
+    match readiness {
+        crate::r4g1_readiness::R4g1EvalReadiness::Ready { scored } => {
+            let (mut top1, mut agree) = (0u64, 0u64);
+            for &i in &test {
+                node_scores.fill(uor_r4_core::transformerless::score_q::ScoreQ::MIN);
+                let hist = hist_at(i);
+                let pred = r4g1.predict_token(&hist, None, &mut node_scores);
+                if pred == c.next[i] {
+                    top1 += 1;
+                }
+                if pred == c.t_argmax[i] {
+                    agree += 1;
+                }
+            }
+            println!(
+                "C R4G1 (graph path): top1 {:.1}% | agreement {:.1}% | WB n/a (not computed on the graph path) | probe: {}/{} scored",
+                100.0 * top1 as f64 / test.len() as f64,
+                100.0 * agree as f64 / test.len() as f64,
+                scored,
+                crate::r4g1_readiness::PROBE_POSITIONS
+            );
         }
-        if pred == c.t_argmax[i] {
-            agree += 1;
+        crate::r4g1_readiness::R4g1EvalReadiness::NoScoredEmission => {
+            println!(
+                "C R4G1 (graph path): SKIPPED — no scored emission on any of {} probe positions (untrained or unscored graph). Full evaluation not run; no measurement recorded.",
+                crate::r4g1_readiness::PROBE_POSITIONS
+            );
+        }
+        crate::r4g1_readiness::R4g1EvalReadiness::ConstantPrediction { token } => {
+            println!(
+                "C R4G1 (graph path): SKIPPED — constant prediction (token {}) across all {} probe positions (untrained or unscored graph). Full evaluation not run; no measurement recorded.",
+                token,
+                crate::r4g1_readiness::PROBE_POSITIONS
+            );
         }
     }
-    println!(
-        "C R4G1 (graph path): top1 {:.1}% | agreement {:.1}% | WB 0.0000 bits/token",
-        100.0 * top1 as f64 / test.len() as f64,
-        100.0 * agree as f64 / test.len() as f64
-    );
 
     // ================= COMPRESSION (PROOF.md P5) =================
 

--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -12,6 +12,7 @@ pub mod long_context;
 pub mod patch_lifecycle;
 pub mod performance_certificate;
 pub mod predictive_sufficiency;
+pub mod r4g1_readiness;
 pub mod score;
 pub mod score_runtime;
 pub mod shortlist_evaluator;

--- a/crates/uor-r4-graph-certify/src/r4g1_readiness.rs
+++ b/crates/uor-r4-graph-certify/src/r4g1_readiness.rs
@@ -1,0 +1,97 @@
+//! Certifier-side readiness probe for the R4G1 graph evaluation (issue #232).
+//!
+//! `certify` converts the legacy store to an R4G1 container and evaluates it
+//! over the full held-out set. When the graph is untrained or unscored, that
+//! evaluation runs for hours and terminates in an all-zero row — output that
+//! reads as a measured failure when it is actually an absent measurement.
+//!
+//! The probe runs the same prediction call over a small, deterministic sample
+//! of held-out positions first and classifies the graph's output shape. Two
+//! degenerate shapes are detected:
+//!
+//! - **No scored emission**: every probe prediction returns `ScoreQ::MIN`,
+//!   i.e. no emission list was ever reached with a real score — the constant
+//!   root-fallback path in `predict_distribution` is the only thing running.
+//! - **Constant prediction**: every probe position yields the same token
+//!   regardless of context. A trained graph queried with varied contexts
+//!   does not produce a single constant token across the whole probe.
+//!
+//! Either shape means the full multi-hour evaluation would produce a vacuous
+//! row; the caller should skip it and say so explicitly.
+//!
+//! Certifier-side code: allocation and iterators are permitted here (this is
+//! not the deployed runtime kernel).
+
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_runtime::R4G1Runtime;
+
+/// Number of held-out positions sampled by the probe. Deterministic: callers
+/// take the first `PROBE_POSITIONS` positions of the held-out set in order.
+pub const PROBE_POSITIONS: usize = 64;
+
+/// Outcome of the readiness probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum R4g1EvalReadiness {
+    /// The graph produced varied, scored predictions on the probe; the full
+    /// evaluation is meaningful. `scored` counts probe positions whose best
+    /// score exceeded `ScoreQ::MIN`.
+    Ready { scored: usize },
+    /// Every probe prediction came back at `ScoreQ::MIN`: no scored emission
+    /// was reachable from any probe context.
+    NoScoredEmission,
+    /// Every probe position predicted the same token — the constant
+    /// root-fallback shape of an untrained or unscored graph.
+    ConstantPrediction { token: u32 },
+}
+
+impl R4g1EvalReadiness {
+    /// True when the full evaluation should run.
+    pub fn is_ready(&self) -> bool {
+        matches!(self, R4g1EvalReadiness::Ready { .. })
+    }
+}
+
+/// Classify the graph's output shape over `probe_contexts`.
+///
+/// `node_scores` must be at least `runtime.node_count()` long; it is reset
+/// before every prediction and left dirty afterwards (callers reset it again
+/// before reuse). An empty probe iterator classifies as `NoScoredEmission`
+/// (there is no evidence the graph can emit).
+pub fn r4g1_eval_readiness<'a, I>(
+    runtime: &R4G1Runtime,
+    probe_contexts: I,
+    node_scores: &mut [ScoreQ],
+) -> R4g1EvalReadiness
+where
+    I: IntoIterator<Item = &'a [u32]>,
+{
+    let mut scored = 0usize;
+    let mut first_token: Option<u32> = None;
+    let mut constant = true;
+    let mut probed = 0usize;
+
+    for ctx in probe_contexts {
+        probed += 1;
+        node_scores.fill(ScoreQ::MIN);
+        let (token, score) = runtime.predict_distribution(ctx, None, node_scores);
+        if score.raw() > ScoreQ::MIN.raw() {
+            scored += 1;
+        }
+        match first_token {
+            None => first_token = Some(token),
+            Some(t) if t != token => constant = false,
+            Some(_) => {}
+        }
+    }
+
+    if probed == 0 || scored == 0 {
+        return R4g1EvalReadiness::NoScoredEmission;
+    }
+    if constant {
+        // `probed > 0` guarantees `first_token` is set.
+        return R4g1EvalReadiness::ConstantPrediction {
+            token: first_token.unwrap_or(0),
+        };
+    }
+    R4g1EvalReadiness::Ready { scored }
+}

--- a/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
+++ b/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
@@ -63,11 +63,8 @@ fn varied_contexts_on_populated_store_are_ready_or_explicitly_degenerate() {
         vec![11, 5, 8],
         vec![2, 3, 4],
     ];
-    let readiness = r4g1_eval_readiness(
-        &rt,
-        contexts.iter().map(|c| c.as_slice()),
-        &mut node_scores,
-    );
+    let readiness =
+        r4g1_eval_readiness(&rt, contexts.iter().map(|c| c.as_slice()), &mut node_scores);
 
     // The fixture-backed graph must not silently classify as Ready while
     // actually emitting nothing: either it is Ready with a nonzero scored
@@ -91,11 +88,8 @@ fn out_of_vocabulary_contexts_classify_as_degenerate() {
     // no emitting node, so predictions collapse to the constant root
     // fallback (or stay unscored). Either way the probe must NOT say Ready.
     let contexts: Vec<Vec<u32>> = (0..8).map(|k| vec![40_000 + k, 41_000 + k]).collect();
-    let readiness = r4g1_eval_readiness(
-        &rt,
-        contexts.iter().map(|c| c.as_slice()),
-        &mut node_scores,
-    );
+    let readiness =
+        r4g1_eval_readiness(&rt, contexts.iter().map(|c| c.as_slice()), &mut node_scores);
 
     assert!(
         !readiness.is_ready(),

--- a/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
+++ b/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
@@ -1,0 +1,114 @@
+//! Readiness-probe tests for the R4G1 certify evaluation guard (issue #232).
+//!
+//! Builds tiny R4G1 containers the same way the runtime's own tests do
+//! (fixture artifacts + synthetic store) and verifies the probe classifies
+//! trained-looking graphs as `Ready` and degenerate output shapes as
+//! skip-worthy.
+
+use std::collections::BTreeMap;
+use uor_r4_core::transformerless::compiler::{self, STAGES};
+use uor_r4_core::transformerless::convert_r4g1;
+use uor_r4_core::transformerless::runtime::{self, Store};
+use uor_r4_graph_certify::r4g1_readiness::{r4g1_eval_readiness, R4g1EvalReadiness};
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_runtime::R4G1Runtime;
+
+fn fixture_artifacts() -> (Vec<u8>, compiler::Compiled) {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(format!(
+        "{dir}/../uor-r4-core/tests/fixtures/tless_artifacts.bin"
+    ))
+    .expect("fixture artifacts present");
+    let artifacts = compiler::parse_artifacts(&bytes).expect("fixture artifacts parse");
+    (bytes, artifacts)
+}
+
+fn synthetic_store() -> Store {
+    let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    let codes: [[u8; 4]; 6] = [
+        [3, 1, 4, 1],
+        [3, 1, 4, 2],
+        [3, 5, 9, 2],
+        [7, 5, 9, 2],
+        [7, 5, 8, 2],
+        [11, 5, 8, 7],
+    ];
+    for (i, code) in codes.iter().enumerate() {
+        runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
+    }
+    store
+}
+
+fn build_runtime_bytes(store: &Store) -> Vec<u8> {
+    let (art_bytes, artifacts) = fixture_artifacts();
+    let store_bytes = runtime::store_bytes(store);
+    let (r4g1_bytes, _) = convert_r4g1::convert(&art_bytes, &artifacts, store, &store_bytes, None)
+        .expect("convert to R4G1 succeeds");
+    r4g1_bytes
+}
+
+#[test]
+fn varied_contexts_on_populated_store_are_ready_or_explicitly_degenerate() {
+    let bytes = build_runtime_bytes(&synthetic_store());
+    let rt = R4G1Runtime::parse(&bytes).expect("parse");
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+
+    // Contexts drawn from the store's own token universe, varied enough that
+    // a functioning graph does not answer with one constant token.
+    let contexts: Vec<Vec<u32>> = vec![
+        vec![1, 2, 3],
+        vec![3, 1, 4],
+        vec![3, 5, 9],
+        vec![7, 5, 8],
+        vec![11, 5, 8],
+        vec![2, 3, 4],
+    ];
+    let readiness = r4g1_eval_readiness(
+        &rt,
+        contexts.iter().map(|c| c.as_slice()),
+        &mut node_scores,
+    );
+
+    // The fixture-backed graph must not silently classify as Ready while
+    // actually emitting nothing: either it is Ready with a nonzero scored
+    // count, or the probe names the degenerate shape.
+    match readiness {
+        R4g1EvalReadiness::Ready { scored } => assert!(scored > 0, "Ready requires scored > 0"),
+        R4g1EvalReadiness::NoScoredEmission | R4g1EvalReadiness::ConstantPrediction { .. } => {
+            // Acceptable classification for a tiny synthetic store — the
+            // point of the guard is that this shape is *named*, not zeroed.
+        }
+    }
+}
+
+#[test]
+fn out_of_vocabulary_contexts_classify_as_degenerate() {
+    let bytes = build_runtime_bytes(&synthetic_store());
+    let rt = R4G1Runtime::parse(&bytes).expect("parse");
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+
+    // Tokens far outside anything the store observed: the suffix walk finds
+    // no emitting node, so predictions collapse to the constant root
+    // fallback (or stay unscored). Either way the probe must NOT say Ready.
+    let contexts: Vec<Vec<u32>> = (0..8).map(|k| vec![40_000 + k, 41_000 + k]).collect();
+    let readiness = r4g1_eval_readiness(
+        &rt,
+        contexts.iter().map(|c| c.as_slice()),
+        &mut node_scores,
+    );
+
+    assert!(
+        !readiness.is_ready(),
+        "degenerate probe output must not classify as Ready, got {readiness:?}"
+    );
+}
+
+#[test]
+fn empty_probe_is_not_ready() {
+    let bytes = build_runtime_bytes(&synthetic_store());
+    let rt = R4G1Runtime::parse(&bytes).expect("parse");
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+
+    let readiness = r4g1_eval_readiness(&rt, std::iter::empty::<&[u32]>(), &mut node_scores);
+    assert_eq!(readiness, R4g1EvalReadiness::NoScoredEmission);
+}


### PR DESCRIPTION
Closes #232.

## What

`certify`'s C-section (R4G1 graph path) previously ran the full held-out evaluation — ~2.5 of 3.2 hours, single-threaded — even when the graph was untrained/unscored, terminating in an all-zero row that reads as a measured failure rather than an absent measurement.

- **Readiness probe** (`r4g1_readiness`, new certifier-side module): runs `predict_distribution` over the first 64 held-out positions (deterministic, in order) and classifies the output shape — `Ready`, `NoScoredEmission` (every prediction at `ScoreQ::MIN`), or `ConstantPrediction` (one token for every context — the constant root-fallback shape). Degenerate shapes skip the full evaluation with an explicit `SKIPPED — … no measurement recorded` marker.
- **Allocation hoist**: one reusable `node_scores` buffer across probe + evaluation, replacing a `node_count`-sized `vec!` allocated per held-out position (for a parameter the runtime doesn't read).
- **Honest WB field**: the `WB 0.0000 bits/token` in the C row was a hardcoded string literal, never a computation — now prints `WB n/a (not computed on the graph path)`.

## Scope

Certifier-side only. No runtime-crate changes: P-4 kernel scan, allocation census, and the `no_std` surface untouched; artifact bytes and κs unchanged.

Out of scope (follow-ups): evaluating `graph/score.r4g1` inside legacy certify; the C-section's `hist` construction feeding rotation offsets as context lags (separate defect, to be filed).

## Gates (macOS arm64, offline)

- `cargo test --workspace --offline` ✅ (incl. 3 new tests in `tests/r4g1_eval_readiness.rs`)
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo check -p uor-r4-graph-format --no-default-features` (+ `--features alloc`) ✅

Expected impact: ~3.2h → ~0.7h for legacy-path `certify` iteration when no trained graph is present (#232's measurement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
