### PR TITLE
build: pin Rust toolchain to 1.97.1 so local gates match CI (#238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,9 @@ jobs:
 
       - name: fuzz parse_arbitrary (60s)
         working-directory: crates/uor-r4-graph-format
-        run: cargo fuzz run parse_arbitrary -- -max_total_time=60 -print_final_stats=1
+        # +nightly explicitly: rust-toolchain.toml pins stable for plain `cargo`
+        run: cargo +nightly fuzz run parse_arbitrary -- -max_total_time=60 -print_final_stats=1
 
       - name: fuzz mutate_valid (60s)
         working-directory: crates/uor-r4-graph-format
-        run: cargo fuzz run mutate_valid -- -max_total_time=60 -print_final_stats=1
+        run: cargo +nightly fuzz run mutate_valid -- -max_total_time=60 -print_final_stats=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ All four must be clean before every commit. CI (`.github/workflows/ci.yml`)
 runs the same plus `cargo nextest`, doc tests, deterministic-rebuild, cargo
 audit, and nightly fuzz smoke — keep it green.
 
+The toolchain is pinned in `rust-toolchain.toml`: rustup-managed `cargo`
+resolves the pin automatically, so the gates above run the same toolchain
+CI does. Caveat: a non-rustup Rust earlier in `PATH` (e.g. Homebrew)
+ignores the pin — verify `which cargo` resolves to `~/.cargo/bin/cargo`,
+or run gates as `rustup run stable cargo …`. Bump the pin in a dedicated
+PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
+
 ## Normative invariants (do not weaken)
 
 - **Runtime kernel**: XOR/AND/OR/shift/rotate/popcount/int add-sub/compare/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+# Pinned so the four local gates (AGENTS.md "Commands") and CI resolve the
+# identical toolchain byte-for-byte (issue #238). rustup-managed `cargo`
+# honors this file automatically. Bump deliberately, in a dedicated PR: a
+# toolchain bump can shift libm-sensitive teacher logprobs — see AGENTS.md
+# "Gate E" notes on kappa re-pinning before trusting post-bump baselines.
+# Nightly-only jobs (`cargo +nightly fuzz`) and Kani's own toolchain use
+# explicit overrides and are unaffected.
+[toolchain]
+channel = "1.97.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #238.

## What

Pins the workspace toolchain via `rust-toolchain.toml` (stable **1.97.1**, `rustfmt` + `clippy` components) and documents it in AGENTS.md's Commands section.

## Why

PR #236 failed CI `cargo fmt --check` after all four local gates passed: the dev machine had Homebrew rust 1.96.1 ahead of rustup in `PATH` while CI's `dtolnay/rust-toolchain@stable` resolved 1.97.1 — two different rustfmts, silent drift. With the pin, every rustup-managed `cargo` invocation resolves the same version by construction.

Nightly-only jobs (`cargo +nightly fuzz`) and Kani's own toolchain use explicit overrides and are unaffected. The AGENTS.md note covers the one hole the pin can't close (a non-rustup Rust earlier in `PATH` ignores it) and ties bumps to Gate E κ re-pinning.

## Gates (macOS arm64, rustup 1.97.1, offline)

- `cargo test --workspace --offline` ✅
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo check -p uor-r4-graph-format --no-default-features` (+ `--features alloc`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
