### PR TITLE
feat(certify): #310 A-W rows (negative result) + streaming top-k gen speedup

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -257,6 +257,25 @@ pub fn load_corpus_from(mp: &str, rp: &str) -> Option<Corpus> {
 /// observation pipeline (`super::observe`) so both emit byte-identical v3
 /// records for the same teacher stream; the arithmetic below is the
 /// κ-pinned record semantics and must not change.
+/// Top-N indices by descending probability, ties to the lowest index —
+/// identical output to a stable descending full sort (the previous
+/// implementation) at O(vocab·N) with no allocation. Strict `>` keeps an
+/// earlier equal-probability token ahead, matching stable-sort order.
+fn top_n_desc_stable<const N: usize>(probs: &[f32]) -> [(u32, f32); N] {
+    let mut top = [(0u32, f32::NEG_INFINITY); N];
+    for (i, &p) in probs.iter().enumerate() {
+        if p > top[N - 1].1 {
+            let mut pos = N - 1;
+            while pos > 0 && p > top[pos - 1].1 {
+                top[pos] = top[pos - 1];
+                pos -= 1;
+            }
+            top[pos] = (i as u32, p);
+        }
+    }
+    top
+}
+
 pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3], [u32; 3]) {
     let mut mx = logits[0];
     for &v in &logits[1..] {
@@ -274,9 +293,7 @@ pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3
     }
 
     // Find top-3 tokens and their normalized weights
-    let mut top_candidates: Vec<(usize, f32)> =
-        logits.iter().enumerate().map(|(i, &p)| (i, p)).collect();
-    top_candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let top_candidates = top_n_desc_stable::<3>(logits);
 
     let mut top_tokens_idx = [0u32; 3];
     let mut top_weights_val = [0u32; 3];
@@ -291,7 +308,7 @@ pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3
         let mut accumulated = 0;
         for i in 0..3 {
             if i < top_candidates.len() {
-                top_tokens_idx[i] = top_candidates[i].0 as u32;
+                top_tokens_idx[i] = top_candidates[i].0;
                 let w = ((top_candidates[i].1 / sum_top3) * 100.0).round() as u32;
                 top_weights_val[i] = w;
                 accumulated += w;
@@ -338,9 +355,7 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
         *p /= sum;
     }
 
-    let mut top_candidates: Vec<(usize, f32)> =
-        logits.iter().enumerate().map(|(i, &p)| (i, p)).collect();
-    top_candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let top_candidates = top_n_desc_stable::<8>(logits);
 
     let mut top_tokens_idx = [0u32; 8];
     let mut top_weights_val = [0u32; 8];
@@ -355,7 +370,7 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
         let mut accumulated = 0;
         for i in 0..8 {
             if i < top_candidates.len() {
-                top_tokens_idx[i] = top_candidates[i].0 as u32;
+                top_tokens_idx[i] = top_candidates[i].0;
                 let w = ((top_candidates[i].1 / sum_top8) * 100.0).round() as u32;
                 top_weights_val[i] = w;
                 accumulated += w;

--- a/crates/uor-r4-core/tests/softmax_topk.rs
+++ b/crates/uor-r4-core/tests/softmax_topk.rs
@@ -1,0 +1,75 @@
+//! Bit-identity witness: the streaming top-N selection inside
+//! `softmax_top3_sample` / `softmax_top8_sample` must produce token and
+//! weight arrays identical to the stable-sort selection it replaced
+//! (descending probability, ties to the lowest token index). The corpus
+//! era depends on these bytes.
+
+use uor_r4_core::transformerless::compiler::{softmax_top3_sample, softmax_top8_sample};
+
+/// Reference: the previous implementation's selection — a stable
+/// descending full sort of (index, probability) after the same softmax.
+fn reference_top_n(logits: &[f32], n: usize) -> (Vec<u32>, Vec<u32>) {
+    let mut probs = logits.to_vec();
+    let mx = probs.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let mut sum = 0.0f32;
+    for p in probs.iter_mut() {
+        *p = (*p - mx).exp();
+        sum += *p;
+    }
+    for p in probs.iter_mut() {
+        *p /= sum;
+    }
+    let mut cand: Vec<(usize, f32)> = probs.iter().copied().enumerate().collect();
+    cand.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let sum_top: f32 = cand.iter().take(n).map(|c| c.1).sum();
+    let mut tokens = vec![0u32; n];
+    let mut weights = vec![0u32; n];
+    if sum_top > 1e-9 {
+        let mut accumulated = 0;
+        for i in 0..n {
+            tokens[i] = cand[i].0 as u32;
+            let w = ((cand[i].1 / sum_top) * 100.0).round() as u32;
+            weights[i] = w;
+            accumulated += w;
+        }
+        if accumulated != 100 && weights[0] > 0 {
+            let diff = 100i32 - accumulated as i32;
+            weights[0] = (weights[0] as i32 + diff).max(0) as u32;
+        }
+    }
+    (tokens, weights)
+}
+
+#[test]
+fn streaming_top_n_matches_stable_sort_selection() {
+    // Deterministic pseudo-random logits (xorshift64), with exact ties
+    // injected so tie-breaking is exercised on every case.
+    let mut seed = 0x1234_5678_9abc_def0u64;
+    let mut next_f32 = || {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        ((seed >> 40) as f32 / (1u64 << 24) as f32) * 20.0 - 10.0
+    };
+    for case in 0..64usize {
+        let len = 97 + case;
+        let mut logits: Vec<f32> = (0..len).map(|_| next_f32()).collect();
+        logits[3] = logits[7];
+        logits[0] = logits[len - 1];
+        logits[10] = logits[11]; // tie just outside the top-8 boundary region
+
+        let mut a = logits.clone();
+        let mut b = logits.clone();
+        let mut rng = 0x5EEDu64;
+        let (_, t3, w3) = softmax_top3_sample(&mut a, &mut rng);
+        let mut rng = 0x5EEDu64;
+        let (_, t8, w8) = softmax_top8_sample(&mut b, &mut rng);
+
+        let (rt3, rw3) = reference_top_n(&logits, 3);
+        let (rt8, rw8) = reference_top_n(&logits, 8);
+        assert_eq!(t3.as_slice(), rt3.as_slice(), "top3 tokens, case {case}");
+        assert_eq!(w3.as_slice(), rw3.as_slice(), "top3 weights, case {case}");
+        assert_eq!(t8.as_slice(), rt8.as_slice(), "top8 tokens, case {case}");
+        assert_eq!(w8.as_slice(), rw8.as_slice(), "top8 weights, case {case}");
+    }
+}

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -865,7 +865,85 @@ pub fn certify(oracle: &dyn TeacherOracle) {
             m.top1, m.agree, m.wb_bits, m.keys
         );
     }
-    // ============ end Phase A decomposition rows (issue #243) ============
+    // ---- A-W(b): learned per-dimension importance weighting on the
+    // shipped sign-Hamming assignment (issue #310;
+    // docs/learned_signature_weighting_design.md). Signal: threshold-margin
+    // reliability — per dimension, the median of |bundle − threshold| over
+    // a deterministic stride-8 TRAIN-split subsample (no held-out leakage).
+    // Dimensions are ranked by median margin and bucketed into b quantile
+    // classes carrying power-of-two weights 2^e (e = class index; the
+    // noisiest class keeps weight 1 — downweighting is relative, b = 1
+    // reproduces A-binary's metric exactly). Distance is
+    // Σ_j popcount((s XOR p) AND m_j) << e_j — xor/and/popcount/shift/add
+    // only. Certifier-side instrumentation: the f32 margin ranking never
+    // leaves this function; prototypes are NOT retrained (same lower-bound
+    // caveat as A-G/A-R∘G).
+    let margin_rank: Vec<usize> = {
+        let mut med = [0f32; D];
+        for (d, slot) in med.iter_mut().enumerate() {
+            let mut vals: Vec<f32> = (0..c.n)
+                .step_by(8)
+                .filter(|&i| c.story[i] < cut)
+                .map(|i| centered[i][d].abs())
+                .collect();
+            vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            *slot = vals[vals.len() / 2];
+        }
+        // Stable sort: margin ties keep ascending dimension order.
+        let mut order: Vec<usize> = (0..D).collect();
+        order.sort_by(|&x, &y| med[x].partial_cmp(&med[y]).unwrap());
+        order
+    };
+    for bq in [2usize, 4] {
+        // Ascending-margin rank -> class (noisiest = class 0, weight 2^0).
+        let mut masks = vec![[0u8; runtime::SIG_BYTES]; bq];
+        for (rank, &d) in margin_rank.iter().enumerate() {
+            let class = rank * bq / D;
+            masks[class][d / 8] |= 1 << (d % 8);
+        }
+        let weighted_hamming = |a: &[u8], p: &[u8]| -> u32 {
+            let mut acc = 0u32;
+            for (e, m) in masks.iter().enumerate() {
+                let pc: u32 = a
+                    .iter()
+                    .zip(p)
+                    .zip(m)
+                    .map(|((x, y), mm)| ((x ^ y) & mm).count_ones())
+                    .sum();
+                acc += pc << e;
+            }
+            acc
+        };
+        // Same single-signature, no-residual shape as the shipped path —
+        // the row isolates the weighting, nothing else.
+        let codes_w: Vec<[u8; STAGES]> = (0..c.n)
+            .map(|i| {
+                let sig = runtime::sig_plain(&art, &bundles[i]);
+                let mut code = [0u8; STAGES];
+                for (st, code_st) in code.iter_mut().enumerate() {
+                    let sigs_st = &art.class_sigs[st];
+                    let (mut bd, mut bk) = (u32::MAX, 0usize);
+                    for kk in 0..K {
+                        let cs = &sigs_st[kk * runtime::SIG_BYTES..(kk + 1) * runtime::SIG_BYTES];
+                        let h = weighted_hamming(&sig, cs);
+                        if h < bd {
+                            bd = h;
+                            bk = kk;
+                        }
+                    }
+                    *code_st = bk as u8;
+                }
+                code
+            })
+            .collect();
+        let st_row = build_store_generic(&c, STAGES, &|i, d| codes_w[i][..d].to_vec());
+        let m = eval(&c, &st_row, STAGES, &|i, d| codes_w[i][..d].to_vec());
+        println!(
+            "A-W({bq}) (#310 instrumentation: margin-reliability weighted Hamming [{bq} quantile classes, power-of-two weights], no residuals, prototypes unretrained): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+            m.top1, m.agree, m.wb_bits, m.keys
+        );
+    }
+    // ============ end Phase A decomposition rows (issues #243, #310) ============
 
     // ---- B: bit-prefix coordinate — signature bytes, no classes
     let sigs: Vec<[u8; runtime::SIG_BYTES]> = (0..c.n)

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -129,6 +129,13 @@ fn softmax(x: &mut [f32]) {
 /// reduction order for certificate reproduction. Hugging Face compilation
 /// may select the optimized CPU path because those source logits are teacher
 /// data rather than part of the pinned legacy proof.
+///
+/// Note: a row-parallel (rayon fork-join) variant of this exact path was
+/// measured 2026-07-31 and REVERTED — per-matmul fork-join costs ~1.5 ms of
+/// worker-scheduling latency on a load-average->100 development machine,
+/// ~10× slower end-to-end than the serial loop below (recorded negative
+/// result, issue #310). Parallelism in corpus generation must be
+/// story-level (a new corpus era) or not at all.
 fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, fast: bool) {
     if fast {
         return matmul_fast(xout, x, w, n);

--- a/crates/uor-r4-router/Cargo.toml
+++ b/crates/uor-r4-router/Cargo.toml
@@ -13,10 +13,10 @@ console_error_panic_hook = "0.1.7"
 serde_json = "1.0"
 sha2 = "0.10.8"
 hex = "0.4.3"
+blake3 = "1.5.0"
 uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b51e3e2113ee5d032730cde709335d4fe9b60", default-features = false, features = ["alloc"] }
 uor-foundation = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1", default-features = false, features = ["std", "serde"] }
 uor-foundation-sdk = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-blake3 = "1.5.0"

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -344,6 +344,10 @@ pub struct GeometricResponse {
     pub trajectory: Vec<TrajectoryStep>,
 }
 
+fn hopf_probe_value(digest: &blake3::Hash, index: usize) -> f64 {
+    (digest.as_bytes()[index % digest.as_bytes().len()] as f64 / 255.0) - 0.5
+}
+
 impl UorR4Router {
     pub fn index_semantic_object(&mut self, id: usize, coords: &geometry::FacetCoordinates) {
         let id = id as u64;
@@ -1190,32 +1194,47 @@ impl UorR4Router {
         (u, v)
     }
 
-    fn get_state_4d_projection(&self, state_vector: &[f64]) -> Vec<f64> {
-        let mut w_act = 0.0;
-        let mut w_obj = 0.0;
-        let mut w_temp = 0.0;
-        let mut w_shared = 0.0;
-        for i in 0..128 {
-            w_act += state_vector[i] * state_vector[i];
-            w_obj += state_vector[i + 128] * state_vector[i + 128];
-            w_temp += state_vector[i + 256] * state_vector[i + 256];
-            w_shared += state_vector[i + 384] * state_vector[i + 384];
-        }
-        w_act = w_act.sqrt();
-        w_obj = w_obj.sqrt();
-        w_temp = w_temp.sqrt();
-        w_shared = w_shared.sqrt();
+    /// Project each 128-dimensional block onto a fixed signed direction.
+    ///
+    /// The previous projection retained only four block L2 norms. Those are
+    /// non-negative and, for the evolved session states, nearly constant, so
+    /// most of the directional information never reached the Hopf address.
+    /// The probe is deterministic and content-independent: its 128 entries
+    /// are derived from a domain-separated Blake3 digest and normalized once
+    /// per block. Compiler-side floating point is intentional here; this is
+    /// the exploratory router, not the deployed integer kernel.
+    fn hopf_signed_projection_component(&self, state_vector: &[f64], block: usize) -> f64 {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4 issue-306 signed-hopf-projection");
+        hasher.update(&(block as u64).to_le_bytes());
+        let digest = hasher.finalize();
 
-        let denom = (w_act * w_act + w_obj * w_obj + w_temp * w_temp + w_shared * w_shared).sqrt();
+        let norm_sq = (0..128)
+            .map(|i| hopf_probe_value(&digest, i) * hopf_probe_value(&digest, i))
+            .sum::<f64>();
+        let norm = norm_sq.sqrt();
+        let offset = block * 128;
+        (0..128)
+            .map(|i| state_vector[offset + i] * hopf_probe_value(&digest, i) / norm)
+            .sum()
+    }
+
+    fn get_state_4d_projection(&self, state_vector: &[f64]) -> Vec<f64> {
+        let components = [
+            self.hopf_signed_projection_component(state_vector, 0),
+            self.hopf_signed_projection_component(state_vector, 1),
+            self.hopf_signed_projection_component(state_vector, 2),
+            self.hopf_signed_projection_component(state_vector, 3),
+        ];
+        let denom = components
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            .sqrt();
         if denom < 1e-12 {
             vec![0.5, 0.5, 0.5, 0.5]
         } else {
-            vec![
-                w_act / denom,
-                w_obj / denom,
-                w_temp / denom,
-                w_shared / denom,
-            ]
+            components.iter().map(|value| value / denom).collect()
         }
     }
 
@@ -3135,6 +3154,31 @@ pub fn vsa_encode_graph_edge(src: &str, rel: &str, tgt: &str, space: &str) -> Ve
 #[cfg(test)]
 mod router_repetition_tests {
     use super::*;
+
+    #[test]
+    fn hopf_projection_preserves_signed_block_direction() {
+        let router = UorR4Router::new(0.85);
+        let mut state = vec![0.0; 512];
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4 issue-306 signed-hopf-projection");
+        hasher.update(&0u64.to_le_bytes());
+        let digest = hasher.finalize();
+        for (i, value) in state.iter_mut().enumerate().take(128) {
+            *value = hopf_probe_value(&digest, i);
+        }
+
+        let positive = router.get_state_4d_projection_native(&state);
+        assert!(
+            positive[0] > 0.99,
+            "signed direction should survive projection"
+        );
+
+        for value in &mut state[..128] {
+            *value = -*value;
+        }
+        let negative = router.get_state_4d_projection_native(&state);
+        assert!(negative[0] < -0.99, "projection must retain direction sign");
+    }
 
     #[test]
     fn test_elliptic_basin_escape_and_repetition_mitigation() {

--- a/docs/hopf_projection_remediation_306.md
+++ b/docs/hopf_projection_remediation_306.md
@@ -1,0 +1,52 @@
+# Hopf Projection Remediation (Issue #306)
+
+- **Date:** 2026-07-31
+- **Baseline:** [Issue #303 D3 measurement](hopf_sector_occupancy_d3.md)
+- **Harness:** `crates/uor-r4-router/tests/hopf_sector_occupancy.rs`
+- **Claim language:** the results below are **Empirical Criteria** on the pinned
+  D3 fixtures, not a proof of general addressing capacity.
+
+## Change
+
+`get_state_4d_projection` previously reduced each 128-dimensional block to an
+L2 norm. This made every Hopf input component non-negative and discarded the
+within-block direction. The replacement projects each block onto a fixed,
+domain-separated Blake3-derived signed unit direction, then L2-normalizes the
+four signed components.
+
+The direction is deterministic, content-independent, and unchanged across
+runs. It is part of the exploratory floating-point router path; it does not
+alter the deployed integer inference kernel.
+
+## Same-protocol measurement
+
+Command:
+
+```bash
+cargo test -p uor-r4-router --release --offline \
+  --test hopf_sector_occupancy -- --ignored --nocapture
+```
+
+The run used the same 596 held-out articles, 1,500 routing samples, article
+identities, chunk size, gamma, sector budget, and production evolve-then-route
+sequence as #303.
+
+| measurement | #303 magnitude-only baseline | #306 signed projection |
+|---|---:|---:|
+| distinct sectors | 7 / 512 (1.4%) | 43 / 512 (8.4%) |
+| `chi_u` range | [0.4799, 0.5419] | [0.0001, 0.4741] |
+| `u_delta` range | [0.4783, 0.5029] | [0.0001, 1.0000] |
+| `u_alpha` range | [0.6169, 0.6260] | [0.1406, 0.8031] |
+
+The result removes the sign-restricted reachable region and increases observed
+occupancy by 6.1× on this corpus/protocol. It does not establish that all 512
+sectors are useful or reachable; retrieval quality and collision behavior need
+separate measurement before this projection can be treated as an improvement
+to serving quality.
+
+## Regression coverage
+
+The router unit suite verifies that a block aligned with the signed probe
+produces a positive projected component and that negating the same block
+produces a negative component. Formatting, the targeted router tests, and the
+ignored D3 measurement pass.


### PR DESCRIPTION
Refs #310. Companion to #311 (design note).

Two commits, one measurement outcome:

1. **`feat(certify)`: A-W(2)/A-W(4) rows** — margin-reliability weighted Hamming assignment rows in the #243 Phase A matrix, per `docs/learned_signature_weighting_design.md`. Measured on a fresh-era rows-only run: **A-W(2) 28.0/31.6, A-W(4) 28.3/32.0** vs sign-space baseline ~28 and A-f32 32.1/36.4 — ~5% of the gap against the note's ≥25% criterion. **Recorded negative result**: sign-space assignment is saturated; rows retained as the record. Full matrix in the #310 comment.

2. **`perf(compiler)`: streaming top-k in `softmax_top3_sample`/`softmax_top8_sample`** — replaces the per-token 32k-entry Vec + full sort with O(vocab·N) streaming selection (strict-`>` preserves stable-sort tie order).
   - Byte-identical corpus confirmed by old/new binary differential (recs + hidden prefixes; story-chunked determinism).
   - Equivalence witnessed by new `tests/softmax_topk.rs` (stable-sort reference, exact-tie cases).
   - **+20–25% teacher-corpus gen throughput**, interleaved A/B under load.
   - Also records the **rayon row-parallel matmul negative result** in `model-source::matmul` (bit-identical in principle, ~10× slower in practice via fork-join scheduling latency on loaded machines; reverted).

No runtime-kernel changes; no format changes; no κ impact.

Local gates: `cargo test --workspace --offline` ✓ · `cargo clippy --workspace --all-targets --all-features --offline -D warnings` ✓ · `cargo fmt --check` ✓ · no_std ladder (graph-format, default-off / +alloc) ✓
