### PR TITLE
Feed session manifold signatures into the graph bias lane

### DIFF
--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -38,6 +38,18 @@ pub struct R4G1Runtime<'a> {
     chain: crate::patch_chain::PatchChain<'a>,
 }
 
+fn signature_affinity_bonus(prototype: &[u8], mask: &[u8], signature: &[u8]) -> i32 {
+    let mut distance = 0u32;
+    for ((&prototype_byte, &mask_byte), &signature_byte) in
+        prototype.iter().zip(mask).zip(signature)
+    {
+        distance += ((signature_byte ^ prototype_byte) & mask_byte).count_ones();
+    }
+    let x = 288i32.saturating_sub(distance as i32);
+    // x * 10 == (x << 3) + (x << 1), preserving the integer-only kernel.
+    (x << 3).saturating_add(x << 1)
+}
+
 impl<'a> R4G1Runtime<'a> {
     /// Create a new R4G1 runtime by running two-stage validation over `bytes`.
     pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
@@ -479,6 +491,29 @@ impl<'a> R4G1Runtime<'a> {
         signature: Option<&[u8]>,
         _node_scores: &mut [ScoreQ],
     ) -> (u32, ScoreQ) {
+        self.predict_distribution_with_signature_lanes(
+            context_tokens,
+            signature,
+            None,
+            _node_scores,
+        )
+    }
+
+    /// Predict with separate context and session signatures.
+    ///
+    /// The context signature remains the only input to ROUT fallback, so
+    /// enabling the session lane starts as a bias-only experiment. The
+    /// optional session signature participates in the existing emission
+    /// affinity bonus below; callers can later opt it into ROUT after an
+    /// evaluation establishes that the fallback prototypes are calibrated
+    /// for session-space inputs.
+    pub fn predict_distribution_with_signature_lanes(
+        &self,
+        context_tokens: &[u32],
+        context_signature: Option<&[u8]>,
+        session_signature: Option<&[u8]>,
+        _node_scores: &mut [ScoreQ],
+    ) -> (u32, ScoreQ) {
         let num_nodes = self.node_count();
         if num_nodes == 0 || context_tokens.is_empty() {
             return (0, ScoreQ::ZERO);
@@ -577,7 +612,7 @@ impl<'a> R4G1Runtime<'a> {
         // If the suffix DFA fell off the manifold, use the continuous 288-bit VSA signature
         // to find the top-M semantic regions N_best (N_best <= 8) to jump back onto the graph!
         if (active_len == 0 || (active_len == 1 && active_nodes[0] == 0))
-            && let Some(sig) = signature
+            && let Some(sig) = context_signature
         {
             let mut best_node = 0;
             let mut best_dist = u32::MAX;
@@ -719,25 +754,18 @@ impl<'a> R4G1Runtime<'a> {
                             ScoreQ::from_raw(1)
                         };
 
-                        let sig_bonus = if let Some(sig) = signature {
+                        let sig_bonus = if let Some(sig) = session_signature.or(context_signature) {
                             let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
                             let proto_offset = (target_node.prototype_word_start as usize) << 3;
                             let mask_offset = (target_node.mask_word_start as usize) << 3;
                             if proto_offset + sig.len() <= rout_bytes.len()
                                 && mask_offset + sig.len() <= rout_bytes.len()
                             {
-                                let mut dist = 0u32;
-                                for k in 0..sig.len() {
-                                    let p = rout_bytes[proto_offset + k];
-                                    let m = rout_bytes[mask_offset + k];
-                                    let s = sig[k];
-                                    dist += ((s ^ p) & m).count_ones();
-                                }
-                                {
-                                    // x * 10 == (x << 3) + (x << 1) (shift/add only).
-                                    let x = 288i32.saturating_sub(dist as i32);
-                                    (x << 3).saturating_add(x << 1)
-                                }
+                                signature_affinity_bonus(
+                                    &rout_bytes[proto_offset..proto_offset + sig.len()],
+                                    &rout_bytes[mask_offset..mask_offset + sig.len()],
+                                    sig,
+                                )
                             } else {
                                 0
                             }
@@ -829,6 +857,25 @@ impl<'a> R4G1Runtime<'a> {
         node_scores: &mut [ScoreQ],
         out_candidates: &mut [(u32, ScoreQ); 8],
     ) -> usize {
+        self.predict_candidates_with_signature_lanes(
+            context_tokens,
+            signature,
+            None,
+            node_scores,
+            out_candidates,
+        )
+    }
+
+    /// Top-k counterpart of
+    /// [`Self::predict_distribution_with_signature_lanes`].
+    pub fn predict_candidates_with_signature_lanes(
+        &self,
+        context_tokens: &[u32],
+        context_signature: Option<&[u8]>,
+        session_signature: Option<&[u8]>,
+        node_scores: &mut [ScoreQ],
+        out_candidates: &mut [(u32, ScoreQ); 8],
+    ) -> usize {
         let prev_token = context_tokens.last().copied().unwrap_or(0);
         let mut tokens_since_period = 0usize;
         for &tok in context_tokens.iter().rev() {
@@ -838,8 +885,12 @@ impl<'a> R4G1Runtime<'a> {
             tokens_since_period += 1;
         }
 
-        let (top_tok, top_score) =
-            self.predict_distribution(context_tokens, signature, node_scores);
+        let (top_tok, top_score) = self.predict_distribution_with_signature_lanes(
+            context_tokens,
+            context_signature,
+            session_signature,
+            node_scores,
+        );
 
         let mut count = 0usize;
         if top_tok != 0 {
@@ -904,5 +955,22 @@ impl<'a> R4G1Runtime<'a> {
         }
         out_candidates[..count].sort_by_key(|b| core::cmp::Reverse(b.1.raw()));
         count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::signature_affinity_bonus;
+
+    #[test]
+    fn session_lane_bonus_is_integer_hamming_affinity() {
+        let prototype = [0u8; 36];
+        let mask = [0xffu8; 36];
+        let near = [0u8; 36];
+        let far = [0xffu8; 36];
+        assert!(
+            signature_affinity_bonus(&prototype, &mask, &near)
+                > signature_affinity_bonus(&prototype, &mask, &far)
+        );
     }
 }

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -69,3 +69,38 @@ fn r4g1_runtime_enforces_no_float_in_prediction_path() {
     assert!(score >= ScoreQ::MIN);
     assert!(score <= ScoreQ::MAX);
 }
+
+#[test]
+fn session_signature_is_bias_only_until_routing_is_calibrated() {
+    let (art_bytes, artifacts) = fixture_artifacts();
+    let store = synthetic_store();
+    let store_bytes = runtime::store_bytes(&store);
+    let (r4g1_bytes, _) =
+        convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None).unwrap();
+    let runtime = R4G1Runtime::parse(&r4g1_bytes).unwrap();
+    let context_signature = [0x55u8; 36];
+    let zero_session = [0u8; 36];
+    let full_session = [0xffu8; 36];
+
+    let mut zero_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let mut full_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let zero = runtime.predict_distribution_with_signature_lanes(
+        &[3, 1, 4],
+        Some(&context_signature),
+        Some(&zero_session),
+        &mut zero_scores,
+    );
+    let full = runtime.predict_distribution_with_signature_lanes(
+        &[3, 1, 4],
+        Some(&context_signature),
+        Some(&full_session),
+        &mut full_scores,
+    );
+
+    assert_eq!(
+        zero.0, full.0,
+        "session lane must not change ROUT fallback yet"
+    );
+    assert!(zero.1 >= ScoreQ::MIN);
+    assert!(full.1 >= ScoreQ::MIN);
+}

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -13,6 +13,11 @@ use wasm_bindgen::prelude::*;
 pub mod benchmark;
 pub mod fallback;
 pub mod geometry;
+pub mod session_signature;
+
+pub use session_signature::{
+    from_state as session_signature_from_state, from_tokens as session_signature_from_tokens,
+};
 
 pub use fallback::{
     run_cascade, run_cascade_with_policy, AbstainPolicy, CascadeOutcome, EngineResponse,

--- a/crates/uor-r4-router/src/session_signature.rs
+++ b/crates/uor-r4-router/src/session_signature.rs
@@ -1,0 +1,85 @@
+//! Server-side quantization for the persistent session manifold.
+//!
+//! The graph runtime consumes only the resulting 288-bit value. Floating
+//! point state construction stays on the serving side, outside the deployed
+//! integer-only prediction contract.
+
+pub const SESSION_SIGNATURE_BITS: usize = 288;
+pub const SESSION_SIGNATURE_BYTES: usize = SESSION_SIGNATURE_BITS / 8;
+
+/// Quantize a centered session-manifold state into the graph's 288-bit
+/// signature space.
+///
+/// Each bit uses a deterministic signed three-coordinate projection. The
+/// fixed index schedule is part of the signature definition: changing it is
+/// a representation change and must be versioned with the graph artifacts.
+pub fn from_state(state: &[f64]) -> [u8; SESSION_SIGNATURE_BYTES] {
+    let mut signature = [0u8; SESSION_SIGNATURE_BYTES];
+    if state.is_empty() {
+        return signature;
+    }
+
+    let mean = state.iter().sum::<f64>() / state.len() as f64;
+    for bit in 0..SESSION_SIGNATURE_BITS {
+        let first = state[(bit * 37 + 11) % state.len()] - mean;
+        let second = state[(bit * 97 + 7) % state.len()] - mean;
+        let third = state[(bit * 193 + 3) % state.len()] - mean;
+        let projection = first + 0.5 * second - 0.25 * third;
+        if projection >= 0.0 {
+            signature[bit >> 3] |= 1 << (bit & 7);
+        }
+    }
+    signature
+}
+
+/// Deterministic fallback for clients that have token history but no
+/// persistent f64 manifold. This preserves the same 288-bit lane and makes
+/// the direct chat client session-sensitive; the HTTP server uses [`from_state`]
+/// from its persistent manifold instead.
+pub fn from_tokens(tokens: &[u32]) -> [u8; SESSION_SIGNATURE_BYTES] {
+    let mut lanes = [0u64; 5];
+    for (position, &token) in tokens.iter().enumerate() {
+        let mut value =
+            u64::from(token).wrapping_add((position as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15));
+        for (lane, slot) in lanes.iter_mut().enumerate() {
+            value = splitmix64(value.wrapping_add(lane as u64));
+            *slot = slot.rotate_left((lane * 11 + position % 17) as u32) ^ value;
+        }
+    }
+
+    let mut signature = [0u8; SESSION_SIGNATURE_BYTES];
+    for (index, byte) in signature.iter_mut().enumerate() {
+        let lane = index % lanes.len();
+        let shift = (index / lanes.len()) * 8;
+        *byte = (lanes[lane] >> shift) as u8;
+    }
+    signature
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_projection_is_deterministic_and_sensitive() {
+        let first: Vec<f64> = (0..512).map(|index| (index as f64 * 0.13).sin()).collect();
+        let second: Vec<f64> = (0..512)
+            .map(|index| (index as f64 * 0.17 + 1.3).cos())
+            .collect();
+        assert_eq!(from_state(&first), from_state(&first));
+        assert_ne!(from_state(&first), from_state(&second));
+    }
+
+    #[test]
+    fn token_history_projection_is_order_sensitive() {
+        assert_ne!(from_tokens(&[1, 2, 3]), from_tokens(&[3, 2, 1]));
+        assert_eq!(from_tokens(&[]), [0; SESSION_SIGNATURE_BYTES]);
+    }
+}

--- a/docs/session_signature_247.md
+++ b/docs/session_signature_247.md
@@ -1,0 +1,34 @@
+# Session-manifold signature lane (#247)
+
+The graph runtime already accepts a 288-bit signature for geometric routing,
+but the serving callers derived it from the same eight-token window used as
+the context. That made the lane blind to conversation history outside the
+window.
+
+This change adds an opt-in two-lane API:
+
+- the context signature remains the input to ROUT fallback;
+- the session signature is used by the existing emission-affinity bonus;
+- the two lanes are deliberately separate so the first experiment cannot
+  route an uncalibrated persistent-state signature into graph prototypes.
+
+The server quantizes the persistent 512-dimensional manifold state with a
+versioned deterministic three-coordinate signed projection. The direct chat
+client, which has no manifold owner, uses an order-sensitive token-history
+fallback. Both produce the graph's 288-bit / 36-byte signature width.
+
+The graph runtime adds no floating-point or multiplication operations. Its
+session lane reuses the existing masked Hamming distance and shift/add bonus.
+ROUT fallback remains context-only until a held-out evaluation establishes
+that session-state prototypes are calibrated for that path.
+
+## A/B guard
+
+The direct-chat regression test constructs two histories with the same final
+eight-token context and different prefixes. Their session signatures differ,
+while the context slices are byte-identical. The runtime test additionally
+checks that enabling the lane does not change the current ROUT fallback token.
+
+This is an architecture-level A/B guard, not a claim of general language
+quality improvement; the empirical quality gate remains a follow-up measurement
+on a pinned multi-turn fixture.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -284,6 +284,7 @@ fn hologram_answer(
         &question_tokens[1..question_count]
     };
     append_history(history, history_len, question_tokens);
+    let session_signature = uor_r4_router::session_signature_from_tokens(&history[..*history_len]);
 
     if let Some(bytes) = r4g1_bytes {
         if let Ok(r4g1) = uor_r4_graph_runtime::R4G1Runtime::parse(bytes) {
@@ -330,9 +331,10 @@ fn hologram_answer(
 
                     let mut cands =
                         [(0u32, uor_r4_core::transformerless::score_q::ScoreQ::ZERO); 8];
-                    let num_cands = r4g1.predict_candidates(
+                    let num_cands = r4g1.predict_candidates_with_signature_lanes(
                         &beam_history,
                         Some(&sig),
+                        Some(&session_signature),
                         &mut node_scores,
                         &mut cands,
                     );
@@ -2362,6 +2364,7 @@ fn render_audit_trace_record(
 #[cfg(test)]
 mod tests {
     use super::{parse_remote_url, repeated_suffix};
+    use uor_r4_router::session_signature_from_tokens;
 
     #[test]
     fn repetition_guard_detects_repeated_token_windows() {
@@ -2380,5 +2383,23 @@ mod tests {
         assert_eq!(host, "localhost");
         assert_eq!(port, 9000);
         assert_eq!(path, "/v1/chat/completions");
+    }
+
+    #[test]
+    fn session_lane_sees_history_beyond_the_shared_eight_token_context() {
+        let shared_context = [10, 11, 12, 13, 14, 15, 16, 17];
+        let mut first_history = vec![1, 2, 3, 4];
+        first_history.extend_from_slice(&shared_context);
+        let mut second_history = vec![91, 92, 93, 94];
+        second_history.extend_from_slice(&shared_context);
+
+        assert_eq!(
+            &first_history[first_history.len() - 8..],
+            &second_history[second_history.len() - 8..]
+        );
+        assert_ne!(
+            session_signature_from_tokens(&first_history),
+            session_signature_from_tokens(&second_history)
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -576,8 +576,13 @@ fn generate_tless_text(
     slot: &Arc<Mutex<Option<tless_uor::TlessState>>>,
     prompt: &str,
     max_tokens: usize,
+    session_signature: Option<&[u8]>,
 ) -> Option<String> {
-    if let Some(r4g1_text) = tless_uor::generate_r4g1_response(prompt, max_tokens) {
+    if let Some(r4g1_text) = tless_uor::generate_r4g1_response_with_session_signature(
+        prompt,
+        max_tokens,
+        session_signature,
+    ) {
         return Some(r4g1_text);
     }
     const MAX_SERVER_TOKENS: usize = 256;
@@ -1234,8 +1239,9 @@ fn transformerless_tier(
     slot: &Arc<Mutex<Option<tless_uor::TlessState>>>,
     prompt: &str,
     max_tokens: usize,
+    session_signature: Option<&[u8]>,
 ) -> TierResult {
-    match generate_tless_text(slot, prompt, max_tokens.max(32)) {
+    match generate_tless_text(slot, prompt, max_tokens.max(32), session_signature) {
         Some(text) if is_usable_generated_text(&text) => TierResult::success(text),
         Some(_) => {
             println!("[-] Transformerless output rejected as non-readable or pathological");
@@ -1322,6 +1328,7 @@ fn run_serving_cascade(
     max_tokens: usize,
     temperature: f64,
     gamma: f64,
+    session_signature: Option<&[u8]>,
     pinned: Option<&'static str>,
 ) -> ServingCascade {
     let mut signal = R4g1Signal::default();
@@ -1340,7 +1347,9 @@ fn run_serving_cascade(
         if include(TIER_TRANSFORMERLESS) {
             tiers.push((
                 TIER_TRANSFORMERLESS,
-                Box::new(move || transformerless_tier(tless, prompt, max_tokens)),
+                Box::new(move || {
+                    transformerless_tier(tless, prompt, max_tokens, session_signature)
+                }),
             ));
         }
         if pinned.is_none() {
@@ -2374,6 +2383,9 @@ fn handle_connection(
         };
 
         router_guard.evolve_state(&identity, routing_prompt, gamma);
+        let session_signature = uor_r4_router::session_signature_from_state(
+            &router_guard.get_brain_state_native(&identity),
+        );
 
         uor_r4_wasm_router::ACTIVE_ROUTER.with(|r| {
             *r.borrow_mut() = Some(router_ptr);
@@ -2401,6 +2413,7 @@ fn handle_connection(
                 max_tokens,
                 temperature,
                 gamma,
+                Some(&session_signature),
                 pinned,
             )
         };
@@ -2576,6 +2589,9 @@ fn handle_connection(
 
         // 3. Evolve the brain state
         router_guard.evolve_state(&identity, &payload.text, gamma);
+        let session_signature = uor_r4_router::session_signature_from_state(
+            &router_guard.get_brain_state_native(&identity),
+        );
 
         // 4. Run final routing on evolved state via UOR pipeline
         let t_route = Instant::now();
@@ -2616,6 +2632,7 @@ fn handle_connection(
                 max_tokens,
                 temperature,
                 gamma,
+                Some(&session_signature),
                 pinned,
             )
         };
@@ -3889,6 +3906,8 @@ fn answer_question(
     let (gamma, temperature) = autotune(kappa, theta_d, uor_bias);
 
     router.evolve_state(identity, text, gamma);
+    let session_signature =
+        uor_r4_router::session_signature_from_state(&router.get_brain_state_native(identity));
 
     uor_r4_wasm_router::ACTIVE_ROUTER.with(|r| *r.borrow_mut() = Some(router_ptr));
     let grounded = uor_r4_wasm_router::UorR4RouterModel::forward(input).expect("final route");
@@ -3911,10 +3930,11 @@ fn answer_question(
     } else {
         text.to_string()
     };
-    let (mut answer_text, mode) = match generate_tless_text(tless, &prompt, max_tokens.max(24)) {
-        Some(generated) => (generated, "transformerless".to_string()),
-        None => (geom.text.clone(), "geometric-decoded".to_string()),
-    };
+    let (mut answer_text, mode) =
+        match generate_tless_text(tless, &prompt, max_tokens.max(24), Some(&session_signature)) {
+            Some(generated) => (generated, "transformerless".to_string()),
+            None => (geom.text.clone(), "geometric-decoded".to_string()),
+        };
     if answer_text.is_empty() {
         answer_text = "Manifold resonance too sparse for synthesis.".to_string();
     }

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -122,6 +122,17 @@ pub fn ensure_owned_tless() {
 pub fn ensure_owned_tless() {}
 
 pub fn generate_r4g1_response(prompt: &str, max_tokens: usize) -> Option<String> {
+    generate_r4g1_response_with_session_signature(prompt, max_tokens, None)
+}
+
+/// Generate through the graph runtime with an optional server-side session
+/// signature. The context signature remains the ROUT input; the session lane
+/// is consumed by the existing emission-affinity bonus.
+pub fn generate_r4g1_response_with_session_signature(
+    prompt: &str,
+    max_tokens: usize,
+    session_signature: Option<&[u8]>,
+) -> Option<String> {
     let guard = match OWNED_R4G1.read() {
         Ok(g) => g,
         Err(_) => {
@@ -209,9 +220,10 @@ pub fn generate_r4g1_response(prompt: &str, max_tokens: usize) -> Option<String>
             });
 
             let mut cands = [(0u32, uor_r4_core::transformerless::score_q::ScoreQ::ZERO); 8];
-            let num_cands = runtime.predict_candidates(
+            let num_cands = runtime.predict_candidates_with_signature_lanes(
                 &beam_tokens,
                 sig.as_ref().map(|s| &s[..]),
+                session_signature,
                 &mut node_scores,
                 &mut cands,
             );


### PR DESCRIPTION
Implements the first measured milestone for #247.

## Summary
- add deterministic 288-bit session-signature quantization for persistent 512D manifold state
- add an order-sensitive token-history fallback for the direct chat client
- extend the graph runtime with separate context/session signature lanes
- keep context signatures on ROUT fallback; use session signatures only in the existing emission-affinity bias path
- wire the server's evolved manifold state into transformerless graph generation
- add same-eight-token/different-history A/B regression coverage and documentation

## Design boundary
This is intentionally bias-only. Session signatures do not enter ROUT fallback until held-out calibration proves that session-state prototypes are valid for that path. The deployed lane remains integer-only and reuses masked Hamming plus shift/add arithmetic; floating-point quantization is server-side.

## Validation
- cargo fmt --all --check
- git diff --check
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo check -p uor-r4-graph-format --no-default-features
- cargo check -p uor-r4-graph-format --no-default-features --features alloc
- cargo test --workspace --offline

The full suite passed, including 100 BDD scenarios. Relates to #247.