### PR TITLE
fix(certify): wall-clock budget for the R4G1 C-stage — silent multi-hour stall becomes a recorded skip (#278)

### DIFF
--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -457,16 +457,45 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         .take(crate::r4g1_readiness::PROBE_POSITIONS)
         .map(|&i| eval_context(&c, i))
         .collect();
-    let readiness = crate::r4g1_readiness::r4g1_eval_readiness(
+
+    // Wall-clock budgets for the R4G1 stage (issue #278): on the current
+    // artifact size, per-position prediction cost is high enough that both
+    // the probe and the full evaluation can outlive any practical session
+    // while emitting no output. The budget turns that silent stall into an
+    // explicit, recorded skip. Checks run between positions, so a single
+    // in-flight prediction bounds the overshoot.
+    let probe_budget_secs: u64 = std::env::var("R4_CERTIFY_R4G1_BUDGET_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(120);
+    let eval_budget_secs: u64 = std::env::var("R4_CERTIFY_R4G1_EVAL_BUDGET_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(600);
+    println!(
+        "C R4G1 readiness probe: {} positions, wall-clock budget {}s (R4_CERTIFY_R4G1_BUDGET_SECS overrides)",
+        crate::r4g1_readiness::PROBE_POSITIONS,
+        probe_budget_secs
+    );
+    let readiness = crate::r4g1_readiness::r4g1_eval_readiness_within(
         &r4g1,
         probe_hists.iter().map(|h| &h[..]),
         &mut node_scores,
+        std::time::Duration::from_secs(probe_budget_secs),
     );
 
     match readiness {
         crate::r4g1_readiness::R4g1EvalReadiness::Ready { scored } => {
+            let eval_start = std::time::Instant::now();
+            let eval_budget = std::time::Duration::from_secs(eval_budget_secs);
             let (mut top1, mut agree) = (0u64, 0u64);
+            let mut done = 0usize;
+            let mut aborted = false;
             for &i in &test {
+                if eval_start.elapsed() >= eval_budget {
+                    aborted = true;
+                    break;
+                }
                 node_scores.fill(uor_r4_core::transformerless::score_q::ScoreQ::MIN);
                 let hist = eval_context(&c, i);
                 let pred = r4g1.predict_token(&hist, None, &mut node_scores);
@@ -476,14 +505,34 @@ pub fn certify(oracle: &dyn TeacherOracle) {
                 if pred == c.t_argmax[i] {
                     agree += 1;
                 }
+                done += 1;
+                if done.is_multiple_of(256) {
+                    println!(
+                        "progress: C R4G1 eval {}/{} ({}%, {}s)",
+                        done,
+                        test.len(),
+                        100 * done / test.len(),
+                        eval_start.elapsed().as_secs()
+                    );
+                }
             }
-            println!(
-                "C R4G1 (graph path): top1 {:.1}% | agreement {:.1}% | WB n/a (not computed on the graph path) | probe: {}/{} scored",
-                100.0 * top1 as f64 / test.len() as f64,
-                100.0 * agree as f64 / test.len() as f64,
-                scored,
-                crate::r4g1_readiness::PROBE_POSITIONS
-            );
+            if aborted {
+                println!(
+                    "C R4G1 (graph path): SKIPPED — evaluation exceeded its {}s wall-clock budget after {}/{} positions ({}s elapsed; R4_CERTIFY_R4G1_EVAL_BUDGET_SECS overrides). Partial counts discarded; no measurement recorded. Perf: issue #278.",
+                    eval_budget_secs,
+                    done,
+                    test.len(),
+                    eval_start.elapsed().as_secs()
+                );
+            } else {
+                println!(
+                    "C R4G1 (graph path): top1 {:.1}% | agreement {:.1}% | WB n/a (not computed on the graph path) | probe: {}/{} scored",
+                    100.0 * top1 as f64 / test.len() as f64,
+                    100.0 * agree as f64 / test.len() as f64,
+                    scored,
+                    crate::r4g1_readiness::PROBE_POSITIONS
+                );
+            }
         }
         crate::r4g1_readiness::R4g1EvalReadiness::NoScoredEmission => {
             println!(
@@ -496,6 +545,15 @@ pub fn certify(oracle: &dyn TeacherOracle) {
                 "C R4G1 (graph path): SKIPPED — constant prediction (token {}) across all {} probe positions (untrained or unscored graph). Full evaluation not run; no measurement recorded.",
                 token,
                 crate::r4g1_readiness::PROBE_POSITIONS
+            );
+        }
+        crate::r4g1_readiness::R4g1EvalReadiness::BudgetExceeded { probed, elapsed } => {
+            println!(
+                "C R4G1 (graph path): SKIPPED — readiness probe exceeded its {}s wall-clock budget after {}/{} positions ({}s elapsed). Full evaluation not run; no measurement recorded. Perf: issue #278.",
+                probe_budget_secs,
+                probed,
+                crate::r4g1_readiness::PROBE_POSITIONS,
+                elapsed.as_secs()
             );
         }
     }

--- a/crates/uor-r4-graph-certify/src/r4g1_readiness.rs
+++ b/crates/uor-r4-graph-certify/src/r4g1_readiness.rs
@@ -22,6 +22,7 @@
 //! Certifier-side code: allocation and iterators are permitted here (this is
 //! not the deployed runtime kernel).
 
+use std::time::{Duration, Instant};
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_runtime::R4G1Runtime;
 
@@ -42,6 +43,11 @@ pub enum R4g1EvalReadiness {
     /// Every probe position predicted the same token — the constant
     /// root-fallback shape of an untrained or unscored graph.
     ConstantPrediction { token: u32 },
+    /// The probe could not finish inside its wall-clock budget (issue
+    /// #278): per-position prediction cost on the current graph size makes
+    /// the full evaluation infeasible. `probed` counts positions completed
+    /// before the budget check tripped.
+    BudgetExceeded { probed: usize, elapsed: Duration },
 }
 
 impl R4g1EvalReadiness {
@@ -65,12 +71,36 @@ pub fn r4g1_eval_readiness<'a, I>(
 where
     I: IntoIterator<Item = &'a [u32]>,
 {
+    r4g1_eval_readiness_within(runtime, probe_contexts, node_scores, Duration::MAX)
+}
+
+/// Budgeted variant of [`r4g1_eval_readiness`] (issue #278): checks
+/// wall-clock elapsed time before each position and classifies as
+/// [`R4g1EvalReadiness::BudgetExceeded`] once `budget` is spent. The check
+/// runs between positions, so a single in-flight prediction bounds the
+/// overshoot past the budget.
+pub fn r4g1_eval_readiness_within<'a, I>(
+    runtime: &R4G1Runtime,
+    probe_contexts: I,
+    node_scores: &mut [ScoreQ],
+    budget: Duration,
+) -> R4g1EvalReadiness
+where
+    I: IntoIterator<Item = &'a [u32]>,
+{
+    let start = Instant::now();
     let mut scored = 0usize;
     let mut first_token: Option<u32> = None;
     let mut constant = true;
     let mut probed = 0usize;
 
     for ctx in probe_contexts {
+        if start.elapsed() >= budget {
+            return R4g1EvalReadiness::BudgetExceeded {
+                probed,
+                elapsed: start.elapsed(),
+            };
+        }
         probed += 1;
         node_scores.fill(ScoreQ::MIN);
         let (token, score) = runtime.predict_distribution(ctx, None, node_scores);

--- a/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
+++ b/crates/uor-r4-graph-certify/tests/r4g1_eval_readiness.rs
@@ -6,10 +6,13 @@
 //! skip-worthy.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 use uor_r4_core::transformerless::compiler::{self, STAGES};
 use uor_r4_core::transformerless::convert_r4g1;
 use uor_r4_core::transformerless::runtime::{self, Store};
-use uor_r4_graph_certify::r4g1_readiness::{r4g1_eval_readiness, R4g1EvalReadiness};
+use uor_r4_graph_certify::r4g1_readiness::{
+    r4g1_eval_readiness, r4g1_eval_readiness_within, R4g1EvalReadiness,
+};
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_runtime::R4G1Runtime;
 
@@ -75,6 +78,9 @@ fn varied_contexts_on_populated_store_are_ready_or_explicitly_degenerate() {
             // Acceptable classification for a tiny synthetic store — the
             // point of the guard is that this shape is *named*, not zeroed.
         }
+        R4g1EvalReadiness::BudgetExceeded { .. } => {
+            panic!("the unbudgeted probe delegates with Duration::MAX and cannot exceed it")
+        }
     }
 }
 
@@ -105,4 +111,54 @@ fn empty_probe_is_not_ready() {
 
     let readiness = r4g1_eval_readiness(&rt, std::iter::empty::<&[u32]>(), &mut node_scores);
     assert_eq!(readiness, R4g1EvalReadiness::NoScoredEmission);
+}
+
+#[test]
+fn zero_budget_classifies_as_budget_exceeded_before_any_position() {
+    // Issue #278: a probe that cannot finish inside its wall-clock budget
+    // must say so explicitly rather than run unbounded. Zero budget trips
+    // the check before the first prediction.
+    let bytes = build_runtime_bytes(&synthetic_store());
+    let rt = R4G1Runtime::parse(&bytes).expect("parse");
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+
+    let contexts: Vec<Vec<u32>> = vec![vec![1, 2, 3], vec![3, 1, 4]];
+    let readiness = r4g1_eval_readiness_within(
+        &rt,
+        contexts.iter().map(|c| c.as_slice()),
+        &mut node_scores,
+        Duration::ZERO,
+    );
+
+    assert!(
+        !readiness.is_ready(),
+        "budget-exceeded probe must not classify as Ready"
+    );
+    match readiness {
+        R4g1EvalReadiness::BudgetExceeded { probed, .. } => {
+            assert_eq!(probed, 0, "zero budget trips before the first position");
+        }
+        other => panic!("zero budget must classify as BudgetExceeded, got {other:?}"),
+    }
+}
+
+#[test]
+fn generous_budget_matches_unbudgeted_classification() {
+    // The budgeted probe with a budget it cannot plausibly exhaust must
+    // classify identically to the unbudgeted wrapper (which delegates with
+    // Duration::MAX).
+    let bytes = build_runtime_bytes(&synthetic_store());
+    let rt = R4G1Runtime::parse(&bytes).expect("parse");
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+
+    let contexts: Vec<Vec<u32>> = vec![vec![1, 2, 3], vec![3, 1, 4], vec![3, 5, 9], vec![7, 5, 8]];
+    let unbudgeted =
+        r4g1_eval_readiness(&rt, contexts.iter().map(|c| c.as_slice()), &mut node_scores);
+    let budgeted = r4g1_eval_readiness_within(
+        &rt,
+        contexts.iter().map(|c| c.as_slice()),
+        &mut node_scores,
+        Duration::from_secs(3600),
+    );
+    assert_eq!(unbudgeted, budgeted);
 }


### PR DESCRIPTION
References #278 (stays open for the perf fix that makes the C row measurable again).

**Problem.** The C-stage (R4G1 graph eval) routes every position through `predict_distribution`, whose per-position cost on current artifact sizes makes the stage computationally infeasible: an observed run spent **15h05m at 100% CPU with zero output** after the "B bit-prefix" row — indistinguishable from a deadlock from the outside. Stack sample (8182 samples): ~94% of time in `check_node_emits` → `GraphView::edge` → per-access `decode_entry`/`decode_edge`. Two working sessions were lost to environment theories before sampling. Full diagnosis in #278.

**Change (certifier-side only, no runtime-kernel change).**
- `r4g1_eval_readiness_within`: budgeted readiness probe (default 120s, `R4_CERTIFY_R4G1_BUDGET_SECS`), new explicit `BudgetExceeded` outcome printed in the same absent-measurement style as the #232 skips.
- Full evaluation: progress line every 256 positions + its own budget (default 600s, `R4_CERTIFY_R4G1_EVAL_BUDGET_SECS`); on budget, partial counts are discarded and the row records the skip. Budget checks run between positions; one in-flight prediction bounds the overshoot.
- Tests: zero-budget classifies as `BudgetExceeded` before any position; generous-budget classification matches the unbudgeted wrapper.

**Verified end-to-end** on the D3 artifacts (2026-07-29, 13 min wall-clock vs. never):
```
C R4G1 readiness probe: 64 positions, wall-clock budget 120s (R4_CERTIFY_R4G1_BUDGET_SECS overrides)
progress: C R4G1 eval 256/30036 (0%, 402s)
C R4G1 (graph path): SKIPPED — evaluation exceeded its 600s wall-clock budget after 340/30036 positions (600s elapsed; R4_CERTIFY_R4G1_EVAL_BUDGET_SECS overrides). Partial counts discarded; no measurement recorded. Perf: issue #278.
CERTIFY_EXIT:0
```
A/B rows, op census, equality witness, and compression witnesses all produced normally. Gates: workspace tests, clippy `-D warnings`, fmt, claim-wording — all green.

**Unblocking note.** certify no longer gates the queue on an infeasible row: measurement-driven decisions (#244 et al.) can proceed on the A/B rows while #278's index/caching fix restores the C measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZjgQf41T8t2HETiw3T1dK
