### PR TITLE
feat(certify): #399 — gated two-pass generation + draft-anchor drift probe: falsifier 1 FIRED

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1925,6 +1925,8 @@ pub struct WinLossReport {
     pub fwd_self_vs_rule12_live: WinLoss,
     /// #399 B′: confidence-gated self-anchor arm on its live slice.
     pub fwd_gated_vs_rule12_live: WinLoss,
+    /// #399 falsifier 1: DRAFT-anchor gated arm on its live slice.
+    pub fwd_draft_vs_rule12_live: WinLoss,
 }
 
 /// Candidate-set recall, reported separately from selected-token
@@ -2180,6 +2182,15 @@ pub struct GateCOutcome {
     pub rule12_fwd_gated_fused: GateCMetrics,
     pub rule12_fwd_gated_fused_live: GateCMetrics,
     pub rule12_on_fwd_gated_live: GateCMetrics,
+    /// #399 falsifier 1: the DRAFT-anchor gated scorer — same gate and
+    /// fusion law as the gated arm, but the anchor is predicted from the
+    /// engine's own greedy DRAFT (pass-1 token here plus drafted
+    /// continuations) instead of teacher-forced corpus context; the
+    /// spread against the gated arm is the draft-drift cost of a real
+    /// two-pass generation.
+    pub rule12_fwd_draft_fused: GateCMetrics,
+    pub rule12_fwd_draft_fused_live: GateCMetrics,
+    pub rule12_on_fwd_draft_live: GateCMetrics,
     /// #399 B′: predicted-anchor accuracy on the anchor-reachable
     /// population (numerator/denominator + rate).
     pub anchor_hat_population: usize,
@@ -2448,6 +2459,14 @@ pub fn evaluate_gate_c(
     let mut rule12_gated_live_bits = 0f64;
     let mut anchor_hat_population = 0usize;
     let mut anchor_hat_correct_count = 0u64;
+    // #399 falsifier 1: DRAFT-anchor gated-arm accumulators.
+    let mut hits_fwd_draft = 0u64;
+    let mut bits_fwd_draft = 0f64;
+    let mut draft_live_positions = 0usize;
+    let mut draft_live_hits = 0u64;
+    let mut draft_live_bits = 0f64;
+    let mut rule12_draft_live_hits = 0u64;
+    let mut rule12_draft_live_bits = 0f64;
     // Per-status Rule 1+2 accumulators: [ExactContext, Graph, Novel].
     let mut status_positions = [0usize; 3];
     let mut status_hits = [0u64; 3];
@@ -2768,6 +2787,20 @@ pub fn evaluate_gate_c(
                 row.hits[2],
             );
         }
+        hits_fwd_draft += u64::from(row.hit_fwd_draft);
+        bits_fwd_draft += row.bits_fwd_draft;
+        if row.fwd_draft_live {
+            draft_live_positions += 1;
+            draft_live_hits += u64::from(row.hit_fwd_draft);
+            draft_live_bits += row.bits_fwd_draft;
+            rule12_draft_live_hits += u64::from(row.hits[2]);
+            rule12_draft_live_bits += row.bits[2];
+            accumulate_win_loss(
+                &mut outcome.win_loss.fwd_draft_vs_rule12_live,
+                row.hit_fwd_draft,
+                row.hits[2],
+            );
+        }
         if let Some(correct) = row.anchor_hat_correct {
             anchor_hat_population += 1;
             anchor_hat_correct_count += u64::from(correct);
@@ -2796,6 +2829,7 @@ pub fn evaluate_gate_c(
     outcome.rule12_fwd_fused = metrics(hits_fwd, bits_fwd);
     outcome.rule12_fwd_self_fused = metrics(hits_fwd_self, bits_fwd_self);
     outcome.rule12_fwd_gated_fused = metrics(hits_fwd_gated, bits_fwd_gated);
+    outcome.rule12_fwd_draft_fused = metrics(hits_fwd_draft, bits_fwd_draft);
     let live_metrics = |hits: u64, bits: f64, live_n: usize| GateCMetrics {
         positions: live_n,
         top1_agreement: if live_n == 0 {
@@ -2825,6 +2859,13 @@ pub fn evaluate_gate_c(
         rule12_gated_live_hits,
         rule12_gated_live_bits,
         gated_live_positions,
+    );
+    outcome.rule12_fwd_draft_fused_live =
+        live_metrics(draft_live_hits, draft_live_bits, draft_live_positions);
+    outcome.rule12_on_fwd_draft_live = live_metrics(
+        rule12_draft_live_hits,
+        rule12_draft_live_bits,
+        draft_live_positions,
     );
     outcome.anchor_hat_population = anchor_hat_population;
     outcome.anchor_hat_correct = anchor_hat_correct_count as usize;
@@ -3161,6 +3202,14 @@ struct GateCRow {
     /// #399 B′: whether the predicted anchor equals the true anchor
     /// (`None` off the anchor-reachable population).
     anchor_hat_correct: Option<bool>,
+    /// #399 falsifier 1: the DRAFT-anchor gated arm — the anchor is
+    /// predicted from the engine's own greedy draft (its pass-1 token at
+    /// this position plus drafted continuations), not from teacher-forced
+    /// corpus context, and is trusted only where the draft's final step
+    /// resolved as ExactContext.
+    hit_fwd_draft: bool,
+    bits_fwd_draft: f64,
+    fwd_draft_live: bool,
 }
 
 struct GateCContext<'a> {
@@ -3257,6 +3306,35 @@ fn fuse_forward_arm(
         best_token,
         (weight_sum / weight).ln() / std::f64::consts::LN_2,
     )
+}
+
+/// Slide one token into the fixed draft window / recent-token buffers of
+/// the #399 falsifier-1 draft loop (mirrors the
+/// `generate_greedy_repetition_rate` sliding rule, with the short-seed
+/// window growing; no allocation).
+fn draft_push(
+    window: &mut [u32; compiler::WINDOW],
+    w_len: &mut usize,
+    recent: &mut [u32; 32],
+    recent_len: &mut usize,
+    track_recent: bool,
+    token: u32,
+) {
+    if *w_len < compiler::WINDOW {
+        window[*w_len] = token;
+        *w_len += 1;
+    } else {
+        window.copy_within(1.., 0);
+        window[compiler::WINDOW - 1] = token;
+    }
+    if track_recent {
+        if *recent_len == 32 {
+            recent.copy_within(1.., 0);
+            *recent_len = 31;
+        }
+        recent[*recent_len] = token;
+        *recent_len += 1;
+    }
 }
 
 fn evaluate_gate_c_row(
@@ -3610,6 +3688,9 @@ fn evaluate_gate_c_row(
     let mut fwd_gated_selected = rule12.selected;
     let mut bits_fwd_gated = bits[2];
     let mut anchor_hat_correct = None;
+    let mut fwd_draft_live = false;
+    let mut fwd_draft_selected = rule12.selected;
+    let mut bits_fwd_draft = bits[2];
     if !target_pos.is_multiple_of(M2_STRIDE) {
         let lookahead = target_pos.next_multiple_of(M2_STRIDE) - target_pos;
         let anchor_position = position + lookahead;
@@ -3659,11 +3740,74 @@ fn evaluate_gate_c_row(
                     bits_fwd_gated = fused_bits;
                 }
             }
+            // Falsifier 1 (draft drift): the gated arm above predicts
+            // the anchor from TEACHER-FORCED context (true corpus tokens
+            // up to the anchor position). A real two-pass generation
+            // only has its own pass-1 DRAFT: seed the window with the
+            // corpus tokens up to this position, append the engine's own
+            // Rule 1+2 token here, then greedily draft `lookahead`
+            // steps with `score_candidates_coded` — the final step's
+            // token is the draft anchor and its witness status is the
+            // gate. Fusion law and comparator population are identical
+            // to the gated arm, so any spread between the two arms is
+            // pure draft-context drift.
+            let mut draft_window = [0u32; compiler::WINDOW];
+            let window_seed = story_bounded_window(context.corpus, position, compiler::WINDOW);
+            let mut draft_w_len = window_seed.len();
+            draft_window[..draft_w_len].copy_from_slice(window_seed);
+            let mut draft_recent = [0u32; 32];
+            let mut draft_recent_len = 0usize;
+            let track_recent = context.config.gate_c_context_window;
+            if track_recent {
+                let recent_seed = story_bounded_window(context.corpus, position, 32);
+                draft_recent_len = recent_seed.len();
+                draft_recent[..draft_recent_len].copy_from_slice(recent_seed);
+            }
+            // The draft's token for THIS position is the engine's own
+            // pass-1 selection.
+            let mut pending = rule12.selected;
+            let mut draft_anchor = pending;
+            let mut draft_gate = false;
+            for _ in 0..lookahead {
+                draft_push(
+                    &mut draft_window,
+                    &mut draft_w_len,
+                    &mut draft_recent,
+                    &mut draft_recent_len,
+                    track_recent,
+                    pending,
+                );
+                let draft_bundle = runtime::bundle_window_plain(
+                    context.artifacts,
+                    context.gate_rotations,
+                    &draft_window[..draft_w_len],
+                );
+                let draft_sig = runtime::sig_plain(context.artifacts, &draft_bundle);
+                let draft_code = runtime::assign_for_bundle(context.artifacts, &draft_bundle);
+                let draft_outcome = context.scorer_with_exct.score_candidates_coded(
+                    &draft_sig,
+                    Some(&draft_code),
+                    &draft_recent[..draft_recent_len],
+                )?;
+                pending = draft_outcome.selected;
+                draft_anchor = pending;
+                draft_gate = draft_outcome.witness.status == ScoreStatus::ExactContext;
+            }
+            if draft_gate {
+                if let Some(fwd_row) = context.fwd_table.get(&(lookahead, draft_anchor)) {
+                    fwd_draft_live = true;
+                    let (selected, fused_bits) =
+                        fuse_forward_arm(context.scorer_with_exct, &rule12, fwd_row, next);
+                    fwd_draft_selected = selected;
+                    bits_fwd_draft = fused_bits;
+                }
+            }
         }
     }
     let hit_fwd = fwd_selected == teacher_argmax;
     let hit_fwd_self = fwd_self_selected == teacher_argmax;
     let hit_fwd_gated = fwd_gated_selected == teacher_argmax;
+    let hit_fwd_draft = fwd_draft_selected == teacher_argmax;
 
     let witness_replay_failed = index < context.config.witness_sample
         && verify_witness_replay(
@@ -3725,6 +3869,9 @@ fn evaluate_gate_c_row(
         bits_fwd_gated,
         fwd_gated_live,
         anchor_hat_correct,
+        hit_fwd_draft,
+        bits_fwd_draft,
+        fwd_draft_live,
     })
 }
 
@@ -3768,7 +3915,11 @@ fn evaluate_gate_c_row(
 /// (`rule12_fwd_fused`, the live-slice pair, and the fused win/loss
 /// cross-tabs) — certifier-side only, the serving scorer is untouched;
 /// 19 = #399 B′ self-anchor and confidence-gated arms (the two-pass
-/// serving question) plus predicted-anchor accuracy.
+/// serving question) plus predicted-anchor accuracy; schema twenty is
+/// the #399 falsifier-1 DRAFT-anchor gated arm (the
+/// `rule12_fwd_draft_fused` rows and the draft win/loss cross-tab),
+/// where the anchor is predicted from the engine's own greedy draft
+/// rather than teacher-forced context.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -3964,7 +4115,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 19,
+        schema: 20,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -2433,6 +2433,176 @@ impl GraphScorer {
     }
 }
 
+/// Anchor stride of the gated two-pass generation path (issue #399):
+/// the same stride-four grid the #394 infill protocol and the Gate C
+/// forward-anchor instrumentation use. A generated position is on the
+/// anchor grid when its emitted token lands on a story position that is
+/// a multiple of this stride (see [`two_pass_infill_generate`] for the
+/// grid definition in generated-stream coordinates).
+pub const INFILL_STRIDE: usize = 4;
+
+/// Result of one gated two-pass generation run
+/// ([`two_pass_infill_generate`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TwoPassGeneration {
+    /// The pass-1 greedy draft, one token per generated position.
+    pub draft: Vec<u32>,
+    /// The pass-2 output: gated free positions re-ranked under the
+    /// forward-anchor channel, every other position identical to the
+    /// draft.
+    pub final_tokens: Vec<u32>,
+    /// Positions where the pass-2 re-rank changed the token.
+    pub changed_positions: usize,
+    /// Free positions that passed the confidence gate (an in-stream
+    /// next anchor whose pass-1 selection resolved as `ExactContext`)
+    /// and were therefore re-scored. `changed_positions` is bounded by
+    /// this count.
+    pub gated_positions: usize,
+    /// Positions on the anchor grid (kept verbatim from the draft).
+    pub anchor_positions: usize,
+}
+
+/// Everything pass 2 needs to re-rank a pass-1 position without
+/// re-generating: the exact context inputs pass 1 scored with, plus the
+/// selected token and its confidence status.
+struct Pass1Record {
+    token: u32,
+    exact_context: bool,
+    sig: [u8; SIG_BYTES],
+    code: [u8; STAGES],
+    recent: Vec<u32>,
+}
+
+/// Gated two-pass generation (issue #399, serving step 2): pass 1 runs
+/// the ordinary greedy loop (window bundle → sig → attested code →
+/// [`GraphScorer::score_candidates_coded`], sliding eight-token window
+/// and 32-token recent deque — the `generate_greedy_repetition_rate`
+/// pattern), recording for every generated position the selected token,
+/// whether it resolved as [`ScoreStatus::ExactContext`], and the exact
+/// context inputs (sig, code, recent tokens) it was scored with. Pass 2
+/// then re-ranks each free position through
+/// [`GraphScorer::score_candidates_infill`] with the DRAFT token at the
+/// next anchor position as the forward anchor — but only where that
+/// anchor's pass-1 selection resolved as `ExactContext` (the measured
+/// B′ confidence gate, the strongest teacher-forced arm: live slice
+/// 45.0% vs 39.4%).
+///
+/// Anchor grid: generated position `i` occupies story position
+/// `seed_len + i` (the seed occupies story positions zero through
+/// `seed_len - 1`), and it is an anchor when `(seed_len + i + 1)` is a
+/// multiple of [`INFILL_STRIDE`] — the emitted token lands on a
+/// stride-multiple story slot, mirroring the corpus-side law
+/// (`(story_pos + 1) % stride == 0`) of the #394 infill protocol and
+/// `compile_forward_anchor_rows`. The lookahead distance from a free
+/// position to its next anchor is the position difference, matching the
+/// FWDA row key `(distance, anchor)`.
+///
+/// Pass 2 is a PURE RE-RANK: every re-score consumes the stored pass-1
+/// context (sig, code, recent tokens), so a changed token never feeds
+/// back into later positions' context. A full iterative re-draft — where
+/// pass-2 corrections propagate into subsequent windows — is future
+/// work; this shape isolates the falsifier question (how much of the
+/// gated lift survives draft-anchor context) from compounding effects.
+///
+/// One deliberate divergence from `generate_greedy_repetition_rate`:
+/// when the seed is shorter than the bundle window, the window here
+/// GROWS as tokens are generated (that probe's seeds always fill the
+/// window, so its non-growing short-seed branch is never exercised).
+pub fn two_pass_infill_generate(
+    scorer: &GraphScorer,
+    artifacts: &Compiled,
+    rotations: &[usize; compiler::WINDOW + 1],
+    seed: &[u32],
+    tokens_to_generate: usize,
+) -> Result<TwoPassGeneration, String> {
+    let seed_len = seed.len();
+
+    // ---- Pass 1: greedy draft, recording per-position context. ----
+    let mut window = [0u32; compiler::WINDOW];
+    let mut w_len = seed_len.min(compiler::WINDOW);
+    window[..w_len].copy_from_slice(&seed[seed_len - w_len..]);
+    let mut recent_tokens = std::collections::VecDeque::with_capacity(32);
+    let r_len = seed_len.min(32);
+    for &t in &seed[seed_len - r_len..] {
+        recent_tokens.push_back(t);
+    }
+
+    let mut records: Vec<Pass1Record> = Vec::with_capacity(tokens_to_generate);
+    for _ in 0..tokens_to_generate {
+        let bundle = runtime::bundle_window_plain(artifacts, rotations, &window[..w_len]);
+        let sig = runtime::sig_plain(artifacts, &bundle);
+        // #243 Phase C option A: attest the metric-respecting code.
+        let code = runtime::assign_for_bundle(artifacts, &bundle);
+        let recent: Vec<u32> = recent_tokens.iter().copied().collect();
+        let outcome = scorer.score_candidates_coded(&sig, Some(&code), &recent)?;
+        let token = outcome.selected;
+        records.push(Pass1Record {
+            token,
+            exact_context: outcome.witness.status == ScoreStatus::ExactContext,
+            sig,
+            code,
+            recent,
+        });
+
+        if w_len < compiler::WINDOW {
+            window[w_len] = token;
+            w_len += 1;
+        } else {
+            window.copy_within(1.., 0);
+            window[compiler::WINDOW - 1] = token;
+        }
+        if recent_tokens.len() == 32 {
+            recent_tokens.pop_front();
+        }
+        recent_tokens.push_back(token);
+    }
+
+    // ---- Pass 2: gated re-rank against the drafted next anchor. ----
+    let draft: Vec<u32> = records.iter().map(|record| record.token).collect();
+    let mut final_tokens = draft.clone();
+    let mut changed_positions = 0usize;
+    let mut gated_positions = 0usize;
+    let mut anchor_positions = 0usize;
+    for (i, record) in records.iter().enumerate() {
+        // Story slot of the token this position emits.
+        let emitted_slot = seed_len + i + 1;
+        if emitted_slot.is_multiple_of(INFILL_STRIDE) {
+            anchor_positions += 1;
+            continue;
+        }
+        let distance = emitted_slot.next_multiple_of(INFILL_STRIDE) - emitted_slot;
+        let anchor_index = i + distance;
+        let Some(anchor_record) = records.get(anchor_index) else {
+            // The next anchor falls beyond the generated stream.
+            continue;
+        };
+        if !anchor_record.exact_context {
+            // B′ confidence gate: the draft anchor is trusted only where
+            // pass 1 resolved it as exact context.
+            continue;
+        }
+        gated_positions += 1;
+        let outcome = scorer.score_candidates_infill(
+            &record.sig,
+            Some(&record.code),
+            &record.recent,
+            Some((anchor_record.token, distance as u8)),
+        )?;
+        if outcome.selected != record.token {
+            final_tokens[i] = outcome.selected;
+            changed_positions += 1;
+        }
+    }
+
+    Ok(TwoPassGeneration {
+        draft,
+        final_tokens,
+        changed_positions,
+        gated_positions,
+        anchor_positions,
+    })
+}
+
 /// Rejection reasons of the independent witness-replay verifier
 /// (Theorems 6 and 10). Each variant names exactly one inconsistency
 /// between the witness's claims and the recomputation from the

--- a/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
+++ b/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
@@ -3,17 +3,19 @@
 //! law, rows survive the artifact byte format exactly, and
 //! `score_candidates_infill` reproduces the measured f64 product-fusion
 //! reference on a hand-computed example while staying byte-identical to
-//! `score_candidates_coded` whenever the channel is off.
+//! `score_candidates_coded` whenever the channel is off. The two-pass
+//! tests cover `two_pass_infill_generate`: the stride-four anchor grid,
+//! the B′ confidence gate (fails closed), and the pass-2 pure re-rank.
 
 use std::collections::BTreeMap;
 
-use uor_r4_core::transformerless::compiler::{Corpus, SIG_BYTES, STAGES};
+use uor_r4_core::transformerless::compiler::{self, Corpus, SIG_BYTES, STAGES};
 use uor_r4_core::transformerless::runtime;
 use uor_r4_graph_certify::score::{
     compile_forward_anchor_rows, emit_scored_r4g1, ContextRow, EmissionTables, ForwardAnchorRow,
     QuantizationErrorStats, ScoredGraphSections, Smoothing,
 };
-use uor_r4_graph_certify::score_runtime::{GraphScorer, RegionParams};
+use uor_r4_graph_certify::score_runtime::{two_pass_infill_generate, GraphScorer, RegionParams};
 use uor_r4_graph_compiler::induction::Observation;
 use uor_r4_graph_format::{GraphView, ScoreQ};
 
@@ -121,10 +123,12 @@ fn emissions() -> EmissionTables {
     }
 }
 
-/// A minimal but fully valid scored artifact: one region, no edges, one
-/// explicit bigram context row (the deterministic base distribution for
-/// the fusion tests), an empty exact-context store, and the given
-/// forward-anchor rows.
+/// A minimal but fully valid scored artifact: one region, no edges, two
+/// explicit unigram context rows (the deterministic base distributions
+/// for the fusion and two-pass tests; the key-6 row makes greedy
+/// generation alternate 6 ↔ 20 with every step an NGRAM ExactContext
+/// hit), an empty exact-context store, and the given forward-anchor
+/// rows.
 fn tiny_artifact(fwd_rows: &[ForwardAnchorRow]) -> Vec<u8> {
     let regions = vec![RegionParams {
         node: 1,
@@ -133,16 +137,27 @@ fn tiny_artifact(fwd_rows: &[ForwardAnchorRow]) -> Vec<u8> {
         sig: [0; SIG_BYTES],
         parent: None,
     }];
-    let context_rows = vec![ContextRow {
-        context_len: 1,
-        key0: 20,
-        key1: 0,
-        entries: vec![
-            (4, ScoreQ::from_raw(-100_000)),
-            (5, ScoreQ::from_raw(-120_000)),
-            (6, ScoreQ::from_raw(-80_000)),
-        ],
-    }];
+    let context_rows = vec![
+        ContextRow {
+            context_len: 1,
+            key0: 6,
+            key1: 0,
+            entries: vec![
+                (7, ScoreQ::from_raw(-100_000)),
+                (20, ScoreQ::from_raw(-80_000)),
+            ],
+        },
+        ContextRow {
+            context_len: 1,
+            key0: 20,
+            key1: 0,
+            entries: vec![
+                (4, ScoreQ::from_raw(-100_000)),
+                (5, ScoreQ::from_raw(-120_000)),
+                (6, ScoreQ::from_raw(-80_000)),
+            ],
+        },
+    ];
     let store: runtime::Store = vec![BTreeMap::new(); STAGES + 1];
     let tls1 = runtime::store_bytes(&store);
     let emissions = emissions();
@@ -332,4 +347,125 @@ fn infill_off_paths_match_coded_exactly() {
     assert_eq!(fused.selected, base.selected);
     assert_eq!(fused.candidates, base.candidates);
     assert_eq!(fused.witness, base.witness);
+}
+
+/// A minimal `Compiled` for the two-pass generation tests: empty token
+/// codes decode to all-zero rows, so every window bundles to zero, the
+/// sig is all-zero (matching the tiny artifact's region signature), and
+/// the graded code is all-zero. Token selection in these tests is
+/// carried entirely by the artifact's NGRAM context rows through the
+/// recent-token deque, which is exactly the surface the two-pass gate
+/// depends on.
+fn tiny_compiled() -> compiler::Compiled {
+    compiler::Compiled {
+        token_codes: Vec::new(),
+        stage_books: Vec::new(),
+        stage_shifts: Vec::new(),
+        thresholds: vec![0i64; compiler::D],
+        class_sigs: Vec::new(),
+        ctx_cb: Vec::new(),
+        token_stage_kappas: Vec::new(),
+        dot_cb: Vec::new(),
+        resid_cb: Vec::new(),
+        resid_scale_shifts: Vec::new(),
+        norm_fold_const: 0,
+    }
+}
+
+/// Gated two-pass generation on the synthetic artifact: seed `[20]`
+/// alternates the draft 6 ↔ 20 through the two NGRAM rows (every step
+/// ExactContext), so the stride-four anchor grid and the B′ gate are
+/// both fully live. With a `(distance 2, anchor 6)` forward row present,
+/// exactly the two gated free positions at lookahead two get re-ranked
+/// to token 5; every other position — anchors included — keeps its
+/// pass-1 token.
+#[test]
+fn two_pass_reranks_gated_positions_only() {
+    let row = ForwardAnchorRow {
+        distance: 2,
+        anchor: 6,
+        total: 50,
+        entries: vec![(5, 50)],
+    };
+    let bytes = tiny_artifact(std::slice::from_ref(&row));
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+    let seed = [20u32];
+
+    let two_pass =
+        two_pass_infill_generate(&scorer, &artifacts, &rotations, &seed, 8).expect("two-pass runs");
+
+    // Pass 1: the NGRAM rows alternate deterministically.
+    assert_eq!(two_pass.draft, vec![6, 20, 6, 20, 6, 20, 6, 20]);
+    // Anchor grid with seed_len = 1: generated index i is an anchor when
+    // (1 + i + 1) is a multiple of four — indices 2 and 6.
+    assert_eq!(two_pass.anchor_positions, 2);
+    // Gated free positions: indices 0, 1, 3, 4, 5 have an in-stream next
+    // anchor whose draft resolved ExactContext; index 7's next anchor
+    // (index 10) falls beyond the stream.
+    assert_eq!(two_pass.gated_positions, 5);
+    // Only the lookahead-two positions (0 and 4) have a matching forward
+    // row; the anchor evidence flips both to token 5.
+    assert_eq!(two_pass.changed_positions, 2);
+    assert_eq!(two_pass.final_tokens, vec![5, 20, 6, 20, 5, 20, 6, 20]);
+    assert!(two_pass.changed_positions <= two_pass.gated_positions);
+    // Anchors are kept verbatim from the draft.
+    for index in [2usize, 6] {
+        assert_eq!(two_pass.final_tokens[index], two_pass.draft[index]);
+    }
+}
+
+/// Without a FWDA section pass 2 is inert: the gate still opens (every
+/// draft anchor resolves ExactContext) but no forward row exists, so the
+/// re-rank is the identity and the final stream equals the draft.
+#[test]
+fn two_pass_empty_fwda_final_equals_draft() {
+    let bytes = tiny_artifact(&[]);
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+    let seed = [20u32];
+
+    let two_pass =
+        two_pass_infill_generate(&scorer, &artifacts, &rotations, &seed, 8).expect("two-pass runs");
+    assert_eq!(two_pass.draft, vec![6, 20, 6, 20, 6, 20, 6, 20]);
+    assert_eq!(two_pass.final_tokens, two_pass.draft);
+    assert_eq!(two_pass.changed_positions, 0);
+    assert_eq!(two_pass.gated_positions, 5);
+    assert_eq!(two_pass.anchor_positions, 2);
+}
+
+/// The confidence gate fails closed: seeded off the NGRAM rows the draft
+/// resolves every position through the graph path (status Graph, token
+/// one from the root prior), so no anchor is ExactContext and pass 2
+/// changes nothing — even though a forward row keyed to the drafted
+/// anchor carries evidence strong enough to flip the argmax if the gate
+/// were ignored.
+#[test]
+fn two_pass_gate_fails_closed_without_exact_context_anchor() {
+    // ln(2 * 1000 + 1) ≈ 7.6 nats of residual spread over the absent
+    // floor — enough to overcome the root-floor entry gap (≈ 6.87
+    // nats), so an open gate WOULD flip gated positions to token 5.
+    let row = ForwardAnchorRow {
+        distance: 2,
+        anchor: 1,
+        total: 1000,
+        entries: vec![(5, 1000)],
+    };
+    let bytes = tiny_artifact(std::slice::from_ref(&row));
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+    // Token 30 hits no NGRAM row, so every draft step selects the root
+    // prior's token one with status Graph — never ExactContext.
+    let seed = [30u32];
+
+    let two_pass =
+        two_pass_infill_generate(&scorer, &artifacts, &rotations, &seed, 8).expect("two-pass runs");
+    assert_eq!(two_pass.draft, vec![1; 8]);
+    assert_eq!(two_pass.anchor_positions, 2);
+    assert_eq!(two_pass.gated_positions, 0);
+    assert_eq!(two_pass.changed_positions, 0);
+    assert_eq!(two_pass.final_tokens, two_pass.draft);
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1253,6 +1253,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     row("1+2 × fwd-anchor (#399 M2)", &gate_c.rule12_fwd_fused);
     row("1+2 × fwd SELF-anchor (B′)", &gate_c.rule12_fwd_self_fused);
     row("1+2 × fwd GATED self (B′)", &gate_c.rule12_fwd_gated_fused);
+    row("1+2 × fwd DRAFT-gated (2p)", &gate_c.rule12_fwd_draft_fused);
     let live_line = |name: &str, fused: &score::GateCMetrics, base: &score::GateCMetrics| {
         println!(
             "  {name} live slice ({} positions): fused {:.1}% vs rule 1+2 {:.1}% | bits {:.4} vs {:.4}",
@@ -1277,6 +1278,11 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         "gated-self ",
         &gate_c.rule12_fwd_gated_fused_live,
         &gate_c.rule12_on_fwd_gated_live,
+    );
+    live_line(
+        "draft-gated",
+        &gate_c.rule12_fwd_draft_fused_live,
+        &gate_c.rule12_on_fwd_draft_live,
     );
     println!(
         "  predicted-anchor accuracy: {:.1}% ({}/{})",
@@ -1319,6 +1325,10 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     win_loss_row(
         "win/loss gated vs 1+2 live",
         &gate_c.win_loss.fwd_gated_vs_rule12_live,
+    );
+    win_loss_row(
+        "win/loss draft vs 1+2 live",
+        &gate_c.win_loss.fwd_draft_vs_rule12_live,
     );
     println!(
         "  witness replay: {}/{} ok",


### PR DESCRIPTION
References #399. Ships the gated two-pass generation path (`two_pass_infill_generate`: pass-1 greedy draft with witness-status recording, pass-2 pure re-rank of gated free positions via `score_candidates_infill`) AND the drift probe that was queued as falsifier 1 for the B′ mechanism reading — with a NEGATIVE result that the record must carry.

**Drift probe (schema 20, natural wiki-obs, 100,306 held-out; all prior rows byte-identical):** the DRAFT-gated arm predicts the anchor from a drafted context (engine's own tokens for the intermediate positions) instead of the teacher-forced context the B′ arms used.

| arm | all | live slice |
|---|---|---|
| gated self (teacher-forced ctx) | 40.0% / 7.8332 | **45.0 vs 39.4** (63,567) |
| **DRAFT-gated (real two-pass)** | **35.9% / 9.3847** | **40.4 vs 41.3** (62,989) |

Win/loss draft vs 1+2 on live: +966 / −1,581 — **net negative**. Draft drift in the intermediate tokens degrades the anchor prediction enough to flip the channel below Rule 1+2.

**Honest scoreboard after falsifier 1:** A-mode infill serving (anchors GIVEN as inputs — no prediction, no drift) stands fully validated at +4.2pp live (M2 row, unchanged). Standalone two-pass B-mode in its naive greedy form is REFUTED — the B′ self-anchor result depended on true intermediate context, exactly as the queued falsifier suspected. Possible rescues (iterative re-draft, beam draft, per-step confidence gating) are future work and unmeasured. The two-pass code ships as the measurement vehicle and for A-mode-adjacent uses; its standalone use is contraindicated by this record.

Tests: 7/7 fwda_roundtrip incl. gate-fails-closed; workspace clippy + test-compile clean.