### PR TITLE
feat: preserve teacher probability metadata

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -43,6 +43,76 @@ fn canonical_expf(value: f32) -> f32 {
 }
 
 #[inline]
+fn canonical_logf(value: f32) -> f32 {
+    if canonical_math_enabled() {
+        libm::logf(value)
+    } else {
+        value.ln()
+    }
+}
+
+/// Compiler-side information about one normalized next-token distribution.
+///
+/// The deployed runtime does not carry this floating-point structure. It is
+/// captured while the teacher logits are still available so message
+/// likelihood and uncertainty can be measured without reconstructing a
+/// distribution from top-k evidence later.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TokenProbabilityStats {
+    /// Natural-log probability of the observed target token.
+    pub target_logprob_nats: f32,
+    /// Shannon entropy of the complete vocabulary distribution, in bits.
+    pub entropy_bits: f32,
+    /// Probability mass covered by the retained top-8 tokens.
+    pub top8_mass: f32,
+    /// Zero-based rank of the target in the full distribution, or `u16::MAX`
+    /// when it is outside the retained top-8 list.
+    pub target_rank: u16,
+}
+
+impl TokenProbabilityStats {
+    /// Calculate target likelihood and full-distribution entropy from a
+    /// normalized vocabulary distribution. `top8_mass` is calculated from
+    /// the unrenormalized top-8 probabilities before they are stored as
+    /// teacher evidence.
+    pub fn from_normalized(
+        probabilities: &[f32],
+        target: usize,
+        top_tokens: &[u32; 8],
+        top8_mass: f32,
+    ) -> Self {
+        let target_probability = probabilities.get(target).copied().unwrap_or(0.0);
+        let target_logprob_nats = if target_probability > 0.0 {
+            canonical_logf(target_probability)
+        } else {
+            f32::NEG_INFINITY
+        };
+        let entropy_bits = probabilities
+            .iter()
+            .copied()
+            .filter(|&probability| probability > 0.0)
+            .map(|probability| -probability * canonical_log2f(probability))
+            .sum();
+        let target_rank = top_tokens
+            .iter()
+            .position(|&token| token == target as u32)
+            .map(|rank| rank as u16)
+            .unwrap_or(u16::MAX);
+        Self {
+            target_logprob_nats,
+            entropy_bits,
+            top8_mass: top8_mass.clamp(0.0, 1.0),
+            target_rank,
+        }
+    }
+
+    /// Information content of the target token in bits.
+    pub fn target_bits(self) -> f32 {
+        -self.target_logprob_nats / std::f32::consts::LN_2
+    }
+}
+
+#[inline]
 fn canonical_log2f(value: f32) -> f32 {
     if canonical_math_enabled() {
         libm::log2f(value)
@@ -551,7 +621,13 @@ pub fn softmax_top3_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 3
     (next, top_tokens_idx, top_weights_val)
 }
 
-pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8], [u32; 8]) {
+/// Normalize logits, retain the top-8 evidence, and sample from the full
+/// vocabulary distribution. The returned statistics describe the sampled
+/// target and the original (not top-8-renormalized) distribution.
+pub fn softmax_top8_sample_with_stats(
+    logits: &mut [f32],
+    rng: &mut u64,
+) -> (usize, [u32; 8], [u32; 8], TokenProbabilityStats) {
     let mut mx = f32::NEG_INFINITY;
     for &p in logits.iter() {
         if p > mx {
@@ -568,6 +644,11 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
     }
 
     let top_candidates = top_n_desc_stable::<8>(logits);
+    let top8_mass = top_candidates
+        .iter()
+        .map(|(_, probability)| *probability)
+        .filter(|probability| probability.is_finite() && *probability > 0.0)
+        .sum::<f32>();
 
     let mut top_tokens_idx = [0u32; 8];
     let mut top_weights_val = [0u32; 8];
@@ -604,7 +685,16 @@ pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8
             break;
         }
     }
-    (next, top_tokens_idx, top_weights_val)
+    let stats = TokenProbabilityStats::from_normalized(logits, next, &top_tokens_idx, top8_mass);
+    (next, top_tokens_idx, top_weights_val, stats)
+}
+
+/// Compatibility wrapper for callers that only need the sampled top-8
+/// evidence. New observation producers should use
+/// [`softmax_top8_sample_with_stats`] so probability metadata is preserved.
+pub fn softmax_top8_sample(logits: &mut [f32], rng: &mut u64) -> (usize, [u32; 8], [u32; 8]) {
+    let (next, top_tokens, top_weights, _) = softmax_top8_sample_with_stats(logits, rng);
+    (next, top_tokens, top_weights)
 }
 
 /// Tokenizer-neutral byte anchors of one sampled token within its story.

--- a/crates/uor-r4-core/tests/softmax_topk.rs
+++ b/crates/uor-r4-core/tests/softmax_topk.rs
@@ -4,7 +4,9 @@
 //! (descending probability, ties to the lowest token index). The corpus
 //! era depends on these bytes.
 
-use uor_r4_core::transformerless::compiler::{softmax_top3_sample, softmax_top8_sample};
+use uor_r4_core::transformerless::compiler::{
+    softmax_top3_sample, softmax_top8_sample, softmax_top8_sample_with_stats,
+};
 
 /// Reference: the previous implementation's selection — a stable
 /// descending full sort of (index, probability) after the same softmax.
@@ -72,4 +74,35 @@ fn streaming_top_n_matches_stable_sort_selection() {
         assert_eq!(t8.as_slice(), rt8.as_slice(), "top8 tokens, case {case}");
         assert_eq!(w8.as_slice(), rw8.as_slice(), "top8 weights, case {case}");
     }
+}
+
+#[test]
+fn probability_stats_use_full_distribution_not_top8_renormalization() {
+    let mut logits = vec![0.0f32; 16];
+    logits[0] = 4.0;
+    let mut rng = 0x5EEDu64;
+    let (_sampled, tokens, weights, stats) = softmax_top8_sample_with_stats(&mut logits, &mut rng);
+    assert_eq!(weights.iter().sum::<u32>(), 100);
+    assert!(stats.top8_mass < 1.0);
+    assert!(stats.top8_mass > 0.8);
+    let expected_entropy: f32 = logits
+        .iter()
+        .copied()
+        .filter(|&p| p > 0.0)
+        .map(|p| -p * p.ln() / std::f32::consts::LN_2)
+        .sum();
+    assert!((stats.entropy_bits - expected_entropy).abs() < 1e-5);
+    let target = tokens[0] as usize;
+    let mut target_stats =
+        uor_r4_core::transformerless::compiler::TokenProbabilityStats::from_normalized(
+            &logits,
+            target,
+            &tokens,
+            stats.top8_mass,
+        );
+    assert_eq!(target_stats.target_rank, 0);
+    assert!((target_stats.target_logprob_nats - logits[target].ln()).abs() < 1e-6);
+    assert!(target_stats.target_bits() > 0.0);
+    target_stats.top8_mass = 0.0;
+    assert_eq!(target_stats.top8_mass, 0.0);
 }

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -37,6 +37,66 @@ use uor_r4_model_source::progress::Progress;
 /// [`compiler::encode_v4_record`].
 pub const RECORD_SIZE: usize = 88;
 
+/// Width of one probability sidecar row. The row is aligned with the
+/// corresponding record in each shard, but is kept separate so the existing
+/// 88-byte observation ABI and old fixtures remain readable.
+pub const PROBABILITY_METADATA_SIZE: usize = 16;
+
+/// Compiler-side probability metadata for one observation row.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProbabilityMetadata {
+    pub target_logprob_nats: f32,
+    pub entropy_bits: f32,
+    pub top8_mass: f32,
+    pub target_rank: u16,
+}
+
+impl ProbabilityMetadata {
+    pub fn encode(self) -> [u8; PROBABILITY_METADATA_SIZE] {
+        let mut bytes = [0u8; PROBABILITY_METADATA_SIZE];
+        bytes[0..4].copy_from_slice(&self.target_logprob_nats.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.entropy_bits.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.top8_mass.to_le_bytes());
+        bytes[12..14].copy_from_slice(&self.target_rank.to_le_bytes());
+        bytes
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != PROBABILITY_METADATA_SIZE {
+            return None;
+        }
+        Some(Self {
+            target_logprob_nats: f32::from_le_bytes(bytes[0..4].try_into().ok()?),
+            entropy_bits: f32::from_le_bytes(bytes[4..8].try_into().ok()?),
+            top8_mass: f32::from_le_bytes(bytes[8..12].try_into().ok()?),
+            target_rank: u16::from_le_bytes(bytes[12..14].try_into().ok()?),
+        })
+    }
+}
+
+/// Return the information content of a message in bits without multiplying
+/// tiny probabilities. A message probability is the product of its
+/// conditional token probabilities, so its log-domain information is their
+/// additive sum.
+pub fn message_information_bits(metadata: &[ProbabilityMetadata]) -> f64 {
+    metadata
+        .iter()
+        .map(|row| -f64::from(row.target_logprob_nats) / f64::from(std::f32::consts::LN_2))
+        .sum()
+}
+
+/// Return average message information in bits per recorded token.
+pub fn message_bits_per_token(metadata: &[ProbabilityMetadata]) -> Option<f64> {
+    if metadata.is_empty()
+        || metadata
+            .iter()
+            .any(|row| !row.target_logprob_nats.is_finite())
+    {
+        return None;
+    }
+    Some(message_information_bits(metadata) / metadata.len() as f64)
+}
+
 /// Maximum shard fan-out accepted by [`ObservationShardWriter`]: shard
 /// files are held open during a pass, so the writer caps the fan-out at
 /// 2^8. [`shard_of`] itself is defined for up to 32 bits.
@@ -143,7 +203,7 @@ impl PartitionCounts {
 /// One completed shard's entry in the observation manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardEntry {
-    /// Number of 48-byte records in the shard file.
+    /// Number of observation records in the shard file.
     pub records: u64,
     /// Content κ of the shard file bytes.
     pub kappa: String,
@@ -152,6 +212,10 @@ pub struct ShardEntry {
     /// path, so its manifest bytes are unchanged).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partitions: Option<PartitionCounts>,
+    /// Content κ of the aligned probability sidecar, when probability
+    /// metadata was captured for this shard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probability_kappa: Option<String>,
 }
 
 /// Manifest of an observation shard directory: the fan-out, the completed
@@ -220,6 +284,7 @@ impl ObservationManifest {
 
 struct ShardHandle {
     file: BufWriter<fs::File>,
+    probability: Option<BufWriter<fs::File>>,
 }
 
 /// Spills observation records into per-shard files with a κ-pinned
@@ -360,6 +425,7 @@ impl ObservationShardWriter {
             }
             self.handles[index] = Some(ShardHandle {
                 file: BufWriter::new(file),
+                probability: None,
             });
         }
         let handle = self.handles[index]
@@ -387,12 +453,78 @@ impl ObservationShardWriter {
         Ok(written)
     }
 
+    /// Append an observation record and its aligned probability metadata.
+    /// Finalization validates that every non-empty shard has a complete,
+    /// aligned sidecar rather than silently publishing partial metadata.
+    pub fn write_record_with_probability(
+        &mut self,
+        record: &[u8; RECORD_SIZE],
+        probability: ProbabilityMetadata,
+        shard: u32,
+    ) -> io::Result<bool> {
+        if self.is_complete(shard) {
+            return Ok(false);
+        }
+        let written = self.write_record(record, shard)?;
+        if !written {
+            return Ok(false);
+        }
+        let index = shard as usize;
+        let path = self.dir.join(format!(
+            "{}.prob",
+            shard_file_name(self.manifest.shard_bits, shard)
+        ));
+        let handle = self.handles[index]
+            .as_mut()
+            .ok_or_else(|| invalid_data(format!("shard {shard} handle was not opened")))?;
+        if handle.probability.is_none() {
+            let file = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)?;
+            let existing = file.metadata()?.len();
+            if existing % PROBABILITY_METADATA_SIZE as u64 != 0 {
+                return Err(invalid_data(format!(
+                    "probability sidecar {} has a torn metadata row",
+                    path.display()
+                )));
+            }
+            handle.probability = Some(BufWriter::new(file));
+        }
+        handle
+            .probability
+            .as_mut()
+            .expect("probability handle opened above")
+            .write_all(&probability.encode())?;
+        Ok(true)
+    }
+
+    /// Probability-sidecar variant of
+    /// [`ObservationShardWriter::write_record_in_partition`].
+    pub fn write_record_with_probability_in_partition(
+        &mut self,
+        record: &[u8; RECORD_SIZE],
+        probability: ProbabilityMetadata,
+        shard: u32,
+        partition: RecordPartition,
+    ) -> io::Result<bool> {
+        let written = self.write_record_with_probability(record, probability, shard)?;
+        if written {
+            self.partition_counts[shard as usize].add(partition);
+            self.partitions_active = true;
+        }
+        Ok(written)
+    }
+
     /// Flush every open shard handle. Called at whole-story checkpoints so
     /// the on-disk shard bytes always cover exactly the completed stories
     /// of the deterministic stream.
     pub fn flush(&mut self) -> io::Result<()> {
         for handle in self.handles.iter_mut().flatten() {
             handle.file.flush()?;
+            if let Some(probability) = handle.probability.as_mut() {
+                probability.flush()?;
+            }
         }
         Ok(())
     }
@@ -412,6 +544,9 @@ impl ObservationShardWriter {
         }
         if let Some(handle) = self.handles[shard as usize].as_mut() {
             handle.file.flush()?;
+            if let Some(probability) = handle.probability.as_mut() {
+                probability.flush()?;
+            }
         }
         let path = self.shard_path(shard);
         if !path.exists() {
@@ -425,12 +560,32 @@ impl ObservationShardWriter {
                 length
             )));
         }
+        let probability_path = self.dir.join(format!(
+            "{}.prob",
+            shard_file_name(self.manifest.shard_bits, shard)
+        ));
+        let probability_kappa = if probability_path.exists() {
+            let probability_length = fs::metadata(&probability_path)?.len();
+            let records = length / RECORD_SIZE as u64;
+            if probability_length != records * PROBABILITY_METADATA_SIZE as u64 {
+                return Err(invalid_data(format!(
+                    "probability sidecar {} has {} bytes for {} records",
+                    probability_path.display(),
+                    probability_length,
+                    records
+                )));
+            }
+            Some(file_kappa(&probability_path)?)
+        } else {
+            None
+        };
         let entry = ShardEntry {
             records: length / RECORD_SIZE as u64,
             kappa: file_kappa(&path)?,
             partitions: self
                 .partitions_active
                 .then_some(self.partition_counts[shard as usize]),
+            probability_kappa,
         };
         self.manifest.total_records = self.manifest.total_records.saturating_add(entry.records);
         self.manifest.completed.insert(shard, entry);
@@ -479,6 +634,134 @@ pub fn merge_shards(dir: impl AsRef<Path>) -> io::Result<Vec<u8>> {
     Ok(merged)
 }
 
+/// Merge aligned probability sidecars in the same deterministic shard order
+/// as [`merge_shards`].
+pub fn merge_probability_metadata(dir: impl AsRef<Path>) -> io::Result<Vec<ProbabilityMetadata>> {
+    let dir = dir.as_ref();
+    let manifest = ObservationManifest::load(dir)?
+        .ok_or_else(|| invalid_data(format!("no observation manifest in {}", dir.display())))?;
+    let mut metadata = Vec::new();
+    for shard in 0..manifest.shard_count() {
+        let Some(entry) = manifest.completed.get(&shard) else {
+            continue;
+        };
+        if entry.probability_kappa.is_none() {
+            if entry.records == 0 {
+                continue;
+            }
+            return Err(invalid_data(format!(
+                "shard {shard} has no probability metadata sidecar"
+            )));
+        }
+        let path = dir.join(format!(
+            "{}.prob",
+            shard_file_name(manifest.shard_bits, shard)
+        ));
+        let bytes = fs::read(&path)?;
+        if bytes.len() != entry.records as usize * PROBABILITY_METADATA_SIZE {
+            return Err(invalid_data(format!(
+                "probability sidecar {} is not aligned",
+                path.display()
+            )));
+        }
+        for row in bytes.chunks_exact(PROBABILITY_METADATA_SIZE) {
+            metadata.push(ProbabilityMetadata::decode(row).ok_or_else(|| {
+                invalid_data(format!(
+                    "invalid probability metadata in {}",
+                    path.display()
+                ))
+            })?);
+        }
+    }
+    Ok(metadata)
+}
+
+/// Reconcile a probability sidecar to the committed observation prefix after
+/// an interrupted producer pass.
+pub fn reconcile_probability_shard(
+    dir: impl AsRef<Path>,
+    shard_bits: u8,
+    shard: u32,
+    committed_record_bytes: u64,
+) -> io::Result<()> {
+    let path = dir
+        .as_ref()
+        .join(format!("{}.prob", shard_file_name(shard_bits, shard)));
+    let expected = committed_record_bytes / RECORD_SIZE as u64 * PROBABILITY_METADATA_SIZE as u64;
+    let length = match fs::metadata(&path) {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if expected == 0 {
+                return Ok(());
+            }
+            return Err(invalid_data(format!(
+                "{} is missing but the checkpoint commits probability metadata",
+                path.display()
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    if length % PROBABILITY_METADATA_SIZE as u64 != 0 || length < expected {
+        return Err(invalid_data(format!(
+            "probability sidecar {} is shorter than the committed prefix",
+            path.display()
+        )));
+    }
+    if length > expected {
+        let file = fs::OpenOptions::new().write(true).open(&path)?;
+        file.set_len(expected)?;
+    }
+    Ok(())
+}
+
+/// Reconcile a generation-path record/sidecar pair after a crash between the
+/// two buffered writes. This path checkpoints only at whole-story boundaries,
+/// so the common prefix of the two files is the recoverable prefix.
+pub fn reconcile_probability_pair(
+    dir: impl AsRef<Path>,
+    shard_bits: u8,
+    shard: u32,
+) -> io::Result<()> {
+    let dir = dir.as_ref();
+    let record_path = dir.join(shard_file_name(shard_bits, shard));
+    let probability_path = dir.join(format!("{}.prob", shard_file_name(shard_bits, shard)));
+    let probability_length = match fs::metadata(&probability_path) {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if probability_length % PROBABILITY_METADATA_SIZE as u64 != 0 {
+        return Err(invalid_data(format!(
+            "probability sidecar {} has a torn metadata row",
+            probability_path.display()
+        )));
+    }
+    let record_length = fs::metadata(&record_path)?.len();
+    if record_length % RECORD_SIZE as u64 != 0 {
+        return Err(invalid_data(format!(
+            "observation shard {} has a torn record",
+            record_path.display()
+        )));
+    }
+    let records = (record_length / RECORD_SIZE as u64)
+        .min(probability_length / PROBABILITY_METADATA_SIZE as u64);
+    let expected_record_length = records * RECORD_SIZE as u64;
+    let expected_probability_length = records * PROBABILITY_METADATA_SIZE as u64;
+    if record_length > expected_record_length {
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&record_path)?
+            .set_len(expected_record_length)?;
+    }
+    if probability_length > expected_probability_length {
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&probability_path)?
+            .set_len(expected_probability_length)?;
+    }
+    Ok(())
+}
+
 /// Outcome of one [`observe_sharded`] invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObserveSummary {
@@ -496,7 +779,8 @@ pub struct ObserveSummary {
 }
 
 /// Run the teacher generation of `compile_hugging_face`'s corpus step,
-/// spilling v3 records into content-addressed shards instead of one
+/// spilling v4 records plus aligned probability metadata into content-addressed
+/// shards instead of one
 /// append-only corpus file. The teacher stream is the same deterministic
 /// stream (seed 0x5EED, whole-story checkpointing); each record is routed
 /// to `shard_of(sample_id(context_window), shard_bits)`, where the context
@@ -513,6 +797,9 @@ pub fn observe_sharded(
 ) -> Result<ObserveSummary, String> {
     let mut writer =
         ObservationShardWriter::open(out, shard_bits).map_err(|error| error.to_string())?;
+    for shard in 0..writer.manifest().shard_count() {
+        reconcile_probability_pair(out, shard_bits, shard).map_err(|error| error.to_string())?;
+    }
     let state_path = out.join(STATE_FILE);
     let (mut n, mut stories, mut rng, mut done) = match fs::read(&state_path) {
         Ok(bytes) if bytes.len() == 25 => (
@@ -557,8 +844,8 @@ pub fn observe_sharded(
         for pos in 0..seq_len {
             progress.set(n as usize);
             oracle.step(token, pos, &mut logits);
-            let (next, top_tokens, top_weights) =
-                compiler::softmax_top8_sample(&mut logits, &mut rng);
+            let (next, top_tokens, top_weights, stats) =
+                compiler::softmax_top8_sample_with_stats(&mut logits, &mut rng);
             window.push(token as u32);
             if window.len() > compiler::WINDOW {
                 window.remove(0);
@@ -578,7 +865,16 @@ pub fn observe_sharded(
                 (byte_start, byte_end),
             );
             if writer
-                .write_record(&record, shard)
+                .write_record_with_probability(
+                    &record,
+                    ProbabilityMetadata {
+                        target_logprob_nats: stats.target_logprob_nats,
+                        entropy_bits: stats.entropy_bits,
+                        top8_mass: stats.top8_mass,
+                        target_rank: stats.target_rank,
+                    },
+                    shard,
+                )
                 .map_err(|error| error.to_string())?
             {
                 written += 1;

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -7,12 +7,14 @@
 //! Record semantics are the generation path's, teacher-forced:
 //!
 //! - per article, the text is tokenized BOS-prefixed and the oracle steps
-//!   over the stream; at each position the v3 48-byte record for
+//!   over the stream; at each position the v4 88-byte record for
 //!   (8-token context window → next text token) is emitted through the
-//!   SHARED [`compiler::encode_v3_record`] / [`compiler::softmax_top3_sample`]
-//!   / [`compiler::byte_anchors`] helpers, so bytes are format-identical to
-//!   the autoregressive path (the sampled token is discarded; the record's
-//!   `next` is the actual next text token);
+//!   shared [`compiler::encode_v4_record`] /
+//!   [`compiler::softmax_top8_sample_with_stats`] /
+//!   [`compiler::byte_anchors`] helpers, with aligned probability metadata
+//!   preserving the full-distribution target likelihood and entropy. The
+//!   sampled token is discarded; the record's `next` is the actual next text
+//!   token;
 //! - sharding is the generation path's scheme: [`observe::sample_id`] over
 //!   the context window → [`observe::shard_of`] — content-addressed, so
 //!   shard bytes are independent of article completion order (T-invariance);
@@ -419,7 +421,7 @@ fn append_story(path: &Path, entry: &StoryEntry) -> Result<(), String> {
 }
 
 /// Outcome of one [`observe_text_corpus`] invocation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ObservationReport {
     /// Articles in the input file.
     pub articles_total: u64,
@@ -451,6 +453,10 @@ pub struct ObservationReport {
     pub shard_count: u32,
     /// κ of the merged shard bytes, once the corpus is complete.
     pub merged_kappa: Option<String>,
+    /// Teacher-forced cross-entropy of the observed message stream, in
+    /// bits/token. This is computed from the probability sidecar rather than
+    /// from top-k-renormalized evidence.
+    pub teacher_bits_per_token: Option<f64>,
     /// Path of the story → article mapping file.
     pub stories_file: PathBuf,
     /// Whether every article is committed and every shard is κ-pinned.
@@ -487,6 +493,13 @@ fn build_report(
     } else {
         None
     };
+    let teacher_bits_per_token = if checkpoint.done {
+        observe::merge_probability_metadata(out_dir)
+            .ok()
+            .and_then(|metadata| observe::message_bits_per_token(&metadata))
+    } else {
+        None
+    };
     Ok(ObservationReport {
         articles_total,
         articles_completed: checkpoint.stories,
@@ -501,13 +514,14 @@ fn build_report(
         shards_completed: writer.manifest().completed.len() as u32,
         shard_count: writer.manifest().shard_count(),
         merged_kappa,
+        teacher_bits_per_token,
         stories_file: stories_path,
         done: checkpoint.done,
     })
 }
 
 /// Run the from-text observation pass over `articles_path` (one JSON
-/// object per line: id, url, title, text), spilling v3 records into
+/// object per line: id, url, title, text), spilling v4 records into
 /// content-addressed shards under `out_dir`.
 ///
 /// The teacher stream is teacher-forced: per article the BOS-prefixed
@@ -589,6 +603,13 @@ pub fn observe_text_corpus(
             shard,
             checkpoint.shards[shard as usize].bytes,
         )?;
+        observe::reconcile_probability_shard(
+            out_dir,
+            shard_bits,
+            shard,
+            checkpoint.shards[shard as usize].bytes,
+        )
+        .map_err(|error| error.to_string())?;
     }
     reconcile_stories(&stories_path, checkpoint.stories)?;
     let counts: Vec<PartitionCounts> = checkpoint
@@ -669,16 +690,23 @@ pub fn observe_text_corpus(
         // Teacher-forced record stream for this article, buffered until
         // the per-article checkpoint so an interrupted article leaves no
         // partial records behind.
-        let mut records: Vec<(u32, [u8; RECORD_SIZE])> = Vec::with_capacity(positions);
+        let mut records: Vec<(u32, [u8; RECORD_SIZE], observe::ProbabilityMetadata)> =
+            Vec::with_capacity(positions);
         oracle.reset();
         window.clear();
         let mut story_byte_offset = 0u32;
         for pos in 0..positions {
             let token = tokens[pos];
             oracle.step(token as usize, pos, &mut logits);
-            let (_sampled, top_tokens, top_weights) =
-                compiler::softmax_top8_sample(&mut logits, &mut checkpoint.rng);
+            let (_sampled, top_tokens, top_weights, sampled_stats) =
+                compiler::softmax_top8_sample_with_stats(&mut logits, &mut checkpoint.rng);
             let next = tokens[pos + 1];
+            let stats = compiler::TokenProbabilityStats::from_normalized(
+                &logits,
+                next as usize,
+                &top_tokens,
+                sampled_stats.top8_mass,
+            );
             window.push(token);
             if window.len() > compiler::WINDOW {
                 window.remove(0);
@@ -697,7 +725,16 @@ pub fn observe_text_corpus(
                 (span_start, span_end),
                 (byte_start, byte_end),
             );
-            records.push((shard, record));
+            records.push((
+                shard,
+                record,
+                observe::ProbabilityMetadata {
+                    target_logprob_nats: stats.target_logprob_nats,
+                    entropy_bits: stats.entropy_bits,
+                    top8_mass: stats.top8_mass,
+                    target_rank: stats.target_rank,
+                },
+            ));
             if token_byte_lengths.is_some() {
                 story_byte_offset = byte_end;
             }
@@ -706,9 +743,9 @@ pub fn observe_text_corpus(
         // Per-article checkpoint: shard bytes first (flush), then the
         // story mapping line, then the atomic committed checkpoint and its
         // state.bin mirror.
-        for (shard, record) in &records {
+        for (shard, record, probability) in &records {
             if writer
-                .write_record_in_partition(record, *shard, partition)
+                .write_record_with_probability_in_partition(record, *probability, *shard, partition)
                 .map_err(|error| error.to_string())?
             {
                 written += 1;
@@ -754,13 +791,14 @@ pub fn observe_text_corpus(
         written,
     )?;
     println!(
-        "text observations: {} / {} articles, {} records ({} written), {}/{} shards complete, done={}",
+        "text observations: {} / {} articles, {} records ({} written), {}/{} shards complete, bits/token={:?}, done={}",
         report.articles_completed,
         report.articles_total,
         report.records,
         report.written,
         report.shards_completed,
         report.shard_count,
+        report.teacher_bits_per_token,
         report.done
     );
     Ok(report)
@@ -1140,6 +1178,7 @@ mod tests {
         assert_eq!(report.shards_completed, SHARD_COUNT);
         assert_eq!(report.written, report.records);
         assert!(report.merged_kappa.is_some());
+        assert!(report.teacher_bits_per_token.is_some());
         assert_eq!(
             report.construction_records + report.held_out_records,
             report.records
@@ -1362,6 +1401,11 @@ mod tests {
             bytes.extend_from_slice(&tail.concat());
             fs::write(dir_b.join(shard_file_name(SHARD_BITS, shard)), bytes)
                 .expect("craft shard bytes");
+            fs::copy(
+                dir_a.join(format!("{}.prob", shard_file_name(SHARD_BITS, shard))),
+                dir_b.join(format!("{}.prob", shard_file_name(SHARD_BITS, shard))),
+            )
+            .expect("craft probability sidecar");
         }
         let mut committed =
             Checkpoint::fresh(SHARD_COUNT, input_kappa(&input).expect("input kappa"));

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -6,8 +6,9 @@
 use std::collections::BTreeSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uor_r4_graph_compiler::observation::{
-    ObservationManifest, ObservationShardWriter, RECORD_SIZE, merge_shards, sample_id,
-    shard_file_name, shard_of,
+    ObservationManifest, ObservationShardWriter, ProbabilityMetadata, RECORD_SIZE,
+    merge_probability_metadata, merge_shards, message_bits_per_token, sample_id, shard_file_name,
+    shard_of,
 };
 use uor_r4_model_source::{BehaviorSource, LlamaOracle, RepresentationSource, TeacherOracle};
 
@@ -233,6 +234,53 @@ fn shard_spill_manifest_resume_and_merge() {
     for dir in [&dir_a, &dir_b, &dir_c] {
         let _ = std::fs::remove_dir_all(dir);
     }
+}
+
+#[test]
+fn probability_sidecar_is_aligned_and_reports_message_bits() {
+    let dir = unique_path("observe-probability");
+    let records = synth_records();
+    let mut writer = ObservationShardWriter::open(&dir, SHARD_BITS).expect("open");
+    for (i, record) in records.iter().take(4).enumerate() {
+        assert!(
+            writer
+                .write_record_with_probability(
+                    record,
+                    ProbabilityMetadata {
+                        target_logprob_nats: -0.5 - i as f32,
+                        entropy_bits: 2.0 + i as f32,
+                        top8_mass: 0.75,
+                        target_rank: i as u16,
+                    },
+                    record_shard(i),
+                )
+                .expect("write probability")
+        );
+    }
+    writer.finalize_all().expect("finalize");
+    let metadata = merge_probability_metadata(&dir).expect("merge probability metadata");
+    assert_eq!(metadata.len(), 4);
+    assert!(metadata.iter().all(|row| row.top8_mass == 0.75));
+    let mut ranks: Vec<u16> = metadata.iter().map(|row| row.target_rank).collect();
+    ranks.sort_unstable();
+    assert_eq!(ranks, vec![0, 1, 2, 3]);
+    let bits = message_bits_per_token(&metadata).expect("non-empty message");
+    let expected = (0.5f64 + 1.5 + 2.5 + 3.5) / std::f64::consts::LN_2 / 4.0;
+    assert!(
+        (bits - expected).abs() < 1e-6,
+        "bits/token={bits}, expected={expected}"
+    );
+    let manifest = ObservationManifest::load(&dir)
+        .expect("load manifest")
+        .expect("manifest");
+    assert!(
+        manifest
+            .completed
+            .values()
+            .filter(|entry| entry.records != 0)
+            .all(|entry| entry.probability_kappa.is_some())
+    );
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 // -------------------------------------------------------- trace surface --

--- a/docs/probability_metadata_127.md
+++ b/docs/probability_metadata_127.md
@@ -1,0 +1,45 @@
+# Probability metadata and message information
+
+The observation compiler computes a full teacher softmax while the teacher
+logits are available. The deployed transformerless runtime does not reproduce
+that softmax: it consumes precompiled integer evidence and `ScoreQ` residuals.
+
+## Recorded quantities
+
+New observation shards retain the original 88-byte observation record and add
+an aligned `shard-NN.bin.prob` sidecar. Each 16-byte row contains:
+
+- `target_logprob_nats`: `ln P(target | context)` for the recorded target;
+- `entropy_bits`: `-sum(p * log2(p))` over the complete teacher vocabulary;
+- `top8_mass`: the original probability mass covered by the eight retained
+  tokens, before their stored evidence weights are renormalized;
+- `target_rank`: the target's rank when it is among those eight, otherwise
+  `u16::MAX`.
+
+The top-8 evidence weights remain a compact distillation surface for compiler
+induction. They sum to 100 **after conditioning on the top eight**, and are
+therefore not the original full-vocabulary probabilities. `top8_mass` is what
+prevents that distinction from being lost.
+
+## Message probability
+
+For a token sequence `x[0..T]`, the teacher message probability is
+
+`P(x) = product_t P(x[t] | x[..t])`.
+
+The implementation never multiplies these probabilities. It reports the
+equivalent additive information quantity:
+
+`message_bits = sum_t -log2(P(x[t] | x[..t]))`
+
+and `bits_per_token = message_bits / T`. This is the cross-entropy/NLL-style
+measurement for a teacher-forced message and remains numerically stable for
+long sequences.
+
+## Runtime boundary
+
+Entropy and log probabilities are compiler/certifier measurements only. Any
+future uncertainty-aware serving policy must lower them to an integer artifact
+field or a precompiled `ScoreQ` penalty/threshold. The deployed runtime must
+not add floating-point logarithms, division, softmax, or probability
+normalization.


### PR DESCRIPTION
## Summary

- preserve compiler-side target log-probability, full-vocabulary entropy, top-8 mass, and target rank while teacher logits are available
- write aligned `shard-NN.bin.prob` sidecars without changing the existing 88-byte observation record ABI
- report teacher-forced message `bits/token` from additive log-domain information
- add crash-recovery, sidecar alignment, entropy, and message-information tests
- document the compiler/runtime boundary: no softmax, logarithm, division, or floating point enters deployed inference

## Why

Top-8 evidence weights are intentionally renormalized for induction and are not the original full-vocabulary probabilities. The sidecar preserves the missing likelihood and uncertainty information needed for honest entropy and message-probability measurements.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- focused core and graph-compiler probability/crash-recovery tests
- full graph-compiler package suite

The workspace test suite reaches the existing R4G1 allocation-census assertion: 2 allocations / 594 bytes in the pre-existing `predict_token + predict_distribution + predict_candidates + step` kernel census. This change does not touch that runtime path.