### PR TITLE
fix(#493): make the VSA switch honest — its zero is a scoring mismatch, not an empty store

### DIFF
--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -607,6 +607,28 @@ impl UorR4Router {
             "vsa" | "Vsa" | "VSA" => GeometryType::Vsa,
             _ => GeometryType::Spectral,
         };
+        // #493 (disposition of #434): fail loud on the knob rather than let
+        // VSA retrieval look like a working semantic path. Measured: after
+        // `index_corpus`/`index_sentence` the facet store IS populated (so the
+        // candidate SET is real), but `retrieve_vsa_multi_facet_resonance`
+        // scores each candidate with `cosine_similarity(query 1024-dim VSA
+        // hypervector, stored 512-dim SPECTRAL content vector)` — a length
+        // mismatch that returns exactly 0.0 for every candidate, so the ranking
+        // is dead. Making the comparison commensurable does not rescue it: the
+        // VSA hypervector is content-hash-derived (`expand_atom`), not a
+        // semantic embedding, so re-grounded scoring ranks at chance (a "fox"
+        // query ranks the fox sentence last). Until VSA has a real encoder,
+        // Spectral is the semantic retrieval path. See
+        // `docs/geometry_ablation_434.md` and #493.
+        if self.geometry_type == GeometryType::Vsa {
+            eprintln!(
+                "warning: geometry_type=Vsa — VSA retrieval does NOT rank by content \
+                 similarity on this store (grounding is content-hash-derived, and the \
+                 scorer compares a VSA hypervector to a spectral content vector); \
+                 relevances are not meaningful. Use Spectral geometry for content \
+                 retrieval. See #493."
+            );
+        }
     }
 
     #[wasm_bindgen]

--- a/crates/uor-r4-router/tests/vsa_scoring_honesty.rs
+++ b/crates/uor-r4-router/tests/vsa_scoring_honesty.rs
@@ -1,0 +1,66 @@
+//! #493 (disposition of #434 item 2): characterize what VSA retrieval actually
+//! does after corpus ingestion, and guard the corrected record.
+//!
+//! #434 recorded the VSA arm's `0.0000` as a *wiring gap* — "index_corpus
+//! populates `corpus_index_by_identity` and never touches `facet_store`". That
+//! is no longer true (and may never have been on current code): `index_corpus`
+//! calls `index_sentence_internal` → `index_sentence_routed`, which grounds each
+//! sentence via `VsaGeometry` and calls `index_semantic_object`, so the facet
+//! store IS populated. The zero has a different cause: the scorer compares the
+//! query's 1024-dim VSA hypervector against the stored 512-dim SPECTRAL content
+//! vector, and `cosine_similarity` returns exactly 0.0 on a length mismatch, so
+//! every candidate scores 0.0 and the ranking is dead.
+//!
+//! This test pins both facts so the record cannot silently drift back, and so a
+//! future change to VSA scoring is forced to update it (and confront that even a
+//! commensurable comparison ranks at chance — the grounding is content-hash
+//! derived, not semantic; see #493 and `docs/geometry_ablation_434.md`).
+
+use uor_r4_router::UorR4Router;
+
+const CORPUS: &str = "The quick brown fox jumps over the lazy dog near the river. \
+Telescopes gather light from distant ancient stars across the night sky. \
+Bread dough rises slowly when the yeast produces carbon dioxide gas. \
+Glaciers carve deep valleys as they advance slowly over many centuries. \
+The chef seasoned the tomato soup with fresh basil and cracked pepper.";
+
+#[test]
+fn vsa_after_index_corpus_populates_facets_but_scores_degenerate() {
+    let mut router = UorR4Router::new(0.5);
+    router.clear_corpus();
+    router.set_geometry_type("vsa");
+
+    let indexed = router.index_corpus(CORPUS, "shared");
+    assert_eq!(
+        indexed, 5,
+        "all five sentences pass the index_corpus filter"
+    );
+
+    // Corrected fact #1: index_corpus DOES populate the facet store (contra the
+    // #434 record). If this regresses to empty, the VSA candidate set dies for a
+    // different reason and the record needs revisiting.
+    let facet_keys = router.facet_store.type_index.len();
+    assert!(
+        facet_keys > 0,
+        "index_corpus must populate facet_store.type_index (it did not: {facet_keys} keys) \
+         — the #434 'never touches facet_store' claim is what this guards against"
+    );
+
+    // Corrected fact #2: retrieval returns the candidate SET, but every
+    // relevance is exactly 0.0 — the 1024-vs-512 length mismatch in the scorer.
+    // This is the honest signature of the dead ranking. A change that makes the
+    // scoring commensurable will break this assertion ON PURPOSE: update it only
+    // together with the disposition (a real VSA encoder), because a re-grounded
+    // hypervector cosine still ranks at chance (grounding is content-hash based).
+    let res = router.get_top_resonances_native("fox jumps over the lazy dog", "shared", 5);
+    assert!(
+        !res.is_empty(),
+        "facet intersection should still return the candidate set"
+    );
+    assert!(
+        res.iter().all(|r| r.relevance == 0.0),
+        "VSA scoring is degenerate on a spectral store (every relevance must be exactly 0.0); \
+         got {:?} — if this changed, see #493 before updating",
+        res.iter().map(|r| r.relevance).collect::<Vec<_>>()
+    );
+}

--- a/docs/geometry_ablation_434.md
+++ b/docs/geometry_ablation_434.md
@@ -158,3 +158,48 @@ worth re-running. The VSA-wiring disposition is re-opened with this corrected
 framing as a follow-up issue.
 See [geometry_selfmatch_486.md](geometry_selfmatch_486.md) and
 [lexical_weight_484.md](lexical_weight_484.md).
+
+## Correction (appended 2026-08-08, #493) — the VSA zero is a scoring mismatch, not an empty store
+
+The "wiring fact" repeated above — *`index_corpus` never populates `facet_store`* —
+is **wrong on current code**, and #493 measured it directly. Both the original
+#434 record and the #487 correction block restated it; this block supersedes
+that claim. The figures still stand; the *cause* of the VSA `0.0000` was
+misattributed.
+
+**`index_corpus` DOES populate the facet store.** It calls
+`index_sentence_internal` → `index_sentence_routed`, which grounds every
+sentence through `VsaGeometry` and calls `index_semantic_object`
+(`crates/uor-r4-router/src/lib.rs`). Probed on a five-sentence corpus in VSA
+mode: `facet_store.type_index` has five keys, `entity_index` two — populated, not
+empty. So VSA retrieval returns the correct candidate **set** from the facet
+intersection.
+
+**The zero comes from the scorer, not the store.** `retrieve_vsa_multi_facet_resonance`
+ranks each candidate with `cosine_similarity(query, stored)` where the query is
+the **1024-dim VSA hypervector** and `stored` is the item's **512-dim spectral
+content vector**. `cosine_similarity` returns exactly `0.0` on a length mismatch
+(`crates/uor-r4-core/src/lib.rs`), so **every candidate scores `0.0`** and the
+ranking is dead — the same category error as #486 (comparing two different kinds
+of object), here guaranteed exactly zero by a dimension check rather than left
+at chance.
+
+**And a commensurable comparison does not rescue it.** Re-grounding each
+candidate's text to its own 1024-dim hypervector and comparing like with like
+makes the relevances non-zero — but the ranking is still at chance: a query of
+*"the quick brown fox jumps over the lazy dog"* ranked the fox sentence **last**.
+`VsaGeometry::ground` builds the hypervector by hashing the exact content string
+(`expand_atom`), so two related sentences get unrelated random ±1 vectors — the
+grounding is a **content-hash placeholder, not a semantic encoder**. There is
+nothing semantic to rank by.
+
+**Disposition (#493).** Option (a) from "What should follow" — connect the store
+and re-run — is already half-done (the store is connected) and the remaining
+half does not pay: VSA has no semantic encoder, so its retrieval cannot rank
+regardless of the scoring wiring. Option (b) — make the switch honest — is the
+right call and is the cheap one: `set_geometry_type("vsa")` now warns loudly that
+VSA retrieval does not rank by content similarity, and
+`tests/vsa_scoring_honesty.rs` pins both corrected facts (facets populated,
+scoring degenerate). Whether VSA should get a real encoder or be deprecated is an
+engine-design decision, filed as #496 for the engine owners. Until then,
+Spectral (now with the #490 content-vector query) is the semantic retrieval path.


### PR DESCRIPTION
Closes #493 (disposition of #434 item 2, unblocked by #490).

## Measured, not assumed
The #434 record (and my own #487 correction) said the VSA `0.0000` was a wiring gap — "`index_corpus` never populates `facet_store`". Probing current code shows that is **stale**:

- `index_corpus` → `index_sentence_internal` → `index_sentence_routed` grounds each sentence and calls `index_semantic_object`, so `facet_store` **is** populated (5 type keys / 2 entity keys on a 5-sentence probe). The candidate **set** is real.
- The zero is a **scoring category error**: `retrieve_vsa_multi_facet_resonance` cosines the query's **1024-dim VSA hypervector** against the stored **512-dim spectral content vector**, and `cosine_similarity` returns exactly `0.0` on a length mismatch → every candidate scores `0.0`, dead ranking. Same class as #486.
- Making it commensurable does **not** rescue it: `VsaGeometry::ground` hashes the exact content string (`expand_atom`), so grounding is a **content-hash placeholder, not a semantic encoder** — a "quick brown fox" query ranked the fox sentence **last**. Nothing semantic to rank by.

## Disposition: option (b), make the switch honest
- `set_geometry_type("vsa")` now **warns loudly** that VSA retrieval does not rank by content similarity (fail-loud at the knob).
- `tests/vsa_scoring_honesty.rs` pins both corrected facts — facets populated, scoring degenerate — so the record can't silently drift and any future scoring change is forced to confront the disposition.
- `docs/geometry_ablation_434.md` carries the measured mechanism, superseding the stale wiring-gap claim.

The real **fix-vs-deprecate** call (VSA needs a semantic encoder) is an engine-design decision, filed as **#496** for the owners.

## Scope / safety
No deployed-path change: Spectral is the default geometry; VSA is opt-in and not set anywhere in serving. `selective_backoff` (the existing VSA test) still passes. fmt / clippy `--all-features` / claim-wording gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
