### PR TITLE
perf(certify): #471 — skip the whole-corpus right-context pass a sampled run never reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ predicts at all, and not past it.
 | #424 | Bott-Fock O(1) context fold | Ceiling measured, A/B not reachable. Long-range signal on this corpus is worth +1.02pp of top-1 (two thirds of it order-carried); the shipped decay constant `>> 2` retains 16% of that, so the lossless upper bound on the fold as shipped is +0.16pp — one standard error. Retuning the decay to `>> 7` would recover the ceiling. `docs/context_horizon_424.md` |
 | #434 | VSA / spectral geometry | Both items done. Item 1 (zeta-grid at scale) shipped as full-width storage. Item 2 measured (`docs/geometry_ablation_434.md`): Spectral **0.7179 MRR / 0.972 recall@20**, VSA **0.0000** — not a quality gap but a wiring one, since `index_corpus` populates the corpus index Spectral reads and never the `facet_store` VSA reads. A caller who sets `geometry_type = Vsa` after `index_corpus` silently loses retrieval |
 | #469 | Vectorize the assign path | Done. Lever A (κ-keyed code sidecar) 625s → 39s; lever B routes the corpus code passes through the existing `simd::dot_argmax` using tables decoded once per artifact — **1.60x** on the pinned TLA7 artifact. Bit-identity is proven, not argued: `tests/assign_prepared.rs` checks prepared == scalar over 1,024 real corpus positions on the committed artifact fixture, and the κ witness carries it on a fresh compile. Per-call decoding would have been a ~4x regression, which is why the batch API exists |
-| #471 | Sampled runs still pay full-corpus table builds | `derive_right_codes` and the two-sided/latent table builds ignore the sample knob |
+| #471 | Sampled runs still pay full-corpus table builds | Knob shipped, cause **only partly explained**. Gate C now prints a per-phase wall clock, and it revised the diagnosis: the two table builds are 0.8% of a sampled run, while the whole-corpus right-context code pass is 59%. `R4_GATE_C_SKIP_ARMS=right_context` drops that pass and the five #446 arms that depend on it — **62.9% off the Gate C phase** at 500k, with all 45 remaining `gate_c` keys identical. But 102 µs/record extrapolates to ~4 minutes at 2.11M, not the 85 that opened the issue, and peak RSS differs by only 5.6%, so the residual is unexplained and filed. `docs/gate_c_arm_skip_471.md` |
 | #456–#459 | Reconstructability, block search, IPF reconstruction, estimation ladder | Active track |
 | #320 | Teacher upgrade (SmolLM2) | P1/P2 rehearsal recorded; migration decision open |
 | #273 | Template rebase / claim register | On-hold; no implementation |
@@ -224,7 +224,14 @@ recomputing; it loads only when eight fields and a blake3 digest all agree, and
 refuses itself entirely in biased-sampling mode so a partial vector can never
 poison a later run. The `capacity_scaling` instrument prints a saturation
 verdict per structure and is meant to be run *before* trusting any measurement
-taken on a given configuration.
+taken on a given configuration. Gate C also prints a **per-phase wall clock**
+(#471) — it exists because "the Gate C phase took eighty-five minutes" was an
+unattributable number that two different proposals blamed on two different
+passes, and neither had been measured; a harness whose cost is invisible gets
+optimized by argument. `R4_GATE_C_SKIP_ARMS=right_context` then drops the
+whole-corpus pass that profile blamed, and the arms that depend on it are
+reported **absent** rather than zeroed, because a skipped row that prints
+`0.0%` is the vacuous-instrument pattern this repository keeps rediscovering.
 
 ## Documentation
 

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1949,6 +1949,142 @@ fn binomial_standard_error(p: f64, n: usize) -> f64 {
 /// UNSET is the full pass, bit-identical to the pre-#467 evaluation.
 pub const GATE_C_SAMPLE_ENV: &str = "R4_GATE_C_SAMPLE";
 
+/// Environment override naming Gate C ARM GROUPS this run must not build
+/// (#471). Comma-separated group names; UNSET evaluates every arm and is
+/// behaviour-identical to the pre-#471 evaluation.
+///
+/// Why a group name and not a boolean. The thing worth skipping is never one
+/// row; it is the closure of one expensive pass — every row that depends on
+/// it. Naming the *cost* rather than the issue number keeps the knob from
+/// degenerating into a list of ad-hoc flags as arms accumulate, and it makes
+/// the skipped set nameable in the output, which is what stops a skipped row
+/// from reading as a measured one.
+///
+/// Why an unknown name PANICS. A typo that silently evaluated everything
+/// would hand back an 85-minute run when the caller asked for a 30-second
+/// one, and — worse in the other direction — a typo that silently skipped
+/// nothing looks exactly like a knob that does not work. Both failures are
+/// invisible; the panic is not.
+pub const GATE_C_SKIP_ARMS_ENV: &str = "R4_GATE_C_SKIP_ARMS";
+
+/// The `right_context` arm group: the #446 M1 two-sided family and the #446
+/// M2 latent family together.
+///
+/// They are one group because they are exactly the closure of
+/// [`derive_right_codes`] — the whole-corpus right-context code pass that
+/// #471 measured at 60% of a sampled Gate C run's wall clock on the 500k
+/// fixture, and a larger share as the corpus grows (the pass scales with
+/// `n`; the scored sample does not). Nothing else in the evaluation reads a
+/// right-context code, so skipping this group and skipping that pass are the
+/// same act.
+pub const ARM_GROUP_RIGHT_CONTEXT: &str = "right_context";
+
+/// Which arm groups a run was told to skip. `Default` is "skip nothing",
+/// which is the unset contract.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SkippedArms {
+    /// [`ARM_GROUP_RIGHT_CONTEXT`].
+    pub right_context: bool,
+}
+
+impl SkippedArms {
+    /// The group names this run skipped, in a stable order, for the report
+    /// and the printed banner.
+    pub fn names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        if self.right_context {
+            names.push(ARM_GROUP_RIGHT_CONTEXT.to_owned());
+        }
+        names
+    }
+
+    pub fn any(&self) -> bool {
+        self.right_context
+    }
+}
+
+/// Parse a [`GATE_C_SKIP_ARMS_ENV`] value. Pure, so the contract is unit
+/// testable without mutating process environment from a test thread.
+///
+/// Empty and whitespace-only values mean "skip nothing", matching UNSET —
+/// `R4_GATE_C_SKIP_ARMS=` in a shell script should not be a different mode
+/// from not writing the line at all. Names are trimmed and matched exactly;
+/// an unrecognised one panics rather than being dropped.
+pub fn parse_skip_arms(value: Option<&str>) -> SkippedArms {
+    let mut skipped = SkippedArms::default();
+    let Some(value) = value else {
+        return skipped;
+    };
+    for name in value.split(',') {
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        match name {
+            ARM_GROUP_RIGHT_CONTEXT => skipped.right_context = true,
+            other => panic!(
+                "{GATE_C_SKIP_ARMS_ENV}: unknown arm group {other:?}; \
+                 known groups: {ARM_GROUP_RIGHT_CONTEXT}"
+            ),
+        }
+    }
+    skipped
+}
+
+fn gate_c_skip_arms() -> SkippedArms {
+    parse_skip_arms(std::env::var(GATE_C_SKIP_ARMS_ENV).ok().as_deref())
+}
+
+/// Wall-clock accounting for the passes [`evaluate_gate_c`] runs, printed to
+/// stderr as the evaluation proceeds (#471).
+///
+/// Why this exists. "The Gate C phase took eighty-five minutes" was, until
+/// #471, an unattributable number: the evaluation runs four whole-corpus
+/// passes before `gate_c_sample` narrows anything, and nothing said which of
+/// them owned the wall clock. Attributing it took a code read, and the first
+/// two proposals for fixing it named different passes. A harness whose cost
+/// is invisible gets optimized by argument rather than by measurement.
+///
+/// Why stderr and not the report. A duration is machine- and load-dependent,
+/// so putting one in `score_report.json` would make the document differ
+/// between two runs of identical pinned inputs — exactly what the
+/// deterministic-rebuild gate exists to catch. These lines are diagnostics
+/// beside the existing `score: …` progress prints, never report content.
+struct PhaseLog {
+    start: std::time::Instant,
+    last: std::time::Instant,
+}
+
+impl PhaseLog {
+    fn new() -> Self {
+        let now = std::time::Instant::now();
+        PhaseLog {
+            start: now,
+            last: now,
+        }
+    }
+
+    /// Close the phase that ended here, naming it and its duration.
+    fn mark(&mut self, phase: &str) {
+        let now = std::time::Instant::now();
+        eprintln!(
+            "gate c phase: {phase} {:.2}s (cumulative {:.2}s)",
+            now.duration_since(self.last).as_secs_f64(),
+            now.duration_since(self.start).as_secs_f64()
+        );
+        self.last = now;
+    }
+
+    /// Close the whole evaluation. Measured from `now`, not from the last
+    /// mark, so any unmarked tail shows up in the total instead of vanishing.
+    fn total(&self) {
+        eprintln!(
+            "gate c phase: TOTAL {:.2}s",
+            self.start.elapsed().as_secs_f64()
+        );
+    }
+}
+
 /// Deterministic stratified subsample of the held-out evaluation list.
 ///
 /// Motivation. The long runs buy precision nobody uses. At 402,802
@@ -2066,15 +2202,6 @@ pub struct WinLossReport {
     /// #399 rescue variant: STRICT-gated draft arm on its live slice
     /// (every draft step ExactContext, not just the final one).
     pub fwd_strict_vs_rule12_live: WinLoss,
-    /// #446 M1: two-sided (left, right) keyed arm vs Rule 1+2 on the
-    /// two-sided live slice — the positions where the pair table
-    /// resolved with support and could change a decision. NOT causal:
-    /// the right key reads tokens after the target, so this cross-tab is
-    /// an infill/analysis measurement, never a generation number.
-    pub twosided_vs_rule12_live: WinLoss,
-    /// #446 M1 falsifier: the foreign-right-key arm against Rule 1+2 on
-    /// its own live slice.
-    pub twosided_shuffled_vs_rule12_live: WinLoss,
 }
 
 /// Candidate-set recall, reported separately from selected-token
@@ -2284,79 +2411,16 @@ pub struct GateCNulls {
     pub held_out_positions: usize,
 }
 
-/// The Gate C outcome: the four number sets (old formula, Rule 1,
-/// Rule 1+2, baseline), the status and win/loss instrumentation,
-/// candidate recall, and the witness-replay sample result.
+/// The #446 right-context arm group: the M1 two-sided family and the M2
+/// latent right-context family, which share the whole-corpus
+/// [`derive_right_codes`] pass and are therefore built, skipped and
+/// reported together.
+///
+/// Carried behind an `Option` on [`GateCOutcome`] so that "not evaluated"
+/// is a different value from "evaluated and zero" — see
+/// [`GateCOutcome::right_context_arms`].
 #[derive(Debug, Clone, Default, Serialize)]
-pub struct GateCOutcome {
-    /// Size of the held-out split the evaluation was handed (#467). Equal
-    /// to the number of positions scored on a full pass.
-    pub held_out_population: usize,
-    /// Number of held-out positions actually scored when the #467 sampled
-    /// decision mode is active, or `0` on a full pass (a census). Nonzero
-    /// means every rate in this outcome is an ESTIMATE whose noise is the
-    /// `standard_error` of its own row.
-    pub positions_sampled: usize,
-    /// OLD Σ-over-cloud formula (with EXCT evidence wired), kept for
-    /// comparison — the confirmed double counting lives there.
-    pub legacy_sum: GateCMetrics,
-    /// NEW Rule 1 (chain-telescoped residuals, no EXCT).
-    pub rule1_chain: GateCMetrics,
-    /// NEW Rule 1+2 (chain-telescoped + D4 EXCT precedence).
-    pub rule12_precedence: GateCMetrics,
-    /// Ablation (issue #66): Rule 1 with predicted-cloud (ΔT) emissions
-    /// disabled — the no-EXCT measure of ΔT's contribution.
-    pub rule1_chain_no_f: GateCMetrics,
-    /// Ablation (issue #66): Rule 1+2 with ΔT emissions disabled — the
-    /// precedence path's measure of ΔT's contribution.
-    pub rule12_precedence_no_f: GateCMetrics,
-    /// Candidate variant (issue #80): Cloud-size normalized scoring.
-    pub rule12_cloud_size_normalized: GateCMetrics,
-    /// Candidate variant (issue #80): Margin-weighted residual scoring.
-    pub rule12_margin_weighted: GateCMetrics,
-    /// TLA3 store baseline (`runtime::predict_witness_plain`).
-    pub tla3_baseline: GateCMetrics,
-    /// #399 M2 instrumentation: Rule 1+2 fused with the forward-anchor
-    /// channel by the measured product law (harness record on #394/#399),
-    /// over ALL held-out positions; where the channel is inert the fused
-    /// selection IS the Rule 1+2 selection, so this row can only differ
-    /// from `rule12_precedence` through live positions.
-    pub rule12_fwd_fused: GateCMetrics,
-    /// #399 M2: the fused scorer on the LIVE slice only.
-    pub rule12_fwd_fused_live: GateCMetrics,
-    /// #399 M2: Rule 1+2 on the same live slice — the honest comparator
-    /// for `rule12_fwd_fused_live` (identical population).
-    pub rule12_on_fwd_live: GateCMetrics,
-    /// #399 B′: the SELF-anchor fused scorer (all positions; live pair
-    /// below) — the two-pass serving question, anchor supplied by the
-    /// engine's own Rule 1+2 prediction at the anchor position.
-    pub rule12_fwd_self_fused: GateCMetrics,
-    pub rule12_fwd_self_fused_live: GateCMetrics,
-    pub rule12_on_fwd_self_live: GateCMetrics,
-    /// #399 B′: the confidence-gated self-anchor scorer (prediction
-    /// trusted only where it resolved as ExactContext).
-    pub rule12_fwd_gated_fused: GateCMetrics,
-    pub rule12_fwd_gated_fused_live: GateCMetrics,
-    pub rule12_on_fwd_gated_live: GateCMetrics,
-    /// #399 falsifier 1: the DRAFT-anchor gated scorer — same gate and
-    /// fusion law as the gated arm, but the anchor is predicted from the
-    /// engine's own greedy DRAFT (pass-1 token here plus drafted
-    /// continuations) instead of teacher-forced corpus context; the
-    /// spread against the gated arm is the draft-drift cost of a real
-    /// two-pass generation.
-    pub rule12_fwd_draft_fused: GateCMetrics,
-    pub rule12_fwd_draft_fused_live: GateCMetrics,
-    pub rule12_on_fwd_draft_live: GateCMetrics,
-    /// #399 rescue variant (responding to the falsifier-1 negative:
-    /// draft-gated live 40.4% vs 41.3% while the teacher-forced gated
-    /// arm measured 45.0% vs 39.4%): the STRICT-gated draft scorer —
-    /// identical draft, anchor, and fusion, but trusted only where EVERY
-    /// intermediate greedy step resolved as ExactContext (drift enters
-    /// through uncertain intermediate steps). Its live slice is a subset
-    /// of the draft arm's.
-    pub rule12_fwd_strict_fused: GateCMetrics,
-    pub rule12_fwd_strict_fused_live: GateCMetrics,
-    pub rule12_on_fwd_strict_live: GateCMetrics,
+pub struct RightContextArms {
     /// #446 M1: Rule 1+2 with the TWO-SIDED (left graded prefix, right
     /// graded prefix) table taking D4-style precedence wherever it
     /// resolves with support, over ALL held-out positions. Where the
@@ -2451,6 +2515,117 @@ pub struct GateCOutcome {
     /// [`LATENT_EXIT_MARGIN`] of top-1 agreement on the same population
     /// AND beat the shuffled-class falsifier.
     pub latent_exit_rule_met: bool,
+    /// #446 M1: two-sided (left, right) keyed arm vs Rule 1+2 on the
+    /// two-sided live slice — the positions where the pair table
+    /// resolved with support and could change a decision. NOT causal:
+    /// the right key reads tokens after the target, so this cross-tab is
+    /// an infill/analysis measurement, never a generation number.
+    ///
+    /// Lives here rather than in `win_loss` (where it sat before schema
+    /// twenty-six) because it is in the closure of the right-context code
+    /// pass: on a skipped run it has no value, and an all-zero cross-tab
+    /// sitting among populated ones is precisely the reading this group's
+    /// `Option` exists to prevent. The #471 equivalence test caught it
+    /// there.
+    pub twosided_vs_rule12_live: WinLoss,
+    /// #446 M1 falsifier: the foreign-right-key arm against Rule 1+2 on
+    /// its own live slice.
+    pub twosided_shuffled_vs_rule12_live: WinLoss,
+}
+
+/// The Gate C outcome: the four number sets (old formula, Rule 1,
+/// Rule 1+2, baseline), the status and win/loss instrumentation,
+/// candidate recall, and the witness-replay sample result.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GateCOutcome {
+    /// Size of the held-out split the evaluation was handed (#467). Equal
+    /// to the number of positions scored on a full pass.
+    pub held_out_population: usize,
+    /// Number of held-out positions actually scored when the #467 sampled
+    /// decision mode is active, or `0` on a full pass (a census). Nonzero
+    /// means every rate in this outcome is an ESTIMATE whose noise is the
+    /// `standard_error` of its own row.
+    pub positions_sampled: usize,
+    /// OLD Σ-over-cloud formula (with EXCT evidence wired), kept for
+    /// comparison — the confirmed double counting lives there.
+    pub legacy_sum: GateCMetrics,
+    /// NEW Rule 1 (chain-telescoped residuals, no EXCT).
+    pub rule1_chain: GateCMetrics,
+    /// NEW Rule 1+2 (chain-telescoped + D4 EXCT precedence).
+    pub rule12_precedence: GateCMetrics,
+    /// Ablation (issue #66): Rule 1 with predicted-cloud (ΔT) emissions
+    /// disabled — the no-EXCT measure of ΔT's contribution.
+    pub rule1_chain_no_f: GateCMetrics,
+    /// Ablation (issue #66): Rule 1+2 with ΔT emissions disabled — the
+    /// precedence path's measure of ΔT's contribution.
+    pub rule12_precedence_no_f: GateCMetrics,
+    /// Candidate variant (issue #80): Cloud-size normalized scoring.
+    pub rule12_cloud_size_normalized: GateCMetrics,
+    /// Candidate variant (issue #80): Margin-weighted residual scoring.
+    pub rule12_margin_weighted: GateCMetrics,
+    /// TLA3 store baseline (`runtime::predict_witness_plain`).
+    pub tla3_baseline: GateCMetrics,
+    /// #399 M2 instrumentation: Rule 1+2 fused with the forward-anchor
+    /// channel by the measured product law (harness record on #394/#399),
+    /// over ALL held-out positions; where the channel is inert the fused
+    /// selection IS the Rule 1+2 selection, so this row can only differ
+    /// from `rule12_precedence` through live positions.
+    pub rule12_fwd_fused: GateCMetrics,
+    /// #399 M2: the fused scorer on the LIVE slice only.
+    pub rule12_fwd_fused_live: GateCMetrics,
+    /// #399 M2: Rule 1+2 on the same live slice — the honest comparator
+    /// for `rule12_fwd_fused_live` (identical population).
+    pub rule12_on_fwd_live: GateCMetrics,
+    /// #399 B′: the SELF-anchor fused scorer (all positions; live pair
+    /// below) — the two-pass serving question, anchor supplied by the
+    /// engine's own Rule 1+2 prediction at the anchor position.
+    pub rule12_fwd_self_fused: GateCMetrics,
+    pub rule12_fwd_self_fused_live: GateCMetrics,
+    pub rule12_on_fwd_self_live: GateCMetrics,
+    /// #399 B′: the confidence-gated self-anchor scorer (prediction
+    /// trusted only where it resolved as ExactContext).
+    pub rule12_fwd_gated_fused: GateCMetrics,
+    pub rule12_fwd_gated_fused_live: GateCMetrics,
+    pub rule12_on_fwd_gated_live: GateCMetrics,
+    /// #399 falsifier 1: the DRAFT-anchor gated scorer — same gate and
+    /// fusion law as the gated arm, but the anchor is predicted from the
+    /// engine's own greedy DRAFT (pass-1 token here plus drafted
+    /// continuations) instead of teacher-forced corpus context; the
+    /// spread against the gated arm is the draft-drift cost of a real
+    /// two-pass generation.
+    pub rule12_fwd_draft_fused: GateCMetrics,
+    pub rule12_fwd_draft_fused_live: GateCMetrics,
+    pub rule12_on_fwd_draft_live: GateCMetrics,
+    /// #399 rescue variant (responding to the falsifier-1 negative:
+    /// draft-gated live 40.4% vs 41.3% while the teacher-forced gated
+    /// arm measured 45.0% vs 39.4%): the STRICT-gated draft scorer —
+    /// identical draft, anchor, and fusion, but trusted only where EVERY
+    /// intermediate greedy step resolved as ExactContext (drift enters
+    /// through uncertain intermediate steps). Its live slice is a subset
+    /// of the draft arm's.
+    pub rule12_fwd_strict_fused: GateCMetrics,
+    pub rule12_fwd_strict_fused_live: GateCMetrics,
+    pub rule12_on_fwd_strict_live: GateCMetrics,
+    /// #446 M1 + M2, THE RIGHT-CONTEXT ARM GROUP (`right_context`).
+    ///
+    /// `None` means these arms were NOT EVALUATED on this run — the
+    /// whole-corpus right-context code pass they all depend on was skipped
+    /// via [`GATE_C_SKIP_ARMS_ENV`] (#471). It does not mean they measured
+    /// zero, and `latent_exit_rule_met` being absent does not mean the exit
+    /// rule failed.
+    ///
+    /// The `Option` is the point. These twenty-four numbers used to sit flat
+    /// on this struct, so a skipped run would have serialised
+    /// `rule12_latent_mix.top1_agreement: 0.0` and
+    /// `latent_exit_rule_met: false` — an all-zero arm set, which this
+    /// repository has learned to read as a harness bug, and a pre-declared
+    /// exit rule reported as failed when it was never run. Absence and a
+    /// measured zero must not share a representation, so they do not.
+    pub right_context_arms: Option<RightContextArms>,
+    /// Arm groups this run was told not to build, by name (#471), so the
+    /// report says what is missing rather than leaving a reader to infer it
+    /// from a null. Empty on an ordinary run.
+    pub skipped_arm_groups: Vec<String>,
     /// #399 B′: predicted-anchor accuracy on the anchor-reachable
     /// population (numerator/denominator + rate).
     pub anchor_hat_population: usize,
@@ -2740,6 +2915,21 @@ fn pack_two_sided(left: u32, right: u32) -> TwoSidedKey {
 }
 
 impl TwoSidedTable {
+    /// The table a run that skipped [`ARM_GROUP_RIGHT_CONTEXT`] carries:
+    /// every level empty, so [`TwoSidedTable::resolve`] is inert at every
+    /// position and the arm falls through to Rule 1+2 exactly as it does
+    /// where no supported pair exists.
+    ///
+    /// The rows this then produces are Rule 1+2 passthrough values and are
+    /// NOT two-sided measurements. They never reach the report:
+    /// [`GateCOutcome::right_context_arms`] is `None` on a skipped run, and
+    /// the type is what keeps them from being published as arm numbers.
+    fn empty() -> Self {
+        TwoSidedTable {
+            levels: (0..=STAGES).map(|_| TwoSidedLevel::default()).collect(),
+        }
+    }
+
     /// Build every depth from the construction positions that carry an
     /// in-story right window.
     fn build(
@@ -2946,6 +3136,18 @@ struct LatentRightTable {
 }
 
 impl LatentRightTable {
+    /// The counterpart of [`TwoSidedTable::empty`] for a run that skipped
+    /// [`ARM_GROUP_RIGHT_CONTEXT`]: every emission and posterior level
+    /// empty, so `resolve_left` finds no supported prefix and the mixture
+    /// arm is inert at every position.
+    fn empty(class_depth: usize) -> Self {
+        LatentRightTable {
+            class_depth,
+            emission: (0..=STAGES).map(|_| TwoSidedLevel::default()).collect(),
+            posterior: (0..=STAGES).map(|_| TwoSidedLevel::default()).collect(),
+        }
+    }
+
     fn build(
         corpus: &Corpus,
         is_held_out: &[bool],
@@ -3108,6 +3310,18 @@ pub fn evaluate_gate_c(
     held_out: &[Observation],
     config: &ScoreConfig,
 ) -> Result<GateCOutcome, String> {
+    // #471: every whole-corpus pass below announces its own cost, and the
+    // arm groups this run was told not to build are resolved up front so the
+    // skip is one decision read in one place.
+    let skipped_arms = gate_c_skip_arms();
+    let mut phases = PhaseLog::new();
+    if skipped_arms.any() {
+        eprintln!(
+            "score: {GATE_C_SKIP_ARMS_ENV}={} — those arm groups are NOT EVALUATED on this run; \
+             their rows are absent from the report, not zero",
+            skipped_arms.names().join(",")
+        );
+    }
     let mut scorer_no_exct =
         GraphScorer::from_artifact(r4g1, None, config.root_top_b, config.exct_top_x)?;
     scorer_no_exct.set_f_emissions(true);
@@ -3152,6 +3366,8 @@ pub fn evaluate_gate_c(
     )?;
     scorer_margin.set_scoring_variant(ScoringVariant::MarginWeighted);
     scorer_margin.set_repetition_penalty_raw(config.repetition_penalty_raw);
+
+    phases.mark("scorer construction");
 
     let mut outcome = GateCOutcome::default();
     let mut bits_legacy = 0f64;
@@ -3213,6 +3429,11 @@ pub fn evaluate_gate_c(
     let mut rule12_strict_live_bits = 0f64;
     // #446 M1 two-sided arm accumulators (all positions + live slice),
     // and the foreign-right-key falsifier. NOT causal — infill/analysis.
+    // #446 M1 cross-tabs. Local rather than written straight onto
+    // `outcome.win_loss`, because they belong to the right-context arm group
+    // and must be absent, not zero, when that group is skipped (#471).
+    let mut twosided_win_loss = WinLoss::default();
+    let mut twosided_shuffled_win_loss = WinLoss::default();
     let mut hits_twosided = 0u64;
     let mut bits_twosided = 0f64;
     let mut twosided_live_positions = 0usize;
@@ -3354,13 +3575,31 @@ pub fn evaluate_gate_c(
         }
     }
 
+    phases.mark("forward-anchor table (#399 M2)");
+
     // #446 M1: the two-sided (left graded prefix, right graded prefix)
     // table, built from the CONSTRUCTION split only (positions outside
     // the held-out set) under the same infill protocol as the forward
     // table above. NOT causal — the right key reads tokens after the
     // target, so this is an infill/analysis (A-mode) measurement or a
     // prospective construction-time signal, never a generation number.
-    let right_codes = derive_right_codes(artifacts, &gate_rotations, corpus);
+    //
+    // #471: this is the pass the arm-skip knob exists for. It is a whole
+    // corpus `bundle_window_plain` + assign, it is NOT sidecar-cached (the
+    // #469 lever-A sidecar keys the LEFT codes), and it scales with `n`
+    // while a sampled evaluation's scored population does not — so its share
+    // of a decision run's wall clock grows with the corpus. Measured at 60%
+    // of a 10,000-position run on the 500k fixture.
+    let right_codes = if skipped_arms.right_context {
+        // The sentinel the two arms already treat as inert: no in-story
+        // right window anywhere. `resolve` and `resolve_left` short-circuit
+        // on it, so no row-level branch is needed and the scored rows take
+        // the same code path they take at a story end today.
+        vec![([0u8; STAGES], false); corpus.n]
+    } else {
+        derive_right_codes(artifacts, &gate_rotations, corpus)
+    };
+    phases.mark("right-context code pass (#446)");
     // #469 lever A: the left (causal) code of every record is the same
     // `code_plain` pass every other consumer runs. Serve it from the
     // κ-keyed sidecar when one verifies against BOTH the artifact κ and the
@@ -3378,7 +3617,13 @@ pub fn evaluate_gate_c(
                 })
                 .collect()
         });
-    let two_sided = TwoSidedTable::build(corpus, &is_held_out, &left_codes, &right_codes);
+    phases.mark("left code pass (sidecar or derive, #469 lever A)");
+    let two_sided = if skipped_arms.right_context {
+        TwoSidedTable::empty()
+    } else {
+        TwoSidedTable::build(corpus, &is_held_out, &left_codes, &right_codes)
+    };
+    phases.mark("two-sided table build (#446 M1)");
     // #446 M2: the latent right-context mixture tables, built from the
     // same construction split. CAUSALLY LEGITIMATE at serving: the right
     // context is observed here, during construction, and marginalized
@@ -3388,13 +3633,18 @@ pub fn evaluate_gate_c(
         .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|depth| (1..=STAGES).contains(depth))
         .unwrap_or(LATENT_CLASS_DEPTH_DEFAULT);
-    let latent = LatentRightTable::build(
-        corpus,
-        &is_held_out,
-        &left_codes,
-        &right_codes,
-        latent_class_depth,
-    );
+    let latent = if skipped_arms.right_context {
+        LatentRightTable::empty(latent_class_depth)
+    } else {
+        LatentRightTable::build(
+            corpus,
+            &is_held_out,
+            &left_codes,
+            &right_codes,
+            latent_class_depth,
+        )
+    };
+    phases.mark("latent right-context tables (#446 M2)");
     // #467: the positions actually SCORED. Full pass unless
     // `R4_GATE_C_SAMPLE` is set; the held-out mask above (and every table
     // built from it) always sees the complete held-out list, so sampling
@@ -3458,6 +3708,8 @@ pub fn evaluate_gate_c(
     let mut null_bits_generalization = 0f64;
     let mut generalization_positions = 0u64;
 
+    phases.mark("unigram null over the construction split (#390)");
+
     // Each held-out position is independent. Collect compact rows in Rayon;
     // reduce them in input order below so floating-point totals and all
     // report bytes retain the serial implementation's determinism.
@@ -3466,6 +3718,7 @@ pub fn evaluate_gate_c(
         .enumerate()
         .map(|(index, observation)| evaluate_gate_c_row(index, observation, &context))
         .collect::<Result<Vec<_>, _>>()?;
+    phases.mark(&format!("scoring {} positions", scored.len()));
     for row in rows {
         hits_legacy += u64::from(row.hits[0]);
         hits_rule1 += u64::from(row.hits[1]);
@@ -3677,11 +3930,7 @@ pub fn evaluate_gate_c(
             twosided_live_bits += row.bits_twosided;
             rule12_twosided_live_hits += u64::from(row.hits[2]);
             rule12_twosided_live_bits += row.bits[2];
-            accumulate_win_loss(
-                &mut outcome.win_loss.twosided_vs_rule12_live,
-                row.hit_twosided,
-                row.hits[2],
-            );
+            accumulate_win_loss(&mut twosided_win_loss, row.hit_twosided, row.hits[2]);
         }
         hits_twosided_shuffled += u64::from(row.hit_twosided_shuffled);
         bits_twosided_shuffled += row.bits_twosided_shuffled;
@@ -3692,7 +3941,7 @@ pub fn evaluate_gate_c(
             rule12_shuffled_live_hits += u64::from(row.hits[2]);
             rule12_shuffled_live_bits += row.bits[2];
             accumulate_win_loss(
-                &mut outcome.win_loss.twosided_shuffled_vs_rule12_live,
+                &mut twosided_shuffled_win_loss,
                 row.hit_twosided_shuffled,
                 row.hits[2],
             );
@@ -3796,77 +4045,94 @@ pub fn evaluate_gate_c(
         rule12_strict_live_bits,
         strict_live_positions,
     );
-    outcome.rule12_twosided = metrics(hits_twosided, bits_twosided);
-    outcome.rule12_twosided_live = live_metrics(
-        twosided_live_hits,
-        twosided_live_bits,
-        twosided_live_positions,
-    );
-    outcome.rule12_on_twosided_live = live_metrics(
-        rule12_twosided_live_hits,
-        rule12_twosided_live_bits,
-        twosided_live_positions,
-    );
-    outcome.rule12_twosided_shuffled = metrics(hits_twosided_shuffled, bits_twosided_shuffled);
-    outcome.rule12_twosided_shuffled_live = live_metrics(
-        shuffled_live_hits,
-        shuffled_live_bits,
-        shuffled_live_positions,
-    );
-    outcome.rule12_on_twosided_shuffled_live = live_metrics(
-        rule12_shuffled_live_hits,
-        rule12_shuffled_live_bits,
-        shuffled_live_positions,
-    );
-    outcome.rule12_twosided_depths = twosided_depths;
-    outcome.rule12_twosided_exct_slice = live_metrics(
-        twosided_exct_hits,
-        twosided_exct_bits,
-        twosided_exct_positions,
-    );
-    outcome.rule12_on_twosided_exct_slice = live_metrics(
-        rule12_exct_slice_hits,
-        rule12_exct_slice_bits,
-        twosided_exct_positions,
-    );
-    outcome.rule12_twosided_exct_slice_live = twosided_exct_live;
-    // #446 M2: the latent mixture rows, plus the pre-declared exit rule.
-    outcome.rule12_latent_mix = metrics(hits_latent, bits_latent_total);
-    outcome.rule12_latent_mix_live =
-        live_metrics(latent_live_hits, latent_live_bits, latent_live_positions);
-    outcome.rule12_on_latent_mix_live = live_metrics(
-        rule12_latent_live_hits,
-        rule12_latent_live_bits,
-        latent_live_positions,
-    );
-    outcome.rule12_latent_oracle = metrics(hits_latent_oracle, bits_latent_oracle_total);
-    outcome.rule12_latent_shuffled = metrics(hits_latent_shuffled, bits_latent_shuffled_total);
-    outcome.latent_oracle_live_positions = latent_oracle_live_positions;
-    outcome.latent_shuffled_live_positions = latent_shuffled_live_positions;
-    outcome.latent_class_depth = latent_class_depth;
-    let (latent_left_cells, latent_class_cells, latent_ratio) = latent.classes_per_full_left();
-    outcome.latent_full_left_cells = latent_left_cells;
-    outcome.latent_full_class_cells = latent_class_cells;
-    outcome.latent_classes_per_full_left = latent_ratio;
-    {
-        let baseline = outcome.rule12_precedence.top1_agreement;
-        let mix = outcome.rule12_latent_mix.top1_agreement;
-        let oracle = outcome.rule12_latent_oracle.top1_agreement;
-        outcome.latent_headroom_fraction = if oracle > baseline {
-            (mix - baseline) / (oracle - baseline)
-        } else {
-            0.0
-        };
-        outcome.latent_exit_rule_met = mix - baseline >= LATENT_EXIT_MARGIN
-            && mix > outcome.rule12_latent_shuffled.top1_agreement;
-    }
-    let (full_left_cells, full_pair_keys) = two_sided.full_depth_subdivision();
-    outcome.twosided_full_left_cells = full_left_cells;
-    outcome.twosided_full_pair_keys = full_pair_keys;
-    outcome.twosided_keys_per_full_left = if full_left_cells == 0 {
-        0.0
+    // #446 M1 + M2: the right-context arm group. Assembled as a whole and
+    // attached as a whole, so a skipped run leaves `None` rather than a
+    // half-populated set of arms nobody can tell apart from measured zeros.
+    outcome.skipped_arm_groups = skipped_arms.names();
+    outcome.right_context_arms = if skipped_arms.right_context {
+        None
     } else {
-        full_pair_keys as f64 / full_left_cells as f64
+        let mut arms = RightContextArms {
+            rule12_twosided: metrics(hits_twosided, bits_twosided),
+            rule12_twosided_live: live_metrics(
+                twosided_live_hits,
+                twosided_live_bits,
+                twosided_live_positions,
+            ),
+            rule12_on_twosided_live: live_metrics(
+                rule12_twosided_live_hits,
+                rule12_twosided_live_bits,
+                twosided_live_positions,
+            ),
+            rule12_twosided_shuffled: metrics(hits_twosided_shuffled, bits_twosided_shuffled),
+            rule12_twosided_shuffled_live: live_metrics(
+                shuffled_live_hits,
+                shuffled_live_bits,
+                shuffled_live_positions,
+            ),
+            rule12_on_twosided_shuffled_live: live_metrics(
+                rule12_shuffled_live_hits,
+                rule12_shuffled_live_bits,
+                shuffled_live_positions,
+            ),
+            rule12_twosided_depths: twosided_depths,
+            rule12_twosided_exct_slice: live_metrics(
+                twosided_exct_hits,
+                twosided_exct_bits,
+                twosided_exct_positions,
+            ),
+            rule12_on_twosided_exct_slice: live_metrics(
+                rule12_exct_slice_hits,
+                rule12_exct_slice_bits,
+                twosided_exct_positions,
+            ),
+            rule12_twosided_exct_slice_live: twosided_exct_live,
+            // #446 M2: the latent mixture rows, plus the pre-declared exit rule.
+            rule12_latent_mix: metrics(hits_latent, bits_latent_total),
+            rule12_latent_mix_live: live_metrics(
+                latent_live_hits,
+                latent_live_bits,
+                latent_live_positions,
+            ),
+            rule12_on_latent_mix_live: live_metrics(
+                rule12_latent_live_hits,
+                rule12_latent_live_bits,
+                latent_live_positions,
+            ),
+            rule12_latent_oracle: metrics(hits_latent_oracle, bits_latent_oracle_total),
+            rule12_latent_shuffled: metrics(hits_latent_shuffled, bits_latent_shuffled_total),
+            latent_oracle_live_positions,
+            latent_shuffled_live_positions,
+            latent_class_depth,
+            twosided_vs_rule12_live: twosided_win_loss,
+            twosided_shuffled_vs_rule12_live: twosided_shuffled_win_loss,
+            ..RightContextArms::default()
+        };
+        let (latent_left_cells, latent_class_cells, latent_ratio) = latent.classes_per_full_left();
+        arms.latent_full_left_cells = latent_left_cells;
+        arms.latent_full_class_cells = latent_class_cells;
+        arms.latent_classes_per_full_left = latent_ratio;
+        {
+            let baseline = outcome.rule12_precedence.top1_agreement;
+            let mix = arms.rule12_latent_mix.top1_agreement;
+            let oracle = arms.rule12_latent_oracle.top1_agreement;
+            arms.latent_headroom_fraction = if oracle > baseline {
+                (mix - baseline) / (oracle - baseline)
+            } else {
+                0.0
+            };
+            arms.latent_exit_rule_met = mix - baseline >= LATENT_EXIT_MARGIN
+                && mix > arms.rule12_latent_shuffled.top1_agreement;
+        }
+        let (full_left_cells, full_pair_keys) = two_sided.full_depth_subdivision();
+        arms.twosided_full_left_cells = full_left_cells;
+        arms.twosided_full_pair_keys = full_pair_keys;
+        arms.twosided_keys_per_full_left = if full_left_cells == 0 {
+            0.0
+        } else {
+            full_pair_keys as f64 / full_left_cells as f64
+        };
+        Some(arms)
     };
     outcome.anchor_hat_population = anchor_hat_population;
     outcome.anchor_hat_correct = anchor_hat_correct_count as usize;
@@ -4104,6 +4370,8 @@ pub fn evaluate_gate_c(
         outcome.repetition_rate_baseline = 0.0;
     }
 
+    phases.mark("reduction, per-status rollups and replay probes");
+    phases.total();
     Ok(outcome)
 }
 
@@ -5187,6 +5455,18 @@ fn evaluate_gate_c_row(
 /// positions the measurement averages over. A row whose
 /// `positions_sampled` is nonzero is an ESTIMATE and must be quoted with
 /// its `standard_error`, never as a census.
+///
+/// Schema twenty-six is the #471 arm-skip knob. The twenty-four #446 M1 and
+/// M2 rows move from the top level of `gate_c` into
+/// `gate_c.right_context_arms`, which is `null` when
+/// `R4_GATE_C_SKIP_ARMS=right_context` told the run not to build the
+/// whole-corpus right-context code pass those arms depend on;
+/// `gate_c.skipped_arm_groups` names what was skipped. This is a MOVE, not a
+/// redefinition: on a run with the override unset every one of those rows
+/// holds the value schema twenty-five gave it, one level deeper. The nesting
+/// exists so that "not evaluated" and "evaluated and zero" stop sharing a
+/// representation — a flat skipped run would have published a full set of
+/// zeroed arms and a pre-declared exit rule reported as unmet.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScoreReport {
     pub schema: u32,
@@ -5379,7 +5659,7 @@ pub fn build_score_report_with_quality_profile(
         can_measure_generalization: strict_exct_miss_rate >= MIN_EXCT_MISS_RATE_FOR_GATE_C,
     };
     ScoreReport {
-        schema: 25,
+        schema: 26,
         inputs,
         config: ScoreReportConfig {
             transition_out_degree: config.transition_out_degree,
@@ -5627,5 +5907,60 @@ mod emission_shrinkage_tests {
         assert!((witten_bell_lambda(100, 10) - 100.0 / 110.0).abs() < 1e-12);
         assert!(witten_bell_lambda(100, 10) > witten_bell_lambda(10, 100));
         assert!(witten_bell_lambda(100, 10) < 1.0);
+    }
+}
+
+#[cfg(test)]
+mod arm_skip_tests {
+    use super::{parse_skip_arms, SkippedArms, ARM_GROUP_RIGHT_CONTEXT};
+
+    /// The unset contract (#471, mirroring #467's): no value means every arm
+    /// is evaluated. This is the branch every existing caller takes, so it is
+    /// the one whose regression would be silent.
+    #[test]
+    fn unset_skips_nothing() {
+        assert_eq!(parse_skip_arms(None), SkippedArms::default());
+        assert!(!parse_skip_arms(None).any());
+        assert!(parse_skip_arms(None).names().is_empty());
+    }
+
+    /// `R4_GATE_C_SKIP_ARMS=` written by a shell script that computed an
+    /// empty list must mean the same thing as not writing the line, and a
+    /// list with stray separators or padding must not become a typo.
+    #[test]
+    fn empty_and_padded_values_skip_nothing_extra() {
+        assert_eq!(parse_skip_arms(Some("")), SkippedArms::default());
+        assert_eq!(parse_skip_arms(Some("   ")), SkippedArms::default());
+        assert_eq!(parse_skip_arms(Some(",,")), SkippedArms::default());
+        let padded = parse_skip_arms(Some("  right_context , "));
+        assert!(padded.right_context);
+        assert_eq!(padded.names(), vec![ARM_GROUP_RIGHT_CONTEXT.to_owned()]);
+    }
+
+    #[test]
+    fn the_right_context_group_is_recognised_and_named_back() {
+        let skipped = parse_skip_arms(Some(ARM_GROUP_RIGHT_CONTEXT));
+        assert!(skipped.right_context);
+        assert!(skipped.any());
+        assert_eq!(skipped.names(), vec![ARM_GROUP_RIGHT_CONTEXT.to_owned()]);
+    }
+
+    /// The failure mode this panic exists to prevent: a caller who meant to
+    /// buy a thirty-second decision run gets an eighty-five-minute one, with
+    /// nothing in the output saying the knob did not take. Silently ignoring
+    /// an unknown name is the one behaviour that cannot be noticed.
+    #[test]
+    #[should_panic(expected = "unknown arm group")]
+    fn an_unknown_group_panics_rather_than_being_ignored() {
+        let _ = parse_skip_arms(Some("right-context"));
+    }
+
+    /// Case is not normalised on purpose: the group name is an identifier in
+    /// a run record, and accepting several spellings of it would make two
+    /// records of the same run disagree on what was skipped.
+    #[test]
+    #[should_panic(expected = "unknown arm group")]
+    fn case_variants_are_not_silently_accepted() {
+        let _ = parse_skip_arms(Some("RIGHT_CONTEXT"));
     }
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1312,11 +1312,38 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         "1+2 × fwd STRICT-gated (2p)",
         &gate_c.rule12_fwd_strict_fused,
     );
-    row("1+2 + TWO-SIDED (#446 M1)", &gate_c.rule12_twosided);
-    row("1+2 + two-sided SHUFFLED", &gate_c.rule12_twosided_shuffled);
-    row("1+2 + LATENT-MIX (#446 M2)", &gate_c.rule12_latent_mix);
-    row("1+2 + latent ORACLE-RIGHT", &gate_c.rule12_latent_oracle);
-    row("1+2 + latent SHUF-CLASS", &gate_c.rule12_latent_shuffled);
+    // #471: the right-context arm group prints its five rows, or says in
+    // each row's own place that it was not evaluated. A blank line or a
+    // zeroed rate here would be read as a measurement — these arms exist to
+    // be compared against `graph chain+EXCT (1+2)` above, and a reader
+    // scanning the column would take 0.0% as a catastrophic arm rather than
+    // an absent one.
+    let skipped_row = |name: &str| {
+        if sampled {
+            println!(
+                "  {:<26} {:>16} {:>12} {:>10} {:>9}",
+                name, "SKIPPED", "SKIPPED", "-", "-"
+            );
+        } else {
+            println!("  {:<26} {:>16} {:>12}", name, "SKIPPED", "SKIPPED");
+        }
+    };
+    match &gate_c.right_context_arms {
+        Some(arms) => {
+            row("1+2 + TWO-SIDED (#446 M1)", &arms.rule12_twosided);
+            row("1+2 + two-sided SHUFFLED", &arms.rule12_twosided_shuffled);
+            row("1+2 + LATENT-MIX (#446 M2)", &arms.rule12_latent_mix);
+            row("1+2 + latent ORACLE-RIGHT", &arms.rule12_latent_oracle);
+            row("1+2 + latent SHUF-CLASS", &arms.rule12_latent_shuffled);
+        }
+        None => {
+            skipped_row("1+2 + TWO-SIDED (#446 M1)");
+            skipped_row("1+2 + two-sided SHUFFLED");
+            skipped_row("1+2 + LATENT-MIX (#446 M2)");
+            skipped_row("1+2 + latent ORACLE-RIGHT");
+            skipped_row("1+2 + latent SHUF-CLASS");
+        }
+    }
     let live_line = |name: &str, fused: &score::GateCMetrics, base: &score::GateCMetrics| {
         println!(
             "  {name} live slice ({} positions): fused {:.1}% vs rule 1+2 {:.1}% | bits {:.4} vs {:.4}",
@@ -1352,85 +1379,103 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         &gate_c.rule12_fwd_strict_fused_live,
         &gate_c.rule12_on_fwd_strict_live,
     );
-    live_line(
-        "two-sided  ",
-        &gate_c.rule12_twosided_live,
-        &gate_c.rule12_on_twosided_live,
-    );
-    live_line(
-        "two-sided SHUF",
-        &gate_c.rule12_twosided_shuffled_live,
-        &gate_c.rule12_on_twosided_shuffled_live,
-    );
-    live_line(
-        "latent-mix ",
-        &gate_c.rule12_latent_mix_live,
-        &gate_c.rule12_on_latent_mix_live,
-    );
-    println!(
-        "  two-sided pair-resolution depth: {}",
-        gate_c
-            .rule12_twosided_depths
-            .iter()
-            .enumerate()
-            .map(|(depth, count)| if depth == 0 {
-                format!("inert {count}")
-            } else {
-                format!("d{depth} {count}")
-            })
-            .collect::<Vec<_>>()
-            .join(" ")
-    );
-    println!(
-        "  two-sided DILUTION slice — ExactContext positions ({}): two-sided {:.1}% vs rule 1+2 {:.1}% | bits {:.4} vs {:.4} | arm live {}",
-        gate_c.rule12_twosided_exct_slice.positions,
-        gate_c.rule12_twosided_exct_slice.top1_agreement * 100.0,
-        gate_c.rule12_on_twosided_exct_slice.top1_agreement * 100.0,
-        gate_c.rule12_twosided_exct_slice.bits_per_token,
-        gate_c.rule12_on_twosided_exct_slice.bits_per_token,
-        gate_c.rule12_twosided_exct_slice_live,
-    );
-    println!(
-        "  two-sided cell subdivision (construction, full graded depth): {:.3} two-sided keys per full left code ({} pair keys / {} left cells)",
-        gate_c.twosided_keys_per_full_left,
-        gate_c.twosided_full_pair_keys,
-        gate_c.twosided_full_left_cells,
-    );
-    println!(
-        "  NOTE (#446 M1): the two-sided rows key on tokens AFTER the target. \
-         Two-sided conditioning is NOT causally available to left-to-right \
-         generation — it is an infill/analysis (A-mode) measurement, or \
-         prospectively a construction-time signal. Never quote it as a \
-         generation number."
-    );
-    println!(
-        "  latent class structure (construction, full left depth): class depth {} byte(s), {:.3} classes per full left code ({} class cells / {} left cells); oracle live {}, shuffled-class live {}",
-        gate_c.latent_class_depth,
-        gate_c.latent_classes_per_full_left,
-        gate_c.latent_full_class_cells,
-        gate_c.latent_full_left_cells,
-        gate_c.latent_oracle_live_positions,
-        gate_c.latent_shuffled_live_positions,
-    );
-    println!(
-        "  latent headroom: baseline {:.1}% -> latent-mix {:.1}% -> oracle-right {:.1}% = {:.1}% of available top-1 headroom | EXIT RULE (>= 2.0pp over baseline AND beats shuffled-class): {}",
-        100.0 * gate_c.rule12_precedence.top1_agreement,
-        100.0 * gate_c.rule12_latent_mix.top1_agreement,
-        100.0 * gate_c.rule12_latent_oracle.top1_agreement,
-        100.0 * gate_c.latent_headroom_fraction,
-        if gate_c.latent_exit_rule_met {
-            "MET (positive)"
-        } else {
-            "NOT MET (negative)"
-        },
-    );
-    println!(
-        "  NOTE (#446 M2): the LATENT-MIX row reads the LEFT key only at \
-         serving — the right context is observed during construction and \
-         marginalized away — so it IS causally legitimate and quotable as a \
-         generation number. ORACLE-RIGHT supplies the true right class at \
-         evaluation time and is an upper bound only, NOT causal."
-    );
+    match &gate_c.right_context_arms {
+        Some(arms) => {
+            live_line(
+                "two-sided  ",
+                &arms.rule12_twosided_live,
+                &arms.rule12_on_twosided_live,
+            );
+            live_line(
+                "two-sided SHUF",
+                &arms.rule12_twosided_shuffled_live,
+                &arms.rule12_on_twosided_shuffled_live,
+            );
+            live_line(
+                "latent-mix ",
+                &arms.rule12_latent_mix_live,
+                &arms.rule12_on_latent_mix_live,
+            );
+            println!(
+                "  two-sided pair-resolution depth: {}",
+                arms.rule12_twosided_depths
+                    .iter()
+                    .enumerate()
+                    .map(|(depth, count)| if depth == 0 {
+                        format!("inert {count}")
+                    } else {
+                        format!("d{depth} {count}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+            println!(
+                "  two-sided DILUTION slice — ExactContext positions ({}): two-sided {:.1}% vs rule 1+2 {:.1}% | bits {:.4} vs {:.4} | arm live {}",
+                arms.rule12_twosided_exct_slice.positions,
+                arms.rule12_twosided_exct_slice.top1_agreement * 100.0,
+                arms.rule12_on_twosided_exct_slice.top1_agreement * 100.0,
+                arms.rule12_twosided_exct_slice.bits_per_token,
+                arms.rule12_on_twosided_exct_slice.bits_per_token,
+                arms.rule12_twosided_exct_slice_live,
+            );
+            println!(
+                "  two-sided cell subdivision (construction, full graded depth): {:.3} two-sided keys per full left code ({} pair keys / {} left cells)",
+                arms.twosided_keys_per_full_left,
+                arms.twosided_full_pair_keys,
+                arms.twosided_full_left_cells,
+            );
+            println!(
+                "  NOTE (#446 M1): the two-sided rows key on tokens AFTER the target. \
+                 Two-sided conditioning is NOT causally available to left-to-right \
+                 generation — it is an infill/analysis (A-mode) measurement, or \
+                 prospectively a construction-time signal. Never quote it as a \
+                 generation number."
+            );
+            println!(
+                "  latent class structure (construction, full left depth): class depth {} byte(s), {:.3} classes per full left code ({} class cells / {} left cells); oracle live {}, shuffled-class live {}",
+                arms.latent_class_depth,
+                arms.latent_classes_per_full_left,
+                arms.latent_full_class_cells,
+                arms.latent_full_left_cells,
+                arms.latent_oracle_live_positions,
+                arms.latent_shuffled_live_positions,
+            );
+            println!(
+                "  latent headroom: baseline {:.1}% -> latent-mix {:.1}% -> oracle-right {:.1}% = {:.1}% of available top-1 headroom | EXIT RULE (>= 2.0pp over baseline AND beats shuffled-class): {}",
+                100.0 * gate_c.rule12_precedence.top1_agreement,
+                100.0 * arms.rule12_latent_mix.top1_agreement,
+                100.0 * arms.rule12_latent_oracle.top1_agreement,
+                100.0 * arms.latent_headroom_fraction,
+                if arms.latent_exit_rule_met {
+                    "MET (positive)"
+                } else {
+                    "NOT MET (negative)"
+                },
+            );
+            println!(
+                "  NOTE (#446 M2): the LATENT-MIX row reads the LEFT key only at \
+                 serving — the right context is observed during construction and \
+                 marginalized away — so it IS causally legitimate and quotable as a \
+                 generation number. ORACLE-RIGHT supplies the true right class at \
+                 evaluation time and is an upper bound only, NOT causal."
+            );
+        }
+        // #471. Everything above depends on the whole-corpus right-context
+        // code pass, so a run that skipped it has no two-sided or latent
+        // numbers at all — including the #446 M2 exit-rule verdict, which is
+        // the line most dangerous to fake. NOT MET and never-ran read the
+        // same to a skimming eye, so the verdict is not printed at all.
+        None => {
+            println!(
+                "  RIGHT-CONTEXT ARMS NOT EVALUATED ({}={}). The #446 M1 two-sided and \
+                 #446 M2 latent rows, the dilution and class-structure statistics, and \
+                 the M2 exit-rule verdict are ABSENT from this run — not zero, and not \
+                 NOT MET. Re-run without the override to measure them.",
+                score::GATE_C_SKIP_ARMS_ENV,
+                gate_c.skipped_arm_groups.join(","),
+            );
+        }
+    }
     println!(
         "  predicted-anchor accuracy: {:.1}% ({}/{})",
         100.0 * gate_c.anchor_hat_accuracy,
@@ -1481,14 +1526,19 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         "win/loss strict vs 1+2 live",
         &gate_c.win_loss.fwd_strict_vs_rule12_live,
     );
-    win_loss_row(
-        "win/loss two-sided vs 1+2 live",
-        &gate_c.win_loss.twosided_vs_rule12_live,
-    );
-    win_loss_row(
-        "win/loss ts-SHUF vs 1+2 live",
-        &gate_c.win_loss.twosided_shuffled_vs_rule12_live,
-    );
+    // #471: two more rows in the right-context group's closure. An all-zero
+    // cross-tab printed among populated ones reads as "the arm never won",
+    // which is a measurement; on a skipped run it is an absence.
+    if let Some(arms) = &gate_c.right_context_arms {
+        win_loss_row(
+            "win/loss two-sided vs 1+2 live",
+            &arms.twosided_vs_rule12_live,
+        );
+        win_loss_row(
+            "win/loss ts-SHUF vs 1+2 live",
+            &arms.twosided_shuffled_vs_rule12_live,
+        );
+    }
     println!(
         "  witness replay: {}/{} ok",
         gate_c.witness_replays - gate_c.witness_replay_failures,

--- a/docs/gate_c_arm_skip_471.md
+++ b/docs/gate_c_arm_skip_471.md
@@ -1,0 +1,232 @@
+# Sampled Gate C runs pay for a whole-corpus pass they never read (#471)
+
+Record for issue #471. Measured 2026-08-07 on the committed 500k fixture
+(`crates/uor-r4-core/tests/fixtures`, 500,000 records / 2,507 stories,
+100,306 held out), two cores, `R4_GATE_C_SAMPLE=10000`.
+
+## The complaint
+
+#467 made Gate C samplable: set `R4_GATE_C_SAMPLE=n` and the evaluation scores
+`n` held-out positions instead of the whole split. On the #460 STAGES=5
+decision run at 2.11M records that knob did not buy what it promised — the
+Gate C phase still ran for about eighty-five minutes. The sample bounds the
+per-position arm loop and nothing before it.
+
+## The instrument this issue produced first
+
+`evaluate_gate_c` now prints a per-phase wall clock to stderr. It costs
+nothing, it is not report content (a duration would make `score_report.json`
+differ between two runs of identical pinned inputs, which is what the
+deterministic-rebuild gate exists to catch), and it turns "the Gate C phase
+took eighty-five minutes" from an unattributable number into an attributed
+one. That mattered immediately: the first two proposals for fixing this issue
+named different passes as the culprit, and neither was checked against a
+measurement.
+
+Control run, 500k, sample 10,000:
+
+| phase | seconds | share |
+|---|---:|---:|
+| scorer construction | 2.60 | 3.0% |
+| forward-anchor table (#399 M2) | 0.08 | 0.1% |
+| **right-context code pass (#446)** | **51.05** | **59.0%** |
+| left code pass (#469 lever A) | 0.09 | 0.1% |
+| two-sided table build (#446 M1) | 0.27 | 0.3% |
+| latent right-context tables (#446 M2) | 0.38 | 0.4% |
+| unigram null (#390) | 0.02 | 0.0% |
+| scoring 10,000 positions | 31.70 | 36.6% |
+| reduction, rollups, replay probes | 0.38 | 0.4% |
+| **total** | **86.56** | |
+
+## What the profile revised
+
+The issue named three things: `derive_right_codes`, `TwoSidedTable::build`
+and `LatentRightTable::build`. Two of the three are not the problem. The two
+table builds together are **0.65s of 86.56s — 0.8%**. All of the cost is the
+right-context code pass, which is a whole-corpus `bundle_window_plain` +
+`assign_code_for_bundle_with`.
+
+Two further passes that look like the same structural complaint turn out not
+to matter either, and both are worth writing down so nobody re-proposes them:
+
+- The **left** code pass costs 0.09s, not because it is cheap but because the
+  #469 lever-A sidecar has already been written by the store build earlier in
+  the same process. It is paid once per run, by someone else, before Gate C
+  starts.
+- The **forward-anchor** table (#399 M2) is 0.08s. There is no case for a
+  `forward_anchor` arm group.
+
+## The knob
+
+`R4_GATE_C_SKIP_ARMS`, comma-separated **arm-group names**. Unset is
+behaviour-identical to the pre-#471 evaluation, in the same contract style as
+`R4_GATE_C_SAMPLE`. An unrecognised name panics: a typo that silently
+evaluated everything hands back an eighty-five-minute run when the caller
+asked for a thirty-second one, and a typo that silently skipped nothing looks
+exactly like a knob that does not work. Both failures are invisible.
+
+One group ships. `right_context` is the #446 M1 two-sided family and the #446
+M2 latent family together, because they are exactly the closure of the
+right-context code pass — nothing else in the evaluation reads a
+right-context code, so skipping the group and skipping the pass are the same
+act. Grouping arms by *what they cost* rather than by issue number is what
+keeps the knob from becoming a list of ad-hoc flags as arms accumulate.
+
+    R4_GATE_C_SAMPLE=10000 R4_GATE_C_SKIP_ARMS=right_context \
+      cargo run --release --bin r4 -- transformerless score …
+
+## Why not the κ-keyed sidecar (option a)
+
+The alternative on the issue was to extend the #469 lever-A sidecar to the
+right-context codes: cache the pass instead of skipping it, and keep all five
+rows. The measurement argues against it, and not on effort grounds.
+
+A sidecar is keyed on the artifact κ and the corpus κ. It hits when both are
+unchanged. But a *decision* run is, almost by definition, a run that changed
+one of them — STAGES=5, a codebook-fit change, a capacity change, a different
+corpus. Those are the runs the knob exists to make cheap, and they are
+precisely the runs on which a κ-keyed cache misses. Option (a) would have
+bought the second run of an unchanged configuration, which is the case nobody
+was waiting on.
+
+It is also worth recording that option (a) would have been *sufficient* in
+one narrow sense the issue did not anticipate: since the table builds turn out
+to cost 0.8%, caching the code pass and skipping it are within a percent of
+each other in effect. The reason to prefer skipping is entirely about which
+runs get the benefit.
+
+## Absence is not zero, and the test caught a leak
+
+The whole risk in skipping arms is what the skipped rows then say. This
+repository found five instruments in a single session that could not fail, and
+wrote down the rule that an all-zero result across every arm is a harness bug
+until proven otherwise. A skip that left `rule12_latent_mix.top1_agreement:
+0.0` in `score_report.json` manufactures exactly that reading — and
+`latent_exit_rule_met: false` is worse, because a pre-declared exit rule
+reported as unmet is a *result*, and this one would never have been run.
+
+So the twenty-six #446 M1/M2 fields moved from the top level of `gate_c` into
+`gate_c.right_context_arms`, which is `null` on a skipped run;
+`gate_c.skipped_arm_groups` names what was skipped; and the CLI prints the
+five rows as `SKIPPED` in their own places, with the M2 exit-rule verdict line
+suppressed entirely rather than printed as NOT MET. Schema 25 → 26. The move
+does not redefine anything: with the override unset, every one of those rows
+holds the value schema 25 gave it, one level deeper.
+
+The equivalence test then earned its keep on the first run. Two of the
+twenty-six fields were ones this record's author had missed —
+`win_loss.twosided_vs_rule12_live` and `win_loss.twosided_shuffled_vs_rule12_live`
+were still sitting flat in the win/loss cross-tab block, and a skipped run
+published them as `{both_correct: 0, neither: 0, other_only: 0, scorer_only:
+0}` next to five populated cross-tabs. That is the vacuous-instrument pattern
+reproduced in miniature, in a change written specifically to avoid it, and
+found by a machine rather than by a reader. They now live in the arm group
+with the rest.
+
+## Result
+
+| | control | `right_context` skipped |
+|---|---:|---:|
+| right-context code pass | 51.05s | 0.00s |
+| two-sided + latent builds | 0.65s | 0.00s |
+| scoring 10,000 positions | 31.70s | 29.12s |
+| **Gate C total** | **86.56s** | **32.14s** |
+| whole `score` pipeline | 138.1s | 82.8s |
+
+**62.9% of the Gate C phase**, 40.1% of the whole scoring pipeline. Forty-five
+`gate_c` keys were compared between the two runs and every one is identical,
+as are the compile inputs and the emitted graph — the skip does not reach
+outside the evaluation. `tests/gate_c_arm_skip.rs` is that comparison, and it
+is also the instrument that produced this table.
+
+Separately, and stronger than the in-run comparison: a schema-25 report
+produced *before* any of this change was written and a schema-26 control
+report produced after it agree on **every value of every `gate_c` key**, once
+the twenty-six moved fields are read back out of `right_context_arms` and the
+two moved cross-tabs out of `win_loss`. The key sets are equal with nothing
+missing and nothing added. The restructure is a move, and the unset knob is
+the old evaluation.
+
+## Scaling, and an honest gap
+
+The skipped pass is `O(n)`; the retained scoring is bounded by the sample.
+Measured at two corpus sizes with the sample held at 10,000:
+
+| records | right-context pass | µs/record | two-sided + latent | scoring 10,000 | Gate C total |
+|---:|---:|---:|---:|---:|---:|
+| 250,000 | 26.42s | 105.7 | 0.23s | 26.94s | 54.71s |
+| 500,000 | 51.05s | 102.1 | 0.65s | 31.70s | 86.56s |
+
+The pass is linear to within 3.5% per record over a 2× range. The scored
+population is fixed but its cost is not quite constant — it grew 18% for 2×
+the records, because a larger store makes each position's scoring a little
+heavier. So the saving *fraction* rises with corpus size: 51.3% of Gate C at
+250k, 62.9% at 500k.
+
+**Where the knob does not pay, which is the same arithmetic read backwards.**
+A census run over the whole held-out split (100,306 positions, same 500k
+corpus) spends 265s of its 322s scoring positions. The right-context pass is
+then about 16%, not 59%. This is a *decision-run* lever by construction: the
+skipped cost is fixed in `n` while the retained cost scales with the sample,
+so the smaller the sample the more the knob is worth. Anyone reaching for it
+on a census run should expect roughly a sixth, not two thirds.
+
+**What this does not explain — stated plainly, because the temptation is to
+round it off.** Extrapolating 102 µs/record to 2.11M records gives about 215s
+of right-context code pass on this two-core box: roughly four minutes, not
+eighty-five. **The linear model does not reproduce the pathology that opened
+this issue.** Everything above is a real saving on a real pass, and the
+eighty-five minutes remains unaccounted for.
+
+Peak resident set, same two runs (sampled every 500ms from `VmHWM`, whole
+`score` process):
+
+| | control | skipped | delta |
+|---|---:|---:|---:|
+| peak RSS | 1,382 MB | 1,305 MB | 77 MB (5.6%) |
+
+That was the leading candidate before it was measured, and the measurement
+weakens it. Seventy-seven megabytes at 500k scales to a few hundred at 2.11M
+even allowing STAGES=5 its extra levels — real, but not on its own the
+difference between four minutes and eighty-five on a 16GB machine. Recording
+it as a negative rather than leaving it as an untested suspicion.
+
+What is left:
+
+1. **The eighty-five minutes may not all have been inside
+   `evaluate_gate_c`.** Nothing at the time could tell the Gate C evaluation
+   apart from the cover induction, store build and emission stages around it.
+   This is now the leading candidate precisely because it is the one nobody
+   could rule out.
+2. **Per-record cost at 2.11M may simply not be 102 µs.** The #469 record has
+   a whole-corpus code pass at 2.11M costing 625s pre-lever-B, which is ~11×
+   more core-time per record than measured here. Either that figure covers
+   more than the code pass, or per-record cost depends on something that a 2×
+   corpus range does not expose. Both are worth knowing and neither is settled
+   by this record.
+3. **STAGES=5**, which the issue raised. Worth 1.25× on stage count alone, so
+   not sufficient by itself.
+
+This is why the phase timing shipped as a permanent, always-on part of the
+harness rather than as scaffolding for this issue. The next 2.11M run
+attributes its own wall clock, and whichever of the three it is arrives as a
+line of output instead of an argument. Until then this record claims exactly
+one thing: the right-context code pass is 59% of a sampled Gate C run at
+500k, it is linear in `n`, and skipping it is free of any effect on the rows
+that remain.
+
+## Follow-ups worth an owner
+
+- **Attribute the 2.11M residual.** Run the phase timing on a real 2.11M
+  corpus and read the gap between 215s of predicted code pass and whatever the
+  total turns out to be. Cheap, and it either closes this record or reopens it
+  against a different pass. **This is the follow-up that matters** — #471
+  removed a measured 59% of a sampled run, but the number that provoked the
+  issue is still not explained, and a knob that makes the symptom tolerable is
+  a reason to check the cause, not a substitute for it.
+- **The right-code pass allocates per record.** `derive_right_codes` builds a
+  `Vec` of at most `TWO_SIDED_RIGHT_R` (default 4) tokens for every corpus
+  position, inside a Rayon map. A stack array would remove one allocation per
+  record from a pass that is 59% of a control run. Unmeasured, and it only
+  helps census runs now that decision runs can skip the pass outright — which
+  is exactly why it should not be done on the assumption that it pays.

--- a/tests/gate_c_arm_skip.rs
+++ b/tests/gate_c_arm_skip.rs
@@ -1,0 +1,219 @@
+//! Issue #471: the Gate C arm-skip knob does not move a number it still
+//! reports.
+//!
+//! # What this test is for
+//!
+//! `R4_GATE_C_SKIP_ARMS=right_context` tells the Gate C evaluation not to run
+//! the whole-corpus right-context code pass, and therefore not to build the
+//! #446 M1 two-sided table or the #446 M2 latent tables. That is a large
+//! saving (measured at 60% of a sampled run's wall clock on the 500k fixture,
+//! and a growing share as the corpus grows) bought by dropping five rows.
+//!
+//! The bought-and-paid-for claim is narrow and exact: **every row the run
+//! still prints must be bit-identical to what a full run prints.** A
+//! performance knob that quietly perturbs `rule12_precedence` would be worse
+//! than the 85-minute run it replaces, because the fast number would look
+//! usable. So this test runs the shipped `r4 transformerless score` binary
+//! twice over the same fixture with the same sample, and compares the two
+//! `score_report.json` documents key by key.
+//!
+//! # Why it spawns the binary instead of calling the library
+//!
+//! The knob is read from the process environment. Setting a process
+//! environment variable from a test thread races every other thread in the
+//! harness, and under edition 2024 it is `unsafe` for exactly that reason.
+//! Spawning the real binary with the variable set gives each arm its own
+//! process, tests the surface a human actually uses, and needs no `unsafe`.
+//!
+//! # Why the control arm asserts before it compares
+//!
+//! An equivalence test between two runs that both measured nothing passes.
+//! This repository has found five instruments that could not fail; the rule
+//! that came out of that is that an all-zero arm set is a harness bug until
+//! proven otherwise. So the control arm asserts, BEFORE any comparison, that
+//! the right-context arms are present, scored a nonzero population, and moved
+//! top-1 away from the Rule 1+2 baseline they are supposed to differ from. If
+//! the fixture ever stops exercising those arms this test fails loudly
+//! instead of turning green and meaningless.
+//!
+//! # Running it
+//!
+//! Ignored by default: two full 500k score runs cost minutes, which is more
+//! than the merge queue should pay per PR. It is also the measurement
+//! instrument for #471 — it prints both wall clocks and the saving.
+//!
+//! ```text
+//! cargo test --release --test gate_c_arm_skip -- --ignored --nocapture
+//! ```
+//!
+//! Knobs: `R4_ARM_SKIP_SAMPLE` (Gate C sample size, default 10,000),
+//! `R4_ARM_SKIP_FIXTURE_DIR` (fixture directory, default the committed
+//! `crates/uor-r4-core/tests/fixtures`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+/// Keys of `gate_c` that a skipped run is EXPECTED to differ on. Everything
+/// else must match exactly.
+const EXPECTED_TO_DIFFER: [&str; 2] = ["right_context_arms", "skipped_arm_groups"];
+
+fn fixture_dir() -> PathBuf {
+    match std::env::var("R4_ARM_SKIP_FIXTURE_DIR") {
+        Ok(dir) if !dir.trim().is_empty() => PathBuf::from(dir),
+        _ => Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/uor-r4-core/tests/fixtures"),
+    }
+}
+
+fn sample_size() -> String {
+    std::env::var("R4_ARM_SKIP_SAMPLE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "10000".to_owned())
+}
+
+/// One `r4 transformerless score` run. Returns the parsed report and the
+/// wall clock, so the test doubles as the #471 before/after measurement.
+fn score_run(out: &Path, skip_arms: Option<&str>) -> (serde_json::Value, f64) {
+    let fixtures = fixture_dir();
+    let _ = std::fs::remove_dir_all(out);
+    let mut command = Command::new(env!("CARGO_BIN_EXE_r4"));
+    command
+        .args(["transformerless", "score"])
+        .arg("--corpus-meta")
+        .arg(fixtures.join("c_meta.bin"))
+        .arg("--corpus-recs")
+        .arg(fixtures.join("c_recs.bin"))
+        .arg("--artifacts")
+        .arg(fixtures.join("tless_artifacts.bin"))
+        .arg("--out")
+        .arg(out)
+        .env("R4_GATE_C_SAMPLE", sample_size());
+    match skip_arms {
+        Some(groups) => {
+            command.env("R4_GATE_C_SKIP_ARMS", groups);
+        }
+        // Explicitly REMOVED rather than merely unset by omission: an
+        // inherited value from the caller's shell would silently turn the
+        // control arm into a second skipped arm, and the comparison would
+        // then pass by comparing a run to itself.
+        None => {
+            command.env_remove("R4_GATE_C_SKIP_ARMS");
+        }
+    }
+    let started = Instant::now();
+    let status = command.status().expect("failed to spawn the r4 binary");
+    let seconds = started.elapsed().as_secs_f64();
+    assert!(status.success(), "score run failed: {status}");
+    let text = std::fs::read_to_string(out.join("score_report.json"))
+        .expect("score run produced no report");
+    (
+        serde_json::from_str(&text).expect("score report is not valid JSON"),
+        seconds,
+    )
+}
+
+#[test]
+#[ignore = "two full score runs over the 500k fixture; minutes, not seconds"]
+fn skipping_the_right_context_arms_changes_no_row_it_still_reports() {
+    let (control, control_seconds) =
+        score_run(&PathBuf::from("/tmp/gate_c_arm_skip_control"), None);
+    let (skipped, skipped_seconds) = score_run(
+        &PathBuf::from("/tmp/gate_c_arm_skip_skipped"),
+        Some("right_context"),
+    );
+
+    let control_gate = control["gate_c"]
+        .as_object()
+        .expect("control report has no gate_c object");
+    let skipped_gate = skipped["gate_c"]
+        .as_object()
+        .expect("skipped report has no gate_c object");
+
+    // ---- anti-vacuity: prove the control arm measured something ----
+    let arms = control_gate["right_context_arms"].as_object().expect(
+        "control run must EVALUATE the right-context arms; if this is null the \
+                 control arm was itself skipped and every comparison below is vacuous",
+    );
+    let two_sided_positions = arms["rule12_twosided"]["positions"]
+        .as_u64()
+        .expect("two-sided row has no position count");
+    assert!(
+        two_sided_positions > 0,
+        "control run scored zero two-sided positions — the fixture no longer exercises \
+         this arm, so the equivalence assertion below would compare two empty runs"
+    );
+    let two_sided_top1 = arms["rule12_twosided"]["top1_agreement"]
+        .as_f64()
+        .expect("two-sided row has no top-1 rate");
+    let baseline_top1 = control_gate["rule12_precedence"]["top1_agreement"]
+        .as_f64()
+        .expect("rule12_precedence row has no top-1 rate");
+    assert!(
+        (two_sided_top1 - baseline_top1).abs() > f64::EPSILON,
+        "control two-sided top-1 ({two_sided_top1}) equals the Rule 1+2 baseline \
+         ({baseline_top1}) — the arm was inert at every position, so a skipped run \
+         would be indistinguishable from a full one for reasons that have nothing to \
+         do with the knob under test"
+    );
+
+    // ---- the skip is declared, not silent ----
+    assert!(
+        skipped_gate["right_context_arms"].is_null(),
+        "a skipped run must report the arms as ABSENT (null), never as zeroed rows"
+    );
+    assert_eq!(
+        skipped_gate["skipped_arm_groups"],
+        serde_json::json!(["right_context"]),
+        "a skipped run must NAME the group it skipped"
+    );
+    assert_eq!(
+        control_gate["skipped_arm_groups"],
+        serde_json::json!([]),
+        "a control run must report an empty skip list"
+    );
+
+    // ---- the claim: every retained row is bit-identical ----
+    assert_eq!(
+        control_gate.keys().collect::<Vec<_>>(),
+        skipped_gate.keys().collect::<Vec<_>>(),
+        "the two runs disagree on which gate_c keys exist; a skipped run must drop \
+         VALUES, never the schema"
+    );
+    let mut compared = 0usize;
+    for (key, control_value) in control_gate {
+        if EXPECTED_TO_DIFFER.contains(&key.as_str()) {
+            continue;
+        }
+        assert_eq!(
+            control_value, &skipped_gate[key],
+            "gate_c.{key} differs between a full run and a run that skipped the \
+             right-context arms; the skip is a cost knob and must not move a number"
+        );
+        compared += 1;
+    }
+    assert!(
+        compared > 20,
+        "only {compared} gate_c keys were compared — the report shrank unexpectedly \
+         and this test is no longer covering what it claims to"
+    );
+
+    // The artifact is upstream of Gate C entirely, so a skip that changed it
+    // would mean the knob leaked out of the evaluation.
+    assert_eq!(
+        control["inputs"], skipped["inputs"],
+        "the skip changed a compile input κ; it must touch the evaluation only"
+    );
+    assert_eq!(
+        control["graph"], skipped["graph"],
+        "the skip changed the emitted graph; it must touch the evaluation only"
+    );
+
+    println!(
+        "#471 arm skip — control {control_seconds:.1}s, skipped {skipped_seconds:.1}s, \
+         saving {:.1}s ({:.1}% of the control run, whole-pipeline); {compared} gate_c \
+         keys compared and identical",
+        control_seconds - skipped_seconds,
+        100.0 * (control_seconds - skipped_seconds) / control_seconds.max(f64::EPSILON),
+    );
+}


### PR DESCRIPTION
Gate C now prints a **per-phase wall clock**, and the profile revised this issue's diagnosis before any code was written for it.

## The profile (500k fixture, 2 cores, `R4_GATE_C_SAMPLE=10000`)

| phase | seconds | share |
|---|---:|---:|
| scorer construction | 2.60 | 3.0% |
| forward-anchor table (#399 M2) | 0.08 | 0.1% |
| **right-context code pass (#446)** | **51.05** | **59.0%** |
| left code pass (#469 lever A, sidecar-served) | 0.09 | 0.1% |
| two-sided table build (#446 M1) | 0.27 | 0.3% |
| latent right-context tables (#446 M2) | 0.38 | 0.4% |
| unigram null (#390) | 0.02 | 0.0% |
| scoring 10,000 positions | 31.70 | 36.6% |
| reduction, rollups, replay probes | 0.38 | 0.4% |
| **total** | **86.56** | |

The issue named three things. **Two of the three are 0.8% combined** — the table builds are not the problem. All of it is `derive_right_codes`, and the left code pass is free because the store build already wrote the #469 sidecar earlier in the same process. There is no case for a `forward_anchor` group either (0.08s).

## The knob

`R4_GATE_C_SKIP_ARMS`, comma-separated **arm-group names**, unset behaviour-identical, unknown name **panics** (a typo that silently measured everything hands back an 85-minute run when you asked for a 30-second one; a typo that silently skipped nothing looks exactly like a knob that does not work — both are invisible).

One group: `right_context`, the #446 M1 + M2 families, because they are exactly the closure of the right-context code pass. Grouped by *what they cost*, not by issue number, so the knob does not become a list of ad-hoc flags as arms accumulate.

| | control | skipped |
|---|---:|---:|
| Gate C phase | 86.56s | **32.14s** (−62.9%) |
| whole `score` pipeline | 138.1s | 82.8s (−40.1%) |

Linear in `n` — 105.7 and 102.1 µs/record at 250k and 500k — so the saving grows with the corpus and shrinks with the sample. On a **census** run it is ~16%, not two thirds; this is a decision-run lever by construction.

**Not option (a).** A κ-keyed sidecar for the right codes misses on exactly the runs that need it: a decision run is one that changed the artifact or the corpus, which is what invalidates the key.

## Absence is not zero

The twenty-six #446 rows move into `gate_c.right_context_arms: Option<..>` (schema 25 → 26), `null` on a skipped run, `skipped_arm_groups` naming what was dropped, CLI printing `SKIPPED` in each row's own place. **The M2 exit-rule verdict is suppressed rather than printed as NOT MET** — a pre-declared exit rule reported as unmet is a result, and this one would never have run.

A flat skip would have published `rule12_latent_mix.top1_agreement: 0.0` across the arm set: the all-zero pattern this repo has learned to read as a harness bug.

## Verification

- **A schema-25 report from before this change and a schema-26 control report from after it agree on every value of every `gate_c` key**, key sets equal, nothing missing or added. The restructure is a move, demonstrated rather than argued.
- `tests/gate_c_arm_skip.rs` (ignored; spawns the shipped binary twice, no `unsafe` env mutation) compares the two runs key by key — 45 keys identical, plus compile inputs and emitted graph. It asserts the control arm is non-degenerate **before** comparing, so it cannot pass by comparing two empty runs.
- **That test earned its keep on its first run**: `win_loss.twosided_vs_rule12_live` and its shuffled twin were still flat and published all-zero cross-tabs beside five populated ones. The vacuous-instrument pattern, reproduced in a change written to avoid it, and caught by a machine.
- 5 env-parse units, `gate_c_trend.sh` green (`rule12 0.3655/8.3222, baseline 0.3917/8.4985`), workspace clippy `-D warnings`, fmt, claim wording, no_std ladder, wasm target check.

## What this does NOT explain

**The 85 minutes.** 102 µs/record extrapolates to ~4 minutes at 2.11M, and peak RSS differs by only 5.6% (1,382 → 1,305 MB), so the memory hypothesis is recorded as a measured negative. The residual is unexplained and named in the record, with the leading remaining candidate being that the 85 minutes was not all inside `evaluate_gate_c` — which nothing at the time could tell. That is why the phase timing ships permanently rather than as scaffolding: the next 2.11M run attributes its own wall clock.

Record: `docs/gate_c_arm_skip_471.md`

Closes #471
