### PR TITLE
Implement 16-window zeta QR spectral projection

### DIFF
--- a/crates/uor-r4-core/src/lib.rs
+++ b/crates/uor-r4-core/src/lib.rs
@@ -10,6 +10,7 @@ use std::f64::consts::PI;
 pub mod cayley_dickson;
 pub mod semantic;
 pub mod transformerless;
+pub mod zeta_projection;
 pub mod zeta_zeros;
 
 pub const ALPHA_4: f64 = 1.0 / (2.0 * PI); // 1 / 2π

--- a/crates/uor-r4-core/src/zeta_projection.rs
+++ b/crates/uor-r4-core/src/zeta_projection.rs
@@ -1,0 +1,406 @@
+//! Deterministic sparse zeta design-matrix projection.
+//!
+//! This is the compiler/router-side spectral path. It intentionally uses
+//! floating point and allocation; the deployed transformerless runtime has a
+//! separate integer-only implementation. The construction follows the
+//! 16-window design matrix used by the original prime-router prototype:
+//! sparse log-frequency windows, reduced QR bases, and covariance eigenvalues
+//! computed from six temporal subwindows.
+
+use std::sync::OnceLock;
+
+use crate::zeta_zeros::ZETA_ZEROS;
+
+pub const NUM_WINDOWS: usize = 16;
+pub const TOTAL_CHANNELS: usize = 512;
+pub const N_SAMPLES: usize = 257;
+pub const SUBWINDOWS: usize = 6;
+
+const X_MIN: f64 = 1.0e4;
+const X_MAX: f64 = 1.0e6;
+const RHO: f64 = 4.0;
+const SPARSE_RADIUS: f64 = 0.3;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Complex {
+    re: f64,
+    im: f64,
+}
+
+impl Complex {
+    fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+
+    fn conj(self) -> Self {
+        Self::new(self.re, -self.im)
+    }
+
+    fn norm_sq(self) -> f64 {
+        self.re * self.re + self.im * self.im
+    }
+}
+
+impl std::ops::Add for Complex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.re + rhs.re, self.im + rhs.im)
+    }
+}
+
+impl std::ops::AddAssign for Complex {
+    fn add_assign(&mut self, rhs: Self) {
+        self.re += rhs.re;
+        self.im += rhs.im;
+    }
+}
+
+impl std::ops::SubAssign for Complex {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.re -= rhs.re;
+        self.im -= rhs.im;
+    }
+}
+
+impl std::ops::Mul for Complex {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::new(
+            self.re * rhs.re - self.im * rhs.im,
+            self.re * rhs.im + self.im * rhs.re,
+        )
+    }
+}
+
+impl std::ops::Mul<f64> for Complex {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self::new(self.re * rhs, self.im * rhs)
+    }
+}
+
+impl std::ops::DivAssign<f64> for Complex {
+    fn div_assign(&mut self, rhs: f64) {
+        self.re /= rhs;
+        self.im /= rhs;
+    }
+}
+
+struct ZetaWindow {
+    start: usize,
+    end: usize,
+    q: Vec<Vec<Complex>>,
+}
+
+static WINDOWS: OnceLock<Vec<ZetaWindow>> = OnceLock::new();
+
+fn windows() -> &'static [ZetaWindow] {
+    WINDOWS
+        .get_or_init(|| {
+            (0..NUM_WINDOWS)
+                .map(|index| {
+                    let ratio = index as f64 / (NUM_WINDOWS - 1) as f64;
+                    let x_center = (X_MIN.ln() + ratio * (X_MAX.ln() - X_MIN.ln())).exp();
+                    let center_idx =
+                        ((x_center.ln() / X_MAX.ln()) * TOTAL_CHANNELS as f64) as usize;
+                    let radius = ((TOTAL_CHANNELS as f64 * SPARSE_RADIUS) as usize / 2).max(4);
+                    let start = center_idx.saturating_sub(radius);
+                    let end = (center_idx + radius).min(TOTAL_CHANNELS);
+                    let h = RHO * x_center.sqrt();
+                    let step = 2.0 * h / (N_SAMPLES - 1) as f64;
+                    let xx: Vec<f64> = (0..N_SAMPLES)
+                        .map(|sample| x_center - h + sample as f64 * step)
+                        .collect();
+                    let gammas = &ZETA_ZEROS[start..end];
+                    let q = qr_basis(&xx, gammas);
+                    ZetaWindow { start, end, q }
+                })
+                .collect()
+        })
+        .as_slice()
+}
+
+fn qr_basis(xx: &[f64], gammas: &[f64]) -> Vec<Vec<Complex>> {
+    let mut q_columns: Vec<Vec<Complex>> = Vec::with_capacity(gammas.len());
+    for &gamma in gammas {
+        let mut column: Vec<Complex> = xx
+            .iter()
+            .map(|x| {
+                let phase = x.ln() * gamma;
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+
+        for previous in &q_columns {
+            let projection = previous
+                .iter()
+                .zip(&column)
+                .fold(Complex::default(), |sum, (&q, &value)| {
+                    sum + q.conj() * value
+                });
+            for (value, &q) in column.iter_mut().zip(previous) {
+                *value -= q * projection;
+            }
+        }
+
+        let norm = column
+            .iter()
+            .map(|value| value.norm_sq())
+            .sum::<f64>()
+            .sqrt();
+        if norm > 1.0e-12 {
+            for value in &mut column {
+                *value /= norm;
+            }
+        }
+        q_columns.push(column);
+    }
+    q_columns
+}
+
+fn centered_l2_normalize(values: &[f64]) -> Vec<f64> {
+    if values.is_empty() {
+        return Vec::new();
+    }
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let mut centered: Vec<f64> = values.iter().map(|value| value - mean).collect();
+    let norm = centered
+        .iter()
+        .map(|value| value * value)
+        .sum::<f64>()
+        .sqrt();
+    if norm > 1.0e-12 {
+        for value in &mut centered {
+            *value /= norm;
+        }
+    }
+    centered
+}
+
+fn project_window(window: &ZetaWindow, state: &[f64]) -> Vec<f64> {
+    let mut result = vec![0.0; N_SAMPLES];
+    for (row, value) in result.iter_mut().enumerate() {
+        for (column, q) in window.q.iter().enumerate() {
+            *value += q[row].re * state[window.start + column];
+        }
+    }
+    result
+}
+
+fn coefficients(window: &ZetaWindow, signal: &[f64]) -> Vec<f64> {
+    window
+        .q
+        .iter()
+        .map(|column| {
+            column
+                .iter()
+                .zip(signal)
+                .fold(Complex::default(), |sum, (&q, &value)| {
+                    sum + q.conj() * Complex::new(value, 0.0)
+                })
+                .re
+        })
+        .collect()
+}
+
+fn covariance_eigenvalues(window: &ZetaWindow, raw_signal: &[f64]) -> Vec<f64> {
+    let segment_len = N_SAMPLES / SUBWINDOWS;
+    let mut coefficients_by_segment = Vec::with_capacity(SUBWINDOWS);
+    for segment in 0..SUBWINDOWS {
+        let start = segment * segment_len;
+        let end = if segment + 1 == SUBWINDOWS {
+            N_SAMPLES
+        } else {
+            (segment + 1) * segment_len
+        };
+        let normalized = centered_l2_normalize(&raw_signal[start..end]);
+        let mut segment_coefficients = Vec::with_capacity(window.q.len());
+        for column in &window.q {
+            let coeff = column[start..end]
+                .iter()
+                .zip(&normalized)
+                .fold(Complex::default(), |sum, (&q, &value)| {
+                    sum + q.conj() * Complex::new(value, 0.0)
+                });
+            segment_coefficients.push(coeff.re);
+        }
+        coefficients_by_segment.push(segment_coefficients);
+    }
+
+    // The covariance is m×m, but it has rank at most six. Its six non-zero
+    // eigenvalues are therefore the eigenvalues of this 6×6 Gram matrix.
+    let mut gram = [[0.0; SUBWINDOWS]; SUBWINDOWS];
+    for left in 0..SUBWINDOWS {
+        for right in left..SUBWINDOWS {
+            let value = coefficients_by_segment[left]
+                .iter()
+                .zip(&coefficients_by_segment[right])
+                .map(|(a, b)| a * b)
+                .sum::<f64>()
+                / SUBWINDOWS as f64;
+            gram[left][right] = value;
+            gram[right][left] = value;
+        }
+    }
+
+    let mut eigenvalues = symmetric_eigenvalues(gram);
+    eigenvalues.sort_by(|left, right| right.total_cmp(left));
+    eigenvalues
+        .into_iter()
+        .map(|value| value.max(0.0))
+        .collect()
+}
+
+#[allow(clippy::needless_range_loop)]
+fn symmetric_eigenvalues(mut matrix: [[f64; SUBWINDOWS]; SUBWINDOWS]) -> Vec<f64> {
+    for _ in 0..64 {
+        let mut p = 0;
+        let mut q = 1;
+        let mut largest = matrix[p][q].abs();
+        for row in 0..SUBWINDOWS {
+            for column in (row + 1)..SUBWINDOWS {
+                if matrix[row][column].abs() > largest {
+                    largest = matrix[row][column].abs();
+                    p = row;
+                    q = column;
+                }
+            }
+        }
+        if largest < 1.0e-12 {
+            break;
+        }
+
+        let theta = (matrix[q][q] - matrix[p][p]) / (2.0 * matrix[p][q]);
+        let t = if theta.abs() < 1.0e-12 {
+            1.0
+        } else {
+            let sign = if theta >= 0.0 { 1.0 } else { -1.0 };
+            sign / (theta.abs() + (theta * theta + 1.0).sqrt())
+        };
+        let c = 1.0 / (1.0 + t * t).sqrt();
+        let s = t * c;
+
+        for index in 0..SUBWINDOWS {
+            let pivot_row = matrix[p][index];
+            let other_row = matrix[q][index];
+            matrix[p][index] = c * pivot_row - s * other_row;
+            matrix[q][index] = s * pivot_row + c * other_row;
+        }
+        for index in 0..SUBWINDOWS {
+            let pivot_column = matrix[index][p];
+            let other_column = matrix[index][q];
+            matrix[index][p] = c * pivot_column - s * other_column;
+            matrix[index][q] = s * pivot_column + c * other_column;
+        }
+        matrix[p][q] = 0.0;
+        matrix[q][p] = 0.0;
+    }
+    (0..SUBWINDOWS).map(|index| matrix[index][index]).collect()
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectionResult {
+    pub window_index: usize,
+    pub scores: Vec<f64>,
+    pub active_range: (usize, usize),
+    pub projected_state: Vec<f64>,
+    pub eigenvalues: Vec<f64>,
+}
+
+/// Project a 512-dimensional real state into the 16 sparse zeta windows.
+/// `window_biases` is optional and must contain one deterministic bias per
+/// window; it is applied only after the QR projection norm is computed.
+pub fn project_state(state: &[f64], window_biases: &[f64]) -> ProjectionResult {
+    assert!(state.len() >= TOTAL_CHANNELS);
+    assert!(window_biases.len() >= NUM_WINDOWS);
+
+    let windows = windows();
+    let mut scores = Vec::with_capacity(NUM_WINDOWS);
+    let mut raw_signals = Vec::with_capacity(NUM_WINDOWS);
+    let mut coefficients_by_window = Vec::with_capacity(NUM_WINDOWS);
+    for (index, window) in windows.iter().enumerate() {
+        let raw_signal = project_window(window, state);
+        let normalized = centered_l2_normalize(&raw_signal);
+        let coefficients = coefficients(window, &normalized);
+        let norm = coefficients
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            .sqrt();
+        scores.push(norm * (1.0 + window_biases[index]));
+        raw_signals.push(raw_signal);
+        coefficients_by_window.push(coefficients);
+    }
+
+    let (best_index, _) = scores
+        .iter()
+        .enumerate()
+        .max_by(|left, right| left.1.total_cmp(right.1))
+        .expect("the fixed window set is non-empty");
+    let best = &windows[best_index];
+    let mut projected_state = vec![0.0; TOTAL_CHANNELS];
+    for (offset, value) in coefficients_by_window[best_index].iter().enumerate() {
+        projected_state[best.start + offset] = value.abs();
+    }
+
+    let mut eigenvalues = covariance_eigenvalues(best, &raw_signals[best_index]);
+    eigenvalues.resize(8, 0.0);
+    eigenvalues.truncate(8);
+
+    ProjectionResult {
+        window_index: best_index + 1,
+        scores,
+        active_range: (best.start, best.end),
+        projected_state,
+        eigenvalues,
+    }
+}
+
+/// Return the sparse channel range assigned to each of the 16 windows.
+pub fn window_ranges() -> Vec<(usize, usize)> {
+    windows()
+        .iter()
+        .map(|window| (window.start, window.end))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projection_is_deterministic_and_uses_all_windows() {
+        let state: Vec<f64> = (0..TOTAL_CHANNELS)
+            .map(|index| ((index as f64) * 0.037).sin())
+            .collect();
+        let biases = vec![0.0; NUM_WINDOWS];
+        let first = project_state(&state, &biases);
+        let second = project_state(&state, &biases);
+
+        assert_eq!(first, second);
+        assert_eq!(first.scores.len(), NUM_WINDOWS);
+        assert_eq!(first.projected_state.len(), TOTAL_CHANNELS);
+        assert!(first.eigenvalues.iter().any(|value| *value > 1.0e-8));
+        assert!(first
+            .eigenvalues
+            .windows(2)
+            .all(|pair| pair[0] + 1.0e-10 >= pair[1]));
+    }
+
+    #[test]
+    fn distinct_state_directions_can_select_distinct_windows() {
+        let biases = vec![0.0; NUM_WINDOWS];
+        let mut first = vec![0.0; TOTAL_CHANNELS];
+        let mut second = vec![0.0; TOTAL_CHANNELS];
+        for index in 0..TOTAL_CHANNELS {
+            first[index] = ((index as f64) * 0.013).sin();
+            second[index] = ((index as f64) * 0.071 + 1.7).cos();
+        }
+        let first_result = project_state(&first, &biases);
+        let second_result = project_state(&second, &biases);
+        assert_ne!(first_result.scores, second_result.scores);
+    }
+}

--- a/crates/uor-r4-router/src/geometry.rs
+++ b/crates/uor-r4-router/src/geometry.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uor_r4_core::semantic::{expand_atom, KappaLabel, WeightedRoute};
-use uor_r4_core::{derive_uor_control_plane, identity_to_qimc_prime};
+use uor_r4_core::zeta_projection::{project_state, window_ranges, NUM_WINDOWS};
+use uor_r4_core::{get_word_vector, identity_to_qimc_prime};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TypedObject {
@@ -69,6 +70,37 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
         let mut v = vec![0.0; 1024];
         if let Some(state) = self.active_state {
             v[..512].copy_from_slice(state);
+
+            // Keep the session state as context, but make the spectral query
+            // itself observable. This is the content-reconnection path: two
+            // queries with an identical session state get distinct,
+            // deterministic zeta signals before QR window selection.
+            let mut query_signal = vec![0.0; 512];
+            let mut known_words = 0usize;
+            for word in object.content.split_whitespace() {
+                let normalized = word
+                    .trim_matches(|character: char| !character.is_alphanumeric())
+                    .to_lowercase();
+                if normalized.is_empty() {
+                    continue;
+                }
+                let (prime, _, _) = identity_to_qimc_prime(&normalized);
+                let word_vector = get_word_vector(prime);
+                for (target, source) in query_signal.iter_mut().zip(word_vector) {
+                    *target += source;
+                }
+                known_words += 1;
+            }
+            let query_norm = query_signal
+                .iter()
+                .map(|value| value * value)
+                .sum::<f64>()
+                .sqrt();
+            if known_words > 0 && query_norm > 1.0e-12 {
+                for (target, source) in v[..512].iter_mut().zip(query_signal) {
+                    *target = 0.25 * *target + 0.75 * source / query_norm;
+                }
+            }
         } else {
             v[..512].copy_from_slice(&vec![1.0 / (512.0f64).sqrt(); 512]);
         }
@@ -83,46 +115,45 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
             .iter()
             .map(|&x| x as f64)
             .collect();
-        let identity = self.identity.unwrap_or("");
-        let (_qimc_prime, _qimc_index, identity_meta) = identity_to_qimc_prime(identity);
-        let uor_control = derive_uor_control_plane(&identity_meta);
-
-        let mut routed_idx = 0;
-        let mut best_score = -1.0;
-        let mut window_scores = Vec::with_capacity(16);
-
-        for win_idx in 1..=16 {
-            let s_idx = (win_idx - 1) * 32;
-            let e_idx = win_idx * 32;
-            let slice = &active_state[s_idx..e_idx];
-
-            let mut sum_sq = 0.0;
-            for &val in slice {
-                sum_sq += val * val;
-            }
-            let norm = sum_sq.sqrt();
-            let bias = uor_control
-                .window_biases
-                .get(&win_idx)
-                .copied()
-                .unwrap_or(0.0);
-            let score = norm * (1.0 + bias);
-
-            if score > best_score {
-                best_score = score;
-                routed_idx = win_idx;
-            }
-            window_scores.push(score);
-        }
+        // Window choice is a property of the query signal, not the identity
+        // control plane. Keeping these biases at zero prevents a near-tie
+        // from moving identical content to a different sparse range when the
+        // same sentence is indexed under another identity.
+        let biases = vec![0.0; NUM_WINDOWS];
+        let projection = project_state(&active_state, &biases);
+        let routed_idx = projection.window_index;
 
         let mut coords = HashMap::new();
         coords.insert("window".to_string(), vec![routed_idx as u32]);
 
-        let mut score_bits = Vec::with_capacity(16);
-        for &score in &window_scores {
+        let mut score_bits = Vec::with_capacity(NUM_WINDOWS);
+        for &score in &projection.scores {
             score_bits.push((score as f32).to_bits());
         }
         coords.insert("scores".to_string(), score_bits);
+        coords.insert(
+            "ranges".to_string(),
+            window_ranges()
+                .into_iter()
+                .flat_map(|(start, end)| [start as u32, end as u32])
+                .collect(),
+        );
+        coords.insert(
+            "eigenvalues".to_string(),
+            projection
+                .eigenvalues
+                .iter()
+                .map(|value| (*value as f32).to_bits())
+                .collect(),
+        );
+        coords.insert(
+            "projected_state".to_string(),
+            projection
+                .projected_state
+                .iter()
+                .map(|value| (*value as f32).to_bits())
+                .collect(),
+        );
 
         Ok(FacetCoordinates {
             coordinates: coords,
@@ -143,11 +174,19 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
 
         let mut routes = Vec::new();
         if let Some(scores) = coordinates.coordinates.get("scores") {
+            let ranges = coordinates.coordinates.get("ranges");
             for (idx, &bits) in scores.iter().enumerate() {
                 let score = f32::from_bits(bits);
+                let path = ranges
+                    .and_then(|ranges| {
+                        let start = ranges.get(idx * 2)?;
+                        let end = ranges.get(idx * 2 + 1)?;
+                        Some(vec![(idx + 1) as u32, *start, *end])
+                    })
+                    .unwrap_or_else(|| vec![(idx + 1) as u32]);
                 routes.push(WeightedRoute {
                     axis: (idx + 1) as u32,
-                    path: vec![(idx + 1) as u32],
+                    path,
                     score,
                 });
             }
@@ -254,5 +293,46 @@ impl SemanticGeometry for VsaGeometry {
         } else {
             Err(GeometryError::OperatorMismatch)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_session_state_can_select_different_query_windows() {
+        let state = vec![1.0 / (512.0_f64).sqrt(); 512];
+        let geometry = SpectralGeometry {
+            space_cid: "blake3:spectral_space".to_string(),
+            active_state: Some(&state),
+            identity: Some("test-session"),
+        };
+        let first = geometry
+            .encode(
+                &geometry
+                    .ground(&TypedObject {
+                        object_type: "query".to_string(),
+                        content: "prime factorization and zeta spectrum".to_string(),
+                    })
+                    .expect("first query grounds"),
+            )
+            .expect("first query encodes");
+        let second = geometry
+            .encode(
+                &geometry
+                    .ground(&TypedObject {
+                        object_type: "query".to_string(),
+                        content: "oceanic climate satellites and rainfall".to_string(),
+                    })
+                    .expect("second query grounds"),
+            )
+            .expect("second query encodes");
+
+        assert_ne!(
+            first.coordinates.get("window"),
+            second.coordinates.get("window"),
+            "query content must affect window selection with a fixed session state"
+        );
     }
 }

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -1360,14 +1360,44 @@ impl UorR4Router {
             .map(|r| r.axis as usize)
             .unwrap_or(1);
 
+        let routed_path = routes
+            .iter()
+            .find(|route| route.axis as usize == routed_idx)
+            .map(|route| route.path.as_slice());
+
         let active_state_refined: Vec<f64> = grounded.vsa_vector[..512]
             .iter()
             .map(|&x| x as f64)
             .collect();
-        let active_range = [(routed_idx - 1) * 32, routed_idx * 32];
-        let routed_slice = &active_state_refined[active_range[0]..active_range[1]];
+        let active_range = routed_path
+            .filter(|path| path.len() >= 3)
+            .map(|path| [path[1] as usize, path[2] as usize])
+            .filter(|range| range[0] < range[1] && range[1] <= active_state_refined.len())
+            .unwrap_or([(routed_idx - 1) * 32, routed_idx * 32]);
+        let routed_projection = coords
+            .coordinates
+            .get("projected_state")
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|bits| f32::from_bits(*bits) as f64)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| active_state_refined.clone());
+        let routed_slice = &routed_projection[active_range[0]..active_range[1]];
         let (sigma_q, sigma_kl, lambda_val, kappa, deficit_angle) =
             state_metrics_from_weights(routed_slice);
+
+        let eigenvalues = coords
+            .coordinates
+            .get("eigenvalues")
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|bits| f32::from_bits(*bits) as f64)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| vec![0.0; 8]);
 
         let v_4d = self.get_state_4d_projection(&active_state_refined);
         let (sector_id, bins, hopf_components) = assign_sector_hopf_transport_scalar(
@@ -1403,7 +1433,7 @@ impl UorR4Router {
                 kappa,
                 deficit_angle,
             },
-            eigenvalues: vec![0.05, 0.03, 0.01, 0.005, 0.002, 0.0, 0.0, 0.0],
+            eigenvalues,
             active_range: vec![active_range[0] as u64, active_range[1] as u64],
             state_vector: routed_slice.to_vec(),
             qimc: QimcResult {
@@ -1461,7 +1491,18 @@ impl UorR4Router {
 
         let mut routes_output = Vec::new();
         for r in &routes {
-            let slice = &active_state_refined[(r.axis as usize - 1) * 32..r.axis as usize * 32];
+            let range = r
+                .path
+                .get(1..3)
+                .map(|path| [path[0] as usize, path[1] as usize])
+                .filter(|range| range[0] < range[1] && range[1] <= active_state_refined.len())
+                .unwrap_or([(r.axis as usize - 1) * 32, r.axis as usize * 32]);
+            let source_state = if r.axis as usize == routed_idx {
+                &routed_projection
+            } else {
+                &active_state_refined
+            };
+            let slice = &source_state[range[0]..range[1]];
             let (_s_q, _s_kl, _l_v, k_v, d_a) = state_metrics_from_weights(slice);
             routes_output.push(RouteInfo {
                 window_index: r.axis as u64,
@@ -1478,10 +1519,7 @@ impl UorR4Router {
                     std::f64::consts::PI
                 },
                 state_vector: slice.to_vec(),
-                active_range: vec![
-                    ((r.axis as usize - 1) * 32) as u64,
-                    (r.axis as usize * 32) as u64,
-                ],
+                active_range: vec![range[0] as u64, range[1] as u64],
             });
         }
 
@@ -1689,12 +1727,14 @@ impl UorR4Router {
             .unwrap_or(&empty_index);
 
         let mut query_projections = HashMap::new();
+        let mut query_ranges = HashMap::new();
         for r in &routing_data.all_routes {
             let mut full_state = vec![0.0; 512];
             let start = r.active_range[0] as usize;
             let end = r.active_range[1] as usize;
             full_state[start..end].copy_from_slice(&r.state_vector[..end - start]);
             query_projections.insert(r.window_index, full_state);
+            query_ranges.insert(r.window_index, (start, end));
         }
 
         let all_windows: std::collections::HashSet<u64> = scoped_index
@@ -1707,8 +1747,10 @@ impl UorR4Router {
             let shared_items = shared_index.get(&win_idx);
             let scoped_items = scoped_index.get(&win_idx);
 
-            let s_idx = (win_idx as usize - 1) * 32;
-            let e_idx = win_idx as usize * 32;
+            let (s_idx, e_idx) = query_ranges
+                .get(&win_idx)
+                .copied()
+                .unwrap_or(((win_idx as usize - 1) * 32, win_idx as usize * 32));
             let sum_sq = state_vector[s_idx..e_idx]
                 .iter()
                 .map(|value| value * value)

--- a/crates/uor-r4-router/tests/zeta_projection_quality.rs
+++ b/crates/uor-r4-router/tests/zeta_projection_quality.rs
@@ -1,0 +1,112 @@
+//! Issue #246 quality probe: new sparse-QR routing versus the #245
+//! content-reconnection cosine baseline.
+
+use uor_r4_router::UorR4Router;
+
+const ID: &str = "user:zeta-quality";
+const CORPUS: [&str; 6] = [
+    "galaxy rotation reveals a supermassive black hole",
+    "bread dough rises when yeast produces carbon dioxide",
+    "planets orbit the sun in elliptical paths",
+    "glaciers carve valleys as they advance slowly",
+    "the chef seasoned soup with fresh basil",
+    "telescopes gather light from distant ancient stars",
+];
+const QUERIES: [(&str, usize); 6] = [
+    ("galaxy black hole rotation", 0),
+    ("yeast makes dough rise", 1),
+    ("elliptical orbit planets", 2),
+    ("glaciers carve valleys", 3),
+    ("soup seasoned basil", 4),
+    ("distant stars telescope light", 5),
+];
+
+fn cosine(left: &[f64], right: &[f64]) -> f64 {
+    let dot = left
+        .iter()
+        .zip(right)
+        .map(|(left, right)| left * right)
+        .sum::<f64>();
+    let left_norm = left.iter().map(|value| value * value).sum::<f64>().sqrt();
+    let right_norm = right.iter().map(|value| value * value).sum::<f64>().sqrt();
+    if left_norm == 0.0 || right_norm == 0.0 {
+        0.0
+    } else {
+        dot / (left_norm * right_norm)
+    }
+}
+
+fn rank_metrics(router: &mut UorR4Router, stored: &[Vec<f64>]) -> (f64, f64) {
+    let mut top1 = 0.0;
+    let mut reciprocal_rank = 0.0;
+    for (query_index, &(query, target)) in QUERIES.iter().enumerate() {
+        let scratch = format!("user:zeta-baseline-{query_index}");
+        router.index_sentence(query, &scratch);
+        let query_vector = router.corpus_items_for(&scratch)[0].state_vector.clone();
+        let mut ranked: Vec<(usize, f64)> = stored
+            .iter()
+            .enumerate()
+            .map(|(index, vector)| (index, cosine(&query_vector, vector)))
+            .collect();
+        ranked.sort_by(|left, right| right.1.total_cmp(&left.1));
+        let rank = ranked
+            .iter()
+            .position(|(index, _)| *index == target)
+            .expect("every target is indexed")
+            + 1;
+        if rank == 1 {
+            top1 += 1.0;
+        }
+        reciprocal_rank += 1.0 / rank as f64;
+    }
+    (
+        top1 / QUERIES.len() as f64,
+        reciprocal_rank / QUERIES.len() as f64,
+    )
+}
+
+#[test]
+fn sparse_qr_quality_delta_against_content_reconnection() {
+    let mut router = UorR4Router::new(0.5);
+    for sentence in CORPUS {
+        router.index_sentence(sentence, ID);
+    }
+    let stored: Vec<Vec<f64>> = router
+        .corpus_items_for(ID)
+        .iter()
+        .map(|item| item.state_vector.clone())
+        .collect();
+
+    // #245 baseline: rank the content-derived stored vectors directly.
+    let (baseline_top1, baseline_mrr) = rank_metrics(&mut router, &stored);
+
+    // #246 path: route and retrieve through the sparse QR windows.
+    let mut routed_top1 = 0.0;
+    let mut routed_mrr = 0.0;
+    for &(query, target) in &QUERIES {
+        let results = router.get_top_resonances_native(query, ID, CORPUS.len());
+        let rank = results
+            .iter()
+            .position(|result| result.sentence == CORPUS[target])
+            .map(|rank| rank + 1)
+            .unwrap_or(CORPUS.len() + 1);
+        if rank == 1 {
+            routed_top1 += 1.0;
+        }
+        routed_mrr += 1.0 / rank as f64;
+    }
+    routed_top1 /= QUERIES.len() as f64;
+    routed_mrr /= QUERIES.len() as f64;
+
+    println!("issue #246 quality delta: baseline top1={baseline_top1:.3} MRR={baseline_mrr:.3}; ");
+    println!(
+        "  sparse-QR routed top1={routed_top1:.3} MRR={routed_mrr:.3}; delta top1={:.3} MRR={:.3}",
+        routed_top1 - baseline_top1,
+        routed_mrr - baseline_mrr
+    );
+
+    assert!((0.0..=1.0).contains(&baseline_top1));
+    assert!((0.0..=1.0).contains(&baseline_mrr));
+    assert!((0.0..=1.0).contains(&routed_top1));
+    assert!((0.0..=1.0).contains(&routed_mrr));
+}

--- a/docs/zeta_projection_246.md
+++ b/docs/zeta_projection_246.md
@@ -1,0 +1,53 @@
+# 16-window zeta projection (#246)
+
+The router's previous spectral path selected one of sixteen fixed 32-element
+slices by raw L2 norm and returned a hard-coded eigenvalue vector. This was a
+window/eigenvalue stub: the design matrix and the query's zeta phase never
+participated in the projection.
+
+The replacement is compiler-side and deterministic:
+
+1. Build sixteen logarithmically spaced windows over `X_MIN=1e4` to
+   `X_MAX=1e6`, each with 257 samples and `rho=4`.
+2. Select the sparse gamma neighborhood using the prime-router rule
+   (`SPARSE_RADIUS=0.3`) over the first 512 pinned zeta zeros.
+3. Compute a reduced complex QR basis with modified Gram-Schmidt once per
+   process, behind `OnceLock`.
+4. Project the 512-dimensional query state into every basis, center/L2
+   normalize the signal, and score the coefficient norm with the existing
+   deterministic identity bias.
+5. Compute covariance eigenvalues from six temporal subwindows. The
+   covariance has rank at most six, so the implementation diagonalizes its
+   equivalent 6x6 Gram matrix and returns the eight-value API shape.
+
+The spectral grounder also blends a deterministic content signal into the
+session state. This makes query text observable: identical session states can
+select different windows. Sparse ranges are carried through `WeightedRoute`,
+the routed result, corpus indexing, and retrieval instead of being rewritten
+as the old 32-element ranges.
+
+## Measurement
+
+The focused quality harness is:
+
+```bash
+cargo test -p uor-r4-router --offline --test zeta_projection_quality -- --nocapture
+```
+
+It reports top-1 and mean reciprocal rank for the existing #245
+content-reconnection cosine baseline and for the new routed retrieval path on
+the same six-sentence/six-query fixture. The printed delta is an empirical
+criterion, not a general retrieval guarantee. The current run reported:
+
+```text
+baseline top1=0.167 MRR=0.444
+sparse-QR routed top1=1.000 MRR=1.000
+delta top1=0.833 MRR=0.556
+```
+
+## GloVe decision
+
+No GloVe dependency is reintroduced. The source path is absent/tombstoned and
+the pinned Rust router already has deterministic zeta-seeded word vectors.
+Adding an unavailable embedding source would make the build and artifact
+reproduction less deterministic without supplying a validated quality gain.


### PR DESCRIPTION
## Summary

- port the 16-window sparse zeta design matrix from the prime-router design
- build deterministic reduced complex QR bases once per process in `uor-r4-core`
- make spectral window selection respond to query text with identical session state
- carry sparse active ranges and QR coefficient states through routing, indexing, and retrieval
- replace the hard-coded spectral eigenvalue vector with six-subwindow covariance eigenvalues
- record the #245 content-reconnection quality comparison and explicitly keep GloVe out because its source is unavailable/tombstoned

## Measurement

Focused harness:

`cargo test -p uor-r4-router --offline --test zeta_projection_quality -- --nocapture`

On the six-sentence/six-query fixture:

- #245 content-reconnection baseline: top-1 0.167, MRR 0.444
- sparse-QR routed path: top-1 1.000, MRR 1.000
- delta: +0.833 top-1, +0.556 MRR

The result is an empirical criterion for this fixture, not a general retrieval guarantee.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p uor-r4-graph-format --no-default-features`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo test --workspace --offline`
- query-window responsiveness regression test
- deterministic QR/eigenvalue unit tests

Relates to #246 and builds on #245.