### PR TITLE
perf(certify): #467 — sampled Gate C decision mode and instrument fast path

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1911,12 +1911,101 @@ fn outcome_bits(
 }
 
 /// One metric set of the Gate C table.
+///
+/// `positions` is the denominator every rate in the row is divided by.
+/// `positions_sampled` and `standard_error` (#467) exist so a sampled
+/// number can never be quoted as a census: the first says whether the run
+/// scored the whole held-out split or a subsample of it, the second says
+/// how much of the printed rate is measurement noise.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GateCMetrics {
     pub positions: usize,
     /// P(selected token == recorded teacher argmax).
     pub top1_agreement: f64,
     pub bits_per_token: f64,
+    /// Sample size of the sampled decision run backing this row (#467), or
+    /// `0` when the run was a full pass — a census over the whole held-out
+    /// split, which is the default and the only mode before schema 25.
+    /// Nonzero means every rate in this row is an ESTIMATE.
+    pub positions_sampled: usize,
+    /// Binomial standard error of `top1_agreement`, `sqrt(p(1-p)/n)` with
+    /// `n = positions`. Reported for full passes too, where it is the
+    /// sampling error the held-out split itself carries as a draw from the
+    /// position population. Not defined for `bits_per_token`.
+    pub standard_error: f64,
+}
+
+/// Binomial standard error of a rate `p` measured over `n` positions:
+/// sqrt of p(1-p)/n, and zero for an empty population.
+fn binomial_standard_error(p: f64, n: usize) -> f64 {
+    if n == 0 {
+        return 0.0;
+    }
+    (p * (1.0 - p) / n as f64).sqrt()
+}
+
+/// Environment override selecting the #467 sampled Gate C decision mode.
+/// UNSET is the full pass, bit-identical to the pre-#467 evaluation.
+pub const GATE_C_SAMPLE_ENV: &str = "R4_GATE_C_SAMPLE";
+
+/// Deterministic stratified subsample of the held-out evaluation list.
+///
+/// Motivation. The long runs buy precision nobody uses. At 402,802
+/// held-out positions with top-1 near 26 percent the standard error of the
+/// rate is 0.07pp, while every pre-declared exit rule in this repository is
+/// written at plus or minus 2pp — about 30x finer than any decision needs,
+/// bought with hours of wall clock. A 10,000-position decision run has
+/// standard error 0.44pp, still comfortably inside a 2pp rule, and costs
+/// about 40x less. Sampling is therefore a decision-speed knob, never a
+/// precision claim: the sample size and the standard error travel with
+/// every rate so a sampled number cannot be mistaken for a census.
+///
+/// Contract, in the [`compiler::capacity_override_usize`] style: UNSET is
+/// behaviour-identical to the full pass (every held-out position scored, in
+/// input order, with bit-identical floating-point reductions). Set to `n`,
+/// the evaluation scores a stride-selected subsample of size
+/// `min(n, population)`.
+///
+/// Selection is a stride, not an RNG: position `k` of the sample is
+/// held-out entry `k * population / n`. That is deterministic (the same
+/// corpus and the same `n` always select the same positions, so a sampled
+/// run is reproducible and diffable), it preserves input order (so the
+/// reduction stays order-deterministic), and it is stratified — the
+/// held-out list is in corpus order, so an even stride spreads the sample
+/// across every story and every region of the corpus instead of
+/// concentrating it in one contiguous block.
+///
+/// What sampling does NOT change: the construction/held-out split itself.
+/// The held-out MASK, and therefore every table built from the
+/// construction split (forward-anchor, two-sided, latent, unigram null),
+/// is derived from the FULL held-out list. Only the set of positions
+/// SCORED shrinks. A sampled run measures the same model as a full run.
+fn gate_c_sample(held_out: &[Observation]) -> (Vec<&Observation>, usize) {
+    let population = held_out.len();
+    let requested = match std::env::var(GATE_C_SAMPLE_ENV) {
+        Ok(value) => {
+            let parsed = value
+                .trim()
+                .replace('_', "")
+                .parse::<usize>()
+                .unwrap_or_else(|_| {
+                    panic!("{GATE_C_SAMPLE_ENV} must be a positive integer, got {value:?}")
+                });
+            assert!(
+                parsed >= 1,
+                "{GATE_C_SAMPLE_ENV} must be >= 1, got {value:?}"
+            );
+            parsed
+        }
+        Err(_) => return (held_out.iter().collect(), 0),
+    };
+    if requested >= population {
+        return (held_out.iter().collect(), 0);
+    }
+    let scored = (0..requested)
+        .map(|k| &held_out[k * population / requested])
+        .collect();
+    (scored, requested)
 }
 
 /// Per-status position counts of the Rule 1+2 scorer (D4 precedence).
@@ -2199,6 +2288,14 @@ pub struct GateCNulls {
 /// candidate recall, and the witness-replay sample result.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GateCOutcome {
+    /// Size of the held-out split the evaluation was handed (#467). Equal
+    /// to the number of positions scored on a full pass.
+    pub held_out_population: usize,
+    /// Number of held-out positions actually scored when the #467 sampled
+    /// decision mode is active, or `0` on a full pass (a census). Nonzero
+    /// means every rate in this outcome is an ESTIMATE whose noise is the
+    /// `standard_error` of its own row.
+    pub positions_sampled: usize,
     /// OLD Σ-over-cloud formula (with EXCT evidence wired), kept for
     /// comparison — the confirmed double counting lives there.
     pub legacy_sum: GateCMetrics,
@@ -3274,7 +3371,12 @@ pub fn evaluate_gate_c(
         &right_codes,
         latent_class_depth,
     );
-    let held_positions: Vec<usize> = held_out
+    // #467: the positions actually SCORED. Full pass unless
+    // `R4_GATE_C_SAMPLE` is set; the held-out mask above (and every table
+    // built from it) always sees the complete held-out list, so sampling
+    // narrows the measurement, never the split.
+    let (scored, sample_size) = gate_c_sample(held_out);
+    let held_positions: Vec<usize> = scored
         .iter()
         .map(|observation| observation.position as usize)
         .collect();
@@ -3335,7 +3437,7 @@ pub fn evaluate_gate_c(
     // Each held-out position is independent. Collect compact rows in Rayon;
     // reduce them in input order below so floating-point totals and all
     // report bytes retain the serial implementation's determinism.
-    let rows: Vec<GateCRow> = held_out
+    let rows: Vec<GateCRow> = scored
         .par_iter()
         .enumerate()
         .map(|(index, observation)| evaluate_gate_c_row(index, observation, &context))
@@ -3593,15 +3695,20 @@ pub fn evaluate_gate_c(
         outcome.witness_replays += usize::from(row.witness_replayed);
         outcome.witness_replay_failures += usize::from(row.witness_replay_failed);
     }
-    let n = held_out.len();
+    let n = scored.len();
     if n == 0 {
         return Err("held-out split is empty; cannot evaluate".to_owned());
     }
     let nf = n as f64;
-    let metrics = |hits: u64, bits: f64| GateCMetrics {
-        positions: n,
-        top1_agreement: hits as f64 / nf,
-        bits_per_token: bits / nf,
+    let metrics = |hits: u64, bits: f64| {
+        let top1 = hits as f64 / nf;
+        GateCMetrics {
+            positions: n,
+            top1_agreement: top1,
+            bits_per_token: bits / nf,
+            positions_sampled: sample_size,
+            standard_error: binomial_standard_error(top1, n),
+        }
     };
     outcome.legacy_sum = metrics(hits_legacy, bits_legacy);
     outcome.rule1_chain = metrics(hits_rule1, bits_rule1);
@@ -3616,18 +3723,23 @@ pub fn evaluate_gate_c(
     outcome.rule12_fwd_gated_fused = metrics(hits_fwd_gated, bits_fwd_gated);
     outcome.rule12_fwd_draft_fused = metrics(hits_fwd_draft, bits_fwd_draft);
     outcome.rule12_fwd_strict_fused = metrics(hits_fwd_strict, bits_fwd_strict);
-    let live_metrics = |hits: u64, bits: f64, live_n: usize| GateCMetrics {
-        positions: live_n,
-        top1_agreement: if live_n == 0 {
+    let live_metrics = |hits: u64, bits: f64, live_n: usize| {
+        let top1 = if live_n == 0 {
             0.0
         } else {
             hits as f64 / live_n as f64
-        },
-        bits_per_token: if live_n == 0 {
-            0.0
-        } else {
-            bits / live_n as f64
-        },
+        };
+        GateCMetrics {
+            positions: live_n,
+            top1_agreement: top1,
+            bits_per_token: if live_n == 0 {
+                0.0
+            } else {
+                bits / live_n as f64
+            },
+            positions_sampled: sample_size,
+            standard_error: binomial_standard_error(top1, live_n),
+        }
     };
     outcome.rule12_fwd_fused_live = live_metrics(fwd_live_hits, fwd_live_bits, fwd_live_positions);
     outcome.rule12_on_fwd_live =
@@ -3751,23 +3863,29 @@ pub fn evaluate_gate_c(
         let hits = status_hits[1] + status_hits[2];
         let bits = status_bits[1] + status_bits[2];
         let nf = (positions as f64).max(1.0);
+        let top1 = hits as f64 / nf;
         GateCMetrics {
             positions,
-            top1_agreement: hits as f64 / nf,
+            top1_agreement: top1,
             bits_per_token: bits / nf,
+            positions_sampled: sample_size,
+            standard_error: binomial_standard_error(top1, positions),
         }
     };
     outcome.nulls = GateCNulls {
         unigram_train_argmax,
-        unigram_null_top1_all: null_hits_all as f64 / (held_out.len() as f64).max(1.0),
-        unigram_null_bits_all: null_bits_all / (held_out.len() as f64).max(1.0),
+        unigram_null_top1_all: null_hits_all as f64 / nf,
+        unigram_null_bits_all: null_bits_all / nf,
         unigram_null_top1_generalization: null_hits_generalization as f64
             / (generalization_positions as f64).max(1.0),
         unigram_null_bits_generalization: null_bits_generalization
             / (generalization_positions as f64).max(1.0),
         train_positions,
-        held_out_positions: held_out.len(),
+        held_out_positions: n,
     };
+    // #467: the sampling provenance of the whole table.
+    outcome.held_out_population = held_out.len();
+    outcome.positions_sampled = sample_size;
     outcome.rule12_exct_probe_levels = exct_level_positions;
     outcome.rule12_exct_probe_absent = exct_probe_absent;
     outcome.rule12_exct_full_depth_supported = exct_full_depth_supported;
@@ -3777,10 +3895,13 @@ pub fn evaluate_gate_c(
             return GateCMetrics::default();
         }
         let denom = positions as f64;
+        let top1 = status_hits[index] as f64 / denom;
         GateCMetrics {
             positions,
-            top1_agreement: status_hits[index] as f64 / denom,
+            top1_agreement: top1,
             bits_per_token: status_bits[index] / denom,
+            positions_sampled: sample_size,
+            standard_error: binomial_standard_error(top1, positions),
         }
     };
     outcome.rule12_per_status = Rule12PerStatus {
@@ -3931,7 +4052,7 @@ pub fn evaluate_gate_c(
     let mut baseline_rep_sum = 0.0;
     let mut probe_count = 0;
 
-    for obs in held_out.iter() {
+    for obs in scored.iter() {
         let pos = obs.position as usize;
         if pos >= 32 && corpus.story[pos] == corpus.story[pos - 32] {
             let seed = &corpus.input[pos - 32..pos];
@@ -5012,6 +5133,29 @@ fn evaluate_gate_c_row(
 /// generation number; the oracle row is an upper bound and remains not
 /// causal. Nothing here changes the artifact format, the serving
 /// scorer's default path, the witness or the replay contract.
+/// Schema twenty-five is the #467 sampled Gate C decision mode: every
+/// [`GateCMetrics`] row gains `positions_sampled` and `standard_error`,
+/// and `gate_c` gains `held_out_population` and `positions_sampled`. The
+/// motivation is arithmetic, not engineering taste. A full pass over
+/// 402,802 held-out positions at a top-1 rate near 26 percent has a
+/// standard error of 0.07pp, while every pre-declared exit rule in this
+/// repository is written at plus or minus 2pp — roughly 30x more
+/// precision than any decision consumes, bought with hours of wall
+/// clock. A 10,000-position decision run has a standard error of 0.44pp,
+/// still well inside a 2pp rule, at about 40x less cost. The mode is
+/// opt-in through the `R4_GATE_C_SAMPLE` environment override; UNSET is
+/// the full pass and is behaviour-identical (bit-identical rates and
+/// bits) to schema twenty-four, where `positions_sampled` is `0` on
+/// every row and `standard_error` is the sampling error the full
+/// held-out split itself carries. When the override is set, the
+/// evaluation scores a deterministic stride-selected, order-preserving
+/// subsample of the held-out list; the held-out MASK and therefore every
+/// construction-split table (forward-anchor, two-sided, latent, unigram
+/// null) is still built from the FULL held-out list, so a sampled run
+/// measures the same model as a full run and differs only in how many
+/// positions the measurement averages over. A row whose
+/// `positions_sampled` is nonzero is an ESTIMATE and must be quoted with
+/// its `standard_error`, never as a census.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -5204,7 +5348,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 24,
+        schema: 25,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,

--- a/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
+++ b/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
@@ -57,6 +57,113 @@
 //! - [`ROW_TRUNCATION_FRACTION_MAX`] — share of FWDA / NGRAM rows clipped by
 //!   their entry cap. Above it, the cap (not the evidence) sets the row width.
 //!
+//! # Cost, sampling, and what is EXACT versus ESTIMATED (#467)
+//!
+//! The 2.11M-record run of this instrument cost about twelve minutes, and
+//! 585 of those 713 seconds were one thing: the per-record graded-code
+//! assignment behind `runtime::build_store_with_threads`. The rest of the
+//! instrument — observation building, FWDA/NGRAM compiles, cover induction
+//! — costs seconds. Any fast path that does not address the code pass is
+//! noise, so this section says exactly what was done to it and what the
+//! result is allowed to claim.
+//!
+//! Three stacking changes, none of which move a reported number:
+//!
+//! - The code pass runs under rayon over corpus positions (mirroring
+//!   `evaluate_gate_c`), and its reduction is an ordered `collect`, so the
+//!   result is the input-order code vector regardless of thread count.
+//! - It calls `runtime::assign_code_for_bundle` — the allocation-free
+//!   per-stage argmax whose tie rule is documented to give the same
+//!   primary code as `assign_for_bundle` — instead of materializing the
+//!   membership beam for 2.11M records and discarding it.
+//! - It never builds the five-level evidence `Store`. Everything this
+//!   instrument reads off the store (occupied keys per level, per-key
+//!   record counts, per-key teacher weight, the support gate) is
+//!   recovered exactly from the sorted construction-split code vector,
+//!   which costs one parallel sort instead of roughly five hundred
+//!   `BTreeMap` insertions per record.
+//!
+//! Measured on the 2.11M corpus, those three changes plus the held-out
+//! sample take the run from 713s to 613s. The residual is almost entirely
+//! the exact construction-split code pass: 468s to assign 1,707,309
+//! records, which is 4 stages x 256 classes x 288 dimensions of branchy
+//! shift-add per record, about 5e11 term applications, already saturating
+//! both cores of this box. Rayon buys nothing over the two threads the old
+//! path used because there are only two cores, and the argmax path proved
+//! no faster than the membership beam it replaced, which locates the cost
+//! in the dot kernel rather than in allocation. Reaching the ten-second
+//! neighbourhood would need a vectorized dot kernel in the core crate, not
+//! a smarter instrument; anything else buys speed by biasing the two
+//! verdicts that sit nearest their limits.
+//!
+//! Only ONE quantity in this instrument is sampled: the held-out
+//! supported-record fraction, under `R4_CAPACITY_SAMPLE` (default
+//! 100,000 held-out records; `0` means census). It is a mean of a
+//! per-record indicator, so a stride subsample of the held-out list is an
+//! unbiased estimator of it, and its binomial standard error
+//! sqrt of p(1-p)/n is printed next to the verdict. At n = 100,000 that
+//! error is about 0.03pp against a threshold the verdict clears by
+//! roughly 9pp.
+//!
+//! Everything else is EXACT, and deliberately so. The tempting move —
+//! subsample the corpus, build the key set from the subsample, scale the
+//! counts back up — is wrong for this instrument, in two separate ways:
+//!
+//! - Distinct occupied keys is not a mean of anything. A key held by `r`
+//!   construction records survives a rate-`f` subsample with probability
+//!   `1 - (1-f)^r`, so a subsample sees strictly fewer keys and the
+//!   shortfall is worst exactly where this corpus lives: 42 percent of
+//!   its full-code keys hold a single record, and every one of those is
+//!   invisible with probability `1-f`. Dividing by `f` does not repair
+//!   it. Since `code.records_per_full_key` is construction records over
+//!   distinct keys, and the measured 36.02 sits only 13 percent above its
+//!   limit of 32, a subsampled key count moves that verdict directly.
+//! - The occupancy histogram is a distribution of per-key counts, and
+//!   subsampling THINS it: a key with `r` records shows up with about
+//!   `Binomial(r, f)` records, which slides mass toward the low buckets
+//!   and deletes keys that draw zero. The shape, not just the scale, is
+//!   wrong, so no single factor rescales it.
+//!
+//! The held-out resolution rate has the same dependency from the other
+//! side: it asks whether a held-out code lands on an occupied, supported
+//! CONSTRUCTION key, so it is unbiased only while the key set it probes
+//! is the complete one. That is why the construction split is never
+//! sampled by default even though it is 81 percent of the corpus, and why
+//! the honest ceiling on this instrument's speedup is the exact code pass.
+//!
+//! `R4_CAPACITY_TRAIN_SAMPLE` (default `0`, meaning census) subsamples the
+//! construction-split code pass anyway, for a fast look and, more
+//! usefully, so the bias above can be reproduced instead of argued about.
+//! Every affected line is labelled `BIASED ESTIMATE` and the run prints a
+//! banner saying the saturation verdicts are not trustworthy in that mode.
+//! Measured on the 2.11M corpus at 100,000 construction records (a
+//! 0.05857 rate): occupied full-code keys read 12,193 against the true
+//! 47,403, a 74 percent shortfall; mean records per key reads 8.20 against
+//! the true 36.02 and its verdict flips SATURATED to PASS; the singleton
+//! share inflates from 0.4170 to 0.5474 as the histogram thins; the
+//! codebook sample fraction reads 0.10000 against the true 0.00586,
+//! flipping its verdict too, because its denominator is the
+//! construction-record count the pass actually saw. The held-out
+//! resolution rate reads 0.9324 against the true 0.9882 — it keeps its
+//! verdict only because it had 8.8pp of margin and the incomplete key set
+//! ate 5.6pp of it. Two of the seven verdicts flip on a corpus whose model
+//! did not change. That is the estimator, not the measurement.
+//!
+//! Summary of the taxonomy, for anyone quoting a number out of the log:
+//!
+//! - EXACT, census over the whole corpus: record and story counts, the
+//!   construction-split record count, occupied keys at every level and
+//!   their occupancy against nominal, mean construction records per
+//!   occupied full-code key, the records-per-key histogram, the singleton
+//!   share, total teacher weight, keys clearing the support gate, all
+//!   FWDA and NGRAM row statistics, and every cover statistic.
+//! - EXACT by construction, independent of the corpus: the codebook
+//!   k-means sample fraction, which is a ratio of pinned constants to the
+//!   construction-split record count.
+//! - ESTIMATED when `R4_CAPACITY_SAMPLE` is nonzero: the held-out
+//!   supported-record fraction, and only that. It is reported with its
+//!   sample size and standard error, and the log labels it ESTIMATE.
+//!
 //! # Running
 //!
 //! On the 500k reference corpus:
@@ -74,10 +181,16 @@
 //! Knobs: `R4_ARTIFACTS` (artifact container, defaults to the core fixture),
 //! `R4_CAP_THREADS` (worker count, default 2), `R4_CAP_SKIP_COVER=1` (skip
 //! cover induction entirely), `R4_CAP_COVER_MAX_TRAIN` (cap on train
-//! observations fed to induction, `0` = unlimited).
+//! observations fed to induction, `0` = unlimited), `R4_CAPACITY_SAMPLE`
+//! (held-out records drawn for the sampled resolution rate, default
+//! 100,000, `0` = census over the whole held-out split),
+//! `R4_CAPACITY_TRAIN_SAMPLE` (construction records drawn for the code
+//! pass, default `0` = census; nonzero is the biased fast look).
 
 use std::collections::BTreeMap;
 use std::time::Instant;
+
+use rayon::prelude::*;
 
 use uor_r4_core::transformerless::compiler::{self, Corpus, K, STAGES};
 use uor_r4_core::transformerless::runtime;
@@ -86,7 +199,7 @@ use uor_r4_graph_certify::score::{
     FWDA_ENTRY_CAP,
 };
 use uor_r4_graph_certify::score_runtime::EXCT_SUPPORT_MIN;
-use uor_r4_graph_compiler::induction::{self, CoverConfig};
+use uor_r4_graph_compiler::induction::{self, CoverConfig, Observation};
 
 /// Mean train observations per induced cover region above which the cover is
 /// a bucketing of the corpus rather than a partition into context classes.
@@ -183,31 +296,27 @@ fn bucket_label(index: usize) -> String {
 }
 
 /// COVER section: induce the cover and report realized region capacity.
-fn report_cover(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize) {
+fn report_cover(observations: &[Observation], threads: usize) {
     println!("\n== COVER (uor-r4-graph-compiler::induction) ==");
     let config = CoverConfig {
         threads: threads as u32,
         ..CoverConfig::default()
     };
-    let (train_positions, _held) = induction::split_positions(corpus);
+    // The observation vector is built once per run and shared with the
+    // FWDA/NGRAM section; it is in train-position order, so the cap is the
+    // same prefix `R4_CAP_COVER_MAX_TRAIN` selected when this section built
+    // its own copy.
     let max_train = env_usize("R4_CAP_COVER_MAX_TRAIN", 0);
-    let mut train_positions = train_positions;
-    if max_train > 0 && train_positions.len() > max_train {
+    let train = if max_train > 0 && observations.len() > max_train {
         println!(
             "  CAP BOUND: train positions {} -> {max_train} (R4_CAP_COVER_MAX_TRAIN)",
-            train_positions.len()
+            observations.len()
         );
-        train_positions.truncate(max_train);
-    }
-    let started = Instant::now();
-    let train =
-        induction::build_observations_with_threads(artifacts, corpus, &train_positions, threads)
-            .expect("train observations");
-    println!(
-        "  train observations: {} (built in {:.1}s)",
-        train.len(),
-        started.elapsed().as_secs_f64()
-    );
+        &observations[..max_train]
+    } else {
+        observations
+    };
+    println!("  train observations: {}", train.len());
     let n = train.len();
     println!(
         "  config: depths={} k0={} (effective {}) regions_budget={} (effective {}) \
@@ -221,7 +330,7 @@ fn report_cover(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize)
         config.split_criterion,
         config.entropy_gain_bits
     );
-    let induced = induction::induce_cover(&train, &config, "i432-artifact", "i432-corpus")
+    let induced = induction::induce_cover(train, &config, "i432-artifact", "i432-corpus")
         .expect("cover induction");
     let cover = &induced.cover;
 
@@ -304,42 +413,198 @@ fn report_cover(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize)
     );
 }
 
-/// GRADED CODE + EXCT sections: prefix-key occupancy and evidence histogram.
-fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize) {
-    println!("\n== GRADED CODE (uor-r4-core::transformerless) ==");
-    let started = Instant::now();
-    let (store, codes) =
-        runtime::build_store_with_threads(artifacts, corpus, threads).expect("store");
-    println!("  store built in {:.1}s", started.elapsed().as_secs_f64());
+/// Default number of held-out records drawn for the sampled resolution
+/// rate. Chosen so the binomial standard error of a rate near 0.99 is
+/// about 0.03pp — two orders finer than the 90 percent threshold the
+/// verdict is decided against, at a twentieth of the code-assignment work
+/// the held-out split would otherwise cost.
+const CAPACITY_SAMPLE_DEFAULT: usize = 100_000;
 
-    // The construction split the store itself uses.
-    let train_cut = compiler::train_cut(corpus);
-    let mut train_records: u64 = 0;
-    for &story in corpus.story.iter().take(corpus.n) {
-        if story < train_cut {
-            train_records += 1;
+/// Environment override for that sample size. `0` restores the census.
+const CAPACITY_SAMPLE_ENV: &str = "R4_CAPACITY_SAMPLE";
+
+/// Opt-in override that ALSO subsamples the construction-split code pass.
+/// Default `0`, meaning the construction split is a census, because every
+/// key-derived statistic in this instrument is biased by a subsample of it
+/// (module docs). It exists so the bias can be reproduced and measured,
+/// and the run labels every affected number `BIASED ESTIMATE`.
+const CAPACITY_TRAIN_SAMPLE_ENV: &str = "R4_CAPACITY_TRAIN_SAMPLE";
+
+/// Deterministic stride subsample of `positions`: entry `k` of the sample
+/// is `positions[k * len / n]`. No RNG — the same corpus and the same `n`
+/// always draw the same records, so a sampled run is reproducible and
+/// diffable, the selection stays in corpus order, and because the held-out
+/// list is in corpus order an even stride spreads the draw across every
+/// story instead of taking one contiguous block.
+fn stride_sample(positions: &[usize], n: usize) -> Vec<usize> {
+    let len = positions.len();
+    if n == 0 || n >= len {
+        return positions.to_vec();
+    }
+    (0..n).map(|k| positions[k * len / n]).collect()
+}
+
+/// Binomial standard error of a rate `p` measured over `n` records.
+fn standard_error(p: f64, n: u64) -> f64 {
+    if n == 0 {
+        return 0.0;
+    }
+    (p * (1.0 - p) / n as f64).sqrt()
+}
+
+/// The per-record graded-code assignment pass, in parallel over corpus
+/// positions and reduced in input order (`collect` on an indexed Rayon
+/// iterator), so the code vector is thread-count independent — the same
+/// discipline `evaluate_gate_c` uses for its held-out rows.
+///
+/// This calls `assign_code_for_bundle`, the allocation-free per-stage
+/// argmax, whose tie rule is documented to yield the same primary code as
+/// `assign_for_bundle`; the membership beam the latter materializes is
+/// discarded by every caller here.
+fn assign_codes(
+    artifacts: &compiler::Compiled,
+    corpus: &Corpus,
+    positions: &[usize],
+) -> Vec<[u8; STAGES]> {
+    let rotations = runtime::derive_rotations();
+    positions
+        .par_iter()
+        .map(|&i| {
+            let bundle = runtime::bundle_plain(artifacts, &rotations, corpus, i);
+            runtime::assign_code_for_bundle(artifacts, &bundle)
+        })
+        .collect()
+}
+
+/// One occupied full-code key of the construction split: the number of
+/// construction records that landed on it and the teacher weight those
+/// records carry. Recovered exactly from the sorted code vector, which is
+/// what the five-level evidence store would have held.
+struct KeyAggregate {
+    code: [u8; STAGES],
+    records: u64,
+    weight: u64,
+}
+
+/// Group the construction split's per-record codes into per-key
+/// aggregates, sorted by code. Exact: every construction record is
+/// counted, and the sort is the whole cost.
+fn aggregate_keys(mut coded: Vec<([u8; STAGES], u64)>) -> Vec<KeyAggregate> {
+    coded.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    let mut keys: Vec<KeyAggregate> = Vec::new();
+    for (code, weight) in coded {
+        match keys.last_mut() {
+            Some(last) if last.code == code => {
+                last.records += 1;
+                last.weight += weight;
+            }
+            _ => keys.push(KeyAggregate {
+                code,
+                records: 1,
+                weight,
+            }),
         }
     }
+    keys
+}
+
+/// GRADED CODE + EXCT sections: prefix-key occupancy and evidence
+/// histogram. Every number here is exact except the held-out resolution
+/// rate, which is the one sampled statistic (module docs).
+fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled) {
+    println!("\n== GRADED CODE (uor-r4-core::transformerless) ==");
+    // The construction split the store itself uses.
+    let train_cut = compiler::train_cut(corpus);
+    let train_positions: Vec<usize> = (0..corpus.n)
+        .filter(|&i| corpus.story[i] < train_cut)
+        .collect();
+    let held_positions: Vec<usize> = (0..corpus.n)
+        .filter(|&i| corpus.story[i] >= train_cut)
+        .collect();
+
+    // The construction-split code pass is EXACT by default. The opt-in
+    // subsample below exists to reproduce, not to hide, the bias it
+    // creates: see the module docs and the banner this prints.
+    let train_requested = env_usize(CAPACITY_TRAIN_SAMPLE_ENV, 0);
+    let train_sample = stride_sample(&train_positions, train_requested);
+    let train_sampled = train_sample.len() < train_positions.len();
+    let train_records = train_sample.len() as u64;
+    if train_sampled {
+        println!(
+            "  BIASED FAST LOOK: {CAPACITY_TRAIN_SAMPLE_ENV}={train_requested} of {} \
+             construction records ({:.5} of the split). Every key-derived number \
+             below is a BIASED ESTIMATE, not a census: the key set is drawn from a \
+             subsample, so occupied keys read LOW, mean records per key reads LOW, \
+             the occupancy histogram is thinned toward its low buckets, and the \
+             held-out resolution rate reads LOW because it probes an incomplete key \
+             set. Saturation verdicts from this mode are NOT trustworthy.",
+            train_positions.len(),
+            ratio(train_records, train_positions.len() as u64)
+        );
+    }
+    let label = if train_sampled {
+        "BIASED ESTIMATE"
+    } else {
+        "exact"
+    };
+
+    let started = Instant::now();
+    let train_codes = assign_codes(artifacts, corpus, &train_sample);
     println!(
-        "  corpus: {} records, {} stories; construction-split records {train_records}",
-        corpus.n, corpus.stories
+        "  construction-split code pass: {} record(s) in {:.1}s ({label}, rayon)",
+        train_codes.len(),
+        started.elapsed().as_secs_f64()
+    );
+    let started = Instant::now();
+    let coded: Vec<([u8; STAGES], u64)> = train_codes
+        .iter()
+        .zip(&train_sample)
+        .map(|(&code, &i)| {
+            let weight: u64 = corpus.top_weights[i].iter().map(|&w| u64::from(w)).sum();
+            (code, weight)
+        })
+        .collect();
+    let keys = aggregate_keys(coded);
+    println!(
+        "  key aggregation: {} occupied full-code key(s) in {:.1}s ({label})",
+        keys.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    println!(
+        "  corpus: {} records, {} stories; construction-split records coded \
+         {train_records} of {} ({label})",
+        corpus.n,
+        corpus.stories,
+        train_positions.len()
     );
     println!("  STAGES={STAGES} K={K}");
 
+    // Occupied keys at prefix level L are the distinct L-byte prefixes of
+    // the occupied full codes, which is what the store's level-L map held.
     let mut nominal: f64 = 1.0;
-    for (level, cells) in store.iter().enumerate() {
+    for level in 0..=STAGES {
         if level > 0 {
             nominal *= K as f64;
         }
+        let occupied_level = if keys.is_empty() {
+            0
+        } else if level == 0 {
+            1
+        } else {
+            1 + keys
+                .windows(2)
+                .filter(|pair| pair[0].code[..level] != pair[1].code[..level])
+                .count()
+        };
         println!(
-            "  level {level}: {} occupied key(s) of {nominal:.3e} nominal ({:.3e} occupancy)",
-            cells.len(),
-            cells.len() as f64 / nominal
+            "  level {level}: {occupied_level} occupied key(s) of {nominal:.3e} nominal \
+             ({:.3e} occupancy)",
+            occupied_level as f64 / nominal
         );
     }
 
-    let full = &store[STAGES];
-    let occupied = full.len() as u64;
+    let occupied = keys.len() as u64;
     let records_per_key = ratio(train_records, occupied);
     println!("  mean construction records per occupied full-code key: {records_per_key:.2}");
 
@@ -360,48 +625,40 @@ fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled, threads
     );
     println!(
         "SATURATION VERDICT code.records_per_full_key: {} \
-         (mean {records_per_key:.2} vs limit {CODE_RECORDS_PER_KEY_MAX:.0})",
+         ({label} {records_per_key:.2} vs limit {CODE_RECORDS_PER_KEY_MAX:.0})",
         verdict(records_per_key, CODE_RECORDS_PER_KEY_MAX, true)
     );
     println!(
         "SATURATION VERDICT code.codebook_sample_fraction: {} \
-         (fraction {sample_fraction:.5} vs floor {CODE_TRAIN_SAMPLE_FRACTION_MIN:.2})",
+         ({label} {sample_fraction:.5} vs floor {CODE_TRAIN_SAMPLE_FRACTION_MIN:.2})",
         verdict(sample_fraction, CODE_TRAIN_SAMPLE_FRACTION_MIN, false)
     );
 
     println!("\n== EXCT (full-code exact-context occupancy) ==");
-    // Per-key RECORD counts. The store's own totals are teacher weight units
+    // Per-key RECORD counts. The per-key totals are teacher weight units
     // (about 100 per record), so they are not a record census and cannot be
     // compared across corpora; the record histogram is the scale-sensitive
-    // quantity. Both are reported.
-    let mut key_records: BTreeMap<&[u8; STAGES], u64> = BTreeMap::new();
-    for (i, code) in codes.iter().enumerate().take(corpus.n) {
-        if corpus.story[i] < train_cut {
-            *key_records.entry(code).or_insert(0) += 1;
-        }
-    }
+    // quantity. Both are reported, and both are exact — see the module docs
+    // on why neither survives a subsample of the construction split.
     let mut histogram = [0u64; EXCT_BUCKETS.len()];
     let mut singleton_keys: u64 = 0;
-    for &records in key_records.values() {
-        if records == 1 {
+    let mut weight_mass: u64 = 0;
+    let mut supported_keys: u64 = 0;
+    for key in &keys {
+        if key.records == 1 {
             singleton_keys += 1;
+        }
+        weight_mass += key.weight;
+        if key.weight >= u64::from(EXCT_SUPPORT_MIN) {
+            supported_keys += 1;
         }
         let mut index = 0usize;
         for (i, &edge) in EXCT_BUCKETS.iter().enumerate() {
-            if records >= u64::from(edge) {
+            if key.records >= u64::from(edge) {
                 index = i;
             }
         }
         histogram[index] += 1;
-    }
-    let mut weight_mass: u64 = 0;
-    let mut supported_keys: u64 = 0;
-    for distribution in full.values() {
-        let total: u64 = distribution.values().map(|&c| u64::from(c)).sum();
-        weight_mass += total;
-        if total >= u64::from(EXCT_SUPPORT_MIN) {
-            supported_keys += 1;
-        }
     }
     println!(
         "  occupied full-code keys: {occupied}; store evidence (teacher weight units): \
@@ -429,44 +686,64 @@ fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled, threads
     // code land on an occupied, supported construction key? A held-out set
     // that almost always resolves exactly cannot exhibit a strict miss, and
     // without strict misses there is no generalization to measure.
-    let mut held_total: u64 = 0;
-    let mut held_resolved: u64 = 0;
-    for (i, code) in codes.iter().enumerate().take(corpus.n) {
-        if corpus.story[i] < train_cut {
-            continue;
-        }
-        held_total += 1;
-        if let Some(distribution) = full.get(code.as_slice()) {
-            let total: u64 = distribution.values().map(|&c| u64::from(c)).sum();
-            if total >= u64::from(EXCT_SUPPORT_MIN) {
-                held_resolved += 1;
-            }
-        }
-    }
+    //
+    // This is the instrument's one SAMPLED statistic. It is the mean of a
+    // per-record indicator, so a stride subsample of the held-out list
+    // estimates it without bias; the key set the indicator probes is the
+    // exact one built above, which is what keeps that true.
+    let requested = env_usize(CAPACITY_SAMPLE_ENV, CAPACITY_SAMPLE_DEFAULT);
+    let held_sample = stride_sample(&held_positions, requested);
+    let sampled = held_sample.len() < held_positions.len();
+    let started = Instant::now();
+    let held_codes = assign_codes(artifacts, corpus, &held_sample);
+    let held_total = held_codes.len() as u64;
+    let held_resolved = held_codes
+        .par_iter()
+        .filter(|code| {
+            keys.binary_search_by(|key| key.code.cmp(code))
+                .map(|index| keys[index].weight >= u64::from(EXCT_SUPPORT_MIN))
+                .unwrap_or(false)
+        })
+        .count() as u64;
     let supported_fraction = ratio(held_resolved, held_total);
+    let error = standard_error(supported_fraction, held_total);
     println!(
-        "  held-out records: {held_total}; resolving at the FULL code: {held_resolved} \
-         ({supported_fraction:.4}); strict miss {:.4}",
+        "  held-out records: {} total in the split; {held_total} scored in {:.1}s ({})",
+        held_positions.len(),
+        started.elapsed().as_secs_f64(),
+        if sampled {
+            format!("SAMPLED, {CAPACITY_SAMPLE_ENV}={requested}")
+        } else {
+            "census".to_owned()
+        }
+    );
+    println!(
+        "  resolving at the FULL code: {held_resolved} ({supported_fraction:.4}); \
+         strict miss {:.4}; standard error {error:.5} over n={held_total}",
         1.0 - supported_fraction
     );
     println!(
         "SATURATION VERDICT exct.supported_record_fraction: {} \
-         (fraction {supported_fraction:.4} vs limit {EXCT_SUPPORTED_RECORD_FRACTION_MAX:.2}) \
+         ({} {supported_fraction:.4} +/- {error:.5} vs limit \
+         {EXCT_SUPPORTED_RECORD_FRACTION_MAX:.2}) \
          - above the limit a strict miss is too rare to measure generalization from",
-        verdict(supported_fraction, EXCT_SUPPORTED_RECORD_FRACTION_MAX, true)
+        verdict(supported_fraction, EXCT_SUPPORTED_RECORD_FRACTION_MAX, true),
+        if train_sampled {
+            "BIASED ESTIMATE"
+        } else if sampled {
+            "ESTIMATE"
+        } else {
+            "fraction"
+        }
     );
 }
 
 /// FWDA + NGRAM sections: row counts and entry-cap truncation shares.
-fn report_tables(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize) {
+fn report_tables(corpus: &Corpus, artifacts: &compiler::Compiled, train: &[Observation]) {
     println!("\n== FWDA + NGRAM (uor-r4-graph-certify::score) ==");
-    let (train_positions, _held) = induction::split_positions(corpus);
-    let train =
-        induction::build_observations_with_threads(artifacts, corpus, &train_positions, threads)
-            .expect("train observations");
     println!("  train observations: {}", train.len());
 
-    let rows = compile_forward_anchor_rows(corpus, &train);
+    let rows = compile_forward_anchor_rows(corpus, train);
     let mut total_sum: u64 = 0;
     let mut truncated: u64 = 0;
     let mut max_total: u32 = 0;
@@ -491,7 +768,7 @@ fn report_tables(corpus: &Corpus, artifacts: &compiler::Compiled, threads: usize
 
     let config = ScoreConfig::default();
     let vocab = u32::try_from(artifacts.token_codes.len() / STAGES).unwrap_or(u32::MAX);
-    let context_rows = compile_context_rows(corpus, &train, vocab, &config);
+    let context_rows = compile_context_rows(corpus, train, vocab, &config);
     let mut bigrams: u64 = 0;
     let mut trigrams: u64 = 0;
     let mut ngram_truncated: u64 = 0;
@@ -537,12 +814,31 @@ fn capacity_scaling() {
     println!("  records:   {} in {} stories", corpus.n, corpus.stories);
     println!("  threads:   {threads}");
 
-    report_code_and_exct(&corpus, &artifacts, threads);
-    report_tables(&corpus, &artifacts, threads);
+    let overall = Instant::now();
+    report_code_and_exct(&corpus, &artifacts);
+
+    // Built once and shared by the FWDA/NGRAM and COVER sections, which
+    // both used to build their own identical copy.
+    let (train_positions, _held) = induction::split_positions(&corpus);
+    let started = Instant::now();
+    let observations =
+        induction::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads)
+            .expect("train observations");
+    println!(
+        "\n  train observations: {} (built once in {:.1}s, shared by FWDA/NGRAM and COVER)",
+        observations.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    report_tables(&corpus, &artifacts, &observations);
     if env_flag("R4_CAP_SKIP_COVER") {
         println!("\n== COVER == skipped (R4_CAP_SKIP_COVER)");
     } else {
-        report_cover(&corpus, &artifacts, threads);
+        report_cover(&observations, threads);
     }
+    println!(
+        "\n  total instrument wall clock: {:.1}s",
+        overall.elapsed().as_secs_f64()
+    );
     println!("\n#460 capacity-scaling instrumentation complete");
 }

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -989,6 +989,7 @@ mod tests {
             positions: 10,
             top1_agreement: 0.5,
             bits_per_token,
+            ..GateCMetrics::default()
         };
         let row = SweepRow {
             label: "k0=8/gain=0.25/budget=128".to_owned(),

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1249,17 +1249,48 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         "gate C — held-out D3 metrics ({} positions):",
         gate_c.rule12_precedence.positions
     );
-    println!(
-        "  {:<26} {:>16} {:>12}",
-        "scorer", "top-1 agree", "bits/token"
-    );
-    let row = |name: &str, m: &score::GateCMetrics| {
+    // #467: a sampled decision run prints its sample size and the standard
+    // error of every rate, so a sampled number cannot be read as a census.
+    let sampled = gate_c.positions_sampled > 0;
+    if sampled {
         println!(
-            "  {:<26} {:>15.1}% {:>12.4}",
-            name,
-            100.0 * m.top1_agreement,
-            m.bits_per_token
+            "  SAMPLED DECISION RUN (R4_GATE_C_SAMPLE): n={} of {} held-out positions \
+             ({:.4} of the split); every rate below is an ESTIMATE, +/- is the binomial \
+             standard error sqrt(p(1-p)/n)",
+            gate_c.positions_sampled,
+            gate_c.held_out_population,
+            gate_c.positions_sampled as f64 / (gate_c.held_out_population as f64).max(1.0)
         );
+    }
+    if sampled {
+        println!(
+            "  {:<26} {:>16} {:>12} {:>10} {:>9}",
+            "scorer", "top-1 agree", "bits/token", "+/- (SE)", "n"
+        );
+    } else {
+        println!(
+            "  {:<26} {:>16} {:>12}",
+            "scorer", "top-1 agree", "bits/token"
+        );
+    }
+    let row = |name: &str, m: &score::GateCMetrics| {
+        if sampled {
+            println!(
+                "  {:<26} {:>15.1}% {:>12.4} {:>9.2}% {:>9}",
+                name,
+                100.0 * m.top1_agreement,
+                m.bits_per_token,
+                100.0 * m.standard_error,
+                m.positions
+            );
+        } else {
+            println!(
+                "  {:<26} {:>15.1}% {:>12.4}",
+                name,
+                100.0 * m.top1_agreement,
+                m.bits_per_token
+            );
+        }
     };
     row("graph Σ-cloud (old)", &gate_c.legacy_sum);
     row("graph chain (Rule 1)", &gate_c.rule1_chain);


### PR DESCRIPTION
References #467. Decision runs should not pay census prices: at 402,802 held-out positions the headline's standard error is 0.07pp while every pre-declared exit rule is written at ±2pp.

**Sampled Gate C** (`R4_GATE_C_SAMPLE`, unset = full pass): deterministic stride selection, no RNG. Every rate now carries n and sqrt(p(1-p)/n) so a sampled number can never be quoted as a census. Measured: 10,000 positions gives 35.83% ± 0.48pp against the census 36.55% ± 0.15pp, with Gate C evaluation dropping **597s → 60s**. **Bit-identity with the knob unset was verified end-to-end, not argued** — `r4` built from origin/main and from this branch, both run on the fixture corpus, reports diffed field by field: the only differences in the entire document are `schema` 24→25 and the new fields.

**Instrument** (`R4_CAPACITY_SAMPLE`, default 100k for the one sampled rate; `R4_CAPACITY_TRAIN_SAMPLE`, default census/off): all seven SATURATION verdicts match the full pass, and every exact quantity is identical to the digit.

**The correctness point, and it matters more than the speedup:** only ONE quantity is estimated — `exct.supported_record_fraction`, a mean of a per-record indicator, printed with its standard error. The construction-split statistics are deliberately NOT sampled, because distinct occupied keys is not a mean: a key holding r records survives a rate-f subsample with probability 1-(1-f)^r, and 42% of this corpus's keys hold exactly one record, so a subsample undercounts and dividing by f does not repair it. Forced on via the opt-in knob, **two of seven verdicts flip** (keys 12,193 vs 47,403; records/key 8.20 vs 36.02) — so that mode labels every affected line `BIASED ESTIMATE`.

**Honest miss on the target:** ~10s is not reachable from the instrument side. The residual 468s is the exact code pass — 4 stages × 256 classes × 288 dims of branchy shift-add per record, ~5e11 term applications, already saturating both available cores. That needs a vectorized kernel in `uor-r4-core`, not a smarter instrument. Also confirmed while looking: the compile does **not** persist per-record codes anywhere reusable (only token codes in `hierarchical_codes.json`), so there is no cache to read — filed as follow-up work rather than invented here.