### PR TITLE
feat(certify): #381 — sweepable repetition penalty (schema 16): the windowed 10pp cost is 100% the penalty, 0% the window

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -432,6 +432,13 @@ pub struct ScoreConfig {
     pub emission_selection: EmissionSelection,
     /// Per-region residual shrinkage (issue #364).
     pub emission_shrinkage: EmissionShrinkage,
+    /// Repetition-suppression penalty magnitude in raw ScoreQ units
+    /// (#381; <= 0). Applied by the scorer when a candidate token appears
+    /// in the recent-token window — which, on Gate C, only happens under
+    /// the #375 window mode. Default is the shipped constant; the knob
+    /// exists to SWEEP the measured ~10pp windowed top-1 cost, not to
+    /// change serving (serving keeps the scorer default).
+    pub repetition_penalty_raw: i32,
     /// Opt-in #375: Gate C rows evaluate with a real story-bounded
     /// recent-token window (up to the scorer's 32-token cap) instead of
     /// the historical empty window. With the window on, NGRAM context
@@ -468,6 +475,7 @@ impl Default for ScoreConfig {
             context_order: DEFAULT_CONTEXT_ORDER,
             context_entries: DEFAULT_CONTEXT_ENTRIES,
             gate_c_context_window: false,
+            repetition_penalty_raw: super::score_runtime::DEFAULT_REPETITION_PENALTY_RAW,
         }
     }
 }
@@ -2058,6 +2066,7 @@ pub fn evaluate_gate_c(
         GraphScorer::from_artifact(r4g1, None, config.root_top_b, config.exct_top_x)?;
     scorer_no_exct.set_f_emissions(true);
     scorer_no_exct.set_scoring_variant(config.scoring_variant);
+    scorer_no_exct.set_repetition_penalty_raw(config.repetition_penalty_raw);
     let mut scorer_with_exct = GraphScorer::from_artifact(
         r4g1,
         Some(artifact_container),
@@ -2066,11 +2075,13 @@ pub fn evaluate_gate_c(
     )?;
     scorer_with_exct.set_f_emissions(true);
     scorer_with_exct.set_scoring_variant(config.scoring_variant);
+    scorer_with_exct.set_repetition_penalty_raw(config.repetition_penalty_raw);
     // Ablation scorers (issue #66): identical configs with ΔT emissions off
     // (the deployed default since the ablation decision).
     let mut scorer_no_exct_no_f =
         GraphScorer::from_artifact(r4g1, None, config.root_top_b, config.exct_top_x)?;
     scorer_no_exct_no_f.set_scoring_variant(config.scoring_variant);
+    scorer_no_exct_no_f.set_repetition_penalty_raw(config.repetition_penalty_raw);
     let mut scorer_with_exct_no_f = GraphScorer::from_artifact(
         r4g1,
         Some(artifact_container),
@@ -2078,6 +2089,7 @@ pub fn evaluate_gate_c(
         config.exct_top_x,
     )?;
     scorer_with_exct_no_f.set_scoring_variant(config.scoring_variant);
+    scorer_with_exct_no_f.set_repetition_penalty_raw(config.repetition_penalty_raw);
     let mut scorer_normalized = GraphScorer::from_artifact(
         r4g1,
         Some(artifact_container),
@@ -2085,6 +2097,7 @@ pub fn evaluate_gate_c(
         config.exct_top_x,
     )?;
     scorer_normalized.set_scoring_variant(ScoringVariant::CloudSizeNormalized);
+    scorer_normalized.set_repetition_penalty_raw(config.repetition_penalty_raw);
     let mut scorer_margin = GraphScorer::from_artifact(
         r4g1,
         Some(artifact_container),
@@ -2092,6 +2105,7 @@ pub fn evaluate_gate_c(
         config.exct_top_x,
     )?;
     scorer_margin.set_scoring_variant(ScoringVariant::MarginWeighted);
+    scorer_margin.set_repetition_penalty_raw(config.repetition_penalty_raw);
 
     let mut outcome = GateCOutcome::default();
     let mut bits_legacy = 0f64;
@@ -2690,7 +2704,8 @@ fn evaluate_gate_c_row(
     let (mut root_lo, mut root_hi) = (i64::MAX, i64::MIN);
     let (mut resid_lo, mut resid_hi) = (i64::MAX, i64::MIN);
     for &(token, root_raw, resid_raw, penalized) in &rule12.candidate_components {
-        let root_term = i64::from(root_raw) + if penalized { -2_000_000 } else { 0 };
+        let penalty = i64::from(context.config.repetition_penalty_raw);
+        let root_term = i64::from(root_raw) + if penalized { penalty } else { 0 };
         if root_term > root_best_score {
             root_best_score = root_term;
             root_best = token;
@@ -2709,7 +2724,12 @@ fn evaluate_gate_c_row(
         .candidate_components
         .iter()
         .map(|&(token, root_raw, _, penalized)| {
-            let raw = root_raw + if penalized { -2_000_000 } else { 0 };
+            let raw = root_raw
+                + if penalized {
+                    context.config.repetition_penalty_raw
+                } else {
+                    0
+                };
             (token, ScoreQ::from_raw(raw))
         })
         .collect();
@@ -2831,7 +2851,13 @@ fn evaluate_gate_c_row(
         let mut best_score = i64::MIN;
         for &(token, root_raw, resid_raw, penalized) in &rule12.candidate_components {
             let scaled = i64::from(resid_raw) * num / den;
-            let score = i64::from(root_raw) + scaled + if penalized { -2_000_000 } else { 0 };
+            let score = i64::from(root_raw)
+                + scaled
+                + if penalized {
+                    i64::from(context.config.repetition_penalty_raw)
+                } else {
+                    0
+                };
             if score > best_score {
                 best_score = score;
                 best_token = token;
@@ -2958,7 +2984,9 @@ fn evaluate_gate_c_row(
 /// `config.context_entries`) recorded so NGRAM A/B bundles are
 /// attributable; 15 = #375 opt-in Gate C window mode recorded
 /// (`config.gate_c_context_window`) — window-on rows are a different
-/// measurement population from every schema-≤14 row.
+/// measurement population from every schema-≤14 row; 16 = #381
+/// sweepable repetition penalty recorded
+/// (`config.repetition_penalty_raw`).
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -3055,6 +3083,9 @@ pub struct ScoreReportConfig {
     /// window-off rows — NGRAM rows fire and the repetition penalty
     /// engages.
     pub gate_c_context_window: bool,
+    /// The repetition-penalty magnitude the scorers applied (#381;
+    /// schema 16; raw ScoreQ units, shipped default -2,000,000).
+    pub repetition_penalty_raw: i32,
     /// Quality-gate basis for this distribution. `pinned` applies the
     /// historical Gate C absolute floor; `relative_tla` only compares the
     /// graph with the TLA baseline measured on the same corpus.
@@ -3151,7 +3182,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 15,
+        schema: 16,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -3167,6 +3198,7 @@ pub fn build_score_report_with_quality_profile(
             context_order: config.context_order,
             context_entries: config.context_entries,
             gate_c_context_window: config.gate_c_context_window,
+            repetition_penalty_raw: config.repetition_penalty_raw,
             quality_profile: quality_profile.to_owned(),
         },
         graph: ScoreReportGraph {

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -155,6 +155,12 @@ pub const EDGE_KIND_FORWARD: u8 = 2;
 /// runtime's top-M).
 pub const TOP_M: usize = 3;
 
+/// The shipped repetition-suppression penalty in raw ScoreQ units
+/// (~-30.5 nats). Issue #381 made the magnitude sweepable at the
+/// certifier level after the windowed Gate C measurement showed it costs
+/// ~10pp top-1 on the fixture distribution.
+pub const DEFAULT_REPETITION_PENALTY_RAW: i32 = -2_000_000;
+
 /// EXCT section body marker for compile-time integer residual tables.
 /// The four-byte storage descriptor still prefixes this body on disk.
 pub const RESIDUAL_EXCT_MAGIC: [u8; 4] = *b"RX1\0";
@@ -770,6 +776,7 @@ pub struct GraphScorer {
     /// F-invariant. Re-enable only with a measured per-token ΔT design.
     f_emissions: bool,
     scoring_variant: ScoringVariant,
+    repetition_penalty_raw: i32,
     fallback_policy: uor_r4_core::transformerless::resolution_status::FallbackPolicy,
 }
 
@@ -800,6 +807,16 @@ impl GraphScorer {
     /// Set the candidate scoring variant (issue #80).
     pub fn set_scoring_variant(&mut self, variant: ScoringVariant) {
         self.scoring_variant = variant;
+    }
+
+    /// Set the repetition-penalty magnitude (issue #381; raw ScoreQ units,
+    /// must be <= 0). The shipped default is
+    /// [`DEFAULT_REPETITION_PENALTY_RAW`]; the knob exists so the penalty's
+    /// measured ~10pp top-1 cost on windowed evaluation can be swept rather
+    /// than assumed. Serving keeps the default unless a maintainer decision
+    /// changes it.
+    pub fn set_repetition_penalty_raw(&mut self, raw: i32) {
+        self.repetition_penalty_raw = raw.min(0);
     }
 
     /// The active candidate scoring variant.
@@ -986,6 +1003,7 @@ impl GraphScorer {
             pop: runtime::derive_popcount_table(),
             f_emissions: false,
             scoring_variant: ScoringVariant::ChainTelescoped,
+            repetition_penalty_raw: DEFAULT_REPETITION_PENALTY_RAW,
             fallback_policy,
         })
     }
@@ -1452,8 +1470,8 @@ impl GraphScorer {
             let mut score = base.saturating_add(with_offset);
             k.adds += 1;
             if recent_tokens.contains(&token) {
-                // ~-30 nats suppression penalty for repetition control
-                score = score.saturating_add(ScoreQ::from_raw(-2_000_000));
+                // Suppression penalty for repetition control (#381 knob).
+                score = score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
                 k.adds += 1;
             }
             contributions.sort_by_key(|c| c.id);
@@ -2236,7 +2254,7 @@ impl GraphScorer {
             .saturating_add(ScoreQ::from_raw(state.residuals[best as usize]));
         k.adds += 1;
         if recent_tokens.contains(&best) {
-            best_score = best_score.saturating_add(ScoreQ::from_raw(-2_000_000));
+            best_score = best_score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
             k.adds += 1;
         }
         for &token in state.touched.iter().skip(1) {
@@ -2247,7 +2265,7 @@ impl GraphScorer {
                 .saturating_add(ScoreQ::from_raw(state.residuals[token as usize]));
             k.adds += 1;
             if recent_tokens.contains(&token) {
-                score = score.saturating_add(ScoreQ::from_raw(-2_000_000));
+                score = score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
                 k.adds += 1;
             }
             if score > best_score || (score == best_score && token < best) {
@@ -2532,6 +2550,7 @@ mod ngram_tests {
             pop: [0; 256],
             f_emissions: false,
             scoring_variant: ScoringVariant::ChainTelescoped,
+            repetition_penalty_raw: DEFAULT_REPETITION_PENALTY_RAW,
             fallback_policy: Default::default(),
         }
     }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -750,6 +750,7 @@ struct ScoreOptions {
     context_order: u8,
     context_entries: usize,
     gate_c_context_window: bool,
+    repetition_penalty_raw: i32,
     root_top_b: usize,
     exct_top_x: usize,
     witness_sample: usize,
@@ -774,6 +775,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
         context_order: score::DEFAULT_CONTEXT_ORDER,
         context_entries: score::DEFAULT_CONTEXT_ENTRIES,
         gate_c_context_window: false,
+        repetition_penalty_raw: score::DEFAULT_REPETITION_PENALTY_RAW,
         root_top_b: score::DEFAULT_ROOT_TOP_B,
         exct_top_x: score::DEFAULT_EXCT_TOP_X,
         witness_sample: score::DEFAULT_WITNESS_SAMPLE,
@@ -852,6 +854,16 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                     .map_err(|_| format!("invalid --context-entries value: {value}"))?;
                 if options.context_entries == 0 {
                     return Err("--context-entries must be at least 1".to_owned());
+                }
+            }
+            "--repetition-penalty-raw" => {
+                options.repetition_penalty_raw = value
+                    .parse()
+                    .map_err(|_| format!("invalid --repetition-penalty-raw value: {value}"))?;
+                if options.repetition_penalty_raw > 0 {
+                    return Err(
+                        "--repetition-penalty-raw must be <= 0 (raw ScoreQ units)".to_owned()
+                    );
                 }
             }
             "--gate-c-context-window" => {
@@ -1008,6 +1020,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         context_order: options.context_order,
         context_entries: options.context_entries,
         gate_c_context_window: options.gate_c_context_window,
+        repetition_penalty_raw: options.repetition_penalty_raw,
     };
     let (train_positions, held_out_positions) = match &options.stories {
         // D3 natural partition (issue #72): the observation pass records
@@ -2674,6 +2687,10 @@ mod tests {
         assert_eq!(options.context_order, score::DEFAULT_CONTEXT_ORDER);
         assert_eq!(options.context_entries, score::DEFAULT_CONTEXT_ENTRIES);
         assert!(!options.gate_c_context_window);
+        assert_eq!(
+            options.repetition_penalty_raw,
+            score::DEFAULT_REPETITION_PENALTY_RAW
+        );
         assert_eq!(options.root_top_b, score::DEFAULT_ROOT_TOP_B);
         assert_eq!(options.exct_top_x, score::DEFAULT_EXCT_TOP_X);
         assert_eq!(options.witness_sample, score::DEFAULT_WITNESS_SAMPLE);


### PR DESCRIPTION
Implements and answers #381's fixture-scale question with a declared 3-point sweep (rows-off, window-on):

| penalty | rule12 top-1 | bits |
|---|---|---|
| 0 | **36.47%** | **8.3534** |
| −1,000,000 | 26.69% | 13.2265 |
| −2,000,000 (shipped) | 26.69% | 18.6749 |

**Attribution is exact:** penalty 0 reproduces the window-OFF row to the digit — the #375 window mode is itself measurement-free, and the entire ~10pp windowed top-1 cost is the repetition penalty. Top-1 damage saturates by half magnitude (identical argmax flips at −1M and −2M); magnitude only inflates bits. On this teacher-forced distribution the penalty is pure cost at every tested magnitude. The −2M arm reproduces the #374 campaign row digit-for-digit.

Mechanics: `GraphScorer.repetition_penalty_raw` (shipped default unchanged; setter clamps ≤0) consumed at the three scorer sites and three Gate C analysis sites; `ScoreConfig` → all six Gate C scorers; CLI `--repetition-penalty-raw`; report records it (schema 16). **Serving keeps the shipped default** — the knob is certifier-side; any serving change is a maintainer decision, and the natural-corpus arm (#381 item 1) remains open on the issue.

Refs #381, #374, #375. Gates from cleaned targets incl. lib-only clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UJdEQFdckSK2et9G44jsm