### PR TITLE
fix(compiler): load the teacher's real byte-level BPE tokenizer for HF-path observation (#242)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/hf_bpe.rs
+++ b/crates/uor-r4-core/src/transformerless/hf_bpe.rs
@@ -1,0 +1,640 @@
+//! Byte-level BPE tokenizer loaded from a Hugging Face `tokenizer.json`
+//! (issue #242).
+//!
+//! The legacy [`scenarios::Tokenizer`](super::scenarios::Tokenizer) HF path
+//! segmented text with iterative greedy pair merging preferring the lowest
+//! MERGED TOKEN ID over the raw vocabulary, with no merges table. The
+//! SmolLM2-Instruct teacher family uses byte-level BPE with an ORDERED
+//! merges list: at every step the adjacent pair with the lowest merge RANK
+//! is merged first. The two rules produce different segmentations, so
+//! observation and evaluation were feeding the teacher token streams it
+//! never saw. This module implements the teacher's actual rule:
+//!
+//! - `model.vocab` is the token → id map (tokens in the GPT-2 byte-level
+//!   alphabet);
+//! - `model.merges` is the ordered merge list — rank = list position;
+//! - `added_tokens` are matched atomically (leftmost occurrence, longest
+//!   content first) BEFORE pre-tokenization;
+//! - pre-tokenization is the GPT-2 `ByteLevel` split (contractions, ` ?`
+//!   letter/number/punctuation runs, whitespace runs keeping the final
+//!   space attached to the following word), honoring `add_prefix_space`
+//!   and an optional preceding `Digits` step (SmolLM2 declares
+//!   `Digits { individual_digits: true }` before `ByteLevel`);
+//! - each pre-token's UTF-8 bytes are mapped through the standard GPT-2
+//!   byte-to-unicode table, merged rank-first to a fixpoint, and looked up
+//!   in the vocabulary; merged results are cached per pre-token.
+//!
+//! The legacy tokenizer and its κ-pinned llama2.c baselines are untouched;
+//! [`TokenizerKind`] lets the HF observation path select this
+//! implementation while every legacy call site keeps its exact behavior.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use super::scenarios::Tokenizer;
+
+/// Upper bound on cached pre-token encodings (bounds memory on adversarial
+/// corpora; natural text saturates far below this).
+const CACHE_CAPACITY: usize = 1 << 16;
+
+/// The standard GPT-2 byte-to-unicode table: printable latin-1 bytes map to
+/// themselves; the remaining 68 bytes map to U+0100.. in ascending order.
+/// This is the exact inverse of `scenarios::bytelevel_inverse`.
+fn bytes_to_unicode() -> [char; 256] {
+    let mut table = ['\0'; 256];
+    let mut assigned = [false; 256];
+    for byte in (b'!'..=b'~').chain(0xA1..=0xAC).chain(0xAE..=0xFF) {
+        // Codepoints 0x21..=0xFF are all valid chars.
+        table[byte as usize] = char::from_u32(u32::from(byte)).expect("latin-1 codepoint is valid");
+        assigned[byte as usize] = true;
+    }
+    let mut extra = 0u32;
+    for byte in 0usize..256 {
+        if !assigned[byte] {
+            // Codepoints 0x100..=0x143 are all valid chars.
+            table[byte] =
+                char::from_u32(256 + extra).expect("byte-level fallback codepoint is valid");
+            extra += 1;
+        }
+    }
+    table
+}
+
+/// One segment of the input after atomic added-token matching.
+enum Piece<'text> {
+    Text(&'text str),
+    Special(u32),
+}
+
+/// A byte-level BPE tokenizer parsed from a Hugging Face `tokenizer.json`.
+pub struct HfBpeTokenizer {
+    /// id → token content: byte-level alphabet for vocabulary tokens,
+    /// literal text for added tokens, empty for unassigned ids.
+    vocab: Vec<String>,
+    token_to_id: HashMap<String, u32>,
+    /// `"left right"` → rank (list position in `model.merges`). Byte-level
+    /// tokens never contain a space, so the joined key is unambiguous.
+    merge_ranks: HashMap<String, u32>,
+    /// Added tokens sorted by content length descending, matched atomically
+    /// before pre-tokenization.
+    added_tokens: Vec<(String, u32)>,
+    /// ids whose content decodes literally (no byte-level reverse mapping).
+    added_ids: HashSet<u32>,
+    byte_encoder: [char; 256],
+    byte_decoder: HashMap<char, u8>,
+    add_prefix_space: bool,
+    /// `Some(individual_digits)` when a `Digits` pre-tokenizer step runs
+    /// before `ByteLevel`.
+    digits_individual: Option<bool>,
+    /// blake3 of the raw `tokenizer.json` bytes, `blake3:<hex>`.
+    address: String,
+    /// Per-pre-token merge cache: raw pre-token text → token ids.
+    cache: Mutex<HashMap<String, Vec<u32>>>,
+}
+
+impl HfBpeTokenizer {
+    /// Parse a tokenizer from raw `tokenizer.json` bytes.
+    pub fn from_tokenizer_json_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let value: serde_json::Value =
+            serde_json::from_slice(bytes).map_err(|error| format!("tokenizer.json: {error}"))?;
+        let model = value
+            .get("model")
+            .ok_or_else(|| "tokenizer.json: missing model".to_owned())?;
+        if let Some(kind) = model.get("type").and_then(serde_json::Value::as_str) {
+            if kind != "BPE" {
+                return Err(format!("tokenizer.json: unsupported model type {kind:?}"));
+            }
+        }
+        let vocab_map = model
+            .get("vocab")
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| "tokenizer.json: missing model.vocab".to_owned())?;
+        let mut token_to_id: HashMap<String, u32> = HashMap::with_capacity(vocab_map.len());
+        let mut max_id = 0u32;
+        for (piece, id) in vocab_map {
+            let id = id
+                .as_u64()
+                .and_then(|id| u32::try_from(id).ok())
+                .ok_or_else(|| format!("tokenizer.json: invalid id for token {piece:?}"))?;
+            max_id = max_id.max(id);
+            token_to_id.insert(piece.clone(), id);
+        }
+
+        let mut added_tokens: Vec<(String, u32)> = Vec::new();
+        if let Some(entries) = value
+            .get("added_tokens")
+            .and_then(serde_json::Value::as_array)
+        {
+            for entry in entries {
+                let content = entry
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "tokenizer.json: added token without content".to_owned())?;
+                let id = entry
+                    .get("id")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|id| u32::try_from(id).ok())
+                    .ok_or_else(|| {
+                        format!("tokenizer.json: invalid id for added token {content:?}")
+                    })?;
+                max_id = max_id.max(id);
+                added_tokens.push((content.to_owned(), id));
+            }
+        }
+
+        let vocab_len = max_id as usize + 1;
+        let mut vocab = vec![String::new(); vocab_len];
+        for (piece, &id) in &token_to_id {
+            vocab[id as usize] = piece.clone();
+        }
+        let mut added_ids = HashSet::with_capacity(added_tokens.len());
+        for (content, id) in &added_tokens {
+            vocab[*id as usize] = content.clone();
+            token_to_id.entry(content.clone()).or_insert(*id);
+            added_ids.insert(*id);
+        }
+        // Longest content first: leftmost-longest atomic matching.
+        added_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(&b.0)));
+
+        let merges = model
+            .get("merges")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| "tokenizer.json: missing model.merges".to_owned())?;
+        let mut merge_ranks: HashMap<String, u32> = HashMap::with_capacity(merges.len());
+        for (rank, entry) in merges.iter().enumerate() {
+            let key = match entry {
+                serde_json::Value::String(pair) => {
+                    if pair.split(' ').count() != 2 {
+                        return Err(format!("tokenizer.json: malformed merge entry {pair:?}"));
+                    }
+                    pair.clone()
+                }
+                serde_json::Value::Array(pair) => match (
+                    pair.first().and_then(serde_json::Value::as_str),
+                    pair.get(1).and_then(serde_json::Value::as_str),
+                    pair.len(),
+                ) {
+                    (Some(left), Some(right), 2) => format!("{left} {right}"),
+                    _ => {
+                        return Err(format!(
+                            "tokenizer.json: malformed merge entry at rank {rank}"
+                        ));
+                    }
+                },
+                _ => {
+                    return Err(format!(
+                        "tokenizer.json: malformed merge entry at rank {rank}"
+                    ));
+                }
+            };
+            let rank = u32::try_from(rank)
+                .map_err(|_| "tokenizer.json: merge list exceeds u32 ranks".to_owned())?;
+            merge_ranks.entry(key).or_insert(rank);
+        }
+
+        let pre_tokenizer = parse_pre_tokenizer(value.get("pre_tokenizer"))?;
+
+        let byte_encoder = bytes_to_unicode();
+        let mut byte_decoder = HashMap::with_capacity(256);
+        for (byte, mapped) in byte_encoder.iter().enumerate() {
+            byte_decoder.insert(*mapped, byte as u8);
+        }
+
+        Ok(Self {
+            vocab,
+            token_to_id,
+            merge_ranks,
+            added_tokens,
+            added_ids,
+            byte_encoder,
+            byte_decoder,
+            add_prefix_space: pre_tokenizer.add_prefix_space,
+            digits_individual: pre_tokenizer.digits_individual,
+            address: format!("blake3:{}", blake3::hash(bytes).to_hex()),
+            cache: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Load `tokenizer.json` from a Hugging Face model snapshot directory.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_dir(dir: &std::path::Path) -> Result<Self, String> {
+        let path = dir.join("tokenizer.json");
+        let bytes = std::fs::read(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+        Self::from_tokenizer_json_bytes(&bytes)
+    }
+
+    /// Encode text to token ids: added tokens atomically, then the optional
+    /// `Digits` split, then GPT-2 byte-level pre-tokenization and
+    /// rank-ordered BPE per pre-token. No BOS/EOS tokens are added
+    /// (matching the legacy HF encode path; SmolLM2's post-processor is
+    /// null).
+    pub fn encode(&self, text: &str) -> Vec<u32> {
+        let mut ids = Vec::new();
+        for piece in self.split_on_added_tokens(text) {
+            match piece {
+                Piece::Special(id) => ids.push(id),
+                Piece::Text(segment) => self.encode_segment(segment, &mut ids),
+            }
+        }
+        ids
+    }
+
+    /// Encode one non-special segment. `ByteLevel` applies
+    /// `add_prefix_space` to EVERY split it receives (each `Digits` split,
+    /// or the whole segment without a `Digits` step), so the prefix is
+    /// applied here, after digit splitting.
+    fn encode_segment(&self, segment: &str, ids: &mut Vec<u32>) {
+        let splits = match self.digits_individual {
+            Some(individual) => split_digits(segment, individual),
+            None => vec![segment],
+        };
+        for split in splits {
+            if split.is_empty() {
+                continue;
+            }
+            let prefixed;
+            let split = if self.add_prefix_space && !split.starts_with(' ') {
+                prefixed = format!(" {split}");
+                prefixed.as_str()
+            } else {
+                split
+            };
+            for pre_token in pre_tokenize(split) {
+                self.bpe(pre_token, ids);
+            }
+        }
+    }
+
+    /// Lossy encode, mirroring the legacy surface: byte-level BPE encodes
+    /// every input exactly, so the replaced-character count is always zero.
+    pub fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64) {
+        (self.encode(text), 0)
+    }
+
+    /// Decode ids: token strings → reverse byte-level mapping → bytes →
+    /// lossy UTF-8. Added tokens decode to their literal content;
+    /// out-of-range ids are skipped.
+    pub fn decode(&self, ids: &[u32]) -> String {
+        String::from_utf8_lossy(&self.decode_bytes(ids)).into_owned()
+    }
+
+    /// Raw decoded bytes of `ids` (before any lossy UTF-8 conversion).
+    fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for &id in ids {
+            let Some(token) = self.vocab.get(id as usize) else {
+                continue;
+            };
+            if self.added_ids.contains(&id) {
+                bytes.extend_from_slice(token.as_bytes());
+                continue;
+            }
+            for ch in token.chars() {
+                match self.byte_decoder.get(&ch) {
+                    Some(&byte) => bytes.push(byte),
+                    None => {
+                        let mut utf8 = [0u8; 4];
+                        bytes.extend_from_slice(ch.encode_utf8(&mut utf8).as_bytes());
+                    }
+                }
+            }
+        }
+        bytes
+    }
+
+    /// Number of id slots (max assigned id + 1, added tokens included).
+    pub fn vocab_size(&self) -> usize {
+        self.vocab.len()
+    }
+
+    /// Byte length of each token's RAW decoded content, indexed by id
+    /// (byte-anchor generation; unassigned ids have length 0). Raw bytes
+    /// are measured before lossy UTF-8 conversion, so a token holding a
+    /// partial UTF-8 sequence counts its true byte length rather than the
+    /// replacement character's.
+    pub fn token_byte_lengths(&self) -> Vec<u32> {
+        (0..self.vocab.len() as u32)
+            .map(|id| self.decode_bytes(&[id]).len() as u32)
+            .collect()
+    }
+
+    /// Content address of the raw `tokenizer.json` bytes: `blake3:<hex>`.
+    pub fn address(&self) -> String {
+        self.address.clone()
+    }
+
+    /// Split text on added-token occurrences, leftmost-longest.
+    fn split_on_added_tokens<'text>(&self, text: &'text str) -> Vec<Piece<'text>> {
+        let mut pieces = Vec::new();
+        let mut rest = text;
+        while !rest.is_empty() {
+            let mut best: Option<(usize, usize, u32)> = None;
+            for (content, id) in &self.added_tokens {
+                if content.is_empty() {
+                    continue;
+                }
+                if let Some(position) = rest.find(content.as_str()) {
+                    // added_tokens is longest-first, so on position ties the
+                    // earlier (longer) match is kept by the strict `<`.
+                    if best.is_none_or(|(existing, _, _)| position < existing) {
+                        best = Some((position, content.len(), *id));
+                    }
+                    if position == 0 {
+                        break;
+                    }
+                }
+            }
+            match best {
+                Some((position, length, id)) => {
+                    if position > 0 {
+                        pieces.push(Piece::Text(&rest[..position]));
+                    }
+                    pieces.push(Piece::Special(id));
+                    rest = &rest[position + length..];
+                }
+                None => {
+                    pieces.push(Piece::Text(rest));
+                    break;
+                }
+            }
+        }
+        pieces
+    }
+
+    /// Rank-ordered BPE over one pre-token, appending token ids to `out`.
+    fn bpe(&self, pre_token: &str, out: &mut Vec<u32>) {
+        if pre_token.is_empty() {
+            return;
+        }
+        {
+            let cache = match self.cache.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if let Some(ids) = cache.get(pre_token) {
+                out.extend_from_slice(ids);
+                return;
+            }
+        }
+
+        let mut symbols: Vec<String> = pre_token
+            .bytes()
+            .map(|byte| self.byte_encoder[byte as usize].to_string())
+            .collect();
+        let mut pair_key = String::new();
+        while symbols.len() > 1 {
+            // The adjacent pair with the LOWEST merge rank merges first.
+            let mut best: Option<(u32, usize)> = None;
+            for index in 0..symbols.len() - 1 {
+                pair_key.clear();
+                pair_key.push_str(&symbols[index]);
+                pair_key.push(' ');
+                pair_key.push_str(&symbols[index + 1]);
+                if let Some(&rank) = self.merge_ranks.get(&pair_key) {
+                    if best.is_none_or(|(existing, _)| rank < existing) {
+                        best = Some((rank, index));
+                    }
+                }
+            }
+            let Some((_, best_index)) = best else {
+                break;
+            };
+            let left = symbols[best_index].clone();
+            let right = symbols[best_index + 1].clone();
+            let merged = format!("{left}{right}");
+            let mut next_symbols = Vec::with_capacity(symbols.len());
+            let mut index = 0usize;
+            while index < symbols.len() {
+                if index + 1 < symbols.len()
+                    && symbols[index] == left
+                    && symbols[index + 1] == right
+                {
+                    next_symbols.push(merged.clone());
+                    index += 2;
+                } else {
+                    next_symbols.push(std::mem::take(&mut symbols[index]));
+                    index += 1;
+                }
+            }
+            symbols = next_symbols;
+        }
+
+        let mut ids = Vec::with_capacity(symbols.len());
+        for symbol in &symbols {
+            if let Some(&id) = self.token_to_id.get(symbol.as_str()) {
+                ids.push(id);
+            } else {
+                // A well-formed byte-level vocabulary contains every
+                // single-byte symbol; fall back per character and skip
+                // anything the vocabulary genuinely lacks.
+                let mut utf8 = [0u8; 4];
+                for ch in symbol.chars() {
+                    if let Some(&id) = self.token_to_id.get(ch.encode_utf8(&mut utf8)) {
+                        ids.push(id);
+                    }
+                }
+            }
+        }
+        out.extend_from_slice(&ids);
+        let mut cache = match self.cache.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if cache.len() < CACHE_CAPACITY {
+            cache.insert(pre_token.to_owned(), ids);
+        }
+    }
+}
+
+/// Parsed pre-tokenizer configuration.
+struct PreTokenizerConfig {
+    /// `add_prefix_space` on the `ByteLevel` step (the tokenizers-library
+    /// default is true).
+    add_prefix_space: bool,
+    /// `Some(individual_digits)` when a `Digits` step precedes `ByteLevel`
+    /// (SmolLM2: `Digits { individual_digits: true }`).
+    digits_individual: Option<bool>,
+}
+
+/// Confirm the pre-tokenizer is `ByteLevel`, optionally preceded by a
+/// `Digits` step in a `Sequence`. Any other configuration is rejected —
+/// approximating an unknown pre-tokenizer would reintroduce exactly the
+/// wrong-segmentation bug this module fixes.
+fn parse_pre_tokenizer(pre: Option<&serde_json::Value>) -> Result<PreTokenizerConfig, String> {
+    let Some(pre) = pre.filter(|value| !value.is_null()) else {
+        return Err("tokenizer.json: missing pre_tokenizer (byte-level BPE required)".to_owned());
+    };
+    let steps: Vec<&serde_json::Value> = match pre.get("type").and_then(serde_json::Value::as_str) {
+        Some("Sequence") => pre
+            .get("pretokenizers")
+            .and_then(serde_json::Value::as_array)
+            .map(|steps| steps.iter().collect())
+            .ok_or_else(|| "tokenizer.json: pre-tokenizer sequence without steps".to_owned())?,
+        Some(_) => vec![pre],
+        None => return Err("tokenizer.json: pre_tokenizer without a type".to_owned()),
+    };
+    let mut config: Option<PreTokenizerConfig> = None;
+    let mut digits_individual = None;
+    for step in steps {
+        match step.get("type").and_then(serde_json::Value::as_str) {
+            Some("ByteLevel") if config.is_none() => {
+                config = Some(PreTokenizerConfig {
+                    add_prefix_space: step
+                        .get("add_prefix_space")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(true),
+                    digits_individual,
+                });
+            }
+            Some("Digits") if config.is_none() => {
+                digits_individual = Some(
+                    step.get("individual_digits")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false),
+                );
+            }
+            other => {
+                return Err(format!(
+                    "tokenizer.json: unsupported pre-tokenizer step {other:?}"
+                ));
+            }
+        }
+    }
+    config.ok_or_else(|| "tokenizer.json: no ByteLevel pre-tokenizer step".to_owned())
+}
+
+/// The `Digits` pre-tokenizer: split into numeric and non-numeric runs
+/// (`char::is_numeric`, the tokenizers-library predicate); with
+/// `individual`, every numeric character becomes its own split.
+fn split_digits(text: &str, individual: bool) -> Vec<&str> {
+    let mut splits = Vec::new();
+    let mut start = 0usize;
+    let mut in_digits = false;
+    for (offset, ch) in text.char_indices() {
+        let numeric = ch.is_numeric();
+        if offset > 0 && (numeric != in_digits || (numeric && individual)) {
+            splits.push(&text[start..offset]);
+            start = offset;
+        }
+        in_digits = numeric;
+    }
+    if start < text.len() {
+        splits.push(&text[start..]);
+    }
+    splits
+}
+
+/// GPT-2 byte-level pre-tokenization, hand-rolled from the reference
+/// pattern `'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|`
+/// `\s+(?!\S)|\s+`: contractions bind without a preceding space; a single
+/// leading space attaches to the following letter/number/punctuation run;
+/// a whitespace run followed by a non-space keeps its last character for
+/// the next pre-token.
+fn pre_tokenize(text: &str) -> Vec<&str> {
+    const CONTRACTIONS: [&str; 7] = ["'s", "'t", "'re", "'ve", "'m", "'ll", "'d"];
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let byte_at = |index: usize| chars.get(index).map_or(text.len(), |(offset, _)| *offset);
+    let mut pieces = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        let (offset, ch) = chars[i];
+        if ch == '\'' {
+            if let Some(contraction) = CONTRACTIONS
+                .iter()
+                .find(|candidate| text[offset..].starts_with(**candidate))
+            {
+                pieces.push(&text[offset..offset + contraction.len()]);
+                i += contraction.chars().count();
+                continue;
+            }
+        }
+        let after_space = if ch == ' ' { i + 1 } else { i };
+        if let Some(&(_, next)) = chars.get(after_space) {
+            if next.is_alphabetic() {
+                let mut end = after_space;
+                while end < chars.len() && chars[end].1.is_alphabetic() {
+                    end += 1;
+                }
+                pieces.push(&text[offset..byte_at(end)]);
+                i = end;
+                continue;
+            }
+            if next.is_numeric() {
+                let mut end = after_space;
+                while end < chars.len() && chars[end].1.is_numeric() {
+                    end += 1;
+                }
+                pieces.push(&text[offset..byte_at(end)]);
+                i = end;
+                continue;
+            }
+            if !next.is_whitespace() {
+                let mut end = after_space;
+                while end < chars.len()
+                    && !chars[end].1.is_whitespace()
+                    && !chars[end].1.is_alphabetic()
+                    && !chars[end].1.is_numeric()
+                {
+                    end += 1;
+                }
+                pieces.push(&text[offset..byte_at(end)]);
+                i = end;
+                continue;
+            }
+        }
+        // Whitespace run (every non-whitespace character was consumed by a
+        // branch above, so `ch` is whitespace here).
+        let mut end = i;
+        while end < chars.len() && chars[end].1.is_whitespace() {
+            end += 1;
+        }
+        if end < chars.len() && end - i > 1 {
+            // `\s+(?!\S)`: leave the final whitespace character to attach
+            // to the following pre-token.
+            end -= 1;
+        }
+        pieces.push(&text[offset..byte_at(end)]);
+        i = end;
+    }
+    pieces
+}
+
+/// Tokenizer selector for observation drivers: the legacy llama2.c
+/// tokenizer keeps its exact behavior (κ-pinned baselines), the HF path
+/// uses the teacher's real byte-level BPE when `tokenizer.json` exists.
+/// The HF variant is boxed: [`HfBpeTokenizer`] carries its byte tables
+/// inline and would otherwise dwarf the legacy variant.
+pub enum TokenizerKind {
+    Legacy(Tokenizer),
+    HfBpe(Box<HfBpeTokenizer>),
+}
+
+impl TokenizerKind {
+    pub fn encode(&self, text: &str) -> Vec<u32> {
+        match self {
+            TokenizerKind::Legacy(tokenizer) => tokenizer.encode(text),
+            TokenizerKind::HfBpe(tokenizer) => tokenizer.encode(text),
+        }
+    }
+
+    pub fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64) {
+        match self {
+            TokenizerKind::Legacy(tokenizer) => tokenizer.encode_lossy(text),
+            TokenizerKind::HfBpe(tokenizer) => tokenizer.encode_lossy(text),
+        }
+    }
+
+    pub fn decode(&self, ids: &[u32]) -> String {
+        match self {
+            TokenizerKind::Legacy(tokenizer) => tokenizer.decode(ids),
+            TokenizerKind::HfBpe(tokenizer) => tokenizer.decode(ids),
+        }
+    }
+
+    pub fn vocab_size(&self) -> usize {
+        match self {
+            TokenizerKind::Legacy(tokenizer) => tokenizer.vocab.len(),
+            TokenizerKind::HfBpe(tokenizer) => tokenizer.vocab_size(),
+        }
+    }
+}

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -290,6 +290,7 @@ pub mod compiler;
 pub mod convert_r4g1;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod graph_patch;
+pub mod hf_bpe;
 pub mod reference_state;
 pub mod resolution_status;
 pub mod runtime;

--- a/crates/uor-r4-core/tests/hf_bpe_tokenizer.rs
+++ b/crates/uor-r4-core/tests/hf_bpe_tokenizer.rs
@@ -1,0 +1,186 @@
+//! Behavioral witnesses for the Hugging Face byte-level BPE tokenizer
+//! (issue #242): merge-RANK order (not lowest-merged-id greedy), atomic
+//! added-token matching, encode/decode round-trips, and the GPT-2
+//! byte-level mapping (Ġ for a leading space, multi-byte UTF-8 characters).
+
+use uor_r4_core::transformerless::hf_bpe::HfBpeTokenizer;
+
+/// A tiny synthetic tokenizer.json with a caller-chosen pre-tokenizer.
+///
+/// Vocabulary (note "ab" has a LOWER id than "bc", while the merge list
+/// ranks "b c" FIRST — the discriminating configuration for test
+/// `merge_rank_order_beats_lowest_token_id_greedy`):
+///
+///   a:0 b:1 c:2 ab:3 bc:4 h:5 e:6 l:7 o:8 w:9 r:10 d:11 he:12 hel:13
+///   hell:14 hello:15 Ġ:16 Ġw:17 Ġwo:18 Ġwor:19 Ġworl:21 Ġworld:22
+///   Ã:23 ©:24 Ã©:25 f:26 1:27 2:28 12:29   +   added token <|end|>:20
+fn tokenizer_json_with(pre_tokenizer: &str) -> String {
+    format!(
+        r#"{{
+  "added_tokens": [
+    {{"id": 20, "content": "<|end|>", "special": true}}
+  ],
+  "pre_tokenizer": {pre_tokenizer},
+  "model": {{
+    "type": "BPE",
+    "vocab": {{
+      "a": 0, "b": 1, "c": 2, "ab": 3, "bc": 4,
+      "h": 5, "e": 6, "l": 7, "o": 8, "w": 9, "r": 10, "d": 11,
+      "he": 12, "hel": 13, "hell": 14, "hello": 15,
+      "Ġ": 16, "Ġw": 17, "Ġwo": 18, "Ġwor": 19, "Ġworl": 21, "Ġworld": 22,
+      "Ã": 23, "©": 24, "Ã©": 25, "f": 26, "1": 27, "2": 28, "12": 29
+    }},
+    "merges": [
+      "b c",
+      "a b",
+      "h e",
+      "he l",
+      "hel l",
+      "hell o",
+      "Ġ w",
+      "Ġw o",
+      "Ġwo r",
+      "Ġwor l",
+      "Ġworl d",
+      "Ã ©",
+      "1 2"
+    ]
+  }}
+}}"#
+    )
+}
+
+fn tokenizer_json(add_prefix_space: bool) -> String {
+    tokenizer_json_with(&format!(
+        r#"{{"type": "ByteLevel", "add_prefix_space": {add_prefix_space}}}"#
+    ))
+}
+
+fn tokenizer() -> HfBpeTokenizer {
+    HfBpeTokenizer::from_tokenizer_json_bytes(tokenizer_json(false).as_bytes())
+        .expect("synthetic tokenizer.json parses")
+}
+
+/// (a) The pair with the lowest merge RANK merges first. On "abc" the
+/// merges table ranks ("b","c") before ("a","b"), so rank-ordered BPE
+/// yields ["a","bc"] = [0, 4]. The legacy lowest-merged-token-id greedy
+/// rule would instead pick "ab" (id 3 < 4) and yield ["ab","c"] = [3, 2].
+#[test]
+fn merge_rank_order_beats_lowest_token_id_greedy() {
+    let tok = tokenizer();
+    assert_eq!(tok.encode("abc"), vec![0, 4]);
+}
+
+/// (b) Added tokens match atomically (no pre-tokenization or merging
+/// through their content) and decode to their literal text.
+#[test]
+fn special_token_matched_atomically() {
+    let tok = tokenizer();
+    assert_eq!(tok.encode("<|end|>"), vec![20]);
+    assert_eq!(tok.encode("hello<|end|>hello"), vec![15, 20, 15]);
+    assert_eq!(tok.decode(&[20]), "<|end|>");
+    assert_eq!(tok.decode(&[15, 20, 15]), "hello<|end|>hello");
+}
+
+/// (c) Encode/decode round-trips, including repeated encodes through the
+/// per-pre-token cache.
+#[test]
+fn encode_decode_round_trip() {
+    let tok = tokenizer();
+    for text in ["hello world", "hello", " world", "hello world<|end|>"] {
+        let ids = tok.encode(text);
+        assert_eq!(tok.decode(&ids), text, "round trip of {text:?}");
+        // Second pass hits the cache and must be identical.
+        assert_eq!(tok.encode(text), ids, "cached encode of {text:?}");
+    }
+}
+
+/// (d) GPT-2 byte-level mapping: the leading space of the second word maps
+/// to Ġ ("hello world" → ["hello", "Ġworld"]), and a non-ASCII character
+/// ("é" = 0xC3 0xA9 → "Ã©") encodes through its byte-level symbols.
+#[test]
+fn byte_level_mapping_space_and_non_ascii() {
+    let tok = tokenizer();
+    assert_eq!(tok.encode("hello world"), vec![15, 22]);
+    // "é" is a single letter pre-token whose two UTF-8 bytes map to the
+    // byte-level chars "Ã" and "©"; merge rank 11 joins them into id 25.
+    assert_eq!(tok.encode("é"), vec![25]);
+    assert_eq!(tok.decode(&[25]), "é");
+    // Double space: `\s+(?!\S)` keeps the last space attached to "world",
+    // the first space stands alone as Ġ.
+    assert_eq!(tok.encode("hello  world"), vec![15, 16, 22]);
+}
+
+#[test]
+fn add_prefix_space_prepends_one_space() {
+    let with_prefix = HfBpeTokenizer::from_tokenizer_json_bytes(tokenizer_json(true).as_bytes())
+        .expect("synthetic tokenizer.json parses");
+    // "world" gains a synthetic leading space → "Ġworld" (id 22); an input
+    // already starting with a space is unchanged.
+    assert_eq!(with_prefix.encode("world"), vec![22]);
+    assert_eq!(with_prefix.encode(" world"), vec![22]);
+}
+
+/// SmolLM2 declares `Digits { individual_digits: true }` before
+/// `ByteLevel`: every digit stands alone, and no merge crosses a digit
+/// boundary even when the merges table contains one ("1 2" here).
+#[test]
+fn digits_pre_tokenizer_isolates_individual_digits() {
+    let plain = tokenizer();
+    // Without the Digits step, merge "1 2" joins the digits into id 29.
+    assert_eq!(plain.encode("12"), vec![29]);
+    assert_eq!(plain.encode("hello 12"), vec![15, 16, 29]);
+
+    let digits = HfBpeTokenizer::from_tokenizer_json_bytes(
+        tokenizer_json_with(
+            r#"{"type": "Sequence", "pretokenizers": [
+                {"type": "Digits", "individual_digits": true},
+                {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true}
+            ]}"#,
+        )
+        .as_bytes(),
+    )
+    .expect("SmolLM2-shaped pre-tokenizer sequence parses");
+    assert_eq!(digits.encode("12"), vec![27, 28]);
+    // The space split off by Digits stands alone as Ġ.
+    assert_eq!(digits.encode("hello 12"), vec![15, 16, 27, 28]);
+    assert_eq!(digits.decode(&[15, 16, 27, 28]), "hello 12");
+}
+
+#[test]
+fn merges_as_array_pairs_parse_identically() {
+    // Newer tokenizer.json files store merges as two-element arrays.
+    let json = tokenizer_json(false).replace(
+        r#""b c",
+      "a b","#,
+        r#"["b", "c"],
+      ["a", "b"],"#,
+    );
+    let tok = HfBpeTokenizer::from_tokenizer_json_bytes(json.as_bytes())
+        .expect("array-format merges parse");
+    assert_eq!(tok.encode("abc"), vec![0, 4]);
+}
+
+#[test]
+fn surface_metadata() {
+    let tok = tokenizer();
+    // Highest assigned id is 29, so 30 id slots.
+    assert_eq!(tok.vocab_size(), 30);
+    let address = tok.address();
+    assert!(address.starts_with("blake3:"), "address is {address:?}");
+    assert_eq!(address.len(), "blake3:".len() + 64);
+    // Byte-level BPE is total: encode_lossy never replaces characters.
+    let (ids, replaced) = tok.encode_lossy("hello world");
+    assert_eq!(ids, vec![15, 22]);
+    assert_eq!(replaced, 0);
+}
+
+#[test]
+fn malformed_json_is_a_recoverable_error() {
+    assert!(HfBpeTokenizer::from_tokenizer_json_bytes(b"not json").is_err());
+    assert!(HfBpeTokenizer::from_tokenizer_json_bytes(b"{}").is_err());
+    // A non-byte-level pre-tokenizer is rejected (the caller falls back to
+    // the legacy tokenizer instead of mis-encoding).
+    let json = tokenizer_json(false).replace("\"ByteLevel\"", "\"Whitespace\"");
+    assert!(HfBpeTokenizer::from_tokenizer_json_bytes(json.as_bytes()).is_err());
+}

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -37,6 +37,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use uor_r4_core::transformerless::hf_bpe::{HfBpeTokenizer, TokenizerKind};
 use uor_r4_core::transformerless::scenarios as core_scenarios;
 use uor_r4_model_source::{BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, TeacherOracle};
 
@@ -277,23 +278,25 @@ pub fn observe_text_command(args: &[String]) -> Result<(), String> {
     let options = parse_observe_text_options(args)?;
     std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
     let token_byte_lengths: Vec<u32>;
-    let tokenizer: scenarios::Tokenizer;
+    let tokenizer: TokenizerKind;
     let mut oracle: Box<dyn TeacherOracle> = if let Some(checkpoint) = &options.checkpoint {
         // Legacy llama2.c checkpoint: the companion tokenizer is the
         // scoreless tokenizer.bin fetched by `setup` (overridable with
         // --tokenizer); its piece byte lengths anchor records into the
-        // article text.
+        // article text. This path is untouched by issue #242 — its κ-pinned
+        // baselines depend on the exact legacy encoding.
         let tokenizer_path = options
             .tokenizer
             .clone()
             .unwrap_or_else(|| PathBuf::from(DEFAULT_TOKENIZER));
-        tokenizer = scenarios::Tokenizer::try_load(&tokenizer_path)
+        let legacy = scenarios::Tokenizer::try_load(&tokenizer_path)
             .map_err(|error| format!("{}: {error}", tokenizer_path.display()))?;
-        token_byte_lengths = tokenizer
+        token_byte_lengths = legacy
             .vocab
             .iter()
             .map(|piece| piece.len() as u32)
             .collect();
+        tokenizer = TokenizerKind::Legacy(legacy);
         let path = checkpoint
             .to_str()
             .ok_or_else(|| "checkpoint path is not UTF-8".to_owned())?;
@@ -311,8 +314,24 @@ pub fn observe_text_command(args: &[String]) -> Result<(), String> {
                 options.output.join("tokenizer.bin"),
             )
             .map_err(|error| error.to_string())?;
-        tokenizer = scenarios::Tokenizer::try_load(options.output.join("tokenizer.bin"))
-            .map_err(|error| error.to_string())?;
+        // Issue #242: segment observation text with the teacher's REAL
+        // byte-level BPE (ordered merges from tokenizer.json), not the
+        // legacy lowest-id greedy heuristic — otherwise every record feeds
+        // the teacher a segmentation it never saw. tokenizer.bin above
+        // remains the compiled runtime artifact; tokenizer.json is
+        // authoritative for observation when present.
+        let tokenizer_json = options.source.join("tokenizer.json");
+        tokenizer = if tokenizer_json.is_file() {
+            TokenizerKind::HfBpe(Box::new(
+                HfBpeTokenizer::from_dir(&options.source)
+                    .map_err(|error| format!("{}: {error}", tokenizer_json.display()))?,
+            ))
+        } else {
+            TokenizerKind::Legacy(
+                scenarios::Tokenizer::try_load(options.output.join("tokenizer.bin"))
+                    .map_err(|error| error.to_string())?,
+            )
+        };
         Box::new(oracle)
     };
     let report = observe_text::observe_text_corpus(

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use uor_r4_core::transformerless::scenarios::Tokenizer;
+use uor_r4_core::transformerless::hf_bpe::TokenizerKind;
 use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::progress::Progress;
 
@@ -430,7 +430,8 @@ pub struct ObservationReport {
     pub articles_truncated: u64,
     /// Characters replaced by the lossy tokenizer fallback during this
     /// invocation (unencodable in the teacher vocab; substituted with a
-    /// space — deterministic, see [`scenarios::Tokenizer::encode_lossy`]).
+    /// space — deterministic, see the legacy `Tokenizer::encode_lossy`;
+    /// always zero on the byte-level BPE path, which encodes every input).
     pub characters_replaced: u64,
     /// Records committed so far (all invocations).
     pub records: u64,
@@ -521,7 +522,7 @@ fn build_report(
 pub fn observe_text_corpus(
     oracle: &mut dyn TeacherOracle,
     budget_s: u64,
-    tokenizer: &Tokenizer,
+    tokenizer: &TokenizerKind,
     token_byte_lengths: Option<&[u32]>,
     articles_path: &Path,
     out_dir: &Path,
@@ -772,6 +773,7 @@ mod tests {
         ObservationManifest, merge_shards, sample_id, shard_file_name, shard_of,
     };
     use std::time::{SystemTime, UNIX_EPOCH};
+    use uor_r4_core::transformerless::scenarios::Tokenizer;
     use uor_r4_model_source::{BehaviorSource, RepresentationSource};
 
     const SHARD_BITS: u8 = 2;
@@ -793,7 +795,7 @@ mod tests {
         std::env::temp_dir().join(format!("uor-r4-observe-text-{name}-{nanos}"))
     }
 
-    fn fixture_tokenizer() -> Tokenizer {
+    fn fixture_tokenizer() -> TokenizerKind {
         let path = unique_path("tokenizer.bin");
         let mut bytes = Vec::new();
         for piece in PIECES {
@@ -803,7 +805,7 @@ mod tests {
         fs::write(&path, bytes).expect("write tokenizer fixture");
         let tokenizer = Tokenizer::try_load(&path).expect("load tokenizer fixture");
         let _ = fs::remove_file(&path);
-        tokenizer
+        TokenizerKind::Legacy(tokenizer)
     }
 
     fn fixture_token_byte_lengths() -> Vec<u32> {
@@ -919,7 +921,7 @@ mod tests {
     /// cross-check that the driver emits format-identical v3 bytes.
     fn expected_shards(
         articles: &[(&str, &str)],
-        tokenizer: &Tokenizer,
+        tokenizer: &TokenizerKind,
         token_byte_lengths: Option<&[u32]>,
         up_to: usize,
     ) -> (Vec<Vec<[u8; RECORD_SIZE]>>, u64) {
@@ -967,7 +969,7 @@ mod tests {
 
     fn expected_merged(
         articles: &[(&str, &str)],
-        tokenizer: &Tokenizer,
+        tokenizer: &TokenizerKind,
         token_byte_lengths: Option<&[u32]>,
     ) -> Vec<u8> {
         let (shards, _) = expected_shards(articles, tokenizer, token_byte_lengths, articles.len());

--- a/src/server.rs
+++ b/src/server.rs
@@ -709,6 +709,7 @@ fn generate_attention_text(
 ) -> Option<(String, usize)> {
     // 1. Construct token seed for prompt
     let formatted_prompt = format!("User: {}\nAssistant:", prompt.trim());
+    // TODO(#242 follow-up): serving-side teacher prompting still uses tless_tokenize
     let seed = match tless_uor::tless_tokenize(&formatted_prompt) {
         Some(s) if !s.is_empty() => s,
         _ => return None,

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -539,6 +539,14 @@ pub fn set_tless_tokenizer(t: uor_r4_core::transformerless::scenarios::Tokenizer
     TLESS_TOKENIZER.with(|tk| *tk.borrow_mut() = Some(t));
 }
 
+// TODO(#242 follow-up): the serving-side tokenizer is still the legacy
+// greedy longest-match encoder over the exported tokenizer.bin vocabulary.
+// `generate_attention_text` (src/server.rs) tokenizes teacher prompts with
+// `tless_tokenize`, so the HF teacher fallback receives segmentations its
+// byte-level BPE never produced. Wiring `hf_bpe::HfBpeTokenizer` here needs
+// the source-snapshot tokenizer.json (only tokenizer.bin is present in the
+// compiled bundle) and a `TokenizerKind` thread-local across the public
+// tless_tokenize/detokenize surface — deferred to keep this change scoped.
 #[cfg(not(target_arch = "wasm32"))]
 fn with_tokenizer<R>(
     f: impl FnOnce(&uor_r4_core::transformerless::scenarios::Tokenizer) -> R,


### PR DESCRIPTION
Closes #242.

## What

Replaces the bespoke tokenizer on the **HF observation path** with a correct byte-level BPE implementation loaded from the model's own `tokenizer.json`:

- New `hf_bpe.rs` (`uor-r4-core/transformerless`): vocab + ordered merges (string and array formats), `added_tokens` matched atomically leftmost-longest before pre-tokenization, GPT-2 `bytes_to_unicode` byte-level mapping, `add_prefix_space` per HF `ByteLevel` semantics, and merge-**rank**-ordered BPE (the bespoke tokenizer merged by lowest merged-token-*id* — a different algorithm producing segmentations the teacher never saw). SmolLM2's actual pre-tokenizer is `Sequence[Digits{individual_digits}, ByteLevel]` (verified against the real published `tokenizer.json`) — both steps implemented; unknown pre-tokenizer steps error loudly instead of being silently approximated.
- `TokenizerKind { Legacy, HfBpe }` wrapper introduced at the HF call sites only: `observe_text_command` (`graph-cli/src/lib.rs:317-334`) selects `HfBpeTokenizer::from_dir(source)` when `tokenizer.json` exists (the same snapshot dir the oracle reads `config.json`/`model.safetensors` from), legacy fallback otherwise. **The legacy llama2.c path is untouched** — κ-pinned baselines unaffected.
- Real tokenizer provenance: `address()` = `blake3:<hex>` of the tokenizer.json bytes, replacing placeholder-string territory.
- 9 unit tests, including the decisive one: a constructed case where lowest-token-id greedy segments **differently** from rank-ordered BPE, asserting the correct result.

## Not in this PR (flagged in-code)

Serving-side teacher prompting (`generate_attention_text`) still uses `tless_tokenize` — fixing it requires threading `TokenizerKind` through the no-alloc `tless_tokenize/detokenize` surface (~10 call sites). `// TODO(#242 follow-up)` markers at `src/server.rs:712` and `src/tless_uor.rs:542`; follow-up issue to be filed on merge.

## Measurement follow-through

After merge: recompile the HF artifact and post before/after `evaluate-report` numbers on #242 — the decisive metric is teacher argmax-vs-next on held-out ≫ chance (vs the ≈uniform 14.84 bits floor that motivated this issue).

## Gates

All four green locally (macOS arm64, pinned 1.97.1, offline); 9/9 new tokenizer tests pass. Compiler/observation-side only — P-4 kernel scan unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6
