### PR TITLE
fix(certify): build R4G1 evaluation context from consecutive story-bounded history (#237)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -192,7 +192,12 @@ pub fn decode_row_kernel(k: &mut OpKernel, art: &Compiled, t: u32, out: &mut [i3
     }
 }
 
-fn history_token(c: &Corpus, i: usize, j: usize) -> Option<u32> {
+/// Token `j-1` positions back from `i` (j == 1 is `input[i]` itself),
+/// bounded to the same story — `None` past the story start. This is the
+/// canonical context-window semantics shared by observation (bundling) and
+/// evaluation (issue #237: evaluation must not cross story boundaries or
+/// use non-consecutive lags).
+pub fn history_token(c: &Corpus, i: usize, j: usize) -> Option<u32> {
     if j == 1 {
         return Some(c.input[i]);
     }

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -157,6 +157,25 @@ pub fn recorded_next_prob(top_tokens: &[u32; 8], top_weights: &[u32; 8], next: u
     (0.01, false)
 }
 
+/// Evaluation context for position `i` (issue #237): the last `WINDOW`
+/// tokens in chronological order — oldest first, ending with `input[i]` as
+/// the most recent — bounded to the position's own story, matching the
+/// compiler's observation semantics (`runtime::history_token`).
+///
+/// Replaces the defective construction that indexed the corpus with the
+/// per-slot *vector rotation offsets* (j·17 mod D) as if they were time
+/// lags — sampling stride-17 positions, in reversed order, across story
+/// boundaries, with a phantom trailing zero token.
+pub fn eval_context(c: &compiler::Corpus, i: usize) -> Vec<u32> {
+    let mut hist = Vec::with_capacity(WINDOW);
+    for j in (1..=WINDOW).rev() {
+        if let Some(t) = runtime::history_token(c, i, j) {
+            hist.push(t);
+        }
+    }
+    hist
+}
+
 pub fn certify(oracle: &dyn TeacherOracle) {
     let c = compiler::load_corpus().expect("corpus incomplete: run `transformerless gen` first");
     let cut = (c.stories as f64 * 0.8) as u32;
@@ -316,23 +335,15 @@ pub fn certify(oracle: &dyn TeacherOracle) {
     let mut node_scores =
         vec![uor_r4_core::transformerless::score_q::ScoreQ::MIN; r4g1.node_count() as usize];
 
-    let hist_at = |i: usize| {
-        let mut hist = [0u32; WINDOW + 1];
-        for (idx, w) in rot.iter().enumerate().take(WINDOW) {
-            hist[idx] = c.input[i.saturating_sub(*w)];
-        }
-        hist
-    };
-
     // Readiness probe (issue #232): bounded and deterministic (first
     // PROBE_POSITIONS held-out positions, in order). An untrained or
     // unscored graph would otherwise spend hours on a full evaluation that
     // terminates in an all-zero row — output that reads as a measured
     // failure when it is an absent measurement.
-    let probe_hists: Vec<[u32; WINDOW + 1]> = test
+    let probe_hists: Vec<Vec<u32>> = test
         .iter()
         .take(crate::r4g1_readiness::PROBE_POSITIONS)
-        .map(|&i| hist_at(i))
+        .map(|&i| eval_context(&c, i))
         .collect();
     let readiness = crate::r4g1_readiness::r4g1_eval_readiness(
         &r4g1,
@@ -345,7 +356,7 @@ pub fn certify(oracle: &dyn TeacherOracle) {
             let (mut top1, mut agree) = (0u64, 0u64);
             for &i in &test {
                 node_scores.fill(uor_r4_core::transformerless::score_q::ScoreQ::MIN);
-                let hist = hist_at(i);
+                let hist = eval_context(&c, i);
                 let pred = r4g1.predict_token(&hist, None, &mut node_scores);
                 if pred == c.next[i] {
                     top1 += 1;

--- a/crates/uor-r4-graph-certify/tests/eval_context.rs
+++ b/crates/uor-r4-graph-certify/tests/eval_context.rs
@@ -1,0 +1,79 @@
+//! Tests for the evaluation context builder (issue #237).
+//!
+//! The previous construction indexed the corpus with per-slot vector
+//! rotation offsets (j·17 mod D) as time lags — stride-17 sampling, in
+//! reversed order, across story boundaries, with a phantom trailing zero.
+//! `eval_context` must instead produce the last WINDOW tokens, oldest →
+//! newest, ending at `input[i]`, bounded to the position's own story.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use uor_r4_core::transformerless::compiler::{Corpus, WINDOW};
+use uor_r4_graph_certify::certify::eval_context;
+
+fn corpus(story: Vec<u32>, input: Vec<u32>) -> Corpus {
+    let n = input.len();
+    let stories = story.iter().copied().max().unwrap_or(0) as u64 + 1;
+    Corpus {
+        n,
+        stories,
+        story,
+        input,
+        next: vec![0; n],
+        t_argmax: vec![0; n],
+        top_tokens: vec![[0; 8]; n],
+        top_weights: vec![[0; 8]; n],
+        span_start: vec![0; n],
+        span_end: vec![0; n],
+        byte_start: vec![0; n],
+        byte_end: vec![0; n],
+        hidden: None,
+    }
+}
+
+#[test]
+fn last_window_tokens_chronological_ending_at_i() {
+    // 12 tokens, one story; position 10 → tokens 3..=10 (WINDOW = 8).
+    let input: Vec<u32> = (100..112).collect();
+    let c = corpus(vec![0; 12], input);
+    let hist = eval_context(&c, 10);
+    assert_eq!(hist.len(), WINDOW);
+    assert_eq!(hist, (103..=110).collect::<Vec<u32>>());
+    assert_eq!(
+        *hist.last().unwrap(),
+        110,
+        "most recent token must be input[i]"
+    );
+}
+
+#[test]
+fn story_boundary_truncates_history() {
+    // Story 1 starts at index 4; position 6 must see only tokens 4..=6.
+    let story = vec![0, 0, 0, 0, 1, 1, 1, 1];
+    let input: Vec<u32> = (200..208).collect();
+    let c = corpus(story, input);
+    let hist = eval_context(&c, 6);
+    assert_eq!(hist, vec![204, 205, 206]);
+}
+
+#[test]
+fn position_zero_yields_single_token() {
+    let c = corpus(vec![0; 4], vec![7, 8, 9, 10]);
+    let hist = eval_context(&c, 0);
+    assert_eq!(hist, vec![7]);
+}
+
+#[test]
+fn no_zero_padding_and_no_reordering() {
+    // Regression guard against the old construction's phantom trailing 0
+    // and reversed order: with distinct tokens, output is strictly the
+    // consecutive ascending slice.
+    let input: Vec<u32> = (300..320).collect();
+    let c = corpus(vec![0; 20], input.clone());
+    for i in [3usize, 9, 19] {
+        let hist = eval_context(&c, i);
+        let lo = i + 1 - hist.len();
+        assert_eq!(hist, input[lo..=i].to_vec());
+        assert!(!hist.contains(&0));
+    }
+}


### PR DESCRIPTION
Closes #237.

## What

The certify C-section built its evaluation context by using per-slot **vector rotation offsets** (`derive_rotations()` = j·17 mod D = `[0,17,34,...,136]` — dimension-space rotation amounts for `bundle_plain`) as **time lags** into the corpus. Three compounding defects: stride-17 token sampling instead of the last consecutive window; reversed order with the true most-recent token placed first (while `predict_distribution` reads the *last* element as most recent) plus a phantom trailing zero in the unwritten 9th slot; and no story-boundary check. The R4G1 row has never measured coherent context — a plausible standalone explanation for the historical all-zero row.

- New `pub fn eval_context(c, i) -> Vec<u32>`: last `WINDOW` tokens, oldest → newest ending at `input[i]`, story-bounded — built on `runtime::history_token` (now `pub`; visibility-only change to the canonical helper observation already uses), so evaluation and observation share one context definition.
- The #232 readiness probe and the full evaluation both switch to it. The rotation table keeps its legitimate uses (bundling, equality witnesses).
- 4 tests: chronological window, story-boundary truncation, position-0 edge, regression guard against all three old defects.

## Interpretation note

After this merges, the C row measures coherent context for the first time. Expect its numbers to change materially from the historical 0.0% row; the #232 SKIPPED marker should now fire only for genuinely untrained/unscored graphs rather than for scrambled input.

## Gates

All four green locally (macOS arm64, pinned 1.97.1, offline); no runtime-kernel changes (`history_token` visibility only — P-4 scan unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
