### PR TITLE
perf: skip VP-tree on small ROUT graphs (#277)

### DIFF
--- a/crates/uor-r4-graph-runtime/benches/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/benches/vp_tree.rs
@@ -157,6 +157,10 @@ fn main() -> Result<(), String> {
     println!("nodes={}", view.node_count().unwrap_or(0));
     println!("queries={}", queries.len());
     println!("iterations={iterations}");
+    println!(
+        "runtime_tree_cutoff_nodes={}",
+        vp_tree::MIN_ROUTE_INDEX_NODES
+    );
     println!("linear_ns_per_query={linear_ns:.1}");
     println!("vptree_ns_per_query={tree_ns:.1}");
     println!("speedup={:.3}", linear_ns / tree_ns);

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::runtime_state::RuntimeState;
 use crate::runtime_state::SemanticStateSlot;
 use crate::status::ResolutionStatus;
-use crate::vp_tree::VpTree;
+use crate::vp_tree::{MIN_ROUTE_INDEX_NODES, VpTree};
 use core::fmt;
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_format::{CODE_OP_HALT, OP_CLEAR_SLOT, OP_SHIFT_SLOTS, OP_UPDATE_SLOT};
@@ -56,9 +56,12 @@ impl<'a> R4G1Runtime<'a> {
     /// Create a new R4G1 runtime by running two-stage validation over `bytes`.
     pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
         let view = GraphView::parse(bytes)?;
+        let route_index = (view.node_count().unwrap_or(0) >= MIN_ROUTE_INDEX_NODES)
+            .then(|| VpTree::from_graph(&view))
+            .flatten();
         Ok(Self {
             chain: crate::patch_chain::PatchChain::new(view),
-            route_index: VpTree::from_graph(&view),
+            route_index,
         })
     }
 

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -11,6 +11,11 @@ use uor_r4_graph_format::{GraphView, SectionId};
 
 const NONE: u32 = u32::MAX;
 
+/// The checked-in 363-node graph is faster with the compact linear scan.
+/// Keep the exact tree for larger graphs, but avoid its measured small-graph
+/// regression. This is a serving heuristic, not a universal crossover claim.
+pub(crate) const MIN_ROUTE_INDEX_NODES: u32 = 512;
+
 #[derive(Debug, Clone)]
 struct Point {
     node_id: u32,

--- a/docs/vp_tree_277.md
+++ b/docs/vp_tree_277.md
@@ -1,0 +1,28 @@
+# VP-tree routing cutoff (#277)
+
+The exact VP-tree adapter remains available for larger ROUT indexes, but the
+current serving graph is below its measured useful range.
+
+On the checked-in SmolLM2-135M graph (363 nodes), release-mode measurements
+with 32 deterministic queries and 1,000 iterations were:
+
+| ROUT lookup | ns/query |
+| --- | ---: |
+| linear masked-Hamming scan | 2,503.8 |
+| exact VP-tree | 2,654.6 |
+
+A repeat measured 2,575.5 ns/query versus 2,758.9 ns/query. The tree was
+therefore approximately 6% slower across the stabilized runs. Both paths
+returned identical nearest nodes, distances, active sets, and checksums.
+
+`R4G1Runtime::parse` now enables the tree only for graphs with at least 512
+nodes. Smaller graphs keep the linear path, avoiding the measured regression;
+the cutoff is a serving heuristic and should be revisited if graph sizes or
+the ROUT layout change. The tree remains exact and contract-legal when used.
+
+Reproduce:
+
+```bash
+cargo bench -p uor-r4-graph-runtime --bench vp_tree --offline -- \
+  .uor-models/compiled/SmolLM2-135M-Instruct-7e27bd9f9532/graph/score.r4g1 1000
+```


### PR DESCRIPTION
## Summary

The exact VP-tree ROUT index is useful only after the graph is large enough to amortize its traversal overhead. On the current 363-node serving graph, repeated release benchmarks show the linear masked-Hamming scan is faster:

- linear: 2.50–2.58 µs/query
- VP-tree: 2.65–2.76 µs/query
- 32 deterministic queries × 1,000 iterations
- exact nearest node, distance, active set, and checksum all match

This PR keeps the exact VP-tree for graphs with at least 512 nodes and uses the linear path below that threshold, avoiding a measured small-graph regression. The cutoff is documented as a serving heuristic, not a universal crossover claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p uor-r4-graph-runtime --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- graph-format no_std checks with and without alloc
- `cargo bench -p uor-r4-graph-runtime --bench vp_tree --offline -- ... 1000`