### PR TITLE
feat: add certifier FMM candidate scorer (#290)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -589,6 +589,14 @@ impl R4Engine {
         (sig, code)
     }
 
+    /// Derive the sign signature for a token window for certifier-side
+    /// experiments. This exposes no deployed scoring semantics; callers still
+    /// receive the same artifact-derived signature used by the graph path.
+    pub fn signature_for_window(&self, window: &[u32]) -> Result<[u8; SIG_BYTES], InferenceError> {
+        self.check_window(window)?;
+        Ok(self.derive_sig_code(window).0)
+    }
+
     /// Derive the stable κ-label for a region identity. The identity is
     /// anchored to the canonical NODE section address and node id, so a
     /// changed graph section or node changes the witness claim. This keeps

--- a/crates/uor-r4-graph-certify/src/fmm.rs
+++ b/crates/uor-r4-graph-certify/src/fmm.rs
@@ -1,0 +1,427 @@
+//! Certifier-side low-rank far-field candidate scorer for issue #290.
+//!
+//! This module is deliberately compiler/certifier-side. It uses floating-point
+//! arithmetic and is not wired into the deployed integer runtime. The scorer
+//! approximates the prototype-to-emission interaction map
+//!
+//! ```text
+//! score(token | q) = root(token) + qᵀ Pᵀ E(token) / D
+//! ```
+//!
+//! where `P` contains the region sign prototypes, `E` contains the sparse
+//! region emission residuals, and `q` is the query sign vector. A deterministic
+//! symmetric eigendecomposition of `PᵀP` retains a bounded number of principal
+//! directions, yielding a measurable low-rank far-field candidate. Exact
+//! context evidence and deployed status policy are intentionally not included;
+//! this is the long-range candidate used by the exploratory accuracy gate.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use uor_r4_graph_format::ScoreQ;
+
+use crate::score_runtime::RegionParams;
+
+/// Configuration for the certifier-side far-field approximation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FmmConfig {
+    /// Maximum number of retained prototype directions.
+    pub max_rank: usize,
+    /// Retain directions whose singular value is at least this fraction of
+    /// the largest singular value.
+    pub relative_singular_tolerance: f64,
+}
+
+impl Default for FmmConfig {
+    fn default() -> Self {
+        Self {
+            max_rank: 20,
+            relative_singular_tolerance: 1.0e-2,
+        }
+    }
+}
+
+impl FmmConfig {
+    fn validate(self, dimension: usize) -> Result<Self, String> {
+        if self.max_rank == 0 {
+            return Err("FMM max_rank must be nonzero".to_owned());
+        }
+        if !self.relative_singular_tolerance.is_finite()
+            || self.relative_singular_tolerance <= 0.0
+            || self.relative_singular_tolerance > 1.0
+        {
+            return Err("FMM relative_singular_tolerance must be in (0, 1]".to_owned());
+        }
+        if dimension == 0 {
+            return Err("FMM prototype dimension must be nonzero".to_owned());
+        }
+        Ok(Self {
+            max_rank: self.max_rank.min(dimension),
+            ..self
+        })
+    }
+}
+
+/// One prediction from the exploratory far-field scorer.
+#[derive(Debug, Clone)]
+pub struct FmmScoreOutcome {
+    pub selected: u32,
+    /// Candidate scores in ascending token order.
+    pub candidates: Vec<(u32, f64)>,
+    pub rank: usize,
+    /// Fraction of prototype spectral energy retained by the basis.
+    pub retained_energy: f64,
+}
+
+/// Deterministic low-rank far-field scorer.
+#[derive(Debug, Clone)]
+pub struct FmmCandidateScorer {
+    config: FmmConfig,
+    dimension: usize,
+    rank: usize,
+    /// Eigenvectors of PᵀP, stored column-major as `dimension × rank`.
+    basis: Vec<f64>,
+    /// Projected emission map, stored row-major as `rank × vocab`.
+    token_factors: Vec<f64>,
+    root_prior: BTreeMap<u32, f64>,
+    root_floor: f64,
+    candidate_tokens: Vec<u32>,
+    retained_energy: f64,
+}
+
+impl FmmCandidateScorer {
+    /// Build a scorer from the graph's region prototypes and sparse emission
+    /// residuals. This constructor allocates once and performs all floating
+    /// point work; `score` only evaluates the bounded research candidate.
+    pub fn from_graph_parts(
+        regions: &[RegionParams],
+        emissions: &[BTreeMap<u32, ScoreQ>],
+        root_prior: &BTreeMap<u32, ScoreQ>,
+        root_floor: ScoreQ,
+        vocab: u32,
+        config: FmmConfig,
+    ) -> Result<Self, String> {
+        if regions.is_empty() || regions.len() != emissions.len() {
+            return Err("FMM regions and emissions must be nonempty and aligned".to_owned());
+        }
+        if vocab == 0 {
+            return Err("FMM vocabulary must be nonzero".to_owned());
+        }
+        let dimension = regions[0].sig.len() * 8;
+        let config = config.validate(dimension)?;
+        if regions.iter().any(|r| r.sig.len() * 8 != dimension) {
+            return Err("FMM region signatures have inconsistent widths".to_owned());
+        }
+
+        let mut gram = vec![0.0; dimension * dimension];
+        for region in regions {
+            let row = sign_row(&region.sig, dimension);
+            for left in 0..dimension {
+                for right in 0..=left {
+                    gram[left * dimension + right] += row[left] * row[right];
+                }
+            }
+        }
+        for left in 0..dimension {
+            for right in 0..left {
+                gram[right * dimension + left] = gram[left * dimension + right];
+            }
+        }
+
+        let (mut eigenvalues, eigenvectors) = symmetric_eigen(gram, dimension)?;
+        let largest = eigenvalues.first().copied().unwrap_or(0.0).max(0.0).sqrt();
+        if largest <= f64::EPSILON {
+            return Err("FMM prototypes have zero spectral energy".to_owned());
+        }
+        let cutoff = largest * config.relative_singular_tolerance;
+        let total_energy = eigenvalues.iter().sum::<f64>();
+        let rank = eigenvalues
+            .iter()
+            .take(config.max_rank)
+            .take_while(|&&value| value.max(0.0).sqrt() >= cutoff)
+            .count()
+            .max(1);
+        eigenvalues.truncate(rank);
+
+        let retained_energy = if total_energy > 0.0 {
+            eigenvalues.iter().sum::<f64>() / total_energy
+        } else {
+            0.0
+        };
+        let basis = take_columns(&eigenvectors, dimension, rank);
+
+        let mut token_set = BTreeSet::new();
+        token_set.extend(root_prior.keys().copied());
+        for map in emissions {
+            token_set.extend(map.keys().copied());
+        }
+        let candidate_tokens: Vec<u32> = token_set.into_iter().collect();
+        if candidate_tokens.is_empty() {
+            return Err("FMM graph has no root or emission candidates".to_owned());
+        }
+        let mut token_index = BTreeMap::new();
+        for (index, &token) in candidate_tokens.iter().enumerate() {
+            token_index.insert(token, index);
+        }
+        let mut token_factors = vec![0.0; rank * candidate_tokens.len()];
+        for (region, map) in regions.iter().zip(emissions) {
+            let row = sign_row(&region.sig, dimension);
+            let mut projection = vec![0.0; rank];
+            for component in 0..rank {
+                let mut value = 0.0;
+                for coordinate in 0..dimension {
+                    value += row[coordinate] * basis[coordinate * rank + component];
+                }
+                projection[component] = value / dimension as f64;
+            }
+            for (&token, &score) in map {
+                let Some(&index) = token_index.get(&token) else {
+                    continue;
+                };
+                let emission = score.raw() as f64 / 65_536.0;
+                for component in 0..rank {
+                    token_factors[component * candidate_tokens.len() + index] +=
+                        projection[component] * emission;
+                }
+            }
+        }
+
+        Ok(Self {
+            config,
+            dimension,
+            rank,
+            basis,
+            token_factors,
+            root_prior: root_prior
+                .iter()
+                .map(|(&token, &score)| (token, score.raw() as f64 / 65_536.0))
+                .collect(),
+            root_floor: root_floor.raw() as f64 / 65_536.0,
+            candidate_tokens,
+            retained_energy,
+        })
+    }
+
+    pub fn config(&self) -> FmmConfig {
+        self.config
+    }
+
+    pub fn rank(&self) -> usize {
+        self.rank
+    }
+
+    pub fn retained_energy(&self) -> f64 {
+        self.retained_energy
+    }
+
+    /// Score one sign signature with the low-rank far-field approximation.
+    pub fn score(&self, sig: &[u8], recent_tokens: &[u32]) -> Result<FmmScoreOutcome, String> {
+        if sig.len() * 8 != self.dimension {
+            return Err("FMM query signature width does not match the graph".to_owned());
+        }
+        let query = sign_row(sig, self.dimension);
+        let mut projected = vec![0.0; self.rank];
+        for (component, projected_value) in projected.iter_mut().enumerate() {
+            for (coordinate, &query_value) in query.iter().enumerate() {
+                *projected_value += query_value * self.basis[coordinate * self.rank + component];
+            }
+        }
+        let mut candidates = Vec::with_capacity(self.candidate_tokens.len());
+        for (index, &token) in self.candidate_tokens.iter().enumerate() {
+            let mut score = self
+                .root_prior
+                .get(&token)
+                .copied()
+                .unwrap_or(self.root_floor);
+            for (component, &projection) in projected.iter().enumerate() {
+                score += projection
+                    * self.token_factors[component * self.candidate_tokens.len() + index];
+            }
+            if recent_tokens.contains(&token) {
+                score -= 2_000_000.0 / 65_536.0;
+            }
+            candidates.push((token, score));
+        }
+        let selected = candidates
+            .iter()
+            .max_by(|(left_token, left_score), (right_token, right_score)| {
+                left_score
+                    .total_cmp(right_score)
+                    .then_with(|| right_token.cmp(left_token))
+            })
+            .map(|&(token, _)| token)
+            .ok_or("FMM produced no candidates")?;
+        Ok(FmmScoreOutcome {
+            selected,
+            candidates,
+            rank: self.rank,
+            retained_energy: self.retained_energy,
+        })
+    }
+}
+
+fn sign_row(sig: &[u8], dimension: usize) -> Vec<f64> {
+    (0..dimension)
+        .map(|bit| {
+            if sig[bit / 8] & (1 << (bit % 8)) != 0 {
+                1.0
+            } else {
+                -1.0
+            }
+        })
+        .collect()
+}
+
+fn take_columns(values: &[f64], dimension: usize, rank: usize) -> Vec<f64> {
+    let mut out = vec![0.0; dimension * rank];
+    for row in 0..dimension {
+        for column in 0..rank {
+            out[row * rank + column] = values[row * dimension + column];
+        }
+    }
+    out
+}
+
+/// Deterministic Jacobi eigensolver for a real symmetric matrix. Eigenpairs
+/// are returned in descending eigenvalue order; the fixed sweep and pivot
+/// order make the certifier output reproducible without an external LAPACK
+/// dependency.
+fn symmetric_eigen(mut matrix: Vec<f64>, dimension: usize) -> Result<(Vec<f64>, Vec<f64>), String> {
+    if matrix.len() != dimension * dimension || dimension == 0 {
+        return Err("invalid symmetric matrix dimensions".to_owned());
+    }
+    let mut vectors = vec![0.0; dimension * dimension];
+    for index in 0..dimension {
+        vectors[index * dimension + index] = 1.0;
+    }
+    for _ in 0..(dimension * 16).max(32) {
+        let mut pivot = None;
+        let mut max = 0.0;
+        for row in 0..dimension {
+            for column in (row + 1)..dimension {
+                let value = matrix[row * dimension + column].abs();
+                if value > max {
+                    max = value;
+                    pivot = Some((row, column));
+                }
+            }
+        }
+        if max <= 1.0e-12 {
+            break;
+        }
+        let (p, q) = pivot.ok_or("Jacobi pivot missing")?;
+        let app = matrix[p * dimension + p];
+        let aqq = matrix[q * dimension + q];
+        let apq = matrix[p * dimension + q];
+        let theta = 0.5 * (aqq - app) / apq;
+        let t = theta.signum() / (theta.abs() + (theta * theta + 1.0).sqrt());
+        let c = 1.0 / (1.0 + t * t).sqrt();
+        let s = t * c;
+        for index in 0..dimension {
+            let mip = matrix[index * dimension + p];
+            let miq = matrix[index * dimension + q];
+            matrix[index * dimension + p] = c * mip - s * miq;
+            matrix[index * dimension + q] = s * mip + c * miq;
+        }
+        for index in 0..dimension {
+            let mpi = matrix[p * dimension + index];
+            let mqi = matrix[q * dimension + index];
+            matrix[p * dimension + index] = c * mpi - s * mqi;
+            matrix[q * dimension + index] = s * mpi + c * mqi;
+            let vpi = vectors[index * dimension + p];
+            let vqi = vectors[index * dimension + q];
+            vectors[index * dimension + p] = c * vpi - s * vqi;
+            vectors[index * dimension + q] = s * vpi + c * vqi;
+        }
+    }
+    let mut order: Vec<usize> = (0..dimension).collect();
+    order.sort_by(|&left, &right| {
+        matrix[right * dimension + right]
+            .total_cmp(&matrix[left * dimension + left])
+            .then_with(|| left.cmp(&right))
+    });
+    let eigenvalues = order
+        .iter()
+        .map(|&index| matrix[index * dimension + index].max(0.0))
+        .collect();
+    let mut ordered_vectors = vec![0.0; dimension * dimension];
+    for row in 0..dimension {
+        for (column, &source) in order.iter().enumerate() {
+            ordered_vectors[row * dimension + column] = vectors[row * dimension + source];
+        }
+    }
+    Ok((eigenvalues, ordered_vectors))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::score_runtime::RegionParams;
+    use uor_r4_core::transformerless::compiler::SIG_BYTES;
+
+    fn region(node: u32, first_byte: u8) -> RegionParams {
+        let mut sig = [0u8; SIG_BYTES];
+        sig[0] = first_byte;
+        RegionParams {
+            node,
+            depth: 1,
+            radius: 8,
+            sig,
+            parent: None,
+        }
+    }
+
+    #[test]
+    fn low_rank_candidate_is_deterministic_and_selects_emission() {
+        let regions = vec![region(1, 0b0000_0001), region(2, 0b0000_0011)];
+        let mut first = BTreeMap::new();
+        first.insert(7, ScoreQ::from_raw(100 << 16));
+        let mut second = BTreeMap::new();
+        second.insert(9, ScoreQ::from_raw(80 << 16));
+        let root = BTreeMap::new();
+        let scorer = FmmCandidateScorer::from_graph_parts(
+            &regions,
+            &[first.clone(), second.clone()],
+            &root,
+            ScoreQ::from_raw(0),
+            16,
+            FmmConfig {
+                max_rank: 1,
+                relative_singular_tolerance: 1.0e-2,
+            },
+        )
+        .expect("candidate builds");
+        let mut left_sig = [0u8; SIG_BYTES];
+        left_sig[0] = 0b0000_0001;
+        let mut right_sig = [0u8; SIG_BYTES];
+        right_sig[0] = 0b0000_0011;
+        let left = scorer.score(&left_sig, &[]).expect("scores");
+        let right = scorer.score(&right_sig, &[]).expect("scores");
+        assert_eq!(left.selected, 7);
+        assert_eq!(right.selected, 7);
+        assert_eq!(left.rank, 1);
+        assert_eq!(
+            left.candidates,
+            scorer.score(&left_sig, &[]).unwrap().candidates
+        );
+        assert!(scorer.retained_energy() > 0.0);
+    }
+
+    #[test]
+    fn invalid_configuration_fails_closed() {
+        let regions = vec![region(1, 1)];
+        let emissions = vec![BTreeMap::from([(1, ScoreQ::from_raw(1))])];
+        let error = FmmCandidateScorer::from_graph_parts(
+            &regions,
+            &emissions,
+            &BTreeMap::new(),
+            ScoreQ::from_raw(0),
+            2,
+            FmmConfig {
+                max_rank: 0,
+                ..FmmConfig::default()
+            },
+        )
+        .expect_err("zero rank must fail");
+        assert!(error.contains("max_rank"));
+    }
+}

--- a/crates/uor-r4-graph-certify/src/fmm.rs
+++ b/crates/uor-r4-graph-certify/src/fmm.rs
@@ -88,6 +88,33 @@ pub struct FmmCandidateScorer {
     retained_energy: f64,
 }
 
+/// One prediction from the fixed-point translation-table candidate.
+#[derive(Debug, Clone)]
+pub struct FmmFixedScoreOutcome {
+    pub selected: u32,
+    /// Candidate scores in ascending token order, represented as Q16.16 raw
+    /// integers widened to i64 for overflow-safe comparison.
+    pub candidates: Vec<(u32, i64)>,
+    pub rank: usize,
+}
+
+/// Quantized form of [`FmmCandidateScorer`]. The basis uses signed Q1.15
+/// values; token factors use a common power-of-two fractional scale, so the
+/// score accumulation and final Q16.16 conversion are integer operations.
+/// This is a feasibility prototype for a future packed runtime table, not yet
+/// the deployed allocation-free kernel.
+#[derive(Debug, Clone)]
+pub struct FmmFixedCandidateScorer {
+    dimension: usize,
+    rank: usize,
+    basis_q15: Vec<i16>,
+    token_factors_q: Vec<i32>,
+    factor_fraction_bits: u8,
+    root_prior: BTreeMap<u32, ScoreQ>,
+    root_floor: ScoreQ,
+    candidate_tokens: Vec<u32>,
+}
+
 impl FmmCandidateScorer {
     /// Build a scorer from the graph's region prototypes and sparse emission
     /// residuals. This constructor allocates once and performs all floating
@@ -213,6 +240,55 @@ impl FmmCandidateScorer {
         self.retained_energy
     }
 
+    /// Quantize the float candidate into a deterministic fixed-point table.
+    pub fn fixed_point(&self) -> Result<FmmFixedCandidateScorer, String> {
+        let basis_q15 = self
+            .basis
+            .iter()
+            .map(|&value| (value * 32_768.0).round().clamp(-32_767.0, 32_767.0) as i16)
+            .collect();
+        let max_factor = self
+            .token_factors
+            .iter()
+            .map(|value| value.abs())
+            .fold(0.0, f64::max);
+        let factor_fraction_bits = choose_fraction_bits(max_factor);
+        let factor_scale = (1u64 << factor_fraction_bits) as f64;
+        let token_factors_q = self
+            .token_factors
+            .iter()
+            .map(|&value| {
+                (value * factor_scale)
+                    .round()
+                    .clamp(i32::MIN as f64, i32::MAX as f64) as i32
+            })
+            .collect();
+        Ok(FmmFixedCandidateScorer {
+            dimension: self.dimension,
+            rank: self.rank,
+            basis_q15,
+            token_factors_q,
+            factor_fraction_bits,
+            root_prior: self
+                .root_prior
+                .iter()
+                .map(|(&token, &score)| {
+                    (token, ScoreQ::from_raw((score * 65_536.0).round() as i32))
+                })
+                .collect(),
+            root_floor: ScoreQ::from_raw((self.root_floor * 65_536.0).round() as i32),
+            candidate_tokens: self.candidate_tokens.clone(),
+        })
+    }
+
+    /// Approximate storage occupied by the float factors and token metadata.
+    pub fn storage_bytes(&self) -> usize {
+        self.basis.len() * std::mem::size_of::<f64>()
+            + self.token_factors.len() * std::mem::size_of::<f64>()
+            + self.candidate_tokens.len() * std::mem::size_of::<u32>()
+            + self.root_prior.len() * (std::mem::size_of::<u32>() + std::mem::size_of::<f64>())
+    }
+
     /// Score one sign signature with the low-rank far-field approximation.
     pub fn score(&self, sig: &[u8], recent_tokens: &[u32]) -> Result<FmmScoreOutcome, String> {
         if sig.len() * 8 != self.dimension {
@@ -257,6 +333,158 @@ impl FmmCandidateScorer {
             retained_energy: self.retained_energy,
         })
     }
+}
+
+impl FmmFixedCandidateScorer {
+    pub fn rank(&self) -> usize {
+        self.rank
+    }
+
+    pub fn factor_fraction_bits(&self) -> u8 {
+        self.factor_fraction_bits
+    }
+
+    /// Approximate storage occupied by the quantized translation table and
+    /// token metadata.
+    pub fn storage_bytes(&self) -> usize {
+        self.basis_q15.len() * std::mem::size_of::<i16>()
+            + self.token_factors_q.len() * std::mem::size_of::<i32>()
+            + self.candidate_tokens.len() * std::mem::size_of::<u32>()
+            + self.root_prior.len() * (std::mem::size_of::<u32>() + std::mem::size_of::<i32>())
+    }
+
+    /// Select the best token without allocating. The caller owns the
+    /// rank-sized projection scratch; this is the adapter shape a future
+    /// fixed-capacity runtime can embed in its step state.
+    pub fn select_into(
+        &self,
+        sig: &[u8],
+        recent_tokens: &[u32],
+        projected: &mut [i64],
+    ) -> Result<(u32, i64), String> {
+        if sig.len() * 8 != self.dimension {
+            return Err("fixed FMM query signature width does not match the graph".to_owned());
+        }
+        if projected.len() < self.rank {
+            return Err("fixed FMM projection scratch is too small".to_owned());
+        }
+        projected[..self.rank].fill(0);
+        for (component, projected_value) in projected[..self.rank].iter_mut().enumerate() {
+            for coordinate in 0..self.dimension {
+                let sign = if sig[coordinate / 8] & (1 << (coordinate % 8)) != 0 {
+                    1i64
+                } else {
+                    -1i64
+                };
+                *projected_value +=
+                    sign * i64::from(self.basis_q15[coordinate * self.rank + component]);
+            }
+        }
+        let token_count = self.candidate_tokens.len();
+        let mut best: Option<(u32, i64)> = None;
+        for (index, &token) in self.candidate_tokens.iter().enumerate() {
+            let mut interaction = 0i128;
+            for (component, &projection) in projected[..self.rank].iter().enumerate() {
+                interaction += projection as i128
+                    * i128::from(self.token_factors_q[component * token_count + index]);
+            }
+            let mut score =
+                i64::from(
+                    self.root_prior
+                        .get(&token)
+                        .copied()
+                        .unwrap_or(self.root_floor)
+                        .raw(),
+                ) + round_shift_signed(interaction, self.factor_fraction_bits.saturating_sub(1));
+            if recent_tokens.contains(&token) {
+                score = score.saturating_sub(2_000_000);
+            }
+            let replace = best.is_none_or(|(best_token, best_score)| {
+                score > best_score || (score == best_score && token < best_token)
+            });
+            if replace {
+                best = Some((token, score));
+            }
+        }
+        best.ok_or("fixed FMM produced no candidates".to_owned())
+    }
+
+    /// Score one signature using only integer table values after the
+    /// compiler-selected quantization scales have been fixed.
+    pub fn score(&self, sig: &[u8], recent_tokens: &[u32]) -> Result<FmmFixedScoreOutcome, String> {
+        if sig.len() * 8 != self.dimension {
+            return Err("fixed FMM query signature width does not match the graph".to_owned());
+        }
+        let mut projected = vec![0i64; self.rank];
+        for (component, projected_value) in projected.iter_mut().enumerate() {
+            for coordinate in 0..self.dimension {
+                let sign = if sig[coordinate / 8] & (1 << (coordinate % 8)) != 0 {
+                    1i64
+                } else {
+                    -1i64
+                };
+                *projected_value +=
+                    sign * i64::from(self.basis_q15[coordinate * self.rank + component]);
+            }
+        }
+        let token_count = self.candidate_tokens.len();
+        let mut candidates = Vec::with_capacity(token_count);
+        for (index, &token) in self.candidate_tokens.iter().enumerate() {
+            let mut interaction = 0i128;
+            for (component, &projection) in projected.iter().enumerate() {
+                interaction += projection as i128
+                    * i128::from(self.token_factors_q[component * token_count + index]);
+            }
+            let mut score =
+                i64::from(
+                    self.root_prior
+                        .get(&token)
+                        .copied()
+                        .unwrap_or(self.root_floor)
+                        .raw(),
+                ) + round_shift_signed(interaction, self.factor_fraction_bits.saturating_sub(1));
+            if recent_tokens.contains(&token) {
+                score = score.saturating_sub(2_000_000);
+            }
+            candidates.push((token, score));
+        }
+        let selected = candidates
+            .iter()
+            .max_by(|(left_token, left_score), (right_token, right_score)| {
+                left_score
+                    .cmp(right_score)
+                    .then_with(|| right_token.cmp(left_token))
+            })
+            .map(|&(token, _)| token)
+            .ok_or("fixed FMM produced no candidates")?;
+        Ok(FmmFixedScoreOutcome {
+            selected,
+            candidates,
+            rank: self.rank,
+        })
+    }
+}
+
+fn choose_fraction_bits(max_abs: f64) -> u8 {
+    for bits in (0..=30).rev() {
+        if max_abs * (1u64 << bits) as f64 <= i32::MAX as f64 {
+            return bits.max(1);
+        }
+    }
+    0
+}
+
+fn round_shift_signed(value: i128, shift: u8) -> i64 {
+    if shift == 0 {
+        return value.clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64;
+    }
+    let divisor = 1i128 << shift;
+    let adjusted = if value >= 0 {
+        value.saturating_add(divisor / 2)
+    } else {
+        value.saturating_sub(divisor / 2)
+    };
+    (adjusted / divisor).clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
 }
 
 fn sign_row(sig: &[u8], dimension: usize) -> Vec<f64> {
@@ -404,6 +632,14 @@ mod tests {
             scorer.score(&left_sig, &[]).unwrap().candidates
         );
         assert!(scorer.retained_energy() > 0.0);
+        let fixed = scorer.fixed_point().expect("fixed candidate builds");
+        assert_eq!(fixed.score(&left_sig, &[]).unwrap().selected, left.selected);
+        let mut projected = [0i64; 1];
+        assert_eq!(
+            fixed.select_into(&left_sig, &[], &mut projected).unwrap().0,
+            left.selected
+        );
+        assert!(fixed.storage_bytes() < scorer.storage_bytes());
     }
 
     #[test]

--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compare;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod compiler_scaling;
 pub mod fairness_provenance;
+pub mod fmm;
 pub mod holographic_encoding;
 pub mod long_context;
 pub mod patch_lifecycle;
@@ -16,5 +17,6 @@ pub mod score;
 pub mod score_runtime;
 pub mod shortlist_evaluator;
 
+pub use fmm::*;
 pub use score::*;
 pub use score_runtime::*;

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -739,6 +739,22 @@ pub struct GraphScorer {
 }
 
 impl GraphScorer {
+    /// Build the certifier-side low-rank far-field candidate for this graph.
+    /// This deliberately does not alter deployed scoring semantics.
+    pub fn fmm_candidate(
+        &self,
+        config: crate::fmm::FmmConfig,
+    ) -> Result<crate::fmm::FmmCandidateScorer, String> {
+        crate::fmm::FmmCandidateScorer::from_graph_parts(
+            &self.regions,
+            &self.emissions,
+            &self.root_prior,
+            self.root_floor,
+            self.vocab,
+            config,
+        )
+    }
+
     /// Enable or disable predicted-cloud (F / ΔT) emissions. Default
     /// disabled since the #66 ablation decision; re-enabling requires a
     /// measured per-token ΔT design (the folded offset is argmax-neutral).

--- a/docs/fmm_290_novel_context_protocol.md
+++ b/docs/fmm_290_novel_context_protocol.md
@@ -67,6 +67,13 @@ Pinned fixture run:
 | legacy TLS store | 96 | 0 | 0.0104 | 0.1771 | 9.2121 |
 | R4G1 graph | 96 | 3 | 0.0104 | 0.0521 | 11.4626 |
 
+The same replay also records teacher cross-entropy for the selected token:
+
+| implementation | teacher bits/token |
+|---|---:|
+| legacy TLS store | 11.7423 |
+| R4G1 graph | 13.9549 |
+
 The last column is the existing parity harness's regret-style diagnostic: the
 teacher-logit gap between its argmax and the selected token, clipped at zero.
 It is not the requested bits/token metric and must not be presented as one.
@@ -74,6 +81,34 @@ The BDD scenario remains the source of truth for the incumbent pass/fail
 floors; this table is the §5.2 baseline snapshot.
 
 ## Candidate comparison and decision rule
+
+The first certifier-side candidate is implemented in
+`uor-r4-graph-certify::fmm`. It forms the prototype/emission interaction map
+from the validated graph, diagonalizes the deterministic symmetric Gram matrix
+`PᵀP`, retains a bounded basis, and scores the same artifact-derived query
+signature through that basis. It uses floating point and is explicitly not a
+serving or integer-kernel implementation.
+
+Run it through the S7 parity scenario with:
+
+```bash
+R4_FMM_POSITIONS=256 \
+  cargo test --test bdd --offline -- --name 'S7' --concurrency 1 -v
+```
+
+The eight prompts contain 96 positions in total, so the 256-position budget
+does not increase this fixed snapshot. With rank 20 and relative singular
+tolerance `1e-2`, the pinned run produced:
+
+| candidate | positions | abstains | rank | retained energy | top-1 | top-8 | teacher bits/token |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| certifier FMM | 96 | 0 | 20 | 0.6967 | 0.0104 | 0.2604 | 10.5879 |
+
+Against the incumbent R4G1 graph, top-1 is unchanged, top-8 improves by
+20.83 percentage points, and teacher cross-entropy improves by 3.3670
+bits/token. This is an exploratory result, not a deployment claim: the
+candidate currently has no integer translation table, allocation-free serving
+path, or §5.4 cost certificate.
 
 The candidate must expose the same teacher-forced prediction contract as the
 incumbent. First compare it at the same 96-position snapshot, then rerun at
@@ -94,11 +129,11 @@ passes accuracy must still clear the §5.4 constant-factor check: measured
 operator work, stored translation data, and routing overhead must beat the
 incumbent on the same fixture.
 
-## Current blocker
+## Remaining work
 
-The repository currently contains the rank-analysis material for §5.1 but no
-FMM operator, M2L translation table, or runtime adapter that can replace the
-R4G1 scorer. Therefore the next implementation task is to define and test a
-candidate operator against the existing graph score interface; extending the
-parity harness before that point would only remeasure the incumbent and could
-not close issue #290.
+The certifier candidate now exists and is measured, but issue #290 is not yet
+closed. The remaining decision is whether the accuracy gain justifies a
+bounded implementation for the deployed contract. That requires a fixed-point
+translation representation, an allocation-free adapter, and the §5.4 cost
+comparison against R4G1. Until those are implemented and certified, the FMM
+candidate remains a research measurement path only.

--- a/docs/fmm_290_novel_context_protocol.md
+++ b/docs/fmm_290_novel_context_protocol.md
@@ -104,6 +104,20 @@ tolerance `1e-2`, the pinned run produced:
 |---|---:|---:|---:|---:|---:|---:|---:|
 | certifier FMM | 96 | 0 | 20 | 0.6967 | 0.0104 | 0.2604 | 10.5879 |
 
+The fixed-point translation-table form uses Q1.15 basis entries and a common
+power-of-two factor scale. On the same replay (`factor_fraction_bits = 29`),
+it selected the same token at every position and produced identical metrics:
+
+| representation | storage estimate | top-1 | top-8 | teacher bits/token |
+|---|---:|---:|---:|---:|
+| float factors | 337,888 B | 0.0104 | 0.2604 | 10.5879 |
+| fixed-point factors | 164,056 B | 0.0104 | 0.2604 | 10.5879 |
+
+The fixed-point scorer also exposes a caller-buffered selection method with no
+per-call allocation. Its current certifier implementation still uses widened
+integer arithmetic, including products, for feasibility measurement; it is not
+yet the deployed multiplication-free kernel.
+
 Against the incumbent R4G1 graph, top-1 is unchanged, top-8 improves by
 20.83 percentage points, and teacher cross-entropy improves by 3.3670
 bits/token. This is an exploratory result, not a deployment claim: the

--- a/docs/fmm_290_novel_context_protocol.md
+++ b/docs/fmm_290_novel_context_protocol.md
@@ -1,0 +1,104 @@
+# Issue #290 §5.2 — novel-context accuracy protocol
+
+Status: protocol and incumbent baseline recorded; the FMM candidate is not yet
+implemented, so this issue is not closed by this document.
+
+## Purpose
+
+Issue #290 proposes a far-field/FMM approximation for long-range semantic
+interactions. The existing Gate C score is not a suitable acceptance test: its
+positions are drawn from the corpus used to compile the graph and therefore
+measure exact-context retrieval and in-distribution memorization. §5.2 must
+measure genuinely novel context and compare the incumbent R4G1 path with the
+candidate under identical teacher-forced histories.
+
+## Fixed evaluation set
+
+Use the eight deterministic prompts already pinned by the teacher-parity BDD
+suite:
+
+```text
+why is the sky blue?
+what is the capital of France?
+explain gravity to a child
+how do computers work?
+what is photosynthesis?
+tell me about the moon
+how does a bicycle work?
+what is the internet?
+```
+
+At each prompt position, advance the teacher with the true preceding token and
+ask the evaluated runtime to predict from that same true history. Do not feed a
+runtime's prediction back into the teacher or into the next runtime window;
+that would measure compounded free-running divergence rather than the local
+decision being tested. The default budget is 256 positions, with the current
+fixture run below using 96 positions so it is directly comparable with the
+existing pinned BDD thresholds.
+
+The evaluation must record, for each implementation:
+
+- evaluated positions and abstentions;
+- top-1 agreement with the teacher argmax;
+- top-8 recall;
+- teacher negative log-probability of the selected token, in bits/token;
+- an implementation label, artifact κ, teacher κ, prompt-set κ, and the exact
+  candidate configuration (rank, tolerance, admissibility rule, and quantile).
+
+The prompt-set κ is the BLAKE3 digest of the UTF-8 prompt bytes in listed
+order (concatenated without separators); for this set it is
+`blake3:3735fa62ec052aac7266a421702b281598ea298ab13b9892325d02ba40b00a2b`.
+A candidate result without all three input κs is not a reproducible
+§5.2 result.
+
+## Incumbent baseline
+
+Command used on 2026-08-02:
+
+```bash
+R4_PARITY_POSITIONS=96 \
+  cargo test --test bdd --offline -- --name 'S[23]' --concurrency 1 -v
+```
+
+Pinned fixture run:
+
+| implementation | positions | abstains | top-1 | top-8 | mean teacher-argmax gap (bits) |
+|---|---:|---:|---:|---:|---:|
+| legacy TLS store | 96 | 0 | 0.0104 | 0.1771 | 9.2121 |
+| R4G1 graph | 96 | 3 | 0.0104 | 0.0521 | 11.4626 |
+
+The last column is the existing parity harness's regret-style diagnostic: the
+teacher-logit gap between its argmax and the selected token, clipped at zero.
+It is not the requested bits/token metric and must not be presented as one.
+The BDD scenario remains the source of truth for the incumbent pass/fail
+floors; this table is the §5.2 baseline snapshot.
+
+## Candidate comparison and decision rule
+
+The candidate must expose the same teacher-forced prediction contract as the
+incumbent. First compare it at the same 96-position snapshot, then rerun at
+the default 256-position budget. Keep the prompt set, teacher math mode,
+artifact, graph, and tokenizer fixed. Report both absolute metrics and the
+candidate-minus-incumbent deltas.
+
+The pre-registered issue rule is:
+
+- kill the FMM route if novel-context top-1 falls by more than 0.5 percentage
+  points versus the incumbent, or
+- kill it if its teacher cross-entropy (bits/token) is worse than the pinned
+  teacher-floor budget for the evaluation.
+
+An implementation that improves the score but does not demonstrate a bounded
+far-field approximation is not an FMM result. Conversely, a candidate that
+passes accuracy must still clear the §5.4 constant-factor check: measured
+operator work, stored translation data, and routing overhead must beat the
+incumbent on the same fixture.
+
+## Current blocker
+
+The repository currently contains the rank-analysis material for §5.1 but no
+FMM operator, M2L translation table, or runtime adapter that can replace the
+R4G1 scorer. Therefore the next implementation task is to define and test a
+candidate operator against the existing graph score interface; extending the
+parity harness before that point would only remeasure the incumbent and could
+not close issue #290.

--- a/features/suites/teacher_parity_benchmarks.feature
+++ b/features/suites/teacher_parity_benchmarks.feature
@@ -43,3 +43,8 @@ Feature: Teacher parity and benchmarks for the compiled transformerless runtimes
     Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
     When the corpus records are replayed against the recorded teacher labels
     Then the in-distribution parity metrics meet the pinned empirical criteria
+
+  Scenario: S7 certifier FMM candidate on novel contexts
+    Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
+    When the certifier FMM candidate is replayed against the teacher on pinned prompts
+    Then the FMM candidate produces a reproducible novel-context measurement

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -89,6 +89,17 @@ impl R4g1State {
             .map_err(|error| error.to_string())
     }
 
+    /// Derive the artifact-backed sign signature for a token window. This is
+    /// exposed for certifier-side research candidates such as issue #290's
+    /// low-rank far-field scorer; serving continues through the normal policy
+    /// path above.
+    pub fn signature_for_window(&self, window: &[u32]) -> Result<[u8; SIG_BYTES], String> {
+        self.engine
+            .borrow()
+            .signature_for_window(window)
+            .map_err(|error| error.to_string())
+    }
+
     /// Generate a greedy continuation with per-step policy decisions:
     /// stops at the first abstention (returning the count so far and
     /// the abstaining status) and never emits a guessed token.

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -10,6 +10,7 @@ use uor_r4_core::transformerless::bott_fock::BottFockContextStore;
 use uor_r4_core::transformerless::compiler::SIG_BYTES;
 use uor_r4_core::transformerless::endomorphism::EndomorphismAlgebra;
 use uor_r4_core::transformerless::lie_jordan::{universal_product_u8, LieJordanSplit};
+use uor_r4_graph_certify::{FmmCandidateScorer, FmmConfig, GraphScorer};
 use uor_r4_graph_compiler::induction::{
     canonical_merge_edge_fragments, CoverEdge, Observation, EDGE_KIND_NEIGHBOR,
     EDGE_KIND_REFINEMENT, EDGE_KIND_TRANSITION,
@@ -202,6 +203,7 @@ struct R4g1World {
     parity_witness_consistent: Option<bool>,
     parity_corpus_legacy: Option<ParityMetrics>,
     parity_corpus_graph: Option<ParityMetrics>,
+    parity_fmm_metrics: Option<ParityMetrics>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -2719,6 +2721,7 @@ struct ParityMetrics {
     top1_agreement: f64,
     top8_recall: f64,
     mean_delta_bits: f64,
+    teacher_bits_per_token: f64,
 }
 
 /// Median free-running generation rates (tokens/second) and compiled/teacher
@@ -2742,6 +2745,7 @@ struct ParityFixtures {
     tokenizer: Tokenizer,
     r4g1: Option<R4g1State>,
     corpus: Option<Corpus>,
+    fmm: Option<FmmCandidateScorer>,
 }
 
 thread_local! {
@@ -2799,6 +2803,7 @@ fn load_parity_fixtures() -> Option<ParityFixtures> {
     let tokenizer = Tokenizer::try_load(bundle.join("tokenizer.bin")).ok()?;
     let r4g1 = load_r4g1(&bundle, &artifact_bytes);
     let corpus = load_parity_corpus(&bundle);
+    let fmm = load_fmm_candidate(&bundle, &artifact_bytes);
     Some(ParityFixtures {
         teacher,
         artifacts,
@@ -2806,7 +2811,33 @@ fn load_parity_fixtures() -> Option<ParityFixtures> {
         tokenizer,
         r4g1,
         corpus,
+        fmm,
     })
+}
+
+/// Build the exploratory FMM candidate from the same validated graph bytes
+/// used by the incumbent parity path. It is deliberately optional: fixtures
+/// without a certifier-readable graph continue to use the existing vacuous
+/// parity convention.
+fn load_fmm_candidate(bundle: &Path, artifact_bytes: &[u8]) -> Option<FmmCandidateScorer> {
+    let graph_path = bundle.join("graph/score.r4g1");
+    let graph = std::fs::read(&graph_path).ok()?;
+    let scorer = GraphScorer::from_artifact(&graph, Some(artifact_bytes), 64, 64).ok()?;
+    let defaults = FmmConfig::default();
+    let max_rank = std::env::var("R4_FMM_RANK")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(defaults.max_rank);
+    let relative_singular_tolerance = std::env::var("R4_FMM_TOLERANCE")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(defaults.relative_singular_tolerance);
+    scorer
+        .fmm_candidate(FmmConfig {
+            max_rank,
+            relative_singular_tolerance,
+        })
+        .ok()
 }
 
 /// Load the bundle's corpus record stream for the S6 in-distribution
@@ -2875,6 +2906,7 @@ fn teacher_forced_eval(fx: &mut ParityFixtures, graph: bool, budget: usize) -> P
     let mut top1_hits = 0usize;
     let mut top8_hits = 0usize;
     let mut delta_bits_sum = 0.0f64;
+    let mut teacher_bits_sum = 0.0f64;
     let mut scored = 0usize;
     let mut logits = vec![0.0f32; fx.teacher.vocab()];
     let mut top8 = [(0u32, 0.0f32); 8];
@@ -2919,6 +2951,7 @@ fn teacher_forced_eval(fx: &mut ParityFixtures, graph: bool, budget: usize) -> P
             if top8[..k].iter().any(|&(t, _)| t == pick) {
                 top8_hits += 1;
             }
+            teacher_bits_sum += teacher_bits_for_token(&logits, pick);
             let gap_nats = logits[teacher_argmax as usize] - logits[pick as usize];
             delta_bits_sum += f64::from(gap_nats.max(0.0)) / std::f64::consts::LN_2;
             scored += 1;
@@ -2931,7 +2964,79 @@ fn teacher_forced_eval(fx: &mut ParityFixtures, graph: bool, budget: usize) -> P
         top1_agreement: top1_hits as f64 / denom,
         top8_recall: top8_hits as f64 / denom,
         mean_delta_bits: delta_bits_sum / scored.max(1) as f64,
+        teacher_bits_per_token: teacher_bits_sum / scored.max(1) as f64,
     }
+}
+
+/// Cross-entropy of a runtime-selected token under the live teacher,
+/// expressed in bits/token. This is the §5.2 local decision metric.
+fn teacher_bits_for_token(logits: &[f32], token: u32) -> f64 {
+    let index = token as usize;
+    if index >= logits.len() || logits.is_empty() {
+        return f64::INFINITY;
+    }
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max) as f64;
+    let log_sum_exp = logits
+        .iter()
+        .map(|&logit| (f64::from(logit) - max).exp())
+        .sum::<f64>()
+        .ln()
+        + max;
+    -(f64::from(logits[index]) - log_sum_exp) / std::f64::consts::LN_2
+}
+
+/// Teacher-forced evaluation of the certifier-side FMM candidate. The
+/// candidate receives the same artifact-derived signature and true history as
+/// the incumbent, but it does not participate in serving status policy.
+fn fmm_teacher_forced_eval(fx: &mut ParityFixtures, budget: usize) -> Option<ParityMetrics> {
+    let fmm = fx.fmm.as_ref()?.clone();
+    let r4g1 = fx.r4g1.as_ref()?;
+    let mut positions = 0usize;
+    let mut top1_hits = 0usize;
+    let mut top8_hits = 0usize;
+    let mut teacher_bits_sum = 0.0f64;
+    let mut remaining = budget;
+    let mut logits = vec![0.0f32; fx.teacher.vocab()];
+    let mut top8 = [(0u32, 0.0f32); 8];
+    'prompts: for prompt in PARITY_PROMPTS {
+        let tokens = fx.tokenizer.encode(prompt);
+        if tokens.len() < 2 {
+            continue;
+        }
+        fx.teacher.reset();
+        for i in 0..tokens.len() - 1 {
+            if remaining == 0 {
+                break 'prompts;
+            }
+            remaining -= 1;
+            fx.teacher.step(tokens[i] as usize, i, &mut logits);
+            let k = fx.teacher.top_k(8, &mut top8);
+            let teacher_argmax = top8[0].0;
+            let window = &tokens[(i + 1).saturating_sub(WINDOW)..=i];
+            let sig = r4g1.signature_for_window(window).ok()?;
+            let outcome = fmm.score(&sig, &[]).ok()?;
+            positions += 1;
+            if outcome.selected == teacher_argmax {
+                top1_hits += 1;
+            }
+            if top8[..k]
+                .iter()
+                .any(|&(token, _)| token == outcome.selected)
+            {
+                top8_hits += 1;
+            }
+            teacher_bits_sum += teacher_bits_for_token(&logits, outcome.selected);
+        }
+    }
+    let denom = positions.max(1) as f64;
+    Some(ParityMetrics {
+        positions,
+        abstains: 0,
+        top1_agreement: top1_hits as f64 / denom,
+        top8_recall: top8_hits as f64 / denom,
+        mean_delta_bits: 0.0,
+        teacher_bits_per_token: teacher_bits_sum / denom,
+    })
 }
 
 fn teacher_argmax(logits: &[f32]) -> usize {
@@ -3090,6 +3195,7 @@ fn parity_legacy_checked(w: &mut R4g1World) {
         "top1_agreement": m.top1_agreement,
         "top8_recall": m.top8_recall,
         "mean_delta_bits": m.mean_delta_bits,
+        "teacher_bits_per_token": m.teacher_bits_per_token,
         "floors": {"top1": LEGACY_TOP1_FLOOR, "top8": LEGACY_TOP8_FLOOR, "delta_bits_ceil": LEGACY_DELTA_BITS_CEIL},
     });
     println!(
@@ -3145,6 +3251,7 @@ fn parity_graph_checked(w: &mut R4g1World) {
         "top1_agreement": m.top1_agreement,
         "top8_recall": m.top8_recall,
         "mean_delta_bits": m.mean_delta_bits,
+        "teacher_bits_per_token": m.teacher_bits_per_token,
         "floors": {"top1": GRAPH_TOP1_FLOOR, "top8": GRAPH_TOP8_FLOOR, "delta_bits_ceil": GRAPH_DELTA_BITS_CEIL},
     });
     println!(
@@ -3183,6 +3290,64 @@ fn parity_graph_abstains_checked(w: &mut R4g1World) {
         "graph abstentions {} above pinned bound {GRAPH_ABSTAIN_BOUND}",
         m.abstains
     );
+}
+
+#[when("the certifier FMM candidate is replayed against the teacher on pinned prompts")]
+fn parity_replay_fmm(w: &mut R4g1World) {
+    if parity_skip(w, "S7") {
+        return;
+    }
+    let has_fmm = with_parity_fixtures(|fx| fx.fmm.is_some() && fx.r4g1.is_some()).unwrap_or(false);
+    if !has_fmm {
+        eprintln!("[parity] S7: FMM candidate unavailable — vacuous pass");
+        return;
+    }
+    let budget = parity_budget("R4_FMM_POSITIONS", 256);
+    w.parity_fmm_metrics = with_parity_fixtures(|fx| fmm_teacher_forced_eval(fx, budget)).flatten();
+    if let Some(metrics) = w.parity_fmm_metrics {
+        let (rank, retained_energy) = with_parity_fixtures(|fx| {
+            fx.fmm
+                .as_ref()
+                .map(|fmm| (fmm.rank(), fmm.retained_energy()))
+        })
+        .flatten()
+        .unwrap_or((0, 0.0));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "suite": "teacher_parity_benchmarks",
+                "scenario": "S7 accuracy certifier FMM candidate",
+                "positions": metrics.positions,
+                "abstains": metrics.abstains,
+                "top1_agreement": metrics.top1_agreement,
+                "top8_recall": metrics.top8_recall,
+                "teacher_bits_per_token": metrics.teacher_bits_per_token,
+                "rank": rank,
+                "retained_energy": retained_energy,
+                "max_rank": with_parity_fixtures(|fx| fx.fmm.as_ref().map(|fmm| fmm.config().max_rank)).flatten(),
+                "relative_singular_tolerance": with_parity_fixtures(|fx| fx.fmm.as_ref().map(|fmm| fmm.config().relative_singular_tolerance)).flatten(),
+                "budget": budget,
+                "decision_rule": "measurement_only; compare against S3 before considering promotion"
+            }))
+            .expect("json")
+        );
+    }
+}
+
+#[then("the FMM candidate produces a reproducible novel-context measurement")]
+fn parity_fmm_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S7") {
+        return;
+    }
+    let Some(metrics) = w.parity_fmm_metrics else {
+        eprintln!("[parity] S7: FMM candidate unavailable — vacuous pass");
+        return;
+    };
+    assert!(
+        metrics.positions > 0,
+        "FMM replay covered at least one position"
+    );
+    assert!(metrics.teacher_bits_per_token.is_finite());
 }
 
 #[when("free-running generation is timed for the teacher and both compiled runtimes")]
@@ -3419,6 +3584,8 @@ fn corpus_replay(fx: &mut ParityFixtures, graph: bool, budget: usize) -> Option<
         top8_recall: top8_hits as f64 / denom,
         // Recorded labels carry no logprobs — Δbits is not defined here.
         mean_delta_bits: 0.0,
+        // Recorded labels carry no live teacher logprobs either.
+        teacher_bits_per_token: 0.0,
     })
 }
 

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -204,6 +204,7 @@ struct R4g1World {
     parity_corpus_legacy: Option<ParityMetrics>,
     parity_corpus_graph: Option<ParityMetrics>,
     parity_fmm_metrics: Option<ParityMetrics>,
+    parity_fmm_fixed_metrics: Option<ParityMetrics>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -2746,6 +2747,7 @@ struct ParityFixtures {
     r4g1: Option<R4g1State>,
     corpus: Option<Corpus>,
     fmm: Option<FmmCandidateScorer>,
+    fmm_fixed: Option<uor_r4_graph_certify::FmmFixedCandidateScorer>,
 }
 
 thread_local! {
@@ -2804,6 +2806,9 @@ fn load_parity_fixtures() -> Option<ParityFixtures> {
     let r4g1 = load_r4g1(&bundle, &artifact_bytes);
     let corpus = load_parity_corpus(&bundle);
     let fmm = load_fmm_candidate(&bundle, &artifact_bytes);
+    let fmm_fixed = fmm
+        .as_ref()
+        .and_then(|candidate| candidate.fixed_point().ok());
     Some(ParityFixtures {
         teacher,
         artifacts,
@@ -2812,6 +2817,7 @@ fn load_parity_fixtures() -> Option<ParityFixtures> {
         r4g1,
         corpus,
         fmm,
+        fmm_fixed,
     })
 }
 
@@ -2990,6 +2996,60 @@ fn teacher_bits_for_token(logits: &[f32], token: u32) -> f64 {
 /// the incumbent, but it does not participate in serving status policy.
 fn fmm_teacher_forced_eval(fx: &mut ParityFixtures, budget: usize) -> Option<ParityMetrics> {
     let fmm = fx.fmm.as_ref()?.clone();
+    let r4g1 = fx.r4g1.as_ref()?;
+    let mut positions = 0usize;
+    let mut top1_hits = 0usize;
+    let mut top8_hits = 0usize;
+    let mut teacher_bits_sum = 0.0f64;
+    let mut remaining = budget;
+    let mut logits = vec![0.0f32; fx.teacher.vocab()];
+    let mut top8 = [(0u32, 0.0f32); 8];
+    'prompts: for prompt in PARITY_PROMPTS {
+        let tokens = fx.tokenizer.encode(prompt);
+        if tokens.len() < 2 {
+            continue;
+        }
+        fx.teacher.reset();
+        for i in 0..tokens.len() - 1 {
+            if remaining == 0 {
+                break 'prompts;
+            }
+            remaining -= 1;
+            fx.teacher.step(tokens[i] as usize, i, &mut logits);
+            let k = fx.teacher.top_k(8, &mut top8);
+            let teacher_argmax = top8[0].0;
+            let window = &tokens[(i + 1).saturating_sub(WINDOW)..=i];
+            let sig = r4g1.signature_for_window(window).ok()?;
+            let outcome = fmm.score(&sig, &[]).ok()?;
+            positions += 1;
+            if outcome.selected == teacher_argmax {
+                top1_hits += 1;
+            }
+            if top8[..k]
+                .iter()
+                .any(|&(token, _)| token == outcome.selected)
+            {
+                top8_hits += 1;
+            }
+            teacher_bits_sum += teacher_bits_for_token(&logits, outcome.selected);
+        }
+    }
+    let denom = positions.max(1) as f64;
+    Some(ParityMetrics {
+        positions,
+        abstains: 0,
+        top1_agreement: top1_hits as f64 / denom,
+        top8_recall: top8_hits as f64 / denom,
+        mean_delta_bits: 0.0,
+        teacher_bits_per_token: teacher_bits_sum / denom,
+    })
+}
+
+/// The same teacher-forced replay through the quantized translation-table
+/// candidate. This measures fixed-point selection drift separately from the
+/// float candidate so quantization loss is visible.
+fn fmm_fixed_teacher_forced_eval(fx: &mut ParityFixtures, budget: usize) -> Option<ParityMetrics> {
+    let fmm = fx.fmm_fixed.as_ref()?.clone();
     let r4g1 = fx.r4g1.as_ref()?;
     let mut positions = 0usize;
     let mut top1_hits = 0usize;
@@ -3297,21 +3357,36 @@ fn parity_replay_fmm(w: &mut R4g1World) {
     if parity_skip(w, "S7") {
         return;
     }
-    let has_fmm = with_parity_fixtures(|fx| fx.fmm.is_some() && fx.r4g1.is_some()).unwrap_or(false);
+    let has_fmm =
+        with_parity_fixtures(|fx| fx.fmm.is_some() && fx.fmm_fixed.is_some() && fx.r4g1.is_some())
+            .unwrap_or(false);
     if !has_fmm {
         eprintln!("[parity] S7: FMM candidate unavailable — vacuous pass");
         return;
     }
     let budget = parity_budget("R4_FMM_POSITIONS", 256);
     w.parity_fmm_metrics = with_parity_fixtures(|fx| fmm_teacher_forced_eval(fx, budget)).flatten();
+    w.parity_fmm_fixed_metrics =
+        with_parity_fixtures(|fx| fmm_fixed_teacher_forced_eval(fx, budget)).flatten();
     if let Some(metrics) = w.parity_fmm_metrics {
-        let (rank, retained_energy) = with_parity_fixtures(|fx| {
-            fx.fmm
-                .as_ref()
-                .map(|fmm| (fmm.rank(), fmm.retained_energy()))
-        })
-        .flatten()
-        .unwrap_or((0, 0.0));
+        let (rank, retained_energy, float_storage, fixed_storage, factor_bits) =
+            with_parity_fixtures(|fx| {
+                fx.fmm
+                    .as_ref()
+                    .zip(fx.fmm_fixed.as_ref())
+                    .map(|(fmm, fixed)| {
+                        (
+                            fmm.rank(),
+                            fmm.retained_energy(),
+                            fmm.storage_bytes(),
+                            fixed.storage_bytes(),
+                            fixed.factor_fraction_bits(),
+                        )
+                    })
+            })
+            .flatten()
+            .unwrap_or((0, 0.0, 0, 0, 0));
+        let fixed = w.parity_fmm_fixed_metrics.expect("fixed FMM measured");
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -3322,8 +3397,16 @@ fn parity_replay_fmm(w: &mut R4g1World) {
                 "top1_agreement": metrics.top1_agreement,
                 "top8_recall": metrics.top8_recall,
                 "teacher_bits_per_token": metrics.teacher_bits_per_token,
+                "fixed_point": {
+                    "top1_agreement": fixed.top1_agreement,
+                    "top8_recall": fixed.top8_recall,
+                    "teacher_bits_per_token": fixed.teacher_bits_per_token,
+                    "storage_bytes": fixed_storage,
+                },
                 "rank": rank,
                 "retained_energy": retained_energy,
+                "float_storage_bytes": float_storage,
+                "factor_fraction_bits": factor_bits,
                 "max_rank": with_parity_fixtures(|fx| fx.fmm.as_ref().map(|fmm| fmm.config().max_rank)).flatten(),
                 "relative_singular_tolerance": with_parity_fixtures(|fx| fx.fmm.as_ref().map(|fmm| fmm.config().relative_singular_tolerance)).flatten(),
                 "budget": budget,
@@ -3348,6 +3431,11 @@ fn parity_fmm_checked(w: &mut R4g1World) {
         "FMM replay covered at least one position"
     );
     assert!(metrics.teacher_bits_per_token.is_finite());
+    let fixed = w
+        .parity_fmm_fixed_metrics
+        .expect("fixed FMM replay measured");
+    assert!(fixed.positions > 0);
+    assert!(fixed.teacher_bits_per_token.is_finite());
 }
 
 #[when("free-running generation is timed for the teacher and both compiled runtimes")]


### PR DESCRIPTION
## Summary
- define reproducible §5.2 novel-context protocol for issue #290
- add deterministic certifier-side low-rank FMM scorer over graph prototypes/emission residuals
- add fixed-point feasibility scorer with caller-buffered selection and S7 parity measurement

## Results
- rank 20 / tolerance 1e-2, retained energy 0.6967
- 96 novel teacher-forced positions: top-1 1.04%, top-8 26.04%, teacher cross-entropy 10.588 bits/token
- fixed-point candidate matched float results and reduced estimated table storage 337,888 B -> 164,056 B
- compared with incumbent R4G1: top-1 unchanged; top-8 +20.83pp; teacher bits/token -3.367

## Scope
- certifier/research path only; not wired into deployed runtime or integer kernel
- fixed candidate currently uses widened integer products in certifier feasibility code; deployment still requires multiplication-free packed translation tables, allocation-free serving integration, and §5.4 cost comparison

## Validation
- cargo fmt --check
- cargo test -p uor-r4-graph-certify --offline
- cargo clippy -p uor-r4-graph-certify --all-targets --all-features --offline -- -D warnings
- cargo check -p uor-r4-graph-format --no-default-features
- cargo check -p uor-r4-graph-format --no-default-features --features alloc
- R4_FMM_POSITIONS=256 cargo test --test bdd --offline -- --name 'S7' --concurrency 1 -v
- workspace suite has a pre-existing R4G1 allocation census failure (2 allocations/594 bytes) outside this change