### PR TITLE
feat(#510): R5 1b(i) — graph-format invariant validators to total form

### DIFF
--- a/crates/uor-r4-graph-format/src/invariant_ownership.rs
+++ b/crates/uor-r4-graph-format/src/invariant_ownership.rs
@@ -238,10 +238,10 @@ impl GraphInvariantOwnershipMatrix {
         degree_limit: usize,
         edges: &[(u32, u32)], // (src, dst)
         evidence_ids: &[u32],
-    ) -> Result<usize, InvariantValidationError> {
+    ) -> Option<InvariantValidationError> {
         // 1. Check degree limit
         if max_node_degree > degree_limit {
-            return Err(InvariantValidationError::DegreeLimitExceeded {
+            return Some(InvariantValidationError::DegreeLimitExceeded {
                 node_id: 0,
                 degree: max_node_degree,
                 limit: degree_limit,
@@ -251,20 +251,20 @@ impl GraphInvariantOwnershipMatrix {
         // 2. Check dangling references with checked bounds
         for (i, &(src, dst)) in edges.iter().enumerate() {
             if (src as usize) >= node_count {
-                return Err(InvariantValidationError::DanglingReference {
+                return Some(InvariantValidationError::DanglingReference {
                     edge_index: i,
                     target_node_id: src,
                 });
             }
             if (dst as usize) >= node_count {
-                return Err(InvariantValidationError::DanglingReference {
+                return Some(InvariantValidationError::DanglingReference {
                     edge_index: i,
                     target_node_id: dst,
                 });
             }
             // Check for self-refinement cycle
             if src == dst {
-                return Err(InvariantValidationError::RefinementCycleDetected {
+                return Some(InvariantValidationError::RefinementCycleDetected {
                     cycle_node_id: src,
                 });
             }
@@ -274,22 +274,23 @@ impl GraphInvariantOwnershipMatrix {
         for i in 0..evidence_ids.len() {
             for j in (i + 1)..evidence_ids.len() {
                 if evidence_ids[i] == evidence_ids[j] {
-                    return Err(InvariantValidationError::DuplicateEvidence {
+                    return Some(InvariantValidationError::DuplicateEvidence {
                         evidence_id: evidence_ids[i],
                     });
                 }
             }
         }
 
-        Ok(node_count)
+        None
     }
 
     /// Helper method to validate score fixed-point overflow boundary.
-    pub fn validate_score_fixed_point(raw_score: i32) -> Result<i16, InvariantValidationError> {
+    pub fn validate_score_fixed_point(raw_score: i32) -> Option<i16> {
+        // Total: `None` is an observed out-of-range score, not a limitation.
         if raw_score < (i16::MIN as i32) || raw_score > (i16::MAX as i32) {
-            Err(InvariantValidationError::FixedArithmeticOverflow { raw_score })
+            None
         } else {
-            Ok(raw_score as i16)
+            Some(raw_score as i16)
         }
     }
 }
@@ -312,7 +313,7 @@ mod tests {
     #[test]
     fn test_boundary_fixture_1_empty_graph() {
         let res = GraphInvariantOwnershipMatrix::validate_graph_structure(0, 0, 10, &[], &[]);
-        assert_eq!(res.unwrap(), 0);
+        assert!(res.is_none());
     }
 
     #[test]
@@ -320,13 +321,13 @@ mod tests {
         // Equal to degree limit -> clean
         let res_clean =
             GraphInvariantOwnershipMatrix::validate_graph_structure(5, 10, 10, &[(0, 1)], &[1, 2]);
-        assert_eq!(res_clean.unwrap(), 5);
+        assert!(res_clean.is_none());
 
         // Exceeds limit -> error
         let res_err =
             GraphInvariantOwnershipMatrix::validate_graph_structure(5, 11, 10, &[(0, 1)], &[1, 2]);
         assert!(matches!(
-            res_err.unwrap_err(),
+            res_err.unwrap(),
             InvariantValidationError::DegreeLimitExceeded { .. }
         ));
     }
@@ -341,7 +342,7 @@ mod tests {
             &[101, 101],
         );
         assert!(matches!(
-            res.unwrap_err(),
+            res.unwrap(),
             InvariantValidationError::DuplicateEvidence { evidence_id: 101 }
         ));
     }
@@ -351,18 +352,15 @@ mod tests {
         let res =
             GraphInvariantOwnershipMatrix::validate_graph_structure(5, 2, 10, &[(2, 2)], &[101]);
         assert!(matches!(
-            res.unwrap_err(),
+            res.unwrap(),
             InvariantValidationError::RefinementCycleDetected { cycle_node_id: 2 }
         ));
     }
 
     #[test]
     fn test_boundary_fixture_5_fixed_arithmetic_overflow() {
-        assert!(GraphInvariantOwnershipMatrix::validate_score_fixed_point(32767).is_ok());
-        assert!(matches!(
-            GraphInvariantOwnershipMatrix::validate_score_fixed_point(32768).unwrap_err(),
-            InvariantValidationError::FixedArithmeticOverflow { raw_score: 32768 }
-        ));
+        assert!(GraphInvariantOwnershipMatrix::validate_score_fixed_point(32767).is_some());
+        assert!(GraphInvariantOwnershipMatrix::validate_score_fixed_point(32768).is_none());
     }
 
     #[test]
@@ -370,7 +368,7 @@ mod tests {
         let res =
             GraphInvariantOwnershipMatrix::validate_graph_structure(5, 2, 10, &[(0, 99)], &[101]);
         assert!(matches!(
-            res.unwrap_err(),
+            res.unwrap(),
             InvariantValidationError::DanglingReference {
                 target_node_id: 99,
                 ..

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -453,7 +453,7 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, crate::NotAProd
     let node_count = head.node_count() as usize;
     let max_node_degree = head.max_frontier_width() as usize;
     let degree_limit = head.max_frontier_width() as usize;
-    if let Err(inv_err) =
+    if let Some(inv_err) =
         crate::invariant_ownership::GraphInvariantOwnershipMatrix::validate_graph_structure(
             node_count,
             max_node_degree,

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -84,8 +84,10 @@ struct R4g1World {
     inv_degree_limit: usize,
     inv_edges: Vec<(u32, u32)>,
     inv_evidence: Vec<u32>,
+    // Outer Option: whether the loader verifier has been run yet.
+    // Inner Option: the total verdict — `Some(err)` on failure, `None` when valid.
     inv_res:
-        Option<Result<usize, uor_r4_graph_format::invariant_ownership::InvariantValidationError>>,
+        Option<Option<uor_r4_graph_format::invariant_ownership::InvariantValidationError>>,
     // Separate Semantic Emission fields (#134)
     decouple_transitions: Vec<(
         &'static str,
@@ -841,7 +843,7 @@ fn bdd_inv_validate_loader(w: &mut R4g1World) {
 
 #[then("validation fails with a degree limit exceeded error")]
 fn bdd_inv_degree_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().unwrap_err();
+    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DegreeLimitExceeded { .. }
@@ -859,7 +861,7 @@ fn bdd_inv_dangling_given(w: &mut R4g1World) {
 
 #[then("validation fails with a dangling reference error")]
 fn bdd_inv_dangling_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().unwrap_err();
+    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DanglingReference { .. }
@@ -877,7 +879,7 @@ fn bdd_inv_duplicate_evidence_given(w: &mut R4g1World) {
 
 #[then("validation fails with a duplicate evidence error")]
 fn bdd_inv_duplicate_evidence_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().unwrap_err();
+    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DuplicateEvidence { .. }

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -86,8 +86,7 @@ struct R4g1World {
     inv_evidence: Vec<u32>,
     // Outer Option: whether the loader verifier has been run yet.
     // Inner Option: the total verdict — `Some(err)` on failure, `None` when valid.
-    inv_res:
-        Option<Option<uor_r4_graph_format::invariant_ownership::InvariantValidationError>>,
+    inv_res: Option<Option<uor_r4_graph_format::invariant_ownership::InvariantValidationError>>,
     // Separate Semantic Emission fields (#134)
     decouple_transitions: Vec<(
         &'static str,
@@ -843,7 +842,12 @@ fn bdd_inv_validate_loader(w: &mut R4g1World) {
 
 #[then("validation fails with a degree limit exceeded error")]
 fn bdd_inv_degree_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
+    let err = w
+        .inv_res
+        .as_ref()
+        .expect("inv_res")
+        .as_ref()
+        .expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DegreeLimitExceeded { .. }
@@ -861,7 +865,12 @@ fn bdd_inv_dangling_given(w: &mut R4g1World) {
 
 #[then("validation fails with a dangling reference error")]
 fn bdd_inv_dangling_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
+    let err = w
+        .inv_res
+        .as_ref()
+        .expect("inv_res")
+        .as_ref()
+        .expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DanglingReference { .. }
@@ -879,7 +888,12 @@ fn bdd_inv_duplicate_evidence_given(w: &mut R4g1World) {
 
 #[then("validation fails with a duplicate evidence error")]
 fn bdd_inv_duplicate_evidence_error_check(w: &mut R4g1World) {
-    let err = w.inv_res.as_ref().expect("inv_res").as_ref().expect("validation should fail");
+    let err = w
+        .inv_res
+        .as_ref()
+        .expect("inv_res")
+        .as_ref()
+        .expect("validation should fail");
     assert!(matches!(
         err,
         InvariantValidationError::DuplicateEvidence { .. }


### PR DESCRIPTION
Continues the R5 march (validators/audits become total — no Result over an unsanctioned error). GraphInvariantOwnershipMatrix's two validators go total: `validate_graph_structure` → `Option<InvariantValidationError>` (None = every invariant holds; the enum is kept as report data), and `validate_score_fixed_point` → `Option<i16>`. The stage2 caller already folds a violation into `FormatError::InvariantViolation` → `NotAProduct`, so it just switches Err→Some. graph-format audit-limits **12→10**, total **333→331**. std+no_std build, tests pass. More of 1b (scoring_semantics, inference_contract, r4g1) follows. Refs #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)