### PR TITLE
Remediate Hopf projection sign loss

### DIFF
--- a/crates/uor-r4-router/Cargo.toml
+++ b/crates/uor-r4-router/Cargo.toml
@@ -13,10 +13,10 @@ console_error_panic_hook = "0.1.7"
 serde_json = "1.0"
 sha2 = "0.10.8"
 hex = "0.4.3"
+blake3 = "1.5.0"
 uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b51e3e2113ee5d032730cde709335d4fe9b60", default-features = false, features = ["alloc"] }
 uor-foundation = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1", default-features = false, features = ["std", "serde"] }
 uor-foundation-sdk = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-blake3 = "1.5.0"

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -344,6 +344,10 @@ pub struct GeometricResponse {
     pub trajectory: Vec<TrajectoryStep>,
 }
 
+fn hopf_probe_value(digest: &blake3::Hash, index: usize) -> f64 {
+    (digest.as_bytes()[index % digest.as_bytes().len()] as f64 / 255.0) - 0.5
+}
+
 impl UorR4Router {
     pub fn index_semantic_object(&mut self, id: usize, coords: &geometry::FacetCoordinates) {
         let id = id as u64;
@@ -1190,32 +1194,47 @@ impl UorR4Router {
         (u, v)
     }
 
-    fn get_state_4d_projection(&self, state_vector: &[f64]) -> Vec<f64> {
-        let mut w_act = 0.0;
-        let mut w_obj = 0.0;
-        let mut w_temp = 0.0;
-        let mut w_shared = 0.0;
-        for i in 0..128 {
-            w_act += state_vector[i] * state_vector[i];
-            w_obj += state_vector[i + 128] * state_vector[i + 128];
-            w_temp += state_vector[i + 256] * state_vector[i + 256];
-            w_shared += state_vector[i + 384] * state_vector[i + 384];
-        }
-        w_act = w_act.sqrt();
-        w_obj = w_obj.sqrt();
-        w_temp = w_temp.sqrt();
-        w_shared = w_shared.sqrt();
+    /// Project each 128-dimensional block onto a fixed signed direction.
+    ///
+    /// The previous projection retained only four block L2 norms. Those are
+    /// non-negative and, for the evolved session states, nearly constant, so
+    /// most of the directional information never reached the Hopf address.
+    /// The probe is deterministic and content-independent: its 128 entries
+    /// are derived from a domain-separated Blake3 digest and normalized once
+    /// per block. Compiler-side floating point is intentional here; this is
+    /// the exploratory router, not the deployed integer kernel.
+    fn hopf_signed_projection_component(&self, state_vector: &[f64], block: usize) -> f64 {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4 issue-306 signed-hopf-projection");
+        hasher.update(&(block as u64).to_le_bytes());
+        let digest = hasher.finalize();
 
-        let denom = (w_act * w_act + w_obj * w_obj + w_temp * w_temp + w_shared * w_shared).sqrt();
+        let norm_sq = (0..128)
+            .map(|i| hopf_probe_value(&digest, i) * hopf_probe_value(&digest, i))
+            .sum::<f64>();
+        let norm = norm_sq.sqrt();
+        let offset = block * 128;
+        (0..128)
+            .map(|i| state_vector[offset + i] * hopf_probe_value(&digest, i) / norm)
+            .sum()
+    }
+
+    fn get_state_4d_projection(&self, state_vector: &[f64]) -> Vec<f64> {
+        let components = [
+            self.hopf_signed_projection_component(state_vector, 0),
+            self.hopf_signed_projection_component(state_vector, 1),
+            self.hopf_signed_projection_component(state_vector, 2),
+            self.hopf_signed_projection_component(state_vector, 3),
+        ];
+        let denom = components
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            .sqrt();
         if denom < 1e-12 {
             vec![0.5, 0.5, 0.5, 0.5]
         } else {
-            vec![
-                w_act / denom,
-                w_obj / denom,
-                w_temp / denom,
-                w_shared / denom,
-            ]
+            components.iter().map(|value| value / denom).collect()
         }
     }
 
@@ -3135,6 +3154,31 @@ pub fn vsa_encode_graph_edge(src: &str, rel: &str, tgt: &str, space: &str) -> Ve
 #[cfg(test)]
 mod router_repetition_tests {
     use super::*;
+
+    #[test]
+    fn hopf_projection_preserves_signed_block_direction() {
+        let router = UorR4Router::new(0.85);
+        let mut state = vec![0.0; 512];
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4 issue-306 signed-hopf-projection");
+        hasher.update(&0u64.to_le_bytes());
+        let digest = hasher.finalize();
+        for (i, value) in state.iter_mut().enumerate().take(128) {
+            *value = hopf_probe_value(&digest, i);
+        }
+
+        let positive = router.get_state_4d_projection_native(&state);
+        assert!(
+            positive[0] > 0.99,
+            "signed direction should survive projection"
+        );
+
+        for value in &mut state[..128] {
+            *value = -*value;
+        }
+        let negative = router.get_state_4d_projection_native(&state);
+        assert!(negative[0] < -0.99, "projection must retain direction sign");
+    }
 
     #[test]
     fn test_elliptic_basin_escape_and_repetition_mitigation() {

--- a/docs/hopf_projection_remediation_306.md
+++ b/docs/hopf_projection_remediation_306.md
@@ -1,0 +1,52 @@
+# Hopf Projection Remediation (Issue #306)
+
+- **Date:** 2026-07-31
+- **Baseline:** [Issue #303 D3 measurement](hopf_sector_occupancy_d3.md)
+- **Harness:** `crates/uor-r4-router/tests/hopf_sector_occupancy.rs`
+- **Claim language:** the results below are **Empirical Criteria** on the pinned
+  D3 fixtures, not a proof of general addressing capacity.
+
+## Change
+
+`get_state_4d_projection` previously reduced each 128-dimensional block to an
+L2 norm. This made every Hopf input component non-negative and discarded the
+within-block direction. The replacement projects each block onto a fixed,
+domain-separated Blake3-derived signed unit direction, then L2-normalizes the
+four signed components.
+
+The direction is deterministic, content-independent, and unchanged across
+runs. It is part of the exploratory floating-point router path; it does not
+alter the deployed integer inference kernel.
+
+## Same-protocol measurement
+
+Command:
+
+```bash
+cargo test -p uor-r4-router --release --offline \
+  --test hopf_sector_occupancy -- --ignored --nocapture
+```
+
+The run used the same 596 held-out articles, 1,500 routing samples, article
+identities, chunk size, gamma, sector budget, and production evolve-then-route
+sequence as #303.
+
+| measurement | #303 magnitude-only baseline | #306 signed projection |
+|---|---:|---:|
+| distinct sectors | 7 / 512 (1.4%) | 43 / 512 (8.4%) |
+| `chi_u` range | [0.4799, 0.5419] | [0.0001, 0.4741] |
+| `u_delta` range | [0.4783, 0.5029] | [0.0001, 1.0000] |
+| `u_alpha` range | [0.6169, 0.6260] | [0.1406, 0.8031] |
+
+The result removes the sign-restricted reachable region and increases observed
+occupancy by 6.1× on this corpus/protocol. It does not establish that all 512
+sectors are useful or reachable; retrieval quality and collision behavior need
+separate measurement before this projection can be treated as an improvement
+to serving quality.
+
+## Regression coverage
+
+The router unit suite verifies that a block aligned with the signed probe
+produces a positive projected component and that negating the same block
+produces a negative component. Formatting, the targeted router tests, and the
+ignored D3 measurement pass.


### PR DESCRIPTION
## Summary

- replace the sign-restricted four-block L2 projection feeding Hopf addressing
- project each 128-dimensional block onto a deterministic signed Blake3-derived direction
- normalize the signed four-vector before sector assignment
- add a regression test and document the same-protocol D3 remeasurement

## Measurement

Using the same 596 held-out articles and 1,500 routing samples as #303:

- distinct sectors: 7/512 (1.4%) baseline -> 43/512 (8.4%)
- u_delta: [0.4783, 0.5029] -> [0.0001, 1.0000]
- u_alpha: [0.6169, 0.6260] -> [0.1406, 0.8031]
- chi_u: [0.4799, 0.5419] -> [0.0001, 0.4741]

This removes the sign-restricted reachable region and increases observed occupancy by 6.1x on the pinned protocol. It does not claim full-sector reachability or serving-quality improvement.

## Validation

- cargo fmt --check
- git diff --check
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo test --workspace --offline
- cargo check -p uor-r4-graph-format --no-default-features
- cargo check -p uor-r4-graph-format --no-default-features --features alloc
- ignored D3 occupancy harness: passed

Relates to #306; follows the baseline measurement in #303.