### PR TITLE
feat: compile transformerless artifacts from recorded observations

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -23,7 +23,7 @@
 use std::collections::{BTreeMap, HashMap};
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
-use uor_r4_model_source::TeacherOracle;
+use uor_r4_model_source::{RepresentationSource, TeacherOracle};
 
 #[inline]
 fn canonical_math_enabled() -> bool {
@@ -113,6 +113,167 @@ pub struct Corpus {
     pub byte_start: Vec<u32>,
     pub byte_end: Vec<u32>,
     pub hidden: Option<Vec<Vec<f32>>>,
+}
+
+/// A representation source reconstructed from a recorded corpus.
+///
+/// This is the compiler-side counterpart to the reference project's
+/// observation-first boundary: the corpus compiler consumes recorded top-k
+/// next-token observations and never loads a teacher model. Rows that were not observed are
+/// filled with a deterministic token-id row so the resulting artifact still
+/// has the caller-requested vocabulary width; those rows are not evidence of
+/// teacher semantics and are reported through the source κ.
+pub struct RecordedRepresentation {
+    rows: Vec<f32>,
+    vocab: usize,
+    kappa: String,
+}
+
+impl RecordedRepresentation {
+    /// Build a representation from recorded next-token observations. An
+    /// optional `<records>.hidden` sidecar may exist, but is deliberately not
+    /// read: the production compiler's input contract is the portable corpus
+    /// record stream itself.
+    pub fn from_corpus(corpus: &Corpus, vocab: usize) -> Result<Self, String> {
+        if vocab == 0 {
+            return Err("recorded compile requires a non-zero vocabulary size".to_owned());
+        }
+        if vocab > u32::MAX as usize {
+            return Err("recorded compile vocabulary exceeds u32 token ids".to_owned());
+        }
+        if corpus.input.len() != corpus.n
+            || corpus.top_tokens.len() != corpus.n
+            || corpus.top_weights.len() != corpus.n
+        {
+            return Err("recorded corpus arrays do not match the record count".to_owned());
+        }
+        let mut sums = vec![0.0f64; vocab * D];
+        let mut counts = vec![0u64; vocab];
+        for index in 0..corpus.n {
+            let token = corpus.input[index] as usize;
+            if token >= vocab {
+                continue;
+            }
+            counts[token] += 1;
+            let base = token * D;
+            for (&target, &weight) in corpus.top_tokens[index]
+                .iter()
+                .zip(corpus.top_weights[index].iter())
+            {
+                if weight == 0 {
+                    continue;
+                }
+                let mut feature_hasher = blake3::Hasher::new();
+                feature_hasher.update(b"uor-r4-recorded-feature-v1");
+                feature_hasher.update(&target.to_le_bytes());
+                let digest = feature_hasher.finalize();
+                for dimension in 0..D {
+                    let byte = digest.as_bytes()[dimension % 32];
+                    let sign = if byte & (1 << (dimension % 8)) == 0 {
+                        -1.0
+                    } else {
+                        1.0
+                    };
+                    sums[base + dimension] += sign * f64::from(weight);
+                }
+            }
+        }
+
+        let mut rows = vec![0.0f32; vocab * D];
+        for (token, &count_value) in counts.iter().enumerate() {
+            let base = token * D;
+            if count_value != 0 {
+                let count = count_value as f64;
+                for dimension in 0..D {
+                    rows[base + dimension] = (sums[base + dimension] / count) as f32;
+                }
+            } else {
+                // Deterministic, non-semantic fallback for vocabulary rows
+                // absent from the captured corpus. The compiler remains
+                // total without pretending that these rows were observed.
+                let mut hasher = blake3::Hasher::new();
+                hasher.update(b"uor-r4-recorded-row-v1");
+                hasher.update(&(token as u64).to_le_bytes());
+                let digest = hasher.finalize();
+                for dimension in 0..D {
+                    let byte = digest.as_bytes()[dimension % 32];
+                    rows[base + dimension] = if byte & (1 << (dimension % 8)) == 0 {
+                        -1.0
+                    } else {
+                        1.0
+                    };
+                }
+            }
+        }
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4-recorded-representation-v1");
+        hasher.update(&(vocab as u64).to_le_bytes());
+        for value in &rows {
+            hasher.update(&value.to_le_bytes());
+        }
+        Ok(Self {
+            rows,
+            vocab,
+            kappa: format!("blake3:{}", hasher.finalize().to_hex()),
+        })
+    }
+
+    pub fn kappa(&self) -> &str {
+        &self.kappa
+    }
+}
+
+impl RepresentationSource for RecordedRepresentation {
+    fn vocab_size(&self) -> usize {
+        self.vocab
+    }
+
+    fn source_dimension(&self) -> usize {
+        D
+    }
+
+    fn tokenizer_address(&self) -> &str {
+        "recorded-corpus-tokenizer-v1"
+    }
+
+    fn read_embedding_rows(
+        &self,
+        range: std::ops::Range<usize>,
+        output: &mut [f32],
+    ) -> Result<(), String> {
+        if range.start > range.end || range.end > self.vocab {
+            return Err("recorded representation row range is out of bounds".to_owned());
+        }
+        let count = range.end - range.start;
+        let width = count * D;
+        if output.len() < width {
+            return Err("recorded representation output buffer too small".to_owned());
+        }
+        output[..width].copy_from_slice(&self.rows[range.start * D..range.end * D]);
+        Ok(())
+    }
+}
+
+/// Compile directly from a completed recorded corpus without loading a
+/// teacher or invoking any model forward path.
+pub fn compile_recorded(corpus: &Corpus, vocab: usize) -> Result<Compiled, String> {
+    if corpus.n == 0 || corpus.stories == 0 {
+        return Err("recorded compile requires a non-empty corpus".to_owned());
+    }
+    if corpus.input.len() != corpus.n {
+        return Err("corpus input/record count mismatch".to_owned());
+    }
+    let source = RecordedRepresentation::from_corpus(corpus, vocab)?;
+    let source_kappa = source.kappa().to_owned();
+    let source_bytes = source.rows.len() * std::mem::size_of::<f32>();
+    Ok(compile_from_representation(
+        &source,
+        &source_kappa,
+        source_bytes,
+        source.tokenizer_address(),
+        corpus,
+    ))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -947,12 +1108,10 @@ pub fn quantile_radius(histogram: &[u32], numerator: u32, denominator: u32) -> u
     histogram.len().saturating_sub(1) as u16
 }
 
-pub fn calibrate_hamming_regions_from_signatures(
+fn signature_histograms(
     class_sigs: &[Vec<u8>],
     signatures: &[[u8; SIG_BYTES]],
-) -> HammingCalibrationReport {
-    const NUMERATOR: u32 = 95;
-    const DENOMINATOR: u32 = 100;
+) -> Vec<Vec<Vec<u32>>> {
     let mut histograms = vec![vec![vec![0u32; D + 1]; K]; STAGES];
     for sig in signatures {
         let mut words = [0u64; SIG_WORDS];
@@ -987,6 +1146,12 @@ pub fn calibrate_hamming_regions_from_signatures(
             }
         }
     }
+    histograms
+}
+
+fn calibration_from_histograms(histograms: Vec<Vec<Vec<u32>>>) -> HammingCalibrationReport {
+    const NUMERATOR: u32 = 95;
+    const DENOMINATOR: u32 = 100;
     let mut regions = Vec::with_capacity(STAGES * K);
     for (stage, stage_histograms) in histograms.iter().enumerate() {
         for (class, histogram) in stage_histograms.iter().enumerate() {
@@ -1007,6 +1172,48 @@ pub fn calibrate_hamming_regions_from_signatures(
         quantile_denominator: DENOMINATOR as u16,
         regions,
     }
+}
+
+/// Deterministically calibrate the Hamming regions. Each worker owns a
+/// private integer histogram, and the ordered reduction makes the result
+/// independent of worker count while removing the serial class-distance scan
+/// from the recorded-corpus compile path.
+pub fn calibrate_hamming_regions_from_signatures(
+    class_sigs: &[Vec<u8>],
+    signatures: &[[u8; SIG_BYTES]],
+) -> HammingCalibrationReport {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let threads = std::thread::available_parallelism()
+            .map(|count| count.get().min(8))
+            .unwrap_or(1);
+        if threads > 1 && signatures.len() >= threads * 2 {
+            let chunk_size = signatures.len().div_ceil(threads);
+            let mut partials = Vec::new();
+            std::thread::scope(|scope| {
+                let mut handles = Vec::new();
+                for chunk in signatures.chunks(chunk_size) {
+                    handles.push(scope.spawn(move || signature_histograms(class_sigs, chunk)));
+                }
+                for handle in handles {
+                    partials.push(handle.join().expect("hamming calibration worker"));
+                }
+            });
+            let mut merged = vec![vec![vec![0u32; D + 1]; K]; STAGES];
+            for partial in partials {
+                for stage in 0..STAGES {
+                    for class in 0..K {
+                        for distance in 0..=D {
+                            merged[stage][class][distance] = merged[stage][class][distance]
+                                .saturating_add(partial[stage][class][distance]);
+                        }
+                    }
+                }
+            }
+            return calibration_from_histograms(merged);
+        }
+    }
+    calibration_from_histograms(signature_histograms(class_sigs, signatures))
 }
 
 pub fn calibrate_hamming_regions(art: &Compiled, corpus: &Corpus) -> HammingCalibrationReport {
@@ -1053,7 +1260,7 @@ pub fn deterministic_project(
     vocab: usize,
     source_dim: usize,
     target_dim: usize,
-    oracle: &dyn TeacherOracle,
+    source: &dyn RepresentationSource,
 ) -> Vec<f32> {
     let mut projected_vecs = vec![0f32; vocab * target_dim];
     let chunk_size = 1000;
@@ -1063,7 +1270,7 @@ pub fn deterministic_project(
     for chunk_start in (0..vocab).step_by(chunk_size) {
         let chunk_end = (chunk_start + chunk_size).min(vocab);
         let count = chunk_end - chunk_start;
-        oracle
+        source
             .read_embedding_rows(chunk_start..chunk_end, &mut raw_chunk[..count * source_dim])
             .unwrap();
         for i in 0..count {
@@ -1081,7 +1288,7 @@ pub fn deterministic_project(
     for chunk_start in (0..vocab).step_by(chunk_size) {
         let chunk_end = (chunk_start + chunk_size).min(vocab);
         let count = chunk_end - chunk_start;
-        oracle
+        source
             .read_embedding_rows(chunk_start..chunk_end, &mut raw_chunk[..count * source_dim])
             .unwrap();
 
@@ -1235,28 +1442,45 @@ pub fn kappa_of_f32s(v: &[f32]) -> String {
 }
 
 pub fn compile(oracle: &dyn TeacherOracle, corpus: &Corpus) -> Compiled {
-    let vocab = oracle.vocab_size();
+    let source_kappa = oracle.kappa();
+    let tokenizer_address = oracle.tokenizer_address().to_owned();
+    compile_from_representation(
+        oracle,
+        &source_kappa,
+        oracle.source_bytes(),
+        &tokenizer_address,
+        corpus,
+    )
+}
+
+/// Compile an artifact from a representation source and explicit provenance.
+///
+/// Keeping this surface independent from [`TeacherOracle`] is what allows a
+/// recorded-corpus build to avoid constructing a transformer at all. The
+/// legacy [`compile`] wrapper remains for source-capture and κ reproduction.
+pub fn compile_from_representation(
+    source: &dyn RepresentationSource,
+    source_kappa: &str,
+    source_bytes: usize,
+    tokenizer_address: &str,
+    corpus: &Corpus,
+) -> Compiled {
+    let vocab = source.vocab_size();
     assert!(
         vocab <= u32::MAX as usize,
         "source vocabulary exceeds u32 token ids"
     );
-    println!(
-        "source κ: {} ({} bytes)",
-        oracle.kappa(),
-        oracle.source_bytes()
-    );
+    println!("source κ: {} ({} bytes)", source_kappa, source_bytes);
 
     let seed_string = format!(
         "{}{}{}",
-        oracle.kappa(),
-        oracle.tokenizer_address(),
-        "r4-geometric-projection-v1"
+        source_kappa, tokenizer_address, "r4-geometric-projection-v1"
     );
     let seed_hash = blake3::hash(seed_string.as_bytes());
     let seed_bytes = seed_hash.as_bytes();
 
-    let source_dim = oracle.source_dimension();
-    let vecs = deterministic_project(seed_bytes, vocab, source_dim, D, oracle);
+    let source_dim = source.source_dimension();
+    let vecs = deterministic_project(seed_bytes, vocab, source_dim, D, source);
 
     let (emb_cb, emb_codes) = sampled_kmeans_rvq(&vecs, vocab, STAGES, K, EMB_ITERS, seed_bytes);
     let emb_stage_kappas: Vec<String> = emb_cb.iter().map(|cb| kappa_of_f32s(cb)).collect();

--- a/crates/uor-r4-core/tests/recorded_representation.rs
+++ b/crates/uor-r4-core/tests/recorded_representation.rs
@@ -1,0 +1,35 @@
+use uor_r4_core::transformerless::compiler::{Corpus, RecordedRepresentation, D};
+use uor_r4_model_source::RepresentationSource;
+
+fn corpus() -> Corpus {
+    Corpus {
+        n: 2,
+        stories: 1,
+        story: vec![0, 0],
+        input: vec![1, 2],
+        next: vec![2, 3],
+        t_argmax: vec![2, 3],
+        top_tokens: vec![[2, 0, 0, 0, 0, 0, 0, 0], [3, 1, 0, 0, 0, 0, 0, 0]],
+        top_weights: vec![[100, 0, 0, 0, 0, 0, 0, 0], [70, 30, 0, 0, 0, 0, 0, 0]],
+        span_start: vec![0, 1],
+        span_end: vec![1, 2],
+        byte_start: vec![u32::MAX; 2],
+        byte_end: vec![u32::MAX; 2],
+        hidden: None,
+    }
+}
+
+#[test]
+fn recorded_representation_uses_records_without_hidden_sidecar() {
+    let first = RecordedRepresentation::from_corpus(&corpus(), 4).expect("records are enough");
+    let second = RecordedRepresentation::from_corpus(&corpus(), 4).expect("deterministic");
+    assert_eq!(first.kappa(), second.kappa());
+    assert_eq!(first.vocab_size(), 4);
+    assert_eq!(first.source_dimension(), D);
+
+    let mut rows = vec![0.0; 4 * D];
+    first
+        .read_embedding_rows(0..4, &mut rows)
+        .expect("rows fit");
+    assert!(rows.iter().any(|value| *value != 0.0));
+}

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -64,6 +64,50 @@ struct CompileOptions {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+struct RecordedCompileOptions {
+    corpus_meta: PathBuf,
+    corpus_recs: PathBuf,
+    vocab_size: usize,
+    output: PathBuf,
+}
+
+fn parse_recorded_compile_options(args: &[String]) -> Result<RecordedCompileOptions, String> {
+    let mut corpus_meta = None;
+    let mut corpus_recs = None;
+    let mut vocab_size = None;
+    let mut output = None;
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--corpus-meta" => corpus_meta = Some(PathBuf::from(value)),
+            "--corpus-recs" => corpus_recs = Some(PathBuf::from(value)),
+            "--vocab-size" => {
+                let parsed = value
+                    .parse()
+                    .map_err(|_| format!("invalid --vocab-size value: {value}"))?;
+                if parsed == 0 {
+                    return Err("--vocab-size must be greater than zero".to_owned());
+                }
+                vocab_size = Some(parsed);
+            }
+            "--out" | "--output" => output = Some(PathBuf::from(value)),
+            _ => return Err(format!("unknown compile-recorded option: {flag}")),
+        }
+        index += 2;
+    }
+    Ok(RecordedCompileOptions {
+        corpus_meta: corpus_meta.ok_or_else(|| "--corpus-meta is required".to_owned())?,
+        corpus_recs: corpus_recs.ok_or_else(|| "--corpus-recs is required".to_owned())?,
+        vocab_size: vocab_size.ok_or_else(|| "--vocab-size is required".to_owned())?,
+        output: output.ok_or_else(|| "--out is required".to_owned())?,
+    })
+}
+
+#[derive(Debug, PartialEq, Eq)]
 struct EvaluateReportOptions {
     source: PathBuf,
     compiled: PathBuf,
@@ -2036,6 +2080,77 @@ where
     Ok(())
 }
 
+/// Compile a completed recorded corpus without loading or executing a
+/// transformer. This is the observation-first production path; teacher
+/// capture remains available through `observe`/`compile` as an explicitly
+/// separate offline step.
+pub fn compile_recorded_corpus(args: &[String]) -> Result<(), String> {
+    let options = parse_recorded_compile_options(args)?;
+    let meta = options
+        .corpus_meta
+        .to_str()
+        .ok_or_else(|| "corpus metadata path is not UTF-8".to_owned())?;
+    let records = options
+        .corpus_recs
+        .to_str()
+        .ok_or_else(|| "corpus records path is not UTF-8".to_owned())?;
+    let corpus = compiler::load_corpus_from(meta, records).ok_or_else(|| {
+        format!(
+            "recorded corpus is incomplete or invalid at {}/{}",
+            options.corpus_meta.display(),
+            options.corpus_recs.display()
+        )
+    })?;
+    eprintln!(
+        "recorded compile: {} records, {} stories, vocabulary {} (no teacher loaded)",
+        corpus.n, corpus.stories, options.vocab_size
+    );
+    let artifacts = compiler::compile_recorded(&corpus, options.vocab_size)?;
+    let calibration = compiler::calibrate_hamming_regions(&artifacts, &corpus);
+    let hierarchical =
+        compiler::induce_hierarchical_codes(&artifacts.token_codes, options.vocab_size, &corpus);
+    let threads = std::thread::available_parallelism()
+        .map(|count| count.get().min(8))
+        .unwrap_or(1);
+    let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads)
+        .map_err(|error| format!("parallel recorded store build failed: {error}"))?;
+
+    std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
+    std::fs::write(
+        options.output.join("tless_artifacts.bin"),
+        compiler::artifact_bytes(&artifacts),
+    )
+    .map_err(|error| error.to_string())?;
+    std::fs::write(
+        options.output.join("tless_store.bin"),
+        runtime::store_bytes(&store),
+    )
+    .map_err(|error| error.to_string())?;
+    std::fs::write(
+        options.output.join("hamming_calibration.json"),
+        serde_json::to_string_pretty(&calibration).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    std::fs::write(
+        options.output.join("hierarchical_codes.json"),
+        serde_json::to_string_pretty(&hierarchical).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    std::fs::copy(&options.corpus_meta, options.output.join("corpus.meta"))
+        .map_err(|error| error.to_string())?;
+    std::fs::copy(&options.corpus_recs, options.output.join("corpus.records"))
+        .map_err(|error| error.to_string())?;
+
+    let artifact_bytes = compiler::artifact_bytes(&artifacts);
+    println!(
+        "recorded compile complete: {} ({} corpus records, artifact κ blake3:{})",
+        options.output.display(),
+        corpus.n,
+        blake3::hash(&artifact_bytes).to_hex()
+    );
+    Ok(())
+}
+
 pub fn run(args: &[String]) -> Result<(), String> {
     match args.first().map(|s| s.as_str()) {
         Some("setup") => setup(),
@@ -2056,6 +2171,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 compile_hugging_face(&args[1..])?;
             }
         }
+        Some("compile-recorded") => compile_recorded_corpus(&args[1..])?,
         Some("store") => {
             let c = compiler::load_corpus()
                 .expect("corpus incomplete: run `transformerless gen` first");
@@ -2094,8 +2210,9 @@ pub fn run(args: &[String]) -> Result<(), String> {
         Some("quantum-eval") => quantum_eval_command(&args[1..])?,
         _ => {
             println!(
-                "R4 transformerless — cross-compile a transformer into a mul-free table artifact\n\
+                "R4 transformerless — compile a mul-free table artifact\n\
                  commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
+                 recorded compile (no transformer): compile-recorded --corpus-meta <META> --corpus-recs <RECS> --vocab-size <N> --out <DIR>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
                  observation pipeline: observe [--source DIR | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR | --checkpoint BIN] [--tokenizer PATH] [--sequence-length N]\n\
@@ -2360,6 +2477,30 @@ mod tests {
         assert_eq!(options.target, 64);
         assert_eq!(options.shards, 3);
         assert_eq!(options.output, PathBuf::from("/tmp/obs"));
+    }
+
+    #[test]
+    fn recorded_compile_requires_explicit_corpus_and_vocab() {
+        let args = [
+            "--corpus-meta",
+            "/tmp/corpus.meta",
+            "--corpus-recs",
+            "/tmp/corpus.records",
+            "--vocab-size",
+            "49152",
+            "--out",
+            "/tmp/recorded",
+        ]
+        .map(str::to_owned);
+        let options = parse_recorded_compile_options(&args).expect("valid recorded options");
+        assert_eq!(options.corpus_meta, PathBuf::from("/tmp/corpus.meta"));
+        assert_eq!(options.corpus_recs, PathBuf::from("/tmp/corpus.records"));
+        assert_eq!(options.vocab_size, 49_152);
+        assert_eq!(options.output, PathBuf::from("/tmp/recorded"));
+
+        assert!(
+            parse_recorded_compile_options(&["--out", "/tmp/recorded"].map(str::to_owned)).is_err()
+        );
     }
 
     #[test]

--- a/docs/transformerless/OBSERVATION_FIRST.md
+++ b/docs/transformerless/OBSERVATION_FIRST.md
@@ -1,0 +1,35 @@
+# Observation-first transformerless compilation
+
+The production compiler boundary is the completed recorded corpus, not a
+Hugging Face model directory.
+
+There are two separate offline workflows:
+
+1. Capture observations, if new teacher data is required. `observe` and the
+   legacy `compile --source` path may load a CPU teacher; that is capture-only
+   work and may use matrix operations internally.
+2. Compile recorded observations. `compile-recorded` consumes only
+   `corpus.meta` and `corpus.records` plus an explicit vocabulary size. It does
+   not construct a teacher, load model weights, call the model-source forward
+   path, or use GPU backends. The representation is a deterministic signed
+   hash projection of the recorded top-k next-token distributions. Calibration
+   and store construction use ordered worker reductions, so output bytes do
+   not depend on worker count.
+
+The root command is:
+
+```text
+cargo run --release --offline --bin r4 -- compile \
+  --corpus-meta <completed corpus.meta> \
+  --corpus-recs <completed corpus.records> \
+  --vocab-size <tokenizer vocabulary size> \
+  --output <compiled directory>
+```
+
+The corpus metadata must have its completion byte set. A resumable capture
+that was interrupted is intentionally rejected until it is complete; this
+prevents a partial teacher sample from being mistaken for a finished model.
+
+This path is an observation-derived native model, not a claim of exact
+teacher parity. Run the existing held-out evaluation and quality gates before
+adopting its artifact.

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ enum Command {
     Client(ClientArgs),
     /// View or export UOR Q&A audit traces and geometry metrics.
     Audit(AuditArgs),
-    /// Compile a local or pinned Hugging Face model into an R⁴ bundle.
+    /// Compile a recorded corpus or a local/pinned Hugging Face model into an R⁴ bundle.
     Compile(CompileArgs),
     /// Download pinned open weights for offline compilation.
     Download(DownloadArgs),
@@ -182,6 +182,15 @@ struct CompileArgs {
     /// Hugging Face owner/repository to download and compile.
     #[arg(long, conflicts_with = "source")]
     model: Option<String>,
+    /// Completed corpus metadata for a transformer-free recorded compile.
+    #[arg(long, requires = "corpus_recs", requires = "vocab_size")]
+    corpus_meta: Option<PathBuf>,
+    /// Completed corpus records for a transformer-free recorded compile.
+    #[arg(long, requires = "corpus_meta", requires = "vocab_size")]
+    corpus_recs: Option<PathBuf>,
+    /// Vocabulary width for a transformer-free recorded compile.
+    #[arg(long, requires = "corpus_meta", requires = "corpus_recs")]
+    vocab_size: Option<usize>,
     /// Immutable 40-character Hugging Face commit SHA.
     #[arg(long, requires = "model")]
     revision: Option<String>,
@@ -403,6 +412,31 @@ fn compile(args: &CompileArgs) -> Result<(), RunError> {
         return Err(RunError::Command(
             "--sequence-length must be greater than zero".to_owned(),
         ));
+    }
+    if let (Some(corpus_meta), Some(corpus_recs), Some(vocab_size)) =
+        (&args.corpus_meta, &args.corpus_recs, args.vocab_size)
+    {
+        if args.source.is_some() || args.model.is_some() || args.revision.is_some() {
+            return Err(RunError::Command(
+                "--corpus-meta/--corpus-recs cannot be combined with a teacher source".to_owned(),
+            ));
+        }
+        let output = args
+            .output
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(".uor-models/compiled/recorded"));
+        let values = vec![
+            "compile-recorded".to_owned(),
+            "--corpus-meta".to_owned(),
+            corpus_meta.display().to_string(),
+            "--corpus-recs".to_owned(),
+            corpus_recs.display().to_string(),
+            "--vocab-size".to_owned(),
+            vocab_size.to_string(),
+            "--out".to_owned(),
+            output.display().to_string(),
+        ];
+        return transformerless_command::run(&values).map_err(RunError::Command);
     }
     let mut values = Vec::new();
     if let Some(source) = &args.source {


### PR DESCRIPTION
## Summary

- add an observation-first transformerless compiler path that consumes completed `corpus.meta` / `corpus.records` directly
- derive deterministic native token representations from recorded top-k next-token distributions without constructing a teacher or invoking model forward/matmul code
- parallelize Hamming calibration with ordered integer reductions and use the existing parallel store builder
- expose the path through `r4 compile --corpus-meta ... --corpus-recs ... --vocab-size ...`
- document the capture-vs-compile boundary and add regression coverage for records without a hidden sidecar

## Why

The previous `compile --source` workflow coupled corpus generation and artifact compilation, so a 360M compile spent hours executing the CPU Hugging Face transformer. The reference `uor-semantic` project makes capture an optional offline boundary and keeps artifact compilation observation-only. This PR brings that boundary to uor-r4.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- focused core and graph-cli tests
- end-to-end release compile of the completed 200k-record fixture: 48.5s wall time, no teacher loaded

The full workspace test reaches the existing long-running allocation census; the change does not touch the deployed runtime.