### PR TITLE
feat(certify,cli): #399 — A-mode infill serving surface (skeleton fill + graph infill subcommand)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -2603,6 +2603,92 @@ pub fn two_pass_infill_generate(
     })
 }
 
+/// The nearest GIVEN skeleton slot strictly after `index`, within the
+/// FWDA lookahead range: `Some((token, distance))` when a `Some` slot
+/// exists at `index + d` for the smallest `d` in one through
+/// [`uor_r4_graph_format::FWDA_MAX_DISTANCE`], `None` when every slot
+/// in that range is free or past the end. This is the anchor-selection
+/// rule of [`infill_fill`], exposed so callers (the CLI summary line)
+/// can reproduce the per-position anchor choice without re-running the
+/// fill.
+pub fn next_skeleton_anchor(skeleton: &[Option<u32>], index: usize) -> Option<(u32, u8)> {
+    for distance in 1..=usize::from(uor_r4_graph_format::FWDA_MAX_DISTANCE) {
+        match skeleton.get(index + distance) {
+            None => return None,
+            Some(&Some(token)) => return Some((token, distance as u8)),
+            Some(&None) => {}
+        }
+    }
+    None
+}
+
+/// A-mode infill serving (issue #399): fill the free positions of a
+/// GIVEN anchor skeleton left to right. This is the measured, validated
+/// serving mode — anchors are inputs, not drafts, so the channel is
+/// immune to draft-anchor drift by construction (the falsifier the
+/// two-pass probe quantified).
+///
+/// `skeleton` is the anchor grid: `Some(token)` at given positions
+/// (any pattern of givens is accepted — the stride-four grid is the
+/// typical shape, not a requirement), `None` at free positions. At a
+/// given position the given token is consumed verbatim. At a free
+/// position the ordinary context pipeline runs (window bundle → sig →
+/// attested code → [`GraphScorer::score_candidates_infill`]) with
+/// `next_anchor` chosen by [`next_skeleton_anchor`]: the nearest
+/// following given within the FWDA lookahead range, or `None` when the
+/// next given is farther than [`uor_r4_graph_format::FWDA_MAX_DISTANCE`]
+/// or absent — in which case the fusion entry point degrades to base
+/// scoring byte-identically.
+///
+/// Window and recent-token handling mirror [`two_pass_infill_generate`]:
+/// the sliding [`compiler::WINDOW`]-token bundle window grows until
+/// full, and the bounded recent deque feeds repetition control. Both
+/// consume given and filled tokens alike, so every position is scored
+/// with the exact context the emitted stream implies.
+pub fn infill_fill(
+    scorer: &GraphScorer,
+    artifacts: &Compiled,
+    rotations: &[usize; compiler::WINDOW + 1],
+    skeleton: &[Option<u32>],
+) -> Result<Vec<u32>, String> {
+    let mut window = [0u32; compiler::WINDOW];
+    let mut w_len = 0usize;
+    let mut recent_tokens = std::collections::VecDeque::with_capacity(32);
+    let mut filled: Vec<u32> = Vec::with_capacity(skeleton.len());
+    for (index, slot) in skeleton.iter().enumerate() {
+        let token = match slot {
+            Some(given) => *given,
+            None => {
+                let bundle = runtime::bundle_window_plain(artifacts, rotations, &window[..w_len]);
+                let sig = runtime::sig_plain(artifacts, &bundle);
+                // #243 Phase C option A: attest the metric-respecting code.
+                let code = runtime::assign_for_bundle(artifacts, &bundle);
+                let recent: Vec<u32> = recent_tokens.iter().copied().collect();
+                let outcome = scorer.score_candidates_infill(
+                    &sig,
+                    Some(&code),
+                    &recent,
+                    next_skeleton_anchor(skeleton, index),
+                )?;
+                outcome.selected
+            }
+        };
+        filled.push(token);
+        if w_len < compiler::WINDOW {
+            window[w_len] = token;
+            w_len += 1;
+        } else {
+            window.copy_within(1.., 0);
+            window[compiler::WINDOW - 1] = token;
+        }
+        if recent_tokens.len() == 32 {
+            recent_tokens.pop_front();
+        }
+        recent_tokens.push_back(token);
+    }
+    Ok(filled)
+}
+
 /// Rejection reasons of the independent witness-replay verifier
 /// (Theorems 6 and 10). Each variant names exactly one inconsistency
 /// between the witness's claims and the recomputation from the

--- a/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
+++ b/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
@@ -6,6 +6,10 @@
 //! `score_candidates_coded` whenever the channel is off. The two-pass
 //! tests cover `two_pass_infill_generate`: the stride-four anchor grid,
 //! the B′ confidence gate (fails closed), and the pass-2 pure re-rank.
+//! The A-mode tests cover `infill_fill`: givens consumed verbatim, free
+//! positions filled with the nearest in-range given as the forward
+//! anchor, base-scoring fallback when the channel is off or the next
+//! given is beyond the FWDA lookahead range.
 
 use std::collections::BTreeMap;
 
@@ -15,7 +19,9 @@ use uor_r4_graph_certify::score::{
     compile_forward_anchor_rows, emit_scored_r4g1, ContextRow, EmissionTables, ForwardAnchorRow,
     QuantizationErrorStats, ScoredGraphSections, Smoothing,
 };
-use uor_r4_graph_certify::score_runtime::{two_pass_infill_generate, GraphScorer, RegionParams};
+use uor_r4_graph_certify::score_runtime::{
+    infill_fill, next_skeleton_anchor, two_pass_infill_generate, GraphScorer, RegionParams,
+};
 use uor_r4_graph_compiler::induction::Observation;
 use uor_r4_graph_format::{GraphView, ScoreQ};
 
@@ -468,4 +474,124 @@ fn two_pass_gate_fails_closed_without_exact_context_anchor() {
     assert_eq!(two_pass.gated_positions, 0);
     assert_eq!(two_pass.changed_positions, 0);
     assert_eq!(two_pass.final_tokens, two_pass.draft);
+}
+
+/// A-mode skeleton fill: given tokens are consumed verbatim, free
+/// positions get filled, and a free position whose nearest in-range
+/// given carries a live forward row is re-ranked by the anchor evidence
+/// (the same `(distance 2, anchor 6)` flip the two-pass test measures),
+/// while a free position whose anchor has no row at its distance stays
+/// on the base selection. A fully given skeleton — tokens with no
+/// scoring rows at all — comes back byte-identical.
+#[test]
+fn infill_fill_respects_givens_and_reranks_free() {
+    let row = ForwardAnchorRow {
+        distance: 2,
+        anchor: 6,
+        total: 50,
+        entries: vec![(5, 50)],
+    };
+    let bytes = tiny_artifact(std::slice::from_ref(&row));
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+
+    // Position one is free with the given anchor 6 at distance two (the
+    // live row: base pick 6 flips to 5); position two is free with the
+    // anchor at distance one (no row there: base pick, the root prior's
+    // token one, survives).
+    let skeleton = [Some(20), None, None, Some(6)];
+    let filled = infill_fill(&scorer, &artifacts, &rotations, &skeleton).expect("fill runs");
+    assert_eq!(filled, vec![20, 5, 1, 6]);
+    assert_eq!(filled[0], 20, "given consumed verbatim");
+    assert_eq!(filled[3], 6, "given consumed verbatim");
+
+    // The anchor-selection rule the fill used, checked directly.
+    assert_eq!(next_skeleton_anchor(&skeleton, 1), Some((6, 2)));
+    assert_eq!(next_skeleton_anchor(&skeleton, 2), Some((6, 1)));
+    assert_eq!(next_skeleton_anchor(&skeleton, 3), None, "nothing follows");
+
+    // A fully given skeleton is returned verbatim even for tokens the
+    // artifact carries no rows for.
+    let all_given = [Some(9), Some(8), Some(7)];
+    let verbatim = infill_fill(&scorer, &artifacts, &rotations, &all_given).expect("fill runs");
+    assert_eq!(verbatim, vec![9, 8, 7]);
+}
+
+/// Without a FWDA section the fill IS base scoring: every free position
+/// matches a manual greedy loop over `score_candidates_coded` that
+/// consumes the same givens with the same window and recent-token
+/// handling — even though the skeleton offers in-range anchors at three
+/// free positions.
+#[test]
+fn infill_fill_absent_fwda_matches_base_scoring() {
+    let bytes = tiny_artifact(&[]);
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    assert_eq!(scorer.forward_anchor_row_count(), 0);
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+
+    let skeleton = [Some(20), None, None, None, None, Some(6)];
+    let filled = infill_fill(&scorer, &artifacts, &rotations, &skeleton).expect("fill runs");
+
+    // Manual base-scoring reference with identical context handling.
+    let mut window = [0u32; compiler::WINDOW];
+    let mut recent: Vec<u32> = Vec::new();
+    let mut reference = Vec::new();
+    for (w_len, slot) in skeleton.iter().enumerate() {
+        let token = match slot {
+            Some(given) => *given,
+            None => {
+                let bundle = runtime::bundle_window_plain(&artifacts, &rotations, &window[..w_len]);
+                let sig = runtime::sig_plain(&artifacts, &bundle);
+                let code = runtime::assign_for_bundle(&artifacts, &bundle);
+                scorer
+                    .score_candidates_coded(&sig, Some(&code), &recent)
+                    .expect("base outcome")
+                    .selected
+            }
+        };
+        reference.push(token);
+        window[w_len] = token;
+        recent.push(token);
+    }
+    assert_eq!(filled, reference);
+    // The base dynamics are the two-pass draft's alternation, so the
+    // comparison is not vacuous.
+    assert_eq!(filled, vec![20, 6, 20, 6, 20, 6]);
+}
+
+/// A next given farther than the FWDA lookahead range yields no anchor
+/// and the position falls back to base scoring — position one keeps its
+/// base pick although the `(distance 2, anchor 6)` row is loaded and a
+/// given 6 sits at distance four, while position three (the same row at
+/// its measured distance) demonstrably flips in the same run.
+#[test]
+fn infill_fill_far_anchor_falls_back_to_base() {
+    let row = ForwardAnchorRow {
+        distance: 2,
+        anchor: 6,
+        total: 50,
+        entries: vec![(5, 50)],
+    };
+    let bytes = tiny_artifact(std::slice::from_ref(&row));
+    let scorer = GraphScorer::from_artifact(&bytes, None, 3, 3).expect("scorer loads");
+    let artifacts = tiny_compiled();
+    let rotations = runtime::derive_rotations();
+
+    let skeleton = [Some(20), None, None, None, None, Some(6)];
+    // Position one sees only free slots within the lookahead range; the
+    // nearest given is four positions ahead.
+    assert_eq!(next_skeleton_anchor(&skeleton, 1), None);
+    assert_eq!(next_skeleton_anchor(&skeleton, 2), Some((6, 3)));
+    assert_eq!(next_skeleton_anchor(&skeleton, 3), Some((6, 2)));
+    assert_eq!(next_skeleton_anchor(&skeleton, 4), Some((6, 1)));
+
+    let filled = infill_fill(&scorer, &artifacts, &rotations, &skeleton).expect("fill runs");
+    // Position one: no anchor in range, base pick 6 (identical to the
+    // absent-FWDA fill at that position). Position two: anchor at
+    // distance three has no row, base pick 20. Position three: anchor at
+    // distance two hits the live row and flips to 5. Position four:
+    // anchor at distance one has no row, base pick (root prior token).
+    assert_eq!(filled, vec![20, 6, 20, 5, 1, 6]);
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2303,6 +2303,130 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Parse a `--skeleton` spec: comma-separated token ids with `_` at
+/// free positions, e.g. `12,_,_,_,99,_,_,_,7`.
+fn parse_skeleton(spec: &str) -> Result<Vec<Option<u32>>, String> {
+    spec.split(',')
+        .map(|slot| {
+            let slot = slot.trim();
+            if slot == "_" {
+                Ok(None)
+            } else {
+                slot.parse::<u32>().map(Some).map_err(|_| {
+                    format!("invalid skeleton slot: {slot:?} (expected a token id or _)")
+                })
+            }
+        })
+        .collect()
+}
+
+/// A `Compiled` with no token codes: every window bundles to zero rows,
+/// so scoring is carried by the artifact's own tables (root prior,
+/// NGRAM context rows through the recent-token deque, FWDA rows). Used
+/// when no `--teacher` TLA container is supplied.
+fn empty_compiled() -> compiler::Compiled {
+    compiler::Compiled {
+        token_codes: Vec::new(),
+        stage_books: Vec::new(),
+        stage_shifts: Vec::new(),
+        thresholds: vec![0i64; compiler::D],
+        class_sigs: Vec::new(),
+        ctx_cb: Vec::new(),
+        token_stage_kappas: Vec::new(),
+        dot_cb: Vec::new(),
+        resid_cb: Vec::new(),
+        resid_scale_shifts: Vec::new(),
+        norm_fold_const: 0,
+    }
+}
+
+/// A-mode infill serving (issue #399): anchors are GIVEN inputs and the
+/// engine fills the free positions between them through the validated
+/// forward-anchor channel (`GraphScorer::score_candidates_infill`).
+/// Token-id level only — no tokenizer involved.
+pub fn graph_infill_command(args: &[String]) -> Result<(), String> {
+    let mut artifact_path: Option<PathBuf> = None;
+    let mut skeleton_spec: Option<String> = None;
+    let mut teacher_path: Option<PathBuf> = None;
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--artifact" => artifact_path = Some(PathBuf::from(value)),
+            "--skeleton" => skeleton_spec = Some(value.clone()),
+            "--teacher" => teacher_path = Some(PathBuf::from(value)),
+            _ => return Err(format!("unknown graph infill option: {flag}")),
+        }
+        index += 2;
+    }
+    let artifact_path = artifact_path.ok_or("pass --artifact <scored R4G1 path>")?;
+    let skeleton_spec =
+        skeleton_spec.ok_or("pass --skeleton <comma-separated token ids, _ for free positions>")?;
+    let skeleton = parse_skeleton(&skeleton_spec)?;
+
+    let r4g1 = std::fs::read(&artifact_path)
+        .map_err(|error| format!("{}: {error}", artifact_path.display()))?;
+    let teacher_bytes = teacher_path
+        .as_ref()
+        .map(|path| std::fs::read(path).map_err(|error| format!("{}: {error}", path.display())))
+        .transpose()?;
+    let artifacts = match &teacher_bytes {
+        Some(bytes) => compiler::parse_artifacts(bytes).ok_or_else(|| {
+            format!(
+                "{}: not a TLA3/TLA4/TLA5 artifact container",
+                teacher_path
+                    .expect("teacher bytes imply a teacher path")
+                    .display()
+            )
+        })?,
+        None => empty_compiled(),
+    };
+    let scorer = score_runtime::GraphScorer::from_artifact(
+        &r4g1,
+        teacher_bytes.as_deref(),
+        score::DEFAULT_ROOT_TOP_B,
+        score::DEFAULT_EXCT_TOP_X,
+    )?;
+    let rotations = runtime::derive_rotations();
+
+    let filled = score_runtime::infill_fill(&scorer, &artifacts, &rotations, &skeleton)?;
+
+    let free_positions = skeleton.iter().filter(|slot| slot.is_none()).count();
+    let live_fwd_positions = skeleton
+        .iter()
+        .enumerate()
+        .filter(|(index, slot)| {
+            slot.is_none()
+                && score_runtime::next_skeleton_anchor(&skeleton, *index).is_some_and(
+                    |(anchor, distance)| scorer.forward_anchor_row(distance, anchor).is_some(),
+                )
+        })
+        .count();
+
+    let rendered: Vec<String> = filled.iter().map(u32::to_string).collect();
+    println!("{}", rendered.join(","));
+    println!(
+        "infill: filled {free_positions} free positions ({live_fwd_positions} with live fwd rows) across {} slots; {} fwd rows loaded",
+        skeleton.len(),
+        scorer.forward_anchor_row_count()
+    );
+    Ok(())
+}
+
+/// Dispatch of the `graph` command family (A-mode serving surfaces).
+pub fn graph_command(args: &[String]) -> Result<(), String> {
+    match args.first().map(|s| s.as_str()) {
+        Some("infill") => graph_infill_command(&args[1..]),
+        _ => Err(
+            "graph commands: infill --artifact <scored R4G1> --skeleton <token ids, _ for free> [--teacher <TLA container>]"
+                .to_owned(),
+        ),
+    }
+}
+
 pub fn run(args: &[String]) -> Result<(), String> {
     match args.first().map(|s| s.as_str()) {
         Some("setup") => setup(),
@@ -2359,6 +2483,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
         Some("cover") => cover_command(&args[1..])?,
         Some("cover-sweep") => cover_sweep::cover_sweep_command(&args[1..])?,
         Some("score") => score_command(&args[1..])?,
+        Some("graph") => graph_command(&args[1..])?,
         Some("cd-compile") => cd_compile_command(&args[1..])?,
         Some("quantum-eval") => quantum_eval_command(&args[1..])?,
         _ => {
@@ -2369,6 +2494,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
                  observation pipeline: observe [--source DIR | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR | --checkpoint BIN] [--tokenizer PATH] [--sequence-length N]\n\
+                 A-mode infill serving: graph infill --artifact <scored R4G1> --skeleton <token ids, _ for free> [--teacher <TLA container>]\n\
                  quantum operations: cd-compile | quantum-eval\n\
                  hf evaluation: evaluate-report [--source DIR] [--compiled DIR] [--report PATH] [--sequence-length N] [--bos] [--max-held-out-stories N]\n\
                  docs: docs/TRANSFORMERLESS.md (extrapolation), docs/PROOF.md (proof + certificate)"

--- a/crates/uor-r4-graph-cli/tests/graph_infill_cli.rs
+++ b/crates/uor-r4-graph-cli/tests/graph_infill_cli.rs
@@ -1,0 +1,160 @@
+//! CLI surface test for the A-mode infill subcommand (issue #399):
+//! `graph infill --artifact <R4G1> --skeleton <ids with _ for free>`
+//! runs end-to-end against a tiny scored artifact written to disk, and
+//! the argument parsing fails closed on malformed input.
+
+use std::collections::BTreeMap;
+
+use uor_r4_core::transformerless::compiler::SIG_BYTES;
+use uor_r4_core::transformerless::runtime;
+use uor_r4_graph_certify::score::{
+    ContextRow, EmissionTables, ForwardAnchorRow, QuantizationErrorStats, ScoredGraphSections,
+    Smoothing, emit_scored_r4g1,
+};
+use uor_r4_graph_certify::score_runtime::RegionParams;
+use uor_r4_graph_cli::{graph_command, graph_infill_command};
+use uor_r4_graph_format::ScoreQ;
+
+/// The fwda_roundtrip tiny artifact, reduced to what the CLI test
+/// needs: one region, two unigram context rows, an empty exact-context
+/// store, and one forward-anchor row.
+fn tiny_artifact_bytes() -> Vec<u8> {
+    let regions = vec![RegionParams {
+        node: 1,
+        depth: 1,
+        radius: 0,
+        sig: [0; SIG_BYTES],
+        parent: None,
+    }];
+    let context_rows = vec![
+        ContextRow {
+            context_len: 1,
+            key0: 6,
+            key1: 0,
+            entries: vec![
+                (7, ScoreQ::from_raw(-100_000)),
+                (20, ScoreQ::from_raw(-80_000)),
+            ],
+        },
+        ContextRow {
+            context_len: 1,
+            key0: 20,
+            key1: 0,
+            entries: vec![
+                (4, ScoreQ::from_raw(-100_000)),
+                (5, ScoreQ::from_raw(-120_000)),
+                (6, ScoreQ::from_raw(-80_000)),
+            ],
+        },
+    ];
+    let store: runtime::Store =
+        vec![BTreeMap::new(); uor_r4_core::transformerless::compiler::STAGES + 1];
+    let tls1 = runtime::store_bytes(&store);
+    let mut root_prior = BTreeMap::new();
+    root_prior.insert(1u32, ScoreQ::from_raw(-50_000));
+    let emissions = EmissionTables {
+        root_prior,
+        root_floor: ScoreQ::from_raw(-500_000),
+        root_total: 10,
+        region_lists: vec![Vec::new()],
+        smoothing: Smoothing::AddOne,
+        root_prior_quantization: QuantizationErrorStats::default(),
+        emission_quantization: QuantizationErrorStats::default(),
+        selection_stats: Default::default(),
+    };
+    let fwd_rows = vec![ForwardAnchorRow {
+        distance: 2,
+        anchor: 6,
+        total: 50,
+        entries: vec![(5, 50)],
+    }];
+    let (bytes, info) = emit_scored_r4g1(
+        b"teacher-container",
+        (b"meta", b"recs"),
+        100,
+        &ScoredGraphSections {
+            regions: &regions,
+            structural: &[],
+            transitions: &[],
+            transition_quantization: QuantizationErrorStats::default(),
+            emissions: &emissions,
+            context_rows: &context_rows,
+            exct_tls1: &tls1,
+            exct_top_x: 3,
+            fmm_section: None,
+            fwd_rows: &fwd_rows,
+        },
+    )
+    .expect("tiny scored artifact");
+    assert_eq!(info.fwda_row_count, 1);
+    bytes
+}
+
+#[test]
+fn graph_infill_runs_end_to_end_on_a_scored_artifact() {
+    let dir = std::env::temp_dir().join(format!("r4-graph-infill-cli-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let artifact = dir.join("score.r4g1");
+    std::fs::write(&artifact, tiny_artifact_bytes()).expect("artifact written");
+
+    let args = vec![
+        "--artifact".to_owned(),
+        artifact.display().to_string(),
+        "--skeleton".to_owned(),
+        "20,_,_,6".to_owned(),
+    ];
+    graph_infill_command(&args).expect("infill subcommand runs");
+
+    // The `graph` family dispatches to the same command.
+    let mut family = vec!["infill".to_owned()];
+    family.extend(args);
+    graph_command(&family).expect("graph dispatch runs");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn graph_infill_arguments_fail_closed() {
+    let missing_artifact = graph_infill_command(&["--skeleton".to_owned(), "_".to_owned()]);
+    assert!(
+        missing_artifact
+            .expect_err("artifact is required")
+            .contains("--artifact")
+    );
+
+    let missing_skeleton = graph_infill_command(&[
+        "--artifact".to_owned(),
+        "/nonexistent/score.r4g1".to_owned(),
+    ]);
+    assert!(
+        missing_skeleton
+            .expect_err("skeleton is required")
+            .contains("--skeleton")
+    );
+
+    let bad_slot = graph_infill_command(&[
+        "--artifact".to_owned(),
+        "/nonexistent/score.r4g1".to_owned(),
+        "--skeleton".to_owned(),
+        "12,x,_".to_owned(),
+    ]);
+    assert!(
+        bad_slot
+            .expect_err("non-numeric slot is rejected")
+            .contains("invalid skeleton slot")
+    );
+
+    let unknown_flag = graph_infill_command(&["--bogus".to_owned(), "1".to_owned()]);
+    assert!(
+        unknown_flag
+            .expect_err("unknown flags are rejected")
+            .contains("unknown graph infill option")
+    );
+
+    let unknown_family = graph_command(&["bogus".to_owned()]);
+    assert!(
+        unknown_family
+            .expect_err("unknown graph subcommands are rejected")
+            .contains("graph commands")
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,13 @@ enum Command {
         #[arg(required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// A-mode graph serving commands, e.g. `r4 graph infill --artifact
+    /// graph/score.r4g1 --skeleton 12,_,_,_,99,_,_,_,7`.
+    Graph {
+        /// Subcommand and arguments forwarded verbatim.
+        #[arg(required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Run the new R4G1 multiresolution graph compiler pipeline.
     GraphCompile {
         /// Subcommand and arguments forwarded verbatim.
@@ -640,6 +647,11 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         Some(Command::TeacherKappa) => run_core("teacher-kappa", &[]),
         Some(Command::Transformerless { args }) => {
             transformerless_command::run(args).map_err(RunError::Command)
+        }
+        Some(Command::Graph { args }) => {
+            let mut values = vec!["graph".to_owned()];
+            values.extend_from_slice(args);
+            transformerless_command::run(&values).map_err(RunError::Command)
         }
         Some(Command::GraphCompile { args }) => {
             uor_r4_graph_compiler::compile(args).map_err(RunError::Command)


### PR DESCRIPTION
References #399. Productizes the VALIDATED A-mode: anchors given as inputs (drift-immune by construction), free positions filled with the fused scorer (+4.2pp live record, M2 row).

**Surface:** `infill_fill(scorer, artifacts, rotations, skeleton: &[Option<u32>])` — any pattern of givens; nearest following anchor within distance 1..=3 keys the FWDA row, farther/absent falls back to base scoring; givens consumed verbatim into context. `next_skeleton_anchor` exposes the anchor rule. CLI: `r4 graph infill --artifact <score.r4g1> --skeleton "12,_,_,_,99,_,_,_,7" [--teacher <TLA>]` → filled ids + fill summary. Runtime engine default path and witness/replay contract untouched.

**Tests:** 5 new non-ignored (givens verbatim, live-row flip, absent-FWDA == base scoring exactly, far-anchor fallback, CLI end-to-end + fail-closed args). Workspace fmt/clippy/test-compile clean.