### PR TITLE
test: calibrate session signature by teacher entropy

### DIFF
--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -14,6 +14,7 @@ pub mod observation_text;
 pub mod pack;
 pub mod patch_induction;
 pub mod perturbation;
+pub mod probability_calibration;
 pub mod quantum_cover;
 pub mod rate_distortion_compression;
 pub mod reference_compiler_ir;

--- a/crates/uor-r4-graph-compiler/src/probability_calibration.rs
+++ b/crates/uor-r4-graph-compiler/src/probability_calibration.rs
@@ -1,0 +1,134 @@
+//! Compiler-side calibration summaries for probability-aware evaluations.
+//!
+//! This module is deliberately outside the deployed graph runtime. It uses
+//! teacher probability metadata to condition evaluation results on teacher
+//! uncertainty; it does not participate in artifact execution or serving.
+
+use crate::observation::{self, ProbabilityMetadata};
+
+/// One deterministic teacher-entropy quartile of an A/B evaluation.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct EntropyBucket {
+    pub samples: u64,
+    pub entropy_bits: f64,
+    pub context_hits: u64,
+    pub session_hits: u64,
+    pub context_teacher_hits: u64,
+    pub session_teacher_hits: u64,
+    pub session_token_changes: u64,
+    pub session_corrections: u64,
+    pub session_regressions: u64,
+}
+
+impl EntropyBucket {
+    pub fn record(
+        &mut self,
+        entropy_bits: f32,
+        context_token: u32,
+        session_token: u32,
+        target: u32,
+        teacher_argmax: u32,
+    ) {
+        self.samples += 1;
+        self.entropy_bits += f64::from(entropy_bits);
+        self.context_hits += u64::from(context_token == target);
+        self.session_hits += u64::from(session_token == target);
+        self.context_teacher_hits += u64::from(context_token == teacher_argmax);
+        self.session_teacher_hits += u64::from(session_token == teacher_argmax);
+        self.session_token_changes += u64::from(session_token != context_token);
+        self.session_corrections += u64::from(context_token != target && session_token == target);
+        self.session_regressions += u64::from(context_token == target && session_token != target);
+    }
+
+    pub fn mean_entropy_bits(self) -> f64 {
+        if self.samples == 0 {
+            0.0
+        } else {
+            self.entropy_bits / self.samples as f64
+        }
+    }
+}
+
+/// Return the inclusive quartile bucket for a teacher entropy value.
+pub fn entropy_bucket(entropy_bits: f32, quartiles: &[f32; 3]) -> usize {
+    quartiles
+        .iter()
+        .position(|threshold| entropy_bits <= *threshold)
+        .unwrap_or(3)
+}
+
+/// Compute deterministic quartile thresholds over sampled positions.
+pub fn entropy_quartiles(
+    positions: &[usize],
+    metadata: Option<&[ProbabilityMetadata]>,
+) -> Option<[f32; 3]> {
+    let metadata = metadata?;
+    let mut values: Vec<f32> = positions
+        .iter()
+        .map(|&position| metadata[position].entropy_bits)
+        .collect();
+    values.sort_by(f32::total_cmp);
+    if values.is_empty() {
+        return None;
+    }
+    Some([
+        values[values.len() / 4],
+        values[values.len() / 2],
+        values[values.len() * 3 / 4],
+    ])
+}
+
+/// Compute teacher-forced information for sampled held-out positions.
+pub fn sampled_teacher_bits_per_token(
+    positions: &[usize],
+    metadata: &[ProbabilityMetadata],
+) -> Option<f64> {
+    let sampled: Vec<_> = positions
+        .iter()
+        .map(|&position| metadata[position])
+        .collect();
+    observation::message_bits_per_token(&sampled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entropy_buckets_are_monotonic_and_inclusive() {
+        assert_eq!(entropy_bucket(1.0, &[1.0, 2.0, 3.0]), 0);
+        assert_eq!(entropy_bucket(2.0, &[1.0, 2.0, 3.0]), 1);
+        assert_eq!(entropy_bucket(3.0, &[1.0, 2.0, 3.0]), 2);
+        assert_eq!(entropy_bucket(4.0, &[1.0, 2.0, 3.0]), 3);
+    }
+
+    #[test]
+    fn bucket_records_corrections_and_regressions_separately() {
+        let mut bucket = EntropyBucket::default();
+        bucket.record(2.0, 10, 11, 11, 11);
+        bucket.record(2.0, 10, 12, 10, 10);
+        bucket.record(2.0, 10, 10, 10, 10);
+
+        assert_eq!(bucket.samples, 3);
+        assert_eq!(bucket.session_corrections, 1);
+        assert_eq!(bucket.session_regressions, 1);
+        assert_eq!(bucket.session_token_changes, 2);
+        assert_eq!(bucket.mean_entropy_bits(), 2.0);
+    }
+
+    #[test]
+    fn quartiles_use_stable_sorted_positions() {
+        let metadata = (0..8)
+            .map(|index| ProbabilityMetadata {
+                target_logprob_nats: -1.0,
+                entropy_bits: index as f32,
+                top8_mass: 0.5,
+                target_rank: u16::MAX,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entropy_quartiles(&[7, 0, 6, 1, 5, 2, 4, 3], Some(&metadata)),
+            Some([2.0, 4.0, 6.0])
+        );
+    }
+}

--- a/crates/uor-r4-graph-runtime/benches/session_signature.rs
+++ b/crates/uor-r4-graph-runtime/benches/session_signature.rs
@@ -12,7 +12,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use uor_r4_core::transformerless::{compiler, runtime};
-use uor_r4_graph_compiler::induction;
+use uor_r4_graph_compiler::{
+    induction, observation,
+    probability_calibration::{
+        EntropyBucket, entropy_bucket, entropy_quartiles, sampled_teacher_bits_per_token,
+    },
+};
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_runtime::R4G1Runtime;
 use uor_r4_router::session_signature_from_tokens;
@@ -20,6 +25,28 @@ use uor_r4_router::session_signature_from_tokens;
 const DEFAULT_ROOT: &str = ".uor-models/compiled/smollm2-135m-instruct";
 const DEFAULT_SAMPLE: usize = 256;
 const WINDOW: usize = compiler::WINDOW;
+
+fn load_probability_metadata(
+    probability_dir: Option<&Path>,
+    expected_records: usize,
+) -> Result<Option<Vec<observation::ProbabilityMetadata>>, String> {
+    let Some(dir) = probability_dir else {
+        return Ok(None);
+    };
+    let metadata = observation::merge_probability_metadata(dir).map_err(|error| {
+        format!(
+            "cannot read probability metadata {}: {error}",
+            dir.display()
+        )
+    })?;
+    if metadata.len() != expected_records {
+        return Err(format!(
+            "probability metadata has {} rows but corpus has {expected_records} records",
+            metadata.len()
+        ));
+    }
+    Ok(Some(metadata))
+}
 
 fn resolve(path: &Path) -> Result<(PathBuf, Vec<u8>), String> {
     let candidates = if path.is_absolute() {
@@ -66,8 +93,17 @@ fn main() -> Result<(), String> {
         .map(|value| value.parse::<usize>().map_err(|_| "invalid sample size"))
         .transpose()?
         .unwrap_or(DEFAULT_SAMPLE);
+    let probability_dir = match args.next() {
+        None => None,
+        Some(flag) if flag == "--probability-dir" => {
+            Some(PathBuf::from(args.next().ok_or_else(|| {
+                "missing value for --probability-dir".to_owned()
+            })?))
+        }
+        Some(path) => Some(PathBuf::from(path)),
+    };
     if sample_target == 0 || args.next().is_some() {
-        return Err("usage: session_signature [BUNDLE_ROOT] [SAMPLE]".to_owned());
+        return Err("usage: session_signature [BUNDLE_ROOT] [SAMPLE] [PROBABILITY_DIR]".to_owned());
     }
 
     let graph = root.join("graph").join("score.r4g1");
@@ -98,6 +134,9 @@ fn main() -> Result<(), String> {
 
     let stride = (held_out.len() / sample_target).max(1);
     let positions: Vec<usize> = held_out.iter().copied().step_by(stride).collect();
+    let probability_metadata = load_probability_metadata(probability_dir.as_deref(), corpus.n)?;
+    let entropy_quartiles = entropy_quartiles(&positions, probability_metadata.as_deref());
+    let mut entropy_buckets = [EntropyBucket::default(); 4];
     let rotations = compiler::derive_rotations();
     let mut node_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
 
@@ -144,6 +183,19 @@ fn main() -> Result<(), String> {
         session_token_changes += u64::from(session_token != context_token);
         alternate_token_changes += u64::from(alternate_token != session_token);
         score_changes += u64::from(session_score != context_score);
+
+        if let (Some(metadata), Some(quartiles)) =
+            (probability_metadata.as_ref(), entropy_quartiles.as_ref())
+        {
+            let bucket = entropy_bucket(metadata[position].entropy_bits, quartiles);
+            entropy_buckets[bucket].record(
+                metadata[position].entropy_bits,
+                context_token,
+                session_token,
+                corpus.next[position],
+                corpus.t_argmax[position],
+            );
+        }
     }
 
     let count = positions.len() as f64;
@@ -192,5 +244,51 @@ fn main() -> Result<(), String> {
         positions.len(),
         score_changes as f64 / count
     );
+    match (probability_metadata.as_ref(), entropy_quartiles) {
+        (Some(metadata), Some(quartiles)) => {
+            println!("probability_metadata=available");
+            println!(
+                "teacher_bits_per_token_all={:.6}",
+                observation::message_bits_per_token(metadata).ok_or_else(|| {
+                    "probability metadata contains invalid log probabilities".to_owned()
+                })?
+            );
+            println!(
+                "teacher_bits_per_token_sample={:.6}",
+                sampled_teacher_bits_per_token(&positions, metadata).ok_or_else(|| {
+                    "sampled probability metadata contains invalid log probabilities".to_owned()
+                })?
+            );
+            println!(
+                "entropy_quartiles_bits={:.6},{:.6},{:.6}",
+                quartiles[0], quartiles[1], quartiles[2]
+            );
+            for (index, bucket) in entropy_buckets.iter().enumerate() {
+                println!(
+                    "entropy_bucket_{index}=samples:{} mean_entropy_bits:{:.6} context_top1:{}/{} session_top1:{}/{} context_teacher_argmax:{}/{} session_teacher_argmax:{}/{} session_token_changes:{}/{} session_corrections:{}/{} session_regressions:{}/{}",
+                    bucket.samples,
+                    bucket.mean_entropy_bits(),
+                    bucket.context_hits,
+                    bucket.samples,
+                    bucket.session_hits,
+                    bucket.samples,
+                    bucket.context_teacher_hits,
+                    bucket.samples,
+                    bucket.session_teacher_hits,
+                    bucket.samples,
+                    bucket.session_token_changes,
+                    bucket.samples,
+                    bucket.session_corrections,
+                    bucket.samples,
+                    bucket.session_regressions,
+                    bucket.samples,
+                );
+            }
+        }
+        (None, _) => println!(
+            "probability_metadata=unavailable (pass an observation directory containing manifest.json and *.prob sidecars)"
+        ),
+        (Some(_), None) => unreachable!("non-empty samples produce entropy quartiles"),
+    }
     Ok(())
 }

--- a/docs/session_signature_247.md
+++ b/docs/session_signature_247.md
@@ -50,3 +50,26 @@ prefix is used as a second deterministic A/B session history. The harness
 does not opt session state into ROUT fallback and does not assert an
 improvement threshold; those remain calibration decisions requiring a pinned
 multi-turn quality target.
+
+When the observation corpus was produced by the probability-aware text
+observer, pass its observation directory as a third argument:
+
+```bash
+cargo bench -p uor-r4-graph-runtime --bench session_signature -- \
+  .uor-models/compiled/smollm2-135m-instruct 256 \
+  .uor-models/observations/smollm2-135m-instruct
+```
+
+The directory must contain `manifest.json` and the aligned `*.prob` shard
+sidecars. The harness verifies that the merged sidecar row count equals the
+corpus record count, then reports teacher-forced bits/token for the full
+corpus and sampled held-out positions. It also reports four deterministic
+teacher-entropy buckets. Each bucket separates session corrections (the
+session lane fixes a context error) from regressions (the session lane breaks
+a context hit), alongside top-1, teacher-argmax agreement, and the rate of
+changed predictions. This makes the quality decision conditional on the
+teacher's uncertainty instead of treating every changed score as evidence of
+improvement.
+
+Probability metadata is evaluation-only. No entropy, logarithm, division, or
+floating-point operation is added to the graph runtime or serving path.


### PR DESCRIPTION
## Summary

- extend the #247 held-out session-signature A/B harness with optional aligned teacher probability sidecars
- report full-corpus and sampled held-out teacher bits/token
- partition session corrections, regressions, prediction changes, and teacher-argmax agreement by deterministic teacher-entropy quartile
- keep all calibration math in the compiler/evaluation side; the graph runtime and serving path are unchanged

## Usage

```bash
cargo bench -p uor-r4-graph-runtime --bench session_signature -- \
  <bundle-root> 256 <probability-observation-dir>
```

The probability directory must contain `manifest.json` and aligned `*.prob` sidecars. The harness verifies sidecar/corpus row alignment.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo test -p uor-r4-graph-compiler --offline`
- `cargo test -p uor-r4-graph-runtime --offline`
- graph-format no-std checks with and without `alloc`
- full workspace tests reach the existing R4G1 allocation-census failure: 2 allocations / 594 bytes in the pre-existing kernel census

Refs #247.