### PR TITLE
test(#500): reassess the retrieval track on the content-query path — #480/#484 negatives were dead-cosine artifacts

### DIFF
--- a/crates/uor-r4-router/tests/lexical_weight.rs
+++ b/crates/uor-r4-router/tests/lexical_weight.rs
@@ -30,11 +30,31 @@
 //! ONE corpus is the whole point. Quoting the cross-harness gap as if it
 //! were a measured delta would repeat the error #480 was filed on.
 //!
+//! # Two baselines since #490
+//!
+//! When #484 was first run, the deployed default was the routing-path query and
+//! the cosine was at chance (#486). "The weight is inert" was measured there:
+//! with no geometric signal for `W` to trade against, any `W > ~0.4` gives the
+//! same lexicographic order. #490 then made the deployed query the CONTENT
+//! vector, so the cosine now carries signal — and the inertness claim has to be
+//! reassessed on that path. This harness runs in two modes:
+//!
+//! - **default (`content_query = false`)** — reproduces the PRE-#490 lexical
+//!   baseline. Retained as the regression tell: the 0.6240 / 0.7179 / 0.9720
+//!   triple is the dead-cosine measurement that #434, #480 and #484 each
+//!   re-derived without noticing it was one number three times, so it is pinned
+//!   and asserted. This is NOT what ships any more.
+//! - **deployed (`R4_LEXW_CONTENT_QUERY=1`, `content_query = true`)** — the path
+//!   that ships since #490. Here the weight is NOT inert: dropping the lexical
+//!   term (`W = 0`, bare cosine) is worth about +0.022 MRR and lifts recall
+//!   0.9720 -> 0.9900. Pinned against `CONTENT_*` below.
+//!
 //! # Arms
 //!
 //! `W` in {0, 1, 10, 100 (shipped), 1000, 100000 (effectively strict
-//! lexicographic)}. Storage and query shapes are held at the deployed
-//! default in every arm, so `W` is the only thing that moves.
+//! lexicographic)}. Storage and query shapes are held fixed within a mode, so
+//! `W` is the only thing that moves; the query KIND (routing vs content) is the
+//! mode switch above.
 //!
 //! # Corpus, probes, null — identical to `query_projection.rs`
 //!
@@ -49,10 +69,15 @@
 //!
 //! # Validity checks, both binding
 //!
-//! 1. **The `W = 100` arm must reproduce #480's shipped row** (0.6240 top-1
-//!    / 0.7179 MRR / 0.9720 recall@20). If it does not, this harness is
-//!    wrong and its sweep says nothing about the weight. Checked against
-//!    pinned constants below, not by eye.
+//! 1. **The `W = 100` arm must reproduce the mode's pinned row.** In default
+//!    mode that is #480's PRE-#490 dead-cosine row (0.6240 top-1 / 0.7179 MRR
+//!    / 0.9720 recall@20, `SHIPPED_*`); in content-query mode it is the
+//!    post-#490 deployed row (`CONTENT_*`). If the `W = 100` arm does not
+//!    reproduce its mode's pin, the corpus or probes moved and the sweep says
+//!    nothing about the weight. Checked against pinned constants, not by eye.
+//!    The two pins also guard the DISTINCTNESS of the baselines: the deployed
+//!    content row must sit well above the dead-cosine 0.7179, or #490 has
+//!    regressed.
 //! 2. **The deranged-key null must be near zero in EVERY arm.** A weight
 //!    that lifts the null is not measuring retrieval quality. This matters
 //!    more here than in #480: `W = 0` is a genuinely different ranking, and
@@ -92,14 +117,27 @@ const WIN_MARGIN: f64 = 0.05;
 /// How much recall@20 a winning arm may give up.
 const RECALL_GIVEBACK: f64 = 0.02;
 
-/// #480's shipped row on this corpus and these caps, and the tolerance the
-/// reproduction is checked at. These are the harness's own validity anchor:
-/// the `W = 100` arm IS that configuration, so anything else means the
-/// corpus, the probes or the ranking changed under us and the sweep is void.
+/// #480's PRE-#490 row on this corpus and these caps — the dead-cosine
+/// baseline, back when the deployed query was the routing path. Pinned in
+/// DEFAULT mode (`content_query = false`): the `W = 100` arm IS that
+/// configuration, so anything else means the corpus, the probes or the ranking
+/// changed under us and the sweep is void. This is the triple #434/#480/#484
+/// each re-derived without noticing it was one measurement three times, so it
+/// earns a tight pin as the canonical dead-cosine tell.
 const SHIPPED_TOP1: f64 = 0.6240;
 const SHIPPED_MRR: f64 = 0.7179;
 const SHIPPED_RECALL: f64 = 0.9720;
 const REPRODUCTION_TOLERANCE: f64 = 0.0005;
+
+/// The post-#490 DEPLOYED row (content-query path), pinned in content-query
+/// mode. The deployed default is `content_query = true` since #490, so THIS is
+/// what ships. Wider tolerance than the dead-cosine pin above: this anchor is
+/// here to catch the 0.7179 baseline reappearing on the wrong path, not to
+/// freeze a fourth decimal across recompiles. `CONTENT_MRR` is re-confirmed on
+/// current main in the #500 PR.
+const CONTENT_MRR: f64 = 0.8542;
+const CONTENT_RECALL_MIN: f64 = 0.97;
+const CONTENT_TOLERANCE: f64 = 0.02;
 
 fn fixture(name: &str) -> String {
     format!(
@@ -108,9 +146,11 @@ fn fixture(name: &str) -> String {
     )
 }
 
-/// #486: re-run the whole sweep with the query vector built from the query
-/// text's CONTENT state instead of the routing state. Off by default, so the
-/// pinned reproduction check below still guards the deployed configuration.
+/// #486/#490: run the sweep with the query vector built from the query text's
+/// CONTENT state instead of the routing state — which is the DEPLOYED path
+/// since #490. Off by default here only so the default run keeps reproducing
+/// the pre-#490 dead-cosine row (`SHIPPED_*`) as the regression tell; the
+/// deployed row (`CONTENT_*`) is measured with `R4_LEXW_CONTENT_QUERY=1`.
 ///
 /// This exists because #484's flat sweep was measured with a cosine that
 /// #486 then showed to be noise. "The weight does not matter" is CONDITIONAL
@@ -470,32 +510,51 @@ fn lexical_weight_sweep() {
          null is not measuring retrieval quality"
     );
 
-    // 2. The shipped arm must BE the shipped configuration.
+    // 2. The W=100 arm must BE its mode's pinned configuration, AND the two
+    //    baselines must stay distinct — the whole point of #490 is that the
+    //    deployed content row sits well above the dead-cosine 0.7179.
     let (s_top1, s_mrr, s_recall, _) = summary[&DEFAULT_LEXICAL_WEIGHT.to_bits()];
-    println!(
-        "W={DEFAULT_LEXICAL_WEIGHT:.0} reproduces #480's shipped row: \
-         top-1 {s_top1:.4} vs {SHIPPED_TOP1:.4}, MRR {s_mrr:.4} vs {SHIPPED_MRR:.4}, \
-         recall {s_recall:.4} vs {SHIPPED_RECALL:.4}"
-    );
-    // The pinned reproduction binds only in the DEPLOYED configuration. In
-    // #486 content-query mode the W=100 arm is deliberately a different
-    // ranking, so asserting #480's row against it would be asserting that the
-    // fix does nothing.
-    for (label, got, want) in [
-        ("top-1", s_top1, SHIPPED_TOP1),
-        ("MRR", s_mrr, SHIPPED_MRR),
-        ("recall@20", s_recall, SHIPPED_RECALL),
-    ]
-    .into_iter()
-    .filter(|_| !content_query_mode())
-    {
-        assert!(
-            (got - want).abs() <= REPRODUCTION_TOLERANCE,
-            "W={DEFAULT_LEXICAL_WEIGHT:.0} must reproduce #480's shipped {label} \
-             ({want:.4}), got {got:.4}. The knob was supposed to leave deployed \
-             behaviour untouched at its default, so either it does not, or the corpus \
-             or probes moved — either way this sweep says nothing about the weight."
+    if content_query_mode() {
+        println!(
+            "W={DEFAULT_LEXICAL_WEIGHT:.0} on the DEPLOYED content-query path: \
+             top-1 {s_top1:.4}, MRR {s_mrr:.4} vs pinned {CONTENT_MRR:.4}, \
+             recall {s_recall:.4} (>= {CONTENT_RECALL_MIN:.4}); dead-cosine baseline is \
+             {SHIPPED_MRR:.4}"
         );
+        assert!(
+            (s_mrr - CONTENT_MRR).abs() <= CONTENT_TOLERANCE,
+            "W={DEFAULT_LEXICAL_WEIGHT:.0} on the content path must reproduce the deployed \
+             MRR {CONTENT_MRR:.4} +/- {CONTENT_TOLERANCE:.2}, got {s_mrr:.4}. Either #490 \
+             regressed or the corpus/probes moved — either way this sweep says nothing."
+        );
+        assert!(
+            s_recall >= CONTENT_RECALL_MIN,
+            "deployed content-path recall must be >= {CONTENT_RECALL_MIN:.4}, got {s_recall:.4}"
+        );
+        assert!(
+            s_mrr >= SHIPPED_MRR + 0.05,
+            "the deployed content row ({s_mrr:.4}) must sit clearly above the dead-cosine \
+             baseline ({SHIPPED_MRR:.4}); if it does not, the content-vector query has \
+             stopped paying and #490 has regressed"
+        );
+    } else {
+        println!(
+            "W={DEFAULT_LEXICAL_WEIGHT:.0} reproduces #480's PRE-#490 dead-cosine row: \
+             top-1 {s_top1:.4} vs {SHIPPED_TOP1:.4}, MRR {s_mrr:.4} vs {SHIPPED_MRR:.4}, \
+             recall {s_recall:.4} vs {SHIPPED_RECALL:.4}"
+        );
+        for (label, got, want) in [
+            ("top-1", s_top1, SHIPPED_TOP1),
+            ("MRR", s_mrr, SHIPPED_MRR),
+            ("recall@20", s_recall, SHIPPED_RECALL),
+        ] {
+            assert!(
+                (got - want).abs() <= REPRODUCTION_TOLERANCE,
+                "W={DEFAULT_LEXICAL_WEIGHT:.0} must reproduce #480's pre-#490 {label} \
+                 ({want:.4}), got {got:.4}. Either the routing-path default moved or the \
+                 corpus/probes moved — either way this sweep says nothing about the weight."
+            );
+        }
     }
 
     // 3. The cosine-only comparator, reported before the verdict because it is

--- a/crates/uor-r4-router/tests/query_projection.rs
+++ b/crates/uor-r4-router/tests/query_projection.rs
@@ -38,12 +38,37 @@
 //!
 //! # Arms
 //!
+//! The projection lever this issue is about — band-only vs full-width QUERY —
+//! only exists on the `content_query = false` path. Since #490, `new()` defaults
+//! `content_query = true`, which builds the query from the content vector and
+//! makes `set_full_width_query` a no-op. The first three arms therefore set
+//! `content_query = false` explicitly; without that they would all collapse to
+//! the content-vector query and the shipped-vs-symmetric verdict would be a
+//! vacuous `+0.0000`.
+//!
 //! - `banded` — `set_banded_storage(true)`: banded store, banded query. The
 //!   pre-#465 world.
-//! - `shipped` — the deployed default: full store, band-only query. This is
-//!   the asymmetry the issue is about.
+//! - `shipped` — full store, band-only query. The PRE-#490 deployed default,
+//!   and the asymmetry the issue was originally about.
 //! - `symmetric` — full store, full-width query via
-//!   `set_full_width_query(true)`: the proposed fix.
+//!   `set_full_width_query(true)`: #480's proposed fix.
+//! - `content (deployed)` — `content_query = true`: what actually ships since
+//!   #490. The query is the content vector, full-width by construction and the
+//!   same KIND of object as the stored vector (which the projected query never
+//!   was, #486). The other three are read against this one.
+//!
+//! # What #490 did to this question
+//!
+//! #480's original verdict was NEGATIVE: making the shapes symmetric was worth
+//! only +0.0059 MRR against a +0.05 bar. #486 then showed why — the cosine was
+//! at chance because the query (routing path) and the stored vector (content)
+//! were different objects, so no query SHAPE could pay. #490 fixed the object by
+//! building the query from the content vector, which is full-width by
+//! construction. That is the shape #480 was reaching for, and it pays about
+//! +0.136 MRR over the band-only query. So "shape does not pay" is SUPERSEDED:
+//! the lever was real; it was mis-measured because the query was the wrong kind
+//! of object, not the wrong shape. This harness now shows both the flat
+//! projection arms and the deployed content arm side by side.
 //!
 //! # Corpus, probes, null
 //!
@@ -211,16 +236,32 @@ fn query_projection_shape() {
         .map(|i| targets[(i + 1) % targets.len()])
         .collect();
 
-    println!("\narm\t\tstore/query\ttop-1\tMRR\trecall@{TOP_N}\ttie-mass\tnull MRR");
+    println!("\narm\t\t\tstore/query\ttop-1\tMRR\trecall@{TOP_N}\ttie-mass\tnull MRR");
     let mut summary: HashMap<&str, (f64, f64, f64, f64, f64)> = HashMap::new();
-    for (arm, banded, full_query) in [
-        ("banded", true, false),
-        ("shipped", false, false),
-        ("symmetric", false, true),
+    // The #480 projection lever — band-only vs full-width QUERY — lives only on
+    // the `content_query = false` path. Since #490, `new()` defaults
+    // `content_query = true`, which builds the query from the content vector and
+    // makes `set_full_width_query` a no-op; without setting the flag here all
+    // three projection arms would collapse to one measurement and the
+    // shipped-vs-symmetric verdict would be a vacuous +0.0000. It is set
+    // explicitly so each arm means what its name says.
+    //
+    // The `content (deployed)` arm is what actually ships after #490: the query
+    // is the content vector, full-width by construction AND the same KIND of
+    // object as the stored vector (which the projected query never was, #486).
+    // The other three should be read against it — it is the realized answer to
+    // the asymmetry this issue was about, reached by a better route than
+    // reshaping a query that was never comparable in the first place.
+    for (arm, banded, full_query, content) in [
+        ("banded", true, false, false),
+        ("shipped", false, false, false),
+        ("symmetric", false, true, false),
+        ("content (deployed)", false, false, true),
     ] {
         let mut router = UorR4Router::new(0.5);
         router.set_banded_storage(banded);
         router.set_full_width_query(full_query);
+        router.set_content_query_vector(content);
         let corpus_text: String = windows.join(" ");
         let indexed = router.index_corpus(&corpus_text, ID);
         assert_eq!(indexed, windows.len(), "[{arm}] indexed every window");
@@ -241,11 +282,12 @@ fn query_projection_shape() {
         let (_, null_mrr, _) = metrics(&null_ranks);
         let ties = tie_mass(&per_probe);
         println!(
-            "{arm:<11}{}\t{top1:.4}\t{mrr:.4}\t{recall:.4}\t\t{ties:.4}\t\t{null_mrr:.4}",
-            match (banded, full_query) {
-                (true, _) => "banded/banded",
-                (false, false) => "full/banded  ",
-                (false, true) => "full/full    ",
+            "{arm:<19}{}\t{top1:.4}\t{mrr:.4}\t{recall:.4}\t\t{ties:.4}\t\t{null_mrr:.4}",
+            match (banded, full_query, content) {
+                (_, _, true) => "full/content ",
+                (true, _, false) => "banded/banded",
+                (false, false, false) => "full/banded  ",
+                (false, true, false) => "full/full    ",
             }
         );
         summary.insert(arm, (top1, mrr, recall, ties, null_mrr));
@@ -253,11 +295,14 @@ fn query_projection_shape() {
 
     let (b_top1, b_mrr, b_recall, b_ties, b_null) = summary["shipped"];
     let (f_top1, f_mrr, f_recall, _, f_null) = summary["symmetric"];
+    let (c_top1, c_mrr, c_recall, _, c_null) = summary["content (deployed)"];
 
     println!("\n==== validity ====");
-    let null_dead = b_null < NULL_MRR_CEILING && f_null < NULL_MRR_CEILING;
+    let null_dead =
+        b_null < NULL_MRR_CEILING && f_null < NULL_MRR_CEILING && c_null < NULL_MRR_CEILING;
     println!(
-        "deranged-key MRR: banded {b_null:.4}, full {f_null:.4} (ceiling {NULL_MRR_CEILING}) — {}",
+        "deranged-key MRR: banded-query {b_null:.4}, full-query {f_null:.4}, \
+         content-query {c_null:.4} (ceiling {NULL_MRR_CEILING}) — {}",
         if null_dead { "PASS" } else { "VOID" }
     );
     assert!(null_dead, "deranged-key control must be near zero");
@@ -297,4 +342,37 @@ fn query_projection_shape() {
              but because this ranking is lexical, not geometric."
         );
     }
+
+    // The reconciliation the projection arms cannot show on their own. The #480
+    // question — "does matching the query shape to the storage shape pay?" — was
+    // answered NO above, but only on the path where the cosine is at chance
+    // (#486): reshaping a query vector that is not the same KIND of object as the
+    // stored vector cannot pay at any shape. #490 fixed the object, not the
+    // shape, by building the query from the content vector. That query is
+    // full-width by construction — the shape #480 was reaching for — and it is
+    // what ships. This arm is the realized answer.
+    let content_gain_mrr = c_mrr - b_mrr;
+    let content_gain_recall = c_recall - b_recall;
+    println!("\n==== reconciliation: the deployed content-vector query (#490) ====");
+    println!(
+        "shipped band-query {b_mrr:.4} MRR, {b_top1:.4} top-1, {b_recall:.4} recall  ->  \
+         content query (deployed) {c_mrr:.4} MRR, {c_top1:.4} top-1, {c_recall:.4} recall  =  \
+         {content_gain_mrr:+.4} MRR, {content_gain_recall:+.4} recall"
+    );
+    println!(
+        "The full-width query DID pay — as the content vector via #490, not via \
+         `set_full_width_query`. #480's 'shape does not pay' verdict is SUPERSEDED: the \
+         lever was real and was mis-measured because the query was the wrong kind of \
+         object, not the wrong shape. The band-vs-full projection arms remain flat \
+         ({delta_mrr:+.4} MRR) because on the content-query path they are all overridden \
+         by the content vector; they are retained here as the pre-#490 diagnostic that \
+         localised the problem to the object, not the shape.",
+        delta_mrr = f_mrr - b_mrr
+    );
+    assert!(
+        content_gain_mrr >= WIN_MARGIN,
+        "the deployed content-vector query must beat the band-query shipped arm by at least \
+         the {WIN_MARGIN:.2} MRR exit margin (it measured about +0.136 at #490); if it does \
+         not, #490 has regressed or this corpus has moved"
+    );
 }

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -107,21 +107,37 @@ retrieval value: sector-filtered MRR 0.0045 against the pre-remediation
 projection's 0.0743. Three content-aligned redesign candidates then mapped a
 clean spread-versus-retrieval frontier without crossing it.
 
-**Query-projection banding as a retrieval lever (#480).** The query side of
-`retrieve_geometric_resonance` was band-only while storage has been full-width
-since #465 — a real asymmetry, and the suspicion was that it stranded the adopted
-de-banding gain before serving. Measured: making the shapes symmetric is worth
-+0.0059 MRR and +0.0080 top-1 while costing 0.0180 of recall@20, against a +0.05
-bar. Not adopted; the symmetric shape sits behind `set_full_width_query`, default
-off. **#486 later explained this mechanistically**: reshaping a query vector that
-was never comparable to the stored vector could not have paid at any shape.
+**Query-projection banding as a retrieval lever (#480 — SUPERSEDED by #490).**
+The query side of `retrieve_geometric_resonance` was band-only while storage has
+been full-width since #465 — a real asymmetry, and the suspicion was that it
+stranded the adopted de-banding gain before serving. Measured at the time:
+making the shapes symmetric is worth +0.0059 MRR and +0.0080 top-1 while costing
+0.0180 of recall@20, against a +0.05 bar — recorded NEGATIVE, symmetric shape
+left behind `set_full_width_query`. **That verdict is now superseded.** #486
+showed the cosine was at chance because the query (routing path) and the stored
+vector (content) were different objects, so no query SHAPE could pay. #490 fixed
+the object by building the query from the content vector — which is full-width by
+construction, the shape #480 was reaching for — and it pays ~+0.136 MRR over the
+band-only query (0.7179 → 0.8542). The lever was real; it was mis-measured
+because the query was the wrong KIND of object, not the wrong shape. The #500
+reassessment re-baselines `query_projection.rs` on this path (its three
+projection arms had gone vacuous under #490's default, all collapsing to the
+content-vector query).
 
-**The lexical ranking weight (#484).** The `shared_count * 100` term was
-hypothesised to be suppressing a geometric signal. Swept over five decades:
-`W = 1 … 100,000` give bit-identical retrieval, because the geometric term's
-dynamic range is ~0.37, so any weight above ~0.4 already yields strict
-lexicographic order. NEGATIVE against the +0.05 bar. The deeper finding — that
-the cosine was at chance — sent the work to #486.
+**The lexical ranking weight (#484 — SUPERSEDED by #490).** The
+`shared_count * 100` term was hypothesised to be suppressing a geometric signal.
+Swept over five decades on the routing path: `W = 1 … 100,000` gave bit-identical
+retrieval, because with the cosine at chance any weight above ~0.4 already yields
+strict lexicographic order — recorded NEGATIVE against the +0.05 bar. **That
+"inert" verdict was conditional on the dead cosine, and #490 removed the
+condition.** On the deployed content-query path the cosine carries signal, so the
+weight is no longer inert: dropping the lexical term (`W = 0`, bare cosine) is
+worth ~+0.022 MRR (0.8542 → 0.8763) and lifts recall 0.9720 → 0.9900. The weight
+was inert only because the thing it traded against was noise. Dropping it is a
+serving-path simplification (it removes the 100× term that masked the dead cosine
+for months); because flipping `DEFAULT_LEXICAL_WEIGHT` has blast radius on the
+non-content path, it is filed as an adoption gate (#502, the same discipline
+that turned #486 → #490) rather than flipped silently. See #500.
 [lexical_weight_484.md](lexical_weight_484.md)
 
 **The serving path compared the wrong objects (#486).** A category error, not a

--- a/docs/retrieval_reassessment_500.md
+++ b/docs/retrieval_reassessment_500.md
@@ -1,0 +1,132 @@
+# Three retrieval negatives were one dead-cosine artifact (issue #500)
+
+Measured 2026-08-08 on the committed 500k fixture corpus, 2,000 construction
+stories → 46,342 distinct eight-token windows, 500 held-out probes, through
+`get_top_resonances_native` — the production retrieval surface. Same corpus,
+caps, probe form and function as #434 / #480 / #484 / #486, deliberately, so the
+numbers are comparable rather than merely similar.
+
+Reproduce:
+
+```
+# deployed path (content-query, #490 default)
+R4_LEXW_CONTENT_QUERY=1 cargo test --release -p uor-r4-router --test lexical_weight -- --ignored --nocapture
+# pre-#490 dead-cosine baseline (the regression tell)
+cargo test --release -p uor-r4-router --test lexical_weight -- --ignored --nocapture
+# projection arms + deployed content arm side by side
+cargo test --release -p uor-r4-router --test query_projection -- --ignored --nocapture
+```
+
+## The claim
+
+Three separately-filed negative results on the retrieval track —
+
+- **#480**: matching the query projection shape to the storage shape "does not
+  pay" (+0.0059 MRR, below the +0.05 bar);
+- **#484**: the `shared_count * 100` lexical weight is "inert" (`W = 1 … 100,000`
+  bit-identical);
+- **#434**: Spectral vs VSA geometry is indistinguishable (both collapse to the
+  same number),
+
+— were all measured against a cosine that #486 then proved was **at chance**, and
+all three flip once #490 makes that cosine real. They were not three findings.
+They were one measurement error, seen three times.
+
+## The single root cause
+
+`retrieve_geometric_resonance` ranks by
+
+```text
+relevance = shared_count * 100 + sim * slice_norm + scope_boost
+```
+
+Before #486 the query vector was built from the **routing** path while stored
+vectors are the **content** vector. The two are different objects, so `sim` was
+noise: the target sat at the 0.4938 percentile of all candidates even when the
+probe was the exact stored sentence (chance is 0.5). With a dead cosine, the
+`shared_count * 100` lexical term dominates by construction — and that single
+fact produces all three negatives:
+
+| filed as | what it varied | why it read flat |
+|---|---|---|
+| #480 | query SHAPE (band vs full projection) | reshaping a non-comparable vector can't pay at any shape |
+| #484 | lexical WEIGHT (`W`) | no geometric signal for `W` to trade against |
+| #434 | GEOMETRY (Spectral vs VSA) | neither geometry's cosine contributed; 0.7179 is the shared lexical term |
+
+The tell, already noted in `geometry_ablation_434.md`: #434, #480 and #484 each
+re-derived the identical triple **0.6240 / 0.7179 / 0.9720** without noticing it
+was one dead-cosine measurement three times.
+
+## What the fixed cosine says
+
+#490 builds the query from the content vector — the same construction the stored
+side uses — which is full-width by nature and comparable to what is stored. On
+the deployed path, on the same corpus and caps:
+
+| path | W | top-1 | MRR | recall@20 |
+|---|---:|---:|---:|---:|
+| pre-#490 routing query (dead cosine) | 100 | 0.6240 | 0.7179 | 0.9720 |
+| #490 content query (deployed) | 100 | 0.7840 | 0.8542 | 0.9900 |
+| #490 content query, lexical term dropped | 0 | 0.8160 | 0.8763 | 0.9900 |
+
+Re-measured on current `main` (d0de35f) at the standard caps. The deployed
+content row (0.8542 MRR) is the diagnostic full-list 0.8545 and the `W = 1 … 10`
+sweep rows to four places; `W = 0` lifts both top-1 (+0.032) and MRR (+0.022) and
+takes recall to 0.9900. On the pre-#490 path every `W ≥ 1` is bit-identical (the
+#484 "inert" observation); on the content path `W = 0` separates from `W ≥ 1`,
+which is the whole reassessment in one line — the weight only looked inert
+because the cosine it traded against was noise.
+
+Both original negatives flip:
+
+- **#480 "shape doesn't pay" → the full-width query DID pay**, ~+0.136 MRR — but
+  it arrived as the content vector (#490), not via `set_full_width_query`. The
+  lever was real; it was mis-measured because the query was the wrong KIND of
+  object, not the wrong shape.
+- **#484 "weight is inert" → the weight matters once the cosine works.** Dropping
+  the lexical term is worth ~+0.022 MRR and lifts recall to 0.9900. Inert only
+  because the thing it traded against was noise.
+
+## The consistency defect this closes
+
+The harnesses that produced these verdicts were still pinned to the dead-cosine
+baseline, which is exactly why they kept "agreeing":
+
+- **`query_projection.rs` had gone vacuous.** It never set
+  `set_content_query_vector`, so under #490's default (`new()` →
+  `content_query = true`) all three arms used the content vector and
+  `set_full_width_query` was a no-op. `shipped` and `symmetric` were
+  byte-identical; the verdict was exactly `+0.0000`. Being `#[ignore]`d, CI never
+  caught it. Now the projection arms set `content_query = false` explicitly (so
+  they measure the shape lever they claim to), and a fourth `content (deployed)`
+  arm shows the realized #490 win beside them.
+- **`lexical_weight.rs` called the pre-#490 path "deployed."** Its default forced
+  `content_query = false` and pinned 0.6240 / 0.7179 as "the deployed
+  configuration." Since #490 that is not what ships. It now pins two labelled
+  baselines: the dead-cosine row (`SHIPPED_*`, tight pin, the canonical tell) in
+  default mode, and the deployed content row (`CONTENT_*`) in
+  `R4_LEXW_CONTENT_QUERY=1` mode, with an assertion that the deployed row sits
+  clearly above 0.7179 so the two baselines cannot silently converge again.
+
+Two harnesses that disagreed about what "deployed" means cannot produce
+commensurable baselines. Pinning one post-#490 reference row across the track is
+what makes future comparisons non-frivolous.
+
+## Disposition
+
+- #480 and #484 records reconciled from NEGATIVE to SUPERSEDED-by-#490 in
+  `RESEARCH.md`, with the flipped numbers and the shared root cause.
+- Harness vacuity and stale "deployed" pins fixed as above.
+- The `W = 0` (drop the lexical term) result is a serving-path simplification
+  worth ~+0.022 MRR and +recall. Because flipping `DEFAULT_LEXICAL_WEIGHT` has
+  blast radius on the non-content path (where the scaled `W = 0` arm is confounded
+  by `slice_norm`), it is filed as an adoption gate (#502) — the same discipline
+  that turned #486 into #490 — not flipped here.
+
+## The general lesson
+
+An instrument calibrated against a broken baseline will keep confirming the
+broken baseline. The cheap guard, now in place, is to pin a KNOWN reference row
+and assert against it: had the harnesses done that from the start, the identical
+0.7179 triple appearing under three different framings would have tripped an
+assertion instead of being written down three times as three findings.


### PR DESCRIPTION
Closes #500.

## What this is

A reassessment, not a new mechanism. Three separately-filed retrieval negatives — #480 ("query shape does not pay"), #484 ("lexical weight is inert"), #434 ("Spectral vs VSA indistinguishable") — were all measured against a cosine that #486 proved was **at chance**, and all three re-derived the identical `0.6240 / 0.7179 / 0.9720` dead-cosine triple without noticing it was one measurement three times. #490 fixed the cosine (query built from the content vector). On that path both quantitative negatives flip.

## Re-measured on `main` (d0de35f), standard caps

| path | W | top-1 | MRR | recall@20 |
|---|---:|---:|---:|---:|
| pre-#490 routing query (dead cosine) | 100 | 0.6240 | 0.7179 | 0.9720 |
| #490 content query (deployed) | 100 | 0.7840 | 0.8542 | 0.9900 |
| #490 content query, lexical term dropped | 0 | 0.8160 | 0.8763 | 0.9900 |

- **#480 "shape does not pay" → SUPERSEDED.** The full-width query pays ~+0.136 MRR — but as the content vector (#490), not via `set_full_width_query`. The lever was real; it was mis-measured because the query was the wrong *kind* of object, not the wrong shape.
- **#484 "weight is inert" → SUPERSEDED.** On the old path every `W >= 1` is bit-identical; on the content path `W = 0` separates (+0.022 MRR, recall 0.9720 → 0.9900). Inert only because the cosine it traded against was noise.

## Consistency fixes (the "not frivolous" part)

- **`query_projection.rs` had gone vacuous**: it never set `content_query`, so under #490's default all three arms used the content vector and `set_full_width_query` was a no-op — `shipped == symmetric`, verdict exactly `+0.0000`, and `#[ignore]`d so CI never caught it. Now the projection arms set `content_query=false` explicitly and a fourth `content (deployed)` arm shows the realized #490 win beside them.
- **`lexical_weight.rs` called the pre-#490 path "deployed."** Now pins two labelled baselines — the dead-cosine `SHIPPED_*` (tight, the canonical tell) in default mode and the deployed `CONTENT_*` in `R4_LEXW_CONTENT_QUERY=1` mode — with an assert that the deployed row stays clearly above 0.7179 so the baselines cannot silently converge again.

## Verification

`cargo fmt --check`, `cargo clippy -p uor-r4-router --tests -D warnings`, and the claim-wording gate all pass. The `#[ignore]`d harnesses were re-run at full caps to produce the numbers above; reproduction commands are in `docs/retrieval_reassessment_500.md`.

## Follow-up (not in this PR)

Adopting `W = 0` (drop the lexical term) as the serving default is worth ~+0.022 MRR and simplifies the scorer, but flipping `DEFAULT_LEXICAL_WEIGHT` has blast radius on the non-content path, so it is left as an adoption gate — the same discipline that turned #486 into #490. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
