### PR TITLE
feat(certify): #318 dot-residual rows (positive) + Phase B design note

### DIFF
--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -737,7 +737,11 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         let s = x.abs().log2().round();
         x.signum() * s.exp2()
     };
-    for (label, terms) in [("A-dot-po2", 1usize), ("A-dot-po2x2", 2usize)] {
+    for (label, terms) in [
+        ("A-dot-po2", 1usize),
+        ("A-dot-po2x2", 2usize),
+        ("A-dot-po2x3", 3usize),
+    ] {
         let quantized: Vec<Vec<f32>> = art
             .ctx_cb
             .iter()
@@ -781,6 +785,101 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         let m = eval(&c, &st_row, STAGES, &|i, d| codes_q[i][..d].to_vec());
         println!(
             "{label} (#243 buildability: shift-add dot, {terms}-term power-of-two centroids): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+            m.top1, m.agree, m.wb_bits, m.keys
+        );
+    }
+
+    // ---- A-dot-resid / A-dot-po2-resid(1/2) (#318 rows, #243 follow-up):
+    // the missing composition cell — dot assignment WITH residual updates
+    // at unit scale. The f32 ceiling normalizes, assigns norm-aware, and
+    // subtracts; the po2 dot rows above measured quantization WITHOUT
+    // subtraction, and the round-2 note records raw-scale subtraction as
+    // negligible — at unit scale it is not. A-dot-resid isolates the
+    // residual effect under the dot metric (f32 centroid values); the
+    // po2-resid rows run assignment AND subtraction from the same
+    // quantized tables — the form a kernel Phase B could actually build
+    // (per-stage integer centroid copies, add/sub only, contract §2).
+    let codes_dr: Vec<[u8; STAGES]> = (0..c.n)
+        .map(|i| {
+            let mut work: Vec<f32> = (0..D).map(|d| centered[i][d] / norms[i]).collect();
+            let mut code = [0u8; STAGES];
+            for (st, cb) in art.ctx_cb.iter().enumerate() {
+                let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
+                for kk in 0..K {
+                    let cent = &cb[kk * D..(kk + 1) * D];
+                    let mut dp = 0f32;
+                    for j in 0..D {
+                        dp += work[j] * cent[j];
+                    }
+                    if dp > best {
+                        best = dp;
+                        bk = kk;
+                    }
+                }
+                code[st] = bk as u8;
+                for j in 0..D {
+                    work[j] -= cb[bk * D + j];
+                }
+            }
+            code
+        })
+        .collect();
+    let st_row = build_store_generic(&c, STAGES, &|i, d| codes_dr[i][..d].to_vec());
+    let m = eval(&c, &st_row, STAGES, &|i, d| codes_dr[i][..d].to_vec());
+    println!(
+        "A-dot-resid (#318 instrumentation, f32: dot assignment on normalized work + per-stage centroid subtraction): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+        m.top1, m.agree, m.wb_bits, m.keys
+    );
+    let quantize = |terms: usize| -> Vec<Vec<f32>> {
+        art.ctx_cb
+            .iter()
+            .map(|cb| {
+                cb.iter()
+                    .map(|&cv| {
+                        let mut acc = 0.0f32;
+                        let mut rem = cv;
+                        for _ in 0..terms {
+                            let q = po2(rem);
+                            acc += q;
+                            rem -= q;
+                        }
+                        acc
+                    })
+                    .collect()
+            })
+            .collect()
+    };
+    for (label, terms) in [("A-dot-po2-resid", 1usize), ("A-dot-po2x2-resid", 2usize)] {
+        let quantized = quantize(terms);
+        let codes_qr: Vec<[u8; STAGES]> = (0..c.n)
+            .map(|i| {
+                let mut work: Vec<f32> = (0..D).map(|d| centered[i][d] / norms[i]).collect();
+                let mut code = [0u8; STAGES];
+                for (st, cb) in quantized.iter().enumerate() {
+                    let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
+                    for kk in 0..K {
+                        let cent = &cb[kk * D..(kk + 1) * D];
+                        let mut dp = 0f32;
+                        for j in 0..D {
+                            dp += work[j] * cent[j];
+                        }
+                        if dp > best {
+                            best = dp;
+                            bk = kk;
+                        }
+                    }
+                    code[st] = bk as u8;
+                    for j in 0..D {
+                        work[j] -= cb[bk * D + j];
+                    }
+                }
+                code
+            })
+            .collect();
+        let st_row = build_store_generic(&c, STAGES, &|i, d| codes_qr[i][..d].to_vec());
+        let m = eval(&c, &st_row, STAGES, &|i, d| codes_qr[i][..d].to_vec());
+        println!(
+            "{label} (#318 buildability: shift-add dot, {terms}-term po2 tables, normalized work + quantized residual subtraction): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
             m.top1, m.agree, m.wb_bits, m.keys
         );
     }

--- a/docs/dot_residual_phase_b_design.md
+++ b/docs/dot_residual_phase_b_design.md
@@ -1,0 +1,104 @@
+# Design: Integer Residual Wiring for the Shift-Add Dot Path (Phase B)
+
+*Issue #318. Status: DESIGN FOR REVIEW — authorized for review only; no
+kernel work until the reproduction requirement below is met. Decision
+points marked ⚑ are open.
+Claim language: Definitions, Objectives, and Empirical Criteria only.*
+
+## Objective
+
+Capture the measured #318 buildable row in the deployed kernel: dot
+assignment **with per-stage residual updates**, realizable under the
+runtime contract (no multiply/divide/float; P-4 machine-checked source
+scan). The measured evidence (fresh-era rows-only run, 2026-07-31,
+equality witness 512/512):
+
+| Row | top-1 | agreement | WB bits | keys |
+|---|---|---|---|---|
+| A-f32 (ceiling) | 32.1 | 36.4 | 9.70 | 92,903 |
+| A-dot-po2x2-resid (buildable shape) | 31.2 | 35.3 | 10.13 | 96,080 |
+| A-dot-po2-resid | 31.1 | 35.2 | 10.18 | 89,704 |
+| A-dot-po2x2 (shipped shape, no residual) | 30.7 | 34.3 | 9.64 | 47,418 |
+
+Residual composition recovers ~36–48% of the remaining top-1/agreement
+gap to the f32 ceiling, and the po2 value-set restriction costs nothing
+once residuals carry the refinement (po2-resid ≥ f32 dot-resid). The
+terms sweep is saturated (x3 regresses to 30.4; 2 terms is the stop).
+
+## Definitions (the buildable kernel form)
+
+Per sample, per stage st ∈ 0..4:
+
+1. **Norm fold** — the measurement normalizes `work` by its L2 norm
+   (f32 division; not kernel-legal). Candidate kernel form: a
+   power-of-two fold `work' = work >> s` with
+   `s ≈ round(log2(||work||))` derived from the L1 norm
+   (`Σ|work_d|` — abs and add only): `s = bit_length(Σ|w|) − CONST`,
+   where CONST is a compile-time content-addressed constant. L1→L2
+   conversion error and the fold's 2× granularity both land in the
+   exponent, which the dot tables absorb as a per-sample scale.
+   ⚑ validate certifier-side first (row: A-dot-po2-resid with the po2
+   norm fold replacing true division; must lose ≤ 0.1pp against the
+   31.1/35.2 row).
+2. **Assignment** — existing shift-add dot (`dot_score_plain`) against
+   the per-stage po2 tables. DOT_TERMS ⚑ 1 vs 2: the x2 row leads by
+   0.1pp at 2× dot cost; decide at Phase B with the op census.
+3. **Residual update** — `work −= cent_int[st][code]` where
+   `cent_int` are per-stage **integer centroid copies**: unit-scale f32
+   centroids quantized with a per-stage power-of-two scale (the token
+   stage-book precedent: exponent from IEEE bits, libm-free).
+   Subtraction is add/sub — contract §2 legal. ⚑ i8 vs i16 copies
+   (fidelity vs 295 KB / 590 KB artifact growth).
+
+Artifact growth: `STAGES × K × D` integer entries + per-stage scale
+exponents; format-era bump (next TLA era) with the usual note; P-4 scan
+and allocation census extended to the new code.
+
+## The WB / key-dispersion problem (must be addressed, not waived)
+
+Residual codes disperse: keys roughly double (47k → 96k) and Witten–Bell
+worsens (9.64 → 10.13 bits/token) even as argmax metrics improve. The
+#318 result is therefore a **quality trade-off, not a pure win**, and
+Phase B's DoD must include a store-shape answer, decided on the #244
+harness (the same discipline that settled A-single vs A-multi):
+
+- Candidate mitigations: beam-depth tuning on the residual codes;
+  prefix-collapsed keys (the codes form a natural 4-deep prefix tree);
+  ⚑ others from review.
+- **Empirical Criterion:** the shipped form must keep ≥ 80% of the
+  measured top-1/agreement gain (≥ +0.4pp / +0.8pp over the shipped
+  baseline at certification-era conditions) with WB regression bounded
+  at ⚑ ≤ 0.3 bits/token against the shipped 9.64. If no store shape
+  meets both bounds, Phase B ships nothing: the rows stand as the
+  recorded result and the ceiling is declared reached for this
+  architecture (teacher upgrade, issue #320, remains).
+
+## Reproduction requirement (before any kernel code)
+
+Per repo discipline (#244 precedent): the #318 rows must reproduce
+bit-for-bit across three rows-only runs (same corpus, same artifact κ)
+before Phase B implementation is authorized. One run is on record.
+
+## Phasing
+
+- **Phase A.5 (certifier-side, no runtime change):** po2-norm-fold row
+  (validates Definition 1) + i8-vs-i16 centroid-copy fidelity rows
+  (settles ⚑ width) + the 3× reproduction. One certify run.
+- **Phase B (kernel):** residual wiring in the integer kernel behind
+  the format-era bump; P-4 scan extension; equality-witness against the
+  plain form; op-census budget ⚑ ≤ 2× current dot-path counts.
+- **Phase C (adoption):** store-shape decision on the #244 harness;
+  κ re-pin with era notes (maintainer decision); BASELINE.md update.
+
+## Explicit non-goals
+
+No floating point, multiply, or divide in the runtime kernel. No change
+to κ-label semantics. No sign-space assignment work (saturated, #310).
+No teacher change (tracked separately as #320).
+
+## Sign-off
+
+- Casey: ____   - Ari: ____   - Alex: ____
+
+⚑ decisions: po2 norm-fold validation · DOT_TERMS 1-vs-2 · centroid
+copy width · WB regression bound · op-census budget


### PR DESCRIPTION
Refs #318. Follow-up to #243/#310.

Two commits:

1. **`feat(certify)`: dot-residual composition rows + po2x3 sweep.** Adds the missing matrix cell — dot assignment *with* per-stage residual updates at unit scale: `A-dot-resid` (f32 values, isolates the residual effect), `A-dot-po2-resid` / `A-dot-po2x2-resid` (assignment AND subtraction from the same quantized tables — the kernel-buildable form), plus `A-dot-po2x3` completing the terms sweep.

   Measured (fresh-era rows-only run; baselines reproduce #310 exactly): **A-dot-po2x2-resid 31.2/35.3** vs shipped-shape 30.7/34.3 and A-f32 ceiling 32.1/36.4 — **recovers ~36-48% of the remaining gap; po2 value-set costs nothing; terms saturate at 2**. WB worsens on doubled keys (trade-off on record). Full matrix: #318 comment.

2. **`docs`: Phase B design note** (`docs/dot_residual_phase_b_design.md`) — integer residual wiring for the shift-add dot path: po2 norm fold via L1 bit-length (division-free normalization candidate, ⚑ validate certifier-side first), per-stage integer centroid copies (token stage-book precedent), WB/key-dispersion Empirical Criterion with a store-shape decision on the #244 harness, and a 3× bit-for-bit reproduction requirement before any kernel code.

No runtime-kernel changes; no format changes; no κ impact. Certifier-side instrumentation + docs only.

Local gates: clippy `-D warnings` + fmt clean on touched crates; claim-wording gate ✓. Full workspace gates run before merge per batch discipline.
