### PR TITLE
Record pinned SmolLM2 135M teacher baseline provenance

### DIFF
--- a/docs/smollm2_teacher_baseline_320.md
+++ b/docs/smollm2_teacher_baseline_320.md
@@ -1,0 +1,50 @@
+# SmolLM2 teacher baseline — issue #320 P1
+
+This records the P1 rehearsal for the teacher-upgrade issue. It does not
+replace the pinned stories15M fixtures or make a baseline-migration decision.
+
+## Pinned source
+
+| field | value |
+|---|---|
+| repository | `HuggingFaceTB/SmolLM2-135M-Instruct` |
+| revision | `7e27bd9f95328f0f3b08261d1252705110c806f8` |
+| source κ | `blake3:12d2cd8a877ef2cdcf785b3d4d1f373e0419074cc884aeaff06fc059686a5ba5` |
+| source κ scope | `model.safetensors` |
+| source bytes | `269060552` |
+| license | Apache-2.0 |
+
+The source κ is emitted by the HF teacher loader after reading the pinned
+weights. The revision and κ are both recorded in
+`models/smollm2-135m-instruct.json`.
+
+## Rehearsal
+
+The source was downloaded with the existing pinned HF path and compiled in an
+isolated worktree:
+
+```bash
+hf download HuggingFaceTB/SmolLM2-135M-Instruct \
+  --revision 7e27bd9f95328f0f3b08261d1252705110c806f8 \
+  --local-dir .uor-models/sources/smollm2-135m-instruct \
+  --include '*.safetensors' --include '*.json' --include '*.model' \
+  --include 'merges.txt' --include 'LICENSE*' --include 'README.md'
+
+cargo run --release --offline --bin r4 -- transformerless compile \
+  --source .uor-models/sources/smollm2-135m-instruct \
+  --output .uor-models/compiled/smollm2-135m-instruct \
+  --seconds 60 --target 1000 --sequence-length 128
+```
+
+Observed rehearsal result:
+
+- source directory: 260 MB;
+- corpus: 1,000 teacher-labeled tokens across 11 stories;
+- teacher generation: 1,000 tokens in 8.77 s (114.1 tokens/s);
+- table-native compilation completed, including artifacts, store, tokenizer,
+  calibration, hierarchical codes, and manifest.
+
+This is a pipeline smoke/rehearsal, not a quotable quality baseline: the
+1,000-token corpus is not the D3 held-out distribution and no comparison with
+the stories15M teacher floor was made. P2 should run the declared row matrix
+on a complete corpus before any migration decision.

--- a/models/smollm2-135m-instruct.json
+++ b/models/smollm2-135m-instruct.json
@@ -1,6 +1,9 @@
 {
   "repository": "HuggingFaceTB/SmolLM2-135M-Instruct",
   "revision": "7e27bd9f95328f0f3b08261d1252705110c806f8",
+  "source_kappa": "blake3:12d2cd8a877ef2cdcf785b3d4d1f373e0419074cc884aeaff06fc059686a5ba5",
+  "source_bytes": 269060552,
+  "source_kappa_scope": "model.safetensors",
   "license": "Apache-2.0",
   "architecture": "LlamaForCausalLM",
   "weight_format": "safetensors",


### PR DESCRIPTION
## Summary

P1 of #320: pin and rehearse the SmolLM2-135M-Instruct teacher path without changing the stories15M fixtures.

- Records the immutable Hugging Face revision in the model descriptor.
- Records the loaded `model.safetensors` source κ and byte size.
- Documents the reproducible download and compile commands.
- Records a bounded 1,000-token/11-story pipeline rehearsal and its 114.1 teacher tokens/s throughput.
- Clearly marks the rehearsal as non-quotable; P2 still needs a complete corpus and row-matrix comparison.

## Validation

- `jq empty models/smollm2-135m-instruct.json`
- `cargo fmt --all -- --check`
- `cargo test -p uor-r4-graph-cli --lib --offline`
- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`

The workspace gates were run on the unchanged code path; this PR only adds metadata and documentation.