### PR TITLE
instr(score): #364 attribution — emission mode in report, contrast stats promoted, NGRAM/EXCT exact-context split (schema 13)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -446,6 +446,9 @@ pub struct PredictOutcome {
     pub token: u32,
     pub status: ScoreStatus,
     pub widened: bool,
+    /// The served token came from an explicit NGRAM context row (#362
+    /// attribution; only possible when `status` is `ExactContext`).
+    pub ngram_hit: bool,
 }
 
 /// A typed abstention: no token was emitted and none is guessed.
@@ -453,6 +456,8 @@ pub struct PredictOutcome {
 pub struct AbstainOutcome {
     pub status: ScoreStatus,
     pub widened: bool,
+    /// The abstained status resolved via an explicit NGRAM context row.
+    pub ngram_hit: bool,
 }
 
 /// The status-aware prediction result of the deployed adapter: either
@@ -531,6 +536,9 @@ impl NovelSeen {
 struct ScoredProbe {
     token: u32,
     status: ScoreStatus,
+    /// The selection came from an explicit NGRAM context row (#362
+    /// attribution; only possible when `status` is `ExactContext`).
+    ngram_hit: bool,
 }
 
 /// A loaded, CID-verified scored graph and the teacher artifact needed to
@@ -668,6 +676,8 @@ impl R4Engine {
             Ok(ScoredProbe {
                 token: outcome.selected,
                 status: outcome.status,
+                ngram_hit: outcome.exact_context_source
+                    == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
             })
         } else {
             let outcome = self
@@ -677,6 +687,8 @@ impl R4Engine {
             Ok(ScoredProbe {
                 token: outcome.selected,
                 status: outcome.witness.status,
+                ngram_hit: outcome.exact_context_source
+                    == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
             })
         }
     }
@@ -727,6 +739,7 @@ impl R4Engine {
                     token: first.token,
                     status: first.status,
                     widened: false,
+                    ngram_hit: first.ngram_hit,
                 }))
             }
             StatusAction::Abstain => {
@@ -734,6 +747,7 @@ impl R4Engine {
                 Ok(PredictDecision::Abstain(AbstainOutcome {
                     status: first.status,
                     widened: false,
+                    ngram_hit: first.ngram_hit,
                 }))
             }
             StatusAction::WidenOnce => {
@@ -744,6 +758,7 @@ impl R4Engine {
                     return Ok(PredictDecision::Abstain(AbstainOutcome {
                         status: first.status,
                         widened: false,
+                        ngram_hit: first.ngram_hit,
                     }));
                 }
                 if self.novel_seen.contains(sig) {
@@ -752,6 +767,7 @@ impl R4Engine {
                     return Ok(PredictDecision::Abstain(AbstainOutcome {
                         status: first.status,
                         widened: false,
+                        ngram_hit: first.ngram_hit,
                     }));
                 }
                 self.counters.widen_attempts += 1;
@@ -765,12 +781,14 @@ impl R4Engine {
                         token: second.token,
                         status: second.status,
                         widened: true,
+                        ngram_hit: second.ngram_hit,
                     }))
                 } else {
                     self.counters.abstains += 1;
                     Ok(PredictDecision::Abstain(AbstainOutcome {
                         status: second.status,
                         widened: true,
+                        ngram_hit: second.ngram_hit,
                     }))
                 }
             }
@@ -807,6 +825,8 @@ impl R4Engine {
                         token: first.selected,
                         status: first.witness.status,
                         widened: false,
+                        ngram_hit: first.exact_context_source
+                            == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
                     }),
                     first_witness,
                 ))
@@ -817,6 +837,8 @@ impl R4Engine {
                     PredictDecision::Abstain(AbstainOutcome {
                         status: first.witness.status,
                         widened: false,
+                        ngram_hit: first.exact_context_source
+                            == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
                     }),
                     first_witness,
                 ))
@@ -828,6 +850,8 @@ impl R4Engine {
                         PredictDecision::Abstain(AbstainOutcome {
                             status: first.witness.status,
                             widened: false,
+                            ngram_hit: first.exact_context_source
+                                == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
                         }),
                         first_witness,
                     ));
@@ -845,6 +869,8 @@ impl R4Engine {
                             token: second.selected,
                             status: second.witness.status,
                             widened: true,
+                            ngram_hit: second.exact_context_source
+                                == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
                         }),
                         second_witness,
                     ))
@@ -854,6 +880,8 @@ impl R4Engine {
                         PredictDecision::Abstain(AbstainOutcome {
                             status: second.witness.status,
                             widened: true,
+                            ngram_hit: second.exact_context_source
+                                == Some(uor_r4_graph_certify::ExactContextSource::NgramRow),
                         }),
                         second_witness,
                     ))

--- a/crates/uor-r4-api/src/serving_eval.rs
+++ b/crates/uor-r4-api/src/serving_eval.rs
@@ -431,11 +431,25 @@ mod tests {
     #[test]
     fn abstain_breakdown_records_by_status() {
         let mut b = StatusBreakdown::default();
-        b.record(PolicyStatus::Novel);
-        b.record(PolicyStatus::Novel);
-        b.record(PolicyStatus::Graph);
+        b.record(PolicyStatus::Novel, false);
+        b.record(PolicyStatus::Novel, false);
+        b.record(PolicyStatus::Graph, false);
         assert_eq!(b.novel, 2);
         assert_eq!(b.graph, 1);
         assert_eq!(b.total(), 3);
+    }
+
+    /// #362 attribution: the NGRAM subcount tracks only exact-context
+    /// records, and the flag is ignored on other statuses.
+    #[test]
+    fn breakdown_splits_exact_context_by_ngram() {
+        let mut b = StatusBreakdown::default();
+        b.record(PolicyStatus::ExactContext, true);
+        b.record(PolicyStatus::ExactContext, false);
+        b.record(PolicyStatus::Graph, true);
+        assert_eq!(b.exact_context, 2);
+        assert_eq!(b.exact_context_ngram, 1);
+        assert_eq!(b.graph, 1);
+        assert_eq!(b.total(), 3, "the ngram split is not a fourth bucket");
     }
 }

--- a/crates/uor-r4-api/src/serving_eval.rs
+++ b/crates/uor-r4-api/src/serving_eval.rs
@@ -112,12 +112,22 @@ pub struct StatusBreakdown {
     pub graph: u64,
     pub novel: u64,
     pub contradictory: u64,
+    /// Of `exact_context`, how many resolved via an explicit NGRAM
+    /// context row rather than the EXCT probe (#362 attribution — the
+    /// two mechanisms share the `ExactContext` status since e77b1d4,
+    /// so era comparisons need the split).
+    pub exact_context_ngram: u64,
 }
 
 impl StatusBreakdown {
-    fn record(&mut self, status: PolicyStatus) {
+    fn record(&mut self, status: PolicyStatus, ngram_hit: bool) {
         match status {
-            PolicyStatus::ExactContext => self.exact_context += 1,
+            PolicyStatus::ExactContext => {
+                self.exact_context += 1;
+                if ngram_hit {
+                    self.exact_context_ngram += 1;
+                }
+            }
             PolicyStatus::Graph => self.graph += 1,
             PolicyStatus::Novel => self.novel += 1,
             PolicyStatus::Contradictory => self.contradictory += 1,
@@ -370,7 +380,8 @@ pub fn evaluate_serving_bundle(
         })? {
             PredictDecision::Serve(outcome) => {
                 row.served += 1;
-                row.served_by.record(outcome.status.into());
+                row.served_by
+                    .record(outcome.status.into(), outcome.ngram_hit);
                 if outcome.widened {
                     row.served_widened += 1;
                 }
@@ -382,7 +393,8 @@ pub fn evaluate_serving_bundle(
                 }
             }
             PredictDecision::Abstain(outcome) => {
-                row.abstained.record(outcome.status.into());
+                row.abstained
+                    .record(outcome.status.into(), outcome.ngram_hit);
             }
         }
         if (done + 1).is_multiple_of(256) {

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -98,8 +98,9 @@ use std::collections::BTreeMap;
 
 use super::score_runtime::{
     binary_memberships, binary_top1_covered, regions_from_view, structural_edges_from_view,
-    verify_witness_replay, GraphScorer, RegionParams, ScoreStatus, ScoringVariant, StructuralEdge,
-    EDGE_KIND_FORWARD, EDGE_KIND_NEIGHBOR, EDGE_KIND_REFINEMENT, RESIDUAL_EXCT_MAGIC,
+    verify_witness_replay, ExactContextSource, GraphScorer, RegionParams, ScoreStatus,
+    ScoringVariant, StructuralEdge, EDGE_KIND_FORWARD, EDGE_KIND_NEIGHBOR, EDGE_KIND_REFINEMENT,
+    RESIDUAL_EXCT_MAGIC,
 };
 use uor_r4_core::transformerless::compiler::{self, Corpus, SIG_BYTES, SIG_WORDS, STAGES};
 use uor_r4_core::transformerless::runtime::{self, Store};
@@ -183,6 +184,29 @@ pub enum EmissionSelection {
     /// Top-E by the region's own next-token probability.
     Probability,
 }
+
+impl EmissionShrinkage {
+    /// Report label; matches the CLI's `--emission-shrinkage` strings.
+    pub fn label(self) -> String {
+        match self {
+            EmissionShrinkage::None => "none",
+            EmissionShrinkage::WittenBell => "witten-bell",
+            EmissionShrinkage::Contrast => "contrast",
+        }
+        .to_owned()
+    }
+}
+
+impl EmissionSelection {
+    /// Report label; matches the CLI's `--emission-selection` strings.
+    pub fn label(self) -> String {
+        match self {
+            EmissionSelection::Ratio => "ratio",
+            EmissionSelection::Probability => "probability",
+        }
+        .to_owned()
+    }
+}
 /// One region's emission list plus the statistics gathered while building it.
 type RegionEmissionResult = (
     Vec<(u32, ScoreQ)>,
@@ -190,7 +214,7 @@ type RegionEmissionResult = (
     EmissionSelectionStats,
 );
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
 pub struct EmissionSelectionStats {
     pub regions: usize,
     /// Witten-Bell lambda = n / (n + T) per region; near 1 means the estimator
@@ -208,6 +232,30 @@ pub struct EmissionSelectionStats {
     pub mean_region_types: f64,
     pub overlap_with_top_count: f64,
     pub probability_mass_kept: f64,
+}
+
+impl EmissionSelectionStats {
+    /// Per-region means from the accumulated per-region sums — the same
+    /// normalization the stderr `[emission-selection]` line applies.
+    /// `min_contrast`/`max_contrast` pass through; identity when
+    /// `regions == 0`.
+    pub fn normalized(&self) -> EmissionSelectionStats {
+        if self.regions == 0 {
+            return *self;
+        }
+        let n = self.regions as f64;
+        EmissionSelectionStats {
+            regions: self.regions,
+            mean_lambda_witten_bell: self.mean_lambda_witten_bell / n,
+            mean_contrast: self.mean_contrast / n,
+            min_contrast: self.min_contrast,
+            max_contrast: self.max_contrast,
+            mean_region_count: self.mean_region_count / n,
+            mean_region_types: self.mean_region_types / n,
+            overlap_with_top_count: self.overlap_with_top_count / n,
+            probability_mass_kept: self.probability_mass_kept / n,
+        }
+    }
 }
 /// Default root-prior candidate count.
 pub const DEFAULT_ROOT_TOP_B: usize = 64;
@@ -555,6 +603,10 @@ pub struct EmissionTables {
     pub root_prior_quantization: QuantizationErrorStats,
     /// Emission-residual quantization errors.
     pub emission_quantization: QuantizationErrorStats,
+    /// Per-region selection/contrast statistics gathered while building
+    /// the emission lists (normalized per-region means; previously
+    /// stderr-only, promoted so reports can attribute #364-era A/Bs).
+    pub selection_stats: EmissionSelectionStats,
 }
 
 /// One canonical context-conditioned lexical row. The root prior in
@@ -940,6 +992,7 @@ pub fn compile_emissions(
         smoothing,
         root_prior_quantization,
         emission_quantization,
+        selection_stats: selection_stats.normalized(),
     }
 }
 
@@ -1004,7 +1057,9 @@ pub fn verify_theorem_7_wired(
 }
 
 /// What an [`emit_scored_r4g1`] call produced, for the report and tests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// (`Eq` dropped at schema 13: the promoted emission-selection statistics
+/// are f64 means; comparisons remain exact via `PartialEq`.)
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScoredGraphInfo {
     pub node_count: u32,
     pub edge_count: u32,
@@ -1028,6 +1083,9 @@ pub struct ScoredGraphInfo {
     pub root_prior_quantization: QuantizationErrorStats,
     pub emission_quantization: QuantizationErrorStats,
     pub exact_context_quantization: QuantizationErrorStats,
+    /// Per-region emission selection/contrast statistics (normalized
+    /// means), carried from [`EmissionTables::selection_stats`].
+    pub emission_selection_stats: EmissionSelectionStats,
 }
 
 /// Data bundle for [`emit_scored_r4g1`] (keeps the argument list
@@ -1459,6 +1517,7 @@ pub fn emit_scored_r4g1(
             root_prior_quantization: emissions.root_prior_quantization,
             emission_quantization: emissions.emission_quantization,
             exact_context_quantization,
+            emission_selection_stats: emissions.selection_stats,
         },
     ))
 }
@@ -1578,6 +1637,12 @@ pub struct StatusCounts {
     pub exact_context: usize,
     pub graph: usize,
     pub novel: usize,
+    /// Exact-context positions resolved by an explicit NGRAM context row
+    /// (#362 attribution; schema 13). Zero on distributions whose probes
+    /// carry no recent-token window.
+    pub exact_context_ngram: usize,
+    /// Exact-context positions resolved by the EXCT full-depth probe.
+    pub exact_context_probe: usize,
 }
 
 /// Rule 1+2 metrics split by the status that fired. A bucket with zero
@@ -2063,6 +2128,8 @@ pub fn evaluate_gate_c(
     let mut status_chain_partial = [0u64; 3];
     let mut status_own_emits = [0u64; 3];
     let mut status_rand_emits = [0u64; 3];
+    let mut status_exact_ngram = 0usize;
+    let mut status_exact_probe = 0usize;
     let mut status_ranks: [Vec<u32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let gate_rotations = compiler::derive_rotations();
     let context = GateCContext {
@@ -2126,6 +2193,11 @@ pub fn evaluate_gate_c(
         status_chain_partial[row.status_index] += u64::from(row.teacher_chain_partial);
         status_own_emits[row.status_index] += u64::from(row.own_region_emits_teacher);
         status_rand_emits[row.status_index] += u64::from(row.random_region_emits_teacher);
+        match row.exact_context_source {
+            Some(ExactContextSource::NgramRow) => status_exact_ngram += 1,
+            Some(ExactContextSource::ExctProbe) => status_exact_probe += 1,
+            None => {}
+        }
         if row.teacher_emitted_off_chain {
             status_emitter_depth[row.status_index] += u64::from(row.teacher_emitter_depth);
             status_emitter_rows[row.status_index] += 1;
@@ -2207,6 +2279,8 @@ pub fn evaluate_gate_c(
         exact_context: status_positions[0],
         graph: status_positions[1],
         novel: status_positions[2],
+        exact_context_ngram: status_exact_ngram,
+        exact_context_probe: status_exact_probe,
     };
     outcome.rule12_exct_probe_levels = exct_level_positions;
     outcome.rule12_exct_probe_absent = exct_probe_absent;
@@ -2455,6 +2529,9 @@ struct GateCRow {
     random_region_emits_teacher: bool,
     witness_replayed: bool,
     witness_replay_failed: bool,
+    /// Which mechanism resolved the rule12 selection when its status is
+    /// ExactContext (#362 attribution; `None` otherwise).
+    exact_context_source: Option<ExactContextSource>,
 }
 
 struct GateCContext<'a> {
@@ -2793,6 +2870,7 @@ fn evaluate_gate_c_row(
         random_region_emits_teacher,
         witness_replayed: index < context.config.witness_sample,
         witness_replay_failed,
+        exact_context_source: rule12.exact_context_source,
     })
 }
 
@@ -2818,7 +2896,13 @@ fn evaluate_gate_c_row(
 /// the STRICT full-code miss rate, and the Gate C validity verdict is
 /// judged on the strict basis.
 /// 11 = graph footprint and quality-profile fields; 12 = packed FMM
-/// footprint, rank, and candidate-count fields.
+/// footprint, rank, and candidate-count fields; 13 = #364 attribution:
+/// `config.emission_selection`/`config.emission_shrinkage` record the
+/// compiled emission mode, `emission_selection_stats` promotes the
+/// per-region contrast/selection statistics (previously stderr-only)
+/// into the report, and `gate_c.rule12_status_counts` splits the
+/// exact-context bucket by resolving mechanism (NGRAM row vs EXCT
+/// probe) so post-#362 rows remain comparable with pre-#362 ones.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -2829,6 +2913,9 @@ pub struct ScoreReport {
     pub quantization: ScoreReportQuantization,
     pub determinism: ScoreReportDeterminism,
     pub distribution: DistributionDeclaration,
+    /// Per-region emission selection/contrast statistics (normalized
+    /// means over regions; schema 13).
+    pub emission_selection_stats: EmissionSelectionStats,
 }
 
 /// Minimum EXCT-miss rate below which a distribution cannot serve as a
@@ -2897,6 +2984,12 @@ pub struct ScoreReportConfig {
     /// The calibrated emission smoothing rule (issue #67;
     /// [`Smoothing::label`]).
     pub smoothing: String,
+    /// How the per-region emission list was chosen (#364;
+    /// [`EmissionSelection::label`]).
+    pub emission_selection: String,
+    /// The per-region residual shrinkage applied (#364;
+    /// [`EmissionShrinkage::label`]).
+    pub emission_shrinkage: String,
     /// Quality-gate basis for this distribution. `pinned` applies the
     /// historical Gate C absolute floor; `relative_tla` only compares the
     /// graph with the TLA baseline measured on the same corpus.
@@ -2993,7 +3086,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 12,
+        schema: 13,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -3004,6 +3097,8 @@ pub fn build_score_report_with_quality_profile(
             top_m: super::score_runtime::TOP_M,
             exct_support_min: super::score_runtime::EXCT_SUPPORT_MIN,
             smoothing: config.smoothing.label(),
+            emission_selection: config.emission_selection.label(),
+            emission_shrinkage: config.emission_shrinkage.label(),
             quality_profile: quality_profile.to_owned(),
         },
         graph: ScoreReportGraph {
@@ -3091,6 +3186,7 @@ pub fn build_score_report_with_quality_profile(
                    artifacts and reports"
                 .to_owned(),
         },
+        emission_selection_stats: info.emission_selection_stats,
     }
 }
 

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -627,6 +627,21 @@ pub struct ScoreWitness {
     pub census: OpKernel,
 }
 
+/// Which mechanism resolved an `ExactContext` selection (#362/#364
+/// attribution). Since the NGRAM context rows landed, an explicit
+/// bigram/trigram row hit and an EXCT full-depth probe resolution both
+/// report [`ScoreStatus::ExactContext`]; measurements that compare the
+/// exact-context slice across eras need to know which mechanism answered.
+/// `None` on outcomes whose status is not `ExactContext`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactContextSource {
+    /// An explicit NGRAM (bigram/trigram) context row supplied the token.
+    NgramRow,
+    /// The EXCT probe resolved at the full graded code with sufficient
+    /// support.
+    ExctProbe,
+}
+
 /// The outcome of [`GraphScorer::score_candidates`]: the selection plus
 /// every candidate's final score (ascending token order) — the certifier
 /// reads the distribution for bits/token; the witness stands alone.
@@ -642,6 +657,10 @@ pub struct ScoreOutcome {
     /// changes any decision, or whether ranking is carried by the root prior.
     pub candidate_components: Vec<(u32, i32, i32, bool)>,
     pub witness: ScoreWitness,
+    /// Attribution for `ExactContext` selections (`None` otherwise). Not
+    /// part of the replayable witness: provenance is measurement metadata,
+    /// so the witness bytes and kappa are untouched.
+    pub exact_context_source: Option<ExactContextSource>,
 }
 
 /// The outcome of [`GraphScorer::score_candidates_legacy`]: the
@@ -1130,6 +1149,7 @@ impl GraphScorer {
                 candidates: vec![(selected, selected_score)],
                 candidate_components: vec![(selected, selected_score.raw(), 0, false)],
                 witness,
+                exact_context_source: Some(ExactContextSource::NgramRow),
             });
         }
         let mut k = OpKernel::default();
@@ -1479,6 +1499,7 @@ impl GraphScorer {
             candidates: candidates_out,
             candidate_components: components,
             witness,
+            exact_context_source: exact_context.then_some(ExactContextSource::ExctProbe),
         })
     }
 
@@ -1697,6 +1718,9 @@ pub struct StepOutcome {
     pub candidate_count: u32,
     /// The op census of this step.
     pub census: OpKernel,
+    /// Attribution for `ExactContext` selections (`None` otherwise);
+    /// see [`ExactContextSource`].
+    pub exact_context_source: Option<ExactContextSource>,
 }
 
 /// Advance the step state's epoch, re-zeroing the stamp buffers on the
@@ -2031,6 +2055,7 @@ impl GraphScorer {
                 status: ScoreStatus::ExactContext,
                 candidate_count: 1,
                 census,
+                exact_context_source: Some(ExactContextSource::NgramRow),
             });
         }
         let mut k = OpKernel::default();
@@ -2224,6 +2249,7 @@ impl GraphScorer {
             status,
             candidate_count: state.touched.len() as u32,
             census: k,
+            exact_context_source: exact_context.then_some(ExactContextSource::ExctProbe),
         })
     }
 }
@@ -2509,5 +2535,25 @@ mod ngram_tests {
             Some((6, ScoreQ::from_raw(100)))
         );
         assert_eq!(scorer.context_prediction(&[30]), None);
+    }
+
+    /// #362 attribution: an NGRAM-row selection reports `NgramRow`
+    /// provenance, and a probe-free non-exact selection reports `None` —
+    /// the exact-context bucket stays attributable after context rows.
+    #[test]
+    fn exact_context_source_attributes_ngram_hits() {
+        let mut rows = BTreeMap::new();
+        rows.insert((1, 20, 0), vec![(6, ScoreQ::from_raw(100))]);
+        let scorer = scorer(rows);
+        let sig = [0u8; SIG_BYTES];
+        let outcome = scorer
+            .score_candidates_coded(&sig, None, &[10, 20])
+            .expect("ngram row scores");
+        assert_eq!(outcome.witness.status, ScoreStatus::ExactContext);
+        assert_eq!(
+            outcome.exact_context_source,
+            Some(ExactContextSource::NgramRow)
+        );
+        assert!(outcome.witness.exct.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,12 +718,13 @@ fn certify_serving_row() {
                     }
                 };
                 println!(
-                    "C serving (R4Engine + score.r4g1 + D4 policy, 80/20 story split, deterministic subsample n={}) bundle {}: served {} ({:.1}%; exact {}, graph {}, novel {}; {} widened) | abstained {} (exact {}, graph {}, novel {}, contradictory {}) | on served: top1 {:.1}% | agreement {:.1}% | overall top1 {:.1}% | probe: {}/{} served, {} hits",
+                    "C serving (R4Engine + score.r4g1 + D4 policy, 80/20 story split, deterministic subsample n={}) bundle {}: served {} ({:.1}%; exact {} ({} ngram), graph {}, novel {}; {} widened) | abstained {} (exact {}, graph {}, novel {}, contradictory {}) | on served: top1 {:.1}% | agreement {:.1}% | overall top1 {:.1}% | probe: {}/{} served, {} hits",
                     row.sample_n,
                     row.bundle.display(),
                     row.served,
                     pct(row.served, row.sample_n as u64),
                     row.served_by.exact_context,
+                    row.served_by.exact_context_ngram,
                     row.served_by.graph,
                     row.served_by.novel,
                     row.served_widened,

--- a/tests/status_policy.rs
+++ b/tests/status_policy.rs
@@ -42,6 +42,7 @@ fn ood_probe_widens_once_then_abstains_with_status_recorded() {
         PredictDecision::Abstain(AbstainOutcome {
             status: ScoreStatus::Novel,
             widened: true,
+            ngram_hit: false,
         }),
         "OOD input resolves Novel, widens once, then abstains"
     );
@@ -72,6 +73,7 @@ fn covered_probes_serve_with_exact_context_and_graph_status() {
             token: 10,
             status: ScoreStatus::ExactContext,
             widened: false,
+            ngram_hit: false,
         })
     );
 
@@ -86,6 +88,7 @@ fn covered_probes_serve_with_exact_context_and_graph_status() {
             token: 20,
             status: ScoreStatus::Graph,
             widened: false,
+            ngram_hit: false,
         })
     );
 
@@ -185,6 +188,7 @@ fn widen_once_bound_holds_for_repeated_novel_probes() {
         PredictDecision::Abstain(AbstainOutcome {
             status: ScoreStatus::Novel,
             widened: true,
+            ngram_hit: false,
         })
     );
     // A second identical Novel input does NOT widen again: the bounded
@@ -197,6 +201,7 @@ fn widen_once_bound_holds_for_repeated_novel_probes() {
         PredictDecision::Abstain(AbstainOutcome {
             status: ScoreStatus::Novel,
             widened: false,
+            ngram_hit: false,
         })
     );
     let counters = state.policy_counters();
@@ -257,6 +262,7 @@ fn adversarial_repetition_is_deterministic() {
                 token: 10,
                 status: ScoreStatus::ExactContext,
                 widened: false,
+                ngram_hit: false,
             })
         );
     }
@@ -400,6 +406,7 @@ fn override_abstain_on_novel_skips_widening() {
         PredictDecision::Abstain(AbstainOutcome {
             status: ScoreStatus::Novel,
             widened: false,
+            ngram_hit: false,
         })
     );
     assert_eq!(state.policy_counters().widen_attempts, 0);

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -171,6 +171,7 @@ fn hand_emissions() -> EmissionTables {
         smoothing: Smoothing::AddOne,
         root_prior_quantization: score::QuantizationErrorStats::default(),
         emission_quantization: score::QuantizationErrorStats::default(),
+        selection_stats: score::EmissionSelectionStats::default(),
     }
 }
 


### PR DESCRIPTION
## Attribution prerequisites for the #364 dual-track

Both #364 follow-on tracks (trigram-rows-as-replacement, cover-induction distinctiveness) are A/B measurements. Today the measurements are unattributable three ways; this PR closes the gaps with instrumentation only — **no artifact-byte or κ change, witness bytes untouched**.

1. **Report records the emission mode.** #366/#368/#370 are merged but opt-in, and `score_report.json` could not say which mode produced it. `config.emission_selection` / `config.emission_shrinkage` added (labels match the CLI strings).
2. **Contrast stats promoted from stderr into the report.** The per-region selection/contrast statistics (`[emission-selection]` stderr line) now land in the report as `emission_selection_stats` (normalized per-region means) — machine-readable, so contrast-distribution comparisons across covers stop being copy-paste.
3. **NGRAM row vs EXCT probe split.** Since #362, an explicit NGRAM row hit and an EXCT full-depth probe hit both report `ScoreStatus::ExactContext` — a per-status row post-#362 measures a different population than #358/#360 did. New `ExactContextSource` provenance (`NgramRow | ExctProbe`) threads scorer → `StepOutcome`/`ScoreOutcome` → api engine (`PredictOutcome.ngram_hit`) → C serving row (`StatusBreakdown.exact_context_ngram`, stdout line now prints `exact N (M ngram)`); Gate C splits `rule12_status_counts.exact_context` the same way.

`ScoreReport` schema 12 → 13 (additive, #293 convention). `ScoredGraphInfo` drops `Eq` (f64 means), keeps exact `PartialEq`.

Scoped gates green: fmt, clippy `--all-targets --all-features`, certify (all suites) / api / cli / status-policy tests.

Refs #364, #362. First of the dual-track series decided 2026-08-03; the context-row config knob (A/B enabler) and the induction distinctiveness term follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UJdEQFdckSK2et9G44jsm
