### PR TITLE
feat(runtime): #247 — pinned multi-turn fixture, ROUT calibration, session lane admitted as secondary fallback probe

### DIFF
--- a/crates/uor-r4-graph-runtime/benches/session_signature.rs
+++ b/crates/uor-r4-graph-runtime/benches/session_signature.rs
@@ -19,12 +19,60 @@ use uor_r4_graph_compiler::{
     },
 };
 use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_format::SectionId;
 use uor_r4_graph_runtime::R4G1Runtime;
-use uor_r4_router::session_signature_from_tokens;
+use uor_r4_router::{fixture_session_signatures, session_signature_from_tokens};
 
 const DEFAULT_ROOT: &str = ".uor-models/compiled/smollm2-135m-instruct";
 const DEFAULT_SAMPLE: usize = 256;
 const WINDOW: usize = compiler::WINDOW;
+
+/// Minimum masked-Hamming distance of `sig` against every node's ROUT
+/// prototype, plus whether any node admits it within the engine's radius
+/// rule (`max(radius, 120)` — the same floor the ROUT fallback applies).
+/// Mirrors the fallback scan in `engine.rs` byte for byte.
+fn rout_distance(runtime: &R4G1Runtime, sig: &[u8]) -> (u32, bool, f64) {
+    let view = runtime.view();
+    let rout_bytes = view.section(SectionId::ROUT).unwrap_or(&[]);
+    let num_nodes = runtime.node_count();
+    let mut best = u32::MAX;
+    let mut within = false;
+    let mut best_ratio = f64::INFINITY;
+    for n in 1..num_nodes {
+        if let Some(node) = view.node(n) {
+            let proto_offset = (node.prototype_word_start as usize) << 3;
+            let mask_offset = (node.mask_word_start as usize) << 3;
+            if proto_offset + sig.len() <= rout_bytes.len()
+                && mask_offset + sig.len() <= rout_bytes.len()
+            {
+                let mut dist = 0u32;
+                for (i, &s) in sig.iter().enumerate() {
+                    let p = rout_bytes[proto_offset + i];
+                    let m = rout_bytes[mask_offset + i];
+                    dist += ((s ^ p) & m).count_ones();
+                }
+                let rad = u32::from(node.radius.0).max(120);
+                if dist <= rad {
+                    within = true;
+                }
+                let ratio = dist as f64 / rad as f64;
+                if ratio < best_ratio {
+                    best_ratio = ratio;
+                }
+                best = best.min(dist);
+            }
+        }
+    }
+    (best, within, best_ratio)
+}
+
+fn median(values: &mut [f64]) -> f64 {
+    if values.is_empty() {
+        return f64::NAN;
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).expect("finite ratios"));
+    values[values.len() / 2]
+}
 
 fn load_probability_metadata(
     probability_dir: Option<&Path>,
@@ -86,7 +134,10 @@ fn alternate_history(history: &[u32]) -> Vec<u32> {
 }
 
 fn main() -> Result<(), String> {
-    let mut args = env::args().skip(1).filter(|arg| arg != "--bench");
+    let rout_calibration = env::args().any(|arg| arg == "--rout-calibration");
+    let mut args = env::args()
+        .skip(1)
+        .filter(|arg| arg != "--bench" && arg != "--rout-calibration");
     let root = PathBuf::from(args.next().unwrap_or_else(|| DEFAULT_ROOT.to_owned()));
     let sample_target = args
         .next()
@@ -140,6 +191,8 @@ fn main() -> Result<(), String> {
     let rotations = compiler::derive_rotations();
     let mut node_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
 
+    let mut context_within = 0u64;
+    let mut context_ratios: Vec<f64> = Vec::new();
     let mut context_hits = 0u64;
     let mut session_hits = 0u64;
     let mut context_teacher_hits = 0u64;
@@ -154,6 +207,11 @@ fn main() -> Result<(), String> {
         let alternate = alternate_history(&history);
         let bundle = runtime::bundle_window_plain(&artifacts, &rotations, &context);
         let context_signature = runtime::sig_plain(&artifacts, &bundle);
+        if rout_calibration {
+            let (_, within, ratio) = rout_distance(&runtime, &context_signature);
+            context_within += u64::from(within);
+            context_ratios.push(ratio);
+        }
         let session_signature = session_signature_from_tokens(&history);
         let alternate_signature = session_signature_from_tokens(&alternate);
 
@@ -289,6 +347,59 @@ fn main() -> Result<(), String> {
             "probability_metadata=unavailable (pass an observation directory containing manifest.json and *.prob sidecars)"
         ),
         (Some(_), None) => unreachable!("non-empty samples produce entropy quartiles"),
+    }
+
+    if rout_calibration {
+        // #247 decision measurement: are the ROUT fallback prototypes
+        // calibrated for session-space inputs? Session signatures come from
+        // the pinned multi-turn fixture through the SHIPPED path
+        // (index_corpus -> evolve_state -> session_signature_from_state);
+        // the reference population is the context signatures of the same
+        // held-out sample. Declared criterion (issue #247, posted before
+        // this run): the session lane may enter ROUT fallback only if the
+        // session within-radius fraction reaches at least half the context
+        // fraction AND the session lane's teacher agreement above is not
+        // below the context lane's.
+        let session_sigs = fixture_session_signatures();
+        let mut session_within = 0u64;
+        let mut session_ratios: Vec<f64> = Vec::new();
+        for sig in &session_sigs {
+            let (_, within, ratio) = rout_distance(&runtime, sig);
+            session_within += u64::from(within);
+            session_ratios.push(ratio);
+        }
+        let context_fraction = context_within as f64 / count;
+        let session_fraction = session_within as f64 / session_sigs.len() as f64;
+        println!(
+            "rout_calibration_context_within_radius={context_within}/{}",
+            positions.len()
+        );
+        println!(
+            "rout_calibration_session_within_radius={session_within}/{}",
+            session_sigs.len()
+        );
+        println!(
+            "rout_calibration_context_median_dist_over_radius={:.4}",
+            median(&mut context_ratios)
+        );
+        println!(
+            "rout_calibration_session_median_dist_over_radius={:.4}",
+            median(&mut session_ratios)
+        );
+        let admit = session_fraction >= 0.5 * context_fraction
+            && session_teacher_hits >= context_teacher_hits;
+        println!(
+            "rout_calibration_verdict={} (session_fraction {:.4} vs 0.5*context_fraction {:.4}; session_teacher {} vs context_teacher {})",
+            if admit {
+                "ADMIT-CANDIDATE"
+            } else {
+                "KEEP-BIAS-ONLY"
+            },
+            session_fraction,
+            0.5 * context_fraction,
+            session_teacher_hits,
+            context_teacher_hits,
+        );
     }
     Ok(())
 }

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -116,6 +116,65 @@ impl<'a> R4G1Runtime<'a> {
             .map_err(|e| RuntimeError::Patch(alloc::borrow::Cow::Borrowed(e)))
     }
 
+    /// One ROUT probe: query `sig` against the per-node prototypes/masks
+    /// (VP-tree when built, linear scan otherwise), filling `active_nodes`
+    /// with the within-radius matches (<= 8) and returning
+    /// `(nearest_node, within_radius_count)`. Extracted from the fallback
+    /// block so the #247 session-lane admission reuses the identical scan.
+    fn rout_probe(
+        &self,
+        base_graph: &uor_r4_graph_format::GraphView<'_>,
+        sig: &[u8],
+        active_nodes: &mut [u32],
+    ) -> (u32, usize) {
+        if let Some(index) = self.route_index.as_ref() {
+            let mut matched_nodes = [0u32; 8];
+            let (best_node, _best_dist, active_count) = index.query(sig, &mut matched_nodes);
+            active_nodes[..active_count].copy_from_slice(&matched_nodes[..active_count]);
+            (best_node, active_count)
+        } else {
+            let num_nodes = base_graph.node_count().unwrap_or(0);
+            let mut best_node = 0;
+            let mut best_dist = u32::MAX;
+            let mut active_count = 0usize;
+            let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
+
+            for n in 1..num_nodes {
+                if let Some(node) = base_graph.node(n) {
+                    let proto_offset = (node.prototype_word_start as usize) << 3;
+                    let mask_offset = (node.mask_word_start as usize) << 3;
+
+                    if proto_offset + sig.len() <= rout_bytes.len()
+                        && mask_offset + sig.len() <= rout_bytes.len()
+                    {
+                        let mut dist = 0u32;
+                        for (i, &s) in sig.iter().enumerate() {
+                            let p = rout_bytes[proto_offset + i];
+                            let m = rout_bytes[mask_offset + i];
+                            dist += ((s ^ p) & m).count_ones();
+                        }
+
+                        if dist < best_dist {
+                            best_dist = dist;
+                            best_node = n;
+                        }
+
+                        // Collect Quantum MoE ensemble nodes matching distance threshold
+                        let rad = u32::from(node.radius.0).max(120);
+                        if dist <= rad
+                            && active_count < 8
+                            && !active_nodes[..active_count].contains(&n)
+                        {
+                            active_nodes[active_count] = n;
+                            active_count += 1;
+                        }
+                    }
+                }
+            }
+            (best_node, active_count)
+        }
+    }
+
     pub fn view(&self) -> &GraphView<'a> {
         self.chain.base_graph()
     }
@@ -550,12 +609,14 @@ impl<'a> R4G1Runtime<'a> {
 
     /// Predict with separate context and session signatures.
     ///
-    /// The context signature remains the only input to ROUT fallback, so
-    /// enabling the session lane starts as a bias-only experiment. The
-    /// optional session signature participates in the existing emission
-    /// affinity bonus below; callers can later opt it into ROUT after an
-    /// evaluation establishes that the fallback prototypes are calibrated
-    /// for session-space inputs.
+    /// The context signature keeps primacy in ROUT fallback. Since the
+    /// #247 calibration (recorded on the issue: pinned multi-turn fixture
+    /// signatures through the shipped quantizer land 24/24 within ROUT
+    /// radii; declared admission criterion met), the session signature is
+    /// consulted as the SECONDARY fallback probe — only when the context
+    /// probe admits nothing within any calibrated radius. The session
+    /// signature also participates in the emission affinity bonus below,
+    /// unchanged.
     pub fn predict_distribution_with_signature_lanes(
         &self,
         context_tokens: &[u32],
@@ -664,55 +725,35 @@ impl<'a> R4G1Runtime<'a> {
         // Geometric Routing Fallback (Phase 6 & 8)
         // If the suffix DFA fell off the manifold, use the continuous 288-bit VSA signature
         // to find the top-M semantic regions N_best (N_best <= 8) to jump back onto the graph!
-        if (active_len == 0 || (active_len == 1 && active_nodes[0] == 0))
-            && let Some(sig) = context_signature
-        {
-            let (best_node, active_count) = if let Some(index) = self.route_index.as_ref() {
-                let mut matched_nodes = [0u32; 8];
-                let (best_node, _best_dist, active_count) = index.query(sig, &mut matched_nodes);
-                active_nodes[..active_count].copy_from_slice(&matched_nodes[..active_count]);
-                (best_node, active_count)
-            } else {
-                let mut best_node = 0;
-                let mut best_dist = u32::MAX;
-                let mut active_count = 0usize;
-                let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
-
-                for n in 1..num_nodes {
-                    if let Some(node) = base_graph.node(n) {
-                        let proto_offset = (node.prototype_word_start as usize) << 3;
-                        let mask_offset = (node.mask_word_start as usize) << 3;
-
-                        if proto_offset + sig.len() <= rout_bytes.len()
-                            && mask_offset + sig.len() <= rout_bytes.len()
-                        {
-                            let mut dist = 0u32;
-                            for i in 0..sig.len() {
-                                let p = rout_bytes[proto_offset + i];
-                                let m = rout_bytes[mask_offset + i];
-                                let s = sig[i];
-                                dist += ((s ^ p) & m).count_ones();
-                            }
-
-                            if dist < best_dist {
-                                best_dist = dist;
-                                best_node = n;
-                            }
-
-                            // Collect Quantum MoE ensemble nodes matching distance threshold
-                            let rad = u32::from(node.radius.0).max(120);
-                            if dist <= rad
-                                && active_count < 8
-                                && !active_nodes[..active_count].contains(&n)
-                            {
-                                active_nodes[active_count] = n;
-                                active_count += 1;
-                            }
-                        }
-                    }
+        //
+        // #247 admission (calibration recorded on the issue: fixture session
+        // signatures land 24/24 within ROUT radii through the shipped
+        // quantizer): the context signature keeps primacy, and the SESSION
+        // signature is consulted as the secondary probe only when the context
+        // probe admits nothing within any calibrated radius (previously such
+        // positions routed via the nearest out-of-radius prototype or fell
+        // through to Novel). Within-radius session routing beats
+        // outside-radius context routing by the radius rule's own semantics.
+        if active_len == 0 || (active_len == 1 && active_nodes[0] == 0) {
+            let mut best_node = 0u32;
+            let mut active_count = 0usize;
+            if let Some(sig) = context_signature {
+                (best_node, active_count) = self.rout_probe(base_graph, sig, &mut active_nodes);
+            }
+            if active_count == 0
+                && let Some(sig) = session_signature
+            {
+                let mut session_nodes = [0u32; 64];
+                let (session_best, session_count) =
+                    self.rout_probe(base_graph, sig, &mut session_nodes);
+                if session_count > 0 {
+                    active_nodes[..session_count].copy_from_slice(&session_nodes[..session_count]);
+                    best_node = session_best;
+                    active_count = session_count;
+                } else if best_node == 0 {
+                    best_node = session_best;
                 }
-                (best_node, active_count)
-            };
+            }
 
             if active_count > 0 {
                 active_len = active_count;

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -213,38 +213,72 @@ fn r4g1_runtime_enforces_no_float_in_prediction_path() {
 }
 
 #[test]
-fn session_signature_is_bias_only_until_routing_is_calibrated() {
+fn session_signature_enters_rout_fallback_as_secondary_probe() {
+    // #247 decision (calibration recorded on the issue): the session lane
+    // is admitted to ROUT fallback as the SECONDARY probe — consulted only
+    // when the context probe admits nothing within a calibrated radius.
+    // Contract pinned here: (1) context primacy — with a context signature
+    // whose probe lands within-radius actives, differing session
+    // signatures cannot change routing; (2) session participation — with
+    // NO context signature, the session lane alone drives the fallback and
+    // the prediction is deterministic per signature.
     let (art_bytes, artifacts) = fixture_artifacts();
     let store = synthetic_store();
     let store_bytes = runtime::store_bytes(&store);
     let (r4g1_bytes, _) =
         convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None).unwrap();
     let runtime = R4G1Runtime::parse(&r4g1_bytes).unwrap();
-    let context_signature = [0x55u8; 36];
     let zero_session = [0u8; 36];
     let full_session = [0xffu8; 36];
 
-    let mut zero_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
-    let mut full_scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
-    let zero = runtime.predict_distribution_with_signature_lanes(
+    // (2) session-only fallback: deterministic, and repeatable per signature.
+    let mut scores_a = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let mut scores_b = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let zero_once = runtime.predict_distribution_with_signature_lanes(
         &[3, 1, 4],
-        Some(&context_signature),
+        None,
         Some(&zero_session),
-        &mut zero_scores,
+        &mut scores_a,
+    );
+    let zero_again = runtime.predict_distribution_with_signature_lanes(
+        &[3, 1, 4],
+        None,
+        Some(&zero_session),
+        &mut scores_b,
+    );
+    assert_eq!(
+        zero_once, zero_again,
+        "session-driven fallback is deterministic"
     );
     let full = runtime.predict_distribution_with_signature_lanes(
         &[3, 1, 4],
+        None,
+        Some(&full_session),
+        &mut scores_b,
+    );
+    assert!(zero_once.1 >= ScoreQ::MIN);
+    assert!(full.1 >= ScoreQ::MIN);
+
+    // (1) context primacy: a context probe that lands within-radius actives
+    // (the all-zero signature matches the synthetic store's zero prototype)
+    // is not perturbed by the session lane.
+    let context_signature = [0u8; 36];
+    let with_zero = runtime.predict_distribution_with_signature_lanes(
+        &[3, 1, 4],
+        Some(&context_signature),
+        Some(&zero_session),
+        &mut scores_a,
+    );
+    let with_full = runtime.predict_distribution_with_signature_lanes(
+        &[3, 1, 4],
         Some(&context_signature),
         Some(&full_session),
-        &mut full_scores,
+        &mut scores_b,
     );
-
     assert_eq!(
-        zero.0, full.0,
-        "session lane must not change ROUT fallback yet"
+        with_zero.0, with_full.0,
+        "context primacy: within-radius context routing is not changed by the session lane"
     );
-    assert!(zero.1 >= ScoreQ::MIN);
-    assert!(full.1 >= ScoreQ::MIN);
 }
 
 #[test]

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -18,7 +18,8 @@ pub mod geometry;
 pub mod session_signature;
 
 pub use session_signature::{
-    from_state as session_signature_from_state, from_tokens as session_signature_from_tokens,
+    fixture_session_signatures, from_state as session_signature_from_state,
+    from_tokens as session_signature_from_tokens, MULTI_TURN_FIXTURE,
 };
 
 pub use fallback::{

--- a/crates/uor-r4-router/src/session_signature.rs
+++ b/crates/uor-r4-router/src/session_signature.rs
@@ -83,3 +83,99 @@ mod tests {
         assert_eq!(from_tokens(&[]), [0; SESSION_SIGNATURE_BYTES]);
     }
 }
+
+/// Pinned multi-turn fixture (issue #247): six deterministic conversations,
+/// four turns each. The text is original to this fixture. Determinism is
+/// guarded by `session_signature::tests::fixture_evolution_is_deterministic`
+/// (two independently constructed routers produce identical signatures), so
+/// the fixture is pinned by construction rather than by golden bytes that
+/// would drift with deliberate vocabulary-representation changes.
+pub const MULTI_TURN_FIXTURE: [[&str; 4]; 6] = [
+    [
+        "Where does the water table sit under the northern ridge this season?",
+        "The survey said the aquifer runs deeper past the second borehole.",
+        "Then route the drilling plan around the ridge and log the depth readings.",
+        "Agreed. Schedule the crew for the dry months and archive the coordinates.",
+    ],
+    [
+        "Explain how the router picks an expert window for a new prompt.",
+        "So the deficit angle decides whether the wave stays trapped or scatters?",
+        "Show me a prompt whose orbit stays symmetric across all scale windows.",
+        "Now perturb one word and tell me which resonance changes first.",
+    ],
+    [
+        "I want to compare two compression runs from last week.",
+        "The second run kept more probability mass in the emission lists.",
+        "Plot the contrast distribution for both and mark the coarse regions.",
+        "Keep the finer cover and re-run the certification overnight.",
+    ],
+    [
+        "Draft a short note about the meeting tomorrow morning.",
+        "Add a reminder about the budget review and the travel forms.",
+        "Actually move the meeting to the afternoon and copy the field team.",
+        "Send it and file the old draft under the project archive.",
+    ],
+    [
+        "What does the coherence measure tell us about a noisy prompt?",
+        "If kappa drops, does the state vector drift off the hypersphere?",
+        "Give an example where two sessions diverge from the same prompt.",
+        "Summarize the divergence in one sentence for the log.",
+    ],
+    [
+        "List the steps to index a new corpus into the manifold.",
+        "How long until the new vocabulary settles into stable coordinates?",
+        "Index the field manual next and keep the identities separate.",
+        "Verify the retrieval quality before switching the default corpus.",
+    ],
+];
+
+/// Deterministic evolution gamma for the fixture. The server derives gamma
+/// dynamically from kappa (src/server.rs); the fixture pins the midpoint so
+/// the measurement is reproducible.
+const FIXTURE_GAMMA: f64 = 0.5;
+
+/// Session signatures from the pinned fixture through the SHIPPED path:
+/// `UorR4Router::new` -> `index_corpus` -> `evolve_state` per turn ->
+/// `session_signature_from_state`. One signature per turn per transcript.
+pub fn fixture_session_signatures() -> Vec<[u8; SESSION_SIGNATURE_BYTES]> {
+    let mut router = crate::UorR4Router::new(0.85);
+    let mut signatures = Vec::with_capacity(MULTI_TURN_FIXTURE.len() * 4);
+    for (index, transcript) in MULTI_TURN_FIXTURE.iter().enumerate() {
+        let identity = format!("fixture-{index}");
+        let joined = transcript.join(" ");
+        router.index_corpus(&joined, &identity);
+        for turn in transcript {
+            router.evolve_state(&identity, turn, FIXTURE_GAMMA);
+            signatures.push(from_state(&router.get_brain_state_native(&identity)));
+        }
+    }
+    signatures
+}
+
+#[cfg(test)]
+mod fixture_tests {
+    use super::*;
+
+    /// The #247 pinned fixture is deterministic by construction: two
+    /// independently constructed routers, evolved over the same pinned
+    /// transcripts, produce byte-identical session signatures. This is the
+    /// pin — golden bytes would silently invalidate on any deliberate
+    /// representation change, while double-construction equality catches
+    /// exactly the nondeterminism that would corrupt the #247 measurement.
+    #[test]
+    fn fixture_evolution_is_deterministic() {
+        let first = fixture_session_signatures();
+        let second = fixture_session_signatures();
+        assert_eq!(first, second, "fixture evolution must be deterministic");
+        assert_eq!(first.len(), MULTI_TURN_FIXTURE.len() * 4);
+        // The signatures must carry information: not all-zero, and turns
+        // must move the state (adjacent turns of one transcript differ).
+        assert!(first.iter().any(|sig| sig.iter().any(|&b| b != 0)));
+        assert!(
+            first
+                .chunks(4)
+                .all(|turns| turns.windows(2).any(|w| w[0] != w[1])),
+            "every transcript must produce at least one state change across turns"
+        );
+    }
+}


### PR DESCRIPTION
## #247: pinned multi-turn fixture, calibration measurement, and the ROUT admission decision — measured, then flipped conservatively

Closes the remaining DoD item ("evaluation extended so the lane is measured") and takes the decision it was for.

**Fixture:** six pinned multi-turn transcripts evolved through the **shipped** path (`UorR4Router::new` → `index_corpus` → `evolve_state` → `session_signature_from_state`, pinned γ=0.5) — the #344 bench had only ever exercised the `from_tokens` client fallback, never the deployed manifold quantizer. Determinism pinned by double-construction equality, not golden bytes (which would silently invalidate on any deliberate representation change).

**Measurement** (`--rout-calibration` mode on the session bench; declared criterion posted to #247 before the run; fixture bundle, 515 held-out positions):

| | result |
|---|---|
| session sigs within ROUT radius | **24/24** (median dist/radius 0.928; context reference 515/515 at 0.765) |
| bias-lane token changes | 0/515 (teacher agreement identical, 227 = 227; 1 score change) |
| verdict per declared criterion | **ADMIT-CANDIDATE** |

Reading: the fallback prototypes **are** calibrated for session-space inputs, and the bias lane is inert wherever context routing already works — so the lane's entire value lives on fallback traffic, which is exactly where admission acts.

**Decision (conservative):** context signature keeps primacy; the session signature becomes the **secondary** fallback probe, consulted only when the context probe admits nothing within any calibrated radius — positions that previously routed via the nearest out-of-radius prototype or fell to Novel. `rout_probe` extracted (byte-identical scan) so both lanes share one implementation. The bias-only contract test is replaced by `session_signature_enters_rout_fallback_as_secondary_probe` (context primacy + deterministic session-only fallback), per the #315 guard's own "until calibrated" wording.

Runtime kernel contract untouched (XOR/AND/popcount/compare). Gates from cleaned targets: fmt, clippy `--all-targets --all-features`, full workspace tests.

Closes #247. Refs #315, #344, #350, #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UJdEQFdckSK2et9G44jsm
