### PR TITLE
fix(cli): #450 — log the resolved teacher container and corpus streams with their κ

### DIFF
--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -114,6 +114,7 @@ use uor_r4_core::transformerless::compiler::{self, Corpus};
 use uor_r4_core::transformerless::runtime::{self, Store};
 use uor_r4_graph_certify::{self as score, GateCMetrics, ScoreConfig};
 use uor_r4_graph_compiler::induction::{self as cover, Observation};
+use uor_r4_graph_compiler::reproducibility as repro;
 
 /// The `cover_sweep.json` schema version (module docs).
 pub const SWEEP_REPORT_SCHEMA: u32 = 2;
@@ -213,13 +214,7 @@ pub fn load_inputs(
     let recs_str = corpus_recs
         .to_str()
         .ok_or_else(|| "corpus records path is not UTF-8".to_owned())?;
-    let corpus = compiler::load_corpus_from(meta_str, recs_str).ok_or_else(|| {
-        format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            corpus_meta.display(),
-            corpus_recs.display()
-        )
-    })?;
+    // #450: announce the resolved containers before the sweep's long work.
     let artifact_container = std::fs::read(artifacts_path)
         .map_err(|error| format!("{}: {error}", artifacts_path.display()))?;
     let artifacts = compiler::parse_artifacts(&artifact_container).ok_or_else(|| {
@@ -228,15 +223,21 @@ pub fn load_inputs(
             artifacts_path.display()
         )
     })?;
-    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let artifact_kappa = repro::container_kappa(&artifact_container);
+    repro::announce_teacher_container(artifacts_path, &artifact_kappa);
     let meta_bytes = std::fs::read(corpus_meta)
         .map_err(|error| format!("{}: {error}", corpus_meta.display()))?;
     let recs_bytes = std::fs::read(corpus_recs)
         .map_err(|error| format!("{}: {error}", corpus_recs.display()))?;
-    let mut corpus_hasher = blake3::Hasher::new();
-    corpus_hasher.update(&meta_bytes);
-    corpus_hasher.update(&recs_bytes);
-    let corpus_kappa = format!("blake3:{}", corpus_hasher.finalize().to_hex());
+    let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
+    repro::announce_corpus(corpus_meta, corpus_recs, &corpus_kappa);
+    let corpus = compiler::load_corpus_from(meta_str, recs_str).ok_or_else(|| {
+        format!(
+            "corpus is incomplete at {}/{}; run compile until it is complete",
+            corpus_meta.display(),
+            corpus_recs.display()
+        )
+    })?;
     let (train_positions, held_out_positions) = cover::split_positions(&corpus);
     let train = cover::build_observations(&artifacts, &corpus, &train_positions);
     let held_out = cover::build_observations(&artifacts, &corpus, &held_out_positions);

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -32,6 +32,7 @@ use uor_r4_graph_certify as score_runtime;
 use uor_r4_graph_compiler::induction as cover;
 use uor_r4_graph_compiler::observation as observe;
 use uor_r4_graph_compiler::observation_text as observe_text;
+use uor_r4_graph_compiler::reproducibility as repro;
 mod convert_r4g1;
 pub mod cover_sweep;
 mod runtime_corpus;
@@ -598,13 +599,9 @@ pub fn cover_command(args: &[String]) -> Result<(), String> {
     let corpus_recs = corpus_recs_path
         .to_str()
         .ok_or_else(|| "corpus records path is not UTF-8".to_owned())?;
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
-        format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            corpus_meta_path.display(),
-            corpus_recs_path.display()
-        )
-    })?;
+    // #450: resolve and announce the inputs *before* the long work, so the
+    // run says which teacher container it actually read. `--artifacts`
+    // defaults to a shared mutable path that helper scripts overwrite.
     let artifact_container = std::fs::read(&options.artifacts)
         .map_err(|error| format!("{}: {error}", options.artifacts.display()))?;
     let artifacts = compiler::parse_artifacts(&artifact_container).ok_or_else(|| {
@@ -613,15 +610,31 @@ pub fn cover_command(args: &[String]) -> Result<(), String> {
             options.artifacts.display()
         )
     })?;
-    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let artifact_kappa = repro::container_kappa(&artifact_container);
+    repro::announce_teacher_container(&options.artifacts, &artifact_kappa);
     let meta_bytes = std::fs::read(&options.corpus_meta)
         .map_err(|error| format!("{}: {error}", options.corpus_meta.display()))?;
     let recs_bytes = std::fs::read(&options.corpus_recs)
         .map_err(|error| format!("{}: {error}", options.corpus_recs.display()))?;
-    let mut corpus_hasher = blake3::Hasher::new();
-    corpus_hasher.update(&meta_bytes);
-    corpus_hasher.update(&recs_bytes);
-    let corpus_kappa = format!("blake3:{}", corpus_hasher.finalize().to_hex());
+    let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
+    repro::announce_corpus(&options.corpus_meta, &options.corpus_recs, &corpus_kappa);
+    if options.corpus_meta != corpus_meta_path || options.corpus_recs != corpus_recs_path {
+        // The κ above addresses the requested paths; the corpus itself is
+        // loaded from the fallback-resolved ones. Say so rather than let a
+        // reader assume the printed κ covers the loaded records.
+        eprintln!(
+            "corpus streams (loaded, after fallback resolution): {} + {}",
+            corpus_meta_path.display(),
+            corpus_recs_path.display()
+        );
+    }
+    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
+        format!(
+            "corpus is incomplete at {}/{}; run compile until it is complete",
+            corpus_meta_path.display(),
+            corpus_recs_path.display()
+        )
+    })?;
 
     let config = cover::CoverConfig {
         depths: options.depths,
@@ -985,13 +998,9 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     let corpus_recs = corpus_recs_path
         .to_str()
         .ok_or_else(|| "corpus records path is not UTF-8".to_owned())?;
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
-        format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            corpus_meta_path.display(),
-            corpus_recs_path.display()
-        )
-    })?;
+    // #450: resolve and announce the inputs *before* the long work, so the
+    // run says which teacher container it actually read. `--artifacts`
+    // defaults to a shared mutable path that helper scripts overwrite.
     let artifact_container = std::fs::read(&options.artifacts)
         .map_err(|error| format!("{}: {error}", options.artifacts.display()))?;
     let artifacts = compiler::parse_artifacts(&artifact_container).ok_or_else(|| {
@@ -1000,15 +1009,21 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
             options.artifacts.display()
         )
     })?;
-    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let artifact_kappa = repro::container_kappa(&artifact_container);
+    repro::announce_teacher_container(&options.artifacts, &artifact_kappa);
     let meta_bytes = std::fs::read(&corpus_meta_path)
         .map_err(|error| format!("{}: {error}", corpus_meta_path.display()))?;
     let recs_bytes = std::fs::read(&corpus_recs_path)
         .map_err(|error| format!("{}: {error}", corpus_recs_path.display()))?;
-    let mut corpus_hasher = blake3::Hasher::new();
-    corpus_hasher.update(&meta_bytes);
-    corpus_hasher.update(&recs_bytes);
-    let corpus_kappa = format!("blake3:{}", corpus_hasher.finalize().to_hex());
+    let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
+    repro::announce_corpus(&corpus_meta_path, &corpus_recs_path, &corpus_kappa);
+    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
+        format!(
+            "corpus is incomplete at {}/{}; run compile until it is complete",
+            corpus_meta_path.display(),
+            corpus_recs_path.display()
+        )
+    })?;
 
     let config = score::ScoreConfig {
         transition_out_degree: options.transition_out_degree,
@@ -1073,6 +1088,13 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         Some(path) => {
             let bytes =
                 std::fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+            // #450: the cached cover is the second container this command
+            // consumes; address it in the log too.
+            eprintln!(
+                "cover container: {} (κ {})",
+                path.display(),
+                repro::container_kappa(&bytes)
+            );
             let (regions, structural) = score::recover_from_artifact(&bytes)?;
             eprintln!(
                 "score: recovered {} regions from {}",

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -136,13 +136,7 @@ pub fn compile(args: &[String]) -> Result<(), String> {
         .corpus_recs
         .to_str()
         .ok_or_else(|| "corpus records path is not UTF-8".to_owned())?;
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
-        format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            options.corpus_meta.display(),
-            options.corpus_recs.display()
-        )
-    })?;
+    // #450: announce the resolved containers before the long work.
     let artifact_container = std::fs::read(&options.artifacts)
         .map_err(|error| format!("{}: {error}", options.artifacts.display()))?;
     let artifacts = compiler::parse_artifacts(&artifact_container).ok_or_else(|| {
@@ -151,15 +145,21 @@ pub fn compile(args: &[String]) -> Result<(), String> {
             options.artifacts.display()
         )
     })?;
-    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_container).to_hex());
+    let artifact_kappa = reproducibility::container_kappa(&artifact_container);
+    reproducibility::announce_teacher_container(&options.artifacts, &artifact_kappa);
     let meta_bytes = std::fs::read(&options.corpus_meta)
         .map_err(|error| format!("{}: {error}", options.corpus_meta.display()))?;
     let recs_bytes = std::fs::read(&options.corpus_recs)
         .map_err(|error| format!("{}: {error}", options.corpus_recs.display()))?;
-    let mut corpus_hasher = blake3::Hasher::new();
-    corpus_hasher.update(&meta_bytes);
-    corpus_hasher.update(&recs_bytes);
-    let corpus_kappa = format!("blake3:{}", corpus_hasher.finalize().to_hex());
+    let corpus_kappa = reproducibility::corpus_stream_kappa(&meta_bytes, &recs_bytes);
+    reproducibility::announce_corpus(&options.corpus_meta, &options.corpus_recs, &corpus_kappa);
+    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
+        format!(
+            "corpus is incomplete at {}/{}; run compile until it is complete",
+            options.corpus_meta.display(),
+            options.corpus_recs.display()
+        )
+    })?;
 
     let config = induction::CoverConfig {
         depths: options.depths,

--- a/crates/uor-r4-graph-compiler/src/reproducibility.rs
+++ b/crates/uor-r4-graph-compiler/src/reproducibility.rs
@@ -113,9 +113,68 @@ impl ParallelReproducibilityHarness {
     }
 }
 
+/// κ-label of a container read from disk (`blake3:<hex>` over the raw
+/// bytes) — the single spelling of the teacher/artifact container address
+/// used by every CLI entry point that loads one (#450).
+pub fn container_kappa(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+/// κ-label of a corpus stream: meta bytes then record bytes (#450).
+pub fn corpus_stream_kappa(meta_bytes: &[u8], recs_bytes: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(meta_bytes);
+    hasher.update(recs_bytes);
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+/// Announce the resolved teacher/artifact container on stderr, before the
+/// long work starts (#450).
+///
+/// The `--artifacts` default is a shared, mutable path, and several helper
+/// scripts stage different teacher containers into it. Without this line a
+/// concurrent run can silently read a different teacher and produce a
+/// materially different table with nothing in the output to say so. One
+/// greppable line, emitted early, makes every run self-diagnosing.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn announce_teacher_container(path: &std::path::Path, kappa: &str) {
+    eprintln!("teacher container: {} (κ {kappa})", path.display());
+}
+
+/// Announce the resolved corpus streams on stderr alongside the teacher
+/// container (#450). Same motivation: pin what was actually read.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn announce_corpus(meta: &std::path::Path, recs: &std::path::Path, kappa: &str) {
+    eprintln!(
+        "corpus streams: {} + {} (κ {kappa})",
+        meta.display(),
+        recs.display()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn container_kappa_matches_the_inline_spelling() {
+        let bytes = b"teacher-container-bytes";
+        assert_eq!(
+            container_kappa(bytes),
+            format!("blake3:{}", blake3::hash(bytes).to_hex())
+        );
+    }
+
+    #[test]
+    fn corpus_stream_kappa_hashes_meta_then_recs() {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"meta");
+        hasher.update(b"recs");
+        assert_eq!(
+            corpus_stream_kappa(b"meta", b"recs"),
+            format!("blake3:{}", hasher.finalize().to_hex())
+        );
+    }
 
     #[test]
     fn test_normative_invariant_verbatim_statement() {


### PR DESCRIPTION
Closes #450. Output-only; no default path changed, no artifact bytes changed, no schema field touched.

Motivated by the #448 false alarm: `--artifacts` defaults to a shared mutable `/tmp` path, a concurrent script staged a different teacher container into it, and nothing in the output revealed which container was read — costing hours and producing a bogus measurement-integrity report.

Adds, before the expensive work starts:
```
teacher container: <path> (κ blake3:8fbf3f68…)
corpus streams: <meta> + <recs> (κ blake3:0702bed3…)
cover container: <path> (κ …)
```
Covers all four sites that resolve an artifacts path (score, cover, cover_sweep, graph-compiler entry). The printed teacher κ cross-checks against `container.kappa` in the pinned `baseline_kappa.json`. κ spellings deduped into `reproducibility::container_kappa` / `corpus_stream_kappa` over the same bytes the four sites each hashed inline.

Incidental find, logged but deliberately NOT fixed (it would change `corpus_kappa` and therefore emitted bytes): `cover_command` hashes the *requested* corpus paths while loading from the *fallback-resolved* ones; `score_command` uses resolved paths for both. The new log line makes the divergence visible.