### PR TITLE
certify: add probability-ranked emission selection (#364)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -110,6 +110,29 @@ use uor_r4_graph_format::ScoreQ;
 pub const DEFAULT_TRANSITION_OUT_DEGREE: usize = 8;
 /// Default per-region emission list bound (top-E by residual score).
 pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
+
+/// How much the top-E-by-log-ratio emission selection differs from a
+/// top-E-by-probability one.
+///
+/// Emissions keep the tokens most over-represented against the parent, not the
+/// most likely next tokens. `overlap_with_top_count` near 0 means the two
+/// selections are nearly disjoint; `probability_mass_kept` says how much of the
+/// region's actual next-token mass the emitted list covers. Low values on both
+/// mean regions emit distinctive-but-unlikely tokens and score the likely ones
+/// at the bare prior.
+/// One region's emission list plus the statistics gathered while building it.
+type RegionEmissionResult = (
+    Vec<(u32, ScoreQ)>,
+    QuantizationErrorStats,
+    EmissionSelectionStats,
+);
+
+#[derive(Debug, Clone, Default)]
+pub struct EmissionSelectionStats {
+    pub regions: usize,
+    pub overlap_with_top_count: f64,
+    pub probability_mass_kept: f64,
+}
 /// Default root-prior candidate count.
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
 /// Default EXCT candidate count.
@@ -563,7 +586,7 @@ pub fn compile_emissions(
         })
         .collect();
 
-    let region_results: Vec<(Vec<(u32, ScoreQ)>, QuantizationErrorStats)> = regions
+    let region_results: Vec<RegionEmissionResult> = regions
         .par_iter()
         .enumerate()
         .map(|(region_id, region)| {
@@ -602,12 +625,46 @@ pub fn compile_emissions(
             residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
-            (residuals, emission_quantization)
+
+            // Selection is by log-RATIO against the parent, which keeps the
+            // most DISTINCTIVE tokens rather than the most LIKELY ones. A rare
+            // token heavily over-represented in this region outranks the
+            // region's actual most-probable next token, whose ratio is near
+            // zero because it is common everywhere. Measure the overlap with a
+            // top-E-by-count selection to see how far apart those two are.
+            let kept: std::collections::BTreeSet<u32> =
+                residuals.iter().map(|&(token, _)| token).collect();
+            let mut by_count: Vec<(u32, u64)> = dist.iter().map(|(&t, &c)| (t, c)).collect();
+            by_count.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            by_count.truncate(config.emission_entries);
+            let overlap = by_count
+                .iter()
+                .filter(|(token, _)| kept.contains(token))
+                .count();
+            let mass_kept: u64 = dist
+                .iter()
+                .filter(|(t, _)| kept.contains(t))
+                .map(|(_, &c)| c)
+                .sum();
+            let selection = EmissionSelectionStats {
+                regions: 1,
+                overlap_with_top_count: overlap as f64 / by_count.len().max(1) as f64,
+                probability_mass_kept: if total == 0 {
+                    0.0
+                } else {
+                    mass_kept as f64 / total as f64
+                },
+            };
+            (residuals, emission_quantization, selection)
         })
         .collect();
     let mut region_lists = Vec::with_capacity(regions.len());
     let mut emission_quantization = QuantizationErrorStats::default();
-    for (residuals, stats) in region_results {
+    let mut selection_stats = EmissionSelectionStats::default();
+    for (residuals, stats, selection) in region_results {
+        selection_stats.regions += selection.regions;
+        selection_stats.overlap_with_top_count += selection.overlap_with_top_count;
+        selection_stats.probability_mass_kept += selection.probability_mass_kept;
         emission_quantization.sample_count += stats.sample_count;
         emission_quantization.sum_abs_error_nano = emission_quantization
             .sum_abs_error_nano
@@ -616,6 +673,17 @@ pub fn compile_emissions(
             .max_abs_error_nano
             .max(stats.max_abs_error_nano);
         region_lists.push(residuals);
+    }
+    if selection_stats.regions > 0 {
+        let n = selection_stats.regions as f64;
+        eprintln!(
+            "[emission-selection] regions={} mean_overlap_with_top_count={:.4} \
+             mean_probability_mass_kept={:.4} (E={})",
+            selection_stats.regions,
+            selection_stats.overlap_with_top_count / n,
+            selection_stats.probability_mass_kept / n,
+            config.emission_entries,
+        );
     }
 
     EmissionTables {

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -120,6 +120,30 @@ pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
 /// region's actual next-token mass the emitted list covers. Low values on both
 /// mean regions emit distinctive-but-unlikely tokens and score the likely ones
 /// at the bare prior.
+/// How the per-region emission list is chosen before truncation (#364).
+///
+/// The shipped rule ranks by log-ratio against the parent, which keeps the most
+/// DISTINCTIVE tokens. Measured on the fixture artifact, that list overlaps a
+/// top-E-by-probability selection by 0.78% and covers 1.57% of the region's
+/// actual next-token mass — so 98.4% of what really happens next carries
+/// residual 0 and is scored at the bare global prior.
+///
+/// `Probability` ranks by the region's own next-token counts instead, still
+/// storing the log-ratio as the value, so `root_score + log-ratio =
+/// log P_region` continues to hold for the tokens that actually occur.
+///
+/// Default is `Ratio`: it reproduces the shipped artifact byte-exactly. Changing
+/// selection changes artifact bytes and kappa, so the alternative stays opt-in
+/// until measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmissionSelection {
+    /// Top-E by log-ratio against the parent (shipped behavior).
+    #[default]
+    Ratio,
+    /// Top-E by the region's own next-token probability.
+    Probability,
+}
+
 /// One region's emission list plus the statistics gathered while building it.
 type RegionEmissionResult = (
     Vec<(u32, ScoreQ)>,
@@ -300,6 +324,8 @@ pub struct ScoreConfig {
     pub smoothing: Smoothing,
     /// Candidate scoring variant (issue #80).
     pub scoring_variant: ScoringVariant,
+    /// Emission list selection rule (issue #364).
+    pub emission_selection: EmissionSelection,
 }
 
 impl Default for ScoreConfig {
@@ -312,6 +338,7 @@ impl Default for ScoreConfig {
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
             scoring_variant: ScoringVariant::ChainTelescoped,
+            emission_selection: EmissionSelection::default(),
         }
     }
 }
@@ -622,7 +649,22 @@ pub fn compile_emissions(
                 .collect();
             // Top-E by residual score (score desc, token asc), stored
             // ascending token.
-            residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            match config.emission_selection {
+                EmissionSelection::Ratio => {
+                    residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                }
+                EmissionSelection::Probability => {
+                    // Rank by the region's own next-token count (probability),
+                    // ties to the lower token id for determinism. The stored
+                    // value stays the log-ratio, so the scoring identity is
+                    // unchanged -- only WHICH tokens get a correction moves.
+                    residuals.sort_by(|a, b| {
+                        let ca = dist.get(&a.0).copied().unwrap_or(0);
+                        let cb = dist.get(&b.0).copied().unwrap_or(0);
+                        cb.cmp(&ca).then_with(|| a.0.cmp(&b.0))
+                    });
+                }
+            }
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
 

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -744,6 +744,7 @@ struct ScoreOptions {
     stories: Option<PathBuf>,
     transition_out_degree: usize,
     emission_entries: usize,
+    emission_selection: score::EmissionSelection,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -763,6 +764,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         stories: None,
         transition_out_degree: score::DEFAULT_TRANSITION_OUT_DEGREE,
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
+        emission_selection: score::EmissionSelection::default(),
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -790,6 +792,18 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                 if options.transition_out_degree == 0 {
                     return Err("--transition-out-degree must be at least 1".to_owned());
                 }
+            }
+            "--emission-selection" => {
+                options.emission_selection = match value.as_str() {
+                    "ratio" => score::EmissionSelection::Ratio,
+                    "probability" => score::EmissionSelection::Probability,
+                    other => {
+                        return Err(format!(
+                            "invalid --emission-selection value: {other} \
+                             (expected ratio|probability)"
+                        ));
+                    }
+                };
             }
             "--emission-entries" => {
                 options.emission_entries = value
@@ -937,6 +951,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
         scoring_variant: options.scoring_variant,
+        emission_selection: options.emission_selection,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records


### PR DESCRIPTION
Implements #364 as an **opt-in ablation**, not a default change. Builds on #365
(the measurement).

## Change

`--emission-selection ratio|probability`, defaulting to `ratio` — the shipped
log-ratio ranking, reproduced byte-exactly. Same opt-in pattern as
`ScoringVariant` (#80) and `Smoothing` (#67). Changing selection changes artifact
bytes and κ, so it stays gated until the numbers justify flipping the default.

Only *which* tokens enter the list moves. Each entry still stores its log-ratio,
so `root_score + log-ratio = log P_region` still holds — the change makes that
identity apply to tokens that actually occur rather than to 64 rare ones.

## Ablation (fixture corpus, ratio → probability)

| metric | ratio (shipped) | probability | Δ |
| --- | ---: | ---: | ---: |
| emission mass coverage | 1.57% | **69.17%** | overlap 0.78% → 100% |
| graph: teacher in region emissions | 3.82% | **70.83%** | **18.5×** |
| graph: candidate recall | 62.97% | **75.98%** | +13.0 pp |
| **graph: bits/token** | 17.10 | **13.32** | **−3.78** |
| graph: top-1 | 1.96% | 2.90% | +0.94 pp |
| exact_context | 42.47% / 6.83 | 42.47% / 6.83 | unchanged |
| novel | 23.53% / 9.29 | 23.53% / 9.31 | +0.03 bits |

The pre-registered check holds. Mass coverage is the quantity #364 claims is
broken, and it moves 1.57% → 69.17% — so the accuracy movement is confirmation
of the mechanism, not a coincidence that happens to correlate.

`teacher_from_active` going 3.82% → 70.83% is the headline: the graph now
actually carries the answer.

## What this does NOT fix

Recorded plainly. Graph top-1 reaches 2.90%, still **below the 8.76% achieved by
disabling the residual entirely**. So even with the right tokens selected, the
term still costs top-1 — a residual **magnitude/calibration** problem separate
from selection. Bits improve more than disabling did (−3.78 vs −3.09), so
coherence is genuinely better, but 13.32 is still 6.5 bits above exact_context's
6.83.

Fixing selection was necessary and is not sufficient. The remaining gap is the
next question.

## Verification

`cargo fmt`, `cargo clippy -p uor-r4-graph-certify -p uor-r4-graph-cli
--all-targets -D warnings`, certify suite (11 files) and graph-cli suite (16
tests) green. Default path is unchanged, so byte-exactness of the shipped
artifact is preserved.

Related: #364, #365, #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
