### PR TITLE
test(certify): #395 ladder step 1 — all-integer table-read assignment costs 0.4pp

### DIFF
--- a/crates/uor-r4-graph-certify/tests/e8_membership_ab.rs
+++ b/crates/uor-r4-graph-certify/tests/e8_membership_ab.rs
@@ -1,0 +1,567 @@
+//! #395 measurement ladder step 1 (Z[phi] conformance note): does the
+//! TABLE-READ serving path cost anything? — lattice-distance assignment A/B.
+//!
+//! The icosian serving story replaces exact f32 distances with finite
+//! table reads: the query residual is lattice-quantized per 8-dim block,
+//! and distance to each (lattice-snapped) centroid is a sum of per-block
+//! entries d(Q(r)_blk, c_blk) — both arguments drawn from finite lattice
+//! point sets, hence precompilable. This harness measures the accuracy
+//! price of that quantized pipeline against the exact-distance arms of
+//! the v1 experiment (PR #404), with training held identical.
+//!
+//! Arms (identical 4-stage x 256-centroid RVQ, deterministic k-means):
+//! - `rvq-f32-exact`: plain centroids, exact f32 distances (v1 control).
+//! - `rvq-e8-exact`: 0.5rms-snapped centroids, exact f32 distances (v1
+//!   winner arm).
+//! - `rvq-e8-tables`: 0.5rms-snapped centroids, query residual lattice-
+//!   quantized per block BEFORE every distance, residual updated in the
+//!   quantized domain — the all-integer, table-implementable pipeline.
+//!
+//! Also carries fast (non-ignored) unit tests for the Z[phi]/E8 kernel
+//! facts the conformance note relies on: the Fibonacci-shift phi
+//! arithmetic, golden-conjugation involution, and Conway–Sloane
+//! nearest-point optimality on a sampled neighborhood.
+//!
+//! Certifier-side instrumentation only (f32/f64 permitted here, never in
+//! the kernel).
+//!
+//! Run the measurement:
+//!   cargo test --release -p uor-r4-graph-certify --test e8_membership_ab -- --ignored --nocapture
+
+use std::collections::BTreeMap;
+
+use uor_r4_core::transformerless::compiler;
+use uor_r4_core::transformerless::compiler::{D, STAGES};
+use uor_r4_core::transformerless::runtime;
+
+const BLOCK: usize = 8;
+const NBLK: usize = D / BLOCK; // 36
+const K: usize = 256;
+const LLOYD_ITERS: usize = 8;
+const TRAIN_STEP: usize = 8;
+const SNAP_MULT: f64 = 0.5;
+
+fn fixture(name: &str) -> String {
+    format!(
+        "{}/../uor-r4-core/tests/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+// ---------- Z[phi] arithmetic (integer pairs (a, b) meaning a + b*phi) ----------
+
+/// Multiply by phi: (a, b) -> (b, a + b) — the Fibonacci shift, adds only.
+fn zphi_mul_phi(x: (i64, i64)) -> (i64, i64) {
+    (x.1, x.0 + x.1)
+}
+
+/// Multiply by phi^-1 = phi - 1: (a, b) -> (b - a, a).
+fn zphi_mul_phi_inv(x: (i64, i64)) -> (i64, i64) {
+    (x.1 - x.0, x.0)
+}
+
+/// Golden conjugation (phi <-> -1/phi): (a, b) -> (a + b, -b).
+fn zphi_conj(x: (i64, i64)) -> (i64, i64) {
+    (x.0 + x.1, -x.1)
+}
+
+fn zphi_to_f64(x: (i64, i64)) -> f64 {
+    const PHI: f64 = 1.618_033_988_749_895;
+    x.0 as f64 + x.1 as f64 * PHI
+}
+
+// ---------- E8 kernel ----------
+
+fn d8_round(y: &[f64; BLOCK]) -> [f64; BLOCK] {
+    let mut f = [0f64; BLOCK];
+    for i in 0..BLOCK {
+        f[i] = y[i].round();
+    }
+    let sum: i64 = f.iter().map(|v| *v as i64).sum();
+    if sum.rem_euclid(2) != 0 {
+        let (mut bi, mut be) = (0usize, -1f64);
+        for i in 0..BLOCK {
+            let e = (y[i] - f[i]).abs();
+            if e > be {
+                be = e;
+                bi = i;
+            }
+        }
+        f[bi] += if y[bi] > f[bi] { 1.0 } else { -1.0 };
+    }
+    f
+}
+
+fn e8_snap(y: &[f64; BLOCK]) -> [f64; BLOCK] {
+    let a = d8_round(y);
+    let mut yh = [0f64; BLOCK];
+    for i in 0..BLOCK {
+        yh[i] = y[i] - 0.5;
+    }
+    let b0 = d8_round(&yh);
+    let mut b = [0f64; BLOCK];
+    for i in 0..BLOCK {
+        b[i] = b0[i] + 0.5;
+    }
+    let da: f64 = (0..BLOCK).map(|i| (y[i] - a[i]).powi(2)).sum();
+    let db: f64 = (0..BLOCK).map(|i| (y[i] - b[i]).powi(2)).sum();
+    if da <= db {
+        a
+    } else {
+        b
+    }
+}
+
+// ---------- fast unit tests for the conformance note ----------
+
+#[test]
+fn zphi_fibonacci_shift_is_phi_multiplication() {
+    for a in -7i64..=7 {
+        for b in -7i64..=7 {
+            let x = (a, b);
+            let shifted = zphi_to_f64(zphi_mul_phi(x));
+            let direct = zphi_to_f64(x) * 1.618_033_988_749_895;
+            assert!(
+                (shifted - direct).abs() < 1e-9,
+                "phi shift mismatch at {x:?}"
+            );
+            let inv = zphi_to_f64(zphi_mul_phi_inv(x));
+            let direct_inv = zphi_to_f64(x) / 1.618_033_988_749_895;
+            assert!((inv - direct_inv).abs() < 1e-9, "phi^-1 mismatch at {x:?}");
+        }
+    }
+}
+
+#[test]
+fn zphi_conjugation_is_an_involution_matching_minus_inv_phi() {
+    for a in -7i64..=7 {
+        for b in -7i64..=7 {
+            let x = (a, b);
+            assert_eq!(zphi_conj(zphi_conj(x)), x, "conjugation not involutive");
+            // conj sends a + b*phi to a + b*(1 - phi) = a + b*(-1/phi)
+            let conj_val = zphi_to_f64(zphi_conj(x));
+            let expect = x.0 as f64 + x.1 as f64 * (1.0 - 1.618_033_988_749_895);
+            assert!((conj_val - expect).abs() < 1e-9);
+        }
+    }
+}
+
+#[test]
+fn conway_sloane_decode_is_nearest_on_sampled_neighborhood() {
+    // brute-force candidates: all E8 points with coords in {-2..2} u {+-1/2,..}
+    // reachable from the decode of a perturbed grid of targets.
+    let mut worst = 0f64;
+    for seed in 0..500u64 {
+        // deterministic pseudo-targets (no RNG per repo discipline)
+        let mut y = [0f64; BLOCK];
+        let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+        for v in y.iter_mut() {
+            s = s.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            *v = ((s >> 33) as f64 / (1u64 << 31) as f64) * 3.0 - 1.5;
+        }
+        let p = e8_snap(&y);
+        let dp: f64 = (0..BLOCK).map(|i| (y[i] - p[i]).powi(2)).sum();
+        // adversarial neighbors: perturb single coordinates by +-1 and pairs
+        // by (+-1, +-1); keep only E8-valid vectors. E8 membership: coords
+        // all integer OR all half-odd-integer, AND the coordinate sum is an
+        // even integer (both cosets).
+        let e8_valid = |q: &[f64; BLOCK]| -> bool {
+            let int_like = q.iter().all(|v| (v - v.round()).abs() < 1e-9);
+            let half_like = q.iter().all(|v| (v - v.floor() - 0.5).abs() < 1e-9);
+            if !int_like && !half_like {
+                return false;
+            }
+            let total = q.iter().sum::<f64>();
+            (total - total.round()).abs() < 1e-9 && (total.round() as i64).rem_euclid(2) == 0
+        };
+        for i in 0..BLOCK {
+            for j in 0..BLOCK {
+                for (da_, db_) in [(1.0, 1.0), (1.0, -1.0), (-1.0, 1.0), (-1.0, -1.0)] {
+                    let mut q = p;
+                    if i == j {
+                        q[i] += da_; // single +-1 (i==j collapses to one bump twice; harmless)
+                    } else {
+                        q[i] += da_;
+                        q[j] += db_;
+                    }
+                    if !e8_valid(&q) {
+                        continue;
+                    }
+                    let dq: f64 = (0..BLOCK).map(|k| (y[k] - q[k]).powi(2)).sum();
+                    if dp - dq > worst {
+                        worst = dp - dq;
+                    }
+                }
+            }
+        }
+    }
+    assert!(worst < 1e-9, "decode beaten by a neighbor by {worst}");
+}
+
+// ---------- measurement machinery (shared shape with the v1 experiment) ----------
+
+type Store = Vec<BTreeMap<Vec<u8>, BTreeMap<u32, u32>>>;
+
+fn build_store_from_codes(
+    c: &compiler::Corpus,
+    cut: u32,
+    key: &dyn Fn(usize, usize) -> Vec<u8>,
+) -> Store {
+    let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    for i in 0..c.n {
+        if c.story[i] >= cut {
+            continue;
+        }
+        for k_idx in 0..c.top_tokens[i].len() {
+            let (tok, weight) = (c.top_tokens[i][k_idx], c.top_weights[i][k_idx]);
+            if weight > 0 {
+                for (d, level) in store.iter_mut().enumerate() {
+                    *level.entry(key(i, d)).or_default().entry(tok).or_default() += weight;
+                }
+            }
+        }
+    }
+    store
+}
+
+struct EvalOut {
+    top1: f64,
+    agree: f64,
+    wb_bits: f64,
+    keys: usize,
+    infill_top1: f64,
+}
+
+fn eval_store(
+    c: &compiler::Corpus,
+    cut: u32,
+    positions: &[usize],
+    store: &Store,
+    key: &dyn Fn(usize, usize) -> Vec<u8>,
+) -> EvalOut {
+    let (mut top1, mut agree, mut bits) = (0u64, 0u64, 0f64);
+    let (mut n, mut inf_hits, mut inf_n) = (0u64, 0u64, 0u64);
+    #[allow(clippy::needless_range_loop)] // i indexes parallel corpus arrays
+    for i in 0..c.n {
+        if c.story[i] < cut {
+            continue;
+        }
+        n += 1;
+        let mut pred = None;
+        for d in (0..=STAGES).rev() {
+            if let Some(dist) = store[d].get(&key(i, d)) {
+                pred = dist
+                    .iter()
+                    .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+                    .map(|(&t, _)| t);
+                break;
+            }
+        }
+        let pred = pred.unwrap_or(0);
+        if pred == c.next[i] {
+            top1 += 1;
+        }
+        if pred == c.t_argmax[i] {
+            agree += 1;
+        }
+        let target_pos = positions[i] + 1;
+        if !target_pos.is_multiple_of(4) {
+            inf_n += 1;
+            if pred == c.next[i] {
+                inf_hits += 1;
+            }
+        }
+        let mut lams: Vec<(f64, &BTreeMap<u32, u32>, u32)> = Vec::new();
+        for (d, level) in store.iter().enumerate().take(STAGES + 1) {
+            if let Some(dist) = level.get(&key(i, d)) {
+                let total: u32 = dist.values().sum();
+                let lam = total as f64 / (total as f64 + dist.len() as f64);
+                lams.push((lam, dist, total));
+            }
+        }
+        let mut p = {
+            let mut rem = 1.0f64;
+            let mut acc = 0.0f64;
+            for li in (0..lams.len()).rev() {
+                let w = rem * lams[li].0;
+                rem *= 1.0 - lams[li].0;
+                if let Some(&cc) = lams[li].1.get(&c.next[i]) {
+                    acc += w * cc as f64 / lams[li].2 as f64;
+                }
+            }
+            acc + rem / 32000.0
+        };
+        if p <= 0.0 {
+            p = 1e-30;
+        }
+        bits += -p.log2();
+    }
+    EvalOut {
+        top1: 100.0 * top1 as f64 / n as f64,
+        agree: 100.0 * agree as f64 / n as f64,
+        wb_bits: bits / n as f64,
+        keys: store.iter().map(|l| l.len()).sum(),
+        infill_top1: 100.0 * inf_hits as f64 / inf_n as f64,
+    }
+}
+
+fn story_positions(c: &compiler::Corpus) -> Vec<usize> {
+    let mut positions = Vec::with_capacity(c.n);
+    let (mut cur, mut pos) = (u32::MAX, 0usize);
+    for i in 0..c.n {
+        if c.story[i] != cur {
+            cur = c.story[i];
+            pos = 0;
+        } else {
+            pos += 1;
+        }
+        positions.push(pos);
+    }
+    positions
+}
+
+fn kmeans(train: &[f32], dim: usize, k: usize, iters: usize) -> Vec<f32> {
+    let n = train.len() / dim;
+    let mut centroids = vec![0f32; k * dim];
+    for j in 0..k {
+        let src = (j * n / k) * dim;
+        centroids[j * dim..(j + 1) * dim].copy_from_slice(&train[src..src + dim]);
+    }
+    let mut assign = vec![0usize; n];
+    for _ in 0..iters {
+        for i in 0..n {
+            let v = &train[i * dim..(i + 1) * dim];
+            let (mut bj, mut bd) = (0usize, f32::MAX);
+            for j in 0..k {
+                let cent = &centroids[j * dim..(j + 1) * dim];
+                let mut d2 = 0f32;
+                for t in 0..dim {
+                    let r = v[t] - cent[t];
+                    d2 += r * r;
+                }
+                if d2 < bd {
+                    bd = d2;
+                    bj = j;
+                }
+            }
+            assign[i] = bj;
+        }
+        let mut sums = vec![0f64; k * dim];
+        let mut counts = vec![0u64; k];
+        for i in 0..n {
+            counts[assign[i]] += 1;
+            for t in 0..dim {
+                sums[assign[i] * dim + t] += train[i * dim + t] as f64;
+            }
+        }
+        for j in 0..k {
+            if counts[j] == 0 {
+                let src = ((j * 2_654_435_761) % n) * dim;
+                centroids[j * dim..(j + 1) * dim].copy_from_slice(&train[src..src + dim]);
+                continue;
+            }
+            for t in 0..dim {
+                centroids[j * dim + t] = (sums[j * dim + t] / counts[j] as f64) as f32;
+            }
+        }
+    }
+    centroids
+}
+
+fn snap_codebooks(stage_cbs: &[Vec<f32>], mult: f64) -> (Vec<Vec<f32>>, Vec<[f64; NBLK]>) {
+    let mut scales_out = Vec::with_capacity(stage_cbs.len());
+    let snapped = stage_cbs
+        .iter()
+        .map(|cb| {
+            let mut out = cb.clone();
+            let mut scales = [0f64; NBLK];
+            for blk in 0..NBLK {
+                let mut sq = 0f64;
+                for j in 0..K {
+                    for t in 0..BLOCK {
+                        let v = cb[j * D + blk * BLOCK + t] as f64;
+                        sq += v * v;
+                    }
+                }
+                let scale = (sq / (K * BLOCK) as f64).sqrt().max(1e-9) * mult;
+                scales[blk] = scale;
+                for j in 0..K {
+                    let mut y = [0f64; BLOCK];
+                    for t in 0..BLOCK {
+                        y[t] = cb[j * D + blk * BLOCK + t] as f64 / scale;
+                    }
+                    let s = e8_snap(&y);
+                    for t in 0..BLOCK {
+                        out[j * D + blk * BLOCK + t] = (s[t] * scale) as f32;
+                    }
+                }
+            }
+            scales_out.push(scales);
+            out
+        })
+        .collect();
+    (snapped, scales_out)
+}
+
+/// Exact-distance RVQ assignment (v1 pipeline).
+fn rvq_assign_exact(bundles: &[f32], n: usize, stage_cbs: &[Vec<f32>]) -> Vec<[u8; STAGES]> {
+    let mut codes = vec![[0u8; STAGES]; n];
+    for i in 0..n {
+        let mut r = [0f32; D];
+        r.copy_from_slice(&bundles[i * D..(i + 1) * D]);
+        for (s, cb) in stage_cbs.iter().enumerate() {
+            let (mut bj, mut bd) = (0usize, f32::MAX);
+            for j in 0..K {
+                let cent = &cb[j * D..(j + 1) * D];
+                let mut d2 = 0f32;
+                for t in 0..D {
+                    let e = r[t] - cent[t];
+                    d2 += e * e;
+                }
+                if d2 < bd {
+                    bd = d2;
+                    bj = j;
+                }
+            }
+            codes[i][s] = bj as u8;
+            let cent = &cb[bj * D..(bj + 1) * D];
+            for t in 0..D {
+                r[t] -= cent[t];
+            }
+        }
+    }
+    codes
+}
+
+/// Table-implementable RVQ assignment: the residual is lattice-quantized per
+/// block BEFORE every distance computation, and the residual update happens
+/// in the quantized domain — every distance is between two lattice points at
+/// the stage's block scales, hence a precompilable table entry.
+fn rvq_assign_tables(
+    bundles: &[f32],
+    n: usize,
+    stage_cbs: &[Vec<f32>],
+    stage_scales: &[[f64; NBLK]],
+) -> Vec<[u8; STAGES]> {
+    let mut codes = vec![[0u8; STAGES]; n];
+    for i in 0..n {
+        let mut r = [0f64; D];
+        for t in 0..D {
+            r[t] = bundles[i * D + t] as f64;
+        }
+        for (s, cb) in stage_cbs.iter().enumerate() {
+            // quantize the residual per block at this stage's scales
+            let mut rq = [0f64; D];
+            for blk in 0..NBLK {
+                let sc = stage_scales[s][blk];
+                let mut y = [0f64; BLOCK];
+                for t in 0..BLOCK {
+                    y[t] = r[blk * BLOCK + t] / sc;
+                }
+                let q = e8_snap(&y);
+                for t in 0..BLOCK {
+                    rq[blk * BLOCK + t] = q[t] * sc;
+                }
+            }
+            let (mut bj, mut bd) = (0usize, f64::MAX);
+            for j in 0..K {
+                let cent = &cb[j * D..(j + 1) * D];
+                let mut d2 = 0f64;
+                for t in 0..D {
+                    let e = rq[t] - cent[t] as f64;
+                    d2 += e * e;
+                }
+                if d2 < bd {
+                    bd = d2;
+                    bj = j;
+                }
+            }
+            codes[i][s] = bj as u8;
+            let cent = &cb[bj * D..(bj + 1) * D];
+            for t in 0..D {
+                r[t] = rq[t] - cent[t] as f64;
+            }
+        }
+    }
+    codes
+}
+
+#[test]
+#[ignore = "measurement; run explicitly with --ignored"]
+fn e8_membership_table_ab() {
+    let c = compiler::load_corpus_from(&fixture("c_meta.bin"), &fixture("c_recs.bin"))
+        .expect("checked-in fixture corpus");
+    let art = compiler::load_artifacts_from(&fixture("tless_artifacts.bin"))
+        .expect("checked-in fixture artifacts");
+    let cut = (c.stories as f64 * 0.8) as u32;
+    let positions = story_positions(&c);
+    let rot = compiler::derive_rotations();
+    println!("e8 membership A/B (#395 ladder 1): {} records", c.n);
+
+    let mut bundles: Vec<f32> = Vec::with_capacity(c.n * D);
+    for i in 0..c.n {
+        let b = runtime::bundle_plain(&art, &rot, &c, i);
+        let w = runtime::centered_work(&art, &b);
+        bundles.extend(w.iter().map(|&v| v as f32));
+    }
+    println!("bundle pass done");
+
+    let mut stage_cbs: Vec<Vec<f32>> = Vec::with_capacity(STAGES);
+    let train_idx: Vec<usize> = (0..c.n)
+        .step_by(TRAIN_STEP)
+        .filter(|&i| c.story[i] < cut)
+        .collect();
+    let mut train: Vec<f32> = Vec::with_capacity(train_idx.len() * D);
+    for &i in &train_idx {
+        train.extend_from_slice(&bundles[i * D..(i + 1) * D]);
+    }
+    for s in 0..STAGES {
+        let cb = kmeans(&train, D, K, LLOYD_ITERS);
+        let tn = train.len() / D;
+        for i in 0..tn {
+            let v = train[i * D..(i + 1) * D].to_vec();
+            let (mut bj, mut bd) = (0usize, f32::MAX);
+            for j in 0..K {
+                let cent = &cb[j * D..(j + 1) * D];
+                let mut d2 = 0f32;
+                for t in 0..D {
+                    let e = v[t] - cent[t];
+                    d2 += e * e;
+                }
+                if d2 < bd {
+                    bd = d2;
+                    bj = j;
+                }
+            }
+            for t in 0..D {
+                train[i * D + t] -= cb[bj * D + t];
+            }
+        }
+        println!("stage {s} trained");
+        stage_cbs.push(cb);
+    }
+    drop(train);
+
+    let (snapped_cbs, snap_scales) = snap_codebooks(&stage_cbs, SNAP_MULT);
+
+    let arms: Vec<(&str, Vec<[u8; STAGES]>)> = vec![
+        ("rvq-f32-exact", rvq_assign_exact(&bundles, c.n, &stage_cbs)),
+        (
+            "rvq-e8-exact",
+            rvq_assign_exact(&bundles, c.n, &snapped_cbs),
+        ),
+        (
+            "rvq-e8-tables",
+            rvq_assign_tables(&bundles, c.n, &snapped_cbs, &snap_scales),
+        ),
+    ];
+    for (name, codes) in &arms {
+        let key = |i: usize, d: usize| codes[i][..d].to_vec();
+        let store = build_store_from_codes(&c, cut, &key);
+        let m = eval_store(&c, cut, &positions, &store, &key);
+        println!(
+            "{name:<16} top1 {:.1}% | agree {:.1}% | WB {:.4} bits | {} keys | infill-free top1 {:.1}%",
+            m.top1, m.agree, m.wb_bits, m.keys, m.infill_top1
+        );
+    }
+}


### PR DESCRIPTION
Membership-metric A/B: rvq-f32-exact 36.8%/7.9266 | rvq-e8-exact 36.7%/7.9175 | rvq-e8-tables 36.3%/7.9769 — the fully table-implementable pipeline (query residual lattice-quantized before every distance) pays 0.4pp/0.06 bits. With v1 (storage free), the green Z[phi]/decode unit tests, and the Cayley-table group action, every layer of the icosian serving story is measured or proven at adds/compares/table-reads. Results comment on #395. Part of #393.