### PR TITLE
fix(certify): clamp zero-quantized teacher-floor collisions and count them (#231)

### DIFF
--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -132,6 +132,31 @@ fn eval(
     }
 }
 
+/// Probability the corpus recorded for the observed next token, from the
+/// integer-percent quantized top-3 weights (issue #231).
+///
+/// Weights are stored as whole percents (`softmax_top3_sample`,
+/// compiler-side), so a top-3 token whose renormalized probability fell
+/// below 0.5% records weight 0 — while the corpus `next` is sampled from
+/// the full CDF and can land on exactly that token. The raw `0/100`
+/// probability would make the teacher floor `-ln(0)` = +inf, so a
+/// zero-weight collision clamps to half a quantization step (0.005) —
+/// the same clamp discipline the HF evaluate path already applies.
+/// Returns `(prob, zero_weight_collision)`.
+pub fn recorded_next_prob(top_tokens: &[u32; 8], top_weights: &[u32; 8], next: u32) -> (f64, bool) {
+    for k in 0..3 {
+        if top_tokens[k] == next {
+            let w = top_weights[k];
+            return if w == 0 {
+                (0.005, true)
+            } else {
+                (w as f64 / 100.0, false)
+            };
+        }
+    }
+    (0.01, false)
+}
+
 pub fn certify(oracle: &dyn TeacherOracle) {
     let c = compiler::load_corpus().expect("corpus incomplete: run `transformerless gen` first");
     let cut = (c.stories as f64 * 0.8) as u32;
@@ -143,28 +168,26 @@ pub fn certify(oracle: &dyn TeacherOracle) {
     );
 
     let (mut floor, mut ceil) = (0f64, 0u64);
+    let mut zero_clamped = 0usize;
     for i in 0..c.n {
         if c.story[i] < cut {
             continue;
         }
-        let prob = if c.top_tokens[i][0] == c.next[i] {
-            c.top_weights[i][0] as f64 / 100.0
-        } else if c.top_tokens[i][1] == c.next[i] {
-            c.top_weights[i][1] as f64 / 100.0
-        } else if c.top_tokens[i][2] == c.next[i] {
-            c.top_weights[i][2] as f64 / 100.0
-        } else {
-            0.01
-        };
+        let (prob, clamped) = recorded_next_prob(&c.top_tokens[i], &c.top_weights[i], c.next[i]);
+        if clamped {
+            zero_clamped += 1;
+        }
         floor += -prob.ln() / std::f64::consts::LN_2;
         if c.top_tokens[i][0] == c.next[i] {
             ceil += 1;
         }
     }
     println!(
-        "teacher floor {:.4} bits/token | teacher ceiling {:.1}%",
+        "teacher floor {:.4} bits/token | teacher ceiling {:.1}% | zero-quantized-weight collisions: {}/{}",
         floor / ntest as f64,
-        100.0 * ceil as f64 / ntest as f64
+        100.0 * ceil as f64 / ntest as f64,
+        zero_clamped,
+        ntest
     );
 
     let art = compiler::compile(oracle, &c);

--- a/crates/uor-r4-graph-certify/tests/teacher_floor.rs
+++ b/crates/uor-r4-graph-certify/tests/teacher_floor.rs
@@ -1,0 +1,69 @@
+//! Tests for the teacher-floor recorded-probability clamp (issue #231).
+//!
+//! The legacy floor reads corpus-recorded integer-percent weights; a top-3
+//! token with weight 0 (renormalized p < 0.5%) hit by the sampled `next`
+//! previously produced `-ln(0)` = +inf, poisoning the whole floor sum.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use uor_r4_graph_certify::certify::recorded_next_prob;
+
+fn toks(a: u32, b: u32, c: u32) -> [u32; 8] {
+    [a, b, c, 0, 0, 0, 0, 0]
+}
+
+fn weights(a: u32, b: u32, c: u32) -> [u32; 8] {
+    [a, b, c, 0, 0, 0, 0, 0]
+}
+
+#[test]
+fn top0_hit_uses_recorded_weight() {
+    let (p, clamped) = recorded_next_prob(&toks(7, 8, 9), &weights(63, 30, 7), 7);
+    assert_eq!(p, 0.63);
+    assert!(!clamped);
+}
+
+#[test]
+fn top2_hit_with_zero_weight_clamps_not_inf() {
+    let (p, clamped) = recorded_next_prob(&toks(7, 8, 9), &weights(70, 30, 0), 9);
+    assert_eq!(p, 0.005);
+    assert!(clamped);
+    let bits = -p.ln() / std::f64::consts::LN_2;
+    assert!(
+        bits.is_finite(),
+        "clamped probability must give finite bits"
+    );
+}
+
+#[test]
+fn outside_top3_uses_fallback() {
+    let (p, clamped) = recorded_next_prob(&toks(7, 8, 9), &weights(70, 20, 10), 42);
+    assert_eq!(p, 0.01);
+    assert!(!clamped);
+}
+
+#[test]
+fn zero_weight_only_flags_actual_hits() {
+    // A zero weight in the table does not flag when `next` hits a nonzero slot.
+    let (p, clamped) = recorded_next_prob(&toks(7, 8, 9), &weights(99, 1, 0), 8);
+    assert_eq!(p, 0.01); // weight 1 → 0.01 via the recorded path, not the fallback
+    assert!(!clamped);
+}
+
+#[test]
+fn floor_sum_stays_finite_across_mixed_positions() {
+    // Property: any mix of recorded weights (including zero-collisions)
+    // yields a finite floor.
+    let cases = [
+        (toks(1, 2, 3), weights(50, 0, 0), 2u32),
+        (toks(1, 2, 3), weights(100, 0, 0), 1),
+        (toks(1, 2, 3), weights(34, 33, 33), 3),
+        (toks(1, 2, 3), weights(1, 0, 0), 9), // outside top-3
+    ];
+    let mut floor = 0f64;
+    for (t, w, next) in cases {
+        let (p, _) = recorded_next_prob(&t, &w, next);
+        floor += -p.ln() / std::f64::consts::LN_2;
+    }
+    assert!(floor.is_finite());
+}


### PR DESCRIPTION
Closes #231 (legacy-path half; the HF-path ≈-uniform floor anomaly is the tokenizer defect, tracked in #242).

## What

- Extracts `recorded_next_prob()`: the corpus-recorded integer-percent probability for the observed next token; a **zero-quantized-weight collision** (next ∈ top-3 with recorded weight 0 — renormalized p < 0.5% at observation time, but still CDF-sampled as `next`) clamps to half a quantization step (0.005) instead of producing `-ln(0)` = +inf. Same clamp discipline the HF evaluate path already applies (`uor-r4-graph-cli/src/lib.rs:1444`).
- The floor output line now reports the collision count (`zero-quantized-weight collisions: N/ntest`) — the instrumentation this issue requested, aimed at the actual mechanism (quantization, not f32 underflow; both softmaxes are max-stabilized).
- 5 unit tests on the extracted function (recorded-weight hit, zero-weight clamp + finiteness, outside-top-3 fallback, non-collision zero in the table, mixed-position finiteness property).

## Why artifacts are safe

Observation records argmax/top-k **ids** (sort-based, quantization-independent) and integer weights; zero weights are dropped at store build (`if weight > 0`). The inf was purely an evaluation-display defect — the certified 1.5960 run simply had no collision in its corpus draw.

## Gates

All four green locally (macOS arm64, pinned 1.97.1, offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
