### PR TITLE
docs: accuracy audit pass — align docs with post-#407/#399 state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ the wasm dashboard are exploratory and stay out of the graph migration path.
 - `crates/uor-r4-core` — R⁴ math + transformerless compiler/runtime (see its README)
 - `crates/uor-r4-router` — geometric router + dashboard backend (f64; untouched by the graph plan)
 - `crates/uor-r4-graph-format` — R4G1 packed artifact format, two-stage validation, borrowed `GraphView`
+- `crates/uor-r4-graph-compiler` — offline graph-compiler stages (observation, cover induction, packing)
+- `crates/uor-r4-graph-certify` — offline certification/measurement (Gate C `score` harness, `score_runtime` reference scorer, certificates)
+- `crates/uor-r4-graph-runtime` — `no_std` allocation-free R4G1 graph runtime (engine, routing, patch chains)
+- `crates/uor-r4-graph-cli` — `r4 transformerless …` CLI stage dispatch (convert-r4g1, scenarios, corpus tools)
+- `crates/uor-r4-model-source` — teacher forward-pass port + pinned Safetensors adapter
 - `crates/uor-r4-proof-model` — executable proof obligations + proof-status matrix
 - `crates/uor-r4-api` — typed compile + engine library façade for downstream consumers (wraps the CLI-shaped stages; see its README)
 - root package `uor-r4-wasm-router` — façade + `r4` CLI + local server/chat

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ landed: the R4G1 packed artifact format with two-stage validation
 observation pipeline (content-addressed sample IDs, deterministic shard
 spill/resume), multiresolution cover induction (spherical k-means with
 calibrated overlapping memberships), semantic transitions + reverse indexes,
-ScoreQ fixed-point residuals, and the executable proof model
-(`crates/uor-r4-proof-model`). CI runs fmt/clippy/tests/no_std/deterministic-
+ScoreQ fixed-point residuals, packed NGRAM context rows (trigram → bigram
+backoff) plus the optional FWDA forward-anchor section with
+anchor-conditioned infill scoring (`score_candidates_infill`, issue #399),
+and the executable proof model (`crates/uor-r4-proof-model`). CI runs fmt/clippy/tests/no_std/deterministic-
 rebuild/audit/fuzz/wasm gates on every push (`.github/workflows/ci.yml`).
 
 There is an important boundary in the current workflow: compiling a Hugging
@@ -541,7 +543,7 @@ flowchart LR
     Runtime --> Apps["r4 ask / r4 chat / HTTP API"]
 ```
 
-The workspace has one public package and four internal implementation crates:
+The workspace has one public package and ten internal implementation crates:
 
 | Package | Responsibility |
 |---|---|
@@ -549,6 +551,12 @@ The workspace has one public package and four internal implementation crates:
 | [`uor-r4-core`](crates/uor-r4-core) | Core R⁴ mathematics and transformerless compiler/runtime/tokenizer/certifier |
 | [`uor-r4-router`](crates/uor-r4-router) | Manifold state, indexing, geometric routing, and router witnesses |
 | [`uor-r4-graph-format`](crates/uor-r4-graph-format) | Canonical R4G1 serialization, two-stage validation, and borrowed graph views |
+| [`uor-r4-graph-compiler`](crates/uor-r4-graph-compiler) | Offline graph-compiler stages: observation pipeline, cover induction, routing/residual packing |
+| [`uor-r4-graph-certify`](crates/uor-r4-graph-certify) | Offline certification and measurement: Gate C scoring harness (`score`), reference scorer (`score_runtime`), certificates, comparison |
+| [`uor-r4-graph-runtime`](crates/uor-r4-graph-runtime) | `no_std` allocation-free R4G1 graph runtime (engine, routing programs, packed kernels, patch chains) |
+| [`uor-r4-graph-cli`](crates/uor-r4-graph-cli) | `r4 transformerless …` CLI stage dispatch (convert-r4g1, scenarios, corpus tools) |
+| [`uor-r4-api`](crates/uor-r4-api) | Typed compile + engine library facade for downstream library consumers |
+| [`uor-r4-model-source`](crates/uor-r4-model-source) | Teacher forward-pass port (llama2.c-exact) and pinned Safetensors adapter |
 | [`uor-r4-proof-model`](crates/uor-r4-proof-model) | Executable graph-compiler proof obligations and proof-status matrix |
 
 The public [`tless_uor`](src/tless_uor.rs) module provides `TlessAxis`,

--- a/crates/uor-r4-core/README.md
+++ b/crates/uor-r4-core/README.md
@@ -19,28 +19,26 @@ This crate hosts two things:
 
 | Module | Role |
 |---|---|
-| `teacher` | `TeacherOracle` two-surface trait (embedding + next-token oracle); llama-family safetensors adapter, optional trace surface |
 | `compiler` | Corpus pipeline, deterministic projection + sampled RVQ codebooks, thresholds, class signatures, TLA container emit/parse, span/byte-anchored observation records |
 | `runtime` | Mul-free integer kernel (`OpKernel` with op census, no multiply method), sign signatures, Hamming assignment, graded evidence store (TLS1), bounded top‑M membership, allocation-free generation |
-| `runtime_state` | Fixed-capacity multi-timescale state: live token state + reserved local/segment/session levels with Phase-8 update hooks |
 | `reference_state` | Reference `ActiveFrontier` + checked packed edge-range resolvers |
 | `transitions` | Forward semantic transitions + reverse indexes (Theorem 7 consistency) |
 | `convert_r4g1` | Migration converter: TLA/TLS1 artifacts → canonical R4G1 containers |
-| `observe` | Observation pipeline v2: content-addressed sample IDs, deterministic shard spill/resume, `observe` CLI |
-| `cover` | Multiresolution cover induction: spherical k-means, entropy-justified splits, calibrated radii, refinement/neighbor edges, R4G1 emission |
-| `score` | Phase-4 compiler: E_f transitions + reverse indexes, root priors + parent-relative emission residuals, scored R4G1 emission, Gate C harness |
-| `score_runtime` | Integer-only reference scorer (ScoreQ accumulation, no float/mul), bounded witness records + independent replay verifier; portable to wasm32 |
-| `certify` / `compare` | Teacher-fidelity certification and runtime comparison |
-| `certificate` / `performance_certificate` | Certificate schema (CIDs, claims, attestation) and bytes-read/cache/branch performance certificates |
 | `score_q` | `ScoreQ` Q16.16 fixed-point log-domain scores (mul-free add/sub) |
 | `resolution_status` | Supported / Boundary / BackedOff / Novel / Contradictory status |
-| `anti_degeneracy` | Semantic anti-degeneracy transformations and evaluation harness |
-| `predictive_sufficiency` | Rate-distortion / predictive-sufficiency reports by graph depth |
-| `fairness_provenance` | Bias amplification, rare-group erasure, provenance-deletion support |
 | `graph_patch` | Immutable content-addressed patch epochs and route translation |
-| `shortlist_evaluator` | Shortlist top‑M recall measurement vs the reference classifier |
 | `scenarios` | ChatML prompt wrappers (`format_instruct_chat_prompt`, `encode_chat_prompt`), byte-level BPE tokenizer export, scenario suite |
-| `command` | `r4 transformerless …` CLI dispatch |
+| `cd_space` / `endomorphism` / `lie_jordan` / `bott_fock` | Dormant Furey-plan substrate modules (see `docs/r4_furey_quantum_geometric_plan.md`, dated deferral record) |
+
+Modules that started here and moved out in the crate split:
+
+| Former module | Current home |
+|---|---|
+| `teacher` (`TeacherOracle`, llama-family adapters) | `uor-r4-model-source` |
+| `runtime_state` (fixed-capacity multi-timescale state) | `uor-r4-graph-runtime::runtime_state` |
+| `observe` / `cover` (observation pipeline, cover induction) | `uor-r4-graph-compiler` (`observation`, `induction`) |
+| `score` (Phase-4 compiler + Gate C harness), `score_runtime` (integer-only reference scorer), `certify` / `compare`, `certificate` / `performance_certificate`, `anti_degeneracy`, `predictive_sufficiency`, `fairness_provenance`, `shortlist_evaluator` | `uor-r4-graph-certify` |
+| `command` (`r4 transformerless …` CLI dispatch) | `uor-r4-graph-cli` |
 
 ## Runtime contract (normative)
 
@@ -62,8 +60,9 @@ in `docs/transformerless/INFERENCE_OPERATION_CONTRACT.md`.
   default; needs the stories15M checkpoint; re-pin helper `dump_baseline_kappa`)
 - `tests/allocation_census.rs` — allocation + op census on real artifacts
 - `tests/deterministic_rebuild_test.rs` — Gate E deterministic rebuild slice
-- `tests/convert_r4g1.rs`, `tests/observation_anchors.rs`, `tests/observe.rs`,
-  `tests/transitions_test.rs`, … — feature suites
+- `tests/convert_r4g1.rs`, `tests/graph_patch_test.rs`,
+  `tests/transitions_test.rs`, … — feature suites (the observation-pipeline
+  suites moved to `uor-r4-graph-compiler` with the crate split)
 
 ## Layout notes
 

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -82,10 +82,12 @@
 //!   store argmax. Every scored candidate receives one root-prior contribution
 //!   before its residual, with the baked smoothing floor for absent tokens.
 //! - **EXCT precedence (Rule 2)**: the existing prefix probe from
-//!   `runtime::predict_witness_plain` (deepest populated prefix). Total
+//!   `runtime::predict_witness_plain` (deepest populated prefix). A
+//!   resolution at the FULL graded code (level == STAGES, #234) with total
 //!   evidence ≥ [`EXCT_SUPPORT_MIN`] ⇒ `S(v) = B(v) + ΔX(X,v)` over the
-//!   admitted local entries, graph candidate generation skipped; below the
-//!   gate the probe is recorded (admitted 0) and Rule 1 decides.
+//!   admitted local entries, graph candidate generation skipped; a
+//!   below-full-depth resolution or a total below the gate is recorded
+//!   (admitted 0) and Rule 1 decides.
 //! - **Status**: every prediction reports exactly one [`ScoreStatus`] —
 //!   `ExactContext` (Rule 2 fired), `Graph` (Rule 1 with a non-empty
 //!   selected chain), `Novel` (Rule 1 with no covered chain — Phase 5

--- a/crates/uor-r4-graph-compiler/README.md
+++ b/crates/uor-r4-graph-compiler/README.md
@@ -8,7 +8,8 @@ This crate implements the offline compilation stages that cross-compile pinned H
 
 ## Key Components
 
-- **Observation Pipeline**: Content-addressed observation extraction with ChatML prompt formatting (`scenarios.rs` / `encode_chat_prompt`).
-- **Cover Induction**: Spherical K-means clustering over teacher representation spaces with calibrated overlapping region radii.
-- **Score & Residual Accumulation**: Pre-quantized fixed-point `ScoreQ` residual computation across resolution depths.
-- **Evaluation Harness**: Produces `instruction-eval.json` evaluation report envelopes carrying BLAKE3 CIDs (`tokenizer_cid`, `artifacts_cid`, `store_cid`) for Gate C certification.
+- **Observation Pipeline** (`observation.rs`, `observation_shards.rs`): Content-addressed observation extraction with deterministic shard spill/resume (ChatML prompt formatting lives in `uor-r4-graph-cli::scenarios`).
+- **Cover Induction** (`induction.rs`): Spherical K-means clustering over teacher representation spaces with calibrated overlapping region radii.
+- **Score & Residual Accumulation** (`residual.rs`, `pack.rs`): Pre-quantized fixed-point `ScoreQ` residual computation across resolution depths and R4G1 packing.
+
+The Gate C scoring harness and the `instruction-eval.json` evaluation report envelope are emitted by `uor-r4-graph-certify::score` and the root `evaluate-report` command, not by this crate.

--- a/crates/uor-r4-graph-format/README.md
+++ b/crates/uor-r4-graph-format/README.md
@@ -13,8 +13,14 @@ version gate).
 
 - **Newtypes** (`types.rs`): `NodeId`, `SectionOffset`, `TokenId`, `ScoreQ`
   (Q16.16 carrier), `Depth`, `Radius`, `ArtifactCid`, `SectionId` with the
-  section inventory (HEAD/CODE/NODE/EDGE/ROUT/EMIT/EXCT/PROV/CERT/PTCH/SECT)
-  and mandatory/optional classification.
+  section inventory (HEAD/CODE/NODE/EDGE/ROUT/EMIT/EXCT/PROV/CERT/PTCH/SECT/
+  RTNX plus the optional-bit extensions FMM/NGRAM/FWDA) and
+  mandatory/optional classification.
+- **Optional context/anchor rows** (`ngram.rs`, `fwda.rs`): borrowed packed
+  NGRAM context rows (bigram/trigram keys; the root prior stays the unigram
+  row in EMIT) and the FWDA forward-anchor rows for infill serving
+  (issue #399; keyed by lookahead distance + next-anchor token, entries are
+  raw counts quantized at load time).
 - **Stage-1 structural validation** (`header.rs`, `view.rs`): magic, version,
   endianness marker, alignment, `total_len`, sorted non-overlapping
   section table, checked offset arithmetic, unknown-mandatory-section and

--- a/crates/uor-r4-router/README.md
+++ b/crates/uor-r4-router/README.md
@@ -18,6 +18,8 @@ holographic graph compiler plan (`docs/r4_graph_compiler_implementation_plan.md`
 (`uor-r4-core::transformerless`) and the R4G1 graph artifacts are the path to
 the mul-free, allocation-free runtime contract, and this router's word-Markov
 generator survives only as a documented fallback for `r4 chat` when no
+compiled store is bound.
+
 - **FallbackRouter Pipeline**: `FallbackRouter` (`src/fallback.rs`) manages dynamic engine cascades from primary `r4g1-graph` to secondary `transformerless-tla5` fallback upon encountering `EngineStatus::UnmappedRegion` or `EngineStatus::Pathological` statuses, returning valid response streams without dropping HTTP/WS payloads.
 
 ## API surface

--- a/docs/r4_furey_quantum_geometric_plan.md
+++ b/docs/r4_furey_quantum_geometric_plan.md
@@ -24,7 +24,9 @@ confusion): the live `uor-r4-graph-runtime/src/cayley_dickson.rs` used by
 `syntactic_morphism_score` is a golden-ratio hash tie-breaker and is *not*
 the Cayley-Dickson algebra of this plan (`uor-r4-core/.../cd_space.rs`,
 dormant). When this plan's phases activate, one of the two should be
-renamed.
+renamed. *(Addendum 2026-08-05: `syntactic_morphism_score` was measured dead
+and removed in PR #410 — #400 A/B, 0/1,998 executions; the graph-runtime
+`cayley_dickson.rs` module remains, now without serving callers.)*
 
 ---
 

--- a/docs/r4_native_architecture.md
+++ b/docs/r4_native_architecture.md
@@ -121,6 +121,11 @@ score has meaning) or measured and removed. Its hard-coded token-id lists
 (determiners/prepositions) are the only explicit syntax mechanism in the
 system and should be superseded by §5.
 
+*Addendum 2026-08-05: resolved by measurement — the #400 A/B recorded the
+term as dead (0/1,998 executions on the surface that calls it) and it was
+removed in PR #410; `cayley_dickson.rs` remains in the crate without serving
+callers.*
+
 ## 8. Program and gates
 
 | track | issue | gate |
@@ -134,6 +139,13 @@ system and should be superseded by §5.
 
 Scoring-term additions to the serving stack are a measured dead end and are
 out of scope for this program.
+
+*Addendum 2026-08-05 (issue records are authoritative): the CD-term-hygiene
+gate closed as removal (#400/#410). The forward-anchor track landed as #399
+(PRs #414–#418): the optional FWDA section plus `score_candidates_infill`,
+with anchors-as-inputs (A-mode) measured positive on the live slice and the
+standalone two-pass B-mode refuted by two falsifiers (Gate C arms for
+true/self/gated/draft/strict anchors, report schema 21).*
 
 ## 9. Governance
 

--- a/docs/transformerless/BASELINE.md
+++ b/docs/transformerless/BASELINE.md
@@ -230,6 +230,15 @@ artifacts (deterministic across runs; debug profile).
   no replacement; the mode is recorded as the certificate reproducibility
   policy and CI Gate E now runs it on Linux and macOS.
 
+- **Baseline anchor moved 2026-08-04, fifth re-pin** (maintainer decision, issue #407,
+  PR #413): `CTX_SAMPLE` raised 6,000 → 50,000 after the #411 attribution sweep (era
+  self-consistency +1.4pp, sample size +0.5–0.7pp; `CTX_ITERS` unchanged at 6). Compiled
+  under canonical deterministic mode (`TLESS_CANONICAL_DETERMINISTIC=1`, the #265 D2 policy,
+  now required for re-pins); container κ moved `blake3:ef6a20f3…` → `blake3:8fbf3f68…`
+  (1,346,836 bytes, size unchanged). Token-side pins and the threshold vector are
+  byte-identical to the prior era by construction; only the context codebooks, class
+  signatures, and container moved. Pins: `baseline_kappa.json`.
+
 - **Phase C adoption evidence recorded 2026-08-01** (issue #335): the
   single-key/query-beam shape remains selected over write-time fan-out
   (34.7% / 39.0% / 8.0249 WB / 179,068 keys versus 20.3% / 22.7% / 8.1473 /

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -63,9 +63,13 @@ graph term is normative for new work. See the terminology bridge in the plan (§
   (chain-telescoped): `S_graph(v) = B(v) + Σ_{n∈chain} ΔE(n,v) + ΔT-offset`, where `chain` is
   the covered refinement chain (root → deepest covered ancestor) of the active region with the
   deepest covered chain — emission corrections compose along one ancestry path instead of
-  stacking across sibling subtrees. Rule 2 (D4 EXCT precedence): when the deepest-populated
-  exact-context prefix carries enough evidence (total ≥ `EXCT_SUPPORT_MIN` = 5),
-  `S(v) = B(v) + ΔX(X,v)` and graph residuals are skipped entirely. Each table is sparse; no
+  stacking across sibling subtrees. Rule 2 (D4 EXCT precedence): when the exact-context probe
+  resolves at the FULL graded code with enough evidence (total ≥ `EXCT_SUPPORT_MIN` = 5),
+  `S(v) = B(v) + ΔX(X,v)` and graph residuals are skipped entirely; a probe that resolves below
+  full depth is prefix backoff, admits nothing, and falls through to Rule 1 (#234, maintainer
+  decision 2026-07-29). An explicit supported NGRAM context row (trigram → bigram backoff, #380)
+  takes the same most-specific precedence before the EXCT probe; the root prior `B(v)` remains
+  the unigram backoff. Each table is sparse; no
   contribution is counted twice (Theorem 10). Supersedes the literal Σ-over-cloud form
   (`B + ΣΔE + ΣΔT + ΔX`), which double-counted correlated sibling residuals (Gate C: 0.3%
   vs 31.7% baseline).
@@ -91,8 +95,9 @@ graph term is normative for new work. See the terminology bridge in the plan (§
 
 ## Artifacts and identity
 
-- **R4G1** — the versioned packed artifact container (sections HEAD/CODE/NODE/EDGE/ROUT/EMIT/
-  EXCT/PROV/CERT). Succeeds TLA3/TLA4/TLS1. See `docs/transformerless/R4G1.md`.
+- **R4G1** — the versioned packed artifact container (mandatory sections HEAD/CODE/NODE/EDGE/
+  ROUT/EMIT/PROV plus optional EXCT/CERT/PTCH/SECT/RTNX/FMM/NGRAM/FWDA). Succeeds
+  TLA3/TLA4/TLS1. See `docs/transformerless/R4G1.md`.
 - **κ (kappa) / content CID** — content address (blake3 label or UOR CID) preserving identity and
   provenance of bytes. CIDs are **not** semantic hashes and are never used as routing codes.
 - **Semantic route code** — a compiled, versioned, intentionally locality-preserving code used for
@@ -133,9 +138,11 @@ graph term is normative for new work. See the terminology bridge in the plan (§
 - **M.V.G. checkpoint** — the minimum-viable-graph go/no-go review at the end of Phase 5
   (decision D1), comparing the graph against pre-agreed targets recorded in
   `docs/transformerless/BASELINE.md`.
-- **Baseline** — the current certified transformerless artifact (TLA3/TLS1) and its measured
-  fidelity: 28.9% top-1, 31.7% teacher-argmax agreement, 6.54 bits/token, 89,200 store keys
-  (PROOF.md P2). Gate C compares the graph against this baseline before replacement.
+- **Baseline** — the certified transformerless artifact and its measured fidelity. The figures
+  here are the original 150k-era record (TLA3/TLS1: 28.9% top-1, 31.7% teacher-argmax agreement,
+  6.54 bits/token, 89,200 store keys — PROOF.md P2); the current-era pins live in the PROOF.md
+  P2/P3 era notes and `baseline_kappa.json`. Gate C compares the graph against this baseline
+  before replacement.
 
 ## Recent Architecture & Engine Additions (Epic #201)
 

--- a/docs/transformerless/PROOF.md
+++ b/docs/transformerless/PROOF.md
@@ -156,6 +156,15 @@ table-read 314,176 / multiply 0. The new pins are the
 `baseline_kappa.json` record; the 150k-era figures above are retained as
 the historical record of the original certificate.
 
+**Era note (2026-08-04, #407 fifth re-pin, maintainer decision).** The
+context-codebook sample size `CTX_SAMPLE` moved 6,000 → 50,000 (attribution
+sweep PR #411), and the era artifact was re-pinned under canonical
+deterministic mode (`TLESS_CANONICAL_DETERMINISTIC=1`, the #265 D2 policy):
+container κ moved `blake3:ef6a20f3…` → `blake3:8fbf3f68…` (1,346,836 bytes,
+size unchanged). Token-side pins and the threshold vector are byte-identical
+to the prior era by construction; the pins are the current
+`baseline_kappa.json` record.
+
 Library witnesses (cargo test): P-1 the popcount table matches its
 definition on all 256 bytes and carries the stratum partition C(8,k);
 P-2 kernel Hamming equals the direct definition with exact op counts;
@@ -206,8 +215,10 @@ storage option.
 **(a) Container, witnessed.** save → load → save is byte-identical and
 κ-stable, asserted every certification run. Era note (#327, maintainer
 decision 2026-08-01): the default emission is the TLA7 container (#318
-Phase B integer residual sections; 500k-corpus era) — current witness
-1,346,836 bytes, `blake3:ef6a20f3…` (2026-08-01 full-certify run). The
+Phase B integer residual sections; 500k-corpus era) — witness
+1,346,836 bytes, `blake3:ef6a20f3…` (2026-08-01 full-certify run; since the
+2026-08-04 #407 fifth re-pin the current container κ is `blake3:8fbf3f68…`,
+same byte length — see the P3 era note). The
 residual sections and the new corpus change the serialization and the
 bundle-derived κs; the token-side κ pins are byte-identical to the TLA5
 era by construction, and prior-era containers (1-term TLA6 1,051,916

--- a/docs/transformerless/R4G1.md
+++ b/docs/transformerless/R4G1.md
@@ -71,6 +71,16 @@ reject any pre-freeze artifact that claims `major >= 1`.
 | 0x09 | CERT | opt. | certification metadata: certificate CID(s), thresholds, metric refs |
 | 0x0A | PTCH | opt. | patch-epoch header when the artifact is a patch layer (Phase 9) |
 | 0x0B | SECT | opt. | per-section hash table — **reserved, future exploration** (§9.2) |
+| 0x0C | RTNX | opt. | route translation index (Phase 9) |
+| bit31 \| 0x0D | FMM | opt. | compiler-precomputed far-field translation table (#290) |
+| bit31 \| 0x0E | NGRAM | opt. | packed lexical context rows: bigram/trigram keys with ScoreQ entries; the root prior stays the unigram row in EMIT |
+| bit31 \| 0x0F | FWDA | opt. | packed forward-anchor rows for infill serving (#399); NGRAM-mirroring layout, `(distance, anchor)` keys, raw-count entries quantized at load time |
+
+The three `bit31 \|` IDs carry the ancillary bit (`SectionId::OPTIONAL_BIT`,
+bit 31) in the wire ID itself so pre-extension readers skip them under the
+unknown-optional-section rule; an artifact without any of them remains valid.
+Implemented layouts: `uor-r4-graph-format::{ngram, fwda, fmm}` (magics
+`NGR1`, `FWA1`, `FMM1`).
 
 ## 4. HEAD contents (normative field set, order fixed)
 


### PR DESCRIPTION
Full-repo documentation accuracy audit (Casey requested 2026-08-05). 13 files: factual fixes (README crate table, core README module map, graph-compiler misattributions, format section inventory, router README mangled sentence from #218, score_runtime pre-#234 Rule 2 bullet), missing coverage added minimally (R4G1.md RFC §3 rows for RTNX/FMM/NGRAM/FWDA, GLOSSARY scoring model + NGRAM precedence), and dated addenda on living/pinned docs (BASELINE.md fifth re-pin, PROOF.md era notes, r4_native_architecture.md §7/§8 post-#410/#399 state). Historical measurement records untouched. Workspace fmt/clippy/test-compile clean.