### PR TITLE
feat(#510): R5 tranche 1a — graph-format parse layer to the sanctioned surface

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1105,8 +1105,9 @@ impl R4Engine {
         // Fail fast with a typed format error before any scorer state is
         // built (the scorer re-validates internally; this surfaces the
         // format crate's focused error at the library boundary).
-        let view = GraphView::parse(parts.graph).map_err(LoadError::InvalidGraph)?;
-        view.verify_cids().map_err(LoadError::InvalidGraph)?;
+        let view = GraphView::parse(parts.graph).map_err(|e| LoadError::InvalidGraph(e.reason))?;
+        view.verify_cids()
+            .map_err(|k| LoadError::InvalidGraph(k.as_format()))?;
         if let Some(tokenizer_bytes) = parts.tokenizer {
             let expected = view
                 .head()

--- a/crates/uor-r4-graph-format/src/code.rs
+++ b/crates/uor-r4-graph-format/src/code.rs
@@ -29,7 +29,7 @@ fn op_size(opcode: u8) -> Option<usize> {
 }
 
 /// Validate a CODE section payload against the HEAD-declared bounds.
-pub(crate) fn validate(bytes: &[u8], max_steps: u32) -> Result<(), FormatError> {
+pub(crate) fn validate(bytes: &[u8], max_steps: u32) -> Result<(), crate::NotAProduct> {
     let mut cursor: usize = 0;
     let mut op_count: u32 = 0;
     let mut halted = false;
@@ -37,16 +37,18 @@ pub(crate) fn validate(bytes: &[u8], max_steps: u32) -> Result<(), FormatError> 
     while cursor < bytes.len() {
         let opcode = bytes[cursor];
         let Some(size) = op_size(opcode) else {
-            return Err(FormatError::UnknownCodeOp {
+            return Err((FormatError::UnknownCodeOp {
                 offset: cursor as u32,
                 opcode,
-            });
+            })
+            .into());
         };
         if cursor + size > bytes.len() {
-            return Err(FormatError::TruncatedCodeOp {
+            return Err((FormatError::TruncatedCodeOp {
                 offset: cursor as u32,
                 opcode,
-            });
+            })
+            .into());
         }
 
         // Cannot overflow: op_count <= bytes.len() <= u32::MAX.
@@ -59,9 +61,10 @@ pub(crate) fn validate(bytes: &[u8], max_steps: u32) -> Result<(), FormatError> 
 
         // level 0 = local, 1 = segment, 2 = session
         if level > 2 {
-            return Err(FormatError::CodeOperandOutOfBounds {
+            return Err((FormatError::CodeOperandOutOfBounds {
                 op_index: op_count - 1,
-            });
+            })
+            .into());
         }
 
         cursor += size;
@@ -74,14 +77,15 @@ pub(crate) fn validate(bytes: &[u8], max_steps: u32) -> Result<(), FormatError> 
     // In CODE, unlike ROUT, HALT is required: there is no implicit fall-through.
     if !halted {
         // Did not halt cleanly
-        return Err(FormatError::CodeProgramUnterminated);
+        return Err((FormatError::CodeProgramUnterminated).into());
     }
 
     if op_count > max_steps {
-        return Err(FormatError::CodeProgramTooDeep {
+        return Err((FormatError::CodeProgramTooDeep {
             ops: op_count,
             max: max_steps,
-        });
+        })
+        .into());
     }
 
     Ok(())

--- a/crates/uor-r4-graph-format/src/fmm.rs
+++ b/crates/uor-r4-graph-format/src/fmm.rs
@@ -36,30 +36,32 @@ pub struct FmmTranslationTable<'a> {
 impl<'a> FmmTranslationTable<'a> {
     /// Parse the fixed header and establish all table slices using checked
     /// arithmetic. No allocation or floating-point conversion occurs here.
-    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, crate::NotAProduct> {
         if bytes.len() < FMM_HEADER_LEN {
-            return Err(FormatError::FmmSectionTooShort {
+            return Err((FormatError::FmmSectionTooShort {
                 actual: bytes.len() as u64,
-            });
+            })
+            .into());
         }
         if bytes[0..4] != FMM_MAGIC {
-            return Err(FormatError::FmmSectionBadMagic);
+            return Err((FormatError::FmmSectionBadMagic).into());
         }
         let version = read_u16_le(bytes, 4);
         if version != FMM_VERSION {
-            return Err(FormatError::FmmSectionUnsupportedVersion(version));
+            return Err((FormatError::FmmSectionUnsupportedVersion(version)).into());
         }
         let dimension = read_u16_le(bytes, 6);
         let rank = read_u16_le(bytes, 8);
         let token_count = read_u32_le(bytes, 12);
         let factor_fraction_bits = bytes[16];
         if dimension == 0 || rank == 0 || token_count == 0 || factor_fraction_bits > 31 {
-            return Err(FormatError::FmmSectionInvalidDimensions {
+            return Err((FormatError::FmmSectionInvalidDimensions {
                 dimension,
                 rank,
                 token_count,
                 factor_fraction_bits,
-            });
+            })
+            .into());
         }
 
         let token_bytes = usize::try_from(token_count)
@@ -81,10 +83,11 @@ impl<'a> FmmTranslationTable<'a> {
             .and_then(|value| value.checked_add(coefficient_bytes))
             .ok_or(FormatError::FmmSectionLengthOverflow)?;
         if bytes.len() != expected {
-            return Err(FormatError::FmmSectionLengthMismatch {
+            return Err((FormatError::FmmSectionLengthMismatch {
                 expected: expected as u64,
                 actual: bytes.len() as u64,
-            });
+            })
+            .into());
         }
 
         let tokens_start = FMM_HEADER_LEN;
@@ -277,17 +280,18 @@ mod tests {
         bytes[0] = b'X';
         assert_eq!(
             FmmTranslationTable::parse(&bytes),
-            Err(FormatError::FmmSectionBadMagic)
+            Err((FormatError::FmmSectionBadMagic).into())
         );
 
         let mut bytes = sample();
         bytes.pop();
         assert_eq!(
             FmmTranslationTable::parse(&bytes),
-            Err(FormatError::FmmSectionLengthMismatch {
+            Err((FormatError::FmmSectionLengthMismatch {
                 expected: 52,
                 actual: 51,
             })
+            .into())
         );
     }
 }

--- a/crates/uor-r4-graph-format/src/fwda.rs
+++ b/crates/uor-r4-graph-format/src/fwda.rs
@@ -105,19 +105,19 @@ pub struct FwdaRows<'a> {
 }
 
 impl<'a> FwdaTable<'a> {
-    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, crate::NotAProduct> {
         if bytes.len() < FWDA_HEADER_LEN {
-            return Err(FormatError::FwdaTooShort);
+            return Err((FormatError::FwdaTooShort).into());
         }
         if bytes[..4] != FWDA_MAGIC {
-            return Err(FormatError::FwdaBadMagic);
+            return Err((FormatError::FwdaBadMagic).into());
         }
         if read_u16(&bytes[4..6]) != FWDA_VERSION {
-            return Err(FormatError::FwdaUnsupportedVersion);
+            return Err((FormatError::FwdaUnsupportedVersion).into());
         }
         if bytes[6..8].iter().any(|&byte| byte != 0) || bytes[14..16].iter().any(|&byte| byte != 0)
         {
-            return Err(FormatError::FwdaNonZeroReserved);
+            return Err((FormatError::FwdaNonZeroReserved).into());
         }
         let row_count = read_u32(&bytes[8..12]);
         let max_entries = read_u16(&bytes[12..14]) as usize;
@@ -128,7 +128,7 @@ impl<'a> FwdaTable<'a> {
             .checked_add(rows_len)
             .ok_or(FormatError::FwdaBounds)?;
         if entries_start > bytes.len() {
-            return Err(FormatError::FwdaBounds);
+            return Err((FormatError::FwdaBounds).into());
         }
 
         let mut previous = None;
@@ -138,20 +138,20 @@ impl<'a> FwdaTable<'a> {
             let row = &bytes[start..start + FWDA_ROW_LEN];
             let distance = row[0];
             if !(1..=FWDA_MAX_DISTANCE).contains(&distance) || row[1] != 0 {
-                return Err(FormatError::FwdaInvalidRow);
+                return Err((FormatError::FwdaInvalidRow).into());
             }
             let entry_count = read_u16(&row[2..4]);
             if usize::from(entry_count) > max_entries {
-                return Err(FormatError::FwdaInvalidRow);
+                return Err((FormatError::FwdaInvalidRow).into());
             }
             let anchor = read_u32(&row[4..8]);
             let total = read_u32(&row[8..12]);
             if total == 0 {
-                return Err(FormatError::FwdaInvalidRow);
+                return Err((FormatError::FwdaInvalidRow).into());
             }
             let entry_start = read_u32(&row[12..16]) as usize;
             if row[16..20].iter().any(|&byte| byte != 0) || entry_start != expected_entry_start {
-                return Err(FormatError::FwdaBounds);
+                return Err((FormatError::FwdaBounds).into());
             }
             let entry_bytes = (entry_count as usize)
                 .checked_mul(FWDA_ENTRY_LEN)
@@ -160,12 +160,12 @@ impl<'a> FwdaTable<'a> {
                 .checked_add(entry_bytes)
                 .ok_or(FormatError::FwdaBounds)?;
             if entry_end > bytes.len() {
-                return Err(FormatError::FwdaBounds);
+                return Err((FormatError::FwdaBounds).into());
             }
             expected_entry_start = entry_end;
             let sort_key = (distance, anchor);
             if previous.is_some_and(|last| last >= sort_key) {
-                return Err(FormatError::FwdaRowsNotSorted);
+                return Err((FormatError::FwdaRowsNotSorted).into());
             }
             previous = Some(sort_key);
             let entries = &bytes[entry_start..entry_end];
@@ -173,14 +173,14 @@ impl<'a> FwdaTable<'a> {
             for chunk in entries.chunks_exact(FWDA_ENTRY_LEN) {
                 let token = read_u32(&chunk[..4]);
                 if previous_token.is_some_and(|last| last >= token) {
-                    return Err(FormatError::FwdaEntriesNotSorted);
+                    return Err((FormatError::FwdaEntriesNotSorted).into());
                 }
                 previous_token = Some(token);
             }
         }
 
         if expected_entry_start != bytes.len() {
-            return Err(FormatError::FwdaBounds);
+            return Err((FormatError::FwdaBounds).into());
         }
 
         Ok(Self { bytes, row_count })

--- a/crates/uor-r4-graph-format/src/head.rs
+++ b/crates/uor-r4-graph-format/src/head.rs
@@ -91,13 +91,13 @@ impl Head {
     /// the module docs: shorter payloads return
     /// [`FormatError::HeadTooShort`], longer ones
     /// [`FormatError::HeadTooLong`].
-    pub fn parse(bytes: &[u8]) -> Result<Self, FormatError> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, crate::NotAProduct> {
         let actual = bytes.len() as u64;
         if bytes.len() < HEAD_PAYLOAD_LEN {
-            return Err(FormatError::HeadTooShort { actual });
+            return Err((FormatError::HeadTooShort { actual }).into());
         }
         if bytes.len() > HEAD_PAYLOAD_LEN {
-            return Err(FormatError::HeadTooLong { actual });
+            return Err((FormatError::HeadTooLong { actual }).into());
         }
         let mut hf_revision = [0u8; 20];
         hf_revision.copy_from_slice(&bytes[128..148]);

--- a/crates/uor-r4-graph-format/src/header.rs
+++ b/crates/uor-r4-graph-format/src/header.rs
@@ -132,39 +132,40 @@ pub(crate) fn read_cid(bytes: &[u8], at: usize) -> ArtifactCid {
 /// invariants: length, magic, major version, endianness marker,
 /// alignment range, `total_len == actual`, and unknown mandatory
 /// feature bits (RFC §6 stage-1 rules 1–2).
-pub(crate) fn parse(bytes: &[u8]) -> Result<Header, FormatError> {
+pub(crate) fn parse(bytes: &[u8]) -> Result<Header, crate::NotAProduct> {
     if bytes.len() < HEADER_LEN {
-        return Err(FormatError::TruncatedHeader);
+        return Err((FormatError::TruncatedHeader).into());
     }
     if &bytes[0..4] != MAGIC {
-        return Err(FormatError::BadMagic);
+        return Err((FormatError::BadMagic).into());
     }
     let major = bytes[4];
     let minor = bytes[5];
     if major != FORMAT_VERSION_MAJOR {
-        return Err(FormatError::UnsupportedMajorVersion(major));
+        return Err((FormatError::UnsupportedMajorVersion(major)).into());
     }
     let endianness = bytes[6];
     if endianness != ENDIANNESS_LITTLE {
-        return Err(FormatError::UnsupportedEndianness(endianness));
+        return Err((FormatError::UnsupportedEndianness(endianness)).into());
     }
     let alignment_log2 = bytes[7];
     if !(MIN_ALIGNMENT_LOG2..=MAX_ALIGNMENT_LOG2).contains(&alignment_log2) {
-        return Err(FormatError::UnsupportedAlignment(alignment_log2));
+        return Err((FormatError::UnsupportedAlignment(alignment_log2)).into());
     }
     let total_len = read_u64_le(bytes, 8);
     let actual = bytes.len() as u64;
     if total_len != actual {
-        return Err(FormatError::TotalLenMismatch {
+        return Err((FormatError::TotalLenMismatch {
             declared: total_len,
             actual,
-        });
+        })
+        .into());
     }
     let section_count = read_u32_le(bytes, 16);
     let flags = read_u32_le(bytes, 20);
     let unknown_mandatory = flags & MANDATORY_FEATURE_SPACE & !KNOWN_MANDATORY_FEATURES;
     if unknown_mandatory != 0 {
-        return Err(FormatError::UnknownMandatoryFeature(unknown_mandatory));
+        return Err((FormatError::UnknownMandatoryFeature(unknown_mandatory)).into());
     }
     let artifact_cid = read_cid(bytes, ARTIFACT_CID_OFFSET);
     let head_cid = read_cid(bytes, HEAD_CID_OFFSET);

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -77,6 +77,7 @@ mod ngram;
 pub mod r4g1;
 pub mod records;
 mod rout;
+pub mod sanctioned;
 pub mod scoring_semantics;
 #[cfg(feature = "alloc")]
 mod ser;
@@ -122,6 +123,7 @@ pub use records::{
     PACKED_NODE_LEN, STORAGE_DESCRIPTOR_LEN,
 };
 pub use rout::{OP_HALT, OP_JMP_FWD, OP_LEAF, OP_TEST_POPCOUNT_LE};
+pub use sanctioned::{KappaError, NotAProduct, ObjectKind, ObservedBound};
 #[cfg(feature = "alloc")]
 pub use ser::ArtifactBuilder;
 pub use types::{ArtifactCid, Depth, NodeId, Radius, ScoreQ, SectionId, SectionOffset, TokenId};

--- a/crates/uor-r4-graph-format/src/ngram.rs
+++ b/crates/uor-r4-graph-format/src/ngram.rs
@@ -77,19 +77,19 @@ pub struct NgramRows<'a> {
 }
 
 impl<'a> NgramTable<'a> {
-    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, crate::NotAProduct> {
         if bytes.len() < NGRAM_HEADER_LEN {
-            return Err(FormatError::NgramTooShort);
+            return Err((FormatError::NgramTooShort).into());
         }
         if bytes[..4] != NGRAM_MAGIC {
-            return Err(FormatError::NgramBadMagic);
+            return Err((FormatError::NgramBadMagic).into());
         }
         if read_u16(&bytes[4..6]) != NGRAM_VERSION {
-            return Err(FormatError::NgramUnsupportedVersion);
+            return Err((FormatError::NgramUnsupportedVersion).into());
         }
         if bytes[6..8].iter().any(|&byte| byte != 0) || bytes[14..16].iter().any(|&byte| byte != 0)
         {
-            return Err(FormatError::NgramNonZeroReserved);
+            return Err((FormatError::NgramNonZeroReserved).into());
         }
         let row_count = read_u32(&bytes[8..12]);
         let max_entries = read_u16(&bytes[12..14]) as usize;
@@ -100,7 +100,7 @@ impl<'a> NgramTable<'a> {
             .checked_add(rows_len)
             .ok_or(FormatError::NgramBounds)?;
         if entries_start > bytes.len() {
-            return Err(FormatError::NgramBounds);
+            return Err((FormatError::NgramBounds).into());
         }
 
         let mut previous = None;
@@ -110,19 +110,19 @@ impl<'a> NgramTable<'a> {
             let row = &bytes[start..start + NGRAM_ROW_LEN];
             let context_len = row[0];
             if !(1..=2).contains(&context_len) || row[1] != 0 {
-                return Err(FormatError::NgramInvalidRow);
+                return Err((FormatError::NgramInvalidRow).into());
             }
             let entry_count = read_u16(&row[2..4]);
             if usize::from(entry_count) > max_entries {
-                return Err(FormatError::NgramInvalidRow);
+                return Err((FormatError::NgramInvalidRow).into());
             }
             let key = (read_u32(&row[4..8]), read_u32(&row[8..12]));
             if context_len == 1 && key.1 != 0 {
-                return Err(FormatError::NgramInvalidRow);
+                return Err((FormatError::NgramInvalidRow).into());
             }
             let entry_start = read_u32(&row[12..16]) as usize;
             if row[16..20].iter().any(|&byte| byte != 0) || entry_start != expected_entry_start {
-                return Err(FormatError::NgramBounds);
+                return Err((FormatError::NgramBounds).into());
             }
             let entry_bytes = (entry_count as usize)
                 .checked_mul(NGRAM_ENTRY_LEN)
@@ -131,12 +131,12 @@ impl<'a> NgramTable<'a> {
                 .checked_add(entry_bytes)
                 .ok_or(FormatError::NgramBounds)?;
             if entry_end > bytes.len() {
-                return Err(FormatError::NgramBounds);
+                return Err((FormatError::NgramBounds).into());
             }
             expected_entry_start = entry_end;
             let sort_key = (context_len, key.0, key.1);
             if previous.is_some_and(|last| last >= sort_key) {
-                return Err(FormatError::NgramRowsNotSorted);
+                return Err((FormatError::NgramRowsNotSorted).into());
             }
             previous = Some(sort_key);
             let entries = &bytes[entry_start..entry_end];
@@ -144,14 +144,14 @@ impl<'a> NgramTable<'a> {
             for chunk in entries.chunks_exact(NGRAM_ENTRY_LEN) {
                 let token = read_u32(&chunk[..4]);
                 if previous_token.is_some_and(|last| last >= token) {
-                    return Err(FormatError::NgramEntriesNotSorted);
+                    return Err((FormatError::NgramEntriesNotSorted).into());
                 }
                 previous_token = Some(token);
             }
         }
 
         if expected_entry_start != bytes.len() {
-            return Err(FormatError::NgramBounds);
+            return Err((FormatError::NgramBounds).into());
         }
 
         Ok(Self { bytes, row_count })

--- a/crates/uor-r4-graph-format/src/r4g1.rs
+++ b/crates/uor-r4-graph-format/src/r4g1.rs
@@ -17,7 +17,7 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::{FormatError, GraphView, SectionId};
+use crate::{GraphView, SectionId};
 
 /// Version of the R4G1 realization skeleton.
 pub const REALIZATION_VERSION: u64 = 1;
@@ -27,8 +27,10 @@ pub const REALIZATION_NAME: &str = "r4g1";
 /// Failure while validating or addressing an R4G1 artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RealizationError {
-    /// The container failed R4G1 structural or semantic validation.
-    InvalidArtifact(FormatError),
+    /// The container is not a valid R4G1 artifact.
+    InvalidArtifact(crate::NotAProduct),
+    /// A CID did not reproduce.
+    CidMismatch(crate::KappaError),
     /// The generated skeleton was not accepted by the CBOR realization.
     AddressingFailed,
 }
@@ -37,6 +39,7 @@ impl core::fmt::Display for RealizationError {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::InvalidArtifact(error) => write!(formatter, "invalid R4G1 artifact: {error}"),
+            Self::CidMismatch(error) => write!(formatter, "R4G1 CID mismatch: {error}"),
             Self::AddressingFailed => write!(formatter, "uor-addr rejected the R4G1 skeleton"),
         }
     }
@@ -70,8 +73,7 @@ pub struct R4G1Address {
 /// Address a validated R4G1 container using its canonical section skeleton.
 pub fn address(bytes: &[u8]) -> Result<R4G1Address, RealizationError> {
     let view = GraphView::parse(bytes).map_err(RealizationError::InvalidArtifact)?;
-    view.verify_cids()
-        .map_err(RealizationError::InvalidArtifact)?;
+    view.verify_cids().map_err(RealizationError::CidMismatch)?;
 
     let mut sections = Vec::with_capacity(view.sections().len());
     for section in view.sections() {

--- a/crates/uor-r4-graph-format/src/records.rs
+++ b/crates/uor-r4-graph-format/src/records.rs
@@ -203,15 +203,15 @@ impl StorageDescriptor {
     /// (RFC §6 item 8): the section must carry at least
     /// [`STORAGE_DESCRIPTOR_LEN`] bytes, `width ∈ {0,1,2}`, and
     /// `|shift| ≤ 31`.
-    pub fn parse(section: SectionId, bytes: &[u8]) -> Result<Self, FormatError> {
+    pub fn parse(section: SectionId, bytes: &[u8]) -> Result<Self, crate::NotAProduct> {
         if bytes.len() < STORAGE_DESCRIPTOR_LEN {
-            return Err(FormatError::InvalidStorageDescriptor { section });
+            return Err((FormatError::InvalidStorageDescriptor { section }).into());
         }
         let width = bytes[0];
         let shift = bytes[1] as i8;
         let zero_point = read_i16_le(bytes, 2);
         if width > 2 || (shift as i16).abs() > 31 {
-            return Err(FormatError::InvalidStorageDescriptor { section });
+            return Err((FormatError::InvalidStorageDescriptor { section }).into());
         }
         Ok(Self {
             width,

--- a/crates/uor-r4-graph-format/src/rout.rs
+++ b/crates/uor-r4-graph-format/src/rout.rs
@@ -64,7 +64,7 @@ fn op_size(opcode: u8) -> Option<usize> {
 /// Two zero-allocation passes over the bytes: structure/termination,
 /// then operands and jump targets. Section lengths are u32 (RFC §9.1),
 /// so all op offsets and counts fit u32.
-pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
+pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), crate::NotAProduct> {
     // Pass 1: op sizes, count, terminator, and the program/table split.
     let mut cursor: usize = 0;
     let mut op_count: u32 = 0;
@@ -73,16 +73,18 @@ pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
     while cursor < bytes.len() {
         let opcode = bytes[cursor];
         let Some(size) = op_size(opcode) else {
-            return Err(FormatError::UnknownRoutingOp {
+            return Err((FormatError::UnknownRoutingOp {
                 offset: cursor as u32,
                 opcode,
-            });
+            })
+            .into());
         };
         if cursor + size > bytes.len() {
-            return Err(FormatError::TruncatedRoutingOp {
+            return Err((FormatError::TruncatedRoutingOp {
                 offset: cursor as u32,
                 opcode,
-            });
+            })
+            .into());
         }
         // Cannot overflow: op_count <= bytes.len() <= u32::MAX.
         op_count += 1;
@@ -94,13 +96,14 @@ pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
         }
     }
     if !halted && last_opcode != Some(OP_LEAF) {
-        return Err(FormatError::RoutingProgramUnterminated);
+        return Err((FormatError::RoutingProgramUnterminated).into());
     }
     if op_count > head.max_program_steps() {
-        return Err(FormatError::RoutingProgramTooDeep {
+        return Err((FormatError::RoutingProgramTooDeep {
             ops: op_count,
             max: head.max_program_steps(),
-        });
+        })
+        .into());
     }
     let table = &bytes[cursor..];
 
@@ -114,17 +117,18 @@ pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
                 let word = bytes[cursor + 1];
                 let threshold = read_u16_le(bytes, cursor + 10);
                 if u16::from(word) >= head.signature_words() || threshold > MAX_POPCOUNT {
-                    return Err(FormatError::RoutingOperandOutOfBounds { op_index: index });
+                    return Err((FormatError::RoutingOperandOutOfBounds { op_index: index }).into());
                 }
             }
             OP_JMP_FWD => {
                 let delta = read_u16_le(bytes, cursor + 1);
                 let target = u64::from(index) + 1 + u64::from(delta);
                 if target >= u64::from(op_count) {
-                    return Err(FormatError::RoutingJumpOutOfBounds {
+                    return Err((FormatError::RoutingJumpOutOfBounds {
                         op_index: index,
                         target,
-                    });
+                    })
+                    .into());
                 }
             }
             OP_LEAF => {
@@ -132,12 +136,16 @@ pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
                 let len = read_u16_le(bytes, cursor + 5);
                 if table.is_empty() {
                     if len != 0 {
-                        return Err(FormatError::RoutingShortlistOutOfBounds { op_index: index });
+                        return Err(
+                            (FormatError::RoutingShortlistOutOfBounds { op_index: index }).into(),
+                        );
                     }
                 } else {
                     let end = u64::from(start) + u64::from(len);
                     if end > table.len() as u64 {
-                        return Err(FormatError::RoutingShortlistOutOfBounds { op_index: index });
+                        return Err(
+                            (FormatError::RoutingShortlistOutOfBounds { op_index: index }).into(),
+                        );
                     }
                 }
             }
@@ -145,10 +153,11 @@ pub(crate) fn validate(bytes: &[u8], head: &Head) -> Result<(), FormatError> {
             // Pass 1 rejected every unknown opcode, but stay explicit
             // rather than unreachable.
             _ => {
-                return Err(FormatError::UnknownRoutingOp {
+                return Err((FormatError::UnknownRoutingOp {
                     offset: cursor as u32,
                     opcode,
                 })
+                .into())
             }
         }
         // Pass 1 established the size, so this never fails.

--- a/crates/uor-r4-graph-format/src/sanctioned.rs
+++ b/crates/uor-r4-graph-format/src/sanctioned.rs
@@ -1,0 +1,166 @@
+//! The sanctioned failure meanings (R5).
+//!
+//! R5 admits no arbitrary limitation. The only conditions a shipped crate may
+//! report are that the requested object does not exist ([`NotAProduct`]), that a
+//! kappa did not reproduce ([`KappaError`]), or that a measured bound was
+//! exceeded ([`ObservedBound`]). This module is that vocabulary.
+//!
+//! The parse layer returns [`NotAProduct`] / [`KappaError`] instead of the
+//! internal [`FormatError`](crate::FormatError) taxonomy. `FormatError` is not
+//! deleted: it is preserved as the *reason* a product was rejected and carried
+//! inside `NotAProduct`, so the validation and its diagnostics are unchanged ---
+//! only the returned *contract* is regularized to the sanctioned set.
+
+use core::fmt;
+
+use crate::error::FormatError;
+
+/// Which object was requested but is not a product of the given bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectKind {
+    /// The whole R4G1 graph artifact.
+    Graph,
+    /// The fixed 88-byte header.
+    Header,
+    /// The HEAD section.
+    Head,
+    /// A section body.
+    Section,
+    /// The n-gram table.
+    NgramTable,
+    /// The forward-anchor table.
+    FwdaTable,
+    /// The FMM translation table.
+    FmmTable,
+    /// A routing (ROUT) program.
+    RoutingProgram,
+    /// A CODE program.
+    CodeProgram,
+    /// A packed record block.
+    Records,
+    /// A serialized artifact under construction.
+    Artifact,
+}
+
+impl fmt::Display for ObjectKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ObjectKind::Graph => "graph",
+            ObjectKind::Header => "header",
+            ObjectKind::Head => "head",
+            ObjectKind::Section => "section",
+            ObjectKind::NgramTable => "n-gram table",
+            ObjectKind::FwdaTable => "forward-anchor table",
+            ObjectKind::FmmTable => "FMM translation table",
+            ObjectKind::RoutingProgram => "routing program",
+            ObjectKind::CodeProgram => "CODE program",
+            ObjectKind::Records => "record block",
+            ObjectKind::Artifact => "artifact",
+        };
+        f.write_str(s)
+    }
+}
+
+/// The requested object is not a product of these bytes (R5).
+///
+/// `object` is what was asked for; `reason` is the observed malformation,
+/// preserved so a caller that wants the structural detail still has it while the
+/// returned contract names only the sanctioned condition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NotAProduct {
+    /// The object that does not exist as a product of the bytes.
+    pub object: ObjectKind,
+    /// Why the bytes are not that object.
+    pub reason: FormatError,
+}
+
+impl NotAProduct {
+    /// The bytes are not `object`, because `reason`.
+    pub const fn new(object: ObjectKind, reason: FormatError) -> Self {
+        Self { object, reason }
+    }
+}
+
+/// A bare [`FormatError`] names the whole graph as the absent object; a function
+/// parsing a more specific object constructs [`NotAProduct::new`] with its kind.
+/// This is what lets `?` propagate a structural failure without per-site
+/// ceremony.
+impl From<FormatError> for NotAProduct {
+    fn from(reason: FormatError) -> Self {
+        Self {
+            object: ObjectKind::Graph,
+            reason,
+        }
+    }
+}
+
+impl fmt::Display for NotAProduct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "not a {}: {}", self.object, self.reason)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NotAProduct {}
+
+/// A kappa (BLAKE3 CID) did not reproduce (R5) --- the only failure a
+/// reproduction check may report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KappaError {
+    /// The HEAD section is absent, so its CID cannot be computed or checked.
+    MissingHead,
+    /// `head_cid` does not recompute to the HEAD body.
+    Head,
+    /// `artifact_cid` does not recompute to `artifact_bytes[56..]`.
+    Artifact,
+    /// `tokenizer_cid` does not match the loaded tokenizer hash.
+    Tokenizer,
+}
+
+impl KappaError {
+    /// The equivalent [`FormatError`] variant, for a caller not yet migrated to
+    /// the sanctioned surface (R5 tranche 1b removes these bridges).
+    pub const fn as_format(self) -> FormatError {
+        match self {
+            KappaError::MissingHead => FormatError::MissingHead,
+            KappaError::Head => FormatError::HeadCidMismatch,
+            KappaError::Artifact => FormatError::ArtifactCidMismatch,
+            KappaError::Tokenizer => FormatError::TokenizerCidMismatch,
+        }
+    }
+}
+
+impl fmt::Display for KappaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            KappaError::MissingHead => "HEAD absent: no CID to reproduce",
+            KappaError::Head => "head_cid does not reproduce",
+            KappaError::Artifact => "artifact_cid does not reproduce",
+            KappaError::Tokenizer => "tokenizer_cid does not match",
+        };
+        f.write_str(s)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for KappaError {}
+
+/// A measured bound was exceeded (R5) --- a property of the observed input, not
+/// a limitation of the code. Carries the observed value and the bound it
+/// crossed, so it reports rather than refuses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObservedBound {
+    /// The value that was observed.
+    pub observed: i64,
+    /// The bound it crossed.
+    pub bound: i64,
+}
+
+impl fmt::Display for ObservedBound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "observed {} past bound {}", self.observed, self.bound)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ObservedBound {}

--- a/crates/uor-r4-graph-format/src/ser.rs
+++ b/crates/uor-r4-graph-format/src/ser.rs
@@ -63,28 +63,28 @@ impl ArtifactBuilder {
     }
 
     /// Emit the canonical container bytes.
-    pub fn build(&self) -> Result<Vec<u8>, FormatError> {
+    pub fn build(&self) -> Result<Vec<u8>, crate::NotAProduct> {
         if !(MIN_ALIGNMENT_LOG2..=MAX_ALIGNMENT_LOG2).contains(&self.alignment_log2) {
-            return Err(FormatError::UnsupportedAlignment(self.alignment_log2));
+            return Err((FormatError::UnsupportedAlignment(self.alignment_log2)).into());
         }
         let unknown_mandatory = self.flags & MANDATORY_FEATURE_SPACE & !KNOWN_MANDATORY_FEATURES;
         if unknown_mandatory != 0 {
-            return Err(FormatError::UnknownMandatoryFeature(unknown_mandatory));
+            return Err((FormatError::UnknownMandatoryFeature(unknown_mandatory)).into());
         }
 
         let mut sections: Vec<&(SectionId, u32, Vec<u8>)> = self.sections.iter().collect();
         sections.sort_by_key(|(id, _, _)| id.0);
         for pair in sections.windows(2) {
             if pair[0].0 == pair[1].0 {
-                return Err(FormatError::DuplicateSection(pair[0].0));
+                return Err((FormatError::DuplicateSection(pair[0].0)).into());
             }
         }
         if !sections.iter().any(|(id, _, _)| *id == SectionId::HEAD) {
-            return Err(FormatError::MissingHead);
+            return Err((FormatError::MissingHead).into());
         }
         for (id, _, _) in &sections {
             if !id.is_known() && id.mandatory() {
-                return Err(FormatError::UnknownMandatorySection(id.0));
+                return Err((FormatError::UnknownMandatorySection(id.0)).into());
             }
         }
 
@@ -162,8 +162,8 @@ impl ArtifactBuilder {
 }
 
 /// Smallest multiple of `align` ≥ `x`, with checked arithmetic.
-fn align_up(x: u64, align: u64) -> Result<u64, FormatError> {
+fn align_up(x: u64, align: u64) -> Result<u64, crate::NotAProduct> {
     x.checked_add(align - 1)
         .map(|v| v & !(align - 1))
-        .ok_or(FormatError::OffsetOverflow)
+        .ok_or_else(|| FormatError::OffsetOverflow.into())
 }

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -39,16 +39,14 @@ use crate::view::GraphView;
 /// Run stage 2 over the sections of a stage-1-validated view. Returns
 /// the decoded [`Head`] when a HEAD section is present; `None` keeps
 /// the container stage-1-only (see module docs).
-pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
+pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, crate::NotAProduct> {
     let head = match view.section(SectionId::HEAD) {
         Some(bytes) => Head::parse(bytes)?,
         None => return Ok(None),
     };
     let unknown_required = head.feature_bits_required() & !KNOWN_FEATURE_BITS_REQUIRED;
     if unknown_required != 0 {
-        return Err(FormatError::UnknownMandatoryFeature(u32::from(
-            unknown_required,
-        )));
+        return Err((FormatError::UnknownMandatoryFeature(u32::from(unknown_required))).into());
     }
     let edge_algebra_v1 = head.feature_bits_required() & FEATURE_EDGE_ALGEBRA_V1 != 0;
 
@@ -59,11 +57,12 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
     let storage_bytes = u32::from(head.signature_words()) * 8;
     let signature_bytes = u32::from(head.signature_bytes());
     if signature_bytes > storage_bytes || signature_bytes <= storage_bytes.saturating_sub(8) {
-        return Err(FormatError::DishonestBounds {
+        return Err((FormatError::DishonestBounds {
             bound: BoundKind::SignatureBytes,
             declared: signature_bytes,
             observed: storage_bytes,
-        });
+        })
+        .into());
     }
 
     // EMIT/EXCT storage descriptors (RFC §6 item 8). Node emission
@@ -108,16 +107,17 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
         Some(bytes) => {
             let expected = u64::from(head.node_count()) * PACKED_NODE_LEN as u64;
             if bytes.len() as u64 != expected {
-                return Err(FormatError::NodeCountMismatch {
+                return Err((FormatError::NodeCountMismatch {
                     declared: head.node_count(),
                     section_len: bytes.len() as u64,
-                });
+                })
+                .into());
             }
             Some(bytes)
         }
         None => {
             if head.node_count() > 0 {
-                return Err(FormatError::MissingNodeSection);
+                return Err((FormatError::MissingNodeSection).into());
             }
             None
         }
@@ -129,16 +129,17 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
             let expected =
                 u64::from(head.edge_count()) * (PACKED_EDGE_LEN + REVERSE_INDEX_ENTRY_LEN) as u64;
             if bytes.len() as u64 != expected {
-                return Err(FormatError::EdgeCountMismatch {
+                return Err((FormatError::EdgeCountMismatch {
                     declared: head.edge_count(),
                     section_len: bytes.len() as u64,
-                });
+                })
+                .into());
             }
             Some(bytes)
         }
         None => {
             if head.edge_count() > 0 {
-                return Err(FormatError::MissingEdgeSection);
+                return Err((FormatError::MissingEdgeSection).into());
             }
             None
         }
@@ -153,39 +154,44 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
             let node = records::decode_node(&bytes[i as usize * PACKED_NODE_LEN..]);
             let child_end = u64::from(node.child_start) + u64::from(node.child_len);
             if child_end > u64::from(head.edge_count()) {
-                return Err(FormatError::RangeOutOfBounds {
+                return Err((FormatError::RangeOutOfBounds {
                     node: i,
                     field: RangeField::Child,
-                });
+                })
+                .into());
             }
             let forward_end = u64::from(node.forward_start) + u64::from(node.forward_len);
             if forward_end > u64::from(head.edge_count()) {
-                return Err(FormatError::RangeOutOfBounds {
+                return Err((FormatError::RangeOutOfBounds {
                     node: i,
                     field: RangeField::Forward,
-                });
+                })
+                .into());
             }
             let emission_end = u64::from(node.emission_start) + u64::from(node.emission_len);
             if emission_end > emit_remainder as u64 {
-                return Err(FormatError::RangeOutOfBounds {
+                return Err((FormatError::RangeOutOfBounds {
                     node: i,
                     field: RangeField::Emission,
-                });
+                })
+                .into());
             }
             // Word starts plus the full W-word extent must resolve
             // within the ROUT section.
             let signature_words = u64::from(head.signature_words());
             if u64::from(node.prototype_word_start) + signature_words > rout_words {
-                return Err(FormatError::RangeOutOfBounds {
+                return Err((FormatError::RangeOutOfBounds {
                     node: i,
                     field: RangeField::Prototype,
-                });
+                })
+                .into());
             }
             if u64::from(node.mask_word_start) + signature_words > rout_words {
-                return Err(FormatError::RangeOutOfBounds {
+                return Err((FormatError::RangeOutOfBounds {
                     node: i,
                     field: RangeField::Mask,
-                });
+                })
+                .into());
             }
             // Zero-padding rule (RFC §4.1): with word-aligned storage of
             // a byte-exact signature, the bytes between the signature
@@ -202,34 +208,39 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
                         let begin = word_start as usize * 8 + signature_bytes;
                         let end = word_start as usize * 8 + storage_bytes;
                         let Some(padding) = rout.get(begin..end) else {
-                            return Err(FormatError::RangeOutOfBounds { node: i, field });
+                            return Err((FormatError::RangeOutOfBounds { node: i, field }).into());
                         };
                         if padding.iter().any(|&byte| byte != 0) {
-                            return Err(FormatError::NonZeroSignaturePadding { node: i, field });
+                            return Err(
+                                (FormatError::NonZeroSignaturePadding { node: i, field }).into()
+                            );
                         }
                     }
                 }
             }
             if node.child_len > head.max_frontier_width() {
-                return Err(FormatError::DishonestBounds {
+                return Err((FormatError::DishonestBounds {
                     bound: BoundKind::FrontierWidth,
                     declared: u32::from(head.max_frontier_width()),
                     observed: u32::from(node.child_len),
-                });
+                })
+                .into());
             }
             if u32::from(node.emission_len) > head.max_emission_entries() {
-                return Err(FormatError::DishonestBounds {
+                return Err((FormatError::DishonestBounds {
                     bound: BoundKind::EmissionEntries,
                     declared: head.max_emission_entries(),
                     observed: u32::from(node.emission_len),
-                });
+                })
+                .into());
             }
             if node.depth.0 >= head.depth_count() {
-                return Err(FormatError::DishonestBounds {
+                return Err((FormatError::DishonestBounds {
                     bound: BoundKind::DepthCount,
                     declared: u32::from(head.depth_count()),
                     observed: u32::from(node.depth.0),
-                });
+                })
+                .into());
             }
         }
     }
@@ -244,53 +255,60 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
             // in bounds.
             let edge = records::decode_edge(&bytes[i as usize * PACKED_EDGE_LEN..]);
             if edge.src.0 >= head.node_count() || edge.dst.0 >= head.node_count() {
-                return Err(FormatError::EdgeEndpointOutOfBounds {
+                return Err((FormatError::EdgeEndpointOutOfBounds {
                     edge: i,
                     src: edge.src.0,
                     dst: edge.dst.0,
-                });
+                })
+                .into());
             }
             let known_kind = EdgeKind::from_raw(edge.kind);
             if known_kind.is_none() && !is_optional_edge_kind(edge.kind) {
-                return Err(FormatError::UnknownMandatoryEdgeKind {
+                return Err((FormatError::UnknownMandatoryEdgeKind {
                     edge: i,
                     kind: edge.kind,
-                });
+                })
+                .into());
             }
             if edge.flags != 0 {
-                return Err(FormatError::InvalidEdgePayload {
+                return Err((FormatError::InvalidEdgePayload {
                     edge: i,
                     field: EdgePayloadField::Flags,
-                });
+                })
+                .into());
             }
             if !edge_algebra_v1 && edge.reserved != 0 {
-                return Err(FormatError::InvalidEdgePayload {
+                return Err((FormatError::InvalidEdgePayload {
                     edge: i,
                     field: EdgePayloadField::Reserved,
-                });
+                })
+                .into());
             }
             if let Some(kind) = known_kind {
                 if kind.directed() && !kind.may_cycle() && edge.src.0 >= edge.dst.0 {
-                    return Err(FormatError::InvalidEdgePayload {
+                    return Err((FormatError::InvalidEdgePayload {
                         edge: i,
                         field: EdgePayloadField::AcyclicOrder,
-                    });
+                    })
+                    .into());
                 }
                 if edge_algebra_v1 && kind.requires_contribution_id() && edge.reserved == 0 {
-                    return Err(FormatError::InvalidEdgePayload {
+                    return Err((FormatError::InvalidEdgePayload {
                         edge: i,
                         field: EdgePayloadField::ContributionId,
-                    });
+                    })
+                    .into());
                 }
             }
             let contribution_id = if edge_algebra_v1 { edge.reserved } else { 0 };
             let key = (edge.src.0, edge.kind, edge.dst.0, contribution_id);
             if let Some(prev) = previous_key {
                 if prev >= key {
-                    return Err(FormatError::EdgeCanonicalOrderViolation {
+                    return Err((FormatError::EdgeCanonicalOrderViolation {
                         previous: i - 1,
                         edge: i,
-                    });
+                    })
+                    .into());
                 }
             }
             previous_key = Some(key);
@@ -316,13 +334,14 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
                         && edge_a.dst == edge_b.dst
                         && edge_a.reserved == edge_b.reserved
                     {
-                        return Err(FormatError::ContributionIdCollision {
+                        return Err((FormatError::ContributionIdCollision {
                             first: a,
                             second: b,
                             src: edge_a.src.0,
                             dst: edge_a.dst.0,
                             contribution_id: edge_a.reserved,
-                        });
+                        })
+                        .into());
                     }
                 }
             }
@@ -331,10 +350,11 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
         for (j, entry) in reverse.chunks_exact(REVERSE_INDEX_ENTRY_LEN).enumerate() {
             let edge_id = read_u32_le(entry, 0);
             if edge_id >= edge_count {
-                return Err(FormatError::ReverseIndexOutOfBounds {
+                return Err((FormatError::ReverseIndexOutOfBounds {
                     index: j as u32,
                     edge_id,
-                });
+                })
+                .into());
             }
         }
         // Existence scan (v0): every canonical edge ID that requires reverse
@@ -353,7 +373,7 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
                 .chunks_exact(REVERSE_INDEX_ENTRY_LEN)
                 .any(|entry| read_u32_le(entry, 0) == i);
             if !found {
-                return Err(FormatError::ReverseIndexMissing { edge: i });
+                return Err((FormatError::ReverseIndexMissing { edge: i }).into());
             }
         }
         // Every declared node reverse range must resolve to incoming edges of
@@ -368,12 +388,13 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
                     let edge_id = read_u32_le(reverse_entry, 0);
                     let edge = records::decode_edge(&bytes[edge_id as usize * PACKED_EDGE_LEN..]);
                     if edge.dst.0 != node {
-                        return Err(FormatError::ReverseRangeTargetMismatch {
+                        return Err((FormatError::ReverseRangeTargetMismatch {
                             node,
                             index,
                             edge_id,
                             edge_dst: edge.dst.0,
-                        });
+                        })
+                        .into());
                     }
                 }
             }
@@ -390,12 +411,13 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
             for edge_id in start..end {
                 let edge = records::decode_edge(&edges[edge_id as usize * PACKED_EDGE_LEN..]);
                 if edge.src.0 != node || edge.kind != EdgeKind::RefinementAbstraction as u8 {
-                    return Err(FormatError::ChildRangeEdgeMismatch {
+                    return Err((FormatError::ChildRangeEdgeMismatch {
                         node,
                         edge: edge_id,
                         edge_src: edge.src.0,
                         edge_kind: edge.kind,
-                    });
+                    })
+                    .into());
                 }
             }
         }
@@ -404,18 +426,20 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
     // PTCH (Phase 9) section: 32-byte parent CID + array of PACKED_TOMBSTONE_LEN.
     if let Some(bytes) = view.section(SectionId::PTCH) {
         if bytes.len() < 32 || (bytes.len() - 32) % records::PACKED_TOMBSTONE_LEN != 0 {
-            return Err(FormatError::PatchSectionMisaligned {
+            return Err((FormatError::PatchSectionMisaligned {
                 actual_len: bytes.len() as u64,
-            });
+            })
+            .into());
         }
     }
 
     // RTNX (Phase 9) section length must be a multiple of PACKED_ROUTE_TRANSLATION_LEN.
     if let Some(bytes) = view.section(SectionId::RTNX) {
         if bytes.len() % records::PACKED_ROUTE_TRANSLATION_LEN != 0 {
-            return Err(FormatError::RouteTranslationSectionMisaligned {
+            return Err((FormatError::RouteTranslationSectionMisaligned {
                 actual_len: bytes.len() as u64,
-            });
+            })
+            .into());
         }
     }
 
@@ -438,7 +462,7 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, FormatError> {
             &[],
         )
     {
-        return Err(FormatError::InvariantViolation(inv_err));
+        return Err((FormatError::InvariantViolation(inv_err)).into());
     }
 
     Ok(Some(head))

--- a/crates/uor-r4-graph-format/src/view.rs
+++ b/crates/uor-r4-graph-format/src/view.rs
@@ -17,6 +17,7 @@ use crate::records::{
     self, PackedEdge, PackedNode, PackedRouteTranslation, PackedTombstone, PACKED_EDGE_LEN,
     PACKED_NODE_LEN, PACKED_ROUTE_TRANSLATION_LEN, PACKED_TOMBSTONE_LEN,
 };
+use crate::sanctioned::KappaError;
 use crate::stage2;
 use crate::types::{ArtifactCid, SectionId};
 
@@ -45,13 +46,13 @@ pub(crate) fn decode_entry(bytes: &[u8], index: u32) -> RawEntry {
 }
 
 /// Byte offset one past the section table.
-fn table_end(header: &Header) -> Result<u64, FormatError> {
+fn table_end(header: &Header) -> Result<u64, crate::NotAProduct> {
     let table_len = (header.section_count as u64)
         .checked_mul(SECTION_ENTRY_LEN as u64)
         .ok_or(FormatError::SectionTableOutOfBounds)?;
     (HEADER_LEN as u64)
         .checked_add(table_len)
-        .ok_or(FormatError::SectionTableOutOfBounds)
+        .ok_or_else(|| FormatError::SectionTableOutOfBounds.into())
 }
 
 /// Run the full stage-1 structural validation of RFC §6 over `bytes`.
@@ -71,12 +72,12 @@ fn table_end(header: &Header) -> Result<u64, FormatError> {
 /// 7. every section body within `total_len`;
 /// 8. no section body overlapping the header/table region or another
 ///    section body.
-pub(crate) fn validate(bytes: &[u8]) -> Result<Header, FormatError> {
+pub(crate) fn validate(bytes: &[u8]) -> Result<Header, crate::NotAProduct> {
     let header = header::parse(bytes)?;
 
     let table_end = table_end(&header)?;
     if table_end > header.total_len {
-        return Err(FormatError::SectionTableOutOfBounds);
+        return Err((FormatError::SectionTableOutOfBounds).into());
     }
 
     let align: u32 = 1 << header.alignment_log2;
@@ -86,18 +87,18 @@ pub(crate) fn validate(bytes: &[u8]) -> Result<Header, FormatError> {
 
         if let Some(prev) = prev_id {
             if entry.id <= prev {
-                return Err(FormatError::SectionsNotSorted);
+                return Err((FormatError::SectionsNotSorted).into());
             }
         }
         prev_id = Some(entry.id);
 
         let section = SectionId(entry.id);
         if !section.is_known() && section.mandatory() {
-            return Err(FormatError::UnknownMandatorySection(entry.id));
+            return Err((FormatError::UnknownMandatorySection(entry.id)).into());
         }
 
         if !entry.offset.is_multiple_of(align) {
-            return Err(FormatError::SectionMisaligned);
+            return Err((FormatError::SectionMisaligned).into());
         }
 
         let end = entry
@@ -105,10 +106,10 @@ pub(crate) fn validate(bytes: &[u8]) -> Result<Header, FormatError> {
             .checked_add(entry.length)
             .ok_or(FormatError::OffsetOverflow)?;
         if u64::from(end) > header.total_len {
-            return Err(FormatError::SectionOutOfBounds);
+            return Err((FormatError::SectionOutOfBounds).into());
         }
         if u64::from(entry.offset) < table_end && entry.length > 0 {
-            return Err(FormatError::SectionsOverlap);
+            return Err((FormatError::SectionsOverlap).into());
         }
 
         // Pairwise body-overlap check in u64, robust against
@@ -118,7 +119,7 @@ pub(crate) fn validate(bytes: &[u8]) -> Result<Header, FormatError> {
             let other = decode_entry(bytes, j);
             let other_end = u64::from(other.offset) + u64::from(other.length);
             if u64::from(entry.offset) < other_end && u64::from(other.offset) < u64::from(end) {
-                return Err(FormatError::SectionsOverlap);
+                return Err((FormatError::SectionsOverlap).into());
             }
         }
     }
@@ -151,7 +152,7 @@ impl<'a> GraphView<'a> {
     /// pure section carriers): [`GraphView::head`] returns `None` and the
     /// typed node/edge accessors report nothing, leaving the sections as
     /// opaque bytes.
-    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, crate::NotAProduct> {
         let header = validate(bytes)?;
         let mut view = Self {
             bytes,
@@ -330,21 +331,23 @@ impl<'a> GraphView<'a> {
     }
 
     /// Parse the optional packed lexical context table.
-    pub fn ngram_table(&self) -> Result<Option<NgramTable<'a>>, FormatError> {
+    pub fn ngram_table(&self) -> Result<Option<NgramTable<'a>>, crate::NotAProduct> {
         self.section(SectionId::NGRAM)
             .map(NgramTable::parse)
             .transpose()
     }
 
     /// Parse the optional packed forward-anchor table (issue #399).
-    pub fn fwda_table(&self) -> Result<Option<FwdaTable<'a>>, FormatError> {
+    pub fn fwda_table(&self) -> Result<Option<FwdaTable<'a>>, crate::NotAProduct> {
         self.section(SectionId::FWDA)
             .map(FwdaTable::parse)
             .transpose()
     }
 
     /// Borrow the optional compiler-folded FMM translation table.
-    pub fn fmm_translation_table(&self) -> Result<Option<FmmTranslationTable<'a>>, FormatError> {
+    pub fn fmm_translation_table(
+        &self,
+    ) -> Result<Option<FmmTranslationTable<'a>>, crate::NotAProduct> {
         self.section(SectionId::FMM)
             .map(FmmTranslationTable::parse)
             .transpose()
@@ -358,31 +361,31 @@ impl<'a> GraphView<'a> {
     /// total_len])`. Returns [`FormatError::MissingHead`] when HEAD is
     /// absent, [`FormatError::HeadCidMismatch`] /
     /// [`FormatError::ArtifactCidMismatch`] on digest mismatch.
-    pub fn verify_cids(&self) -> Result<(), FormatError> {
+    pub fn verify_cids(&self) -> Result<(), KappaError> {
         let head = self
             .section(SectionId::HEAD)
-            .ok_or(FormatError::MissingHead)?;
+            .ok_or(KappaError::MissingHead)?;
         if blake3::hash(head).as_bytes() != &self.header.head_cid.0 {
-            return Err(FormatError::HeadCidMismatch);
+            return Err(KappaError::Head);
         }
         let artifact = blake3::hash(&self.bytes[header::ARTIFACT_HASH_START..]);
         if artifact.as_bytes() != &self.header.artifact_cid.0 {
-            return Err(FormatError::ArtifactCidMismatch);
+            return Err(KappaError::Artifact);
         }
         Ok(())
     }
 
     /// Verify that the loaded tokenizer bytes match the header's `tokenizer_cid`.
-    pub fn verify_tokenizer_cid(&self, tokenizer_bytes: &[u8]) -> Result<(), FormatError> {
+    pub fn verify_tokenizer_cid(&self, tokenizer_bytes: &[u8]) -> Result<(), KappaError> {
         let expected = self
             .head()
-            .ok_or(FormatError::MissingHead)?
+            .ok_or(KappaError::MissingHead)?
             .tokenizer_cid()
             .0;
         if expected != [0u8; 32] {
             let actual = blake3::hash(tokenizer_bytes);
             if expected != *actual.as_bytes() {
-                return Err(FormatError::TokenizerCidMismatch);
+                return Err(KappaError::Tokenizer);
             }
         }
         Ok(())

--- a/crates/uor-r4-graph-format/tests/realization.rs
+++ b/crates/uor-r4-graph-format/tests/realization.rs
@@ -70,8 +70,10 @@ fn malformed_or_tampered_artifacts_are_rejected() {
     let mut tampered = sample(3, false);
     let last = tampered.len() - 1;
     tampered[last] ^= 1;
+    // Flipping a content byte leaves the structure valid but breaks the
+    // artifact CID, so the failure is now the sanctioned kappa condition.
     assert!(matches!(
         r4g1::address(&tampered),
-        Err(r4g1::RealizationError::InvalidArtifact(_))
+        Err(r4g1::RealizationError::CidMismatch(_))
     ));
 }

--- a/crates/uor-r4-graph-format/tests/stage1.rs
+++ b/crates/uor-r4-graph-format/tests/stage1.rs
@@ -13,7 +13,7 @@ mod common;
 
 use common::{head_payload, node_section, storage_section, HeadFields, NodeFields};
 use uor_r4_graph_format::{
-    ArtifactBuilder, Depth, FormatError, GraphView, NodeId, Radius, ScoreQ, SectionId,
+    ArtifactBuilder, Depth, FormatError, GraphView, KappaError, NodeId, Radius, ScoreQ, SectionId,
     SectionOffset, TokenId, HEADER_LEN,
 };
 
@@ -98,7 +98,7 @@ fn build_sample() -> Vec<u8> {
 fn err_of(bytes: &[u8]) -> FormatError {
     match GraphView::parse(bytes) {
         Ok(_) => panic!("expected rejection, but the artifact parsed"),
-        Err(e) => e,
+        Err(e) => e.reason,
     }
 }
 
@@ -183,7 +183,7 @@ fn tokenizer_cid_mismatch_detected() {
     );
     assert_eq!(
         view.verify_tokenizer_cid(dummy_tokenizer),
-        Err(FormatError::TokenizerCidMismatch)
+        Err(KappaError::Tokenizer)
     );
 }
 
@@ -197,7 +197,7 @@ fn head_cid_tamper_detected() {
     let mut tampered = bytes.clone();
     tampered[head_off] ^= 0xFF;
     let view = GraphView::parse(&tampered).unwrap();
-    assert_eq!(view.verify_cids(), Err(FormatError::HeadCidMismatch));
+    assert_eq!(view.verify_cids(), Err(KappaError::Head));
 }
 
 #[test]
@@ -212,13 +212,13 @@ fn artifact_cid_tamper_detected() {
     let mut tampered = bytes.clone();
     tampered[opaque_off + 1] ^= 0xFF;
     let view = GraphView::parse(&tampered).unwrap();
-    assert_eq!(view.verify_cids(), Err(FormatError::ArtifactCidMismatch));
+    assert_eq!(view.verify_cids(), Err(KappaError::Artifact));
 
     // Flip a section-table flags byte: same result.
     let mut tampered = bytes.clone();
     tampered[HEADER_LEN + 4] ^= 0xFF;
     let view = GraphView::parse(&tampered).unwrap();
-    assert_eq!(view.verify_cids(), Err(FormatError::ArtifactCidMismatch));
+    assert_eq!(view.verify_cids(), Err(KappaError::Artifact));
 }
 
 #[test]
@@ -394,7 +394,10 @@ fn reject_unknown_mandatory_feature_bit() {
 fn builder_requires_head() {
     let mut b = ArtifactBuilder::new(3);
     b.add_section(SectionId::NODE, 0, &[0u8; 4]);
-    assert_eq!(b.build(), Err(FormatError::MissingHead));
+    assert_eq!(
+        b.build().map_err(|e| e.reason),
+        Err(FormatError::MissingHead)
+    );
 }
 
 #[test]
@@ -403,7 +406,7 @@ fn builder_rejects_duplicate_sections() {
     b.add_section(SectionId::HEAD, 0, b"a");
     b.add_section(SectionId::HEAD, 0, b"b");
     assert_eq!(
-        b.build(),
+        b.build().map_err(|e| e.reason),
         Err(FormatError::DuplicateSection(SectionId::HEAD))
     );
 }
@@ -413,7 +416,10 @@ fn builder_rejects_unknown_mandatory_id() {
     let mut b = ArtifactBuilder::new(3);
     b.add_section(SectionId::HEAD, 0, b"head");
     b.add_section(SectionId(0x40), 0, b"nope");
-    assert_eq!(b.build(), Err(FormatError::UnknownMandatorySection(0x40)));
+    assert_eq!(
+        b.build().map_err(|e| e.reason),
+        Err(FormatError::UnknownMandatorySection(0x40))
+    );
 }
 
 // ── Newtype smoke ─────────────────────────────────────────────────────

--- a/crates/uor-r4-graph-format/tests/stage2.rs
+++ b/crates/uor-r4-graph-format/tests/stage2.rs
@@ -11,8 +11,8 @@ use common::{
     storage_section, EdgeFields, HeadFields, NodeFields,
 };
 use uor_r4_graph_format::{
-    ArtifactBuilder, BoundKind, Depth, EdgeKind, EdgePayloadField, FormatError, GraphView, NodeId,
-    Radius, RangeField, ScoreQ, SectionId, FEATURE_EDGE_ALGEBRA_V1, HEADER_LEN,
+    ArtifactBuilder, BoundKind, Depth, EdgeKind, EdgePayloadField, FormatError, GraphView,
+    KappaError, NodeId, Radius, RangeField, ScoreQ, SectionId, FEATURE_EDGE_ALGEBRA_V1, HEADER_LEN,
 };
 
 /// The happy-path packed node records: two nodes whose ranges resolve
@@ -147,7 +147,7 @@ impl Fixture {
 fn err_of(bytes: &[u8]) -> FormatError {
     match GraphView::parse(bytes) {
         Ok(_) => panic!("expected rejection, but the artifact parsed"),
-        Err(e) => e,
+        Err(e) => e.reason,
     }
 }
 
@@ -389,7 +389,7 @@ fn container_without_head_is_stage1_only() {
     assert_eq!(view.edge(0), None);
     assert_eq!(view.reverse_edge_id(0), None);
     assert_eq!(view.section(SectionId::NODE), Some(&[1, 2, 3, 4][..]));
-    assert_eq!(view.verify_cids(), Err(FormatError::MissingHead));
+    assert_eq!(view.verify_cids(), Err(KappaError::MissingHead));
 }
 
 // ── HEAD payload (RFC §4) ─────────────────────────────────────────────

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -96,7 +96,7 @@ fn best_context_entry(
 impl<'a> R4G1Runtime<'a> {
     /// Create a new R4G1 runtime by running two-stage validation over `bytes`.
     pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
-        let view = GraphView::parse(bytes)?;
+        let view = GraphView::parse(bytes).map_err(|e| e.reason)?;
         let route_index = (view.node_count().unwrap_or(0) >= MIN_ROUTE_INDEX_NODES)
             .then(|| VpTree::from_graph(&view))
             .flatten();
@@ -108,7 +108,7 @@ impl<'a> R4G1Runtime<'a> {
 
     /// Appends a patch epoch to the runtime's chain.
     pub fn try_push_patch(&mut self, patch_bytes: &'a [u8]) -> Result<(), RuntimeError> {
-        let view = GraphView::parse(patch_bytes).map_err(RuntimeError::Format)?;
+        let view = GraphView::parse(patch_bytes).map_err(|e| RuntimeError::Format(e.reason))?;
         self.chain
             .try_push_patch(view)
             .map_err(|e| RuntimeError::Patch(alloc::borrow::Cow::Borrowed(e)))


### PR DESCRIPTION
First tranche of the R5 full-rearchitecture (per the march plan on #510). Introduces the sanctioned failure vocabulary and moves graph-format's parse/CID layer onto it, **diagnostic-preserving**. graph-format R5 violations **31 → 12**; audit-limits total **352 → 333**.

**New `sanctioned.rs`:** `NotAProduct { object, reason }` (which object is absent + the preserved `FormatError` reason), `KappaError` (a CID did not reproduce), `ObservedBound` (a measured bound). The returned *contract* is regularized to the sanctioned set; `FormatError` stays as internal validation detail carried inside `NotAProduct`, so **no diagnostic is lost** and validation is unchanged.

- 17 parse/validate/build fns → `NotAProduct` (via `From<FormatError>`); the 2 CID checks → `KappaError`; r4g1 `RealizationError` gains `CidMismatch(KappaError)`.
- External callers (graph-runtime, api) bridged via the preserved `.reason` / `KappaError::as_format`; those crates convert in later tranches, removing the bridges.
- Tests updated to the sanctioned surface (the content-tamper realization test now expects `CidMismatch`).

std + no_std build, clippy clean on both, all graph-format + dependent runtime/api tests, the register meta-gate, and the 101-scenario BDD suite pass.

Remaining graph-format (tranche 1b): the other 5 error enums (12 sites). Refs #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)