### PR TITLE
feat(router): #434 — full-width content-bearing storage (adopted de-banding)

### DIFF
--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -435,6 +435,16 @@ pub struct UorR4Router {
     pub facet_store: MultiFacetStore,
     #[serde(default = "default_geometry_type")]
     pub geometry_type: GeometryType,
+    /// Issue #434 (adopted de-banding): when true the content-bearing
+    /// store keeps only the routed window band of the content vector
+    /// (the pre-#434 behavior, one sixteenth of the width, zeros
+    /// elsewhere); when false — the DEFAULT since #434 — the store keeps
+    /// the full-width content vector. Retained as a flag so the
+    /// measurement harnesses can A/B and so rollback is a one-line
+    /// setter. Serialized so an exported store records which shape its
+    /// vectors have.
+    #[serde(default)]
+    banded_storage: bool,
 }
 
 #[derive(Serialize)]
@@ -547,6 +557,7 @@ impl UorR4Router {
             last_routing_data: None,
             facet_store: MultiFacetStore::default(),
             geometry_type: default_geometry_type(),
+            banded_storage: false,
         };
 
         // Initialize default corpus
@@ -969,6 +980,20 @@ impl UorR4Router {
             trajectory,
         };
         serde_wasm_bindgen::to_value(&geom_res).unwrap_or(JsValue::NULL)
+    }
+
+    /// Whether the content-bearing store bands its stored vectors
+    /// (issue #434). False — full-width storage — is the default.
+    pub fn banded_storage(&self) -> bool {
+        self.banded_storage
+    }
+
+    /// Selects the storage shape for subsequently indexed sentences
+    /// (issue #434). `true` restores the pre-#434 banded storage; the
+    /// default `false` keeps the full-width content vector. Already
+    /// indexed items are not rewritten, so flip this before ingestion.
+    pub fn set_banded_storage(&mut self, banded: bool) {
+        self.banded_storage = banded;
     }
 
     /// Exports the full router system database to JSON string
@@ -1747,10 +1772,25 @@ impl UorR4Router {
 
         let prime_product = self.get_sentence_prime_product(words);
 
-        let mut state_vector = vec![0.0; 512];
+        // Issue #434 (adopted de-banding): the stored vector is the
+        // FULL-WIDTH content vector by default. The pre-#434 shape kept
+        // only `active_range` — thirty-two of five hundred twelve
+        // coefficients, one sixteenth of the width — which PR #442
+        // measured as the dominant cost of retrieval quality. Banding is
+        // retained behind `banded_storage` for A/B and rollback. The
+        // content-free path (issue #255 arm one) supplies no content
+        // vector and keeps the banded shape either way, so that arm's
+        // pre-#245 reconstruction stays byte-identical.
         let s_idx = best.active_range[0] as usize;
         let e_idx = best.active_range[1] as usize;
-        state_vector[s_idx..e_idx].copy_from_slice(&best.state_vector[..e_idx - s_idx]);
+        let state_vector = match state {
+            Some(full) if !self.banded_storage && full.len() == 512 => full.to_vec(),
+            _ => {
+                let mut banded = vec![0.0; 512];
+                banded[s_idx..e_idx].copy_from_slice(&best.state_vector[..e_idx - s_idx]);
+                banded
+            }
+        };
 
         let (u, v) = self.get_sentence_projection(&state_vector, idx_win as usize);
         let v_4d = self.get_state_4d_projection(&state_vector);

--- a/crates/uor-r4-router/tests/memory_lift_ab.rs
+++ b/crates/uor-r4-router/tests/memory_lift_ab.rs
@@ -69,6 +69,10 @@ fn retrieval_metrics(router: &mut UorR4Router, vectors: &[Vec<f64>]) -> (f64, f6
 fn three_arm_memory_lift_table() {
     // Arm 1: content-free (pre-#245 stub reconstruction).
     let mut r1 = UorR4Router::new(0.5);
+    // Issue #434: arm one is the pre-#245 banded stub and its queries are
+    // built through the same router, so query and store must share a
+    // shape (see the corpus-scale harness note).
+    r1.set_banded_storage(true);
     for s in CORPUS {
         r1.index_sentence_content_free(s, ID);
     }

--- a/crates/uor-r4-router/tests/memory_lift_corpus.rs
+++ b/crates/uor-r4-router/tests/memory_lift_corpus.rs
@@ -316,6 +316,13 @@ fn three_arm_memory_lift_corpus_scale() {
     // ---- arm one: content-free (pre-#245 stub reconstruction) ----
     let (h1, m1) = {
         let mut r1 = UorR4Router::new(0.5);
+        // Issue #434: arm one reconstructs the PRE-#245 stub, whose stored
+        // vectors are banded slices of the session state. Its probe
+        // queries come from the same router through `index_sentence`, so
+        // the arm is only self-consistent when query and store share a
+        // shape — hold this router in the banded mode. Arm two (the
+        // production arm) uses the post-#434 full-width default.
+        r1.set_banded_storage(true);
         for w in &windows {
             r1.index_sentence_content_free(w, ID);
         }

--- a/crates/uor-r4-router/tests/zeta_state_retrieval.rs
+++ b/crates/uor-r4-router/tests/zeta_state_retrieval.rs
@@ -494,6 +494,13 @@ fn zeta_grid_state_as_retrieval_vector() {
     // vocabulary (word-prime order, zeta word vectors) is fixed HERE,
     // before any state evolution (determinism, module docs) ----
     let mut router = UorR4Router::new(0.5);
+    // Issue #434: this harness is the BAND-MATCHED control set — its arms
+    // are defined relative to the banded stored shape (arm ZB re-bands,
+    // and `content_full_and_band` asserts the store is zero outside the
+    // band). Full-width storage is the default since #434, so the banded
+    // shape is requested explicitly here to keep these controls measuring
+    // what they were declared to measure.
+    router.set_banded_storage(true);
     let corpus_text: String = windows.join(" ");
     let indexed = router.index_corpus(&corpus_text, ID);
     assert_eq!(

--- a/docs/debanding_audit_434.md
+++ b/docs/debanding_audit_434.md
@@ -1,0 +1,160 @@
+# Issue #434 — consumer audit of band-sparsity assumptions
+
+Step (1) of the adopted de-banding order (issue #434, decision recorded on
+PR #442: free top-1 8.17% full-width vs 7.64% banded, anchor accuracy
+11.4% vs 9.3%, all three pre-declared conditions PASS). This document
+enumerates every consumer of the stored `CorpusItem.state_vector` and
+records whether it assumes band sparsity, whether full-width storage
+breaks it or merely enlarges it, and the accommodation where one is
+needed.
+
+## What was banded
+
+`UorR4Router::index_sentence_routed` (`crates/uor-r4-router/src/lib.rs`,
+the issue-#245 content-bearing storage path) built the stored vector as a
+512-zero buffer with only the routed window's `active_range` filled from
+`RoutedResult::state_vector`:
+
+    let mut state_vector = vec![0.0; 512];
+    let s_idx = best.active_range[0] as usize;
+    let e_idx = best.active_range[1] as usize;
+    state_vector[s_idx..e_idx].copy_from_slice(&best.state_vector[..e_idx - s_idx]);
+
+`active_range` is produced in `route_query_to_manifold_internal`
+(same file): it is the soft-route path's `[path[1], path[2]]` when the
+path has three or more entries, otherwise the hard fallback
+`[(routed_idx - 1) * 32, routed_idx * 32]`. The fallback constant is the
+banding constant: width 32 of 512, one sixteenth of the width, sixteen
+window channels (`soft_route(&coords, 16)`, and the `"windows": 16`
+capability record). On the D3 natural corpus the issue-#434 band-matched
+controls (`crates/uor-r4-router/tests/zeta_state_retrieval.rs`) assert
+that the realized `active_range` is always one of those sixteen 32-wide
+channel ranges, so the natural-corpus store kept 32 of 512 coefficients
+per sentence. On a synthetic probe corpus the soft-route path can widen
+the band (measured mean span 152 of 512); the audit numbers below give
+both.
+
+The content vector itself was never banded: `content_state_vector`
+returns the full 512-d L2-normalized zeta word-sum, and it was passed to
+the router only to steer window choice — the storage step then threw
+away fifteen sixteenths of it.
+
+## Consumer table
+
+| Consumer (file) | Assumes band sparsity? | Break or just bigger? | Accommodation |
+| --- | --- | --- | --- |
+| `sparse_vector_serde` (`router/src/lib.rs`) | Yes, implicitly: it encodes a contiguous run from first to last nonzero as `{start_idx, values}` | Just bigger. Full width yields `start_idx = 0`, `values.len() = 512`; the deserializer's `end_idx <= 512` guard still holds and round-trips exactly | None needed |
+| `get_top_resonances_native` cosine retrieval (`router/src/lib.rs`) | Partially: the QUERY projection is still assembled band-only (`full_state[start..end]` from `all_routes`), then cosined against the stored item | Just bigger — no panic, both sides are 512-d. Scores shift: the stored norm now spans the full width, so `sim` shrinks uniformly within a window. Ranking is dominated by `shared_count * 100.0` anyway, with `sim * slice_norm` a secondary term | None required. Follow-up (out of #434 scope): supplying a full-width query projection here would recover the ARM BF geometry inside the production retrieval surface too |
+| `get_sentence_projection` (u, v) and `get_state_4d_projection` (v_4d) on the stored vector | No | Values change (computed over 512 instead of 32 coefficients); no sparsity assumption | None needed |
+| Semantic-map point serving (`corpus_index_by_identity` walks in `router/src/lib.rs`) and `index.html` | No — the browser reads `routed.state_vector` / `routed.active_range` from the ROUTING result, not stored items | Unaffected | None needed |
+| `get_suggested_token_limit` stratum count, `generate_geometric_response` trajectory stratum | No — both count nonzeros of the ROUTING result's banded slice, not of stored items | Unaffected | None needed |
+| `verify_corpus_provenance` | No — provenance is recomputed from sentence text, words and word-primes | Unaffected | None needed |
+| `export_state` / `import_state` / `import_state_native` (JSON persistence) | No, but size is proportional to the stored run length | Just bigger, ~16x on the vector payload (numbers below) | Flagged, not blocked; the new `banded_storage` flag is serialized so an exported store records its own shape |
+| wasm-bindgen API surface | No: `ResonanceResult` carries no state vector, and `CorpusItem` reaches JS only through `export_state` JSON | Just bigger | None needed |
+| `tests/content_bearing_index.rs` (non-ignored) | No — asserts non-degeneracy, session independence, and a cosine inequality | Passes unchanged | None needed |
+| `tests/memory_lift_ab.rs` (non-ignored) and `tests/memory_lift_corpus.rs` — ARM ONE (content-free) | **YES, indirectly.** Arm one's STORE is content-free (always banded), but its probe QUERIES are built through `index_sentence` on the same router, which is full width by default. Query and store then have different shapes and the arm's retrieval collapses | Does not panic, but silently **INVALIDATES the control**: measured arm-one MRR fell from the recorded 0.1674 to 0.0006 purely from the shape mismatch | Applied: both harnesses call `set_banded_storage(true)` on the arm-one router only. Arm one is back to exactly 0.1674 (see gate results) |
+| `tests/zeta_projection_quality.rs`, `tests/hopf_retrieval_quality.rs` | No — they read stored vectors as opaque 512-d vectors (the Hopf harness slices 128-blocks, which is well defined at full width) | Just different numbers, which is the point of the change | None needed |
+| `tests/zeta_state_retrieval.rs` — `content_full_and_band` | **YES.** Asserts `stored[i] == 0.0` outside `active_range`, and arm ZB is defined as "re-band the full vector" | **BREAKS** under full-width storage | Applied: the harness now calls `router.set_banded_storage(true)` before ingestion. It is the band-matched control set; its arms are only meaningful against the banded shape |
+| `crates/uor-r4-graph-certify/tests/router_reconnect.rs` | No | ARM B's stored and query vectors become full width under the new default, so ARM B converges on ARM BF; ARM BF still builds its own vectors test-side and is unchanged | None needed |
+| `router/src/lib.rs` unit test pinning `active_range: [64, 96]` | No — pins `RoutedResult` serde, not stored items | Unaffected | None needed |
+
+Nothing in the shipping (non-test) code breaks. Two consumers need an
+accommodation, and both are measurement harnesses whose CONTROL arms are
+defined against the banded shape: the `#434` band-matched control set
+(hard assertion failure) and the content-free arm one of the two
+memory-lift harnesses (silent control invalidation). Both are pinned to
+`set_banded_storage(true)`, which is exactly what they were always
+measuring.
+
+## Size impact
+
+Measured on a 500-sentence synthetic store via `export_state` (serde_json
+f64 formatting, ~20.3 bytes per coefficient):
+
+| Quantity | Banded (32-wide, natural corpus) | Banded (152-wide, synthetic probe) | Full width (512) |
+| --- | --- | --- | --- |
+| `state_vector` JSON, one copy | ~0.65 KB | 3.06 KB (measured) | 10.78 KB (measured) |
+| Per stored item, both copies (`corpus_index` and `corpus_index_by_identity` are both serialized) | ~1.3 KB | 6.1 KB | 21.6 KB |
+| Whole-store `export_state` per item (vectors plus sentence, words, provenance) | ~3.5 KB | 8.69 KB (measured) | 24.19 KB (measured) |
+| 46k-window store, total export | ~160 MB | ~400 MB | ~1.11 GB (measured basis) |
+| 46k-window store, vector payload only | ~60 MB | ~280 MB | ~992 MB |
+
+In-memory footprint is UNCHANGED: `CorpusItem.state_vector` was always a
+512-element `Vec<f64>` (4 KB, 8 KB counting the duplicate index) in both
+modes — banding only wrote zeros into it. The cost is entirely in JSON
+persistence, roughly 16x on the vector payload against the natural
+32-wide band. That is a real operational cost for large on-disk stores
+and is the reason the banded path is retained behind a flag rather than
+deleted.
+
+## Storage change (step 2)
+
+`UorR4Router` gains a serialized `banded_storage: bool` field, default
+`false` (full width), with `banded_storage()` / `set_banded_storage()`
+accessors on the wasm-bindgen impl. `index_sentence_routed` stores the
+full-width content vector when one is available and the flag is off, and
+otherwise falls back to the pre-#434 banded copy.
+
+The content-free path (issue #255, arm one) supplies no content vector,
+so it keeps the banded shape in both modes and its pre-#245
+reconstruction stays byte-identical.
+
+Determinism and canonical ordering are preserved: the stored vector is
+`content_state_vector(sentence)`, which depends only on the sentence's
+words and the arrival-ordered word-to-prime assignment — the same
+quantity that already selected the window. Window bucketing, item order
+within a window, and the corpus-item id sequence are untouched.
+
+## Regression gates (step 3)
+
+### memory-lift at corpus scale
+
+`crates/uor-r4-router/tests/memory_lift_corpus.rs`, 46,438 windows, 500
+probes, natural stack (`/tmp/c_meta.bin`, `/tmp/c_recs.bin`,
+`/tmp/wiki-obs/stories.jsonl`). Log: `/tmp/deband_memlift.log`.
+
+| Arm | Baseline (banded) | De-banded | Delta |
+| --- | --- | --- | --- |
+| arm 2 content-derived, MRR | 0.2348 | **0.8948** | +0.6600 |
+| arm 2 content-derived, top-1 | 0.208 | **0.832** | +0.624 |
+| arm 1 content-free, MRR | 0.1674 | 0.1674 | unchanged (banded by construction) |
+| arm 3 shuffled control, MRR | 0.0002 | 0.0001 | flat at the noise floor |
+
+Exit rule PASSES: arm 2 beats arm 1 by +0.7274 (need +0.020) and beats
+arm 3. The content-derived MRR lands exactly on the 0.8948 the #434
+band-matched controls predicted for full width.
+
+### router reconnection
+
+`crates/uor-r4-graph-certify/tests/router_reconnect.rs`, 91,966 store
+contexts, 19,083 queries, 9,867 anchors, 29,841 free positions. Inputs:
+`R4_ARTIFACTS=/tmp/old_fixture_artifacts.bin`,
+`R4_SCORED_R4G1=/tmp/strict_score/score.r4g1` (the container/scored pair
+whose teacher CIDs match; `/tmp/tless_artifacts.bin` has since been
+overwritten by a later corpus and no longer pairs with `strict_score`).
+Log: `/tmp/deband_reconnect.log`.
+
+| Arm | Baseline free top-1 | De-banded free top-1 | Anchor accuracy |
+| --- | --- | --- | --- |
+| ARM A true-anchor (ceiling) | 31.5 | 31.5 | 100.0% |
+| ARM B router-anchor | 7.64 (banded) | **8.17** | **11.4%** (was 9.3%, +2.1pp) |
+| ARM B2 router-draft | 4.9 | 5.08 | 3.3% |
+| ARM BF full-width (test-side) | 8.17 | 8.17 | 11.4% |
+| ARM C unigram null | 2.14 | 2.14 | 6.0% |
+| ARM D shuffled null | 3.09 | 3.07 | 1.3% |
+
+ARM B — the PRODUCTION path — now reproduces ARM BF exactly (8.17 free
+top-1, 11.43% vs 11.42% anchor accuracy, a one-anchor difference from
+the second renormalization in `evolve_state`). That is the adopted
+payoff landing in the shipping code: the storage surface itself now
+supplies what ARM BF had to construct test-side.
+
+Consequence for the harness's own printout: the #434 pre-declared rule
+"ARM BF must exceed ARM B's same-run free top-one" compared BF against a
+BANDED ARM B. With banding removed by default, ARM B is full width, so
+BF minus B is +0.00pp and the harness prints "recorded NEGATIVE". That
+line is now VACUOUS, not a regression — it is the two arms agreeing. The
+decision-relevant comparison is the de-banded ARM B (8.17 / 11.4%)
+against the recorded banded ARM B baseline (7.64 / 9.3%), which is the
++0.53pp / +2.1pp the adoption was based on. Setting
+`set_banded_storage(true)` reproduces the 7.64 / 9.3 baseline.


### PR DESCRIPTION
Implements the de-banding decision adopted on #434 after PR #442's payoff measurement. Follows the approved order: consumer audit, storage change, regression gates.

**What was banded:** `index_sentence_routed` (lib.rs:1749-1753) copied only `active_range` — width 32 of 512 (**1/16**) — into the stored vector. The content vector itself was **never** banded: `content_state_vector` already returned the full 512-d zeta word-sum, and storage discarded 15/16 of it.

**Change:** serialized `banded_storage: bool`, **default false (full width)**, with wasm accessors; the pre-#434 banded copy is retained behind the flag for A/B and cheap rollback. Content-free (#255 arm one) path is byte-identical in both modes. Determinism and canonical ordering preserved.

**Consumer audit** (docs/debanding_audit_434.md): no shipping consumer breaks. Two TEST consumers assumed sparsity and are now pinned to `set_banded_storage(true)` — `zeta_state_retrieval::content_full_and_band` (asserts zeros outside the band) and memory-lift ARM ONE, which was a **silent control invalidation**: its stored side stayed banded while its queries went full width, collapsing arm-one MRR 0.1674 → 0.0006. Pinned, it restores to exactly 0.1674. Size: in-memory unchanged (banding wrote zeros); JSON persistence ~16× on the vector payload (~60 MB → ~992 MB for a 46k-window store) — flagged in the audit as the real cost.

**Regression gates — both PASS:**

| gate | baseline | de-banded |
|---|---|---|
| memory-lift content-derived MRR / top-1 | 0.2348 / 0.208 | **0.8948 / 0.832** |
| memory-lift content-free (control) | 0.1674 | 0.1674 |
| memory-lift shuffled (control) | 0.0002 | 0.0001 |
| reconnection ARM B free top-1 | 7.64 | **8.17** |
| reconnection ARM B anchor accuracy | 9.3% | **11.4%** |
| reconnection ceiling / nulls | 31.5 / 2.14 / 3.09 | 31.5 / 2.14 / 3.07 |

ARM B (production path) now reproduces ARM BF exactly — the harness's BF-vs-B rule is **vacuous**, not regressed, because it compared BF against a banded B. `set_banded_storage(true)` reproduces 7.64 / 9.3.