### PR TITLE
certify: contrast-weighted residual — reaches parity, establishes the ceiling (#364)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -110,6 +110,29 @@ use uor_r4_graph_format::ScoreQ;
 pub const DEFAULT_TRANSITION_OUT_DEGREE: usize = 8;
 /// Default per-region emission list bound (top-E by residual score).
 pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
+
+/// How much the top-E-by-log-ratio emission selection differs from a
+/// top-E-by-probability one.
+///
+/// Emissions keep the tokens most over-represented against the parent, not the
+/// most likely next tokens. `overlap_with_top_count` near 0 means the two
+/// selections are nearly disjoint; `probability_mass_kept` says how much of the
+/// region's actual next-token mass the emitted list covers. Low values on both
+/// mean regions emit distinctive-but-unlikely tokens and score the likely ones
+/// at the bare prior.
+/// One region's emission list plus the statistics gathered while building it.
+type RegionEmissionResult = (
+    Vec<(u32, ScoreQ)>,
+    QuantizationErrorStats,
+    EmissionSelectionStats,
+);
+
+#[derive(Debug, Clone, Default)]
+pub struct EmissionSelectionStats {
+    pub regions: usize,
+    pub overlap_with_top_count: f64,
+    pub probability_mass_kept: f64,
+}
 /// Default root-prior candidate count.
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
 /// Default EXCT candidate count.
@@ -563,7 +586,7 @@ pub fn compile_emissions(
         })
         .collect();
 
-    let region_results: Vec<(Vec<(u32, ScoreQ)>, QuantizationErrorStats)> = regions
+    let region_results: Vec<RegionEmissionResult> = regions
         .par_iter()
         .enumerate()
         .map(|(region_id, region)| {
@@ -602,12 +625,46 @@ pub fn compile_emissions(
             residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
-            (residuals, emission_quantization)
+
+            // Selection is by log-RATIO against the parent, which keeps the
+            // most DISTINCTIVE tokens rather than the most LIKELY ones. A rare
+            // token heavily over-represented in this region outranks the
+            // region's actual most-probable next token, whose ratio is near
+            // zero because it is common everywhere. Measure the overlap with a
+            // top-E-by-count selection to see how far apart those two are.
+            let kept: std::collections::BTreeSet<u32> =
+                residuals.iter().map(|&(token, _)| token).collect();
+            let mut by_count: Vec<(u32, u64)> = dist.iter().map(|(&t, &c)| (t, c)).collect();
+            by_count.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            by_count.truncate(config.emission_entries);
+            let overlap = by_count
+                .iter()
+                .filter(|(token, _)| kept.contains(token))
+                .count();
+            let mass_kept: u64 = dist
+                .iter()
+                .filter(|(t, _)| kept.contains(t))
+                .map(|(_, &c)| c)
+                .sum();
+            let selection = EmissionSelectionStats {
+                regions: 1,
+                overlap_with_top_count: overlap as f64 / by_count.len().max(1) as f64,
+                probability_mass_kept: if total == 0 {
+                    0.0
+                } else {
+                    mass_kept as f64 / total as f64
+                },
+            };
+            (residuals, emission_quantization, selection)
         })
         .collect();
     let mut region_lists = Vec::with_capacity(regions.len());
     let mut emission_quantization = QuantizationErrorStats::default();
-    for (residuals, stats) in region_results {
+    let mut selection_stats = EmissionSelectionStats::default();
+    for (residuals, stats, selection) in region_results {
+        selection_stats.regions += selection.regions;
+        selection_stats.overlap_with_top_count += selection.overlap_with_top_count;
+        selection_stats.probability_mass_kept += selection.probability_mass_kept;
         emission_quantization.sample_count += stats.sample_count;
         emission_quantization.sum_abs_error_nano = emission_quantization
             .sum_abs_error_nano
@@ -616,6 +673,17 @@ pub fn compile_emissions(
             .max_abs_error_nano
             .max(stats.max_abs_error_nano);
         region_lists.push(residuals);
+    }
+    if selection_stats.regions > 0 {
+        let n = selection_stats.regions as f64;
+        eprintln!(
+            "[emission-selection] regions={} mean_overlap_with_top_count={:.4} \
+             mean_probability_mass_kept={:.4} (E={})",
+            selection_stats.regions,
+            selection_stats.overlap_with_top_count / n,
+            selection_stats.probability_mass_kept / n,
+            config.emission_entries,
+        );
     }
 
     EmissionTables {

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -196,6 +196,14 @@ pub struct EmissionSelectionStats {
     /// Witten-Bell lambda = n / (n + T) per region; near 1 means the estimator
     /// barely shrinks and cannot test the sparsity hypothesis.
     pub mean_lambda_witten_bell: f64,
+    /// Distribution of per-region contrast against the global prior. Spread
+    /// says whether region construction has headroom: uniformly mid-range
+    /// contrast means the cover is generic everywhere, while high variance
+    /// means some regions are genuinely distinctive and granularity is the
+    /// lever.
+    pub mean_contrast: f64,
+    pub min_contrast: f64,
+    pub max_contrast: f64,
     pub mean_region_count: f64,
     pub mean_region_types: f64,
     pub overlap_with_top_count: f64,
@@ -859,6 +867,9 @@ pub fn compile_emissions(
             let selection = EmissionSelectionStats {
                 regions: 1,
                 mean_lambda_witten_bell: lambda_wb,
+                mean_contrast: contrast,
+                min_contrast: contrast,
+                max_contrast: contrast,
                 mean_region_count: total as f64,
                 mean_region_types: types as f64,
                 overlap_with_top_count: overlap as f64 / by_count.len().max(1) as f64,
@@ -879,6 +890,14 @@ pub fn compile_emissions(
         selection_stats.overlap_with_top_count += selection.overlap_with_top_count;
         selection_stats.probability_mass_kept += selection.probability_mass_kept;
         selection_stats.mean_lambda_witten_bell += selection.mean_lambda_witten_bell;
+        selection_stats.mean_contrast += selection.mean_contrast;
+        if selection_stats.regions == 1 {
+            selection_stats.min_contrast = selection.min_contrast;
+            selection_stats.max_contrast = selection.max_contrast;
+        } else {
+            selection_stats.min_contrast = selection_stats.min_contrast.min(selection.min_contrast);
+            selection_stats.max_contrast = selection_stats.max_contrast.max(selection.max_contrast);
+        }
         selection_stats.mean_region_count += selection.mean_region_count;
         selection_stats.mean_region_types += selection.mean_region_types;
         emission_quantization.sample_count += stats.sample_count;
@@ -895,13 +914,16 @@ pub fn compile_emissions(
         eprintln!(
             "[emission-selection] regions={} mean_overlap_with_top_count={:.4} \
              mean_probability_mass_kept={:.4} mean_lambda_wb={:.4} \
-             mean_n={:.0} mean_types={:.0} (E={})",
+             mean_n={:.0} mean_types={:.0} contrast mean={:.4} min={:.4} max={:.4} (E={})",
             selection_stats.regions,
             selection_stats.overlap_with_top_count / n,
             selection_stats.probability_mass_kept / n,
             selection_stats.mean_lambda_witten_bell / n,
             selection_stats.mean_region_count / n,
             selection_stats.mean_region_types / n,
+            selection_stats.mean_contrast / n,
+            selection_stats.min_contrast,
+            selection_stats.max_contrast,
             config.emission_entries,
         );
     }

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1641,6 +1641,11 @@ pub struct ResidualInfluence {
     /// where they are present at some levels but missing at others.
     pub teacher_chain_complete: f64,
     pub teacher_chain_partial: f64,
+    /// Control for whether the cover groups by next-token structure: rate at
+    /// which the context's own region emits the teacher, versus an unrelated
+    /// region. Equal rates mean routing carries no predictive information.
+    pub own_region_emits_teacher: f64,
+    pub random_region_emits_teacher: f64,
 }
 
 /// Residual-influence measurement split by resolution status.
@@ -1988,6 +1993,8 @@ pub fn evaluate_gate_c(
     let mut status_chain_emit_levels = [0u64; 3];
     let mut status_chain_complete = [0u64; 3];
     let mut status_chain_partial = [0u64; 3];
+    let mut status_own_emits = [0u64; 3];
+    let mut status_rand_emits = [0u64; 3];
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -2049,6 +2056,8 @@ pub fn evaluate_gate_c(
         status_chain_emit_levels[row.status_index] += u64::from(row.chain_levels_emitting_teacher);
         status_chain_complete[row.status_index] += u64::from(row.teacher_chain_complete);
         status_chain_partial[row.status_index] += u64::from(row.teacher_chain_partial);
+        status_own_emits[row.status_index] += u64::from(row.own_region_emits_teacher);
+        status_rand_emits[row.status_index] += u64::from(row.random_region_emits_teacher);
         if row.teacher_emitted_off_chain {
             status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
             status_emitter_rows[row.status_index] += 1;
@@ -2235,6 +2244,8 @@ pub fn evaluate_gate_c(
             mean_chain_levels_emitting_teacher: status_chain_emit_levels[index] as f64 / denom,
             teacher_chain_complete: status_chain_complete[index] as f64 / denom,
             teacher_chain_partial: status_chain_partial[index] as f64 / denom,
+            own_region_emits_teacher: status_own_emits[index] as f64 / denom,
+            random_region_emits_teacher: status_rand_emits[index] as f64 / denom,
         };
         match index {
             0 => influence.exact_context = value,
@@ -2366,6 +2377,14 @@ struct GateCRow {
     teacher_chain_complete: bool,
     /// The teacher is emitted by some but not all chain levels (broken).
     teacher_chain_partial: bool,
+    /// Control: does the context's OWN region emit the teacher, versus a
+    /// deterministically chosen UNRELATED region? If the two rates match, the
+    /// cover is not grouping contexts by next-token structure -- every region's
+    /// emission list is essentially the same globally-common set, and routing
+    /// carries no predictive information no matter how well each region is
+    /// estimated.
+    own_region_emits_teacher: bool,
+    random_region_emits_teacher: bool,
     witness_replayed: bool,
     witness_replay_failed: bool,
 }
@@ -2546,6 +2565,23 @@ fn evaluate_gate_c_row(
     // teacher only ~4.3% of the time. Attribute the rest: the candidate set is
     // active + predicted + root_top, and which source supplies the teacher
     // decides whether the graph contributes anything to finding the answer.
+    // Own-region versus unrelated-region control. The unrelated node is chosen
+    // by a fixed integer hash of the position index -- deterministic, no RNG,
+    // and independent of the context's geometry.
+    let node_count = context.scorer_with_exct.emission_node_count();
+    let own_region_emits_teacher = rule12
+        .witness
+        .chain
+        .last()
+        .is_some_and(|&node| context.scorer_with_exct.node_emits(node, teacher_argmax));
+    let random_region_emits_teacher = if node_count == 0 {
+        false
+    } else {
+        let mixed = (position as u64).wrapping_mul(2_654_435_761) >> 16;
+        let node = (mixed % node_count as u64) as u32 + 1;
+        context.scorer_with_exct.node_emits(node, teacher_argmax)
+    };
+
     // Telescoping integrity: how much of the selected chain actually carries a
     // term for the teacher token.
     let chain_levels = rule12.witness.chain.len() as u32;
@@ -2686,6 +2722,8 @@ fn evaluate_gate_c_row(
         chain_levels_emitting_teacher,
         teacher_chain_complete,
         teacher_chain_partial,
+        own_region_emits_teacher,
+        random_region_emits_teacher,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
     })

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -143,6 +143,21 @@ pub enum EmissionShrinkage {
     None,
     /// Scale by n / (n + T) per region.
     WittenBell,
+    /// Scale by the region's measured CONTRAST against the global prior.
+    ///
+    /// The cover's regions are densely estimated (3.1M observations each) and
+    /// genuinely predictive (own region emits the teacher 1.41x more often than
+    /// an unrelated one), but their emission lists are largely the same
+    /// globally-common tokens -- an unrelated region's top-E contains the
+    /// teacher 42.7% of the time. Specialization is thin, and the scorer applies
+    /// that thin margin as though it were a full correction.
+    ///
+    /// This weights each region's residual by how far its own top-E departs from
+    /// the global prior's top-E: a region indistinguishable from the prior
+    /// contributes nothing, a genuinely distinctive one contributes fully.
+    /// Evidence count is not the binding constraint (WittenBell measured
+    /// lambda = 0.9992 and changed nothing); contrast is.
+    Contrast,
 }
 
 /// How the per-region emission list is chosen before truncation (#364).
@@ -716,6 +731,16 @@ pub fn compile_emissions(
         })
         .collect();
 
+    // The global prior's own top-E, used as the contrast reference: a region
+    // whose most-likely tokens are the prior's most-likely tokens is not
+    // conditioning on anything.
+    let root_top_set: std::collections::BTreeSet<u32> = {
+        let mut top: Vec<(u32, u64)> = root_dist.iter().map(|(&t, &c)| (t, c)).collect();
+        top.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        top.truncate(config.emission_entries);
+        top.into_iter().map(|(t, _)| t).collect()
+    };
+
     let region_results: Vec<RegionEmissionResult> = regions
         .par_iter()
         .enumerate()
@@ -734,6 +759,22 @@ pub fn compile_emissions(
                 None => (&root_dist, root_total),
             };
             let parent_types = parent_dist.len();
+            // Contrast: how far this region's own most-likely tokens depart from
+            // the global prior's. Overlap 1.0 means the region looks exactly
+            // like the prior and its "correction" is noise; overlap 0 means it
+            // is fully distinctive. Computed on counts, independent of which
+            // selection rule is in force.
+            let contrast = {
+                let mut region_top: Vec<(u32, u64)> = dist.iter().map(|(&t, &c)| (t, c)).collect();
+                region_top.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                region_top.truncate(config.emission_entries);
+                let shared = region_top
+                    .iter()
+                    .filter(|(token, _)| root_top_set.contains(token))
+                    .count();
+                let denom = region_top.len().max(1) as f64;
+                1.0 - (shared as f64 / denom)
+            };
             let mut residuals: Vec<(u32, ScoreQ)> = dist
                 .iter()
                 .map(|(&token, &count)| {
@@ -758,6 +799,7 @@ pub fn compile_emissions(
                             let lambda = if n + t > 0.0 { n / (n + t) } else { 0.0 };
                             (f64::from(ln) * lambda) as f32
                         }
+                        EmissionShrinkage::Contrast => (f64::from(ln) * contrast) as f32,
                     };
                     let score = ScoreQ::from_logprob(ln);
                     emission_quantization.record_ln_quantization(ln, score);

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1418,6 +1418,14 @@ pub struct ResidualInfluence {
     /// Teacher retrieved, but ONLY by the context-free root prior — no graph
     /// region and no predicted transition supplied it.
     pub teacher_only_root_top: f64,
+    /// Mean chain length, and mean number of chain levels carrying a term for
+    /// the teacher token. A gap means the telescoping sum is incomplete.
+    pub mean_chain_levels: f64,
+    pub mean_chain_levels_emitting_teacher: f64,
+    /// Share of positions where the teacher's chain terms are complete, and
+    /// where they are present at some levels but missing at others.
+    pub teacher_chain_complete: f64,
+    pub teacher_chain_partial: f64,
 }
 
 /// Residual-influence measurement split by resolution status.
@@ -1761,6 +1769,10 @@ pub fn evaluate_gate_c(
     let mut status_src_predicted = [0u64; 3];
     let mut status_src_root_top = [0u64; 3];
     let mut status_src_only_root = [0u64; 3];
+    let mut status_chain_levels = [0u64; 3];
+    let mut status_chain_emit_levels = [0u64; 3];
+    let mut status_chain_complete = [0u64; 3];
+    let mut status_chain_partial = [0u64; 3];
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -1818,6 +1830,10 @@ pub fn evaluate_gate_c(
         status_src_predicted[row.status_index] += u64::from(row.teacher_from_predicted);
         status_src_root_top[row.status_index] += u64::from(row.teacher_from_root_top);
         status_src_only_root[row.status_index] += u64::from(row.teacher_only_root_top);
+        status_chain_levels[row.status_index] += u64::from(row.chain_levels);
+        status_chain_emit_levels[row.status_index] += u64::from(row.chain_levels_emitting_teacher);
+        status_chain_complete[row.status_index] += u64::from(row.teacher_chain_complete);
+        status_chain_partial[row.status_index] += u64::from(row.teacher_chain_partial);
         if row.teacher_emitted_off_chain {
             status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
             status_emitter_rows[row.status_index] += 1;
@@ -2000,6 +2016,10 @@ pub fn evaluate_gate_c(
             teacher_from_predicted: status_src_predicted[index] as f64 / denom,
             teacher_from_root_top: status_src_root_top[index] as f64 / denom,
             teacher_only_root_top: status_src_only_root[index] as f64 / denom,
+            mean_chain_levels: status_chain_levels[index] as f64 / denom,
+            mean_chain_levels_emitting_teacher: status_chain_emit_levels[index] as f64 / denom,
+            teacher_chain_complete: status_chain_complete[index] as f64 / denom,
+            teacher_chain_partial: status_chain_partial[index] as f64 / denom,
         };
         match index {
             0 => influence.exact_context = value,
@@ -2118,6 +2138,19 @@ struct GateCRow {
     teacher_from_root_top: bool,
     /// Teacher present, but ONLY from the context-free root prior.
     teacher_only_root_top: bool,
+    /// Chain length, and how many of its levels emit the teacher token.
+    /// The residual is a TELESCOPING sum: each level stores
+    /// log P_level - log P_parent, so summing a complete root-to-leaf chain
+    /// gives log P_leaf - log P_root. Truncation is per level, so a token kept
+    /// at a descendant need not be kept at its ancestors; a missing level
+    /// contributes 0 instead of its real correction and the sum is no longer
+    /// log P_leaf. Count the levels that actually contribute.
+    chain_levels: u32,
+    chain_levels_emitting_teacher: u32,
+    /// The teacher is emitted by the full chain (telescoping intact).
+    teacher_chain_complete: bool,
+    /// The teacher is emitted by some but not all chain levels (broken).
+    teacher_chain_partial: bool,
     witness_replayed: bool,
     witness_replay_failed: bool,
 }
@@ -2298,6 +2331,19 @@ fn evaluate_gate_c_row(
     // teacher only ~4.3% of the time. Attribute the rest: the candidate set is
     // active + predicted + root_top, and which source supplies the teacher
     // decides whether the graph contributes anything to finding the answer.
+    // Telescoping integrity: how much of the selected chain actually carries a
+    // term for the teacher token.
+    let chain_levels = rule12.witness.chain.len() as u32;
+    let chain_levels_emitting_teacher = rule12
+        .witness
+        .chain
+        .iter()
+        .filter(|&&node| context.scorer_with_exct.node_emits(node, teacher_argmax))
+        .count() as u32;
+    let teacher_chain_complete = chain_levels > 0 && chain_levels_emitting_teacher == chain_levels;
+    let teacher_chain_partial =
+        chain_levels_emitting_teacher > 0 && chain_levels_emitting_teacher < chain_levels;
+
     let teacher_present = rule12
         .candidate_components
         .iter()
@@ -2421,6 +2467,10 @@ fn evaluate_gate_c_row(
         teacher_from_predicted,
         teacher_from_root_top,
         teacher_only_root_top,
+        chain_levels,
+        chain_levels_emitting_teacher,
+        teacher_chain_complete,
+        teacher_chain_partial,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
     })

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -120,6 +120,31 @@ pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
 /// region's actual next-token mass the emitted list covers. Low values on both
 /// mean regions emit distinctive-but-unlikely tokens and score the likely ones
 /// at the bare prior.
+/// Per-region shrinkage applied to the emission residual (#364).
+///
+/// Measured on the fixture corpus, `log P_region` is a WORSE next-token
+/// predictor than the global unigram prior on graph-status positions: applying
+/// the residual at full strength costs top-1 (2.90% vs 8.76%) and bits (+1.32)
+/// even where the telescoping chain is complete and the correction is
+/// mathematically right. That is the signature of sparse conditional estimates
+/// -- roughly 2,600 positions per region against a 32,000-token vocabulary --
+/// rather than of a defect in the arithmetic. The alpha sweep peaks near 0.25,
+/// the shape of a shrinkage coefficient.
+///
+/// `WittenBell` scales each region's residual by `n / (n + T)`, where `n` is the
+/// region's total next-token count and `T` its distinct-type count, so
+/// sparsely-supported regions fall back toward the parent and well-supported
+/// ones contribute fully. The scaling is applied at COMPILE time to the stored
+/// value, so the runtime, kernel and artifact ABI are untouched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmissionShrinkage {
+    /// Apply the residual at full strength (shipped behavior).
+    #[default]
+    None,
+    /// Scale by n / (n + T) per region.
+    WittenBell,
+}
+
 /// How the per-region emission list is chosen before truncation (#364).
 ///
 /// The shipped rule ranks by log-ratio against the parent, which keeps the most
@@ -153,6 +178,11 @@ type RegionEmissionResult = (
 #[derive(Debug, Clone, Default)]
 pub struct EmissionSelectionStats {
     pub regions: usize,
+    /// Witten-Bell lambda = n / (n + T) per region; near 1 means the estimator
+    /// barely shrinks and cannot test the sparsity hypothesis.
+    pub mean_lambda_witten_bell: f64,
+    pub mean_region_count: f64,
+    pub mean_region_types: f64,
     pub overlap_with_top_count: f64,
     pub probability_mass_kept: f64,
 }
@@ -327,6 +357,8 @@ pub struct ScoreConfig {
     pub scoring_variant: ScoringVariant,
     /// Emission list selection rule (issue #364).
     pub emission_selection: EmissionSelection,
+    /// Per-region residual shrinkage (issue #364).
+    pub emission_shrinkage: EmissionShrinkage,
 }
 
 impl Default for ScoreConfig {
@@ -340,6 +372,7 @@ impl Default for ScoreConfig {
             smoothing: Smoothing::AddOne,
             scoring_variant: ScoringVariant::ChainTelescoped,
             emission_selection: EmissionSelection::default(),
+            emission_shrinkage: EmissionShrinkage::default(),
         }
     }
 }
@@ -712,6 +745,20 @@ pub fn compile_emissions(
                         parent_types,
                     );
                     let ln = lp_n - lp_p;
+                    // Shrink sparse regions toward the parent. n / (n + T)
+                    // approaches 1 when a region has many observations per
+                    // distinct type and approaches 0 when its distribution is
+                    // mostly singletons -- exactly the regime where the
+                    // conditional estimate is noise.
+                    let ln = match config.emission_shrinkage {
+                        EmissionShrinkage::None => ln,
+                        EmissionShrinkage::WittenBell => {
+                            let n = total as f64;
+                            let t = types as f64;
+                            let lambda = if n + t > 0.0 { n / (n + t) } else { 0.0 };
+                            (f64::from(ln) * lambda) as f32
+                        }
+                    };
                     let score = ScoreQ::from_logprob(ln);
                     emission_quantization.record_ln_quantization(ln, score);
                     (token, score)
@@ -758,8 +805,20 @@ pub fn compile_emissions(
                 .filter(|(t, _)| kept.contains(t))
                 .map(|(_, &c)| c)
                 .sum();
+            let lambda_wb = {
+                let n = total as f64;
+                let t = types as f64;
+                if n + t > 0.0 {
+                    n / (n + t)
+                } else {
+                    0.0
+                }
+            };
             let selection = EmissionSelectionStats {
                 regions: 1,
+                mean_lambda_witten_bell: lambda_wb,
+                mean_region_count: total as f64,
+                mean_region_types: types as f64,
                 overlap_with_top_count: overlap as f64 / by_count.len().max(1) as f64,
                 probability_mass_kept: if total == 0 {
                     0.0
@@ -777,6 +836,9 @@ pub fn compile_emissions(
         selection_stats.regions += selection.regions;
         selection_stats.overlap_with_top_count += selection.overlap_with_top_count;
         selection_stats.probability_mass_kept += selection.probability_mass_kept;
+        selection_stats.mean_lambda_witten_bell += selection.mean_lambda_witten_bell;
+        selection_stats.mean_region_count += selection.mean_region_count;
+        selection_stats.mean_region_types += selection.mean_region_types;
         emission_quantization.sample_count += stats.sample_count;
         emission_quantization.sum_abs_error_nano = emission_quantization
             .sum_abs_error_nano
@@ -790,10 +852,14 @@ pub fn compile_emissions(
         let n = selection_stats.regions as f64;
         eprintln!(
             "[emission-selection] regions={} mean_overlap_with_top_count={:.4} \
-             mean_probability_mass_kept={:.4} (E={})",
+             mean_probability_mass_kept={:.4} mean_lambda_wb={:.4} \
+             mean_n={:.0} mean_types={:.0} (E={})",
             selection_stats.regions,
             selection_stats.overlap_with_top_count / n,
             selection_stats.probability_mass_kept / n,
+            selection_stats.mean_lambda_witten_bell / n,
+            selection_stats.mean_region_count / n,
+            selection_stats.mean_region_types / n,
             config.emission_entries,
         );
     }

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -120,6 +120,30 @@ pub const DEFAULT_EMISSION_ENTRIES: usize = 64;
 /// region's actual next-token mass the emitted list covers. Low values on both
 /// mean regions emit distinctive-but-unlikely tokens and score the likely ones
 /// at the bare prior.
+/// How the per-region emission list is chosen before truncation (#364).
+///
+/// The shipped rule ranks by log-ratio against the parent, which keeps the most
+/// DISTINCTIVE tokens. Measured on the fixture artifact, that list overlaps a
+/// top-E-by-probability selection by 0.78% and covers 1.57% of the region's
+/// actual next-token mass — so 98.4% of what really happens next carries
+/// residual 0 and is scored at the bare global prior.
+///
+/// `Probability` ranks by the region's own next-token counts instead, still
+/// storing the log-ratio as the value, so `root_score + log-ratio =
+/// log P_region` continues to hold for the tokens that actually occur.
+///
+/// Default is `Ratio`: it reproduces the shipped artifact byte-exactly. Changing
+/// selection changes artifact bytes and kappa, so the alternative stays opt-in
+/// until measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmissionSelection {
+    /// Top-E by log-ratio against the parent (shipped behavior).
+    #[default]
+    Ratio,
+    /// Top-E by the region's own next-token probability.
+    Probability,
+}
+
 /// One region's emission list plus the statistics gathered while building it.
 type RegionEmissionResult = (
     Vec<(u32, ScoreQ)>,
@@ -300,6 +324,8 @@ pub struct ScoreConfig {
     pub smoothing: Smoothing,
     /// Candidate scoring variant (issue #80).
     pub scoring_variant: ScoringVariant,
+    /// Emission list selection rule (issue #364).
+    pub emission_selection: EmissionSelection,
 }
 
 impl Default for ScoreConfig {
@@ -312,6 +338,7 @@ impl Default for ScoreConfig {
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
             scoring_variant: ScoringVariant::ChainTelescoped,
+            emission_selection: EmissionSelection::default(),
         }
     }
 }
@@ -622,7 +649,22 @@ pub fn compile_emissions(
                 .collect();
             // Top-E by residual score (score desc, token asc), stored
             // ascending token.
-            residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            match config.emission_selection {
+                EmissionSelection::Ratio => {
+                    residuals.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                }
+                EmissionSelection::Probability => {
+                    // Rank by the region's own next-token count (probability),
+                    // ties to the lower token id for determinism. The stored
+                    // value stays the log-ratio, so the scoring identity is
+                    // unchanged -- only WHICH tokens get a correction moves.
+                    residuals.sort_by(|a, b| {
+                        let ca = dist.get(&a.0).copied().unwrap_or(0);
+                        let cb = dist.get(&b.0).copied().unwrap_or(0);
+                        cb.cmp(&ca).then_with(|| a.0.cmp(&b.0))
+                    });
+                }
+            }
             residuals.truncate(config.emission_entries);
             residuals.sort_by_key(|&(token, _)| token);
 

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -986,6 +986,11 @@ impl GraphScorer {
 
     /// The stored root prior B(v), or the smoothing floor for tokens
     /// absent from the root block.
+    /// Number of emission nodes (regions + 1 offset). Measurement-only.
+    pub fn emission_node_count(&self) -> usize {
+        self.emissions.len()
+    }
+
     /// Is `token` in the global root prior's top-B list? Measurement-only.
     pub fn root_top_contains(&self, token: u32) -> bool {
         self.root_top.contains(&token)

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -744,6 +744,7 @@ struct ScoreOptions {
     stories: Option<PathBuf>,
     transition_out_degree: usize,
     emission_entries: usize,
+    emission_selection: score::EmissionSelection,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -763,6 +764,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         stories: None,
         transition_out_degree: score::DEFAULT_TRANSITION_OUT_DEGREE,
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
+        emission_selection: score::EmissionSelection::default(),
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -790,6 +792,18 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                 if options.transition_out_degree == 0 {
                     return Err("--transition-out-degree must be at least 1".to_owned());
                 }
+            }
+            "--emission-selection" => {
+                options.emission_selection = match value.as_str() {
+                    "ratio" => score::EmissionSelection::Ratio,
+                    "probability" => score::EmissionSelection::Probability,
+                    other => {
+                        return Err(format!(
+                            "invalid --emission-selection value: {other} \
+                             (expected ratio|probability)"
+                        ));
+                    }
+                };
             }
             "--emission-entries" => {
                 options.emission_entries = value
@@ -937,6 +951,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         witness_sample: options.witness_sample,
         smoothing: options.smoothing,
         scoring_variant: options.scoring_variant,
+        emission_selection: options.emission_selection,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -745,6 +745,7 @@ struct ScoreOptions {
     transition_out_degree: usize,
     emission_entries: usize,
     emission_selection: score::EmissionSelection,
+    emission_shrinkage: score::EmissionShrinkage,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -765,6 +766,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         transition_out_degree: score::DEFAULT_TRANSITION_OUT_DEGREE,
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
         emission_selection: score::EmissionSelection::default(),
+        emission_shrinkage: score::EmissionShrinkage::default(),
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -792,6 +794,18 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                 if options.transition_out_degree == 0 {
                     return Err("--transition-out-degree must be at least 1".to_owned());
                 }
+            }
+            "--emission-shrinkage" => {
+                options.emission_shrinkage = match value.as_str() {
+                    "none" => score::EmissionShrinkage::None,
+                    "witten-bell" => score::EmissionShrinkage::WittenBell,
+                    other => {
+                        return Err(format!(
+                            "invalid --emission-shrinkage value: {other} \
+                             (expected none|witten-bell)"
+                        ));
+                    }
+                };
             }
             "--emission-selection" => {
                 options.emission_selection = match value.as_str() {
@@ -952,6 +966,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         smoothing: options.smoothing,
         scoring_variant: options.scoring_variant,
         emission_selection: options.emission_selection,
+        emission_shrinkage: options.emission_shrinkage,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -799,10 +799,11 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                 options.emission_shrinkage = match value.as_str() {
                     "none" => score::EmissionShrinkage::None,
                     "witten-bell" => score::EmissionShrinkage::WittenBell,
+                    "contrast" => score::EmissionShrinkage::Contrast,
                     other => {
                         return Err(format!(
                             "invalid --emission-shrinkage value: {other} \
-                             (expected none|witten-bell)"
+                             (expected none|witten-bell|contrast)"
                         ));
                     }
                 };


### PR DESCRIPTION
Direction 2 from #364, plus the measurement that closes the scoring-side
investigation. **Stacked on #366/#367/#369.**

## Contrast weighting works

Weights each region's residual by `1 − overlap(region top-E, global prior top-E)`
— a region whose most-likely tokens *are* the prior's conditions on nothing.
Distinct from the evidence-count shrinkage in #369, which measured λ = 0.9992 and
was never the binding constraint.

| variant | graph top-1 | graph bits |
| --- | ---: | ---: |
| probability + none | 2.90% | 13.32 |
| probability + witten-bell | 2.90% | 13.31 |
| **probability + contrast** | **5.42%** | **12.01** |
| **root-only baseline** | **8.76%** | **12.00** |

Nearly doubles top-1 and **closes the bits gap entirely** (12.01 vs 12.00). It
also beats the equivalent global constant (α = 0.5 → 5.26%), so per-region
contrast carries real variance.

## …and establishes the ceiling

It does not clear the bar. Conditioning is now **break-even on coherence and
still negative on top-1**. At this cover's specialization, the best geometric
emission conditioning achieves is **parity with not conditioning at all**.

## Why: the cover is uniformly semi-generic

```
contrast  mean=0.5012  min=0.3906  max=0.7500   (38 regions)
```

Every region shares 25–61% of its top-E with the global prior. Even the most
distinctive shares a quarter; none approaches high specialization.

**The architectural statement:** the cover is induced by context-bundle geometry,
but predictive value requires grouping by *continuation* — and the two are only
weakly aligned (1.41× own-region lift, #369). Tuning granularity does not address
that; it needs an induction objective optimizing continuation discriminativeness
rather than signature-space compactness.

## What this closes

Every scoring-side component is now measured:

| component | verdict |
| --- | --- |
| emission selection | defect, fixed (#366) |
| ranking / calibration | exonerated |
| residual sign, scale | exonerated |
| chain selection | exonerated |
| telescoping | intact |
| estimate sparsity | refuted (#369) |
| conditioning weight | **optimized — parity, not gain** |

The remaining lever is region construction, upstream of the scorer entirely.

## Bearing on other work

- **#362**: compare trigram rows against a geometric path whose realistic
  contribution is parity with a unigram prior — not against zero, not against the
  shipped 1.96%.
- **#290 / #359 / #361**: those optimize emission-residual machinery now measured
  at break-even on the graph slice. The speedups are real; worth knowing what
  they accelerate.

## Verification

`cargo fmt`, `cargo clippy -p uor-r4-graph-certify -p uor-r4-graph-cli
--all-targets -D warnings`, certify suite (11 files) green. `--emission-shrinkage`
defaults to `none`, preserving shipped behavior byte-exactly.

Related: #364, #366, #367, #369, #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
