### PR TITLE
batch-1: process amendment + #255 memory-lift harness (running batch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,19 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   with compiler-side f32 conversions). Consolidation onto the format crate is
   a scheduled pre-Phase-5 cleanup — don't add a third.
 
+## Batch flow for small issues (process amendment, 2026-07-29)
+
+Small, low-risk issues (docs, help text, certifier-side rows, test
+harnesses, telemetry) are worked on ONE integration branch (`batch-N`)
+with one commit per issue (message refs `#N`), and the four local gates +
+merge queue run ONCE per batch of 3-6 issues — not per issue. Authoring
+feedback during a batch is `cargo check` on a warm shared target
+(`CARGO_TARGET_DIR`); the full workspace suite still gates every merge in
+CI, so rigor is unchanged — it just stops running serially per issue.
+Runtime-kernel and serving-semantics changes still get individual PRs.
+Measurement runs are background science with scheduled harvests; they
+never sit between two pieces of code work.
+
 ## Things that bite
 
 - `/tmp/ref/out/model.bin` disappears on reboot/periodic /tmp cleanup — κ tests

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -1512,7 +1512,24 @@ impl UorR4Router {
             .unwrap_or_default()
     }
 
-    fn index_sentence_internal(&mut self, sentence: &str, identity: &str) {
+    /// Content-free indexing (issue #255, arm 1): reconstructs the
+    /// pre-#245 stub exactly — the sentence routes with no content-derived
+    /// state vector, so the stored vector is whatever the session state
+    /// happened to be. Test/harness surface only; production indexing is
+    /// `index_sentence`.
+    pub fn index_sentence_content_free(&mut self, sentence: &str, identity: &str) {
+        self.index_sentence_with_state_override(sentence, identity, true)
+    }
+
+    /// Shared body for issue #255's arms: identical to
+    /// `index_sentence_internal` except `content_free` forces the pre-#245
+    /// `None` routing state.
+    fn index_sentence_with_state_override(
+        &mut self,
+        sentence: &str,
+        identity: &str,
+        content_free: bool,
+    ) {
         let s_clean = sentence.trim();
         if s_clean.is_empty() || s_clean.len() < 10 {
             return;
@@ -1523,20 +1540,36 @@ impl UorR4Router {
                 self.add_word_to_vocabulary(w);
             }
         }
+        let content_state = if content_free {
+            None
+        } else {
+            self.content_state_vector(s_clean)
+        };
+        self.index_sentence_routed(s_clean, identity, &words, content_state.as_deref());
+    }
 
+    fn index_sentence_internal(&mut self, sentence: &str, identity: &str) {
+        self.index_sentence_with_state_override(sentence, identity, false)
+    }
+
+    fn index_sentence_routed(
+        &mut self,
+        s_clean: &str,
+        identity: &str,
+        words: &[String],
+        state: Option<&[f64]>,
+    ) {
         // Issue #245: route the sentence through its own content-derived
         // state, not the session brain state at index time — stored
         // state_vectors must encode the sentence, or cosine resonance
         // retrieval is degenerate. Falls back to session state only when no
         // word of the sentence is in the vocabulary (words were just added
         // above, so this is rare).
-        let content_state = self.content_state_vector(s_clean);
-        let routing_data =
-            self.route_query_to_manifold_internal(s_clean, identity, content_state.as_deref());
+        let routing_data = self.route_query_to_manifold_internal(s_clean, identity, state);
         let best = routing_data.routed;
         let idx_win = best.window_index;
 
-        let prime_product = self.get_sentence_prime_product(&words);
+        let prime_product = self.get_sentence_prime_product(words);
 
         let mut state_vector = vec![0.0; 512];
         let s_idx = best.active_range[0] as usize;
@@ -1580,7 +1613,7 @@ impl UorR4Router {
             kappa: best.metrics.kappa,
             deficit_angle: best.metrics.deficit_angle,
             prime_product: prime_product.to_string(),
-            words,
+            words: words.to_vec(),
             u,
             v,
             v_4d,

--- a/crates/uor-r4-router/tests/memory_lift_ab.rs
+++ b/crates/uor-r4-router/tests/memory_lift_ab.rs
@@ -1,0 +1,122 @@
+//! Memory-lift A/B harness (issue #255): content-free (pre-#245 stub,
+//! arm 1) vs content-derived (arm 2) vs shuffled-vector control (arm 3),
+//! all on one code vintage. Retrieval quality = rank of the indexed
+//! sentence whose content matches each probe query, by cosine over stored
+//! state vectors. The table prints regardless of direction (DoD).
+
+use uor_r4_router::UorR4Router;
+
+const ID: &str = "user:ab";
+
+const CORPUS: [&str; 10] = [
+    "the galaxy rotates around a supermassive black hole",
+    "bread dough rises because yeast produces carbon dioxide",
+    "planets orbit the sun in elliptical paths",
+    "glaciers carve valleys as they advance slowly",
+    "the chef seasoned the soup with fresh basil",
+    "prime numbers thin out along the number line",
+    "volcanic eruptions reshape coastlines over centuries",
+    "honeybees communicate direction through a waggle dance",
+    "rivers deposit sediment where the current slows",
+    "telescopes gather light from distant ancient stars",
+];
+
+// Probe queries share content words with exactly one corpus sentence.
+const QUERIES: [(&str, usize); 6] = [
+    ("black hole at the galaxy center", 0),
+    ("yeast makes dough rise", 1),
+    ("elliptical orbit of planets", 2),
+    ("soup seasoned with basil", 4),
+    ("waggle dance of honeybees", 7),
+    ("light from distant stars", 9),
+];
+
+fn cosine(a: &[f64], b: &[f64]) -> f64 {
+    let dot: f64 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// (top-1 hit rate, mean reciprocal rank) of the matching sentence for
+/// each probe, ranking stored vectors by cosine against a query vector
+/// built through the same public surface (scratch-identity indexing).
+fn retrieval_metrics(router: &mut UorR4Router, vectors: &[Vec<f64>]) -> (f64, f64) {
+    let (mut hits, mut mrr) = (0f64, 0f64);
+    for (qi, &(q, target)) in QUERIES.iter().enumerate() {
+        let scratch = format!("user:q{qi}");
+        router.index_sentence(q, &scratch);
+        let qv = router.corpus_items_for(&scratch)[0].state_vector.clone();
+        let mut scored: Vec<(usize, f64)> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i, cosine(&qv, v)))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        let rank = scored.iter().position(|&(i, _)| i == target).unwrap() + 1;
+        if rank == 1 {
+            hits += 1.0;
+        }
+        mrr += 1.0 / rank as f64;
+    }
+    (hits / QUERIES.len() as f64, mrr / QUERIES.len() as f64)
+}
+
+#[test]
+fn three_arm_memory_lift_table() {
+    // Arm 1: content-free (pre-#245 stub reconstruction).
+    let mut r1 = UorR4Router::new(0.5);
+    for s in CORPUS {
+        r1.index_sentence_content_free(s, ID);
+    }
+    let v1: Vec<Vec<f64>> = r1
+        .corpus_items_for(ID)
+        .iter()
+        .map(|it| it.state_vector.clone())
+        .collect();
+    let (h1, m1) = retrieval_metrics(&mut r1, &v1);
+
+    // Arm 2: content-derived (production, post-#245).
+    let mut r2 = UorR4Router::new(0.5);
+    for s in CORPUS {
+        r2.index_sentence(s, ID);
+    }
+    let v2: Vec<Vec<f64>> = r2
+        .corpus_items_for(ID)
+        .iter()
+        .map(|it| it.state_vector.clone())
+        .collect();
+    let (h2, m2) = retrieval_metrics(&mut r2, &v2);
+
+    // Arm 3: shuffled-vector control — content-derived vectors permuted
+    // across sentences (deterministic rotation; content decoupled from
+    // location, magnitudes preserved).
+    let n = v2.len();
+    let v3: Vec<Vec<f64>> = (0..n).map(|i| v2[(i + n / 2) % n].clone()).collect();
+    let mut r3 = UorR4Router::new(0.5);
+    for s in CORPUS {
+        r3.index_sentence(s, ID);
+    }
+    let (h3, m3) = retrieval_metrics(&mut r3, &v3);
+
+    println!(
+        "memory-lift A/B (issue #255): {} sentences, {} probes",
+        CORPUS.len(),
+        QUERIES.len()
+    );
+    println!("  arm 1 content-free (pre-#245 stub): top1 {h1:.2} | MRR {m1:.3}");
+    println!("  arm 2 content-derived (production):  top1 {h2:.2} | MRR {m2:.3}");
+    println!("  arm 3 shuffled-vector control:       top1 {h3:.2} | MRR {m3:.3}");
+
+    assert_eq!(v1.len(), CORPUS.len(), "arm 1 indexed all sentences");
+    assert_eq!(v2.len(), CORPUS.len(), "arm 2 indexed all sentences");
+    // Direction is a RESULT, not an assertion (DoD: posted regardless);
+    // the only hard invariant is that the control cannot beat production.
+    assert!(
+        m2 >= m3,
+        "shuffled control must not beat content-derived: {m2:.3} vs {m3:.3}"
+    );
+}


### PR DESCRIPTION
Open batch under the new batching flow (AGENTS.md amendment is commit 1). Lands when the batch closes (3-6 small issues). So far: #255 three-arm harness with first fixture reading (content-free 0.376 / content-derived 0.328 / shuffled 0.260 MRR).

https://claude.ai/code/session_017tu2Y4AGZvcgM4vmoSz5x6