### PR TITLE
feat: add D2 canonical deterministic compile mode (#265)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "blake3",
  "ciborium",
  "hex",
+ "libm",
  "proptest",
  "serde",
  "serde_json",
@@ -1840,6 +1841,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "env_logger",
+ "libm",
  "log",
  "rayon",
  "serde",
@@ -1872,6 +1874,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "hex",
+ "libm",
  "safetensors",
  "serde",
  "serde_json",

--- a/crates/uor-r4-core/Cargo.toml
+++ b/crates/uor-r4-core/Cargo.toml
@@ -15,6 +15,7 @@ blake3 = "=1.5.0"
 ciborium = "0.2"
 uor-r4-graph-runtime = { path = "../uor-r4-graph-runtime" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+libm = "0.2"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -25,6 +25,50 @@ use std::collections::HashMap;
 use std::io::Write;
 use uor_r4_model_source::TeacherOracle;
 
+#[inline]
+fn canonical_math_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0")
+    })
+}
+
+#[inline]
+fn canonical_expf(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::expf(value)
+    } else {
+        value.exp()
+    }
+}
+
+#[inline]
+fn canonical_log2f(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::log2f(value)
+    } else {
+        value.log2()
+    }
+}
+
+#[inline]
+fn canonical_exp2f(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::exp2f(value)
+    } else {
+        value.exp2()
+    }
+}
+
+#[inline]
+fn canonical_sqrtf(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::sqrtf(value)
+    } else {
+        value.sqrt()
+    }
+}
+
 pub const STAGES: usize = 4;
 pub const K: usize = 256;
 pub const D: usize = 288;
@@ -130,7 +174,7 @@ pub fn load_corpus_from(mp: &str, rp: &str) -> Option<Corpus> {
             let argmax = u16::from_le_bytes(rb[o + 6..o + 8].try_into().unwrap()) as u32;
             t_argmax.push(argmax);
             let lp = f32::from_le_bytes(rb[o + 8..o + 12].try_into().unwrap());
-            let next_prob = (lp.exp() * 100.0).clamp(0.0, 100.0) as u32;
+            let next_prob = (canonical_expf(lp) * 100.0).clamp(0.0, 100.0) as u32;
 
             let mut tokens_val = [0u32; 8];
             let mut weights_val = [0u32; 8];
@@ -285,7 +329,7 @@ pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3
     }
     let mut sum = 0.0f32;
     for p in logits.iter_mut() {
-        *p = (*p - mx).exp();
+        *p = canonical_expf(*p - mx);
         sum += *p;
     }
     for p in logits.iter_mut() {
@@ -348,7 +392,7 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
     }
     let mut sum = 0.0f32;
     for p in logits.iter_mut() {
-        *p = (*p - mx).exp();
+        *p = canonical_expf(*p - mx);
         sum += *p;
     }
     for p in logits.iter_mut() {
@@ -743,8 +787,8 @@ pub fn pack_dot_entry(value: f32) -> u16 {
         if rem == 0.0 || !rem.is_finite() {
             break;
         }
-        let e = rem.abs().log2().round().clamp(-32.0, 31.0);
-        let term = rem.signum() * e.exp2();
+        let e = canonical_log2f(rem.abs()).round().clamp(-32.0, 31.0);
+        let term = rem.signum() * canonical_exp2f(e);
         *slot = 0x40 | ((e as i32 + 32) as u8 & 0x3F) | if rem < 0.0 { 0x80 } else { 0 };
         rem -= term;
     }
@@ -955,12 +999,7 @@ pub fn deterministic_project(
                 projected_row[target] += sign * centered_val;
             }
 
-            let n = projected_row
-                .iter()
-                .map(|x| x * x)
-                .sum::<f32>()
-                .sqrt()
-                .max(1e-9);
+            let n = canonical_sqrtf(projected_row.iter().map(|x| x * x).sum::<f32>()).max(1e-9);
             for x in projected_row.iter_mut() {
                 *x /= n;
             }
@@ -1229,7 +1268,7 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
             row[d] = x;
             nn += x * x;
         }
-        let nn = nn.sqrt().max(1e-9);
+        let nn = canonical_sqrtf(nn).max(1e-9);
         for d in 0..D {
             samp[v * D + d] = row[d] / nn;
         }

--- a/crates/uor-r4-graph-compiler/Cargo.toml
+++ b/crates/uor-r4-graph-compiler/Cargo.toml
@@ -8,6 +8,7 @@ uor-r4-model-source = { path = "../uor-r4-model-source" }
 uor-r4-graph-format = { path = "../uor-r4-graph-format" }
 uor-r4-core = { path = "../uor-r4-core" }
 rayon = "1.10.0"
+libm = "0.2"
 blake3 = "1.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -111,6 +111,32 @@ use uor_r4_core::transformerless::compiler::{
 };
 use uor_r4_core::transformerless::runtime;
 
+#[inline]
+fn canonical_math_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0")
+    })
+}
+
+#[inline]
+fn canonical_sqrtf(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::sqrtf(value)
+    } else {
+        value.sqrt()
+    }
+}
+
+#[inline]
+fn canonical_log2(value: f64) -> f64 {
+    if canonical_math_enabled() {
+        libm::log2(value)
+    } else {
+        value.log2()
+    }
+}
+
 /// Default multiresolution depth cap (root at depth 0; regions at 1..=3).
 pub const DEFAULT_DEPTHS: usize = 3;
 /// Default number of regions of the broad depth-1 cover.
@@ -420,7 +446,7 @@ fn build_observations_serial(
             }
         }
 
-        let nn = nn.sqrt().max(1e-9);
+        let nn = canonical_sqrtf(nn).max(1e-9);
         for x in vector.iter_mut() {
             *x /= nn;
         }
@@ -523,7 +549,7 @@ fn normalize(v: &mut [f32]) {
     for &x in v.iter() {
         nn += x * x;
     }
-    let nn = nn.sqrt().max(1e-9);
+    let nn = canonical_sqrtf(nn).max(1e-9);
     for x in v.iter_mut() {
         *x /= nn;
     }
@@ -750,7 +776,7 @@ fn entropy_bits<K: Ord>(counts: &BTreeMap<K, u64>) -> f64 {
     let mut h = 0.0f64;
     for &count in counts.values() {
         let p = count as f64 / total as f64;
-        h -= p * p.log2();
+        h -= p * canonical_log2(p);
     }
     h
 }

--- a/crates/uor-r4-model-source/Cargo.toml
+++ b/crates/uor-r4-model-source/Cargo.toml
@@ -8,4 +8,5 @@ safetensors = { version = "0.6", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 blake3 = "=1.5.0"
+libm = "0.2"
 hex = "0.4.3"

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -37,6 +37,8 @@ pub struct Llama {
     w3: usize,
     rms_final: usize,
     wcls: usize,
+    /// Use the portable pure-Rust math path required by D2 canonical mode.
+    canonical_math: bool,
 }
 
 pub struct State {
@@ -84,12 +86,57 @@ impl State {
     }
 }
 
-fn rmsnorm(o: &mut [f32], x: &[f32], weight: &[f32]) {
+#[inline]
+fn sqrtf(value: f32, canonical: bool) -> f32 {
+    if canonical {
+        libm::sqrtf(value)
+    } else {
+        value.sqrt()
+    }
+}
+
+#[inline]
+fn expf(value: f32, canonical: bool) -> f32 {
+    if canonical {
+        libm::expf(value)
+    } else {
+        value.exp()
+    }
+}
+
+#[inline]
+fn powf(base: f32, exponent: f32, canonical: bool) -> f32 {
+    if canonical {
+        libm::powf(base, exponent)
+    } else {
+        base.powf(exponent)
+    }
+}
+
+#[inline]
+fn sinf(value: f32, canonical: bool) -> f32 {
+    if canonical {
+        libm::sinf(value)
+    } else {
+        value.sin()
+    }
+}
+
+#[inline]
+fn cosf(value: f32, canonical: bool) -> f32 {
+    if canonical {
+        libm::cosf(value)
+    } else {
+        value.cos()
+    }
+}
+
+fn rmsnorm_with_mode(o: &mut [f32], x: &[f32], weight: &[f32], canonical: bool) {
     let size = x.len();
     let mut ss = x.iter().map(|value| value * value).sum::<f32>();
     ss /= size as f32;
     ss += 1e-5f32;
-    ss = 1.0f32 / ss.sqrt();
+    ss = 1.0f32 / sqrtf(ss, canonical);
     for ((output, value), weight) in o.iter_mut().zip(x).zip(weight) {
         *output = *weight * (ss * *value);
     }
@@ -97,18 +144,18 @@ fn rmsnorm(o: &mut [f32], x: &[f32], weight: &[f32]) {
 
 /// In-place variant matching C's rmsnorm(x, x, w): C computes ss from x
 /// first, then writes; identical here.
-fn rmsnorm_inplace(x: &mut [f32], weight: &[f32]) {
+fn rmsnorm_inplace_with_mode(x: &mut [f32], weight: &[f32], canonical: bool) {
     let size = x.len();
     let mut ss = x.iter().map(|value| value * value).sum::<f32>();
     ss /= size as f32;
     ss += 1e-5f32;
-    ss = 1.0f32 / ss.sqrt();
+    ss = 1.0f32 / sqrtf(ss, canonical);
     for (value, weight) in x.iter_mut().zip(weight) {
         *value = *weight * (ss * *value);
     }
 }
 
-fn softmax(x: &mut [f32]) {
+fn softmax_with_mode(x: &mut [f32], canonical: bool) {
     let mut max_val = x[0];
     for &value in x.iter().skip(1) {
         if value > max_val {
@@ -117,7 +164,7 @@ fn softmax(x: &mut [f32]) {
     }
     let mut sum = 0.0f32;
     for value in x.iter_mut() {
-        *value = (*value - max_val).exp();
+        *value = expf(*value - max_val, canonical);
         sum += *value;
     }
     for value in x.iter_mut() {
@@ -446,6 +493,7 @@ impl Llama {
             w3,
             rms_final,
             wcls,
+            canonical_math: false,
         }
     }
 
@@ -492,6 +540,7 @@ impl Llama {
             w3,
             rms_final,
             wcls,
+            canonical_math: false,
         }
     }
 
@@ -508,10 +557,11 @@ impl Llama {
         st.x.copy_from_slice(&w[self.emb + token * dim..self.emb + (token + 1) * dim]);
 
         for l in 0..c.n_layers {
-            rmsnorm(
+            rmsnorm_with_mode(
                 &mut st.xb,
                 &st.x,
                 &w[self.rms_att + l * dim..self.rms_att + (l + 1) * dim],
+                self.canonical_math,
             );
 
             let loff = l * c.seq_len * kv_dim;
@@ -550,10 +600,15 @@ impl Llama {
                 let mut i = 0usize;
                 while i < dim {
                     let head_dim = i % head_size;
-                    let freq = 1.0f32 / c.rope_theta.powf(head_dim as f32 / head_size as f32);
+                    let freq = 1.0f32
+                        / powf(
+                            c.rope_theta,
+                            head_dim as f32 / head_size as f32,
+                            self.canonical_math,
+                        );
                     let val = pos as f32 * freq;
-                    let fcr = val.cos();
-                    let fci = val.sin();
+                    let fcr = cosf(val, self.canonical_math);
+                    let fci = sinf(val, self.canonical_math);
                     let rotn = if i < kv_dim { 2 } else { 1 };
                     for v in 0..rotn {
                         let vec: &mut [f32] = if v == 0 { &mut st.q } else { &mut *k };
@@ -570,10 +625,17 @@ impl Llama {
                     for head in vector.chunks_exact_mut(head_size) {
                         let half = head_size / 2;
                         for i in 0..half {
-                            let freq =
-                                1.0f32 / c.rope_theta.powf((2 * i) as f32 / head_size as f32);
+                            let freq = 1.0f32
+                                / powf(
+                                    c.rope_theta,
+                                    (2 * i) as f32 / head_size as f32,
+                                    self.canonical_math,
+                                );
                             let angle = pos as f32 * freq;
-                            let (cos, sin) = (angle.cos(), angle.sin());
+                            let (cos, sin) = (
+                                cosf(angle, self.canonical_math),
+                                sinf(angle, self.canonical_math),
+                            );
                             let first = head[i];
                             let second = head[i + half];
                             head[i] = first * cos - second * sin;
@@ -606,10 +668,10 @@ impl Llama {
                                 + q_chunk[3] * k_chunk[3];
                             head_score += dot_4d;
                         }
-                        head_score /= (head_size as f32).sqrt();
+                        head_score /= sqrtf(head_size as f32, self.canonical_math);
                         *attention = head_score;
                     }
-                    softmax(att);
+                    softmax_with_mode(att, self.canonical_math);
                 } else {
                     // Standard Llama scaled dot-product attention
                     for (t, attention) in att.iter_mut().enumerate() {
@@ -619,10 +681,10 @@ impl Llama {
                         for i in 0..head_size {
                             score += q[i] * k[i];
                         }
-                        score /= (head_size as f32).sqrt();
+                        score /= sqrtf(head_size as f32, self.canonical_math);
                         *attention = score;
                     }
-                    softmax(att);
+                    softmax_with_mode(att, self.canonical_math);
                 }
 
                 let xb = &mut st.xb[h * head_size..(h + 1) * head_size];
@@ -648,10 +710,11 @@ impl Llama {
                 st.x[i] += st.xb2[i];
             }
 
-            rmsnorm(
+            rmsnorm_with_mode(
                 &mut st.xb,
                 &st.x,
                 &w[self.rms_ffn + l * dim..self.rms_ffn + (l + 1) * dim],
+                self.canonical_math,
             );
             matmul(
                 &mut st.hb,
@@ -669,7 +732,7 @@ impl Llama {
             );
             for i in 0..hid {
                 let mut val = st.hb[i];
-                val *= 1.0f32 / (1.0f32 + (-val).exp());
+                val *= 1.0f32 / (1.0f32 + expf(-val, self.canonical_math));
                 val *= st.hb2[i];
                 st.hb[i] = val;
             }
@@ -689,7 +752,7 @@ impl Llama {
         // C: rmsnorm(x, x, w) — in-place with pre-read ss.
         {
             let (wslice, x) = (&w[rf..rf + dim], &mut st.x);
-            rmsnorm_inplace(x, wslice);
+            rmsnorm_inplace_with_mode(x, wslice, self.canonical_math);
         }
         matmul(&mut st.logits, &st.x, &w[self.wcls..], dim, fast_matmul);
     }
@@ -759,7 +822,12 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
 /// `State` retains after `step`. Softmax is computed in the same f32
 /// max-subtracted form the corpus generator uses; ordering is canonical
 /// (probability descending, token id ascending on ties).
-fn top_k_from_logits(logits: &[f32], k: usize, out: &mut [(u32, f32)]) -> usize {
+fn top_k_from_logits(
+    logits: &[f32],
+    k: usize,
+    out: &mut [(u32, f32)],
+    canonical_math: bool,
+) -> usize {
     let count = k.min(out.len()).min(logits.len());
     if count == 0 {
         return 0;
@@ -773,7 +841,7 @@ fn top_k_from_logits(logits: &[f32], k: usize, out: &mut [(u32, f32)]) -> usize 
     let mut sum = 0.0f32;
     let mut probs = vec![0.0f32; logits.len()];
     for (prob, &logit) in probs.iter_mut().zip(logits.iter()) {
-        *prob = (logit - max).exp();
+        *prob = expf(logit - max, canonical_math);
         sum += *prob;
     }
     for prob in probs.iter_mut() {
@@ -879,7 +947,7 @@ impl TeacherOracle for LlamaOracle {
         Some(&self.state.x)
     }
     fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
-        top_k_from_logits(&self.state.logits, k, out)
+        top_k_from_logits(&self.state.logits, k, out, self.model.canonical_math)
     }
 }
 
@@ -1041,10 +1109,15 @@ impl HuggingFaceLlamaOracle {
         }
         let kappa = format!("blake3:{}", blake3::hash(&model_bytes).to_hex());
         let source_bytes = model_bytes.len();
-        let model = Llama::from_flat(cfg, weights, config.tie_word_embeddings);
+        let canonical_math =
+            std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0");
+        let mut model = Llama::from_flat(cfg, weights, config.tie_word_embeddings);
+        model.canonical_math = canonical_math;
         let state = State::new(&model.cfg);
-        let fast_matmul = std::env::var("TLESS_EXACT_SCALAR").is_err();
-        let backend = if fast_matmul {
+        let fast_matmul = !canonical_math && std::env::var("TLESS_EXACT_SCALAR").is_err();
+        let backend = if canonical_math {
+            "canonical libm scalar (D2)"
+        } else if fast_matmul {
             fast_matmul_backend()
         } else {
             "exact scalar (deterministic)"
@@ -1171,7 +1244,7 @@ impl TeacherOracle for HuggingFaceLlamaOracle {
         Some(&self.state.x)
     }
     fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
-        top_k_from_logits(&self.state.logits, k, out)
+        top_k_from_logits(&self.state.logits, k, out, self.model.canonical_math)
     }
 }
 
@@ -1181,6 +1254,35 @@ pub type SmolLm2Oracle = HuggingFaceLlamaOracle;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_math_delegates_to_portable_libm() {
+        let values = [-7.25f32, -1.0, 0.125, 1.0, 7.25];
+        for &value in &values {
+            assert_eq!(
+                sqrtf(value.abs() + 0.5, true).to_bits(),
+                libm::sqrtf(value.abs() + 0.5).to_bits()
+            );
+            assert_eq!(expf(value, true).to_bits(), libm::expf(value).to_bits());
+            assert_eq!(sinf(value, true).to_bits(), libm::sinf(value).to_bits());
+            assert_eq!(cosf(value, true).to_bits(), libm::cosf(value).to_bits());
+            assert_eq!(
+                powf(10_000.0, value / 8.0, true).to_bits(),
+                libm::powf(10_000.0, value / 8.0).to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_softmax_is_repeatable() {
+        let input = [3.0f32, -1.0, 0.25, 7.0];
+        let mut first = input;
+        let mut second = input;
+        softmax_with_mode(&mut first, true);
+        softmax_with_mode(&mut second, true);
+        assert_eq!(first, second);
+        assert!((first.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+    }
 
     #[cfg(target_arch = "aarch64")]
     #[test]

--- a/docs/d2_canonical_compile.md
+++ b/docs/d2_canonical_compile.md
@@ -1,0 +1,29 @@
+# D2 canonical deterministic compile mode
+
+Issue #265 adds a target-independent compiler mode for certificate-bearing
+artifacts. Enable it with:
+
+```bash
+cargo run --release --bin r4 -- compile \
+  --source /path/to/pinned-model \
+  --canonical-deterministic
+```
+
+The mode is selected by `TLESS_CANONICAL_DETERMINISTIC=1` and currently does
+the following:
+
+- disables Accelerate/NEON/AVX2 teacher matmul in favor of the ordered scalar
+  path;
+- routes teacher `sqrt`, `exp`, `pow`, `sin`, and `cos` through the portable
+  pure-Rust `libm` implementation;
+- routes transformerless compiler softmax, power-of-two packing, projection
+  normalization, and graph-cover normalization/entropy through the same
+  portable math family.
+
+`--exact-scalar` remains the faster local-iteration switch. It selects scalar
+matmul only and does not claim cross-platform byte reproducibility.
+
+The mode is compiler-side only; the deployed runtime contract is unchanged.
+The remaining D2 acceptance work is a macOS/Linux differential compile of a
+pinned checkpoint and corpus, followed by recording the mode in the artifact
+certificate and re-pinning the canonical fixture under maintainer review.

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,9 @@ struct CompileArgs {
     /// Force exact scalar CPU math instead of Apple Accelerate / SIMD hardware matrix acceleration.
     #[arg(long, default_value_t = false)]
     exact_scalar: bool,
+    /// Use the portable libm teacher path and scalar reductions for certificate-bearing builds.
+    #[arg(long, default_value_t = false)]
+    canonical_deterministic: bool,
 }
 
 #[derive(Args, Debug)]
@@ -425,6 +428,9 @@ fn compile(args: &CompileArgs) -> Result<(), RunError> {
     }
     if args.exact_scalar {
         std::env::set_var("TLESS_EXACT_SCALAR", "1");
+    }
+    if args.canonical_deterministic {
+        std::env::set_var("TLESS_CANONICAL_DETERMINISTIC", "1");
     }
     transformerless_command::compile_hugging_face(&values).map_err(RunError::Command)
 }


### PR DESCRIPTION
Refs #265.

## Summary

- adds `--canonical-deterministic` for certificate-bearing compile runs
- disables accelerated teacher matmul and routes teacher transcendental math through portable pure-Rust `libm`
- applies the same mode to transformerless softmax/packing/projection and graph-cover normalization/entropy
- documents the mode and keeps `--exact-scalar` as the faster local-iteration option

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --offline`
- workspace clippy with `-D warnings`
- graph-compiler tests: 80 unit + 20 integration passing, with one fixture workload ignored
- model-source tests: 4 passing
- core library tests, including canonical-mode run: 19 passing
- graph-format no-std checks: default-off and `alloc`
- claim-wording gate passing

The full workspace test command still hits the pre-existing R4G1 allocation census failure: 2 allocations / 594 bytes in the runtime steady-state assertion, unrelated to this compiler-side change.

The final #265 acceptance proof remains a macOS/Linux differential compile of the same pinned model and corpus, followed by maintainer-reviewed canonical fixture re-pinning. This PR supplies the canonical mode needed for that proof; it does not claim that cross-OS result yet.