### PR TITLE
perf(transformerless): vectorize shift-add dot assignment (#330)

### DIFF
--- a/crates/uor-r4-core/Cargo.toml
+++ b/crates/uor-r4-core/Cargo.toml
@@ -21,3 +21,7 @@ libm = "0.2"
 [dev-dependencies]
 serde_json = "1.0"
 proptest = "1.4.0"
+
+[[bench]]
+name = "transformerless_dot"
+harness = false

--- a/crates/uor-r4-core/benches/transformerless_dot.rs
+++ b/crates/uor-r4-core/benches/transformerless_dot.rs
@@ -1,0 +1,164 @@
+//! Wall-clock baseline for the transformerless shift-add dot path.
+//!
+//! This intentionally uses only the standard library. It measures the scalar
+//! reference scan and the complete allocation-free assignment step against a
+//! TLA6 artifact, which is the first data point required by issue #330 before
+//! adding an architecture-specific adapter.
+
+use std::env;
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use uor_r4_core::transformerless::compiler::{self, D, K, STAGES, WINDOW};
+use uor_r4_core::transformerless::runtime::{self, Runtime};
+
+const DEFAULT_ARTIFACT: &str = "tests/fixtures/tless_artifacts.bin";
+const DEFAULT_ITERATIONS: usize = 100;
+
+fn parse_iterations(value: Option<&String>) -> Result<usize, String> {
+    let iterations = value
+        .map(|raw| {
+            raw.parse::<usize>()
+                .map_err(|_| format!("invalid iteration count: {raw}"))
+        })
+        .transpose()?
+        .unwrap_or(DEFAULT_ITERATIONS);
+    if iterations == 0 {
+        return Err("iteration count must be greater than zero".to_owned());
+    }
+    Ok(iterations)
+}
+
+fn deterministic_work() -> [i64; D] {
+    let mut work = [0i64; D];
+    let mut value = -143i64;
+    for slot in &mut work {
+        *slot = value;
+        value = value.wrapping_add(97);
+        if value > 143 {
+            value = -143;
+        }
+    }
+    work
+}
+
+fn deterministic_window(vocab: usize) -> [u32; WINDOW] {
+    let mut window = [0u32; WINDOW];
+    let modulus = vocab.max(1) as u32;
+    let mut value = 17u32;
+    for token in &mut window {
+        *token = value % modulus;
+        value = value.wrapping_add(7919);
+    }
+    window
+}
+
+fn nanos_per_operation(elapsed: std::time::Duration, operations: usize) -> f64 {
+    elapsed.as_secs_f64() * 1e9 / operations as f64
+}
+
+fn read_artifact(path: &str) -> Result<(PathBuf, Vec<u8>), String> {
+    let requested = Path::new(path);
+    let mut candidates = vec![requested.to_owned()];
+    if requested.is_relative() {
+        candidates.push(Path::new("../..").join(requested));
+    }
+    for candidate in candidates {
+        match fs::read(&candidate) {
+            Ok(bytes) => return Ok((candidate, bytes)),
+            Err(_) => continue,
+        }
+    }
+    Err(format!("cannot read {path}"))
+}
+
+fn main() -> Result<(), String> {
+    let mut args = env::args().skip(1).filter(|arg| arg != "--bench");
+    let artifact_path = args.next().unwrap_or_else(|| DEFAULT_ARTIFACT.to_owned());
+    let iterations = parse_iterations(args.next().as_ref())?;
+    if args.next().is_some() {
+        return Err("usage: transformerless_dot [ARTIFACT] [ITERATIONS]".to_owned());
+    }
+
+    let (resolved_path, bytes) = read_artifact(&artifact_path)?;
+    let artifact = compiler::parse_artifacts(&bytes).ok_or_else(|| {
+        format!(
+            "invalid transformerless artifact: {}",
+            resolved_path.display()
+        )
+    })?;
+    if artifact.dot_cb.is_empty() {
+        return Err(format!(
+            "artifact {} has no TLA6 dot tables; use a TLA6 fixture",
+            resolved_path.display()
+        ));
+    }
+    let rows_per_scan = artifact.dot_cb.len() * K;
+    if rows_per_scan != STAGES * K {
+        return Err(format!(
+            "unexpected dot table shape: {} stages, expected {STAGES}",
+            artifact.dot_cb.len()
+        ));
+    }
+
+    let work = deterministic_work();
+    let vocab = artifact.token_codes.len() / STAGES;
+    let window = deterministic_window(vocab);
+
+    let mut scalar_checksum = 0i64;
+    for _ in 0..10 {
+        for table in &artifact.dot_cb {
+            for row in table.chunks_exact(D) {
+                scalar_checksum =
+                    scalar_checksum.wrapping_add(runtime::dot_score_plain(row, &work));
+            }
+        }
+    }
+    let scalar_start = Instant::now();
+    for _ in 0..iterations {
+        for table in &artifact.dot_cb {
+            for row in table.chunks_exact(D) {
+                scalar_checksum =
+                    scalar_checksum.wrapping_add(runtime::dot_score_plain(row, &work));
+            }
+        }
+    }
+    let scalar_elapsed = scalar_start.elapsed();
+
+    let mut runtime = Runtime::new(&artifact);
+    let mut runtime_checksum = [0u8; STAGES];
+    for _ in 0..10 {
+        runtime_checksum = runtime.assign_window(&window);
+    }
+    let runtime_start = Instant::now();
+    for _ in 0..iterations {
+        runtime_checksum = runtime.assign_window(black_box(&window));
+    }
+    let runtime_elapsed = runtime_start.elapsed();
+
+    println!("artifact={}", resolved_path.display());
+    println!("format=TLA6");
+    println!("iterations={iterations}");
+    println!("dot_rows_per_scan={rows_per_scan}");
+    println!(
+        "scalar_dot_ns_per_scan={:.1}",
+        nanos_per_operation(scalar_elapsed, iterations)
+    );
+    println!(
+        "scalar_dot_ns_per_row={:.1}",
+        nanos_per_operation(scalar_elapsed, iterations * rows_per_scan)
+    );
+    println!(
+        "runtime_assign_ns_per_token={:.1}",
+        nanos_per_operation(runtime_elapsed, iterations)
+    );
+    println!(
+        "runtime_assign_tokens_per_second={:.1}",
+        iterations as f64 / runtime_elapsed.as_secs_f64()
+    );
+    println!("scalar_checksum={scalar_checksum}");
+    println!("runtime_checksum={runtime_checksum:?}");
+    Ok(())
+}

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -84,6 +84,17 @@ impl OpKernel {
         self.table_reads += 1;
         v
     }
+    /// Records one four-lane, two-term SIMD dot vector. The counts are
+    /// logical vector operations, not scalar lane expansions; the lane
+    /// width is fixed by the adapter and the scalar semantics remain the
+    /// equality oracle.
+    #[inline]
+    pub fn simd_dot_vector(&mut self) {
+        self.adds += 2;
+        self.shifts += 2;
+        self.compares += 1;
+        self.table_reads += 2;
+    }
 
     pub fn report(&self) -> String {
         format!(
@@ -915,6 +926,7 @@ pub struct Runtime<'a> {
     pub pop: [u8; 256],
     pub kernel: OpKernel,
     pub state: RuntimeState,
+    dot_tables: Option<super::simd::DotTables>,
 }
 
 impl<'a> Runtime<'a> {
@@ -925,6 +937,7 @@ impl<'a> Runtime<'a> {
             pop: derive_popcount_table(),
             kernel: OpKernel::default(),
             state: RuntimeState::default(),
+            dot_tables: super::simd::DotTables::from_packed(&art.dot_cb),
         }
     }
 
@@ -1006,8 +1019,8 @@ impl<'a> Runtime<'a> {
             *w = self.kernel.add(b, -t);
         }
         let mut code = [0u8; STAGES];
-        for (st_code, table) in code.iter_mut().zip(self.art.dot_cb.iter()) {
-            *st_code = self.dot_argmax(table, &work);
+        for (stage, (st_code, table)) in code.iter_mut().zip(self.art.dot_cb.iter()).enumerate() {
+            *st_code = self.dot_argmax(stage, table, &work);
         }
         code
     }
@@ -1015,7 +1028,18 @@ impl<'a> Runtime<'a> {
     /// Per-stage dot argmax through the kernel: one candidate scan per
     /// class, one table read per dimension entry, at most two shifts +
     /// two adds per term pair, one compare per candidate.
-    fn dot_argmax(&mut self, table: &[u16], work: &[i64; D]) -> u8 {
+    fn dot_argmax(&mut self, stage: usize, table: &[u16], work: &[i64; D]) -> u8 {
+        if let Some(dot_tables) = self.dot_tables.as_ref() {
+            let dot_stage = &dot_tables.stages[stage];
+            let class = super::simd::dot_argmax(dot_stage, work);
+            for _ in 0..K {
+                self.kernel.candidate_scan();
+            }
+            for _ in 0..dot_stage.vectors.len() {
+                self.kernel.simd_dot_vector();
+            }
+            return class;
+        }
         let mut best = i64::MIN;
         let mut best_k = 0u8;
         for (kk, row) in table.chunks_exact(D).enumerate() {
@@ -1089,13 +1113,18 @@ impl<'a> Runtime<'a> {
             }
         }
         let mut code = [0u8; STAGES];
-        for ((st_code, table), (copies, &shift)) in code.iter_mut().zip(self.art.dot_cb.iter()).zip(
-            self.art
-                .resid_cb
-                .iter()
-                .zip(self.art.resid_scale_shifts.iter()),
-        ) {
-            *st_code = self.dot_argmax(table, &work);
+        for (stage, ((st_code, table), (copies, &shift))) in code
+            .iter_mut()
+            .zip(self.art.dot_cb.iter())
+            .zip(
+                self.art
+                    .resid_cb
+                    .iter()
+                    .zip(self.art.resid_scale_shifts.iter()),
+            )
+            .enumerate()
+        {
+            *st_code = self.dot_argmax(stage, table, &work);
             if let Some(copy_row) = copies.chunks_exact(D).nth(usize::from(*st_code)) {
                 for (w, &c) in work.iter_mut().zip(copy_row.iter()) {
                     let v = self.kernel.table_fetch(i64::from(c));

--- a/crates/uor-r4-core/src/transformerless/simd.rs
+++ b/crates/uor-r4-core/src/transformerless/simd.rs
@@ -1,4 +1,4 @@
-use super::compiler::SIG_BYTES;
+use super::compiler::{D, K, SIG_BYTES};
 
 #[inline(always)]
 pub fn hamming_distance_36_scalar(a: &[u8; SIG_BYTES], b: &[u8; SIG_BYTES]) -> u32 {
@@ -102,6 +102,255 @@ pub fn hamming_distance_36(a: &[u8; SIG_BYTES], b: &[u8; SIG_BYTES]) -> u32 {
     {
         hamming_distance_36_scalar(a, b)
     }
+}
+
+const DOT_LANES: usize = 4;
+const DOT_GROUPS: usize = K / DOT_LANES;
+
+/// One dimension's decoded shift/add terms for four adjacent classes.
+///
+/// This is a load-time expansion of the packed u16 table. It keeps the
+/// deployed artifact unchanged while giving SIMD adapters contiguous shift
+/// and sign metadata. `active` and `negative` use all-zero/all-one i64 masks.
+#[derive(Clone, Copy)]
+pub(crate) struct DotTermVector {
+    shifts: [i64; DOT_LANES],
+    active: [i64; DOT_LANES],
+    negative: [i64; DOT_LANES],
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct DotVector {
+    /// Terms are ordered high byte then low byte, matching the scalar path.
+    terms: [DotTermVector; 2],
+}
+
+pub(crate) struct DotStage {
+    /// Dimension-major: D vectors, each containing K/4 class groups.
+    pub(crate) vectors: Vec<DotVector>,
+}
+
+pub(crate) struct DotTables {
+    pub(crate) stages: Vec<DotStage>,
+}
+
+fn decode_dot_term(term: u8) -> (i64, i64, i64) {
+    if term & 0x40 == 0 {
+        return (0, 0, 0);
+    }
+    let exponent = i64::from(term & 0x3F) - 32;
+    let negative = if term & 0x80 != 0 { -1 } else { 0 };
+    (exponent, -1, negative)
+}
+
+impl DotTables {
+    pub(crate) fn from_packed(packed: &[Vec<u16>]) -> Option<Self> {
+        if packed.is_empty() {
+            return None;
+        }
+        let mut stages = Vec::with_capacity(packed.len());
+        for table in packed {
+            if table.len() != D * K {
+                return None;
+            }
+            let mut vectors = Vec::with_capacity(D * DOT_GROUPS);
+            for dimension in 0..D {
+                for group in 0..DOT_GROUPS {
+                    let mut terms = [DotTermVector {
+                        shifts: [0; DOT_LANES],
+                        active: [0; DOT_LANES],
+                        negative: [0; DOT_LANES],
+                    }; 2];
+                    for lane in 0..DOT_LANES {
+                        let class = group * DOT_LANES + lane;
+                        let entry = table[class * D + dimension].to_le_bytes();
+                        let (hi_shift, hi_active, hi_negative) = decode_dot_term(entry[1]);
+                        let (lo_shift, lo_active, lo_negative) = decode_dot_term(entry[0]);
+                        terms[0].shifts[lane] = hi_shift;
+                        terms[0].active[lane] = hi_active;
+                        terms[0].negative[lane] = hi_negative;
+                        terms[1].shifts[lane] = lo_shift;
+                        terms[1].active[lane] = lo_active;
+                        terms[1].negative[lane] = lo_negative;
+                    }
+                    vectors.push(DotVector { terms });
+                }
+            }
+            stages.push(DotStage { vectors });
+        }
+        Some(Self { stages })
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline]
+fn dot_term_scalar(work: i64, term: &DotTermVector, lane: usize) -> i64 {
+    if term.active[lane] == 0 {
+        return 0;
+    }
+    let shift = term.shifts[lane];
+    let shifted = if shift >= 0 {
+        work << shift
+    } else {
+        work >> -shift
+    };
+    if term.negative[lane] != 0 {
+        -shifted
+    } else {
+        shifted
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+pub(crate) fn dot_argmax_scalar(stage: &DotStage, work: &[i64; D]) -> u8 {
+    let mut scores = [0i64; K];
+    for (dimension, groups) in stage.vectors.chunks_exact(DOT_GROUPS).enumerate() {
+        for (group, vector) in groups.iter().enumerate() {
+            for lane in 0..DOT_LANES {
+                let class = group * DOT_LANES + lane;
+                scores[class] += dot_term_scalar(work[dimension], &vector.terms[0], lane);
+                scores[class] += dot_term_scalar(work[dimension], &vector.terms[1], lane);
+            }
+        }
+    }
+    let mut best_class = 0u8;
+    let mut best_score = i64::MIN;
+    for (class, &score) in scores.iter().enumerate() {
+        if score > best_score {
+            best_score = score;
+            best_class = class as u8;
+        }
+    }
+    best_class
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn dot_argmax_avx2(stage: &DotStage, work: &[i64; D]) -> u8 {
+    use std::arch::x86_64::*;
+
+    let zero = _mm256_setzero_si256();
+    let all_ones = _mm256_set1_epi64x(-1);
+    let sixty_four = _mm256_set1_epi64x(64);
+    let mut accumulators = [zero; DOT_GROUPS];
+    for (dimension, groups) in stage.vectors.chunks_exact(DOT_GROUPS).enumerate() {
+        let work_vector = _mm256_set1_epi64x(work[dimension]);
+        for (group, vector) in groups.iter().enumerate() {
+            for term in &vector.terms {
+                let shifts = _mm256_loadu_si256(term.shifts.as_ptr() as *const __m256i);
+                let active = _mm256_loadu_si256(term.active.as_ptr() as *const __m256i);
+                let negative = _mm256_loadu_si256(term.negative.as_ptr() as *const __m256i);
+                let is_right = _mm256_cmpgt_epi64(zero, shifts);
+                let absolute_shift = _mm256_sub_epi64(zero, shifts);
+                let left = _mm256_sllv_epi64(work_vector, shifts);
+                let logical_right = _mm256_srlv_epi64(work_vector, absolute_shift);
+                let sign = _mm256_cmpgt_epi64(zero, work_vector);
+                let fill_shift = _mm256_sub_epi64(sixty_four, absolute_shift);
+                let fill = _mm256_sllv_epi64(all_ones, fill_shift);
+                let arithmetic_right = _mm256_or_si256(logical_right, _mm256_and_si256(sign, fill));
+                let shifted = _mm256_blendv_epi8(left, arithmetic_right, is_right);
+                let negated = _mm256_sub_epi64(zero, shifted);
+                let signed = _mm256_blendv_epi8(shifted, negated, negative);
+                let active_value = _mm256_blendv_epi8(zero, signed, active);
+                accumulators[group] = _mm256_add_epi64(accumulators[group], active_value);
+            }
+        }
+    }
+
+    let mut scores = [0i64; K];
+    for (group, accumulator) in accumulators.iter().enumerate() {
+        let mut lanes = [0i64; DOT_LANES];
+        _mm256_storeu_si256(lanes.as_mut_ptr() as *mut __m256i, *accumulator);
+        for (lane, &score) in lanes.iter().enumerate() {
+            scores[group * DOT_LANES + lane] = score;
+        }
+    }
+    let mut best_class = 0u8;
+    let mut best_score = i64::MIN;
+    for (class, &score) in scores.iter().enumerate() {
+        if score > best_score {
+            best_score = score;
+            best_class = class as u8;
+        }
+    }
+    best_class
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn dot_argmax_neon(stage: &DotStage, work: &[i64; D]) -> u8 {
+    use std::arch::aarch64::*;
+
+    let zero = vdupq_n_s64(0);
+    let mut accumulators_a = [zero; DOT_GROUPS];
+    let mut accumulators_b = [zero; DOT_GROUPS];
+    for (dimension, groups) in stage.vectors.chunks_exact(DOT_GROUPS).enumerate() {
+        let work_vector = vdupq_n_s64(work[dimension]);
+        for (group, vector) in groups.iter().enumerate() {
+            for term in &vector.terms {
+                let shifts_a = vld1q_s64(term.shifts.as_ptr());
+                let shifts_b = vld1q_s64(term.shifts.as_ptr().add(2));
+                let active_a = vld1q_s64(term.active.as_ptr());
+                let active_b = vld1q_s64(term.active.as_ptr().add(2));
+                let negative_a = vld1q_s64(term.negative.as_ptr());
+                let negative_b = vld1q_s64(term.negative.as_ptr().add(2));
+                let shifted_a = vshlq_s64(work_vector, shifts_a);
+                let shifted_b = vshlq_s64(work_vector, shifts_b);
+                let signed_a = vbslq_s64(
+                    vreinterpretq_u64_s64(negative_a),
+                    vnegq_s64(shifted_a),
+                    shifted_a,
+                );
+                let signed_b = vbslq_s64(
+                    vreinterpretq_u64_s64(negative_b),
+                    vnegq_s64(shifted_b),
+                    shifted_b,
+                );
+                accumulators_a[group] = vaddq_s64(
+                    accumulators_a[group],
+                    vbslq_s64(vreinterpretq_u64_s64(active_a), signed_a, zero),
+                );
+                accumulators_b[group] = vaddq_s64(
+                    accumulators_b[group],
+                    vbslq_s64(vreinterpretq_u64_s64(active_b), signed_b, zero),
+                );
+            }
+        }
+    }
+
+    let mut scores = [0i64; K];
+    for group in 0..DOT_GROUPS {
+        scores[group * DOT_LANES] = vget_lane_s64(vget_low_s64(accumulators_a[group]), 0);
+        scores[group * DOT_LANES + 1] = vget_lane_s64(vget_high_s64(accumulators_a[group]), 0);
+        scores[group * DOT_LANES + 2] = vget_lane_s64(vget_low_s64(accumulators_b[group]), 0);
+        scores[group * DOT_LANES + 3] = vget_lane_s64(vget_high_s64(accumulators_b[group]), 0);
+    }
+    let mut best_class = 0u8;
+    let mut best_score = i64::MIN;
+    for (class, &score) in scores.iter().enumerate() {
+        if score > best_score {
+            best_score = score;
+            best_class = class as u8;
+        }
+    }
+    best_class
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn dot_argmax(stage: &DotStage, work: &[i64; D]) -> u8 {
+    if std::arch::is_x86_feature_detected!("avx2") {
+        return unsafe { dot_argmax_avx2(stage, work) };
+    }
+    dot_argmax_scalar(stage, work)
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn dot_argmax(stage: &DotStage, work: &[i64; D]) -> u8 {
+    unsafe { dot_argmax_neon(stage, work) }
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+pub(crate) fn dot_argmax(stage: &DotStage, work: &[i64; D]) -> u8 {
+    dot_argmax_scalar(stage, work)
 }
 
 #[cfg(test)]

--- a/docs/simd_dot_scan_design.md
+++ b/docs/simd_dot_scan_design.md
@@ -72,7 +72,11 @@ the negative result.
 
 - **Phase 0 (prerequisite)**: serving wall-clock harness (ns/token,
   no new deps) with the TLA6 and TLA7 paths as its first two data
-  points — lands independently of this design.
+  points — implemented as `cargo bench -p uor-r4-core
+  --bench transformerless_dot -- <ARTIFACT> <ITERATIONS>` (the default
+  artifact is `tests/fixtures/tless_artifacts.bin`).
+  The harness reports the scalar dot scan and complete runtime assignment,
+  and prints checksums that an adapter must preserve.
 - **Phase 1**: transposed layout + AVX2 adapter + proptest witness +
   microbenchmark; numbers posted to this issue.
 - **Phase 2**: NEON adapter (after the ⚑ rounding semantics are


### PR DESCRIPTION
## Summary

Part 2 of #330: adds the contract-legal SIMD adapter behind the scalar shift-add dot assignment.

- Expands packed dot terms into load-time transposed metadata; artifact bytes and format are unchanged.
- Adds AVX2 four-lane and NEON two-pair shift/add adapters.
- Keeps scalar fallback and exact scalar semantics as the equality oracle.
- Preserves operation census accounting and the no-multiply runtime contract.
- Applies to both the TLA6 dot path and TLA7 residual path; residual subtraction remains scalar and bounded.

## Measurement

On the checked-in TLA6 fixture, arm64 macOS:

- Scalar baseline: 294.0 µs per complete assignment, 3,401 assignments/sec.
- NEON adapter: 187.9 µs per complete assignment, 5,322 assignments/sec.
- Improvement: approximately 1.56x.
- Runtime checksum unchanged: `[35, 216, 124, 191]`.

The 3x isolated / 2x end-to-end issue criterion is not claimed yet; this is the first adapter data point. A pinned TLA7 artifact is still needed for the second matrix row.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p uor-r4-core --all-targets --offline -- -D warnings`
- `cargo check -p uor-r4-core --all-targets --target x86_64-apple-darwin --offline`
- `cargo test -p uor-r4-core --lib --offline` (25 passed, including P-4 and equality witnesses)
- `cargo bench -p uor-r4-core --bench transformerless_dot --offline -- tests/fixtures/tless_artifacts.bin 100`

Depends on #333.