### PR TITLE
fix(router): store content-derived state vectors in the angular corpus index (#245)

### DIFF
--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -1470,6 +1470,44 @@ impl UorR4Router {
         }
     }
 
+    /// Content-derived 512-d state for a piece of text (issue #245): the
+    /// L2-normalized sum of the zeta-seeded vocabulary vectors of its known
+    /// words — the same construction `evolve_brain_state` uses for queries.
+    /// `None` when no word of the text is in the vocabulary.
+    fn content_state_vector(&self, text: &str) -> Option<Vec<f64>> {
+        let words = tokenize(text);
+        let mut s_vec = vec![0.0; 512];
+        let mut word_count = 0usize;
+        for w in words {
+            if let Some(v) = self.vocab_vectors.get(&w) {
+                for (sum, value) in s_vec.iter_mut().zip(v) {
+                    *sum += *value;
+                }
+                word_count += 1;
+            }
+        }
+        if word_count == 0 {
+            return None;
+        }
+        let norm = s_vec.iter().map(|v| v * v).sum::<f64>().sqrt();
+        if norm > 0.0 {
+            for v in &mut s_vec {
+                *v /= norm;
+            }
+        }
+        Some(s_vec)
+    }
+
+    /// Read-only view of the indexed corpus items for an identity (test and
+    /// inspection surface for the content-bearing store, issue #245).
+    pub fn corpus_items_for(&self, identity: &str) -> Vec<&CorpusItem> {
+        let key = identity_key(identity);
+        self.corpus_index_by_identity
+            .get(&key)
+            .map(|store| store.values().flatten().collect())
+            .unwrap_or_default()
+    }
+
     fn index_sentence_internal(&mut self, sentence: &str, identity: &str) {
         let s_clean = sentence.trim();
         if s_clean.is_empty() || s_clean.len() < 10 {
@@ -1482,7 +1520,15 @@ impl UorR4Router {
             }
         }
 
-        let routing_data = self.route_query_to_manifold_internal(s_clean, identity, None);
+        // Issue #245: route the sentence through its own content-derived
+        // state, not the session brain state at index time — stored
+        // state_vectors must encode the sentence, or cosine resonance
+        // retrieval is degenerate. Falls back to session state only when no
+        // word of the sentence is in the vocabulary (words were just added
+        // above, so this is rare).
+        let content_state = self.content_state_vector(s_clean);
+        let routing_data =
+            self.route_query_to_manifold_internal(s_clean, identity, content_state.as_deref());
         let best = routing_data.routed;
         let idx_win = best.window_index;
 

--- a/crates/uor-r4-router/tests/content_bearing_index.rs
+++ b/crates/uor-r4-router/tests/content_bearing_index.rs
@@ -1,0 +1,111 @@
+//! Content-bearing angular storage tests (issue #245).
+//!
+//! Before the fix, `index_sentence_internal` routed every sentence with
+//! `state_vector = None`, so stored `CorpusItem.state_vector`s were slices
+//! of whatever the session brain state happened to be at index time —
+//! independent of the sentence's words. These tests pin the repaired
+//! behavior: stored vectors derive from sentence content.
+
+use uor_r4_router::UorR4Router;
+
+const ID: &str = "user:test";
+
+fn nonzero(v: &[f64]) -> bool {
+    v.iter().any(|&x| x != 0.0)
+}
+
+fn cosine(a: &[f64], b: &[f64]) -> f64 {
+    let dot: f64 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+#[test]
+fn different_sentences_store_different_state_vectors() {
+    let mut router = UorR4Router::new(0.5);
+    router.index_sentence("the galaxy rotates around a supermassive black hole", ID);
+    router.index_sentence(
+        "bread dough rises because yeast produces carbon dioxide",
+        ID,
+    );
+
+    let items = router.corpus_items_for(ID);
+    assert_eq!(items.len(), 2, "both sentences indexed");
+    let a = &items[0].state_vector;
+    let b = &items[1].state_vector;
+    assert!(nonzero(a) && nonzero(b), "stored vectors must be populated");
+    assert_ne!(
+        a, b,
+        "different sentences must not store identical state vectors"
+    );
+}
+
+#[test]
+fn stored_vector_is_session_independent_within_a_router() {
+    // The same sentence indexed before and after unrelated session
+    // activity must store identical vectors: index-time session state must
+    // not leak into storage. (Note: vectors are NOT comparable across
+    // routers with different vocabulary histories — word→prime assignment
+    // is arrival-ordered, so the address space is vocabulary-relative.)
+    let sentence = "prime numbers thin out along the number line";
+
+    let mut router = UorR4Router::new(0.5);
+    router.index_sentence(sentence, "user:one");
+
+    // Perturb session/vocabulary state with unrelated indexing.
+    router.index_sentence(
+        "volcanic eruptions reshape coastlines over centuries",
+        "user:noise",
+    );
+    router.index_sentence("glaciers carve valleys as they advance", "user:noise");
+
+    router.index_sentence(sentence, "user:two");
+
+    let v1 = router.corpus_items_for("user:one")[0].state_vector.clone();
+    let items2 = router.corpus_items_for("user:two");
+    assert_eq!(items2.len(), 1);
+    let v2 = items2[0].state_vector.clone();
+    assert_eq!(
+        v1, v2,
+        "same sentence must store the same content-derived vector regardless of session activity"
+    );
+}
+
+#[test]
+fn matching_query_scores_closer_than_unrelated_sentence() {
+    // DoD retrieval fixture: for a query sharing content with sentence A,
+    // the stored vector of A must be closer (cosine) than the stored
+    // vector of unrelated sentence B.
+    let mut router = UorR4Router::new(0.5);
+    let a = "planets orbit the sun in elliptical paths";
+    let b = "the chef seasoned the soup with fresh basil";
+    router.index_sentence(a, ID);
+    router.index_sentence(b, ID);
+
+    // Build the query vector through the same public surface: index the
+    // exact text of A under a scratch identity and read its stored vector —
+    // content-determinism (previous test) guarantees it equals A's stored
+    // vector, so cos(q, A) = 1 while B differs.
+    router.index_sentence(a, "user:scratch");
+    let q = router.corpus_items_for("user:scratch")[0]
+        .state_vector
+        .clone();
+
+    let items = router.corpus_items_for(ID);
+    let (va, vb) = if items[0].sentence == a {
+        (&items[0].state_vector, &items[1].state_vector)
+    } else {
+        (&items[1].state_vector, &items[0].state_vector)
+    };
+
+    let ca = cosine(&q, va);
+    let cb = cosine(&q, vb);
+    assert!(
+        ca > cb,
+        "content-matching sentence must score closer: cos(A)={ca} vs cos(B)={cb}"
+    );
+}


### PR DESCRIPTION
Closes #245.

## What

Stored `CorpusItem.state_vector`s now derive from sentence **content** instead of capturing the session brain state at index time. The fix flows through the existing `state_vector: Option<&[f64]>` parameter of `route_query_to_manifold_internal` (the vocabulary lives on the router, not the geometry structs — so no geometry-trait change): a new `content_state_vector()` builds the L2-normalized sum of the sentence's known zeta-seeded vocab vectors, exactly as `evolve_brain_state` does for queries.

This revives the cosine term of `retrieve_geometric_resonance` (previously degenerate — retrieval was effectively shared-prime overlap only), per-sentence Hopf coordinates, and the semantic map — all already wired downstream.

## Tests (all impossible before the fix)

- Different sentences store different vectors.
- Same sentence stores an identical vector before/after unrelated session activity (session-independence within a router). A recorded caveat: vectors are **vocabulary-relative across routers** — word→prime assignment is arrival-ordered — noted for the future UOR-canonicalization discussion of this address space.
- A query with sentence A's content scores strictly closer (cosine) to A's stored vector than to unrelated B's.

## Scope

`uor-r4-router` only — exploratory crate, outside the graph migration path (AGENTS.md). Gates: all four green locally (macOS arm64, pinned 1.97.1, offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
