### PR TITLE
Add canonical R4G1 uor-addr realization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "serde",
+ "uor-addr",
 ]
 
 [[package]]

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1006,7 +1006,8 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
             exct_top_x: config.exct_top_x,
         },
     )?;
-    let graph_kappa = format!("blake3:{}", blake3::hash(&artifact_bytes).to_hex());
+    let graph_kappa = uor_r4_graph_format::r4g1::artifact_kappa(&artifact_bytes)
+        .map_err(|error| format!("cannot address emitted R4G1 artifact: {error}"))?;
 
     eprintln!("score: running Gate C evaluation [========================] 100%");
     let gate_c = score::evaluate_gate_c(

--- a/crates/uor-r4-graph-format/Cargo.toml
+++ b/crates/uor-r4-graph-format/Cargo.toml
@@ -7,7 +7,7 @@ description = "R4G1 packed graph artifact container: no_std-compatible fixed-wid
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = []
+alloc = ["dep:uor-addr"]
 
 [dependencies]
 # Pinned to the workspace-wide blake3 version. `default-features = false`
@@ -17,3 +17,4 @@ blake3 = { version = "=1.5.0", default-features = false }
 # Serde on the wire newtypes (ScoreQ and peers flow into certificates and
 # manifests); no_std-compatible via derive-only, no std/alloc requirement.
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b51e3e2113ee5d032730cde709335d4fe9b60", default-features = false, features = ["alloc"], optional = true }

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -69,6 +69,8 @@ mod head;
 mod header;
 pub mod inference_contract;
 pub mod invariant_ownership;
+#[cfg(feature = "alloc")]
+pub mod r4g1;
 pub mod records;
 mod rout;
 pub mod scoring_semantics;

--- a/crates/uor-r4-graph-format/src/r4g1.rs
+++ b/crates/uor-r4-graph-format/src/r4g1.rs
@@ -1,0 +1,191 @@
+//! The canonical `uor-addr` realization for an R4G1 artifact.
+//!
+//! R4G1's wire CIDs remain byte-level integrity checks: they protect the
+//! exact container that a runtime mapped.  This module provides the
+//! representation-level address used in manifests, reports, and serving
+//! attestations.  It deliberately omits offsets, alignment padding, and the
+//! two wire CIDs, so equivalent containers have the same address.
+//!
+//! The realization is a small Merkle skeleton.  A section address commits to
+//! its semantic table identity (`id` and `flags`) and payload.  The artifact
+//! address then commits to the sorted list of section identities and section
+//! addresses.  Both levels are fed through the pinned CBOR realization of
+//! `uor-addr` on its BLAKE3 axis.
+
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use crate::{FormatError, GraphView, SectionId};
+
+/// Version of the R4G1 realization skeleton.
+pub const REALIZATION_VERSION: u64 = 1;
+/// Stable realization discriminator included in every skeleton.
+pub const REALIZATION_NAME: &str = "r4g1";
+
+/// Failure while validating or addressing an R4G1 artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealizationError {
+    /// The container failed R4G1 structural or semantic validation.
+    InvalidArtifact(FormatError),
+    /// The generated skeleton was not accepted by the CBOR realization.
+    AddressingFailed,
+}
+
+impl core::fmt::Display for RealizationError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidArtifact(error) => write!(formatter, "invalid R4G1 artifact: {error}"),
+            Self::AddressingFailed => write!(formatter, "uor-addr rejected the R4G1 skeleton"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RealizationError {}
+
+/// A section's representation-level address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SectionAddress {
+    /// Wire section identifier.
+    pub id: SectionId,
+    /// Section-table flags, which are part of the section's identity.
+    pub flags: u32,
+    /// BLAKE3-axis UOR κ-label for this section.
+    pub kappa: String,
+}
+
+/// The complete address and replayable skeleton inputs for one artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct R4G1Address {
+    /// BLAKE3-axis UOR κ-label for the canonical artifact skeleton.
+    pub artifact_kappa: String,
+    /// Per-section addresses in canonical section-ID order.
+    pub sections: Vec<SectionAddress>,
+    /// Canonical CBOR skeleton addressed by `artifact_kappa`.
+    pub skeleton: Vec<u8>,
+}
+
+/// Address a validated R4G1 container using its canonical section skeleton.
+pub fn address(bytes: &[u8]) -> Result<R4G1Address, RealizationError> {
+    let view = GraphView::parse(bytes).map_err(RealizationError::InvalidArtifact)?;
+    view.verify_cids()
+        .map_err(RealizationError::InvalidArtifact)?;
+
+    let mut sections = Vec::with_capacity(view.sections().len());
+    for section in view.sections() {
+        let section_skeleton = section_skeleton(section.id, section.flags, section.payload);
+        let kappa = address_cbor(&section_skeleton)?;
+        sections.push(SectionAddress {
+            id: section.id,
+            flags: section.flags,
+            kappa,
+        });
+    }
+
+    let skeleton = artifact_skeleton(&sections);
+    let artifact_kappa = address_cbor(&skeleton)?;
+    Ok(R4G1Address {
+        artifact_kappa,
+        sections,
+        skeleton,
+    })
+}
+
+/// Return only the representation-level artifact κ-label.
+pub fn artifact_kappa(bytes: &[u8]) -> Result<String, RealizationError> {
+    Ok(address(bytes)?.artifact_kappa)
+}
+
+/// Return the representation-level κ-label for one section.
+pub fn section_kappa(bytes: &[u8], id: SectionId) -> Result<Option<String>, RealizationError> {
+    Ok(address(bytes)?
+        .sections
+        .into_iter()
+        .find(|section| section.id == id)
+        .map(|section| section.kappa))
+}
+
+fn address_cbor(skeleton: &[u8]) -> Result<String, RealizationError> {
+    uor_addr::cbor::address_blake3(skeleton)
+        .map(|outcome| outcome.address.to_string())
+        .map_err(|_| RealizationError::AddressingFailed)
+}
+
+fn section_skeleton(id: SectionId, flags: u32, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(payload.len() + 48);
+    cbor_array(&mut out, 5);
+    cbor_uint(&mut out, REALIZATION_VERSION);
+    cbor_text(&mut out, REALIZATION_NAME);
+    cbor_uint(&mut out, u64::from(id.raw()));
+    cbor_uint(&mut out, u64::from(flags));
+    cbor_bytes(&mut out, payload);
+    out
+}
+
+fn artifact_skeleton(sections: &[SectionAddress]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(32 + sections.len() * 96);
+    cbor_array(&mut out, 3);
+    cbor_uint(&mut out, REALIZATION_VERSION);
+    cbor_text(&mut out, REALIZATION_NAME);
+    cbor_array(&mut out, sections.len() as u64);
+    for section in sections {
+        cbor_array(&mut out, 3);
+        cbor_uint(&mut out, u64::from(section.id.raw()));
+        cbor_uint(&mut out, u64::from(section.flags));
+        cbor_text(&mut out, &section.kappa);
+    }
+    out
+}
+
+fn cbor_array(out: &mut Vec<u8>, length: u64) {
+    cbor_head(out, 4, length);
+}
+
+fn cbor_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    cbor_head(out, 2, bytes.len() as u64);
+    out.extend_from_slice(bytes);
+}
+
+fn cbor_text(out: &mut Vec<u8>, text: &str) {
+    cbor_head(out, 3, text.len() as u64);
+    out.extend_from_slice(text.as_bytes());
+}
+
+fn cbor_uint(out: &mut Vec<u8>, value: u64) {
+    cbor_head(out, 0, value);
+}
+
+fn cbor_head(out: &mut Vec<u8>, major: u8, value: u64) {
+    debug_assert!(major < 8);
+    if value <= 23 {
+        out.push((major << 5) | value as u8);
+    } else if value <= u8::MAX as u64 {
+        out.push((major << 5) | 24);
+        out.push(value as u8);
+    } else if value <= u16::MAX as u64 {
+        out.push((major << 5) | 25);
+        out.extend_from_slice(&(value as u16).to_be_bytes());
+    } else if value <= u32::MAX as u64 {
+        out.push((major << 5) | 26);
+        out.extend_from_slice(&(value as u32).to_be_bytes());
+    } else {
+        out.push((major << 5) | 27);
+        out.extend_from_slice(&value.to_be_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cbor_heads_are_minimally_encoded() {
+        let mut out = Vec::new();
+        cbor_uint(&mut out, 23);
+        cbor_uint(&mut out, 24);
+        cbor_uint(&mut out, 256);
+        assert_eq!(out, [0x17, 0x18, 0x18, 0x19, 0x01, 0x00]);
+    }
+}

--- a/crates/uor-r4-graph-format/tests/realization.rs
+++ b/crates/uor-r4-graph-format/tests/realization.rs
@@ -1,0 +1,77 @@
+//! Conformance vectors for the representation-level R4G1 address.
+
+mod common;
+
+use common::{head_payload, node_section, storage_section, HeadFields, NodeFields};
+use uor_r4_graph_format::{r4g1, ArtifactBuilder, SectionId};
+
+fn sample(alignment_log2: u8, reverse_insertion: bool) -> Vec<u8> {
+    let mut builder = ArtifactBuilder::new(alignment_log2);
+    let head = head_payload(&HeadFields::default());
+    let node = node_section(&[] as &[NodeFields]);
+    let rout = [0u8; 64];
+    let emit = storage_section(1, 0, 0, &[]);
+    if reverse_insertion {
+        builder.add_section(SectionId::EMIT, 0, &emit);
+        builder.add_section(SectionId::ROUT, 0, &rout);
+        builder.add_section(SectionId::NODE, 7, &node);
+        builder.add_section(SectionId::HEAD, 0, &head);
+    } else {
+        builder.add_section(SectionId::HEAD, 0, &head);
+        builder.add_section(SectionId::NODE, 7, &node);
+        builder.add_section(SectionId::ROUT, 0, &rout);
+        builder.add_section(SectionId::EMIT, 0, &emit);
+    }
+    builder.build().expect("stage-2-valid sample must build")
+}
+
+#[test]
+fn equivalent_reserializations_share_the_realization_address() {
+    let first = r4g1::address(&sample(3, false)).expect("valid sample");
+    let second = r4g1::address(&sample(5, true)).expect("valid sample");
+
+    assert_eq!(first.skeleton, second.skeleton);
+    assert_eq!(first.artifact_kappa, second.artifact_kappa);
+    assert_eq!(first.sections, second.sections);
+}
+
+#[test]
+fn payload_changes_change_the_section_and_artifact_addresses() {
+    let original = sample(3, false);
+    let mut changed_builder = ArtifactBuilder::new(3);
+    let head = head_payload(&HeadFields::default());
+    let node = node_section(&[] as &[NodeFields]);
+    let rout = [0u8; 64];
+    let changed_emit = storage_section(2, 0, 0, &[]);
+    changed_builder.add_section(SectionId::HEAD, 0, &head);
+    changed_builder.add_section(SectionId::NODE, 7, &node);
+    changed_builder.add_section(SectionId::ROUT, 0, &rout);
+    changed_builder.add_section(SectionId::EMIT, 0, &changed_emit);
+    let changed_bytes = changed_builder
+        .build()
+        .expect("stage-2-valid sample must build");
+
+    let original = r4g1::address(&original).expect("valid sample");
+    let changed = r4g1::address(&changed_bytes).expect("valid sample");
+    assert_ne!(original.artifact_kappa, changed.artifact_kappa);
+    assert_ne!(
+        r4g1::section_kappa(&sample(3, false), SectionId::EMIT).expect("valid sample"),
+        r4g1::section_kappa(&changed_bytes, SectionId::EMIT).expect("valid sample")
+    );
+}
+
+#[test]
+fn malformed_or_tampered_artifacts_are_rejected() {
+    assert!(matches!(
+        r4g1::address(b"not an R4G1 artifact"),
+        Err(r4g1::RealizationError::InvalidArtifact(_))
+    ));
+
+    let mut tampered = sample(3, false);
+    let last = tampered.len() - 1;
+    tampered[last] ^= 1;
+    assert!(matches!(
+        r4g1::address(&tampered),
+        Err(r4g1::RealizationError::InvalidArtifact(_))
+    ));
+}

--- a/docs/r4g1_realization_264.md
+++ b/docs/r4g1_realization_264.md
@@ -1,0 +1,38 @@
+# R4G1 representation realization
+
+Issue #264 adds the first in-repository realization of an R4G1 artifact for
+`uor-addr`. It separates two identities that serve different purposes:
+
+- `GraphView::verify_cids()` continues to verify the exact bytes mapped by a
+  runtime. Those wire CIDs are integrity checks and intentionally remain
+  sensitive to layout and padding.
+- `uor_r4_graph_format::r4g1::address()` produces the representation-level
+  κ-label used in reports, manifests, and serving attestations. It ignores
+  offsets, alignment padding, and the two wire CID fields.
+
+The realization is a two-level Merkle skeleton encoded as deterministic CBOR
+and addressed through the pinned `uor-addr` BLAKE3 axis:
+
+```text
+section skeleton := [version, "r4g1", section_id, section_flags, payload]
+section κ       := uor-addr/cbor/blake3(section skeleton)
+
+artifact skeleton := [version, "r4g1",
+                      [[section_id, section_flags, section κ], ...]]
+artifact κ       := uor-addr/cbor/blake3(artifact skeleton)
+```
+
+Sections are consumed in R4G1's canonical section-ID order. The section
+address is therefore independently usable for future immutable graph patches
+and region-object manifests, while the artifact address is stable across
+equivalent container reserializations. A changed section payload or section
+flag changes both its own κ-label and the artifact κ-label.
+
+The implementation is allocation-gated with the graph-format crate's
+`alloc` feature; the no-std parser and runtime feature ladder do not pull the
+realization dependency into their zero-allocation build.
+
+The ignored `uor_standards/` checkout is local reference material rather than
+a repository input. The implementation is pinned to the same `uor-addr`
+revision declared in the workspace manifest; upstream conformance vectors can
+be added there when the standards repository accepts the realization.

--- a/src/server.rs
+++ b/src/server.rs
@@ -940,8 +940,10 @@ fn validate_uor_address_syntax(address: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
-/// blake3 CID of the artifact the serving cascade would load, mtime-cached
-/// (issue #256: a real content address or nothing — never a placeholder).
+/// Representation-level UOR κ-label of the artifact the serving cascade
+/// would load, mtime-cached. The R4G1 wire CIDs remain internal integrity
+/// checks; external attestations use the canonical section-addressable
+/// realization from issue #264.
 fn active_artifact_cid() -> Option<String> {
     use std::sync::{Mutex, OnceLock};
     static CACHE: OnceLock<Mutex<Option<(std::path::PathBuf, std::time::SystemTime, String)>>> =
@@ -959,7 +961,7 @@ fn active_artifact_cid() -> Option<String> {
         }
     }
     let bytes = std::fs::read(path).ok()?;
-    let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    let cid = uor_r4_graph_format::r4g1::artifact_kappa(&bytes).ok()?;
     *guard = Some((path.to_path_buf(), mtime, cid.clone()));
     Some(cid)
 }


### PR DESCRIPTION
## Summary

Implements the first in-repository `uor-addr` realization for R4G1 artifacts and switches external graph artifact κ reporting/serving attestation to the representation-level address.

- Adds an allocation-gated two-level CBOR Merkle skeleton:
  - per-section κ commits to section ID, flags, and payload;
  - artifact κ commits to the canonical section-ID-ordered list.
- Keeps R4G1 wire CIDs as exact-byte runtime integrity checks.
- Switches scored graph reporting and active serving artifact attestation from raw container hashes to the realization.
- Adds positive/negative conformance vectors and documents the realization contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- `cargo test -p uor-r4-graph-format --offline` (20 unit, 2 fuzz-smoke, 3 realization, 26 stage-1, 46 stage-2 passed)
- `cargo test --workspace --offline` reached 79 graph-compiler tests passed but has one unrelated pre-existing fixture failure: `observation_text::tests::crash_trims_converge_to_single_pass_kappa` cannot find its tokenizer fixture.

Closes #264