### PR TITLE
feat(transformerless): #318 Phase B — integer residual wiring, era TLA7

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -759,7 +759,41 @@ pub struct Compiled {
     /// container (see `artifact_bytes`); empty on TLA3/4/5 loads, which
     /// keeps loaded legacy artifacts on the sign-Hamming path.
     pub dot_cb: Vec<Vec<u16>>,
+    /// Integer residual centroid copies (issue #318 Phase B): per stage,
+    /// K × D i8 values — the unit-scale f32 context centroids quantized
+    /// with a per-stage power-of-two scale (the token stage-book
+    /// precedent: max-abs → IEEE-exponent scale, libm-free). After each
+    /// stage's dot argmax the runtime subtracts the winning centroid's
+    /// copy, decoded as `copy << resid_scale_shifts[st]`, from the
+    /// norm-folded work vector — add/sub and shifts only (contract §2).
+    /// Filled at compile time from `ctx_cb`; serialized only by the TLA7
+    /// container (see `artifact_bytes`); empty on pre-TLA7 loads, which
+    /// keeps those artifacts on the non-residual dot path.
+    pub resid_cb: Vec<Vec<i8>>,
+    /// Per-stage decode shift for `resid_cb` (STAGES entries when
+    /// `resid_cb` is populated): `RESID_WORK_FRACTION − e_st`, where e_st
+    /// is the stage's IEEE-exponent quantization scale, so the shifted
+    /// copy lands at the norm-folded work scale.
+    pub resid_scale_shifts: Vec<u8>,
+    /// Norm-fold CONST (issue #318 Phase B): the train-split median of
+    /// round(log2(L1/L2)) over the deterministic stride-8 subsample — the
+    /// certifier's Phase A.5 derivation — PLUS `RESID_WORK_FRACTION`, the
+    /// fixed-point fraction the integer kernel folds to (the f32
+    /// emulation folds to unit scale; the integer kernel must fold to a
+    /// large-magnitude scale or every value truncates to zero). The
+    /// kernel computes s = bit_length(Σ|w_d|) − norm_fold_const and
+    /// shifts work right by s (left when s < 0). 0 when unset
+    /// (pre-TLA7 loads), which keeps the residual path inactive.
+    pub norm_fold_const: i32,
 }
+
+/// Fixed-point fraction of the norm-folded work vector (issue #318 Phase
+/// B): after the po2 norm fold, unit scale (the f32 emulation's
+/// normalized work) sits at 2^RESID_WORK_FRACTION. 20 bits keeps a
+/// unit-magnitude dimension at ~1e6 — the raw work-vector scale the
+/// shift-add dot tables already operate at — with i64 headroom for the
+/// 288-dim dot reduction.
+pub const RESID_WORK_FRACTION: i32 = 20;
 
 /// Number of power-of-two terms emitted per dot-table entry.
 ///
@@ -801,6 +835,63 @@ pub fn quantize_dot_tables(ctx_cb: &[Vec<f32>]) -> Vec<Vec<u16>> {
         .iter()
         .map(|cb| cb.iter().map(|&c| pack_dot_entry(c)).collect())
         .collect()
+}
+
+/// Quantize the per-stage context codebooks into i8 residual centroid
+/// copies (issue #318 Phase B; the Phase A.5 cpy8 row's kernel form):
+/// per stage, max-abs → power-of-two scale from the IEEE-754 exponent of
+/// the ratio (the token stage-book precedent, libm-free), values
+/// round(x·2^e) clamped to i8. The returned per-stage decode shift is
+/// `RESID_WORK_FRACTION − e` (clamped at 0 — e beyond the fraction is a
+/// pathologically flat codebook, |x| < 2^-13, and the copies carry no
+/// representable signal anyway), so `copy << shift` lands at the
+/// norm-folded work scale. Deterministic: pure functions of `ctx_cb`.
+pub fn quantize_resid_copies(ctx_cb: &[Vec<f32>]) -> (Vec<Vec<i8>>, Vec<u8>) {
+    let mut copies = Vec::with_capacity(ctx_cb.len());
+    let mut shifts = Vec::with_capacity(ctx_cb.len());
+    for cb in ctx_cb {
+        let m = cb.iter().fold(0f32, |a, &x| a.max(x.abs())).max(1e-9);
+        let r = 127.0 / m;
+        let e = ((r.to_bits() >> 23) as i32) - 127;
+        let scale = (2.0f32).powi(e);
+        copies.push(
+            cb.iter()
+                .map(|&x| (x * scale).round().clamp(-127.0, 127.0) as i8)
+                .collect(),
+        );
+        shifts.push((RESID_WORK_FRACTION - e).clamp(0, 63) as u8);
+    }
+    (copies, shifts)
+}
+
+/// The norm-fold CONST (issue #318 Phase B): mirror of the certifier's
+/// Phase A.5 `ratios`/`norm_const` derivation — the train-split median of
+/// log2(L1/L2) over the deterministic stride-8 subsample, rounded — plus
+/// `RESID_WORK_FRACTION` (the integer kernel's fixed-point fold target;
+/// see the field doc). Deterministic: ordered corpus scan, no RNG.
+fn norm_fold_const(art: &Compiled, rot: &[usize; WINDOW + 1], corpus: &Corpus, cut: u32) -> i32 {
+    let mut ratios: Vec<f32> = (0..corpus.n)
+        .step_by(8)
+        .filter(|&i| corpus.story[i] < cut)
+        .map(|i| {
+            let b = super::runtime::bundle_plain(art, rot, corpus, i);
+            let mut l1 = 0f32;
+            let mut l2sq = 0f32;
+            for (&bv, &t) in b.iter().zip(art.thresholds.iter()) {
+                let w = (bv - t) as f32;
+                l1 += w.abs();
+                l2sq += w * w;
+            }
+            canonical_log2f(l1 / canonical_sqrtf(l2sq).max(1e-9))
+        })
+        .collect();
+    ratios.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let Some(&median) = ratios.get(ratios.len() / 2) else {
+        // Degenerate corpus (no train positions in the stride-8
+        // subsample): fold to the fixed-point scale only.
+        return RESID_WORK_FRACTION;
+    };
+    median.round() as i32 + RESID_WORK_FRACTION
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -1216,6 +1307,9 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
         ctx_cb: Vec::new(),
         token_stage_kappas: emb_stage_kappas,
         dot_cb: Vec::new(),
+        resid_cb: Vec::new(),
+        resid_scale_shifts: Vec::new(),
+        norm_fold_const: 0,
     };
     let rot = derive_rotations();
 
@@ -1297,6 +1391,19 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
     // centroids, deterministically, at compile time. In-memory always;
     // on disk only under TLA6 (era note in `artifact_bytes`).
     art.dot_cb = quantize_dot_tables(&art.ctx_cb);
+    // #318 Phase B: the integer residual wiring — per-stage i8 centroid
+    // copies and the norm-fold CONST, derived from the same centroids and
+    // the train-split corpus, deterministically (ordered stride-8 scan,
+    // no RNG). In-memory always; on disk only under TLA7 (era note in
+    // `artifact_bytes`).
+    let (resid_cb, resid_scale_shifts) = quantize_resid_copies(&art.ctx_cb);
+    art.resid_cb = resid_cb;
+    art.resid_scale_shifts = resid_scale_shifts;
+    art.norm_fold_const = norm_fold_const(&art, &rot, corpus, cut);
+    println!(
+        "norm-fold CONST (incl. fixed-point fraction): {}",
+        art.norm_fold_const
+    );
     art
 }
 
@@ -1310,6 +1417,11 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
 /// Format TLA6 (issue #243 Phase B) = the TLA5 payload + the packed
 /// shift-add dot tables (STAGES × K × D u16, little-endian).
 ///
+/// Format TLA7 (issue #318 Phase B) = the TLA6 payload + the integer
+/// residual sections: the norm-fold CONST (i32, little-endian), the
+/// per-stage copy decode shifts (STAGES × u8), and the per-stage i8
+/// centroid copies (STAGES × K × D i8).
+///
 /// TLA6 is the DEFAULT emission since the Phase C adoption decision
 /// (issue #243, maintainer decision 2026-07-29): fresh compiles emit
 /// TLA6 with 1-term dot tables (`DOT_TERMS`), and the κ re-pin that
@@ -1320,13 +1432,29 @@ pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
 /// era-comparison runs. Loaded TLA5 artifacts keep the sign-Hamming
 /// query path; loaded TLA6 artifacts (and fresh in-memory compiles)
 /// take the shift-add dot path.
+///
+/// TLA7 is the DEFAULT emission for artifacts that carry residual
+/// copies (fresh compiles since issue #318 Phase B); `R4_TLESS_TLA7=0`
+/// opts a compile back out to TLA6 emission for era-comparison runs.
+/// Loaded pre-TLA7 artifacts keep the non-residual dot path; loaded TLA7
+/// artifacts (and fresh in-memory compiles) take the residual-wired dot
+/// path. The κ re-pin this implies is a Phase C maintainer decision
+/// (docs/dot_residual_phase_b_design.md) — the pinned baseline is
+/// TLA5-era and remains a valid address for TLA5-era bytes.
 pub fn artifact_bytes(a: &Compiled) -> Vec<u8> {
     let emit_tla6 = !a.dot_cb.is_empty()
         && std::env::var("R4_TLESS_TLA6")
             .map(|v| v != "0")
             .unwrap_or(true);
+    let emit_tla7 = emit_tla6
+        && !a.resid_cb.is_empty()
+        && std::env::var("R4_TLESS_TLA7")
+            .map(|v| v != "0")
+            .unwrap_or(true);
     let vocab = a.token_codes.len() / STAGES;
-    let mut b: Vec<u8> = if emit_tla6 {
+    let mut b: Vec<u8> = if emit_tla7 {
+        b"TLA7".to_vec()
+    } else if emit_tla6 {
         b"TLA6".to_vec()
     } else {
         b"TLA5".to_vec()
@@ -1348,6 +1476,13 @@ pub fn artifact_bytes(a: &Compiled) -> Vec<u8> {
             for entry in table {
                 b.extend_from_slice(&entry.to_le_bytes());
             }
+        }
+    }
+    if emit_tla7 {
+        b.extend_from_slice(&a.norm_fold_const.to_le_bytes());
+        b.extend_from_slice(&a.resid_scale_shifts);
+        for copies in &a.resid_cb {
+            b.extend(copies.iter().map(|&x| x as u8));
         }
     }
     b
@@ -1384,19 +1519,22 @@ pub fn load_artifacts_from(path: &str) -> Option<Compiled> {
     Some(art)
 }
 
-/// Parse a TLA3, TLA4, TLA5, or TLA6 container from bytes.
+/// Parse a TLA3, TLA4, TLA5, TLA6, or TLA7 container from bytes.
 ///
 /// TLA3/TLA4 are legacy formats that include f32 ctx_cb bytes; these are
 /// silently discarded on load (ctx_cb is not part of the deployed artifact).
 /// TLA5 is the current default format: u32 vocab prefix, no ctx_cb.
 /// TLA6 appends the packed shift-add dot tables (issue #243 Phase B).
+/// TLA7 appends the integer residual sections — norm-fold CONST, per-stage
+/// copy decode shifts, i8 centroid copies (issue #318 Phase B).
 pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
-    let (vocab, mut o, has_ctx_cb, has_dot_cb) = match b.get(..4)? {
-        b"TLA3" => (V, 4usize, true, false),
+    let (vocab, mut o, has_ctx_cb, has_dot_cb, has_resid_cb) = match b.get(..4)? {
+        b"TLA3" => (V, 4usize, true, false, false),
         b"TLA4" => (
             u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
             8usize,
             true,
+            false,
             false,
         ),
         b"TLA5" => (
@@ -1404,11 +1542,20 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
             8usize,
             false,
             false,
+            false,
         ),
         b"TLA6" => (
             u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
             8usize,
             false,
+            true,
+            false,
+        ),
+        b"TLA7" => (
+            u32::from_le_bytes(b.get(4..8)?.try_into().ok()?) as usize,
+            8usize,
+            false,
+            true,
             true,
         ),
         _ => return None,
@@ -1419,7 +1566,12 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
     let cs = STAGES * K * D / 8;
     let cc = if has_ctx_cb { STAGES * K * D * 4 } else { 0 };
     let dc = if has_dot_cb { STAGES * K * D * 2 } else { 0 };
-    if b.len() != o + STAGES + tc + bk + th + cs + cc + dc {
+    let rc = if has_resid_cb {
+        4 + STAGES + STAGES * K * D
+    } else {
+        0
+    };
+    if b.len() != o + STAGES + tc + bk + th + cs + cc + dc + rc {
         return None;
     }
     let stage_shifts = b[o..o + STAGES].to_vec();
@@ -1462,6 +1614,24 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
             dot_cb.push(table);
         }
     }
+    let mut norm_fold_const = 0i32;
+    let mut resid_scale_shifts = Vec::new();
+    let mut resid_cb = Vec::new();
+    if has_resid_cb {
+        norm_fold_const = i32::from_le_bytes(b[o..o + 4].try_into().unwrap());
+        o += 4;
+        resid_scale_shifts = b[o..o + STAGES].iter().map(|&x| x.min(63)).collect();
+        o += STAGES;
+        for _ in 0..STAGES {
+            resid_cb.push(
+                b[o..o + K * D]
+                    .iter()
+                    .map(|&x| x as i8)
+                    .collect::<Vec<i8>>(),
+            );
+            o += K * D;
+        }
+    }
     let _ = o; // all bytes consumed
     Some(Compiled {
         token_codes,
@@ -1472,6 +1642,9 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
         dot_cb,
+        resid_cb,
+        resid_scale_shifts,
+        norm_fold_const,
     })
 }
 

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -320,6 +320,9 @@ mod dot_assignment_tests {
             ctx_cb: Vec::new(),
             token_stage_kappas: Vec::new(),
             dot_cb: Vec::new(),
+            resid_cb: Vec::new(),
+            resid_scale_shifts: Vec::new(),
+            norm_fold_const: 0,
         };
         art.dot_cb = (0..compiler::STAGES)
             .map(|st| {
@@ -331,6 +334,24 @@ mod dot_assignment_tests {
                     .collect()
             })
             .collect();
+        art
+    }
+
+    /// The synthetic dot artifact plus the #318 Phase B residual
+    /// sections: i8 centroid copies and decode shifts shaped like the
+    /// compiler's `quantize_resid_copies` output, and a norm-fold CONST
+    /// exercising the right-shift branch on the ramp bundle below.
+    fn synthetic_resid_art() -> compiler::Compiled {
+        let mut art = synthetic_dot_art();
+        art.resid_cb = (0..compiler::STAGES)
+            .map(|st| {
+                (0..compiler::K * compiler::D)
+                    .map(|i| (((i + st) % 13) as i8) - 6)
+                    .collect()
+            })
+            .collect();
+        art.resid_scale_shifts = vec![4u8; compiler::STAGES];
+        art.norm_fold_const = 10;
         art
     }
 
@@ -365,5 +386,104 @@ mod dot_assignment_tests {
         assert_eq!(plain, kernel, "kernel/plain dot assignment divergence");
         assert!(rt.kernel.shifts > 0, "dot path must count shifts");
         assert!(rt.kernel.adds > 0, "dot path must count adds");
+    }
+
+    /// #318 Phase B equality witness: the residual-wired kernel form
+    /// (`code_from_bundle_resid`) computes the plain form's
+    /// (`assign_code_for_bundle_resid`) code exactly, across bundles
+    /// exercising every norm-fold branch (s ≥ 0, s < 0, L1 = 0) and the
+    /// per-stage copy subtraction.
+    #[test]
+    fn resid_kernel_equals_plain_on_synthetic_artifact() {
+        let art = synthetic_resid_art();
+        let bundles: Vec<[i64; compiler::D]> = vec![
+            // ramp: large L1, fold shifts right (s > 0)
+            std::array::from_fn(|d| ((d as i64 * 97) % 193) - 96),
+            // tiny: L1 below the CONST scale, fold shifts left (s < 0)
+            std::array::from_fn(|d| ((d as i64) % 3) - 1),
+            // centered exactly: L1 = 0, fold leaves the zero vector
+            std::array::from_fn(|d| (d as i64 % 7) - 3),
+            // negative-heavy ramp
+            std::array::from_fn(|d| -((d as i64 % 89) + 1)),
+        ];
+        let mut rt = runtime::Runtime::new(&art);
+        for bundle in &bundles {
+            let plain = runtime::assign_code_for_bundle_resid(&art, bundle);
+            assert_eq!(
+                plain,
+                runtime::assign_code_for_bundle(&art, bundle),
+                "assign_code_for_bundle routes TLA7 artifacts to the residual path"
+            );
+            let kernel = rt.code_from_bundle_resid(bundle);
+            assert_eq!(
+                plain, kernel,
+                "kernel/plain residual divergence on {bundle:?}"
+            );
+        }
+        assert!(rt.kernel.shifts > 0, "residual path must count shifts");
+        assert!(rt.kernel.adds > 0, "residual path must count adds");
+        assert!(rt.kernel.compares > 0, "residual path must count compares");
+        assert!(
+            rt.kernel.table_reads > 0,
+            "residual path must count table reads"
+        );
+    }
+
+    /// #318 Phase B routing witness: the corpus-free kernel entry point
+    /// takes the residual path for TLA7 artifacts, identical to the
+    /// plain window path.
+    #[test]
+    fn resid_assign_window_matches_plain_window_path() {
+        let art = synthetic_resid_art();
+        let rot = compiler::derive_rotations();
+        let window = [0u32];
+        let plain = {
+            let b = runtime::bundle_window_plain(&art, &rot, &window);
+            runtime::assign_code_for_bundle(&art, &b)
+        };
+        let mut rt = runtime::Runtime::new(&art);
+        assert_eq!(rt.assign_window(&window), plain);
+    }
+
+    /// #318 Phase B container eras: TLA7 round-trips the residual
+    /// sections byte-identically; a dot-only artifact still emits TLA6
+    /// with no residual sections (pre-TLA7 loads unchanged).
+    #[test]
+    fn tla7_container_roundtrip() {
+        let art = synthetic_resid_art();
+        let bytes = compiler::artifact_bytes(&art);
+        assert!(bytes.starts_with(b"TLA7"), "residual artifact emits TLA7");
+        let parsed = compiler::parse_artifacts(&bytes).expect("TLA7 parses");
+        assert_eq!(parsed.resid_cb, art.resid_cb, "centroid copies round-trip");
+        assert_eq!(
+            parsed.resid_scale_shifts, art.resid_scale_shifts,
+            "decode shifts round-trip"
+        );
+        assert_eq!(
+            parsed.norm_fold_const, art.norm_fold_const,
+            "norm-fold CONST round-trips"
+        );
+        assert_eq!(parsed.dot_cb, art.dot_cb, "dot tables round-trip");
+        assert_eq!(
+            compiler::artifact_bytes(&parsed),
+            bytes,
+            "TLA7 parse → serialize is byte-identical"
+        );
+        assert!(
+            compiler::parse_artifacts(&bytes[..bytes.len() - 1]).is_none(),
+            "truncated TLA7 container rejected"
+        );
+
+        let dot_only = synthetic_dot_art();
+        let tla6 = compiler::artifact_bytes(&dot_only);
+        assert!(tla6.starts_with(b"TLA6"), "dot-only artifact emits TLA6");
+        let parsed6 = compiler::parse_artifacts(&tla6).expect("TLA6 parses");
+        assert!(parsed6.resid_cb.is_empty(), "TLA6 loads carry no residual");
+        assert_eq!(parsed6.norm_fold_const, 0);
+        assert_eq!(
+            compiler::artifact_bytes(&parsed6),
+            tla6,
+            "TLA6 parse → serialize is byte-identical"
+        );
     }
 }

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -445,6 +445,55 @@ mod dot_assignment_tests {
         assert_eq!(rt.assign_window(&window), plain);
     }
 
+    /// #318 Phase B routing consistency: EVERY bundle-holding entry
+    /// point takes the residual path for TLA7 artifacts — plain beam
+    /// form, plain allocation-free serving form, membership primary,
+    /// and kernel form must all agree. Regression test for the first
+    /// quality run's divergence: `assign_for_bundle` kept the
+    /// non-residual dot path while the kernel took the residual path,
+    /// and the resid-vs-resid synthetic witness could not see it.
+    #[test]
+    fn resid_routing_consistent_across_all_entry_points() {
+        let art = synthetic_resid_art();
+        let mut art6 = synthetic_resid_art();
+        art6.resid_cb = Vec::new(); // non-residual reference (TLA6 shape)
+        let mut rt = runtime::Runtime::new(&art);
+        let mut saw_residual_effect = false;
+        for seed in 0..8usize {
+            let bundle: [i64; compiler::D] =
+                std::array::from_fn(|d| (((d * 31 + seed * 17) % 211) as i64) - 105);
+            let resid = runtime::assign_code_for_bundle_resid(&art, &bundle);
+            assert_eq!(
+                runtime::assign_for_bundle(&art, &bundle),
+                resid,
+                "beam form must route to the residual path"
+            );
+            assert_eq!(
+                runtime::assign_code_for_bundle(&art, &bundle),
+                resid,
+                "serving form must route to the residual path"
+            );
+            assert_eq!(
+                runtime::assign_memberships_for_bundle(&art, &bundle).0,
+                resid,
+                "membership primary must route to the residual path"
+            );
+            assert_eq!(
+                rt.code_from_bundle_resid(&bundle),
+                resid,
+                "kernel form agrees with all plain forms"
+            );
+            if runtime::assign_for_bundle(&art6, &bundle) != resid {
+                saw_residual_effect = true;
+            }
+        }
+        assert!(
+            saw_residual_effect,
+            "the synthetic fixture must make the residual update change at least one code, \
+             or this consistency check passes vacuously"
+        );
+    }
+
     /// #318 Phase B container eras: TLA7 round-trips the residual
     /// sections byte-identically; a dot-only artifact still emits TLA6
     /// with no residual sections (pre-TLA7 loads unchanged).

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -386,7 +386,11 @@ pub fn assign_plain(art: &Compiled, sig: &[u8; SIG_BYTES]) -> [u8; STAGES] {
 // becomes a shift-and-add reduction — no multiply operation exists in
 // this code path (P-4 scans this module). Active only when the
 // artifact carries dot tables (fresh compiles, TLA6 containers);
-// TLA3/4/5 loads keep the sign-Hamming path unchanged.
+// TLA3/4/5 loads keep the sign-Hamming path unchanged. TLA7 containers
+// (issue #318 Phase B) additionally carry the integer residual
+// sections and take the residual-wired path below: same dot argmax per
+// stage, preceded by a power-of-two norm fold and followed by the
+// winning centroid's integer-copy subtraction.
 
 /// The centered work vector: bundle minus thresholds, integer sub.
 pub fn centered_work(art: &Compiled, bundle: &[i64; D]) -> [i64; D] {
@@ -518,6 +522,9 @@ pub fn assign_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
 /// matches `dot_stage_top` (strict improvement, lowest class index),
 /// so the code equals `assign_for_bundle`'s primary code.
 pub fn assign_code_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
+    if !art.resid_cb.is_empty() {
+        return assign_code_for_bundle_resid(art, bundle);
+    }
     if art.dot_cb.is_empty() {
         // Sign metric, argmax only — assign_plain delegates to the
         // membership-beam builder and allocates; this path must not.
@@ -551,6 +558,90 @@ pub fn assign_code_for_bundle(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES]
             }
         }
         *st_code = best_class;
+    }
+    code
+}
+
+// ------------- integer residual wiring (#318 Phase B, TLA7) ------------
+//
+// The kernel form of the certifier's Phase A.5 rows
+// (docs/dot_residual_phase_b_design.md): the po2 norm fold replaces f32
+// division (row a), and per-stage i8 centroid copies carry the residual
+// subtraction (row b). Everything below is add/sub, shifts, compares,
+// and table reads — the P-4 scan covers this module.
+
+/// L1 norm of the work vector (Σ|w_d|): compare, negate, add only.
+fn work_l1(work: &[i64; D]) -> i64 {
+    let mut l1 = 0i64;
+    for &w in work.iter() {
+        l1 += if w < 0 { -w } else { w };
+    }
+    l1
+}
+
+/// Bit length of a positive value — the position of its highest set
+/// bit, floor(log2(v)) + 1 — by shift and compare only. 0 for v = 0.
+fn bit_length(v: i64) -> i32 {
+    let mut v = v;
+    let mut n = 0i32;
+    while v > 0 {
+        v >>= 1;
+        n += 1;
+    }
+    n
+}
+
+/// Power-of-two norm fold, plain form: `work >>= s` (arithmetic) with
+/// `s = bit_length(L1) − CONST`; s < 0 shifts left, and L1 = 0 leaves
+/// the (all-zero) vector untouched. The kernel must never see a shift
+/// amount outside the word width, so s is clamped to the i64 range.
+fn norm_fold_plain(work: &mut [i64; D], norm_const: i32) {
+    let l1 = work_l1(work);
+    if l1 == 0 {
+        return;
+    }
+    let s = (i64::from(bit_length(l1)) - i64::from(norm_const)).clamp(-63, 63);
+    for w in work.iter_mut() {
+        *w = if s >= 0 { *w >> s } else { *w << (-s) };
+    }
+}
+
+/// Residual-wired shift-add dot assignment (#318 Phase B), allocation-
+/// free plain form: center the bundle, apply the po2 norm fold, then
+/// per stage argmax `dot_score_plain` over the stage's po2 table and
+/// subtract the winning centroid's integer copy (`<<` the stage's
+/// decode shift) from the work vector — add/sub and shifts only. The
+/// per-sample scale error of the crude fold lands in the exponent,
+/// which the dot tables absorb (assignment is argmax, scale-invariant);
+/// the copies ride the same folded scale by construction
+/// (`RESID_WORK_FRACTION − e_st`). Active only for TLA7 artifacts
+/// (`resid_cb` populated); pre-TLA7 artifacts keep the non-residual
+/// dot path. Tie rule matches `assign_code_for_bundle` (strict
+/// improvement, lowest class index).
+pub fn assign_code_for_bundle_resid(art: &Compiled, bundle: &[i64; D]) -> [u8; STAGES] {
+    let mut work = centered_work(art, bundle);
+    norm_fold_plain(&mut work, art.norm_fold_const);
+    let mut code = [0u8; STAGES];
+    for ((st_code, table), (copies, &shift)) in code
+        .iter_mut()
+        .zip(art.dot_cb.iter())
+        .zip(art.resid_cb.iter().zip(art.resid_scale_shifts.iter()))
+    {
+        let mut best = i64::MIN;
+        let mut best_class = 0u8;
+        for (class, row) in table.chunks_exact(D).enumerate() {
+            let score = dot_score_plain(row, &work);
+            if score > best {
+                best = score;
+                best_class = class as u8;
+            }
+        }
+        *st_code = best_class;
+        if let Some(copy_row) = copies.chunks_exact(D).nth(usize::from(best_class)) {
+            for (w, &c) in work.iter_mut().zip(copy_row.iter()) {
+                *w -= i64::from(c) << shift;
+            }
+        }
     }
     code
 }
@@ -810,6 +901,9 @@ impl<'a> Runtime<'a> {
     pub fn assign(&mut self, c: &Corpus, i: usize) -> [u8; STAGES] {
         let rot = self.rot;
         let b = bundle_kernel(&mut self.kernel, self.art, &rot, c, i);
+        if !self.art.resid_cb.is_empty() {
+            return self.code_from_bundle_resid(&b);
+        }
         if !self.art.dot_cb.is_empty() {
             return self.code_from_bundle_dot(&b);
         }
@@ -822,6 +916,9 @@ impl<'a> Runtime<'a> {
     pub fn assign_window(&mut self, window: &[u32]) -> [u8; STAGES] {
         let rot = self.rot;
         let b = bundle_window_kernel(&mut self.kernel, self.art, &rot, window);
+        if !self.art.resid_cb.is_empty() {
+            return self.code_from_bundle_resid(&b);
+        }
         if !self.art.dot_cb.is_empty() {
             return self.code_from_bundle_dot(&b);
         }
@@ -842,6 +939,15 @@ impl<'a> Runtime<'a> {
     ) -> ([u8; STAGES], Vec<Vec<Vec<u8>>>) {
         let rot = self.rot;
         let b = bundle_window_kernel(&mut self.kernel, self.art, &rot, window);
+        if !self.art.resid_cb.is_empty() {
+            // #318 Phase B: the primary code is residual-wired; the
+            // membership beam itself remains the #281 non-residual rule
+            // pending the Phase C store-shape decision
+            // (docs/dot_residual_phase_b_design.md).
+            let code = self.code_from_bundle_resid(&b);
+            let (_, by_depth) = assign_memberships_for_bundle(self.art, &b);
+            return (code, by_depth);
+        }
         if !self.art.dot_cb.is_empty() {
             let code = self.code_from_bundle_dot(&b);
             let (_, by_depth) = assign_memberships_for_bundle(self.art, &b);
@@ -871,34 +977,102 @@ impl<'a> Runtime<'a> {
         }
         let mut code = [0u8; STAGES];
         for (st_code, table) in code.iter_mut().zip(self.art.dot_cb.iter()) {
-            let mut best = i64::MIN;
-            let mut best_k = 0u8;
-            for (kk, row) in table.chunks_exact(D).enumerate() {
-                self.kernel.candidate_scan();
-                let mut acc = 0i64;
-                for (&entry, &w) in row.iter().zip(work.iter()) {
-                    let packed = self.kernel.table_fetch(i64::from(entry)) as u16;
-                    let [lo, hi] = packed.to_le_bytes();
-                    for term in [hi, lo] {
-                        if term & 0x40 == 0 {
-                            continue;
-                        }
-                        let exp = (term & 0x3F) as i32 - 32;
-                        let shifted = if exp >= 0 {
-                            self.kernel.shl(w, exp as u32)
-                        } else {
-                            self.kernel.shr(w, (-exp) as u32)
-                        };
-                        let signed = if term & 0x80 != 0 { -shifted } else { shifted };
-                        acc = self.kernel.add(acc, signed);
+            *st_code = self.dot_argmax(table, &work);
+        }
+        code
+    }
+
+    /// Per-stage dot argmax through the kernel: one candidate scan per
+    /// class, one table read per dimension entry, at most two shifts +
+    /// two adds per term pair, one compare per candidate.
+    fn dot_argmax(&mut self, table: &[u16], work: &[i64; D]) -> u8 {
+        let mut best = i64::MIN;
+        let mut best_k = 0u8;
+        for (kk, row) in table.chunks_exact(D).enumerate() {
+            self.kernel.candidate_scan();
+            let mut acc = 0i64;
+            for (&entry, &w) in row.iter().zip(work.iter()) {
+                let packed = self.kernel.table_fetch(i64::from(entry)) as u16;
+                let [lo, hi] = packed.to_le_bytes();
+                for term in [hi, lo] {
+                    if term & 0x40 == 0 {
+                        continue;
                     }
-                }
-                if self.kernel.lt(best, acc) {
-                    best = acc;
-                    best_k = kk as u8;
+                    let exp = (term & 0x3F) as i32 - 32;
+                    let shifted = if exp >= 0 {
+                        self.kernel.shl(w, exp as u32)
+                    } else {
+                        self.kernel.shr(w, (-exp) as u32)
+                    };
+                    let signed = if term & 0x80 != 0 { -shifted } else { shifted };
+                    acc = self.kernel.add(acc, signed);
                 }
             }
-            *st_code = best_k;
+            if self.kernel.lt(best, acc) {
+                best = acc;
+                best_k = kk as u8;
+            }
+        }
+        best_k
+    }
+
+    /// Residual-wired shift-add dot assignment (#318 Phase B, kernel
+    /// form — every operation counted): identical values to
+    /// `assign_code_for_bundle_resid` (plain form), with the po2 norm
+    /// fold and the per-stage integer centroid-copy subtraction
+    /// dispatched through `OpKernel`. Added ops over the non-residual
+    /// form: the fold (D compare+add for the L1 norm, ≤ 63 shift+add
+    /// for the bit length, D shifts for the fold itself) and per stage
+    /// D table reads + shifts + adds for the copy subtraction — a
+    /// ~1/(2K) fraction of the dot scan, far inside the design note's
+    /// ⚑ 2× op-census budget.
+    pub(crate) fn code_from_bundle_resid(&mut self, bundle: &[i64; D]) -> [u8; STAGES] {
+        let mut work = [0i64; D];
+        for ((w, &b), &t) in work
+            .iter_mut()
+            .zip(bundle.iter())
+            .zip(self.art.thresholds.iter())
+        {
+            *w = self.kernel.add(b, -t);
+        }
+        // po2 norm fold: L1 = Σ|w_d| by compare + add; bit length by
+        // shift + compare; then one shift per dimension.
+        let mut l1 = 0i64;
+        for &w in work.iter() {
+            let mag = if self.kernel.lt(w, 0) { -w } else { w };
+            l1 = self.kernel.add(l1, mag);
+        }
+        if l1 != 0 {
+            let mut bits = 0i64;
+            let mut v = l1;
+            while self.kernel.lt(0, v) {
+                v = self.kernel.shr(v, 1);
+                bits = self.kernel.add(bits, 1);
+            }
+            let s = (bits - i64::from(self.art.norm_fold_const)).clamp(-63, 63);
+            for w in work.iter_mut() {
+                *w = if s >= 0 {
+                    self.kernel.shr(*w, s as u32)
+                } else {
+                    self.kernel.shl(*w, (-s) as u32)
+                };
+            }
+        }
+        let mut code = [0u8; STAGES];
+        for ((st_code, table), (copies, &shift)) in code.iter_mut().zip(self.art.dot_cb.iter()).zip(
+            self.art
+                .resid_cb
+                .iter()
+                .zip(self.art.resid_scale_shifts.iter()),
+        ) {
+            *st_code = self.dot_argmax(table, &work);
+            if let Some(copy_row) = copies.chunks_exact(D).nth(usize::from(*st_code)) {
+                for (w, &c) in work.iter_mut().zip(copy_row.iter()) {
+                    let v = self.kernel.table_fetch(i64::from(c));
+                    let shifted = self.kernel.shl(v, u32::from(shift));
+                    *w = self.kernel.add(*w, -shifted);
+                }
+            }
         }
         code
     }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -483,9 +483,10 @@ fn dot_stage_top(table: &[u16], work: &[i64; D]) -> Vec<(u8, u32)> {
     top
 }
 
-/// Membership assignment for a bundle: dot path when the artifact
-/// carries dot tables, sign-Hamming otherwise. The by-depth beam shape
-/// and fallback-floor rule are identical between the two metrics.
+/// Membership assignment for a bundle: residual-wired dot path when the
+/// artifact carries residual copies (TLA7), dot path when it carries dot
+/// tables (TLA6), sign-Hamming otherwise. The by-depth beam shape and
+/// fallback-floor rule are identical between the metrics.
 #[allow(clippy::type_complexity)]
 pub fn assign_memberships_for_bundle(
     art: &Compiled,
@@ -493,6 +494,28 @@ pub fn assign_memberships_for_bundle(
 ) -> ([u8; STAGES], Vec<Vec<Vec<u8>>>) {
     if art.dot_cb.is_empty() {
         return assign_memberships_plain(art, &sig_plain(art, bundle));
+    }
+    if !art.resid_cb.is_empty() {
+        // #318 Phase B: the beam's per-stage candidate lists come from
+        // the SAME residual-evolving work vector the kernel form and the
+        // allocation-free serving form use — candidate selection per
+        // stage is `dot_stage_top` on the folded work, then the winning
+        // centroid's integer copy is subtracted before the next stage.
+        let mut work = centered_work(art, bundle);
+        norm_fold_plain(&mut work, art.norm_fold_const);
+        let mut code = [0u8; STAGES];
+        let mut stage_top: Vec<Vec<(u8, u32)>> = Vec::with_capacity(STAGES);
+        for ((st_code, table), (copies, &shift)) in code
+            .iter_mut()
+            .zip(art.dot_cb.iter())
+            .zip(art.resid_cb.iter().zip(art.resid_scale_shifts.iter()))
+        {
+            let top = dot_stage_top(table, &work);
+            *st_code = top.first().map(|(k, _)| *k).unwrap_or(0);
+            resid_subtract_plain(&mut work, copies, shift, *st_code);
+            stage_top.push(top);
+        }
+        return memberships_from_stage_top(code, stage_top);
     }
     let work = centered_work(art, bundle);
     let mut code = [0u8; STAGES];
@@ -606,6 +629,17 @@ fn norm_fold_plain(work: &mut [i64; D], norm_const: i32) {
     }
 }
 
+/// Subtract one stage's winning integer centroid copy from the work
+/// vector (plain form): per dimension, one shift and one subtract.
+/// Plain form of the kernel's table-fetch + shl + add sequence.
+fn resid_subtract_plain(work: &mut [i64; D], copies: &[i8], shift: u8, class: u8) {
+    if let Some(copy_row) = copies.chunks_exact(D).nth(usize::from(class)) {
+        for (w, &c) in work.iter_mut().zip(copy_row.iter()) {
+            *w -= i64::from(c) << shift;
+        }
+    }
+}
+
 /// Residual-wired shift-add dot assignment (#318 Phase B), allocation-
 /// free plain form: center the bundle, apply the po2 norm fold, then
 /// per stage argmax `dot_score_plain` over the stage's po2 table and
@@ -637,11 +671,7 @@ pub fn assign_code_for_bundle_resid(art: &Compiled, bundle: &[i64; D]) -> [u8; S
             }
         }
         *st_code = best_class;
-        if let Some(copy_row) = copies.chunks_exact(D).nth(usize::from(best_class)) {
-            for (w, &c) in work.iter_mut().zip(copy_row.iter()) {
-                *w -= i64::from(c) << shift;
-            }
-        }
+        resid_subtract_plain(&mut work, copies, shift, best_class);
     }
     code
 }
@@ -940,10 +970,10 @@ impl<'a> Runtime<'a> {
         let rot = self.rot;
         let b = bundle_window_kernel(&mut self.kernel, self.art, &rot, window);
         if !self.art.resid_cb.is_empty() {
-            // #318 Phase B: the primary code is residual-wired; the
-            // membership beam itself remains the #281 non-residual rule
-            // pending the Phase C store-shape decision
-            // (docs/dot_residual_phase_b_design.md).
+            // #318 Phase B: primary code and membership beam are both
+            // residual-wired (`assign_memberships_for_bundle` derives
+            // its candidate lists from the same folded, residual-
+            // evolving work vector), so the pair stays consistent.
             let code = self.code_from_bundle_resid(&b);
             let (_, by_depth) = assign_memberships_for_bundle(self.art, &b);
             return (code, by_depth);

--- a/crates/uor-r4-core/tests/allocation_census.rs
+++ b/crates/uor-r4-core/tests/allocation_census.rs
@@ -325,6 +325,70 @@ fn allocation_census() {
         "steady-state prediction and generation must be allocation-free"
     );
 
+    // Phase 3b — #318 Phase B residual path: the census fixtures are
+    // pre-TLA7, so the residual-wired assign path is censused on a
+    // synthetic TLA7 artifact. Plain and kernel forms must agree and
+    // allocate nothing.
+    let resid_art = {
+        let vocab = 4usize;
+        Compiled {
+            token_codes: (0..vocab * STAGES).map(|i| (i % 256) as u8).collect(),
+            stage_books: (0..STAGES)
+                .map(|st| {
+                    (0..compiler::K * compiler::D)
+                        .map(|i| (((i + st) % 5) as i8) - 2)
+                        .collect()
+                })
+                .collect(),
+            stage_shifts: vec![0; STAGES],
+            thresholds: (0..compiler::D as i64).map(|d| (d % 11) - 5).collect(),
+            class_sigs: (0..STAGES)
+                .map(|_| vec![0u8; compiler::K * compiler::D / 8])
+                .collect(),
+            ctx_cb: Vec::new(),
+            token_stage_kappas: Vec::new(),
+            dot_cb: (0..STAGES)
+                .map(|st| {
+                    (0..compiler::K * compiler::D)
+                        .map(|i| compiler::pack_dot_entry((((i + st) % 13) as f32 - 6.0) / 8.0))
+                        .collect()
+                })
+                .collect(),
+            resid_cb: (0..STAGES)
+                .map(|st| {
+                    (0..compiler::K * compiler::D)
+                        .map(|i| (((i + st) % 13) as i8) - 6)
+                        .collect()
+                })
+                .collect(),
+            resid_scale_shifts: vec![4; STAGES],
+            norm_fold_const: 10,
+        }
+    };
+    let rot = compiler::derive_rotations();
+    let resid_window = [1u32, 2];
+    let resid_bundle = runtime::bundle_window_plain(&resid_art, &rot, &resid_window);
+    let mut resid_rt = runtime::Runtime::new(&resid_art);
+    let ((resid_plain, resid_kernel), resid_cen) = measure(|| {
+        (
+            runtime::assign_code_for_bundle(&resid_art, &resid_bundle),
+            resid_rt.assign_window(&resid_window),
+        )
+    });
+    assert_eq!(
+        resid_plain, resid_kernel,
+        "residual kernel/plain assignment agree"
+    );
+    assert_eq!(
+        resid_cen, ZERO,
+        "residual-wired assign path must be allocation-free"
+    );
+    println!(
+        "[runtime] #318 residual assign (plain + kernel, synthetic TLA7) \
+         → {} allocations, {} bytes",
+        resid_cen.allocations, resid_cen.bytes
+    );
+
     // Phase 4 — per-token op census from the Runtime's public OpKernel.
     let t = GEN_TOKENS as f64;
     println!(

--- a/crates/uor-r4-core/tests/kappa_reproduction.rs
+++ b/crates/uor-r4-core/tests/kappa_reproduction.rs
@@ -190,3 +190,77 @@ fn dump_baseline_kappa() {
         eprintln!("wrote {} bytes to {fixture}", container.len());
     }
 }
+
+/// #318 Phase B witness on a REAL compile: the TLA7 residual-wired
+/// assignment must agree across every form of the path — kernel
+/// (`Runtime::assign`), the plain bundle entry points (`code_plain`,
+/// `assign_for_bundle`, membership primary), and the allocation-free
+/// serving form (`assign_code_for_bundle`) — over hundreds of corpus
+/// positions, on both the in-memory compile and the serialized → parsed
+/// TLA7 container. Regression test for the kernel-residual vs
+/// plain-non-residual routing divergence the first Phase B quality run
+/// hit (certify.rs "code kernel/plain divergence"). Same harness and
+/// skip convention as the κ-reproduction test above.
+#[test]
+#[ignore]
+fn tla7_resid_kernel_plain_witness() {
+    use uor_r4_core::transformerless::runtime;
+
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let ckpt =
+        std::env::var("TLESS_CHECKPOINT").unwrap_or_else(|_| "/tmp/ref/out/model.bin".to_string());
+    if std::fs::metadata(&ckpt).is_err() {
+        eprintln!("skipping: source checkpoint not found at {ckpt} (see `transformerless setup`)");
+        return;
+    }
+    let corpus = compiler::load_corpus_from(
+        &format!("{dir}/tests/fixtures/c_meta.bin"),
+        &format!("{dir}/tests/fixtures/c_recs.bin"),
+    )
+    .expect("corpus fixtures load");
+    let oracle = LlamaOracle::load(&ckpt);
+    let art = compiler::compile(&oracle, &corpus);
+    assert!(
+        !art.resid_cb.is_empty(),
+        "fresh compile carries the TLA7 residual sections"
+    );
+    let parsed = compiler::parse_artifacts(&compiler::artifact_bytes(&art))
+        .expect("TLA7 container round-trips");
+    assert_eq!(parsed.resid_cb, art.resid_cb);
+    assert_eq!(parsed.resid_scale_shifts, art.resid_scale_shifts);
+    assert_eq!(parsed.norm_fold_const, art.norm_fold_const);
+
+    let rot = compiler::derive_rotations();
+    for (label, a) in [("in-memory", &art), ("parsed-tla7", &parsed)] {
+        let mut rt = runtime::Runtime::new(a);
+        let sample_n = 512usize;
+        let stride = corpus.n / sample_n;
+        for s in 0..sample_n {
+            let i = s * stride;
+            let bk = runtime::bundle_kernel(&mut rt.kernel, a, &rot, &corpus, i);
+            let bp = runtime::bundle_plain(a, &rot, &corpus, i);
+            assert_eq!(bk, bp, "[{label}] bundle kernel/plain divergence at {i}");
+            let ck = rt.assign(&corpus, i);
+            let cp = runtime::code_plain(a, &rot, &corpus, i);
+            assert_eq!(ck, cp, "[{label}] code kernel/plain divergence at {i}");
+            assert_eq!(
+                runtime::assign_for_bundle(a, &bp),
+                cp,
+                "[{label}] assign_for_bundle divergence at {i}"
+            );
+            assert_eq!(
+                runtime::assign_code_for_bundle(a, &bp),
+                cp,
+                "[{label}] serving-form divergence at {i}"
+            );
+            let (primary, _) = runtime::assign_memberships_for_bundle(a, &bp);
+            assert_eq!(
+                primary, cp,
+                "[{label}] membership primary divergence at {i}"
+            );
+        }
+        println!(
+            "[{label}] TLA7 residual witness: {sample_n}/{sample_n} positions, all forms agree"
+        );
+    }
+}

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -165,6 +165,9 @@ fn synthetic_compiled() -> compiler::Compiled {
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
         dot_cb: Vec::new(),
+        resid_cb: Vec::new(),
+        resid_scale_shifts: Vec::new(),
+        norm_fold_const: 0,
     }
 }
 

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -51,6 +51,9 @@ pub fn synthetic_compiled() -> compiler::Compiled {
         ctx_cb: Vec::new(),
         token_stage_kappas: Vec::new(),
         dot_cb: Vec::new(),
+        resid_cb: Vec::new(),
+        resid_scale_shifts: Vec::new(),
+        norm_fold_const: 0,
     }
 }
 


### PR DESCRIPTION
Refs #318. Implements `docs/dot_residual_phase_b_design.md` Phase B (merged via #323, Phase A.5 via #325; reproduction + A.5 evidence in the #318 comments).

**Draft pending the TLA7 quality-confirmation run** (kernel residual path vs the certifier's A.5 row numbers on the 500k corpus — results posted here and on #318 before this is marked ready).

## What lands

- **Compiler**: `Compiled` gains `resid_cb` (per-stage i8 centroid copies, IEEE-exponent po2 stage scale, libm-free), `resid_scale_shifts`, `norm_fold_const` (stride-8 train median of log2(L1/L2), D2-canonical float functions). Serialized under new artifact era **TLA7** (TLA6 payload + CONST + shifts + copies ≈ +288 KB), default-on with `R4_TLESS_TLA7=0` opt-out, mirroring the TLA6 mechanism.
- **Runtime**: TLA7 artifacts route to `assign_code_for_bundle_resid` — po2 norm fold (L1 bit-length − CONST, one arithmetic shift per dim; division-free), then per-stage dot argmax + winning-centroid integer-copy subtraction. Add/sub/shift/compare/table-read only; P-4 scan clean. Allocation-free serving path preserved (new ZERO-allocation census phase). Pre-TLA7 artifacts unchanged; membership beam stays on the #281 rule pending Phase C's store-shape decision.
- **Witnesses**: kernel==plain (s>0, s<0, L1=0, negative-heavy), TLA7 roundtrip + truncation rejection + TLA6-unchanged, TLA5 fixture byte-identical.

## Design note for reviewers

The doc's literal fold spec (normalize to unit scale) is degenerate in integer arithmetic (truncates to zero); the implementation folds to unit·2²⁰ (`RESID_WORK_FRACTION`), which keeps the copies and folded work on a common scale and leaves argmax scale-invariant. Documented on the field; flagged in the doc/code gap note on #318.

## Gates (worktree, offline)

`cargo test -p uor-r4-core` (22 binaries, incl. allocation census + P-4) ✓ · workspace clippy `-D warnings` ✓ · fmt ✓ · `cargo check --workspace` ✓

## Explicitly deferred (Phase C, per the design doc)

κ re-pin + fixtures (tracks #327), certifier-side TLA7 witness rows, store-shape/beam decision on the #244 harness, BASELINE.md.
