### PR TITLE
test(certify): #460 lever 1 — the cover scales when its capacity is allowed to; two traps fixed first

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ identity argument, all against pre-declared rules; v3 mass-linear mixing
 reduces algebraically to flat. The oracle-stratum edge (36.3 vs 35.2) stands as
 recorded unrecovered signal, but no routing design reached it.
 
+One reading that came out of this track has since been revised. The cover's
+non-participation — "the absolute entropy floor rejects every split at this
+scale", 8 to 22 regions at mass-kept 0.0006 — was recorded as a property of the
+geometry. It is a property of the shipped *configuration*: turning on the
+already-implemented scaled capacity takes regions 48 to 110 on the 500k fixture
+and lifts region-path held-out top-1 by 5.0pp (#460 lever 1,
+`docs/cover_scaling_460.md`). The cover can be made to participate. What that
+is worth is separately capped — see the #460 row below.
+
 **Hopf sector transport as a router-quality lever (#422/#306).** The #306
 remediation's occupancy gain (16 to 456 of 512 sectors) does not translate into
 retrieval value: sector-filtered MRR 0.0045 against the pre-remediation
@@ -167,11 +176,20 @@ that touches the graded code itself rather than storage or calibration. The
 distinction to carry forward is *which key evidence lands on* (fit — helps)
 versus *how many keys there are* (resolution — has never helped).
 
+One boundary on that, from #460 lever 1. Added resolution *does* help when a
+structure is not merely coarse but barely partitioned at all: the induced cover
+sits at 48 regions for 400,006 records, so each region's emission is close to
+the global prior, and scaling its capacity to 110 regions lifts region-path
+held-out top-1 by 5.0pp. This is not a counterexample — the resolution levers
+that failed all subdivided structures already resolved enough to be predictive.
+The refinement is that resolution pays up to the point where a structure
+predicts at all, and not past it.
+
 ### Open, with defined work
 
 | Issue | Question | State |
 |---|---|---|
-| #460 | Cover split criterion and codebook fit | Codebook fit measured (`docs/codebook_fit_460.md`): raising the k-means training set is worth **+0.44pp** and saturates near `N/10`; below the +1.0pp exit rule, κ-affecting, so it belongs in the next re-pin rather than triggering one. It also showed records-per-key is a *symptom*, not the binding quantity — it fell here while top-1 rose. Still dark: `SplitCriterion::{RelativeGain,Mdl}` with scaled k0 (`cover_scaling.rs` unrun) |
+| #460 | Cover split criterion and codebook fit | Both levers measured. **Codebook fit** (`docs/codebook_fit_460.md`): +0.44pp, saturates near `N/10`, below the exit rule; showed records-per-key is a *symptom*, not the binding quantity. **Cover split criterion** (`docs/cover_scaling_460.md`): the shipped absolute floor does not scale (regions 50→48→46→48 over an 8× data range), and scaled capacity fixes it — regions 48→110, region-path held-out top-1 **+5.0pp**, contrast maintained. Serving impact is capped near 0.15pp because the graph path answers ~1–3% of positions, so this arms the broad-corpus directions rather than paying today |
 | #424 | Bott-Fock O(1) context fold | Ceiling measured, A/B not reachable. Long-range signal on this corpus is worth +1.02pp of top-1 (two thirds of it order-carried); the shipped decay constant `>> 2` retains 16% of that, so the lossless upper bound on the fold as shipped is +0.16pp — one standard error. Retuning the decay to `>> 7` would recover the ceiling. `docs/context_horizon_424.md` |
 | #434 | VSA / spectral geometry | Item 1 (zeta-grid at scale) done and shipped; item 2 never measured beyond a synthetic smoke test |
 | #469 | Vectorize the assign path | Done. Lever A (κ-keyed code sidecar) 625s → 39s; lever B routes the corpus code passes through the existing `simd::dot_argmax` using tables decoded once per artifact — **1.60x** on the pinned TLA7 artifact. Bit-identity is proven, not argued: `tests/assign_prepared.rs` checks prepared == scalar over 1,024 real corpus positions on the committed artifact fixture, and the κ witness carries it on a fresh compile. Per-call decoding would have been a ~4x regression, which is why the batch API exists |

--- a/crates/uor-r4-graph-certify/tests/cover_scaling.rs
+++ b/crates/uor-r4-graph-certify/tests/cover_scaling.rs
@@ -52,6 +52,29 @@
 //! Every criterion is reported regardless of verdict; a negative result is a
 //! valid result and is reported as such.
 //!
+//! # Two traps this harness had, both fixed 2026-08-07 (#460 lever 1)
+//!
+//! **The fallback partition was not prefix-compatible.** Nested prefixes need
+//! every corpus-size prefix to contain both partitions. The `R4_STORIES` path
+//! satisfies that (`blake3(article id) % 5` interleaves held-out stories); the
+//! fallback was a contiguous tail split, so on the committed fixture every
+//! prefix below 80% had an empty held-out set and was skipped. The four-size
+//! curve silently became one point — and the verdict block then printed
+//! `PASS ... monotone_regions=true`, because `windows(2).all(..)` is vacuously
+//! true over one row. The fallback is now an interleaved 80/20 (`sid % 5 != 0`)
+//! and an arm with fewer than two sizes reports INCONCLUSIVE, never PASS.
+//!
+//! **The scaling anchor coincides with the fixture's full size.** The capacity
+//! law is `(n / capacity_ref_n)^alpha` with `DEFAULT_CAPACITY_REF_N = 400_000`,
+//! and the committed 500k fixture yields 400,006 train observations. At the
+//! anchor every scaled knob equals its base value, so `scaled-k0` reduces
+//! *exactly* to `absolute` at the largest size — identical regions, contrast
+//! and top-1 — and condition 3 compares the arm with itself. It passes, and
+//! the pass means nothing. The `@ref50k` arms lower the anchor to 50,000 so
+//! the fixture's largest size sits 8x above it and the law is exercised where
+//! the verdict is read. **Read `scaled-k0` on this corpus as a control, not a
+//! result; read `scaled-k0@ref50k` as the measurement.**
+//!
 //! # Runtime caps (printed at start, never silent)
 //!
 //! - `R4_SCALING_FRACS` (default `13,25,50,100`) — story-prefix percentages.
@@ -183,6 +206,29 @@ fn arm_config(arm: &str) -> CoverConfig {
             split_criterion: SplitCriterion::RelativeGain,
             scale_k0: true,
             scale_regions_budget: true,
+            ..base
+        },
+        // Anchor-shifted controls. The capacity law is `(n / capacity_ref_n)^alpha`
+        // and `DEFAULT_CAPACITY_REF_N = 400_000`, which is — to within six
+        // observations — the full-size train count of the committed 500k
+        // fixture. At that size every scaled knob equals its base value, so
+        // `scaled-k0` reduces *exactly* to `absolute` there and the exit
+        // rule's largest-size comparison is the arm against itself.
+        //
+        // Lowering the anchor to 50 000 puts the fixture's largest size 8x
+        // above it, so the scaling law is actually exercised where the verdict
+        // is read. This tests the law rather than the coincidence.
+        "scaled-k0@ref50k" => CoverConfig {
+            scale_k0: true,
+            scale_regions_budget: true,
+            capacity_ref_n: 50_000,
+            ..base
+        },
+        "relative+scaled@ref50k" => CoverConfig {
+            split_criterion: SplitCriterion::RelativeGain,
+            scale_k0: true,
+            scale_regions_budget: true,
+            capacity_ref_n: 50_000,
             ..base
         },
         other => panic!("unknown arm {other:?}"),
@@ -361,9 +407,28 @@ fn cover_scaling() {
             }
             flags
         }
-        Err(_) => (0..corpus.stories)
-            .map(|sid| sid < u64::from(cut))
-            .collect(),
+        // Fallback partition: INTERLEAVED 80/20, not a contiguous tail.
+        //
+        // This measurement is built on nested corpus-size prefixes, so every
+        // prefix must contain both partitions. A tail split (`sid < cut`) puts
+        // all held-out stories above the 80% mark, so every prefix below 80%
+        // has an empty held-out set and is skipped — on the committed 500k
+        // fixture that silently reduced a four-size scaling curve to a single
+        // point, and the verdict block below then reported `monotone_regions`
+        // PASS over one row. The `R4_STORIES` path never had this problem
+        // because `stories.jsonl` partitions by `blake3(article id) % 5`,
+        // which is already interleaved.
+        //
+        // `sid % 5 != 0` keeps the 80/20 ratio and the document-level
+        // boundary (no position from an evaluated story trains the cover)
+        // while making every prefix usable. It does change which stories are
+        // held out relative to a tail split, so absolute numbers from this
+        // fallback are not comparable with runs that supplied `R4_STORIES`;
+        // arm-to-arm and size-to-size comparisons within one run are.
+        Err(_) => {
+            let _ = cut;
+            (0..corpus.stories).map(|sid| sid % 5 != 0).collect()
+        }
     };
     // Nested prefixes require the position lists to be grouped by story:
     // observations are built in the given position order and each size is a
@@ -517,6 +582,13 @@ fn cover_scaling() {
         if arm_rows.is_empty() {
             continue;
         }
+        // Condition 1 is a statement about how region count moves WITH corpus
+        // size. One row cannot support it, and `windows(2).all(..)` is
+        // vacuously true over one row — which is how a degenerate run printed
+        // PASS. Fewer than two sizes means the condition is unevaluable, and
+        // an unevaluable condition is not a satisfied one.
+        let sizes = arm_rows.len();
+        let monotone_evaluable = sizes >= 2;
         let monotone = arm_rows
             .windows(2)
             .all(|pair| pair[1].regions >= pair[0].regions);
@@ -525,13 +597,23 @@ fn cover_scaling() {
             .all(|row| row.contrast_mean >= contrast_floor);
         let largest = arm_rows.iter().max_by_key(|row| row.train).unwrap();
         let predictive_ok = baseline_largest.is_none_or(|baseline| largest.held_top1 >= baseline);
-        let verdict = if monotone && contrast_ok && predictive_ok {
+        let verdict = if !monotone_evaluable {
+            "INCONCLUSIVE"
+        } else if monotone && contrast_ok && predictive_ok {
             "PASS"
         } else {
             "FAIL"
         };
+        if !monotone_evaluable {
+            println!(
+                "INCONCLUSIVE {arm:<16} only {sizes} corpus size produced a row; condition 1 \
+                 (monotone regions) is UNEVALUABLE. Raise R4_SCALING_FRACS coverage or supply \
+                 a corpus whose partition survives prefixing — do not read the remaining \
+                 columns as a verdict."
+            );
+        }
         println!(
-            "{verdict} {arm:<16} monotone_regions={monotone} contrast_ok={contrast_ok} \
+            "{verdict} {arm:<16} sizes={sizes} monotone_regions={monotone} contrast_ok={contrast_ok} \
              (min mean {:.4} vs floor {contrast_floor:.4}) predictive_ok={predictive_ok} \
              (top1 {:.4} vs baseline {:.4})",
             arm_rows

--- a/docs/cover_scaling_460.md
+++ b/docs/cover_scaling_460.md
@@ -1,0 +1,136 @@
+# Cover split criterion: the capacity law works, and the cover is not the bottleneck
+
+Issue #460 lever 1. Measured 2026-08-07 on the committed 500k fixture corpus
+(`crates/uor-r4-core/tests/fixtures/c_{meta,recs}.bin` + `tless_artifacts.bin`),
+four story-prefix sizes, held-out top-1 of a region-path-keyed store.
+
+Reproduce with:
+
+```
+cargo test --release -p uor-r4-graph-certify --test cover_scaling -- --ignored --nocapture
+R4_SCALING_ARMS="absolute,scaled-k0@ref50k,relative+scaled@ref50k" \
+  cargo test --release -p uor-r4-graph-certify --test cover_scaling -- --ignored --nocapture
+```
+
+About four minutes for five arms; no teacher, no checkpoint.
+
+## The harness was reporting PASS on one data point
+
+Before any result: running `cover_scaling.rs` as it stood produced
+
+```
+frac 13%: empty partition, skipped
+frac 25%: empty partition, skipped
+frac 50%: empty partition, skipped
+PASS absolute monotone_regions=true ... predictive_ok=true (top1 0.1270 vs baseline 0.1270)
+```
+
+Three of four sizes skipped, then a PASS whose condition 1 (monotone region
+count *in corpus size*) was evaluated over a single size, and whose condition 3
+compared the baseline arm against itself. This is the #354 vacuous-green class,
+in the harness whose only job is to decide this lever, and it is the most
+likely reason the lever stayed dark: the run does not fail, it just says
+nothing.
+
+Cause: nested prefixes need every prefix to contain both partitions. The
+`R4_STORIES` path partitions by `blake3(article id) % 5`, which interleaves.
+The fallback was a contiguous tail split, so all held-out stories sat above the
+80% mark and no smaller prefix had any. Fixed by making the fallback an
+interleaved 80/20 (`sid % 5 != 0`), and by refusing to print PASS for an arm
+with fewer than two sizes.
+
+## The shipped criterion does not scale — visible at 500k, not just at 2.11M
+
+With four real sizes, the `absolute` arm's region count against an 8× data
+range:
+
+| train observations | 51,696 | 99,455 | 199,562 | 400,006 |
+|---|---:|---:|---:|---:|
+| regions | 50 | 48 | 46 | 48 |
+
+Flat, and non-monotone — **FAIL on condition 1**. The defect was previously
+inferred from 500k (38 regions) versus 2.11M (14 regions); it is now visible
+inside a single 500k corpus. Capacity does not track the data at any point in
+the tested range.
+
+## The capacity law works when it is actually exercised
+
+`scaled-k0` as shipped **passes degenerately on this corpus and the pass must
+not be believed.** The capacity law is `(n / capacity_ref_n)^alpha` with
+`DEFAULT_CAPACITY_REF_N = 400_000`, and the fixture's full size is 400,006
+train observations. At the anchor every scaled knob equals its base value, so
+at the largest size `scaled-k0` *is* `absolute` — identical regions (48),
+contrast (0.6217) and top-1 (0.1307) — and condition 3 compares it with
+itself. Its monotonicity comes from being throttled below the anchor, not from
+demonstrated growth above it.
+
+Lowering the anchor to 50,000 puts the largest size 8× above it and tests the
+law rather than the coincidence:
+
+| arm | regions @51k | @99k | @199k | @400k | held-out top-1 @400k |
+|---|---:|---:|---:|---:|---:|
+| `absolute` (shipped) | 50 | 48 | 46 | 48 | 0.1307 |
+| `scaled-k0@ref50k` | 50 | 63 | 71 | **104** | **0.1713** |
+| `relative+scaled@ref50k` | 46 | 65 | 81 | **110** | **0.1809** |
+
+Both anchored arms **PASS all three pre-declared conditions**:
+
+1. monotone region count — 50 → 63 → 71 → 104 and 46 → 65 → 81 → 110;
+2. contrast does not collapse — 0.6649 and 0.6643 against a 0.2506 floor, in
+   fact slightly *above* the `absolute` arm's 0.6217;
+3. prediction is not bought at a loss — **+4.1pp and +5.0pp** of held-out top-1
+   on the region-path-keyed store.
+
+Mean support per region falls 20,722 → 8,886 while top-1 rises. That is the
+same fit-versus-resolution distinction the codebook measurement drew
+(`docs/codebook_fit_460.md`), in the one place where added resolution genuinely
+helps: at 48 regions for 400,006 records, the cover is so far under-resolved
+that each region's emission is close to the global prior and the structure is
+barely partitioned at all.
+
+The two failing alternatives are informative too. `mdl` scales monotonically
+(10 → 26 regions) but costs 1.7pp of held-out top-1 — capacity bought at a
+loss, which is exactly what condition 3 exists to catch. `relative` alone,
+without scaled capacity, stays flat: making the *bar* track the data does
+nothing while `k0` and the region budget stay fixed. Capacity, not the
+criterion, is the binding knob.
+
+## What this is worth, and what it is not
+
+**The serving impact is small and that must be said plainly.** The metric above
+is the region-path-keyed store's own top-1. The deployed stack consults exact
+context first: `exct.supported_record_fraction` is 0.9882 at the 4-stage
+baseline, and the STAGES=5 run resolved 283 of 10,000 positions on the graph
+path. So a cover-side change is bounded by roughly 1–3pp of headline movement,
+and +5pp on a path that answers ~1–3% of positions is on the order of **0.15pp**
+of headline today.
+
+That bound is not a reason to discard the result. It locates the bottleneck:
+**the cover is not what is limiting the engine — exact-context dominance is.**
+The cover fix is cheap, already implemented, default-off, and now measured. It
+pays when exact-context coverage falls, which is precisely what the broad-corpus
+directions (#320's teacher upgrade, the #433 frontier) would cause. This result
+means that when a broad corpus lands, the cover is ready rather than being a
+fresh unknown.
+
+It also revises a standing reading. #435 and the #460 STAGES=5 outcome both
+recorded the cover as simply not participating — "8 regions, mass kept 0.0006,
+the absolute entropy floor rejects every split at this scale." True of the
+shipped configuration, and now known to be **fixable with an existing knob**
+rather than a property of the geometry.
+
+## Scope limits
+
+- The `@ref50k` anchor is a measurement device, not a proposed default.
+  Choosing a production anchor is a calibration question this run does not
+  settle; `DEFAULT_CAPACITY_REF_N = 400_000` was itself calibrated to the 500k
+  reference and is only degenerate *on a corpus of that exact size*.
+- Adoption of any non-`Absolute` criterion or of scaled capacity is
+  κ-affecting and needs the #407 re-pin ceremony.
+- Measured to 400,006 train observations. Whether region growth continues at
+  2.11M, and whether contrast holds there, is untested — that is the run that
+  would justify adoption, and it is the same corpus the original 14-region
+  collapse was observed on.
+- The fallback partition changed from a tail split to interleaved, so absolute
+  numbers here are not comparable with runs that supplied `R4_STORIES`.
+  Arm-to-arm and size-to-size comparisons within one run are.


### PR DESCRIPTION
Closes #460 (lever 2 landed in #477; this is lever 1, the last one).

## Why this lever stayed dark: the harness said PASS on one data point

Running `cover_scaling.rs` as it stood:

```
frac 13%: empty partition, skipped
frac 25%: empty partition, skipped
frac 50%: empty partition, skipped
PASS absolute monotone_regions=true ... predictive_ok=true (top1 0.1270 vs baseline 0.1270)
```

Condition 1 is "region count non-decreasing **in corpus size**" — evaluated over a single size, because `windows(2).all(..)` is vacuously true over one row. Condition 3 compared the baseline arm with itself. The run does not fail; it just says nothing, which is the #354 vacuous-green class in the harness whose only job is to decide this lever.

**Cause.** Nested prefixes need every prefix to contain both partitions. The `R4_STORIES` path partitions by `blake3(article id) % 5` and interleaves; the fallback was a contiguous tail split, so all held-out stories sat above the 80% mark and no smaller prefix had any. Fixed: interleaved 80/20 fallback, and an arm with fewer than two sizes now reports **INCONCLUSIVE** and can never print PASS.

**Second trap.** `DEFAULT_CAPACITY_REF_N = 400_000`; the committed fixture yields **400,006** train observations. At the anchor every scaled knob equals its base value, so at the largest size `scaled-k0` reduces *exactly* to `absolute` — identical regions (48), contrast (0.6217) and top-1 (0.1307) — and passes the exit rule by comparing itself with itself. Added `@ref50k` arms that lower the anchor to 50,000 so the law is exercised where the verdict is read.

## The shipped criterion does not scale — visible inside 500k

| train obs | 51,696 | 99,455 | 199,562 | 400,006 |
|---|---:|---:|---:|---:|
| `absolute` regions | 50 | 48 | 46 | 48 |

Flat and non-monotone over an 8× data range — **FAIL on condition 1**. Previously this was inferred from 500k (38 regions) vs 2.11M (14); it is now visible within one corpus.

## Capacity, not the criterion, is the binding knob

| arm | @51k | @99k | @199k | @400k | held-out top-1 @400k |
|---|---:|---:|---:|---:|---:|
| `absolute` | 50 | 48 | 46 | 48 | 0.1307 |
| `scaled-k0@ref50k` | 50 | 63 | 71 | **104** | **0.1713** (+4.1pp) |
| `relative+scaled@ref50k` | 46 | 65 | 81 | **110** | **0.1809** (+5.0pp) |

Both **PASS all three pre-declared conditions**: monotone regions; contrast 0.6649 / 0.6643 against a 0.2506 floor (above `absolute`'s 0.6217); and prediction not bought at a loss. Mean support per region falls 20,722 → 8,886 while top-1 rises.

The failures are informative. `mdl` scales (10 → 26 regions) but costs 1.7pp — capacity bought at a loss, exactly what condition 3 exists to catch. `relative` alone stays flat: making the *bar* track the data does nothing while `k0` and the region budget stay fixed.

## What it is worth — stated plainly

**Serving impact is capped near 0.15pp.** `exct.supported_record_fraction` is 0.9882 and the STAGES=5 run resolved 283 of 10,000 positions on the graph path, so +5pp on a path answering ~1–3% of positions is small. I pre-declared that cap on the issue before running.

The value is that it locates the bottleneck: **the cover is not what limits the engine — exact-context dominance is.** And the fix is cheap, already implemented, default-off, and now measured, so it is ready when a broad corpus drops exact-context coverage (#320, #433) instead of being a fresh unknown then.

It also revises a standing reading. #435 and the #460 STAGES=5 outcome both recorded the cover as simply not participating — "the absolute entropy floor rejects every split at this scale." True of the shipped *configuration*; not a property of the geometry.

## Pattern refinement

The README pattern says resolution has never helped. This is a boundary on it, not a counterexample: added resolution helps when a structure is *barely partitioned at all* — 48 regions for 400,006 records puts each region's emission near the global prior. The failed resolution levers all subdivided structures already resolved enough to be predictive. Resolution pays up to the point where a structure predicts, and not past it.

## Scope limits

`@ref50k` is a measurement device, not a proposed default — choosing a production anchor is a calibration question this run does not settle. Adoption of any non-`Absolute` criterion or scaled capacity is κ-affecting and needs the #407 ceremony. Measured to 400,006 train observations; whether growth and contrast hold at 2.11M is untested and is the run that would justify adoption.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check_claim_wording.py`, `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`, and the `uor-r4-graph-certify` suite all green. The harness is `--ignored`, ~4 minutes for five arms, no teacher or checkpoint.