### PR TITLE
batch-2: #243 decision rows (metric verdict), #267 close-out, #268 floor slices, #234 declaration, #276 design doc

### DIFF
--- a/.uor-models/corpora/simple-wiki-20231101/manifest.json
+++ b/.uor-models/corpora/simple-wiki-20231101/manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
   "name": "simple-wiki-20231101-sample",
-  "role": "D3 natural partition (docs/transformerless/BASELINE.md \u00a72)",
+  "role": "D3 natural partition (docs/transformerless/BASELINE.md §2)",
   "source": {
     "dataset": "wikimedia/wikipedia",
     "config": "20231101.simple",
@@ -15,10 +15,16 @@
     "url": "https://creativecommons.org/licenses/by-sa/4.0/"
   },
   "article_count": 3000,
-  "text_bytes": 11972624,
   "corpus_cid": "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf",
   "split_rule": "held-out partition = articles where blake3(id as utf-8)[0] % 5 == 0 (deterministic, content-addressed, ~20%); remainder is construction",
   "files": [
     "articles.jsonl (one JSON object per article: id, url, title, text)"
-  ]
+  ],
+  "text_chars": 11972624,
+  "text_utf8_bytes": 12038579,
+  "accounting_note": "text_chars is len(text) in Unicode characters (the value historically stored as text_bytes); the 2026-07-29 issue #267 investigation confirmed the 2026-07-28 refetch reproduces corpus_cid bit-for-bit — no upstream drift occurred",
+  "retrieval": {
+    "primary": "GitHub release tag d3-corpus-simple-wiki-20231101, asset articles.jsonl (12539119 file bytes, blake3 = corpus_cid)",
+    "fallback": "scripts/fetch_d3_corpus.py (re-fetches from datasets-server and verifies against this manifest)"
+  }
 }

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -709,6 +709,72 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         m.top1, m.agree, m.wb_bits, m.keys
     );
 
+    // ---- A-dot-po2 / A-dot-po2x2 (#243 buildability rows): the round-2
+    // result (A-dot-only 30.4/34.2 with NO subtraction; A-resid-sign
+    // collapsing to A-single) pins the dominant loss on the assignment
+    // metric itself. A dot product against centroids whose entries are
+    // (sums of) signed powers of two is realizable in the kernel as
+    // shifts and adds only — contract §4 legal, no multiply op. These
+    // rows measure how much of the dot row survives that value-set
+    // restriction: po2 = one term (c ≈ ±2^s), po2x2 = greedy two-term
+    // expansion. Emulated in f32 over the same raw-scale work vectors;
+    // the value set, not the arithmetic type, is what the kernel form
+    // depends on.
+    let po2 = |x: f32| -> f32 {
+        if x == 0.0 || !x.is_finite() {
+            return 0.0;
+        }
+        let s = x.abs().log2().round();
+        x.signum() * s.exp2()
+    };
+    for (label, terms) in [("A-dot-po2", 1usize), ("A-dot-po2x2", 2usize)] {
+        let quantized: Vec<Vec<f32>> = art
+            .ctx_cb
+            .iter()
+            .map(|cb| {
+                cb.iter()
+                    .map(|&c| {
+                        let mut acc = 0.0f32;
+                        let mut rem = c;
+                        for _ in 0..terms {
+                            let q = po2(rem);
+                            acc += q;
+                            rem -= q;
+                        }
+                        acc
+                    })
+                    .collect()
+            })
+            .collect();
+        let codes_q: Vec<[u8; STAGES]> = (0..c.n)
+            .map(|i| {
+                let mut code = [0u8; STAGES];
+                for (st, cb) in quantized.iter().enumerate() {
+                    let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
+                    for kk in 0..K {
+                        let cent = &cb[kk * D..(kk + 1) * D];
+                        let mut dp = 0f32;
+                        for j in 0..D {
+                            dp += centered[i][j] * cent[j];
+                        }
+                        if dp > best {
+                            best = dp;
+                            bk = kk;
+                        }
+                    }
+                    code[st] = bk as u8;
+                }
+                code
+            })
+            .collect();
+        let st_row = build_store_generic(&c, STAGES, &|i, d| codes_q[i][..d].to_vec());
+        let m = eval(&c, &st_row, STAGES, &|i, d| codes_q[i][..d].to_vec());
+        println!(
+            "{label} (#243 buildability: shift-add dot, {terms}-term power-of-two centroids): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+            m.top1, m.agree, m.wb_bits, m.keys
+        );
+    }
+
     // ---- A-R∘G(b): graded signature OF the residual. Per-stage ladders
     // from the R-loop's residual distributions (deterministic stride-8
     // sample); prototypes are the integer centroid copies graded through

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -621,65 +621,91 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         m.top1, m.agree, m.wb_bits, m.keys
     );
 
-    // ---- A-R-retrained: Design R with per-stage prototypes retrained
-    // in residual space — the #243 Phase A decision row. The Phase A
-    // table confirmed the doc's risk note empirically: original-space
-    // class_sigs re-thresholded against residuals recover exactly 0% of
-    // the gap, while the residual signal itself is dominant (A-resid-only
-    // 65%). Retraining here is the canonical mul-free projection of the
-    // true prototypes: the residual-space class signature of
-    // (stage, class) is the sign-signature of that stage's RVQ centroid
-    // — the object the residual actually clusters around. Query loop is
-    // unchanged from A-R (add/sub + sign re-threshold + Hamming): the
-    // runtime cost model is identical, only the compiled prototype
-    // table differs (contract §4: compile-side retraining is free).
-    // Sign packing matches sig_plain's layout (bit d%8 of byte d/8,
-    // strictly-positive test), and sign(ctx_cb) == sign(cent_int) since
-    // the corpus-mean-norm scale is a positive constant.
-    let resid_sigs: Vec<Vec<[u8; runtime::SIG_BYTES]>> = (0..STAGES)
-        .map(|st| {
-            (0..K)
-                .map(|kk| {
-                    let mut sig = [0u8; runtime::SIG_BYTES];
-                    for d in 0..D {
-                        if art.ctx_cb[st][kk * D + d] > 0.0 {
-                            sig[d / 8] |= 1 << (d % 8);
-                        }
+    // ---- A-dot-only / A-resid-sign (#243 decision rows, round 2).
+    // Round 1 finding (recorded): an "A-R-retrained" row using centroid
+    // sign-signatures as prototypes measured BIT-IDENTICAL to A-R,
+    // because class_sigs already are exactly that (compiler.rs derives
+    // them from ctx_cb > 0). Prototype retraining at the sign level is
+    // definitionally a no-op; the doc's Design-R risk note pointed at a
+    // difference that does not exist at this layer.
+    //
+    // What actually separates A-resid-only (30.3/33.9) from A-R
+    // (27.0/30.5) must then be assignment geometry and scale: centered
+    // bundles are RAW-scale while ctx_cb centroids are unit-scale, so
+    // A-resid-only's per-stage Euclidean argmin over ||work - cent||^2
+    // is dominated by the cross term — it degenerates toward
+    // argmax dot(work, cent) — and its centroid subtraction is nearly
+    // negligible at that scale. These two rows split the hypothesis:
+    //
+    // - A-dot-only: per-stage argmax dot(centered, cent), NO residual
+    //   subtraction at all. If this reproduces A-resid-only, the "65%
+    //   residual recovery" was really dot-product assignment against
+    //   per-stage codebooks, and the mul-free Phase B target becomes a
+    //   shift-add dot approximation (power-of-two-quantized centroids
+    //   are contract-legal: shifts and adds only), not residual wiring.
+    // - A-resid-sign: sign-Hamming assignment (the kernel metric) with
+    //   A-resid-only's own unscaled f32 subtraction. If this collapses
+    //   to A-R, the sign projection is where the information dies.
+    let codes_dot: Vec<[u8; STAGES]> = (0..c.n)
+        .map(|i| {
+            let mut code = [0u8; STAGES];
+            for (st, cb) in art.ctx_cb.iter().enumerate() {
+                let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
+                for kk in 0..K {
+                    let cent = &cb[kk * D..(kk + 1) * D];
+                    let mut dp = 0f32;
+                    for j in 0..D {
+                        dp += centered[i][j] * cent[j];
                     }
-                    sig
-                })
-                .collect()
+                    if dp > best {
+                        best = dp;
+                        bk = kk;
+                    }
+                }
+                code[st] = bk as u8;
+            }
+            code
         })
         .collect();
-    let assign_rr = |i: usize| -> [u8; STAGES] {
-        let mut r: [i64; D] = std::array::from_fn(|d| bundles[i][d] - art.thresholds[d]);
-        let mut code = [0u8; STAGES];
-        for st in 0..STAGES {
-            let mut fake = [0i64; D];
-            for d in 0..D {
-                fake[d] = r[d] + art.thresholds[d];
-            }
-            let sig = runtime::sig_plain(&art, &fake);
-            let (mut bd, mut bk) = (u32::MAX, 0usize);
-            for (kk, cs) in resid_sigs[st].iter().enumerate() {
-                let h = hamming(&sig, cs);
-                if h < bd {
-                    bd = h;
-                    bk = kk;
+    let st_row = build_store_generic(&c, STAGES, &|i, d| codes_dot[i][..d].to_vec());
+    let m = eval(&c, &st_row, STAGES, &|i, d| codes_dot[i][..d].to_vec());
+    println!(
+        "A-dot-only (#243 instrumentation, f32: per-stage dot-product assignment, no residual subtraction): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+        m.top1, m.agree, m.wb_bits, m.keys
+    );
+    let codes_rsg: Vec<[u8; STAGES]> = (0..c.n)
+        .map(|i| {
+            let mut work = centered[i];
+            let mut code = [0u8; STAGES];
+            for (st, code_slot) in code.iter_mut().enumerate() {
+                let mut sig = [0u8; runtime::SIG_BYTES];
+                for d in 0..D {
+                    if work[d] > 0.0 {
+                        sig[d / 8] |= 1 << (d % 8);
+                    }
+                }
+                let sigs_st = &art.class_sigs[st];
+                let (mut bd, mut bk) = (u32::MAX, 0usize);
+                for kk in 0..K {
+                    let cs = &sigs_st[kk * runtime::SIG_BYTES..(kk + 1) * runtime::SIG_BYTES];
+                    let h = hamming(&sig, cs);
+                    if h < bd {
+                        bd = h;
+                        bk = kk;
+                    }
+                }
+                *code_slot = bk as u8;
+                for (j, w) in work.iter_mut().enumerate() {
+                    *w -= art.ctx_cb[st][bk * D + j];
                 }
             }
-            code[st] = bk as u8;
-            for d in 0..D {
-                r[d] -= cent_int[st][bk * D + d];
-            }
-        }
-        code
-    };
-    let codes_rr: Vec<[u8; STAGES]> = (0..c.n).map(assign_rr).collect();
-    let st_row = build_store_generic(&c, STAGES, &|i, d| codes_rr[i][..d].to_vec());
-    let m = eval(&c, &st_row, STAGES, &|i, d| codes_rr[i][..d].to_vec());
+            code
+        })
+        .collect();
+    let st_row = build_store_generic(&c, STAGES, &|i, d| codes_rsg[i][..d].to_vec());
+    let m = eval(&c, &st_row, STAGES, &|i, d| codes_rsg[i][..d].to_vec());
     println!(
-        "A-R-retrained (#243 Phase B decision row: residual-space centroid-sign prototypes, integer query loop unchanged): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+        "A-resid-sign (#243 instrumentation: sign-Hamming assignment, unscaled f32 residual subtraction): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
         m.top1, m.agree, m.wb_bits, m.keys
     );
 

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -621,6 +621,68 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         m.top1, m.agree, m.wb_bits, m.keys
     );
 
+    // ---- A-R-retrained: Design R with per-stage prototypes retrained
+    // in residual space — the #243 Phase A decision row. The Phase A
+    // table confirmed the doc's risk note empirically: original-space
+    // class_sigs re-thresholded against residuals recover exactly 0% of
+    // the gap, while the residual signal itself is dominant (A-resid-only
+    // 65%). Retraining here is the canonical mul-free projection of the
+    // true prototypes: the residual-space class signature of
+    // (stage, class) is the sign-signature of that stage's RVQ centroid
+    // — the object the residual actually clusters around. Query loop is
+    // unchanged from A-R (add/sub + sign re-threshold + Hamming): the
+    // runtime cost model is identical, only the compiled prototype
+    // table differs (contract §4: compile-side retraining is free).
+    // Sign packing matches sig_plain's layout (bit d%8 of byte d/8,
+    // strictly-positive test), and sign(ctx_cb) == sign(cent_int) since
+    // the corpus-mean-norm scale is a positive constant.
+    let resid_sigs: Vec<Vec<[u8; runtime::SIG_BYTES]>> = (0..STAGES)
+        .map(|st| {
+            (0..K)
+                .map(|kk| {
+                    let mut sig = [0u8; runtime::SIG_BYTES];
+                    for d in 0..D {
+                        if art.ctx_cb[st][kk * D + d] > 0.0 {
+                            sig[d / 8] |= 1 << (d % 8);
+                        }
+                    }
+                    sig
+                })
+                .collect()
+        })
+        .collect();
+    let assign_rr = |i: usize| -> [u8; STAGES] {
+        let mut r: [i64; D] = std::array::from_fn(|d| bundles[i][d] - art.thresholds[d]);
+        let mut code = [0u8; STAGES];
+        for st in 0..STAGES {
+            let mut fake = [0i64; D];
+            for d in 0..D {
+                fake[d] = r[d] + art.thresholds[d];
+            }
+            let sig = runtime::sig_plain(&art, &fake);
+            let (mut bd, mut bk) = (u32::MAX, 0usize);
+            for (kk, cs) in resid_sigs[st].iter().enumerate() {
+                let h = hamming(&sig, cs);
+                if h < bd {
+                    bd = h;
+                    bk = kk;
+                }
+            }
+            code[st] = bk as u8;
+            for d in 0..D {
+                r[d] -= cent_int[st][bk * D + d];
+            }
+        }
+        code
+    };
+    let codes_rr: Vec<[u8; STAGES]> = (0..c.n).map(assign_rr).collect();
+    let st_row = build_store_generic(&c, STAGES, &|i, d| codes_rr[i][..d].to_vec());
+    let m = eval(&c, &st_row, STAGES, &|i, d| codes_rr[i][..d].to_vec());
+    println!(
+        "A-R-retrained (#243 Phase B decision row: residual-space centroid-sign prototypes, integer query loop unchanged): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+        m.top1, m.agree, m.wb_bits, m.keys
+    );
+
     // ---- A-R∘G(b): graded signature OF the residual. Per-stage ladders
     // from the R-loop's residual distributions (deterministic stride-8
     // sample); prototypes are the integer centroid copies graded through

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1568,7 +1568,10 @@ pub fn evaluate_gate_c(
 /// variants were zero-information (bit-identical to `rule12_precedence`
 /// on every measured corpus, where ExactContext precedence dominates); 7 =
 /// explicit quality-gate profile for distribution-aware validation; 8 =
-/// per-residual-kind compile-time quantization error rows.
+/// per-residual-kind compile-time quantization error rows; 9 =
+/// issue-#234 `distribution` declaration (EXCT-miss rate as a fixed
+/// property of the evaluation distribution, with the Gate C validity
+/// verdict).
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -1578,6 +1581,34 @@ pub struct ScoreReport {
     pub gate_c: GateCOutcome,
     pub quantization: ScoreReportQuantization,
     pub determinism: ScoreReportDeterminism,
+    pub distribution: DistributionDeclaration,
+}
+
+/// Minimum EXCT-miss rate below which a distribution cannot serve as a
+/// Gate C corpus (issue #234): with (almost) every held-out probe
+/// answered by exact-context lookup, the routing/residual machinery is
+/// never exercised and Gate C restates the baseline by construction.
+pub const MIN_EXCT_MISS_RATE_FOR_GATE_C: f64 = 0.05;
+
+/// The issue-#234 evaluation-distribution declaration, fixed at scoring
+/// time as a property of the corpus/split pair: how much of the
+/// held-out set escapes exact-context resolution under the Rule 1+2
+/// scorer. Reported in every score report so the failure mode is
+/// visible in the artifact of record rather than discoverable only by
+/// reading the risk register.
+#[derive(Debug, Clone, Serialize)]
+pub struct DistributionDeclaration {
+    /// Held-out positions the Gate C evaluation scored.
+    pub held_out_positions: usize,
+    /// Positions the Rule 1+2 scorer resolved as ExactContext.
+    pub exct_resolved_positions: usize,
+    /// `1 - exct_resolved/held_out` — the declared miss rate.
+    pub exct_miss_rate: f64,
+    /// The [`MIN_EXCT_MISS_RATE_FOR_GATE_C`] threshold in force.
+    pub min_miss_rate_for_gate_c: f64,
+    /// Whether Gate C on this distribution measures anything beyond
+    /// exact-context recall.
+    pub can_measure_generalization: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1667,8 +1698,22 @@ pub fn build_score_report_with_quality_profile(
     quality_profile: &str,
 ) -> ScoreReport {
     let graph_kappa = inputs.graph_kappa.clone();
+    let held_out_positions = gate_c.rule12_precedence.positions;
+    let exct_resolved_positions = gate_c.rule12_status_counts.exact_context;
+    let exct_miss_rate = if held_out_positions == 0 {
+        0.0
+    } else {
+        1.0 - exct_resolved_positions as f64 / held_out_positions as f64
+    };
+    let distribution = DistributionDeclaration {
+        held_out_positions,
+        exct_resolved_positions,
+        exct_miss_rate,
+        min_miss_rate_for_gate_c: MIN_EXCT_MISS_RATE_FOR_GATE_C,
+        can_measure_generalization: exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
+    };
     ScoreReport {
-        schema: 8,
+        schema: 9,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -1696,6 +1741,7 @@ pub fn build_score_report_with_quality_profile(
             baseline_repetition_rate: gate_c.repetition_rate_baseline,
         },
         gate_c,
+        distribution,
         quantization: ScoreReportQuantization {
             format: "ScoreQ Q16.16 in i32; EMIT storage descriptor {width: i32, shift: 0, \
                      zero_point: 0}; edge weights and residuals via ScoreQ::from_logprob"

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1019,6 +1019,17 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         &options.quality_profile,
     );
 
+    println!(
+        "distribution declaration (#234): EXCT-miss rate {:.1}% ({}/{} held-out positions escape exact-context) — {}",
+        100.0 * report.distribution.exct_miss_rate,
+        report.distribution.held_out_positions - report.distribution.exct_resolved_positions,
+        report.distribution.held_out_positions,
+        if report.distribution.can_measure_generalization {
+            "Gate C measures generalization here"
+        } else {
+            "Gate C CANNOT measure generalization on this distribution (issue #234): the row restates exact-context recall"
+        }
+    );
     std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
     let artifact_path = options.output.join("score.r4g1");
     std::fs::write(&artifact_path, &artifact_bytes)

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1115,6 +1115,7 @@ struct EvaluationReport {
     source: EvaluationSource,
     artifacts: EvaluationArtifacts,
     metrics: EvaluationMetrics,
+    floor_decomposition: FloorDecomposition,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -1154,6 +1155,26 @@ struct EvaluationMetrics {
     bits_per_token: f64,
     teacher_floor_bits_per_token: f64,
     bits_over_teacher_floor: f64,
+}
+
+/// One slice of the #268 teacher-floor decomposition: which subset,
+/// how many held-out tokens it covers, and the mean floor there.
+#[derive(Debug, Serialize, Clone)]
+struct FloorSlice {
+    label: String,
+    tokens: usize,
+    floor_bits_per_token: f64,
+}
+
+/// Teacher-floor decomposition (issue #268): the ~13.4-bit D3 floor
+/// sliced by position-in-story, next-token class, and worst articles,
+/// so the dominant observation/eval confounder can be named instead of
+/// guessed. Slices are reported with every evaluation run.
+#[derive(Debug, Serialize, Clone)]
+struct FloorDecomposition {
+    by_position_in_story: Vec<FloorSlice>,
+    by_next_token_class: Vec<FloorSlice>,
+    worst_articles: Vec<FloorSlice>,
 }
 
 fn parse_compile_options(args: &[String]) -> Result<CompileOptions, String> {
@@ -1402,6 +1423,54 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
     let mut bits = 0f64;
     let mut current_story = None;
     let mut story_position = 0usize;
+
+    // ---- #268 floor decomposition accumulators ------------------------
+    // Position bands are powers-of-two ranges around the observation
+    // window (--sequence-length, default 128): a floor concentrated in
+    // the low bands is the short-effective-context signature (candidate
+    // 1); a floor exploding at 128+ is the context-reset/replay mismatch
+    // (candidate 2); a digit-heavy floor is candidate 4.
+    const POSITION_BANDS: [(usize, usize, &str); 6] = [
+        (0, 8, "0-7"),
+        (8, 16, "8-15"),
+        (16, 32, "16-31"),
+        (32, 64, "32-63"),
+        (64, 128, "64-127"),
+        (128, usize::MAX, "128+"),
+    ];
+    const TOKEN_CLASSES: [&str; 4] = ["digit", "alpha", "other", "unclassified"];
+    let mut floor_by_band = [(0usize, 0f64); POSITION_BANDS.len()];
+    let mut floor_by_class = [(0usize, 0f64); TOKEN_CLASSES.len()];
+    let mut floor_by_story: std::collections::BTreeMap<u32, (usize, f64)> =
+        std::collections::BTreeMap::new();
+    // Next-token class through the HF byte-level BPE (the corpus id
+    // space post-#242); tokenizer absence degrades to "unclassified"
+    // rather than failing the evaluation.
+    let bpe = HfBpeTokenizer::from_dir(&options.source).ok();
+    let mut class_cache: std::collections::BTreeMap<u32, usize> = std::collections::BTreeMap::new();
+    let mut classify = |token: u32| -> usize {
+        if let Some(&class) = class_cache.get(&token) {
+            return class;
+        }
+        let class = match &bpe {
+            None => 3,
+            Some(tokenizer) => {
+                let text = tokenizer.decode(&[token]);
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    2
+                } else if trimmed.chars().all(|ch| ch.is_ascii_digit()) {
+                    0
+                } else if trimmed.chars().all(char::is_alphabetic) {
+                    1
+                } else {
+                    2
+                }
+            }
+        };
+        class_cache.insert(token, class);
+        class
+    };
     let start_eval_time = std::time::Instant::now();
     for index in 0..corpus.n {
         if index % 1000 == 0 || index + 1 == corpus.n {
@@ -1461,7 +1530,23 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
         }
         let next_probability =
             ((teacher_logits[next_token] - max_logit) as f64).exp() / denominator.max(1e-30);
-        teacher_floor_bits_total += -next_probability.max(1e-30).log2();
+        let floor_bits = -next_probability.max(1e-30).log2();
+        teacher_floor_bits_total += floor_bits;
+        let position_in_story = story_position - 1;
+        let band = POSITION_BANDS
+            .iter()
+            .position(|(lo, hi, _)| position_in_story >= *lo && position_in_story < *hi)
+            .unwrap_or(POSITION_BANDS.len() - 1);
+        floor_by_band[band].0 += 1;
+        floor_by_band[band].1 += floor_bits;
+        let class = classify(corpus.next[index]);
+        floor_by_class[class].0 += 1;
+        floor_by_class[class].1 += floor_bits;
+        let story_entry = floor_by_story
+            .entry(corpus.story[index])
+            .or_insert((0, 0.0));
+        story_entry.0 += 1;
+        story_entry.1 += floor_bits;
         bits += -score::witten_bell_probability(&store, &code, corpus.next[index]).log2();
     }
     if held_out_tokens == 0 {
@@ -1473,8 +1558,74 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
     let teacher_floor_bits_per_token = teacher_floor_bits_total / held_out_tokens as f64;
     let bits_over_teacher_floor = bits_per_token - teacher_floor_bits_per_token;
 
+    let slice = |label: &str, tokens: usize, total: f64| FloorSlice {
+        label: label.to_owned(),
+        tokens,
+        floor_bits_per_token: if tokens == 0 {
+            0.0
+        } else {
+            total / tokens as f64
+        },
+    };
+    let by_position_in_story: Vec<FloorSlice> = POSITION_BANDS
+        .iter()
+        .zip(floor_by_band.iter())
+        .filter(|(_, (tokens, _))| *tokens > 0)
+        .map(|((_, _, label), (tokens, total))| slice(label, *tokens, *total))
+        .collect();
+    let by_next_token_class: Vec<FloorSlice> = TOKEN_CLASSES
+        .iter()
+        .zip(floor_by_class.iter())
+        .filter(|(_, (tokens, _))| *tokens > 0)
+        .map(|(label, (tokens, total))| slice(label, *tokens, *total))
+        .collect();
+    // Worst articles by mean floor, ties broken by story id for
+    // deterministic report bytes; 20-token minimum keeps stubs out.
+    let mut article_rows: Vec<(u32, usize, f64)> = floor_by_story
+        .iter()
+        .filter(|(_, (tokens, _))| *tokens >= 20)
+        .map(|(story, (tokens, total))| (*story, *tokens, total / *tokens as f64))
+        .collect();
+    article_rows.sort_by(|a, b| b.2.total_cmp(&a.2).then(a.0.cmp(&b.0)));
+    let worst_articles: Vec<FloorSlice> = article_rows
+        .iter()
+        .take(10)
+        .map(|(story, tokens, mean)| {
+            slice(&format!("story {story}"), *tokens, mean * *tokens as f64)
+        })
+        .collect();
+    let floor_decomposition = FloorDecomposition {
+        by_position_in_story,
+        by_next_token_class,
+        worst_articles,
+    };
+    println!("teacher-floor decomposition (#268):");
+    for group in [
+        (
+            "position-in-story",
+            &floor_decomposition.by_position_in_story,
+        ),
+        ("next-token class", &floor_decomposition.by_next_token_class),
+        (
+            "worst articles (>=20 tokens)",
+            &floor_decomposition.worst_articles,
+        ),
+    ] {
+        let rows: Vec<String> = group
+            .1
+            .iter()
+            .map(|row| {
+                format!(
+                    "{} {:.3} bits/token (n={})",
+                    row.label, row.floor_bits_per_token, row.tokens
+                )
+            })
+            .collect();
+        println!("  by {}: {}", group.0, rows.join(" | "));
+    }
+
     let report = EvaluationReport {
-        schema: 1,
+        schema: 2,
         distribution: EvaluationDistribution {
             name: "D3-held-out".to_owned(),
             split: "compiler::train_cut 80/20 by story id".to_owned(),
@@ -1500,6 +1651,7 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
             teacher_floor_bits_per_token,
             bits_over_teacher_floor,
         },
+        floor_decomposition,
     };
     if let Some(parent) = report_path.parent() {
         std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
@@ -2019,6 +2171,19 @@ mod tests {
                 bits_per_token: 18.2,
                 teacher_floor_bits_per_token: 14.8,
                 bits_over_teacher_floor: 3.4,
+            },
+            floor_decomposition: FloorDecomposition {
+                by_position_in_story: vec![FloorSlice {
+                    label: "0-7".to_owned(),
+                    tokens: 100,
+                    floor_bits_per_token: 15.1,
+                }],
+                by_next_token_class: vec![FloorSlice {
+                    label: "digit".to_owned(),
+                    tokens: 40,
+                    floor_bits_per_token: 16.9,
+                }],
+                worst_articles: Vec::new(),
             },
         };
 

--- a/docs/phase_clock_address_design.md
+++ b/docs/phase_clock_address_design.md
@@ -1,0 +1,141 @@
+# Design P: Complex Discrete Phase-Clock Addressing (Cyclic Graded Codes on the Zeta Torus)
+
+*Issue #276. Status: DESIGN FOR REVIEW — decision points marked ⚑ are open
+until Casey / Ari / Alex sign off on this document (review on the PR).
+Claim language: Definitions, Objectives, and Empirical Criteria only.*
+
+## Objective
+
+Give the address layer a **phase channel**: a discrete, mul-free context
+coordinate built from the lineage's zeta-seeded frequencies, on which
+"near" is cyclic distance and next-token transport is an exact digit
+rotation. Design P is the cyclic sibling of Design G
+(docs/graded_signature_address_design.md): G grades **magnitude on a
+line**, P grades **phase on a circle**. Like every representational
+choice in this repo, it is address-space design
+(docs/addr_prism_correspondence.md): the bucket structure decides
+collision geometry, what "near" means for #263's region objects, and
+what a distributed serving tier could shard on.
+
+## Where P sits after the Phase A table (2026-07-29, #243)
+
+Phase A attributed the assignment gap: residuals dominate (A-resid-only
+recovers ~65% of the f32 gap), magnitude grading is partial (A-G(4)
+~35-37%), normalization ~49%. P does not compete with the residual fix —
+it contributes a channel the sign signature **discards entirely** (the
+imaginary half of every zeta clock), which no R/G row can recover.
+Objective, not assumption: whether that channel carries context-
+discriminative signal at certify scale is exactly what the P row
+measures. The prime-router evidence is consistent but not sufficient:
+the mod12 signal-preservation tables (research report §6; recorded in
+docs/prime_router_geometric_context_evidence.md, PR #275) show linear
+decodability resolving to 1.0 on a discrete phase coordinate at
+trajectory end — on router-lineage trajectories, not on the graph
+compiler's bundles.
+
+## Definitions
+
+- **Analytic completion.** Per frequency γᵢ, the lineage vector
+  component `sin(ln(p)·γᵢ)` is the real part of a clock; the completed
+  signal stores the pair `(cos(ln(p)·γᵢ), sin(ln(p)·γᵢ))` — i.e.
+  complex discrete L2, one phasor per frequency. Compile-side only;
+  floats are unrestricted there (INFERENCE_OPERATION_CONTRACT.md §4).
+- **Clock digit.** Phase θᵢ = atan2(sin, cos) quantized into b buckets:
+  cᵢ ∈ Z_b. A context address is the digit vector (c₁, …, c_F) — a
+  point on the torus Z_b^F.
+- **Cyclic distance.** Per digit d(x, y) = min(|x−y|, b−|x−y|) (Lee
+  metric), summed over F. Satisfies the triangle inequality, so the
+  #277 VP-tree applies unchanged.
+- **Transport.** The per-token phase step is a rotation: digit
+  increment δᵢ mod b per frequency. On the completed signal this is
+  exact; on real-parts-only it is undefined — this is the mechanical
+  content of "completing the analytic signal".
+- **Capacity (Definition, not Guarantee).** A single b-clock addresses
+  b states; the torus addresses b^F. The 4D continuous embedding's
+  collision collapse (32k tokens × contexts in R⁴) is the negative
+  capacity datum this design responds to; top-M membership over 288-bit
+  signatures is the positive one (k-NN under Hamming already works
+  where the space is large enough).
+
+## Runtime realization (mul-free by construction)
+
+Two candidate encodings, ⚑ pick by measurement:
+
+1. **Cyclic thermometer (two-arc unary).** Encode digit c as b bits with
+   a contiguous arc of ⌈b/2⌉ ones starting at c (circular). Hamming
+   distance between two such codes = 2·Lee distance (order-preserving).
+   Distance machinery is then **identical to Design G's popcount path**
+   — same kernels, same P-4 scan surface, width F·b bits.
+2. **Digit LUT.** Pack digits (b ≤ 16 → 4 bits each) and resolve per-
+   digit Lee distance through a b×b table read. Smaller signatures,
+   new (but table-read-only) kernel shape.
+
+Transport is integer digit addition mod b in either encoding. No
+multiply, divide, or float anywhere on the query side; the contract §4
+runtime op census must be unchanged in the measured rows.
+
+⚑ b ∈ {8, 12, 16}: 12 is the empirically privileged modulus in the
+prime-router tables; 8 and 16 are the power-of-two controls.
+⚑ F: the 16-window zeta design-matrix frequencies (#246 re-port) are
+the natural candidate set; a stride-sampled subset is the cheap control.
+
+## Address-space consequences (review as interface changes)
+
+- Signature width becomes F·b bits (encoding 1) or 4·F bits (encoding
+  2) — ROUT prototype/mask layout interplay is the same class of change
+  Design G already declares (#247 consumes widths; #263 derives region
+  keys). If G and P both land, widths compose additively (channels
+  concatenate; ⚑ joint vs separate membership scans).
+- Phase-bucket boundaries are compile-time constants derived from the
+  frequency set: content-addressed into the artifact, κ-pinned,
+  platform-sensitivity noted — until D2 (#265) lands they are part of
+  the macOS-pinned baseline with an era note, exactly like G's ladders.
+- Sessions: #247's signature lane can carry transported phase state
+  without new plumbing — P gives that lane a discrete, exact-transport
+  coordinate instead of a float trajectory.
+
+## Measurement (the DoD's teeth)
+
+P joins the **same** decomposition harness as R and G (certify.rs Phase
+A rows; no separate harness). ⚑ The one genuinely open mapping question:
+where do per-context phases come from in the harness?
+
+- **Lane (b) — transport-composed (primary):** zeta-seeded token
+  phasors composed over the context window by per-token transport;
+  this exercises the mechanism P actually claims (exact rotation
+  composition) and needs nothing from #246.
+- **Lane (a) — design-matrix projection:** phases of the #246
+  re-ported 16-window design-matrix projection of the bundle; runs
+  only if/after #246 lands.
+
+Rows: P(b) for the chosen b set, and P∘G (phase digits concatenated
+with graded magnitude) as the composition row. Baselines and criterion
+are the standing ones — measured against the A row that is shipped at
+run time (post-#243-decision), at unchanged op census:
+**Empirical Criterion: ≥ 30.1% top-1 and ≥ 34.1% agreement**, with the
+#244 store-key envelope. Exit rule: if every P row measures below the
+best shipped-family row on both metrics, P closes as a recorded
+negative result and the phase channel is retired from address-space
+candidates (the #247 session-lane use is unaffected — it is a state
+channel, not an address claim).
+
+## Sequencing
+
+1. The #243 A-R-retrained decision run is in flight; its outcome sets
+   the baseline the P rows must beat. P work does not start before that
+   decision is recorded on #243.
+2. Lane (b) rows are certifier-side only and follow the batch-flow
+   amendment (rows land as code, measurement runs backgrounded, table
+   posted on #276 before any kernel work).
+3. #246 unlocks lane (a); #277's VP-tree gains a second metric the day
+   any P row ships (Lee distance is triangle-inequality-clean).
+
+## Explicit non-goals
+
+No floating point or multiplies in the runtime kernel under either
+encoding. No change to κ-label semantics (identity layer untouched).
+No capacity Guarantee — b^F is a Definition about address counts, not a
+claim about usable discrimination; only the harness rows can license
+the latter. Not a residual-VQ replacement: R fixes how the existing
+magnitude channel is quantized; P adds a channel — they compose or
+compete only through measurement.

--- a/docs/phase_clock_address_design.md
+++ b/docs/phase_clock_address_design.md
@@ -17,11 +17,13 @@ choice in this repo, it is address-space design
 collision geometry, what "near" means for #263's region objects, and
 what a distributed serving tier could shard on.
 
-## Where P sits after the Phase A table (2026-07-29, #243)
+## Where P sits after the Phase A/B decision rows (2026-07-29, #243)
 
-Phase A attributed the assignment gap: residuals dominate (A-resid-only
-recovers ~65% of the f32 gap), magnitude grading is partial (A-G(4)
-~35-37%), normalization ~49%. P does not compete with the residual fix —
+The round-2 metric-isolation rows revised Phase A's attribution: the
+dominant loss is the **assignment metric** (A-dot-only 30.4/34.2 with
+no residual updates; sign-Hamming + residuals collapses to the floor),
+and Phase B pivots to a shift-add dot approximation. P does not compete
+with that fix —
 it contributes a channel the sign signature **discards entirely** (the
 imaginary half of every zeta clock), which no R/G row can recover.
 Objective, not assumption: whether that channel carries context-

--- a/scripts/fetch_d3_corpus.py
+++ b/scripts/fetch_d3_corpus.py
@@ -44,7 +44,14 @@ def main() -> int:
 
     manifest = json.loads(Path(args.manifest).read_text())
     want_count = manifest["article_count"]
-    want_bytes = manifest["text_bytes"]
+    # Issue #267 postscript: the pinned total is a CHARACTER count
+    # (len(text)), not a utf-8 byte count — the "0.5% drift" reported in
+    # the issue was this accounting mismatch, not upstream drift; the
+    # refetched file reproduces the pinned corpus_cid bit-for-bit.
+    # `text_chars` is authoritative going forward; the legacy
+    # `text_bytes` name is honored for manifests that predate the fix.
+    want_chars = manifest.get("text_chars", manifest.get("text_bytes"))
+    want_cid = manifest.get("corpus_cid")
 
     rows = []
     for offset in range(0, want_count, 100):
@@ -66,7 +73,7 @@ def main() -> int:
         print(f"expected {want_count} rows, got {len(rows)}", file=sys.stderr)
         return 2
 
-    text_bytes = 0
+    text_chars = 0
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", encoding="utf-8") as handle:
@@ -78,15 +85,25 @@ def main() -> int:
                 "title": row["title"],
                 "text": row["text"],
             }
-            text_bytes += len(row["text"].encode("utf-8"))
+            text_chars += len(row["text"])
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     print(
-        f"wrote {len(rows)} articles, text_bytes={text_bytes} "
-        f"(manifest pins {want_count} / {want_bytes})"
+        f"wrote {len(rows)} articles, text_chars={text_chars} "
+        f"(manifest pins {want_count} / {want_chars})"
     )
-    if text_bytes == want_bytes:
-        print("MATCH: totals reproduce the manifest")
+    cid_line = ""
+    try:  # strong check when the blake3 module is present (pip install blake3)
+        import blake3  # type: ignore
+
+        cid_line = "blake3:" + blake3.blake3(out_path.read_bytes()).hexdigest()
+        print(f"corpus_cid computed {cid_line} (manifest pins {want_cid})")
+    except ImportError:
+        print("blake3 module unavailable — CID not verified (character totals only)")
+    if (cid_line and want_cid and cid_line == want_cid) or (
+        not cid_line and text_chars == want_chars
+    ):
+        print("MATCH: fetch reproduces the pinned corpus")
         return 0
     print(
         "DRIFT: upstream content differs from the pinned corpus "


### PR DESCRIPTION
Batch per the 2026-07-29 process amendment — one commit per issue-unit, gates run once here. Eight commits:

## #243 (three commits) — the Phase B decision, made by measurement
Round 1: A-R-retrained measured bit-identical to A-R — class_sigs already ARE centroid sign-signatures; recorded no-op. Round 2: A-dot-only 30.4/34.2 with no residual subtraction vs A-resid-sign collapsing to the floor — the dominant loss is the assignment metric, not residuals. Round 3: **A-dot-po2 30.6/34.2 and A-dot-po2x2 30.7/34.3 — both pass the Empirical Criterion (≥30.1/≥34.1)** at ~47-48k keys (7.2× under the shipped store). Phase B kernel design settled: shift-add dot against power-of-two centroids (shifts+adds only, contract §4). Kernel PR follows separately (runtime change = individual PR).

## #267 — closes on merge
The 'unre-materializable corpus' premise dissolved: manifest text_bytes was a character count; blake3 of the refetch equals the pinned corpus_cid bit-for-bit. Manifest gains text_chars/text_utf8_bytes/accounting note/retrieval field; fetch script verifies chars + CID; corpus uploaded as release asset d3-corpus-simple-wiki-20231101 keyed by corpus_cid.

## #268 — instrumentation (issue stays open for the replay fix)
evaluate-report (schema 2) decomposes the teacher floor by position-in-story band, next-token class, worst articles. First run named the dominant cause: record-stream story interleaving (~9.2-token runs) + per-run oracle resets → ~4.6-token mean effective context → the 13.4-bit floor is a bound under those conditions, not a model-quality bound (posted on the issue with the fix path).

## #234 — declaration machinery (item 2 stays open)
score_report schema 9 adds DistributionDeclaration: EXCT-miss rate fixed at declaration time + Gate C validity verdict against a declared 5% minimum, printed loudly at score time.

## #276 — Design P doc (REVIEW)
docs/phase_clock_address_design.md — cyclic graded codes on the zeta torus, positioned post-round-2 (channel addition, not residual-fix competitor); ⚑ flags open for Casey/Ari/Alex.

## Verification
cargo check/clippy(-D warnings)/fmt clean per commit on the warm shared target; three full certify runs + one evaluate-report run executed against these rows (logs on Casey's Mac); claim-wording gate passed. Full suite gates here in CI per the amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cWTa3B7xnsk6wygnfgL7o