### PR TITLE
perf: optimize CPU teacher compilation

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -43,6 +43,53 @@ fn canonical_expf(value: f32) -> f32 {
 }
 
 #[inline]
+fn teacher_vector_exp_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        // Accelerate's vForce implementation is CPU vector math.  Use it by
+        // default on macOS for the noncanonical teacher path; the explicit
+        // zero value remains an escape hatch for scalar comparisons.
+        let requested = std::env::var("TLESS_TEACHER_VFORCE_EXP")
+            .map_or(cfg!(target_os = "macos"), |value| value != "0");
+        !canonical_math_enabled() && requested
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "Accelerate", kind = "framework")]
+unsafe extern "C" {
+    fn vvexpf(output: *mut f32, input: *const f32, count: *const i32);
+}
+
+/// Exponentiate a vocabulary-sized logit vector and return its sum.
+///
+/// The macOS path uses Accelerate's CPU vForce implementation in place. It is
+/// disabled for canonical math and can be disabled with
+/// `TLESS_TEACHER_VFORCE_EXP=0`; it is a teacher-side backend, not part of the
+/// κ-pinned deterministic mode.
+#[inline]
+fn teacher_exp_sum(logits: &mut [f32], max_logit: f32) -> f32 {
+    #[cfg(target_os = "macos")]
+    if teacher_vector_exp_enabled() {
+        for logit in logits.iter_mut() {
+            *logit -= max_logit;
+        }
+        let count = logits.len().min(i32::MAX as usize) as i32;
+        // SAFETY: output and input point to the same initialized contiguous
+        // slice, which vForce supports for its unary vector functions.
+        unsafe { vvexpf(logits.as_mut_ptr(), logits.as_ptr(), &count) };
+        return logits.iter().copied().sum();
+    }
+
+    let mut sum = 0.0f32;
+    for logit in logits.iter_mut() {
+        *logit = canonical_expf(*logit - max_logit);
+        sum += *logit;
+    }
+    sum
+}
+
+#[inline]
 fn canonical_log2f(value: f32) -> f32 {
     if canonical_math_enabled() {
         libm::log2f(value)
@@ -334,11 +381,7 @@ pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3
             mx = v;
         }
     }
-    let mut sum = 0.0f32;
-    for p in logits.iter_mut() {
-        *p = canonical_expf(*p - mx);
-        sum += *p;
-    }
+    let sum = teacher_exp_sum(logits, mx);
     for p in logits.iter_mut() {
         *p /= sum;
     }
@@ -397,11 +440,7 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
             mx = p;
         }
     }
-    let mut sum = 0.0f32;
-    for p in logits.iter_mut() {
-        *p = canonical_expf(*p - mx);
-        sum += *p;
-    }
+    let sum = teacher_exp_sum(logits, mx);
     for p in logits.iter_mut() {
         *p /= sum;
     }

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -42,6 +42,7 @@ fn canonical_expf(value: f32) -> f32 {
     }
 }
 
+#[cfg(target_os = "macos")]
 #[inline]
 fn teacher_vector_exp_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -24,6 +24,10 @@ pub struct Config {
 pub struct Llama {
     pub cfg: Config,
     w: Vec<f32>,
+    // RoPE angles depend only on the position and head dimension.  Keeping
+    // them here avoids recomputing pow/cos/sin once per layer and token.
+    rope_cos: Vec<f32>,
+    rope_sin: Vec<f32>,
     // float offsets into w
     emb: usize,
     rms_att: usize,
@@ -425,6 +429,31 @@ fn fast_matmul_backend() -> &'static str {
 }
 
 impl Llama {
+    fn build_rope_cache(cfg: &Config, canonical_math: bool) -> (Vec<f32>, Vec<f32>) {
+        let head_size = cfg.dim / cfg.n_heads;
+        let half = head_size / 2;
+        let mut cos = Vec::with_capacity(cfg.seq_len * half);
+        let mut sin = Vec::with_capacity(cfg.seq_len * half);
+        for pos in 0..cfg.seq_len {
+            for i in 0..half {
+                let freq = 1.0f32
+                    / powf(
+                        cfg.rope_theta,
+                        (2 * i) as f32 / head_size as f32,
+                        canonical_math,
+                    );
+                let angle = pos as f32 * freq;
+                cos.push(cosf(angle, canonical_math));
+                sin.push(sinf(angle, canonical_math));
+            }
+        }
+        (cos, sin)
+    }
+
+    fn rebuild_rope_cache(&mut self) {
+        (self.rope_cos, self.rope_sin) = Self::build_rope_cache(&self.cfg, self.canonical_math);
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(path: &str) -> Llama {
         let raw = std::fs::read(path).expect("checkpoint");
@@ -478,9 +507,11 @@ impl Llama {
         p += cfg.seq_len * hs / 2; // skip legacy freq_cis_real
         p += cfg.seq_len * hs / 2; // skip legacy freq_cis_imag
         let wcls = if shared { emb } else { p };
-        Llama {
+        let mut model = Llama {
             cfg,
             w,
+            rope_cos: Vec::new(),
+            rope_sin: Vec::new(),
             emb,
             rms_att,
             wq,
@@ -494,7 +525,9 @@ impl Llama {
             rms_final,
             wcls,
             canonical_math: false,
-        }
+        };
+        model.rebuild_rope_cache();
+        model
     }
 
     fn from_flat(cfg: Config, w: Vec<f32>, shared: bool) -> Self {
@@ -525,9 +558,11 @@ impl Llama {
         p += dim;
         let wcls = if shared { emb } else { p };
         assert_eq!(w.len(), if shared { p } else { p + cfg.vocab * dim });
-        Self {
+        let mut model = Self {
             cfg,
             w,
+            rope_cos: Vec::new(),
+            rope_sin: Vec::new(),
             emb,
             rms_att,
             wq,
@@ -541,7 +576,9 @@ impl Llama {
             rms_final,
             wcls,
             canonical_math: false,
-        }
+        };
+        model.rebuild_rope_cache();
+        model
     }
 
     /// One forward step. After return, st.x holds the post-final-rmsnorm
@@ -597,18 +634,12 @@ impl Llama {
             // Hugging Face Safetensors rotate the two head halves.
             if c.rope_interleaved {
                 let k = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                let rope_offset = pos * (head_size / 2);
                 let mut i = 0usize;
                 while i < dim {
-                    let head_dim = i % head_size;
-                    let freq = 1.0f32
-                        / powf(
-                            c.rope_theta,
-                            head_dim as f32 / head_size as f32,
-                            self.canonical_math,
-                        );
-                    let val = pos as f32 * freq;
-                    let fcr = cosf(val, self.canonical_math);
-                    let fci = sinf(val, self.canonical_math);
+                    let angle_index = rope_offset + (i % head_size) / 2;
+                    let fcr = self.rope_cos[angle_index];
+                    let fci = self.rope_sin[angle_index];
                     let rotn = if i < kv_dim { 2 } else { 1 };
                     for v in 0..rotn {
                         let vec: &mut [f32] = if v == 0 { &mut st.q } else { &mut *k };
@@ -625,17 +656,9 @@ impl Llama {
                     for head in vector.chunks_exact_mut(head_size) {
                         let half = head_size / 2;
                         for i in 0..half {
-                            let freq = 1.0f32
-                                / powf(
-                                    c.rope_theta,
-                                    (2 * i) as f32 / head_size as f32,
-                                    self.canonical_math,
-                                );
-                            let angle = pos as f32 * freq;
-                            let (cos, sin) = (
-                                cosf(angle, self.canonical_math),
-                                sinf(angle, self.canonical_math),
-                            );
+                            let angle_index = pos * half + i;
+                            let cos = self.rope_cos[angle_index];
+                            let sin = self.rope_sin[angle_index];
                             let first = head[i];
                             let second = head[i + half];
                             head[i] = first * cos - second * sin;
@@ -1113,6 +1136,12 @@ impl HuggingFaceLlamaOracle {
             std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0");
         let mut model = Llama::from_flat(cfg, weights, config.tie_word_embeddings);
         model.canonical_math = canonical_math;
+        // `from_flat` builds the fast native-math cache first; rebuild it if
+        // D2 canonical math was requested so the cache uses the same libm
+        // implementation as the rest of the forward pass.
+        if canonical_math {
+            model.rebuild_rope_cache();
+        }
         let state = State::new(&model.cfg);
         let fast_matmul = !canonical_math && std::env::var("TLESS_EXACT_SCALAR").is_err();
         let backend = if canonical_math {
@@ -1270,6 +1299,33 @@ mod tests {
                 powf(10_000.0, value / 8.0, true).to_bits(),
                 libm::powf(10_000.0, value / 8.0).to_bits()
             );
+        }
+    }
+
+    #[test]
+    fn rope_cache_preserves_angle_bits() {
+        let cfg = Config {
+            dim: 12,
+            hidden: 16,
+            n_layers: 1,
+            n_heads: 3,
+            n_kv_heads: 1,
+            vocab: 8,
+            seq_len: 5,
+            rope_theta: 10_000.0,
+            rms_norm_eps: 1e-5,
+            rope_interleaved: false,
+            r4_attention: false,
+        };
+        let (cos, sin) = Llama::build_rope_cache(&cfg, false);
+        let half = cfg.dim / cfg.n_heads / 2;
+        for pos in 0..cfg.seq_len {
+            for i in 0..half {
+                let freq = 1.0f32 / cfg.rope_theta.powf((2 * i) as f32 / (2 * half) as f32);
+                let angle = pos as f32 * freq;
+                assert_eq!(cos[pos * half + i].to_bits(), angle.cos().to_bits());
+                assert_eq!(sin[pos * half + i].to_bits(), angle.sin().to_bits());
+            }
         }
     }
 

--- a/docs/smollm2_teacher_baseline_320.md
+++ b/docs/smollm2_teacher_baseline_320.md
@@ -108,3 +108,23 @@ and the graph does not improve on the same-corpus TLA baseline. The declared
 next step remains P3 only as a maintainer decision after a larger/stronger
 teacher corpus or the 360M rehearsal; the pinned stories15M fixtures remain
 unchanged.
+
+## CPU teacher path — issue #320 follow-up
+
+The Hugging Face teacher compiler remains CPU-only. The native macOS path uses
+Accelerate's CPU matrix-vector and vForce math kernels; it does not select
+CUDA, Metal, OpenCL, or any GPU backend. The deployed transformerless runtime
+is unaffected and remains multiplication-free.
+
+Two CPU-side costs were reduced:
+
+- RoPE `powf`/`sin`/`cos` values are precomputed once per position and head
+  dimension instead of once per layer and token.
+- macOS vocabulary exponentiation uses CPU vForce by default in noncanonical
+  mode. Set `TLESS_TEACHER_VFORCE_EXP=0` for the scalar comparison path;
+  `TLESS_CANONICAL_DETERMINISTIC=1` always disables the fast math backend.
+
+On the local 360M source, a fresh 5,000-token compile measured 74.5 tokens/s
+with both changes enabled, versus 54.5 tokens/s in the earlier scalar-exp /
+uncached-RoPE run. This is a throughput measurement, not a quality or
+determinism claim; canonical mode remains the reproducibility path.


### PR DESCRIPTION
## Summary

- cache RoPE sine/cosine angles once per position and head dimension, removing repeated `powf`/`sin`/`cos` work from every layer
- use macOS Accelerate vForce CPU exponentiation for the noncanonical teacher path by default, with `TLESS_TEACHER_VFORCE_EXP=0` as a scalar fallback
- keep `TLESS_CANONICAL_DETERMINISTIC=1` on the portable deterministic path
- document the CPU-only backend and local throughput measurement

The deployed transformerless runtime is unchanged and remains multiplication-free. No CUDA, Metal, OpenCL, or GPU backend is added or selected.

## Measurement

On the local SmolLM2 360M source, a fresh 5,000-token compile measured 74.5 tokens/s with both changes enabled versus 54.5 tokens/s in the earlier scalar-exp / uncached-RoPE run.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- focused model-source, softmax, and cache angle-bit tests pass
- `cargo test --workspace --offline` reaches the existing R4G1 allocation census failure: 2 allocations / 594 bytes in steady state; changed files do not touch runtime code