### PR TITLE
feat: add trigram-to-unigram context fallback rows

### DIFF
--- a/crates/uor-r4-core/src/transformerless/cover_sweep.rs
+++ b/crates/uor-r4-core/src/transformerless/cover_sweep.rs
@@ -405,6 +405,12 @@ pub fn run_point(
     );
     let vocab = u32::try_from(inputs.artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
+    let context_rows = score::compile_context_rows(
+        &inputs.corpus,
+        &inputs.train,
+        vocab,
+        score_config.smoothing,
+    );
     let emissions = score::compile_emissions(
         &inputs.corpus,
         &inputs.store,
@@ -424,6 +430,7 @@ pub fn run_point(
             transitions: &transitions,
             transition_quantization,
             emissions: &emissions,
+            context_rows: &context_rows,
             exct_tls1: &inputs.tls1,
             exct_top_x: score_config.exct_top_x,
         },

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -749,6 +749,9 @@ pub struct ScoredGraphInfo {
     pub root_prior_entries: u32,
     pub emission_list_entries: u32,
     pub exct_bytes: u32,
+    pub context_row_count: u32,
+    pub context_entry_count: u32,
+    pub context_bytes: u32,
     pub artifact_bytes: usize,
     pub transition_quantization: QuantizationErrorStats,
     pub root_prior_quantization: QuantizationErrorStats,
@@ -1155,6 +1158,17 @@ pub fn emit_scored_r4g1(
             root_prior_entries: root_entry_count,
             emission_list_entries,
             exct_bytes: exct.len() as u32,
+            context_row_count: u32::try_from(context_rows.len())
+                .map_err(|_| "NGRAM row count exceeds u32".to_owned())?,
+            context_entry_count: u32::try_from(
+                context_rows
+                    .iter()
+                    .map(|row| row.entries.len())
+                    .sum::<usize>(),
+            )
+            .map_err(|_| "NGRAM entry count exceeds u32".to_owned())?,
+            context_bytes: u32::try_from(ngram.len())
+                .map_err(|_| "NGRAM section exceeds u32".to_owned())?,
             artifact_bytes,
             transition_quantization,
             root_prior_quantization: emissions.root_prior_quantization,
@@ -2352,6 +2366,9 @@ pub struct ScoreReportGraph {
     pub root_prior_entries: u32,
     pub emission_list_entries: u32,
     pub exct_bytes: u32,
+    pub context_row_count: u32,
+    pub context_entry_count: u32,
+    pub context_bytes: u32,
     pub artifact_bytes: usize,
     pub graph_repetition_rate: f64,
     pub baseline_repetition_rate: f64,
@@ -2425,7 +2442,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 11,
+        schema: 12,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -2448,6 +2465,9 @@ pub fn build_score_report_with_quality_profile(
             root_prior_entries: info.root_prior_entries,
             emission_list_entries: info.emission_list_entries,
             exct_bytes: info.exct_bytes,
+            context_row_count: info.context_row_count,
+            context_entry_count: info.context_entry_count,
+            context_bytes: info.context_bytes,
             artifact_bytes: info.artifact_bytes,
             graph_repetition_rate: gate_c.repetition_rate_rule12,
             baseline_repetition_rate: gate_c.repetition_rate_baseline,
@@ -2549,5 +2569,55 @@ fn smoothing_description(smoothing: Smoothing) -> String {
              δ·T_n / total_n spread over the max(V − T_n, 1) unseen types \
              (T_n = seen types); {evidence}"
         ),
+    }
+}
+
+#[cfg(test)]
+mod context_rows_tests {
+    use super::{compile_context_rows, Smoothing};
+    use uor_r4_core::transformerless::compiler::{Corpus, SIG_BYTES};
+    use uor_r4_graph_compiler::induction::Observation;
+
+    fn corpus() -> Corpus {
+        Corpus {
+            n: 5,
+            stories: 2,
+            story: vec![0, 0, 1, 1, 1],
+            input: vec![10, 20, 30, 40, 50],
+            next: vec![20, 30, 40, 50, 60],
+            t_argmax: vec![0; 5],
+            top_tokens: vec![[0; 8]; 5],
+            top_weights: vec![[0; 8]; 5],
+            span_start: vec![0; 5],
+            span_end: vec![0; 5],
+            byte_start: vec![0; 5],
+            byte_end: vec![0; 5],
+            hidden: None,
+        }
+    }
+
+    #[test]
+    fn context_rows_do_not_cross_story_boundaries() {
+        let corpus = corpus();
+        let observations: Vec<Observation> = (0..corpus.n)
+            .map(|position| Observation {
+                position: position as u32,
+                sample: [0; 32],
+                vector: Vec::new(),
+                sig: [0; SIG_BYTES],
+                prev: corpus.input[position],
+                next: corpus.next[position],
+            })
+            .collect();
+        let rows = compile_context_rows(&corpus, &observations, 100, Smoothing::AddOne);
+        assert!(rows
+            .iter()
+            .any(|row| { row.context_len == 2 && row.key0 == 10 && row.key1 == 20 }));
+        assert!(rows
+            .iter()
+            .any(|row| { row.context_len == 2 && row.key0 == 40 && row.key1 == 50 }));
+        assert!(!rows
+            .iter()
+            .any(|row| { row.context_len == 2 && row.key0 == 20 && row.key1 == 30 }));
     }
 }

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -114,6 +114,8 @@ pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
 /// Default EXCT candidate count.
 pub const DEFAULT_EXCT_TOP_X: usize = 64;
+/// Default per-context candidate bound for packed bigram/trigram rows.
+pub const DEFAULT_CONTEXT_ENTRIES: usize = 64;
 /// Default held-out position count whose witnesses are replayed in Gate C.
 pub const DEFAULT_WITNESS_SAMPLE: usize = 64;
 
@@ -450,6 +452,75 @@ pub struct EmissionTables {
     pub emission_quantization: QuantizationErrorStats,
 }
 
+/// One canonical context-conditioned lexical row. The root prior in
+/// [`EmissionTables`] is the unigram row; `context_len` 1 and 2 are bigram
+/// and trigram rows respectively.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextRow {
+    pub context_len: u8,
+    pub key0: u32,
+    pub key1: u32,
+    /// Absolute smoothed log scores, stored in ascending token order.
+    pub entries: Vec<(u32, ScoreQ)>,
+}
+
+/// Compile explicit bigram and trigram rows from the teacher-forced corpus.
+/// Story boundaries never form a trigram key. Rows are retained when the
+/// context was observed; the runtime's exact row-presence rule then defines
+/// the deterministic most-specific backoff.
+pub fn compile_context_rows(
+    corpus: &Corpus,
+    train: &[Observation],
+    vocab: u32,
+    smoothing: Smoothing,
+) -> Vec<ContextRow> {
+    let mut counts: BTreeMap<(u8, u32, u32), BTreeMap<u32, u64>> = BTreeMap::new();
+    for observation in train {
+        let i = observation.position as usize;
+        if i >= corpus.n || corpus.next[i] != observation.next {
+            continue;
+        }
+        let bigram = (1, corpus.input[i], 0);
+        *counts
+            .entry(bigram)
+            .or_default()
+            .entry(corpus.next[i])
+            .or_insert(0) += 1;
+        if i > 0 && corpus.story[i - 1] == corpus.story[i] {
+            let trigram = (2, corpus.input[i - 1], corpus.input[i]);
+            *counts
+                .entry(trigram)
+                .or_default()
+                .entry(corpus.next[i])
+                .or_insert(0) += 1;
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|((context_len, key0, key1), distribution)| {
+            let total: u64 = distribution.values().sum();
+            let types = distribution.len();
+            let mut ranked: Vec<(u32, ScoreQ)> = distribution
+                .iter()
+                .map(|(&token, &count)| {
+                    let ln = smoothing.ln_prob(count, total, vocab, types);
+                    (token, ScoreQ::from_logprob(ln))
+                })
+                .collect();
+            ranked.sort_by(|a, b| b.1.raw().cmp(&a.1.raw()).then_with(|| a.0.cmp(&b.0)));
+            ranked.truncate(DEFAULT_CONTEXT_ENTRIES);
+            ranked.sort_by_key(|&(token, _)| token);
+            ContextRow {
+                context_len,
+                key0,
+                key1,
+                entries: ranked,
+            }
+        })
+        .collect()
+}
+
 /// ln of an add-one-smoothed probability (compiler-side f64; module
 /// docs for the platform pinning). This is the [`Smoothing::AddOne`]
 /// arm; the other rules live in [`Smoothing::ln_prob`].
@@ -699,10 +770,72 @@ pub struct ScoredGraphSections<'a> {
     pub transition_quantization: QuantizationErrorStats,
     /// Root prior + per-region residual lists.
     pub emissions: &'a EmissionTables,
+    /// Explicit bigram/trigram context rows; the root unigram remains EMIT.
+    pub context_rows: &'a [ContextRow],
     /// TLS1 container bytes used as compiler input for residualized EXCT.
     pub exct_tls1: &'a [u8],
     /// Number of exact-context residual entries retained per prefix.
     pub exct_top_x: usize,
+}
+
+fn encode_context_rows(rows: &[ContextRow]) -> Result<Vec<u8>, String> {
+    let row_count =
+        u32::try_from(rows.len()).map_err(|_| "NGRAM row count exceeds u32".to_owned())?;
+    let header_len = uor_r4_graph_format::NGRAM_HEADER_LEN;
+    let row_len = uor_r4_graph_format::NGRAM_ROW_LEN;
+    let entries_start = header_len
+        .checked_add(
+            row_len
+                .checked_mul(rows.len())
+                .ok_or("NGRAM row bytes overflow")?,
+        )
+        .ok_or("NGRAM header bytes overflow")?;
+    let mut bytes = Vec::with_capacity(entries_start);
+    bytes.extend_from_slice(&uor_r4_graph_format::NGRAM_MAGIC);
+    bytes.extend_from_slice(&uor_r4_graph_format::NGRAM_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&[0u8; 2]);
+    bytes.extend_from_slice(&row_count.to_le_bytes());
+    let max_entries = rows.iter().map(|row| row.entries.len()).max().unwrap_or(0);
+    bytes.extend_from_slice(
+        &u16::try_from(max_entries)
+            .map_err(|_| "NGRAM row entry count exceeds u16".to_owned())?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&[0u8; 2]);
+    bytes.resize(entries_start, 0);
+    let mut entry_offset = entries_start;
+    let mut previous = None;
+    for (index, row) in rows.iter().enumerate() {
+        if !(1..=2).contains(&row.context_len) || (row.context_len == 1 && row.key1 != 0) {
+            return Err("NGRAM row has an invalid context key".to_owned());
+        }
+        let key = (row.context_len, row.key0, row.key1);
+        if previous.is_some_and(|last| last >= key) {
+            return Err("NGRAM rows are not canonically sorted".to_owned());
+        }
+        previous = Some(key);
+        let entry_count = u16::try_from(row.entries.len())
+            .map_err(|_| "NGRAM row entry count exceeds u16".to_owned())?;
+        let header = header_len + index * row_len;
+        bytes[header] = row.context_len;
+        bytes[header + 2..header + 4].copy_from_slice(&entry_count.to_le_bytes());
+        bytes[header + 4..header + 8].copy_from_slice(&row.key0.to_le_bytes());
+        bytes[header + 8..header + 12].copy_from_slice(&row.key1.to_le_bytes());
+        let entry_offset_u32 =
+            u32::try_from(entry_offset).map_err(|_| "NGRAM entry offset exceeds u32".to_owned())?;
+        bytes[header + 12..header + 16].copy_from_slice(&entry_offset_u32.to_le_bytes());
+        let mut previous_token = None;
+        for &(token, score) in &row.entries {
+            if previous_token.is_some_and(|last| last >= token) {
+                return Err("NGRAM entries are not canonically sorted".to_owned());
+            }
+            previous_token = Some(token);
+            bytes.extend_from_slice(&token.to_le_bytes());
+            bytes.extend_from_slice(&score.raw().to_le_bytes());
+        }
+        entry_offset = bytes.len();
+    }
+    Ok(bytes)
 }
 
 /// Encode the exact-context store as compile-time ScoreQ residuals. The
@@ -780,6 +913,7 @@ pub fn emit_scored_r4g1(
         transitions,
         transition_quantization,
         emissions,
+        context_rows,
         exct_tls1,
         exct_top_x,
     } = *sections;
@@ -955,6 +1089,7 @@ pub fn emit_scored_r4g1(
     let mut exct = Vec::with_capacity(4 + exct_body.len());
     exct.extend_from_slice(&[2, 0, 0, 0]);
     exct.extend_from_slice(&exct_body);
+    let ngram = encode_context_rows(context_rows)?;
 
     // HEAD: the fixed 224-byte v0 prefix (convert_r4g1 conventions).
     let (meta, recs) = corpus_cid_material;
@@ -993,6 +1128,7 @@ pub fn emit_scored_r4g1(
     builder.add_section(uor_r4_graph_format::SectionId::ROUT, 0, &rout);
     builder.add_section(uor_r4_graph_format::SectionId::EMIT, 0, &emit);
     builder.add_section(uor_r4_graph_format::SectionId::EXCT, 0, &exct);
+    builder.add_section(uor_r4_graph_format::SectionId::NGRAM, 0, &ngram);
     let bytes = builder
         .build()
         .map_err(|error| format!("R4G1 serialization failed: {error}"))?;

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -4,11 +4,13 @@
 //! Two rules, both scored per context:
 //!
 //! ```text
-//! Rule 2 (D4 EXCT precedence): S(v) = B(v) + ΔX(X,v)
+//! Rule 2 (D4 exact-context precedence): S(v) = B(v) + ΔX(X,v)
 //!     when the EXCT probe resolves at the FULL graded code (level ==
 //!     STAGES) with total evidence ≥ EXCT_SUPPORT_MIN — strict
 //!     exact-context evidence dominates and graph residuals are skipped
-//!     entirely (status ExactContext). A probe that resolves below full
+//!     entirely (status ExactContext). An explicit supported NGRAM row
+//!     takes the same most-specific precedence before the EXCT probe. A
+//!     probe that resolves below full
 //!     depth is prefix backoff, not exact context (#234, maintainer
 //!     decision 2026-07-29): it is recorded in the witness but admits
 //!     nothing, and the position falls through to Rule 1.
@@ -558,8 +560,9 @@ pub struct ExctProbe {
 /// consumes this status per decision D4). Recorded in every witness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScoreStatus {
-    /// Rule 2 fired: the EXCT probe resolved at the FULL graded code
-    /// (#234) with total evidence ≥ [`EXCT_SUPPORT_MIN`];
+    /// Rule 2 fired: an explicit NGRAM row matched, or the EXCT probe
+    /// resolved at the FULL graded code (#234) with total evidence ≥
+    /// [`EXCT_SUPPORT_MIN`];
     /// `S(v) = B(v) + ΔX(X,v)`, graph residuals skipped entirely.
     ExactContext,
     /// Rule 1 fired with a non-empty selected covered chain:
@@ -591,6 +594,9 @@ pub struct ScoreWitness {
     /// kernel==plain equality witnesses, and replay proves consistent
     /// CONSUMPTION. `None` when no artifact/EXCT surface is wired.
     pub input_code: Option<[u8; STAGES]>,
+    /// Recent lexical tokens used by the explicit NGRAM backoff, retained so
+    /// independent replay can reproduce the same context decision.
+    pub context_tokens: Vec<u32>,
     /// Which rule fired (module docs).
     pub status: ScoreStatus,
     /// Active cloud A (ascending region id) with margins; empty under
@@ -726,6 +732,9 @@ pub struct GraphScorer {
     root_top: Vec<u32>,
     /// Per-region emission maps (index = region id), token → ΔE.
     emissions: Vec<BTreeMap<u32, ScoreQ>>,
+    /// Explicit bigram/trigram rows. The root prior remains the unigram
+    /// fallback in EMIT.
+    context_rows: BTreeMap<(u8, u32, u32), Vec<(u32, ScoreQ)>>,
     residual_exct: Option<Vec<BTreeMap<Vec<u8>, ResidualExctContext>>>,
     store: Option<Store>,
     artifacts: Option<Compiled>,
@@ -879,6 +888,23 @@ impl GraphScorer {
             node_index += 1;
         }
 
+        let mut context_rows = BTreeMap::new();
+        if let Some(table) = view
+            .ngram_table()
+            .map_err(|e| format!("invalid NGRAM section: {e}"))?
+        {
+            for row in table.rows() {
+                let entries: Vec<(u32, ScoreQ)> = row
+                    .entries()
+                    .map(|entry| (entry.token, entry.score_q))
+                    .collect();
+                if !entries.is_empty() {
+                    let key = (row.context_len(), row.key().0, row.key().1);
+                    context_rows.insert(key, entries);
+                }
+            }
+        }
+
         // EXCT: prefer compile-time residual tables. They can be used by
         // the deployed integer-only runtime; raw TLS1 remains accepted for
         // legacy Gate C/converter artifacts and uses the old certifier-side
@@ -930,6 +956,7 @@ impl GraphScorer {
             root_floor,
             root_top,
             emissions,
+            context_rows,
             residual_exct,
             store,
             artifacts,
@@ -964,6 +991,43 @@ impl GraphScorer {
             .get(&token)
             .copied()
             .unwrap_or(self.root_floor)
+    }
+
+    /// Apply the explicit lexical backoff rule. A row is supported only when
+    /// it has at least one candidate; empty rows fall through to the next
+    /// context order and finally to the normal root/graph scorer.
+    fn context_prediction(&self, recent_tokens: &[u32]) -> Option<(u32, ScoreQ)> {
+        let tokens = if recent_tokens.first().is_some_and(|&token| token <= 1) {
+            &recent_tokens[1..]
+        } else {
+            recent_tokens
+        };
+        let keys = if tokens.len() >= 2 {
+            [
+                Some((2, tokens[tokens.len() - 2], tokens[tokens.len() - 1])),
+                tokens.last().copied().map(|token| (1, token, 0)),
+            ]
+        } else {
+            [None, tokens.last().copied().map(|token| (1, token, 0))]
+        };
+        for key in keys.into_iter().flatten() {
+            let Some(entries) = self.context_rows.get(&key) else {
+                continue;
+            };
+            let mut best = None;
+            for &(token, score) in entries {
+                if best.is_none_or(|(best_token, best_score): (u32, ScoreQ)| {
+                    score.raw() > best_score.raw()
+                        || (score.raw() == best_score.raw() && token < best_token)
+                }) {
+                    best = Some((token, score));
+                }
+            }
+            if best.is_some() {
+                return best;
+            }
+        }
+        None
     }
 
     /// Score one context signature: compute the active cloud A, the
@@ -1016,6 +1080,39 @@ impl GraphScorer {
         } else {
             recent_tokens
         };
+        if let Some((selected, selected_score)) = self.context_prediction(recent_tokens) {
+            let census = OpKernel {
+                table_reads: 1,
+                ..Default::default()
+            };
+            let context_tokens = recent_tokens.to_vec();
+            let witness = ScoreWitness {
+                graph_cid: self.graph_cid,
+                input_sig: *sig,
+                input_code: input_code.copied(),
+                context_tokens,
+                status: ScoreStatus::ExactContext,
+                active: Vec::new(),
+                chain: Vec::new(),
+                predicted: Vec::new(),
+                edges_applied: Vec::new(),
+                transition_offset: ScoreQ::ZERO,
+                f_emissions: self.f_emissions,
+                exct: None,
+                selected,
+                selected_score,
+                selected_contributions: Vec::new(),
+                candidate_count: 1,
+                census,
+            };
+            return Ok(ScoreOutcome {
+                selected,
+                selected_score,
+                candidates: vec![(selected, selected_score)],
+                candidate_components: vec![(selected, selected_score.raw(), 0, false)],
+                witness,
+            });
+        }
         let mut k = OpKernel::default();
 
         // Active cloud A: top-M memberships at each depth — exactly the
@@ -1336,6 +1433,7 @@ impl GraphScorer {
             graph_cid: self.graph_cid,
             input_sig: *sig,
             input_code: witness_code,
+            context_tokens: recent_tokens.to_vec(),
             status: if exact_context {
                 ScoreStatus::ExactContext
             } else if selected_chain.is_empty() {
@@ -1903,6 +2001,19 @@ impl GraphScorer {
         if state.residuals.len() != self.vocab as usize {
             return Err("step state does not match this scorer".to_owned());
         }
+        if let Some((selected, selected_score)) = self.context_prediction(recent_tokens) {
+            let census = OpKernel {
+                table_reads: 1,
+                ..Default::default()
+            };
+            return Ok(StepOutcome {
+                selected,
+                selected_score,
+                status: ScoreStatus::ExactContext,
+                candidate_count: 1,
+                census,
+            });
+        }
         let mut k = OpKernel::default();
         // Fresh epoch: stale stamps compare older and are overwritten on
         // first touch, so no vocabulary-sized buffer is re-zeroed.
@@ -2214,13 +2325,22 @@ pub fn verify_witness_replay(
         return Err(ReplayError::GraphCidMismatch);
     }
     let outcome = scorer
-        .score_candidates_coded(&witness.input_sig, witness.input_code.as_ref(), &[])
+        .score_candidates_coded(
+            &witness.input_sig,
+            witness.input_code.as_ref(),
+            &witness.context_tokens,
+        )
         .map_err(ReplayError::Artifact)?;
     let recomputed = &outcome.witness;
 
     if recomputed.input_code != witness.input_code {
         return Err(ReplayError::Artifact(
             "input_code mismatch on replay (witness contract, #243 Phase C)".to_owned(),
+        ));
+    }
+    if recomputed.context_tokens != witness.context_tokens {
+        return Err(ReplayError::Artifact(
+            "context_tokens mismatch on replay".to_owned(),
         ));
     }
     if recomputed.active != witness.active {
@@ -2321,5 +2441,54 @@ mod shift_arithmetic_tests {
         assert_eq!(shift_div_i128(42, 0), 0);
         assert_eq!(shift_div_i128(-42, 0), 0);
         assert_eq!(shift_div_i128(0, 0), 0);
+    }
+}
+
+#[cfg(test)]
+mod ngram_tests {
+    use super::*;
+
+    fn scorer(rows: BTreeMap<(u8, u32, u32), Vec<(u32, ScoreQ)>>) -> GraphScorer {
+        GraphScorer {
+            graph_cid: [0; 32],
+            regions: Vec::new(),
+            max_depth: 0,
+            forward_by_src: BTreeMap::new(),
+            root_prior: BTreeMap::new(),
+            root_floor: ScoreQ::ZERO,
+            root_top: Vec::new(),
+            emissions: Vec::new(),
+            context_rows: rows,
+            residual_exct: None,
+            store: None,
+            artifacts: None,
+            vocab: 32,
+            exct_top_x: 0,
+            pop: [0; 256],
+            f_emissions: false,
+            scoring_variant: ScoringVariant::ChainTelescoped,
+            fallback_policy: Default::default(),
+        }
+    }
+
+    #[test]
+    fn context_backoff_prefers_trigram_then_bigram() {
+        let mut rows = BTreeMap::new();
+        rows.insert((1, 20, 0), vec![(6, ScoreQ::from_raw(100))]);
+        rows.insert(
+            (2, 10, 20),
+            vec![(4, ScoreQ::from_raw(10)), (5, ScoreQ::from_raw(20))],
+        );
+        let mut scorer = scorer(rows);
+        assert_eq!(
+            scorer.context_prediction(&[10, 20]),
+            Some((5, ScoreQ::from_raw(20)))
+        );
+        scorer.context_rows.remove(&(2, 10, 20));
+        assert_eq!(
+            scorer.context_prediction(&[10, 20]),
+            Some((6, ScoreQ::from_raw(100)))
+        );
+        assert_eq!(scorer.context_prediction(&[30]), None);
     }
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1035,6 +1035,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     );
     let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
+    let context_rows = score::compile_context_rows(&corpus, &train, vocab, config.smoothing);
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
     let (artifact_bytes, info) = score::emit_scored_r4g1(
@@ -1047,6 +1048,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
             transitions: &transitions,
             transition_quantization,
             emissions: &emissions,
+            context_rows: &context_rows,
             exct_tls1: &tls1,
             exct_top_x: config.exct_top_x,
         },

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1122,14 +1122,17 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         .map_err(|error| format!("{}: {error}", report_path.display()))?;
 
     println!(
-        "score complete: {} nodes, {} edges ({} refinement + {} neighbor + {} forward), {} emission entries, EXCT {} bytes",
+        "score complete: {} nodes, {} edges ({} refinement + {} neighbor + {} forward), {} emission entries, EXCT {} bytes, NGRAM {} rows/{} entries ({} bytes)",
         info.node_count,
         info.edge_count,
         info.refinement_edges,
         info.neighbor_edges,
         info.forward_edges,
         info.emission_list_entries,
-        info.exct_bytes
+        info.exct_bytes,
+        info.context_row_count,
+        info.context_entry_count,
+        info.context_bytes
     );
     println!(
         "gate C — held-out D3 metrics ({} positions):",

--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -188,6 +188,22 @@ pub enum FormatError {
         /// Actual EDGE section length in bytes.
         section_len: u64,
     },
+    /// NGRAM has no complete fixed header.
+    NgramTooShort,
+    /// NGRAM magic is not `NGR1`.
+    NgramBadMagic,
+    /// NGRAM version is not supported.
+    NgramUnsupportedVersion,
+    /// NGRAM reserved bytes are non-zero.
+    NgramNonZeroReserved,
+    /// NGRAM row or entry offset arithmetic is invalid.
+    NgramBounds,
+    /// NGRAM row keys are not in canonical order.
+    NgramRowsNotSorted,
+    /// NGRAM entry tokens are not in canonical order.
+    NgramEntriesNotSorted,
+    /// NGRAM row metadata is invalid.
+    NgramInvalidRow,
     /// A packed-node range field does not resolve within its target
     /// section under checked arithmetic (RFC §6 item 4). For
     /// `Prototype`/`Mask` the full W-word extent from the word start
@@ -508,6 +524,16 @@ impl fmt::Display for FormatError {
                 f,
                 "EDGE section holds {section_len} bytes, not edge_count {declared} x 20"
             ),
+            FormatError::NgramTooShort => write!(f, "NGRAM section is shorter than its header"),
+            FormatError::NgramBadMagic => write!(f, "NGRAM magic is not NGR1"),
+            FormatError::NgramUnsupportedVersion => write!(f, "NGRAM version is unsupported"),
+            FormatError::NgramNonZeroReserved => write!(f, "NGRAM reserved bytes are non-zero"),
+            FormatError::NgramBounds => write!(f, "NGRAM row or entry range is out of bounds"),
+            FormatError::NgramRowsNotSorted => write!(f, "NGRAM rows are not canonically sorted"),
+            FormatError::NgramEntriesNotSorted => {
+                write!(f, "NGRAM entries are not canonically sorted")
+            }
+            FormatError::NgramInvalidRow => write!(f, "NGRAM row metadata is invalid"),
             FormatError::RangeOutOfBounds { node, field } => write!(
                 f,
                 "node {node}: {field} range does not resolve within its target section"

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -3,7 +3,7 @@
 //! R4G1 is the versioned packed artifact container for the R⁴ holographic
 //! graph compiler: a single little-endian, fixed-width, explicitly-aligned
 //! binary format that carries a compiled semantic-region graph (sections
-//! HEAD/CODE/NODE/EDGE/ROUT/EMIT plus optional EXCT/PROV/CERT/PTCH/SECT)
+//! HEAD/CODE/NODE/EDGE/ROUT/EMIT plus optional EXCT/NGRAM/PROV/CERT/PTCH/SECT)
 //! from the offline compiler to the deployed runtime. It succeeds the
 //! ad-hoc TLA3/TLA4/TLS1 containers.
 //!
@@ -103,8 +103,8 @@ pub use invariant_ownership::{
     OPERATION_SET_CONFORMANCE_ROW,
 };
 pub use ngram::{
-    NgramEntries, NgramEntry, NgramRow, NgramTable, NGRAM_ENTRY_LEN, NGRAM_HEADER_LEN, NGRAM_MAGIC,
-    NGRAM_ROW_LEN, NGRAM_VERSION,
+    NgramEntries, NgramEntry, NgramRow, NgramRows, NgramTable, NGRAM_ENTRY_LEN, NGRAM_HEADER_LEN,
+    NGRAM_MAGIC, NGRAM_ROW_LEN, NGRAM_VERSION,
 };
 pub use records::{
     EdgeKind, PackedEdge, PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, PACKED_EDGE_LEN,

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -69,6 +69,7 @@ mod head;
 mod header;
 pub mod inference_contract;
 pub mod invariant_ownership;
+mod ngram;
 #[cfg(feature = "alloc")]
 pub mod r4g1;
 pub mod records;
@@ -100,6 +101,10 @@ pub use invariant_ownership::{
     GraphInvariantId, GraphInvariantOwnershipMatrix, InvariantOwner, InvariantOwnershipEntry,
     InvariantOwnershipRow, InvariantValidationError, INVARIANT_OWNERSHIP_ROWS, MATRIX_VERSION,
     OPERATION_SET_CONFORMANCE_ROW,
+};
+pub use ngram::{
+    NgramEntries, NgramEntry, NgramRow, NgramTable, NGRAM_ENTRY_LEN, NGRAM_HEADER_LEN, NGRAM_MAGIC,
+    NGRAM_ROW_LEN, NGRAM_VERSION,
 };
 pub use records::{
     EdgeKind, PackedEdge, PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, PACKED_EDGE_LEN,

--- a/crates/uor-r4-graph-format/src/ngram.rs
+++ b/crates/uor-r4-graph-format/src/ngram.rs
@@ -71,6 +71,11 @@ pub struct NgramTable<'a> {
     row_count: u32,
 }
 
+pub struct NgramRows<'a> {
+    table: NgramTable<'a>,
+    next: usize,
+}
+
 impl<'a> NgramTable<'a> {
     pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
         if bytes.len() < NGRAM_HEADER_LEN {
@@ -146,6 +151,13 @@ impl<'a> NgramTable<'a> {
         self.row_count
     }
 
+    pub fn rows(&self) -> NgramRows<'a> {
+        NgramRows {
+            table: *self,
+            next: 0,
+        }
+    }
+
     pub fn find(&self, context_len: u8, key0: u32, key1: u32) -> Option<NgramRow<'a>> {
         let target = (context_len, key0, key1);
         let mut low = 0usize;
@@ -177,6 +189,16 @@ impl<'a> NgramTable<'a> {
             bytes,
             entries: self.bytes.get(entry_start..entry_end)?,
         })
+    }
+}
+
+impl<'a> Iterator for NgramRows<'a> {
+    type Item = NgramRow<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row = self.table.row(self.next)?;
+        self.next += 1;
+        Some(row)
     }
 }
 

--- a/crates/uor-r4-graph-format/src/ngram.rs
+++ b/crates/uor-r4-graph-format/src/ngram.rs
@@ -92,6 +92,7 @@ impl<'a> NgramTable<'a> {
             return Err(FormatError::NgramNonZeroReserved);
         }
         let row_count = read_u32(&bytes[8..12]);
+        let max_entries = read_u16(&bytes[12..14]) as usize;
         let rows_len = (row_count as usize)
             .checked_mul(NGRAM_ROW_LEN)
             .ok_or(FormatError::NgramBounds)?;
@@ -103,6 +104,7 @@ impl<'a> NgramTable<'a> {
         }
 
         let mut previous = None;
+        let mut expected_entry_start = entries_start;
         for index in 0..row_count as usize {
             let start = NGRAM_HEADER_LEN + index * NGRAM_ROW_LEN;
             let row = &bytes[start..start + NGRAM_ROW_LEN];
@@ -111,12 +113,15 @@ impl<'a> NgramTable<'a> {
                 return Err(FormatError::NgramInvalidRow);
             }
             let entry_count = read_u16(&row[2..4]);
+            if usize::from(entry_count) > max_entries {
+                return Err(FormatError::NgramInvalidRow);
+            }
             let key = (read_u32(&row[4..8]), read_u32(&row[8..12]));
             if context_len == 1 && key.1 != 0 {
                 return Err(FormatError::NgramInvalidRow);
             }
             let entry_start = read_u32(&row[12..16]) as usize;
-            if row[16..20].iter().any(|&byte| byte != 0) || entry_start < entries_start {
+            if row[16..20].iter().any(|&byte| byte != 0) || entry_start != expected_entry_start {
                 return Err(FormatError::NgramBounds);
             }
             let entry_bytes = (entry_count as usize)
@@ -128,6 +133,7 @@ impl<'a> NgramTable<'a> {
             if entry_end > bytes.len() {
                 return Err(FormatError::NgramBounds);
             }
+            expected_entry_start = entry_end;
             let sort_key = (context_len, key.0, key.1);
             if previous.is_some_and(|last| last >= sort_key) {
                 return Err(FormatError::NgramRowsNotSorted);
@@ -142,6 +148,10 @@ impl<'a> NgramTable<'a> {
                 }
                 previous_token = Some(token);
             }
+        }
+
+        if expected_entry_start != bytes.len() {
+            return Err(FormatError::NgramBounds);
         }
 
         Ok(Self { bytes, row_count })

--- a/crates/uor-r4-graph-format/src/ngram.rs
+++ b/crates/uor-r4-graph-format/src/ngram.rs
@@ -1,0 +1,192 @@
+//! Borrowed packed lexical context rows.
+//!
+//! The root prior remains the unigram row in EMIT. NGRAM carries the
+//! context-conditioned rows: one-token keys are bigrams and two-token keys
+//! are trigrams. Rows and entries are canonical, so lookup is deterministic
+//! and requires no allocation.
+
+use crate::error::FormatError;
+use crate::types::ScoreQ;
+
+pub const NGRAM_MAGIC: [u8; 4] = *b"NGR1";
+pub const NGRAM_VERSION: u16 = 1;
+pub const NGRAM_HEADER_LEN: usize = 16;
+pub const NGRAM_ROW_LEN: usize = 20;
+pub const NGRAM_ENTRY_LEN: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NgramRow<'a> {
+    bytes: &'a [u8],
+    entries: &'a [u8],
+}
+
+impl<'a> NgramRow<'a> {
+    pub fn context_len(&self) -> u8 {
+        self.bytes[0]
+    }
+
+    pub fn key(&self) -> (u32, u32) {
+        (read_u32(&self.bytes[4..8]), read_u32(&self.bytes[8..12]))
+    }
+
+    pub fn entries(&self) -> NgramEntries<'a> {
+        NgramEntries {
+            bytes: self.entries,
+            remaining: (self.entries.len() / NGRAM_ENTRY_LEN) as u32,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NgramEntry {
+    pub token: u32,
+    pub score_q: ScoreQ,
+}
+
+pub struct NgramEntries<'a> {
+    bytes: &'a [u8],
+    remaining: u32,
+}
+
+impl Iterator for NgramEntries<'_> {
+    type Item = NgramEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let entry = self.bytes.get(..NGRAM_ENTRY_LEN)?;
+        self.bytes = &self.bytes[NGRAM_ENTRY_LEN..];
+        self.remaining -= 1;
+        Some(NgramEntry {
+            token: read_u32(&entry[..4]),
+            score_q: ScoreQ::from_raw(i32::from_le_bytes(entry[4..8].try_into().ok()?)),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NgramTable<'a> {
+    bytes: &'a [u8],
+    row_count: u32,
+}
+
+impl<'a> NgramTable<'a> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+        if bytes.len() < NGRAM_HEADER_LEN {
+            return Err(FormatError::NgramTooShort);
+        }
+        if bytes[..4] != NGRAM_MAGIC {
+            return Err(FormatError::NgramBadMagic);
+        }
+        if read_u16(&bytes[4..6]) != NGRAM_VERSION {
+            return Err(FormatError::NgramUnsupportedVersion);
+        }
+        if bytes[6..8].iter().any(|&byte| byte != 0) || bytes[14..16].iter().any(|&byte| byte != 0)
+        {
+            return Err(FormatError::NgramNonZeroReserved);
+        }
+        let row_count = read_u32(&bytes[8..12]);
+        let rows_len = (row_count as usize)
+            .checked_mul(NGRAM_ROW_LEN)
+            .ok_or(FormatError::NgramBounds)?;
+        let entries_start = NGRAM_HEADER_LEN
+            .checked_add(rows_len)
+            .ok_or(FormatError::NgramBounds)?;
+        if entries_start > bytes.len() {
+            return Err(FormatError::NgramBounds);
+        }
+
+        let mut previous = None;
+        for index in 0..row_count as usize {
+            let start = NGRAM_HEADER_LEN + index * NGRAM_ROW_LEN;
+            let row = &bytes[start..start + NGRAM_ROW_LEN];
+            let context_len = row[0];
+            if !(1..=2).contains(&context_len) || row[1] != 0 {
+                return Err(FormatError::NgramInvalidRow);
+            }
+            let entry_count = read_u16(&row[2..4]);
+            let key = (read_u32(&row[4..8]), read_u32(&row[8..12]));
+            if context_len == 1 && key.1 != 0 {
+                return Err(FormatError::NgramInvalidRow);
+            }
+            let entry_start = read_u32(&row[12..16]) as usize;
+            if row[16..20].iter().any(|&byte| byte != 0) || entry_start < entries_start {
+                return Err(FormatError::NgramBounds);
+            }
+            let entry_bytes = (entry_count as usize)
+                .checked_mul(NGRAM_ENTRY_LEN)
+                .ok_or(FormatError::NgramBounds)?;
+            let entry_end = entry_start
+                .checked_add(entry_bytes)
+                .ok_or(FormatError::NgramBounds)?;
+            if entry_end > bytes.len() {
+                return Err(FormatError::NgramBounds);
+            }
+            let sort_key = (context_len, key.0, key.1);
+            if previous.is_some_and(|last| last >= sort_key) {
+                return Err(FormatError::NgramRowsNotSorted);
+            }
+            previous = Some(sort_key);
+            let entries = &bytes[entry_start..entry_end];
+            let mut previous_token = None;
+            for chunk in entries.chunks_exact(NGRAM_ENTRY_LEN) {
+                let token = read_u32(&chunk[..4]);
+                if previous_token.is_some_and(|last| last >= token) {
+                    return Err(FormatError::NgramEntriesNotSorted);
+                }
+                previous_token = Some(token);
+            }
+        }
+
+        Ok(Self { bytes, row_count })
+    }
+
+    pub fn row_count(&self) -> u32 {
+        self.row_count
+    }
+
+    pub fn find(&self, context_len: u8, key0: u32, key1: u32) -> Option<NgramRow<'a>> {
+        let target = (context_len, key0, key1);
+        let mut low = 0usize;
+        let mut high = self.row_count as usize;
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let row = self.row(mid)?;
+            let current = (row.context_len(), row.key().0, row.key().1);
+            if current < target {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        let row = self.row(low)?;
+        ((row.context_len(), row.key().0, row.key().1) == target).then_some(row)
+    }
+
+    fn row(&self, index: usize) -> Option<NgramRow<'a>> {
+        if index >= self.row_count as usize {
+            return None;
+        }
+        let start = NGRAM_HEADER_LEN + index * NGRAM_ROW_LEN;
+        let bytes = self.bytes.get(start..start + NGRAM_ROW_LEN)?;
+        let entry_count = read_u16(&bytes[2..4]) as usize;
+        let entry_start = read_u32(&bytes[12..16]) as usize;
+        let entry_end = entry_start.checked_add(entry_count.checked_mul(NGRAM_ENTRY_LEN)?)?;
+        Some(NgramRow {
+            bytes,
+            entries: self.bytes.get(entry_start..entry_end)?,
+        })
+    }
+}
+
+fn read_u32(bytes: &[u8]) -> u32 {
+    u32::from(bytes[0])
+        | (u32::from(bytes[1]) << 8)
+        | (u32::from(bytes[2]) << 16)
+        | (u32::from(bytes[3]) << 24)
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    u16::from(bytes[0]) | (u16::from(bytes[1]) << 8)
+}

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -79,6 +79,9 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
     if let Some(bytes) = view.section(SectionId::EXCT) {
         StorageDescriptor::parse(SectionId::EXCT, bytes)?;
     }
+    if let Some(bytes) = view.section(SectionId::NGRAM) {
+        crate::ngram::NgramTable::parse(bytes)?;
+    }
 
     // ROUT section-internal bytecode validation (RFC §6 item 6) runs
     // before the per-node cross-references into the section, mirroring

--- a/crates/uor-r4-graph-format/src/types.rs
+++ b/crates/uor-r4-graph-format/src/types.rs
@@ -179,6 +179,8 @@ impl SectionId {
     pub const SECT: SectionId = SectionId(0x0B);
     /// RTNX — route translation index (optional, Phase 9).
     pub const RTNX: SectionId = SectionId(0x0C);
+    /// NGRAM — packed bigram/trigram context rows (optional).
+    pub const NGRAM: SectionId = SectionId(Self::OPTIONAL_BIT | 0x0E);
 
     /// Ancillary bit classifying *unknown* section IDs.
     ///
@@ -196,9 +198,10 @@ impl SectionId {
         self.0
     }
 
-    /// True when the ID is in the RFC §3 inventory (`0x01..=0x0B`).
+    /// True when the ID is in the RFC §3 inventory or a known optional
+    /// extension implemented by this reader.
     pub const fn is_known(self) -> bool {
-        matches!(self.0, 0x01..=0x0C)
+        matches!(self.0, 0x01..=0x0C) || self.0 == Self::NGRAM.0
     }
 
     /// Mandatory-ness per the RFC §3 column for known IDs.
@@ -209,6 +212,7 @@ impl SectionId {
         match self.0 {
             0x01..=0x06 | 0x08 => true,
             0x07 | 0x09..=0x0C => false,
+            value if value == Self::NGRAM.0 => false,
             _ => self.0 & Self::OPTIONAL_BIT == 0,
         }
     }

--- a/crates/uor-r4-graph-format/src/view.rs
+++ b/crates/uor-r4-graph-format/src/view.rs
@@ -10,6 +10,7 @@
 use crate::error::FormatError;
 use crate::head::Head;
 use crate::header::{self, Header, HEADER_LEN, SECTION_ENTRY_LEN};
+use crate::ngram::NgramTable;
 use crate::records::{
     self, PackedEdge, PackedNode, PackedRouteTranslation, PackedTombstone, PACKED_EDGE_LEN,
     PACKED_NODE_LEN, PACKED_ROUTE_TRANSLATION_LEN, PACKED_TOMBSTONE_LEN,
@@ -324,6 +325,13 @@ impl<'a> GraphView<'a> {
             next: 0,
             remaining,
         }
+    }
+
+    /// Parse the optional packed lexical context table.
+    pub fn ngram_table(&self) -> Result<Option<NgramTable<'a>>, FormatError> {
+        self.section(SectionId::NGRAM)
+            .map(NgramTable::parse)
+            .transpose()
     }
 
     /// Recompute both integrity CIDs against the bytes and compare with

--- a/crates/uor-r4-graph-format/tests/ngram.rs
+++ b/crates/uor-r4-graph-format/tests/ngram.rs
@@ -10,6 +10,7 @@ fn fixture() -> Vec<u8> {
     bytes[..4].copy_from_slice(&NGRAM_MAGIC);
     bytes[4..6].copy_from_slice(&NGRAM_VERSION.to_le_bytes());
     bytes[8..12].copy_from_slice(&(rows as u32).to_le_bytes());
+    bytes[12..14].copy_from_slice(&2u16.to_le_bytes());
     bytes[NGRAM_HEADER_LEN] = 1;
     bytes[NGRAM_HEADER_LEN + 2..NGRAM_HEADER_LEN + 4].copy_from_slice(&1u16.to_le_bytes());
     bytes[NGRAM_HEADER_LEN + 4..NGRAM_HEADER_LEN + 8].copy_from_slice(&7u32.to_le_bytes());
@@ -51,4 +52,29 @@ fn rejects_noncanonical_rows() {
     bytes[NGRAM_HEADER_LEN] = 2;
     bytes[NGRAM_HEADER_LEN + 8..NGRAM_HEADER_LEN + 12].copy_from_slice(&9u32.to_le_bytes());
     assert!(NgramTable::parse(&bytes).is_err());
+}
+
+#[test]
+fn rejects_malformed_header_and_entry_ranges() {
+    let mut bad_magic = fixture();
+    bad_magic[..4].copy_from_slice(b"BAD!");
+    assert!(NgramTable::parse(&bad_magic).is_err());
+
+    let mut bad_reserved = fixture();
+    bad_reserved[6] = 1;
+    assert!(NgramTable::parse(&bad_reserved).is_err());
+
+    let mut bad_entry_count = fixture();
+    bad_entry_count[12..14].copy_from_slice(&1u16.to_le_bytes());
+    assert!(NgramTable::parse(&bad_entry_count).is_err());
+
+    let mut overlapping = fixture();
+    let first_offset = (NGRAM_HEADER_LEN + NGRAM_ROW_LEN * 2) as u32;
+    overlapping[NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 12..NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 16]
+        .copy_from_slice(&first_offset.to_le_bytes());
+    assert!(NgramTable::parse(&overlapping).is_err());
+
+    let mut trailing = fixture();
+    trailing.extend_from_slice(&[0; NGRAM_ENTRY_LEN]);
+    assert!(NgramTable::parse(&trailing).is_err());
 }

--- a/crates/uor-r4-graph-format/tests/ngram.rs
+++ b/crates/uor-r4-graph-format/tests/ngram.rs
@@ -1,0 +1,54 @@
+use uor_r4_graph_format::{
+    NgramTable, ScoreQ, NGRAM_ENTRY_LEN, NGRAM_HEADER_LEN, NGRAM_MAGIC, NGRAM_ROW_LEN,
+    NGRAM_VERSION,
+};
+
+fn fixture() -> Vec<u8> {
+    let rows = 2usize;
+    let entries_start = NGRAM_HEADER_LEN + rows * NGRAM_ROW_LEN;
+    let mut bytes = vec![0u8; entries_start];
+    bytes[..4].copy_from_slice(&NGRAM_MAGIC);
+    bytes[4..6].copy_from_slice(&NGRAM_VERSION.to_le_bytes());
+    bytes[8..12].copy_from_slice(&(rows as u32).to_le_bytes());
+    bytes[NGRAM_HEADER_LEN] = 1;
+    bytes[NGRAM_HEADER_LEN + 2..NGRAM_HEADER_LEN + 4].copy_from_slice(&1u16.to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + 4..NGRAM_HEADER_LEN + 8].copy_from_slice(&7u32.to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + 12..NGRAM_HEADER_LEN + 16]
+        .copy_from_slice(&(entries_start as u32).to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + NGRAM_ROW_LEN] = 2;
+    bytes[NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 2..NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 4]
+        .copy_from_slice(&2u16.to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 4..NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 8]
+        .copy_from_slice(&7u32.to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 8..NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 12]
+        .copy_from_slice(&9u32.to_le_bytes());
+    bytes[NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 12..NGRAM_HEADER_LEN + NGRAM_ROW_LEN + 16]
+        .copy_from_slice(&((entries_start + NGRAM_ENTRY_LEN) as u32).to_le_bytes());
+    bytes.extend_from_slice(&11u32.to_le_bytes());
+    bytes.extend_from_slice(&ScoreQ::from_raw(20).raw().to_le_bytes());
+    bytes.extend_from_slice(&13u32.to_le_bytes());
+    bytes.extend_from_slice(&ScoreQ::from_raw(30).raw().to_le_bytes());
+    bytes.extend_from_slice(&15u32.to_le_bytes());
+    bytes.extend_from_slice(&ScoreQ::from_raw(40).raw().to_le_bytes());
+    bytes
+}
+
+#[test]
+fn finds_rows_by_specific_context_key() {
+    let bytes = fixture();
+    let table = NgramTable::parse(&bytes).expect("valid NGRAM");
+    assert_eq!(table.row_count(), 2);
+    let row = table.find(2, 7, 9).expect("trigram row");
+    let entries: Vec<_> = row.entries().collect();
+    assert_eq!(entries[0].token, 13);
+    assert_eq!(entries[1].score_q.raw(), 40);
+    assert!(table.find(1, 8, 0).is_none());
+}
+
+#[test]
+fn rejects_noncanonical_rows() {
+    let mut bytes = fixture();
+    bytes[NGRAM_HEADER_LEN] = 2;
+    bytes[NGRAM_HEADER_LEN + 8..NGRAM_HEADER_LEN + 12].copy_from_slice(&9u32.to_le_bytes());
+    assert!(NgramTable::parse(&bytes).is_err());
+}

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -52,6 +52,47 @@ fn signature_affinity_bonus(prototype: &[u8], mask: &[u8], signature: &[u8]) -> 
     (x << 3).saturating_add(x << 1)
 }
 
+/// Resolve the explicit lexical context rows before geometric graph scoring.
+/// The first non-empty row wins: trigram, then bigram, then the EMIT
+/// unigram path (represented by `None`).
+fn context_backoff(view: &GraphView<'_>, context_tokens: &[u32]) -> Option<(u32, ScoreQ)> {
+    let table = view.ngram_table().ok().flatten()?;
+    let tokens = if context_tokens.first().is_some_and(|&token| token <= 1) {
+        &context_tokens[1..]
+    } else {
+        context_tokens
+    };
+    let mut best = None;
+    if tokens.len() >= 2
+        && let Some(row) = table.find(2, tokens[tokens.len() - 2], tokens[tokens.len() - 1])
+    {
+        best = best_context_entry(row.entries());
+    }
+    if best.is_none()
+        && let Some(&previous) = tokens.last()
+        && let Some(row) = table.find(1, previous, 0)
+    {
+        best = best_context_entry(row.entries());
+    }
+    best
+}
+
+fn best_context_entry(
+    entries: impl Iterator<Item = uor_r4_graph_format::NgramEntry>,
+) -> Option<(u32, ScoreQ)> {
+    let mut best = None;
+    for entry in entries {
+        let candidate = (entry.token, entry.score_q);
+        if best.is_none_or(|(token, score): (u32, ScoreQ)| {
+            candidate.1.raw() > score.raw()
+                || (candidate.1.raw() == score.raw() && candidate.0 < token)
+        }) {
+            best = Some(candidate);
+        }
+    }
+    best
+}
+
 impl<'a> R4G1Runtime<'a> {
     /// Create a new R4G1 runtime by running two-stage validation over `bytes`.
     pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
@@ -523,6 +564,10 @@ impl<'a> R4G1Runtime<'a> {
         let num_nodes = self.node_count();
         if num_nodes == 0 || context_tokens.is_empty() {
             return (0, ScoreQ::ZERO);
+        }
+
+        if let Some(prediction) = context_backoff(self.chain.base_graph(), context_tokens) {
+            return prediction;
         }
 
         let base_graph = self.chain.base_graph();

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -1,11 +1,47 @@
 //! R4G1Runtime unit tests verifying multiplication-free zero-allocation prediction behavior over R4G1 GraphView containers.
 
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use uor_r4_core::transformerless::compiler::{self, STAGES};
 use uor_r4_core::transformerless::convert_r4g1;
 use uor_r4_core::transformerless::runtime::{self, Store};
-use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_format::{ArtifactBuilder, GraphView, ScoreQ, SectionId};
 use uor_r4_graph_runtime::R4G1Runtime;
+
+struct CountingAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+thread_local! {
+    static COUNTING_ENABLED: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        COUNTING_ENABLED.with(|enabled| {
+            if enabled.get() {
+                ALLOCATIONS.with(|count| count.set(count.get().saturating_add(1)));
+            }
+        });
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) };
+    }
+}
+
+fn counted_allocations(f: impl FnOnce()) -> usize {
+    ALLOCATIONS.with(|count| count.set(0));
+    COUNTING_ENABLED.with(|enabled| enabled.set(true));
+    f();
+    COUNTING_ENABLED.with(|enabled| enabled.set(false));
+    ALLOCATIONS.with(Cell::get)
+}
 
 fn fixture_artifacts() -> (Vec<u8>, compiler::Compiled) {
     let dir = env!("CARGO_MANIFEST_DIR");
@@ -31,6 +67,60 @@ fn synthetic_store() -> Store {
         runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
     }
     store
+}
+
+fn base_r4g1_artifact() -> Vec<u8> {
+    let (art_bytes, artifacts) = fixture_artifacts();
+    let store = synthetic_store();
+    let store_bytes = runtime::store_bytes(&store);
+    convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None)
+        .expect("convert to R4G1 succeeds")
+        .0
+}
+
+fn ngram_payload(include_trigram: bool) -> Vec<u8> {
+    let row_count = if include_trigram { 2usize } else { 1usize };
+    let entries_start =
+        uor_r4_graph_format::NGRAM_HEADER_LEN + row_count * uor_r4_graph_format::NGRAM_ROW_LEN;
+    let mut bytes = vec![0u8; entries_start];
+    bytes[..4].copy_from_slice(&uor_r4_graph_format::NGRAM_MAGIC);
+    bytes[4..6].copy_from_slice(&uor_r4_graph_format::NGRAM_VERSION.to_le_bytes());
+    bytes[8..12].copy_from_slice(&(row_count as u32).to_le_bytes());
+    bytes[12..14].copy_from_slice(&2u16.to_le_bytes());
+
+    let mut entry_offset = entries_start;
+    let mut add_row =
+        |index: usize, context_len: u8, key0: u32, key1: u32, entries: &[(u32, i32)]| {
+            let header =
+                uor_r4_graph_format::NGRAM_HEADER_LEN + index * uor_r4_graph_format::NGRAM_ROW_LEN;
+            bytes[header] = context_len;
+            bytes[header + 2..header + 4].copy_from_slice(&(entries.len() as u16).to_le_bytes());
+            bytes[header + 4..header + 8].copy_from_slice(&key0.to_le_bytes());
+            bytes[header + 8..header + 12].copy_from_slice(&key1.to_le_bytes());
+            bytes[header + 12..header + 16].copy_from_slice(&(entry_offset as u32).to_le_bytes());
+            for &(token, score) in entries {
+                bytes.extend_from_slice(&token.to_le_bytes());
+                bytes.extend_from_slice(&score.to_le_bytes());
+            }
+            entry_offset = bytes.len();
+        };
+
+    add_row(0, 1, 20, 0, &[(7, 100)]);
+    if include_trigram {
+        add_row(1, 2, 10, 20, &[(8, 200), (9, 200)]);
+    }
+    bytes
+}
+
+fn artifact_with_ngram(include_trigram: bool) -> Vec<u8> {
+    let base = base_r4g1_artifact();
+    let view = GraphView::parse(&base).expect("base artifact parses");
+    let mut builder = ArtifactBuilder::new(view.header().alignment_log2);
+    for section in view.sections() {
+        builder.add_section(section.id, section.flags, section.payload);
+    }
+    builder.add_section(SectionId::NGRAM, 0, &ngram_payload(include_trigram));
+    builder.build().expect("artifact with NGRAM builds")
 }
 
 #[test]
@@ -103,4 +193,54 @@ fn session_signature_is_bias_only_until_routing_is_calibrated() {
     );
     assert!(zero.1 >= ScoreQ::MIN);
     assert!(full.1 >= ScoreQ::MIN);
+}
+
+#[test]
+fn ngram_runtime_prefers_trigram_then_bigram_without_allocations() {
+    let trigram_bytes = artifact_with_ngram(true);
+    let trigram_runtime = R4G1Runtime::parse(&trigram_bytes).expect("trigram artifact parses");
+    let mut scores = vec![ScoreQ::MIN; trigram_runtime.node_count() as usize];
+    let trigram = trigram_runtime.predict_distribution(&[1, 10, 20], None, &mut scores);
+    assert_eq!(trigram, (8, ScoreQ::from_raw(200)));
+
+    let allocations = counted_allocations(|| {
+        for _ in 0..64 {
+            assert_eq!(
+                trigram_runtime.predict_distribution(&[1, 10, 20], None, &mut scores),
+                trigram
+            );
+        }
+    });
+    assert_eq!(allocations, 0, "NGRAM lookup must be allocation-free");
+
+    let bigram_bytes = artifact_with_ngram(false);
+    let bigram_runtime = R4G1Runtime::parse(&bigram_bytes).expect("bigram artifact parses");
+    let mut bigram_scores = vec![ScoreQ::MIN; bigram_runtime.node_count() as usize];
+    assert_eq!(
+        bigram_runtime.predict_distribution(&[1, 10, 20], None, &mut bigram_scores),
+        (7, ScoreQ::from_raw(100))
+    );
+}
+
+#[test]
+fn ngram_lookup_kernel_is_integer_only_by_source_scan() {
+    let source = include_str!("../src/engine.rs");
+    let start = source
+        .find("fn context_backoff")
+        .expect("context lookup source exists");
+    let end = source
+        .find("impl<'a> R4G1Runtime")
+        .expect("runtime implementation follows lookup helpers");
+    let kernel = &source[start..end];
+    for forbidden in ["*", "/", "f32", "f64"] {
+        assert!(
+            !kernel.contains(forbidden),
+            "NGRAM lookup kernel contains forbidden operation/type {forbidden:?}"
+        );
+    }
+}
+
+#[test]
+fn ngram_artifact_bytes_are_deterministic() {
+    assert_eq!(artifact_with_ngram(true), artifact_with_ngram(true));
 }

--- a/docs/r4_graph_compiler_implementation_plan.md
+++ b/docs/r4_graph_compiler_implementation_plan.md
@@ -149,6 +149,7 @@ runtime. The graph compiler generalizes it from *flat quantized classes + graded
 | Boolean context codes (36-byte sign-bit signatures) | `compiler.rs:248` (`SIG_BYTES`), `runtime.rs:108` (`sign_signature`) | The seed of the PDF's "compiled Boolean semantic code" H(x) |
 | Hamming class assignment | `runtime.rs:95` (`hamming`), `:330` (`assign_plain`) | Exhaustive over 4×256 classes today; graph verifier will be masked-Hamming over shortlisted regions |
 | Graded evidence store (code-prefix → next-token counts) | `runtime.rs:130` (`Store`), `:539` (`build_store`), TLS1 container `:559/:578` | Becomes the EXCT exact-context residual store + root priors |
+| Hierarchical lexical context rows (unigram/bigram/trigram) | Root priors plus a compiler-side bigram weighting heuristic; no explicit trigram rows or lexical backoff | **Build new** (issue #362): packed context rows with trigram → bigram → unigram precedence |
 | Mul-free integer kernel with op census | `runtime.rs:28` (`OpKernel`) | No multiply method exists; source-scan witness P-4 enforces this in CI (`transformerless/mod.rs:75-121`) |
 | Allocation-free generation loop | `runtime.rs:497` (`generate_greedy_into`), `scenarios.rs:179/247` (`encode_into`/`decode_into`) | Caller-owned buffers; pattern to extend to `step()`; zero-alloc now machine-asserted by `tests/allocation_census.rs` |
 | Packed containers | TLA3/TLA4 (`compiler.rs:585`, parse `:642`), TLS1 (`runtime.rs:559`) | Fixed-width LE; R4G1 succeeds them |
@@ -382,6 +383,13 @@ Objective: the scoring model S(v) = B(v) + ΣΔE(n,v) + ΣΔT(m,v) + ΔX(X,v) (P
   base priors B(v) (generalizes the level-0 backoff counts in today's store); children store
   corrections relative to parents; overlap nodes store interaction residuals only (Theorem 10
   non-duplication); exact-context store (EXCT, generalizes TLS1) captures remaining local evidence.
+- Hierarchical lexical context evidence is compiled alongside the residual tables: unigram/root
+  rows carry the context-free prior, bigram rows are keyed by the immediately preceding token,
+  and trigram rows by the preceding two tokens. A prediction consults the most specific
+  supported row first (trigram, then bigram, then unigram); sparse rows must fall back rather
+  than contribute a misleading partial boost. Rows are story-boundary-safe, canonically sorted,
+  and quantized into the same ScoreQ language as the root prior. This is a
+  context-conditioned emission layer, not a replacement for masked-Hamming region similarity.
 - Replace f32 semantic route scores in deployed paths with ScoreQ fixed point; remove `ctx_cb`
   f32 tables from deployed artifacts (certifier-only data moves to PROV/CERT or side files).
 - Fixed-capacity top-K candidate structure with canonical tie-breaking (highest score, then
@@ -400,6 +408,10 @@ Objective: `uor-r4-graph-runtime` implementing the PDF §16/§21 step contract.
 - Rolling context code updated incrementally (shift/XOR/add recurrence from prior state + entering
   + expiring token — generalizes the current window bundle, `runtime.rs:261-306`); never
   reconstruct the full context representation.
+- Borrowed context-table lookup over the packed unigram/bigram/trigram rows, with fixed-capacity
+  candidate output and exact trigram → bigram → unigram fallback. The deployed lookup uses only
+  integer comparisons, table reads, and saturating add/sub; no allocation, multiplication,
+  division, or float is permitted.
 - Normative scalar kernel: extend the `OpKernel` discipline — complete operation set
   {xor,and,or,shl,shr,rot,popcount,add,sub,cmp,table read}, saturating where declared, **no
   multiply/divide/float**, census retained; source-scan witness test ported (P-4 pattern).
@@ -599,15 +611,17 @@ The table is the source content.
 14. Predictive-sufficiency + rate-distortion reports by depth → Phase 3 (#24).
 15. Explicit `ResolutionStatus` + manifest fallback policy → Phase 5 (#25, policy per D4).
 16. Shortlist top-M recall + fallback measurement vs. reference classifier → Phase 6 (#26).
-17. Bytes-read / cache-miss / branch-miss counters in performance certificates → Phase 7 (#27).
-18. Multi-timescale fixed-capacity `RuntimeState` design (local/segment/session) → Phase 5 skeleton, Phase 8 full (#28).
-19. Tokenizer-neutral span and byte anchors in observation schema → Phase 2 (#29).
-20. Immutable graph patch + route-translation RFC → Phase 9 (#30).
-21. Source-bias amplification, rare-group erasure, provenance-deletion tests → Phase 3/9 (#31).
-22. Threat model: semantic collisions, frontier exhaustion, candidate explosion, integer saturation → Phase 0 doc (#32; `docs/transformerless/THREAT_MODEL.md`), suites in 5/6/9 (Gate I).
-23. Behavioral graph-equivalence + confidence-bounded empirical claims spec →
+17. Explicit unigram/bigram/trigram context rows with deterministic most-specific backoff →
+    Phase 4/5 (#362).
+18. Bytes-read / cache-miss / branch-miss counters in performance certificates → Phase 7 (#27).
+19. Multi-timescale fixed-capacity `RuntimeState` design (local/segment/session) → Phase 5 skeleton, Phase 8 full (#28).
+20. Tokenizer-neutral span and byte anchors in observation schema → Phase 2 (#29).
+21. Immutable graph patch + route-translation RFC → Phase 9 (#30).
+22. Source-bias amplification, rare-group erasure, provenance-deletion tests → Phase 3/9 (#31).
+23. Threat model: semantic collisions, frontier exhaustion, candidate explosion, integer saturation → Phase 0 doc (#32; `docs/transformerless/THREAT_MODEL.md`), suites in 5/6/9 (Gate I).
+24. Behavioral graph-equivalence + confidence-bounded empirical claims spec →
    `docs/transformerless/EQUIVALENCE_AND_EMPIRICAL_PROTOCOL.md` (Phase 0/3, #33, feeds D2).
-24. Evaluation-report tooling for HF-compiled (SmolLM2) models → Phase 0/2 (#34; blocks Gate C harness).
+25. Evaluation-report tooling for HF-compiled (SmolLM2) models → Phase 0/2 (#34; blocks Gate C harness).
 
 ---
 

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -130,6 +130,7 @@ fn emit_and_persist(
             transitions: &[],
             transition_quantization: score::QuantizationErrorStats::default(),
             emissions,
+            context_rows: &[],
             exct_tls1: &tls1,
             exct_top_x: score::ScoreConfig::default().exct_top_x,
         },


### PR DESCRIPTION
## Objective

Integrate explicit hierarchical context evidence into the R4G1 prediction path:

- unigram/root rows: no context, token frequency prior;
- bigram rows: `previous_token -> next_token`;
- trigram rows: `(previous_previous_token, previous_token) -> next_token`;
- prediction precedence: use a supported trigram row first, then its bigram row, then the unigram/root prior.

The fallback is deterministic and allocation-free in the deployed runtime.

## Implementation

- derive unigram, bigram, and trigram counts from corpus positions without crossing story boundaries;
- define sparse-context support/backoff semantics and deterministic tie-breaking;
- add the packed optional R4G1 NGRAM section with canonical sorted rows;
- add a borrowed GraphView accessor and integer-only runtime lookup;
- wire the compiler/exporter into the normal scored artifact path;
- retain the 8-token rolling window and masked-Hamming router as separate semantic-region machinery.

## Validation

- full local workspace test suite and clippy pass;
- no-std and alloc format ladders pass;
- malformed header, row-range, overlap, reserved-byte, ordering, and trailing-byte rejection;
- deterministic artifact-byte rebuild;
- deployed R4G1 runtime parity for trigram precedence and bigram fallback;
- deterministic tie-breaking, zero steady-state allocations, and integer-only source scan;
- GitHub CI run 30780462653 on `acff2d0`: audit, D2 differential (Ubuntu/macOS), wasm, fuzz smoke, fmt/clippy/nextest, BDD, docs, no-std, deterministic rebuild, canonical κ, and Gate C all successful.

## Non-goals

This does not redefine graph-region similarity or replace the masked-Hamming router. If trigram context is later used as a routing feature, that should be a separately measured change.

The held-out teacher-forced ablation comparing unigram-only, unigram+bigram, and trigram backoff remains the empirical decision gate for enabling this optional section by default.

Related: #359, #290