### PR TITLE
feat(#490): adopt the #486 content-vector query as the deployed default

### DIFF
--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -406,6 +406,21 @@ fn default_geometry_type() -> GeometryType {
 /// rather than editing the constant.
 pub const DEFAULT_LEXICAL_WEIGHT: f64 = 100.0;
 
+/// Deployed default for `content_query_vector` (issue #490, adopting #486).
+///
+/// The retrieval query vector is built from the query text's own CONTENT
+/// state — the same construction every stored vector uses — rather than from
+/// the routing state, which #486 measured to be at chance against the stored
+/// vectors. `true` since #490 (minimal variant: query vector only,
+/// `DEFAULT_LEXICAL_WEIGHT` unchanged). This is a named function rather than
+/// `Default::default()` so the DESERIALIZED router (the server restores router
+/// state through `import_state`) carries the deployed default too — a plain
+/// `#[serde(skip)]` bool would reset to `false` on load and silently disable
+/// the fix on the one surface it is meant to improve.
+fn content_query_vector_default() -> bool {
+    true
+}
+
 /// The unified router core coordinator.
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize)]
@@ -504,7 +519,9 @@ pub struct UorR4Router {
     /// Measurement knob for issue #486: build the retrieval query vector from
     /// the query text's own CONTENT state, the same construction
     /// `index_sentence_internal` stores, instead of from the routing state.
-    /// Default OFF — deployed retrieval ordering is unchanged.
+    /// Default ON since #490 (see [`content_query_vector_default`]); set it
+    /// OFF with [`UorR4Router::set_content_query_vector`] to reproduce the
+    /// pre-#490 deployed ordering for measurement.
     ///
     /// Why it exists. #486 measured that the deployed query projection has no
     /// relationship to the stored vector: querying with the exact text of a
@@ -520,8 +537,9 @@ pub struct UorR4Router {
     /// corpus item and reading its stored vector back — the same encode path
     /// on both sides. This knob does that directly and without mutating state.
     ///
-    /// Not serialized: a measurement configuration, not a stored property.
-    #[serde(skip)]
+    /// Not serialized: retrieval configuration, not stored corpus state. The
+    /// `default` keeps the deployed value on the deserialize path (#490).
+    #[serde(skip, default = "content_query_vector_default")]
     content_query_vector: bool,
 }
 
@@ -639,7 +657,7 @@ impl UorR4Router {
             full_width_query: false,
             lexical_weight: None,
             unscaled_geometric_term: false,
-            content_query_vector: false,
+            content_query_vector: content_query_vector_default(),
         };
 
         // Initialize default corpus
@@ -1125,7 +1143,9 @@ impl UorR4Router {
     }
 
     /// Build the retrieval query vector from the query text's own content
-    /// state rather than from the routing state (issue #486). Default off.
+    /// state rather than from the routing state (issue #486). **Default ON
+    /// since #490**; pass `false` to reproduce the pre-#490 routing-query
+    /// ordering for measurement.
     ///
     /// This is the arm that makes the query and the stored vector the same
     /// KIND of object. Falls back to the deployed projection for any text


### PR DESCRIPTION
Closes #490. Minimal variant: flip the retrieval query vector to the content construction; `DEFAULT_LEXICAL_WEIGHT` unchanged at 100 (one behaviour change).

## Measured gain (docs/geometry_selfmatch_486.md, 500k fixture, 46,342 windows, 500 probes)
| ranking | top-1 | MRR | recall@20 |
|---|---:|---:|---:|
| deployed (routing query, W=100) | 0.6240 | 0.7179 | 0.9720 |
| **content query, W=100 (this PR)** | **0.7840** | **0.8542** | **0.9900** |

+0.1363 MRR / +0.16 top-1 / +0.018 recall from one change, vs a +0.05 bar.

## The serde-default fix (why flipping new() alone is not enough)
The knob is `#[serde(skip)]` and the server restores router state via `import_state` on startup (`src/server.rs`), so a plain skip resets the field to `false` on the deserialize path — silently disabling the fix on the live server, the exact surface #490 targets. The default is a named function wired into **both** `new()` and `#[serde(default = ...)]`, so the deployed and deserialized routers both carry it.

## Blast radius, checked
Only `get_top_resonances_native` consumes the knob: `src/server.rs` (chat viz / welcome / RAG-context), `src/tless_uor.rs` (token priors), the WASM dashboard facade — every one wants content relevance and keeps identity/session scoping separate, so all strictly improve. `router_reconnect`, the `memory_lift`/`zeta` family, and the score pipeline build their own content-cosine and never call it → **invariant to the flip by construction**.

## Verification
fmt clean; `clippy --all-targets --all-features -D warnings` clean; all four CI tests that hit `get_top_resonances_native` pass (`provenance`, `selective_backoff`, `zeta_projection_quality`, lib `test_indexing_and_resonance_retrieval`). The `zeta_projection_quality` CI probe directly shows the effect: routed retrieval rises to **top1 1.000 / MRR 1.000** under the flip (baseline MRR 0.208).

## Binding gate
`router_reconnect` against a freshly-built scored R4G1 artifact (the run #480 could never make; artifact κ `blake3:8ef32e06…`, 7743 FWDA rows) is completing on the 500k fixture; its #421 anchor rows are **invariant to this flip by construction** (it never calls `get_top_resonances_native`) and will be appended to the record. The `W=0` full variant (+0.022 MRR more) stays available as a separately-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)