### PR TITLE
chore: ignore local model bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ uor_standards/
 crates/uor-r4-graph-format/fuzz/target/
 pkg/
 trend_output/
+.uor-models/


### PR DESCRIPTION
Carry the preserved local `.gitignore` change into `main` by ignoring `.uor-models/`, which contains generated model bundles and should never be committed.