### PR TITLE
certify: test whether chain selection discards usable evidence

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1258,6 +1258,14 @@ pub struct ResidualInfluence {
     /// Mean selected-chain depth, and mean depth of the best teacher emitter.
     pub mean_chain_depth: f64,
     pub mean_teacher_emitter_depth: f64,
+    /// Which source supplies the teacher token, as a share of positions.
+    /// These overlap: a token can come from more than one source.
+    pub teacher_from_active: f64,
+    pub teacher_from_predicted: f64,
+    pub teacher_from_root_top: f64,
+    /// Teacher retrieved, but ONLY by the context-free root prior — no graph
+    /// region and no predicted transition supplied it.
+    pub teacher_only_root_top: f64,
 }
 
 /// Residual-influence measurement split by resolution status.
@@ -1597,6 +1605,10 @@ pub fn evaluate_gate_c(
     let mut status_chain_depth = [0u64; 3];
     let mut status_emitter_depth = [0u64; 3];
     let mut status_emitter_rows = [0u64; 3];
+    let mut status_src_active = [0u64; 3];
+    let mut status_src_predicted = [0u64; 3];
+    let mut status_src_root_top = [0u64; 3];
+    let mut status_src_only_root = [0u64; 3];
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -1650,6 +1662,10 @@ pub fn evaluate_gate_c(
         status_teacher_better_margin[row.status_index] +=
             u64::from(row.teacher_emitter_better_margin);
         status_chain_depth[row.status_index] += u64::from(row.chain_depth);
+        status_src_active[row.status_index] += u64::from(row.teacher_from_active);
+        status_src_predicted[row.status_index] += u64::from(row.teacher_from_predicted);
+        status_src_root_top[row.status_index] += u64::from(row.teacher_from_root_top);
+        status_src_only_root[row.status_index] += u64::from(row.teacher_only_root_top);
         if row.teacher_emitted_off_chain {
             status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
             status_emitter_rows[row.status_index] += 1;
@@ -1828,6 +1844,10 @@ pub fn evaluate_gate_c(
             } else {
                 status_emitter_depth[index] as f64 / status_emitter_rows[index] as f64
             },
+            teacher_from_active: status_src_active[index] as f64 / denom,
+            teacher_from_predicted: status_src_predicted[index] as f64 / denom,
+            teacher_from_root_top: status_src_root_top[index] as f64 / denom,
+            teacher_only_root_top: status_src_only_root[index] as f64 / denom,
         };
         match index {
             0 => influence.exact_context = value,
@@ -1940,6 +1960,12 @@ struct GateCRow {
     /// Depth of the selected chain, and of the best teacher-emitting region.
     chain_depth: u32,
     teacher_emitter_depth: u32,
+    /// Which source supplied the teacher token to the candidate set.
+    teacher_from_active: bool,
+    teacher_from_predicted: bool,
+    teacher_from_root_top: bool,
+    /// Teacher present, but ONLY from the context-free root prior.
+    teacher_only_root_top: bool,
     witness_replayed: bool,
     witness_replay_failed: bool,
 }
@@ -2116,6 +2142,28 @@ fn evaluate_gate_c_row(
         }
     }
 
+    // Candidate recall was 63% on the graph slice while active regions emit the
+    // teacher only ~4.3% of the time. Attribute the rest: the candidate set is
+    // active + predicted + root_top, and which source supplies the teacher
+    // decides whether the graph contributes anything to finding the answer.
+    let teacher_present = rule12
+        .candidate_components
+        .iter()
+        .any(|&(token, _, _, _)| token == teacher_argmax);
+    let teacher_from_active = rule12.witness.active.iter().any(|a| {
+        context
+            .scorer_with_exct
+            .node_emits(a.region + 1, teacher_argmax)
+    });
+    let teacher_from_predicted = rule12
+        .witness
+        .predicted
+        .iter()
+        .any(|&node| context.scorer_with_exct.node_emits(node, teacher_argmax));
+    let teacher_from_root_top = context.scorer_with_exct.root_top_contains(teacher_argmax);
+    let teacher_only_root_top =
+        teacher_present && teacher_from_root_top && !teacher_from_active && !teacher_from_predicted;
+
     let total_candidates = rule12.candidate_components.len().max(1) as f64;
     let zeros = rule12
         .candidate_components
@@ -2217,6 +2265,10 @@ fn evaluate_gate_c_row(
         teacher_emitter_better_margin,
         chain_depth,
         teacher_emitter_depth,
+        teacher_from_active,
+        teacher_from_predicted,
+        teacher_from_root_top,
+        teacher_only_root_top,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
     })

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1251,6 +1251,13 @@ pub struct ResidualInfluence {
     pub teacher_on_chain: f64,
     /// Fraction of positions where an off-chain (zero-residual) token won.
     pub selected_off_chain: f64,
+    /// An active region OUTSIDE the selected chain emits the teacher token.
+    pub teacher_emitted_off_chain: f64,
+    /// That region also fits the context better than the selected chain.
+    pub teacher_emitter_better_margin: f64,
+    /// Mean selected-chain depth, and mean depth of the best teacher emitter.
+    pub mean_chain_depth: f64,
+    pub mean_teacher_emitter_depth: f64,
 }
 
 /// Residual-influence measurement split by resolution status.
@@ -1585,6 +1592,11 @@ pub fn evaluate_gate_c(
     let mut status_zero_share = [0f64; 3];
     let mut status_teacher_on_chain = [0u64; 3];
     let mut status_selected_off_chain = [0u64; 3];
+    let mut status_teacher_off_chain = [0u64; 3];
+    let mut status_teacher_better_margin = [0u64; 3];
+    let mut status_chain_depth = [0u64; 3];
+    let mut status_emitter_depth = [0u64; 3];
+    let mut status_emitter_rows = [0u64; 3];
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -1634,6 +1646,14 @@ pub fn evaluate_gate_c(
         status_zero_share[row.status_index] += row.zero_resid_share;
         status_teacher_on_chain[row.status_index] += u64::from(row.teacher_on_chain);
         status_selected_off_chain[row.status_index] += u64::from(row.selected_off_chain);
+        status_teacher_off_chain[row.status_index] += u64::from(row.teacher_emitted_off_chain);
+        status_teacher_better_margin[row.status_index] +=
+            u64::from(row.teacher_emitter_better_margin);
+        status_chain_depth[row.status_index] += u64::from(row.chain_depth);
+        if row.teacher_emitted_off_chain {
+            status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
+            status_emitter_rows[row.status_index] += 1;
+        }
         if let Some(level) = row.exct_level {
             exct_level_positions[level] += 1;
         } else {
@@ -1800,6 +1820,14 @@ pub fn evaluate_gate_c(
             mean_zero_residual_share: status_zero_share[index] / denom,
             teacher_on_chain: status_teacher_on_chain[index] as f64 / denom,
             selected_off_chain: status_selected_off_chain[index] as f64 / denom,
+            teacher_emitted_off_chain: status_teacher_off_chain[index] as f64 / denom,
+            teacher_emitter_better_margin: status_teacher_better_margin[index] as f64 / denom,
+            mean_chain_depth: status_chain_depth[index] as f64 / denom,
+            mean_teacher_emitter_depth: if status_emitter_rows[index] == 0 {
+                0.0
+            } else {
+                status_emitter_depth[index] as f64 / status_emitter_rows[index] as f64
+            },
         };
         match index {
             0 => influence.exact_context = value,
@@ -1905,6 +1933,13 @@ struct GateCRow {
     teacher_on_chain: bool,
     /// The selected token carries a zero residual (an off-chain token won).
     selected_off_chain: bool,
+    /// An active region outside the selected chain emits the teacher token.
+    teacher_emitted_off_chain: bool,
+    /// That region's membership margin beats the selected chain's.
+    teacher_emitter_better_margin: bool,
+    /// Depth of the selected chain, and of the best teacher-emitting region.
+    chain_depth: u32,
+    teacher_emitter_depth: u32,
     witness_replayed: bool,
     witness_replay_failed: bool,
 }
@@ -2044,6 +2079,43 @@ fn evaluate_gate_c_row(
     // log-prob-like and negative, chain tokens carry a summed penalty while
     // off-chain tokens sit at zero, and both are ranked by root + residual.
     // Measure whether that is what decides graph-slice selections.
+    // Chain selection ranks by chain LENGTH first, with membership margin only
+    // breaking ties among equal-length chains. So a deep chain the context
+    // barely belongs to beats a shallow one it fits well. Candidate generation
+    // meanwhile draws on every active/predicted node. Measure whether a
+    // better-fitting region outside the chain could have supplied the teacher.
+    let chain_nodes: std::collections::BTreeSet<u32> =
+        rule12.witness.chain.iter().copied().collect();
+    let chain_margin = rule12
+        .witness
+        .active
+        .iter()
+        .filter(|a| chain_nodes.contains(&(a.region + 1)))
+        .map(|a| a.margin)
+        .max()
+        .unwrap_or(i16::MIN);
+    let chain_depth = rule12.witness.chain.len() as u32;
+    let mut teacher_emitted_off_chain = false;
+    let mut teacher_emitter_better_margin = false;
+    let mut teacher_emitter_depth = 0u32;
+    let mut best_emitter_margin = i16::MIN;
+    for a in &rule12.witness.active {
+        let node = a.region + 1;
+        if chain_nodes.contains(&node) {
+            continue;
+        }
+        if context.scorer_with_exct.node_emits(node, teacher_argmax) {
+            teacher_emitted_off_chain = true;
+            if a.margin > best_emitter_margin {
+                best_emitter_margin = a.margin;
+                teacher_emitter_depth = u32::from(a.depth);
+            }
+            if a.margin > chain_margin {
+                teacher_emitter_better_margin = true;
+            }
+        }
+    }
+
     let total_candidates = rule12.candidate_components.len().max(1) as f64;
     let zeros = rule12
         .candidate_components
@@ -2141,6 +2213,10 @@ fn evaluate_gate_c_row(
         zero_resid_share,
         teacher_on_chain,
         selected_off_chain,
+        teacher_emitted_off_chain,
+        teacher_emitter_better_margin,
+        chain_depth,
+        teacher_emitter_depth,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
     })

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -959,6 +959,11 @@ impl GraphScorer {
 
     /// The stored root prior B(v), or the smoothing floor for tokens
     /// absent from the root block.
+    /// Is `token` in the global root prior's top-B list? Measurement-only.
+    pub fn root_top_contains(&self, token: u32) -> bool {
+        self.root_top.contains(&token)
+    }
+
     /// Does `node` (1-based) emit `token`? Measurement-only accessor for
     /// asking which regions could have supplied a token, independent of which
     /// chain was selected.

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -959,6 +959,15 @@ impl GraphScorer {
 
     /// The stored root prior B(v), or the smoothing floor for tokens
     /// absent from the root block.
+    /// Does `node` (1-based) emit `token`? Measurement-only accessor for
+    /// asking which regions could have supplied a token, independent of which
+    /// chain was selected.
+    pub fn node_emits(&self, node: u32, token: u32) -> bool {
+        self.emissions
+            .get((node - 1) as usize)
+            .is_some_and(|emissions| emissions.contains_key(&token))
+    }
+
     fn root_score(&self, token: u32) -> ScoreQ {
         self.root_prior
             .get(&token)


### PR DESCRIPTION
Follow-up to #360, on a fresh branch off `main`. Tests whether chain selection is
the graph path's defect. **It is not**, and the measurement corrects a framing I
recorded in #358.

## Chain selection is exonerated

Chain selection ranks by chain **length** first, with membership margin only
breaking ties among equal-length chains — so a deep chain the context barely
belongs to beats a shallow one it fits well. The hypothesis was that this
discards better-fitting regions which could have supplied the teacher token.

| graph slice | |
| --- | ---: |
| teacher emitted by an active region OUTSIDE the selected chain | **2.95%** |
| …and that region also fits the context better than the chain | **0.59%** |
| mean selected-chain depth | 2.73 |
| mean depth of best teacher emitter | 2.32 |

Usable evidence is discarded in 0.59% of positions. Chain selection is doing
about as well as the cover allows; the depth-first rule is not the defect.

## The correction

Teacher on chain is 1.35%, off-chain active 2.95% — so **active regions emit the
teacher only ~4.3% of the time**, against the 63% candidate recall measured in
#358. The candidate set is `active ∪ predicted ∪ root_top` (global prior top-B,
B = 256), so the teacher arrives via the prior or predicted cloud F, **not via
region emissions**.

I recorded in #358 that "retrieval works, ranking does not," attributing the 63%
to the graph. That attribution was wrong: retrieval works because of the
*context-free* global prior. The graph's regions rarely emit the answer, and the
scorer then boosts those emissions over a candidate list whose useful content
came from elsewhere.

## Open sub-question

This measured off-chain **active** regions only. The remaining ~59% is not yet
split between predicted cloud F and `root_top`, and that split locates the
defect: mostly `root_top` → region emissions carry almost none of the answer, and
the question is compiler-side emission construction; substantially predicted F →
the transition machinery is finding what the regions do not emit.

Relevant to #362 (trigram context rows), which adds context-conditioned evidence
against exactly this gap.

## Verification

`cargo fmt`, `cargo clippy -p uor-r4-graph-certify --all-targets -D warnings`,
and the certify suite (11 files) green. Figures from the Gate C fixture-corpus
run.

Adds one measurement-only accessor, `GraphScorer::node_emits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
