### PR TITLE
research(e8): #395 spike measurement 1 — E8-256 beats sign code at matched bits

### DIFF
--- a/crates/uor-r4-graph-certify/tests/e8_dump_bundles.rs
+++ b/crates/uor-r4-graph-certify/tests/e8_dump_bundles.rs
@@ -1,0 +1,55 @@
+//! #395 E8/icosian spike support: dump real store content for the research
+//! prototype. Writes a sample of centered context-bundle vectors (the exact
+//! f32 objects the shipped path sign-codes into 36 bytes) plus the artifact
+//! thresholds, as little-endian f32 binaries under /tmp/e8_spike/.
+//!
+//! Research tooling only (research/395-e8); never part of certify rows.
+//!
+//! Run:
+//!   cargo test --release -p uor-r4-graph-certify --test e8_dump_bundles -- --ignored --nocapture
+
+use std::io::Write;
+
+use uor_r4_core::transformerless::compiler;
+use uor_r4_core::transformerless::runtime;
+
+fn fixture(name: &str) -> String {
+    format!(
+        "{}/../uor-r4-core/tests/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+#[test]
+#[ignore = "spike tooling; run explicitly with --ignored"]
+fn dump_bundles() {
+    const SAMPLE_EVERY: usize = 10; // 500k records -> 50k vectors
+    let c = compiler::load_corpus_from(&fixture("c_meta.bin"), &fixture("c_recs.bin"))
+        .expect("checked-in fixture corpus");
+    let art = compiler::load_artifacts_from(&fixture("tless_artifacts.bin"))
+        .expect("checked-in fixture artifacts");
+    let rot = compiler::derive_rotations();
+
+    std::fs::create_dir_all("/tmp/e8_spike").expect("mkdir");
+    let mut out =
+        std::io::BufWriter::new(std::fs::File::create("/tmp/e8_spike/bundles.f32").expect("open"));
+    let mut count = 0usize;
+    let mut dim = 0usize;
+    for i in (0..c.n).step_by(SAMPLE_EVERY) {
+        let bundle = runtime::bundle_plain(&art, &rot, &c, i);
+        let centered = runtime::centered_work(&art, &bundle);
+        dim = centered.len();
+        for v in centered.iter() {
+            out.write_all(&(*v as f32).to_le_bytes()).expect("write");
+        }
+        count += 1;
+    }
+    drop(out);
+    let mut thr = std::io::BufWriter::new(
+        std::fs::File::create("/tmp/e8_spike/thresholds.f32").expect("open"),
+    );
+    for t in art.thresholds.iter() {
+        thr.write_all(&(*t as f32).to_le_bytes()).expect("write");
+    }
+    println!("dumped {count} centered bundle vectors, dim {dim}, to /tmp/e8_spike/");
+}

--- a/research/395-e8/RESULT-1.md
+++ b/research/395-e8/RESULT-1.md
@@ -1,0 +1,66 @@
+# #395 E8/icosian spike — Measurement 1: neighborhood preservation at matched bits
+
+- **Date:** 2026-08-04
+- **Issue:** #395 (program: #393)
+- **Tooling:** `crates/uor-r4-graph-certify/tests/e8_dump_bundles.rs` (dump) +
+  `research/395-e8/e8_spike.py` (measurement)
+- **Data:** 50,000 centered context-bundle vectors (dim 288), sampled every
+  10th record from the checked-in fixture corpus — the exact f32 objects the
+  shipped path sign-codes into 36 bytes. Disjoint train (25k) / pool (20k) /
+  query (500) split, seed 395.
+- **Claim language:** Empirical Criterion, status Empirical (pinned-corpus
+  measurement with declared protocol; not a proof).
+
+## Question
+
+At an exactly matched budget of 288 bits/vector, does E8 lattice quantization
+of real store content preserve neighborhood structure better than the shipped
+orthant (sign-bit) code?
+
+## Codes
+
+| code | construction | bits |
+|---|---|---|
+| SIGN | sign bit per dim; Hamming ranking | 288 |
+| E8-256 | 36 blocks × 8 dims; Conway–Sloane nearest E8 point (best of D8, D8+½) at a per-block scale grid-picked on train MSE; codebook = 256 most frequent train lattice points per block; ranking by L2 between dequantized vectors | 36 × 8 = 288 |
+
+## Results
+
+| metric | SIGN | E8-256 |
+|---|---|---|
+| recall@10 vs cosine ground truth | 0.553 | **0.606** |
+| recall@10 vs L2 ground truth | 0.541 | **0.634** |
+| relative reconstruction MSE | 0.446 | **0.213** |
+
+Train data occupies ~22k distinct lattice points per block; the 256-point cap
+discards most of them and E8 still wins on every metric. Reconstruction error
+halves; L2 neighborhood recall improves +9.3pp absolute (+17% relative).
+
+## Icosian reading
+
+Each 8-dim block codeword is an E8 lattice point; via the icosian ring
+(quaternions over Z[φ], Turyn norm) every such point is canonically a
+golden-coupled **pair of R⁴ points**. A 288-dim context vector under this code
+is 36 icosian pairs — 72 quaternionic orientations — rather than 288
+uncoupled sign bits. This is the construction-level R⁴ substrate #393 calls
+for; nothing here touches scoring channels.
+
+## Caveats
+
+- recall@10 against a 20k pool is a retrieval proxy; the decision-grade test
+  is downstream (region assignment / store keys built from E8 codes, graded
+  by certify metrics and the #394 infill criterion).
+- Fixture distribution only; natural-corpus rerun pending #381 obs corpus.
+- Heavy-tailed blocks (per-block scale grid was necessary); no entropy coding
+  assumed — hard 8 bits/block cap.
+- Decoder cost: Conway–Sloane E8 is round/compare/coset-select per block —
+  compatible in principle with the no-multiply contract (fixed-point scales),
+  but kernel-contract conformance is unverified and is future work.
+
+## Decision gate
+
+Per #395: E8 preserves neighborhood structure better than orthant signs at
+equal bits → **promote to a construction experiment**: compile a bundle whose
+assignment path consumes E8 block codes (prototype/membership geometry over
+icosian pairs), grade with certify + #394 infill rows against the shipped
+assignment at equal store budget.

--- a/research/395-e8/e8_spike.py
+++ b/research/395-e8/e8_spike.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""#395 E8/icosian codebook spike, measurement 1: neighborhood preservation.
+
+Question: at an exactly matched bit budget (288 bits/vector), does E8 lattice
+quantization of the real store content preserve neighborhood structure better
+than the shipped 288-sign-bit orthant code?
+
+Data: 50,000 centered context-bundle vectors (dim 288) dumped from the
+checked-in fixture corpus by e8_dump_bundles.rs — the exact f32 objects the
+shipped path sign-codes into 36 bytes.
+
+Codes compared, both 288 bits/vector:
+  SIGN   — shipped: sign bit per dim, Hamming ranking.
+  E8-256 — 36 blocks x 8 dims; per block, decode to the nearest E8 lattice
+           point (Conway-Sloane: best of D8 and D8+1/2) at a per-block scale
+           chosen from a small grid on train data; codebook capped to the 256
+           most frequent train lattice points (8 bits/block); ranking by L2
+           between dequantized vectors.
+
+Metric: recall@10 vs float-space ground truth (cosine and L2), mean over 500
+held-out queries against a 20,000-vector pool; plus relative reconstruction
+MSE. Train/eval split disjoint.
+"""
+import numpy as np
+
+rng = np.random.default_rng(395)
+D, B = 288, 8
+NBLK = D // B
+POOL, NQ, K = 20_000, 500, 10
+
+X = np.fromfile("/tmp/e8_spike/bundles.f32", dtype="<f4").reshape(-1, D).astype(np.float64)
+rng.shuffle(X)
+train, pool, queries = X[:25_000], X[25_000 : 25_000 + POOL], X[45_000 : 45_000 + NQ]
+print(f"vectors: train {len(train)}, pool {len(pool)}, queries {len(queries)}")
+
+
+def d8_round(y):
+    """Nearest D8 point (integer coords, even sum) per row of (..., 8)."""
+    f = np.rint(y)
+    s = f.sum(axis=-1)
+    odd = (np.mod(s, 2) != 0)
+    if odd.any():
+        err = np.abs(y - f)
+        idx = np.argmax(err, axis=-1)
+        rows = np.nonzero(odd)[0]
+        for r in rows:  # flip the worst coordinate the other way
+            j = idx[r]
+            f[r, j] += 1.0 if y[r, j] > f[r, j] else -1.0
+    return f
+
+
+def e8_decode(y):
+    """Nearest E8 point: best of D8(y) and D8(y - 1/2) + 1/2."""
+    a = d8_round(y)
+    b = d8_round(y - 0.5) + 0.5
+    da = ((y - a) ** 2).sum(axis=-1)
+    db = ((y - b) ** 2).sum(axis=-1)
+    return np.where((da <= db)[:, None], a, b)
+
+
+def blocks(M):
+    return M.reshape(len(M), NBLK, B)
+
+
+# --- per-block scale: grid over multiples of block RMS, pick min train MSE ---
+tb = blocks(train)
+rms = np.sqrt((tb**2).mean(axis=(0, 2))) + 1e-9  # (NBLK,)
+scales = np.empty(NBLK)
+for blk in range(NBLK):
+    best = (np.inf, None)
+    for mult in (0.25, 0.5, 1.0, 2.0, 4.0):
+        s = rms[blk] * mult
+        y = tb[:, blk, :] / s
+        q = e8_decode(y) * s
+        mse = ((tb[:, blk, :] - q) ** 2).mean()
+        if mse < best[0]:
+            best = (mse, s)
+    scales[blk] = best[1]
+
+# --- capped codebook: top-256 train lattice points per block ---
+codebooks = []
+oov_blocks = 0
+for blk in range(NBLK):
+    y = tb[:, blk, :] / scales[blk]
+    pts = e8_decode(y)
+    key = np.round(pts * 2).astype(np.int64)  # half-integer safe
+    uniq, counts = np.unique(key, axis=0, return_counts=True)
+    order = np.argsort(-counts)
+    cb = uniq[order[:256]].astype(np.float64) / 2.0
+    if len(cb) < 256:
+        pad = np.zeros((256 - len(cb), B))
+        cb = np.vstack([cb, pad])
+    codebooks.append(cb)
+    oov_blocks += max(0, len(uniq) - 256)
+print(f"codebooks built; mean distinct train lattice points/block: "
+      f"{np.mean([len(np.unique(np.round(e8_decode(blocks(train)[:, b, :] / scales[b]) * 2).astype(np.int64), axis=0)) for b in range(0, NBLK, 12)]):.0f} (sampled)")
+
+
+def encode_e8(M):
+    """Quantize to capped codebook; return dequantized vectors."""
+    Mb = blocks(M)
+    out = np.empty_like(Mb)
+    for blk in range(NBLK):
+        y = Mb[:, blk, :] / scales[blk]
+        cb = codebooks[blk]
+        d2 = ((y[:, None, :] - cb[None, :, :]) ** 2).sum(axis=-1)
+        out[:, blk, :] = cb[np.argmin(d2, axis=1)] * scales[blk]
+    return out.reshape(len(M), D)
+
+
+def recall_at_k(rank_pred, rank_true, k=K):
+    return np.mean([len(set(p[:k]) & set(t[:k])) / k for p, t in zip(rank_pred, rank_true)])
+
+
+def top_idx(dist, k=K):
+    return np.argpartition(dist, k, axis=1)[:, : k + 1][
+        np.arange(len(dist))[:, None],
+        np.argsort(np.take_along_axis(dist, np.argpartition(dist, k, axis=1)[:, : k + 1], axis=1), axis=1),
+    ][:, :k]
+
+
+# --- ground truths ---
+qn = queries / (np.linalg.norm(queries, axis=1, keepdims=True) + 1e-12)
+pn = pool / (np.linalg.norm(pool, axis=1, keepdims=True) + 1e-12)
+gt_cos = top_idx(1.0 - qn @ pn.T)
+d_l2 = ((queries**2).sum(1)[:, None] - 2 * queries @ pool.T + (pool**2).sum(1)[None, :])
+gt_l2 = top_idx(d_l2)
+
+# --- SIGN code ranking (Hamming == mismatched sign count) ---
+qs = (queries >= 0).astype(np.int8)
+ps = (pool >= 0).astype(np.int8)
+ham = (qs[:, None, :] != ps[None, :, :]).sum(axis=2)
+r_sign = top_idx(ham.astype(np.float64))
+
+# --- E8-256 ranking (L2 between dequantized) ---
+pq = encode_e8(pool)
+qq = encode_e8(queries)
+d_e8 = ((qq**2).sum(1)[:, None] - 2 * qq @ pq.T + (pq**2).sum(1)[None, :])
+r_e8 = top_idx(d_e8)
+
+# --- reconstruction MSE (relative) ---
+pool_mse_e8 = ((pool - pq) ** 2).mean() / (pool**2).mean()
+sign_recon = np.sign(pool) * np.sqrt((pool**2).mean(axis=0, keepdims=True))
+pool_mse_sign = ((pool - sign_recon) ** 2).mean() / (pool**2).mean()
+
+print("\n=== #395 spike, measurement 1 (matched 288-bit budget) ===")
+print(f"recall@{K} vs cosine GT : SIGN {recall_at_k(r_sign, gt_cos):.3f} | E8-256 {recall_at_k(r_e8, gt_cos):.3f}")
+print(f"recall@{K} vs L2 GT     : SIGN {recall_at_k(r_sign, gt_l2):.3f} | E8-256 {recall_at_k(r_e8, gt_l2):.3f}")
+print(f"relative recon MSE      : SIGN(+rms) {pool_mse_sign:.4f} | E8-256 {pool_mse_e8:.4f}")


### PR DESCRIPTION
Dump tooling (ignored test) + research prototype + RESULT-1 for the #395 E8/icosian spike. Real store vectors, matched 288-bit budget: recall@10 0.606/0.634 (cos/L2) vs SIGN 0.553/0.541; relative recon MSE 0.213 vs 0.446. Decision gate met — construction experiment is the follow-on. Part of the #393 program. Results comment on #395.