### PR TITLE
feat(score): #234 — Rule 2 EXCT precedence fires at full code only

### DIFF
--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -5,9 +5,13 @@
 //!
 //! ```text
 //! Rule 2 (D4 EXCT precedence): S(v) = B(v) + ΔX(X,v)
-//!     when the deepest-populated-prefix EXCT probe resolves with total
-//!     evidence ≥ EXCT_SUPPORT_MIN — exact-context evidence dominates and
-//!     graph residuals are skipped entirely (status ExactContext).
+//!     when the EXCT probe resolves at the FULL graded code (level ==
+//!     STAGES) with total evidence ≥ EXCT_SUPPORT_MIN — strict
+//!     exact-context evidence dominates and graph residuals are skipped
+//!     entirely (status ExactContext). A probe that resolves below full
+//!     depth is prefix backoff, not exact context (#234, maintainer
+//!     decision 2026-07-29): it is recorded in the witness but admits
+//!     nothing, and the position falls through to Rule 1.
 //! Rule 1 (chain-telescoped):   S_graph(v) = T_selected(v) + ΔT-offset
 //!     with T_r(v) = B(v) + Σ_{n ∈ chain(r)} ΔE(n,v) over the covered
 //!     refinement chain of the selected active region (status Graph, or
@@ -152,11 +156,12 @@ pub const TOP_M: usize = 3;
 pub const RESIDUAL_EXCT_MAGIC: [u8; 4] = *b"RX1\0";
 
 /// Rule 2 (D4 EXCT precedence) support gate: the exact-context evidence
-/// dominates the graph residuals only when the probed deepest-populated
-/// prefix's total evidence count reaches this bound; below it the probe
-/// is recorded (admitted 0) and the chain-telescoped Rule 1 score
-/// decides. The value 5 matches the baseline's confident-prefix regime:
-/// a prefix with fewer observations is too thin to outrank compressed
+/// dominates the graph residuals only when the probe resolves at the
+/// FULL graded code (#234 maintainer decision, 2026-07-29) AND its
+/// total evidence count reaches this bound; otherwise the probe is
+/// recorded (admitted 0) and the chain-telescoped Rule 1 score decides.
+/// The value 5 matches the baseline's confident-prefix regime: a
+/// context with fewer observations is too thin to outrank compressed
 /// graph residuals (issue #64; the gate is witness-recorded, so the
 /// threshold is part of the replayed semantics).
 pub const EXCT_SUPPORT_MIN: u32 = 5;
@@ -553,9 +558,9 @@ pub struct ExctProbe {
 /// consumes this status per decision D4). Recorded in every witness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScoreStatus {
-    /// Rule 2 fired: the EXCT probe resolved with total evidence ≥
-    /// [`EXCT_SUPPORT_MIN`]; `S(v) = B(v) + ΔX(X,v)`, graph residuals
-    /// skipped entirely.
+    /// Rule 2 fired: the EXCT probe resolved at the FULL graded code
+    /// (#234) with total evidence ≥ [`EXCT_SUPPORT_MIN`];
+    /// `S(v) = B(v) + ΔX(X,v)`, graph residuals skipped entirely.
     ExactContext,
     /// Rule 1 fired with a non-empty selected covered chain:
     /// `S(v) = B(v) + Σ_{chain} ΔE + ΔT-offset`.
@@ -1118,7 +1123,12 @@ impl GraphScorer {
             if let Some(residual_exct) = &self.residual_exct {
                 for level in (0..=STAGES).rev() {
                     if let Some(context) = residual_exct[level].get(&code[..level]) {
-                        let supported = context.total >= EXCT_SUPPORT_MIN;
+                        // #234 maintainer decision (2026-07-29): Rule 2
+                        // fires at FULL CODE ONLY. A probe that resolves
+                        // below level STAGES is prefix backoff, not exact
+                        // context; it is recorded in the witness but never
+                        // admits evidence or preempts the graph.
+                        let supported = level == STAGES && context.total >= EXCT_SUPPORT_MIN;
                         let admitted = if supported {
                             context.entries.len().min(self.exct_top_x) as u32
                         } else {
@@ -1150,7 +1160,8 @@ impl GraphScorer {
                         let mut ranked: Vec<(u32, u32)> =
                             dist.iter().map(|(&t, &c)| (t, c)).collect();
                         ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-                        let supported = total >= EXCT_SUPPORT_MIN;
+                        // #234: full code only (see the RX1 branch above).
+                        let supported = level == STAGES && total >= EXCT_SUPPORT_MIN;
                         let mut admitted = 0u32;
                         if supported {
                             for &(token, count) in ranked.iter().take(self.exct_top_x) {
@@ -1898,7 +1909,9 @@ impl GraphScorer {
             let code = assign_code_plain(art, sig);
             for level in (0..=STAGES).rev() {
                 if let Some(context) = residual_exct[level].get(&code[..level]) {
-                    let supported = context.total >= EXCT_SUPPORT_MIN;
+                    // #234 maintainer decision: Rule 2 fires at FULL
+                    // CODE ONLY (reference parity with score_candidates).
+                    let supported = level == STAGES && context.total >= EXCT_SUPPORT_MIN;
                     let admitted = if supported {
                         context.entries.len().min(self.exct_top_x)
                     } else {

--- a/docs/transformerless/gate_c_pinned.json
+++ b/docs/transformerless/gate_c_pinned.json
@@ -1,10 +1,10 @@
 {
   "schema": 1,
   "purpose": "Pinned Gate C quality record for the CI trend alarm (issue #77). The alarm fails when a run regresses beyond the thresholds below vs THIS record. Bump deliberately, maintainer-only, like the kappa baseline.",
-  "pinned_at": "2026-07-29",
-  "pinned_from": "Rule 1+2 chain-telescoped + EXCT precedence, add-one smoothing, fixture corpus. Era note (#281): re-pinned for single-key store + read-time query-beam (the #244 decision); fixture price top-1 -1.7pp, rule12 +0.375 bits, tla3-baseline +0.478 bits; D3 price +-0.0pp / +0.087 bits at 2.56x fewer keys (PR #283 disclosure). Thresholds unchanged.",
-  "rule12_top1_agreement": 0.30024,
-  "rule12_bits_per_token": 10.23571,
+  "pinned_at": "2026-07-30",
+  "pinned_from": "Rule 1+2 chain-telescoped + EXCT precedence (FULL CODE ONLY), add-one smoothing, fixture corpus. Era note (#234): re-pinned for the Rule 2 full-code-only maintainer decision (Casey, 2026-07-29) — sub-full-depth EXCT resolutions are prefix backoff and no longer preempt the graph. The honest row prices the change at rule12 -8.97pp / +2.2946 bits vs the #281-era tie: status split ExactContext 14,919 / Graph 15,080 / Novel 37 (per-status: exact 41.1%/8.55, graph 1.23%/16.47). Deliberate and accepted on the #234 record: Gate C now measures the graph path instead of restating exact-context recall, and the graph row is the number to improve. TLA3 baseline unchanged. Prior era (#281): single-key store + read-time query-beam re-pin, PR #283 disclosure. Thresholds unchanged.",
+  "rule12_top1_agreement": 0.21055,
+  "rule12_bits_per_token": 12.53034,
   "baseline_top1_agreement": 0.30024,
   "baseline_bits_per_token": 12.356403,
   "alarm": {

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -169,8 +169,9 @@ fn hand_emissions() -> EmissionTables {
 
 /// The signature-level fixture: two depth-1 regions at the all-zeros and
 /// all-ones extremes (radius 4), exact-context evidence attached to the
-/// covered signature's class prefix only, so one fixture exercises all
-/// three resolution statuses deterministically:
+/// covered signature's FULL graded code only (#234: Rule 2 fires at full
+/// code only), so one fixture exercises all three resolution statuses
+/// deterministically:
 /// - `covered_sig` ([0x00; _]) → ExactContext (support ≥ EXCT_SUPPORT_MIN),
 /// - `graph_sig` ([0xFF; _]) → Graph,
 /// - `ood_sig` (144 of 288 bits set) → Novel (distance 144 from both
@@ -184,20 +185,19 @@ pub fn signature_fixture(status_policy_override: Option<serde_json::Value>) -> P
         *byte = 0xFF;
     }
 
-    // Exact-context evidence: one populated prefix for the covered
-    // signature only, with total ≥ EXCT_SUPPORT_MIN. Choose the shallowest
-    // level whose prefix distinguishes the covered probe from the other two.
+    // Exact-context evidence: the covered signature's FULL graded code
+    // only, with total ≥ EXCT_SUPPORT_MIN. Rule 2 fires at full code
+    // only (#234, maintainer decision 2026-07-29) — a shallower prefix
+    // would be recorded as backoff and resolve Graph, not ExactContext.
     let codes =
         [covered_sig, graph_sig, ood_sig].map(|sig| runtime::assign_plain(&artifacts, &sig));
-    let level = (1..=STAGES)
-        .find(|&level| {
-            let covered = &codes[0][..level];
-            covered != &codes[1][..level] && covered != &codes[2][..level]
-        })
-        .expect("a distinguishing EXCT level exists");
+    assert!(
+        codes[0] != codes[1] && codes[0] != codes[2],
+        "the covered probe's full code must distinguish it from the graph/ood probes"
+    );
     let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
-    store[level].insert(
-        codes[0][..level].to_vec(),
+    store[STAGES].insert(
+        codes[0].to_vec(),
         [(10u32, EXCT_SUPPORT_MIN + 1)].into_iter().collect(),
     );
 


### PR DESCRIPTION
## Summary

Implements the maintainer decision recorded on #234 (Casey, 2026-07-29): Rule 2 EXCT precedence fires only when the probe resolves at the FULL graded code (level == STAGES) with support ≥ EXCT_SUPPORT_MIN. Sub-full-depth resolutions are prefix backoff: still recorded in the witness (level/total, admitted 0), but they admit no evidence and no longer preempt the graph — the position falls through to Rule 1. Both live probe surfaces change together (score_candidates + streaming step scorer); witness replay rebuilds a fresh scorer and stays consistent by construction (64/64 replays ok on the evidence run); the legacy Σ-over-cloud comparison path is intentionally unchanged.

## The honest Gate C row (pinned fixture harness, 30,036 held-out)

| | before (tie) | after (honest) |
|---|---|---|
| status split | ExactContext 30,036 / 0 / 0 | ExactContext 14,919 / Graph 15,080 / Novel 37 |
| Rule 1+2 blended | 30.02% / 10.24 bits | **21.05% / 12.53 bits** |
| per-status exact | 30.02% / 10.24 | 41.11% / 8.55 |
| per-status graph | — (never exercised) | **1.23% / 16.47** |
| win/loss vs baseline | 0 / 0 (identical argmax) | 117 scorer-only / 2,811 baseline-only |

The regression vs the old tie is the accepted, recorded consequence: Gate C now measures the graph path's actual contribution on the ~50% strict-miss slice instead of restating exact-context recall. The ExactContext split at 14,919 equals the probe-level histogram's L4 count exactly (#293's instrumentation) — the two changes cross-verify.

Serving statuses shift accordingly (Graph/Novel → D4 policy where prefix backoff used to serve as EXCT); the C serving row re-measures under #243 Phase C adoption.

Advances #234 (with #293); the graph-path number (1.2%) is now the one to improve.