### PR TITLE
feat(kernel): shift-add dot assignment — #243 Phase B (TLA6, P-4 clean, beam metric-consistent)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -691,6 +691,42 @@ pub struct Compiled {
     /// (the stages themselves quantize into `stage_books`; the labels are
     /// witness metadata and are not serialized into the container).
     pub token_stage_kappas: Vec<String>,
+    /// Shift-add dot-assignment tables (issue #243 Phase B): per stage,
+    /// K × D packed u16 entries encoding each context-centroid value as
+    /// a signed two-term power-of-two sum, so the runtime scores
+    /// `dot(work, centroid)` with shifts and integer adds only. Filled
+    /// at compile time from `ctx_cb`; serialized only by the TLA6
+    /// container (see `artifact_bytes`); empty on TLA3/4/5 loads, which
+    /// keeps loaded legacy artifacts on the sign-Hamming path.
+    pub dot_cb: Vec<Vec<u16>>,
+}
+
+/// Pack one f32 centroid value as two power-of-two terms in a u16
+/// (issue #243 Phase B). Per byte term: bit7 = negative sign, bit6 =
+/// nonzero flag, bits 5..0 = biased exponent (e + 32, e ∈ [-32, 31]).
+/// High byte is the first (larger) term. The decode side lives in
+/// `runtime::dot_term_apply`, integer shifts only.
+pub fn pack_dot_entry(value: f32) -> u16 {
+    let mut packed = [0u8; 2];
+    let mut rem = value;
+    for slot in packed.iter_mut() {
+        if rem == 0.0 || !rem.is_finite() {
+            break;
+        }
+        let e = rem.abs().log2().round().clamp(-32.0, 31.0);
+        let term = rem.signum() * e.exp2();
+        *slot = 0x40 | ((e as i32 + 32) as u8 & 0x3F) | if rem < 0.0 { 0x80 } else { 0 };
+        rem -= term;
+    }
+    u16::from_le_bytes([packed[1], packed[0]])
+}
+
+/// Quantize the full per-stage context codebooks into dot tables.
+pub fn quantize_dot_tables(ctx_cb: &[Vec<f32>]) -> Vec<Vec<u16>> {
+    ctx_cb
+        .iter()
+        .map(|cb| cb.iter().map(|&c| pack_dot_entry(c)).collect())
+        .collect()
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -1110,6 +1146,7 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
         class_sigs: Vec::new(),
         ctx_cb: Vec::new(),
         token_stage_kappas: emb_stage_kappas,
+        dot_cb: Vec::new(),
     };
     let rot = derive_rotations();
 
@@ -1187,6 +1224,10 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
         art.class_sigs.push(sigs);
     }
     art.ctx_cb = ctx_cb;
+    // #243 Phase B: the shift-add dot tables are derived from the same
+    // centroids, deterministically, at compile time. In-memory always;
+    // on disk only under TLA6 (era note in `artifact_bytes`).
+    art.dot_cb = quantize_dot_tables(&art.ctx_cb);
     art
 }
 
@@ -1196,9 +1237,26 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
 /// re-derivable from the bytes; the store is rebuilt from the corpus).
 ///
 /// Format TLA5: always includes a u32 vocab prefix; ctx_cb is not serialized.
+///
+/// Format TLA6 (issue #243 Phase B) = the TLA5 payload + the packed
+/// shift-add dot tables (STAGES × K × D u16, little-endian). Emission
+/// is opt-in via `R4_TLESS_TLA6=1` until the Phase C adoption decision:
+/// a TLA6 container has different bytes and therefore a different κ —
+/// flipping the default is a maintainer re-pin (era note), not a code
+/// change. Loaded TLA5 artifacts keep the sign-Hamming query path;
+/// loaded TLA6 artifacts (and fresh in-memory compiles) take the
+/// shift-add dot path.
 pub fn artifact_bytes(a: &Compiled) -> Vec<u8> {
+    let emit_tla6 = !a.dot_cb.is_empty()
+        && std::env::var("R4_TLESS_TLA6")
+            .map(|v| v == "1")
+            .unwrap_or(false);
     let vocab = a.token_codes.len() / STAGES;
-    let mut b: Vec<u8> = b"TLA5".to_vec();
+    let mut b: Vec<u8> = if emit_tla6 {
+        b"TLA6".to_vec()
+    } else {
+        b"TLA5".to_vec()
+    };
     b.extend_from_slice(&(vocab as u32).to_le_bytes());
     b.extend_from_slice(&a.stage_shifts);
     b.extend_from_slice(&a.token_codes);
@@ -1210,6 +1268,13 @@ pub fn artifact_bytes(a: &Compiled) -> Vec<u8> {
     }
     for s in &a.class_sigs {
         b.extend_from_slice(s);
+    }
+    if emit_tla6 {
+        for table in &a.dot_cb {
+            for entry in table {
+                b.extend_from_slice(&entry.to_le_bytes());
+            }
+        }
     }
     b
 }
@@ -1245,23 +1310,32 @@ pub fn load_artifacts_from(path: &str) -> Option<Compiled> {
     Some(art)
 }
 
-/// Parse a TLA3, TLA4, or TLA5 container from bytes.
+/// Parse a TLA3, TLA4, TLA5, or TLA6 container from bytes.
 ///
 /// TLA3/TLA4 are legacy formats that include f32 ctx_cb bytes; these are
 /// silently discarded on load (ctx_cb is not part of the deployed artifact).
-/// TLA5 is the current format: always includes a u32 vocab prefix, no ctx_cb.
+/// TLA5 is the current default format: u32 vocab prefix, no ctx_cb.
+/// TLA6 appends the packed shift-add dot tables (issue #243 Phase B).
 pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
-    let (vocab, mut o, has_ctx_cb) = match b.get(..4)? {
-        b"TLA3" => (V, 4usize, true),
+    let (vocab, mut o, has_ctx_cb, has_dot_cb) = match b.get(..4)? {
+        b"TLA3" => (V, 4usize, true, false),
         b"TLA4" => (
             u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
             8usize,
             true,
+            false,
         ),
         b"TLA5" => (
             u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
             8usize,
             false,
+            false,
+        ),
+        b"TLA6" => (
+            u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
+            8usize,
+            false,
+            true,
         ),
         _ => return None,
     };
@@ -1270,7 +1344,8 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
     let th = D * 8;
     let cs = STAGES * K * D / 8;
     let cc = if has_ctx_cb { STAGES * K * D * 4 } else { 0 };
-    if b.len() != o + STAGES + tc + bk + th + cs + cc {
+    let dc = if has_dot_cb { STAGES * K * D * 2 } else { 0 };
+    if b.len() != o + STAGES + tc + bk + th + cs + cc + dc {
         return None;
     }
     let stage_shifts = b[o..o + STAGES].to_vec();
@@ -1298,9 +1373,20 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
         o += K * D / 8;
     }
     // Legacy TLA3/TLA4 containers include f32 ctx_cb bytes; advance past them
-    // without reading. TLA5 containers do not include ctx_cb at all.
+    // without reading. TLA5/TLA6 containers do not include ctx_cb at all.
     if has_ctx_cb {
         o += STAGES * K * D * 4;
+    }
+    let mut dot_cb = Vec::new();
+    if has_dot_cb {
+        for _ in 0..STAGES {
+            let mut table = Vec::with_capacity(K * D);
+            for _ in 0..K * D {
+                table.push(u16::from_le_bytes(b[o..o + 2].try_into().unwrap()));
+                o += 2;
+            }
+            dot_cb.push(table);
+        }
     }
     let _ = o; // all bytes consumed
     Some(Compiled {
@@ -1311,6 +1397,7 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
         class_sigs,
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
+        dot_cb,
     })
 }
 

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -298,3 +298,69 @@ pub mod scenarios;
 pub mod score_q;
 pub mod simd;
 pub mod transitions;
+
+/// #243 dot-assignment tests live HERE rather than in runtime.rs: the
+/// P-4 scan covers all of runtime.rs including its test code, and test
+/// fixture arithmetic (K * D, %, /) must not appear in that file.
+#[cfg(test)]
+mod dot_assignment_tests {
+    use super::{compiler, runtime};
+
+    fn synthetic_dot_art() -> compiler::Compiled {
+        let mut art = compiler::Compiled {
+            token_codes: vec![0u8; compiler::STAGES],
+            stage_books: (0..compiler::STAGES)
+                .map(|_| vec![0i8; compiler::K * compiler::D])
+                .collect(),
+            stage_shifts: vec![0u8; compiler::STAGES],
+            thresholds: (0..compiler::D as i64).map(|d| (d % 7) - 3).collect(),
+            class_sigs: (0..compiler::STAGES)
+                .map(|_| vec![0u8; compiler::K * compiler::D / 8])
+                .collect(),
+            ctx_cb: Vec::new(),
+            token_stage_kappas: Vec::new(),
+            dot_cb: Vec::new(),
+        };
+        art.dot_cb = (0..compiler::STAGES)
+            .map(|st| {
+                (0..compiler::K * compiler::D)
+                    .map(|i| {
+                        let v = ((i + st) % 13) as f32 - 6.0;
+                        compiler::pack_dot_entry(v / 8.0)
+                    })
+                    .collect()
+            })
+            .collect();
+        art
+    }
+
+    #[test]
+    fn pack_dot_entry_round_trips_powers_of_two() {
+        let one = compiler::pack_dot_entry(1.0).to_le_bytes();
+        assert_eq!(one[1] & 0x40, 0x40, "nonzero flag");
+        assert_eq!(one[1] & 0x80, 0, "positive");
+        assert_eq!((one[1] & 0x3F) as i32 - 32, 0, "exponent 0");
+        assert_eq!(one[0], 0, "no residual term");
+        let v = compiler::pack_dot_entry(-0.375).to_le_bytes();
+        assert_eq!((v[1] & 0x3F) as i32 - 32, -1);
+        assert_eq!(v[1] & 0x80, 0x80, "first term negative");
+        assert_eq!((v[0] & 0x3F) as i32 - 32, -3);
+        assert_eq!(v[0] & 0x80, 0, "residual term positive");
+        assert_eq!(compiler::pack_dot_entry(0.0), 0);
+    }
+
+    #[test]
+    fn dot_kernel_equals_plain_on_synthetic_artifact() {
+        let art = synthetic_dot_art();
+        let mut bundle = [0i64; compiler::D];
+        for (d, slot) in bundle.iter_mut().enumerate() {
+            *slot = ((d as i64) % 97) - 48;
+        }
+        let plain = runtime::assign_for_bundle(&art, &bundle);
+        let mut rt = runtime::Runtime::new(&art);
+        let kernel = rt.code_from_bundle_dot(&bundle);
+        assert_eq!(plain, kernel, "kernel/plain dot assignment divergence");
+        assert!(rt.kernel.shifts > 0, "dot path must count shifts");
+        assert!(rt.kernel.adds > 0, "dot path must count adds");
+    }
+}

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -494,7 +494,18 @@ pub fn assign_memberships_for_bundle(
     let mut code = [0u8; STAGES];
     let mut stage_top: Vec<Vec<(u8, u32)>> = Vec::with_capacity(STAGES);
     for (st_code, table) in code.iter_mut().zip(art.dot_cb.iter()) {
-        let top = dot_stage_top(table, &work);
+        let mut top = dot_stage_top(table, &work);
+        // Beam OFF under the dot metric (Casey, 2026-07-29, on the run-2
+        // evidence): the #244 query-beam was tuned to Hamming ambiguity —
+        // near-tie runner-up classes that share store evidence. Under dot
+        // the #1→#2 gap is wide and runner-up keys are simply wrong, so
+        // the beam's evidence merge diluted 30.6/34.2 to 18.3/20.6
+        // (cost-scale fix measured no change; the keys themselves were
+        // the problem). Membership prefixes degenerate to the nearest
+        // chain: single-key reads, criterion-passing, and the beam's
+        // extra scan ops disappear. #244's beam decision stays recorded
+        // as a sign-metric result; a dot-tuned beam is future work.
+        top.truncate(1);
         *st_code = top.first().map(|(k, _)| *k).unwrap_or(0);
         stage_top.push(top);
     }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -435,9 +435,16 @@ pub fn dot_score_plain(row: &[u16], work: &[i64; D]) -> i64 {
 }
 
 /// Per-stage top-M candidates under the dot metric, expressed as the
-/// same ascending-cost shape the membership beam consumes: cost =
-/// (stage-best dot − class dot), saturated to u32. Ties keep the
-/// lowest class index (ascending scan, strict improvement) — the same
+/// same ascending-cost shape the membership beam consumes. Candidate
+/// selection ranks by (stage-best dot − class dot); the EMITTED costs
+/// are the candidates' ranks (0, 1, 2, …), not the raw dot gaps —
+/// dot gaps live on the raw work-vector scale (~1e6), and feeding
+/// them to the beam's cross-stage sum and evidence merge (both tuned
+/// to Hamming-scale costs) mis-weights everything downstream: the
+/// first integer-semantics run measured the shipped beam row at
+/// 18.3/20.6 against 30.6/34.2 for the primary key alone. Rank costs
+/// are scale-free and metric-agnostic. Ties keep the lowest class
+/// index (ascending scan, strict improvement) — the same
 /// deterministic rule as the Hamming path.
 fn dot_stage_top(table: &[u16], work: &[i64; D]) -> Vec<(u8, u32)> {
     let mut dots = [0i64; K];
@@ -465,6 +472,9 @@ fn dot_stage_top(table: &[u16], work: &[i64; D]) -> Vec<(u8, u32)> {
         if inserted && top.len() > TOP_M_MEMBERSHIPS {
             top.pop();
         }
+    }
+    for (rank, slot) in top.iter_mut().enumerate() {
+        slot.1 = rank as u32;
     }
     top
 }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -815,7 +815,7 @@ impl<'a> Runtime<'a> {
     /// dimension entry, at most two shifts + two adds per term pair, one
     /// compare per candidate. Equality with `assign_for_bundle` (plain
     /// form) is witnessed per certification run.
-    fn code_from_bundle_dot(&mut self, bundle: &[i64; D]) -> [u8; STAGES] {
+    pub(crate) fn code_from_bundle_dot(&mut self, bundle: &[i64; D]) -> [u8; STAGES] {
         let mut work = [0i64; D];
         for ((w, &b), &t) in work
             .iter_mut()
@@ -1394,73 +1394,4 @@ pub fn store_kappa(store: &Store) -> String {
 /// remove a contribution is to remove its κ.
 pub fn remove_entry(store: &mut Store, depth: usize, key: &[u8]) -> Option<BTreeMap<u32, u32>> {
     store.get_mut(depth)?.remove(key)
-}
-
-#[cfg(test)]
-mod dot_assignment_tests {
-    use super::*;
-    use crate::transformerless::compiler::{pack_dot_entry, Compiled};
-
-    /// Deterministic synthetic artifact: zeroed books/thresholds, dot
-    /// tables packed from a simple varying pattern. No RNG, no clock.
-    fn synthetic_art() -> Compiled {
-        let mut art = Compiled {
-            token_codes: vec![0u8; STAGES],
-            stage_books: (0..STAGES).map(|_| vec![0i8; K * D]).collect(),
-            stage_shifts: vec![0u8; STAGES],
-            thresholds: (0..D as i64).map(|d| (d % 7) - 3).collect(),
-            class_sigs: (0..STAGES).map(|_| vec![0u8; K * D / 8]).collect(),
-            ctx_cb: Vec::new(),
-            token_stage_kappas: Vec::new(),
-            dot_cb: Vec::new(),
-        };
-        art.dot_cb = (0..STAGES)
-            .map(|st| {
-                (0..K * D)
-                    .map(|i| {
-                        let v = ((i + st) % 13) as f32 - 6.0;
-                        pack_dot_entry(v / 8.0)
-                    })
-                    .collect()
-            })
-            .collect();
-        art
-    }
-
-    #[test]
-    fn pack_dot_entry_round_trips_powers_of_two() {
-        // 1.0 = +2^0 exactly: one term, second term zero.
-        let one = pack_dot_entry(1.0).to_le_bytes();
-        assert_eq!(one[1] & 0x40, 0x40, "nonzero flag");
-        assert_eq!(one[1] & 0x80, 0, "positive");
-        assert_eq!((one[1] & 0x3F) as i32 - 32, 0, "exponent 0");
-        assert_eq!(one[0], 0, "no residual term");
-        // -0.375 = -0.5 + 0.125: two terms, exponents -1 and -3.
-        let v = pack_dot_entry(-0.375).to_le_bytes();
-        assert_eq!((v[1] & 0x3F) as i32 - 32, -1);
-        assert_eq!(v[1] & 0x80, 0x80, "first term negative");
-        assert_eq!((v[0] & 0x3F) as i32 - 32, -3);
-        assert_eq!(v[0] & 0x80, 0, "residual term positive");
-        // Zero packs to all-zero (both terms flagged absent).
-        assert_eq!(pack_dot_entry(0.0), 0);
-    }
-
-    #[test]
-    fn dot_kernel_equals_plain_on_synthetic_artifact() {
-        let art = synthetic_art();
-        let mut bundle = [0i64; D];
-        for (d, slot) in bundle.iter_mut().enumerate() {
-            *slot = ((d as i64) % 97) - 48;
-        }
-        // Plain form.
-        let plain = assign_for_bundle(&art, &bundle);
-        // Kernel form (private path exercised through Runtime): build a
-        // runtime and call the public window path shape by scoring the
-        // bundle directly through the counted ops.
-        let mut rt = Runtime::new(&art);
-        let kernel = rt.code_from_bundle_dot(&bundle);
-        assert_eq!(plain, kernel, "kernel/plain dot assignment divergence");
-        assert!(rt.kernel.shifts > 0, "dot path must count shifts");
-        assert!(rt.kernel.adds > 0, "dot path must count adds");
-    }
 }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -19,7 +19,7 @@
 //!   query keys come from one code path by construction.
 
 pub use super::compiler::{derive_rotations, train_cut, SIG_BYTES, SIG_WORDS};
-use super::compiler::{Compiled, Corpus, D, STAGES, WINDOW};
+use super::compiler::{Compiled, Corpus, D, K, STAGES, WINDOW};
 use uor_r4_graph_runtime::runtime_state::RuntimeState;
 
 const TOP_M_MEMBERSHIPS: usize = 3;
@@ -51,6 +51,11 @@ impl OpKernel {
     pub fn shl(&mut self, a: i64, s: u32) -> i64 {
         self.shifts += 1;
         a << s
+    }
+    #[inline]
+    pub fn shr(&mut self, a: i64, s: u32) -> i64 {
+        self.shifts += 1;
+        a >> s
     }
     #[inline]
     pub fn xor(&mut self, a: u8, b: u8) -> u8 {
@@ -370,6 +375,131 @@ pub fn assign_plain(art: &Compiled, sig: &[u8; SIG_BYTES]) -> [u8; STAGES] {
     assign_memberships_plain(art, sig).0
 }
 
+// ------------------- shift-add dot assignment (#243 Phase B) -----------
+//
+// The decision rows (issue #243, 2026-07-29) attributed the shipped
+// assignment gap to the sign-Hamming metric itself: dot-product
+// assignment against the per-stage context centroids measures
+// 30.6-30.7% top1 / 34.2-34.3% agreement at ~47-48k store keys even
+// with centroid values restricted to two signed powers of two. That
+// restriction is what makes the runtime form legal: `dot(work, cent)`
+// becomes a shift-and-add reduction — no multiply operation exists in
+// this code path (P-4 scans this module). Active only when the
+// artifact carries dot tables (fresh compiles, TLA6 containers);
+// TLA3/4/5 loads keep the sign-Hamming path unchanged.
+
+/// The centered work vector: bundle minus thresholds, integer sub.
+pub fn centered_work(art: &Compiled, bundle: &[i64; D]) -> [i64; D] {
+    let mut work = [0i64; D];
+    for ((w, &b), &t) in work
+        .iter_mut()
+        .zip(bundle.iter())
+        .zip(art.thresholds.iter())
+    {
+        *w = b - t;
+    }
+    work
+}
+
+/// Apply one packed power-of-two term to a work value: decode
+/// (sign, nonzero, biased exponent) and shift accordingly. Plain form
+/// of the kernel's shr/shl + add sequence.
+#[inline]
+fn dot_term_apply(work: i64, term: u8) -> i64 {
+    if term & 0x40 == 0 {
+        return 0;
+    }
+    let exp = (term & 0x3F) as i32 - 32;
+    let shifted = if exp >= 0 {
+        work << exp
+    } else {
+        work >> (-exp)
+    };
+    if term & 0x80 != 0 {
+        -shifted
+    } else {
+        shifted
+    }
+}
+
+/// Shift-add dot score of one class row (D packed u16 entries) against
+/// the work vector.
+pub fn dot_score_plain(row: &[u16], work: &[i64; D]) -> i64 {
+    let mut acc = 0i64;
+    for (&entry, &w) in row.iter().zip(work.iter()) {
+        let [lo, hi] = entry.to_le_bytes();
+        acc += dot_term_apply(w, hi);
+        acc += dot_term_apply(w, lo);
+    }
+    acc
+}
+
+/// Per-stage top-M candidates under the dot metric, expressed as the
+/// same ascending-cost shape the membership beam consumes: cost =
+/// (stage-best dot − class dot), saturated to u32. Ties keep the
+/// lowest class index (ascending scan, strict improvement) — the same
+/// deterministic rule as the Hamming path.
+fn dot_stage_top(table: &[u16], work: &[i64; D]) -> Vec<(u8, u32)> {
+    let mut dots = [0i64; K];
+    let mut best = i64::MIN;
+    for (slot, row) in dots.iter_mut().zip(table.chunks_exact(D)) {
+        *slot = dot_score_plain(row, work);
+        if *slot > best {
+            best = *slot;
+        }
+    }
+    let mut top: Vec<(u8, u32)> = Vec::with_capacity(TOP_M_MEMBERSHIPS);
+    for (kk, &dot) in dots.iter().enumerate() {
+        let cost = u32::try_from(best - dot).unwrap_or(u32::MAX);
+        let mut inserted = false;
+        for (idx, &(_, c0)) in top.iter().enumerate() {
+            if cost < c0 {
+                top.insert(idx, (kk as u8, cost));
+                inserted = true;
+                break;
+            }
+        }
+        if !inserted && top.len() < TOP_M_MEMBERSHIPS {
+            top.push((kk as u8, cost));
+        }
+        if inserted && top.len() > TOP_M_MEMBERSHIPS {
+            top.pop();
+        }
+    }
+    top
+}
+
+/// Membership assignment for a bundle: dot path when the artifact
+/// carries dot tables, sign-Hamming otherwise. The by-depth beam shape
+/// and fallback-floor rule are identical between the two metrics.
+#[allow(clippy::type_complexity)]
+pub fn assign_memberships_for_bundle(
+    art: &Compiled,
+    bundle: &[i64; D],
+) -> ([u8; STAGES], Vec<Vec<Vec<u8>>>) {
+    if art.dot_cb.is_empty() {
+        return assign_memberships_plain(art, &sig_plain(art, bundle));
+    }
+    let work = centered_work(art, bundle);
+    let mut code = [0u8; STAGES];
+    let mut stage_top: Vec<Vec<(u8, u32)>> = Vec::with_capacity(STAGES);
+    for (st_code, table) in code.iter_mut().zip(art.dot_cb.iter()) {
+        let top = dot_stage_top(table, &work);
+        *st_code = top.first().map(|(k, _)| *k).unwrap_or(0);
+        stage_top.push(top);
+    }
+    memberships_from_stage_top(code, stage_top)
+}
+
+/// Plain class code for a bundle under whichever metric the artifact
+/// declares. `assign_plain`/`assign_memberships_plain` remain the
+/// signature-only sign-metric entry points for callers that never see
+/// a bundle (score-time signature replay); bundle-holding callers go
+/// through here so TLA6 artifacts assign by shift-add dot.
+pub fn assign_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
+    assign_memberships_for_bundle(art, bundle).0
+}
+
 /// Bounded multi-membership assignment per depth, with nearest-class
 /// membership retained at every depth as the fallback floor.
 pub fn assign_memberships_plain(
@@ -401,6 +531,19 @@ pub fn assign_memberships_plain(
         *st_code = top.first().map(|(k, _)| *k).unwrap_or(0);
         stage_top.push(top);
     }
+    memberships_from_stage_top(code, stage_top)
+}
+
+/// The shared membership beam: per-depth prefix expansion over the
+/// per-stage top-M candidate lists, with the nearest-class prefix
+/// retained at every depth as the fallback floor. Metric-agnostic —
+/// candidates arrive as ascending (class, cost) lists from either the
+/// Hamming or the shift-add dot scorer.
+#[allow(clippy::type_complexity)]
+fn memberships_from_stage_top(
+    code: [u8; STAGES],
+    stage_top: Vec<Vec<(u8, u32)>>,
+) -> ([u8; STAGES], Vec<Vec<Vec<u8>>>) {
     let mut by_depth: Vec<Vec<Vec<u8>>> = (0..=STAGES).map(|_| Vec::new()).collect();
     by_depth[0].push(Vec::new());
     let mut beam: Vec<(Vec<u8>, u32)> = vec![(Vec::new(), 0)];
@@ -436,10 +579,10 @@ pub fn assign_memberships_plain(
     (code, by_depth)
 }
 
-/// Full plain path: position → graded class code.
+/// Full plain path: position → graded class code (metric per artifact).
 pub fn code_plain(art: &Compiled, rot: &[usize; WINDOW + 1], c: &Corpus, i: usize) -> [u8; STAGES] {
     let b = bundle_plain(art, rot, c, i);
-    assign_plain(art, &sig_plain(art, &b))
+    assign_for_bundle(art, &b)
 }
 
 /// A prediction with its resolution witness: the store level that answered
@@ -612,6 +755,9 @@ impl<'a> Runtime<'a> {
     pub fn assign(&mut self, c: &Corpus, i: usize) -> [u8; STAGES] {
         let rot = self.rot;
         let b = bundle_kernel(&mut self.kernel, self.art, &rot, c, i);
+        if !self.art.dot_cb.is_empty() {
+            return self.code_from_bundle_dot(&b);
+        }
         let sig = sign_signature(&mut self.kernel, &b, &self.art.thresholds);
         self.code_from_sig(&sig)
     }
@@ -621,6 +767,9 @@ impl<'a> Runtime<'a> {
     pub fn assign_window(&mut self, window: &[u32]) -> [u8; STAGES] {
         let rot = self.rot;
         let b = bundle_window_kernel(&mut self.kernel, self.art, &rot, window);
+        if !self.art.dot_cb.is_empty() {
+            return self.code_from_bundle_dot(&b);
+        }
         let sig = sign_signature(&mut self.kernel, &b, &self.art.thresholds);
         self.code_from_sig(&sig)
     }
@@ -638,10 +787,65 @@ impl<'a> Runtime<'a> {
     ) -> ([u8; STAGES], Vec<Vec<Vec<u8>>>) {
         let rot = self.rot;
         let b = bundle_window_kernel(&mut self.kernel, self.art, &rot, window);
+        if !self.art.dot_cb.is_empty() {
+            let code = self.code_from_bundle_dot(&b);
+            let (_, by_depth) = assign_memberships_for_bundle(self.art, &b);
+            return (code, by_depth);
+        }
         let sig = sign_signature(&mut self.kernel, &b, &self.art.thresholds);
         let code = self.code_from_sig(&sig);
         let (_, by_depth) = assign_memberships_plain(self.art, &sig);
         (code, by_depth)
+    }
+
+    /// Graded class assignment from a bundle by shift-add dot scoring
+    /// (#243 Phase B, kernel form — every operation counted): center the
+    /// bundle with integer adds, then per stage argmax over K classes of
+    /// the two-term power-of-two dot. Ops per class: one table read per
+    /// dimension entry, at most two shifts + two adds per term pair, one
+    /// compare per candidate. Equality with `assign_for_bundle` (plain
+    /// form) is witnessed per certification run.
+    fn code_from_bundle_dot(&mut self, bundle: &[i64; D]) -> [u8; STAGES] {
+        let mut work = [0i64; D];
+        for ((w, &b), &t) in work
+            .iter_mut()
+            .zip(bundle.iter())
+            .zip(self.art.thresholds.iter())
+        {
+            *w = self.kernel.add(b, -t);
+        }
+        let mut code = [0u8; STAGES];
+        for (st_code, table) in code.iter_mut().zip(self.art.dot_cb.iter()) {
+            let mut best = i64::MIN;
+            let mut best_k = 0u8;
+            for (kk, row) in table.chunks_exact(D).enumerate() {
+                self.kernel.candidate_scan();
+                let mut acc = 0i64;
+                for (&entry, &w) in row.iter().zip(work.iter()) {
+                    let packed = self.kernel.table_fetch(i64::from(entry)) as u16;
+                    let [lo, hi] = packed.to_le_bytes();
+                    for term in [hi, lo] {
+                        if term & 0x40 == 0 {
+                            continue;
+                        }
+                        let exp = (term & 0x3F) as i32 - 32;
+                        let shifted = if exp >= 0 {
+                            self.kernel.shl(w, exp as u32)
+                        } else {
+                            self.kernel.shr(w, (-exp) as u32)
+                        };
+                        let signed = if term & 0x80 != 0 { -shifted } else { shifted };
+                        acc = self.kernel.add(acc, signed);
+                    }
+                }
+                if self.kernel.lt(best, acc) {
+                    best = acc;
+                    best_k = kk as u8;
+                }
+            }
+            *st_code = best_k;
+        }
+        code
     }
 
     /// Graded class assignment from a bit signature: Hamming to each
@@ -943,7 +1147,7 @@ pub fn build_store(art: &Compiled, c: &Corpus) -> (Store, Vec<[u8; STAGES]>) {
     let mut codes: Vec<[u8; STAGES]> = Vec::with_capacity(c.n);
     for i in 0..c.n {
         let b = bundle_plain(art, &rot, c, i);
-        let code = assign_plain(art, &sig_plain(art, &b));
+        let code = assign_for_bundle(art, &b);
         codes.push(code);
         if c.story[i] >= cut {
             continue;
@@ -1180,4 +1384,73 @@ pub fn store_kappa(store: &Store) -> String {
 /// remove a contribution is to remove its κ.
 pub fn remove_entry(store: &mut Store, depth: usize, key: &[u8]) -> Option<BTreeMap<u32, u32>> {
     store.get_mut(depth)?.remove(key)
+}
+
+#[cfg(test)]
+mod dot_assignment_tests {
+    use super::*;
+    use crate::transformerless::compiler::{pack_dot_entry, Compiled};
+
+    /// Deterministic synthetic artifact: zeroed books/thresholds, dot
+    /// tables packed from a simple varying pattern. No RNG, no clock.
+    fn synthetic_art() -> Compiled {
+        let mut art = Compiled {
+            token_codes: vec![0u8; STAGES],
+            stage_books: (0..STAGES).map(|_| vec![0i8; K * D]).collect(),
+            stage_shifts: vec![0u8; STAGES],
+            thresholds: (0..D as i64).map(|d| (d % 7) - 3).collect(),
+            class_sigs: (0..STAGES).map(|_| vec![0u8; K * D / 8]).collect(),
+            ctx_cb: Vec::new(),
+            token_stage_kappas: Vec::new(),
+            dot_cb: Vec::new(),
+        };
+        art.dot_cb = (0..STAGES)
+            .map(|st| {
+                (0..K * D)
+                    .map(|i| {
+                        let v = ((i + st) % 13) as f32 - 6.0;
+                        pack_dot_entry(v / 8.0)
+                    })
+                    .collect()
+            })
+            .collect();
+        art
+    }
+
+    #[test]
+    fn pack_dot_entry_round_trips_powers_of_two() {
+        // 1.0 = +2^0 exactly: one term, second term zero.
+        let one = pack_dot_entry(1.0).to_le_bytes();
+        assert_eq!(one[1] & 0x40, 0x40, "nonzero flag");
+        assert_eq!(one[1] & 0x80, 0, "positive");
+        assert_eq!((one[1] & 0x3F) as i32 - 32, 0, "exponent 0");
+        assert_eq!(one[0], 0, "no residual term");
+        // -0.375 = -0.5 + 0.125: two terms, exponents -1 and -3.
+        let v = pack_dot_entry(-0.375).to_le_bytes();
+        assert_eq!((v[1] & 0x3F) as i32 - 32, -1);
+        assert_eq!(v[1] & 0x80, 0x80, "first term negative");
+        assert_eq!((v[0] & 0x3F) as i32 - 32, -3);
+        assert_eq!(v[0] & 0x80, 0, "residual term positive");
+        // Zero packs to all-zero (both terms flagged absent).
+        assert_eq!(pack_dot_entry(0.0), 0);
+    }
+
+    #[test]
+    fn dot_kernel_equals_plain_on_synthetic_artifact() {
+        let art = synthetic_art();
+        let mut bundle = [0i64; D];
+        for (d, slot) in bundle.iter_mut().enumerate() {
+            *slot = ((d as i64) % 97) - 48;
+        }
+        // Plain form.
+        let plain = assign_for_bundle(&art, &bundle);
+        // Kernel form (private path exercised through Runtime): build a
+        // runtime and call the public window path shape by scoring the
+        // bundle directly through the counted ops.
+        let mut rt = Runtime::new(&art);
+        let kernel = rt.code_from_bundle_dot(&bundle);
+        assert_eq!(plain, kernel, "kernel/plain dot assignment divergence");
+        assert!(rt.kernel.shifts > 0, "dot path must count shifts");
+        assert!(rt.kernel.adds > 0, "dot path must count adds");
+    }
 }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -494,18 +494,7 @@ pub fn assign_memberships_for_bundle(
     let mut code = [0u8; STAGES];
     let mut stage_top: Vec<Vec<(u8, u32)>> = Vec::with_capacity(STAGES);
     for (st_code, table) in code.iter_mut().zip(art.dot_cb.iter()) {
-        let mut top = dot_stage_top(table, &work);
-        // Beam OFF under the dot metric (Casey, 2026-07-29, on the run-2
-        // evidence): the #244 query-beam was tuned to Hamming ambiguity —
-        // near-tie runner-up classes that share store evidence. Under dot
-        // the #1→#2 gap is wide and runner-up keys are simply wrong, so
-        // the beam's evidence merge diluted 30.6/34.2 to 18.3/20.6
-        // (cost-scale fix measured no change; the keys themselves were
-        // the problem). Membership prefixes degenerate to the nearest
-        // chain: single-key reads, criterion-passing, and the beam's
-        // extra scan ops disappear. #244's beam decision stays recorded
-        // as a sign-metric result; a dot-tuned beam is future work.
-        top.truncate(1);
+        let top = dot_stage_top(table, &work);
         *st_code = top.first().map(|(k, _)| *k).unwrap_or(0);
         stage_top.push(top);
     }

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -310,6 +310,14 @@ pub fn certify(oracle: &dyn TeacherOracle) {
 
     // ---- store, by the runtime's own path (key identity by construction)
     let (store, codes) = build_store(&art, &c);
+    println!(
+        "assignment metric: {}",
+        if art.dot_cb.is_empty() {
+            "sign-Hamming (no dot tables in artifact)"
+        } else {
+            "shift-add dot (#243 Phase B: power-of-two centroid tables active)"
+        }
+    );
 
     // ---- equality witnesses: kernel path == plain path, three stages deep
     let mut rt = Runtime::new(&art);
@@ -326,10 +334,8 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         assert_eq!(ck, cp, "code kernel/plain divergence at {}", i);
 
         rt.state.clear_token_state();
-        let (_, by_depth_k) =
-            runtime::assign_memberships_plain(&art, &runtime::sig_plain(&art, &bk));
-        let (_, by_depth_p) =
-            runtime::assign_memberships_plain(&art, &runtime::sig_plain(&art, &bp));
+        let (_, by_depth_k) = runtime::assign_memberships_for_bundle(&art, &bk);
+        let (_, by_depth_p) = runtime::assign_memberships_for_bundle(&art, &bp);
         assert_eq!(
             rt.predict_witness_beam(&store, &by_depth_k).token,
             runtime::predict_witness_plain_beam(&store, &by_depth_p).token,

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -166,8 +166,12 @@ fn eval_query_beam(
     let (mut top1, mut agree, mut bits) = (0u64, 0u64, 0f64);
     for &i in &test {
         let bundle = bundle_plain(art, rot, c, i);
-        let sig = runtime::sig_plain(art, &bundle);
-        let (_code, by_depth) = runtime::assign_memberships_plain(art, &sig);
+        // Metric-consistent beam: memberships must come from the same
+        // metric that keyed the store. Runs 1-2 of the #243 kernel work
+        // measured 18.3/20.6 here because this call derived SIGN-metric
+        // prefixes and probed them against a DOT-keyed store — a pure
+        // key mismatch, initially misread as "the beam hurts under dot".
+        let (_code, by_depth) = runtime::assign_memberships_for_bundle(art, &bundle);
 
         let mut lams: Vec<(f64, BTreeMap<u32, u32>, u32)> = Vec::new();
         for (d, level) in store.iter().enumerate().take(STAGES + 1) {

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -164,6 +164,7 @@ fn synthetic_compiled() -> compiler::Compiled {
         class_sigs: (0..STAGES).map(|_| rand_bytes(K * SIG_BYTES)).collect(),
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
+        dot_cb: Vec::new(),
     }
 }
 

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -50,6 +50,7 @@ pub fn synthetic_compiled() -> compiler::Compiled {
         class_sigs: (0..STAGES).map(|_| rand_bytes(K * SIG_BYTES)).collect(),
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
+        dot_cb: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Individual PR (runtime-kernel change). Implements the #243 Phase B decision made by measurement across three certify rounds, then corrected and confirmed on true integer semantics.

## Measured (integer kernel semantics, D3 harness, corpus 150k/754 stories/30,036 held-out)

| Row | top1 | agree | WB | keys |
|---|---|---|---|---|
| OLD shipped (sign-Hamming + beam) | 28.2 | 31.9 | 9.7868 | 134,733 |
| **NEW shipped (shift-add dot + metric-consistent beam)** | **30.7** | **34.3** | **9.0242** | **47,476** |
| NEW primary-key only (A-single) | 30.6 | 34.2 | 9.6389 | 47,476 |
| A-f32 ceiling | 32.1 | 36.4 | 9.6982 | 92,903 |

**Empirical Criterion (≥30.1 / ≥34.1): PASS** on real kernel arithmetic. +2.5pp top1 / +2.4pp agreement over shipped at **2.8× fewer store keys**, WB best-in-matrix. Kernel==plain equality witnessed (bundle/code/beam, CERTIFY_EXIT:0); op census: **multiply 0** — adds, shifts (shl/shr), compares, table reads only.

## What this changes

- `Compiled.dot_cb`: per-stage K×D packed u16 tables — each centroid value as two signed powers of two — derived deterministically from ctx_cb at compile time. `dot(work, cent)` is a shift-add reduction; P-4 source scan passes (chunks_exact indexing, no value multiplication in the runtime module).
- **TLA6 container** = TLA5 payload + dot tables. **Emission is opt-in (`R4_TLESS_TLA6=1`)**: a TLA6 artifact has a different κ, so flipping the default is the Phase C maintainer re-pin (era note), not a code change. TLA3/4/5 loads keep dot_cb empty → sign-Hamming path bit-for-bit unchanged (serving bundles, score-time replay, Gate C trend, κ gate all untouched).
- Runtime: both forms — plain (`assign_for_bundle`/`assign_memberships_for_bundle`, metric-agnostic membership beam) and kernel (`code_from_bundle_dot`, every op counted; OpKernel gains `shr` under the shift class). Active iff the artifact carries dot tables.
- certify: witnesses + `eval_query_beam` run through the bundle-metric dispatch; the run prints the active assignment metric.

## The beam record (honest history, commits in order)

Runs 1-2 measured the beam row at 18.3/20.6 and I misdiagnosed it twice (cost scale; dot runner-up quality) — both hypotheses were patched into functions the measured row never called, and two certify runs were wasted confirming nothing. The actual mechanism: `eval_query_beam` derived **sign-metric** membership prefixes and probed a **dot-keyed** store — pure key-space mismatch. With metric-consistent memberships the beam **helps** (30.7/34.3 vs 30.6/34.2, WB 9.02 vs 9.64), so #244's beam decision shape stands. Casey's interim beam-off approval was made on the faulty diagnosis and is superseded by this measurement.

## ⚑ For review (Casey)

- **Op budget**: dot scan ≈ 612k adds + 612k shifts per token vs ~46k on the sign path (~13×, over the design doc's ≤2× flag; all single-cycle integer ops). Mitigations, in cost order: 1-term po2 tables (measured equal accuracy in f32 emulation, halves ops), per-stage early exit, #277 VP-tree over the dot metric (the structural fix). None block this PR; certify wall-clock is unchanged.
- **A-multi ablation row** now reads 17.2/19.2 — it still fans out writes via sign memberships against the dot store (metric-inconsistent by construction). It is a non-shipped ablation; flagging rather than fixing here.

Phase C (TLA6 default + κ re-pin + serving/score signature-path adoption + BASELINE table) follows per the design doc's phasing; it also closes #230 (fragmentation resolves at 47.5k keys with higher accuracy).

Logs: /tmp/i243-kernel{,2,3,4}-certify.log (Casey's Mac).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cWTa3B7xnsk6wygnfgL7o