### PR TITLE
fix: canonicalize hierarchical code serialization (#265)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -20,7 +20,7 @@
 //! architecture-generic (llama / qwen / phi differ only in the teacher
 //! adapter). This crate instantiates the llama-family adapter.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
 use uor_r4_model_source::TeacherOracle;
@@ -1657,7 +1657,10 @@ pub fn parse_artifacts(b: &[u8]) -> Option<Compiled> {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct HierarchicalCodes {
-    pub token_type_prefixes: HashMap<String, Vec<u8>>,
+    /// BTreeMap is required here: this JSON is part of the emitted bundle,
+    /// so HashMap iteration order would make canonical artifacts platform- or
+    /// run-dependent even when the compiled codes are identical.
+    pub token_type_prefixes: BTreeMap<String, Vec<u8>>,
     pub relational_prefixes: Vec<Vec<u32>>,
 }
 
@@ -1666,7 +1669,7 @@ pub fn induce_hierarchical_codes(
     vocab: usize,
     corpus: &Corpus,
 ) -> HierarchicalCodes {
-    let mut token_type_prefixes = HashMap::new();
+    let mut token_type_prefixes = BTreeMap::new();
     for token_id in 0..vocab {
         let offset = token_id * STAGES;
         if offset + STAGES <= token_codes.len() {

--- a/crates/uor-r4-core/tests/hierarchical_compiler.rs
+++ b/crates/uor-r4-core/tests/hierarchical_compiler.rs
@@ -44,6 +44,10 @@ fn test_induce_hierarchical_codes() {
 
     let hc = induce_hierarchical_codes(&token_codes, vocab, &corpus);
 
+    let first_json = serde_json::to_vec(&hc).expect("hierarchical codes serialize");
+    let second_json = serde_json::to_vec(&hc).expect("hierarchical codes serialize");
+    assert_eq!(first_json, second_json, "hierarchical JSON is canonical");
+
     // Verify stable type prefixes
     assert_eq!(hc.token_type_prefixes.get("10"), Some(&vec![1, 2, 3, 4]));
 


### PR DESCRIPTION
## Summary

- replace the emitted bundle’s hierarchical-code HashMap with BTreeMap
- add a regression assertion for canonical JSON serialization
- fix the concrete cross-platform mismatch found by PR #342’s merge-group D2 run

## Evidence

PR #342 compiled successfully on both macOS arm64 and Linux x86_64. Its comparison isolated the only output mismatch to `hierarchical_codes.json`; all other source and bundle files matched. The mismatch was caused by HashMap iteration order during JSON serialization.

This follow-up makes that emitted structure ordered, so the D2 differential manifests can compare equal.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p uor-r4-core --test hierarchical_compiler --offline`
- `git diff --check`

Follow-up to #342; refs #265