### PR TITLE
test(router): #480 — the query-projection asymmetry is real and fixing it does not pay

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ retrieval value: sector-filtered MRR 0.0045 against the pre-remediation
 projection's 0.0743. Three content-aligned redesign candidates then mapped a
 clean spread-versus-retrieval frontier without crossing it.
 
+**Query-projection banding as a retrieval lever (#480).** The query side of
+`retrieve_geometric_resonance` is band-only while storage has been full-width
+since #465 — a real asymmetry, and the suspicion was that it stranded the
+adopted de-banding gain (MRR 0.2348 → 0.8948) before serving. Measured: making
+the shapes symmetric is worth +0.0059 MRR and +0.0080 top-1 while costing
+0.0180 of recall@20, against a +0.05 bar. The reason is that this path ranks by
+`shared_count * 100 + sim * slice_norm`, so the lexical term is a hundred times
+the cosine and the vector shape only reorders candidates already tied on word
+overlap. The #442 figure came from a harness that ranked by cosine alone. Not
+adopted; the symmetric shape sits behind `set_full_width_query`, default off,
+and the asymmetry is documented as deliberate. The live question it leaves is
+the `* 100` weight itself, which has never been measured against alternatives.
+
 **Cayley–Dickson syntactic morphism (#400), FMM far-field (#290), granularity
 (#393), E8 group-keying (#395).** Each measured dead with a scoped record; the
 CD term executed 0 times out of 1,998 before removal.

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -445,6 +445,14 @@ pub struct UorR4Router {
     /// vectors have.
     #[serde(default)]
     banded_storage: bool,
+    /// Measurement knob for issue #480: build the QUERY projection
+    /// full-width instead of band-only. Default OFF, so deployed retrieval
+    /// ordering is unchanged.
+    ///
+    /// Not serialized: it selects a measurement configuration, not a
+    /// property of a stored vector, so an exported store must not carry it.
+    #[serde(skip)]
+    full_width_query: bool,
 }
 
 #[derive(Serialize)]
@@ -558,6 +566,7 @@ impl UorR4Router {
             facet_store: MultiFacetStore::default(),
             geometry_type: default_geometry_type(),
             banded_storage: false,
+            full_width_query: false,
         };
 
         // Initialize default corpus
@@ -994,6 +1003,13 @@ impl UorR4Router {
     /// indexed items are not rewritten, so flip this before ingestion.
     pub fn set_banded_storage(&mut self, banded: bool) {
         self.banded_storage = banded;
+    }
+
+    /// Build the query projection full-width rather than band-only
+    /// (issue #480). Default off — see `docs/query_projection_480.md` for
+    /// why the symmetric shape was measured and NOT adopted.
+    pub fn set_full_width_query(&mut self, full_width: bool) {
+        self.full_width_query = full_width;
     }
 
     /// Exports the full router system database to JSON string
@@ -1925,14 +1941,42 @@ impl UorR4Router {
             .get("shared:shared")
             .unwrap_or(&empty_index);
 
+        // Issue #480: the query projection is band-only while STORAGE is
+        // full-width by default (#434, PR #465). That asymmetry is real —
+        // zeroed query coordinates contribute nothing to a dot product, so
+        // the cosine only ever sees the band however wide the stored vector
+        // is — and it is **deliberately retained**. Do not "fix" it without
+        // reading `docs/query_projection_480.md` first.
+        //
+        // Measured at 46,342 windows / 500 probes: making the shapes
+        // symmetric is worth +0.006 MRR and +0.008 top-1 while costing
+        // ~0.018 of recall@20, against a pre-declared +0.05 MRR bar. The
+        // reason it cannot pay here is the relevance form below —
+        //     relevance = shared_count * 100 + sim * slice_norm + scope_boost
+        // — where the lexical term is 100x the cosine, so the vector shape
+        // only reorders candidates already tied on word overlap. The 0.8948
+        // de-banding figure came from a harness that ranked by cosine ALONE.
+        //
+        // The symmetric shape stays reachable through `set_full_width_query`
+        // so the measurement reproduces, and because it becomes the right
+        // default the moment the lexical term stops dominating.
+        //
+        // `slice_norm` below is intentionally left on the band slice: it is a
+        // scale factor on the cosine term, not part of the vector shape.
+        let full_width_query = self.full_width_query && state_vector.len() == 512;
         let mut query_projections = HashMap::new();
         let mut query_ranges = HashMap::new();
         for r in &routing_data.all_routes {
-            let mut full_state = vec![0.0; 512];
             let start = r.active_range[0] as usize;
             let end = r.active_range[1] as usize;
-            full_state[start..end].copy_from_slice(&r.state_vector[..end - start]);
-            query_projections.insert(r.window_index, full_state);
+            let projection = if full_width_query {
+                state_vector.to_vec()
+            } else {
+                let mut banded = vec![0.0; 512];
+                banded[start..end].copy_from_slice(&r.state_vector[..end - start]);
+                banded
+            };
+            query_projections.insert(r.window_index, projection);
             query_ranges.insert(r.window_index, (start, end));
         }
 

--- a/crates/uor-r4-router/tests/query_projection.rs
+++ b/crates/uor-r4-router/tests/query_projection.rs
@@ -1,0 +1,300 @@
+//! Query-projection shape vs retrieval quality (issue #480).
+//!
+//! # The asymmetry
+//!
+//! PR #465 adopted full-width content-bearing storage: `banded_storage`
+//! defaults to false and the stored vector keeps all 512 coefficients. The
+//! query side did not follow — `retrieve_geometric_resonance` built a
+//! band-only projection (zero outside `active_range`) regardless. Zeroed
+//! query coordinates contribute nothing to a dot product, so the cosine only
+//! ever saw the band no matter how wide the stored vector was, and the
+//! adopted de-banding gain (retrieval MRR 0.2348 -> 0.8948, router anchor
+//! accuracy 9.3% -> 11.4%, #442) could not reach this path.
+//!
+//! The fix makes the query projection obey the same rule storage obeys, so
+//! the two shapes are symmetric by construction rather than by coincidence.
+//!
+//! # What this harness can and cannot show
+//!
+//! Relevance in that function is
+//!
+//! ```text
+//! relevance = shared_count * 100 + sim * slice_norm + scope_boost
+//! ```
+//!
+//! `shared_count` is the number of query primes present in the item, times
+//! **100**; `sim` is bounded by 1 and `slice_norm` is a band-slice norm. The
+//! ranking is therefore dominated by lexical overlap, and the cosine acts as
+//! a **tie-breaker within equal-overlap groups**. A query-shape change can
+//! only reorder candidates that are tied on `shared_count`; it cannot rescue
+//! a target the lexical term has already placed below others, and it cannot
+//! improve recall, which was already 0.9720 at these caps (#479).
+//!
+//! So the honest expectation is a small MRR gain concentrated in top-1, not a
+//! move toward the 0.8948 figure from #442 — that number came from a harness
+//! ranking by cosine ALONE, with no lexical term. This harness reports the
+//! tie-mass explicitly so the size of the reachable slice is visible next to
+//! the result rather than inferred from it.
+//!
+//! # Arms
+//!
+//! - `banded` — `set_banded_storage(true)`: banded store, banded query. The
+//!   pre-#465 world.
+//! - `shipped` — the deployed default: full store, band-only query. This is
+//!   the asymmetry the issue is about.
+//! - `symmetric` — full store, full-width query via
+//!   `set_full_width_query(true)`: the proposed fix.
+//!
+//! # Corpus, probes, null
+//!
+//! The #422/#423 laws, unchanged, as in `geometry_ablation.rs`: D3 token
+//! corpus, synthetic word rendering, eight-token windows deduplicated to
+//! first occurrence, probes in the held-out even-offset-reversed form, and a
+//! deranged answer key (probe `i` graded against target `i + 1 (mod n)`) as
+//! the falsifier. Ground truth is matched on the stored SENTENCE, never on
+//! `ResonanceResult::window_index`, which is a routing-window identifier
+//! shared by several stored sentences.
+//!
+//! # Pre-declared exit rule
+//!
+//! - The deranged-key null must be near zero in both arms, or the harness is
+//!   void.
+//! - Positive if `full` beats `banded` by >= 0.05 MRR.
+//!
+//! Recorded outcome: `docs/query_projection_480.md`.
+
+use std::collections::{HashMap, HashSet};
+
+use uor_r4_core::transformerless::compiler;
+use uor_r4_router::UorR4Router;
+
+const ID: &str = "user:qproj";
+const TOP_N: usize = 20;
+const NULL_MRR_CEILING: f64 = 0.02;
+const WIN_MARGIN: f64 = 0.05;
+
+fn fixture(name: &str) -> String {
+    format!(
+        "{}/../uor-r4-core/tests/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn token_word(token: u32) -> String {
+    format!("t{token:05}")
+}
+
+fn render_window(tokens: &[u32]) -> String {
+    let words: Vec<String> = tokens.iter().map(|&token| token_word(token)).collect();
+    format!("{}.", words.join(" "))
+}
+
+fn render_query(tokens: &[u32]) -> String {
+    let words: Vec<String> = tokens
+        .iter()
+        .step_by(2)
+        .rev()
+        .map(|&token| token_word(token))
+        .collect();
+    words.join(" ")
+}
+
+fn metrics(ranks: &[usize]) -> (f64, f64, f64) {
+    let n = ranks.len() as f64;
+    let hits = ranks.iter().filter(|&&r| r == 1).count() as f64;
+    let found = ranks.iter().filter(|&&r| r > 0).count() as f64;
+    let mrr: f64 = ranks
+        .iter()
+        .map(|&r| if r == 0 { 0.0 } else { 1.0 / r as f64 })
+        .sum();
+    (hits / n, mrr / n, found / n)
+}
+
+fn rank_of(results: &[uor_r4_router::ResonanceResult], target_text: &str) -> usize {
+    results
+        .iter()
+        .position(|r| r.sentence == target_text)
+        .map(|p| p + 1)
+        .unwrap_or(0)
+}
+
+/// Fraction of probes whose returned list contains at least one OTHER result
+/// within a hair of the target's relevance — i.e. tied on the lexical term,
+/// where the cosine is the only thing that can reorder. This is the slice a
+/// query-shape change can act on, and it bounds any gain reported below.
+fn tie_mass(router_results: &[(Vec<uor_r4_router::ResonanceResult>, String)]) -> f64 {
+    let mut contested = 0usize;
+    for (results, target) in router_results {
+        let Some(pos) = results.iter().position(|r| &r.sentence == target) else {
+            continue;
+        };
+        let target_relevance = results[pos].relevance;
+        // The lexical term moves in steps of 100; anything inside one step of
+        // the target is in the same overlap bucket.
+        let same_bucket = results
+            .iter()
+            .enumerate()
+            .filter(|(i, r)| *i != pos && (r.relevance - target_relevance).abs() < 100.0)
+            .count();
+        if same_bucket > 0 {
+            contested += 1;
+        }
+    }
+    contested as f64 / router_results.len() as f64
+}
+
+#[test]
+#[ignore = "measurement harness (issue #480); run explicitly with --ignored"]
+fn query_projection_shape() {
+    let meta_path = std::env::var("R4_CORPUS_META").unwrap_or_else(|_| fixture("c_meta.bin"));
+    let recs_path = std::env::var("R4_CORPUS_RECS").unwrap_or_else(|_| fixture("c_recs.bin"));
+    let Some(c) = compiler::load_corpus_from(&meta_path, &recs_path) else {
+        println!("SKIP: corpus fixtures absent ({meta_path} + {recs_path})");
+        return;
+    };
+    println!("#480: query-projection shape vs retrieval quality");
+    println!("corpus: {meta_path} + {recs_path} ({} records)", c.n);
+
+    let cut = (c.stories as f64 * 0.8) as u32;
+    let constr: Vec<bool> = (0..c.stories).map(|sid| sid < u64::from(cut)).collect();
+
+    let mut streams: Vec<(u32, Vec<u32>)> = Vec::new();
+    for ((&sid, &input), &next) in c.story.iter().zip(&c.input).zip(&c.next).take(c.n) {
+        if streams.last().map(|(last, _)| *last) != Some(sid) {
+            streams.push((sid, vec![input]));
+        }
+        let (_, stream) = streams.last_mut().expect("just pushed");
+        stream.push(next);
+    }
+
+    let story_cap = env_usize("R4_HOPF_CONSTR_STORIES", 2_000);
+    let probe_cap = env_usize("R4_HOPF_PROBES", 500).max(1);
+    let capped: Vec<&(u32, Vec<u32>)> = streams
+        .iter()
+        .filter(|(sid, _)| constr[*sid as usize])
+        .take(story_cap)
+        .collect();
+
+    let mut windows: Vec<String> = Vec::new();
+    let mut window_tokens: Vec<Vec<u32>> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for (_, stream) in &capped {
+        for chunk in stream.chunks_exact(compiler::WINDOW) {
+            let sentence = render_window(chunk);
+            if seen.insert(sentence.clone()) {
+                windows.push(sentence);
+                window_tokens.push(chunk.to_vec());
+            }
+        }
+    }
+    println!(
+        "CAPS: {} stories, {} distinct windows, up to {probe_cap} probes, top_n {TOP_N}",
+        capped.len(),
+        windows.len()
+    );
+    assert!(windows.len() > probe_cap, "more windows than probes");
+
+    let stride = (windows.len() / probe_cap).max(1);
+    let targets: Vec<usize> = (0..windows.len()).step_by(stride).take(probe_cap).collect();
+    let queries: Vec<String> = targets
+        .iter()
+        .map(|&t| render_query(&window_tokens[t]))
+        .collect();
+    let deranged: Vec<usize> = (0..targets.len())
+        .map(|i| targets[(i + 1) % targets.len()])
+        .collect();
+
+    println!("\narm\t\tstore/query\ttop-1\tMRR\trecall@{TOP_N}\ttie-mass\tnull MRR");
+    let mut summary: HashMap<&str, (f64, f64, f64, f64, f64)> = HashMap::new();
+    for (arm, banded, full_query) in [
+        ("banded", true, false),
+        ("shipped", false, false),
+        ("symmetric", false, true),
+    ] {
+        let mut router = UorR4Router::new(0.5);
+        router.set_banded_storage(banded);
+        router.set_full_width_query(full_query);
+        let corpus_text: String = windows.join(" ");
+        let indexed = router.index_corpus(&corpus_text, ID);
+        assert_eq!(indexed, windows.len(), "[{arm}] indexed every window");
+
+        let mut ranks = Vec::with_capacity(queries.len());
+        let mut null_ranks = Vec::with_capacity(queries.len());
+        let mut per_probe = Vec::with_capacity(queries.len());
+        for (qi, query) in queries.iter().enumerate() {
+            // Identity-scoped retrieval: query under the identity the corpus
+            // was indexed with, or the index is empty and every arm scores 0.
+            let results = router.get_top_resonances_native(query, ID, TOP_N);
+            ranks.push(rank_of(&results, &windows[targets[qi]]));
+            null_ranks.push(rank_of(&results, &windows[deranged[qi]]));
+            per_probe.push((results, windows[targets[qi]].clone()));
+        }
+
+        let (top1, mrr, recall) = metrics(&ranks);
+        let (_, null_mrr, _) = metrics(&null_ranks);
+        let ties = tie_mass(&per_probe);
+        println!(
+            "{arm:<11}{}\t{top1:.4}\t{mrr:.4}\t{recall:.4}\t\t{ties:.4}\t\t{null_mrr:.4}",
+            match (banded, full_query) {
+                (true, _) => "banded/banded",
+                (false, false) => "full/banded  ",
+                (false, true) => "full/full    ",
+            }
+        );
+        summary.insert(arm, (top1, mrr, recall, ties, null_mrr));
+    }
+
+    let (b_top1, b_mrr, b_recall, b_ties, b_null) = summary["shipped"];
+    let (f_top1, f_mrr, f_recall, _, f_null) = summary["symmetric"];
+
+    println!("\n==== validity ====");
+    let null_dead = b_null < NULL_MRR_CEILING && f_null < NULL_MRR_CEILING;
+    println!(
+        "deranged-key MRR: banded {b_null:.4}, full {f_null:.4} (ceiling {NULL_MRR_CEILING}) — {}",
+        if null_dead { "PASS" } else { "VOID" }
+    );
+    assert!(null_dead, "deranged-key control must be near zero");
+
+    println!(
+        "\nreachable slice: {:.1}% of probes have another candidate inside the target's \
+         lexical bucket, which is where a query-shape change can act at all",
+        b_ties * 100.0
+    );
+
+    let delta_mrr = f_mrr - b_mrr;
+    let delta_top1 = f_top1 - b_top1;
+    println!("\n==== verdict against the pre-declared exit rule ====");
+    let delta_recall = f_recall - b_recall;
+    println!(
+        "shipped (full/banded) {b_mrr:.4} MRR, {b_top1:.4} top-1, {b_recall:.4} recall  ->  \
+         symmetric (full/full) {f_mrr:.4} MRR, {f_top1:.4} top-1, {f_recall:.4} recall  =  \
+         {delta_mrr:+.4} MRR, {delta_top1:+.4} top-1, {delta_recall:+.4} recall \
+         [exit rule: >= +{WIN_MARGIN:.2} MRR]"
+    );
+    if delta_mrr >= WIN_MARGIN {
+        println!(
+            "POSITIVE: matching the query shape to the storage shape is worth \
+             {delta_mrr:+.4} MRR. Re-run the #421 reconnection and memory-lift gates \
+             that de-banding was adopted against before treating this as shipped."
+        );
+    } else {
+        println!(
+            "NEGATIVE against the exit rule: {delta_mrr:+.4} MRR, and recall moves \
+             {delta_recall:+.4}. The asymmetry is real but fixing it does not pay on this \
+             path, so the symmetric shape stays behind `set_full_width_query` and the \
+             deployed default is unchanged. The 0.8948 de-banding figure was never going \
+             to appear here: that harness ranked by cosine ALONE, while this path adds a \
+             lexical term worth 100x the cosine, so the vector shape only reorders \
+             candidates already tied on word overlap. The premise that a measured gain \
+             was going unrealized at serving is REFUTED — not because de-banding failed, \
+             but because this ranking is lexical, not geometric."
+        );
+    }
+}

--- a/docs/query_projection_480.md
+++ b/docs/query_projection_480.md
@@ -1,0 +1,114 @@
+# The query-projection asymmetry is real, and fixing it does not pay
+
+Issue #480. Measured 2026-08-07 on the committed 500k fixture, 2,000
+construction stories → 46,342 distinct windows, 500 held-out probes, through
+`get_top_resonances_native`.
+
+Reproduce with:
+
+```
+cargo test --release -p uor-r4-router --test query_projection -- --ignored --nocapture
+```
+
+About eleven minutes for three arms; no teacher, no checkpoint.
+
+## The asymmetry
+
+PR #465 adopted full-width content-bearing storage — `banded_storage` defaults
+to false and stored vectors keep all 512 coefficients. The query side did not
+follow. `retrieve_geometric_resonance` built a band-only projection, zero
+outside `active_range`. Zeroed query coordinates contribute nothing to a dot
+product, so the cosine only ever saw the band however wide the stored vector
+was.
+
+That is a genuine wiring asymmetry and it is exactly what the #465 scope note
+suspected. The hypothesis attached to it — that the adopted de-banding gain
+(retrieval MRR 0.2348 → 0.8948, router anchor accuracy 9.3% → 11.4%) was
+therefore going unrealized at serving — is **refuted**.
+
+## Result
+
+| arm | store / query | top-1 | MRR | recall@20 | tie-mass |
+|---|---|---:|---:|---:|---:|
+| `banded` | banded / banded (pre-#465) | 0.6240 | 0.7195 | 0.9640 | 0.7580 |
+| **`shipped`** | **full / banded (deployed)** | **0.6240** | **0.7179** | **0.9720** | 0.8120 |
+| `symmetric` | full / full (the proposed fix) | 0.6320 | 0.7238 | 0.9540 | 0.7860 |
+
+Deranged-key null 0.0000 in every arm. The `shipped` row reproduces the #479
+figures exactly, which is the check that the knob added here leaves deployed
+behaviour untouched.
+
+**Fixing the asymmetry is worth +0.0059 MRR and +0.0080 top-1, and costs
+0.0180 of recall@20**, against a pre-declared +0.05 MRR bar. Roughly a tenth of
+the threshold on the metric it was supposed to move, and negative on recall.
+
+Note also that `banded/banded` beats `shipped` on MRR (0.7195 vs 0.7179). The
+de-banding gain does not reach this path from the storage side either.
+
+## Why it cannot pay here
+
+The relevance form is
+
+```
+relevance = shared_count * 100 + sim * slice_norm + scope_boost
+```
+
+`shared_count` is the number of query primes present in the item, multiplied
+by **100**. `sim` is bounded by 1 and `slice_norm` is a band-slice norm.
+Observed relevances look like 415 / 215 / 115 — four, two and one shared words
+plus a fractional cosine. **The ranking is lexical; the cosine is a
+tie-breaker.**
+
+A vector-shape change can therefore only reorder candidates already tied on
+word overlap. The harness reports that tie-mass directly: 81.2% of probes do
+have a same-bucket competitor, so the reachable slice is large — and even
+across that slice, widening the query vector moves almost nothing. It is not
+that the cosine had no room; it is that the cosine's input shape barely
+changes the ordering it produces.
+
+The 0.8948 figure in #442 came from a harness that ranked by **cosine alone**,
+with no lexical term. That number was never going to appear on this path, and
+the original filing (mine) was wrong to treat the gap as unrealized gain. The
+correct statement: de-banding is worth what #442 measured *for cosine-ranked
+retrieval*, and this serving path is not cosine-ranked.
+
+## Disposition
+
+**Not adopted. Deployed behaviour is unchanged.** The symmetric shape sits
+behind `set_full_width_query`, default off, for three reasons:
+
+1. the measured gain is a tenth of the pre-declared bar and recall moves the
+   wrong way;
+2. changing retrieval ordering moves the pinned #421 anchor-accuracy rows, and
+   the regression gate that would catch downstream damage
+   (`router_reconnect.rs`) needs a scored R4G1 artifact that was not available
+   for this run — shipping an ordering change without it would be exactly the
+   kind of unmeasured move the run-contract discipline exists to prevent;
+3. it becomes the right default the moment the lexical term stops dominating,
+   so the capability is worth keeping reachable rather than deleting.
+
+`retrieve_geometric_resonance` now carries a comment saying the asymmetry is
+known, measured and deliberate, pointing here — so this is not re-filed from a
+fresh reading of the code.
+
+## What would change the answer
+
+The lexical term is the reason this lever is dead, so the live question is
+whether `shared_count * 100` is the right ranking at all. It is a hard-coded
+weight, never measured against alternatives, and it dominates a geometric
+retrieval stack by two orders of magnitude. Measuring *that* weight — or
+ranking by cosine within lexical buckets rather than adding the two — is the
+experiment this record points at. It is not filed as an issue: it needs an
+owner and a pre-declared exit rule, and it is a larger question than #480 was.
+
+## Scope limits
+
+- Synthetic word renderings of token ids (`t00042`), the standing #422/#423
+  law for this stack.
+- One corpus, one probe form, `top_n = 20`. The recall figure is a
+  within-top-20 measure and the 0.018 movement is roughly 2 standard errors at
+  500 probes — small, but pointing the wrong way, which is enough at a +0.0059
+  MRR gain.
+- `slice_norm` was deliberately left on the band slice in the symmetric arm:
+  it is a scale factor on the cosine term, not part of the vector shape, and
+  moving both at once would have confounded the measurement.


### PR DESCRIPTION
Closes #480.

I filed this issue claiming the adopted de-banding gain was going unrealized at serving. Measured, **that premise is refuted** — and the reason turns out to be more useful than the fix would have been.

## The asymmetry is real

Storage has been full-width since #465 (`banded_storage` defaults false). `retrieve_geometric_resonance` kept building a **band-only query projection**, zero outside `active_range`. Zeroed query coordinates contribute nothing to a dot product, so the cosine only ever saw the band however wide the stored vector was. That part of the filing was correct.

## Result

500k fixture, 46,342 windows, 500 probes, deranged-key null **0.0000 in every arm**:

| arm | store / query | top-1 | MRR | recall@20 | tie-mass |
|---|---|---:|---:|---:|---:|
| `banded` | banded / banded (pre-#465) | 0.6240 | 0.7195 | 0.9640 | 0.7580 |
| **`shipped`** | **full / banded (deployed)** | **0.6240** | **0.7179** | **0.9720** | 0.8120 |
| `symmetric` | full / full (the fix) | 0.6320 | 0.7238 | 0.9540 | 0.7860 |

Fixing it is worth **+0.0059 MRR / +0.0080 top-1** while costing **0.0180 recall@20**, against a pre-declared **+0.05 MRR** bar. A tenth of the threshold on the metric it was meant to move, and negative on recall.

Note `banded/banded` beats `shipped` on MRR — the de-banding gain doesn't reach this path from the storage side either.

The `shipped` row reproduces #479's figures exactly, which is the check that the knob added here leaves deployed behaviour untouched.

## Why it cannot pay

```
relevance = shared_count * 100 + sim * slice_norm + scope_boost
```

`shared_count` is word overlap × **100**; `sim` is bounded by 1. Observed relevances look like 415 / 215 / 115 — four, two, one shared words plus a fractional cosine. **The ranking is lexical; the cosine is a tie-breaker.** A vector-shape change can only reorder candidates already tied on word overlap.

The harness reports that tie-mass directly — **81.2%** of probes have a same-bucket competitor — so the reachable slice is large, and the shape *still* barely moves the ordering. The cosine had room; widening its input just doesn't change what it produces.

The 0.8948 figure in #442 came from a harness ranking by **cosine alone**. De-banding is worth what #442 measured *for cosine-ranked retrieval*; this serving path is not cosine-ranked. My filing was wrong to read the gap as unrealized gain.

## Not adopted — deployed behaviour unchanged

The symmetric shape sits behind `set_full_width_query` (default off, `#[serde(skip)]`):

1. the gain is a tenth of the bar and recall moves the wrong way;
2. an ordering change moves the pinned #421 anchor-accuracy rows, and `router_reconnect.rs` needs a scored R4G1 artifact that wasn't available here — shipping without that gate would be exactly the unmeasured move the run-contract discipline exists to prevent;
3. it becomes the right default the moment the lexical term stops dominating, so it's worth keeping reachable rather than deleting.

`retrieve_geometric_resonance` now carries a comment saying the asymmetry is known, measured and deliberate, pointing at the record — so this doesn't get re-filed from a fresh reading of the code.

## What this points at

The `* 100` lexical weight is hard-coded, never measured against alternatives, and dominates a geometric retrieval stack by two orders of magnitude. Measuring that weight — or ranking by cosine *within* lexical buckets rather than summing the two — is the experiment worth running. Recorded in the doc, deliberately **not** filed: it needs an owner and a pre-declared exit rule, and it's a larger question than this issue was.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check_claim_wording.py`, `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`, full `uor-r4-router` suite and dependent builds all green. Harness is `--ignored` (~11 min, three arms, no teacher).