### PR TITLE
feat: add packed FMM runtime table foundation (#359)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/cover_sweep.rs
+++ b/crates/uor-r4-core/src/transformerless/cover_sweep.rs
@@ -414,6 +414,7 @@ pub fn run_point(
         vocab,
         score_config,
     );
+    let fmm_section = score::compile_fmm_section(&regions, &emissions, vocab)?;
     let (artifact_bytes, _info) = score::emit_scored_r4g1(
         &inputs.artifact_container,
         (&inputs.meta_bytes, &inputs.recs_bytes),
@@ -426,6 +427,7 @@ pub fn run_point(
             emissions: &emissions,
             exct_tls1: &inputs.tls1,
             exct_top_x: score_config.exct_top_x,
+            fmm_section: Some(&fmm_section),
         },
     )?;
     let gate_c = score::evaluate_gate_c(

--- a/crates/uor-r4-graph-certify/src/fmm.rs
+++ b/crates/uor-r4-graph-certify/src/fmm.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_format::{ScoreQ, FMM_HEADER_LEN, FMM_MAGIC, FMM_VERSION};
 
 use crate::score_runtime::RegionParams;
 
@@ -353,6 +353,79 @@ impl FmmFixedCandidateScorer {
             + self.root_prior.len() * (std::mem::size_of::<u32>() + std::mem::size_of::<i32>())
     }
 
+    /// Emit the compiler-folded FMM section consumed by
+    /// [`uor_r4_graph_format::GraphView::fmm_translation_table`]. The
+    /// rank-factor products are evaluated here, offline; the resulting
+    /// runtime table needs only signed additions and table reads.
+    pub fn to_packed_section(&self) -> Result<Vec<u8>, String> {
+        let dimension = u16::try_from(self.dimension)
+            .map_err(|_| "FMM dimension exceeds the packed u16 width".to_owned())?;
+        let rank = u16::try_from(self.rank)
+            .map_err(|_| "FMM rank exceeds the packed u16 width".to_owned())?;
+        let token_count = u32::try_from(self.candidate_tokens.len())
+            .map_err(|_| "FMM candidate count exceeds the packed u32 width".to_owned())?;
+        if self.dimension == 0 || self.rank == 0 || self.candidate_tokens.is_empty() {
+            return Err(
+                "FMM packed table cannot have an empty dimension, rank, or candidate set"
+                    .to_owned(),
+            );
+        }
+        let expected_factors = self
+            .rank
+            .checked_mul(self.candidate_tokens.len())
+            .ok_or_else(|| "FMM factor dimensions overflow".to_owned())?;
+        if self.token_factors_q.len() != expected_factors
+            || self.basis_q15.len() != self.dimension * self.rank
+        {
+            return Err("FMM fixed-point factor dimensions are inconsistent".to_owned());
+        }
+
+        let mut bytes = Vec::with_capacity(
+            FMM_HEADER_LEN
+                + self.candidate_tokens.len() * 8
+                + self.dimension * self.candidate_tokens.len() * 4,
+        );
+        bytes.extend_from_slice(&FMM_MAGIC);
+        bytes.extend_from_slice(&FMM_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&dimension.to_le_bytes());
+        bytes.extend_from_slice(&rank.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&token_count.to_le_bytes());
+        bytes.push(self.factor_fraction_bits);
+        bytes.extend_from_slice(&[0u8; 3]);
+
+        for &token in &self.candidate_tokens {
+            bytes.extend_from_slice(&token.to_le_bytes());
+        }
+        for &token in &self.candidate_tokens {
+            let score = self
+                .root_prior
+                .get(&token)
+                .copied()
+                .unwrap_or(self.root_floor);
+            bytes.extend_from_slice(&score.raw().to_le_bytes());
+        }
+
+        let shift = self.factor_fraction_bits.saturating_sub(1);
+        for coordinate in 0..self.dimension {
+            for token_index in 0..self.candidate_tokens.len() {
+                let mut unscaled = 0i128;
+                for component in 0..self.rank {
+                    let basis = i128::from(self.basis_q15[coordinate * self.rank + component]);
+                    let factor = i128::from(
+                        self.token_factors_q[component * self.candidate_tokens.len() + token_index],
+                    );
+                    unscaled = unscaled.saturating_add(basis.saturating_mul(factor));
+                }
+                let coefficient = round_shift_signed(unscaled, shift);
+                let coefficient = i32::try_from(coefficient)
+                    .map_err(|_| "FMM packed coefficient exceeds i32".to_owned())?;
+                bytes.extend_from_slice(&coefficient.to_le_bytes());
+            }
+        }
+        Ok(bytes)
+    }
+
     /// Select the best token without allocating. The caller owns the
     /// rank-sized projection scratch; this is the adapter shape a future
     /// fixed-capacity runtime can embed in its step state.
@@ -633,6 +706,13 @@ mod tests {
         );
         assert!(scorer.retained_energy() > 0.0);
         let fixed = scorer.fixed_point().expect("fixed candidate builds");
+        let packed = fixed.to_packed_section().expect("packed table builds");
+        let table =
+            uor_r4_graph_format::FmmTranslationTable::parse(&packed).expect("packed table parses");
+        assert_eq!(table.dimension(), SIG_BYTES as u16 * 8);
+        assert_eq!(table.rank(), 1);
+        assert_eq!(table.token_count(), 2);
+        assert_eq!(table.token(0), Some(uor_r4_graph_format::TokenId(7)));
         assert_eq!(fixed.score(&left_sig, &[]).unwrap().selected, left.selected);
         let mut projected = [0i64; 1];
         assert_eq!(

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -450,6 +450,31 @@ pub struct EmissionTables {
     pub emission_quantization: QuantizationErrorStats,
 }
 
+/// Compile the optional FMM section from the same regions and emission tables
+/// that feed the normal scored-artifact path. All floating-point work remains
+/// in the certifier; the returned bytes contain only the folded integer table
+/// consumed by the runtime kernel.
+pub fn compile_fmm_section(
+    regions: &[RegionParams],
+    emissions: &EmissionTables,
+    vocab: u32,
+) -> Result<Vec<u8>, String> {
+    let emission_maps: Vec<BTreeMap<u32, ScoreQ>> = emissions
+        .region_lists
+        .iter()
+        .map(|entries| entries.iter().copied().collect())
+        .collect();
+    let scorer = crate::fmm::FmmCandidateScorer::from_graph_parts(
+        regions,
+        &emission_maps,
+        &emissions.root_prior,
+        emissions.root_floor,
+        vocab,
+        crate::fmm::FmmConfig::default(),
+    )?;
+    scorer.fixed_point()?.to_packed_section()
+}
+
 /// ln of an add-one-smoothed probability (compiler-side f64; module
 /// docs for the platform pinning). This is the [`Smoothing::AddOne`]
 /// arm; the other rules live in [`Smoothing::ln_prob`].
@@ -678,6 +703,9 @@ pub struct ScoredGraphInfo {
     pub root_prior_entries: u32,
     pub emission_list_entries: u32,
     pub exct_bytes: u32,
+    pub fmm_bytes: u32,
+    pub fmm_rank: u16,
+    pub fmm_candidate_count: u32,
     pub artifact_bytes: usize,
     pub transition_quantization: QuantizationErrorStats,
     pub root_prior_quantization: QuantizationErrorStats,
@@ -703,6 +731,8 @@ pub struct ScoredGraphSections<'a> {
     pub exct_tls1: &'a [u8],
     /// Number of exact-context residual entries retained per prefix.
     pub exct_top_x: usize,
+    /// Optional compiler-folded FMM translation table.
+    pub fmm_section: Option<&'a [u8]>,
 }
 
 /// Encode the exact-context store as compile-time ScoreQ residuals. The
@@ -782,6 +812,7 @@ pub fn emit_scored_r4g1(
         emissions,
         exct_tls1,
         exct_top_x,
+        fmm_section,
     } = *sections;
     if regions.len() != emissions.region_lists.len() {
         return Err("emission lists do not match the region count".to_owned());
@@ -956,6 +987,11 @@ pub fn emit_scored_r4g1(
     exct.extend_from_slice(&[2, 0, 0, 0]);
     exct.extend_from_slice(&exct_body);
 
+    let fmm_table = fmm_section
+        .map(uor_r4_graph_format::FmmTranslationTable::parse)
+        .transpose()
+        .map_err(|error| format!("invalid FMM section: {error}"))?;
+
     // HEAD: the fixed 224-byte v0 prefix (convert_r4g1 conventions).
     let (meta, recs) = corpus_cid_material;
     let mut corpus_hasher = blake3::Hasher::new();
@@ -993,6 +1029,9 @@ pub fn emit_scored_r4g1(
     builder.add_section(uor_r4_graph_format::SectionId::ROUT, 0, &rout);
     builder.add_section(uor_r4_graph_format::SectionId::EMIT, 0, &emit);
     builder.add_section(uor_r4_graph_format::SectionId::EXCT, 0, &exct);
+    if let Some(fmm_section) = fmm_section {
+        builder.add_section(uor_r4_graph_format::SectionId::FMM, 0, fmm_section);
+    }
     let bytes = builder
         .build()
         .map_err(|error| format!("R4G1 serialization failed: {error}"))?;
@@ -1019,6 +1058,9 @@ pub fn emit_scored_r4g1(
             root_prior_entries: root_entry_count,
             emission_list_entries,
             exct_bytes: exct.len() as u32,
+            fmm_bytes: fmm_section.map_or(0, |bytes| bytes.len() as u32),
+            fmm_rank: fmm_table.map_or(0, |table| table.rank()),
+            fmm_candidate_count: fmm_table.map_or(0, |table| table.token_count()),
             artifact_bytes,
             transition_quantization,
             root_prior_quantization: emissions.root_prior_quantization,
@@ -2121,6 +2163,8 @@ fn evaluate_gate_c_row(
 /// included), so the declaration adds the probe-level histogram and
 /// the STRICT full-code miss rate, and the Gate C validity verdict is
 /// judged on the strict basis.
+/// 11 = graph footprint and quality-profile fields; 12 = packed FMM
+/// footprint, rank, and candidate-count fields.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -2216,6 +2260,9 @@ pub struct ScoreReportGraph {
     pub root_prior_entries: u32,
     pub emission_list_entries: u32,
     pub exct_bytes: u32,
+    pub fmm_bytes: u32,
+    pub fmm_rank: u16,
+    pub fmm_candidate_count: u32,
     pub artifact_bytes: usize,
     pub graph_repetition_rate: f64,
     pub baseline_repetition_rate: f64,
@@ -2289,7 +2336,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 11,
+        schema: 12,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -2312,6 +2359,9 @@ pub fn build_score_report_with_quality_profile(
             root_prior_entries: info.root_prior_entries,
             emission_list_entries: info.emission_list_entries,
             exct_bytes: info.exct_bytes,
+            fmm_bytes: info.fmm_bytes,
+            fmm_rank: info.fmm_rank,
+            fmm_candidate_count: info.fmm_candidate_count,
             artifact_bytes: info.artifact_bytes,
             graph_repetition_rate: gate_c.repetition_rate_rule12,
             baseline_repetition_rate: gate_c.repetition_rate_baseline,

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1037,6 +1037,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
+    let fmm_section = score::compile_fmm_section(&regions, &emissions, vocab)?;
     let (artifact_bytes, info) = score::emit_scored_r4g1(
         &artifact_container,
         (&meta_bytes, &recs_bytes),
@@ -1049,6 +1050,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
             emissions: &emissions,
             exct_tls1: &tls1,
             exct_top_x: config.exct_top_x,
+            fmm_section: Some(&fmm_section),
         },
     )?;
     let graph_kappa = uor_r4_graph_format::r4g1::artifact_kappa(&artifact_bytes)
@@ -1120,14 +1122,17 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         .map_err(|error| format!("{}: {error}", report_path.display()))?;
 
     println!(
-        "score complete: {} nodes, {} edges ({} refinement + {} neighbor + {} forward), {} emission entries, EXCT {} bytes",
+        "score complete: {} nodes, {} edges ({} refinement + {} neighbor + {} forward), {} emission entries, EXCT {} bytes, FMM {} bytes (rank {}, {} candidates)",
         info.node_count,
         info.edge_count,
         info.refinement_edges,
         info.neighbor_edges,
         info.forward_edges,
         info.emission_list_entries,
-        info.exct_bytes
+        info.exct_bytes,
+        info.fmm_bytes,
+        info.fmm_rank,
+        info.fmm_candidate_count
     );
     println!(
         "gate C — held-out D3 metrics ({} positions):",

--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -391,6 +391,35 @@ pub enum FormatError {
         /// Actual length
         actual_len: u64,
     },
+    /// FMM section is shorter than its fixed header.
+    FmmSectionTooShort {
+        /// Actual length.
+        actual: u64,
+    },
+    /// FMM section does not begin with `FMM1`.
+    FmmSectionBadMagic,
+    /// FMM section version is not supported by this reader.
+    FmmSectionUnsupportedVersion(u16),
+    /// FMM dimensions or scale descriptor are invalid.
+    FmmSectionInvalidDimensions {
+        /// Signature-bit coordinate count.
+        dimension: u16,
+        /// Compiler rank metadata.
+        rank: u16,
+        /// Candidate-token count.
+        token_count: u32,
+        /// Compiler factor fractional-bit count.
+        factor_fraction_bits: u8,
+    },
+    /// FMM section length arithmetic overflowed.
+    FmmSectionLengthOverflow,
+    /// FMM section length does not match its dimensions.
+    FmmSectionLengthMismatch {
+        /// Expected length from the header dimensions.
+        expected: u64,
+        /// Actual section length.
+        actual: u64,
+    },
     /// Loader invariant validation failure
     InvariantViolation(crate::invariant_ownership::InvariantValidationError),
     /// A node's actual degree — derived from the edge list, never from a
@@ -633,6 +662,27 @@ impl fmt::Display for FormatError {
             FormatError::RouteTranslationSectionMisaligned { actual_len } => write!(
                 f,
                 "RTNX section holds {actual_len} bytes, not a multiple of 12"
+            ),
+            FormatError::FmmSectionTooShort { actual } => {
+                write!(f, "FMM section is {actual} bytes, shorter than its 20-byte header")
+            }
+            FormatError::FmmSectionBadMagic => write!(f, "FMM section has bad magic"),
+            FormatError::FmmSectionUnsupportedVersion(version) => {
+                write!(f, "unsupported FMM section version {version}")
+            }
+            FormatError::FmmSectionInvalidDimensions {
+                dimension,
+                rank,
+                token_count,
+                factor_fraction_bits,
+            } => write!(
+                f,
+                "invalid FMM dimensions: dimension={dimension}, rank={rank}, tokens={token_count}, factor_fraction_bits={factor_fraction_bits}"
+            ),
+            FormatError::FmmSectionLengthOverflow => write!(f, "FMM section length overflow"),
+            FormatError::FmmSectionLengthMismatch { expected, actual } => write!(
+                f,
+                "FMM section length mismatch: expected {expected}, got {actual}"
             ),
             FormatError::InvariantViolation(err) => write!(f, "graph invariant violation: {err}"),
             FormatError::NodeDegreeExceeded { node, degree, limit } => write!(

--- a/crates/uor-r4-graph-format/src/fmm.rs
+++ b/crates/uor-r4-graph-format/src/fmm.rs
@@ -1,0 +1,293 @@
+//! Borrowed view of the optional FMM translation-table section.
+//!
+//! The compiler folds the fixed-point low-rank factors into one signed
+//! coefficient for every signature bit and candidate token. A deployed
+//! reader therefore selects a coefficient by the input bit, adds or
+//! subtracts it, and never evaluates a projection/token-factor product.
+
+use crate::error::FormatError;
+use crate::header::{read_i32_le, read_u16_le, read_u32_le};
+use crate::types::{ScoreQ, TokenId};
+
+/// Four-byte section magic for the first packed FMM translation-table form.
+pub const FMM_MAGIC: [u8; 4] = *b"FMM1";
+/// Wire version emitted by the first table form.
+pub const FMM_VERSION: u16 = 1;
+/// Fixed header length in bytes.
+pub const FMM_HEADER_LEN: usize = 20;
+/// One little-endian u32 token identifier.
+pub const FMM_TOKEN_LEN: usize = 4;
+/// One little-endian i32 root or translation score.
+pub const FMM_SCORE_LEN: usize = 4;
+
+/// A zero-copy, validated FMM translation table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FmmTranslationTable<'a> {
+    dimension: u16,
+    rank: u16,
+    token_count: u32,
+    factor_fraction_bits: u8,
+    tokens: &'a [u8],
+    root_scores: &'a [u8],
+    coefficients: &'a [u8],
+    coefficient_row_len: usize,
+}
+
+impl<'a> FmmTranslationTable<'a> {
+    /// Parse the fixed header and establish all table slices using checked
+    /// arithmetic. No allocation or floating-point conversion occurs here.
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+        if bytes.len() < FMM_HEADER_LEN {
+            return Err(FormatError::FmmSectionTooShort {
+                actual: bytes.len() as u64,
+            });
+        }
+        if bytes[0..4] != FMM_MAGIC {
+            return Err(FormatError::FmmSectionBadMagic);
+        }
+        let version = read_u16_le(bytes, 4);
+        if version != FMM_VERSION {
+            return Err(FormatError::FmmSectionUnsupportedVersion(version));
+        }
+        let dimension = read_u16_le(bytes, 6);
+        let rank = read_u16_le(bytes, 8);
+        let token_count = read_u32_le(bytes, 12);
+        let factor_fraction_bits = bytes[16];
+        if dimension == 0 || rank == 0 || token_count == 0 || factor_fraction_bits > 31 {
+            return Err(FormatError::FmmSectionInvalidDimensions {
+                dimension,
+                rank,
+                token_count,
+                factor_fraction_bits,
+            });
+        }
+
+        let token_bytes = usize::try_from(token_count)
+            .ok()
+            .and_then(|count| count.checked_mul(FMM_TOKEN_LEN))
+            .ok_or(FormatError::FmmSectionLengthOverflow)?;
+        let coefficient_count = usize::from(dimension)
+            .checked_mul(
+                usize::try_from(token_count).map_err(|_| FormatError::FmmSectionLengthOverflow)?,
+            )
+            .ok_or(FormatError::FmmSectionLengthOverflow)?;
+        let score_bytes = token_bytes;
+        let coefficient_bytes = coefficient_count
+            .checked_mul(FMM_SCORE_LEN)
+            .ok_or(FormatError::FmmSectionLengthOverflow)?;
+        let expected = FMM_HEADER_LEN
+            .checked_add(token_bytes)
+            .and_then(|value| value.checked_add(score_bytes))
+            .and_then(|value| value.checked_add(coefficient_bytes))
+            .ok_or(FormatError::FmmSectionLengthOverflow)?;
+        if bytes.len() != expected {
+            return Err(FormatError::FmmSectionLengthMismatch {
+                expected: expected as u64,
+                actual: bytes.len() as u64,
+            });
+        }
+
+        let tokens_start = FMM_HEADER_LEN;
+        let root_start = tokens_start + token_bytes;
+        let coefficients_start = root_start + score_bytes;
+        Ok(Self {
+            dimension,
+            rank,
+            token_count,
+            factor_fraction_bits,
+            tokens: &bytes[tokens_start..root_start],
+            root_scores: &bytes[root_start..coefficients_start],
+            coefficients: &bytes[coefficients_start..],
+            coefficient_row_len: coefficient_bytes / usize::from(dimension),
+        })
+    }
+
+    pub fn dimension(&self) -> u16 {
+        self.dimension
+    }
+
+    pub fn rank(&self) -> u16 {
+        self.rank
+    }
+
+    pub fn token_count(&self) -> u32 {
+        self.token_count
+    }
+
+    pub fn factor_fraction_bits(&self) -> u8 {
+        self.factor_fraction_bits
+    }
+
+    pub fn token(&self, index: u32) -> Option<TokenId> {
+        self.tokens().nth(index as usize)
+    }
+
+    pub fn root_score(&self, index: u32) -> Option<ScoreQ> {
+        self.root_scores().nth(index as usize)
+    }
+
+    /// Read the compiler-folded contribution for one signature bit and
+    /// candidate token. The runtime selects its sign from the query bit and
+    /// adds this value; it never multiplies basis and factor values.
+    pub fn tokens(&self) -> FmmTokenIter<'a> {
+        FmmTokenIter {
+            chunks: self.tokens.chunks_exact(FMM_TOKEN_LEN),
+        }
+    }
+
+    pub fn root_scores(&self) -> FmmScoreIter<'a> {
+        FmmScoreIter {
+            chunks: self.root_scores.chunks_exact(FMM_SCORE_LEN),
+        }
+    }
+
+    /// Iterate coefficient rows in signature-coordinate order.
+    pub fn coefficient_rows(&self) -> FmmRows<'a> {
+        FmmRows {
+            rows: self.coefficients.chunks_exact(self.coefficient_row_len),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FmmTokenIter<'a> {
+    chunks: core::slice::ChunksExact<'a, u8>,
+}
+
+impl Iterator for FmmTokenIter<'_> {
+    type Item = TokenId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(TokenId(read_u32_le(self.chunks.next()?, 0)))
+    }
+}
+
+impl ExactSizeIterator for FmmTokenIter<'_> {
+    fn len(&self) -> usize {
+        self.chunks.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FmmScoreIter<'a> {
+    chunks: core::slice::ChunksExact<'a, u8>,
+}
+
+impl Iterator for FmmScoreIter<'_> {
+    type Item = ScoreQ;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(ScoreQ::from_raw(read_i32_le(self.chunks.next()?, 0)))
+    }
+}
+
+impl ExactSizeIterator for FmmScoreIter<'_> {
+    fn len(&self) -> usize {
+        self.chunks.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FmmRows<'a> {
+    rows: core::slice::ChunksExact<'a, u8>,
+}
+
+impl<'a> Iterator for FmmRows<'a> {
+    type Item = FmmCoefficientRow<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(FmmCoefficientRow {
+            bytes: self.rows.next()?,
+        })
+    }
+}
+
+impl ExactSizeIterator for FmmRows<'_> {
+    fn len(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FmmCoefficientRow<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> FmmCoefficientRow<'a> {
+    pub fn values(self) -> FmmScoreIter<'a> {
+        FmmScoreIter {
+            chunks: self.bytes.chunks_exact(FMM_SCORE_LEN),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<u8> {
+        let dimension = 2u16;
+        let rank = 1u16;
+        let token_count = 2u32;
+        let mut bytes = Vec::from(FMM_MAGIC);
+        bytes.extend_from_slice(&FMM_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&dimension.to_le_bytes());
+        bytes.extend_from_slice(&rank.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&token_count.to_le_bytes());
+        bytes.push(29);
+        bytes.extend_from_slice(&[0, 0, 0]);
+        bytes.extend_from_slice(&11u32.to_le_bytes());
+        bytes.extend_from_slice(&22u32.to_le_bytes());
+        bytes.extend_from_slice(&7i32.to_le_bytes());
+        bytes.extend_from_slice(&8i32.to_le_bytes());
+        bytes.extend_from_slice(&101i32.to_le_bytes());
+        bytes.extend_from_slice(&202i32.to_le_bytes());
+        bytes.extend_from_slice(&(-303i32).to_le_bytes());
+        bytes.extend_from_slice(&404i32.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn parses_borrowed_table_and_reads_rows() {
+        let bytes = sample();
+        let table = FmmTranslationTable::parse(&bytes).expect("valid table");
+        assert_eq!(table.dimension(), 2);
+        assert_eq!(table.rank(), 1);
+        assert_eq!(table.factor_fraction_bits(), 29);
+        assert_eq!(table.token(0), Some(TokenId(11)));
+        assert_eq!(table.token(1), Some(TokenId(22)));
+        assert_eq!(table.root_score(1), Some(ScoreQ::from_raw(8)));
+        let mut rows = table.coefficient_rows();
+        assert_eq!(
+            rows.next().unwrap().values().collect::<Vec<_>>(),
+            vec![ScoreQ::from_raw(101), ScoreQ::from_raw(202),]
+        );
+        assert_eq!(
+            rows.next().unwrap().values().collect::<Vec<_>>(),
+            vec![ScoreQ::from_raw(-303), ScoreQ::from_raw(404),]
+        );
+        assert!(rows.next().is_none());
+        assert_eq!(table.token(2), None);
+    }
+
+    #[test]
+    fn rejects_bad_magic_and_length() {
+        let mut bytes = sample();
+        bytes[0] = b'X';
+        assert_eq!(
+            FmmTranslationTable::parse(&bytes),
+            Err(FormatError::FmmSectionBadMagic)
+        );
+
+        let mut bytes = sample();
+        bytes.pop();
+        assert_eq!(
+            FmmTranslationTable::parse(&bytes),
+            Err(FormatError::FmmSectionLengthMismatch {
+                expected: 52,
+                actual: 51,
+            })
+        );
+    }
+}

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -65,6 +65,7 @@ extern crate alloc;
 
 mod code;
 mod error;
+mod fmm;
 mod head;
 mod header;
 pub mod inference_contract;
@@ -82,6 +83,10 @@ mod view;
 
 pub use code::{OP_CLEAR_SLOT, OP_HALT as CODE_OP_HALT, OP_SHIFT_SLOTS, OP_UPDATE_SLOT};
 pub use error::{BoundKind, EdgePayloadField, FormatError, RangeField};
+pub use fmm::{
+    FmmCoefficientRow, FmmRows, FmmScoreIter, FmmTokenIter, FmmTranslationTable, FMM_HEADER_LEN,
+    FMM_MAGIC, FMM_VERSION,
+};
 pub use head::{
     Head, FALLBACK_POLICY_COUNT, FEATURE_EDGE_ALGEBRA_V1, HEAD_PAYLOAD_LEN,
     KNOWN_FEATURE_BITS_REQUIRED,

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -413,6 +413,12 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
         }
     }
 
+    // FMM is optional and compiler-folded. Validate its fixed-width table
+    // before exposing the borrowed accessor to runtime callers.
+    if let Some(bytes) = view.section(SectionId::FMM) {
+        crate::fmm::FmmTranslationTable::parse(bytes)?;
+    }
+
     // Invariant Ownership Matrix loader validation (Issue #135)
     let node_count = head.node_count() as usize;
     let max_node_degree = head.max_frontier_width() as usize;

--- a/crates/uor-r4-graph-format/src/types.rs
+++ b/crates/uor-r4-graph-format/src/types.rs
@@ -179,6 +179,11 @@ impl SectionId {
     pub const SECT: SectionId = SectionId(0x0B);
     /// RTNX — route translation index (optional, Phase 9).
     pub const RTNX: SectionId = SectionId(0x0C);
+    /// FMM — compiler-precomputed far-field translation table (optional).
+    ///
+    /// The optional bit is part of the wire ID so older readers can skip the
+    /// section while preserving the R4G1 unknown-optional-section rule.
+    pub const FMM: SectionId = SectionId(Self::OPTIONAL_BIT | 0x0D);
 
     /// Ancillary bit classifying *unknown* section IDs.
     ///
@@ -198,7 +203,7 @@ impl SectionId {
 
     /// True when the ID is in the RFC §3 inventory (`0x01..=0x0B`).
     pub const fn is_known(self) -> bool {
-        matches!(self.0, 0x01..=0x0C)
+        matches!(self.0, 0x01..=0x0C) || self.0 == Self::FMM.0
     }
 
     /// Mandatory-ness per the RFC §3 column for known IDs.
@@ -209,6 +214,7 @@ impl SectionId {
         match self.0 {
             0x01..=0x06 | 0x08 => true,
             0x07 | 0x09..=0x0C => false,
+            value if value == Self::FMM.0 => false,
             _ => self.0 & Self::OPTIONAL_BIT == 0,
         }
     }

--- a/crates/uor-r4-graph-format/src/view.rs
+++ b/crates/uor-r4-graph-format/src/view.rs
@@ -8,6 +8,7 @@
 //! when a HEAD section is present (see [`GraphView::parse`]).
 
 use crate::error::FormatError;
+use crate::fmm::FmmTranslationTable;
 use crate::head::Head;
 use crate::header::{self, Header, HEADER_LEN, SECTION_ENTRY_LEN};
 use crate::records::{
@@ -324,6 +325,13 @@ impl<'a> GraphView<'a> {
             next: 0,
             remaining,
         }
+    }
+
+    /// Borrow the optional compiler-folded FMM translation table.
+    pub fn fmm_translation_table(&self) -> Result<Option<FmmTranslationTable<'a>>, FormatError> {
+        self.section(SectionId::FMM)
+            .map(FmmTranslationTable::parse)
+            .transpose()
     }
 
     /// Recompute both integrity CIDs against the bytes and compare with

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -12,6 +12,7 @@ use uor_r4_graph_format::{FormatError, GraphView, SectionId};
 pub enum RuntimeError {
     Format(FormatError),
     InvalidNode,
+    FmmBufferTooSmall,
     Patch(alloc::borrow::Cow<'static, str>),
 }
 
@@ -20,6 +21,7 @@ impl fmt::Display for RuntimeError {
         match self {
             Self::Format(e) => write!(f, "Format error: {:?}", e),
             Self::InvalidNode => write!(f, "Invalid node reference in graph"),
+            Self::FmmBufferTooSmall => write!(f, "FMM candidate buffer is too small"),
             Self::Patch(msg) => write!(f, "Patch error: {}", msg),
         }
     }

--- a/crates/uor-r4-graph-runtime/src/packed_kernels.rs
+++ b/crates/uor-r4-graph-runtime/src/packed_kernels.rs
@@ -264,6 +264,70 @@ pub fn evaluate_no_alloc_predict_step<const N: usize, const C: usize, const K: u
     Ok(output.predictions[0].0)
 }
 
+/// Evaluate the optional compiler-folded FMM table without multiplication,
+/// division, allocation, or floating-point conversion.
+///
+/// `scores` is caller-owned scratch with one slot per FMM candidate token.
+/// The table stores one precomputed coefficient row per signature bit, so
+/// each row update is only a sign choice and a saturating integer add/sub.
+pub fn evaluate_fmm_translation_table(
+    view: &GraphView<'_>,
+    signature: &[u8],
+    recent_tokens: &[u32],
+    scores: &mut [(u32, ScoreQ)],
+) -> Result<Option<(u32, ScoreQ)>, RuntimeError> {
+    let Some(table) = view.fmm_translation_table().map_err(RuntimeError::Format)? else {
+        return Ok(None);
+    };
+    let expected_bytes = (usize::from(table.dimension()).saturating_add(7)) >> 3;
+    if signature.len() != expected_bytes {
+        return Err(RuntimeError::InvalidNode);
+    }
+
+    let token_count = table.token_count() as usize;
+    if scores.len() < token_count {
+        return Err(RuntimeError::FmmBufferTooSmall);
+    }
+
+    let mut count = 0usize;
+    for (slot, (token, root)) in scores
+        .iter_mut()
+        .zip(table.tokens().zip(table.root_scores()))
+    {
+        if count == token_count {
+            break;
+        }
+        *slot = (token.0, root);
+        count += 1;
+    }
+
+    for (coordinate, row) in table.coefficient_rows().enumerate() {
+        let bit_set = signature[coordinate >> 3] & (1 << (coordinate & 7)) != 0;
+        for (slot, coefficient) in scores[..count].iter_mut().zip(row.values()) {
+            slot.1 = if bit_set {
+                slot.1.saturating_add(coefficient)
+            } else {
+                slot.1.saturating_sub(coefficient)
+            };
+        }
+    }
+
+    for slot in &mut scores[..count] {
+        if recent_tokens.contains(&slot.0) {
+            slot.1 = slot.1.saturating_sub(ScoreQ::from_raw(2_000_000));
+        }
+    }
+
+    Ok(scores[..count].iter().copied().max_by(
+        |(left_token, left_score), (right_token, right_score)| {
+            left_score
+                .raw()
+                .cmp(&right_score.raw())
+                .then_with(|| right_token.cmp(left_token))
+        },
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -1,11 +1,42 @@
 //! R4G1Runtime unit tests verifying multiplication-free zero-allocation prediction behavior over R4G1 GraphView containers.
 
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use uor_r4_core::transformerless::compiler::{self, STAGES};
 use uor_r4_core::transformerless::convert_r4g1;
 use uor_r4_core::transformerless::runtime::{self, Store};
-use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_format::{ArtifactBuilder, GraphView, ScoreQ, SectionId};
 use uor_r4_graph_runtime::R4G1Runtime;
+use uor_r4_graph_runtime::packed_kernels::evaluate_fmm_translation_table;
+
+struct CountingAllocator;
+
+thread_local! {
+    static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let _ = COUNT_ALLOCATIONS.try_with(|gate| {
+                if gate.get() {
+                    let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+                }
+            });
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
 
 fn fixture_artifacts() -> (Vec<u8>, compiler::Compiled) {
     let dir = env!("CARGO_MANIFEST_DIR");
@@ -31,6 +62,55 @@ fn synthetic_store() -> Store {
         runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
     }
     store
+}
+
+fn fmm_section_fixture() -> Vec<u8> {
+    let dimension = 288u16;
+    let rank = 1u16;
+    let token_count = 2u32;
+    let mut bytes = Vec::with_capacity(20 + 2 * 4 + 2 * 4 + usize::from(dimension) * 2 * 4);
+    bytes.extend_from_slice(b"FMM1");
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.extend_from_slice(&dimension.to_le_bytes());
+    bytes.extend_from_slice(&rank.to_le_bytes());
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    bytes.extend_from_slice(&token_count.to_le_bytes());
+    bytes.push(1);
+    bytes.extend_from_slice(&[0u8; 3]);
+    bytes.extend_from_slice(&7u32.to_le_bytes());
+    bytes.extend_from_slice(&9u32.to_le_bytes());
+    bytes.extend_from_slice(&100i32.to_le_bytes());
+    bytes.extend_from_slice(&100i32.to_le_bytes());
+    for coordinate in 0..usize::from(dimension) {
+        bytes.extend_from_slice(&(if coordinate == 0 { -10i32 } else { 0 }).to_le_bytes());
+        bytes.extend_from_slice(&(if coordinate == 0 { 10i32 } else { 0 }).to_le_bytes());
+    }
+    bytes
+}
+
+fn add_fmm_to_artifact(base: &[u8], fmm: &[u8]) -> Vec<u8> {
+    let view = GraphView::parse(base).expect("converted artifact parses");
+    let mut builder = ArtifactBuilder::new(6);
+    for section in [
+        SectionId::HEAD,
+        SectionId::CODE,
+        SectionId::NODE,
+        SectionId::EDGE,
+        SectionId::ROUT,
+        SectionId::EMIT,
+        SectionId::EXCT,
+        SectionId::PROV,
+        SectionId::CERT,
+        SectionId::PTCH,
+        SectionId::SECT,
+        SectionId::RTNX,
+    ] {
+        if let Some(bytes) = view.section(section) {
+            builder.add_section(section, 0, bytes);
+        }
+    }
+    builder.add_section(SectionId::FMM, 0, fmm);
+    builder.build().expect("artifact with FMM section builds")
 }
 
 #[test]
@@ -103,4 +183,57 @@ fn session_signature_is_bias_only_until_routing_is_calibrated() {
     );
     assert!(zero.1 >= ScoreQ::MIN);
     assert!(full.1 >= ScoreQ::MIN);
+}
+
+#[test]
+fn packed_fmm_runtime_matches_folded_integer_table_without_allocations() {
+    let (art_bytes, artifacts) = fixture_artifacts();
+    let store = synthetic_store();
+    let store_bytes = runtime::store_bytes(&store);
+    let (base, _) = convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None)
+        .expect("convert to R4G1 succeeds");
+    let fmm = fmm_section_fixture();
+    let bytes = add_fmm_to_artifact(&base, &fmm);
+    let view = GraphView::parse(&bytes).expect("FMM artifact parses");
+    let table = view
+        .fmm_translation_table()
+        .expect("FMM section validates")
+        .expect("FMM section is present");
+    assert_eq!(table.dimension(), 288);
+    assert_eq!(table.token_count(), 2);
+    let artifact_delta = bytes.len() - base.len();
+    assert!(artifact_delta >= fmm.len() + 16);
+    println!(
+        "FMM footprint: {} bytes; artifact delta: {} bytes; serving work: {} sign/add updates per query",
+        fmm.len(),
+        artifact_delta,
+        usize::from(table.dimension()) * table.token_count() as usize
+    );
+    let signature = [1u8; 36];
+    let mut scores = [(0u32, ScoreQ::ZERO); 2];
+
+    let selected = evaluate_fmm_translation_table(&view, &signature, &[], &mut scores)
+        .expect("integer FMM evaluation succeeds")
+        .expect("FMM table returns a candidate");
+    assert_eq!(selected, (9, ScoreQ::from_raw(110)));
+
+    ALLOCATIONS.with(|count| count.set(0));
+    COUNT_ALLOCATIONS.with(|gate| gate.set(true));
+    for _ in 0..64 {
+        let mut scores = [(0u32, ScoreQ::ZERO); 2];
+        let result = evaluate_fmm_translation_table(&view, &signature, &[], &mut scores)
+            .expect("steady-state FMM evaluation succeeds")
+            .expect("steady-state FMM table returns a candidate");
+        assert_eq!(result.0, 9);
+    }
+    COUNT_ALLOCATIONS.with(|gate| gate.set(false));
+    let allocations = ALLOCATIONS.with(Cell::get);
+    assert_eq!(allocations, 0);
+
+    let recent = [9u32];
+    let mut scores = [(0u32, ScoreQ::ZERO); 2];
+    let penalized = evaluate_fmm_translation_table(&view, &signature, &recent, &mut scores)
+        .expect("recent-token penalty evaluation succeeds")
+        .expect("penalized FMM table returns a candidate");
+    assert_eq!(penalized.0, 7);
 }

--- a/docs/fmm_290_novel_context_protocol.md
+++ b/docs/fmm_290_novel_context_protocol.md
@@ -1,7 +1,8 @@
 # Issue #290 §5.2 — novel-context accuracy protocol
 
-Status: protocol and incumbent baseline recorded; the FMM candidate is not yet
-implemented, so this issue is not closed by this document.
+Status: protocol and incumbent baseline recorded; the compiler-folded fixed-point
+translation table and allocation-free runtime kernel are implemented in #361.
+The novel-context accuracy and cost decision for #290 remains open.
 
 ## Purpose
 
@@ -87,7 +88,9 @@ The first certifier-side candidate is implemented in
 from the validated graph, diagonalizes the deterministic symmetric Gram matrix
 `PᵀP`, retains a bounded basis, and scores the same artifact-derived query
 signature through that basis. It uses floating point and is explicitly not a
-serving or integer-kernel implementation.
+serving implementation by itself. The compiler folds its fixed-point factors
+into the optional FMM1 section on the normal scored-artifact path; the deployed
+reader uses only sign-selected table reads and saturating integer add/sub.
 
 Run it through the S7 parity scenario with:
 
@@ -114,15 +117,19 @@ it selected the same token at every position and produced identical metrics:
 | fixed-point factors | 164,056 B | 0.0104 | 0.2604 | 10.5879 |
 
 The fixed-point scorer also exposes a caller-buffered selection method with no
-per-call allocation. Its current certifier implementation still uses widened
-integer arithmetic, including products, for feasibility measurement; it is not
-yet the deployed multiplication-free kernel.
+per-call allocation. The packed runtime adapter is covered by an end-to-end
+R4G1 fixture, including deterministic tie-breaking, recent-token penalties,
+and a steady-state zero-allocation census. Compiler-side factor products remain
+outside the deployed kernel.
 
 Against the incumbent R4G1 graph, top-1 is unchanged, top-8 improves by
 20.83 percentage points, and teacher cross-entropy improves by 3.3670
-bits/token. This is an exploratory result, not a deployment claim: the
-candidate currently has no integer translation table, allocation-free serving
-path, or §5.4 cost certificate.
+bits/token. The packed table is now an implementation result, not an accuracy
+claim: artifact reports expose its byte footprint, rank, and candidate count,
+while the runtime fixture measures the fixed work shape (`dimension ×
+candidate_count` sign/add updates per query). A pinned §5.4 comparison on the
+full teacher fixture is still required before choosing it as the default serving
+route.
 
 The candidate must expose the same teacher-forced prediction contract as the
 incumbent. First compare it at the same 96-position snapshot, then rerun at
@@ -145,9 +152,8 @@ incumbent on the same fixture.
 
 ## Remaining work
 
-The certifier candidate now exists and is measured, but issue #290 is not yet
-closed. The remaining decision is whether the accuracy gain justifies a
-bounded implementation for the deployed contract. That requires a fixed-point
-translation representation, an allocation-free adapter, and the §5.4 cost
-comparison against R4G1. Until those are implemented and certified, the FMM
-candidate remains a research measurement path only.
+The certifier candidate and bounded fixed-point adapter now exist, but issue
+#290 is not yet closed. The remaining decision is whether the measured accuracy
+gain justifies enabling the FMM route in serving. That requires the full
+teacher-forced replay plus the §5.4 cost comparison against R4G1, with the
+artifact and runtime evidence linked to the result.

--- a/docs/r4_graph_compiler_implementation_plan.md
+++ b/docs/r4_graph_compiler_implementation_plan.md
@@ -387,6 +387,10 @@ Objective: the scoring model S(v) = B(v) + ΣΔE(n,v) + ΣΔT(m,v) + ΔX(X,v) (P
 - Fixed-capacity top-K candidate structure with canonical tie-breaking (highest score, then
   lowest token ID — matches current `predict` tie rule).
 - Emission blocks shared across regions where profiling shows duplication.
+- Optional FMM1 translation rows: compiler-side low-rank factors are folded into
+  a canonical fixed-point table; the borrowed runtime reader performs only
+  sign-selected table reads and saturating add/sub, with artifact footprint and
+  zero-allocation coverage recorded for the #290/#359 cost decision.
 - Exit: witness replays S(v) exactly; graph prediction fixtures match reference runtime; Gate C
   measurement on declared held-out sets vs. 31.7%-agreement baseline.
 
@@ -608,6 +612,7 @@ The table is the source content.
 23. Behavioral graph-equivalence + confidence-bounded empirical claims spec →
    `docs/transformerless/EQUIVALENCE_AND_EMPIRICAL_PROTOCOL.md` (Phase 0/3, #33, feeds D2).
 24. Evaluation-report tooling for HF-compiled (SmolLM2) models → Phase 0/2 (#34; blocks Gate C harness).
+25. Compiler-folded FMM translation table with allocation-free packed evaluation → Phase 4/5 (#359; accuracy and cost decision remains under #290).
 
 ---
 

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -107,6 +107,8 @@ fn emit_and_persist(
     let artifacts = synthetic_compiled();
     let teacher = compiler::artifact_bytes(&artifacts);
     let tls1 = runtime::store_bytes(store);
+    let fmm_section =
+        score::compile_fmm_section(regions, emissions, 64).expect("fixture FMM section compiles");
     let (bytes, _) = score::emit_scored_r4g1(
         &teacher,
         (b"status-meta", b"status-recs"),
@@ -132,6 +134,7 @@ fn emit_and_persist(
             emissions,
             exct_tls1: &tls1,
             exct_top_x: score::ScoreConfig::default().exct_top_x,
+            fmm_section: Some(&fmm_section),
         },
     )
     .expect("fixture emit succeeds");


### PR DESCRIPTION
## Summary
- define the optional versioned FMM R4G1 section (FMM1)
- add zero-copy validated GraphView access and coefficient-row iterators
- fold fixed-point basis/factor products into compiler-side per-bit/per-token coefficients
- wire FMM section generation into the normal scored-artifact and cover-sweep exporters
- add a multiplication-free, allocation-free packed runtime evaluator with caller-owned scratch
- expose FMM footprint, rank, and candidate count in scored-artifact reports

## Design boundary

The compiler/certifier performs the floating-point low-rank decomposition and folds it into signed fixed-point coefficient rows. Serving selects a coefficient sign from each query bit and performs only table reads, saturating integer add/subtract, comparison, and bounded recent-token checks. The existing certifier-side low-rank scorer remains the compiler-side source of those coefficients.

FMM remains an optional artifact section. It does not replace masked-Hamming routing or the existing exact-context/graph scorer; the #290 novel-context accuracy and cost decision remains a separate measured gate.

## Validation

- cargo test --workspace --offline
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo fmt --check
- cargo check -p uor-r4-graph-format --no-default-features --offline
- cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline
- end-to-end R4G1 FMM artifact parsing and runtime parity
- deterministic tie-breaking and recent-token penalty coverage
- steady-state zero-allocation runtime census
- packed footprint and serving-work measurement: 2340 FMM bytes; 2439 artifact delta; 576 sign/add updates per query on the fixture
- GitHub CI: workspace nextest, BDD, docs, no-std, deterministic rebuild, canonical κ, audit, fuzz smoke, wasm parity, Gate C, and Kani all green

Related: #290, #356.