### PR TITLE
feat: add cover between-region distinctiveness objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,11 @@ versioned objective block (`objective.config.schema`) with separate train and
 held-out components for predictive entropy (`H(A|R)`), future-state entropy
 proxies (`H(S_future|R)`), teacher-loss proxy, runtime/artifact/bytes/structure
 costs, and information-bottleneck proxy terms (`I(Z;X) - βI(Z;Y_future)`),
-plus auditable split decisions. Objective versions migrate by appending new
-fields under `objective` while keeping Gate C and predictive-sufficiency
-reports as separate reproducible artifacts. Then compile semantic
+plus a bounded top-64 between-region distinctiveness term against the global
+next-token prior (default weight `0`, preserving the default cover), and
+auditable split decisions. Objective versions migrate by appending new fields
+under `objective` while keeping Gate C and predictive-sufficiency reports as
+separate reproducible artifacts. Then compile semantic
 transitions, fixed-point emission residuals, and exact-evidence carryover:
 
 ```bash

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -63,6 +63,9 @@
 //! the previously unmeasured axis behind the #364 cover-ceiling verdict.
 //! Everything else in the sweep is unchanged; the default invocation
 //! reproduces schema-1 rows exactly (modulo the added config fields).
+//! The optional `--distinctiveness-weight` applies the induction objective's
+//! between-region distinctiveness reward to every cover point; its default is
+//! zero, preserving the byte-exact default cover.
 //!
 //! ```text
 //! schema:          2
@@ -295,6 +298,8 @@ pub struct SweepRowConfig {
     pub regions_budget: usize,
     pub min_support: usize,
     pub memory_budget_bytes: u64,
+    /// Induction-time reward weight against the global next-token prior.
+    pub distinctiveness_weight: f64,
 }
 
 /// One rate–distortion table row: one sweep point's regions × bytes ×
@@ -492,6 +497,11 @@ pub fn run_point(
             regions_budget: point.config.regions_budget,
             min_support: point.config.min_support,
             memory_budget_bytes: point.config.memory_budget_bytes,
+            distinctiveness_weight: point
+                .config
+                .objective
+                .weights
+                .between_region_distinctiveness,
         },
         regions: SweepRegions {
             total: cover.regions.len(),
@@ -631,18 +641,28 @@ pub fn recommend(rows: &[SweepRow]) -> Option<Recommendation> {
 
 /// Run the full 9-point sweep over the shared inputs with the fixed
 /// scorer and assemble the report.
-pub fn run_sweep(inputs: &SweepInputs, score_config: &ScoreConfig) -> Result<SweepReport, String> {
+pub fn run_sweep(
+    inputs: &SweepInputs,
+    score_config: &ScoreConfig,
+    distinctiveness_weight: f64,
+) -> Result<SweepReport, String> {
     let points = sweep_grid();
     let mut rows = Vec::with_capacity(points.len());
     let mut tla3_baseline: Option<GateCMetrics> = None;
     for (index, point) in points.iter().enumerate() {
+        let mut point = point.clone();
+        point
+            .config
+            .objective
+            .weights
+            .between_region_distinctiveness = distinctiveness_weight;
         eprintln!(
             "cover-sweep: point {}/{} ({})...",
             index + 1,
             points.len(),
             point.label
         );
-        let (row, baseline_metrics, _bytes) = run_point(inputs, point, score_config)?;
+        let (row, baseline_metrics, _bytes) = run_point(inputs, &point, score_config)?;
         eprintln!(
             "cover-sweep: {} regions, {} bytes, Rule 1+2 top-1 {:.4}, {:.4} bits/token",
             row.regions.total,
@@ -757,7 +777,7 @@ pub fn render_table(report: &SweepReport) -> String {
 
 // ------------------------------------------------------------ CLI --------
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 struct CoverSweepOptions {
     corpus_meta: PathBuf,
     corpus_recs: PathBuf,
@@ -765,6 +785,7 @@ struct CoverSweepOptions {
     output: PathBuf,
     emission_selection: score::EmissionSelection,
     emission_shrinkage: score::EmissionShrinkage,
+    distinctiveness_weight: f64,
 }
 
 fn parse_cover_sweep_options(args: &[String]) -> Result<CoverSweepOptions, String> {
@@ -776,6 +797,7 @@ fn parse_cover_sweep_options(args: &[String]) -> Result<CoverSweepOptions, Strin
         output: PathBuf::from("cover_sweep"),
         emission_selection: score::EmissionSelection::default(),
         emission_shrinkage: score::EmissionShrinkage::default(),
+        distinctiveness_weight: 0.0,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -813,6 +835,17 @@ fn parse_cover_sweep_options(args: &[String]) -> Result<CoverSweepOptions, Strin
                     }
                 };
             }
+            "--distinctiveness-weight" => {
+                let weight = value.parse::<f64>().map_err(|error| {
+                    format!("invalid --distinctiveness-weight value {value}: {error}")
+                })?;
+                if !weight.is_finite() || weight < 0.0 {
+                    return Err(format!(
+                        "invalid --distinctiveness-weight value {value} (expected finite non-negative number)"
+                    ));
+                }
+                options.distinctiveness_weight = weight;
+            }
             _ => return Err(format!("unknown cover-sweep option: {flag}")),
         }
         index += 2;
@@ -822,8 +855,9 @@ fn parse_cover_sweep_options(args: &[String]) -> Result<CoverSweepOptions, Strin
 
 /// Cover fineness sweep (issue #70, module docs): run the 9-point
 /// rate–distortion grid under the fixed scorer and write
-/// `cover_sweep.json` plus the console table. Release-mode workload on
-/// the fixture corpus.
+/// `cover_sweep.json` plus the console table. `--distinctiveness-weight`
+/// sets the optional induction-time between-region contrast reward.
+/// Release-mode workload on the fixture corpus.
 pub fn cover_sweep_command(args: &[String]) -> Result<(), String> {
     #[cfg(debug_assertions)]
     eprintln!(
@@ -842,13 +876,14 @@ pub fn cover_sweep_command(args: &[String]) -> Result<(), String> {
     };
     eprintln!(
         "cover-sweep: {} train / {} held-out observations; running the 9-point grid (fixed scorer, \
-         emission {}/{})...",
+         emission {}/{}, cover distinctiveness {})...",
         inputs.train.len(),
         inputs.held_out.len(),
         score_config.emission_selection.label(),
-        score_config.emission_shrinkage.label()
+        score_config.emission_shrinkage.label(),
+        options.distinctiveness_weight
     );
-    let report = run_sweep(&inputs, &score_config)?;
+    let report = run_sweep(&inputs, &score_config, options.distinctiveness_weight)?;
 
     std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
     let report_json = serde_json::to_string_pretty(&report).map_err(|error| error.to_string())?;
@@ -881,6 +916,7 @@ mod tests {
             options.emission_shrinkage,
             score::EmissionShrinkage::default()
         );
+        assert_eq!(options.distinctiveness_weight, 0.0);
 
         let args = [
             "--corpus-meta",
@@ -895,6 +931,8 @@ mod tests {
             "probability",
             "--emission-shrinkage",
             "contrast",
+            "--distinctiveness-weight",
+            "1.5",
         ]
         .map(str::to_owned);
         let options = parse_cover_sweep_options(&args).expect("valid options");
@@ -910,9 +948,12 @@ mod tests {
             options.emission_shrinkage,
             score::EmissionShrinkage::Contrast
         );
+        assert_eq!(options.distinctiveness_weight, 1.5);
 
         let bad_shrinkage = ["--emission-shrinkage", "sideways"].map(str::to_owned);
         assert!(parse_cover_sweep_options(&bad_shrinkage).is_err());
+        let bad_distinctiveness = ["--distinctiveness-weight", "-1"].map(str::to_owned);
+        assert!(parse_cover_sweep_options(&bad_distinctiveness).is_err());
 
         let bad = ["--k0", "16"].map(str::to_owned);
         assert!(parse_cover_sweep_options(&bad).is_err());

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -61,12 +61,14 @@
 //!   same-machine determinism is pinned by the T-invariance tests, and
 //!   cross-platform byte equality awaits the D2 canonical deterministic
 //!   compile mode, exactly as for `compile()`'s macOS-pinned κ baseline.)
-//! - **Objective scoring (schema 1)**: each eligible split records
+//! - **Objective scoring (schema 2)**: each eligible split records
 //!   `H(A|R)` and `H(S_future|R)` proxies, an information-bottleneck term
 //!   `I(Z;X) - beta·I(Z;Y_future)`, and runtime/artifact/bytes/structure
-//!   cost proxies; weighted objective ties deterministically resolve to
-//!   "keep". Fitting uses train observations only; reports emit both train
-//!   and held-out decompositions so regressions are visible per component.
+//!   cost proxies plus a bounded top-E distinctiveness reward against the
+//!   global next-token prior; weighted objective ties deterministically
+//!   resolve to "keep". Fitting uses train observations only; reports emit
+//!   both train and held-out decompositions so regressions are visible per
+//!   component. The new reward defaults to zero for byte-exact compatibility.
 //!
 //! # Regions, membership, reference classifier
 //!
@@ -157,8 +159,10 @@ pub fn sample_id(tokens: &[u32]) -> [u8; 32] {
 pub const DEFAULT_MIN_SUPPORT: usize = 64;
 /// Default entropy-reduction floor for accepting a split, in bits/token.
 pub const DEFAULT_SPLIT_ENTROPY_GAIN_BITS: f64 = 0.25;
+/// Top-token bound used by the induction-time distinctiveness objective.
+pub const DISTINCTIVENESS_TOP_E: usize = 64;
 /// Objective configuration schema version carried in compile reports.
-pub const OBJECTIVE_CONFIG_SCHEMA: u32 = 1;
+pub const OBJECTIVE_CONFIG_SCHEMA: u32 = 2;
 /// Bounded multi-membership per depth (matches the runtime's top-M).
 pub const TOP_M: usize = 3;
 /// Radius calibration quantile: the 95th percentile of member distances.
@@ -249,6 +253,10 @@ pub struct ObjectiveWeights {
     pub bytes_read: f64,
     pub structural_complexity: f64,
     pub ib_term: f64,
+    /// Reward candidate partitions whose child distributions depart from the
+    /// global next-token prior. Lower weighted objective scores are better, so
+    /// this component is subtracted when its weight is positive.
+    pub between_region_distinctiveness: f64,
 }
 
 /// Metadata describing approximations used by objective estimators.
@@ -262,6 +270,7 @@ pub struct ObjectiveEstimatorMetadata {
     pub bytes_read: String,
     pub structural_complexity: String,
     pub ib_term: String,
+    pub between_region_distinctiveness: String,
     pub fit_partition: String,
     pub report_partitions: String,
 }
@@ -289,6 +298,7 @@ impl Default for ObjectiveConfig {
                 bytes_read: 0.0,
                 structural_complexity: 0.0,
                 ib_term: 0.25,
+                between_region_distinctiveness: 0.0,
             },
             estimators: ObjectiveEstimatorMetadata {
                 predictive_entropy: "H(A|R) from empirical next-token frequencies".to_owned(),
@@ -302,6 +312,10 @@ impl Default for ObjectiveConfig {
                 structural_complexity: "regions+edges proxy".to_owned(),
                 ib_term: "I(Z;X)-beta*I(Z;Y_future), X via deterministic assignment proxy"
                     .to_owned(),
+                between_region_distinctiveness: format!(
+                    "weighted mean of 1 - top-{} child/prior token overlap over next-token counts",
+                    DISTINCTIVENESS_TOP_E
+                ),
                 fit_partition: "train".to_owned(),
                 report_partitions: "train,held_out".to_owned(),
             },
@@ -766,6 +780,48 @@ fn next_token_counts(observations: &[Observation], members: &[usize]) -> BTreeMa
     counts
 }
 
+fn all_next_token_counts(observations: &[Observation]) -> BTreeMap<u32, u64> {
+    let members: Vec<usize> = (0..observations.len()).collect();
+    next_token_counts(observations, &members)
+}
+
+/// Distinctiveness of a child distribution against the global prior.
+///
+/// This is the serving-side `1 - overlap` analogue: compare the top-E token
+/// sets by count, with token-id ordering breaking equal-count ties. The
+/// denominator is the child set, so a child with a unique top token receives
+/// full credit even when the prior has fewer than E entries.
+fn top_token_distinctiveness(
+    child_counts: &BTreeMap<u32, u64>,
+    prior_counts: &BTreeMap<u32, u64>,
+) -> f64 {
+    if child_counts.is_empty() || prior_counts.is_empty() {
+        return 0.0;
+    }
+    let mut child: Vec<(u32, u64)> = child_counts
+        .iter()
+        .map(|(&token, &count)| (token, count))
+        .collect();
+    let mut prior: Vec<(u32, u64)> = prior_counts
+        .iter()
+        .map(|(&token, &count)| (token, count))
+        .collect();
+    let by_count_then_token = |left: &(u32, u64), right: &(u32, u64)| {
+        right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0))
+    };
+    child.sort_by(by_count_then_token);
+    prior.sort_by(by_count_then_token);
+    child.truncate(DISTINCTIVENESS_TOP_E);
+    prior.truncate(DISTINCTIVENESS_TOP_E);
+    let prior_tokens: std::collections::BTreeSet<u32> =
+        prior.into_iter().map(|(token, _)| token).collect();
+    let shared = child
+        .iter()
+        .filter(|(token, _)| prior_tokens.contains(token))
+        .count();
+    1.0 - shared as f64 / child.len() as f64
+}
+
 /// Shannon entropy of a token distribution in bits (f64, tokens in
 /// ascending order; libm-sensitive cross-platform — see module docs).
 fn entropy_bits<K: Ord>(counts: &BTreeMap<K, u64>) -> f64 {
@@ -863,6 +919,7 @@ pub struct ObjectiveComponents {
     pub artifact_size_bytes: f64,
     pub bytes_read: f64,
     pub structural_complexity: f64,
+    pub between_region_distinctiveness: f64,
     pub ib_i_zx_bits: f64,
     pub ib_i_zy_future_bits: f64,
     pub ib_objective_bits: f64,
@@ -881,6 +938,8 @@ impl ObjectiveComponents {
             + w.bytes_read * values.bytes_read
             + w.structural_complexity * values.structural_complexity
             + w.ib_term * ib_objective;
+        let weighted_score = weighted_score
+            - w.between_region_distinctiveness * values.between_region_distinctiveness;
         Self {
             predictive_entropy_bits: values.predictive_entropy_bits,
             future_state_entropy_bits: values.future_state_entropy_bits,
@@ -889,6 +948,7 @@ impl ObjectiveComponents {
             artifact_size_bytes: values.artifact_size_bytes,
             bytes_read: values.bytes_read,
             structural_complexity: values.structural_complexity,
+            between_region_distinctiveness: values.between_region_distinctiveness,
             ib_i_zx_bits: values.ib_i_zx_bits,
             ib_i_zy_future_bits: values.ib_i_zy_future_bits,
             ib_objective_bits: ib_objective,
@@ -906,6 +966,7 @@ struct ObjectiveRawValues {
     artifact_size_bytes: f64,
     bytes_read: f64,
     structural_complexity: f64,
+    between_region_distinctiveness: f64,
     ib_i_zx_bits: f64,
     ib_i_zy_future_bits: f64,
 }
@@ -951,6 +1012,7 @@ fn objective_for_partition(
                 artifact_size_bytes: costs.artifact_size_bytes,
                 bytes_read: costs.bytes_read,
                 structural_complexity: costs.structural_complexity,
+                between_region_distinctiveness: 0.0,
                 ib_i_zx_bits: 0.0,
                 ib_i_zy_future_bits: 0.0,
             },
@@ -965,6 +1027,21 @@ fn objective_for_partition(
     let teacher_loss_bits = predictive_entropy_bits;
     let ib_i_zx_bits = assignment_entropy(assignments);
     let ib_i_zy_future_bits = (next_entropy(observations) - predictive_entropy_bits).max(0.0);
+    let prior_counts = all_next_token_counts(observations);
+    let mut region_distinctiveness = 0.0;
+    let mut region_counts: BTreeMap<u32, BTreeMap<u32, u64>> = BTreeMap::new();
+    for (observation, &region) in observations.iter().zip(assignments.iter()) {
+        *region_counts
+            .entry(region)
+            .or_default()
+            .entry(observation.next)
+            .or_insert(0) += 1;
+    }
+    for counts in region_counts.values() {
+        let support: u64 = counts.values().sum();
+        region_distinctiveness +=
+            support as f64 / count as f64 * top_token_distinctiveness(counts, &prior_counts);
+    }
     ObjectiveComponents::weighted(
         config,
         ObjectiveRawValues {
@@ -975,6 +1052,7 @@ fn objective_for_partition(
             artifact_size_bytes: costs.artifact_size_bytes,
             bytes_read: costs.bytes_read,
             structural_complexity: costs.structural_complexity,
+            between_region_distinctiveness: region_distinctiveness,
             ib_i_zx_bits,
             ib_i_zy_future_bits,
         },
@@ -986,6 +1064,7 @@ fn objective_for_member_partition(
     observations: &[Observation],
     members: &[usize],
     assignments: &[u32],
+    prior_counts: &BTreeMap<u32, u64>,
     costs: ObjectiveCostTerms,
 ) -> ObjectiveComponents {
     let count = members.len().min(assignments.len());
@@ -1000,6 +1079,7 @@ fn objective_for_member_partition(
                 artifact_size_bytes: costs.artifact_size_bytes,
                 bytes_read: costs.bytes_read,
                 structural_complexity: costs.structural_complexity,
+                between_region_distinctiveness: 0.0,
                 ib_i_zx_bits: 0.0,
                 ib_i_zy_future_bits: 0.0,
             },
@@ -1040,6 +1120,16 @@ fn objective_for_member_partition(
     let teacher_loss_bits = predictive_entropy_bits;
     let ib_i_zx_bits = assignment_entropy(&assignments[..count]);
     let ib_i_zy_future_bits = (entropy_bits(&next_counts) - predictive_entropy_bits).max(0.0);
+    let mut region_distinctiveness = 0.0;
+    for counts in region_next_counts.values() {
+        let support: u64 = counts.values().sum();
+        let token_counts: BTreeMap<u32, u64> = counts
+            .iter()
+            .map(|(&token, &count)| (token as u32, count))
+            .collect();
+        region_distinctiveness +=
+            support as f64 / count as f64 * top_token_distinctiveness(&token_counts, prior_counts);
+    }
     ObjectiveComponents::weighted(
         config,
         ObjectiveRawValues {
@@ -1050,6 +1140,7 @@ fn objective_for_member_partition(
             artifact_size_bytes: costs.artifact_size_bytes,
             bytes_read: costs.bytes_read,
             structural_complexity: costs.structural_complexity,
+            between_region_distinctiveness: region_distinctiveness,
             ib_i_zx_bits,
             ib_i_zy_future_bits,
         },
@@ -1308,6 +1399,7 @@ pub fn induce_cover(
     );
     let n = observations.len();
     let points: Vec<&[f32]> = observations.iter().map(|o| o.vector.as_slice()).collect();
+    let global_prior_counts = all_next_token_counts(observations);
 
     let mut regions: Vec<CoverRegion> = Vec::new();
     let mut members_of: Vec<Vec<usize>> = Vec::new();
@@ -1395,6 +1487,7 @@ pub fn induce_cover(
             observations,
             &parent_members,
             &keep_assignments,
+            &global_prior_counts,
             ObjectiveCostTerms {
                 runtime_cost_units: 0.0,
                 artifact_size_bytes: 0.0,
@@ -1407,6 +1500,7 @@ pub fn induce_cover(
             observations,
             &parent_members,
             &split_assignments,
+            &global_prior_counts,
             ObjectiveCostTerms {
                 runtime_cost_units: SPLIT_CHILDREN as f64,
                 artifact_size_bytes: (SPLIT_CHILDREN.saturating_sub(1)) as f64
@@ -2160,6 +2254,7 @@ pub struct ObjectiveTradeoffDelta {
     pub artifact_size_bytes: f64,
     pub bytes_read: f64,
     pub structural_complexity: f64,
+    pub between_region_distinctiveness: f64,
     pub ib_objective_bits: f64,
     pub weighted_score: f64,
 }
@@ -2317,7 +2412,7 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
         config.threads
     );
     CoverReport {
-        schema: 1,
+        schema: 2,
         config: CoverReportConfig {
             depths: config.depths,
             k0: config.k0,
@@ -2360,6 +2455,8 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
                 bytes_read: objective_held_out.bytes_read - objective_train.bytes_read,
                 structural_complexity: objective_held_out.structural_complexity
                     - objective_train.structural_complexity,
+                between_region_distinctiveness: objective_held_out.between_region_distinctiveness
+                    - objective_train.between_region_distinctiveness,
                 ib_objective_bits: objective_held_out.ib_objective_bits
                     - objective_train.ib_objective_bits,
                 weighted_score: objective_held_out.weighted_score - objective_train.weighted_score,
@@ -2410,6 +2507,10 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
 
 #[cfg(test)]
 mod compiler_invariant_tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
     use uor_r4_graph_format::invariant_ownership::{
         GraphInvariantId, GraphInvariantOwnershipMatrix, InvariantOwner,
     };
@@ -2427,5 +2528,39 @@ mod compiler_invariant_tests {
             InvariantOwner::CompilerConstruction
         );
         assert_eq!(stage4_entry.validation_stage, "Compiler Stage 4");
+    }
+
+    #[test]
+    fn distinctiveness_is_bounded_deterministic_and_rewarded() {
+        let mut child = BTreeMap::new();
+        child.insert(7, 10);
+        child.insert(8, 9);
+        let mut prior = BTreeMap::new();
+        prior.insert(1, 100);
+        prior.insert(2, 90);
+        assert_eq!(top_token_distinctiveness(&child, &prior), 1.0);
+
+        prior.insert(7, 110);
+        assert_eq!(top_token_distinctiveness(&child, &prior), 0.5);
+
+        let mut config = ObjectiveConfig::default();
+        config.weights.between_region_distinctiveness = 2.0;
+        let components = ObjectiveComponents::weighted(
+            &config,
+            ObjectiveRawValues {
+                predictive_entropy_bits: 0.0,
+                future_state_entropy_bits: 0.0,
+                teacher_loss_bits: 0.0,
+                runtime_cost_units: 0.0,
+                artifact_size_bytes: 0.0,
+                bytes_read: 0.0,
+                structural_complexity: 0.0,
+                between_region_distinctiveness: 0.5,
+                ib_i_zx_bits: 0.0,
+                ib_i_zy_future_bits: 0.0,
+            },
+        );
+        assert_eq!(components.between_region_distinctiveness, 0.5);
+        assert_eq!(components.weighted_score, -1.0);
     }
 }


### PR DESCRIPTION
## Summary
- add a schema-2, default-off between-region distinctiveness term to cover induction
- score deterministic top-64 child/prior overlap against the global next-token prior and expose it in split audits and cover reports
- add `--distinctiveness-weight` to `cover-sweep`, with CLI coverage and README documentation

Closes #379.

## Validation
- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --check`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`

## Measurement
Fixture sweep at `--distinctiveness-weight 1.0` with probability emission selection and contrast shrinkage: the 9-point frontier recommends `k0=8/gain=0.1/budget=128`, +17,472 bytes for +0.0052 Rule 1+2 top-1 agreement over the default row. The report records schema 2 and the applied weight per point.