### PR TITLE
research: track the #290 §5.1/§5.2 far-field pipeline

### DIFF
--- a/research/290-fmm/README.md
+++ b/research/290-fmm/README.md
@@ -1,0 +1,91 @@
+# §5.1 / §5.2 far-field analysis (issue #290)
+
+Tracked deliberately. The original §5.1 analysis lived in an untracked
+`scratch/fmm_rank/` and was destroyed by a working-tree cleanup, leaving a
+published result with no reproducible pipeline behind it. Nothing here goes back
+in `scratch/`.
+
+## Contents
+
+| file | role |
+| --- | --- |
+| `fmm_dump.rs` | extractor — re-induces the cover and dumps vectors / sigs / prototypes / members |
+| `validate_51.py` | rebuilt analysis; reproduces §5.1's published figures as an acceptance gate |
+
+## Running
+
+`fmm_dump.rs` targets the **compile-era API at commit `9d95961`** and does not
+build against current `main`. Run it from a worktree pinned there, as a
+`uor-r4-graph-compiler` example:
+
+```
+# from a worktree at 9d95961, with the example placed in
+# crates/uor-r4-graph-compiler/examples/
+B=.uor-models/compiled/SmolLM2-135M-Instruct-7e27bd9f9532
+cargo run --release --example fmm_dump -- \
+    "$B/corpus.meta" "$B/corpus.records" "$B/tless_artifacts.bin" <out_dir>
+
+python3 validate_51.py <out_dir> --eta 1.0
+```
+
+The dump self-verifies against three pinned kappas and the region census, and
+**exits non-zero rather than emitting a usable dump** if reproduction fails.
+`validate_51.py` refuses to analyze a dump whose `reproduction_verified` is
+false. Do not weaken either check.
+
+## Reproduction status (2026-08-02)
+
+The dump reproduces bit-for-bit:
+
+```
+artifact_kappa blake3:c0916469…  MATCH
+corpus_kappa   blake3:74491d1d…  MATCH
+cover_kappa    blake3:67d957c3…  MATCH
+regions 362, per_depth [16, 30, 58, 98, 160], n_train 159658
+```
+
+Analysis vs the figures published in the #290 §5.1 comment:
+
+| figure | published | rebuilt | |
+| --- | ---: | ---: | --- |
+| admissible pairs, depths 1–5 (η=1.0) | 2 / 5 / 16 / 29 / 87 | 2 / 5 / 16 / 29 / 87 | exact |
+| r(1e-2) at n=1024 | 20.5 | 20.0 | ±1 |
+| r(1e-3) at n=1024 | 134.0 | 132.0 | ±2 |
+| r(1e-4) at n=1024 | 274.5 | 273.0 | ±2 |
+| growth exponents | 0.11 / 0.45 / 0.64 | 0.119 / 0.438 / 0.637 | ≤0.012 |
+| null control at n=1024 | 57 / 198 / 287 | 58 / 198 / 287 | ±1 |
+| pairs in exponent fit | **37** | **79** | unreconciled |
+
+Every §5.1 conclusion reproduces: rank flat at ~20 for ε=1e-2 across a 32× block
+range, sub-proportional ~n^0.44 growth at 1e-3, ambient saturation at 1e-4, and
+admissible blocks sitting ~2.9× below the unstructured null at 1e-2.
+
+### Two rebuild details worth keeping
+
+**`diam` is taken over full membership.** Subsampling to ≤1024 rows applies to
+block construction only. A first rebuild computed the q95 member angular radius
+on the subsample, which shifted the admissibility threshold and produced 27 / 85
+at depths 4 and 5 instead of 29 / 87 — the depths with the largest regions.
+Getting this wrong is silent and only shows up as a small pair-count drift.
+
+**The exponent-fit pair count does not match and was left alone.** Requiring the
+full nested ladder (both regions ≥1024 members) yields 79 pairs; §5.1 reports 37.
+The original filter is unrecoverable — `analyze.py` is gone. Since the exponents
+agree to ≤0.012 and no §5.1 conclusion depends on the count, this is recorded as
+an open discrepancy rather than tuned until 37 falls out. Fitting the filter to
+reproduce a pair count would be fitting to a number, not reproducing a method.
+
+### Spurious numpy warnings
+
+`RuntimeWarning: overflow/invalid/divide by zero encountered in matmul` appears
+on macOS with numpy 2.x over Accelerate. The data is clean — 0 non-finite entries
+across 159658×288, no zero-norm rows, max |value| 0.71 — and unit-normalized
+float64 cannot overflow. Verified, not suppressed blindly.
+
+## §5.2
+
+Criteria are pre-registered in the #290 thread before any numbers: the primary
+measurement is the **Graph status slice** (n = 15,080, currently 1.23% top-1),
+not the blended figure, which is ~half ExactContext rows that a far-field
+operator cannot affect. Per §7 the next implementation step is baseline 4
+(ℋ-matrix / HODLR), not full FMM.

--- a/research/290-fmm/RESULT-52.md
+++ b/research/290-fmm/RESULT-52.md
@@ -1,0 +1,125 @@
+## §5.2 gate — negative. The far-field operator cannot reach usable precision, and there is no asymptotic win to buy.
+
+Per §10 ("a recorded answer either way"), recording a negative. This is the
+offline precision check that **gates** §5.2's accuracy measurement, not §5.2
+itself: held-out top-1 / bits-token on the Graph slice was never run, because the
+precondition it rests on — that a compressed far field reproduces the
+interaction operator at a stated tolerance — fails first. Nothing was built into
+the deployed path, the artifact format, or the kernel; total cost was one SVD per
+admissible pair.
+
+### Method
+
+Measurement-only, on the same bit-for-bit cover as §5.1 (`cover_kappa
+blake3:67d957c3…`, 362 regions, 159,658 train observations; all three pinned
+kappas re-verified). Admissible pairs recomputed and matching §5.1 exactly:
+**2 / 5 / 16 / 29 / 87** at depths 1–5, η = 1.0.
+
+Error is measured against the **truncated SVD**, which by Eckart–Young is the
+optimal rank-k approximation. That makes every number here an *upper bound on
+achievable quality*: any practical scheme — ACA, cross approximation,
+interpolatory bases — does worse. If optimal rank-k misses, nothing cheaper hits.
+
+Reported quantity is operator error, `||Kx − K̃x|| / ||Kx||`, median over 79
+admissible pairs at n = 1024 with 32 random right-hand sides. An ℋ-matrix is
+*applied*; Frobenius error of an isolated block would flatter the result.
+
+### Numbers
+
+| rank | cosine: rel Frobenius | σ_k/σ₁ | **rel matvec** | sign-bit: rel Frobenius | σ_k/σ₁ | **rel matvec** |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 (monopole) | 10.81% | 5.32% | **15.02%** | 6.88% | 3.07% | **10.29%** |
+| 8 | 6.28% | 1.84% | **8.97%** | 4.72% | 0.95% | **6.97%** |
+| 16 | 4.55% | 1.12% | **6.64%** | 4.13% | 0.67% | **6.05%** |
+| 20 | 4.04% | 0.92% | **5.97%** | 3.93% | 0.61% | **5.82%** |
+| 32 | 2.98% | 0.63% | **4.53%** | 3.44% | 0.50% | **4.98%** |
+| 64 | 1.61% | 0.30% | **2.45%** | 2.53% | 0.34% | **3.68%** |
+
+Rank 1 reproduces §5.1's monopole figure (σ₂/σ₁ = 5.32%, against the recorded
+5–7%), and σ₂₁/σ₁ = 0.92% reproduces `r(1e-2) ≈ 20` exactly. The pipeline agrees
+with §5.1 wherever the two overlap.
+
+### Finding 1 — `r(ε) ≈ 20` is not a 1% error budget
+
+`r(ε) = #{σᵢ ≥ ε·σ₁}` counts spectrum above a threshold. It was never an error
+bound, and the two differ by ~6× here: at rank 20 the *next* singular value is
+0.92% of the first, while discarding the tail costs 4.0% Frobenius and **~6%
+operator error**.
+
+My own §5.2 pre-registration earlier in this thread inherited that ambiguity
+when it wrote "a ~1%-precise, rank-~20 far field." Those are two different
+quantities. Correcting it here: there is no rank at which this far field is 1%
+precise without approaching the ambient dimension.
+
+Against the bar that matters, rank 20 beats the Barnes-Hut monopole by only
+**2.5× (cosine) / 1.8× (sign-bit)** — for the whole M2L apparatus, admissibility
+bookkeeping, and compile-time translation tables.
+
+### Finding 2 — the kernel is already globally low-rank, so there is no O(n²) to remove
+
+This is the structural objection and it does not depend on any tolerance.
+
+The interaction block, as §5.1 operationally defines it, is
+
+```
+K_AB = V_A V_Bᵀ
+```
+
+an inner product of L2-normalized threshold-centered context bundles in
+D = 288 dimensions. It is therefore **exactly rank ≤ 288 by construction** —
+§5.1 already noted this ceiling in passing, observing r(1e-4) ≈ 275 approaching
+it. The exact operator application factors by associativity:
+
+```
+K x = V_A (V_Bᵀ x)        cost O((n_A + n_B)·D), exact, no approximation
+```
+
+FMM exists to accelerate kernels such as 1/r that are *not* globally low rank;
+its win comes from replacing a dense O(n²) interaction that has no exact
+factorization. Here the interaction is an inner-product kernel that already has
+one. Any far-field operator must therefore beat rank 288 to earn anything at all,
+and at rank 64 the error is still 2.5–3.7% — roughly 4.5× compression at a
+precision no one pre-registered as acceptable. Driving error toward 1% pushes the
+rank back toward the ambient dimension, where the compression vanishes.
+
+The premise in §2 — "three of the six FMM stages are already built" — holds. What
+does not hold is the assumption that the missing stage buys an asymptotic
+improvement. Against this kernel it buys a constant factor bounded by D, and
+§5.4 already flagged constant factors as "the usual assassin."
+
+### Incidental correction to §5.1
+
+§5.1 recorded the deployed sign-bit / masked-Hamming geometry as ~2× worse than
+cosine (median rank 266–279 vs 134 at 1e-3) and inferred that binarization
+destroys low-rank structure. In **reconstruction-error** terms that does not
+hold: 5.82% vs 5.97% at rank 20, essentially identical, and sign-bit is *better*
+at rank 1 (10.29% vs 15.02%). The ~2× gap is real in rank counts and absent in
+error. The #230-style concern is not supported by this measurement.
+
+### What this does and does not kill
+
+**Killed:** FMM / ℋ-matrix / HODLR far-field aggregation over this interaction
+object. Per §7 the sequencing was ℋ-matrix before FMM precisely so this could be
+answered cheaply; it has been, and full FMM does not need evaluating.
+
+**Not killed:** the §3a motivation. Long-range context remains a real gap — the
+graph-path slice sits at 1.23% top-1 (#234's closure names it "the number to
+improve"). This result says a far-field operator over the semantic Gram is not
+the mechanism, not that the goal is wrong.
+
+### Caveat on Finding 2
+
+It rests on the interaction object being the Gram block of 288-dim bundles, which
+is how §5.1 operationalized it and how a far field would be constructed. If the
+intended object is something else — a kernel that is not an inner product of
+bounded-dimension vectors — the associativity argument does not transfer and this
+should be re-examined. Flagging rather than asserting it as settled.
+
+### Reproduction
+
+Branch `issue-290-hmatrix-prototype`, `research/290-fmm/` — `fmm_dump.rs`
+(extractor, self-verifying against the pinned kappas), `validate_51.py` (§5.1
+reproduction gate), `hmatrix_proto.py` (this measurement). Tracked deliberately:
+the original §5.1 analysis lived in an untracked scratch directory and was
+destroyed by a working-tree cleanup, which is why the reproduction status and
+both known discrepancies are written into the README rather than left implicit.

--- a/research/290-fmm/fmm_dump.rs
+++ b/research/290-fmm/fmm_dump.rs
@@ -1,0 +1,146 @@
+//! FMM §5.1 data dump (issue #290): reproduce the cover that produced
+//! `.uor-models/compiled/SmolLM2-135M-Instruct-7e27bd9f9532/graph-cover/cover.r4g1`
+//! bit-for-bit (verified via the pinned kappas in cover_report.json),
+//! then dump train observation vectors, sign signatures, region
+//! prototypes, radii and top-1 member lists for offline SVD analysis.
+//!
+//! Usage: fmm_dump <corpus_meta> <corpus_recs> <artifacts> <out_dir>
+
+use std::fs;
+use std::path::Path;
+
+use uor_r4_core::transformerless::compiler;
+use uor_r4_graph_compiler::induction;
+
+fn main() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 5 {
+        return Err("usage: fmm_dump <corpus_meta> <corpus_recs> <artifacts> <out_dir>".into());
+    }
+    let artifact_container = fs::read(&args[3]).map_err(|e| format!("{}: {e}", args[3]))?;
+    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let meta_bytes = fs::read(&args[1]).map_err(|e| e.to_string())?;
+    let recs_bytes = fs::read(&args[2]).map_err(|e| e.to_string())?;
+    let mut h = blake3::Hasher::new();
+    h.update(&meta_bytes);
+    h.update(&recs_bytes);
+    let corpus_kappa = format!("blake3:{}", h.finalize().to_hex());
+
+    let corpus = compiler::load_corpus_from(&args[1], &args[2])
+        .ok_or_else(|| "corpus incomplete".to_owned())?;
+    let artifacts = compiler::parse_artifacts(&artifact_container)
+        .ok_or_else(|| "not a TLA3/TLA4/TLA5 artifact container".to_owned())?;
+
+    // Config pinned by graph-cover/cover_report.json (schema 1).
+    let config = induction::CoverConfig {
+        depths: 5,
+        k0: 16,
+        regions_budget: 2048,
+        memory_budget_bytes: 2147483648,
+        threads: 8,
+        min_support: 32,
+        entropy_gain_bits: 0.1,
+        radius_quantile_numerator: 80,
+        radius_quantile_denominator: 100,
+    };
+    let (train_positions, _held_out) = induction::split_positions(&corpus);
+    eprintln!("building {} train observations...", train_positions.len());
+    let train = induction::build_observations(&artifacts, &corpus, &train_positions);
+    eprintln!("inducing cover...");
+    let induced = induction::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)?;
+    let cover_kappa = induced.cover.kappa();
+
+    // Verification against the pinned report values.
+    let per_depth: Vec<usize> = (1..=induced.cover.max_depth)
+        .map(|d| induced.cover.regions_at_depth(d).len())
+        .collect();
+    let checks = [
+        ("artifact_kappa", artifact_kappa.as_str(), "blake3:c09164697949ec7189b58b0ad83713ac30565a59f6a8637afab571baa88e3567"),
+        ("corpus_kappa", corpus_kappa.as_str(), "blake3:74491d1d80f426f675a35f22a98e6ca0a7de83bbfd1f87bcb9ad763ebe96f12a"),
+        ("cover_kappa", cover_kappa.as_str(), "blake3:67d957c3bdfae5d78697e484faeb553c3a137d2b848e9fb69758c52853aba651"),
+    ];
+    let mut ok = true;
+    for (name, got, want) in checks {
+        let pass = got == want;
+        ok &= pass;
+        eprintln!("check {name}: {got} {} (pinned {want})", if pass { "MATCH" } else { "MISMATCH" });
+    }
+    eprintln!(
+        "regions: total {} per_depth {:?} (pinned 362 / [16, 30, 58, 98, 160])",
+        induced.cover.regions.len(),
+        per_depth
+    );
+    ok &= induced.cover.regions.len() == 362 && per_depth == [16, 30, 58, 98, 160];
+
+    // Dump.
+    let out = Path::new(&args[4]);
+    fs::create_dir_all(out).map_err(|e| e.to_string())?;
+    let d = compiler::D;
+    let n = train.len();
+
+    let mut vbuf = Vec::with_capacity(n * d * 4);
+    for o in &train {
+        for &x in &o.vector {
+            vbuf.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    fs::write(out.join("vectors.bin"), &vbuf).map_err(|e| e.to_string())?;
+
+    let mut sbuf = Vec::with_capacity(n * compiler::SIG_BYTES);
+    for o in &train {
+        sbuf.extend_from_slice(&o.sig);
+    }
+    fs::write(out.join("sigs.bin"), &sbuf).map_err(|e| e.to_string())?;
+
+    let regions = &induced.cover.regions;
+    let mut pbuf = Vec::with_capacity(regions.len() * d * 4);
+    for r in regions {
+        for &x in &r.prototype {
+            pbuf.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    fs::write(out.join("prototypes.bin"), &pbuf).map_err(|e| e.to_string())?;
+
+    let regions_json: Vec<serde_json::Value> = regions
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.id,
+                "depth": r.depth,
+                "parent": r.parent,
+                "radius": r.radius,
+                "support": r.support,
+                "members": induced.cover.members[r.id as usize],
+            })
+        })
+        .collect();
+    let meta = serde_json::json!({
+        "d": d,
+        "sig_bytes": compiler::SIG_BYTES,
+        "n_train": n,
+        "n_regions": regions.len(),
+        "max_depth": induced.cover.max_depth,
+        "artifact_kappa": artifact_kappa,
+        "corpus_kappa": corpus_kappa,
+        "cover_kappa": cover_kappa,
+        "per_depth": per_depth,
+        "reproduction_verified": ok,
+    });
+    fs::write(
+        out.join("regions.json"),
+        serde_json::to_string(&regions_json).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+    fs::write(
+        out.join("meta.json"),
+        serde_json::to_string_pretty(&meta).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    eprintln!("dump complete; reproduction_verified = {ok}");
+    if ok {
+        Ok(())
+    } else {
+        Err("reproduction checks FAILED — do not use this dump".into())
+    }
+}

--- a/research/290-fmm/hmatrix_proto.py
+++ b/research/290-fmm/hmatrix_proto.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""§5.2 offline prototype: can a rank-k far field reproduce the scores? (#290)
+
+Measurement only. Nothing here touches the deployed path or the artifact format
+-- §5.1 showed compressibility is a ~1%-tolerance phenomenon that vanishes by
+1e-4, so the cheapest place to kill this proposal is offline, before any M2L
+machinery or compile-time tables exist.
+
+What is measured, and why this ordering:
+
+1. **Optimal rank-k block error** via truncated SVD. By Eckart-Young this is the
+   best any rank-k approximation can do, so it is an upper bound on every
+   practical scheme (ACA, cross approximation, interpolatory). If optimal rank-20
+   cannot reach ~1%, no cheaper method will, and the proposal dies here for the
+   cost of one SVD per admissible pair.
+2. **Monopole (Barnes-Hut) baseline** at rank 1 -- the bar §5.1 recorded at
+   sigma_2/sigma_1 ~ 5-7%. Any FMM/H-matrix machinery must beat this by enough to
+   justify itself.
+3. **Operator error, not just block error.** An H-matrix is applied, so the
+   quantity that matters downstream is ||Kx - K~x|| / ||Kx|| for the far-field
+   aggregation, not the Frobenius error of an isolated block.
+4. **Both kernels.** Cosine is the geometry §5.1 measured; the DEPLOYED kernel is
+   sign-bit / masked-Hamming, which §5.1 found ~2x worse at 1e-3 (median rank
+   266-279 vs 134). A far field that only works in cosine is not deployable, and
+   the #230 precedent says mul-free surrogates have already cost us structure
+   once.
+
+Usage: hmatrix_proto.py <dump_dir> [--eta 1.0] [--ranks 1,8,16,20,32,64]
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+import numpy as np
+
+NESTED_N = 1024
+MATVEC_SEED = 290502  # distinct from §5.1's null-control seed (290501)
+MATVEC_TRIALS = 32
+
+
+def load(dump_dir: pathlib.Path):
+    meta = json.loads((dump_dir / "meta.json").read_text())
+    if not meta.get("reproduction_verified"):
+        sys.exit("dump reports reproduction_verified = false; refusing to analyze")
+    d = meta["d"]
+    regions = json.loads((dump_dir / "regions.json").read_text())
+    vectors = np.fromfile(dump_dir / "vectors.bin", dtype="<f4").reshape(-1, d)
+    prototypes = np.fromfile(dump_dir / "prototypes.bin", dtype="<f4").reshape(-1, d)
+    sigs = np.fromfile(dump_dir / "sigs.bin", dtype=np.uint8).reshape(
+        -1, meta["sig_bytes"]
+    )
+    return meta, regions, vectors, prototypes, sigs
+
+
+def l2_normalize(mat: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return mat / norms
+
+
+def member_angular_radius(units: np.ndarray, prototype: np.ndarray) -> float:
+    p = prototype / (np.linalg.norm(prototype) or 1.0)
+    return 2.0 * float(np.quantile(np.arccos(np.clip(units @ p, -1.0, 1.0)), 0.95))
+
+
+def admissible_pairs(regions, protos, units, full_members, eta):
+    """arccos(<p_A,p_B>) > eta * max(diam); diam over FULL membership.
+
+    The full-membership scope is load-bearing: computing the q95 radius on the
+    subsample shifts the threshold and silently changes which pairs qualify.
+    See README.md.
+    """
+    diam = {
+        r["id"]: (
+            member_angular_radius(units[full_members[r["id"]]], protos[r["id"]])
+            if full_members[r["id"]].size
+            else 0.0
+        )
+        for r in regions
+    }
+    by_depth: dict[int, list[int]] = {}
+    for r in regions:
+        by_depth.setdefault(r["depth"], []).append(r["id"])
+    out = []
+    for depth, ids in sorted(by_depth.items()):
+        for i, a in enumerate(ids):
+            for b in ids[i + 1:]:
+                sep = np.arccos(np.clip(float(protos[a] @ protos[b]), -1.0, 1.0))
+                if sep > eta * max(diam[a], diam[b]):
+                    out.append((depth, a, b))
+    return out
+
+
+def sign_bit_kernel(sig_a: np.ndarray, sig_b: np.ndarray) -> np.ndarray:
+    """Deployed geometry: masked Hamming similarity over packed sign bits.
+
+    Returned as a similarity in [0,1] (1 - normalized Hamming distance) so its
+    spectrum is comparable to the cosine Gram block.
+    """
+    bits_a = np.unpackbits(sig_a, axis=1).astype(np.float64)
+    bits_b = np.unpackbits(sig_b, axis=1).astype(np.float64)
+    nbits = bits_a.shape[1]
+    # Hamming distance via inner products on +-1 encoding.
+    pm_a = 2.0 * bits_a - 1.0
+    pm_b = 2.0 * bits_b - 1.0
+    agree = (pm_a @ pm_b.T + nbits) / 2.0
+    return agree / nbits
+
+
+def block_errors(block: np.ndarray, ranks, rng) -> dict:
+    u, sv, vt = np.linalg.svd(block, full_matrices=False)
+    fro = float(np.linalg.norm(sv))
+    if fro == 0.0:
+        return {}
+    x = rng.standard_normal((block.shape[1], MATVEC_TRIALS))
+    exact = block @ x
+    exact_norm = np.linalg.norm(exact, axis=0)
+    exact_norm[exact_norm == 0.0] = 1.0
+
+    out = {}
+    for k in ranks:
+        kk = min(k, sv.size)
+        approx = (u[:, :kk] * sv[:kk]) @ vt[:kk]
+        tail = float(np.linalg.norm(sv[kk:])) if kk < sv.size else 0.0
+        rel_fro = tail / fro
+        rel_spec = float(sv[kk] / sv[0]) if kk < sv.size else 0.0
+        rel_mv = float(
+            np.median(np.linalg.norm(exact - approx @ x, axis=0) / exact_norm)
+        )
+        out[k] = (rel_fro, rel_spec, rel_mv)
+    return out
+
+
+def summarize(label, per_pair, ranks):
+    print(f"\n=== {label} ===")
+    print(f"{'rank':>5} | {'rel Frobenius':>14} | {'sigma_k/sigma_1':>15} | "
+          f"{'rel matvec':>12}")
+    print("-" * 56)
+    for k in ranks:
+        fr = [p[k][0] for p in per_pair if k in p]
+        sp = [p[k][1] for p in per_pair if k in p]
+        mv = [p[k][2] for p in per_pair if k in p]
+        if not fr:
+            continue
+        print(f"{k:>5} | {np.median(fr):13.4%} | {np.median(sp):14.4%} | "
+              f"{np.median(mv):11.4%}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump_dir", type=pathlib.Path)
+    ap.add_argument("--eta", type=float, default=1.0)
+    ap.add_argument("--ranks", default="1,8,16,20,32,64")
+    args = ap.parse_args()
+    ranks = [int(x) for x in args.ranks.split(",")]
+
+    meta, regions, vectors, protos_raw, sigs = load(args.dump_dir)
+    print(f"dump n_train={meta['n_train']} regions={meta['n_regions']}")
+    print(f"cover_kappa={meta['cover_kappa']}")
+
+    units = l2_normalize(vectors.astype(np.float64))
+    protos = l2_normalize(protos_raw.astype(np.float64))
+    full_members = {r["id"]: np.asarray(r["members"], dtype=np.int64) for r in regions}
+
+    pairs = admissible_pairs(regions, protos, units, full_members, args.eta)
+    print(f"admissible pairs (eta={args.eta}): {len(pairs)}")
+
+    usable = [
+        (d, a, b)
+        for d, a, b in pairs
+        if full_members[a].size >= NESTED_N and full_members[b].size >= NESTED_N
+    ]
+    print(f"pairs with >= {NESTED_N} members on both sides: {len(usable)}")
+
+    rng = np.random.default_rng(MATVEC_SEED)
+    cos_pairs, sig_pairs = [], []
+    for _, a, b in usable:
+        ma = full_members[a][:NESTED_N]
+        mb = full_members[b][:NESTED_N]
+        cos_block = units[ma] @ units[mb].T
+        e = block_errors(cos_block, ranks, rng)
+        if e:
+            cos_pairs.append(e)
+        e2 = block_errors(sign_bit_kernel(sigs[ma], sigs[mb]), ranks, rng)
+        if e2:
+            sig_pairs.append(e2)
+
+    summarize(f"cosine kernel (n={NESTED_N}, {len(cos_pairs)} pairs)", cos_pairs, ranks)
+    summarize(
+        f"DEPLOYED sign-bit/masked-Hamming kernel (n={NESTED_N}, {len(sig_pairs)} pairs)",
+        sig_pairs,
+        ranks,
+    )
+
+    print("\nReading guide:")
+    print("  rank 1 == monopole / Barnes-Hut baseline (§5.1 recorded 5-7%).")
+    print("  'rel matvec' is the operator error a far-field aggregation incurs;")
+    print("  it is the number §5.2 accuracy claims must ultimately rest on.")
+    print("  A far field usable only in cosine is not deployable: the shipped")
+    print("  kernel is the sign-bit one (§5.1: ~2x worse at 1e-3; cf. #230).")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/290-fmm/validate_51.py
+++ b/research/290-fmm/validate_51.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Reproduce the §5.1 published numbers from a fresh `fmm_dump` (issue #290).
+
+§5.1's original analysis lived in an untracked scratch directory and was lost to
+a working-tree cleanup. The extractor (`fmm_dump.rs`) survived; this rebuilds the
+analysis side and checks it against the figures already published in the issue,
+so §5.2 is not built on an unvalidated pipeline.
+
+Targets from the #290 §5.1 comment (cosine kernel, eta = 1.0):
+
+  admissible same-depth pairs   2 / 5 / 16 / 29 / 87   at depths 1..5
+  within-pair nested medians, r(eps) at n = 1024:
+      eps=1e-2 -> ~20.5      eps=1e-3 -> ~134.0     eps=1e-4 -> ~274.5
+  median growth exponents      0.11 / 0.45 / 0.64
+  null control at n = 1024     57 / 198 / 287        (seed 290501)
+
+Operational definitions restated from the issue:
+
+  interaction block  submatrix of the semantic Gram matrix K(x,y) = <v(x),v(y)>
+                     over the cover's top-1 partition, on L2-normalized
+                     threshold-centered context bundles
+  admissibility      arccos(<p_A,p_B>) > eta * max(diam), diam = 2 * q95 of
+                     member angular radius
+  numerical rank     r(eps) = #{sigma_i >= eps * sigma_1}
+
+Usage: validate_51.py <dump_dir> [--eta 1.0]
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+import numpy as np
+
+EPSILONS = (1e-2, 1e-3, 1e-4)
+NESTED_SIZES = (32, 64, 128, 256, 512, 1024)
+NULL_SEED = 290501
+MAX_BLOCK_ROWS = 1024
+
+
+def load(dump_dir: pathlib.Path):
+    meta = json.loads((dump_dir / "meta.json").read_text())
+    if not meta.get("reproduction_verified"):
+        sys.exit("dump reports reproduction_verified = false; refusing to analyze")
+    d = meta["d"]
+    regions = json.loads((dump_dir / "regions.json").read_text())
+    vectors = np.fromfile(dump_dir / "vectors.bin", dtype="<f4").reshape(-1, d)
+    prototypes = np.fromfile(dump_dir / "prototypes.bin", dtype="<f4").reshape(-1, d)
+    if vectors.shape[0] != meta["n_train"]:
+        sys.exit(f"vectors.bin has {vectors.shape[0]} rows, meta says {meta['n_train']}")
+    if prototypes.shape[0] != meta["n_regions"]:
+        sys.exit("prototypes.bin row count disagrees with meta")
+    return meta, regions, vectors, prototypes
+
+
+def l2_normalize(mat: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return mat / norms
+
+
+def numerical_rank(block: np.ndarray) -> dict:
+    # Gram blocks are symmetric PSD only when A == B; use plain SVD for the
+    # general off-diagonal case.
+    sv = np.linalg.svd(block, compute_uv=False)
+    if sv.size == 0 or sv[0] == 0.0:
+        return {eps: 0 for eps in EPSILONS}
+    return {eps: int(np.count_nonzero(sv >= eps * sv[0])) for eps in EPSILONS}
+
+
+def member_angular_radius(unit_vectors: np.ndarray, prototype: np.ndarray) -> float:
+    """diam = 2 * q95 of member angular distance to the region prototype."""
+    p = prototype / (np.linalg.norm(prototype) or 1.0)
+    cos = np.clip(unit_vectors @ p, -1.0, 1.0)
+    return 2.0 * float(np.quantile(np.arccos(cos), 0.95))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump_dir", type=pathlib.Path)
+    ap.add_argument("--eta", type=float, default=1.0)
+    args = ap.parse_args()
+
+    meta, regions, vectors, prototypes = load(args.dump_dir)
+    print(f"dump: n_train={meta['n_train']} regions={meta['n_regions']} "
+          f"per_depth={meta['per_depth']}")
+    print(f"cover_kappa={meta['cover_kappa']}")
+
+    units = l2_normalize(vectors.astype(np.float64))
+    protos = l2_normalize(prototypes.astype(np.float64))
+
+    by_depth: dict[int, list[int]] = {}
+    for r in regions:
+        by_depth.setdefault(r["depth"], []).append(r["id"])
+
+    # Subsampling applies to BLOCK CONSTRUCTION only. The q95 member angular
+    # radius that sets admissibility is taken over full membership: computing it
+    # on the subsample shifts the threshold and changes which pairs qualify,
+    # which is where a first rebuild diverged from §5.1 at depths 4 and 5 (the
+    # depths with the largest regions).
+    full_members = {r["id"]: np.asarray(r["members"], dtype=np.int64) for r in regions}
+    members = {}
+    for rid, m in full_members.items():
+        if m.size > MAX_BLOCK_ROWS:
+            stride = m.size / MAX_BLOCK_ROWS
+            idx = (np.arange(MAX_BLOCK_ROWS) * stride).astype(np.int64)
+            m = m[idx]
+        members[rid] = m
+
+    diam = {}
+    for r in regions:
+        m = full_members[r["id"]]
+        diam[r["id"]] = (
+            member_angular_radius(units[m], protos[r["id"]]) if m.size else 0.0
+        )
+
+    print(f"\n=== admissible same-depth pairs (eta = {args.eta}) ===")
+    admissible: list[tuple[int, int, int]] = []
+    for depth in sorted(by_depth):
+        ids = by_depth[depth]
+        count = 0
+        for i, a in enumerate(ids):
+            for b in ids[i + 1:]:
+                sep = np.arccos(np.clip(float(protos[a] @ protos[b]), -1.0, 1.0))
+                if sep > args.eta * max(diam[a], diam[b]):
+                    admissible.append((depth, a, b))
+                    count += 1
+        total = len(ids) * (len(ids) - 1) // 2
+        pct = 100.0 * count / total if total else 0.0
+        print(f"  depth {depth}: {count} / {total} pairs ({pct:.2f}%)")
+
+    if not admissible:
+        print("\nno admissible pairs; nothing further to measure")
+        return
+
+    print(f"\n=== within-pair nested scaling ({len(admissible)} pairs) ===")
+    rows: dict[int, dict[float, list[int]]] = {
+        n: {eps: [] for eps in EPSILONS} for n in NESTED_SIZES
+    }
+    slopes: dict[float, list[float]] = {eps: [] for eps in EPSILONS}
+
+    for depth, a, b in admissible:
+        ma, mb = members[a], members[b]
+        # §5.1 fits growth over the full nested ladder; a pair qualifies only
+        # if both regions reach the largest block size. Accepting short ladders
+        # inflates the pair count (103 vs the published 37) and biases the
+        # median exponent toward small-n behavior.
+        usable = [n for n in NESTED_SIZES if ma.size >= n and mb.size >= n]
+        if len(usable) != len(NESTED_SIZES):
+            continue
+        per_eps: dict[float, list[tuple[int, int]]] = {eps: [] for eps in EPSILONS}
+        for n in usable:
+            block = units[ma[:n]] @ units[mb[:n]].T
+            ranks = numerical_rank(block)
+            for eps in EPSILONS:
+                rows[n][eps].append(ranks[eps])
+                per_eps[eps].append((n, ranks[eps]))
+        for eps in EPSILONS:
+            pts = [(n, r) for n, r in per_eps[eps] if r > 0]
+            if len(pts) >= 3:
+                xs = np.log(np.array([p[0] for p in pts], dtype=float))
+                ys = np.log(np.array([p[1] for p in pts], dtype=float))
+                slopes[eps].append(float(np.polyfit(xs, ys, 1)[0]))
+
+    print(f"{'n':>6} | " + " | ".join(f"r({e:g})".rjust(12) for e in EPSILONS))
+    for n in NESTED_SIZES:
+        cells = []
+        for eps in EPSILONS:
+            vals = rows[n][eps]
+            if vals:
+                med = float(np.median(vals))
+                cells.append(f"{med:6.1f} ({med / n:4.2f})")
+            else:
+                cells.append(" " * 12)
+        print(f"{n:>6} | " + " | ".join(cells))
+
+    print("\n=== median growth exponents (log-log slope of r vs n) ===")
+    for eps in EPSILONS:
+        if slopes[eps]:
+            print(f"  eps={eps:g}: n^{float(np.median(slopes[eps])):.3f} "
+                  f"({len(slopes[eps])} pairs)")
+
+    print(f"\n=== null control (random subsets, n = {MAX_BLOCK_ROWS}, "
+          f"seed {NULL_SEED}) ===")
+    rng = np.random.default_rng(NULL_SEED)
+    total = units.shape[0]
+    null: dict[float, list[int]] = {eps: [] for eps in EPSILONS}
+    for _ in range(16):
+        ia = rng.choice(total, size=MAX_BLOCK_ROWS, replace=False)
+        ib = rng.choice(total, size=MAX_BLOCK_ROWS, replace=False)
+        ranks = numerical_rank(units[ia] @ units[ib].T)
+        for eps in EPSILONS:
+            null[eps].append(ranks[eps])
+    for eps in EPSILONS:
+        print(f"  eps={eps:g}: median r = {float(np.median(null[eps])):.1f}")
+
+    print("\nCompare against the §5.1 figures in the docstring before using this "
+          "pipeline for §5.2.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Records the #290 §5.1/§5.2 far-field investigation as a tracked, reproducible
pipeline. Research artifacts only — no crate, runtime, or artifact changes.

## Why tracked

The original §5.1 analysis lived in an untracked `scratch/fmm_rank/` and was
destroyed by a working-tree cleanup, leaving a published result on #290 with no
reproducible pipeline behind it. The extractor survived only in a preserved
worktree. Nothing here goes back in `scratch/`.

## Contents

| file | role |
| --- | --- |
| `fmm_dump.rs` | extractor — re-induces the cover, dumps vectors/sigs/prototypes/members |
| `validate_51.py` | rebuilt analysis; reproduces §5.1's published figures as an acceptance gate |
| `hmatrix_proto.py` | §5.2 offline precision gate |
| `README.md` | reproduction status, including two known discrepancies |
| `RESULT-52.md` | the §5.2 negative, as posted to #290 |

## Reproduction status

The dump reproduces **bit-for-bit** — `artifact_kappa`, `corpus_kappa`, and
`cover_kappa blake3:67d957c3…` all MATCH, 362 regions, per_depth
[16, 30, 58, 98, 160], 159,658 observations. It exits non-zero rather than
emitting a usable dump if any check fails, and `validate_51.py` refuses to
analyze a dump whose `reproduction_verified` is false.

Analysis against the figures published on #290:

| figure | published | rebuilt |
| --- | ---: | ---: |
| admissible pairs, depths 1–5 (η=1.0) | 2 / 5 / 16 / 29 / 87 | **exact match** |
| r(1e-2) / r(1e-3) / r(1e-4) at n=1024 | 20.5 / 134.0 / 274.5 | 20.0 / 132.0 / 273.0 |
| growth exponents | 0.11 / 0.45 / 0.64 | 0.119 / 0.438 / 0.637 |
| null control | 57 / 198 / 287 | 58 / 198 / 287 |
| pairs in exponent fit | **37** | **79** — unreconciled |

Two rebuild details are written into the README rather than left implicit: `diam`
must be taken over **full** membership (computing it on the subsample shifts
admissibility and gives 27/85 instead of 29/87 at depths 4–5), and the
exponent-fit pair count does not match — the original filter is unrecoverable, the
exponents agree to ≤0.012, and it is recorded as an open discrepancy rather than
tuned until 37 falls out.

## §5.2 result

`RESULT-52.md` records the negative: measured against the optimal truncated SVD
(Eckart–Young, so an upper bound on any practical scheme), rank-20 operator error
is ~6%, not the ~1% the pre-registration assumed — `r(ε)` counts spectrum above a
threshold and was never an error bound. Structurally, the interaction block is
`V_A V_Bᵀ`, exactly rank ≤ D = 288 by construction, so the exact matvec already
factors in O((n_A+n_B)·D) and a far field buys a constant factor bounded by D
rather than an asymptotic win.

Scoped explicitly to that object: #356's scorer compresses graph prototypes
against emission residuals, which the associativity argument does not cover. The
reconciliation is on #290.

Related: #290, #356, #359, #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
