### PR TITLE
certify: measure telescoping integrity of the chain residual sum (#364)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -110,6 +110,29 @@ use uor_r4_graph_format::ScoreQ;
 pub const DEFAULT_TRANSITION_OUT_DEGREE: usize = 8;
 /// Default per-region emission list bound (top-E by residual score).
 pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
+
+/// How much the top-E-by-log-ratio emission selection differs from a
+/// top-E-by-probability one.
+///
+/// Emissions keep the tokens most over-represented against the parent, not the
+/// most likely next tokens. `overlap_with_top_count` near 0 means the two
+/// selections are nearly disjoint; `probability_mass_kept` says how much of the
+/// region's actual next-token mass the emitted list covers. Low values on both
+/// mean regions emit distinctive-but-unlikely tokens and score the likely ones
+/// at the bare prior.
+/// One region's emission list plus the statistics gathered while building it.
+type RegionEmissionResult = (
+    Vec<(u32, ScoreQ)>,
+    QuantizationErrorStats,
+    EmissionSelectionStats,
+);
+
+#[derive(Debug, Clone, Default)]
+pub struct EmissionSelectionStats {
+    pub regions: usize,
+    pub overlap_with_top_count: f64,
+    pub probability_mass_kept: f64,
+}
 /// Default root-prior candidate count.
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
 /// Default EXCT candidate count.
@@ -563,7 +586,7 @@ pub fn compile_emissions(
         })
         .collect();
 
-    let region_results: Vec<(Vec<(u32, ScoreQ)>, QuantizationErrorStats)> = regions
+    let region_results: Vec<RegionEmissionResult> = regions
         .par_iter()
         .enumerate()
         .map(|(region_id, region)| {
@@ -602,12 +625,46 @@ pub fn compile_emissions(
             residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
-            (residuals, emission_quantization)
+
+            // Selection is by log-RATIO against the parent, which keeps the
+            // most DISTINCTIVE tokens rather than the most LIKELY ones. A rare
+            // token heavily over-represented in this region outranks the
+            // region's actual most-probable next token, whose ratio is near
+            // zero because it is common everywhere. Measure the overlap with a
+            // top-E-by-count selection to see how far apart those two are.
+            let kept: std::collections::BTreeSet<u32> =
+                residuals.iter().map(|&(token, _)| token).collect();
+            let mut by_count: Vec<(u32, u64)> = dist.iter().map(|(&t, &c)| (t, c)).collect();
+            by_count.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            by_count.truncate(config.emission_entries);
+            let overlap = by_count
+                .iter()
+                .filter(|(token, _)| kept.contains(token))
+                .count();
+            let mass_kept: u64 = dist
+                .iter()
+                .filter(|(t, _)| kept.contains(t))
+                .map(|(_, &c)| c)
+                .sum();
+            let selection = EmissionSelectionStats {
+                regions: 1,
+                overlap_with_top_count: overlap as f64 / by_count.len().max(1) as f64,
+                probability_mass_kept: if total == 0 {
+                    0.0
+                } else {
+                    mass_kept as f64 / total as f64
+                },
+            };
+            (residuals, emission_quantization, selection)
         })
         .collect();
     let mut region_lists = Vec::with_capacity(regions.len());
     let mut emission_quantization = QuantizationErrorStats::default();
-    for (residuals, stats) in region_results {
+    let mut selection_stats = EmissionSelectionStats::default();
+    for (residuals, stats, selection) in region_results {
+        selection_stats.regions += selection.regions;
+        selection_stats.overlap_with_top_count += selection.overlap_with_top_count;
+        selection_stats.probability_mass_kept += selection.probability_mass_kept;
         emission_quantization.sample_count += stats.sample_count;
         emission_quantization.sum_abs_error_nano = emission_quantization
             .sum_abs_error_nano
@@ -616,6 +673,17 @@ pub fn compile_emissions(
             .max_abs_error_nano
             .max(stats.max_abs_error_nano);
         region_lists.push(residuals);
+    }
+    if selection_stats.regions > 0 {
+        let n = selection_stats.regions as f64;
+        eprintln!(
+            "[emission-selection] regions={} mean_overlap_with_top_count={:.4} \
+             mean_probability_mass_kept={:.4} (E={})",
+            selection_stats.regions,
+            selection_stats.overlap_with_top_count / n,
+            selection_stats.probability_mass_kept / n,
+            config.emission_entries,
+        );
     }
 
     EmissionTables {

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1418,6 +1418,14 @@ pub struct ResidualInfluence {
     /// Teacher retrieved, but ONLY by the context-free root prior — no graph
     /// region and no predicted transition supplied it.
     pub teacher_only_root_top: f64,
+    /// Mean chain length, and mean number of chain levels carrying a term for
+    /// the teacher token. A gap means the telescoping sum is incomplete.
+    pub mean_chain_levels: f64,
+    pub mean_chain_levels_emitting_teacher: f64,
+    /// Share of positions where the teacher's chain terms are complete, and
+    /// where they are present at some levels but missing at others.
+    pub teacher_chain_complete: f64,
+    pub teacher_chain_partial: f64,
 }
 
 /// Residual-influence measurement split by resolution status.
@@ -1761,6 +1769,10 @@ pub fn evaluate_gate_c(
     let mut status_src_predicted = [0u64; 3];
     let mut status_src_root_top = [0u64; 3];
     let mut status_src_only_root = [0u64; 3];
+    let mut status_chain_levels = [0u64; 3];
+    let mut status_chain_emit_levels = [0u64; 3];
+    let mut status_chain_complete = [0u64; 3];
+    let mut status_chain_partial = [0u64; 3];
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -1818,6 +1830,10 @@ pub fn evaluate_gate_c(
         status_src_predicted[row.status_index] += u64::from(row.teacher_from_predicted);
         status_src_root_top[row.status_index] += u64::from(row.teacher_from_root_top);
         status_src_only_root[row.status_index] += u64::from(row.teacher_only_root_top);
+        status_chain_levels[row.status_index] += u64::from(row.chain_levels);
+        status_chain_emit_levels[row.status_index] += u64::from(row.chain_levels_emitting_teacher);
+        status_chain_complete[row.status_index] += u64::from(row.teacher_chain_complete);
+        status_chain_partial[row.status_index] += u64::from(row.teacher_chain_partial);
         if row.teacher_emitted_off_chain {
             status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
             status_emitter_rows[row.status_index] += 1;
@@ -2000,6 +2016,10 @@ pub fn evaluate_gate_c(
             teacher_from_predicted: status_src_predicted[index] as f64 / denom,
             teacher_from_root_top: status_src_root_top[index] as f64 / denom,
             teacher_only_root_top: status_src_only_root[index] as f64 / denom,
+            mean_chain_levels: status_chain_levels[index] as f64 / denom,
+            mean_chain_levels_emitting_teacher: status_chain_emit_levels[index] as f64 / denom,
+            teacher_chain_complete: status_chain_complete[index] as f64 / denom,
+            teacher_chain_partial: status_chain_partial[index] as f64 / denom,
         };
         match index {
             0 => influence.exact_context = value,
@@ -2118,6 +2138,19 @@ struct GateCRow {
     teacher_from_root_top: bool,
     /// Teacher present, but ONLY from the context-free root prior.
     teacher_only_root_top: bool,
+    /// Chain length, and how many of its levels emit the teacher token.
+    /// The residual is a TELESCOPING sum: each level stores
+    /// log P_level - log P_parent, so summing a complete root-to-leaf chain
+    /// gives log P_leaf - log P_root. Truncation is per level, so a token kept
+    /// at a descendant need not be kept at its ancestors; a missing level
+    /// contributes 0 instead of its real correction and the sum is no longer
+    /// log P_leaf. Count the levels that actually contribute.
+    chain_levels: u32,
+    chain_levels_emitting_teacher: u32,
+    /// The teacher is emitted by the full chain (telescoping intact).
+    teacher_chain_complete: bool,
+    /// The teacher is emitted by some but not all chain levels (broken).
+    teacher_chain_partial: bool,
     witness_replayed: bool,
     witness_replay_failed: bool,
 }
@@ -2298,6 +2331,19 @@ fn evaluate_gate_c_row(
     // teacher only ~4.3% of the time. Attribute the rest: the candidate set is
     // active + predicted + root_top, and which source supplies the teacher
     // decides whether the graph contributes anything to finding the answer.
+    // Telescoping integrity: how much of the selected chain actually carries a
+    // term for the teacher token.
+    let chain_levels = rule12.witness.chain.len() as u32;
+    let chain_levels_emitting_teacher = rule12
+        .witness
+        .chain
+        .iter()
+        .filter(|&&node| context.scorer_with_exct.node_emits(node, teacher_argmax))
+        .count() as u32;
+    let teacher_chain_complete = chain_levels > 0 && chain_levels_emitting_teacher == chain_levels;
+    let teacher_chain_partial =
+        chain_levels_emitting_teacher > 0 && chain_levels_emitting_teacher < chain_levels;
+
     let teacher_present = rule12
         .candidate_components
         .iter()
@@ -2421,6 +2467,10 @@ fn evaluate_gate_c_row(
         teacher_from_predicted,
         teacher_from_root_top,
         teacher_only_root_top,
+        chain_levels,
+        chain_levels_emitting_teacher,
+        teacher_chain_complete,
+        teacher_chain_partial,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
     })

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -120,6 +120,30 @@ pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
 /// region's actual next-token mass the emitted list covers. Low values on both
 /// mean regions emit distinctive-but-unlikely tokens and score the likely ones
 /// at the bare prior.
+/// How the per-region emission list is chosen before truncation (#364).
+///
+/// The shipped rule ranks by log-ratio against the parent, which keeps the most
+/// DISTINCTIVE tokens. Measured on the fixture artifact, that list overlaps a
+/// top-E-by-probability selection by 0.78% and covers 1.57% of the region's
+/// actual next-token mass — so 98.4% of what really happens next carries
+/// residual 0 and is scored at the bare global prior.
+///
+/// `Probability` ranks by the region's own next-token counts instead, still
+/// storing the log-ratio as the value, so `root_score + log-ratio =
+/// log P_region` continues to hold for the tokens that actually occur.
+///
+/// Default is `Ratio`: it reproduces the shipped artifact byte-exactly. Changing
+/// selection changes artifact bytes and kappa, so the alternative stays opt-in
+/// until measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmissionSelection {
+    /// Top-E by log-ratio against the parent (shipped behavior).
+    #[default]
+    Ratio,
+    /// Top-E by the region's own next-token probability.
+    Probability,
+}
+
 /// One region's emission list plus the statistics gathered while building it.
 type RegionEmissionResult = (
     Vec<(u32, ScoreQ)>,
@@ -300,6 +324,8 @@ pub struct ScoreConfig {
     pub smoothing: Smoothing,
     /// Candidate scoring variant (issue #80).
     pub scoring_variant: ScoringVariant,
+    /// Emission list selection rule (issue #364).
+    pub emission_selection: EmissionSelection,
 }
 
 impl Default for ScoreConfig {
@@ -312,6 +338,7 @@ impl Default for ScoreConfig {
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
             scoring_variant: ScoringVariant::ChainTelescoped,
+            emission_selection: EmissionSelection::default(),
         }
     }
 }
@@ -622,7 +649,22 @@ pub fn compile_emissions(
                 .collect();
             // Top-E by residual score (score desc, token asc), stored
             // ascending token.
-            residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            match config.emission_selection {
+                EmissionSelection::Ratio => {
+                    residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                }
+                EmissionSelection::Probability => {
+                    // Rank by the region's own next-token count (probability),
+                    // ties to the lower token id for determinism. The stored
+                    // value stays the log-ratio, so the scoring identity is
+                    // unchanged -- only WHICH tokens get a correction moves.
+                    residuals.sort_by(|a, b| {
+                        let ca = dist.get(&a.0).copied().unwrap_or(0);
+                        let cb = dist.get(&b.0).copied().unwrap_or(0);
+                        cb.cmp(&ca).then_with(|| a.0.cmp(&b.0))
+                    });
+                }
+            }
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
 

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -744,6 +744,7 @@ struct ScoreOptions {
     stories: Option<PathBuf>,
     transition_out_degree: usize,
     emission_entries: usize,
+    emission_selection: score::EmissionSelection,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -763,6 +764,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         stories: None,
         transition_out_degree: score::DEFAULT_TRANSITION_OUT_DEGREE,
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
+        emission_selection: score::EmissionSelection::default(),
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -790,6 +792,18 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                 if options.transition_out_degree == 0 {
                     return Err("--transition-out-degree must be at least 1".to_owned());
                 }
+            }
+            "--emission-selection" => {
+                options.emission_selection = match value.as_str() {
+                    "ratio" => score::EmissionSelection::Ratio,
+                    "probability" => score::EmissionSelection::Probability,
+                    other => {
+                        return Err(format!(
+                            "invalid --emission-selection value: {other} \
+                             (expected ratio|probability)"
+                        ));
+                    }
+                };
             }
             "--emission-entries" => {
                 options.emission_entries = value
@@ -937,6 +951,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
         scoring_variant: options.scoring_variant,
+        emission_selection: options.emission_selection,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records


### PR DESCRIPTION
Measurement only. **Stacked on #366** — until that lands this PR also shows its
commit; the diff collapses to a single commit once #366 merges.

## Question

The residual is a telescoping sum: each level stores
`log P_level − log P_parent`, so a complete root-to-leaf chain sums to
`log P_leaf − log P_root`, and adding `root_score` recovers `log P_leaf`.
Truncation is per level, so a token kept at a descendant need not be kept at its
ancestors — and a missing level contributes 0 rather than its real correction.
The hypothesis was that broken sums explain why the residual still costs top-1
even after #366 fixed which tokens are kept.

## Result — largely refuted

| graph slice | ratio (shipped) | probability (#366) |
| --- | ---: | ---: |
| mean chain levels | 2.73 | 2.73 |
| mean levels emitting teacher | 0.01 | 1.60 |
| **telescoping COMPLETE** | 0.09% | **54.18%** |
| telescoping PARTIAL (broken sum) | 1.26% | 9.61% |

Partial sums are real but 9.61% — far too few to explain graph top-1 of 2.90%
against 8.76% with the residual disabled. Under corrected selection the sum is
intact for 54% of positions.

## The harder conclusion

Even where the chain is complete and the correction is mathematically right,
applying it makes both metrics worse (top-1 2.90% vs 8.76%; bits +1.32). So on
graph-status positions **`log P_region` is a worse next-token predictor than the
global unigram prior**.

That is not a defect in selection, telescoping, or scoring arithmetic — all now
measured and either fixed or exonerated. It says the region-conditional
distributions do not carry predictive value over the prior.

Most likely cause is **sparsity rather than a bug**: roughly 2,600 positions per
region against a 32,000-token vocabulary makes per-region next-token estimates
dominated by sampling noise, and add-one smoothing does not rescue them. The α
sweep independently agrees, peaking near **α ≈ 0.25** — the shape of a shrinkage
coefficient, not of a sign error (would peak at α < 0) or a plain scale error.

## Direction (not implemented here)

1. shrinkage toward the parent weighted by region evidence count (Witten-Bell /
   Jelinek-Mercer style) — the stored value is already a parent-relative delta,
   so this is a per-region weight, not a format change;
2. fewer/larger regions — trades resolution for estimate quality;
3. a better `Smoothing` variant — already a configurable enum from #67, so cheap
   to ablate.

## Verification

`cargo fmt`, `cargo clippy -p uor-r4-graph-certify --all-targets -D warnings`,
certify suite (11 files) green. No behavior change; adds four fields to the
per-status residual-influence block.

Related: #364, #366, #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
