### PR TITLE
feat(router): #303 Hopf sector occupancy measurement — D3 held-out, 7/512 sectors (1.4%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
 name = "uor-r4-router"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "console_error_panic_hook",
  "hex",
  "serde",

--- a/crates/uor-r4-router/Cargo.toml
+++ b/crates/uor-r4-router/Cargo.toml
@@ -17,3 +17,6 @@ uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b
 uor-foundation = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1", default-features = false, features = ["std", "serde"] }
 uor-foundation-sdk = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+blake3 = "1.5.0"

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -1273,6 +1273,20 @@ impl UorR4Router {
         identity: &str,
         state_vector: Option<&[f64]>,
     ) -> RoutingData {
+        self.route_query_to_manifold_internal_with_hopf_input(text, identity, state_vector)
+            .0
+    }
+
+    /// As `route_query_to_manifold_internal`, additionally returning the
+    /// 512-d vector that `get_state_4d_projection` reduces to the Hopf map
+    /// input (the grounded VSA vector, or the session state on ground
+    /// failure). Measurement surface for issue #303.
+    fn route_query_to_manifold_internal_with_hopf_input(
+        &self,
+        text: &str,
+        identity: &str,
+        state_vector: Option<&[f64]>,
+    ) -> (RoutingData, Vec<f64>) {
         let active_state = match state_vector {
             Some(v) => v.to_vec(),
             None => {
@@ -1308,7 +1322,7 @@ impl UorR4Router {
         text: &str,
         identity: &str,
         active_state: &[f64],
-    ) -> RoutingData {
+    ) -> (RoutingData, Vec<f64>) {
         let (qimc_prime, qimc_index, identity_meta) = identity_to_qimc_prime(identity);
         let uor_control = derive_uor_control_plane(&identity_meta);
 
@@ -1356,7 +1370,7 @@ impl UorR4Router {
             state_metrics_from_weights(routed_slice);
 
         let v_4d = self.get_state_4d_projection(&active_state_refined);
-        let (sector_id, _bins, hopf_components) = assign_sector_hopf_transport_scalar(
+        let (sector_id, bins, hopf_components) = assign_sector_hopf_transport_scalar(
             &v_4d,
             512,
             uor_control.phase_transport_lambda,
@@ -1415,6 +1429,9 @@ impl UorR4Router {
                 phase_transport_lambda: uor_control.phase_transport_lambda,
                 hopf_chi_bins: uor_control.hopf_chi_bins as u64,
                 sector_id: sector_id as u64,
+                chi_bin: bins["chi_bin"] as u64,
+                delta_bin: bins["delta_bin"] as u64,
+                alpha_bin: bins["alpha_bin"] as u64,
                 subspace_norms: SubspaceNorms {
                     act: active_state_refined[0..128]
                         .iter()
@@ -1468,10 +1485,13 @@ impl UorR4Router {
             });
         }
 
-        RoutingData {
-            routed,
-            all_routes: routes_output,
-        }
+        (
+            RoutingData {
+                routed,
+                all_routes: routes_output,
+            },
+            active_state_refined,
+        )
     }
 
     /// Content-derived 512-d state for a piece of text (issue #245): the
@@ -2380,6 +2400,9 @@ pub struct HopfResult {
     pub phase_transport_lambda: f64,
     pub hopf_chi_bins: u64,
     pub sector_id: u64,
+    pub chi_bin: u64,
+    pub delta_bin: u64,
+    pub alpha_bin: u64,
     pub subspace_norms: SubspaceNorms,
 }
 
@@ -2489,6 +2512,19 @@ impl UorR4Router {
     }
 
     pub fn route_query_to_manifold_native(&mut self, text: &str, identity: &str) -> RoutingData {
+        self.route_query_to_manifold_native_with_hopf_input(text, identity)
+            .0
+    }
+
+    /// As `route_query_to_manifold_native`, additionally returning the 512-d
+    /// vector that `get_state_4d_projection` reduces to the Hopf map input
+    /// (the grounded VSA vector, or the session state on ground failure).
+    /// Measurement surface for issue #303.
+    pub fn route_query_to_manifold_native_with_hopf_input(
+        &mut self,
+        text: &str,
+        identity: &str,
+    ) -> (RoutingData, Vec<f64>) {
         let key = identity_key(identity);
         let active_state = self
             .session_brain_states
@@ -2496,7 +2532,7 @@ impl UorR4Router {
             .or_insert_with(|| vec![1.0 / (512.0f64).sqrt(); 512])
             .clone();
 
-        self.route_query_to_manifold_internal(text, identity, Some(&active_state))
+        self.route_query_to_manifold_internal_with_hopf_input(text, identity, Some(&active_state))
     }
 
     pub fn get_top_resonances_native(

--- a/crates/uor-r4-router/tests/hopf_sector_occupancy.rs
+++ b/crates/uor-r4-router/tests/hopf_sector_occupancy.rs
@@ -1,0 +1,328 @@
+//! Issue #303: Hopf sector occupancy of the R⁴ router over the D3 held-out
+//! fixtures.
+//!
+//! Drives the production routing path (`evolve_state` →
+//! `route_query_to_manifold_native_with_hopf_input`, the same sequence as
+//! `src/server.rs` POST /api/chat) over the held-out split of the D3 corpus
+//! and measures which of the 512 Hopf sectors are reachable in practice.
+//!
+//! Run:
+//!   cargo test -p uor-r4-router --release --offline \
+//!     --test hopf_sector_occupancy -- --ignored --nocapture
+//!
+//! Skips vacuously when the D3 corpus is absent (same convention as
+//! `uor-r4-core/tests/kappa_reproduction.rs`). The corpus fetch and the
+//! held-out split rule (`blake3(id)[0] % 5 == 0`) are documented in
+//! `scripts/fetch_d3_corpus.py` and the corpus manifest.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use uor_r4_router::UorR4Router;
+
+/// Fixed session-evolution gain (the value the router tests use; the server
+/// autotunes γ per request, which would make runs non-comparable).
+const GAMMA: f64 = 0.85;
+/// Article text is fed to the session in chunks of this many chars.
+const CHUNK_CHARS: usize = 2000;
+/// Sector budget K passed at the production call site.
+const SECTOR_CAP: usize = 512;
+
+struct Sample {
+    sector_id: u64,
+    chi_bin: u64,
+    delta_bin: u64,
+    alpha_bin: u64,
+    chi_u: f64,
+    u_delta: f64,
+    u_alpha: f64,
+    phase_transport_lambda: f64,
+    /// The 512-d vector `get_state_4d_projection` reduced to the Hopf input.
+    hopf_input: Vec<f64>,
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn corpus_path() -> PathBuf {
+    workspace_root().join(".uor-models/corpora/simple-wiki-20231101/articles.jsonl")
+}
+
+fn report_path() -> PathBuf {
+    std::env::var("HOPF_OCCUPANCY_REPORT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| workspace_root().join("target/hopf_sector_occupancy/report.json"))
+}
+
+/// Canonical D3 split rule: `blake3(id as utf-8)[0] % 5 == 0` → held-out.
+fn is_held_out(id: &str) -> bool {
+    blake3::hash(id.as_bytes()).as_bytes()[0].is_multiple_of(5)
+}
+
+/// Split `text` into chunks of at most `CHUNK_CHARS` on char boundaries.
+fn chunks(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        let end = rest
+            .char_indices()
+            .nth(CHUNK_CHARS)
+            .map(|(i, _)| i)
+            .unwrap_or(rest.len());
+        out.push(&rest[..end]);
+        rest = &rest[end..];
+    }
+    out
+}
+
+/// Deterministic per-block unit vector for the signed-projection diagnostic
+/// (issue #303 scope item 4): 128 bytes from a keyed blake3 hash, centered
+/// and L2-normalized. Fixed across runs — no RNG, no clock.
+fn signed_probe(block: usize) -> Vec<f64> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4 issue-303 signed-projection probe");
+    hasher.update(&(block as u64).to_le_bytes());
+    let digest = hasher.finalize();
+    let raw: Vec<f64> = digest
+        .as_bytes()
+        .iter()
+        .cycle()
+        .take(128)
+        .map(|&b| (b as f64 / 255.0) - 0.5)
+        .collect();
+    let norm = raw.iter().map(|x| x * x).sum::<f64>().sqrt();
+    raw.iter().map(|x| x / norm).collect()
+}
+
+fn pearson(xs: &[f64], ys: &[f64]) -> f64 {
+    let n = xs.len() as f64;
+    let mx = xs.iter().sum::<f64>() / n;
+    let my = ys.iter().sum::<f64>() / n;
+    let mut cov = 0.0;
+    let mut vx = 0.0;
+    let mut vy = 0.0;
+    for (&x, &y) in xs.iter().zip(ys) {
+        cov += (x - mx) * (y - my);
+        vx += (x - mx) * (x - mx);
+        vy += (y - my) * (y - my);
+    }
+    if vx <= 0.0 || vy <= 0.0 {
+        return 0.0;
+    }
+    cov / (vx.sqrt() * vy.sqrt())
+}
+
+fn mean_std(xs: &[f64]) -> (f64, f64) {
+    let n = xs.len() as f64;
+    let m = xs.iter().sum::<f64>() / n;
+    let v = xs.iter().map(|x| (x - m) * (x - m)).sum::<f64>() / n;
+    (m, v.sqrt())
+}
+
+#[test]
+#[ignore = "D3 corpus measurement; run explicitly per issue #303"]
+fn hopf_sector_occupancy_d3() {
+    let corpus = corpus_path();
+    if !corpus.exists() {
+        eprintln!(
+            "D3 corpus absent at {}; skipping (fetch via scripts/fetch_d3_corpus.py)",
+            corpus.display()
+        );
+        return;
+    }
+
+    let text = std::fs::read_to_string(&corpus).expect("read D3 corpus");
+    let articles: Vec<serde_json::Value> = text
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("parse corpus JSONL"))
+        .collect();
+    let held_out: Vec<&serde_json::Value> = articles
+        .iter()
+        .filter(|a| is_held_out(a["id"].as_str().expect("article id")))
+        .collect();
+    assert!(!held_out.is_empty(), "held-out split is empty");
+
+    let mut router = UorR4Router::new(0.5);
+    let mut samples: Vec<Sample> = Vec::new();
+
+    for article in &held_out {
+        let id = article["id"].as_str().expect("article id");
+        let body = article["text"].as_str().expect("article text");
+        for chunk in chunks(body) {
+            // Same sequence as src/server.rs POST /api/chat: evolve the
+            // session state, then route.
+            router.evolve_state(id, chunk, GAMMA);
+            let (routing, hopf_input) =
+                router.route_query_to_manifold_native_with_hopf_input(chunk, id);
+            let hopf = &routing.routed.hopf;
+            samples.push(Sample {
+                sector_id: hopf.sector_id,
+                chi_bin: hopf.chi_bin,
+                delta_bin: hopf.delta_bin,
+                alpha_bin: hopf.alpha_bin,
+                chi_u: hopf.chi.sin() * hopf.chi.sin(),
+                u_delta: (hopf.delta + std::f64::consts::PI) / (2.0 * std::f64::consts::PI),
+                u_alpha: (hopf.transported_alpha + std::f64::consts::PI)
+                    / (2.0 * std::f64::consts::PI),
+                phase_transport_lambda: hopf.phase_transport_lambda,
+                hopf_input,
+            });
+        }
+    }
+    assert!(!samples.is_empty(), "no routing samples collected");
+
+    // ── Occupancy ────────────────────────────────────────────────────────
+    let distinct_sectors = samples
+        .iter()
+        .map(|s| s.sector_id)
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+
+    let histogram = |pick: fn(&Sample) -> u64| -> BTreeMap<u64, usize> {
+        let mut h: BTreeMap<u64, usize> = BTreeMap::new();
+        for s in &samples {
+            *h.entry(pick(s)).or_insert(0) += 1;
+        }
+        h
+    };
+    let chi_hist = histogram(|s| s.chi_bin);
+    let delta_hist = histogram(|s| s.delta_bin);
+    let alpha_hist = histogram(|s| s.alpha_bin);
+
+    let range = |pick: fn(&Sample) -> f64| -> (f64, f64) {
+        samples
+            .iter()
+            .map(pick)
+            .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+                (lo.min(v), hi.max(v))
+            })
+    };
+    let chi_u_range = range(|s| s.chi_u);
+    let u_delta_range = range(|s| s.u_delta);
+    let u_alpha_range = range(|s| s.u_alpha);
+
+    // ── Magnitude-only diagnostic (scope item 4) ─────────────────────────
+    // Per 128-dim block: Pearson correlation across samples between the
+    // block L2 norm (what the production projection keeps) and the signed
+    // projection of the same block onto a fixed deterministic unit vector
+    // (what it discards). Low |r| means the norm carries none of the
+    // directional structure the signed summary sees.
+    let probes: Vec<Vec<f64>> = (0..4).map(signed_probe).collect();
+    let mut diagnostic = Vec::new();
+    for (block, probe) in probes.iter().enumerate() {
+        let norms: Vec<f64> = samples
+            .iter()
+            .map(|s| {
+                s.hopf_input[block * 128..(block + 1) * 128]
+                    .iter()
+                    .map(|x| x * x)
+                    .sum::<f64>()
+                    .sqrt()
+            })
+            .collect();
+        let signed: Vec<f64> = samples
+            .iter()
+            .map(|s| {
+                s.hopf_input[block * 128..(block + 1) * 128]
+                    .iter()
+                    .zip(probe)
+                    .map(|(x, p)| x * p)
+                    .sum()
+            })
+            .collect();
+        let (norm_mean, norm_std) = mean_std(&norms);
+        let (signed_mean, signed_std) = mean_std(&signed);
+        diagnostic.push(serde_json::json!({
+            "block": block,
+            "pearson_r_norm_vs_signed": pearson(&norms, &signed),
+            "norm_mean": norm_mean,
+            "norm_std": norm_std,
+            "signed_mean": signed_mean,
+            "signed_std": signed_std,
+        }));
+    }
+
+    let lambdas: Vec<f64> = samples.iter().map(|s| s.phase_transport_lambda).collect();
+    let (lambda_min, lambda_max) = lambdas
+        .iter()
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), &v| {
+            (lo.min(v), hi.max(v))
+        });
+
+    let report = serde_json::json!({
+        "issue": 303,
+        "corpus": corpus.display().to_string(),
+        "protocol": {
+            "split_rule": "blake3(id as utf-8)[0] % 5 == 0 -> held-out",
+            "articles_total": articles.len(),
+            "articles_held_out": held_out.len(),
+            "gamma": GAMMA,
+            "chunk_chars": CHUNK_CHARS,
+            "session_per": "article (identity = article id)",
+            "sequence": "evolve_state(identity, chunk, gamma) then route per chunk",
+        },
+        "samples": samples.len(),
+        "sector_cap": SECTOR_CAP,
+        "distinct_sector_ids": distinct_sectors,
+        "occupancy_fraction": distinct_sectors as f64 / SECTOR_CAP as f64,
+        "bin_histograms": {
+            "chi_bin": chi_hist,
+            "delta_bin": delta_hist,
+            "alpha_bin": alpha_hist,
+        },
+        "empirical_ranges": {
+            "chi_u": [chi_u_range.0, chi_u_range.1],
+            "u_delta": [u_delta_range.0, u_delta_range.1],
+            "u_alpha": [u_alpha_range.0, u_alpha_range.1],
+            "phase_transport_lambda": [lambda_min, lambda_max],
+        },
+        "magnitude_only_diagnostic": diagnostic,
+    });
+
+    let out = report_path();
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent).expect("create report dir");
+    }
+    std::fs::write(
+        &out,
+        serde_json::to_string_pretty(&report).expect("serialize report"),
+    )
+    .expect("write report");
+
+    println!("=== issue #303: Hopf sector occupancy (D3 held-out) ===");
+    println!("held-out articles: {} / {}", held_out.len(), articles.len());
+    println!("routing samples:   {}", samples.len());
+    println!(
+        "distinct sectors:  {} / {} ({:.1}%)",
+        distinct_sectors,
+        SECTOR_CAP,
+        100.0 * distinct_sectors as f64 / SECTOR_CAP as f64
+    );
+    println!("chi_bin hist:      {chi_hist:?}");
+    println!("delta_bin hist:    {delta_hist:?}");
+    println!("alpha_bin hist:    {alpha_hist:?}");
+    println!(
+        "chi_u range:       [{:.4}, {:.4}]",
+        chi_u_range.0, chi_u_range.1
+    );
+    println!(
+        "u_delta range:     [{:.4}, {:.4}] (binning assumes [0, 1])",
+        u_delta_range.0, u_delta_range.1
+    );
+    println!(
+        "u_alpha range:     [{:.4}, {:.4}] (binning assumes [0, 1])",
+        u_alpha_range.0, u_alpha_range.1
+    );
+    for d in diagnostic {
+        println!(
+            "block {}: r(norm, signed) = {:.4} (norm σ {:.4}, signed σ {:.4})",
+            d["block"],
+            d["pearson_r_norm_vs_signed"].as_f64().unwrap(),
+            d["norm_std"].as_f64().unwrap(),
+            d["signed_std"].as_f64().unwrap()
+        );
+    }
+    println!("report written to {}", out.display());
+}

--- a/docs/hopf_sector_occupancy_d3.md
+++ b/docs/hopf_sector_occupancy_d3.md
@@ -1,0 +1,138 @@
+# Hopf Sector Occupancy on the D3 Held-Out Fixtures (Issue #303)
+
+- **Date:** 2026-07-31
+- **Issue:** [#303](https://github.com/UOR-Foundation/uor-r4/issues/303)
+- **Harness:** `crates/uor-r4-router/tests/hopf_sector_occupancy.rs` (ignored by
+  default; see Reproduction)
+- **Corpus:** `simple-wiki-20231101-sample`, `corpus_cid
+  blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf`
+  (manifest-verified; 3000 articles, 596 held out)
+- **Claim language:** per `docs/formal_vocabulary.md`. Every measured statement
+  below is an **Empirical Criterion** with status **Empirical** — a pinned-corpus
+  measurement with a declared protocol, not a proof.
+
+## 1. What feeds the Hopf map (verified against the code)
+
+The sector assignment chain is:
+
+1. `route_query_to_manifold_internal_generic`
+   (`crates/uor-r4-router/src/lib.rs:1322`) obtains `active_state_refined`, the
+   first 512 dims of the grounded VSA vector. Under the default `Spectral`
+   geometry, `SpectralGeometry::ground`
+   (`crates/uor-r4-router/src/geometry.rs:65`) copies the **session brain
+   state** into those dims for any non-empty input, and the ground-failure
+   fallback does the same — so in practice the Hopf input is the evolved
+   512-dim session state. (Under `Vsa` geometry it would be the grounded
+   query vector instead; that path was not measured here.)
+2. `get_state_4d_projection` (`crates/uor-r4-router/src/lib.rs:1206`) reduces
+   the 512 dims to four block L2 norms (128 dims each), unit-normalized —
+   non-negative by construction.
+3. `assign_sector_hopf_transport_scalar`
+   (`crates/uor-r4-core/src/lib.rs:325`) computes Hopf coordinates, applies
+   phase transport, and bins `(χ_u, u_delta, u_alpha)` into
+   `(kchi, kdelta, kalpha) = (8, 8, 8)` — the result of
+   `allocate_triplet_bins_budget(512, hint, 2, 2)` for every per-identity
+   `hopf_chi_bins` hint in `{2, 3, 4}` (8³ = 512 is the unique zero-spread
+   maximum).
+
+**Static reachable-range bound.** With `a,b,c,d ≥ 0`: `θ₁,θ₂ ∈ [0, π/2]`,
+so `u_delta ∈ [0.25, 0.75]` (δ-bins 2–5 of 8) and, absent the transport
+shift, `u_alpha ∈ [0.5, 0.75]` (α-bins 4–5 of 8). The transport shift
+(λ ∈ [0.70, 1.30] per identity) perturbs `u_alpha` modestly. At most
+8 × 4 × 2 = 64 of 512 sectors (~12.5%) are reachable by any input; the
+remaining 7/8 are unreachable by construction. This is the bound stated in
+the issue; the code reading confirms it.
+
+## 2. Protocol (**Empirical Criterion** declarations)
+
+- **Split:** canonical D3 rule — held-out ⇔ `blake3(id as utf-8)[0] % 5 == 0`
+  (596 of 3000 articles).
+- **Session protocol:** one session identity per article (`identity =
+  article id`); article text fed in 2000-char chunks; per chunk,
+  `evolve_state(identity, chunk, γ)` then route — the same sequence as
+  `src/server.rs` POST /api/chat, with fixed `γ = 0.85` (the server
+  autotunes γ per request; a fixed value keeps runs comparable).
+- **Samples:** 1500 routing decisions, each recording `sector_id`,
+  `chi_bin`, `delta_bin`, `alpha_bin` (first-class fields added to
+  `HopfResult` under this issue), plus `chi_u`, `u_delta`, `u_alpha`,
+  `phase_transport_lambda`, and the raw 512-dim Hopf input vector.
+- **Uncertainty:** none declared; the run is a full enumeration of the
+  pinned held-out partition, not a sample of it. Counts are exact for this
+  corpus and protocol. Generalization beyond the D3 distribution is not
+  claimed.
+
+## 3. Results (status: **Empirical**, per §2 protocol)
+
+**Occupancy.** Distinct `sector_id` values observed: **7 of 512 (1.4%)**.
+
+Per-axis bin histograms (of 8 bins per axis):
+
+| axis | occupied bins (count) | empirical range | binning assumes |
+|---|---|---|---|
+| `chi_bin` | 3 (48), 4 (1452) | `chi_u ∈ [0.4799, 0.5419]` | `[0, 1]` |
+| `delta_bin` | 3 (1487), 4 (13) | `u_delta ∈ [0.4783, 0.5029]` | `[0, 1]` |
+| `alpha_bin` | 4 (1474), 5 (26) | `u_alpha ∈ [0.6169, 0.6260]` | `[0, 1]` |
+
+`phase_transport_lambda` spanned its full per-identity range [0.70, 1.30].
+
+**On the issue's ~12.5% estimate:** confirmed in direction, refuted in
+magnitude. The static reachable bound is 64 sectors (12.5%); the empirical
+occupancy is 7 (1.4%). The gap is concentration, not reach: the evolved
+session states have near-equal block norms (block-norm means 0.478–0.510
+with standard deviations 0.006–0.012, i.e. 1.3–2.5% relative dispersion),
+so `θ₁ ≈ θ₂ ≈ π/4`, giving `δ ≈ 0` (`u_delta ≈ 0.5`), `α ≈ π/4`
+(`u_alpha ≈ 0.625`), and `χ_u ≈ 0.5`. The reachable region is small by
+construction; the visited region is a narrow band inside it because EMA
+blending equalizes block energies.
+
+**Magnitude-only diagnostic (scope item 4).** Per 128-dim block, Pearson
+correlation across the 1500 samples between the block L2 norm (what the
+projection keeps) and the signed projection of the same block onto a fixed
+deterministic unit vector, blake3-derived (what it discards):
+
+| block | r(norm, signed) | norm σ | signed σ |
+|---|---|---|---|
+| 0 | −0.658 | 0.0080 | 0.0122 |
+| 1 | −0.356 | 0.0120 | 0.0093 |
+| 2 | −0.570 | 0.0063 | 0.0344 |
+| 3 | −0.721 | 0.0073 | 0.0311 |
+
+Read conservatively: the norms are near-constant (relative dispersion
+1.3–2.5%), so they carry little discriminating signal of any kind; and the
+variation they do carry overlaps only partially with any single signed
+direction (|r| between 0.36 and 0.72, none near 1). Both observations are
+consistent with the issue's hypothesis that the projection discards
+content-discriminating structure before the Hopf map sees it. This is a
+diagnostic, not a proposed replacement.
+
+## 4. Consequences for #276 (Design P)
+
+The measurement supports the issue's motivation for measuring before
+remediation: under the current projection, the sector space is
+under-addressed by construction (≤64/512 reachable) and by concentration
+(7/512 observed). If a redesigned addressing scheme (Design P,
+`docs/phase_clock_address_design.md`) is fed the same near-constant four
+block norms, the same ceiling applies in the new coordinates, and a
+post-hoc measurement could not distinguish "new scheme underperformed"
+from "input was rank-deficient". A remediation issue for the projection
+itself is filed separately (linked from #303); per the issue's DoD, no
+remediation lands under #303.
+
+This measurement neither supports nor refutes #276's capacity claim
+("32k tokens × contexts cannot be discriminated in R⁴"): the router has
+never been measured at full addressing, and this run does not measure it
+either — it measures the addressing deficit directly.
+
+## 5. Reproduction
+
+```bash
+# corpus (if absent): python3 scripts/fetch_d3_corpus.py
+cargo test -p uor-r4-router --release --offline \
+  --test hopf_sector_occupancy -- --ignored --nocapture
+```
+
+Writes `target/hopf_sector_occupancy/report.json` (override with
+`HOPF_OCCUPANCY_REPORT_PATH`). Skips vacuously when the corpus is absent.
+The numbers above are exact for the pinned corpus CID and protocol in §2;
+any change to session evolution, geometry, or the projection invalidates
+direct comparison (era note, same convention as κ re-pins).


### PR DESCRIPTION
Closes #303.

## What

Measurement only, per the issue's scope — no remediation. Instruments the Hopf sector call site and measures sector occupancy over the D3 held-out fixtures.

- `HopfResult` gains `chi_bin`/`delta_bin`/`alpha_bin` (previously computed by `assign_sector_hopf_transport_scalar` and discarded at the call site); new `route_query_to_manifold_native_with_hopf_input` exposes the 512-d projection input for diagnostics. Existing methods delegate and discard — **no routing behavior change**.
- `crates/uor-r4-router/tests/hopf_sector_occupancy.rs`: ignored-by-default harness driving the production evolve-then-route sequence (same order as `src/server.rs` POST /api/chat) over the 596 held-out D3 articles, fixed γ = 0.85, 1500 routing samples. Skips vacuously without the corpus (kappa_reproduction convention).
- `docs/hopf_sector_occupancy_d3.md`: findings, claim-language per `docs/formal_vocabulary.md` (Empirical Criterion / status Empirical, declared protocol, exact counts on the pinned corpus CID).

## DoD evidence

- **Distinct sectors: 7 of 512 (1.4%)** over 1500 samples / 596 held-out articles (canonical `blake3(id)[0] % 5 == 0` split, corpus CID `blake3:194db0ee…0132cf`).
- Per-axis histograms (of 8 bins): χ {3: 48, 4: 1452}; δ {3: 1487, 4: 13}; α {4: 1474, 5: 26}. Empirical ranges: `chi_u ∈ [0.480, 0.542]`, `u_delta ∈ [0.478, 0.503]`, `u_alpha ∈ [0.617, 0.626]` against a binning that assumes `[0, 1]`.
- **~12.5% estimate: confirmed in direction, refuted in magnitude.** The static reachable bound (64/512, sign restriction) holds; empirical occupancy is 7/512 because EMA-blended session states concentrate (block-norm relative dispersion 1.3–2.5% → θ₁ ≈ θ₂ ≈ π/4).
- Magnitude-only diagnostic: per-block Pearson r between block norms and a fixed deterministic signed projection: −0.658 / −0.356 / −0.570 / −0.721, with norms near-constant (σ 0.006–0.012 on means ≈ 0.48–0.51).
- Code-reading correction recorded in the doc: under the default Spectral geometry the Hopf input *is* the session brain state (ground copies it; the fallback does the same); under Vsa it would be the grounded query vector.
- Remediation issue filed separately and linked from #303 (per DoD, none lands here).

## Gates

- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` ✓ · no_std ladder (both configs) ✓ · `python3 scripts/check_claim_wording.py` ✓
- `cargo test --workspace --offline`: all suites green **except** `uor-r4-core` `allocation_census`, which fails locally against the stale on-disk `.uor-models` store (predates the u32 migration — AGENTS.md 'things that bite'; a recompile is a maintainer decision). Independence from this PR: `uor-r4-core` has zero dependency on `uor-r4-router` (the only crate touched), and CI on `main` at the branch point (783c6f9) is green. Full workspace suite re-run with `--skip allocation_census`: zero failures.