### PR TITLE
feat(#488): phase timing across the whole score pipeline

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -2035,8 +2035,14 @@ fn gate_c_skip_arms() -> SkippedArms {
     parse_skip_arms(std::env::var(GATE_C_SKIP_ARMS_ENV).ok().as_deref())
 }
 
-/// Wall-clock accounting for the passes [`evaluate_gate_c`] runs, printed to
-/// stderr as the evaluation proceeds (#471).
+/// Wall-clock accounting for the passes of a scoring stage, printed to stderr
+/// as the stage proceeds (#471, generalized in #488). Each instance carries a
+/// `prefix` so the same instrument reads as one log across two levels:
+/// `evaluate_gate_c` runs it with `"gate c phase"`, and the `score` pipeline
+/// (`graph-cli::score_command`) runs it with `"score phase"` around the stages
+/// BEFORE Gate C — cover induction, store build, transition and row
+/// compilation, emission, artifact emission — where a real corpus's hours
+/// actually live (#488).
 ///
 /// Why this exists. "The Gate C phase took eighty-five minutes" was, until
 /// #471, an unattributable number: the evaluation runs four whole-corpus
@@ -2050,36 +2056,44 @@ fn gate_c_skip_arms() -> SkippedArms {
 /// between two runs of identical pinned inputs — exactly what the
 /// deterministic-rebuild gate exists to catch. These lines are diagnostics
 /// beside the existing `score: …` progress prints, never report content.
-struct PhaseLog {
+pub struct PhaseLog {
+    prefix: &'static str,
     start: std::time::Instant,
     last: std::time::Instant,
 }
 
 impl PhaseLog {
-    fn new() -> Self {
+    /// `prefix` is the log label (e.g. `"gate c phase"` or `"score phase"`);
+    /// every line this instance prints begins with it, so lines from nested
+    /// instances stay distinguishable while reading as one stream.
+    pub fn new(prefix: &'static str) -> Self {
         let now = std::time::Instant::now();
         PhaseLog {
+            prefix,
             start: now,
             last: now,
         }
     }
 
     /// Close the phase that ended here, naming it and its duration.
-    fn mark(&mut self, phase: &str) {
+    pub fn mark(&mut self, phase: &str) {
         let now = std::time::Instant::now();
         eprintln!(
-            "gate c phase: {phase} {:.2}s (cumulative {:.2}s)",
+            "{}: {phase} {:.2}s (cumulative {:.2}s)",
+            self.prefix,
             now.duration_since(self.last).as_secs_f64(),
             now.duration_since(self.start).as_secs_f64()
         );
         self.last = now;
     }
 
-    /// Close the whole evaluation. Measured from `now`, not from the last
-    /// mark, so any unmarked tail shows up in the total instead of vanishing.
-    fn total(&self) {
+    /// Close the whole stage. Measured from `now`, not from the last mark, so
+    /// any unmarked tail shows up in the total instead of vanishing — the
+    /// remainder is the check that no stage went unnamed (#488).
+    pub fn total(&self) {
         eprintln!(
-            "gate c phase: TOTAL {:.2}s",
+            "{}: TOTAL {:.2}s",
+            self.prefix,
             self.start.elapsed().as_secs_f64()
         );
     }
@@ -3314,7 +3328,7 @@ pub fn evaluate_gate_c(
     // arm groups this run was told not to build are resolved up front so the
     // skip is one decision read in one place.
     let skipped_arms = gate_c_skip_arms();
-    let mut phases = PhaseLog::new();
+    let mut phases = PhaseLog::new("gate c phase");
     if skipped_arms.any() {
         eprintln!(
             "score: {GATE_C_SKIP_ARMS_ENV}={} — those arm groups are NOT EVALUATED on this run; \

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -960,6 +960,12 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         "warning: debug builds make scoring much slower; use `cargo run --release -- transformerless score ...`"
     );
     let options = parse_score_options(args)?;
+    // #488: account for where a real corpus's hours go across the WHOLE score
+    // pipeline, not just Gate C. Same instrument, same conventions as #471
+    // (stderr only — a duration in `score_report.json` would break the
+    // deterministic-rebuild gate); the "score phase:" lines bracket the
+    // "gate c phase:" lines so the two read as one log.
+    let mut phases = score::PhaseLog::new("score phase");
     let corpus_meta_path = if !options.corpus_meta.exists() {
         if let Some(parent) = options.corpus_meta.parent() {
             if parent.join("corpus.meta").exists() {
@@ -1079,6 +1085,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         cover::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads)?;
     let held_out =
         cover::build_observations_with_threads(&artifacts, &corpus, &held_out_positions, threads)?;
+    phases.mark("inputs + observations (load, split, observe)");
 
     // Region parameters + structural edges: recovered from a previously
     // emitted cover artifact (--cover) or re-induced with the default
@@ -1129,6 +1136,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         }
     };
     let max_depth = regions.iter().map(|r| r.depth as usize).max().unwrap_or(1);
+    phases.mark("cover induction");
 
     eprintln!("score: building graded store [========================] 100%");
     // #469 lever A: per-record codes come from the κ-keyed sidecar when one
@@ -1136,6 +1144,10 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     // when it does not. Store bytes are identical on both branches.
     let (store, _) = code_sidecar::build_store_cached(&artifacts, &corpus, threads)?;
     let tls1 = runtime::store_bytes(&store);
+    // The "code sidecar: HIT/MISS/WROTE/LOADED" line above is inside this
+    // phase: a cold miss recomputes every record code (#469 lever A), which is
+    // the difference between this phase costing seconds and costing minutes.
+    phases.mark("graded store build (+ code sidecar)");
 
     eprintln!("score: compiling forward transitions [========================] 100%");
     let (transitions, transition_quantization) = score::compile_transitions_with_quantization(
@@ -1145,12 +1157,15 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         max_depth,
         config.transition_out_degree,
     );
+    phases.mark("forward transitions");
     let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
         .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
     let context_rows = score::compile_context_rows(&corpus, &train, vocab, &config);
     let fwd_rows = score::compile_forward_anchor_rows(&corpus, &train);
+    phases.mark("context + forward-anchor rows");
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
+    phases.mark("emission compilation");
     let (artifact_bytes, info) = score::emit_scored_r4g1(
         &artifact_container,
         (&meta_bytes, &recs_bytes),
@@ -1169,6 +1184,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     )?;
     let graph_kappa = uor_r4_graph_format::r4g1::artifact_kappa(&artifact_bytes)
         .map_err(|error| format!("cannot address emitted R4G1 artifact: {error}"))?;
+    phases.mark("R4G1 artifact emission");
 
     eprintln!("score: running Gate C evaluation [========================] 100%");
     let gate_c = score::evaluate_gate_c(
@@ -1180,6 +1196,9 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         &held_out,
         &config,
     )?;
+    // The "gate c phase:" lines above break this phase down further (#471);
+    // here it is one line so the score-level total stays complete.
+    phases.mark("gate c evaluation");
 
     let report = score::build_score_report_with_quality_profile(
         &config,
@@ -1234,6 +1253,10 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     let report_path = options.output.join("score_report.json");
     std::fs::write(&report_path, &report_json)
         .map_err(|error| format!("{}: {error}", report_path.display()))?;
+    // #488: report build (from the gate-c mark) + both artifact writes. The
+    // trailing stdout summary below is negligible and shows up as the total's
+    // remainder — which is the check that no stage went unnamed.
+    phases.mark("report build + artifact write");
 
     println!(
         "score complete: {} nodes, {} edges ({} refinement + {} neighbor + {} forward), {} emission entries, EXCT {} bytes, NGRAM {} rows/{} entries ({} bytes)",
@@ -1558,6 +1581,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         graph_kappa
     );
     println!("  report: {}", report_path.display());
+    phases.total();
     Ok(())
 }
 #[derive(Debug, Serialize, Clone)]


### PR DESCRIPTION
Refs #488 (**kept open** — see below). Generalizes the #471 Gate C instrument to the whole `score` pipeline, where a real corpus's hours actually live (#483 showed Gate C is not).

## What changed
`PhaseLog` (`crates/uor-r4-graph-certify/src/score.rs`) is now `pub` and carries a `prefix`, so one instrument reads as one log at two levels. `evaluate_gate_c` runs it as `"gate c phase"`; `graph-cli::score_command` runs it as `"score phase"` with a `mark()` after every stage plus `total()`. stderr only — a duration in `score_report.json` would break the deterministic-rebuild gate (#471 convention).

## Verified on the 500k fixture — phases sum to the total with ZERO remainder
```
score phase: inputs + observations           1.56s
score phase: cover induction                27.88s
score phase: graded store build (+sidecar)   1.78s
score phase: forward transitions             0.95s
score phase: context + forward-anchor rows   0.31s
score phase: emission compilation            0.41s
score phase: R4G1 artifact emission          0.71s
score phase: gate c evaluation             326.01s   (gate c phase: ... nested)
score phase: report build + artifact write   0.08s
score phase: TOTAL                         359.69s
```
Sum of stages = 359.69s = TOTAL, so no stage is unnamed — the remainder is the DoD's own completeness check. It immediately attributes the run: Gate C's **scoring pass dominates (247s / 100,306 positions)**, and within the pre-Gate-C stages **cover induction is largest (27.88s)**; the store build is 1.78s only because the #469 code sidecar HIT (vs the ~625s cold path).

## Why #488 stays open
The 500k run verifies the *instrument*. Attributing a real **2.11M** run's hours — the actual point of #488 — still needs a corpus at that scale, which is gone from disk and non-reproducible (`fetch_d3_corpus.py` warns of upstream drift). Sourcing one remains the open work.

fmt clean; clippy `--all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
