### PR TITLE
test: make allocation census gate thread-local (#353)

### DIFF
--- a/crates/uor-r4-core/tests/allocation_census.rs
+++ b/crates/uor-r4-core/tests/allocation_census.rs
@@ -13,10 +13,21 @@
 //! the numbers. Fixed seed, no wall-clock assertions: the census is
 //! deterministic for a given artifact set.
 //!
+//! The gate is THREAD-LOCAL, not process-wide. A single `#[test]` keeps other
+//! measured tests from interleaving, but libtest's own runner thread keeps
+//! allocating while this test runs: once a test passes 60 seconds,
+//! `test::run_tests::get_timed_out_tests` grows a `Vec<TestDesc>` (512 + 82 =
+//! 594 bytes) and a process-wide gate charges that to whichever measured
+//! section happens to be open. That produced a spurious
+//! "kernels must be allocation-free" failure whose attribution wandered
+//! between entry points from run to run (#353). Gating per-thread counts only
+//! the thread inside `measure`, so foreign bookkeeping cannot land in the
+//! census.
+//!
 //! Run with: `cargo test -p uor-r4-core --test allocation_census -- --nocapture`
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::cell::Cell;
 
 use uor_r4_core::transformerless::compiler::{self, Compiled, STAGES, WINDOW};
 use uor_r4_core::transformerless::runtime::{self, OpKernel, Prediction, Store};
@@ -31,16 +42,26 @@ use uor_r4_core::transformerless::runtime::{self, OpKernel, Prediction, Store};
 /// measured section ask for", not "what was live at the end".
 struct CountingAlloc;
 
-static GATE: AtomicBool = AtomicBool::new(false);
-static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
-static BYTES: AtomicUsize = AtomicUsize::new(0);
+thread_local! {
+    /// Open only on the thread currently inside `measure`, so allocations made
+    /// by libtest's runner thread are never counted. See the module docs.
+    static GATE: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+    static BYTES: Cell<usize> = const { Cell::new(0) };
+}
 
 unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ptr = unsafe { System.alloc(layout) };
-        if !ptr.is_null() && GATE.load(Ordering::SeqCst) {
-            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
-            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        if !ptr.is_null() {
+            // `try_with`: during thread teardown the TLS may already be
+            // destroyed, and allocating then must not panic.
+            let _ = GATE.try_with(|gate| {
+                if gate.get() {
+                    let _ = ALLOCATIONS.try_with(|c| c.set(c.get() + 1));
+                    let _ = BYTES.try_with(|c| c.set(c.get() + layout.size()));
+                }
+            });
         }
         ptr
     }
@@ -65,19 +86,19 @@ const ZERO: Census = Census {
 
 fn census() -> Census {
     Census {
-        allocations: ALLOCATIONS.load(Ordering::Relaxed),
-        bytes: BYTES.load(Ordering::Relaxed),
+        allocations: ALLOCATIONS.with(Cell::get),
+        bytes: BYTES.with(Cell::get),
     }
 }
 
 /// Run `f` with the counting gate open; return its output and the census of
 /// what it allocated.
 fn measure<T>(f: impl FnOnce() -> T) -> (T, Census) {
-    ALLOCATIONS.store(0, Ordering::Relaxed);
-    BYTES.store(0, Ordering::Relaxed);
-    GATE.store(true, Ordering::SeqCst);
+    ALLOCATIONS.with(|c| c.set(0));
+    BYTES.with(|c| c.set(0));
+    GATE.with(|g| g.set(true));
     let out = f();
-    GATE.store(false, Ordering::SeqCst);
+    GATE.with(|g| g.set(false));
     (out, census())
 }
 
@@ -253,6 +274,47 @@ fn parse_store_measured() -> (Store, String) {
 
 #[test]
 fn allocation_census() {
+    // #353 regression guard. The gate must be thread-local: libtest's runner
+    // thread allocates while this test runs (`get_timed_out_tests` grows a
+    // Vec<TestDesc> once the test passes 60s), and a process-wide gate charged
+    // those 594 bytes to whichever measured section was open — a spurious
+    // failure whose attribution moved between entry points run to run.
+    // This check costs microseconds; the real thing took 100s to surface.
+    //
+    // The helper thread is spawned OUTSIDE the measured window: `thread::spawn`
+    // allocates on the spawning thread (boxed closure, JoinHandle, thread
+    // name), and those allocations are genuinely the measured thread's.
+    // Coordination is atomic-only, which does not allocate.
+    {
+        use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+        use std::sync::Arc;
+
+        let go = Arc::new(AtomicBool::new(false));
+        let done = Arc::new(AtomicBool::new(false));
+        let (go_t, done_t) = (Arc::clone(&go), Arc::clone(&done));
+        let helper = std::thread::spawn(move || {
+            while !go_t.load(AtomicOrdering::SeqCst) {
+                std::hint::spin_loop();
+            }
+            let buffer: Vec<u8> = Vec::with_capacity(4096);
+            std::hint::black_box(&buffer);
+            done_t.store(true, AtomicOrdering::SeqCst);
+        });
+
+        let (_, foreign) = measure(|| {
+            go.store(true, AtomicOrdering::SeqCst);
+            while !done.load(AtomicOrdering::SeqCst) {
+                std::hint::spin_loop();
+            }
+        });
+        helper.join().expect("helper thread joins");
+
+        assert_eq!(
+            foreign, ZERO,
+            "allocations on other threads must not enter the census"
+        );
+    }
+
     println!("=== allocation census: uor-r4-core transformerless runtime (Phase-0 baseline) ===");
 
     // Phase 1 — container parsing (expected > 0; reported, not asserted).


### PR DESCRIPTION
Fixes #353.

## What was wrong

The allocation census gate was a process-wide `AtomicBool`, so allocations made
by **any** thread while a measured section was open were counted into that
section. libtest's runner thread allocates during the test: once a test passes
60 seconds, `test::run_tests::get_timed_out_tests` grows a `Vec<TestDesc>`.

```
 12: <alloc::raw_vec::RawVec<test::types::TestDesc>>::grow_one
 14: <alloc::vec::Vec<test::types::TestDesc>>::push
 15: test::run_tests::get_timed_out_tests
 17: test::console::run_tests_console
 19: test::test_main_static
 20: allocation_census::main
```

512 + 82 = exactly the 594 bytes that were failing the "R4G1 runtime kernels
must be allocation-free in steady state" assertion.

**The R4G1 kernels never allocated.** I originally filed #353 as a violated
zero-alloc invariant; that was wrong and is corrected in the issue.

## Why it read as a runtime bug

- Attribution **wandered** between `step` and `predict_candidates` across
  identical builds and inputs — it tracked whichever call was executing when the
  60s timer fired.
- A restructured diagnostic made it **disappear**: regrouping the calls pushed
  the run to 170s, so the watchdog fired outside the measured window and the test
  passed.
- The `running for over 60 seconds` line prints immediately before the failure in
  the log.

The module docstring already anticipated the cross-*test* form of this hazard and
mitigated it with a single `#[test]`. That closes the cross-test leak but not the
cross-*thread* leak from the runner itself.

## Fix

Gate and counters become thread-local, so only the thread inside `measure` is
counted. `try_with` keeps allocations during TLS teardown from panicking.

## Verification

Every other census figure is byte-identical before and after — artifacts
13/530884, store 121405/11389105, r4g1 parse 1548/258148, add_evidence
563/51088, op census and generated tokens unchanged. The only movement is the
R4G1 kernel line: **2 allocations / 594 bytes → 0 / 0**.

The passing run still logs `running for over 60 seconds`, so the watchdog is
still firing — the fix stops it being *counted*, it doesn't just make the test
faster.

## Regression guard

Added a guard that allocates 4 KB on a helper thread and asserts the census stays
zero. The helper is spawned **outside** the measured window on purpose:
`thread::spawn` allocates on the spawning thread (boxed closure, `JoinHandle`,
thread name), and those allocations legitimately belong to the measured thread —
my first attempt got this wrong and failed for that reason. Coordination is
atomic-only, which does not allocate.

Verified to fail against the pre-fix harness (`1 allocation, 4096 bytes`) and
pass after — in 0.00s, versus the ~100s run the real symptom required.

## Related

#354 (fixture-absent vacuous green) is the other half. The two interlock: with
artifacts absent the test finishes in ~1.9s and passes without asserting
anything; with them present it runs ~100s, crosses 60s, and failed spuriously.
There was no configuration in which this test was both running and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
