### PR TITLE
measure: record Phase C TLA7 adoption evidence (#335)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -122,8 +122,15 @@ pub fn corpus_paths() -> (&'static str, &'static str) {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_corpus() -> Option<Corpus> {
-    let (mp, rp) = corpus_paths();
-    load_corpus_from(mp, rp)
+    // Keep the historical defaults for normal certification, but allow
+    // re-pin measurements to point at an explicitly preserved corpus. This
+    // avoids replacing the checked-in era fixtures before their κ set has
+    // been reviewed. The override is compiler/test tooling only; deployed
+    // runtime code never loads a corpus.
+    let (default_meta, default_recs) = corpus_paths();
+    let meta = std::env::var("R4_CORPUS_META").unwrap_or_else(|_| default_meta.to_owned());
+    let recs = std::env::var("R4_CORPUS_RECS").unwrap_or_else(|_| default_recs.to_owned());
+    load_corpus_from(&meta, &recs)
 }
 
 /// Load a corpus record stream from explicit paths (fixtures, mirrors).

--- a/crates/uor-r4-core/tests/kappa_reproduction.rs
+++ b/crates/uor-r4-core/tests/kappa_reproduction.rs
@@ -125,11 +125,13 @@ fn kappa_reproduction() {
 /// baseline JSON (asserted fields) on stdout. Use when the compiler is
 /// intentionally redesigned and the pins must move:
 ///
+///   R4_CORPUS_META=/path/c_meta.bin R4_CORPUS_RECS=/path/c_recs.bin \
 ///   cargo test -p uor-r4-core --release --test kappa_reproduction -- \
 ///     --ignored --nocapture dump_baseline_kappa > /tmp/new_baseline.json
 ///
-/// then review the diff against tests/fixtures/baseline_kappa.json before
-/// adopting (a maintainer decision, never automatic).
+/// The corpus variables are optional and default to /tmp/c_meta.bin and
+/// /tmp/c_recs.bin. Review the diff against tests/fixtures/baseline_kappa.json
+/// before adopting (a maintainer decision, never automatic).
 #[test]
 #[ignore]
 fn dump_baseline_kappa() {

--- a/crates/uor-r4-graph-certify/src/certify.rs
+++ b/crates/uor-r4-graph-certify/src/certify.rs
@@ -312,6 +312,27 @@ pub fn certify(oracle: &dyn TeacherOracle) {
     let art = compiler::compile(oracle, &c);
     compiler::save_artifacts(&art);
 
+    if std::env::var("R4_CERTIFY_PHASE_C_ONLY").is_ok_and(|value| value != "0") {
+        let bundles = build_bundles_parallel(&art, &compiler::derive_rotations(), &c);
+        let centered: Vec<[f32; D]> = bundles
+            .iter()
+            .map(|b| std::array::from_fn(|d| (b[d] - art.thresholds[d]) as f32))
+            .collect();
+        let mut ratios: Vec<f32> = (0..c.n)
+            .step_by(8)
+            .filter(|&i| c.story[i] < (c.stories as f64 * 0.8) as u32)
+            .map(|i| {
+                let l1: f32 = centered[i].iter().map(|x| x.abs()).sum();
+                let l2: f32 = centered[i].iter().map(|x| x * x).sum::<f32>().sqrt();
+                (l1 / l2.max(1e-9)).log2()
+            })
+            .collect();
+        ratios.sort_by(|a, b| a.partial_cmp(b).expect("finite norm-fold ratio"));
+        let norm_const = ratios[ratios.len() / 2].round();
+        certify_phase_c_norm_fold_rows(&c, &art, &centered, norm_const);
+        return;
+    }
+
     // ---- store, by the runtime's own path (key identity by construction)
     let (store, codes) = build_store(&art, &c);
     println!(
@@ -351,6 +372,39 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         "equality witness: bundles, codes, predictions — kernel path == plain path on {}/{} sampled positions",
         sample_n, sample_n
     );
+
+    // TLA7 is the persisted form of the residual-wired path. Repeat the
+    // bundle/code witness after serialization so the certificate covers the
+    // actual era-tagged bytes, not only the in-memory compiler result.
+    let container = compiler::artifact_bytes(&art);
+    if container.starts_with(b"TLA7") {
+        let parsed = compiler::parse_artifacts(&container).expect("TLA7 container round-trips");
+        assert!(!parsed.resid_cb.is_empty(), "TLA7 carries residual copies");
+        assert_eq!(parsed.resid_cb, art.resid_cb);
+        assert_eq!(parsed.resid_scale_shifts, art.resid_scale_shifts);
+        assert_eq!(parsed.norm_fold_const, art.norm_fold_const);
+        let mut parsed_rt = Runtime::new(&parsed);
+        let parsed_rot = parsed_rt.rot;
+        for s in 0..sample_n {
+            let i = s * stride;
+            let bundle_kernel_value =
+                bundle_kernel(&mut parsed_rt.kernel, &parsed, &parsed_rot, &c, i);
+            let bundle_plain_value = bundle_plain(&parsed, &parsed_rot, &c, i);
+            assert_eq!(
+                bundle_kernel_value, bundle_plain_value,
+                "TLA7 bundle kernel/plain divergence at {i}"
+            );
+            assert_eq!(
+                parsed_rt.assign(&c, i),
+                code_plain(&parsed, &parsed_rot, &c, i),
+                "TLA7 code kernel/plain divergence at {i}"
+            );
+        }
+        println!(
+            "TLA7 persisted witness: container {} bytes, bundle/code equality on {}/{} sampled positions",
+            container.len(), sample_n, sample_n
+        );
+    }
     let k = &rt.kernel;
     println!(
         "per-token op census (kernel path, n={}): add {:.0} | xor {:.0} | shift {:.0} | compare {:.0} | table-read {:.0} | multiply 0 (no such operation exists in the kernel)",
@@ -913,11 +967,13 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         let scale = (-s).exp2();
         (0..D).map(|d| centered[i][d] * scale).collect()
     };
-    {
+    let measure_norm_fold_row = |label: &str,
+                                 description: &str,
+                                 fold: &dyn Fn(usize) -> Vec<f32>| {
         let quantized = quantize(1);
         let codes_nf: Vec<[u8; STAGES]> = (0..c.n)
             .map(|i| {
-                let mut work = norm_fold(i);
+                let mut work = fold(i);
                 let mut code = [0u8; STAGES];
                 for (st, cb) in quantized.iter().enumerate() {
                     let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
@@ -943,10 +999,38 @@ pub fn certify(oracle: &dyn TeacherOracle) {
         let st_row = build_store_generic(&c, STAGES, &|i, d| codes_nf[i][..d].to_vec());
         let m = eval(&c, &st_row, STAGES, &|i, d| codes_nf[i][..d].to_vec());
         println!(
-            "A-dot-po2-nf-resid (#318 Phase A.5: po2 norm fold [L1 bit-length, CONST {norm_const}], 1-term tables): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
-            m.top1, m.agree, m.wb_bits, m.keys
-        );
-    }
+                "{label} ({description}): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+                m.top1, m.agree, m.wb_bits, m.keys
+            );
+    };
+    measure_norm_fold_row(
+        "A-dot-po2-nf-resid",
+        &format!(
+            "#318 Phase A.5: po2 norm fold [L1 bit-length, CONST {norm_const}], 1-term tables"
+        ),
+        &norm_fold,
+    );
+
+    // Phase C candidate: retain one extra L1 mantissa bit by applying the
+    // legal 1.5x shift-add scale when the normalized mantissa is >= 1.5.
+    // This is certifier-side f32 emulation of the integer rule; the runtime
+    // implementation, if adopted, would use shifts/adds only.
+    let mantissa_fold = |i: usize| {
+        let l1: f32 = centered[i].iter().map(|x| x.abs()).sum::<f32>().max(1e-9);
+        let exponent = l1.log2().floor();
+        let coarse_s = exponent + 1.0 - norm_const;
+        let mantissa = l1 / exponent.exp2();
+        let mantissa_scale = if mantissa >= 1.5 { 1.5 } else { 1.0 };
+        let scale = mantissa_scale * (-coarse_s).exp2();
+        (0..D).map(|d| centered[i][d] * scale).collect()
+    };
+    measure_norm_fold_row(
+        "A-dot-po2-mf-resid",
+        &format!(
+            "#335 Phase C: po2 norm fold + one mantissa bit [1.5x threshold, CONST {norm_const}], 1-term tables"
+        ),
+        &mantissa_fold,
+    );
     // (b) integer centroid-copy widths — assignment against 1-term po2
     // tables (shipped), residual subtraction with DEQUANTIZED per-stage
     // integer copies at a power-of-two stage scale (token stage-book
@@ -1289,6 +1373,112 @@ pub fn certify(oracle: &dyn TeacherOracle) {
     );
 
     crate::long_context::certify_long_context();
+}
+
+/// Narrow Phase C measurement mode for #335. It keeps the historical full
+/// matrix untouched while making the mantissa-fold experiment cheap enough to
+/// rerun at the 500k pinned corpus scale.
+fn build_bundles_parallel(
+    art: &compiler::Compiled,
+    rot: &[usize; WINDOW + 1],
+    c: &compiler::Corpus,
+) -> Vec<[i64; D]> {
+    let threads = std::thread::available_parallelism()
+        .map(|count| count.get().min(8))
+        .unwrap_or(1);
+    let chunk = c.n.div_ceil(threads.max(1));
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..c.n)
+            .step_by(chunk.max(1))
+            .map(|start| {
+                let end = (start + chunk).min(c.n);
+                scope.spawn(move || {
+                    (start..end)
+                        .map(|i| bundle_plain(art, rot, c, i))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("bundle worker completed"))
+            .collect()
+    })
+}
+
+fn certify_phase_c_norm_fold_rows(
+    c: &compiler::Corpus,
+    art: &compiler::Compiled,
+    centered: &[[f32; D]],
+    norm_const: f32,
+) {
+    let po2 = |x: f32| -> f32 {
+        if x == 0.0 || !x.is_finite() {
+            return 0.0;
+        }
+        let s = x.abs().log2().round();
+        x.signum() * s.exp2()
+    };
+    let quantized: Vec<Vec<f32>> = art
+        .ctx_cb
+        .iter()
+        .map(|cb| cb.iter().map(|&cv| po2(cv)).collect())
+        .collect();
+
+    for (label, mantissa_refinement) in
+        [("A-dot-po2-nf-resid", false), ("A-dot-po2-mf-resid", true)]
+    {
+        let codes: Vec<[u8; STAGES]> = (0..c.n)
+            .map(|i| {
+                let l1: f32 = centered[i].iter().map(|x| x.abs()).sum::<f32>().max(1e-9);
+                let exponent = l1.log2().floor();
+                let coarse_s = exponent + 1.0 - norm_const;
+                let mantissa = l1 / exponent.exp2();
+                let factor = if mantissa_refinement && mantissa >= 1.5 {
+                    1.5
+                } else {
+                    1.0
+                };
+                let scale = factor * (-coarse_s).exp2();
+                let mut work: Vec<f32> = centered[i].iter().map(|&x| x * scale).collect();
+                let mut code = [0u8; STAGES];
+                for (st, cb) in quantized.iter().enumerate() {
+                    let (mut best, mut bk) = (f32::NEG_INFINITY, 0usize);
+                    for kk in 0..K {
+                        let cent = &cb[kk * D..(kk + 1) * D];
+                        let mut dp = 0f32;
+                        for j in 0..D {
+                            dp += work[j] * cent[j];
+                        }
+                        if dp > best {
+                            best = dp;
+                            bk = kk;
+                        }
+                    }
+                    code[st] = bk as u8;
+                    for j in 0..D {
+                        work[j] -= cb[bk * D + j];
+                    }
+                }
+                code
+            })
+            .collect();
+        let store = build_store_generic(c, STAGES, &|i, d| codes[i][..d].to_vec());
+        let metrics = eval(c, &store, STAGES, &|i, d| codes[i][..d].to_vec());
+        let description = if mantissa_refinement {
+            format!(
+                "#335 Phase C: po2 norm fold + one mantissa bit [1.5x threshold, CONST {norm_const}], 1-term tables"
+            )
+        } else {
+            format!(
+                "#318 Phase A.5: po2 norm fold [L1 bit-length, CONST {norm_const}], 1-term tables"
+            )
+        };
+        println!(
+            "{label} ({description}): top1 {:.1}% | agreement {:.1}% | WB {:.4} bits/token | {} keys",
+            metrics.top1, metrics.agree, metrics.wb_bits, metrics.keys
+        );
+    }
 }
 
 fn build_store_generic(

--- a/docs/dot_residual_phase_b_design.md
+++ b/docs/dot_residual_phase_b_design.md
@@ -73,6 +73,36 @@ harness (the same discipline that settled A-single vs A-multi):
   recorded result and the ceiling is declared reached for this
   architecture (teacher upgrade, issue #320, remains).
 
+### Phase C adoption evidence — 500k/TLA7 era (2026-08-01)
+
+The full certifier matrix was rerun against the pinned 500,000-token corpus
+(100,306 held-out positions, TLA7 container κ `blake3:ef6a20f3…`). The
+single-key store with query-time beam remains the selected shape:
+
+| Shape | top-1 | agreement | WB bits/token | keys |
+|---|---:|---:|---:|---:|
+| shipped single-key + query-beam | 34.7% | 39.0% | 8.0249 | 179,068 |
+| write-time fan-out (A-multi) | 20.3% | 22.7% | 8.1473 | 817,683 |
+| i8 residual copies (cpy8) | 35.3% | 39.6% | 8.5247 | 195,650 |
+| i16 residual copies (cpy16) | 35.3% | 39.5% | 8.5205 | 196,220 |
+
+The i8 and i16 rows are fidelity-equivalent at this precision; i8 is the
+adopted width because it is smaller and already witnessed in TLA7. A-multi is
+rejected: it adds 4.6× as many keys while losing 14.4 percentage points of
+top-1 accuracy.
+
+The Phase C mantissa-bit candidate was also run with the train-derived
+constant (CONST 4, excluding the 20-bit fixed-point fraction):
+
+| Norm fold | top-1 | agreement | WB bits/token | keys |
+|---|---:|---:|---:|---:|
+| coarse power-of-two | 34.6% | 38.8% | 8.4241 | 167,799 |
+| + one 1.5× mantissa bit | 34.6% | 38.9% | 8.3097 | 162,119 |
+
+This is a useful WB/key-shape improvement but no top-1 improvement, so the
+mantissa refinement is recorded as an empirical candidate and is not enabled
+in the deployed runtime.
+
 ## Reproduction requirement (before any kernel code)
 
 Per repo discipline (#244 precedent): the #318 rows must reproduce
@@ -88,7 +118,40 @@ before Phase B implementation is authorized. One run is on record.
   the format-era bump; P-4 scan extension; equality-witness against the
   plain form; op-census budget ⚑ ≤ 2× current dot-path counts.
 - **Phase C (adoption):** store-shape decision on the #244 harness;
-  κ re-pin with era notes (maintainer decision); BASELINE.md update.
+  κ re-pin with era notes (maintainer decision); BASELINE.md update; record
+  the mantissa-bit row and the TLA7 persisted witness.
+
+## Phase C result (500k/TLA7 era)
+
+Measured 2026-08-01 on the pinned 500,000-token corpus (2,507 stories;
+100,306 held-out positions), with the TLA7 artifact from the #327 re-pin
+(`blake3:ef6a20f3…`, 1,346,836 bytes). The shipped row is the comparison
+point:
+
+| Row | top-1 | agreement | WB bits | keys |
+|---|---:|---:|---:|---:|
+| A, shipped single-key + query-beam | 34.7% | 39.0% | 8.0249 | 179,068 |
+| A-dot-po2-resid | 35.1% | 39.4% | 8.4462 | 178,997 |
+| A-dot-po2-resid-cpy8 | 35.3% | 39.6% | 8.5247 | 195,650 |
+| A-dot-po2-resid-cpy16 | 35.3% | 39.5% | 8.5205 | 196,220 |
+| A-dot-po2-nf-resid | 34.6% | 38.8% | 8.4241 | 167,799 |
+| A-dot-po2-mf-resid | 34.6% | 38.9% | 8.3097 | 162,119 |
+
+The cpy8 row retains the residual quality gain, but its +0.4998 WB
+regression exceeds the Phase B bound of +0.3 bits/token. The mantissa-bit
+fold lowers the coarse norm-fold regression to +0.2848 bits/token and slightly
+improves agreement over the coarse fold, but it does not retain the shipped
+row's quality, so it does not clear the adoption criterion either. cpy16 is
+not preferred: it is larger, has one more key, and is fractionally worse on
+agreement than cpy8.
+
+**Decision:** keep the shipped single-key/query-beam store shape and record
+the residual rows as a measured quality-versus-dispersion trade-off. Do not
+change the membership beam or widen centroid copies on this era. The TLA7
+runtime path remains witnessed and deployed; this decision concerns the
+certifier-side store shape only. The narrow rerun command is
+`R4_CERTIFY_PHASE_C_ONLY=1` with `R4_CORPUS_META`/`R4_CORPUS_RECS` set to the
+preserved 500k corpus paths.
 
 ## Explicit non-goals
 

--- a/docs/transformerless/BASELINE.md
+++ b/docs/transformerless/BASELINE.md
@@ -59,6 +59,8 @@ formally committed. Full text: plan §2.
 | **teacher-argmax agreement (500k era)** | **39.0%** | fresh, 2026-08-01 | same |
 | **bits/token WB (500k era)** | **8.0249** (teacher floor 1.4260, ceiling 70.5%) | fresh, 2026-08-01 | same |
 | **store keys (500k era)** | **179,068** | fresh, 2026-08-01 | same |
+| **TLA7 cpy8 residual row (500k era)** | **35.3% / 39.6% / 8.5247 WB / 195,650 keys** | fresh, 2026-08-01 | #335 Phase C rows; certifier log |
+| **TLA7 mantissa-fold candidate (500k era)** | **34.6% / 38.9% / 8.3097 WB / 162,119 keys** | fresh, not adopted | #335 Phase C rows; no top-1 gain |
 | HF-path evaluation tooling | exists | landed | PR #41 (`evaluate-report`); issue #34 closed |
 | **Gate C harness (Phase 4)** | TLA3 store baseline 31.7% / 11.88 bits-token | fresh, 2026-07-22 | `r4 transformerless score`, fixture corpus, 30,036 held-out positions — reproduces the P2 agreement anchor; bits/token is the canonical cross-entropy definition (GLOSSARY.md), scorer+ds named |
 | **Gate C: graph formula v1 (Σ-over-cloud)** | **0.3% / 70.47 bits-token** | fresh, unfavorable | correlated sibling-subtree residual stacking (issue #64, redesign in flight) |
@@ -220,6 +222,15 @@ artifacts (deterministic across runs; debug profile).
   context-codebook, class-signature and container κs moved with the corpus. Fixture
   `c_recs.bin` grew 1.8 MB → 24 MB (12-byte legacy records → 48-byte records with anchors/top-8).
   Full-certificate record: PROOF.md P2 era note; pins: `baseline_kappa.json`.
+
+- **Phase C adoption evidence recorded 2026-08-01** (issue #335): the
+  single-key/query-beam shape remains selected over write-time fan-out
+  (34.7% / 39.0% / 8.0249 WB / 179,068 keys versus 20.3% / 22.7% / 8.1473 /
+  817,683). i8 and i16 residual-copy rows are tied at reported precision;
+  i8 is retained for the smaller artifact. The 1.5× mantissa-bit norm-fold
+  candidate improves WB and key count but does not improve top-1, so it is
+  recorded rather than enabled. The certifier also replays the persisted
+  TLA7 container witness on 512/512 sampled positions.
 
 ## 4. M.V.G. checkpoint targets (D1) — CONFIRMED
 

--- a/docs/transformerless/PROOF.md
+++ b/docs/transformerless/PROOF.md
@@ -159,7 +159,22 @@ the historical record of the original certificate.
 Library witnesses (cargo test): P-1 the popcount table matches its
 definition on all 256 bytes and carries the stratum partition C(8,k);
 P-2 kernel Hamming equals the direct definition with exact op counts;
-P-3 sign signatures agree with the direct definition bit for bit.
+P-3 sign signatures agree with the direct definition bit for bit. The TLA7
+residual-wired path adds a persisted-container witness: after save/parse,
+bundle and code outputs agree between kernel and plain paths on 512/512
+sampled positions; the same witness is independently replayed by
+`kappa_reproduction::tla7_resid_kernel_plain_witness` when the checkpoint is
+present.
+
+**Phase C adoption record (2026-08-01, #335).** On the 500k/TLA7 corpus,
+write-time fan-out measured 20.3% top-1 / 22.7% teacher agreement / 8.1473
+WB bits/token / 817,683 keys versus the selected single-key/query-beam shape
+at 34.7% / 39.0% / 8.0249 / 179,068. The cpy8 and cpy16 rows were 35.3% /
+39.6% / 8.5247 / 195,650 and 35.3% / 39.5% / 8.5205 / 196,220,
+respectively; cpy8 is retained. The one-bit 1.5× mantissa refinement was
+34.6% / 38.9% / 8.3097 / 162,119 against the coarse fold's 34.6% / 38.8% /
+8.4241 / 167,799. It improves distribution shape but not top-1, so it is
+not enabled in the runtime.
 
 ## P4 — The compilation is architecture-generic. (By construction,
 ## type-enforced; instantiated for one family.)


### PR DESCRIPTION
## Summary

Completes the remaining Phase C adoption evidence for #335 after the 500k/TLA7 re-pin in #338.

- Adds compiler/test corpus-path overrides so κ re-pin review can use preserved corpora without replacing default fixtures.
- Adds an explicit persisted TLA7 bundle/code equality witness to the certifier.
- Adds the Phase C mantissa-bit fold row and a narrow `R4_CERTIFY_PHASE_C_ONLY=1` measurement mode.
- Records the 500k store-shape decision: cpy8 improves quality but exceeds the WB regression bound; the mantissa fold stays recorded but is not adopted.

## Evidence

500k/TLA7 rows:

- shipped A: 34.7% / 39.0% / 8.0249 WB / 179,068 keys
- cpy8 residual: 35.3% / 39.6% / 8.5247 WB / 195,650 keys
- mantissa fold: 34.6% / 38.9% / 8.3097 WB / 162,119 keys

The persisted TLA7 witness is 512/512 on the 1,346,836-byte container.

## Verification

- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all -- --check`
- graph-format no_std + alloc checks
- claim-wording gate

Closes #335.