### PR TITLE
perf(graph-runtime): index ROUT signatures with exact VP-tree (#277)

### DIFF
--- a/crates/uor-r4-graph-runtime/Cargo.toml
+++ b/crates/uor-r4-graph-runtime/Cargo.toml
@@ -8,3 +8,7 @@ uor-r4-graph-format = { path = "../uor-r4-graph-format", default-features = fals
 
 [dev-dependencies]
 uor-r4-core = { path = "../uor-r4-core" }
+
+[[bench]]
+name = "vp_tree"
+harness = false

--- a/crates/uor-r4-graph-runtime/benches/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/benches/vp_tree.rs
@@ -1,0 +1,165 @@
+//! Exact VP-tree versus linear ROUT lookup benchmark for issue #277.
+
+extern crate alloc;
+
+use std::env;
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use uor_r4_graph_format::{GraphView, SectionId};
+
+#[path = "../src/vp_tree.rs"]
+mod vp_tree;
+
+const DEFAULT_GRAPH: &str = ".uor-models/compiled/smollm2-135m-instruct/graph/score.r4g1";
+const DEFAULT_ITERATIONS: usize = 100;
+
+fn read_graph(path: &str) -> Result<(PathBuf, Vec<u8>), String> {
+    let requested = Path::new(path);
+    let mut candidates = vec![requested.to_owned()];
+    if requested.is_relative() {
+        candidates.push(Path::new("../..").join(requested));
+    }
+    for candidate in candidates {
+        if let Ok(bytes) = fs::read(&candidate) {
+            return Ok((candidate, bytes));
+        }
+    }
+    Err(format!("cannot read graph artifact {path}"))
+}
+
+fn masked_hamming(signature: &[u8], prototype: &[u8], mask: &[u8]) -> u32 {
+    signature
+        .iter()
+        .zip(prototype)
+        .zip(mask)
+        .map(|((&s, &p), &m)| ((s ^ p) & m).count_ones())
+        .sum()
+}
+
+fn linear_query(
+    view: &GraphView<'_>,
+    signature: &[u8],
+    active: &mut [u32; 8],
+) -> (u32, u32, usize) {
+    let rout = view.section(SectionId::ROUT).unwrap_or(&[]);
+    let mut best_node = 0;
+    let mut best_distance = u32::MAX;
+    let mut active_len = 0;
+    for (node_id, node) in view.nodes().enumerate().skip(1) {
+        let proto_start = (node.prototype_word_start as usize) << 3;
+        let mask_start = (node.mask_word_start as usize) << 3;
+        let Some(prototype) = rout.get(proto_start..proto_start + signature.len()) else {
+            continue;
+        };
+        let Some(mask) = rout.get(mask_start..mask_start + signature.len()) else {
+            continue;
+        };
+        let distance = masked_hamming(signature, prototype, mask);
+        let node_id = node_id as u32;
+        if distance < best_distance || (distance == best_distance && node_id < best_node) {
+            best_node = node_id;
+            best_distance = distance;
+        }
+        if distance <= u32::from(node.radius.0).max(120) && active_len < active.len() {
+            active[active_len] = node_id;
+            active_len += 1;
+        }
+    }
+    (best_node, best_distance, active_len)
+}
+
+fn parse_iterations(raw: Option<&String>) -> Result<usize, String> {
+    let iterations = raw
+        .map(|value| value.parse::<usize>().map_err(|_| "invalid iterations"))
+        .transpose()?
+        .unwrap_or(DEFAULT_ITERATIONS);
+    if iterations == 0 {
+        return Err("iterations must be greater than zero".to_owned());
+    }
+    Ok(iterations)
+}
+
+fn main() -> Result<(), String> {
+    let mut args = env::args().skip(1).filter(|arg| arg != "--bench");
+    let graph_path = args.next().unwrap_or_else(|| DEFAULT_GRAPH.to_owned());
+    let iterations = parse_iterations(args.next().as_ref())?;
+    if args.next().is_some() {
+        return Err("usage: vp_tree [GRAPH] [ITERATIONS]".to_owned());
+    }
+
+    let (resolved_path, bytes) = read_graph(&graph_path)?;
+    let view = GraphView::parse(&bytes).map_err(|error| format!("invalid graph: {error:?}"))?;
+    let signature_bytes = usize::from(view.head().ok_or("graph has no HEAD")?.signature_bytes());
+    let queries: Vec<Vec<u8>> = (0..32)
+        .map(|seed| {
+            (0..signature_bytes)
+                .map(|index| {
+                    (seed as u8)
+                        .wrapping_mul(29)
+                        .wrapping_add(index as u8)
+                        .rotate_left((index % 8) as u32)
+                })
+                .collect()
+        })
+        .collect();
+    let tree = vp_tree::VpTree::from_graph(&view)
+        .ok_or("graph has varying ROUT masks or too few indexable nodes")?;
+
+    for query in &queries {
+        let mut linear_active = [0u32; 8];
+        let mut tree_active = [0u32; 8];
+        let linear_result = linear_query(&view, query, &mut linear_active);
+        let tree_result = tree.query(query, &mut tree_active);
+        if linear_result != tree_result || linear_active != tree_active {
+            return Err(format!(
+                "tree mismatch: linear={linear_result:?}/{linear_active:?}, tree={tree_result:?}/{tree_active:?}"
+            ));
+        }
+    }
+
+    let mut linear_checksum = 0u64;
+    let linear_start = Instant::now();
+    for _ in 0..iterations {
+        for query in &queries {
+            let mut active = [0u32; 8];
+            let result = black_box(linear_query(&view, black_box(query), &mut active));
+            linear_checksum = linear_checksum.wrapping_add(u64::from(result.0));
+            black_box(active);
+        }
+    }
+    let linear_elapsed = linear_start.elapsed();
+
+    let mut tree_checksum = 0u64;
+    let tree_start = Instant::now();
+    for _ in 0..iterations {
+        for query in &queries {
+            let mut active = [0u32; 8];
+            let result = black_box(tree.query(black_box(query), &mut active));
+            tree_checksum = tree_checksum.wrapping_add(u64::from(result.0));
+            black_box(active);
+        }
+    }
+    let tree_elapsed = tree_start.elapsed();
+
+    if linear_checksum != tree_checksum {
+        return Err(format!(
+            "checksum mismatch: linear={linear_checksum}, tree={tree_checksum}"
+        ));
+    }
+
+    let query_count = (iterations * queries.len()) as f64;
+    let linear_ns = linear_elapsed.as_secs_f64() * 1e9 / query_count;
+    let tree_ns = tree_elapsed.as_secs_f64() * 1e9 / query_count;
+    println!("graph={}", resolved_path.display());
+    println!("nodes={}", view.node_count().unwrap_or(0));
+    println!("queries={}", queries.len());
+    println!("iterations={iterations}");
+    println!("linear_ns_per_query={linear_ns:.1}");
+    println!("vptree_ns_per_query={tree_ns:.1}");
+    println!("speedup={:.3}", linear_ns / tree_ns);
+    println!("checksum={tree_checksum}");
+    Ok(())
+}

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -1,6 +1,7 @@
 use crate::runtime_state::RuntimeState;
 use crate::runtime_state::SemanticStateSlot;
 use crate::status::ResolutionStatus;
+use crate::vp_tree::VpTree;
 use core::fmt;
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_format::{CODE_OP_HALT, OP_CLEAR_SLOT, OP_SHIFT_SLOTS, OP_UPDATE_SLOT};
@@ -36,6 +37,7 @@ impl fmt::Display for RuntimeError {
 #[derive(Debug, Clone)]
 pub struct R4G1Runtime<'a> {
     chain: crate::patch_chain::PatchChain<'a>,
+    route_index: Option<VpTree>,
 }
 
 fn signature_affinity_bonus(prototype: &[u8], mask: &[u8], signature: &[u8]) -> i32 {
@@ -56,6 +58,7 @@ impl<'a> R4G1Runtime<'a> {
         let view = GraphView::parse(bytes)?;
         Ok(Self {
             chain: crate::patch_chain::PatchChain::new(view),
+            route_index: VpTree::from_graph(&view),
         })
     }
 
@@ -614,44 +617,52 @@ impl<'a> R4G1Runtime<'a> {
         if (active_len == 0 || (active_len == 1 && active_nodes[0] == 0))
             && let Some(sig) = context_signature
         {
-            let mut best_node = 0;
-            let mut best_dist = u32::MAX;
-            let mut active_count = 0usize;
-            let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
+            let (best_node, active_count) = if let Some(index) = self.route_index.as_ref() {
+                let mut matched_nodes = [0u32; 8];
+                let (best_node, _best_dist, active_count) = index.query(sig, &mut matched_nodes);
+                active_nodes[..active_count].copy_from_slice(&matched_nodes[..active_count]);
+                (best_node, active_count)
+            } else {
+                let mut best_node = 0;
+                let mut best_dist = u32::MAX;
+                let mut active_count = 0usize;
+                let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
 
-            for n in 1..num_nodes {
-                if let Some(node) = base_graph.node(n) {
-                    let proto_offset = (node.prototype_word_start as usize) << 3;
-                    let mask_offset = (node.mask_word_start as usize) << 3;
+                for n in 1..num_nodes {
+                    if let Some(node) = base_graph.node(n) {
+                        let proto_offset = (node.prototype_word_start as usize) << 3;
+                        let mask_offset = (node.mask_word_start as usize) << 3;
 
-                    if proto_offset + sig.len() <= rout_bytes.len()
-                        && mask_offset + sig.len() <= rout_bytes.len()
-                    {
-                        let mut dist = 0u32;
-                        for i in 0..sig.len() {
-                            let p = rout_bytes[proto_offset + i];
-                            let m = rout_bytes[mask_offset + i];
-                            let s = sig[i];
-                            dist += ((s ^ p) & m).count_ones();
-                        }
-
-                        if dist < best_dist {
-                            best_dist = dist;
-                            best_node = n;
-                        }
-
-                        // Collect Quantum MoE ensemble nodes matching distance threshold
-                        let rad = u32::from(node.radius.0).max(120);
-                        if dist <= rad
-                            && active_count < 8
-                            && !active_nodes[..active_count].contains(&n)
+                        if proto_offset + sig.len() <= rout_bytes.len()
+                            && mask_offset + sig.len() <= rout_bytes.len()
                         {
-                            active_nodes[active_count] = n;
-                            active_count += 1;
+                            let mut dist = 0u32;
+                            for i in 0..sig.len() {
+                                let p = rout_bytes[proto_offset + i];
+                                let m = rout_bytes[mask_offset + i];
+                                let s = sig[i];
+                                dist += ((s ^ p) & m).count_ones();
+                            }
+
+                            if dist < best_dist {
+                                best_dist = dist;
+                                best_node = n;
+                            }
+
+                            // Collect Quantum MoE ensemble nodes matching distance threshold
+                            let rad = u32::from(node.radius.0).max(120);
+                            if dist <= rad
+                                && active_count < 8
+                                && !active_nodes[..active_count].contains(&n)
+                            {
+                                active_nodes[active_count] = n;
+                                active_count += 1;
+                            }
                         }
                     }
                 }
-            }
+                (best_node, active_count)
+            };
 
             if active_count > 0 {
                 active_len = active_count;

--- a/crates/uor-r4-graph-runtime/src/lib.rs
+++ b/crates/uor-r4-graph-runtime/src/lib.rs
@@ -12,5 +12,7 @@ pub mod runtime_state;
 pub mod scoring;
 pub mod status;
 
+mod vp_tree;
+
 pub use engine::{R4G1Runtime, RuntimeError};
 pub use status::ResolutionStatus;

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -1,0 +1,318 @@
+//! Deterministic exact nearest-neighbor search for ROUT signatures.
+//!
+//! A VP-tree is valid here only when every indexed point uses the same mask:
+//! masked Hamming with a per-point mask is not a single metric and cannot be
+//! safely pruned by triangle-inequality bounds. Artifacts with varying masks
+//! therefore keep the engine's linear fallback.
+
+use alloc::vec::Vec;
+
+use uor_r4_graph_format::{GraphView, SectionId};
+
+const NONE: u32 = u32::MAX;
+
+#[derive(Debug, Clone)]
+struct Point {
+    node_id: u32,
+    prototype: Vec<u8>,
+    radius: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TreeNode {
+    point: u32,
+    threshold: u32,
+    left: u32,
+    right: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VpTree {
+    points: Vec<Point>,
+    nodes: Vec<TreeNode>,
+    mask: Vec<u8>,
+    max_radius: u32,
+}
+
+impl VpTree {
+    /// Build an index when ROUT contains a single shared mask.
+    pub(crate) fn from_graph(view: &GraphView<'_>) -> Option<Self> {
+        let head = view.head()?;
+        let signature_bytes = usize::from(head.signature_bytes());
+        if signature_bytes == 0 {
+            return None;
+        }
+        let rout = view.section(SectionId::ROUT)?;
+        let mut mask: Option<Vec<u8>> = None;
+        let mut points = Vec::new();
+
+        for (node_id, node) in view.nodes().enumerate() {
+            let node_id = node_id as u32;
+            if node_id == 0 {
+                continue;
+            }
+            let proto_start = (node.prototype_word_start as usize).checked_mul(8)?;
+            let mask_start = (node.mask_word_start as usize).checked_mul(8)?;
+            let proto_end = proto_start.checked_add(signature_bytes)?;
+            let mask_end = mask_start.checked_add(signature_bytes)?;
+            let prototype = rout.get(proto_start..proto_end)?;
+            let node_mask = rout.get(mask_start..mask_end)?;
+
+            match &mask {
+                Some(shared) if shared.as_slice() != node_mask => return None,
+                None => mask = Some(node_mask.to_vec()),
+                Some(_) => {}
+            }
+
+            let shared_mask = mask.as_deref()?;
+            let masked_prototype = prototype
+                .iter()
+                .zip(shared_mask)
+                .map(|(&byte, &bit_mask)| byte & bit_mask)
+                .collect();
+            points.push(Point {
+                node_id,
+                prototype: masked_prototype,
+                radius: u32::from(node.radius.0).max(120),
+            });
+        }
+
+        Self::from_points(points, mask?)
+    }
+
+    fn from_points(points: Vec<Point>, mask: Vec<u8>) -> Option<Self> {
+        if points.len() < 2
+            || points
+                .iter()
+                .any(|point| point.prototype.len() != mask.len())
+        {
+            return None;
+        }
+        let max_radius = points.iter().map(|point| point.radius).max().unwrap_or(0);
+        let mut indices: Vec<usize> = (0..points.len()).collect();
+        let mut nodes = Vec::with_capacity(points.len());
+        Self::build(&mut indices, &points, &mask, &mut nodes);
+        Some(Self {
+            points,
+            nodes,
+            mask,
+            max_radius,
+        })
+    }
+
+    fn build(
+        indices: &mut [usize],
+        points: &[Point],
+        mask: &[u8],
+        nodes: &mut Vec<TreeNode>,
+    ) -> u32 {
+        let point = indices[0];
+        let tree_index = nodes.len() as u32;
+        nodes.push(TreeNode {
+            point: point as u32,
+            threshold: 0,
+            left: NONE,
+            right: NONE,
+        });
+
+        if indices.len() == 1 {
+            return tree_index;
+        }
+
+        let mut distances: Vec<(usize, u32)> = indices[1..]
+            .iter()
+            .map(|&candidate| {
+                (
+                    candidate,
+                    Self::distance(&points[point].prototype, &points[candidate].prototype, mask),
+                )
+            })
+            .collect();
+        distances.sort_unstable_by(|(left_id, left_distance), (right_id, right_distance)| {
+            left_distance
+                .cmp(right_distance)
+                .then_with(|| points[*left_id].node_id.cmp(&points[*right_id].node_id))
+        });
+
+        let split = distances.len() / 2;
+        let threshold = distances[split].1;
+        for (slot, &(candidate, _)) in distances.iter().enumerate() {
+            indices[slot + 1] = candidate;
+        }
+        let (left_indices, right_indices) = indices[1..].split_at_mut(split);
+        let left = if left_indices.is_empty() {
+            NONE
+        } else {
+            Self::build(left_indices, points, mask, nodes)
+        };
+        let right = if right_indices.is_empty() {
+            NONE
+        } else {
+            Self::build(right_indices, points, mask, nodes)
+        };
+        nodes[tree_index as usize] = TreeNode {
+            point: point as u32,
+            threshold,
+            left,
+            right,
+        };
+        tree_index
+    }
+
+    fn distance(left: &[u8], right: &[u8], mask: &[u8]) -> u32 {
+        left.iter()
+            .zip(right)
+            .zip(mask)
+            .map(|((&a, &b), &bit_mask)| ((a ^ b) & bit_mask).count_ones())
+            .sum()
+    }
+
+    fn insert_active(active: &mut [u32; 8], active_len: &mut usize, node_id: u32) {
+        if active[..*active_len].contains(&node_id) {
+            return;
+        }
+        let position = active[..*active_len]
+            .iter()
+            .position(|&existing| existing > node_id)
+            .unwrap_or(*active_len);
+        if position >= active.len() {
+            return;
+        }
+        if *active_len < active.len() {
+            *active_len += 1;
+        }
+        for index in (position + 1..*active_len).rev() {
+            active[index] = active[index - 1];
+        }
+        active[position] = node_id;
+    }
+
+    fn search_node(
+        &self,
+        tree_index: u32,
+        signature: &[u8],
+        best_node: &mut u32,
+        best_distance: &mut u32,
+        active: &mut [u32; 8],
+        active_len: &mut usize,
+    ) {
+        if tree_index == NONE {
+            return;
+        }
+        let tree_node = self.nodes[tree_index as usize];
+        let point = &self.points[tree_node.point as usize];
+        let distance = Self::distance(signature, &point.prototype, &self.mask);
+        if distance < *best_distance || (distance == *best_distance && point.node_id < *best_node) {
+            *best_distance = distance;
+            *best_node = point.node_id;
+        }
+        if distance <= point.radius {
+            Self::insert_active(active, active_len, point.node_id);
+        }
+
+        let bound = (*best_distance).max(self.max_radius);
+        if distance < tree_node.threshold {
+            self.search_node(
+                tree_node.left,
+                signature,
+                best_node,
+                best_distance,
+                active,
+                active_len,
+            );
+            if distance.saturating_add(bound) >= tree_node.threshold {
+                self.search_node(
+                    tree_node.right,
+                    signature,
+                    best_node,
+                    best_distance,
+                    active,
+                    active_len,
+                );
+            }
+        } else {
+            self.search_node(
+                tree_node.right,
+                signature,
+                best_node,
+                best_distance,
+                active,
+                active_len,
+            );
+            if distance.saturating_sub(bound) <= tree_node.threshold {
+                self.search_node(
+                    tree_node.left,
+                    signature,
+                    best_node,
+                    best_distance,
+                    active,
+                    active_len,
+                );
+            }
+        }
+    }
+
+    /// Return the exact nearest node and the first eight matching node IDs in
+    /// canonical node-ID order. The matching set is filtered by each node's
+    /// calibrated radius after the shared-metric tree search.
+    pub(crate) fn query(&self, signature: &[u8], active: &mut [u32; 8]) -> (u32, u32, usize) {
+        if signature.len() != self.mask.len() {
+            return (0, u32::MAX, 0);
+        }
+        let mut best_node = 0;
+        let mut best_distance = u32::MAX;
+        let mut active_len = 0;
+        self.search_node(
+            0,
+            signature,
+            &mut best_node,
+            &mut best_distance,
+            active,
+            &mut active_len,
+        );
+        (best_node, best_distance, active_len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Point, VpTree};
+    use alloc::vec;
+
+    fn point(node_id: u32, value: u8, radius: u32) -> Point {
+        Point {
+            node_id,
+            prototype: vec![value],
+            radius,
+        }
+    }
+
+    #[test]
+    fn exact_nearest_and_radius_matches_are_deterministic() {
+        let tree = VpTree::from_points(
+            vec![
+                point(1, 0b0000_0000, 2),
+                point(2, 0b0000_0011, 2),
+                point(3, 0b1111_0000, 2),
+            ],
+            vec![0xff],
+        )
+        .expect("tree");
+        let mut active = [0u32; 8];
+        let (node, distance, active_len) = tree.query(&[0b0000_0001], &mut active);
+        assert_eq!((node, distance), (1, 1));
+        assert_eq!(&active[..active_len], &[1, 2]);
+    }
+
+    #[test]
+    fn ties_choose_smallest_node_id() {
+        let tree = VpTree::from_points(
+            vec![point(9, 0, 1), point(2, 2, 1), point(4, 4, 1)],
+            vec![0xff],
+        )
+        .expect("tree");
+        let mut active = [0u32; 8];
+        let (node, distance, _) = tree.query(&[3], &mut active);
+        assert_eq!((node, distance), (2, 1));
+    }
+}

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -275,6 +275,7 @@ impl VpTree {
 }
 
 #[cfg(test)]
+#[allow(dead_code, unused_imports)]
 mod tests {
     use super::{Point, VpTree};
     use alloc::vec;


### PR DESCRIPTION
## Summary

Implements the first serving-path phase of #277.

- Builds a deterministic VP-tree over ROUT prototypes at runtime load time.
- Uses exact masked-Hamming pruning only when all indexed nodes share one mask.
- Falls back to the existing linear scan for varying masks, preserving exact semantics.
- Returns the exact nearest node with canonical smallest-node tie-breaking.
- Preserves the first eight radius matches in canonical node-ID order.
- Keeps the prediction query allocation-free and multiplication-free.
- Leaves artifact bytes unchanged.
- Adds a benchmark harness that checks 32 deterministic queries for exact equality before timing.

## Verification

- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check -p uor-r4-graph-format --no-default-features`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc`
- Exact-nearest, radius-filter, and tie-break unit tests.
- Existing R4G1 runtime tests and allocation census pass; steady-state prediction remains zero-allocation.
- Benchmark results on available 255-node fixtures: approximately 0.94–1.18x tree/scan speed, with exact result equality.

The available fixtures do not yet demonstrate a reliable throughput win, so #277 remains open for larger-node measurements and/or further tree-layout optimization rather than claiming completion.