### PR TITLE
test(core): #460 lever 2 — codebook fit measured; records-per-key is a symptom, not the binding quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,18 @@ strongest possible form. Raising STAGES from 4 to 5 bought exactly the
 subdivision the hypothesis asked for — occupied full-code keys 47,403 to
 90,824, records per key 36.02 to 18.80, clearing the instrument gate — and
 Rule 1+2 top-1 came in at 25.6% ± 0.44pp against a 26.5% baseline, *below* it.
-The store baseline fell alongside (26.4 to 25.4), which is the signature of
-thinner per-key evidence rather than sharper context. Exact-context dominance
+The store baseline fell alongside (26.4 to 25.4). Exact-context dominance
 barely responded (98.8% to 97.1%).
+
+That fall was originally read as thinner per-key evidence, full stop. The
+codebook-fit measurement narrows it: raising the codebook's training set also
+lowers records-per-key (5.04 to 4.68) and top-1 *rises* (+0.44pp,
+`docs/codebook_fit_460.md`). So records-per-key is a **symptom, not the
+binding quantity** — thinning is harmful when it comes from added key
+*resolution*, which splits evidence that belonged together, and harmless or
+better when it comes from improved *fit*, which moves evidence onto the key
+that represents it. The subdivision negative stands; only its causal reading
+narrows, to resolution specifically.
 
 **Construction-time stratification (#435).** Three routing designs plus an
 identity argument, all against pre-declared rules; v3 mass-linear mixing
@@ -142,17 +151,27 @@ CD term executed 0 times out of 1,998 before removal.
 
 ### The pattern these results draw
 
-Every lever that added *key resolution* failed — a better-fitted codebook, more
-cover regions, a finer code space. The only two changes that helped improved
-*evidence quality per key*. That is the clearest signal the programme has, and
-it is why the open work below concentrates on evidence and estimation rather
-than on subdivision.
+Every lever that added *key resolution* failed — more cover regions, a finer
+code space, more stages. The changes that helped improved *evidence quality per
+key*. That is the clearest signal the programme has, and it is why the open
+work below concentrates on evidence and estimation rather than on subdivision.
+
+An earlier statement of this pattern listed "a better-fitted codebook" among
+the failures. That was a misclassification on both counts: codebook fit is not
+a key-resolution lever — it changes which key evidence lands on, at fixed `K`,
+fixed `STAGES` and a fixed nominal key space — and when finally measured in
+isolation it came out **positive**, at +0.44pp (#460 lever 2,
+`docs/codebook_fit_460.md`). It is a small lever, but it is on the side the
+pattern predicts, and it is the first confirmation of that pattern on something
+that touches the graded code itself rather than storage or calibration. The
+distinction to carry forward is *which key evidence lands on* (fit — helps)
+versus *how many keys there are* (resolution — has never helped).
 
 ### Open, with defined work
 
 | Issue | Question | State |
 |---|---|---|
-| #460 | Cover split criterion and codebook fit | Two implemented-but-dark levers: `SplitCriterion::{RelativeGain,Mdl}` with scaled k0 (default-off, harness `cover_scaling.rs` unrun) and `RVQ_SAMPLE_CAP` capping codebook training at 0.59% of the split |
+| #460 | Cover split criterion and codebook fit | Codebook fit measured (`docs/codebook_fit_460.md`): raising the k-means training set is worth **+0.44pp** and saturates near `N/10`; below the +1.0pp exit rule, κ-affecting, so it belongs in the next re-pin rather than triggering one. It also showed records-per-key is a *symptom*, not the binding quantity — it fell here while top-1 rose. Still dark: `SplitCriterion::{RelativeGain,Mdl}` with scaled k0 (`cover_scaling.rs` unrun) |
 | #424 | Bott-Fock O(1) context fold | Ceiling measured, A/B not reachable. Long-range signal on this corpus is worth +1.02pp of top-1 (two thirds of it order-carried); the shipped decay constant `>> 2` retains 16% of that, so the lossless upper bound on the fold as shipped is +0.16pp — one standard error. Retuning the decay to `>> 7` would recover the ceiling. `docs/context_horizon_424.md` |
 | #434 | VSA / spectral geometry | Item 1 (zeta-grid at scale) done and shipped; item 2 never measured beyond a synthetic smoke test |
 | #469 | Vectorize the assign path | Done. Lever A (κ-keyed code sidecar) 625s → 39s; lever B routes the corpus code passes through the existing `simd::dot_argmax` using tables decoded once per artifact — **1.60x** on the pinned TLA7 artifact. Bit-identity is proven, not argued: `tests/assign_prepared.rs` checks prepared == scalar over 1,024 real corpus positions on the committed artifact fixture, and the κ witness carries it on a fresh compile. Per-call decoding would have been a ~4x regression, which is why the batch API exists |

--- a/crates/uor-r4-core/tests/codebook_fit.rs
+++ b/crates/uor-r4-core/tests/codebook_fit.rs
@@ -1,0 +1,399 @@
+//! Codebook training-set size vs graded-code quality (issue #460 lever 2).
+//!
+//! ## Front
+//!
+//! `RVQ_SAMPLE_CAP = 10_000` (`compiler.rs`) hard-caps the context codebook's
+//! k-means training set at 10,000 vectors **independent of corpus size**.
+//! `sampled_kmeans_rvq` subsamples its input to that cap and the caller
+//! discards the full-set codes, so at the 500k fixture corpus the codebook
+//! that produces every graded class code is fit on 2.5% of the construction
+//! split — 39 vectors per centroid, per stage.
+//!
+//! Two facts make this worth a measurement rather than an assumption.
+//!
+//! First, `docs/capacity_scaling_432.md` §3.1 argues that issue #407's
+//! `CTX_SAMPLE` 6,000 → 50,000 raise "did not change the codebook's
+//! training-set size at all", so the +0.5–0.7pp #407 attributed to sample
+//! starvation was never delivered. **That claim is one step too strong, and
+//! the arithmetic matters here.** The training set is
+//! `min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`. At `CTX_SAMPLE = 6_000` the 10,000 cap
+//! does not bind, so #407's raise moved the training set 6,000 → 10,000 — a
+//! real increase, just a small one. What cannot help is raising the pool
+//! *above* the cap, which is every configuration since. Sweep A below tests
+//! exactly that regime.
+//!
+//! Second, §6 records `code.codebook_sample_fraction` as already SATURATED at
+//! 500k, meaning the measurements the rest of the programme is calibrated
+//! against were themselves taken on an under-fit codebook. How much that
+//! costs has never been measured, and it bounds how much any recalibration
+//! could recover.
+//!
+//! ## Arms
+//!
+//! The k-means training set is `min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`, so the two
+//! knobs have to be swept together to say anything. Two sweeps:
+//!
+//! **Sweep A — does `CTX_SAMPLE` alone do anything?** `RVQ_SAMPLE_CAP` pinned
+//! at the shipped 10,000 while `CTX_SAMPLE` ∈ {10k, 50k, 200k}. This is the
+//! direct adjudication of §3.1's claim, and of #407's attribution: #407 raised
+//! `CTX_SAMPLE` 6k → 50k and credited +0.5–0.7pp to sample starvation, while
+//! §3.1 argues that raise could not have reached the codebook at all. One of
+//! those is wrong and this sweep says which. Prediction under §3.1: flat.
+//!
+//! **Sweep B — does the training set itself matter?** `CTX_SAMPLE` and
+//! `RVQ_SAMPLE_CAP` moved together ∈ {10k, 50k, 200k}, so the training set is
+//! genuinely 10k / 50k / 200k vectors.
+//!
+//! Every arm is a full teacher-free `compile_recorded` of the pinned fixture
+//! corpus followed by a construction-only store build and a held-out top-1
+//! read. Same corpus, same split, same `K`, same `STAGES`, same nominal key
+//! space, same cover throughout — only the codebook moves.
+//!
+//! The shipped configuration (`CTX_SAMPLE = 50_000`, `RVQ_SAMPLE_CAP =
+//! 10_000`) is one of the sweep-A arms, so the baseline every delta is quoted
+//! against is the deployed one rather than a nearby stand-in.
+//!
+//! ## Metric
+//!
+//! Held-out store top-1: the fraction of held-out records whose
+//! `predict_witness_plain` token equals the recorded next token. This is the
+//! "store baseline" row #460 reported moving 26.4 → 25.4 under STAGES=5, so
+//! the two experiments are directly comparable.
+//!
+//! ## Validity gate (hard)
+//!
+//! Every arm must produce its own codebook κ. Two arms sharing a codebook
+//! would mean a knob is not reaching `sampled_kmeans_rvq`, and the comparison
+//! between them would be vacuous rather than null — the failure mode that
+//! made #407's attribution wrong in the first place.
+//!
+//! ## Exit rule (pre-declared)
+//!
+//! Positive if held-out top-1 at the largest training set exceeds the SHIPPED
+//! configuration by ≥ 1.0pp.
+//!
+//! Deltas are compared against the standard error of the *difference*, not of
+//! a single arm. The arms share the held-out set, so the independent-sample
+//! form used here overstates the error; it is the conservative choice.
+//!
+//! ## Why this is not a re-run of the STAGES=5 negative
+//!
+//! Both mechanisms are expected to lower records-per-key, for opposite
+//! reasons. STAGES=5 lowered it by adding key *resolution*, and top-1 fell —
+//! read as thinner evidence per key. A better-fit codebook lowers it by
+//! putting evidence on the *right* key. So occupancy-up-and-top-1-up
+//! separates fit from resolution and confirms the evidence-quality thesis on
+//! an independent lever; occupancy-up-and-top-1-down means records-per-key is
+//! the binding quantity whatever the cause, which is a stronger and more
+//! general negative than #460's and would mean the STAGES=5 result was never
+//! about subdivision specifically.
+//!
+//! ## Cost and κ
+//!
+//! Five recorded compiles plus five store builds on 500k records, about 30
+//! minutes on two cores; no teacher, no Gate C, no checkpoint. Adopting a
+//! different cap is κ-affecting and would need the #407 re-pin ceremony —
+//! this harness only measures, and writes nothing.
+
+use std::collections::BTreeSet;
+
+use uor_r4_core::transformerless::{compiler, runtime};
+
+/// `(ctx_sample, rvq_cap, label)`. The k-means training set is the min of the
+/// two. Sweep A pins the cap and moves the pool; sweep B moves both.
+const ARMS: [(usize, usize, &str); 5] = [
+    (10_000, 10_000, "A: pool 10k, cap 10k"),
+    (50_000, 10_000, "A: pool 50k, cap 10k  <- SHIPPED"),
+    (200_000, 10_000, "A: pool 200k, cap 10k"),
+    (50_000, 50_000, "B: pool 50k, cap 50k"),
+    (200_000, 200_000, "B: pool 200k, cap 200k"),
+];
+/// Index of the shipped configuration in `ARMS` — the baseline for deltas.
+const SHIPPED: usize = 1;
+/// Pre-declared: positive if the largest training set beats shipped by this.
+const EXIT_RULE_PP: f64 = 1.0;
+
+fn fixture(name: &str) -> String {
+    format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+struct Arm {
+    label: &'static str,
+    ctx_sample: usize,
+    cap: usize,
+    training_set: usize,
+    occupied_keys: usize,
+    records_per_key: f64,
+    top1: f64,
+    standard_error: f64,
+    held_out: usize,
+    codebook_kappa: String,
+}
+
+/// One arm: compile at `(ctx_sample, cap)`, build the construction-only
+/// store, read held-out top-1.
+fn run_arm(
+    corpus: &compiler::Corpus,
+    vocab: usize,
+    (ctx_sample, cap, label): (usize, usize, &'static str),
+) -> Arm {
+    // Both knobs are read through `capacity_override_usize`, so these env
+    // vars are the only thing that differs between arms.
+    std::env::set_var("R4_CTX_SAMPLE", ctx_sample.to_string());
+    std::env::set_var("R4_RVQ_SAMPLE_CAP", cap.to_string());
+
+    let art = compiler::compile_recorded(corpus, vocab).expect("recorded compile");
+    let (store, codes) = runtime::build_store(&art, corpus);
+
+    // Occupancy over the CONSTRUCTION split only: held-out records do not
+    // contribute evidence, so counting their codes would inflate occupancy
+    // without any store consequence.
+    let cut = compiler::train_cut(corpus);
+    let mut distinct = BTreeSet::new();
+    let mut construction = 0usize;
+    for (i, code) in codes.iter().enumerate() {
+        if corpus.story[i] >= cut {
+            continue;
+        }
+        construction += 1;
+        distinct.insert(*code);
+    }
+
+    let mut correct = 0usize;
+    let mut held_out = 0usize;
+    for (i, code) in codes.iter().enumerate() {
+        if corpus.story[i] < cut {
+            continue;
+        }
+        held_out += 1;
+        if runtime::predict_witness_plain(&store, code).token == corpus.next[i] {
+            correct += 1;
+        }
+    }
+
+    let top1 = correct as f64 / held_out as f64 * 100.0;
+    Arm {
+        label,
+        ctx_sample,
+        cap,
+        training_set: ctx_sample.min(cap),
+        occupied_keys: distinct.len(),
+        records_per_key: construction as f64 / distinct.len() as f64,
+        top1,
+        standard_error: (top1 / 100.0 * (1.0 - top1 / 100.0) / held_out as f64).sqrt() * 100.0,
+        held_out,
+        // The codebook κ distinguishes arms: if two caps produce the same
+        // codebook the comparison between them is vacuous.
+        codebook_kappa: codebook_kappa(&art),
+    }
+}
+
+/// Content digest of the artifact's context codebooks — the quantity the arms
+/// are supposed to be changing.
+fn codebook_kappa(art: &compiler::Compiled) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for stage in &art.dot_cb {
+        for entry in stage {
+            hasher.update(&entry.to_le_bytes());
+        }
+    }
+    hasher.finalize().to_hex()[..16].to_owned()
+}
+
+#[test]
+#[ignore = "measurement harness (issue #460 lever 2); run explicitly with --ignored"]
+fn codebook_fit_sweep() {
+    let meta = std::env::var("R4_CORPUS_META").unwrap_or_else(|_| fixture("c_meta.bin"));
+    let recs = std::env::var("R4_CORPUS_RECS").unwrap_or_else(|_| fixture("c_recs.bin"));
+    let Some(corpus) = compiler::load_corpus_from(&meta, &recs) else {
+        println!("SKIP: corpus fixtures absent ({meta} + {recs}); vacuous green");
+        return;
+    };
+    let vocab = corpus
+        .next
+        .iter()
+        .chain(corpus.top_tokens.iter().flatten())
+        .copied()
+        .max()
+        .unwrap_or(0) as usize
+        + 1;
+    let cut = compiler::train_cut(&corpus);
+    let construction = corpus.story.iter().filter(|&&s| s < cut).count();
+    println!(
+        "codebook fit sweep (#460 lever 2): {} records, {} stories, \
+         cut at story {cut} => {construction} construction / {} held out; vocab {vocab}",
+        corpus.n,
+        corpus.stories,
+        corpus.n - construction
+    );
+    println!("K = {}, STAGES = {}", compiler::K, compiler::STAGES);
+
+    let mut arms = Vec::new();
+    for spec in ARMS {
+        let training = spec.0.min(spec.1);
+        println!(
+            "\n-- {} : training set {training} ({:.2}% of the construction split, \
+             {:.0} vectors per centroid per stage) --",
+            spec.2,
+            training as f64 / construction as f64 * 100.0,
+            training as f64 / compiler::K as f64
+        );
+        let arm = run_arm(&corpus, vocab, spec);
+        println!(
+            "   codebook κ {}  occupied keys {}  records/key {:.2}  \
+             held-out top-1 {:.2}% ± {:.2}pp (n={})",
+            arm.codebook_kappa,
+            arm.occupied_keys,
+            arm.records_per_key,
+            arm.top1,
+            arm.standard_error,
+            arm.held_out
+        );
+        arms.push(arm);
+    }
+
+    let shipped = &arms[SHIPPED];
+    println!("\n==== summary (deltas vs the SHIPPED configuration) ====");
+    println!("arm\t\t\t\tpool\tcap\ttrain\tocc.keys\trec/key\ttop-1\t±\tvs shipped");
+    for arm in &arms {
+        println!(
+            "{:<30}\t{}\t{}\t{}\t{}\t\t{:.2}\t{:.2}%\t{:.2}\t{:+.2}pp",
+            arm.label,
+            arm.ctx_sample,
+            arm.cap,
+            arm.training_set,
+            arm.occupied_keys,
+            arm.records_per_key,
+            arm.top1,
+            arm.standard_error,
+            arm.top1 - shipped.top1
+        );
+    }
+
+    // --- validity: the arms must actually be different compiles ---
+    let distinct: BTreeSet<&str> = arms.iter().map(|a| a.codebook_kappa.as_str()).collect();
+    println!("\n==== validity ====");
+    println!(
+        "distinct codebooks across {} arms: {} {}",
+        arms.len(),
+        distinct.len(),
+        if distinct.len() == arms.len() {
+            "PASS"
+        } else {
+            "VOID — arms share a codebook, so some comparison measures nothing"
+        }
+    );
+    assert_eq!(
+        distinct.len(),
+        arms.len(),
+        "each arm must produce its own codebook; if two coincide the knobs are \
+         not reaching `sampled_kmeans_rvq` and those numbers are void"
+    );
+
+    // --- sweep A: does CTX_SAMPLE alone do anything? (§3.1 / #407) ---
+    let sweep_a: Vec<&Arm> = arms.iter().filter(|a| a.cap == 10_000).collect();
+    let a_spread = sweep_a
+        .iter()
+        .map(|a| a.top1)
+        .fold(f64::NEG_INFINITY, f64::max)
+        - sweep_a.iter().map(|a| a.top1).fold(f64::INFINITY, f64::min);
+    println!("\n==== sweep A: CTX_SAMPLE alone, cap pinned at the shipped 10k ====");
+    println!(
+        "top-1 spread across a 20x pool range: {a_spread:.2}pp (SE {:.2}pp)",
+        shipped.standard_error
+    );
+    println!(
+        "{}",
+        if a_spread < 2.0 * shipped.standard_error {
+            "CONFIRMS the operative half of docs/capacity_scaling_432.md §3.1: \
+             widening the draw pool ABOVE the cap does not move the codebook's \
+             quality. Note what this does NOT say — #407 raised CTX_SAMPLE from \
+             6,000, below the 10,000 cap, so its raise did move the training set \
+             (6k -> 10k) and §3.1's 'did not change the training-set size at all' \
+             is too strong. What is dead is raising CTX_SAMPLE any further while \
+             the cap stands, which is every configuration since #407."
+        } else {
+            "REFUTES §3.1: the draw pool alone moves top-1 even above the cap, so \
+             something other than the training-set size is carrying the effect."
+        }
+    );
+
+    // --- sweep B: the training set itself ---
+    println!("\n==== sweep B: the k-means training set ====");
+    let best = arms
+        .iter()
+        .max_by(|a, b| a.top1.partial_cmp(&b.top1).expect("finite"))
+        .expect("arms");
+    let largest = arms.last().expect("arms");
+    let delta = largest.top1 - shipped.top1;
+    let best_delta = best.top1 - shipped.top1;
+    println!(
+        "shipped {:.2}%  ->  best {:.2}% at training set {} ({best_delta:+.2}pp)",
+        shipped.top1, best.top1, best.training_set
+    );
+    println!(
+        "largest training set ({}) gives {:.2}% ({delta:+.2}pp vs shipped) \
+         [exit rule: >= +{EXIT_RULE_PP:.1}pp]",
+        largest.training_set, largest.top1
+    );
+
+    // The delta is a difference between two arms, so the single-arm standard
+    // error is the wrong yardstick. Arms share the held-out set, which makes
+    // this paired and means the independent-sample form below OVERSTATES the
+    // error — it is used deliberately as the conservative choice, since the
+    // per-record discordance needed for the paired form is not retained here.
+    let se_diff = (shipped.standard_error.powi(2) + best.standard_error.powi(2)).sqrt();
+    println!(
+        "\nstandard error of the DIFFERENCE: {se_diff:.2}pp (conservative; arms are \
+         paired on the held-out set). Best delta is {:.1} SE.",
+        best_delta / se_diff
+    );
+
+    println!("\n==== verdict against the pre-declared exit rule ====");
+    if delta >= EXIT_RULE_PP {
+        println!("POSITIVE: codebook fit clears the exit rule. Propose §5.3 scaling.");
+    } else if best_delta > 2.0 * se_diff {
+        println!(
+            "NEGATIVE against the exit rule, but NOT null. The training set is a \
+             real lever worth {best_delta:+.2}pp ({:.1} SE) — well below the \
+             +{EXIT_RULE_PP:.1}pp bar and it SATURATES: the largest training set ({}) \
+             does not beat the best ({}). So §5.3's uncapped `min(N/10, 500k)` \
+             prescription buys nothing above the saturation point and should be \
+             narrowed to it.",
+            best_delta / se_diff,
+            largest.training_set,
+            best.training_set
+        );
+    } else {
+        println!(
+            "NEGATIVE: the training set moves top-1 by {best_delta:+.2}pp at best, \
+             which is {:.1} SE on the difference — not separable from noise at this \
+             held-out size. Withdraw the §5.3 codebook-scaling recommendation rather \
+             than leaving it standing as untested advice.",
+            best_delta / se_diff
+        );
+    }
+
+    // --- the discriminating comparison against the STAGES=5 negative ---
+    println!("\n==== records-per-key: is it the binding quantity? ====");
+    println!(
+        "#460 read the STAGES=5 negative as 'thinner per-key evidence' — records/key \
+         fell 36.02 -> 18.80 and top-1 fell with it."
+    );
+    if best.records_per_key < shipped.records_per_key && best.top1 > shipped.top1 {
+        println!(
+            "HERE, records/key FELL {:.2} -> {:.2} while top-1 ROSE {:+.2}pp. \
+             Lower records-per-key is therefore NOT intrinsically bad: it is bad when \
+             it comes from added key RESOLUTION and good when it comes from better \
+             codebook FIT. Records-per-key is a symptom, not the binding quantity, \
+             and #460's causal reading should be narrowed to resolution specifically.",
+            shipped.records_per_key, best.records_per_key, best_delta
+        );
+    } else {
+        println!(
+            "HERE, records/key {:.2} -> {:.2} and top-1 {:+.2}pp — this arm does not \
+             separate fit from resolution, so #460's reading stands unrefined.",
+            shipped.records_per_key, best.records_per_key, best_delta
+        );
+    }
+}

--- a/docs/capacity_scaling_432.md
+++ b/docs/capacity_scaling_432.md
@@ -431,6 +431,36 @@ Measurement: at fixed corpus, sweep `R4_RVQ_SAMPLE_CAP` over
 occupied key, and held-out top-1. If the codebook is under-fit, occupancy rises
 and records-per-key falls monotonically with the cap.
 
+**RUN 2026-08-07 (#460 lever 2) — see `docs/codebook_fit_460.md`. This section
+stands in shape and is over-stated in value; narrow it before adopting.**
+
+The sweep above was run as specified, plus a control sweep that moves the pool
+alone. Held-out top-1 against the SHIPPED configuration: **+0.44pp at a 50,000
+training set (2.1 SE), and +0.37pp at 200,000** — the lever is real, it is
+small, and it **saturates**. `N/10` at this corpus is 39,969, essentially the
+measured saturation point, so the formula's *shape* is confirmed; what is not
+confirmed is any benefit from the 500,000 ceiling, which measurably buys
+nothing here. Adoption is kappa-affecting and worth about 0.44pp, so it belongs
+in the next re-pin that happens for another reason rather than triggering one.
+
+Occupancy did **not** rise monotonically (77,799 -> 85,496 -> 79,933), so the
+proposed instrument reading — "occupancy rises and records-per-key falls
+monotonically with the cap" — is not a reliable signature of relieved
+under-fit and should not be used as a gate.
+
+Two corrections this run forces on the text above:
+
+- **§3.1 is one step too strong.** It states that #407's `CTX_SAMPLE`
+  6,000 -> 50,000 raise "did not change the codebook's training-set size at
+  all". The training set is `min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`, and at
+  `CTX_SAMPLE = 6_000` the 10,000 cap does not bind — so that raise moved the
+  training set 6,000 -> 10,000 and #407's attributed starvation share was real.
+  What is dead is raising `CTX_SAMPLE` further while the cap stands: over a 20x
+  pool range above the cap, top-1 moves 0.21pp, inside noise.
+- **The §6 calibration worry is now bounded.** "The 500k measurements
+  everything else is calibrated against were themselves taken on an under-fit
+  codebook" is true, and the under-fit is worth 0.44pp.
+
 ### 5.4 Scale emission width by region mass
 
 ```

--- a/docs/codebook_fit_460.md
+++ b/docs/codebook_fit_460.md
@@ -1,0 +1,114 @@
+# Codebook fit: how much the RVQ training-set cap actually costs
+
+Issue #460 lever 2. Measured 2026-08-07 on the pinned 500k fixture corpus
+(`crates/uor-r4-core/tests/fixtures/c_{meta,recs}.bin`, 500,000 records /
+2,507 stories, 399,694 construction / 100,306 held out), teacher-free
+`compile_recorded`, cover held fixed.
+
+Reproduce with:
+
+```
+cargo test --release -p uor-r4-core --test codebook_fit -- --ignored --nocapture
+```
+
+Five recorded compiles, about 30 minutes on two cores. No teacher, no
+checkpoint, no Gate C.
+
+## Result
+
+| arm | pool | cap | training set | occupied keys | rec/key | held-out top-1 | vs shipped |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| A | 10k | 10k | 10,000 | 77,799 | 5.14 | 35.53% ± 0.15 | −0.16pp |
+| **A — SHIPPED** | **50k** | **10k** | **10,000** | **79,244** | **5.04** | **35.69% ± 0.15** | — |
+| A | 200k | 10k | 10,000 | 74,952 | 5.33 | 35.74% ± 0.15 | +0.05pp |
+| B | 50k | 50k | 50,000 | 85,496 | 4.68 | **36.14% ± 0.15** | **+0.44pp** |
+| B | 200k | 200k | 200,000 | 79,933 | 5.00 | 36.06% ± 0.15 | +0.37pp |
+
+All five arms produced distinct codebook digests, so no comparison here is
+vacuous.
+
+**Verdict: NEGATIVE against the pre-declared +1.0pp exit rule, but not null.**
+The best arm is **+0.44pp at 2.1 SE** on the difference (conservative: the
+arms are paired on the held-out set, so the independent-sample error used here
+overstates the uncertainty). And it **saturates** — quadrupling the training
+set again, 50k → 200k, buys nothing.
+
+## Three things this settles
+
+### 1. Raising `CTX_SAMPLE` above the cap does nothing (sweep A)
+
+Over a 20× pool range with the cap pinned at the shipped 10,000, top-1 moves
+0.21pp — inside noise. The k-means training set is
+`min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`, and once the pool exceeds the cap the pool
+is irrelevant.
+
+**But §3.1 of `capacity_scaling_432.md` is one step too strong**, and the
+arithmetic matters. It states that #407's `CTX_SAMPLE` 6,000 → 50,000 raise
+"did not change the codebook's training-set size at all". At
+`CTX_SAMPLE = 6_000` the 10,000 cap **does not bind**, so that raise did move
+the training set — from 6,000 to 10,000. #407's attributed +0.5–0.7pp
+starvation share was therefore real, and bought by a 4,000-vector increment.
+What is dead is raising `CTX_SAMPLE` any further while the cap stands, which
+is every configuration since #407.
+
+Read together with sweep B, the three points form one coherent
+diminishing-returns curve: 6k → 10k bought roughly +0.5pp (#407), 10k → 50k
+buys +0.44pp (here), 50k → 200k buys nothing.
+
+### 2. `RVQ_SAMPLE_CAP` is a real but small lever, and it saturates near N/10
+
+The audit's §5.3 prescription is `RVQ_SAMPLE_CAP(N) = min(N/10, 500_000)`. At
+this corpus `N/10 = 39,969`, which lands almost exactly on the measured
+saturation point of 50,000. **The formula's shape is right and its ceiling is
+about +0.44pp** — it should be narrowed to the saturation point rather than
+left implying that more is better, because 200,000 measurably is not.
+
+Whether to adopt it is a judgement call this record does not make: the change
+is κ-affecting and would require the #407 re-pin ceremony, which is a lot of
+process for 0.44pp. The reasonable course is to bundle it into the next re-pin
+that happens for another reason, not to trigger one.
+
+This also bounds a standing worry. §6 records
+`code.codebook_sample_fraction` as SATURATED at 500k, noting that "the 500k
+measurements everything else is calibrated against were themselves taken on an
+under-fit codebook." True — and the under-fit is worth **0.44pp**. The
+calibration concern is real and small, which closes it rather than leaving it
+open as an unbounded doubt about every pinned row.
+
+### 3. Records-per-key is a symptom, not the binding quantity
+
+This is the result with consequences beyond #460.
+
+The STAGES=5 negative was read as: records/key fell 36.02 → 18.80 and top-1
+fell with it, which is "the signature of thinner per-key evidence rather than
+sharper context."
+
+Here, records/key fell **5.04 → 4.68** and top-1 **rose +0.44pp**.
+
+Both changes thin the evidence per key. They differ in *why*: STAGES=5 thinned
+it by adding key **resolution**, splitting evidence that belonged together; a
+larger codebook training set thins it by improving **fit**, moving evidence
+onto the key that represents it. So a falling records-per-key is not itself a
+warning sign, and #460's causal reading should be narrowed to resolution
+specifically rather than left as a general claim about per-key evidence.
+
+The programme-level pattern in `README.md` — every key-*resolution* lever
+failed, and the only changes that helped improved *evidence quality per key* —
+survives this and is sharpened by it. Codebook fit is an evidence-quality
+lever and it moved the metric in the right direction; it is simply a small
+one. It is the first independent confirmation of that pattern on a lever that
+touches the code itself rather than storage or calibration.
+
+## Scope limits
+
+- Measured at 500k records with a teacher-free recorded compile. The pinned
+  era rows are TLA7 compiles against a teacher; absolute numbers here are not
+  comparable to `BASELINE.md`, only the arm-to-arm deltas are.
+- Saturation was located between 50k and 200k on a 500k corpus. Whether the
+  saturation point tracks `N/10` at 2.11M is untested, and that is the one
+  thing that would change the recommendation — if it scales, the lever stays
+  worth ~0.44pp at every corpus size; if it is absolute, larger corpora are
+  already past it.
+- Held-out store top-1 is the metric, matching the "store baseline" row #460
+  reported. Full Gate C Rule 1+2 was not run: at a 0.44pp effect it could not
+  have separated the arms any better, and it costs hours.


### PR DESCRIPTION
References #460 (lever 2 of the rescoped issue; lever 1, `cover_scaling.rs`, is untouched and still dark).

I took lever 2 ahead of your recommended lever 1 — reasoning is in the run contract on the issue. Short version: the graph path saw 283 of 10,000 positions in the STAGES=5 run, so the cover lever is capped in the low single digits by construction, whereas the codebook produces the graded code every position is keyed under.

## Result

Five teacher-free `compile_recorded` runs on the pinned 500k fixture corpus, cover held fixed, held-out store top-1. The k-means training set is `min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`, so both knobs are swept.

| arm | pool | cap | train | occ. keys | rec/key | top-1 | vs shipped |
|---|---:|---:|---:|---:|---:|---:|---:|
| A | 10k | 10k | 10,000 | 77,799 | 5.14 | 35.53% ± 0.15 | −0.16pp |
| **A — SHIPPED** | **50k** | **10k** | **10,000** | **79,244** | **5.04** | **35.69% ± 0.15** | — |
| A | 200k | 10k | 10,000 | 74,952 | 5.33 | 35.74% ± 0.15 | +0.05pp |
| B | 50k | 50k | 50,000 | 85,496 | 4.68 | **36.14% ± 0.15** | **+0.44pp** |
| B | 200k | 200k | 200,000 | 79,933 | 5.00 | 36.06% ± 0.15 | +0.37pp |

**NEGATIVE against the pre-declared +1.0pp exit rule, but not null.** +0.44pp at 2.1 SE on the *difference* (conservative — the arms are paired on the held-out set), and it **saturates**: 200k does not beat 50k.

## The result with consequences beyond this issue

**Records-per-key is a symptom, not the binding quantity.**

The STAGES=5 negative was read as: records/key fell 36.02 → 18.80 and top-1 fell with it, "the signature of thinner per-key evidence." Here records/key falls **5.04 → 4.68** and top-1 **rises +0.44pp**.

Both thin the evidence per key; they differ in *why*. Added key **resolution** splits evidence that belonged together. Better **fit** moves evidence onto the key that represents it. So a falling records-per-key is not itself a warning sign, and #460's causal reading narrows to resolution specifically. The subdivision negative itself stands untouched.

This forces a correction to the README pattern paragraph, which listed *"a better-fitted codebook"* among the failed key-resolution levers. That was a misclassification on both counts: fit is not resolution (fixed `K`, fixed `STAGES`, fixed nominal key space — it changes *which* key evidence lands on), and measured in isolation it is **positive**. The distinction to carry forward is **which key evidence lands on** (fit — helps) versus **how many keys there are** (resolution — has never helped). This is the first confirmation of the evidence-quality pattern on something that touches the graded code itself rather than storage or calibration.

## Two corrections to `capacity_scaling_432.md`

**§3.1 is one step too strong.** It states #407's `CTX_SAMPLE` 6,000 → 50,000 raise "did not change the codebook's training-set size at all." The training set is `min(CTX_SAMPLE, RVQ_SAMPLE_CAP)`, and at 6,000 the 10,000 cap **does not bind** — so that raise moved it 6k → 10k and #407's attributed starvation share was real. What sweep A kills is raising `CTX_SAMPLE` *further* while the cap stands (0.21pp over a 20× pool range), which is every configuration since #407. The three points form one diminishing-returns curve: 6k→10k ≈ +0.5pp, 10k→50k +0.44pp, 50k→200k nothing.

**§5.3 is right in shape and over-valued.** `N/10` = 39,969 here, essentially the measured saturation point — the formula's shape is confirmed. The 500,000 ceiling measurably buys nothing. Adoption is κ-affecting and worth 0.44pp, so it belongs in the next re-pin that happens for another reason rather than triggering one. Also: the proposed instrument reading ("occupancy rises and records-per-key falls monotonically") is **not usable as a gate** — occupancy went 77,799 → 85,496 → 79,933.

And §6's standing worry that the calibrated 500k rows were themselves taken on an under-fit codebook is true and now **bounded at 0.44pp**, which closes it rather than leaving it as open-ended doubt about every pinned row.

## Scope limits

Teacher-free recorded compile at 500k, so absolute numbers are not comparable to `BASELINE.md` — only arm-to-arm deltas are. Saturation was located between 50k and 200k on a 500k corpus; whether it tracks `N/10` at 2.11M is untested and is the one thing that would change the recommendation. Full Gate C was not run: at a 0.44pp effect it could not have separated the arms better and it costs hours.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check_claim_wording.py`, `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib` all green. The harness is `--ignored` (~30 min, five compiles, no teacher or checkpoint required).