### PR TITLE
feat(score): #364 track A — context-row compile knobs (--context-order / --context-entries) enable the trigram A/B

### DIFF
--- a/crates/uor-r4-core/src/transformerless/cover_sweep.rs
+++ b/crates/uor-r4-core/src/transformerless/cover_sweep.rs
@@ -405,12 +405,8 @@ pub fn run_point(
     );
     let vocab = u32::try_from(inputs.artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
-    let context_rows = score::compile_context_rows(
-        &inputs.corpus,
-        &inputs.train,
-        vocab,
-        score_config.smoothing,
-    );
+    let context_rows =
+        score::compile_context_rows(&inputs.corpus, &inputs.train, vocab, score_config);
     let emissions = score::compile_emissions(
         &inputs.corpus,
         &inputs.store,

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -263,6 +263,8 @@ pub const DEFAULT_ROOT_TOP_B: usize = 64;
 pub const DEFAULT_EXCT_TOP_X: usize = 64;
 /// Default per-context candidate bound for packed bigram/trigram rows.
 pub const DEFAULT_CONTEXT_ENTRIES: usize = 64;
+/// Default highest compiled lexical context order (bigram + trigram).
+pub const DEFAULT_CONTEXT_ORDER: u8 = 2;
 /// Default held-out position count whose witnesses are replayed in Gate C.
 pub const DEFAULT_WITNESS_SAMPLE: usize = 64;
 
@@ -430,6 +432,16 @@ pub struct ScoreConfig {
     pub emission_selection: EmissionSelection,
     /// Per-region residual shrinkage (issue #364).
     pub emission_shrinkage: EmissionShrinkage,
+    /// Highest explicit lexical context order compiled into NGRAM rows:
+    /// 0 = no rows (geometric path serves everywhere), 1 = bigram only,
+    /// 2 = bigram + trigram (shipped default). The #364/#362 A/B knob:
+    /// rows take most-specific precedence over the geometric path at
+    /// serving, so "trigram rows as the replacement for emission
+    /// conditioning" vs "geometric everywhere" is a compile-time choice.
+    /// Non-default values change artifact bytes and kappa by design.
+    pub context_order: u8,
+    /// Per-context candidate bound for packed bigram/trigram rows.
+    pub context_entries: usize,
 }
 
 impl Default for ScoreConfig {
@@ -444,6 +456,8 @@ impl Default for ScoreConfig {
             scoring_variant: ScoringVariant::ChainTelescoped,
             emission_selection: EmissionSelection::default(),
             emission_shrinkage: EmissionShrinkage::default(),
+            context_order: DEFAULT_CONTEXT_ORDER,
+            context_entries: DEFAULT_CONTEXT_ENTRIES,
         }
     }
 }
@@ -629,8 +643,12 @@ pub fn compile_context_rows(
     corpus: &Corpus,
     train: &[Observation],
     vocab: u32,
-    smoothing: Smoothing,
+    config: &ScoreConfig,
 ) -> Vec<ContextRow> {
+    let smoothing = config.smoothing;
+    if config.context_order == 0 {
+        return Vec::new();
+    }
     let mut counts: BTreeMap<(u8, u32, u32), BTreeMap<u32, u64>> = BTreeMap::new();
     for observation in train {
         let i = observation.position as usize;
@@ -643,7 +661,7 @@ pub fn compile_context_rows(
             .or_default()
             .entry(corpus.next[i])
             .or_insert(0) += 1;
-        if i > 0 && corpus.story[i - 1] == corpus.story[i] {
+        if config.context_order >= 2 && i > 0 && corpus.story[i - 1] == corpus.story[i] {
             let trigram = (2, corpus.input[i - 1], corpus.input[i]);
             *counts
                 .entry(trigram)
@@ -666,7 +684,7 @@ pub fn compile_context_rows(
                 })
                 .collect();
             ranked.sort_by(|a, b| b.1.raw().cmp(&a.1.raw()).then_with(|| a.0.cmp(&b.0)));
-            ranked.truncate(DEFAULT_CONTEXT_ENTRIES);
+            ranked.truncate(config.context_entries);
             ranked.sort_by_key(|&(token, _)| token);
             ContextRow {
                 context_len,
@@ -2902,7 +2920,10 @@ fn evaluate_gate_c_row(
 /// per-region contrast/selection statistics (previously stderr-only)
 /// into the report, and `gate_c.rule12_status_counts` splits the
 /// exact-context bucket by resolving mechanism (NGRAM row vs EXCT
-/// probe) so post-#362 rows remain comparable with pre-#362 ones.
+/// probe) so post-#362 rows remain comparable with pre-#362 ones;
+/// 14 = context-row compile knobs (`config.context_order` /
+/// `config.context_entries`) recorded so NGRAM A/B bundles are
+/// attributable.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -2990,6 +3011,10 @@ pub struct ScoreReportConfig {
     /// The per-region residual shrinkage applied (#364;
     /// [`EmissionShrinkage::label`]).
     pub emission_shrinkage: String,
+    /// Highest compiled lexical context order (0 = no NGRAM rows).
+    pub context_order: u8,
+    /// Per-context candidate bound for the compiled NGRAM rows.
+    pub context_entries: usize,
     /// Quality-gate basis for this distribution. `pinned` applies the
     /// historical Gate C absolute floor; `relative_tla` only compares the
     /// graph with the TLA baseline measured on the same corpus.
@@ -3086,7 +3111,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 13,
+        schema: 14,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -3099,6 +3124,8 @@ pub fn build_score_report_with_quality_profile(
             smoothing: config.smoothing.label(),
             emission_selection: config.emission_selection.label(),
             emission_shrinkage: config.emission_shrinkage.label(),
+            context_order: config.context_order,
+            context_entries: config.context_entries,
             quality_profile: quality_profile.to_owned(),
         },
         graph: ScoreReportGraph {
@@ -3224,7 +3251,7 @@ fn smoothing_description(smoothing: Smoothing) -> String {
 
 #[cfg(test)]
 mod context_rows_tests {
-    use super::{compile_context_rows, Smoothing};
+    use super::{compile_context_rows, ScoreConfig};
     use uor_r4_core::transformerless::compiler::{Corpus, SIG_BYTES};
     use uor_r4_graph_compiler::induction::Observation;
 
@@ -3259,7 +3286,7 @@ mod context_rows_tests {
                 next: corpus.next[position],
             })
             .collect();
-        let rows = compile_context_rows(&corpus, &observations, 100, Smoothing::AddOne);
+        let rows = compile_context_rows(&corpus, &observations, 100, &ScoreConfig::default());
         assert!(rows
             .iter()
             .any(|row| { row.context_len == 2 && row.key0 == 10 && row.key1 == 20 }));
@@ -3269,6 +3296,43 @@ mod context_rows_tests {
         assert!(!rows
             .iter()
             .any(|row| { row.context_len == 2 && row.key0 == 20 && row.key1 == 30 }));
+    }
+
+    /// The #362 A/B knob: order 0 compiles no rows, order 1 compiles
+    /// bigram rows only, and the entries bound truncates per row.
+    #[test]
+    fn context_order_gates_row_compilation() {
+        let corpus = corpus();
+        let observations: Vec<Observation> = (0..corpus.n)
+            .map(|position| Observation {
+                position: position as u32,
+                sample: [0; 32],
+                vector: Vec::new(),
+                sig: [0; SIG_BYTES],
+                prev: corpus.input[position],
+                next: corpus.next[position],
+            })
+            .collect();
+        let off = ScoreConfig {
+            context_order: 0,
+            ..ScoreConfig::default()
+        };
+        assert!(compile_context_rows(&corpus, &observations, 100, &off).is_empty());
+
+        let bigram_only = ScoreConfig {
+            context_order: 1,
+            ..ScoreConfig::default()
+        };
+        let rows = compile_context_rows(&corpus, &observations, 100, &bigram_only);
+        assert!(!rows.is_empty());
+        assert!(rows.iter().all(|row| row.context_len == 1));
+
+        let bounded = ScoreConfig {
+            context_entries: 1,
+            ..ScoreConfig::default()
+        };
+        let rows = compile_context_rows(&corpus, &observations, 100, &bounded);
+        assert!(rows.iter().all(|row| row.entries.len() <= 1));
     }
 }
 

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -746,6 +746,8 @@ struct ScoreOptions {
     emission_entries: usize,
     emission_selection: score::EmissionSelection,
     emission_shrinkage: score::EmissionShrinkage,
+    context_order: u8,
+    context_entries: usize,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -767,6 +769,8 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         emission_entries: score::DEFAULT_EMISSION_ENTRIES,
         emission_selection: score::EmissionSelection::default(),
         emission_shrinkage: score::EmissionShrinkage::default(),
+        context_order: score::DEFAULT_CONTEXT_ORDER,
+        context_entries: score::DEFAULT_CONTEXT_ENTRIES,
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -826,6 +830,25 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                     .map_err(|_| format!("invalid --emission-entries value: {value}"))?;
                 if options.emission_entries == 0 {
                     return Err("--emission-entries must be at least 1".to_owned());
+                }
+            }
+            "--context-order" => {
+                options.context_order = value
+                    .parse()
+                    .map_err(|_| format!("invalid --context-order value: {value}"))?;
+                if options.context_order > 2 {
+                    return Err(
+                        "--context-order must be 0 (no NGRAM rows), 1 (bigram), or 2                          (bigram + trigram, default)"
+                            .to_owned(),
+                    );
+                }
+            }
+            "--context-entries" => {
+                options.context_entries = value
+                    .parse()
+                    .map_err(|_| format!("invalid --context-entries value: {value}"))?;
+                if options.context_entries == 0 {
+                    return Err("--context-entries must be at least 1".to_owned());
                 }
             }
             "--root-top-b" => {
@@ -968,6 +991,8 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         scoring_variant: options.scoring_variant,
         emission_selection: options.emission_selection,
         emission_shrinkage: options.emission_shrinkage,
+        context_order: options.context_order,
+        context_entries: options.context_entries,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records
@@ -1066,7 +1091,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     );
     let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
-    let context_rows = score::compile_context_rows(&corpus, &train, vocab, config.smoothing);
+    let context_rows = score::compile_context_rows(&corpus, &train, vocab, &config);
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
     let fmm_section = score::compile_fmm_section(&regions, &emissions, vocab)?;
@@ -2630,6 +2655,8 @@ mod tests {
         assert_eq!(options.emission_entries, score::DEFAULT_EMISSION_ENTRIES);
         assert_eq!(options.emission_selection, score::EmissionSelection::Ratio);
         assert_eq!(options.emission_shrinkage, score::EmissionShrinkage::None);
+        assert_eq!(options.context_order, score::DEFAULT_CONTEXT_ORDER);
+        assert_eq!(options.context_entries, score::DEFAULT_CONTEXT_ENTRIES);
         assert_eq!(options.root_top_b, score::DEFAULT_ROOT_TOP_B);
         assert_eq!(options.exct_top_x, score::DEFAULT_EXCT_TOP_X);
         assert_eq!(options.witness_sample, score::DEFAULT_WITNESS_SAMPLE);


### PR DESCRIPTION
## #364 Track A: the context-row compile knob — makes the trigram A/B runnable

Since #362, NGRAM rows compile **unconditionally** and take most-specific precedence over the geometric path at serving. The #364 verdict positions trigram rows as a candidate *replacement* for emission conditioning (geometric path retained for routing) — but that comparison could not be run: there was no way to build a rows-free bundle.

- `ScoreConfig.context_order`: **0** = no NGRAM rows (geometric path serves everywhere), **1** = bigram only, **2** = bigram + trigram (default); `ScoreConfig.context_entries` (default 64). **Defaults reproduce the shipped artifact byte-exactly**; non-default values change artifact bytes and κ by design — that is the A/B.
- CLI: `--context-order` / `--context-entries` beside the emission flags, validated; `cover_sweep` call site updated.
- `score_report.json` records both knobs (schema 13 → 14, additive) so A/B bundles stay attributable — continuing #371's discipline; with #371's `exact_context_ngram` split, the two bundle rows decompose cleanly.
- New unit test pins the order gating (0 → empty, 1 → bigram-only, entries bound); CLI defaults test extended.

The A/B itself (default bundle vs `--context-order 0` bundle on the fixture corpus, rule12 + per-status rows) follows once this lands.

Refs #364, #362. Second PR of the dual-track series; Track B (cover-sweep × contrast shrinkage, then induction distinctiveness term) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UJdEQFdckSK2et9G44jsm
