### PR TITLE
fix(router): #486 — the serving path compared a routing vector to a content vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ Two changes improved results by improving *evidence quality per key*, and both
 are shipped: full-width content-bearing storage (#434, PR #465) — the storage
 path had been discarding fifteen sixteenths of an already-full-width content
 vector, and de-banding moved retrieval MRR from 0.2348 to 0.8948 and router
-anchor accuracy from 9.3% to 11.4% (that 0.8948 is a **cosine-ranked** figure
-and, per #484, does not describe `get_top_resonances_native`, whose ordering
-is word overlap — see `docs/lexical_weight_484.md` before quoting it as a
-serving number); and the two-sided calibration gain (#446),
+anchor accuracy from 9.3% to 11.4% (that 0.8948 is a **cosine-ranked** figure;
+per #484 it did not describe `get_top_resonances_native` ordering, and per #486 the
+reason is that the serving path compared a routing vector against the stored
+content vector — fixing that comparison reaches 0.8763 MRR on the serving
+path, so the number was real all along and simply unreachable there. See
+`docs/geometry_selfmatch_486.md`); and the two-sided calibration gain (#446),
 which is causally legitimate, sits at top-1 parity, and grows large at scale in
 bits (latent-mix 15.4778 vs 22.2078).
 
@@ -211,6 +213,7 @@ predicts at all, and not past it.
 | #469 | Vectorize the assign path | Done. Lever A (κ-keyed code sidecar) 625s → 39s; lever B routes the corpus code passes through the existing `simd::dot_argmax` using tables decoded once per artifact — **1.60x** on the pinned TLA7 artifact. Bit-identity is proven, not argued: `tests/assign_prepared.rs` checks prepared == scalar over 1,024 real corpus positions on the committed artifact fixture, and the κ witness carries it on a fresh compile. Per-call decoding would have been a ~4x regression, which is why the batch API exists |
 | #471, #483 | Sampled runs still pay full-corpus table builds | Both closed. Gate C now prints a per-phase wall clock, and it revised the diagnosis twice. First: the two table builds are 0.8% of a sampled run while the whole-corpus right-context code pass is 59%, so `R4_GATE_C_SKIP_ARMS=right_context` drops it — **62.9% off the Gate C phase** at 500k, all 45 remaining `gate_c` keys identical. Then the 2.11M run settled the rest: Gate C there is **51.94s**, not 85 minutes, and per-record cost *falls* with scale (204 µs → 152 µs core-time). The 85 minutes was never Gate C; nothing at the time could separate it from the compile stages around it. `docs/gate_c_arm_skip_471.md` |
 | #484 | Is the `shared_count * 100` lexical weight right? | Closed NEGATIVE, and the answer is bigger than the weight. Every weight from 1 to 100,000 gives bit-identical retrieval, because the geometric term's dynamic range is ~0.37 — the shipped 100 sits on a plateau starting below 1. The reason: ranking by bare cosine puts the target at median rank **21,082 of 46,342** (random is 23,171) *even when the probe is the exact stored sentence*. The geometry does not identify a sentence from itself on this path, so there was never a signal for the lexical term to suppress. `docs/lexical_weight_484.md` |
+| #486 | Why doesn't the cosine identify a sentence from itself? | **Answered, and it was a category error.** `retrieve_geometric_resonance` built its query vector from the ROUTING path while `index_sentence_internal` stores a CONTENT vector — different objects, so their cosine is chance by construction (self-similarity at the 0.4938 percentile; 0.5 is chance). Not saturated vectors and not the band projection: both ruled out by measurement. Building the query with the same `content_state_vector` construction the stored side uses takes retrieval from **0.7179 to 0.8542 MRR** with the weight unchanged, and **0.8763** with the lexical term dropped — recall rises too (0.9720 → 0.9900). That is where #442's 0.8948 went. `set_content_query_vector` ships default OFF; adoption is gated on `router_reconnect` and the pinned #421 rows. `docs/geometry_selfmatch_486.md` |
 | #456–#459 | Reconstructability, block search, IPF reconstruction, estimation ladder | Active track |
 | #320 | Teacher upgrade (SmolLM2) | P1/P2 rehearsal recorded; migration decision open |
 | #273 | Template rebase / claim register | On-hold; no implementation |

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -501,6 +501,28 @@ pub struct UorR4Router {
     /// are not.
     #[serde(skip)]
     unscaled_geometric_term: bool,
+    /// Measurement knob for issue #486: build the retrieval query vector from
+    /// the query text's own CONTENT state, the same construction
+    /// `index_sentence_internal` stores, instead of from the routing state.
+    /// Default OFF — deployed retrieval ordering is unchanged.
+    ///
+    /// Why it exists. #486 measured that the deployed query projection has no
+    /// relationship to the stored vector: querying with the exact text of a
+    /// stored sentence, `cosine(query, that sentence's stored vector)` sits at
+    /// the 0.4938 percentile of all candidates — chance — with the cross
+    /// distribution carrying real spread (0.045 sd), so the stored vectors are
+    /// fine and it is the comparison that is wrong. The query side reads a
+    /// ROUTING state; the stored side is a CONTENT vector. They are different
+    /// objects and their cosine is noise by construction.
+    ///
+    /// The harnesses that measured cosine retrieval working on this stack
+    /// (#442, MRR 0.8948) sidestepped this by indexing the query text as a
+    /// corpus item and reading its stored vector back — the same encode path
+    /// on both sides. This knob does that directly and without mutating state.
+    ///
+    /// Not serialized: a measurement configuration, not a stored property.
+    #[serde(skip)]
+    content_query_vector: bool,
 }
 
 #[derive(Serialize)]
@@ -617,6 +639,7 @@ impl UorR4Router {
             full_width_query: false,
             lexical_weight: None,
             unscaled_geometric_term: false,
+            content_query_vector: false,
         };
 
         // Initialize default corpus
@@ -1099,6 +1122,17 @@ impl UorR4Router {
     /// scale rather than by similarity.
     pub fn set_unscaled_geometric_term(&mut self, unscaled: bool) {
         self.unscaled_geometric_term = unscaled;
+    }
+
+    /// Build the retrieval query vector from the query text's own content
+    /// state rather than from the routing state (issue #486). Default off.
+    ///
+    /// This is the arm that makes the query and the stored vector the same
+    /// KIND of object. Falls back to the deployed projection for any text
+    /// with no vocabulary word, so the knob can never leave a query without a
+    /// vector.
+    pub fn set_content_query_vector(&mut self, content: bool) {
+        self.content_query_vector = content;
     }
 
     /// Exports the full router system database to JSON string
@@ -2057,17 +2091,29 @@ impl UorR4Router {
         // one call is ranked under one weight and one geometric scaling.
         let lexical_weight = self.lexical_weight();
         let unscaled_geometric_term = self.unscaled_geometric_term;
+        // #486: the query text's own content vector, built by the SAME
+        // construction that produced every stored vector. `None` here means
+        // the text has no vocabulary word at all, in which case the deployed
+        // projection is used unchanged rather than leaving the query with no
+        // vector.
+        let content_query = if self.content_query_vector {
+            self.content_state_vector(text)
+        } else {
+            None
+        };
         let mut query_projections = HashMap::new();
         let mut query_ranges = HashMap::new();
         for r in &routing_data.all_routes {
             let start = r.active_range[0] as usize;
             let end = r.active_range[1] as usize;
-            let projection = if full_width_query {
-                state_vector.to_vec()
-            } else {
-                let mut banded = vec![0.0; 512];
-                banded[start..end].copy_from_slice(&r.state_vector[..end - start]);
-                banded
+            let projection = match &content_query {
+                Some(content) => content.clone(),
+                None if full_width_query => state_vector.to_vec(),
+                None => {
+                    let mut banded = vec![0.0; 512];
+                    banded[start..end].copy_from_slice(&r.state_vector[..end - start]);
+                    banded
+                }
             };
             query_projections.insert(r.window_index, projection);
             query_ranges.insert(r.window_index, (start, end));

--- a/crates/uor-r4-router/tests/geometry_selfmatch.rs
+++ b/crates/uor-r4-router/tests/geometry_selfmatch.rs
@@ -1,0 +1,363 @@
+//! Does the cosine identify a stored sentence from its own text? (issue #486)
+//!
+//! # What #484 left open
+//!
+//! Ranking by bare cosine through `retrieve_geometric_resonance`, the target
+//! sits at median rank 21,082 of 46,342 **even when the probe is the exact
+//! stored sentence** — against a random median of 23,171. Not the probe form,
+//! not subsampling, not word order; `docs/lexical_weight_484.md` ruled those
+//! out. What it did not do is say WHY.
+//!
+//! That matters because the same stack has a measurement showing cosine
+//! retrieval works: #442's de-banding result, retrieval MRR 0.2348 -> 0.8948,
+//! from a harness ranking by cosine ALONE. The same stored vectors support
+//! 0.8948 in one harness and sit at chance in this one, so the fault lives
+//! somewhere specific and this is a bisection rather than an exploration.
+//!
+//! # Why this needs no new router API
+//!
+//! With `set_lexical_weight(0.0)` and `set_unscaled_geometric_term(true)`
+//! (both #484), relevance reduces to `sim + scope_boost` with `scope_boost`
+//! constant at 15.0 for identity-scoped items. So the ranked list IS the
+//! cosine of every candidate against the query, straight out of the deployed
+//! path — no reimplementation to get subtly wrong, which is the usual way a
+//! diagnostic ends up measuring itself instead of the system.
+//!
+//! The 15.0 offset is asserted, not assumed: if the observed relevance range
+//! leaves `[-1, 1]` after subtracting it, the boost is not what this harness
+//! thinks and every number below is void.
+//!
+//! # What each arm decides
+//!
+//! - **self vs cross separation, identity probe, band query (deployed).** The
+//!   headline. If `sim(q(S), v(S))` is not separated from `sim(q(S), v(T))`
+//!   for random `T`, the query projection and the stored vector do not
+//!   correspond and everything downstream is explained.
+//! - **the same with `set_full_width_query(true)`.** THE LEADING HYPOTHESIS:
+//!   #465 made storage full-width and left the query band-only, so the cosine
+//!   sees one sixteenth of the query's coordinates. #480 measured that the
+//!   symmetric shape does not change ORDERING; nobody checked whether it
+//!   changes SELF-IDENTIFICATION, which is a different question.
+//! - **the spread of the cross distribution.** If every candidate scores
+//!   nearly the same cosine, the stored vectors are saturated and there is
+//!   nothing to discriminate — a bug with a fix, not an architectural fact.
+//! - **determinism.** The same sentence indexed twice must produce the same
+//!   retrieval, or nothing above means anything.
+//!
+//! # Reading the output
+//!
+//! `self percentile` is where the target's own cosine falls in the
+//! distribution of all candidates' cosines, 1.0 being best. **0.5 is chance.**
+//! A working content geometry puts it at or near 1.0.
+//!
+//! # Running it
+//!
+//! ```text
+//! cargo test --release -p uor-r4-router --test geometry_selfmatch -- --ignored --nocapture
+//! ```
+//!
+//! A few minutes; no teacher, no checkpoint. Knobs: `R4_SELFMATCH_PROBES`
+//! (100), `R4_HOPF_CONSTR_STORIES` (2,000), `R4_CORPUS_META`/`R4_CORPUS_RECS`.
+
+use std::collections::HashSet;
+
+use uor_r4_core::transformerless::compiler;
+use uor_r4_router::UorR4Router;
+
+const ID: &str = "user:selfmatch";
+/// The `scope_boost` every identity-scoped candidate carries, asserted below.
+const SCOPE_BOOST: f64 = 15.0;
+
+fn fixture(name: &str) -> String {
+    format!(
+        "{}/../uor-r4-core/tests/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn token_word(token: u32) -> String {
+    format!("t{token:05}")
+}
+
+fn render_window(tokens: &[u32]) -> String {
+    let words: Vec<String> = tokens.iter().map(|&token| token_word(token)).collect();
+    format!("{}.", words.join(" "))
+}
+
+fn render_query(tokens: &[u32]) -> String {
+    let words: Vec<String> = tokens
+        .iter()
+        .step_by(2)
+        .rev()
+        .map(|&token| token_word(token))
+        .collect();
+    words.join(" ")
+}
+
+/// Mean and standard deviation.
+fn moments(values: &[f64]) -> (f64, f64) {
+    if values.is_empty() {
+        return (0.0, 0.0);
+    }
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n;
+    (mean, variance.sqrt())
+}
+
+struct ArmResult {
+    self_percentile_mean: f64,
+    self_sim_mean: f64,
+    cross_sim_mean: f64,
+    cross_sim_sd: f64,
+    separation_sd: f64,
+    top1_rate: f64,
+}
+
+#[test]
+#[ignore = "diagnostic harness (issue #486); run explicitly with --ignored"]
+fn does_the_cosine_identify_a_sentence_from_itself() {
+    let meta_path = std::env::var("R4_CORPUS_META").unwrap_or_else(|_| fixture("c_meta.bin"));
+    let recs_path = std::env::var("R4_CORPUS_RECS").unwrap_or_else(|_| fixture("c_recs.bin"));
+    let Some(c) = compiler::load_corpus_from(&meta_path, &recs_path) else {
+        println!("SKIP: corpus fixtures absent ({meta_path} + {recs_path})");
+        return;
+    };
+    println!("#486: does the cosine identify a sentence from itself?");
+    println!("corpus: {meta_path} + {recs_path} ({} records)", c.n);
+
+    let cut = (c.stories as f64 * 0.8) as u32;
+    let constr: Vec<bool> = (0..c.stories).map(|sid| sid < u64::from(cut)).collect();
+
+    let mut streams: Vec<(u32, Vec<u32>)> = Vec::new();
+    for ((&sid, &input), &next) in c.story.iter().zip(&c.input).zip(&c.next).take(c.n) {
+        if streams.last().map(|(last, _)| *last) != Some(sid) {
+            streams.push((sid, vec![input]));
+        }
+        let (_, stream) = streams.last_mut().expect("just pushed");
+        stream.push(next);
+    }
+
+    let story_cap = env_usize("R4_HOPF_CONSTR_STORIES", 2_000);
+    let probe_cap = env_usize("R4_SELFMATCH_PROBES", 100).max(1);
+    let capped: Vec<&(u32, Vec<u32>)> = streams
+        .iter()
+        .filter(|(sid, _)| constr[*sid as usize])
+        .take(story_cap)
+        .collect();
+
+    let mut windows: Vec<String> = Vec::new();
+    let mut window_tokens: Vec<Vec<u32>> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for (_, stream) in &capped {
+        for chunk in stream.chunks_exact(compiler::WINDOW) {
+            let sentence = render_window(chunk);
+            if seen.insert(sentence.clone()) {
+                windows.push(sentence);
+                window_tokens.push(chunk.to_vec());
+            }
+        }
+    }
+    let stride = (windows.len() / probe_cap).max(1);
+    let targets: Vec<usize> = (0..windows.len()).step_by(stride).take(probe_cap).collect();
+    println!(
+        "CAPS: {} stories, {} distinct windows, {} probes",
+        capped.len(),
+        windows.len(),
+        targets.len()
+    );
+
+    let corpus_text: String = windows.join(" ");
+
+    let arm = |label: &str, full_width: bool, identity_probe: bool, content: bool| -> ArmResult {
+        let mut router = UorR4Router::new(0.5);
+        router.set_lexical_weight(0.0);
+        router.set_unscaled_geometric_term(true);
+        router.set_full_width_query(full_width);
+        router.set_content_query_vector(content);
+        let indexed = router.index_corpus(&corpus_text, ID);
+        assert_eq!(indexed, windows.len(), "[{label}] indexed every window");
+
+        let mut self_percentiles = Vec::new();
+        let mut self_sims = Vec::new();
+        let mut cross_means = Vec::new();
+        let mut cross_sds = Vec::new();
+        let mut separations = Vec::new();
+        let mut top1 = 0usize;
+
+        for &t in &targets {
+            let probe = if identity_probe {
+                windows[t].clone()
+            } else {
+                render_query(&window_tokens[t])
+            };
+            let results = router.get_top_resonances_native(&probe, ID, windows.len());
+            assert!(!results.is_empty(), "[{label}] retrieval returned nothing");
+
+            // The boost is asserted, not assumed: strip it and the remainder
+            // must be a cosine. If it is not, this harness is reading the
+            // wrong quantity and every number it prints is void.
+            let sims: Vec<f64> = results.iter().map(|r| r.relevance - SCOPE_BOOST).collect();
+            for &s in &sims {
+                assert!(
+                    (-1.001..=1.001).contains(&s),
+                    "[{label}] relevance minus scope_boost is {s}, not a cosine — the \
+                     boost assumption is wrong and this diagnostic is void"
+                );
+            }
+
+            let Some(pos) = results.iter().position(|r| r.sentence == windows[t]) else {
+                panic!("[{label}] target absent from the full candidate list");
+            };
+            let self_sim = sims[pos];
+            let cross: Vec<f64> = sims
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != pos)
+                .map(|(_, &s)| s)
+                .collect();
+            let below = cross.iter().filter(|&&s| s < self_sim).count() as f64;
+            self_percentiles.push(below / cross.len() as f64);
+            self_sims.push(self_sim);
+            let (mean, sd) = moments(&cross);
+            cross_means.push(mean);
+            cross_sds.push(sd);
+            separations.push(if sd > 0.0 {
+                (self_sim - mean) / sd
+            } else {
+                0.0
+            });
+            if pos == 0 {
+                top1 += 1;
+            }
+        }
+
+        ArmResult {
+            self_percentile_mean: moments(&self_percentiles).0,
+            self_sim_mean: moments(&self_sims).0,
+            cross_sim_mean: moments(&cross_means).0,
+            cross_sim_sd: moments(&cross_sds).0,
+            separation_sd: moments(&separations).0,
+            top1_rate: top1 as f64 / targets.len() as f64,
+        }
+    };
+
+    println!("\narm\t\t\t\tself pct\tself sim\tcross sim\tcross sd\tsep (sd)\ttop-1");
+    let mut rows = Vec::new();
+    for (label, full_width, identity_probe, content) in [
+        ("identity probe, band query", false, true, false),
+        ("identity probe, FULL-WIDTH query", true, true, false),
+        ("shipped probe, band query", false, false, false),
+        ("shipped probe, FULL-WIDTH query", true, false, false),
+        // #486 THE FIX ARM: query encoded through the same content
+        // construction that produced every stored vector.
+        ("identity probe, CONTENT query", false, true, true),
+        ("shipped probe, CONTENT query", false, false, true),
+    ] {
+        let r = arm(label, full_width, identity_probe, content);
+        println!(
+            "{label:<32}{:.4}\t\t{:+.4}\t\t{:+.4}\t\t{:.4}\t\t{:+.2}\t\t{:.4}",
+            r.self_percentile_mean,
+            r.self_sim_mean,
+            r.cross_sim_mean,
+            r.cross_sim_sd,
+            r.separation_sd,
+            r.top1_rate
+        );
+        rows.push((label, r));
+    }
+
+    println!(
+        "\n`self pct` is where the target's own cosine falls among all {} candidates' \
+         cosines; 1.0 is perfect, **0.5 is chance**. `sep` is the same thing in standard \
+         deviations of the cross distribution.",
+        windows.len()
+    );
+
+    // ---- determinism: the same text indexed twice must retrieve the same ----
+    {
+        let mut a = UorR4Router::new(0.5);
+        a.set_lexical_weight(0.0);
+        a.set_unscaled_geometric_term(true);
+        a.index_corpus(&corpus_text, ID);
+        let mut b = UorR4Router::new(0.5);
+        b.set_lexical_weight(0.0);
+        b.set_unscaled_geometric_term(true);
+        b.index_corpus(&corpus_text, ID);
+        let probe = windows[targets[0]].clone();
+        let ra = a.get_top_resonances_native(&probe, ID, 50);
+        let rb = b.get_top_resonances_native(&probe, ID, 50);
+        let same = ra.len() == rb.len()
+            && ra.iter().zip(&rb).all(|(x, y)| {
+                x.sentence == y.sentence && (x.relevance - y.relevance).abs() < 1e-12
+            });
+        println!(
+            "\ndeterminism: two independent indexings of the same corpus retrieve {} — {}",
+            if same { "identically" } else { "DIFFERENTLY" },
+            if same {
+                "PASS"
+            } else {
+                "VOID (nothing above means anything)"
+            }
+        );
+        assert!(
+            same,
+            "indexing is not deterministic; the diagnostic is void"
+        );
+    }
+
+    // ---- classification ----
+    println!("\n==== classification ====");
+    let (_, identity_band) = &rows[0];
+    let (_, identity_full) = &rows[1];
+    println!(
+        "identity probe, deployed band query: self percentile {:.4}, separation {:+.2} sd",
+        identity_band.self_percentile_mean, identity_band.separation_sd
+    );
+    println!(
+        "identity probe, full-width query:    self percentile {:.4}, separation {:+.2} sd",
+        identity_full.self_percentile_mean, identity_full.separation_sd
+    );
+    let band_works = identity_band.self_percentile_mean > 0.95;
+    let full_works = identity_full.self_percentile_mean > 0.95;
+    if band_works {
+        println!(
+            "The deployed query projection DOES identify a sentence from itself. The #484 \
+             ranking failure is then downstream of the vectors, not in them — look at the \
+             ranking, not the geometry."
+        );
+    } else if full_works {
+        println!(
+            "(c) BAND-PROJECTION LOSS. The deployed band-only query cannot identify a \
+             sentence from itself; the full-width query can. #465 made storage full-width \
+             and left the query banded, and #480 measured only that the symmetric shape \
+             does not change ORDERING under a lexical ranking — which it would not, since \
+             the lexical term decides the order. This is a BUG WITH A FIX: flipping the \
+             query shape makes geometric retrieval reachable, and the #480/#484 negatives \
+             should be re-run against it."
+        );
+    } else if identity_band.cross_sim_sd < 0.01 {
+        println!(
+            "(a) SATURATED STORED VECTORS. Cross-candidate cosine spread is {:.5}, so every \
+             stored vector looks alike and there is nothing for a cosine to discriminate. \
+             A bug with a fix, upstream in what `index_corpus` writes.",
+            identity_band.cross_sim_sd
+        );
+    } else {
+        println!(
+            "(b) NON-CORRESPONDING OBJECTS. The cross distribution has real spread \
+             ({:.5} sd), so the vectors differ from each other — but the query projection \
+             of a sentence does not match that sentence's stored vector under either \
+             shape. The query and stored vectors are not the same kind of object. This is \
+             ARCHITECTURAL, not a wiring bug, and it is the decision flagged on #486.",
+            identity_band.cross_sim_sd
+        );
+    }
+}

--- a/crates/uor-r4-router/tests/lexical_weight.rs
+++ b/crates/uor-r4-router/tests/lexical_weight.rs
@@ -108,6 +108,20 @@ fn fixture(name: &str) -> String {
     )
 }
 
+/// #486: re-run the whole sweep with the query vector built from the query
+/// text's CONTENT state instead of the routing state. Off by default, so the
+/// pinned reproduction check below still guards the deployed configuration.
+///
+/// This exists because #484's flat sweep was measured with a cosine that
+/// #486 then showed to be noise. "The weight does not matter" is CONDITIONAL
+/// on that: with a working geometric term the balance between the two terms
+/// is a live question again, and the same sweep answers it.
+fn content_query_mode() -> bool {
+    std::env::var("R4_LEXW_CONTENT_QUERY")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false)
+}
+
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name)
         .ok()
@@ -343,6 +357,7 @@ fn lexical_weight_sweep() {
         let mut router = UorR4Router::new(0.5);
         router.set_lexical_weight(weight);
         router.set_unscaled_geometric_term(unscaled);
+        router.set_content_query_vector(content_query_mode());
         let corpus_text: String = windows.join(" ");
         let indexed = router.index_corpus(&corpus_text, ID);
         assert_eq!(indexed, windows.len(), "[{label}] indexed every window");
@@ -397,6 +412,7 @@ fn lexical_weight_sweep() {
         let mut router = UorR4Router::new(0.5);
         router.set_lexical_weight(weight);
         router.set_unscaled_geometric_term(unscaled);
+        router.set_content_query_vector(content_query_mode());
         let corpus_text: String = windows.join(" ");
         let indexed = router.index_corpus(&corpus_text, ID);
         assert_eq!(indexed, windows.len(), "[W={weight}] indexed every window");
@@ -461,11 +477,18 @@ fn lexical_weight_sweep() {
          top-1 {s_top1:.4} vs {SHIPPED_TOP1:.4}, MRR {s_mrr:.4} vs {SHIPPED_MRR:.4}, \
          recall {s_recall:.4} vs {SHIPPED_RECALL:.4}"
     );
+    // The pinned reproduction binds only in the DEPLOYED configuration. In
+    // #486 content-query mode the W=100 arm is deliberately a different
+    // ranking, so asserting #480's row against it would be asserting that the
+    // fix does nothing.
     for (label, got, want) in [
         ("top-1", s_top1, SHIPPED_TOP1),
         ("MRR", s_mrr, SHIPPED_MRR),
         ("recall@20", s_recall, SHIPPED_RECALL),
-    ] {
+    ]
+    .into_iter()
+    .filter(|_| !content_query_mode())
+    {
         assert!(
             (got - want).abs() <= REPRODUCTION_TOLERANCE,
             "W={DEFAULT_LEXICAL_WEIGHT:.0} must reproduce #480's shipped {label} \

--- a/docs/geometry_selfmatch_486.md
+++ b/docs/geometry_selfmatch_486.md
@@ -1,0 +1,126 @@
+# The serving path was comparing a routing vector to a content vector (#486)
+
+Record for issue #486. Measured 2026-08-07 on the committed 500k fixture,
+2,000 construction stories → 46,342 distinct windows, through
+`get_top_resonances_native`.
+
+Reproduce with:
+
+```
+cargo test --release -p uor-r4-router --test geometry_selfmatch -- --ignored --nocapture
+R4_LEXW_CONTENT_QUERY=1 cargo test --release -p uor-r4-router --test lexical_weight -- --ignored --nocapture
+```
+
+## What #484 left open
+
+Ranking by bare cosine, the target sat at median rank 21,082 of 46,342 **even
+when the probe was the exact stored sentence**. Probe form, subsampling and
+word order were ruled out. Nobody knew why.
+
+## The diagnosis
+
+Self-match over 100 probes, reporting where the target's own cosine falls
+among all 46,342 candidates' cosines. **0.5 is chance; 1.0 is perfect.**
+
+| arm | self pct | self sim | cross sim | cross sd | separation | top-1 |
+|---|---:|---:|---:|---:|---:|---:|
+| identity probe, band query (deployed) | 0.4938 | −0.0006 | +0.0003 | 0.0447 | −0.01 sd | 0.0000 |
+| identity probe, full-width query | 0.4690 | +0.0056 | +0.0083 | 0.0430 | −0.06 sd | 0.0000 |
+| shipped probe, band query | 0.4879 | −0.0018 | +0.0004 | 0.0449 | −0.05 sd | 0.0000 |
+| shipped probe, full-width query | 0.4690 | +0.0056 | +0.0083 | 0.0430 | −0.06 sd | 0.0000 |
+| **identity probe, CONTENT query** | **1.0000** | **+1.0000** | +0.0855 | 0.1005 | **+9.42 sd** | **1.0000** |
+| **shipped probe, CONTENT query** | **1.0000** | **+0.7156** | +0.0585 | 0.0963 | **+7.57 sd** | **0.8000** |
+
+Two hypotheses died on the first four rows:
+
+- **Not saturated stored vectors.** The cross distribution carries real spread
+  (0.045 sd). The stored vectors are perfectly distinguishable from each
+  other; the query simply does not land near its own.
+- **Not the band projection.** `set_full_width_query(true)` does not help. #480
+  measured that the symmetric shape does not change *ordering*; it does not
+  change *self-identification* either.
+
+Indexing is deterministic (two independent indexings retrieve identically), so
+none of this is noise.
+
+## The cause
+
+`retrieve_geometric_resonance` builds its query vector from the **routing**
+path — `route_query_to_manifold_internal`, then a band of `RouteInfo::state_vector`.
+`index_sentence_internal` stores a **content** vector, the L2-normalized sum of
+the zeta-seeded vocabulary vectors of the sentence's words (`content_state_vector`,
+issue #245).
+
+**Those are different objects from different code paths, and their cosine is
+noise by construction.** Not a tuning problem, not a shape problem — a category
+error in what gets compared.
+
+The harnesses that measured cosine retrieval *working* on this stack (#442,
+MRR 0.2348 → 0.8948 — `memory_lift_ab.rs`, `zeta_projection_quality.rs`)
+sidestepped it without anyone noticing: they build the query vector by indexing
+the query text as a corpus item under a scratch identity and reading its stored
+vector back, so both sides go through the same encode. That is why 0.8948 was
+real and why it never appeared at serving.
+
+## The fix, measured
+
+`set_content_query_vector(true)` (default OFF) builds the query vector with
+`content_state_vector` — the same construction every stored vector uses. Then
+the #484 weight sweep, re-run:
+
+| ranking | top-1 | MRR | recall@20 |
+|---|---:|---:|---:|
+| **deployed** (routing query, W=100) | 0.6240 | 0.7179 | 0.9720 |
+| content query, W=100 (weight unchanged) | 0.7840 | **0.8542** | 0.9900 |
+| content query, W=1 / 10 / 1000 | 0.7840 | 0.8542 | 0.9900 |
+| **content query, W=0 (pure geometry)** | **0.8160** | **0.8763** | **0.9900** |
+
+Deranged-key null 0.0000 in every arm.
+
+**Changing one thing — the query vector — is worth +0.1363 MRR and +0.16 top-1,
+with recall *up* 0.018.** Dropping the lexical term as well takes it to +0.1584
+MRR. The pre-declared bar on this path has been +0.05 throughout; this is three
+times it.
+
+The 0.8763 also lands beside #442's 0.8948 on a different corpus and caps,
+which is the check that this is the same quantity that measurement was talking
+about all along.
+
+## What this revises
+
+**#484's flat weight sweep was conditional on a broken cosine, and the record
+now says so.** "The ranking is insensitive to a weight spanning decades" was
+true *of a ranking whose geometric term was noise*. With a working geometric
+term the curve lifts from 0.7179 to 0.854–0.876 and the optimum moves to
+`W = 0` — the opposite end from the shipped value. The plateau for `W >= 1`
+survives (the lexical term still outranks a geometric term of bounded range),
+but it is now a plateau at 0.8542 rather than 0.7179.
+
+**#480's negative is fully explained.** Reshaping a query vector that was never
+comparable to the stored vector could not have paid at any shape.
+
+**#487's correction stands and sharpens.** #434's Spectral row (0.6240 / 0.7179
+/ 0.9720) is the lexical ranking; the geometry it was crediting was inert.
+
+## Not adopted here, and why
+
+`set_content_query_vector` defaults **off** and no deployed behaviour changes in
+this PR. Changing the query vector changes retrieval **ordering**, which moves
+the pinned #421 anchor-accuracy rows, and `router_reconnect.rs` against a
+scored R4G1 artifact is the gate #480 recorded for exactly this class of
+change. That gate has not been run. Filed as the adoption issue.
+
+There is also a design question the measurement cannot settle: the routing
+state vector is presumably in that position for a reason (session state, drift,
+personalization). This record shows it is the wrong thing to take a cosine
+against; it does not show that nothing else depended on it. The adoption issue
+carries that question.
+
+## Scope limits
+
+Synthetic word renderings of token ids (the standing #422/#423 law), one
+corpus, one probe form, `top_n = 20`, 100 probes for the self-match table and
+500 for the sweep. The `identity probe, CONTENT query` row scoring exactly
++1.0000 self-similarity is a tautology by construction — identical text through
+an identical encode — and is included as the harness's sanity anchor, not as a
+result.

--- a/docs/lexical_weight_484.md
+++ b/docs/lexical_weight_484.md
@@ -134,6 +134,32 @@ itself.** All measured retrieval quality is word overlap.
   artifact — the gate #480 recorded. Nothing here asks to move it: the sweep
   is flat, so there is no ordering change worth gating.
 
+## SUPERSEDED IN PART by #486 — read this before quoting the flat sweep
+
+The sweep above is flat because the geometric term it competes with is noise,
+and #486 then found out why: `retrieve_geometric_resonance` builds its query
+vector from the ROUTING path while `index_sentence_internal` stores a CONTENT
+vector. Different objects; their cosine is chance by construction.
+
+With the query vector built by the same construction as the stored vector
+(`set_content_query_vector(true)`, #486), this same sweep is **not flat**:
+
+| ranking | top-1 | MRR | recall@20 |
+|---|---:|---:|---:|
+| deployed (routing query, W=100) | 0.6240 | 0.7179 | 0.9720 |
+| content query, W=100 | 0.7840 | 0.8542 | 0.9900 |
+| content query, W=0 | **0.8160** | **0.8763** | **0.9900** |
+
+So the conclusion "the ranking is insensitive to a weight spanning decades"
+holds only *of a ranking whose geometric term is inert*. The plateau for
+`W >= 1` survives, but it sits at 0.8542 instead of 0.7179, and the optimum is
+`W = 0` — the opposite end from the shipped value.
+
+What does NOT change: the measurement of the geometric term's dynamic range,
+the full-list and identity-probe diagnostics, and the finding that the shipped
+`100.0` was never a tuning parameter under the deployed configuration. See
+`docs/geometry_selfmatch_486.md`.
+
 ## Follow-up worth an owner
 
 **Why does the cosine not identify a sentence from itself?** That is now a


### PR DESCRIPTION
#484 found the cosine at chance on this path and could not say why. It is a **category error**, not a tuning or shape problem.

## Diagnosis

Self-match over 46,342 candidates — where does the target's own cosine fall among all candidates' cosines? **0.5 is chance.**

| arm | self pct | self sim | cross sd | separation | top-1 |
|---|---:|---:|---:|---:|---:|
| identity probe, band query (deployed) | 0.4938 | −0.0006 | 0.0447 | −0.01 sd | 0.0000 |
| identity probe, full-width query | 0.4690 | +0.0056 | 0.0430 | −0.06 sd | 0.0000 |
| **identity probe, CONTENT query** | **1.0000** | **+1.0000** | 0.1005 | **+9.42 sd** | **1.0000** |
| **shipped probe, CONTENT query** | **1.0000** | **+0.7156** | 0.0963 | **+7.57 sd** | **0.8000** |

Querying with the **exact stored sentence**, its own vector ranks at chance. Two hypotheses died on the first rows: cross-candidate spread is 0.045 sd, so the stored vectors are perfectly distinguishable (**not saturated**), and full-width query does not help (**not the band projection**). Indexing is deterministic.

## Cause

`retrieve_geometric_resonance` builds its query vector from the **routing** path. `index_sentence_internal` stores a **content** vector (`content_state_vector`, #245). Different objects from different code paths — their cosine is noise by construction.

The harnesses that measured cosine retrieval *working* on this stack (#442, MRR 0.8948 — `memory_lift_ab.rs`, `zeta_projection_quality.rs`) index the query text as a corpus item and read its stored vector back, so **both sides share one encode**. That is why 0.8948 was real and why it never appeared at serving.

## Fix, measured

| ranking | top-1 | MRR | recall@20 |
|---|---:|---:|---:|
| deployed (routing query, W=100) | 0.6240 | 0.7179 | 0.9720 |
| content query, W=100 (weight unchanged) | 0.7840 | **0.8542** | 0.9900 |
| content query, W=0 | **0.8160** | **0.8763** | **0.9900** |

**Changing one thing is worth +0.1363 MRR and +0.16 top-1, with recall UP 0.018** — against a bar that has been +0.05 on this path throughout. Deranged null 0.0000 in every arm. 0.8763 lands beside #442's 0.8948, which is the check that this is the same quantity that measurement was talking about.

## Revises #484

Its flat sweep was **conditional on a broken cosine**. With a working geometric term the curve lifts to 0.854–0.876 and the optimum moves to `W = 0` — the opposite end from the shipped value. `docs/lexical_weight_484.md` now carries that correction inline rather than being silently superseded.

## Not adopted

`set_content_query_vector` defaults **OFF**; no deployed behaviour changes here. An ordering change moves the pinned #421 anchor-accuracy rows and needs `router_reconnect` against a scored R4G1 artifact — the gate #480 recorded. Filed separately as the adoption issue.

Also open by design: the routing state vector is presumably in that position for a reason (session state, drift, personalization). This shows it is the wrong thing to take a cosine against; it does not show nothing else depended on it.

Records: `docs/geometry_selfmatch_486.md`, `docs/lexical_weight_484.md`

Closes #486
