### PR TITLE
perf(core): #469 lever A — per-record code sidecar, κ-keyed and fallback-safe

### DIFF
--- a/crates/uor-r4-core/src/transformerless/code_sidecar.rs
+++ b/crates/uor-r4-core/src/transformerless/code_sidecar.rs
@@ -1,0 +1,412 @@
+//! Per-record graded-code sidecar (issue #469 lever A).
+//!
+//! # Why this exists
+//!
+//! Every consumer of the transformerless pipeline — the graded store
+//! build, the #460 capacity instrument, each scoring harness — needs the
+//! same thing first: the graded class code of every corpus record,
+//! `assign_for_bundle(bundle_plain(i))` for `i in 0..n`. That pass is the
+//! dominant cost of a measurement run on a large corpus, and every
+//! consumer recomputes it from scratch because nothing persists it (the
+//! compile persists TOKEN codes only, in `hierarchical_codes.json`).
+//!
+//! This module persists that one pass and reads it back.
+//!
+//! # Why it cannot change a number
+//!
+//! The sidecar is a CACHE OF AN EXISTING DETERMINISTIC COMPUTATION, never
+//! a new definition of it. Nothing here computes a code: the writer takes
+//! codes a caller already derived through the ordinary runtime path, and
+//! the reader either returns exactly those bytes or returns `None` and the
+//! caller computes as before. There is no third outcome, no interpolation,
+//! no partial load, and no code arithmetic anywhere in this file.
+//!
+//! A load succeeds only when ALL of the following hold:
+//!
+//! - the magic is [`MAGIC`] and the version is [`VERSION`];
+//! - the stored artifact κ equals the caller's artifact κ;
+//! - the stored corpus κ equals the caller's corpus κ;
+//! - the stored record count equals the caller's record count;
+//! - the stored stage count equals [`STAGES`];
+//! - the file length is exactly the length the header implies;
+//! - the blake3 digest of the packed code block matches the stored digest.
+//!
+//! A stale, foreign, truncated or corrupted sidecar therefore cannot be
+//! loaded silently: it fails one of those checks and the caller falls back
+//! to computing. That is the whole safety property.
+//!
+//! # Format `R4CS`, version 1
+//!
+//! All integers little-endian; the layout is fixed, so the bytes are a
+//! function of the codes and the two κs alone (κ-pinnable in turn).
+//!
+//! - `0..4`   magic `R4CS`
+//! - `4..8`   u32 version
+//! - `8..12`  u32 stage count
+//! - `12..20` u64 record count `n`
+//! - then u16 artifact-κ length, then that many UTF-8 bytes
+//! - then u16 corpus-κ length, then that many UTF-8 bytes
+//! - then 32 bytes: blake3 of the packed code block
+//! - then `n × stages` code bytes, record index implicit in order
+//!
+//! At `STAGES = 4` that is four bytes per record — about 8.5 MB for a
+//! 2.11M-record corpus.
+//!
+//! # Paths
+//!
+//! The default path mirrors [`ART_PATH`]; `R4_CODES_PATH` overrides it, in
+//! the established `R4_*` style. A default-path collision between two
+//! different corpora is a cache MISS (the κs differ), never a wrong load.
+
+use super::compiler::{Compiled, Corpus, STAGES};
+use super::runtime;
+
+/// Container magic of the per-record code sidecar.
+pub const MAGIC: &[u8; 4] = b"R4CS";
+
+/// Container version. Bumped whenever the layout below changes; an old
+/// file then fails the version check and the caller recomputes.
+pub const VERSION: u32 = 1;
+
+/// Default sidecar path, mirroring `compiler::ART_PATH`.
+pub const CODES_PATH: &str = "/tmp/tless_codes.bin";
+
+/// Environment override for [`CODES_PATH`].
+pub const CODES_PATH_ENV: &str = "R4_CODES_PATH";
+
+/// Fixed header bytes before the two length-prefixed κ strings.
+const HEADER_FIXED: usize = 20;
+
+/// Digest width of the packed code block (blake3).
+const DIGEST_BYTES: usize = 32;
+
+/// Resolve the sidecar path: `R4_CODES_PATH` when set and non-empty,
+/// otherwise [`CODES_PATH`].
+pub fn codes_path() -> String {
+    match std::env::var(CODES_PATH_ENV) {
+        Ok(value) if !value.trim().is_empty() => value.trim().to_owned(),
+        _ => CODES_PATH.to_owned(),
+    }
+}
+
+fn hash_u32_slice(hasher: &mut blake3::Hasher, values: &[u32]) {
+    let mut scratch = [0u8; 4096];
+    let mut filled = 0usize;
+    for &value in values {
+        scratch[filled..filled + 4].copy_from_slice(&value.to_le_bytes());
+        filled += 4;
+        if filled == scratch.len() {
+            hasher.update(&scratch);
+            filled = 0;
+        }
+    }
+    if filled > 0 {
+        hasher.update(&scratch[..filled]);
+    }
+}
+
+/// κ-label of a corpus's CONTENT (`blake3:<hex>`), the sidecar's corpus key.
+///
+/// Derived from the in-memory corpus rather than from the file bytes it was
+/// loaded from, so it addresses what the codes actually depend on and is
+/// available to every consumer regardless of how the corpus was obtained.
+/// It covers strictly more than the code derivation reads (which is
+/// `story` and `input` only), so a corpus that differs anywhere is a MISS —
+/// the conservative direction.
+pub fn corpus_content_kappa(c: &Corpus) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"r4-corpus-content-v1");
+    hasher.update(&(c.n as u64).to_le_bytes());
+    hasher.update(&c.stories.to_le_bytes());
+    for column in [
+        &c.story,
+        &c.input,
+        &c.next,
+        &c.t_argmax,
+        &c.span_start,
+        &c.span_end,
+        &c.byte_start,
+        &c.byte_end,
+    ] {
+        hasher.update(&(column.len() as u64).to_le_bytes());
+        hash_u32_slice(&mut hasher, column);
+    }
+    hasher.update(&(c.top_tokens.len() as u64).to_le_bytes());
+    for row in &c.top_tokens {
+        hash_u32_slice(&mut hasher, row);
+    }
+    hasher.update(&(c.top_weights.len() as u64).to_le_bytes());
+    for row in &c.top_weights {
+        hash_u32_slice(&mut hasher, row);
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+/// The two κs the sidecar is keyed by, for a given artifact and corpus.
+pub fn sidecar_keys(art: &Compiled, c: &Corpus) -> (String, String) {
+    (
+        super::compiler::artifact_kappa(art),
+        corpus_content_kappa(c),
+    )
+}
+
+/// Serialize a sidecar. Byte layout is fixed (see the module docs), so the
+/// output is a deterministic function of its inputs.
+pub fn sidecar_bytes(artifact_kappa: &str, corpus_kappa: &str, codes: &[[u8; STAGES]]) -> Vec<u8> {
+    let mut packed = Vec::with_capacity(codes.len() * STAGES);
+    for code in codes {
+        packed.extend_from_slice(code);
+    }
+    let digest = blake3::hash(&packed);
+    let art_key = artifact_kappa.as_bytes();
+    let corpus_key = corpus_kappa.as_bytes();
+    let mut b = Vec::with_capacity(
+        HEADER_FIXED + 2 + art_key.len() + 2 + corpus_key.len() + DIGEST_BYTES + packed.len(),
+    );
+    b.extend_from_slice(MAGIC);
+    b.extend_from_slice(&VERSION.to_le_bytes());
+    b.extend_from_slice(&(STAGES as u32).to_le_bytes());
+    b.extend_from_slice(&(codes.len() as u64).to_le_bytes());
+    b.extend_from_slice(&(art_key.len() as u16).to_le_bytes());
+    b.extend_from_slice(art_key);
+    b.extend_from_slice(&(corpus_key.len() as u16).to_le_bytes());
+    b.extend_from_slice(corpus_key);
+    b.extend_from_slice(digest.as_bytes());
+    b.extend_from_slice(&packed);
+    b
+}
+
+/// Why a sidecar was not usable. Reported in the provenance log so a MISS
+/// is never mysterious.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidecarReject {
+    Magic,
+    Version(u32),
+    Stages(u32),
+    RecordCount(u64),
+    ArtifactKappa(String),
+    CorpusKappa(String),
+    Truncated,
+    Digest,
+}
+
+impl std::fmt::Display for SidecarReject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SidecarReject::Magic => write!(f, "not an {} container", MAGIC.escape_ascii()),
+            SidecarReject::Version(v) => write!(f, "version {v} (expected {VERSION})"),
+            SidecarReject::Stages(s) => write!(f, "stages {s} (expected {STAGES})"),
+            SidecarReject::RecordCount(n) => write!(f, "record count {n} does not match corpus"),
+            SidecarReject::ArtifactKappa(k) => write!(f, "artifact κ {k} does not match"),
+            SidecarReject::CorpusKappa(k) => write!(f, "corpus κ {k} does not match"),
+            SidecarReject::Truncated => write!(f, "truncated or over-long container"),
+            SidecarReject::Digest => write!(f, "code-block digest mismatch"),
+        }
+    }
+}
+
+fn read_u16(b: &[u8], at: usize) -> Option<usize> {
+    let raw = b.get(at..at + 2)?;
+    Some(u16::from_le_bytes([raw[0], raw[1]]) as usize)
+}
+
+/// Parse a sidecar, returning the codes only when every check in the module
+/// docs passes. Any failure yields the reason instead — never codes.
+pub fn parse_sidecar(
+    bytes: &[u8],
+    artifact_kappa: &str,
+    corpus_kappa: &str,
+    records: usize,
+) -> Result<Vec<[u8; STAGES]>, SidecarReject> {
+    if bytes.len() < HEADER_FIXED || &bytes[0..4] != MAGIC {
+        return Err(SidecarReject::Magic);
+    }
+    let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    if version != VERSION {
+        return Err(SidecarReject::Version(version));
+    }
+    let stages = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    if stages as usize != STAGES {
+        return Err(SidecarReject::Stages(stages));
+    }
+    let count = u64::from_le_bytes(bytes[12..20].try_into().unwrap());
+    if count != records as u64 {
+        return Err(SidecarReject::RecordCount(count));
+    }
+    let mut offset = HEADER_FIXED;
+    let art_len = read_u16(bytes, offset).ok_or(SidecarReject::Truncated)?;
+    offset += 2;
+    let art_key = bytes
+        .get(offset..offset + art_len)
+        .ok_or(SidecarReject::Truncated)?;
+    offset += art_len;
+    let corpus_len = read_u16(bytes, offset).ok_or(SidecarReject::Truncated)?;
+    offset += 2;
+    let corpus_key = bytes
+        .get(offset..offset + corpus_len)
+        .ok_or(SidecarReject::Truncated)?;
+    offset += corpus_len;
+    if art_key != artifact_kappa.as_bytes() {
+        return Err(SidecarReject::ArtifactKappa(
+            String::from_utf8_lossy(art_key).into_owned(),
+        ));
+    }
+    if corpus_key != corpus_kappa.as_bytes() {
+        return Err(SidecarReject::CorpusKappa(
+            String::from_utf8_lossy(corpus_key).into_owned(),
+        ));
+    }
+    let digest = bytes
+        .get(offset..offset + DIGEST_BYTES)
+        .ok_or(SidecarReject::Truncated)?
+        .to_vec();
+    offset += DIGEST_BYTES;
+    let packed_len = records
+        .checked_mul(STAGES)
+        .ok_or(SidecarReject::RecordCount(count))?;
+    let packed = bytes
+        .get(offset..offset + packed_len)
+        .ok_or(SidecarReject::Truncated)?;
+    if offset + packed_len != bytes.len() {
+        return Err(SidecarReject::Truncated);
+    }
+    if blake3::hash(packed).as_bytes()[..] != digest[..] {
+        return Err(SidecarReject::Digest);
+    }
+    let mut codes = Vec::with_capacity(records);
+    for chunk in packed.chunks_exact(STAGES) {
+        let mut code = [0u8; STAGES];
+        code.copy_from_slice(chunk);
+        codes.push(code);
+    }
+    Ok(codes)
+}
+
+/// Read the sidecar at [`codes_path`] and verify it against the given keys.
+/// `None` means "compute as today"; the reason is logged (#450 precedent:
+/// one greppable stderr line naming the path and the κs).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn load_codes(
+    artifact_kappa: &str,
+    corpus_kappa: &str,
+    records: usize,
+) -> Option<Vec<[u8; STAGES]>> {
+    let path = codes_path();
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!(
+                "code sidecar: MISS {path} ({error}); computing {records} record codes \
+                 (artifact κ {artifact_kappa}, corpus κ {corpus_kappa})"
+            );
+            return None;
+        }
+    };
+    match parse_sidecar(&bytes, artifact_kappa, corpus_kappa, records) {
+        Ok(codes) => {
+            eprintln!(
+                "code sidecar: LOADED {path} ({} records, {} bytes, artifact κ \
+                 {artifact_kappa}, corpus κ {corpus_kappa})",
+                codes.len(),
+                bytes.len()
+            );
+            Some(codes)
+        }
+        Err(reason) => {
+            eprintln!(
+                "code sidecar: MISS {path} ({reason}); computing {records} record codes \
+                 (artifact κ {artifact_kappa}, corpus κ {corpus_kappa})"
+            );
+            None
+        }
+    }
+}
+
+/// Write the sidecar at [`codes_path`], atomically (temp file then rename)
+/// so a concurrent reader never sees a partial container. Write failure is
+/// reported and otherwise ignored: this is a cache, not an output.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn save_codes(artifact_kappa: &str, corpus_kappa: &str, codes: &[[u8; STAGES]]) {
+    let path = codes_path();
+    let bytes = sidecar_bytes(artifact_kappa, corpus_kappa, codes);
+    let temp = format!("{path}.tmp.{}", std::process::id());
+    let written = std::fs::write(&temp, &bytes).and_then(|()| std::fs::rename(&temp, &path));
+    match written {
+        Ok(()) => eprintln!(
+            "code sidecar: WROTE {path} ({} records, {} bytes, artifact κ {artifact_kappa}, \
+             corpus κ {corpus_kappa})",
+            codes.len(),
+            bytes.len()
+        ),
+        Err(error) => {
+            let _ = std::fs::remove_file(&temp);
+            eprintln!("code sidecar: WRITE FAILED {path} ({error})");
+        }
+    }
+}
+
+/// Wasm has no filesystem, so there is no sidecar to consult: the cache
+/// degrades to the caller's own derivation. Keeping the signature here
+/// rather than making every call site cfg-aware preserves the invariant
+/// that this module never derives a code itself and never changes one.
+#[cfg(target_arch = "wasm32")]
+pub fn corpus_codes_cached<F>(_art: &Compiled, _c: &Corpus, compute: F) -> Vec<[u8; STAGES]>
+where
+    F: FnOnce() -> Vec<[u8; STAGES]>,
+{
+    compute()
+}
+
+/// The wasm counterpart of [`build_store_cached`]: no sidecar, so the code
+/// pass and the store build run exactly as they did before this module
+/// existed.
+#[cfg(target_arch = "wasm32")]
+pub fn build_store_cached(
+    art: &Compiled,
+    c: &Corpus,
+    _threads: usize,
+) -> Result<(runtime::Store, Vec<[u8; STAGES]>), String> {
+    Ok(runtime::build_store(art, c))
+}
+
+/// Per-record codes for a whole corpus: served from the sidecar when it
+/// verifies, otherwise produced by `compute` and then written back.
+///
+/// `compute` is the caller's existing derivation, unchanged — this function
+/// never derives a code itself.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn corpus_codes_cached<F>(art: &Compiled, c: &Corpus, compute: F) -> Vec<[u8; STAGES]>
+where
+    F: FnOnce() -> Vec<[u8; STAGES]>,
+{
+    let (artifact_kappa, corpus_kappa) = sidecar_keys(art, c);
+    if let Some(codes) = load_codes(&artifact_kappa, &corpus_kappa, c.n) {
+        return codes;
+    }
+    let codes = compute();
+    save_codes(&artifact_kappa, &corpus_kappa, &codes);
+    codes
+}
+
+/// [`runtime::build_store_with_threads`] with the code pass served from the
+/// sidecar when it verifies. The store is then built through
+/// `runtime::store_from_codes`, the same insertion path, so the store bytes
+/// are identical on both branches.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn build_store_cached(
+    art: &Compiled,
+    c: &Corpus,
+    threads: usize,
+) -> Result<(runtime::Store, Vec<[u8; STAGES]>), String> {
+    let (artifact_kappa, corpus_kappa) = sidecar_keys(art, c);
+    let codes = match load_codes(&artifact_kappa, &corpus_kappa, c.n) {
+        Some(codes) => codes,
+        None => {
+            let codes = runtime::codes_with_threads(art, c, threads)?;
+            save_codes(&artifact_kappa, &corpus_kappa, &codes);
+            codes
+        }
+    };
+    let store = runtime::store_from_codes(c, &codes);
+    Ok((store, codes))
+}

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -282,6 +282,7 @@ mod witnesses {
 
 // Portable items are available on all targets; fs-dependent functions
 // (corpus load/generate, artifact save/load) are cfg-gated per item.
+pub mod code_sidecar;
 pub mod compiler;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod convert_r4g1;

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -1430,13 +1430,24 @@ pub fn add_evidence_multi(
 /// the #244 matrix measured as accuracy-identical at 2.56× fewer keys.
 pub fn build_store(art: &Compiled, c: &Corpus) -> (Store, Vec<[u8; STAGES]>) {
     let rot = derive_rotations();
-    let cut = train_cut(c);
-    let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
     let mut codes: Vec<[u8; STAGES]> = Vec::with_capacity(c.n);
     for i in 0..c.n {
         let b = bundle_plain(art, &rot, c, i);
-        let code = assign_for_bundle(art, &b);
-        codes.push(code);
+        codes.push(assign_for_bundle(art, &b));
+    }
+    let store = store_from_codes(c, &codes);
+    (store, codes)
+}
+
+/// The store-insertion half of [`build_store`], factored out so a caller
+/// that already holds the per-record codes (issue #469 lever A: the
+/// κ-keyed code sidecar) inserts evidence through exactly this path.
+/// Insertion order is ascending record index in both callers, so the
+/// resulting B-tree — and therefore `store_bytes` — is identical.
+pub fn store_from_codes(c: &Corpus, codes: &[[u8; STAGES]]) -> Store {
+    let cut = train_cut(c);
+    let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    for (i, code) in codes.iter().enumerate() {
         if c.story[i] >= cut {
             continue;
         }
@@ -1444,25 +1455,32 @@ pub fn build_store(art: &Compiled, c: &Corpus) -> (Store, Vec<[u8; STAGES]>) {
             let tok = c.top_tokens[i][k_idx];
             let weight = c.top_weights[i][k_idx];
             if weight > 0 {
-                add_evidence(&mut store, &codes[i], tok, weight);
+                add_evidence(&mut store, code, tok, weight);
             }
         }
     }
-    (store, codes)
+    store
 }
 
-/// Parallel code-generation front-end for [`build_store`]. The expensive
-/// bundle/code derivation is independent per corpus position; evidence is
-/// then inserted through the same canonical serial path as `build_store` so
-/// BTreeMap ordering and artifact bytes remain unchanged.
+/// Parallel per-record code derivation — the code half of
+/// [`build_store_with_threads`], factored out so the sidecar
+/// (issue #469 lever A) caches exactly the bytes this returns.
+/// Chunks are joined in chunk-id order, so the result is the serial
+/// `code_plain` sequence regardless of `threads`.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn build_store_with_threads(
+pub fn codes_with_threads(
     art: &Compiled,
     c: &Corpus,
     threads: usize,
-) -> Result<(Store, Vec<[u8; STAGES]>), String> {
+) -> Result<Vec<[u8; STAGES]>, String> {
     if threads <= 1 || c.n < 2 {
-        return Ok(build_store(art, c));
+        let rot = derive_rotations();
+        return Ok((0..c.n)
+            .map(|i| {
+                let bundle = bundle_plain(art, &rot, c, i);
+                assign_for_bundle(art, &bundle)
+            })
+            .collect());
     }
     let worker_count = threads.min(c.n);
     let chunk_size = c.n.div_ceil(worker_count);
@@ -1497,21 +1515,24 @@ pub fn build_store_with_threads(
     for (_, chunk) in chunks {
         codes.extend(chunk);
     }
+    Ok(codes)
+}
 
-    let cut = train_cut(c);
-    let mut store: Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
-    for (i, code) in codes.iter().enumerate() {
-        if c.story[i] >= cut {
-            continue;
-        }
-        for k_idx in 0..c.top_tokens[i].len() {
-            let tok = c.top_tokens[i][k_idx];
-            let weight = c.top_weights[i][k_idx];
-            if weight > 0 {
-                add_evidence(&mut store, code, tok, weight);
-            }
-        }
+/// Parallel code-generation front-end for [`build_store`]. The expensive
+/// bundle/code derivation is independent per corpus position; evidence is
+/// then inserted through the same canonical serial path as `build_store` so
+/// BTreeMap ordering and artifact bytes remain unchanged.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn build_store_with_threads(
+    art: &Compiled,
+    c: &Corpus,
+    threads: usize,
+) -> Result<(Store, Vec<[u8; STAGES]>), String> {
+    if threads <= 1 || c.n < 2 {
+        return Ok(build_store(art, c));
     }
+    let codes = codes_with_threads(art, c, threads)?;
+    let store = store_from_codes(c, &codes);
     Ok((store, codes))
 }
 

--- a/crates/uor-r4-core/tests/code_sidecar.rs
+++ b/crates/uor-r4-core/tests/code_sidecar.rs
@@ -1,0 +1,242 @@
+//! Regression suite for the per-record graded-code sidecar (#469 lever A).
+//!
+//! The sidecar is a cache of an existing deterministic computation. Two
+//! things must therefore be true, and both are asserted here on the fixture
+//! corpus:
+//!
+//! - what comes back is IDENTICAL to what a fresh computation produces, for
+//!   every record — never approximately, never for a prefix;
+//! - anything that is not exactly the right file for exactly this artifact
+//!   and this corpus fails to load, returning `None` so the caller computes
+//!   as before. A wrong-code load must be unreachable, not unlikely.
+//!
+//! Only `sidecar_round_trip_matches_fresh_codes` touches the process
+//! environment (`R4_CODES_PATH`); every rejection case exercises the pure
+//! parser, so the suite is parallel-safe within this test binary.
+
+use uor_r4_core::transformerless::code_sidecar::{
+    self, parse_sidecar, sidecar_bytes, SidecarReject,
+};
+use uor_r4_core::transformerless::compiler::{self, Compiled, Corpus, STAGES};
+use uor_r4_core::transformerless::runtime;
+
+fn fixture(name: &str) -> String {
+    format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Records of the fixture corpus used by the round-trip test. The fixture
+/// is 500k records and one code pass over it is minutes of work; the
+/// property under test (read-back equals fresh computation for EVERY
+/// record) is a per-record identity, so a prefix witnesses it at a cost
+/// that belongs in the default suite. `code_plain` at position `i` reads
+/// only positions at or before `i` within the same story, so a prefix
+/// corpus produces exactly the codes the full corpus produces there.
+const ROUND_TRIP_RECORDS: usize = 12_000;
+
+fn load_corpus() -> Corpus {
+    compiler::load_corpus_from(&fixture("c_meta.bin"), &fixture("c_recs.bin"))
+        .expect("corpus fixtures load")
+}
+
+/// The first `records` positions of the fixture corpus, as a corpus.
+fn prefix_corpus(records: usize) -> Corpus {
+    let mut c = load_corpus();
+    let n = records.min(c.n);
+    c.story.truncate(n);
+    c.input.truncate(n);
+    c.next.truncate(n);
+    c.t_argmax.truncate(n);
+    c.top_tokens.truncate(n);
+    c.top_weights.truncate(n);
+    c.span_start.truncate(n);
+    c.span_end.truncate(n);
+    c.byte_start.truncate(n);
+    c.byte_end.truncate(n);
+    c.hidden = None;
+    c.stories = u64::from(c.story[n - 1]) + 1;
+    c.n = n;
+    c
+}
+
+fn load() -> (Compiled, Corpus) {
+    let artifacts =
+        compiler::load_artifacts_from(&fixture("tless_artifacts.bin")).expect("artifact fixture");
+    (artifacts, prefix_corpus(ROUND_TRIP_RECORDS))
+}
+
+/// Freshly computed codes, straight through the ordinary runtime path.
+fn fresh_codes(art: &Compiled, c: &Corpus) -> Vec<[u8; STAGES]> {
+    let rot = compiler::derive_rotations();
+    (0..c.n)
+        .map(|i| runtime::code_plain(art, &rot, c, i))
+        .collect()
+}
+
+/// THE regression test: a sidecar written from one run and read back in
+/// another yields byte-identical codes for every record, and the store built
+/// from them is byte-identical too.
+#[test]
+fn sidecar_round_trip_matches_fresh_codes() {
+    let (art, corpus) = load();
+    let path = std::env::temp_dir().join(format!("r4-codes-roundtrip-{}.bin", std::process::id()));
+    std::env::set_var(code_sidecar::CODES_PATH_ENV, &path);
+    let _ = std::fs::remove_file(&path);
+
+    let expected = fresh_codes(&art, &corpus);
+    assert_eq!(expected.len(), corpus.n, "fixture corpus is non-empty");
+
+    // Cold: no sidecar exists, so the closure runs and the result is written.
+    let mut computed = 0usize;
+    let cold = code_sidecar::corpus_codes_cached(&art, &corpus, || {
+        computed += 1;
+        runtime::codes_with_threads(&art, &corpus, 2).expect("codes")
+    });
+    assert_eq!(computed, 1, "cold run must compute");
+    assert_eq!(cold, expected, "computed codes match code_plain");
+    assert!(path.exists(), "cold run writes the sidecar");
+
+    // Warm: the sidecar verifies, so the closure must NOT run, and every
+    // record's code must be identical to the fresh computation.
+    let warm = code_sidecar::corpus_codes_cached(&art, &corpus, || {
+        panic!("warm run must not recompute");
+    });
+    assert_eq!(warm.len(), expected.len());
+    for (i, (got, want)) in warm.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got, want, "record {i} code differs after read-back");
+    }
+
+    // The store built from read-back codes is byte-identical to the store
+    // built by the uncached path.
+    let (reference_store, reference_codes) =
+        runtime::build_store_with_threads(&art, &corpus, 2).expect("reference store");
+    assert_eq!(reference_codes, expected);
+    let (cached_store, cached_codes) =
+        code_sidecar::build_store_cached(&art, &corpus, 2).expect("cached store");
+    assert_eq!(cached_codes, expected);
+    assert_eq!(
+        runtime::store_bytes(&cached_store),
+        runtime::store_bytes(&reference_store),
+        "store bytes must not depend on where the codes came from"
+    );
+
+    std::env::remove_var(code_sidecar::CODES_PATH_ENV);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The serialized container is a deterministic function of its inputs.
+#[test]
+fn sidecar_bytes_are_deterministic() {
+    let codes = vec![[1u8, 2, 3, 4], [5, 6, 7, 8]];
+    let a = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    let b = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    assert_eq!(a, b);
+    assert_eq!(&a[0..4], code_sidecar::MAGIC);
+    assert_ne!(a, sidecar_bytes("blake3:other", "blake3:corpus", &codes));
+    assert_ne!(a, sidecar_bytes("blake3:art", "blake3:other", &codes));
+}
+
+fn good_codes() -> Vec<[u8; STAGES]> {
+    (0..64u8).map(|i| [i, i, i, i]).collect()
+}
+
+#[test]
+fn a_mismatched_artifact_kappa_is_rejected() {
+    let codes = good_codes();
+    let bytes = sidecar_bytes("blake3:art-A", "blake3:corpus", &codes);
+    let got = parse_sidecar(&bytes, "blake3:art-B", "blake3:corpus", codes.len());
+    assert!(
+        matches!(got, Err(SidecarReject::ArtifactKappa(_))),
+        "{got:?}"
+    );
+}
+
+#[test]
+fn a_mismatched_corpus_kappa_is_rejected() {
+    let codes = good_codes();
+    let bytes = sidecar_bytes("blake3:art", "blake3:corpus-A", &codes);
+    let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus-B", codes.len());
+    assert!(matches!(got, Err(SidecarReject::CorpusKappa(_))), "{got:?}");
+}
+
+#[test]
+fn a_truncated_container_is_rejected() {
+    let codes = good_codes();
+    let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    for cut in [0usize, 4, 12, 24, 60, bytes.len() - 1] {
+        let got = parse_sidecar(&bytes[..cut], "blake3:art", "blake3:corpus", codes.len());
+        assert!(got.is_err(), "prefix of {cut} bytes must not load");
+    }
+    // Over-long is rejected too: the header must account for every byte.
+    let mut extended = bytes.clone();
+    extended.push(0);
+    let got = parse_sidecar(&extended, "blake3:art", "blake3:corpus", codes.len());
+    assert!(matches!(got, Err(SidecarReject::Truncated)), "{got:?}");
+}
+
+#[test]
+fn a_wrong_stage_count_is_rejected() {
+    let codes = good_codes();
+    let mut bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    let wrong = (STAGES as u32) + 1;
+    bytes[8..12].copy_from_slice(&wrong.to_le_bytes());
+    let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len());
+    assert!(matches!(got, Err(SidecarReject::Stages(_))), "{got:?}");
+}
+
+#[test]
+fn a_wrong_record_count_is_rejected() {
+    let codes = good_codes();
+    let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len() + 1);
+    assert!(matches!(got, Err(SidecarReject::RecordCount(_))), "{got:?}");
+}
+
+#[test]
+fn a_wrong_magic_or_version_is_rejected() {
+    let codes = good_codes();
+    let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    let mut foreign = bytes.clone();
+    foreign[0..4].copy_from_slice(b"TLA7");
+    assert!(matches!(
+        parse_sidecar(&foreign, "blake3:art", "blake3:corpus", codes.len()),
+        Err(SidecarReject::Magic)
+    ));
+    let mut future = bytes;
+    future[4..8].copy_from_slice(&(code_sidecar::VERSION + 1).to_le_bytes());
+    assert!(matches!(
+        parse_sidecar(&future, "blake3:art", "blake3:corpus", codes.len()),
+        Err(SidecarReject::Version(_))
+    ));
+}
+
+#[test]
+fn a_corrupted_code_block_is_rejected() {
+    let codes = good_codes();
+    let mut bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0xff;
+    let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len());
+    assert!(matches!(got, Err(SidecarReject::Digest)), "{got:?}");
+}
+
+/// The corpus key changes when the corpus content changes, so a sidecar
+/// written for one corpus can never be served for another.
+#[test]
+fn corpus_content_kappa_separates_corpora() {
+    let (art, corpus) = load();
+    let base = code_sidecar::corpus_content_kappa(&corpus);
+    assert_eq!(base, code_sidecar::corpus_content_kappa(&corpus));
+
+    let mut mutated = prefix_corpus(ROUND_TRIP_RECORDS);
+    mutated.input[0] ^= 1;
+    assert_ne!(base, code_sidecar::corpus_content_kappa(&mutated));
+
+    // And the artifact key round-trips through the container bytes, so a
+    // loaded artifact addresses the same sidecar the writer addressed.
+    let bytes = compiler::artifact_bytes(&art);
+    let reparsed = compiler::parse_artifacts(&bytes).expect("artifact round-trip");
+    assert_eq!(
+        compiler::artifact_kappa(&art),
+        compiler::artifact_kappa(&reparsed)
+    );
+}

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -172,6 +172,7 @@ use super::score_runtime::{
     ScoreStatus, ScoringVariant, StructuralEdge, EDGE_KIND_FORWARD, EDGE_KIND_NEIGHBOR,
     EDGE_KIND_REFINEMENT, EXCT_SUPPORT_MIN, RESIDUAL_EXCT_MAGIC,
 };
+use uor_r4_core::transformerless::code_sidecar;
 use uor_r4_core::transformerless::compiler::{self, Corpus, SIG_BYTES, SIG_WORDS, STAGES};
 use uor_r4_core::transformerless::runtime::{self, Store};
 use uor_r4_graph_compiler::induction::{self as cover, Observation};
@@ -3350,10 +3351,18 @@ pub fn evaluate_gate_c(
     // target, so this is an infill/analysis (A-mode) measurement or a
     // prospective construction-time signal, never a generation number.
     let right_codes = derive_right_codes(artifacts, &gate_rotations, corpus);
-    let left_codes: Vec<[u8; STAGES]> = (0..corpus.n)
-        .into_par_iter()
-        .map(|position| runtime::code_plain(artifacts, &gate_rotations, corpus, position))
-        .collect();
+    // #469 lever A: the left (causal) code of every record is the same
+    // `code_plain` pass every other consumer runs. Serve it from the
+    // κ-keyed sidecar when one verifies against BOTH the artifact κ and the
+    // corpus κ; otherwise run exactly the derivation below and write it
+    // back. Cache only — the codes are unchanged either way.
+    let left_codes: Vec<[u8; STAGES]> =
+        code_sidecar::corpus_codes_cached(artifacts, corpus, || {
+            (0..corpus.n)
+                .into_par_iter()
+                .map(|position| runtime::code_plain(artifacts, &gate_rotations, corpus, position))
+                .collect()
+        });
     let two_sided = TwoSidedTable::build(corpus, &is_held_out, &left_codes, &right_codes);
     // #446 M2: the latent right-context mixture tables, built from the
     // same construction split. CAUSALLY LEGITIMATE at serving: the right
@@ -4386,12 +4395,19 @@ fn evaluate_gate_c_row(
     } else {
         &[]
     };
-    let code = runtime::code_plain(
-        context.artifacts,
-        context.gate_rotations,
-        context.corpus,
-        position,
-    );
+    // #469 lever A: `left_codes[position]` IS `code_plain` at this
+    // position — the same whole-corpus pass, already materialized (and now
+    // sidecar-served) by the caller. Read it instead of recomputing; the
+    // fallback keeps the old derivation for an out-of-range position.
+    let code = match context.left_codes.get(position) {
+        Some(code) => *code,
+        None => runtime::code_plain(
+            context.artifacts,
+            context.gate_rotations,
+            context.corpus,
+            position,
+        ),
+    };
 
     let legacy = context
         .scorer_with_exct

--- a/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
+++ b/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
@@ -57,7 +57,7 @@
 //! - [`ROW_TRUNCATION_FRACTION_MAX`] — share of FWDA / NGRAM rows clipped by
 //!   their entry cap. Above it, the cap (not the evidence) sets the row width.
 //!
-//! # Cost, sampling, and what is EXACT versus ESTIMATED (#467)
+//! # Cost, sampling, the code sidecar, and what is EXACT versus ESTIMATED (#467, #469)
 //!
 //! The 2.11M-record run of this instrument cost about twelve minutes, and
 //! 585 of those 713 seconds were one thing: the per-record graded-code
@@ -67,7 +67,7 @@
 //! noise, so this section says exactly what was done to it and what the
 //! result is allowed to claim.
 //!
-//! Three stacking changes, none of which move a reported number:
+//! Four stacking changes, none of which move a reported number:
 //!
 //! - The code pass runs under rayon over corpus positions (mirroring
 //!   `evaluate_gate_c`), and its reduction is an ordered `collect`, so the
@@ -82,9 +82,14 @@
 //!   recovered exactly from the sorted construction-split code vector,
 //!   which costs one parallel sort instead of roughly five hundred
 //!   `BTreeMap` insertions per record.
+//! - The code pass itself is served from the κ-keyed per-record code
+//!   sidecar (#469 lever A, `code_sidecar`), so a corpus whose codes have
+//!   already been assigned once — by this instrument or by any other
+//!   consumer of the transformerless pipeline — pays nothing for them
+//!   again. See "The code sidecar" below.
 //!
-//! Measured on the 2.11M corpus, those three changes plus the held-out
-//! sample take the run from 713s to 613s. The residual is almost entirely
+//! Measured on the 2.11M corpus, those three in-instrument changes plus the
+//! held-out sample take the run from 713s to 613s. The residual is almost entirely
 //! the exact construction-split code pass: 468s to assign 1,707,309
 //! records, which is 4 stages x 256 classes x 288 dimensions of branchy
 //! shift-add per record, about 5e11 term applications, already saturating
@@ -164,6 +169,65 @@
 //!   supported-record fraction, and only that. It is reported with its
 //!   sample size and standard error, and the log labels it ESTIMATE.
 //!
+//! # The code sidecar (#469 lever A), and how it composes with sampling
+//!
+//! The sidecar is a CACHE, not a statistic and not an estimator. It is a
+//! κ-keyed file (`R4_CODES_PATH`, default `/tmp/tless_codes.bin`) holding
+//! the per-record graded code of every corpus record, keyed by artifact κ
+//! and by a content κ of the corpus. A load succeeds only when both κs, the
+//! record count, the stage count, the container length and a blake3 digest
+//! of the code block all agree; anything else is a MISS and the codes are
+//! computed exactly as before. There is no third outcome, so the sidecar
+//! cannot change a reported number — it can only decide whether the code
+//! pass is paid for again. Every run prints one provenance line, `LOADED`,
+//! `MISS` or `WROTE`, naming the path and both κs.
+//!
+//! It exists because the code pass is a CENSUS quantity that this
+//! instrument cannot legitimately shrink. The section above establishes
+//! that: occupied keys, records per key and the occupancy histogram are all
+//! functions of the complete construction-split key set, so the honest way
+//! to make the pass cheap is not to sample it but to stop repeating it.
+//!
+//! The two mechanisms therefore act on different axes and do not interact:
+//!
+//! - The sidecar decides HOW THE CODES ARE OBTAINED — recomputed, or read
+//!   back from a verified cache of the identical computation. It covers the
+//!   whole corpus, so it serves the construction split and the held-out
+//!   records alike.
+//! - `R4_CAPACITY_SAMPLE` decides HOW MANY HELD-OUT RECORDS ARE SCORED
+//!   against the construction key set, and only that. It is a sample of
+//!   records to look up, never a sample of records the key set is built
+//!   from, so it cannot bypass or shrink the sidecar's census: switching
+//!   sampling on and off changes the reported sample size and standard
+//!   error of one rate, and changes nothing about the codes or the cache.
+//!
+//! The one mode where they would collide is `R4_CAPACITY_TRAIN_SAMPLE`, the
+//! opt-in biased fast look, whose code pass deliberately covers only a
+//! subsample of the construction split. A sidecar written from that pass
+//! would be a partial code vector sitting at the default path, and every
+//! later run — this instrument, the store build, any scoring harness —
+//! would be measuring a corpus fragment while believing it had a census.
+//! That is silent corruption of future measurements, which is worse than
+//! any speedup is worth, so the biased mode does not touch the sidecar in
+//! EITHER direction:
+//!
+//! - It never WRITES one, because a partial pass is not the artifact the
+//!   container claims to be.
+//! - It never READS one either. A read would be sound in isolation, but it
+//!   would make the mode's output depend on whether a cache happened to
+//!   exist — a run with a hit would quietly become a census and would not
+//!   reproduce the bias figures quoted above, which were measured with no
+//!   cache present. A diagnostic whose numbers depend on cache state is not
+//!   a diagnostic.
+//!
+//! This is enforced structurally rather than by convention: the only call
+//! into `code_sidecar` is `census_codes`, which builds its own positions
+//! from `0..corpus.n` — a sample cannot be passed to it — and asserts that
+//! the vector it returns is `corpus.n` long. `report_code_and_exct` calls
+//! it only on the census branch, and the biased branch assigns its own
+//! subsample codes locally and drops them. The run says which branch it
+//! took on the construction-split code-pass line.
+//!
 //! # Running
 //!
 //! On the 500k reference corpus:
@@ -185,13 +249,16 @@
 //! (held-out records drawn for the sampled resolution rate, default
 //! 100,000, `0` = census over the whole held-out split),
 //! `R4_CAPACITY_TRAIN_SAMPLE` (construction records drawn for the code
-//! pass, default `0` = census; nonzero is the biased fast look).
+//! pass, default `0` = census; nonzero is the biased fast look, which also
+//! disables the sidecar in both directions), `R4_CODES_PATH` (per-record
+//! code sidecar, issue #469 lever A; defaults to `/tmp/tless_codes.bin`).
 
 use std::collections::BTreeMap;
 use std::time::Instant;
 
 use rayon::prelude::*;
 
+use uor_r4_core::transformerless::code_sidecar;
 use uor_r4_core::transformerless::compiler::{self, Corpus, K, STAGES};
 use uor_r4_core::transformerless::runtime;
 use uor_r4_graph_certify::score::{
@@ -476,6 +543,32 @@ fn assign_codes(
         .collect()
 }
 
+/// Whole-corpus per-record codes, served from the κ-keyed sidecar when one
+/// verifies and written back when it does not (#469 lever A). The codes are
+/// identical either way: the sidecar caches an existing deterministic
+/// computation and rejects anything it cannot prove is that computation.
+///
+/// This is a separate function because it carries the sidecar's safety
+/// property. The sidecar is a WHOLE-CORPUS artifact — its header stores the
+/// record count and a digest over exactly that many codes — so the only
+/// vector allowed to reach it is the census over `0..corpus.n`. Those
+/// positions are built here, from the corpus alone; no sample of any kind
+/// can cross this boundary, and the assertion below fails loudly rather than
+/// letting a short vector be written. Callers running the biased
+/// `R4_CAPACITY_TRAIN_SAMPLE` mode must not call this at all.
+fn census_codes(corpus: &Corpus, artifacts: &compiler::Compiled) -> Vec<[u8; STAGES]> {
+    let codes = code_sidecar::corpus_codes_cached(artifacts, corpus, || {
+        let all: Vec<usize> = (0..corpus.n).collect();
+        assign_codes(artifacts, corpus, &all)
+    });
+    assert_eq!(
+        codes.len(),
+        corpus.n,
+        "the code sidecar must serve a whole-corpus census"
+    );
+    codes
+}
+
 /// One occupied full-code key of the construction split: the number of
 /// construction records that landed on it and the teacher weight those
 /// records carry. Recovered exactly from the sorted code vector, which is
@@ -548,12 +641,35 @@ fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled) {
         "exact"
     };
 
+    // #469 lever A composed with the #467 sampling above. The sidecar is a
+    // WHOLE-CORPUS κ-keyed cache of exactly this pass, so it is consulted
+    // precisely where the pass is a census — the default mode — and there it
+    // serves the construction split AND the held-out records the sampled
+    // rate scores, so sampling never bypasses it. In the biased
+    // `R4_CAPACITY_TRAIN_SAMPLE` mode the pass covers a subsample, there is
+    // no census vector to cache, and the sidecar is skipped in BOTH
+    // directions: writing a partial pass would poison every later run, and
+    // reading one would silently turn the mode into the census it exists to
+    // be measured against. See the module docs.
     let started = Instant::now();
-    let train_codes = assign_codes(artifacts, corpus, &train_sample);
+    let corpus_codes = if train_sampled {
+        None
+    } else {
+        Some(census_codes(corpus, artifacts))
+    };
+    let train_codes: Vec<[u8; STAGES]> = match &corpus_codes {
+        Some(codes) => train_sample.iter().map(|&i| codes[i]).collect(),
+        None => assign_codes(artifacts, corpus, &train_sample),
+    };
     println!(
-        "  construction-split code pass: {} record(s) in {:.1}s ({label}, rayon)",
+        "  construction-split code pass: {} record(s) in {:.1}s ({label}, rayon, {})",
         train_codes.len(),
-        started.elapsed().as_secs_f64()
+        started.elapsed().as_secs_f64(),
+        if corpus_codes.is_some() {
+            "code sidecar consulted"
+        } else {
+            "code sidecar SKIPPED: biased mode neither reads nor writes it"
+        }
     );
     let started = Instant::now();
     let coded: Vec<([u8; STAGES], u64)> = train_codes
@@ -690,12 +806,22 @@ fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled) {
     // This is the instrument's one SAMPLED statistic. It is the mean of a
     // per-record indicator, so a stride subsample of the held-out list
     // estimates it without bias; the key set the indicator probes is the
-    // exact one built above, which is what keeps that true.
+    // `keys` built above, which is the census key set in every mode but the
+    // biased one, and that is what keeps the estimate unbiased. Sampling
+    // never reaches the construction split, and the sample drawn here is a
+    // sample of RECORDS TO SCORE — it selects which codes are looked up in
+    // the key set, never which records the key set was built from.
     let requested = env_usize(CAPACITY_SAMPLE_ENV, CAPACITY_SAMPLE_DEFAULT);
     let held_sample = stride_sample(&held_positions, requested);
     let sampled = held_sample.len() < held_positions.len();
     let started = Instant::now();
-    let held_codes = assign_codes(artifacts, corpus, &held_sample);
+    // Served from the same whole-corpus sidecar vector when there is one, so
+    // no held-out code is ever assigned twice and the sidecar is not
+    // bypassed by having sampling switched on.
+    let held_codes: Vec<[u8; STAGES]> = match &corpus_codes {
+        Some(codes) => held_sample.iter().map(|&i| codes[i]).collect(),
+        None => assign_codes(artifacts, corpus, &held_sample),
+    };
     let held_total = held_codes.len() as u64;
     let held_resolved = held_codes
         .par_iter()
@@ -708,13 +834,18 @@ fn report_code_and_exct(corpus: &Corpus, artifacts: &compiler::Compiled) {
     let supported_fraction = ratio(held_resolved, held_total);
     let error = standard_error(supported_fraction, held_total);
     println!(
-        "  held-out records: {} total in the split; {held_total} scored in {:.1}s ({})",
+        "  held-out records: {} total in the split; {held_total} scored in {:.1}s ({}, {})",
         held_positions.len(),
         started.elapsed().as_secs_f64(),
         if sampled {
             format!("SAMPLED, {CAPACITY_SAMPLE_ENV}={requested}")
         } else {
             "census".to_owned()
+        },
+        if corpus_codes.is_some() {
+            "codes from the sidecar pass"
+        } else {
+            "codes assigned here, sidecar skipped"
         }
     );
     println!(

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -26,7 +26,7 @@
 //! table + next-token oracle); this crate ships the llama-family adapter,
 //! and qwen/phi-class sources differ only in that adapter.
 
-use uor_r4_core::transformerless::{compiler, runtime};
+use uor_r4_core::transformerless::{code_sidecar, compiler, runtime};
 use uor_r4_graph_certify as score;
 use uor_r4_graph_certify as score_runtime;
 use uor_r4_graph_compiler::induction as cover;
@@ -1131,7 +1131,10 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     let max_depth = regions.iter().map(|r| r.depth as usize).max().unwrap_or(1);
 
     eprintln!("score: building graded store [========================] 100%");
-    let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads)?;
+    // #469 lever A: per-record codes come from the κ-keyed sidecar when one
+    // verifies against this artifact κ and corpus κ, and are written back
+    // when it does not. Store bytes are identical on both branches.
+    let (store, _) = code_sidecar::build_store_cached(&artifacts, &corpus, threads)?;
     let tls1 = runtime::store_bytes(&store);
 
     eprintln!("score: compiling forward transitions [========================] 100%");


### PR DESCRIPTION
References #469 (lever A only; lever B — vectorizing `assign_for_bundle` — is κ-pinned and stays on its own branch behind a bit-identity proof).

**Measured on the 2.11M corpus:** instrument **624.9s → 38.9s (16.1×)**; the graded-code store section **604.7s → 19.6s (30.9×)**. Sidecar is 8,440,642 bytes for 2,110,111 records. The cold run writes it — the win is on every subsequent consumer, which is exactly our access pattern (one compile, many measurements).

**κ-neutral by construction, and demonstrated:** this caches an existing deterministic computation and never redefines it. `assign_for_bundle` and `code_plain` are byte-for-byte untouched. The two runs' report output is identical line for line apart from provenance and timing lines (`diff` clean) — on the real 2.11M corpus, not just the fixture.

**Safety is the point, not the speed.** A sidecar loads only if magic, version, stages, record count, artifact κ, corpus κ, exact file length, and a blake3 over the code block ALL match; anything else returns `None` and the caller computes as today. Writes are temp-file + rename so a partial container is never visible. The path taken is logged with both κs per the #450 precedent (`code sidecar: LOADED|MISS|WROTE …`). Corpus key is a content κ over the corpus columns — strictly broader than what the code derivation reads, so any doubt resolves as a MISS.

**Consumers wired:** the whole-corpus code pass in `evaluate_gate_c`, its per-row `code_plain` (served from the already-materialized index), the `capacity_scaling` instrument, and the graph-cli score command's store build — so a score run now pays the code pass zero times. Not wired: `derive_right_codes` (#446's right-context codes are a different quantity needing their own key).

**Tests (10, non-ignored):** read-back equals fresh `code_plain` for every record and cached `store_bytes` equals uncached; plus rejection tests for mismatched artifact κ, mismatched corpus κ, truncation, wrong stage count, wrong record count, bad magic/version, and a corrupted code block — each must fall back cleanly, never load a wrong code.

Placed in its own module (`code_sidecar.rs`) rather than inside `runtime.rs`, partly because `runtime.rs` is machine-scanned by the P-4 forbidden-arithmetic witness, and partly so the "no code is computed here" claim is inspectable in one file.