### PR TITLE
feat(#514): scale_sweep.sh — the saturation-sweep harness (β calibration)

### DIFF
--- a/docs/scaling_law.md
+++ b/docs/scaling_law.md
@@ -66,35 +66,32 @@ the record stream and re-run the cheap downstream (cover → score) at each size
 the point where held-out top-1 and EXCT-miss flatten is that teacher's knee.
 Three teachers → three knees → β by least-squares on `log N_knee vs log S`.
 
-Runbook (one observe already in hand at `$OBS` → `corpus.meta`/`corpus.records`):
+Runbook (one observe already in hand → its `state.bin`/`merged.bin`, or a
+`corpus.meta`/`corpus.records` pair). The sweep is one script:
 
 ```bash
-# Sub-sample the record stream to a target N (records are fixed-width; take a
-# uniform stride so the construction/held-out split is preserved in proportion).
-for N in 50000 200000 800000 2000000; do
-  r4 transformerless subsample-corpus --in $OBS --out /tmp/sweep-$N --records $N   # (harness, #514)
-  r4 transformerless compile-recorded --corpus-meta /tmp/sweep-$N/corpus.meta \
-     --corpus-recs /tmp/sweep-$N/corpus.records --vocab-size 49152 --out /tmp/sweep-$N
-  r4 transformerless cover --corpus-meta /tmp/sweep-$N/corpus.meta \
-     --corpus-recs /tmp/sweep-$N/corpus.records --artifacts /tmp/sweep-$N/tless_artifacts.bin \
-     --out /tmp/sweep-$N/graph-cover
-  r4 transformerless score --corpus-meta /tmp/sweep-$N/corpus.meta \
-     --corpus-recs /tmp/sweep-$N/corpus.records --artifacts /tmp/sweep-$N/tless_artifacts.bin \
-     --cover /tmp/sweep-$N/graph-cover/cover.r4g1 --quality-profile relative_tla \
-     --out /tmp/sweep-$N/graph
-  # record top-1 and EXCT-miss from graph/score_report.json
-done
-# The knee is the smallest N past which top-1 and EXCT-miss stop moving.
+# <src-meta> <src-recs> <vocab-size> [record sizes...]
+scripts/scale_sweep.sh obs/state.bin obs/merged.bin 49152 \
+    50000 200000 800000 2000000
 ```
 
-The `subsample-corpus` harness is the remaining code piece; the compile/cover/
-score legs already exist and are what #509 used. Until β is calibrated, treat
-the calculator as an order-of-magnitude guide, not a promise.
+It sub-samples with `scripts/mc1_subsample_corpus.py` (truncating to the last
+complete story-run boundary at or before the target, so the 80/20 `train_cut`
+split stays on the same story-id partition), then runs compile-recorded → cover
+→ score at each size and prints `records | held_out | top1_rule12 | exct_miss_%`.
+The knee is the smallest N past which top-1 and EXCT-miss stop moving.
+
+The harness is in place (`scale_sweep.sh` + the existing `mc1_subsample_corpus.py`);
+the compile/cover/score legs are the same ones #509 used. Until β is calibrated
+from real knees, treat the calculator as an order-of-magnitude guide, not a
+promise.
 
 ## Status
 
-- `recommend-scale` estimator: **shipped** (this change).
-- `subsample-corpus` sweep harness: pending.
-- β calibration: pending the 360M/135M/15M observes (dev hardware; a 2M-record
-  observe is a multi-day teacher run — the #509 observe managed 176/3000 articles
-  in this sandbox before it was interrupted).
+- `recommend-scale` estimator: **shipped** (#517).
+- Saturation-sweep harness: **shipped** — `scripts/scale_sweep.sh` over the
+  existing `scripts/mc1_subsample_corpus.py`.
+- β calibration: pending the 360M/135M/15M observes. The 360M observe is running
+  on dev hardware (#516) at ~5.5s/article; once it lands, `scale_sweep.sh` over
+  its corpus produces the first real knee. (A 2M-record observe is a multi-hour
+  to multi-day teacher run; the sandbox managed only 176/3000 articles for #509.)

--- a/scripts/scale_sweep.sh
+++ b/scripts/scale_sweep.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scale_sweep.sh --- the #514 saturation sweep.
+#
+# Sub-sample ONE observation corpus to several record counts and record where
+# held-out top-1 and EXCT-miss flatten. That knee is the teacher's needed scale;
+# fitting log(N_knee) against log(S) across teachers calibrates the `beta` in
+# `r4 transformerless recommend-scale` (docs/scaling_law.md). You observe once at
+# the top scale --- this reuses that one corpus, no re-observation.
+#
+# Usage:
+#   scripts/scale_sweep.sh <src-meta> <src-recs> <vocab-size> [record-sizes...]
+# Example (a 360M wiki observe at 2M records):
+#   scripts/scale_sweep.sh obs/state.bin obs/merged.bin 49152 \
+#       50000 200000 800000 2000000
+#
+# R4 overrides the r4 binary path (default ./target/release/r4); WORK overrides
+# the scratch dir (default /tmp/scale-sweep).
+set -euo pipefail
+
+R4=${R4:-./target/release/r4}
+WORK=${WORK:-/tmp/scale-sweep}
+
+if [ "$#" -lt 3 ]; then
+    echo "usage: scripts/scale_sweep.sh <src-meta> <src-recs> <vocab-size> [sizes...]" >&2
+    exit 2
+fi
+SRC_META="$1"; SRC_RECS="$2"; VOCAB="$3"; shift 3
+SIZES=("$@")
+if [ "${#SIZES[@]}" -eq 0 ]; then
+    SIZES=(50000 200000 800000 2000000)
+fi
+
+mkdir -p "$WORK"
+printf '%-12s %-10s %-12s %-12s\n' records held_out top1_rule12 exct_miss_%
+
+for N in "${SIZES[@]}"; do
+    D="$WORK/n-$N"
+    mkdir -p "$D"
+    python3 scripts/mc1_subsample_corpus.py \
+        --src-meta "$SRC_META" --src-recs "$SRC_RECS" \
+        --out-meta "$D/corpus.meta" --out-recs "$D/corpus.records" \
+        --records "$N" >/dev/null
+    "$R4" transformerless compile-recorded \
+        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
+        --vocab-size "$VOCAB" --out "$D" >/dev/null 2>&1
+    "$R4" transformerless cover \
+        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
+        --artifacts "$D/tless_artifacts.bin" --out "$D/graph-cover" >/dev/null 2>&1
+    "$R4" transformerless score \
+        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
+        --artifacts "$D/tless_artifacts.bin" --cover "$D/graph-cover/cover.r4g1" \
+        --quality-profile relative_tla --out "$D/graph" >/dev/null 2>&1
+    python3 - "$D/graph/score_report.json" "$N" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+n = sys.argv[2]
+gc = d["gate_c"]
+dist = d.get("distribution", {})
+ho = gc.get("held_out_population", 0)
+t1 = gc.get("rule12_precedence", {}).get("top1_agreement", 0.0)
+miss = dist.get("exct_miss_rate", float("nan"))
+print(f"{n:<12} {ho:<10} {t1 * 100:<12.2f} {miss * 100:<12.2f}")
+PY
+done
+
+echo
+echo "The knee is the smallest N past which top1 and exct_miss stop moving."
+echo "Feed the (N_knee, teacher-S) points into the recommend-scale beta calibration (docs/scaling_law.md)."


### PR DESCRIPTION
Second #514 deliverable. `scripts/scale_sweep.sh` sub-samples one observation corpus to several record counts (via the existing `scripts/mc1_subsample_corpus.py`, truncating to a story-run boundary so the 80/20 train_cut split is preserved), runs compile-recorded → cover → score at each, and prints `records | held_out | top1_rule12 | exct_miss_%`. The knee (smallest N past which top-1 and EXCT-miss flatten) is that teacher's needed scale; log(N_knee) vs log(S) calibrates the recommend-scale β. Observe once at the top scale — the sweep reuses that corpus.

Validated: mc1_subsample_corpus.py on the wiki-360m corpus (21,235 → 9,882 at a story boundary, valid records/meta). docs/scaling_law.md points at the real scripts.

Remaining #514: β calibration from real knees — runs on #516's observe (in progress on dev hardware). Refs #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)