### PR TITLE
chore(process): preflight parity gate, two-mode trend check, build-isolation conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,17 @@ jobs:
             --corpus-recs crates/uor-r4-core/tests/fixtures/c_recs.bin \
             --artifacts crates/uor-r4-core/tests/fixtures/tless_artifacts.bin \
             --out trend_output
-          ./scripts/check_gate_c_regression.py trend_output/score_report.json
+          # Base pin for the two-mode check (regression vs re-pin
+          # self-consistency; see scripts/check_gate_c_regression.py):
+          # a PR that re-pins with an era note is validated against its
+          # OWN measured row, so re-pins travel in the PR that prices
+          # them and merge order stops mattering.
+          git fetch --depth=1 origin main
+          if git show FETCH_HEAD:docs/transformerless/gate_c_pinned.json > /tmp/base_pin.json 2>/dev/null; then
+            ./scripts/check_gate_c_regression.py trend_output/score_report.json --base-pin /tmp/base_pin.json
+          else
+            ./scripts/check_gate_c_regression.py trend_output/score_report.json
+          fi
 
       - name: Upload Gate C trend JSON
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,41 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
 
 ## Process conventions
 
+- **Preflight before EVERY push (2026-07-30, after a night that lost ~an hour
+  per miss): `./scripts/preflight.sh`** runs the exact
+  `fmt / clippy / tests / no_std / κ` CI gate locally — including
+  `cargo fmt --check`, clippy with `--all-targets --all-features` (plain
+  `--workspace` clippy passes things CI rejects), the full test ladder, and
+  the Gate C trend harness. A push without a green preflight is how PRs die
+  in the merge queue 5 minutes after you stop watching. `PREFLIGHT_FAST=1`
+  exists for the inner loop; never push on a fast-only pass.
+- **Build isolation: one target dir per worktree.** Preflight enforces this
+  (worktree-local `target/`). Sharing one warm `CARGO_TARGET_DIR` across
+  worktrees caused three stale-binary incidents in one night — cargo can
+  link a sibling worktree's rlib (fields missing at compile time, or worse,
+  an evidence binary printing the other branch's strings). First build per
+  worktree is cold; after that it's warm and uncontaminable. If you must
+  share a target for a one-off, `touch` the changed crate's sources and
+  verify the produced binary by a string only the new code prints.
+- **Enqueue is not merged.** `gh pr merge N --squash` prints "merge strategy
+  set by queue" even when the PR is failing head CI and never entered the
+  queue. After every enqueue: `gh pr checks N`, and arm a watch (the merge
+  queue's own `merge_group` runs do NOT appear on head-SHA checks). A
+  force-push or amend clears the queue entry — re-check and re-enqueue after
+  every push.
+- **Measured-row pins (gate_c_pinned.json): re-pin IN the PR that changes
+  the row.** The trend check is two-mode (see
+  scripts/check_gate_c_regression.py): pin unchanged vs base → regression
+  alarm; pin changed → the new pin must match the PR's own measured row
+  (self-consistency, both directions). Era note in `pinned_from` always.
+  This makes re-pins merge-order-independent; do NOT sequence PRs around
+  the pin file by hand.
+- **Science/measurement runs: pin the binary, assert freshness.** Every
+  background run script copies its binary to a run-stamped name at build
+  time and asserts a marker only the new code can produce (an op-census
+  value, a new stdout string) before results count. A run whose census
+  matches the previous era measured the previous era.
+
 - **Merge workflow (since 2026-07-22): NO direct pushes to `main`.** A ruleset
   ("main: required checks", id 19597522) protects `main`: all changes land via
   PR, and the five CI checks (`fmt / clippy / tests / no_std / κ`,

--- a/scripts/check_gate_c_regression.py
+++ b/scripts/check_gate_c_regression.py
@@ -1,61 +1,111 @@
 #!/usr/bin/env python3
+"""Gate C trend check (issue #77; reworked 2026-07-30, process fix).
+
+Two modes, chosen automatically:
+
+REGRESSION (pin unchanged vs base): the measured row must not regress
+beyond the alarm thresholds relative to the pinned record — the
+original trend alarm.
+
+RE-PIN SELF-CONSISTENCY (this revision's pin differs from the base
+revision's pin): the PR is deliberately accepting a new row (semantic
+change + era note, maintainer-priced). The check then verifies the NEW
+pin honestly matches the measured row within the alarm thresholds in
+BOTH directions — a stale, optimistic, or fat-fingered re-pin fails.
+
+Why: pinned-absolute-only checking coupled every accepted semantic
+change to merge-queue ordering gymnastics (2026-07-30: two PRs + a
+queue simulation + manual sequencing for one re-pin). With
+self-consistency mode, a re-pin travels IN the PR that changes the
+semantics, any merge order works, and the alarm still catches every
+unintended regression — an intended one is exactly a pin diff with an
+era note, which is what maintainer review reads.
+
+Usage:
+  check_gate_c_regression.py <score_report.json> [--base-pin <path>]
+
+--base-pin: the base revision's gate_c_pinned.json (CI passes
+`git show` output; preflight passes origin/main's copy). Omitted →
+regression mode against the working-tree pin (original behavior).
+"""
 import sys
 import json
-
-# Single source of truth for the pinned record and thresholds:
-# docs/transformerless/gate_c_pinned.json — shared with the trend-alarm
-# job (scripts/gate_c_trend.sh). Re-pins happen in that one file, with an
-# era note (#281 established the discipline after a dual-pin miss).
 import os
+
 _PIN_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "docs", "transformerless", "gate_c_pinned.json",
 )
-with open(_PIN_PATH) as _f:
-    _PIN = json.load(_f)
-PINNED_TOP1_AGREEMENT = _PIN["rule12_top1_agreement"]
-PINNED_BITS_PER_TOKEN = _PIN["rule12_bits_per_token"]
-MAX_TOP1_DROP = _PIN["alarm"]["top1_drop_abs"]
-MAX_BPT_WORSEN = _PIN["alarm"]["bits_regress_abs"]
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: check_gate_c_regression.py <path/to/score_report.json>")
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: check_gate_c_regression.py <path/to/score_report.json> [--base-pin <path>]")
         sys.exit(1)
+    report_path = args[0]
+    base_pin_path = None
+    if "--base-pin" in args:
+        base_pin_path = args[args.index("--base-pin") + 1]
 
-    report_path = sys.argv[1]
-    with open(report_path, 'r') as f:
-        report = json.load(f)
-    
-    rule12 = report.get('gate_c', {}).get('rule12_precedence')
+    pin = load(_PIN_PATH)
+    report = load(report_path)
+    rule12 = report.get("gate_c", {}).get("rule12_precedence")
     if not rule12:
         print("Error: 'rule12_precedence' metrics not found in the report.")
         sys.exit(1)
-        
-    top1 = rule12.get('top1_agreement', 0.0)
-    bpt = rule12.get('bits_per_token', 0.0)
-    
+    top1 = rule12.get("top1_agreement", 0.0)
+    bpt = rule12.get("bits_per_token", 0.0)
+    pin_top1 = pin["rule12_top1_agreement"]
+    pin_bpt = pin["rule12_bits_per_token"]
+    max_drop = pin["alarm"]["top1_drop_abs"]
+    max_worsen = pin["alarm"]["bits_regress_abs"]
+
+    repin = False
+    if base_pin_path:
+        try:
+            base = load(base_pin_path)
+            repin = (
+                base.get("rule12_top1_agreement") != pin_top1
+                or base.get("rule12_bits_per_token") != pin_bpt
+            )
+        except (OSError, json.JSONDecodeError):
+            print("note: base pin unreadable; falling back to regression mode")
+
     print(f"Gate C (Rule 1+2) Current: top-1={top1:.4f} ({top1*100:.1f}%), bits/token={bpt:.4f}")
-    print(f"Gate C (Rule 1+2) Pinned : top-1={PINNED_TOP1_AGREEMENT:.4f} ({PINNED_TOP1_AGREEMENT*100:.1f}%), bits/token={PINNED_BITS_PER_TOKEN:.4f}")
-    
+    print(f"Gate C (Rule 1+2) Pinned : top-1={pin_top1:.4f} ({pin_top1*100:.1f}%), bits/token={pin_bpt:.4f}")
+
     failed = False
-    
-    if top1 < (PINNED_TOP1_AGREEMENT - MAX_TOP1_DROP):
-        print(f"🚨 REGRESSION ALARM: top-1 agreement dropped by more than {MAX_TOP1_DROP*100:.1f} points!")
-        print(f"   Delta: {(top1 - PINNED_TOP1_AGREEMENT)*100:.2f} points")
-        failed = True
-        
-    if bpt > (PINNED_BITS_PER_TOKEN + MAX_BPT_WORSEN):
-        print(f"🚨 REGRESSION ALARM: bits/token worsened by more than {MAX_BPT_WORSEN:.2f}!")
-        print(f"   Delta: {bpt - PINNED_BITS_PER_TOKEN:+.4f} bits/token")
-        failed = True
-        
+    if repin:
+        print("Mode: RE-PIN SELF-CONSISTENCY (pin differs from base revision — era-note re-pin)")
+        if abs(top1 - pin_top1) > max_drop:
+            print(f"🚨 RE-PIN MISMATCH: measured top-1 differs from the new pin by {abs(top1 - pin_top1)*100:.2f} points (> {max_drop*100:.1f})")
+            failed = True
+        if abs(bpt - pin_bpt) > max_worsen:
+            print(f"🚨 RE-PIN MISMATCH: measured bits/token differs from the new pin by {abs(bpt - pin_bpt):.4f} (> {max_worsen:.2f})")
+            failed = True
+    else:
+        print("Mode: REGRESSION (pin unchanged vs base)")
+        if top1 < (pin_top1 - max_drop):
+            print(f"🚨 REGRESSION ALARM: top-1 agreement dropped by more than {max_drop*100:.1f} points!")
+            print(f"   Delta: {(top1 - pin_top1)*100:.2f} points")
+            failed = True
+        if bpt > (pin_bpt + max_worsen):
+            print(f"🚨 REGRESSION ALARM: bits/token worsened by more than {max_worsen:.2f}!")
+            print(f"   Delta: {bpt - pin_bpt:+.4f} bits/token")
+            failed = True
+
     if failed:
         print("Gate C regression check FAILED.")
         sys.exit(1)
-    else:
-        print("Gate C regression check PASSED.")
-        sys.exit(0)
+    print("Gate C regression check PASSED.")
+    sys.exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# preflight.sh — run the EXACT `fmt / clippy / tests / no_std / κ` CI gate
+# locally, before every push. One command; a green preflight means the only
+# CI surprises left are environment-level (network, runner), not code.
+#
+#   ./scripts/preflight.sh            # full gate (worktree-local target)
+#   PREFLIGHT_FAST=1 ./scripts/...    # skip the two slowest steps (trend
+#                                     # harness + BDD) for inner-loop use;
+#                                     # NEVER push on a fast-only pass.
+#
+# Build isolation (2026-07-30 process decision): preflight defaults to the
+# WORKTREE-LOCAL target dir. Sharing one CARGO_TARGET_DIR across worktrees
+# caused three stale-binary incidents in one night (cargo fingerprints can
+# resolve to another worktree's rlib for same-named crates); the first build
+# per worktree is cold, everything after is warm and CANNOT be contaminated
+# by builds from sibling worktrees. Set PREFLIGHT_TARGET to override.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+export CARGO_TARGET_DIR="${PREFLIGHT_TARGET:-$PWD/target}"
+echo "preflight: target dir $CARGO_TARGET_DIR"
+
+step() { echo; echo "== preflight: $1"; }
+
+step "claim-wording gate"
+python3 scripts/check_claim_wording.py
+
+step "inference contract audit"
+cargo test -q -p uor-r4-proof-model --lib inference_audit
+
+step "cargo fmt --check"
+cargo fmt --check
+
+step "cargo clippy (--all-targets --all-features -D warnings)  [CI parity: not just --workspace]"
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+step "workspace tests"
+if command -v cargo-nextest >/dev/null 2>&1; then
+  cargo nextest run --workspace -E 'not binary(bdd)'
+else
+  echo "(cargo-nextest not installed; falling back to cargo test)"
+  cargo test --workspace -q
+fi
+
+if [ -z "${PREFLIGHT_FAST:-}" ]; then
+  step "cucumber BDD suite"
+  cargo test -q --test bdd
+fi
+
+step "doc tests"
+cargo test -q --doc --workspace
+
+step "no_std ladder (graph-format)"
+cargo check -q -p uor-r4-graph-format --no-default-features
+
+step "deterministic rebuild (Gate E slice)"
+cargo test -q -p uor-r4-core --test deterministic_rebuild_test
+
+if [ -z "${PREFLIGHT_FAST:-}" ]; then
+  step "Gate C trend harness + regression/re-pin check (the one that ejects queue entries)"
+  rm -rf trend_output
+  cargo run -q --release --bin r4 -- transformerless score \
+    --corpus-meta crates/uor-r4-core/tests/fixtures/c_meta.bin \
+    --corpus-recs crates/uor-r4-core/tests/fixtures/c_recs.bin \
+    --artifacts crates/uor-r4-core/tests/fixtures/tless_artifacts.bin \
+    --out trend_output >/dev/null
+  BASE_PIN=$(git show origin/main:docs/transformerless/gate_c_pinned.json 2>/dev/null || true)
+  if [ -n "$BASE_PIN" ]; then
+    ./scripts/check_gate_c_regression.py trend_output/score_report.json \
+      --base-pin <(echo "$BASE_PIN")
+  else
+    ./scripts/check_gate_c_regression.py trend_output/score_report.json
+  fi
+fi
+
+if [ -f /tmp/ref/out/model.bin ]; then
+  step "κ-reproduction (checkpoint present)"
+  TLESS_CHECKPOINT=/tmp/ref/out/model.bin cargo test -q -p uor-r4-core --release --test kappa_reproduction -- --ignored
+else
+  echo "== preflight: κ-reproduction SKIPPED (no /tmp/ref/out/model.bin — vacuous green, see AGENTS.md)"
+fi
+
+echo
+echo "preflight: ALL GATES GREEN — safe to push"


### PR DESCRIPTION
## Summary

Ends three recurring waste classes structurally (details in the commit message and AGENTS.md):

- **`scripts/preflight.sh`** — the exact CI gate locally, one command, before every push. Includes the two checks that ejected PRs from the merge queue tonight (fmt-check, trend harness) and the clippy `--all-targets --all-features` parity gap. Worktree-local target dir by default.
- **Two-mode Gate C trend check** — regression mode when the pin is untouched; re-pin self-consistency mode when a PR re-pins (its own measured row must match the new pin, both directions). Era re-pins now travel inside the PR that prices them and are merge-order-independent. All three modes verified locally.
- **AGENTS.md process conventions** — preflight-before-push, per-worktree build isolation (three stale-binary incidents in one night), enqueue≠merged watching discipline, science-run binary freshness asserts.

Self-tested: pushed only after its own preflight ran ALL GATES GREEN (κ-reproduction included).