### PR TITLE
test(certify): #399 step-2 region conditioning + #394 stride sweep

### DIFF
--- a/crates/uor-r4-graph-certify/tests/anchor_infill.rs
+++ b/crates/uor-r4-graph-certify/tests/anchor_infill.rs
@@ -24,8 +24,6 @@ use std::collections::BTreeMap;
 use uor_r4_core::transformerless::compiler;
 use uor_r4_core::transformerless::runtime;
 
-const ANCHOR_STRIDE: usize = 4;
-
 fn fixture(name: &str) -> String {
     format!(
         "{}/../uor-r4-core/tests/fixtures/{name}",
@@ -53,16 +51,16 @@ fn story_positions(c: &compiler::Corpus) -> Vec<usize> {
 
 struct Arm {
     name: &'static str,
-    hits: [u64; ANCHOR_STRIDE],
-    totals: [u64; ANCHOR_STRIDE],
+    hits: Vec<u64>,
+    totals: Vec<u64>,
 }
 
 impl Arm {
-    fn new(name: &'static str) -> Self {
+    fn new(name: &'static str, stride: usize) -> Self {
         Arm {
             name,
-            hits: [0; ANCHOR_STRIDE],
-            totals: [0; ANCHOR_STRIDE],
+            hits: vec![0; stride],
+            totals: vec![0; stride],
         }
     }
     fn score(&mut self, offset: usize, pred: Option<u32>, truth: u32) {
@@ -86,7 +84,7 @@ impl Arm {
             pct(hits, totals),
             totals
         );
-        for offset in 1..ANCHOR_STRIDE {
+        for offset in 1..self.hits.len() {
             print!(
                 " off{offset} {:>5.1}%",
                 pct(self.hits[offset], self.totals[offset])
@@ -166,17 +164,21 @@ fn anchor_infill_day0() {
         .expect("checked-in fixture artifacts");
     let cut = (c.stories as f64 * 0.8) as u32;
     let positions = story_positions(&c);
+    let stride: usize = std::env::var("R4_INFILL_STRIDE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4);
 
     println!(
         "anchor-infill Day-0 (#394): {} records, {} stories, anchor stride {}",
-        c.n, c.stories, ANCHOR_STRIDE
+        c.n, c.stories, stride
     );
 
     // ---- construction-partition tables (story < cut ONLY) ----
     let mut unigram: BTreeMap<u32, u64> = BTreeMap::new();
     let mut bigram: BTreeMap<u32, BTreeMap<u32, u64>> = BTreeMap::new();
     // forward-anchor table: (distance to next anchor, anchor token) -> dist.
-    // distance d in 1..ANCHOR_STRIDE: the target sits d positions before the
+    // distance d in 1..stride: the target sits d positions before the
     // next pinned token in the reference stream.
     let mut fwd_anchor: BTreeMap<(usize, u32), BTreeMap<u32, u64>> = BTreeMap::new();
     // #399 step 2: E_b-style REGION conditioning — key the forward table by
@@ -198,9 +200,9 @@ fn anchor_infill_day0() {
             .or_default() += 1;
         // target stream index of this record's prediction:
         let target_pos = positions[i] + 1;
-        if !target_pos.is_multiple_of(ANCHOR_STRIDE) {
+        if !target_pos.is_multiple_of(stride) {
             // next anchor stream index and its token value, if inside story
-            let next_anchor_pos = target_pos.next_multiple_of(ANCHOR_STRIDE);
+            let next_anchor_pos = target_pos.next_multiple_of(stride);
             let lookahead = next_anchor_pos - target_pos; // 1..=3
             let j = i + lookahead; // record whose *next* is the anchor token
             if j < c.n && c.story[j] == c.story[i] {
@@ -227,24 +229,24 @@ fn anchor_infill_day0() {
     let (store, codes) = runtime::build_store(&art, &c);
 
     // ---- grade all arms on held-out free targets ----
-    let mut store_arm = Arm::new("shipped-store");
-    let mut unigram_arm = Arm::new("null:unigram");
-    let mut bigram_arm = Arm::new("null:bigram");
-    let mut prev_anchor_arm = Arm::new("null:prev-anchor-copy");
-    let mut fwd_anchor_arm = Arm::new("null:fwd-anchor-table");
+    let mut store_arm = Arm::new("shipped-store", stride);
+    let mut unigram_arm = Arm::new("null:unigram", stride);
+    let mut bigram_arm = Arm::new("null:bigram", stride);
+    let mut prev_anchor_arm = Arm::new("null:prev-anchor-copy", stride);
+    let mut fwd_anchor_arm = Arm::new("null:fwd-anchor-table", stride);
     // #399 headroom probes: cheapest possible consumers of forward context,
     // fused with the causal store. Instrumentation upper bounds only.
-    let mut route_arm = Arm::new("fuse:offset-route");
-    let mut conf_arm = Arm::new("fuse:count-confidence");
-    let mut product_arm = Arm::new("fuse:product");
+    let mut route_arm = Arm::new("fuse:offset-route", stride);
+    let mut conf_arm = Arm::new("fuse:count-confidence", stride);
+    let mut product_arm = Arm::new("fuse:product", stride);
     // #399 step 2 arms: region-conditioned forward tables.
     let mut region_arms: Vec<Arm> = vec![
-        Arm::new("null:fwd-region-d1"),
-        Arm::new("null:fwd-region-d2"),
-        Arm::new("null:fwd-region-d3"),
-        Arm::new("null:fwd-region-d4"),
+        Arm::new("null:fwd-region-d1", stride),
+        Arm::new("null:fwd-region-d2", stride),
+        Arm::new("null:fwd-region-d3", stride),
+        Arm::new("null:fwd-region-d4", stride),
     ];
-    let mut product_region_arm = Arm::new("fuse:product-region");
+    let mut product_region_arm = Arm::new("fuse:product-region", stride);
     let mut token_key_missing = 0u64;
     let mut region3_key_missing = 0u64;
 
@@ -253,7 +255,7 @@ fn anchor_infill_day0() {
             continue;
         }
         let target_pos = positions[i] + 1;
-        let offset = target_pos % ANCHOR_STRIDE;
+        let offset = target_pos % stride;
         if offset == 0 {
             continue; // target is a pinned anchor: given, not graded
         }
@@ -272,7 +274,7 @@ fn anchor_infill_day0() {
         );
         // previous anchor token: the reference token at the last pinned
         // stream index at or before target_pos.
-        let prev_anchor_pos = (target_pos / ANCHOR_STRIDE) * ANCHOR_STRIDE;
+        let prev_anchor_pos = (target_pos / stride) * stride;
         let back = target_pos - prev_anchor_pos; // 1..=3
         let prev_anchor_tok = if back <= positions[i] + 1 {
             // token at stream index prev_anchor_pos is this record's input
@@ -283,7 +285,7 @@ fn anchor_infill_day0() {
         };
         prev_anchor_arm.score(offset, prev_anchor_tok, truth);
 
-        let next_anchor_pos = target_pos.next_multiple_of(ANCHOR_STRIDE);
+        let next_anchor_pos = target_pos.next_multiple_of(stride);
         let lookahead = next_anchor_pos - target_pos;
         let j = i + lookahead;
         let fwd_dist = if j < c.n && c.story[j] == c.story[i] {
@@ -299,7 +301,7 @@ fn anchor_infill_day0() {
         let store_pred = Some(store_witness.token);
 
         // (a) route by offset: forward table owns the pre-anchor position.
-        let route_pred = if offset == ANCHOR_STRIDE - 1 {
+        let route_pred = if offset == stride - 1 {
             fwd_pred_raw.or(store_pred)
         } else {
             store_pred

--- a/crates/uor-r4-graph-certify/tests/anchor_infill.rs
+++ b/crates/uor-r4-graph-certify/tests/anchor_infill.rs
@@ -149,6 +149,14 @@ fn fuse_product(
     }
 }
 
+/// The compiled graded code of a token — its geometric address in the
+/// artifact's token codebook ([V × STAGES] bytes).
+fn token_code(art: &compiler::Compiled, t: u32) -> Option<&[u8]> {
+    art.token_codes
+        .chunks_exact(compiler::STAGES)
+        .nth(t as usize)
+}
+
 #[test]
 #[ignore = "Day-0 measurement harness; run explicitly with --ignored"]
 fn anchor_infill_day0() {
@@ -171,6 +179,12 @@ fn anchor_infill_day0() {
     // distance d in 1..ANCHOR_STRIDE: the target sits d positions before the
     // next pinned token in the reference stream.
     let mut fwd_anchor: BTreeMap<(usize, u32), BTreeMap<u32, u64>> = BTreeMap::new();
+    // #399 step 2: E_b-style REGION conditioning — key the forward table by
+    // the anchor token's graded-code prefix (its compiled geometric address)
+    // instead of its raw identity, at every depth. Statistics are shared
+    // across geometrically similar anchors; the held-out comparison against
+    // the token-identity table is the "does geometry carry syntax" test.
+    let mut fwd_region: BTreeMap<(usize, usize, Vec<u8>), BTreeMap<u32, u64>> = BTreeMap::new();
     #[allow(clippy::needless_range_loop)] // index i addresses four parallel corpus arrays
     for i in 0..c.n {
         if c.story[i] >= cut {
@@ -195,6 +209,15 @@ fn anchor_infill_day0() {
                     .or_default()
                     .entry(c.next[i])
                     .or_default() += 1;
+                if let Some(code) = token_code(&art, c.next[j]) {
+                    for depth in 1..=compiler::STAGES {
+                        *fwd_region
+                            .entry((lookahead, depth, code[..depth].to_vec()))
+                            .or_default()
+                            .entry(c.next[i])
+                            .or_default() += 1;
+                    }
+                }
             }
         }
     }
@@ -214,6 +237,16 @@ fn anchor_infill_day0() {
     let mut route_arm = Arm::new("fuse:offset-route");
     let mut conf_arm = Arm::new("fuse:count-confidence");
     let mut product_arm = Arm::new("fuse:product");
+    // #399 step 2 arms: region-conditioned forward tables.
+    let mut region_arms: Vec<Arm> = vec![
+        Arm::new("null:fwd-region-d1"),
+        Arm::new("null:fwd-region-d2"),
+        Arm::new("null:fwd-region-d3"),
+        Arm::new("null:fwd-region-d4"),
+    ];
+    let mut product_region_arm = Arm::new("fuse:product-region");
+    let mut token_key_missing = 0u64;
+    let mut region3_key_missing = 0u64;
 
     for i in 0..c.n {
         if c.story[i] < cut {
@@ -297,6 +330,43 @@ fn anchor_infill_day0() {
         // (c) product-of-experts over the union support.
         let product_pred = fuse_product(store_dist(&store, &codes[i]), fwd_dist).or(store_pred);
         product_arm.score(offset, product_pred, truth);
+
+        // ---- #399 step 2: region-conditioned forward tables ----
+        let anchor_code = if j < c.n && c.story[j] == c.story[i] {
+            token_code(&art, c.next[j])
+        } else {
+            None
+        };
+        let mut region_dists: [Option<&BTreeMap<u32, u64>>; 4] = [None; 4];
+        if let Some(code) = anchor_code {
+            for depth in 1..=compiler::STAGES {
+                region_dists[depth - 1] =
+                    fwd_region.get(&(lookahead, depth, code[..depth].to_vec()));
+            }
+        }
+        for depth in 1..=compiler::STAGES {
+            region_arms[depth - 1].score(
+                offset,
+                region_dists[depth - 1].and_then(argmax).or(unigram_pred),
+                truth,
+            );
+        }
+        if fwd_dist.is_none() {
+            token_key_missing += 1;
+        }
+        if region_dists[2].is_none() {
+            region3_key_missing += 1;
+        }
+        // token table when populated, else deepest populated region prefix:
+        // the E_b-style backoff chain, product-fused with the causal store.
+        let eb_dist = fwd_dist
+            .or(region_dists[3])
+            .or(region_dists[2])
+            .or(region_dists[1])
+            .or(region_dists[0]);
+        let product_region_pred =
+            fuse_product(store_dist(&store, &codes[i]), eb_dist).or(store_pred);
+        product_region_arm.score(offset, product_region_pred, truth);
     }
 
     for arm in [
@@ -311,4 +381,11 @@ fn anchor_infill_day0() {
     ] {
         arm.report();
     }
+    for arm in &region_arms {
+        arm.report();
+    }
+    product_region_arm.report();
+    println!(
+        "backoff diagnostics: token-table key missing {token_key_missing} | region-d3 key missing {region3_key_missing}"
+    );
 }


### PR DESCRIPTION
Two harness measurements: (1) #399 step 2 — forward tables keyed by the anchor's graded-code prefix: d3 reproduces the token-identity table to 0.1pp (geometric address is a sufficient statistic at fixture density; generalization test deferred to natural corpus where sparsity is real). (2) #394 stride sweep via R4_INFILL_STRIDE: fusion gain +11.6/+8.7/+6.3pp at stride 3/4/5, pre-anchor position ~50% at every stride, causal store stride-invariant. Results comments on #399 and #394. Part of #393.