### PR TITLE
feat(core,compiler): env-overridable capacity knobs + M-C1 subsample control (capacity-starvation hypothesis)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -196,6 +196,51 @@ pub const ROT: usize = 17;
 const EMB_ITERS: usize = 10;
 const CTX_SAMPLE: usize = 50_000;
 const CTX_ITERS: usize = 6;
+/// Per-run k-means training subsample cap of [`sampled_kmeans_rvq`]. (The
+/// compile log's "RVQ assignment …100000" progress total is
+/// `EMB_ITERS × RVQ_SAMPLE_CAP` = 10 × 10 000 — the cap itself is 10k.)
+const RVQ_SAMPLE_CAP: usize = 10_000;
+
+/// Capacity-override environment variable (#399/#393 M-C2, usize knobs).
+///
+/// Unset returns `default`, so every pinned code path is byte-identical
+/// (κ-neutral) unless a measurement explicitly opts in. A set-but-invalid
+/// or zero value panics: a capacity measurement must never silently fall
+/// back to the constant it was trying to change. Underscore separators
+/// are accepted (`R4_CTX_SAMPLE=211_000`).
+pub fn capacity_override_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(value) => {
+            let parsed = value
+                .trim()
+                .replace('_', "")
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{name} must be a positive integer, got {value:?}"));
+            assert!(parsed >= 1, "{name} must be >= 1, got {value:?}");
+            parsed
+        }
+        Err(_) => default,
+    }
+}
+
+/// Capacity-override environment variable (#399/#393 M-C2, f64 knobs).
+/// Same contract as [`capacity_override_usize`]: unset is κ-neutral,
+/// invalid panics. Non-negative finite values only.
+pub fn capacity_override_f64(name: &str, default: f64) -> f64 {
+    match std::env::var(name) {
+        Ok(value) => {
+            let parsed = value.trim().parse::<f64>().unwrap_or_else(|_| {
+                panic!("{name} must be a floating-point number, got {value:?}")
+            });
+            assert!(
+                parsed.is_finite() && parsed >= 0.0,
+                "{name} must be finite and >= 0, got {value:?}"
+            );
+            parsed
+        }
+        Err(_) => default,
+    }
+}
 
 pub fn xorshift(s: &mut u64) -> u64 {
     let mut x = *s;
@@ -1465,7 +1510,9 @@ fn sampled_kmeans_rvq(
         indices.swap(i, j);
     }
 
-    let sample_size = nvec.min(10000);
+    // #399/#393 M-C2: the training-subsample cap is env-overridable for
+    // capacity measurements; unset keeps the pinned 10k constant.
+    let sample_size = nvec.min(capacity_override_usize("R4_RVQ_SAMPLE_CAP", RVQ_SAMPLE_CAP));
     let mut sample_vecs = vec![0f32; sample_size * D];
     for i in 0..sample_size {
         let src_idx = indices[i];
@@ -1708,11 +1755,14 @@ pub fn compile_from_representation(
     // 4: context RVQ on (centered, normalized) runtime bundles; binarize
     // centroids to sign bits for Hamming assignment.
     let train_idx: Vec<usize> = (0..corpus.n).filter(|&i| corpus.story[i] < cut).collect();
+    // #399/#393 M-C2: the context-RVQ sample count is env-overridable for
+    // capacity measurements; unset keeps the pinned 50k constant.
+    let ctx_sample = capacity_override_usize("R4_CTX_SAMPLE", CTX_SAMPLE);
     let mut s = 0x5A3B1Eu64;
-    let mut samp = vec![0f32; CTX_SAMPLE * D];
+    let mut samp = vec![0f32; ctx_sample * D];
     let mut context_progress =
-        uor_r4_model_source::progress::Progress::new("context samples", CTX_SAMPLE);
-    for v in 0..CTX_SAMPLE {
+        uor_r4_model_source::progress::Progress::new("context samples", ctx_sample);
+    for v in 0..ctx_sample {
         context_progress.set(v);
         let i = train_idx[(xorshift(&mut s) as usize) % train_idx.len()];
         let b = super::runtime::bundle_plain(&art, &rot, corpus, i);
@@ -1729,7 +1779,7 @@ pub fn compile_from_representation(
         }
     }
     context_progress.finish();
-    let (ctx_cb, _) = sampled_kmeans_rvq(&samp, CTX_SAMPLE, STAGES, K, CTX_ITERS, seed_bytes);
+    let (ctx_cb, _) = sampled_kmeans_rvq(&samp, ctx_sample, STAGES, K, CTX_ITERS, seed_bytes);
     for (st, cb) in ctx_cb.iter().enumerate() {
         println!("context codebook stage {} κ: {}", st, kappa_of_f32s(cb));
         let mut sigs = vec![0u8; K * D / 8];
@@ -2066,5 +2116,42 @@ pub fn induce_hierarchical_codes(
     HierarchicalCodes {
         token_type_prefixes,
         relational_prefixes,
+    }
+}
+
+#[cfg(test)]
+mod capacity_override_tests {
+    use super::{capacity_override_f64, capacity_override_usize};
+
+    #[test]
+    fn unset_returns_pinned_default() {
+        // κ-neutrality contract (#399/#393 M-C2): an unset override is the
+        // pinned constant, bit for bit.
+        assert_eq!(capacity_override_usize("R4_TEST_CAP_UNSET", 50_000), 50_000);
+        assert_eq!(capacity_override_f64("R4_TEST_CAP_F64_UNSET", 0.25), 0.25);
+    }
+
+    #[test]
+    fn set_value_overrides_with_separators() {
+        std::env::set_var("R4_TEST_CAP_SET", "211_000");
+        assert_eq!(capacity_override_usize("R4_TEST_CAP_SET", 50_000), 211_000);
+        std::env::remove_var("R4_TEST_CAP_SET");
+        std::env::set_var("R4_TEST_CAP_F64_SET", "0.05");
+        assert_eq!(capacity_override_f64("R4_TEST_CAP_F64_SET", 0.25), 0.05);
+        std::env::remove_var("R4_TEST_CAP_F64_SET");
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a positive integer")]
+    fn invalid_value_fails_loudly() {
+        std::env::set_var("R4_TEST_CAP_BAD", "lots");
+        let _ = capacity_override_usize("R4_TEST_CAP_BAD", 50_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be >= 1")]
+    fn zero_fails_loudly() {
+        std::env::set_var("R4_TEST_CAP_ZERO", "0");
+        let _ = capacity_override_usize("R4_TEST_CAP_ZERO", 50_000);
     }
 }

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -461,19 +461,34 @@ pub struct ScoreConfig {
 }
 
 impl Default for ScoreConfig {
+    /// The pinned defaults, with the capacity knobs each overridable by an
+    /// `R4_*` environment variable for capacity measurements (#399/#393
+    /// M-C2). Every override falls back to the pinned constant when unset,
+    /// so default-config behavior is byte-identical (κ-neutral) unless a
+    /// measurement explicitly opts in; a set-but-invalid value panics
+    /// (see [`compiler::capacity_override_usize`]).
     fn default() -> Self {
         Self {
-            transition_out_degree: DEFAULT_TRANSITION_OUT_DEGREE,
-            emission_entries: DEFAULT_EMISSION_ENTRIES,
-            root_top_b: DEFAULT_ROOT_TOP_B,
-            exct_top_x: DEFAULT_EXCT_TOP_X,
+            transition_out_degree: compiler::capacity_override_usize(
+                "R4_TRANSITION_OUT_DEGREE",
+                DEFAULT_TRANSITION_OUT_DEGREE,
+            ),
+            emission_entries: compiler::capacity_override_usize(
+                "R4_EMISSION_ENTRIES",
+                DEFAULT_EMISSION_ENTRIES,
+            ),
+            root_top_b: compiler::capacity_override_usize("R4_ROOT_TOP_B", DEFAULT_ROOT_TOP_B),
+            exct_top_x: compiler::capacity_override_usize("R4_EXCT_TOP_X", DEFAULT_EXCT_TOP_X),
             witness_sample: DEFAULT_WITNESS_SAMPLE,
             smoothing: Smoothing::AddOne,
             scoring_variant: ScoringVariant::ChainTelescoped,
             emission_selection: EmissionSelection::default(),
             emission_shrinkage: EmissionShrinkage::default(),
             context_order: DEFAULT_CONTEXT_ORDER,
-            context_entries: DEFAULT_CONTEXT_ENTRIES,
+            context_entries: compiler::capacity_override_usize(
+                "R4_CONTEXT_ENTRIES",
+                DEFAULT_CONTEXT_ENTRIES,
+            ),
             gate_c_context_window: false,
             repetition_penalty_raw: super::score_runtime::DEFAULT_REPETITION_PENALTY_RAW,
         }
@@ -793,6 +808,9 @@ pub fn compile_forward_anchor_rows(
             }
         }
     }
+    // #399/#393 M-C2: the per-row entry cap is env-overridable for capacity
+    // measurements; unset keeps the pinned constant (κ-neutral).
+    let entry_cap = compiler::capacity_override_usize("R4_FWDA_ENTRY_CAP", FWDA_ENTRY_CAP);
     counts
         .into_iter()
         .filter_map(|((distance, anchor), distribution)| {
@@ -803,7 +821,7 @@ pub fn compile_forward_anchor_rows(
             }
             let mut ranked: Vec<(u32, u32)> = distribution.into_iter().collect();
             ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-            ranked.truncate(FWDA_ENTRY_CAP);
+            ranked.truncate(entry_cap);
             ranked.sort_by_key(|&(token, _)| token);
             Some(ForwardAnchorRow {
                 distance,

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -324,15 +324,35 @@ impl Default for ObjectiveConfig {
 }
 
 impl Default for CoverConfig {
+    /// The pinned defaults, each overridable by an `R4_COVER_*`
+    /// environment variable for capacity measurements (#399/#393 M-C2).
+    /// Every override falls back to the pinned constant when unset, so
+    /// default-config behavior is byte-identical (κ-neutral) unless a
+    /// measurement explicitly opts in; a set-but-invalid value panics
+    /// (see [`compiler::capacity_override_usize`]).
     fn default() -> Self {
         Self {
-            depths: DEFAULT_DEPTHS,
-            k0: DEFAULT_K0,
-            regions_budget: DEFAULT_REGIONS_BUDGET,
-            memory_budget_bytes: DEFAULT_MEMORY_BUDGET_MB * 1024 * 1024,
+            depths: compiler::capacity_override_usize("R4_COVER_DEPTHS", DEFAULT_DEPTHS),
+            k0: compiler::capacity_override_usize("R4_COVER_K0", DEFAULT_K0),
+            regions_budget: compiler::capacity_override_usize(
+                "R4_COVER_REGIONS_BUDGET",
+                DEFAULT_REGIONS_BUDGET,
+            ),
+            memory_budget_bytes: compiler::capacity_override_usize(
+                "R4_COVER_MEMORY_BUDGET_MB",
+                DEFAULT_MEMORY_BUDGET_MB as usize,
+            ) as u64
+                * 1024
+                * 1024,
             threads: 1,
-            min_support: DEFAULT_MIN_SUPPORT,
-            entropy_gain_bits: DEFAULT_SPLIT_ENTROPY_GAIN_BITS,
+            min_support: compiler::capacity_override_usize(
+                "R4_COVER_MIN_SUPPORT",
+                DEFAULT_MIN_SUPPORT,
+            ),
+            entropy_gain_bits: compiler::capacity_override_f64(
+                "R4_COVER_ENTROPY_GAIN_BITS",
+                DEFAULT_SPLIT_ENTROPY_GAIN_BITS,
+            ),
             radius_quantile_numerator: RADIUS_QUANTILE_NUMERATOR,
             radius_quantile_denominator: RADIUS_QUANTILE_DENOMINATOR,
             objective: ObjectiveConfig::default(),

--- a/scripts/mc1_subsample_corpus.py
+++ b/scripts/mc1_subsample_corpus.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""M-C1 subsample control for the #399/#393 capacity-starvation hypothesis.
+
+Produces a record-count-matched control corpus from a larger v3 (88-byte
+record) observation corpus: the FIRST `--records` records of the source,
+truncated back to the last complete story-run boundary at or before the
+target, with a correctly rewritten 25-byte meta.
+
+Background: a merged observation corpus (e.g. /tmp/wiki10k-obs/merged.bin,
+the 16-shard wiki10k merge) is a concatenation of shards in which EVERY
+story contributes a slice of sparse probed positions to EACH shard, stories
+ascending within a shard. Story ids are therefore not globally monotonic
+and a story is not globally contiguous; the honest truncation point is a
+story-RUN boundary (the record where the story id changes), which is what
+the corpus loader treats as a story transition when rebuilding `input`.
+
+The meta `stories` field is written as `max story id + 1`: consumers index
+`vec![true; c.stories]` by story id, so the field must exceed every id
+present, and the 80/20 `train_cut` stays on the same story-id split as the
+full corpus.
+
+Usage:
+  python3 scripts/mc1_subsample_corpus.py \
+      --src-meta /tmp/wiki10k-obs/state.bin \
+      --src-recs /tmp/wiki10k-obs/merged.bin \
+      --out-meta /tmp/mc1_meta.bin --out-recs /tmp/mc1_recs.bin \
+      --records 500000
+"""
+
+import argparse
+import struct
+import sys
+
+RECORD_SIZE = 88  # v3: story u32 | next u32 | top8 tokens | top8 weights | 4 anchors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src-meta", required=True)
+    parser.add_argument("--src-recs", required=True)
+    parser.add_argument("--out-meta", required=True)
+    parser.add_argument("--out-recs", required=True)
+    parser.add_argument("--records", type=int, default=500_000)
+    args = parser.parse_args()
+
+    meta = open(args.src_meta, "rb").read()
+    if len(meta) != 25 or meta[24] != 1:
+        print(f"source meta is not a finished 25-byte corpus meta: {args.src_meta}")
+        return 1
+    n_src, stories_src, rng = struct.unpack("<QQQ", meta[:24])
+
+    target = args.records
+    with open(args.src_recs, "rb") as f:
+        buf = f.read((target + 1) * RECORD_SIZE)
+    n_avail = len(buf) // RECORD_SIZE
+    if n_avail <= target:
+        print(f"source has only {n_avail} records; nothing to truncate")
+        return 1
+
+    def story(i: int) -> int:
+        return struct.unpack_from("<I", buf, i * RECORD_SIZE)[0]
+
+    # Truncate at the last complete story-run boundary at or before target.
+    cut = target
+    if story(target - 1) == story(target):
+        i = target - 1
+        while i >= 0 and story(i) == story(target - 1):
+            i -= 1
+        cut = i + 1
+    if cut == 0:
+        print("no story-run boundary at or before the target record count")
+        return 1
+
+    kept = {story(i) for i in range(cut)}
+    stories_field = max(kept) + 1
+
+    with open(args.out_recs, "wb") as g:
+        g.write(buf[: cut * RECORD_SIZE])
+    with open(args.out_meta, "wb") as g:
+        g.write(struct.pack("<QQQ", cut, stories_field, rng) + b"\x01")
+
+    print(
+        f"M-C1 subsample: {cut} records (target {target}) of {n_src}; "
+        f"{len(kept)} distinct story ids, meta stories field {stories_field} "
+        f"(source {stories_src}); last kept story {story(cut - 1)}, "
+        f"first dropped story {story(cut)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
References #399 #393. The falsifier-2 scale run collapsed the whole substrate (Rule 1+2 26.1% vs 36.5%; cover 15 nodes vs 39; harness store 0.3%; M-R2 negative) — diagnosis (Casey's hypothesis, confirmed in code): every capacity knob is a fixed constant while data grew 4.2×. Root causes located: cover split-acceptance uses an ABSOLUTE 0.25-bit entropy-gain floor that broad heterogeneous regions cannot clear (the cover anti-scales); real RVQ k-means cap is 10k samples (the '100k' in logs is a progress-bar total).

This PR: every capacity knob env-overridable (R4_CTX_SAMPLE, R4_RVQ_SAMPLE_CAP, R4_COVER_{K0,DEPTHS,REGIONS_BUDGET,MEMORY_BUDGET_MB,MIN_SUPPORT,ENTROPY_GAIN_BITS}, R4_{CONTEXT_ENTRIES,EXCT_TOP_X,ROOT_TOP_B,EMISSION_ENTRIES,FWDA_ENTRY_CAP,TRANSITION_OUT_DEGREE}) — **all default to the pinned constants; κ-neutral when unset, verified: kappa_reproduction passes bit-identical (canonical mode, 93.7s)**. Invalid values panic loudly. Plus scripts/mc1_subsample_corpus.py (499,985-record story-boundary subsample of the 10k corpus) and unit tests.

M-C1 (subsample control, defaults) and M-C2 (full corpus, ratio-scaled knobs) measurements are running; results follow on #399/#393.