### PR TITLE
batch-3: #268 replay fix + candidate-3 arms (measured), R4_CERTIFY_ROWS_ONLY fast mode

### DIFF
--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -889,6 +889,19 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         m.top1, m.agree, m.wb_bits, m.keys
     );
 
+    // ---- R4_CERTIFY_ROWS_ONLY: fast measurement iteration. Everything
+    // above is the decision-row matrix (equality witnesses, op census,
+    // A/B rows and their ablations); everything below is the P5
+    // compression witness suite and the long-context certification,
+    // which do not move when a row experiment changes. The skip is
+    // recorded, never silent — a rows-only log is not a certificate.
+    if std::env::var("R4_CERTIFY_ROWS_ONLY").is_ok_and(|value| value != "0") {
+        println!(
+            "R4_CERTIFY_ROWS_ONLY set: compression witnesses (P5) and long-context certification SKIPPED — rows-only run, not a full certificate. No measurement recorded for the skipped sections."
+        );
+        return;
+    }
+
     // ---- C: serving surface (issue #280)
     // The former C row here measured the `convert_r4g1` scaffold, which
     // was never a functional prediction path (issue #280 diagnosis); its

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1483,13 +1483,24 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
         class
     };
     let start_eval_time = std::time::Instant::now();
-    for index in 0..corpus.n {
-        if index % 1000 == 0 || index + 1 == corpus.n {
-            let pct = (index as f64 / corpus.n as f64) * 100.0;
+    // #268 fix: story-contiguous replay. The record stream interleaves
+    // stories in short runs (measured mean run length 9.2 tokens on the
+    // D3 bundle), so replaying in stream order cold-started the oracle
+    // every few tokens — ~4.6-token mean effective context, which is
+    // what the 13.4-bit "teacher floor" was actually measuring. Group
+    // positions by story (stable sort keeps in-story stream order) and
+    // reset only at true story boundaries. The position-in-story
+    // decomposition slices double as verification: bands beyond 8-15
+    // populate iff grouping reconstructed real contexts.
+    let mut replay_order: Vec<usize> = (0..corpus.n).collect();
+    replay_order.sort_by_key(|&position| corpus.story[position]);
+    for (done, &index) in replay_order.iter().enumerate() {
+        if done % 1000 == 0 || done + 1 == corpus.n {
+            let pct = (done as f64 / corpus.n as f64) * 100.0;
             let elapsed = start_eval_time.elapsed().as_secs();
             println!(
                 "progress: evaluated {}/{} positions ({:.1}%, {}s)",
-                index, corpus.n, pct, elapsed
+                done, corpus.n, pct, elapsed
             );
         }
         if current_story != Some(corpus.story[index]) {

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -68,6 +68,14 @@ struct EvaluateReportOptions {
     compiled: PathBuf,
     report: Option<PathBuf>,
     sequence_length: usize,
+    /// #268 candidate 3 (prompt framing): prepend the source tokenizer's
+    /// BOS token at every held-out story boundary before teacher-forcing.
+    bos: bool,
+    /// Smoke-run cap: evaluate only the first N held-out stories. The
+    /// report is stamped as a SMOKE run and its numbers are not quotable;
+    /// this exists so a change can be verified to sit in the measured
+    /// path before a full run is spent on it.
+    max_held_out_stories: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1147,6 +1155,9 @@ struct EvaluationSource {
     directory: String,
     cid: String,
     sequence_length: usize,
+    /// #268 candidate 3: whether a BOS token was prepended at every
+    /// held-out story boundary during teacher-forcing (schema 3).
+    bos_prefix: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -1278,10 +1289,17 @@ fn parse_evaluate_report_options(args: &[String]) -> Result<EvaluateReportOption
         compiled: PathBuf::from(DEFAULT_HF_COMPILED_PATH),
         report: None,
         sequence_length: 128,
+        bos: false,
+        max_held_out_stories: None,
     };
     let mut index = 0usize;
     while index < args.len() {
         let flag = &args[index];
+        if flag == "--bos" {
+            options.bos = true;
+            index += 1;
+            continue;
+        }
         let value = args
             .get(index + 1)
             .ok_or_else(|| format!("missing value for {flag}"))?;
@@ -1296,6 +1314,15 @@ fn parse_evaluate_report_options(args: &[String]) -> Result<EvaluateReportOption
                 if options.sequence_length == 0 {
                     return Err("--sequence-length must be greater than zero".to_owned());
                 }
+            }
+            "--max-held-out-stories" => {
+                let limit: u32 = value
+                    .parse()
+                    .map_err(|_| format!("invalid --max-held-out-stories value: {value}"))?;
+                if limit == 0 {
+                    return Err("--max-held-out-stories must be greater than zero".to_owned());
+                }
+                options.max_held_out_stories = Some(limit);
             }
             _ => return Err(format!("unknown evaluate-report option: {flag}")),
         }
@@ -1408,8 +1435,14 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
         )
     })?;
     let held_out_cut = compiler::train_cut(&corpus);
+    // --bos occupies one oracle position per story, so a full
+    // `sequence_length`-token story needs one extra cache slot. The
+    // extra slot is buffer capacity only (RoPE is absolute, attention is
+    // causal over cached positions); it does not change the arithmetic
+    // of the no-BOS arms.
+    let oracle_sequence_length = options.sequence_length + usize::from(options.bos);
     let mut oracle =
-        HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, options.sequence_length)
+        HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, oracle_sequence_length)
             .map_err(|error| format!("failed to load Hugging Face model: {error}"))?;
     let mut teacher_logits = vec![0f32; oracle.vocab()];
     let artifacts_bytes = std::fs::read(&artifacts_path).map_err(|error| error.to_string())?;
@@ -1494,6 +1527,13 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
     // populate iff grouping reconstructed real contexts.
     let mut replay_order: Vec<usize> = (0..corpus.n).collect();
     replay_order.sort_by_key(|&position| corpus.story[position]);
+    // #268 candidate 3 (prompt framing): optionally prepend BOS at every
+    // held-out story boundary. `oracle_position` is the oracle's RoPE
+    // position (includes the BOS step when enabled); `story_position`
+    // keeps counting evaluated corpus tokens only, so the
+    // position-in-story decomposition bands stay comparable across arms.
+    let bos_token = oracle.bos_token();
+    let mut oracle_position = 0usize;
     for (done, &index) in replay_order.iter().enumerate() {
         if done % 1000 == 0 || done + 1 == corpus.n {
             let pct = (done as f64 / corpus.n as f64) * 100.0;
@@ -1503,19 +1543,32 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
                 done, corpus.n, pct, elapsed
             );
         }
+        if let Some(limit) = options.max_held_out_stories {
+            // Replay order is story-sorted, so the first story past the
+            // cap ends the smoke run.
+            if corpus.story[index] >= held_out_cut.saturating_add(limit) {
+                break;
+            }
+        }
         if current_story != Some(corpus.story[index]) {
             current_story = Some(corpus.story[index]);
             story_position = 0;
+            oracle_position = 0;
             oracle.reset();
+            if options.bos && corpus.story[index] >= held_out_cut {
+                oracle.step(bos_token, oracle_position, &mut teacher_logits);
+                oracle_position += 1;
+            }
         }
         if corpus.story[index] < held_out_cut {
             continue;
         }
         oracle.step(
             corpus.input[index] as usize,
-            story_position,
+            oracle_position,
             &mut teacher_logits,
         );
+        oracle_position += 1;
         story_position += 1;
         held_out_tokens += 1;
         let code = runtime::code_plain(&artifacts, &rotations, &corpus, index);
@@ -1646,10 +1699,16 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
         println!("  by {}: {}", group.0, rows.join(" | "));
     }
 
+    let distribution_name = match options.max_held_out_stories {
+        None => "D3-held-out".to_owned(),
+        Some(limit) => format!(
+            "D3-held-out SMOKE (first {limit} held-out stories; path-verification only, numbers not quotable)"
+        ),
+    };
     let report = EvaluationReport {
-        schema: 2,
+        schema: 3,
         distribution: EvaluationDistribution {
-            name: "D3-held-out".to_owned(),
+            name: distribution_name,
             split: "compiler::train_cut 80/20 by story id".to_owned(),
             held_out_tokens,
         },
@@ -1657,6 +1716,7 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
             directory: options.source.display().to_string(),
             cid: source_cid,
             sequence_length: options.sequence_length,
+            bos_prefix: options.bos,
         },
         artifacts: EvaluationArtifacts {
             directory: options.compiled.display().to_string(),
@@ -1692,6 +1752,14 @@ fn evaluate_report(args: &[String]) -> Result<(), String> {
         "evaluation report written: {} ({})",
         report_path.display(),
         report_cid
+    );
+    println!(
+        "arm: source={} | bos_prefix={} | held-out stories={}",
+        options.source.display(),
+        options.bos,
+        options
+            .max_held_out_stories
+            .map_or("all".to_owned(), |limit| format!("first {limit} (SMOKE)"))
     );
     println!(
         "held-out D3 metrics: top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token (teacher floor {:.4}, +{:.4})",
@@ -2002,7 +2070,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                  observation pipeline: observe [--source DIR | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR | --checkpoint BIN] [--tokenizer PATH] [--sequence-length N]\n\
                  quantum operations: cd-compile | quantum-eval\n\
-                 hf evaluation: evaluate-report [--source DIR] [--compiled DIR] [--report PATH] [--sequence-length N]\n\
+                 hf evaluation: evaluate-report [--source DIR] [--compiled DIR] [--report PATH] [--sequence-length N] [--bos] [--max-held-out-stories N]\n\
                  docs: docs/TRANSFORMERLESS.md (extrapolation), docs/PROOF.md (proof + certificate)"
             );
         }
@@ -2143,6 +2211,8 @@ mod tests {
         assert_eq!(options.compiled, PathBuf::from(DEFAULT_HF_COMPILED_PATH));
         assert_eq!(options.sequence_length, 128);
         assert_eq!(options.report, None);
+        assert!(!options.bos);
+        assert_eq!(options.max_held_out_stories, None);
     }
 
     #[test]
@@ -2156,6 +2226,9 @@ mod tests {
             "/tmp/out.json",
             "--sequence-length",
             "256",
+            "--bos",
+            "--max-held-out-stories",
+            "5",
         ]
         .map(str::to_owned);
         let options = parse_evaluate_report_options(&args).expect("valid options");
@@ -2163,6 +2236,8 @@ mod tests {
         assert_eq!(options.compiled, PathBuf::from("/tmp/compiled"));
         assert_eq!(options.report, Some(PathBuf::from("/tmp/out.json")));
         assert_eq!(options.sequence_length, 256);
+        assert!(options.bos);
+        assert_eq!(options.max_held_out_stories, Some(5));
     }
 
     #[test]
@@ -2178,6 +2253,7 @@ mod tests {
                 directory: ".uor-models/sources/smollm2-135m-instruct".to_owned(),
                 cid: "blake3:1111".to_owned(),
                 sequence_length: 256,
+                bos_prefix: false,
             },
             artifacts: EvaluationArtifacts {
                 directory: ".uor-models/compiled/smollm2-135m-instruct".to_owned(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,7 +570,13 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             let checkpoint = reference_checkpoint_path()?;
             let oracle = uor_r4_model_source::LlamaOracle::load(&checkpoint);
             uor_r4_graph_certify::certify::certify(&oracle);
-            certify_serving_row();
+            if std::env::var("R4_CERTIFY_ROWS_ONLY").is_ok_and(|value| value != "0") {
+                println!(
+                    "R4_CERTIFY_ROWS_ONLY set: C serving row SKIPPED — rows-only run, not a full certificate. No measurement recorded."
+                );
+            } else {
+                certify_serving_row();
+            }
             Ok(())
         }
         Some(Command::Compare) => {


### PR DESCRIPTION
## Summary

Three commits, all evidence posted on #268:

1. **#268 story-contiguous replay fix** — the 13.4-bit "teacher floor" was measuring stream interleaving (~4.6-token mean effective context), not the teacher. Stable-sort by story, reset only at article boundaries. Measured: floor 13.446 → 11.651; band counts match article structure; context gradient clean and monotone.
2. **R4_CERTIFY_ROWS_ONLY fast mode** — promised on the batch-2 record: rows-only certify with recorded skips for the P5 compression witnesses, long-context certification, and the C serving row. A rows-only log is not a certificate and says so.
3. **#268 candidate-3 arms** — `evaluate-report --bos` (BOS at every held-out story boundary; oracle cache sized seq_len+1 in BOS mode — the smoke gate caught the pos-128 panic on exactly-sized att/KV buffers) and `--max-held-out-stories N` smoke cap (reports stamped SMOKE, not quotable). Report schema 2→3 (`source.bos_prefix`). **Measured (4 arms, one run, posted on #268): BOS retired (+0.04 bits both checkpoints); base vs instruct −0.48 bits concentrated in bands 0-15; floor quotable as 11.17 (base) / full-context band ~10.8, checkpoint- and framing-robust.** Store metrics bit-identical across arms — correct invariant.

#268 stays open: the external-referee experiment (same text, same checkpoint, outside the pipeline) is proposed on the issue to decide whether the remaining ~10.8-bit full-context floor is ours or the model's.