### PR TITLE
feat: add κ-addressed region objects and resolver (#263)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tracing",
+ "uor-addr",
  "uor-r4-graph-format",
  "uor-r4-graph-runtime",
  "uor-r4-model-source",

--- a/crates/uor-r4-core/Cargo.toml
+++ b/crates/uor-r4-core/Cargo.toml
@@ -14,6 +14,7 @@ hex = "0.4.3"
 blake3 = "=1.5.0"
 ciborium = "0.2"
 uor-r4-graph-runtime = { path = "../uor-r4-graph-runtime" }
+uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b51e3e2113ee5d032730cde709335d4fe9b60", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 libm = "0.2"
 

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -25,6 +25,7 @@ pub mod bott_fock;
 pub mod cd_space;
 pub mod endomorphism;
 pub mod lie_jordan;
+pub mod region_store;
 
 pub use reference_state::{ActiveFrontier, ActiveFrontierEntry, PackedEdgeRanges};
 pub use runtime::{derive_popcount_table, hamming, sign_signature, OpKernel};

--- a/crates/uor-r4-core/src/transformerless/region_store.rs
+++ b/crates/uor-r4-core/src/transformerless/region_store.rs
@@ -1,0 +1,466 @@
+//! I/O-side region objects and resolver-backed store access (#263).
+//!
+//! TLS1 remains the compact monolithic store used by the existing runtime.
+//! This module gives each `(depth, prefix)` subtree an independently
+//! addressable canonical object and provides the adapter needed to serve a
+//! prediction from a manifest plus a resolver. No prediction-kernel code is
+//! changed here.
+
+use std::collections::BTreeMap;
+
+use super::compiler::STAGES;
+use super::runtime::{Prediction, Store};
+
+/// Region-object wire schema version.
+pub const REGION_OBJECT_SCHEMA: u64 = 1;
+/// Manifest wire schema version.
+pub const REGION_MANIFEST_SCHEMA: u32 = 1;
+
+/// One canonical region object: a graded prefix and its token distribution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionObject {
+    /// Store grade / prefix depth.
+    pub depth: u8,
+    /// The class-prefix key at `depth`.
+    pub key: Vec<u8>,
+    /// Deterministically ordered next-token evidence.
+    pub distribution: BTreeMap<u32, u32>,
+}
+
+/// One manifest entry identifying a resolver-backed region object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionReference {
+    /// Store grade / prefix depth.
+    pub depth: u8,
+    /// The class-prefix key at `depth`.
+    pub key: Vec<u8>,
+    /// UOR κ-label of the canonical region object.
+    pub kappa: String,
+    /// Canonical object byte length.
+    pub bytes: u64,
+}
+
+/// A manifest sufficient to address every region without loading payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionManifest {
+    /// Manifest schema version.
+    pub schema: u32,
+    /// UOR κ-label of the canonical manifest skeleton.
+    pub manifest_kappa: String,
+    /// Region references in `(depth, key)` order.
+    pub regions: Vec<RegionReference>,
+}
+
+/// Export result containing the manifest and objects to place in a CAS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionExport {
+    pub manifest: RegionManifest,
+    pub objects: Vec<RegionObject>,
+}
+
+/// Errors from canonical region serialization or address derivation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionObjectError {
+    InvalidSchema,
+    InvalidKeyDepth,
+    DuplicateToken,
+    Malformed,
+    AddressingFailed,
+}
+
+impl core::fmt::Display for RegionObjectError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
+            Self::InvalidSchema => "unsupported region-object schema",
+            Self::InvalidKeyDepth => "region key length does not match depth",
+            Self::DuplicateToken => "region object contains a duplicate token",
+            Self::Malformed => "malformed region object or manifest",
+            Self::AddressingFailed => "uor-addr rejected the region skeleton",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for RegionObjectError {}
+
+/// Resolver errors are separate from a cache miss (`Ok(None)`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegionResolveError {
+    InvalidObject(RegionObjectError),
+    Backend(String),
+}
+
+impl core::fmt::Display for RegionResolveError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidObject(error) => write!(formatter, "invalid region object: {error}"),
+            Self::Backend(error) => write!(formatter, "region resolver backend failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RegionResolveError {}
+
+/// Fetch a region object by its manifest κ-label.
+pub trait RegionResolver {
+    fn resolve(&self, kappa: &str) -> Result<Option<RegionObject>, RegionResolveError>;
+}
+
+/// In-memory resolver useful for tests, local caches, and composition.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryRegionResolver {
+    objects: BTreeMap<String, RegionObject>,
+}
+
+impl MemoryRegionResolver {
+    pub fn from_export(export: &RegionExport) -> Result<Self, RegionObjectError> {
+        let mut resolver = Self::default();
+        for object in &export.objects {
+            resolver.insert(object.clone())?;
+        }
+        Ok(resolver)
+    }
+
+    pub fn insert(&mut self, object: RegionObject) -> Result<String, RegionObjectError> {
+        let kappa = region_kappa(&object)?;
+        self.objects.insert(kappa.clone(), object);
+        Ok(kappa)
+    }
+}
+
+impl RegionResolver for MemoryRegionResolver {
+    fn resolve(&self, kappa: &str) -> Result<Option<RegionObject>, RegionResolveError> {
+        Ok(self.objects.get(kappa).cloned())
+    }
+}
+
+/// Convert every TLS1 entry into one canonical region object.
+pub fn export_store(store: &Store) -> Result<RegionExport, RegionObjectError> {
+    let mut objects = Vec::new();
+    let mut regions = Vec::new();
+    for (depth, level) in store.iter().enumerate() {
+        let depth = u8::try_from(depth).map_err(|_| RegionObjectError::InvalidKeyDepth)?;
+        for (key, distribution) in level {
+            if key.len() != usize::from(depth) {
+                return Err(RegionObjectError::InvalidKeyDepth);
+            }
+            let object = RegionObject {
+                depth,
+                key: key.clone(),
+                distribution: distribution.clone(),
+            };
+            let bytes = canonical_region_bytes(&object)?;
+            let kappa = region_kappa(&object)?;
+            regions.push(RegionReference {
+                depth,
+                key: key.clone(),
+                kappa,
+                bytes: bytes.len() as u64,
+            });
+            objects.push(object);
+        }
+    }
+    let manifest_kappa = manifest_kappa_for(&regions)?;
+    Ok(RegionExport {
+        manifest: RegionManifest {
+            schema: REGION_MANIFEST_SCHEMA,
+            manifest_kappa,
+            regions,
+        },
+        objects,
+    })
+}
+
+/// Canonical CBOR bytes for one region object.
+pub fn canonical_region_bytes(object: &RegionObject) -> Result<Vec<u8>, RegionObjectError> {
+    validate_object(object)?;
+    let mut out = Vec::new();
+    cbor_array(&mut out, 4);
+    cbor_uint(&mut out, REGION_OBJECT_SCHEMA);
+    cbor_uint(&mut out, u64::from(object.depth));
+    cbor_bytes(&mut out, &object.key);
+    cbor_array(&mut out, object.distribution.len() as u64);
+    for (&token, &count) in &object.distribution {
+        cbor_array(&mut out, 2);
+        cbor_uint(&mut out, u64::from(token));
+        cbor_uint(&mut out, u64::from(count));
+    }
+    Ok(out)
+}
+
+#[derive(serde::Deserialize)]
+struct RegionWire(u64, u8, Vec<u8>, Vec<(u32, u32)>);
+
+/// Decode and validate one canonical region object.
+pub fn decode_region_bytes(bytes: &[u8]) -> Result<RegionObject, RegionObjectError> {
+    let mut cursor = std::io::Cursor::new(bytes);
+    let RegionWire(schema, depth, key, entries): RegionWire =
+        ciborium::de::from_reader(&mut cursor).map_err(|_| RegionObjectError::Malformed)?;
+    if cursor.position() != bytes.len() as u64 || schema != REGION_OBJECT_SCHEMA {
+        return Err(RegionObjectError::Malformed);
+    }
+    let mut distribution = BTreeMap::new();
+    for (token, count) in entries {
+        if distribution.insert(token, count).is_some() {
+            return Err(RegionObjectError::DuplicateToken);
+        }
+    }
+    let object = RegionObject {
+        depth,
+        key,
+        distribution,
+    };
+    if canonical_region_bytes(&object)?.as_slice() != bytes {
+        return Err(RegionObjectError::Malformed);
+    }
+    Ok(object)
+}
+
+/// Address one canonical region object through the pinned UOR CBOR axis.
+pub fn region_kappa(object: &RegionObject) -> Result<String, RegionObjectError> {
+    let bytes = canonical_region_bytes(object)?;
+    uor_addr::cbor::address_blake3(&bytes)
+        .map(|outcome| outcome.address.to_string())
+        .map_err(|_| RegionObjectError::AddressingFailed)
+}
+
+/// Resolve the deepest available prefix and apply deterministic token argmax.
+pub fn predict_witness_with_resolver<R: RegionResolver>(
+    resolver: &R,
+    manifest: &RegionManifest,
+    code: &[u8; STAGES],
+) -> Result<Prediction, RegionResolveError> {
+    if manifest.schema != REGION_MANIFEST_SCHEMA {
+        return Err(RegionResolveError::InvalidObject(
+            RegionObjectError::InvalidSchema,
+        ));
+    }
+    for depth in (0..=STAGES).rev() {
+        let depth_u8 = depth as u8;
+        let key = &code[..depth];
+        let Some(reference) = manifest
+            .regions
+            .iter()
+            .find(|region| region.depth == depth_u8 && region.key == key)
+        else {
+            continue;
+        };
+        let Some(object) = resolver.resolve(&reference.kappa)? else {
+            continue;
+        };
+        if object.depth != depth_u8 || object.key != key {
+            return Err(RegionResolveError::InvalidObject(
+                RegionObjectError::InvalidKeyDepth,
+            ));
+        }
+        let object_bytes =
+            canonical_region_bytes(&object).map_err(RegionResolveError::InvalidObject)?;
+        let object_kappa = region_kappa(&object).map_err(RegionResolveError::InvalidObject)?;
+        if object_bytes.len() as u64 != reference.bytes || object_kappa != reference.kappa {
+            return Err(RegionResolveError::InvalidObject(
+                RegionObjectError::Malformed,
+            ));
+        }
+        return Ok(argmax(depth_u8, &object.distribution));
+    }
+    Ok(Prediction::default())
+}
+
+fn argmax(depth: u8, distribution: &BTreeMap<u32, u32>) -> Prediction {
+    let mut best = Prediction::default();
+    let mut best_count = None;
+    for (&token, &count) in distribution {
+        if best_count.is_none_or(|best_count| count > best_count) {
+            best = Prediction {
+                token,
+                depth,
+                count,
+            };
+            best_count = Some(count);
+        }
+    }
+    best
+}
+
+fn validate_object(object: &RegionObject) -> Result<(), RegionObjectError> {
+    if object.key.len() != usize::from(object.depth) {
+        return Err(RegionObjectError::InvalidKeyDepth);
+    }
+    Ok(())
+}
+
+/// Canonical CBOR bytes for a region manifest.
+pub fn canonical_manifest_bytes(manifest: &RegionManifest) -> Result<Vec<u8>, RegionObjectError> {
+    if manifest.schema != REGION_MANIFEST_SCHEMA {
+        return Err(RegionObjectError::InvalidSchema);
+    }
+    validate_regions(&manifest.regions)?;
+    let mut bytes = Vec::new();
+    cbor_array(&mut bytes, 4);
+    cbor_uint(&mut bytes, u64::from(REGION_MANIFEST_SCHEMA));
+    cbor_text(&mut bytes, "r4-region-manifest");
+    cbor_text(&mut bytes, &manifest.manifest_kappa);
+    cbor_array(&mut bytes, manifest.regions.len() as u64);
+    for region in &manifest.regions {
+        cbor_array(&mut bytes, 4);
+        cbor_uint(&mut bytes, u64::from(region.depth));
+        cbor_bytes(&mut bytes, &region.key);
+        cbor_text(&mut bytes, &region.kappa);
+        cbor_uint(&mut bytes, region.bytes);
+    }
+    Ok(bytes)
+}
+
+/// Derive the manifest κ-label from its canonical skeleton.
+pub fn manifest_kappa_for(regions: &[RegionReference]) -> Result<String, RegionObjectError> {
+    validate_regions(regions)?;
+    let mut bytes = Vec::new();
+    cbor_array(&mut bytes, 3);
+    cbor_uint(&mut bytes, u64::from(REGION_MANIFEST_SCHEMA));
+    cbor_text(&mut bytes, "r4-region-manifest");
+    cbor_array(&mut bytes, regions.len() as u64);
+    for region in regions {
+        cbor_array(&mut bytes, 4);
+        cbor_uint(&mut bytes, u64::from(region.depth));
+        cbor_bytes(&mut bytes, &region.key);
+        cbor_text(&mut bytes, &region.kappa);
+        cbor_uint(&mut bytes, region.bytes);
+    }
+    uor_addr::cbor::address_blake3(&bytes)
+        .map(|outcome| outcome.address.to_string())
+        .map_err(|_| RegionObjectError::AddressingFailed)
+}
+
+fn validate_regions(regions: &[RegionReference]) -> Result<(), RegionObjectError> {
+    let mut previous: Option<(&u8, &[u8])> = None;
+    for region in regions {
+        if region.key.len() != usize::from(region.depth) {
+            return Err(RegionObjectError::InvalidKeyDepth);
+        }
+        let current = (&region.depth, region.key.as_slice());
+        if previous.is_some_and(|previous| current <= previous) {
+            return Err(RegionObjectError::Malformed);
+        }
+        previous = Some(current);
+    }
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct ManifestWire(u32, String, String, Vec<(u8, Vec<u8>, String, u64)>);
+
+/// Decode and validate a canonical region manifest.
+pub fn decode_manifest_bytes(bytes: &[u8]) -> Result<RegionManifest, RegionObjectError> {
+    let mut cursor = std::io::Cursor::new(bytes);
+    let ManifestWire(schema, domain, kappa, entries): ManifestWire =
+        ciborium::de::from_reader(&mut cursor).map_err(|_| RegionObjectError::Malformed)?;
+    if cursor.position() != bytes.len() as u64
+        || schema != REGION_MANIFEST_SCHEMA
+        || domain != "r4-region-manifest"
+    {
+        return Err(RegionObjectError::Malformed);
+    }
+    let regions = entries
+        .into_iter()
+        .map(|(depth, key, kappa, bytes)| RegionReference {
+            depth,
+            key,
+            kappa,
+            bytes,
+        })
+        .collect::<Vec<_>>();
+    let expected = manifest_kappa_for(&regions)?;
+    if expected != kappa {
+        return Err(RegionObjectError::Malformed);
+    }
+    let manifest = RegionManifest {
+        schema,
+        manifest_kappa: kappa,
+        regions,
+    };
+    if canonical_manifest_bytes(&manifest)?.as_slice() != bytes {
+        return Err(RegionObjectError::Malformed);
+    }
+    Ok(manifest)
+}
+
+fn cbor_array(out: &mut Vec<u8>, length: u64) {
+    cbor_head(out, 4, length);
+}
+
+fn cbor_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    cbor_head(out, 2, bytes.len() as u64);
+    out.extend_from_slice(bytes);
+}
+
+fn cbor_text(out: &mut Vec<u8>, text: &str) {
+    cbor_head(out, 3, text.len() as u64);
+    out.extend_from_slice(text.as_bytes());
+}
+
+fn cbor_uint(out: &mut Vec<u8>, value: u64) {
+    cbor_head(out, 0, value);
+}
+
+fn cbor_head(out: &mut Vec<u8>, major: u8, value: u64) {
+    if value <= 23 {
+        out.push((major << 5) | value as u8);
+    } else if value <= u8::MAX as u64 {
+        out.extend_from_slice(&[(major << 5) | 24, value as u8]);
+    } else if value <= u16::MAX as u64 {
+        out.push((major << 5) | 25);
+        out.extend_from_slice(&(value as u16).to_be_bytes());
+    } else if value <= u32::MAX as u64 {
+        out.push((major << 5) | 26);
+        out.extend_from_slice(&(value as u32).to_be_bytes());
+    } else {
+        out.push((major << 5) | 27);
+        out.extend_from_slice(&value.to_be_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transformerless::runtime::predict_witness_plain;
+
+    fn fixture_store() -> Store {
+        let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+        store[0].insert(vec![], BTreeMap::from([(7, 2), (9, 1)]));
+        store[1].insert(vec![1], BTreeMap::from([(11, 4), (12, 3)]));
+        store[2].insert(vec![1, 2], BTreeMap::from([(21, 5)]));
+        store
+    }
+
+    #[test]
+    fn manifest_resolver_matches_monolithic_predictions() {
+        let store = fixture_store();
+        let export = export_store(&store).expect("fixture exports");
+        let resolver = MemoryRegionResolver::from_export(&export).expect("resolver loads");
+        let code = [1, 2, 3, 4];
+        let expected = predict_witness_plain(&store, &code);
+        let actual = predict_witness_with_resolver(&resolver, &export.manifest, &code)
+            .expect("resolver prediction");
+        assert_eq!(actual, expected);
+        assert!(export.manifest.manifest_kappa.starts_with("blake3:"));
+    }
+
+    #[test]
+    fn region_kappas_are_deterministic_and_payload_bound() {
+        let first = RegionObject {
+            depth: 1,
+            key: vec![4],
+            distribution: BTreeMap::from([(3, 1)]),
+        };
+        let second = RegionObject {
+            distribution: BTreeMap::from([(3, 2)]),
+            ..first.clone()
+        };
+        assert_eq!(region_kappa(&first), region_kappa(&first));
+        assert_ne!(region_kappa(&first), region_kappa(&second));
+        assert_eq!(
+            canonical_region_bytes(&first).unwrap(),
+            canonical_region_bytes(&first).unwrap()
+        );
+    }
+}

--- a/docs/region_objects_263.md
+++ b/docs/region_objects_263.md
@@ -1,0 +1,33 @@
+# κ-addressed region objects
+
+Issue #263 adds an I/O-side export and resolver layer for the graded TLS1
+store. The existing monolithic `Store` and prediction kernel remain the
+reference implementation; this layer makes each `(depth, prefix)` entry a
+portable object.
+
+## Object and manifest identities
+
+Each region object is encoded as deterministic CBOR:
+
+```text
+[schema, depth, prefix_bytes, [[token_id, evidence_count], ...]]
+```
+
+The token distribution is emitted in ascending token-ID order. Its κ-label is
+the pinned `uor-addr` CBOR realization on the BLAKE3 axis. A manifest contains
+the sorted `(depth, prefix, κ, byte_length)` references and has its own κ-label
+over a skeleton that excludes the self-reference.
+
+`ModelStore` uses the existing local CAS layout for these labels. Writes emit
+canonical bytes; reads reject malformed, non-canonical, or κ-mismatched
+objects. The `RegionResolver` trait makes a local CAS resolver interchangeable
+with a future network resolver.
+
+## Prediction boundary
+
+`predict_witness_with_resolver` walks the manifest's deepest available prefix,
+fetches only the selected region object, and applies the same deterministic
+token argmax rule as the monolithic TLS1 path. The conformance test starts with
+only the manifest and resolver-backed objects and asserts byte-for-byte
+equivalent prediction witnesses. No graph-runtime kernel or TLS1 wire format
+changes are required.

--- a/src/model.rs
+++ b/src/model.rs
@@ -84,6 +84,7 @@ pub enum ModelError {
     Io(std::io::Error),
     Json(serde_json::Error),
     InvalidCid(String),
+    InvalidRegionObject(String),
     SizeMismatch {
         cid: String,
         expected: u64,
@@ -114,6 +115,9 @@ impl fmt::Display for ModelError {
             Self::Json(error) => write!(formatter, "invalid model manifest: {error}"),
             Self::InvalidCid(cid) => {
                 write!(formatter, "model object failed CID verification: {cid}")
+            }
+            Self::InvalidRegionObject(error) => {
+                write!(formatter, "region object failed canonical verification: {error}")
             }
             Self::SizeMismatch {
                 cid,
@@ -235,6 +239,76 @@ impl ModelStore {
         Ok(bytes)
     }
 
+    /// Store one canonical region object under its UOR κ-label.
+    pub fn put_region_object(
+        &self,
+        object: &uor_r4_core::transformerless::region_store::RegionObject,
+    ) -> Result<ModelObject, ModelError> {
+        let bytes = uor_r4_core::transformerless::region_store::canonical_region_bytes(object)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        let cid = uor_r4_core::transformerless::region_store::region_kappa(object)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        self.put_addressed_bytes(&cid, &bytes)
+    }
+
+    /// Load and verify one region object from the local CAS. A missing object
+    /// is a normal resolver miss; malformed or tampered bytes are errors.
+    pub fn get_region_object(
+        &self,
+        kappa: &str,
+    ) -> Result<Option<uor_r4_core::transformerless::region_store::RegionObject>, ModelError> {
+        let path = self.object_path(kappa)?;
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(ModelError::Io(error)),
+        };
+        let object = uor_r4_core::transformerless::region_store::decode_region_bytes(&bytes)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        let actual = uor_r4_core::transformerless::region_store::region_kappa(&object)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        if actual != kappa {
+            return Err(ModelError::InvalidCid(kappa.to_owned()));
+        }
+        Ok(Some(object))
+    }
+
+    /// Store a canonical region manifest under its manifest κ-label.
+    pub fn put_region_manifest(
+        &self,
+        manifest: &uor_r4_core::transformerless::region_store::RegionManifest,
+    ) -> Result<ModelObject, ModelError> {
+        let expected =
+            uor_r4_core::transformerless::region_store::manifest_kappa_for(&manifest.regions)
+                .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        if expected != manifest.manifest_kappa {
+            return Err(ModelError::InvalidCid(manifest.manifest_kappa.clone()));
+        }
+        let bytes = uor_r4_core::transformerless::region_store::canonical_manifest_bytes(manifest)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        self.put_addressed_bytes(&manifest.manifest_kappa, &bytes)
+    }
+
+    /// Load and verify a region manifest from the local CAS.
+    pub fn get_region_manifest(
+        &self,
+        kappa: &str,
+    ) -> Result<Option<uor_r4_core::transformerless::region_store::RegionManifest>, ModelError>
+    {
+        let path = self.object_path(kappa)?;
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(ModelError::Io(error)),
+        };
+        let manifest = uor_r4_core::transformerless::region_store::decode_manifest_bytes(&bytes)
+            .map_err(|error| ModelError::InvalidRegionObject(error.to_string()))?;
+        if manifest.manifest_kappa != kappa {
+            return Err(ModelError::InvalidCid(kappa.to_owned()));
+        }
+        Ok(Some(manifest))
+    }
+
     pub fn write_manifest(&self, manifest: &ModelManifest) -> Result<String, ModelError> {
         let bytes = serde_json::to_vec_pretty(manifest)?;
         let object = self.put(&bytes)?;
@@ -296,6 +370,36 @@ impl ModelStore {
             return Err(ModelError::InvalidCid(cid.to_owned()));
         }
         Ok(self.root.join("objects").join("blake3").join(hash))
+    }
+
+    fn put_addressed_bytes(&self, cid: &str, bytes: &[u8]) -> Result<ModelObject, ModelError> {
+        let path = self.object_path(cid)?;
+        if !path.exists() {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, bytes)?;
+        }
+        Ok(ModelObject {
+            cid: cid.to_owned(),
+            bytes: bytes.len() as u64,
+        })
+    }
+}
+
+impl uor_r4_core::transformerless::region_store::RegionResolver for ModelStore {
+    fn resolve(
+        &self,
+        kappa: &str,
+    ) -> Result<
+        Option<uor_r4_core::transformerless::region_store::RegionObject>,
+        uor_r4_core::transformerless::region_store::RegionResolveError,
+    > {
+        self.get_region_object(kappa).map_err(|error| {
+            uor_r4_core::transformerless::region_store::RegionResolveError::Backend(
+                error.to_string(),
+            )
+        })
     }
 }
 
@@ -668,6 +772,49 @@ mod tests {
             .read_manifest("compiled-model")
             .unwrap_err();
         assert!(matches!(error, ModelError::CompiledNotImported(path) if path == compiled));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn model_store_resolves_region_objects_from_manifest_only() {
+        use std::collections::BTreeMap;
+        use uor_r4_core::transformerless::region_store::{
+            export_store, predict_witness_with_resolver, RegionResolver,
+        };
+        use uor_r4_core::transformerless::runtime::{predict_witness_plain, Store};
+
+        let root =
+            std::env::temp_dir().join(format!("uor-r4-region-store-test-{}", std::process::id()));
+        let mut store: Store = (0..=4).map(|_| BTreeMap::new()).collect();
+        store[0].insert(vec![], BTreeMap::from([(7, 2), (9, 1)]));
+        store[1].insert(vec![1], BTreeMap::from([(11, 4), (12, 3)]));
+        store[2].insert(vec![1, 2], BTreeMap::from([(21, 5)]));
+
+        let export = export_store(&store).expect("region export");
+        let model_store = ModelStore::new(&root);
+        for object in &export.objects {
+            model_store
+                .put_region_object(object)
+                .expect("region object write");
+        }
+        model_store
+            .put_region_manifest(&export.manifest)
+            .expect("manifest write");
+
+        let manifest = model_store
+            .get_region_manifest(&export.manifest.manifest_kappa)
+            .expect("manifest read")
+            .expect("manifest exists");
+        let code = [1, 2, 3, 4];
+        let expected = predict_witness_plain(&store, &code);
+        let actual = predict_witness_with_resolver(&model_store, &manifest, &code)
+            .expect("resolver prediction");
+        assert_eq!(actual, expected);
+        assert!(
+            <ModelStore as RegionResolver>::resolve(&model_store, &manifest.regions[0].kappa)
+                .expect("resolver read")
+                .is_some()
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 }


### PR DESCRIPTION
Closes #263

This lands the existing κ-addressed region-object implementation onto main.

What changed:
- Adds canonical CBOR `RegionObject`, `RegionManifest`, and export types with deterministic ordering and κ validation.
- Adds `MemoryRegionResolver` and manifest-driven prediction witnesses.
- Adds ModelStore CAS put/get APIs and the RegionResolver implementation.
- Adds deterministic region/manifest conformance tests and implementation documentation.
- Keeps the deployed runtime kernel unchanged; this is compiler/storage/resolver-side work.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- graph-format no-std checks (default and `alloc`)
- `cargo test -p uor-r4-core --lib --offline`
- `cargo test --workspace --offline --exclude uor-r4-core`
- claim-wording and diff checks

The full workspace suite reaches the pre-existing R4G1 allocation census failure (2 allocations / 594 bytes, expected 0); the transformerless census and all #263 tests pass.