### PR TITLE
feat(score): #243 Phase C part 2 — witness-attested graded codes (option A) + metric-consistent trend re-pin

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -497,10 +497,16 @@ impl R4Engine {
         self.counters
     }
 
-    /// Derive the packed input signature of a token window.
-    fn derive_sig(&self, window: &[u32]) -> [u8; SIG_BYTES] {
+    /// Derive the packed input signature AND the graded code of a token
+    /// window (#243 Phase C option A): the code is assigned under the
+    /// artifact's declared metric (`assign_for_bundle` — shift-add dot
+    /// on TLA6, sign-Hamming otherwise) and attested into the witness;
+    /// the sig keys the cover memberships either way.
+    fn derive_sig_code(&self, window: &[u32]) -> ([u8; SIG_BYTES], [u8; compiler::STAGES]) {
         let bundle = runtime::bundle_window_plain(&self.artifacts, &self.rotations, window);
-        runtime::sig_plain(&self.artifacts, &bundle)
+        let sig = runtime::sig_plain(&self.artifacts, &bundle);
+        let code = runtime::assign_for_bundle(&self.artifacts, &bundle);
+        (sig, code)
     }
 
     /// Reject a window carrying a token id the teacher artifact cannot
@@ -530,13 +536,14 @@ impl R4Engine {
     fn score_sig(
         &mut self,
         sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
         top_m: usize,
         recent_tokens: &[u32],
     ) -> Result<ScoredProbe, InferenceError> {
         if self.step_supported {
             let outcome = self
                 .scorer
-                .score_step_with_recent(sig, top_m, &mut self.step, recent_tokens)
+                .score_step_coded_with_recent(sig, input_code, top_m, &mut self.step, recent_tokens)
                 .map_err(InferenceError::Scorer)?;
             Ok(ScoredProbe {
                 token: outcome.selected,
@@ -545,7 +552,7 @@ impl R4Engine {
         } else {
             let outcome = self
                 .scorer
-                .score_candidates(sig, recent_tokens)
+                .score_candidates_coded(sig, input_code, recent_tokens)
                 .map_err(InferenceError::Scorer)?;
             Ok(ScoredProbe {
                 token: outcome.selected,
@@ -563,16 +570,17 @@ impl R4Engine {
         &mut self,
         sig: &[u8; SIG_BYTES],
     ) -> Result<PredictDecision, InferenceError> {
-        self.predict_signature_status_with_recent(sig, &[])
+        self.predict_signature_status_with_recent(sig, None, &[])
     }
 
     fn predict_signature_status_with_recent(
         &mut self,
         sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
         recent_tokens: &[u32],
     ) -> Result<PredictDecision, InferenceError> {
         self.counters.predicts += 1;
-        let first = self.score_sig(sig, TOP_M, recent_tokens)?;
+        let first = self.score_sig(sig, input_code, TOP_M, recent_tokens)?;
         match self.policy.action(first.status.into()) {
             StatusAction::Serve => {
                 self.counters.serves += 1;
@@ -608,7 +616,7 @@ impl R4Engine {
                     }));
                 }
                 self.counters.widen_attempts += 1;
-                let second = self.score_sig(sig, WIDENED_TOP_M, recent_tokens)?;
+                let second = self.score_sig(sig, input_code, WIDENED_TOP_M, recent_tokens)?;
                 if second.status == ScoreStatus::Novel {
                     self.novel_seen.insert(sig);
                 }
@@ -635,7 +643,8 @@ impl R4Engine {
     /// no guessed token is emitted.
     pub fn predict_decision(&mut self, window: &[u32]) -> Result<PredictDecision, InferenceError> {
         self.check_window(window)?;
-        self.predict_signature_status_with_recent(&self.derive_sig(window), window)
+        let (sig, code) = self.derive_sig_code(window);
+        self.predict_signature_status_with_recent(&sig, Some(&code), window)
     }
 
     /// Score one token window into a caller-owned output slot. Mirrors

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -505,7 +505,11 @@ impl R4Engine {
     fn derive_sig_code(&self, window: &[u32]) -> ([u8; SIG_BYTES], [u8; compiler::STAGES]) {
         let bundle = runtime::bundle_window_plain(&self.artifacts, &self.rotations, window);
         let sig = runtime::sig_plain(&self.artifacts, &bundle);
-        let code = runtime::assign_for_bundle(&self.artifacts, &bundle);
+        // Allocation-free variant: steady-state serving is censused
+        // (tests/status_policy_census.rs) — the membership-beam
+        // materializing assign_for_bundle allocates and must not be
+        // called per prediction.
+        let code = runtime::assign_code_for_bundle(&self.artifacts, &bundle);
         (sig, code)
     }
 

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -510,6 +510,51 @@ pub fn assign_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
     assign_memberships_for_bundle(art, bundle).0
 }
 
+/// Allocation-free plain code assignment for a bundle under the
+/// artifact's declared metric (#243 Phase C): per-stage argmax only —
+/// no membership-beam materialization, so the steady-state serving
+/// path (`R4Engine::derive_sig_code`, allocation-censused by
+/// tests/status_policy_census.rs) stays allocation-free. Tie rule
+/// matches `dot_stage_top` (strict improvement, lowest class index),
+/// so the code equals `assign_for_bundle`'s primary code.
+pub fn assign_code_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
+    if art.dot_cb.is_empty() {
+        // Sign metric, argmax only — assign_plain delegates to the
+        // membership-beam builder and allocates; this path must not.
+        let sig = sig_plain(art, bundle);
+        let mut code = [0u8; STAGES];
+        for (st_code, sigs) in code.iter_mut().zip(art.class_sigs.iter()) {
+            let mut best = u32::MAX;
+            let mut best_class = 0u8;
+            for (class, cs) in sigs.chunks_exact(SIG_BYTES).enumerate() {
+                let dist =
+                    crate::transformerless::simd::hamming_distance_36(&sig, cs.try_into().unwrap());
+                if dist < best {
+                    best = dist;
+                    best_class = class as u8;
+                }
+            }
+            *st_code = best_class;
+        }
+        return code;
+    }
+    let work = centered_work(art, bundle);
+    let mut code = [0u8; STAGES];
+    for (st_code, table) in code.iter_mut().zip(art.dot_cb.iter()) {
+        let mut best = i64::MIN;
+        let mut best_class = 0u8;
+        for (class, row) in table.chunks_exact(D).enumerate() {
+            let score = dot_score_plain(row, &work);
+            if score > best {
+                best = score;
+                best_class = class as u8;
+            }
+        }
+        *st_code = best_class;
+    }
+    code
+}
+
 /// Bounded multi-membership assignment per depth, with nearest-class
 /// membership retained at every depth as the fallback floor.
 pub fn assign_memberships_plain(

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1217,12 +1217,15 @@ fn generate_greedy_repetition_rate(
     for _ in 0..tokens_to_generate {
         let bundle = runtime::bundle_window_plain(artifacts, rotations, &window[..w_len]);
         let sig = runtime::sig_plain(artifacts, &bundle);
+        // #243 Phase C option A: attest the metric-respecting code.
+        let code = runtime::assign_for_bundle(artifacts, &bundle);
 
         let recent_len = recent_tokens.len();
         for (i, &t) in recent_tokens.iter().enumerate() {
             recent_array[i] = t;
         }
-        let outcome = scorer.score_candidates(&sig, &recent_array[..recent_len])?;
+        let outcome =
+            scorer.score_candidates_coded(&sig, Some(&code), &recent_array[..recent_len])?;
         let token = outcome.selected;
 
         if recent_tokens.contains(&token) {
@@ -1268,8 +1271,9 @@ fn baseline_greedy_repetition_rate(
 
     for _ in 0..tokens_to_generate {
         let bundle = runtime::bundle_window_plain(artifacts, rotations, &window[..w_len]);
-        let sig = runtime::sig_plain(artifacts, &bundle);
-        let code = runtime::assign_plain(artifacts, &sig);
+        // #243 Phase C: the store is keyed under the artifact's declared
+        // metric — query it the same way (assign_for_bundle).
+        let code = runtime::assign_for_bundle(artifacts, &bundle);
         let p = runtime::predict_witness_plain(store, &code);
         let token = p.token;
 
@@ -1395,19 +1399,28 @@ pub fn evaluate_gate_c(
     let mut recall_rule1_top3 = 0u64;
     let mut recall_rule12_top1 = 0u64;
     let mut recall_rule12_top3 = 0u64;
+    let gate_rotations = compiler::derive_rotations();
     for (index, observation) in held_out.iter().enumerate() {
         let position = observation.position as usize;
         let teacher_argmax = corpus.t_argmax[position];
         let next = corpus.next[position];
-        let code = runtime::assign_plain(artifacts, &observation.sig);
+        // #243 Phase C option A: one metric-respecting code per position
+        // (corpus bundle → assign_for_bundle), consumed consistently by
+        // the WB/store baseline and attested to every coded scorer call.
+        // The legacy Σ-over-cloud row intentionally keeps its own old
+        // semantics for comparison.
+        let code = runtime::code_plain(artifacts, &gate_rotations, corpus, position);
 
         let legacy = scorer_with_exct.score_candidates_legacy(&observation.sig)?;
-        let rule1 = scorer_no_exct.score_candidates(&observation.sig, &[])?;
-        let rule12 = scorer_with_exct.score_candidates(&observation.sig, &[])?;
-        let rule1_no_f = scorer_no_exct_no_f.score_candidates(&observation.sig, &[])?;
-        let rule12_no_f = scorer_with_exct_no_f.score_candidates(&observation.sig, &[])?;
-        let normalized = scorer_normalized.score_candidates(&observation.sig, &[])?;
-        let margin = scorer_margin.score_candidates(&observation.sig, &[])?;
+        let rule1 = scorer_no_exct.score_candidates_coded(&observation.sig, Some(&code), &[])?;
+        let rule12 = scorer_with_exct.score_candidates_coded(&observation.sig, Some(&code), &[])?;
+        let rule1_no_f =
+            scorer_no_exct_no_f.score_candidates_coded(&observation.sig, Some(&code), &[])?;
+        let rule12_no_f =
+            scorer_with_exct_no_f.score_candidates_coded(&observation.sig, Some(&code), &[])?;
+        let normalized =
+            scorer_normalized.score_candidates_coded(&observation.sig, Some(&code), &[])?;
+        let margin = scorer_margin.score_candidates_coded(&observation.sig, Some(&code), &[])?;
         let baseline = runtime::predict_witness_plain(store, &code);
 
         let legacy_hit = legacy.selected == teacher_argmax;

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -582,6 +582,15 @@ pub struct ScoreWitness {
     pub graph_cid: [u8; 32],
     /// H(x): the context's sign-bit signature.
     pub input_sig: [u8; SIG_BYTES],
+    /// The graded code the EXCT probe consumed (#243 Phase C, option A —
+    /// maintainer decision 2026-07-30). Attested by the producer and
+    /// verified-as-consumed on replay: under a sign-metric (TLA3/4/5)
+    /// artifact it is re-derivable from `input_sig`; under TLA6 it
+    /// derives from the integer bundle, which the witness does not
+    /// carry — code DERIVATION is proven at certify time by the
+    /// kernel==plain equality witnesses, and replay proves consistent
+    /// CONSUMPTION. `None` when no artifact/EXCT surface is wired.
+    pub input_code: Option<[u8; STAGES]>,
     /// Which rule fired (module docs).
     pub status: ScoreStatus,
     /// Active cloud A (ascending region id) with margins; empty under
@@ -947,6 +956,40 @@ impl GraphScorer {
         sig: &[u8; SIG_BYTES],
         recent_tokens: &[u32],
     ) -> Result<ScoreOutcome, String> {
+        self.score_candidates_coded(sig, None, recent_tokens)
+    }
+
+    /// Resolve the graded code the EXCT probe consumes (#243 Phase C,
+    /// option A): an attested caller code wins; a sign-metric artifact
+    /// derives it from the sig (that IS its declared metric); a TLA6
+    /// artifact without a caller code is a contract error — the sig
+    /// cannot reconstruct a dot-metric code.
+    fn probe_code(
+        art: &Compiled,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+    ) -> Result<[u8; STAGES], String> {
+        match input_code {
+            Some(code) => Ok(*code),
+            None if art.dot_cb.is_empty() => Ok(runtime::assign_plain(art, sig)),
+            None => Err(
+                "TLA6 artifact: the EXCT probe requires the assigned graded code \
+                 (witness contract, #243 Phase C option A)"
+                    .to_owned(),
+            ),
+        }
+    }
+
+    /// [`GraphScorer::score_candidates`] with an explicitly attested
+    /// graded code (#243 Phase C option A): bundle-holding callers
+    /// (serving, harness) assign under the artifact's declared metric
+    /// and pass the code through; replay passes the witnessed code.
+    pub fn score_candidates_coded(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        recent_tokens: &[u32],
+    ) -> Result<ScoreOutcome, String> {
         let recent_tokens = if recent_tokens.len() > 32 {
             &recent_tokens[recent_tokens.len() - 32..]
         } else {
@@ -1117,9 +1160,11 @@ impl GraphScorer {
         // prefix) over the exact-context store; ΔX(X,v) = quantized
         // probe log-prob minus the stored root prior (integer sub).
         let mut exct_probe: Option<ExctProbe> = None;
+        let mut witness_code: Option<[u8; STAGES]> = None;
         let mut exact_residuals: Vec<(u32, ScoreQ)> = Vec::new();
         if let Some(art) = &self.artifacts {
-            let code = runtime::assign_plain(art, sig);
+            let code = Self::probe_code(art, sig, input_code)?;
+            witness_code = Some(code);
             if let Some(residual_exct) = &self.residual_exct {
                 for level in (0..=STAGES).rev() {
                     if let Some(context) = residual_exct[level].get(&code[..level]) {
@@ -1262,6 +1307,7 @@ impl GraphScorer {
         let witness = ScoreWitness {
             graph_cid: self.graph_cid,
             input_sig: *sig,
+            input_code: witness_code,
             status: if exact_context {
                 ScoreStatus::ExactContext
             } else if selected_chain.is_empty() {
@@ -1791,6 +1837,22 @@ impl GraphScorer {
         state: &mut StepState,
         recent_tokens: &[u32],
     ) -> Result<StepOutcome, String> {
+        self.score_step_coded_with_recent(sig, None, top_m, state, recent_tokens)
+    }
+
+    /// [`GraphScorer::score_step_with_recent`] with an explicitly
+    /// attested graded code (#243 Phase C option A) — the serving
+    /// surface assigns under the artifact's declared metric from the
+    /// live bundle and passes the code through; sign-metric artifacts
+    /// may omit it (derived from the sig, which IS their metric).
+    pub fn score_step_coded_with_recent(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+    ) -> Result<StepOutcome, String> {
         if top_m == 0 || top_m > state.max_top_m {
             return Err(format!(
                 "membership width {top_m} outside the step state bound {}",
@@ -1906,7 +1968,17 @@ impl GraphScorer {
         // only the admitted local entries.
         let mut exact_context = false;
         if let (Some(art), Some(residual_exct)) = (&self.artifacts, &self.residual_exct) {
-            let code = assign_code_plain(art, sig);
+            let code = match input_code {
+                Some(code) => *code,
+                None if art.dot_cb.is_empty() => assign_code_plain(art, sig),
+                None => {
+                    return Err(
+                        "TLA6 artifact: the EXCT probe requires the assigned graded code \
+                         (witness contract, #243 Phase C option A)"
+                            .to_owned(),
+                    );
+                }
+            };
             for level in (0..=STAGES).rev() {
                 if let Some(context) = residual_exct[level].get(&code[..level]) {
                     // #234 maintainer decision: Rule 2 fires at FULL
@@ -2113,10 +2185,15 @@ pub fn verify_witness_replay(
         return Err(ReplayError::GraphCidMismatch);
     }
     let outcome = scorer
-        .score_candidates(&witness.input_sig, &[])
+        .score_candidates_coded(&witness.input_sig, witness.input_code.as_ref(), &[])
         .map_err(ReplayError::Artifact)?;
     let recomputed = &outcome.witness;
 
+    if recomputed.input_code != witness.input_code {
+        return Err(ReplayError::Artifact(
+            "input_code mismatch on replay (witness contract, #243 Phase C)".to_owned(),
+        ));
+    }
     if recomputed.active != witness.active {
         return Err(ReplayError::ActiveMismatch);
     }

--- a/docs/transformerless/gate_c_pinned.json
+++ b/docs/transformerless/gate_c_pinned.json
@@ -2,11 +2,11 @@
   "schema": 1,
   "purpose": "Pinned Gate C quality record for the CI trend alarm (issue #77). The alarm fails when a run regresses beyond the thresholds below vs THIS record. Bump deliberately, maintainer-only, like the kappa baseline.",
   "pinned_at": "2026-07-30",
-  "pinned_from": "Rule 1+2 chain-telescoped + EXCT precedence (FULL CODE ONLY, #234), 1-term TLA6 fixture artifact (#243 Phase C), add-one smoothing, fixture corpus. Era note (#243 Phase C): the TLA6 fixture assigns via the shift-add dot path; its finer code space (48,321 single-write keys) drops strict full-code EXCT coverage to 0.97% (ExactContext 291 / Graph 29,725 / Novel 20) and the honest row collapses to rule12 1.11%/15.9742 (graph per-status 0.84%/16.03). Deliberate composition of the two maintainer decisions, flagged on #243 pre-merge (queue simulation): the graph path is now unambiguously the load-bearing number to improve (#277/#246 retrieval work). TLA3-baseline row on the dot-path store: 22.98%/9.5092 (bits improve 12.36->9.51). Prior eras: #234 full-code-only re-pin (21.05/12.5303, sign-path fixture); #281 single-key re-pin. Thresholds unchanged.",
-  "rule12_top1_agreement": 0.01109,
-  "rule12_bits_per_token": 15.97416,
-  "baseline_top1_agreement": 0.22983,
-  "baseline_bits_per_token": 9.509162,
+  "pinned_from": "Rule 1+2 chain-telescoped + EXCT precedence (FULL CODE ONLY, #234), 1-term TLA6 fixture, METRIC-CONSISTENT probes (#243 Phase C part 2, option A: witness-attested graded codes). Era note: the prior 1.11%/15.9742 pin measured sign-code probes against the dot-keyed store \u2014 the writer/reader mismatch part 2 removes \u2014 not the true strict-EXCT x dot-code row. Consistent probes: rule12 31.63%/9.1181 (best recorded fixture row; prior sign-era tie 30.02/10.2357), status ExactContext 25,853 / Graph 4,182 / Novel 1, strict miss 13.93% (Gate C valid, graph path exercised on real probes; per-status exact 36.65%/7.95). Baseline (dot store, dot codes) 33.83%/11.9515. Prior eras: #296 mismatch row; #234 full-code-only; #281 single-key. Thresholds unchanged.",
+  "rule12_top1_agreement": 0.31629,
+  "rule12_bits_per_token": 9.1181,
+  "baseline_top1_agreement": 0.33829,
+  "baseline_bits_per_token": 11.951519,
   "alarm": {
     "top1_drop_abs": 0.02,
     "bits_regress_abs": 0.1


### PR DESCRIPTION
## Summary

Implements the part-2 maintainer decision (Casey, 2026-07-30, on #243): the serving surface adopts the artifact's declared metric via a **4-byte attested code in the witness** rather than carrying the integer bundle.

- `ScoreWitness.input_code` — attested by the producer, replay verifies consistent consumption (coded replay + equality check); code derivation stays proven at certify time (kernel==plain witnesses).
- `score_candidates_coded` / `score_step_coded_with_recent` — coded entry points; sign-metric artifacts may omit the code (the sig IS their metric); TLA6 without a code is a contract error, never a silent sign fallback.
- `R4Engine::derive_sig_code` — serving windows attest metric-respecting codes through `predict_decision`.
- Gate C harness — one metric-consistent code per position (`code_plain`), consumed by baseline and attested to every coded row; both repetition probes likewise.

## The headline measurement

The pinned 1.11%/15.9742 "collapse" row was the writer/reader mismatch itself (sign-code probes on a dot-keyed store), not the system. Metric-consistent probes measure:

| | mismatch era (#296 pin) | **consistent (this PR)** |
|---|---|---|
| rule12 | 1.11% / 15.9742 | **31.63% / 9.1181** (best recorded fixture row; sign-era tie was 30.02/10.24) |
| status split | 291 / 29,725 / 20 | **25,853 / 4,182 / 1** |
| strict EXCT miss | 99.03% | **13.93%** — Gate C valid AND the graph path runs on 4,182 real probes |
| baseline (dot store) | 22.98 / 9.51 | 33.83 / 11.95 |

Trend re-pin travels in this PR; self-consistency mode validates it (first live use of the #297 two-mode check). The graph-runtime EXCT reader (chat/wasm) is token-keyed — outside option-A scope, recorded in the commit.

Remaining Phase C: C-row evidence pair on the TLA6-recompiled D3 bundle (in flight), BASELINE table, closes #230.