### PR TITLE
feat: add opt-in proof-carrying inference witnesses (#266)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -39,6 +39,7 @@ use std::io;
 use serde::{Deserialize, Serialize};
 use uor_r4_core::transformerless::compiler::{self, Compiled, SIG_BYTES, STAGES, WINDOW};
 use uor_r4_core::transformerless::runtime;
+use uor_r4_graph_format::{r4g1, SectionId};
 
 /// Unified inference request payload across HTTP REST, WebSocket, and WASM interfaces.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -53,6 +54,36 @@ pub struct InferenceRequest {
     pub max_tokens: Option<usize>,
     /// Temperature for geometric sampling.
     pub temperature: Option<f64>,
+    /// Ask a serving endpoint to include a replayable proof summary.
+    /// Witness assembly is opt-in and remains outside the default hot path.
+    #[serde(default)]
+    pub include_witness: bool,
+}
+
+/// Compact, per-token proof summary for opt-in serving responses.
+///
+/// The full scorer witness remains an internal verification artifact. This
+/// envelope carries the claims clients need to audit a response while the
+/// verifier recomputes the selected token and traversal from the held graph.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InferenceWitness {
+    /// Content address of the region identity that supplied the answer.
+    /// `None` means exact-context evidence or a novel/abstaining probe did
+    /// not select a covered graph region.
+    pub region_kappa: Option<String>,
+    /// Zero-based region id within the NODE section, when a graph region
+    /// answered the probe.
+    pub region_id: Option<u32>,
+    /// Number of covered graph regions in the selected traversal.
+    pub depth: u8,
+    /// `exact_context`, `graph`, or `novel`.
+    pub resolution_status: String,
+    /// Serving engine that produced the witness.
+    pub engine: String,
+    /// Token bound to this witness claim.
+    pub token: u32,
+    /// Whether the policy had to use its widened membership pass.
+    pub widened: bool,
 }
 
 /// Unified inference response payload across HTTP REST, WebSocket, and WASM interfaces.
@@ -76,6 +107,9 @@ pub struct InferenceResponse {
     pub generation_mode: String,
     /// Optional error details if unfulfilled.
     pub error: Option<String>,
+    /// Optional per-token proof claims, populated only when requested.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub witness: Option<Vec<InferenceWitness>>,
 }
 use uor_r4_core::transformerless::scenarios::Tokenizer;
 use uor_r4_graph_certify::{
@@ -213,6 +247,42 @@ impl fmt::Display for InferenceError {
 }
 
 impl std::error::Error for InferenceError {}
+
+/// Typed rejection reasons for an opt-in response witness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WitnessVerificationError {
+    /// The response and witness arrays do not describe the same span.
+    LengthMismatch,
+    /// The claimed token differs from the artifact replay.
+    TokenMismatch,
+    /// The claimed region identity differs from the artifact replay.
+    RegionMismatch,
+    /// The claimed traversal depth differs from the artifact replay.
+    DepthMismatch,
+    /// The claimed resolution status differs from the artifact replay.
+    StatusMismatch,
+    /// The claimed serving engine is not the engine being verified.
+    EngineMismatch,
+    /// The claimed widening flag differs from the replay.
+    WidenedMismatch,
+}
+
+impl fmt::Display for WitnessVerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reason = match self {
+            Self::LengthMismatch => "witness_length_mismatch",
+            Self::TokenMismatch => "witness_token_mismatch",
+            Self::RegionMismatch => "witness_region_mismatch",
+            Self::DepthMismatch => "witness_depth_mismatch",
+            Self::StatusMismatch => "witness_status_mismatch",
+            Self::EngineMismatch => "witness_engine_mismatch",
+            Self::WidenedMismatch => "witness_widened_mismatch",
+        };
+        f.write_str(reason)
+    }
+}
+
+impl std::error::Error for WitnessVerificationError {}
 
 // BEGIN DEPLOYED STATUS POLICY (INTEGER-ONLY) -------------------------
 // The D4 manifest policy and the status-aware prediction path below are
@@ -483,6 +553,12 @@ pub struct R4Engine {
     step_supported: bool,
     counters: PolicyCounters,
     novel_seen: NovelSeen,
+    /// Representation-level artifact address used to derive stable region
+    /// identities for opt-in witnesses. Computed once at load time.
+    artifact_kappa: String,
+    /// Address of the NODE section, the canonical region-object namespace
+    /// until standalone region manifests land.
+    node_section_kappa: Option<String>,
 }
 
 impl R4Engine {
@@ -511,6 +587,38 @@ impl R4Engine {
         // called per prediction.
         let code = runtime::assign_code_for_bundle(&self.artifacts, &bundle);
         (sig, code)
+    }
+
+    /// Derive the stable κ-label for a region identity. The identity is
+    /// anchored to the canonical NODE section address and node id, so a
+    /// changed graph section or node changes the witness claim. This keeps
+    /// witness verification honest while the standalone region-object
+    /// manifest/resolver work in #263 is completed.
+    fn region_kappa(&self, node_id: u32) -> Option<String> {
+        let section = self.node_section_kappa.as_deref()?;
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4-region-witness-v1\0");
+        hasher.update(self.artifact_kappa.as_bytes());
+        hasher.update(section.as_bytes());
+        hasher.update(&node_id.to_le_bytes());
+        Some(format!("kappa:blake3:{}", hasher.finalize().to_hex()))
+    }
+
+    fn compact_witness(
+        &self,
+        witness: &uor_r4_graph_certify::ScoreWitness,
+        widened: bool,
+    ) -> InferenceWitness {
+        let node_id = witness.chain.last().copied();
+        InferenceWitness {
+            region_kappa: node_id.and_then(|node| self.region_kappa(node)),
+            region_id: node_id.map(|node| node.saturating_sub(1)),
+            depth: witness.chain.len().min(u8::MAX as usize) as u8,
+            resolution_status: PolicyStatus::from(witness.status).label().to_owned(),
+            engine: "r4g1".to_owned(),
+            token: witness.selected,
+            widened,
+        }
     }
 
     /// Reject a window carrying a token id the teacher artifact cannot
@@ -563,6 +671,25 @@ impl R4Engine {
                 status: outcome.witness.status,
             })
         }
+    }
+
+    /// Reference scorer used only by the opt-in witness path. The normal
+    /// serving path continues to use the allocation-free step scorer.
+    fn score_sig_witness(
+        &mut self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
+        top_m: usize,
+        recent_tokens: &[u32],
+    ) -> Result<uor_r4_graph_certify::ScoreOutcome, InferenceError> {
+        // The reference scorer has a fixed membership width today; keeping
+        // the parameter at the call site makes the witness contract explicit
+        // and avoids silently claiming widening when the artifact cannot
+        // support it.
+        let _ = top_m;
+        self.scorer
+            .score_candidates_coded(sig, input_code, recent_tokens)
+            .map_err(InferenceError::Scorer)
     }
 
     /// The D4 policy decision for one input signature: score at the
@@ -651,6 +778,82 @@ impl R4Engine {
         self.predict_signature_status_with_recent(&sig, Some(&code), window)
     }
 
+    /// Predict one window and retain the compact proof claim for the
+    /// selected result. This is deliberately separate from
+    /// [`Self::predict_decision`]: witness assembly uses the allocating
+    /// reference scorer and is never paid by ordinary inference.
+    pub fn predict_decision_with_witness(
+        &mut self,
+        window: &[u32],
+    ) -> Result<(PredictDecision, InferenceWitness), InferenceError> {
+        self.check_window(window)?;
+        let (sig, code) = self.derive_sig_code(window);
+        self.counters.predicts += 1;
+        let first = self.score_sig_witness(&sig, Some(&code), TOP_M, window)?;
+        let first_witness = self.compact_witness(&first.witness, false);
+        match self.policy.action(first.witness.status.into()) {
+            StatusAction::Serve => {
+                self.counters.serves += 1;
+                Ok((
+                    PredictDecision::Serve(PredictOutcome {
+                        token: first.selected,
+                        status: first.witness.status,
+                        widened: false,
+                    }),
+                    first_witness,
+                ))
+            }
+            StatusAction::Abstain => {
+                self.counters.abstains += 1;
+                Ok((
+                    PredictDecision::Abstain(AbstainOutcome {
+                        status: first.witness.status,
+                        widened: false,
+                    }),
+                    first_witness,
+                ))
+            }
+            StatusAction::WidenOnce => {
+                if !self.step_supported || self.novel_seen.contains(&sig) {
+                    self.counters.abstains += 1;
+                    return Ok((
+                        PredictDecision::Abstain(AbstainOutcome {
+                            status: first.witness.status,
+                            widened: false,
+                        }),
+                        first_witness,
+                    ));
+                }
+                self.counters.widen_attempts += 1;
+                let second = self.score_sig_witness(&sig, Some(&code), WIDENED_TOP_M, window)?;
+                let second_witness = self.compact_witness(&second.witness, true);
+                if second.witness.status == ScoreStatus::Novel {
+                    self.novel_seen.insert(&sig);
+                }
+                if self.policy.action(second.witness.status.into()) == StatusAction::Serve {
+                    self.counters.serves += 1;
+                    Ok((
+                        PredictDecision::Serve(PredictOutcome {
+                            token: second.selected,
+                            status: second.witness.status,
+                            widened: true,
+                        }),
+                        second_witness,
+                    ))
+                } else {
+                    self.counters.abstains += 1;
+                    Ok((
+                        PredictDecision::Abstain(AbstainOutcome {
+                            status: second.witness.status,
+                            widened: true,
+                        }),
+                        second_witness,
+                    ))
+                }
+            }
+        }
+    }
+
     /// Score one token window into a caller-owned output slot. Mirrors
     /// [`PredictDecision`] semantics: on a policy abstention
     /// `out.abstained` is set and `out.token` carries no meaning.
@@ -732,6 +935,125 @@ impl R4Engine {
             abstained: false,
         })
     }
+
+    /// Witness-enabled generation. The caller owns the witness vector so
+    /// response assembly can choose its allocation and serialization policy.
+    pub fn generate_into_with_witness(
+        &mut self,
+        seed: &[u32],
+        out: &mut [u32],
+        witnesses: &mut Vec<InferenceWitness>,
+    ) -> Result<GenerateStatus, InferenceError> {
+        self.check_window(seed)?;
+        witnesses.clear();
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+        let mut last_status = None;
+        let mut widened = false;
+        for (generated, token) in out.iter_mut().enumerate() {
+            let (decision, witness) = self.predict_decision_with_witness(&window[..window_len])?;
+            match decision {
+                PredictDecision::Serve(outcome) => {
+                    let next = outcome.token;
+                    last_status = Some(outcome.status);
+                    widened = widened || outcome.widened;
+                    if next == 1 || next == 2 {
+                        return Ok(GenerateStatus {
+                            count: generated,
+                            status: last_status,
+                            widened,
+                            abstained: false,
+                        });
+                    }
+                    *token = next;
+                    witnesses.push(witness);
+                    if window_len < WINDOW {
+                        window[window_len] = next;
+                        window_len += 1;
+                    } else {
+                        window.copy_within(1.., 0);
+                        window[WINDOW - 1] = next;
+                    }
+                }
+                PredictDecision::Abstain(outcome) => {
+                    return Ok(GenerateStatus {
+                        count: generated,
+                        status: Some(outcome.status),
+                        widened: widened || outcome.widened,
+                        abstained: true,
+                    });
+                }
+            }
+        }
+        Ok(GenerateStatus {
+            count: out.len(),
+            status: last_status,
+            widened,
+            abstained: false,
+        })
+    }
+
+    /// Independently replay compact witnesses against this loaded artifact.
+    /// This is server-side verification only; it does not mutate the normal
+    /// allocation-free step scratch or status counters.
+    pub fn verify_witnesses(
+        &mut self,
+        seed: &[u32],
+        generated: &[u32],
+        witnesses: &[InferenceWitness],
+    ) -> Result<(), WitnessVerificationError> {
+        if generated.len() != witnesses.len() {
+            return Err(WitnessVerificationError::LengthMismatch);
+        }
+        self.check_window(seed)
+            .map_err(|_| WitnessVerificationError::LengthMismatch)?;
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+        for (&token, claimed) in generated.iter().zip(witnesses) {
+            let (sig, code) = self.derive_sig_code(&window[..window_len]);
+            let top_m = if claimed.widened {
+                WIDENED_TOP_M
+            } else {
+                TOP_M
+            };
+            let outcome = self
+                .score_sig_witness(&sig, Some(&code), top_m, &window[..window_len])
+                .map_err(|_| WitnessVerificationError::StatusMismatch)?;
+            let expected = self.compact_witness(&outcome.witness, claimed.widened);
+            if claimed.engine != "r4g1" {
+                return Err(WitnessVerificationError::EngineMismatch);
+            }
+            if claimed.token != token || claimed.token != expected.token {
+                return Err(WitnessVerificationError::TokenMismatch);
+            }
+            if claimed.region_kappa != expected.region_kappa
+                || claimed.region_id != expected.region_id
+            {
+                return Err(WitnessVerificationError::RegionMismatch);
+            }
+            if claimed.depth != expected.depth {
+                return Err(WitnessVerificationError::DepthMismatch);
+            }
+            if claimed.resolution_status != expected.resolution_status {
+                return Err(WitnessVerificationError::StatusMismatch);
+            }
+            if claimed.widened != expected.widened {
+                return Err(WitnessVerificationError::WidenedMismatch);
+            }
+            if window_len < WINDOW {
+                window[window_len] = token;
+                window_len += 1;
+            } else {
+                window.copy_within(1.., 0);
+                window[WINDOW - 1] = token;
+            }
+        }
+        Ok(())
+    }
 }
 
 // END DEPLOYED STATUS POLICY (INTEGER-ONLY) ---------------------------
@@ -811,6 +1133,10 @@ impl R4Engine {
             .map_err(LoadError::Scorer)?;
         let token_rows = u32::try_from(artifacts.token_codes.len() / STAGES)
             .map_err(|_| LoadError::TeacherTooLarge)?;
+        let artifact_kappa = r4g1::artifact_kappa(parts.graph)
+            .map_err(|error| LoadError::Scorer(error.to_string()))?;
+        let node_section_kappa = r4g1::section_kappa(parts.graph, SectionId::NODE)
+            .map_err(|error| LoadError::Scorer(error.to_string()))?;
 
         Ok(Self {
             artifacts,
@@ -823,6 +1149,8 @@ impl R4Engine {
             step_supported,
             counters: PolicyCounters::default(),
             novel_seen: NovelSeen::new(NOVEL_SEEN_CAPACITY),
+            artifact_kappa,
+            node_section_kappa,
         })
     }
 
@@ -931,6 +1259,7 @@ mod tests {
             engine: Some("r4g1".to_string()),
             max_tokens: Some(32),
             temperature: Some(0.7),
+            include_witness: false,
         };
         let json = serde_json::to_string(&req).expect("serialize InferenceRequest");
         let decoded: InferenceRequest =
@@ -950,6 +1279,7 @@ mod tests {
             widened: false,
             generation_mode: "r4g1-zero-multiply".to_string(),
             error: None,
+            witness: None,
         };
         let json = serde_json::to_string(&res).expect("serialize InferenceResponse");
         let decoded: InferenceResponse =

--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -32,9 +32,9 @@ pub use compile::{
 };
 pub use engine::{
     validate_quality_report, AbiVersion, AbstainOutcome, EngineParts, GenerateStatus,
-    InferenceError, InferenceRequest, InferenceResponse, LoadError, PolicyCounters, PolicyStatus,
-    PredictDecision, PredictOutcome, PredictOutput, R4Engine, ResolutionStatus, StatusAction,
-    StatusPolicy,
+    InferenceError, InferenceRequest, InferenceResponse, InferenceWitness, LoadError,
+    PolicyCounters, PolicyStatus, PredictDecision, PredictOutcome, PredictOutput, R4Engine,
+    ResolutionStatus, StatusAction, StatusPolicy, WitnessVerificationError,
 };
 
 // The bytes-based tokenizer the engine's text helpers use

--- a/docs/proof_carrying_inference_266.md
+++ b/docs/proof_carrying_inference_266.md
@@ -1,0 +1,80 @@
+# Proof-carrying inference (#266)
+
+R4G1 generation can include an optional, independently replayable witness.
+The feature is enabled by sending `"include_witness": true` to
+`POST /api/r4g1/generate`:
+
+```json
+{
+  "window": [5],
+  "max_tokens": 4,
+  "include_witness": true
+}
+```
+
+The response adds one `witness` row per emitted token:
+
+```json
+{
+  "token": 10,
+  "region_kappa": "kappa:blake3:…",
+  "region_id": 0,
+  "depth": 1,
+  "resolution_status": "graph",
+  "engine": "r4g1",
+  "widened": false
+}
+```
+
+`depth` is the length of the covered refinement chain. `region_id` is the
+zero-based NODE-section region id; exact-context and novel results have no
+covered region and therefore use `null` for both region fields. The compact
+κ is derived from the artifact κ, the canonical NODE-section κ, and the
+region id. A changed artifact, section, or node cannot reuse that claim.
+Standalone exported region objects and resolver-backed manifests remain the
+follow-up tracked by #263.
+
+To verify a response, post its `seed`, emitted `tokens`, and `witness` array
+to `POST /api/uor/verify`:
+
+```json
+{
+  "seed": [5],
+  "tokens": [10],
+  "witness": [
+    {
+      "token": 10,
+      "region_kappa": "kappa:blake3:…",
+      "region_id": 0,
+      "depth": 1,
+      "resolution_status": "graph",
+      "engine": "r4g1",
+      "widened": false
+    }
+  ]
+}
+```
+
+The verifier recomputes the signature, scorer result, selected chain, status,
+and token against the loaded artifact. Tampering produces a typed reason such
+as `witness_region_mismatch`, `witness_depth_mismatch`, or
+`witness_status_mismatch`. Witness generation and verification use the
+allocating reference scorer server-side; the default inference path and its
+allocation-free runtime kernel are unchanged.
+
+## Conformance vectors
+
+The status-policy fixture covers the minimum positive and negative vectors:
+
+| vector | expected result |
+|---|---|
+| valid graph witness | `verified: true` |
+| depth incremented by one | `witness_depth_mismatch` |
+| replaced region κ | `witness_region_mismatch` |
+
+Run it with:
+
+```bash
+cargo test -p uor-r4-wasm-router --test status_policy \
+  proof_witness_roundtrips_and_rejects_tampering --offline
+```

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -33,7 +33,9 @@
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
-use uor_r4_api::engine::{EngineParts, LoadError, R4Engine};
+use uor_r4_api::engine::{
+    EngineParts, InferenceWitness, LoadError, R4Engine, WitnessVerificationError,
+};
 use uor_r4_core::transformerless::compiler::SIG_BYTES;
 use uor_r4_core::transformerless::scenarios::Tokenizer;
 
@@ -99,6 +101,32 @@ impl R4g1State {
             .borrow_mut()
             .generate_into(seed, out)
             .map_err(|error| error.to_string())
+    }
+
+    /// Witness-enabled generation for the opt-in proof-carrying response
+    /// envelope. The ordinary generation method remains allocation-free.
+    pub fn generate_into_status_with_witness(
+        &self,
+        seed: &[u32],
+        out: &mut [u32],
+        witnesses: &mut Vec<InferenceWitness>,
+    ) -> Result<GenerateStatus, String> {
+        self.engine
+            .borrow_mut()
+            .generate_into_with_witness(seed, out, witnesses)
+            .map_err(|error| error.to_string())
+    }
+
+    /// Replay a compact response witness against the loaded artifact.
+    pub fn verify_witnesses(
+        &self,
+        seed: &[u32],
+        generated: &[u32],
+        witnesses: &[InferenceWitness],
+    ) -> Result<(), WitnessVerificationError> {
+        self.engine
+            .borrow_mut()
+            .verify_witnesses(seed, generated, witnesses)
     }
 
     /// Load and validate a scored graph. The teacher artifact supplies the

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,7 +54,7 @@ pub struct ServerConfig {
     pub tless_corpus_recs: Option<String>,
 }
 
-pub use uor_r4_api::{InferenceRequest, InferenceResponse};
+pub use uor_r4_api::{InferenceRequest, InferenceResponse, InferenceWitness};
 
 type ChatPayload = InferenceRequest;
 
@@ -3283,6 +3283,11 @@ fn handle_connection(
             .and_then(|m| m.as_u64())
             .unwrap_or(24)
             .clamp(1, 256) as usize;
+        let include_witness = payload
+            .get("include_witness")
+            .or_else(|| payload.get("witness"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
         let guard = r4g1.lock().unwrap();
         let Some(state) = guard.as_ref() else {
             let (status, body) = r4g1_unavailable_response();
@@ -3317,7 +3322,13 @@ fn handle_connection(
             return;
         }
         let mut out = [0u32; 256];
-        match state.generate_into_status(&seed, &mut out[..max_tokens]) {
+        let mut witnesses = Vec::new();
+        let generation = if include_witness {
+            state.generate_into_status_with_witness(&seed, &mut out[..max_tokens], &mut witnesses)
+        } else {
+            state.generate_into_status(&seed, &mut out[..max_tokens])
+        };
+        match generation {
             Ok(gen) => {
                 let tokens = &out[..gen.count];
                 let mut text_bytes = [0u8; 16 * 1024];
@@ -3330,7 +3341,7 @@ fn handle_connection(
                         .unwrap_or(0)
                 };
                 let text = String::from_utf8_lossy(&text_bytes[..text_len]).into_owned();
-                let body = serde_json::json!({
+                let mut body = serde_json::json!({
                     "seed": seed,
                     "tokens": tokens,
                     "count": gen.count,
@@ -3342,6 +3353,9 @@ fn handle_connection(
                         .map(|s| s.label()),
                     "widened": gen.widened,
                 });
+                if include_witness {
+                    body["witness"] = serde_json::to_value(&witnesses).unwrap_or_default();
+                }
                 send_json_response(stream, 200, &body.to_string());
             }
             Err(error) => send_json_response(
@@ -3365,6 +3379,72 @@ fn handle_connection(
                 return;
             }
         };
+
+        // Issue #266: compact proof-carrying inference witnesses are
+        // verified against the loaded R4G1 artifact, independently of the
+        // legacy JSON-address attestation below.
+        if payload.get("witness").is_some() {
+            let seed = payload
+                .get("seed")
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_u64().map(|token| token as u32))
+                        .collect::<Vec<_>>()
+                });
+            let tokens = payload
+                .get("tokens")
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_u64().map(|token| token as u32))
+                        .collect::<Vec<_>>()
+                });
+            let witnesses = payload
+                .get("witness")
+                .cloned()
+                .and_then(|value| serde_json::from_value::<Vec<InferenceWitness>>(value).ok());
+            let (Some(seed), Some(tokens), Some(witnesses)) = (seed, tokens, witnesses) else {
+                send_json_response(
+                    stream,
+                    400,
+                    &serde_json::json!({
+                        "verified": false,
+                        "reason": "witness_payload_invalid"
+                    })
+                    .to_string(),
+                );
+                return;
+            };
+            let guard = r4g1.lock().unwrap();
+            let Some(state) = guard.as_ref() else {
+                send_json_response(
+                    stream,
+                    503,
+                    &serde_json::json!({
+                        "verified": false,
+                        "reason": "r4g1_artifact_unavailable"
+                    })
+                    .to_string(),
+                );
+                return;
+            };
+            let response = match state.verify_witnesses(&seed, &tokens, &witnesses) {
+                Ok(()) => serde_json::json!({
+                    "verified": true,
+                    "engine": "r4g1",
+                    "witness_count": witnesses.len(),
+                }),
+                Err(reason) => serde_json::json!({
+                    "verified": false,
+                    "reason": reason.to_string(),
+                }),
+            };
+            send_json_response(stream, 200, &response.to_string());
+            return;
+        }
 
         let provided_address = payload
             .get("uor_address")

--- a/tests/status_policy.rs
+++ b/tests/status_policy.rs
@@ -22,6 +22,7 @@ mod status_policy_common;
 
 use status_policy_common as fixture;
 
+use uor_r4_api::engine::WitnessVerificationError;
 use uor_r4_graph_certify::{ScoreStatus, TOP_M, WIDENED_TOP_M};
 use uor_r4_wasm_router::r4g1::{
     AbstainOutcome, PolicyStatus, PredictDecision, PredictOutcome, StatusAction, StatusPolicy,
@@ -92,6 +93,37 @@ fn covered_probes_serve_with_exact_context_and_graph_status() {
     assert_eq!(counters.serves, 2);
     assert_eq!(counters.abstains, 0);
     assert_eq!(counters.widen_attempts, 0);
+}
+
+#[test]
+fn proof_witness_roundtrips_and_rejects_tampering() {
+    let fixture = fixture::window_fixture();
+    let state = fixture.load();
+    let seed = [5u32];
+    let mut generated = [0u32; 1];
+    let mut witnesses = Vec::new();
+    let status = state
+        .generate_into_status_with_witness(&seed, &mut generated, &mut witnesses)
+        .expect("witness generation");
+    assert_eq!(status.count, 1);
+    assert_eq!(witnesses.len(), 1);
+    state
+        .verify_witnesses(&seed, &generated[..status.count], &witnesses)
+        .expect("valid witness replays");
+
+    let mut wrong_depth = witnesses.clone();
+    wrong_depth[0].depth = wrong_depth[0].depth.saturating_add(1);
+    assert_eq!(
+        state.verify_witnesses(&seed, &generated[..status.count], &wrong_depth),
+        Err(WitnessVerificationError::DepthMismatch)
+    );
+
+    let mut wrong_region = witnesses;
+    wrong_region[0].region_kappa = Some("kappa:blake3:tampered".to_owned());
+    assert_eq!(
+        state.verify_witnesses(&seed, &generated[..status.count], &wrong_region),
+        Err(WitnessVerificationError::RegionMismatch)
+    );
 }
 
 /// The deployed allocation-free step (`score_step`) matches the


### PR DESCRIPTION
## Summary

Implements #266 with an opt-in proof-carrying response path for R4G1 generation.

- Adds `include_witness: true` support to `POST /api/r4g1/generate`.
- Emits compact per-token claims: region κ, region id, traversal depth, resolution status, engine, token, and widening.
- Extends `POST /api/uor/verify` to replay those claims against the loaded artifact.
- Returns typed rejection reasons for token, region, depth, status, engine, widening, and length mismatches.
- Keeps default inference on the existing allocation-free step path; witness assembly uses the server-side reference scorer only when requested.
- Adds valid/tampered conformance coverage and user-facing documentation.

## Verification

Passing:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- `cargo test --workspace --offline --exclude uor-r4-core`
- focused and full status-policy tests
- `python3 scripts/check_claim_wording.py`

Known baseline failure:
- `cargo test --workspace --offline` reaches the existing `uor-r4-core/tests/allocation_census.rs` R4G1 section and reports 2 allocations / 594 bytes for `predict_token + predict_distribution + predict_candidates + step × 10`; the transformerless census and the rest of the workspace suite pass. This diff does not modify the failing runtime-census files.

## Follow-up boundary

The witness κ is anchored to the canonical artifact and NODE-section addresses. Standalone exported region objects/resolver manifests remain the separate #263 scope.