### PR TITLE
bench: measure #330 isolated dot scan (3.82×)

### DIFF
--- a/crates/uor-r4-core/Cargo.toml
+++ b/crates/uor-r4-core/Cargo.toml
@@ -18,6 +18,12 @@ uor-addr = { git = "https://github.com/UOR-Foundation/uor-addr.git", rev = "165b
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 libm = "0.2"
 
+[features]
+# Measurement-only surface for the #330 isolated dot-scan microbenchmark.
+# Off by default: it exposes no deployed prediction-path behavior, only a
+# read-only handle onto the already-built SIMD dot tables.
+bench-internals = []
+
 [dev-dependencies]
 serde_json = "1.0"
 proptest = "1.4.0"

--- a/crates/uor-r4-core/benches/transformerless_dot.rs
+++ b/crates/uor-r4-core/benches/transformerless_dot.rs
@@ -127,6 +127,78 @@ fn main() -> Result<(), String> {
     }
     let scalar_elapsed = scalar_start.elapsed();
 
+    // Isolated SIMD scan (#330 ≥3× criterion). Timed against the same total
+    // work as the scalar loop above: one full K×D scan per stage. The scalar
+    // reference is `dot_score_plain` — deliberately NOT the scalar fallback in
+    // `Runtime::dot_argmax`, which routes every table entry through the
+    // op-census kernel and would inflate the baseline. The SIMD side also
+    // performs the argmax compare that the scalar loop omits, so the reported
+    // ratio is conservative.
+    #[cfg(feature = "bench-internals")]
+    let simd_scan_report = {
+        use uor_r4_core::transformerless::simd::bench::{DotLayout, DotScan};
+
+        let scan = DotScan::from_packed(&artifact.dot_cb)
+            .ok_or_else(|| "cannot build SIMD dot tables from artifact".to_owned())?;
+        let layout = if (0..scan.stage_count()).all(|s| scan.layout(s) == DotLayout::Compact) {
+            "compact"
+        } else if (0..scan.stage_count()).all(|s| scan.layout(s) == DotLayout::TwoTerm) {
+            "two_term"
+        } else {
+            "mixed"
+        };
+
+        let legacy = DotScan::from_packed_forced_two_term(&artifact.dot_cb)
+            .ok_or_else(|| "cannot build legacy dot tables from artifact".to_owned())?;
+
+        // Both representations decode the same packed ABI, so they must agree
+        // class-for-class. Checked before timing: a layout that disagreed
+        // would make the speedup meaningless.
+        for stage in 0..scan.stage_count() {
+            let compact_class = scan.argmax(stage, &work);
+            let legacy_class = legacy.argmax(stage, &work);
+            if compact_class != legacy_class {
+                return Err(format!(
+                    "layout disagreement at stage {stage}: \
+                     compact={compact_class} legacy={legacy_class}"
+                ));
+            }
+        }
+
+        let mut simd_checksum = 0u64;
+        for _ in 0..10 {
+            for stage in 0..scan.stage_count() {
+                simd_checksum = simd_checksum.wrapping_add(u64::from(scan.argmax(stage, &work)));
+            }
+        }
+        let simd_start = Instant::now();
+        for _ in 0..iterations {
+            for stage in 0..scan.stage_count() {
+                simd_checksum =
+                    simd_checksum.wrapping_add(u64::from(scan.argmax(stage, black_box(&work))));
+            }
+        }
+        let simd_elapsed = simd_start.elapsed();
+
+        let mut legacy_checksum = 0u64;
+        for _ in 0..10 {
+            for stage in 0..legacy.stage_count() {
+                legacy_checksum =
+                    legacy_checksum.wrapping_add(u64::from(legacy.argmax(stage, &work)));
+            }
+        }
+        let legacy_start = Instant::now();
+        for _ in 0..iterations {
+            for stage in 0..legacy.stage_count() {
+                legacy_checksum =
+                    legacy_checksum.wrapping_add(u64::from(legacy.argmax(stage, black_box(&work))));
+            }
+        }
+        let legacy_elapsed = legacy_start.elapsed();
+
+        (layout, simd_elapsed, simd_checksum, legacy_elapsed)
+    };
+
     let mut runtime = Runtime::new(&artifact);
     let mut runtime_checksum = [0u8; STAGES];
     for _ in 0..10 {
@@ -158,6 +230,25 @@ fn main() -> Result<(), String> {
         "runtime_assign_tokens_per_second={:.1}",
         iterations as f64 / runtime_elapsed.as_secs_f64()
     );
+    #[cfg(feature = "bench-internals")]
+    {
+        let (layout, simd_elapsed, simd_checksum, legacy_elapsed) = simd_scan_report;
+        let simd_ns = nanos_per_operation(simd_elapsed, iterations);
+        let legacy_ns = nanos_per_operation(legacy_elapsed, iterations);
+        println!("simd_dot_layout={layout}");
+        println!("simd_dot_ns_per_scan={simd_ns:.1}");
+        println!(
+            "simd_dot_ns_per_row={:.1}",
+            nanos_per_operation(simd_elapsed, iterations * rows_per_scan)
+        );
+        println!("legacy_two_term_ns_per_scan={legacy_ns:.1}");
+        println!(
+            "isolated_speedup={:.2}",
+            nanos_per_operation(scalar_elapsed, iterations) / simd_ns
+        );
+        println!("layout_speedup={:.2}", legacy_ns / simd_ns);
+        println!("simd_checksum={simd_checksum}");
+    }
     println!("scalar_checksum={scalar_checksum}");
     println!("runtime_checksum={runtime_checksum:?}");
     Ok(())

--- a/crates/uor-r4-core/src/transformerless/simd.rs
+++ b/crates/uor-r4-core/src/transformerless/simd.rs
@@ -174,8 +174,85 @@ fn decode_dot_term(term: u8) -> (i64, i64, i64) {
     (exponent, -1, negative)
 }
 
+/// True when no entry activates both packed bytes, i.e. the compiler emitted
+/// at most one active term per dot entry (every current Phase C artifact).
+fn is_single_term(table: &[u16]) -> bool {
+    table.iter().all(|entry| {
+        let [lo, hi] = entry.to_le_bytes();
+        !(lo & 0x40 != 0 && hi & 0x40 != 0)
+    })
+}
+
+fn build_single_term(table: &[u16]) -> Vec<DotSingleVector> {
+    let mut vectors = Vec::with_capacity(D * DOT_GROUPS);
+    for dimension in 0..D {
+        for group in 0..DOT_GROUPS {
+            let mut shifts = [0; DOT_LANES];
+            let mut negative = [0; DOT_LANES];
+            for lane in 0..DOT_LANES {
+                let class = group * DOT_LANES + lane;
+                let entry = table[class * D + dimension].to_le_bytes();
+                let term = if entry[1] & 0x40 != 0 {
+                    entry[1]
+                } else {
+                    entry[0]
+                };
+                let (shift, _, sign) = decode_dot_term(term);
+                shifts[lane] = shift;
+                negative[lane] = sign;
+            }
+            vectors.push(DotSingleVector { shifts, negative });
+        }
+    }
+    vectors
+}
+
+fn build_two_term(table: &[u16]) -> Vec<DotVector> {
+    let mut vectors = Vec::with_capacity(D * DOT_GROUPS);
+    for dimension in 0..D {
+        for group in 0..DOT_GROUPS {
+            let mut terms = [DotTermVector {
+                shifts: [0; DOT_LANES],
+                active: [0; DOT_LANES],
+                negative: [0; DOT_LANES],
+            }; 2];
+            for lane in 0..DOT_LANES {
+                let class = group * DOT_LANES + lane;
+                let entry = table[class * D + dimension].to_le_bytes();
+                let (hi_shift, hi_active, hi_negative) = decode_dot_term(entry[1]);
+                let (lo_shift, lo_active, lo_negative) = decode_dot_term(entry[0]);
+                terms[0].shifts[lane] = hi_shift;
+                terms[0].active[lane] = hi_active;
+                terms[0].negative[lane] = hi_negative;
+                terms[1].shifts[lane] = lo_shift;
+                terms[1].active[lane] = lo_active;
+                terms[1].negative[lane] = lo_negative;
+            }
+            vectors.push(DotVector { terms });
+        }
+    }
+    vectors
+}
+
 impl DotTables {
     pub(crate) fn from_packed(packed: &[Vec<u16>]) -> Option<Self> {
+        Self::build(packed, false)
+    }
+
+    /// Build every stage in the legacy two-term representation regardless of
+    /// what the artifact would select, so the #330 benchmark can compare both
+    /// layouts in one process under one protocol instead of across two
+    /// commits — and so the tests can witness that the two representations
+    /// decode the same packed ABI to the same class.
+    ///
+    /// Not reachable from the deployed path: `from_packed` is what the runtime
+    /// calls, and this is gated to tests and the measurement feature.
+    #[cfg(any(test, feature = "bench-internals"))]
+    pub(crate) fn from_packed_forced_two_term(packed: &[Vec<u16>]) -> Option<Self> {
+        Self::build(packed, true)
+    }
+
+    fn build(packed: &[Vec<u16>], force_two_term: bool) -> Option<Self> {
         if packed.is_empty() {
             return None;
         }
@@ -184,62 +261,12 @@ impl DotTables {
             if table.len() != D * K {
                 return None;
             }
-            let single_term = table.iter().all(|entry| {
-                let [lo, hi] = entry.to_le_bytes();
-                !(lo & 0x40 != 0 && hi & 0x40 != 0)
-            });
-            if single_term {
-                let mut vectors = Vec::with_capacity(D * DOT_GROUPS);
-                for dimension in 0..D {
-                    for group in 0..DOT_GROUPS {
-                        let mut shifts = [0; DOT_LANES];
-                        let mut negative = [0; DOT_LANES];
-                        for lane in 0..DOT_LANES {
-                            let class = group * DOT_LANES + lane;
-                            let entry = table[class * D + dimension].to_le_bytes();
-                            let term = if entry[1] & 0x40 != 0 {
-                                entry[1]
-                            } else {
-                                entry[0]
-                            };
-                            let (shift, _, sign) = decode_dot_term(term);
-                            shifts[lane] = shift;
-                            negative[lane] = sign;
-                        }
-                        vectors.push(DotSingleVector { shifts, negative });
-                    }
-                }
-                stages.push(DotStage {
-                    data: DotStageData::Single(vectors),
-                });
+            let data = if !force_two_term && is_single_term(table) {
+                DotStageData::Single(build_single_term(table))
             } else {
-                let mut vectors = Vec::with_capacity(D * DOT_GROUPS);
-                for dimension in 0..D {
-                    for group in 0..DOT_GROUPS {
-                        let mut terms = [DotTermVector {
-                            shifts: [0; DOT_LANES],
-                            active: [0; DOT_LANES],
-                            negative: [0; DOT_LANES],
-                        }; 2];
-                        for lane in 0..DOT_LANES {
-                            let class = group * DOT_LANES + lane;
-                            let entry = table[class * D + dimension].to_le_bytes();
-                            let (hi_shift, hi_active, hi_negative) = decode_dot_term(entry[1]);
-                            let (lo_shift, lo_active, lo_negative) = decode_dot_term(entry[0]);
-                            terms[0].shifts[lane] = hi_shift;
-                            terms[0].active[lane] = hi_active;
-                            terms[0].negative[lane] = hi_negative;
-                            terms[1].shifts[lane] = lo_shift;
-                            terms[1].active[lane] = lo_active;
-                            terms[1].negative[lane] = lo_negative;
-                        }
-                        vectors.push(DotVector { terms });
-                    }
-                }
-                stages.push(DotStage {
-                    data: DotStageData::Two(vectors),
-                });
-            }
+                DotStageData::Two(build_two_term(table))
+            };
+            stages.push(DotStage { data });
         }
         Some(Self { stages })
     }
@@ -548,6 +575,62 @@ pub(crate) fn dot_argmax(stage: &DotStage, work: &[i64; D]) -> u8 {
     dot_argmax_scalar(stage, work)
 }
 
+/// Measurement-only handle onto the built dot tables (#330).
+///
+/// The isolated microbenchmark criterion needs to time `dot_argmax` without
+/// the surrounding bundle/threshold work, and the scalar fallback inside
+/// `Runtime::dot_argmax` is not a usable wall-clock baseline (it routes every
+/// table entry through the op-census kernel). This module exposes the scan
+/// itself plus the layout actually selected at load time, so the benchmark can
+/// witness which representation it measured rather than assuming.
+///
+/// Nothing here participates in the deployed prediction path.
+#[cfg(feature = "bench-internals")]
+pub mod bench {
+    use super::{dot_argmax, DotStageData, DotTables, D};
+
+    /// Which load-time representation `from_packed` selected.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum DotLayout {
+        /// Compact 64-byte one-term vectors (current TLA6/TLA7 artifacts).
+        Compact,
+        /// Legacy 192-byte two-term vectors.
+        TwoTerm,
+    }
+
+    pub struct DotScan(DotTables);
+
+    impl DotScan {
+        pub fn from_packed(packed: &[Vec<u16>]) -> Option<Self> {
+            DotTables::from_packed(packed).map(Self)
+        }
+
+        /// Force the legacy two-term layout for a same-process,
+        /// same-protocol comparison against the compact one.
+        pub fn from_packed_forced_two_term(packed: &[Vec<u16>]) -> Option<Self> {
+            DotTables::from_packed_forced_two_term(packed).map(Self)
+        }
+
+        pub fn stage_count(&self) -> usize {
+            self.0.stages.len()
+        }
+
+        /// The representation chosen for `stage`, so a benchmark can assert it
+        /// exercised the compact path instead of silently timing the legacy one.
+        pub fn layout(&self, stage: usize) -> DotLayout {
+            match &self.0.stages[stage].data {
+                DotStageData::Single(_) => DotLayout::Compact,
+                DotStageData::Two(_) => DotLayout::TwoTerm,
+            }
+        }
+
+        #[inline]
+        pub fn argmax(&self, stage: usize, work: &[i64; D]) -> u8 {
+            dot_argmax(&self.0.stages[stage], work)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -578,6 +661,40 @@ mod tests {
     }
 
     proptest! {
+        /// The compact one-term layout is only a valid substitution if it
+        /// decodes the same packed ABI to the same argmax as the legacy
+        /// two-term layout. #330 swaps representations on the hot path, so
+        /// this equality is the load-layout counterpart to the existing
+        /// scalar/SIMD output witnesses.
+        #[test]
+        fn compact_and_legacy_layouts_agree(
+            weights in proptest::collection::vec(-1.0f32..1.0, K),
+            work_seed in proptest::collection::vec(-4096i64..4096, D),
+        ) {
+            let mut table = vec![0u16; D * K];
+            for class in 0..K {
+                for dimension in 0..D {
+                    table[class * D + dimension] =
+                        compiler::pack_dot_entry(weights[class] * ((dimension % 7) as f32 - 3.0));
+                }
+            }
+            let packed = vec![table];
+
+            let compact = DotTables::from_packed(&packed).expect("valid dot table");
+            let legacy =
+                DotTables::from_packed_forced_two_term(&packed).expect("valid dot table");
+            prop_assert!(matches!(&compact.stages[0].data, DotStageData::Single(_)));
+            prop_assert!(matches!(&legacy.stages[0].data, DotStageData::Two(_)));
+
+            let mut work = [0i64; D];
+            work.copy_from_slice(&work_seed);
+
+            prop_assert_eq!(
+                dot_argmax(&compact.stages[0], &work),
+                dot_argmax(&legacy.stages[0], &work)
+            );
+        }
+
         #[test]
         fn test_simd_hamming_equivalence(
             a in proptest::collection::vec(any::<u8>(), SIG_BYTES).prop_map(|v| {

--- a/docs/dot_layout_330.md
+++ b/docs/dot_layout_330.md
@@ -17,20 +17,77 @@ Both layouts remain dimension-major (`D × K/4`) so SIMD lanes still represent
 adjacent classes. The on-disk `u16` dot-table ABI is unchanged, and the scalar
 path remains the reference for exact output equality.
 
-On the local arm64 TLA6 fixture (`smollm2-135m-instruct-tla6`, 5,000 release
-iterations), the complete assignment benchmark measured:
+The improvement comes from selecting the compact representation for the actual
+high-byte-first one-term artifact; the inactive term and mask traffic had
+previously kept the legacy 192-byte vector layout on the hot path.
 
-| layout | assignment ns/token |
-| --- | ---: |
-| previous two-term load layout | 159,189 |
-| compact one-term load layout | 59,556 |
+## Measurement
 
-That is approximately a 2.67× wall-clock improvement on this fixture, clearing
-the original ≥2× end-to-end criterion. The improvement comes from selecting
-the compact representation for the actual high-byte-first one-term artifact;
-the inactive term and mask traffic had previously kept the legacy 192-byte
-vector layout on the hot path. The ≥3× isolated criterion still needs a
-separate measurement/design decision.
+Isolated scans are timed through a measurement-only surface behind the
+`bench-internals` feature (`simd::bench`), which exposes the built dot tables
+read-only and reports which layout load-time selection chose. Nothing in it
+participates in the deployed prediction path.
+
+```
+cargo bench --features bench-internals --bench transformerless_dot -p uor-r4-core \
+  -- <artifact> 20000
+```
+
+Local arm64 (M4 Max), release, min-floor over 8 runs at 20,000 iterations on an
+otherwise-idle machine (per-metric spread ≤2%), TLA6 fixture
+`smollm2-135m-instruct-tla6`. All three scans cover identical work — one full
+K×D scan per stage, 1024 class rows — in a single process, so they share
+fixture, build, and machine state:
+
+| isolated dot scan | ns/scan | ns/row | vs scalar |
+| --- | ---: | ---: | ---: |
+| scalar reference (`dot_score_plain`) | 211,712 | 206.7 | 1.00× |
+| legacy two-term SIMD layout | 142,213 | 138.9 | 1.49× |
+| compact one-term SIMD layout | 55,397 | 54.1 | **3.82×** |
+
+Complete assignment (`assign_window`, compact layout): **57,425 ns/token**.
+
+The checked-in fixture (`crates/uor-r4-core/tests/fixtures/tless_artifacts.bin`,
+no external path required) reproduces this independently — min-floor over 6 runs
+at 20,000 iterations, `simd_dot_layout=compact`:
+
+| isolated dot scan | ns/scan | vs scalar |
+| --- | ---: | ---: |
+| scalar reference | 213,546 | 1.00× |
+| legacy two-term SIMD layout | 144,770 | 1.48× |
+| compact one-term SIMD layout | 56,284 | **3.79×** |
+
+Complete assignment: 59,032 ns/token. Layout delta 2.57×, matching the
+`smollm2-135m-instruct-tla6` figure to two significant figures.
+
+### Against the #330 criteria
+
+- **≥3× isolated: met — 3.82× (3.79× on the checked-in fixture).** The
+  baseline is `dot_score_plain`, the uninstrumented scalar reference —
+  deliberately *not* the scalar fallback in `Runtime::dot_argmax`, which routes
+  every table entry through the op-census kernel (~295k counter increments per
+  token) and would inflate the baseline. The SIMD side additionally performs
+  the argmax compare that the scalar loop omits, so the ratio is conservative.
+- **≥2× end-to-end: met, ≥3.69×.** A directly-measured scalar *serving*
+  baseline is unavailable for the reason above, so this is stated as a bound:
+  the dot scan is ~95% of steady-state serving cost (op-census figure from
+  #330), so scalar serving is at least the 211,712 ns scalar scan, against
+  57,425 ns/token measured here. Taking the 95% figure at face value gives
+  3.88×; the 3.69× floor assumes the remaining ~5% is free.
+- **Layout delta: 2.57×** (legacy 142,213 → compact 55,397) — the portion
+  attributable to the compact layout rather than to #334's adapter. Both
+  layouts are built from the same packed artifact in one process, and the
+  benchmark asserts they agree class-for-class before timing either.
+
+Two corroborations: the legacy layout's 1.49× isolated ratio independently
+lands near #334's reported ~1.5×, and compact end-to-end minus compact isolated
+leaves ~2.0µs of per-token bundling. An earlier single 5,000-iteration sample
+reported 159,189 ns/token for the previous layout and 59,556 for the compact
+one; those figures are superseded — the first implies ~17µs of bundling for the
+same work and was taken on a contended machine.
+
+Existing scalar/SIMD assignment witnesses remain the semantic-equality check;
+the scalar path stays the reference for exact output equality.
 
 No multiply, divide, float, allocation, or GPU operation enters the deployed
 prediction path.


### PR DESCRIPTION
Follow-up to #351, which landed the compact one-term dot layout but left #330's
pre-registered **≥3× isolated microbenchmark** criterion unmeasured — the #330
thread had judged it "out of reach on i64×2 lanes without a storage-design
change," and #351 *was* that storage-design change, so it was the first real
test of that claim.

This adds the measurement surface, takes the number, and corrects the framing of
the figures #351 recorded.

## Result

**≥3× isolated: met at 3.82×.**

arm64 (M4 Max), release, min-floor over 8 runs at 20,000 iterations on an idle
machine (spread ≤2%), TLA6 fixture `smollm2-135m-instruct-tla6`. All three scans
cover identical work — one full K×D scan per stage, 1024 class rows — in a single
process, so they share fixture, build, and machine state.

| isolated dot scan | ns/scan | vs scalar |
| --- | ---: | ---: |
| scalar reference (`dot_score_plain`) | 211,712 | 1.00× |
| legacy two-term SIMD layout | 142,213 | 1.49× |
| compact one-term SIMD layout | 55,397 | **3.82×** |

The checked-in fixture reproduces independently at **3.79×** (min-floor over 6
runs), with the same 2.57× layout delta.

## Corrections to what #351 recorded

**The ≥2× end-to-end claim compared the wrong pair.** #351 reported 159,189 →
59,556 ns/token as clearing that criterion, but both sides are SIMD — that is a
layout delta, not a ratio against the scalar baseline the criterion names.

There is no usable scalar *serving* baseline: the scalar fallback in
`Runtime::dot_argmax` routes every table entry through the op-census kernel
(~295k counter increments per token), so timing it would inflate the baseline and
flatter the ratio. The criterion is therefore restated as a bound, using #330's
own op-census figure (dot scan ≈95% of steady-state serving cost): scalar serving
≥ the 211,712 ns scalar scan, against 57,425 ns/token measured. At face value
3.88×; the **≥3.69×** floor assumes the remaining ~5% is free. Either way ≥2× is
comfortably met — but as a labelled bound, not an unqualified ratio.

**The 159,189 ns/token figure is superseded.** It implies ~17µs of per-token
bundling for work that measures ~2.0µs here, and was a single 5,000-iteration
sample on a contended machine. The layout delta is now measured in-process
against a forced legacy build (2.57×) instead of across two commits.

Two corroborations fell out: the legacy layout's 1.49× isolated ratio
independently lands near #334's reported ~1.5×, and compact end-to-end minus
compact isolated leaves the ~2.0µs of bundling noted above.

## Measurement surface

Isolated timing needs to reach `dot_argmax` directly, so `simd::bench` exposes
the built tables read-only behind a default-off `bench-internals` feature. It
also reports which layout load-time selection chose: the benchmark prints
`simd_dot_layout=compact`, witnessing that the compact path is what was measured
rather than assuming the selection predicate engaged. (#330's own thread records
a dispatch-default bug class where a census silently exercised scalar — this is
the cheap guard against that.)

`DotTables::from_packed_forced_two_term` is gated to
`#[cfg(any(test, feature = "bench-internals"))]`; the deployed path only ever
calls `from_packed`. `from_packed` itself is refactored into shared
`build_single_term`/`build_two_term` helpers with no behavior change.

## Test

New proptest `compact_and_legacy_layouts_agree` asserts both representations
decode the same packed ABI to the same argmax over random weights and work
vectors — the load-layout counterpart to the existing scalar/SIMD output
witnesses. It runs under plain `cargo test`, not only under the bench feature.
The benchmark also cross-checks the two layouts before timing either.

`cargo fmt`, `cargo clippy --all-targets -D warnings` (both feature states), and
`cargo test -p uor-r4-core --lib` are green locally.

## Unrelated pre-existing failure found while verifying

`cargo test -p uor-r4-core --test allocation_census` **fails on main**: the R4G1
kernels (`predict_token`/`predict_distribution`/`predict_candidates`/`step`) do 2
allocations / 594 bytes where the invariant demands zero. Bisected to before the
dot-layout work — it reproduces at 34e1062 — so it is not from #330 and is not
addressed here.

It appears to be green in CI because the test resolves artifacts from
`.uor-models/compiled/` and passes vacuously in ~1.9s when they are absent
(versus ~100s when it actually runs) — the skip-to-vacuous-green case AGENTS.md
lists under "Things that bite". Not yet filed as its own issue; flagging it here
so it is on the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
