### PR TITLE
feat(format,certify): #399 — FWDA forward-anchor section + score_candidates_infill serving entry point

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -714,6 +714,107 @@ pub fn compile_context_rows(
         .collect()
 }
 
+/// Per-row entry cap for the FWDA forward-anchor section: keep the
+/// highest-count entries (canonical tie: lowest token) so a hot anchor
+/// cannot blow up the section.
+pub const FWDA_ENTRY_CAP: usize = 64;
+/// Rows with less total evidence than this are not emitted (size bound;
+/// a one-observation row carries no measurable signal).
+pub const FWDA_MIN_TOTAL: u32 = 2;
+
+/// One compiled forward-anchor row (issue #399): the raw count
+/// distribution over the token emitted `distance` positions before an
+/// anchor whose token is `anchor`. Counts stay raw on the wire — the
+/// serving loader derives smoothed ScoreQ residuals from `total`, which
+/// is the FULL pre-truncation evidence total (see the format crate's
+/// `fwda` module docs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardAnchorRow {
+    /// Lookahead distance to the anchor (one through `M2_STRIDE` minus one).
+    pub distance: u8,
+    /// The anchor's emitted token.
+    pub anchor: u32,
+    /// Full evidence total before the entry cap was applied.
+    pub total: u32,
+    /// Bounded `(token, raw count)` entries, ascending token order.
+    pub entries: Vec<(u32, u32)>,
+}
+
+/// Compile forward-anchor rows from the construction split — the same
+/// loop the Gate C instrumentation uses to build its `fwd_table`
+/// (issue #399 M2, the #394 infill protocol), run over the `train`
+/// observations that also feed the store and the NGRAM context rows: a
+/// position is an anchor when its EMITTED token lands on a
+/// story-relative position that is a multiple of the stride, and each
+/// anchor contributes its same-story construction-split predecessors at
+/// every lookahead distance. Rows are canonical (ascending
+/// `(distance, anchor)`, entries ascending token), capped at
+/// [`FWDA_ENTRY_CAP`] entries keeping the highest counts (ties to the
+/// lowest token), and dropped below [`FWDA_MIN_TOTAL`] total evidence.
+pub fn compile_forward_anchor_rows(
+    corpus: &Corpus,
+    train: &[Observation],
+) -> Vec<ForwardAnchorRow> {
+    let mut in_train = vec![false; corpus.n];
+    for observation in train {
+        let i = observation.position as usize;
+        if i < corpus.n && corpus.next[i] == observation.next {
+            in_train[i] = true;
+        }
+    }
+    let mut story_pos = Vec::with_capacity(corpus.n);
+    {
+        let (mut current_story, mut position_in_story) = (u32::MAX, 0u32);
+        for &story in corpus.story.iter().take(corpus.n) {
+            if story != current_story {
+                current_story = story;
+                position_in_story = 0;
+            } else {
+                position_in_story += 1;
+            }
+            story_pos.push(position_in_story);
+        }
+    }
+    let mut counts: BTreeMap<(u8, u32), BTreeMap<u32, u32>> = BTreeMap::new();
+    for j in 0..corpus.n {
+        if !in_train[j] || !(story_pos[j] as usize + 1).is_multiple_of(M2_STRIDE) {
+            continue;
+        }
+        for distance in 1..M2_STRIDE {
+            if j >= distance
+                && corpus.story[j - distance] == corpus.story[j]
+                && in_train[j - distance]
+            {
+                *counts
+                    .entry((distance as u8, corpus.next[j]))
+                    .or_default()
+                    .entry(corpus.next[j - distance])
+                    .or_default() += 1;
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|((distance, anchor), distribution)| {
+            let total: u64 = distribution.values().map(|&count| u64::from(count)).sum();
+            let total = u32::try_from(total).unwrap_or(u32::MAX);
+            if total < FWDA_MIN_TOTAL {
+                return None;
+            }
+            let mut ranked: Vec<(u32, u32)> = distribution.into_iter().collect();
+            ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            ranked.truncate(FWDA_ENTRY_CAP);
+            ranked.sort_by_key(|&(token, _)| token);
+            Some(ForwardAnchorRow {
+                distance,
+                anchor,
+                total,
+                entries: ranked,
+            })
+        })
+        .collect()
+}
+
 /// Compile the optional FMM section from the same regions and emission tables
 /// that feed the normal scored-artifact path. All floating-point work remains
 /// in the certifier; the returned bytes contain only the folded integer table
@@ -1111,6 +1212,8 @@ pub struct ScoredGraphInfo {
     pub context_row_count: u32,
     pub context_entry_count: u32,
     pub context_bytes: u32,
+    pub fwda_row_count: u32,
+    pub fwda_bytes: u32,
     pub fmm_bytes: u32,
     pub fmm_rank: u16,
     pub fmm_candidate_count: u32,
@@ -1146,6 +1249,10 @@ pub struct ScoredGraphSections<'a> {
     pub exct_top_x: usize,
     /// Optional compiler-folded FMM translation table.
     pub fmm_section: Option<&'a [u8]>,
+    /// Forward-anchor rows for the optional FWDA section (issue #399);
+    /// empty means the section is not emitted and infill serving runs
+    /// without the channel.
+    pub fwd_rows: &'a [ForwardAnchorRow],
 }
 
 fn encode_context_rows(rows: &[ContextRow]) -> Result<Vec<u8>, String> {
@@ -1202,6 +1309,71 @@ fn encode_context_rows(rows: &[ContextRow]) -> Result<Vec<u8>, String> {
             previous_token = Some(token);
             bytes.extend_from_slice(&token.to_le_bytes());
             bytes.extend_from_slice(&score.raw().to_le_bytes());
+        }
+        entry_offset = bytes.len();
+    }
+    Ok(bytes)
+}
+
+/// Encode compiled forward-anchor rows as the FWDA section body (same
+/// canonical header/row/entry layout as NGRAM; raw counts on the wire,
+/// the row total in the second key slot — format crate `fwda` docs).
+fn encode_forward_anchor_rows(rows: &[ForwardAnchorRow]) -> Result<Vec<u8>, String> {
+    let row_count =
+        u32::try_from(rows.len()).map_err(|_| "FWDA row count exceeds u32".to_owned())?;
+    let header_len = uor_r4_graph_format::FWDA_HEADER_LEN;
+    let row_len = uor_r4_graph_format::FWDA_ROW_LEN;
+    let entries_start = header_len
+        .checked_add(
+            row_len
+                .checked_mul(rows.len())
+                .ok_or("FWDA row bytes overflow")?,
+        )
+        .ok_or("FWDA header bytes overflow")?;
+    let mut bytes = Vec::with_capacity(entries_start);
+    bytes.extend_from_slice(&uor_r4_graph_format::FWDA_MAGIC);
+    bytes.extend_from_slice(&uor_r4_graph_format::FWDA_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&[0u8; 2]);
+    bytes.extend_from_slice(&row_count.to_le_bytes());
+    let max_entries = rows.iter().map(|row| row.entries.len()).max().unwrap_or(0);
+    bytes.extend_from_slice(
+        &u16::try_from(max_entries)
+            .map_err(|_| "FWDA row entry count exceeds u16".to_owned())?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&[0u8; 2]);
+    bytes.resize(entries_start, 0);
+    let mut entry_offset = entries_start;
+    let mut previous = None;
+    for (index, row) in rows.iter().enumerate() {
+        if !(1..=uor_r4_graph_format::FWDA_MAX_DISTANCE).contains(&row.distance)
+            || row.total < FWDA_MIN_TOTAL
+        {
+            return Err("FWDA row has an invalid distance or total".to_owned());
+        }
+        let key = (row.distance, row.anchor);
+        if previous.is_some_and(|last| last >= key) {
+            return Err("FWDA rows are not canonically sorted".to_owned());
+        }
+        previous = Some(key);
+        let entry_count = u16::try_from(row.entries.len())
+            .map_err(|_| "FWDA row entry count exceeds u16".to_owned())?;
+        let header = header_len + index * row_len;
+        bytes[header] = row.distance;
+        bytes[header + 2..header + 4].copy_from_slice(&entry_count.to_le_bytes());
+        bytes[header + 4..header + 8].copy_from_slice(&row.anchor.to_le_bytes());
+        bytes[header + 8..header + 12].copy_from_slice(&row.total.to_le_bytes());
+        let entry_offset_u32 =
+            u32::try_from(entry_offset).map_err(|_| "FWDA entry offset exceeds u32".to_owned())?;
+        bytes[header + 12..header + 16].copy_from_slice(&entry_offset_u32.to_le_bytes());
+        let mut previous_token = None;
+        for &(token, count) in &row.entries {
+            if previous_token.is_some_and(|last| last >= token) {
+                return Err("FWDA entries are not canonically sorted".to_owned());
+            }
+            previous_token = Some(token);
+            bytes.extend_from_slice(&token.to_le_bytes());
+            bytes.extend_from_slice(&count.to_le_bytes());
         }
         entry_offset = bytes.len();
     }
@@ -1287,6 +1459,7 @@ pub fn emit_scored_r4g1(
         exct_tls1,
         exct_top_x,
         fmm_section,
+        fwd_rows,
     } = *sections;
     if regions.len() != emissions.region_lists.len() {
         return Err("emission lists do not match the region count".to_owned());
@@ -1505,6 +1678,13 @@ pub fn emit_scored_r4g1(
     builder.add_section(uor_r4_graph_format::SectionId::EMIT, 0, &emit);
     builder.add_section(uor_r4_graph_format::SectionId::EXCT, 0, &exct);
     builder.add_section(uor_r4_graph_format::SectionId::NGRAM, 0, &ngram);
+    let fwda = if fwd_rows.is_empty() {
+        Vec::new()
+    } else {
+        let fwda = encode_forward_anchor_rows(fwd_rows)?;
+        builder.add_section(uor_r4_graph_format::SectionId::FWDA, 0, &fwda);
+        fwda
+    };
     if let Some(fmm_section) = fmm_section {
         builder.add_section(uor_r4_graph_format::SectionId::FMM, 0, fmm_section);
     }
@@ -1545,6 +1725,10 @@ pub fn emit_scored_r4g1(
             .map_err(|_| "NGRAM entry count exceeds u32".to_owned())?,
             context_bytes: u32::try_from(ngram.len())
                 .map_err(|_| "NGRAM section exceeds u32".to_owned())?,
+            fwda_row_count: u32::try_from(fwd_rows.len())
+                .map_err(|_| "FWDA row count exceeds u32".to_owned())?,
+            fwda_bytes: u32::try_from(fwda.len())
+                .map_err(|_| "FWDA section exceeds u32".to_owned())?,
             fmm_bytes: fmm_section.map_or(0, |bytes| bytes.len() as u32),
             fmm_rank: fmm_table.map_or(0, |table| table.rank()),
             fmm_candidate_count: fmm_table.map_or(0, |table| table.token_count()),

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -435,6 +435,18 @@ fn quantize_exct(count: u32, total: u32, vocab: u32) -> ScoreQ {
     ScoreQ::from_logprob(p.ln() as f32)
 }
 
+/// FWDA load-time quantization (issue #399): the forward-anchor section
+/// stores raw counts plus the row total, and the residual
+/// `ln((count + 0.5) / (total + vocab * 0.5))` is baked into ScoreQ once
+/// at scorer construction — the measured Gate C fusion law's smoothing
+/// (`fuse_forward_arm` in `score.rs`). Like [`quantize_exct`] this
+/// helper is kept out of every accumulation function; the per-token
+/// serving path reads only the pre-quantized integers.
+fn quantize_fwda(count: u32, total: u32, vocab: u32) -> ScoreQ {
+    let p = (f64::from(count) + 0.5) / (f64::from(total) + f64::from(vocab) * 0.5);
+    ScoreQ::from_logprob(p.ln() as f32)
+}
+
 // END COMPILER-SIDE FLOAT QUANTIZATION -----------------------------------
 
 /// Integer multiply for the `#80` candidate scoring variants, built only
@@ -748,6 +760,19 @@ pub enum ScoringVariant {
     MarginWeighted,
 }
 
+/// One loaded forward-anchor row (issue #399): pre-quantized ScoreQ
+/// residuals under the measured product-fusion law, plus the row's
+/// absent-token floor residual (the zero-count smoothing value under the
+/// same denominator). Both are derived once at load time from the FWDA
+/// section's raw counts; the serving path is integer-only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardAnchorServingRow {
+    /// Residual applied to tokens absent from the row's entries.
+    pub absent_floor: ScoreQ,
+    /// Bounded `(token, residual)` entries, ascending token order.
+    pub entries: Vec<(u32, ScoreQ)>,
+}
+
 pub struct GraphScorer {
     graph_cid: [u8; 32],
     regions: Vec<RegionParams>,
@@ -762,6 +787,9 @@ pub struct GraphScorer {
     /// Explicit bigram/trigram rows. The root prior remains the unigram
     /// fallback in EMIT.
     context_rows: BTreeMap<(u8, u32, u32), Vec<(u32, ScoreQ)>>,
+    /// Forward-anchor rows keyed `(lookahead distance, anchor token)`,
+    /// loaded from the optional FWDA section (empty when absent).
+    fwd_rows: BTreeMap<(u8, u32), ForwardAnchorServingRow>,
     residual_exct: Option<Vec<BTreeMap<Vec<u8>, ResidualExctContext>>>,
     store: Option<Store>,
     artifacts: Option<Compiled>,
@@ -943,6 +971,31 @@ impl GraphScorer {
             }
         }
 
+        // FWDA (issue #399): the optional forward-anchor section stores
+        // raw counts plus each row's full total; residuals are quantized
+        // here, once, so the per-token infill fusion stays integer-only.
+        let mut fwd_rows = BTreeMap::new();
+        if let Some(table) = view
+            .fwda_table()
+            .map_err(|e| format!("invalid FWDA section: {e}"))?
+        {
+            let vocab = head.vocab_size();
+            for row in table.rows() {
+                let total = row.total();
+                let entries: Vec<(u32, ScoreQ)> = row
+                    .entries()
+                    .map(|entry| (entry.token, quantize_fwda(entry.count, total, vocab)))
+                    .collect();
+                fwd_rows.insert(
+                    (row.distance(), row.anchor()),
+                    ForwardAnchorServingRow {
+                        absent_floor: quantize_fwda(0, total, vocab),
+                        entries,
+                    },
+                );
+            }
+        }
+
         // EXCT: prefer compile-time residual tables. They can be used by
         // the deployed integer-only runtime; raw TLS1 remains accepted for
         // legacy Gate C/converter artifacts and uses the old certifier-side
@@ -995,6 +1048,7 @@ impl GraphScorer {
             root_top,
             emissions,
             context_rows,
+            fwd_rows,
             residual_exct,
             store,
             artifacts,
@@ -1538,6 +1592,93 @@ impl GraphScorer {
             witness,
             exact_context_source: exact_context.then_some(ExactContextSource::ExctProbe),
         })
+    }
+
+    /// The loaded forward-anchor row for `(distance, anchor)`, when the
+    /// artifact carries a FWDA section with that key. Measurement and
+    /// test accessor; serving goes through
+    /// [`GraphScorer::score_candidates_infill`].
+    pub fn forward_anchor_row(
+        &self,
+        distance: u8,
+        anchor: u32,
+    ) -> Option<&ForwardAnchorServingRow> {
+        self.fwd_rows.get(&(distance, anchor))
+    }
+
+    /// Number of loaded forward-anchor rows (zero when the FWDA section
+    /// is absent).
+    pub fn forward_anchor_row_count(&self) -> usize {
+        self.fwd_rows.len()
+    }
+
+    /// Infill serving entry point (issue #399): score the position with
+    /// [`GraphScorer::score_candidates_coded`], then — when the caller
+    /// knows the NEXT anchor token and its lookahead distance, and the
+    /// artifact carries a forward-anchor row for that key — fuse the
+    /// forward-anchor channel by the measured product law in the
+    /// log domain: every candidate's ScoreQ gets a saturating add of its
+    /// row residual (or the row's absent floor), and row tokens outside
+    /// the base candidate set enter at the offset-shifted root floor
+    /// (`root_floor + transition_offset`, the same accounting rule the
+    /// Gate C `fuse_forward_arm` instrumentation measured) plus their
+    /// residual. Selection is re-run under the canonical rule (highest
+    /// score, ties to the lowest token). The fusion itself is
+    /// integer-only; the residuals were quantized once at load time.
+    ///
+    /// A `None` anchor, a missing row, or an artifact without a FWDA
+    /// section returns the base outcome unchanged — byte-identical to
+    /// `score_candidates_coded`.
+    ///
+    /// Witness semantics: infill fusion is post-witness serving-side
+    /// re-ranking. The returned witness (and `candidate_components`)
+    /// keep the BASE outcome's contents, so independent replay covers
+    /// the base prediction; only `selected`, `selected_score`, and
+    /// `candidates` reflect the fused distribution.
+    pub fn score_candidates_infill(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        recent_tokens: &[u32],
+        next_anchor: Option<(u32, u8)>,
+    ) -> Result<ScoreOutcome, String> {
+        let base = self.score_candidates_coded(sig, input_code, recent_tokens)?;
+        let Some((anchor, distance)) = next_anchor else {
+            return Ok(base);
+        };
+        let Some(row) = self.fwd_rows.get(&(distance, anchor)) else {
+            return Ok(base);
+        };
+        let floor_base = self
+            .root_floor
+            .saturating_add(base.witness.transition_offset);
+        let mut fused: BTreeMap<u32, ScoreQ> = BTreeMap::new();
+        for &(token, score) in &base.candidates {
+            let residual = match row.entries.binary_search_by_key(&token, |&(t, _)| t) {
+                Ok(index) => row.entries[index].1,
+                Err(_) => row.absent_floor,
+            };
+            fused.insert(token, score.saturating_add(residual));
+        }
+        for &(token, residual) in &row.entries {
+            fused
+                .entry(token)
+                .or_insert_with(|| floor_base.saturating_add(residual));
+        }
+        let mut best: Option<(u32, ScoreQ)> = None;
+        for (&token, &score) in &fused {
+            if best.is_none_or(|(_, current)| score.raw() > current.raw()) {
+                best = Some((token, score));
+            }
+        }
+        let Some((selected, selected_score)) = best else {
+            return Ok(base);
+        };
+        let mut outcome = base;
+        outcome.selected = selected;
+        outcome.selected_score = selected_score;
+        outcome.candidates = fused.into_iter().collect();
+        Ok(outcome)
     }
 
     /// The pre-#64 Σ-over-cloud formula `S(v) = B(v) + Σ_{n∈A} ΔE(n,v) +
@@ -2542,6 +2683,7 @@ mod ngram_tests {
             root_top: Vec::new(),
             emissions: Vec::new(),
             context_rows: rows,
+            fwd_rows: BTreeMap::new(),
             residual_exct: None,
             store: None,
             artifacts: None,

--- a/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
+++ b/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
@@ -1,0 +1,335 @@
+//! FWDA forward-anchor section round-trip and infill-fusion tests
+//! (issue #399): the compile loop matches the Gate C instrumentation
+//! law, rows survive the artifact byte format exactly, and
+//! `score_candidates_infill` reproduces the measured f64 product-fusion
+//! reference on a hand-computed example while staying byte-identical to
+//! `score_candidates_coded` whenever the channel is off.
+
+use std::collections::BTreeMap;
+
+use uor_r4_core::transformerless::compiler::{Corpus, SIG_BYTES, STAGES};
+use uor_r4_core::transformerless::runtime;
+use uor_r4_graph_certify::score::{
+    compile_forward_anchor_rows, emit_scored_r4g1, ContextRow, EmissionTables, ForwardAnchorRow,
+    QuantizationErrorStats, ScoredGraphSections, Smoothing,
+};
+use uor_r4_graph_certify::score_runtime::{GraphScorer, RegionParams};
+use uor_r4_graph_compiler::induction::Observation;
+use uor_r4_graph_format::{GraphView, ScoreQ};
+
+const VOCAB: u32 = 100;
+const ROOT_FLOOR_RAW: i32 = -500_000;
+
+fn observation(position: usize, corpus: &Corpus) -> Observation {
+    Observation {
+        position: position as u32,
+        sample: [0; 32],
+        vector: Vec::new(),
+        sig: [0; SIG_BYTES],
+        prev: corpus.input[position],
+        next: corpus.next[position],
+    }
+}
+
+/// Two identical eight-token stories: story-relative positions run zero
+/// through seven, so the stride-four anchors sit at story positions
+/// three and seven in each story.
+fn two_story_corpus() -> Corpus {
+    let n = 16;
+    let story: Vec<u32> = (0..n).map(|i| (i / 8) as u32).collect();
+    let input: Vec<u32> = (0..n).map(|i| 10 + (i % 8) as u32).collect();
+    let next: Vec<u32> = (0..n).map(|i| 11 + (i % 8) as u32).collect();
+    Corpus {
+        n,
+        stories: 2,
+        story,
+        input,
+        next,
+        t_argmax: vec![0; n],
+        top_tokens: vec![[0; 8]; n],
+        top_weights: vec![[0; 8]; n],
+        span_start: vec![0; n],
+        span_end: vec![0; n],
+        byte_start: vec![0; n],
+        byte_end: vec![0; n],
+        hidden: None,
+    }
+}
+
+/// The compile loop reproduces the Gate C instrumentation law on the
+/// construction split: stride-four anchors keyed by EMITTED token,
+/// same-story construction-split predecessors at each lookahead
+/// distance, and rows below the minimum total dropped.
+#[test]
+fn compile_matches_gate_c_table_law() {
+    let corpus = two_story_corpus();
+    // Construction split: every position except 2 — this starves the
+    // (distance 1, anchor 14) row down to a single observation, which
+    // the minimum-total gate must then drop.
+    let train: Vec<Observation> = (0..corpus.n)
+        .filter(|&i| i != 2)
+        .map(|i| observation(i, &corpus))
+        .collect();
+    let rows = compile_forward_anchor_rows(&corpus, &train);
+    let expected = vec![
+        ForwardAnchorRow {
+            distance: 1,
+            anchor: 18,
+            total: 2,
+            entries: vec![(17, 2)],
+        },
+        ForwardAnchorRow {
+            distance: 2,
+            anchor: 14,
+            total: 2,
+            entries: vec![(12, 2)],
+        },
+        ForwardAnchorRow {
+            distance: 2,
+            anchor: 18,
+            total: 2,
+            entries: vec![(16, 2)],
+        },
+        ForwardAnchorRow {
+            distance: 3,
+            anchor: 14,
+            total: 2,
+            entries: vec![(11, 2)],
+        },
+        ForwardAnchorRow {
+            distance: 3,
+            anchor: 18,
+            total: 2,
+            entries: vec![(15, 2)],
+        },
+    ];
+    assert_eq!(rows, expected);
+}
+
+fn emissions() -> EmissionTables {
+    let mut root_prior = BTreeMap::new();
+    root_prior.insert(1u32, ScoreQ::from_raw(-50_000));
+    EmissionTables {
+        root_prior,
+        root_floor: ScoreQ::from_raw(ROOT_FLOOR_RAW),
+        root_total: 10,
+        region_lists: vec![Vec::new()],
+        smoothing: Smoothing::AddOne,
+        root_prior_quantization: QuantizationErrorStats::default(),
+        emission_quantization: QuantizationErrorStats::default(),
+        selection_stats: Default::default(),
+    }
+}
+
+/// A minimal but fully valid scored artifact: one region, no edges, one
+/// explicit bigram context row (the deterministic base distribution for
+/// the fusion tests), an empty exact-context store, and the given
+/// forward-anchor rows.
+fn tiny_artifact(fwd_rows: &[ForwardAnchorRow]) -> Vec<u8> {
+    let regions = vec![RegionParams {
+        node: 1,
+        depth: 1,
+        radius: 0,
+        sig: [0; SIG_BYTES],
+        parent: None,
+    }];
+    let context_rows = vec![ContextRow {
+        context_len: 1,
+        key0: 20,
+        key1: 0,
+        entries: vec![
+            (4, ScoreQ::from_raw(-100_000)),
+            (5, ScoreQ::from_raw(-120_000)),
+            (6, ScoreQ::from_raw(-80_000)),
+        ],
+    }];
+    let store: runtime::Store = vec![BTreeMap::new(); STAGES + 1];
+    let tls1 = runtime::store_bytes(&store);
+    let emissions = emissions();
+    let (bytes, info) = emit_scored_r4g1(
+        b"teacher-container",
+        (b"meta", b"recs"),
+        VOCAB,
+        &ScoredGraphSections {
+            regions: &regions,
+            structural: &[],
+            transitions: &[],
+            transition_quantization: QuantizationErrorStats::default(),
+            emissions: &emissions,
+            context_rows: &context_rows,
+            exct_tls1: &tls1,
+            exct_top_x: 3,
+            fmm_section: None,
+            fwd_rows,
+        },
+    )
+    .expect("tiny scored artifact");
+    assert_eq!(info.fwda_row_count as usize, fwd_rows.len());
+    bytes
+}
+
+fn fusion_rows() -> Vec<ForwardAnchorRow> {
+    vec![
+        ForwardAnchorRow {
+            distance: 1,
+            anchor: 99,
+            total: 14,
+            entries: vec![(5, 10), (6, 1), (7, 3)],
+        },
+        ForwardAnchorRow {
+            distance: 2,
+            anchor: 42,
+            total: 2,
+            entries: vec![(3, 2)],
+        },
+    ]
+}
+
+/// Rows written into the FWDA section come back byte-exact through the
+/// validated view: distance, anchor, full total, and raw count entries.
+#[test]
+fn fwda_rows_roundtrip_exactly() {
+    let rows = fusion_rows();
+    let bytes = tiny_artifact(&rows);
+    let view = GraphView::parse(&bytes).expect("emitted artifact re-validates");
+    let table = view
+        .fwda_table()
+        .expect("FWDA section parses")
+        .expect("FWDA section is present");
+    let recovered: Vec<ForwardAnchorRow> = table
+        .rows()
+        .map(|row| ForwardAnchorRow {
+            distance: row.distance(),
+            anchor: row.anchor(),
+            total: row.total(),
+            entries: row
+                .entries()
+                .map(|entry| (entry.token, entry.count))
+                .collect(),
+        })
+        .collect();
+    assert_eq!(recovered, rows);
+    // Canonical binary-search lookup agrees.
+    let found = table.find(1, 99).expect("row (1, 99) is found");
+    assert_eq!(found.total(), 14);
+    assert!(table.find(1, 98).is_none());
+    assert!(table.find(3, 99).is_none());
+}
+
+/// The quantized integer fusion selects the same token as the measured
+/// f64 reference law on a three-candidate example — and the selection
+/// differs from the base scorer's, so the channel demonstrably re-ranks.
+#[test]
+fn infill_fusion_matches_f64_reference() {
+    let bytes = tiny_artifact(&fusion_rows());
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    assert_eq!(scorer.forward_anchor_row_count(), 2);
+    let sig = [0u8; SIG_BYTES];
+    let recent = [10u32, 20];
+
+    let base = scorer
+        .score_candidates_coded(&sig, None, &recent)
+        .expect("base outcome");
+    assert_eq!(base.selected, 6, "base argmax is the context row's");
+
+    let fused = scorer
+        .score_candidates_infill(&sig, None, &recent, Some((99, 1)))
+        .expect("fused outcome");
+
+    // f64 reference: fused_ln(t) = base_q(t)/65536 + ln((c+0.5)/(total +
+    // vocab*0.5)); base absentees enter at (root_floor +
+    // transition_offset)/65536; argmax with lowest-token tie-break.
+    let counts: BTreeMap<u32, u32> = [(5u32, 10u32), (6, 1), (7, 3)].into_iter().collect();
+    let smooth = 14.0f64 + f64::from(VOCAB) * 0.5;
+    let ln_fwd = |t: u32| ((f64::from(counts.get(&t).copied().unwrap_or(0)) + 0.5) / smooth).ln();
+    let base_ln: BTreeMap<u32, f64> = base
+        .candidates
+        .iter()
+        .map(|&(t, s)| (t, f64::from(s.raw()) / 65536.0))
+        .collect();
+    let floor_ln = f64::from(ROOT_FLOOR_RAW) / 65536.0; // transition offset is zero here
+    let mut reference: BTreeMap<u32, f64> = BTreeMap::new();
+    for (&t, &ln12) in &base_ln {
+        reference.insert(t, ln12 + ln_fwd(t));
+    }
+    for &t in counts.keys() {
+        reference.entry(t).or_insert(floor_ln + ln_fwd(t));
+    }
+    let (mut ref_token, mut ref_score) = (u32::MAX, f64::NEG_INFINITY);
+    for (&t, &score) in &reference {
+        if score > ref_score {
+            ref_token = t;
+            ref_score = score;
+        }
+    }
+
+    assert_eq!(fused.selected, ref_token, "quantized argmax == f64 argmax");
+    assert_eq!(fused.selected, 5, "the anchor evidence flips the pick");
+    assert_ne!(fused.selected, base.selected);
+
+    // The fused candidate set is the base set plus the row-only token,
+    // and the row-only token entered at the offset-shifted root floor
+    // plus its quantized residual.
+    let fused_map: BTreeMap<u32, ScoreQ> = fused.candidates.iter().copied().collect();
+    assert_eq!(
+        fused_map.keys().copied().collect::<Vec<_>>(),
+        vec![4, 5, 6, 7]
+    );
+    let residual_7 = ScoreQ::from_logprob(((3.0f64 + 0.5) / smooth).ln() as f32);
+    assert_eq!(
+        fused_map[&7],
+        ScoreQ::from_raw(ROOT_FLOOR_RAW).saturating_add(residual_7)
+    );
+
+    // Post-witness re-ranking: the witness and the components keep the
+    // base outcome's contents.
+    assert_eq!(fused.witness, base.witness);
+    assert_eq!(fused.candidate_components, base.candidate_components);
+}
+
+/// Channel-off paths are byte-identical to `score_candidates_coded`: a
+/// `None` anchor, an anchor without a matching row, and an artifact
+/// without any FWDA section.
+#[test]
+fn infill_off_paths_match_coded_exactly() {
+    let with_rows = tiny_artifact(&fusion_rows());
+    let without_rows = tiny_artifact(&[]);
+    let sig = [0u8; SIG_BYTES];
+    let recent = [10u32, 20];
+
+    let view = GraphView::parse(&without_rows).expect("artifact without FWDA re-validates");
+    assert!(view.fwda_table().expect("parses").is_none());
+
+    for bytes in [&with_rows, &without_rows] {
+        let scorer = GraphScorer::from_artifact(bytes, None, 3, 3).expect("scorer loads");
+        let base = scorer
+            .score_candidates_coded(&sig, None, &recent)
+            .expect("base outcome");
+        let none_anchor = scorer
+            .score_candidates_infill(&sig, None, &recent, None)
+            .expect("infill without anchor");
+        let missing_row = scorer
+            .score_candidates_infill(&sig, None, &recent, Some((77, 2)))
+            .expect("infill with unmatched anchor");
+        for outcome in [&none_anchor, &missing_row] {
+            assert_eq!(outcome.selected, base.selected);
+            assert_eq!(outcome.selected_score, base.selected_score);
+            assert_eq!(outcome.candidates, base.candidates);
+            assert_eq!(outcome.candidate_components, base.candidate_components);
+            assert_eq!(outcome.witness, base.witness);
+            assert_eq!(outcome.exact_context_source, base.exact_context_source);
+        }
+    }
+
+    let scorer = GraphScorer::from_artifact(&without_rows, None, 3, 3).expect("scorer loads");
+    assert_eq!(scorer.forward_anchor_row_count(), 0);
+    let base = scorer
+        .score_candidates_coded(&sig, None, &recent)
+        .expect("base outcome");
+    let fused = scorer
+        .score_candidates_infill(&sig, None, &recent, Some((99, 1)))
+        .expect("infill on a channel-less artifact");
+    assert_eq!(fused.selected, base.selected);
+    assert_eq!(fused.candidates, base.candidates);
+    assert_eq!(fused.witness, base.witness);
+}

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -440,6 +440,7 @@ pub fn run_point(
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
     let context_rows =
         score::compile_context_rows(&inputs.corpus, &inputs.train, vocab, score_config);
+    let fwd_rows = score::compile_forward_anchor_rows(&inputs.corpus, &inputs.train);
     let emissions = score::compile_emissions(
         &inputs.corpus,
         &inputs.store,
@@ -464,6 +465,7 @@ pub fn run_point(
             exct_tls1: &inputs.tls1,
             exct_top_x: score_config.exct_top_x,
             fmm_section: Some(&fmm_section),
+            fwd_rows: &fwd_rows,
         },
     )?;
     let gate_c = score::evaluate_gate_c(

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1120,6 +1120,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
     let context_rows = score::compile_context_rows(&corpus, &train, vocab, &config);
+    let fwd_rows = score::compile_forward_anchor_rows(&corpus, &train);
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
     let fmm_section = score::compile_fmm_section(&regions, &emissions, vocab)?;
@@ -1137,6 +1138,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
             exct_tls1: &tls1,
             exct_top_x: config.exct_top_x,
             fmm_section: Some(&fmm_section),
+            fwd_rows: &fwd_rows,
         },
     )?;
     let graph_kappa = uor_r4_graph_format::r4g1::artifact_kappa(&artifact_bytes)

--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -204,6 +204,22 @@ pub enum FormatError {
     NgramEntriesNotSorted,
     /// NGRAM row metadata is invalid.
     NgramInvalidRow,
+    /// FWDA has no complete fixed header.
+    FwdaTooShort,
+    /// FWDA magic is not `FWA1`.
+    FwdaBadMagic,
+    /// FWDA version is not supported.
+    FwdaUnsupportedVersion,
+    /// FWDA reserved bytes are non-zero.
+    FwdaNonZeroReserved,
+    /// FWDA row or entry offset arithmetic is invalid.
+    FwdaBounds,
+    /// FWDA row keys are not in canonical order.
+    FwdaRowsNotSorted,
+    /// FWDA entry tokens are not in canonical order.
+    FwdaEntriesNotSorted,
+    /// FWDA row metadata is invalid.
+    FwdaInvalidRow,
     /// A packed-node range field does not resolve within its target
     /// section under checked arithmetic (RFC §6 item 4). For
     /// `Prototype`/`Mask` the full W-word extent from the word start
@@ -563,6 +579,16 @@ impl fmt::Display for FormatError {
                 write!(f, "NGRAM entries are not canonically sorted")
             }
             FormatError::NgramInvalidRow => write!(f, "NGRAM row metadata is invalid"),
+            FormatError::FwdaTooShort => write!(f, "FWDA section is shorter than its header"),
+            FormatError::FwdaBadMagic => write!(f, "FWDA magic is not FWA1"),
+            FormatError::FwdaUnsupportedVersion => write!(f, "FWDA version is unsupported"),
+            FormatError::FwdaNonZeroReserved => write!(f, "FWDA reserved bytes are non-zero"),
+            FormatError::FwdaBounds => write!(f, "FWDA row or entry range is out of bounds"),
+            FormatError::FwdaRowsNotSorted => write!(f, "FWDA rows are not canonically sorted"),
+            FormatError::FwdaEntriesNotSorted => {
+                write!(f, "FWDA entries are not canonically sorted")
+            }
+            FormatError::FwdaInvalidRow => write!(f, "FWDA row metadata is invalid"),
             FormatError::RangeOutOfBounds { node, field } => write!(
                 f,
                 "node {node}: {field} range does not resolve within its target section"

--- a/crates/uor-r4-graph-format/src/fwda.rs
+++ b/crates/uor-r4-graph-format/src/fwda.rs
@@ -1,0 +1,254 @@
+//! Borrowed packed forward-anchor rows (issue #399).
+//!
+//! FWDA carries the forward-anchor channel measured by the Gate C
+//! instrumentation: a table keyed by (lookahead distance, next-anchor
+//! token) whose value is the raw count distribution over the token
+//! emitted `distance` positions before that anchor. The section is
+//! optional; an artifact without it simply serves without the channel.
+//!
+//! The wire layout mirrors NGRAM byte for byte (same header, row, and
+//! entry widths, same canonical ordering rules) with these semantic
+//! differences:
+//!
+//! - the row `context_len` byte is the lookahead distance (one through
+//!   three, the free positions between stride-four anchors);
+//! - the row key is `(anchor_token, total)` — the second key slot,
+//!   unused by single-token NGRAM keys, carries the row's FULL
+//!   pre-truncation evidence total so the loader can derive smoothed
+//!   residuals without any extra storage;
+//! - entries store `(token, raw count)` as two little-endian u32 words
+//!   instead of `(token, ScoreQ)`. Quantization to ScoreQ happens at
+//!   load time where the row total is in hand, following the same
+//!   delimited compiler-side-float convention the legacy EXCT
+//!   quantization uses. Storing counts keeps the section
+//!   quantization-law-agnostic and exactly round-trippable.
+
+use crate::error::FormatError;
+
+pub const FWDA_MAGIC: [u8; 4] = *b"FWA1";
+pub const FWDA_VERSION: u16 = 1;
+pub const FWDA_HEADER_LEN: usize = 16;
+pub const FWDA_ROW_LEN: usize = 20;
+pub const FWDA_ENTRY_LEN: usize = 8;
+/// Largest lookahead distance a row may carry (stride minus one).
+pub const FWDA_MAX_DISTANCE: u8 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FwdaRow<'a> {
+    bytes: &'a [u8],
+    entries: &'a [u8],
+}
+
+impl<'a> FwdaRow<'a> {
+    /// Lookahead distance to the next anchor (one through three).
+    pub fn distance(&self) -> u8 {
+        self.bytes[0]
+    }
+
+    /// The next-anchor token this row conditions on.
+    pub fn anchor(&self) -> u32 {
+        read_u32(&self.bytes[4..8])
+    }
+
+    /// The row's full pre-truncation evidence total (the smoothing
+    /// denominator source), stored in the second key slot.
+    pub fn total(&self) -> u32 {
+        read_u32(&self.bytes[8..12])
+    }
+
+    pub fn entries(&self) -> FwdaEntries<'a> {
+        FwdaEntries {
+            bytes: self.entries,
+            remaining: (self.entries.len() / FWDA_ENTRY_LEN) as u32,
+        }
+    }
+}
+
+/// One `(token, raw count)` evidence entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FwdaEntry {
+    pub token: u32,
+    pub count: u32,
+}
+
+pub struct FwdaEntries<'a> {
+    bytes: &'a [u8],
+    remaining: u32,
+}
+
+impl Iterator for FwdaEntries<'_> {
+    type Item = FwdaEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let entry = self.bytes.get(..FWDA_ENTRY_LEN)?;
+        self.bytes = &self.bytes[FWDA_ENTRY_LEN..];
+        self.remaining -= 1;
+        Some(FwdaEntry {
+            token: read_u32(&entry[..4]),
+            count: read_u32(&entry[4..8]),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FwdaTable<'a> {
+    bytes: &'a [u8],
+    row_count: u32,
+}
+
+pub struct FwdaRows<'a> {
+    table: FwdaTable<'a>,
+    next: usize,
+}
+
+impl<'a> FwdaTable<'a> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+        if bytes.len() < FWDA_HEADER_LEN {
+            return Err(FormatError::FwdaTooShort);
+        }
+        if bytes[..4] != FWDA_MAGIC {
+            return Err(FormatError::FwdaBadMagic);
+        }
+        if read_u16(&bytes[4..6]) != FWDA_VERSION {
+            return Err(FormatError::FwdaUnsupportedVersion);
+        }
+        if bytes[6..8].iter().any(|&byte| byte != 0) || bytes[14..16].iter().any(|&byte| byte != 0)
+        {
+            return Err(FormatError::FwdaNonZeroReserved);
+        }
+        let row_count = read_u32(&bytes[8..12]);
+        let max_entries = read_u16(&bytes[12..14]) as usize;
+        let rows_len = (row_count as usize)
+            .checked_mul(FWDA_ROW_LEN)
+            .ok_or(FormatError::FwdaBounds)?;
+        let entries_start = FWDA_HEADER_LEN
+            .checked_add(rows_len)
+            .ok_or(FormatError::FwdaBounds)?;
+        if entries_start > bytes.len() {
+            return Err(FormatError::FwdaBounds);
+        }
+
+        let mut previous = None;
+        let mut expected_entry_start = entries_start;
+        for index in 0..row_count as usize {
+            let start = FWDA_HEADER_LEN + index * FWDA_ROW_LEN;
+            let row = &bytes[start..start + FWDA_ROW_LEN];
+            let distance = row[0];
+            if !(1..=FWDA_MAX_DISTANCE).contains(&distance) || row[1] != 0 {
+                return Err(FormatError::FwdaInvalidRow);
+            }
+            let entry_count = read_u16(&row[2..4]);
+            if usize::from(entry_count) > max_entries {
+                return Err(FormatError::FwdaInvalidRow);
+            }
+            let anchor = read_u32(&row[4..8]);
+            let total = read_u32(&row[8..12]);
+            if total == 0 {
+                return Err(FormatError::FwdaInvalidRow);
+            }
+            let entry_start = read_u32(&row[12..16]) as usize;
+            if row[16..20].iter().any(|&byte| byte != 0) || entry_start != expected_entry_start {
+                return Err(FormatError::FwdaBounds);
+            }
+            let entry_bytes = (entry_count as usize)
+                .checked_mul(FWDA_ENTRY_LEN)
+                .ok_or(FormatError::FwdaBounds)?;
+            let entry_end = entry_start
+                .checked_add(entry_bytes)
+                .ok_or(FormatError::FwdaBounds)?;
+            if entry_end > bytes.len() {
+                return Err(FormatError::FwdaBounds);
+            }
+            expected_entry_start = entry_end;
+            let sort_key = (distance, anchor);
+            if previous.is_some_and(|last| last >= sort_key) {
+                return Err(FormatError::FwdaRowsNotSorted);
+            }
+            previous = Some(sort_key);
+            let entries = &bytes[entry_start..entry_end];
+            let mut previous_token = None;
+            for chunk in entries.chunks_exact(FWDA_ENTRY_LEN) {
+                let token = read_u32(&chunk[..4]);
+                if previous_token.is_some_and(|last| last >= token) {
+                    return Err(FormatError::FwdaEntriesNotSorted);
+                }
+                previous_token = Some(token);
+            }
+        }
+
+        if expected_entry_start != bytes.len() {
+            return Err(FormatError::FwdaBounds);
+        }
+
+        Ok(Self { bytes, row_count })
+    }
+
+    pub fn row_count(&self) -> u32 {
+        self.row_count
+    }
+
+    pub fn rows(&self) -> FwdaRows<'a> {
+        FwdaRows {
+            table: *self,
+            next: 0,
+        }
+    }
+
+    /// Canonical binary-search lookup by `(distance, anchor_token)`.
+    pub fn find(&self, distance: u8, anchor: u32) -> Option<FwdaRow<'a>> {
+        let target = (distance, anchor);
+        let mut low = 0usize;
+        let mut high = self.row_count as usize;
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let row = self.row(mid)?;
+            let current = (row.distance(), row.anchor());
+            if current < target {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        let row = self.row(low)?;
+        ((row.distance(), row.anchor()) == target).then_some(row)
+    }
+
+    fn row(&self, index: usize) -> Option<FwdaRow<'a>> {
+        if index >= self.row_count as usize {
+            return None;
+        }
+        let start = FWDA_HEADER_LEN + index * FWDA_ROW_LEN;
+        let bytes = self.bytes.get(start..start + FWDA_ROW_LEN)?;
+        let entry_count = read_u16(&bytes[2..4]) as usize;
+        let entry_start = read_u32(&bytes[12..16]) as usize;
+        let entry_end = entry_start.checked_add(entry_count.checked_mul(FWDA_ENTRY_LEN)?)?;
+        Some(FwdaRow {
+            bytes,
+            entries: self.bytes.get(entry_start..entry_end)?,
+        })
+    }
+}
+
+impl<'a> Iterator for FwdaRows<'a> {
+    type Item = FwdaRow<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row = self.table.row(self.next)?;
+        self.next += 1;
+        Some(row)
+    }
+}
+
+fn read_u32(bytes: &[u8]) -> u32 {
+    u32::from(bytes[0])
+        | (u32::from(bytes[1]) << 8)
+        | (u32::from(bytes[2]) << 16)
+        | (u32::from(bytes[3]) << 24)
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    u16::from(bytes[0]) | (u16::from(bytes[1]) << 8)
+}

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -3,7 +3,8 @@
 //! R4G1 is the versioned packed artifact container for the R⁴ holographic
 //! graph compiler: a single little-endian, fixed-width, explicitly-aligned
 //! binary format that carries a compiled semantic-region graph (sections
-//! HEAD/CODE/NODE/EDGE/ROUT/EMIT plus optional EXCT/NGRAM/PROV/CERT/PTCH/SECT)
+//! HEAD/CODE/NODE/EDGE/ROUT/EMIT plus optional
+//! EXCT/NGRAM/FWDA/PROV/CERT/PTCH/SECT)
 //! from the offline compiler to the deployed runtime. It succeeds the
 //! ad-hoc TLA3/TLA4/TLS1 containers.
 //!
@@ -66,6 +67,7 @@ extern crate alloc;
 mod code;
 mod error;
 mod fmm;
+mod fwda;
 mod head;
 mod header;
 pub mod inference_contract;
@@ -87,6 +89,10 @@ pub use error::{BoundKind, EdgePayloadField, FormatError, RangeField};
 pub use fmm::{
     FmmCoefficientRow, FmmRows, FmmScoreIter, FmmTokenIter, FmmTranslationTable, FMM_HEADER_LEN,
     FMM_MAGIC, FMM_VERSION,
+};
+pub use fwda::{
+    FwdaEntries, FwdaEntry, FwdaRow, FwdaRows, FwdaTable, FWDA_ENTRY_LEN, FWDA_HEADER_LEN,
+    FWDA_MAGIC, FWDA_MAX_DISTANCE, FWDA_ROW_LEN, FWDA_VERSION,
 };
 pub use head::{
     Head, FALLBACK_POLICY_COUNT, FEATURE_EDGE_ALGEBRA_V1, HEAD_PAYLOAD_LEN,

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -82,6 +82,9 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
     if let Some(bytes) = view.section(SectionId::NGRAM) {
         crate::ngram::NgramTable::parse(bytes)?;
     }
+    if let Some(bytes) = view.section(SectionId::FWDA) {
+        crate::fwda::FwdaTable::parse(bytes)?;
+    }
 
     // ROUT section-internal bytecode validation (RFC §6 item 6) runs
     // before the per-node cross-references into the section, mirroring

--- a/crates/uor-r4-graph-format/src/types.rs
+++ b/crates/uor-r4-graph-format/src/types.rs
@@ -181,6 +181,10 @@ impl SectionId {
     pub const RTNX: SectionId = SectionId(0x0C);
     /// NGRAM — packed bigram/trigram context rows (optional).
     pub const NGRAM: SectionId = SectionId(Self::OPTIONAL_BIT | 0x0E);
+    /// FWDA — packed forward-anchor rows for infill serving (optional,
+    /// issue #399). Absent section means the channel is off; every
+    /// pre-FWDA artifact remains valid.
+    pub const FWDA: SectionId = SectionId(Self::OPTIONAL_BIT | 0x0F);
     /// FMM — compiler-precomputed far-field translation table (optional).
     ///
     /// The optional bit is part of the wire ID so older readers can skip the
@@ -206,7 +210,10 @@ impl SectionId {
     /// True when the ID is in the RFC §3 inventory or a known optional
     /// extension implemented by this reader.
     pub const fn is_known(self) -> bool {
-        matches!(self.0, 0x01..=0x0C) || self.0 == Self::FMM.0 || self.0 == Self::NGRAM.0
+        matches!(self.0, 0x01..=0x0C)
+            || self.0 == Self::FMM.0
+            || self.0 == Self::NGRAM.0
+            || self.0 == Self::FWDA.0
     }
 
     /// Mandatory-ness per the RFC §3 column for known IDs.
@@ -218,6 +225,7 @@ impl SectionId {
             0x01..=0x06 | 0x08 => true,
             0x07 | 0x09..=0x0C => false,
             value if value == Self::NGRAM.0 => false,
+            value if value == Self::FWDA.0 => false,
             value if value == Self::FMM.0 => false,
             _ => self.0 & Self::OPTIONAL_BIT == 0,
         }

--- a/crates/uor-r4-graph-format/src/view.rs
+++ b/crates/uor-r4-graph-format/src/view.rs
@@ -9,6 +9,7 @@
 
 use crate::error::FormatError;
 use crate::fmm::FmmTranslationTable;
+use crate::fwda::FwdaTable;
 use crate::head::Head;
 use crate::header::{self, Header, HEADER_LEN, SECTION_ENTRY_LEN};
 use crate::ngram::NgramTable;
@@ -332,6 +333,13 @@ impl<'a> GraphView<'a> {
     pub fn ngram_table(&self) -> Result<Option<NgramTable<'a>>, FormatError> {
         self.section(SectionId::NGRAM)
             .map(NgramTable::parse)
+            .transpose()
+    }
+
+    /// Parse the optional packed forward-anchor table (issue #399).
+    pub fn fwda_table(&self) -> Result<Option<FwdaTable<'a>>, FormatError> {
+        self.section(SectionId::FWDA)
+            .map(FwdaTable::parse)
             .transpose()
     }
 

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -133,6 +133,7 @@ fn emit_and_persist(
             transition_quantization: score::QuantizationErrorStats::default(),
             emissions,
             context_rows: &[],
+            fwd_rows: &[],
             exct_tls1: &tls1,
             exct_top_x: score::ScoreConfig::default().exct_top_x,
             fmm_section: Some(&fmm_section),


### PR DESCRIPTION
References #399. Productionizes the measured forward-anchor channel (M2/B′ records: gated-self fused 40.0% / 45.0-vs-39.4 live) as a serving-side capability.

**FWDA section** (`FWA1`, optional — absent section = feature off, all existing artifacts stay valid): NGRAM-mirrored layout; context_len byte = lookahead distance 1..=3, key.0 = anchor token, key.1 = the row's full pre-truncation total; entries store raw counts (token, u32), cap 64 per row (highest count, tie lowest token), min row total 2. Built from the same construction split that feeds `compile_context_rows` and the store (anchor and predecessor both in-train), stride-4 infill protocol.

**Loading/quantization:** load-time `quantize_fwda` in the sanctioned compiler-side float block next to `quantize_exct` — `ScoreQ::from_logprob(ln((c+0.5)/(total+V·0.5)))`, absent floor same law at c=0, carried per-row. Serving fusion itself is integer-only saturating adds.

**`score_candidates_infill(sig, code, recent, next_anchor: Option<(token, distance)>)`:** runs `score_candidates_coded`, then product-law re-ranking when the anchor row is live — candidates gain their fwd residual, fwd-only tokens enter at root_floor + transition_offset + residual, canonical re-argmax. Post-witness serving-side re-ranking: the witness keeps the base outcome, replay covers the base path. `next_anchor: None` and absent-section paths are byte-identical to `score_candidates_coded` (asserted).

**Tests (4/4, non-ignored):** table law matches the Gate C build; exact row round-trip; fusion selection matches the f64 reference (flip case asserted, floor-entry integer value exact); off-paths byte-identical. fmt/clippy clean across format, certify, cli.

Next PR: the gated two-pass generation path (pass-1 draft anchors + ExactContext gate per B′).