### PR TITLE
fix(compiler): #451 — canonical tie-break in emit_r4g1 (LIVE nondeterminism, not latent — needs a call)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2329,9 +2329,14 @@ pub fn emit_r4g1(
 
     for (index, _) in cover.regions.iter().enumerate() {
         let i = 1 + index;
-        let mut freq: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
-        let mut bigram_freq: std::collections::HashMap<(u32, u32), u32> =
-            std::collections::HashMap::new();
+        // #451: the emission tables are ordered maps and the selection
+        // carries an explicit tie-break, matching the transition-list
+        // convention above (`transition_lists`: BTreeMap keyed by token,
+        // sorted by descending count then ascending id). A HashMap here
+        // let randomized iteration order decide which equal-weight tokens
+        // survive `truncate(64)` and in what order they were written.
+        let mut freq: BTreeMap<u32, u32> = BTreeMap::new();
+        let mut bigram_freq: BTreeMap<(u32, u32), u32> = BTreeMap::new();
         for &obs_idx in &cover.members[index] {
             if let Some(obs) = observations.get(obs_idx) {
                 let prev_token = obs.prev;
@@ -2340,8 +2345,7 @@ pub fn emit_r4g1(
                 *bigram_freq.entry((prev_token, next_token)).or_insert(0) += 1;
             }
         }
-        let mut candidate_weights: std::collections::HashMap<u32, u32> =
-            std::collections::HashMap::new();
+        let mut candidate_weights: BTreeMap<u32, u32> = BTreeMap::new();
         for (&next_token, &count) in &freq {
             let mut weight = count * 10;
             for (&(prev, next), &bcount) in &bigram_freq {
@@ -2352,7 +2356,8 @@ pub fn emit_r4g1(
             candidate_weights.insert(next_token, weight);
         }
         let mut sorted: Vec<_> = candidate_weights.into_iter().collect();
-        sorted.sort_by_key(|&(_, weight)| std::cmp::Reverse(weight));
+        // Canonical order: descending weight, ties to the lowest token id.
+        sorted.sort_by_key(|&(token, weight)| (std::cmp::Reverse(weight), token));
         sorted.truncate(64); // max E = 64
 
         let start_in_remainder = (emit.len() - 4) as u32;

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -1366,3 +1366,123 @@ fn relative_criterion_admits_splits_the_absolute_floor_rejects() {
     let repeat = induce_synthetic(&observations, &relative);
     assert_eq!(relative_cover.cover.kappa(), repeat.cover.kappa());
 }
+
+// ------------------------------- #451 canonical emission tie-break --
+
+/// A one-region cover whose members plant a deliberate weight tie that
+/// spans the 64-entry emission truncation cut.
+///
+/// Token 200 occurs five times (weight 50, the unique maximum); tokens
+/// `1..=100` occur once each (weight 10 apiece, a 100-way tie). All
+/// observations carry `prev == 0`, so the bigram bonus never applies and
+/// the weights are exactly `count * 10`. Selecting 64 of the 65 slots
+/// from a 100-way tie is precisely the decision the old randomized
+/// `HashMap` iteration order was making.
+fn tie_at_cut_cover_and_observations() -> (Cover, Vec<Observation>) {
+    let mut observations = Vec::new();
+    let mut push = |position: u32, next: u32| {
+        observations.push(Observation {
+            position,
+            sample: blake3::hash(&position.to_le_bytes()).into(),
+            vector: vec![0.0; D],
+            sig: [0u8; SIG_BYTES],
+            prev: 0,
+            next,
+        });
+    };
+    let mut position = 0u32;
+    for _ in 0..5 {
+        push(position, 200);
+        position += 1;
+    }
+    for token in 1..=100u32 {
+        push(position, token);
+        position += 1;
+    }
+    let members: Vec<usize> = (0..observations.len()).collect();
+    let cover = Cover {
+        regions: vec![CoverRegion {
+            id: 0,
+            depth: 1,
+            parent: None,
+            children: Vec::new(),
+            prototype: vec![0.0; D],
+            sig: [0u8; SIG_BYTES],
+            radius: 1,
+            support: members.len() as u32,
+            entropy_bits: 0.0,
+            split_gain_bits: 0.0,
+        }],
+        max_depth: 1,
+        paths: vec![vec![0]; observations.len()],
+        members: vec![members],
+    };
+    (cover, observations)
+}
+
+/// #451: the emission selection is canonical under a weight tie that
+/// spans the truncation cut — repeated emissions are byte-identical, and
+/// the tie resolves to the documented order (descending weight, then
+/// ascending token id).
+#[test]
+fn emission_tie_at_truncation_cut_is_canonical() {
+    let (cover, observations) = tie_at_cut_cover_and_observations();
+    let prior = cover::root_prior(&observations);
+    let emit = || {
+        cover::emit_r4g1(
+            b"tie-fixture-container",
+            (b"tie-fixture-meta", b"tie-fixture-recs"),
+            256,
+            &cover,
+            &[],
+            &prior,
+            &observations,
+        )
+        .expect("emit succeeds")
+        .0
+    };
+
+    // Repeated runs agree. Under the old HashMap this failed: the 100-way
+    // tie made both the surviving 64 tokens and their written order vary
+    // from emission to emission.
+    let first = emit();
+    for round in 1..8 {
+        assert_eq!(
+            first,
+            emit(),
+            "emission {round} differs: the tie at the truncation cut is not canonical"
+        );
+    }
+
+    // The tie resolves to the lowest token ids, in ascending order, after
+    // the unique weight-50 maximum. The emission block writes each entry
+    // as (i32 token, i32 count) little-endian, so the canonical selection
+    // is a contiguous byte run of the artifact.
+    let mut expected = Vec::new();
+    let mut entry = |token: i32, weight: i32| {
+        expected.extend_from_slice(&token.to_le_bytes());
+        expected.extend_from_slice(&weight.to_le_bytes());
+    };
+    // The weight-50 maximum takes the first of the 64 slots, so exactly 63
+    // of the 100 tied tokens are admitted: ids 1..=63.
+    entry(200, 50);
+    for token in 1..=63i32 {
+        entry(token, 10);
+    }
+    assert!(
+        first
+            .windows(expected.len())
+            .any(|window| window == expected.as_slice()),
+        "canonical emission selection (token 200 then tokens 1..=63) is not present"
+    );
+    // Token 64 is the first loser of the tie and never follows token 63.
+    let mut with_64 = expected.clone();
+    with_64.extend_from_slice(&64i32.to_le_bytes());
+    with_64.extend_from_slice(&10i32.to_le_bytes());
+    assert!(
+        !first
+            .windows(with_64.len())
+            .any(|w| w == with_64.as_slice()),
+        "token 64 must lose the tie at the cut"
+    );
+}


### PR DESCRIPTION
References #451. **The issue understated this: it is not latent. Emitted `cover.r4g1` is nondeterministic TODAY.**

Evidence — three `transformerless cover` runs, identical inputs, pinned fixture, 79,348 bytes each:
- before: κ `e2f5d452…`, `e9286b83…`, `5087c271…` — three different digests
- after: κ `093a2dd4…` × 3

Two emissions **in a single process** already differed. Replaying old vs new selection across the fixture's 42 regions: 42/42 differ in write order, **15/42 differ in which tokens survive the 64-entry cut**, and 28/42 have a weight tie spanning the cut. The old selection's own set-wise digest differed between two runs in one process — the selected token *set* was nondeterministic in shipped output.

Fix: build in `BTreeMap` **and** sort `(Reverse(weight), token)`, matching the sibling transition compiler ~270 lines above which does exactly both. Sibling maps audited: `freq` fed only `candidate_weights`; `bigram_freq` accumulates a commutative integer sum — neither reached an ordering-sensitive decision, both converted anyway so the block is canonical by construction.

Regression test `emission_tie_at_truncation_cut_is_canonical` (non-ignored): 100-way tie across the cut, asserts 8 emissions byte-identical and canonical resolution. **Verified it fails on unfixed code** (exit 101).

**The decision, Casey:** no committed baseline is contradicted — every pinned κ addresses either the induced cover (untouched) or an R4G1 emitted from an empty observation slice. But this changes emitted `cover.r4g1` relative to any container already on disk, and 15/42 regions change tokens, which can move Gate C for runs that consume a pre-existing `--cover`. My read is that replacing random output with defined output is strictly an improvement and this should land — but it is your call, so it is stacked on #452 rather than merged.