### PR TITLE
feat(#510): R5 1b(iii) — inference_contract to the sanctioned surface

### DIFF
--- a/crates/uor-r4-graph-format/src/inference_contract.rs
+++ b/crates/uor-r4-graph-format/src/inference_contract.rs
@@ -37,14 +37,14 @@ impl ContractVersion {
         ((self.major as u32) << 20) | ((self.minor as u32) << 10) | self.patch as u32
     }
 
-    pub fn decode_packed(raw: u32) -> Result<Self, InferenceContractError> {
+    pub fn decode_packed(raw: u32) -> Option<Self> {
         let major = ((raw >> 20) & 0x0fff) as u16;
         let minor = ((raw >> 10) & 0x03ff) as u16;
         let patch = (raw & 0x03ff) as u16;
         if major == 0 && minor == 0 && patch == 0 {
-            return Err(InferenceContractError::InvalidPackedVersion(raw));
+            return None;
         }
-        Ok(Self {
+        Some(Self {
             major,
             minor,
             patch,
@@ -215,30 +215,29 @@ impl InferenceContractVerifier {
     pub fn audit_operation(
         activity: BoundaryActivity,
         op: OperationClass,
-    ) -> Result<(), ContractValidationError> {
+    ) -> Option<ContractValidationError> {
         match (activity, op) {
             (BoundaryActivity::HotPathInference, OperationClass::ForbiddenFloat) => {
-                Err(ContractValidationError::ForbiddenFloatOperationDetected)
+                Some(ContractValidationError::ForbiddenFloatOperationDetected)
             }
             (BoundaryActivity::HotPathInference, OperationClass::ForbiddenMultiplyDivide) => {
-                Err(ContractValidationError::ForbiddenMultiplicationDetected)
+                Some(ContractValidationError::ForbiddenMultiplicationDetected)
             }
             (BoundaryActivity::HotPathInference, OperationClass::ForbiddenHeapAlloc) => {
-                Err(ContractValidationError::SteadyStateAllocationDetected)
+                Some(ContractValidationError::SteadyStateAllocationDetected)
             }
-            _ => Ok(()),
+            _ => None,
         }
     }
 
-    pub fn audit_contract_compliance(
-    ) -> Result<InferenceContractAuditReport, ContractValidationError> {
-        Ok(InferenceContractAuditReport {
+    pub fn audit_contract_compliance() -> InferenceContractAuditReport {
+        InferenceContractAuditReport {
             contract_version: Self::version(),
             permitted_op_classes_count: 6,
             is_zero_allocation_guaranteed: true,
             is_cpu_only_target: true,
             is_certified: true,
-        })
+        }
     }
 }
 
@@ -362,14 +361,11 @@ pub const ACTIVITY_OWNERS: [ActivityOwner; 9] = [
     },
 ];
 
-pub fn owner_for_activity(
-    activity: BoundaryActivity,
-) -> Result<&'static str, InferenceContractError> {
+pub fn owner_for_activity(activity: BoundaryActivity) -> Option<&'static str> {
     ACTIVITY_OWNERS
         .iter()
         .find(|entry| entry.activity == activity)
         .map(|entry| entry.module_path)
-        .ok_or(InferenceContractError::UnknownBoundaryActivity(activity))
 }
 
 #[cfg(test)]
@@ -429,21 +425,21 @@ mod tests {
                 BoundaryActivity::HotPathInference,
                 OperationClass::ForbiddenFloat
             ),
-            Err(ContractValidationError::ForbiddenFloatOperationDetected)
+            Some(ContractValidationError::ForbiddenFloatOperationDetected)
         );
         assert_eq!(
             InferenceContractVerifier::audit_operation(
                 BoundaryActivity::HotPathInference,
                 OperationClass::ForbiddenMultiplyDivide
             ),
-            Err(ContractValidationError::ForbiddenMultiplicationDetected)
+            Some(ContractValidationError::ForbiddenMultiplicationDetected)
         );
         assert_eq!(
             InferenceContractVerifier::audit_operation(
                 BoundaryActivity::HotPathInference,
                 OperationClass::ForbiddenHeapAlloc
             ),
-            Err(ContractValidationError::SteadyStateAllocationDetected)
+            Some(ContractValidationError::SteadyStateAllocationDetected)
         );
     }
 }

--- a/crates/uor-r4-proof-model/src/structural_guarantees.rs
+++ b/crates/uor-r4-proof-model/src/structural_guarantees.rs
@@ -403,15 +403,8 @@ impl StructuralGuaranteeVerifier {
         obligation_id: &str,
     ) -> Result<ProofVerificationReport, ProofValidationError> {
         use uor_r4_graph_format::inference_contract::InferenceContractVerifier;
-        let contract_report =
-            InferenceContractVerifier::audit_contract_compliance().map_err(|_| {
-                ProofValidationError::ResourceBoundExceeded {
-                    obligation_id: obligation_id.to_string(),
-                    metric: "contract_audit".to_string(),
-                    actual: 1,
-                    limit: 0,
-                }
-            })?;
+        // Total audit: the compliance report is always produced.
+        let contract_report = InferenceContractVerifier::audit_contract_compliance();
 
         Ok(ProofVerificationReport {
             obligation_id: obligation_id.to_string(),

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -1945,7 +1945,8 @@ fn bdd_contract_spec_given(_w: &mut R4g1World) {}
 
 #[when("audited by the inference contract verifier")]
 fn bdd_contract_audit_when(w: &mut R4g1World) {
-    let rep = InferenceContractVerifier::audit_contract_compliance().expect("contract audit");
+    // audit_contract_compliance is total: it always returns the report.
+    let rep = InferenceContractVerifier::audit_contract_compliance();
     w.contract_report = Some(rep);
 }
 
@@ -1970,16 +1971,17 @@ fn bdd_contract_op_audit_when(_w: &mut R4g1World) {}
 
 #[then("permitted bitwise and integer operations are accepted")]
 fn bdd_contract_permitted_accepted(_w: &mut R4g1World) {
+    // audit_operation is total: `None` is the accept verdict.
     assert!(InferenceContractVerifier::audit_operation(
         BoundaryActivity::HotPathInference,
         OperationClass::PermittedBitwise
     )
-    .is_ok());
+    .is_none());
     assert!(InferenceContractVerifier::audit_operation(
         BoundaryActivity::HotPathInference,
         OperationClass::PermittedIntArithmetic
     )
-    .is_ok());
+    .is_none());
 }
 
 #[then("forbidden float and multiplication operations are rejected")]
@@ -1989,14 +1991,14 @@ fn bdd_contract_forbidden_rejected(_w: &mut R4g1World) {
             BoundaryActivity::HotPathInference,
             OperationClass::ForbiddenFloat
         ),
-        Err(ContractValidationError::ForbiddenFloatOperationDetected)
+        Some(ContractValidationError::ForbiddenFloatOperationDetected)
     );
     assert_eq!(
         InferenceContractVerifier::audit_operation(
             BoundaryActivity::HotPathInference,
             OperationClass::ForbiddenMultiplyDivide
         ),
-        Err(ContractValidationError::ForbiddenMultiplicationDetected)
+        Some(ContractValidationError::ForbiddenMultiplicationDetected)
     );
 }
 


### PR DESCRIPTION
Continues the R5 march. decode_packed → Option<Self>; audit_operation → total Option<ContractValidationError>; audit_contract_compliance → InferenceContractAuditReport (it never fails, so no Result); owner_for_activity → Option<&static str>. The proof-model contract caller drops its map_err. graph-format audit-limits −4; std+no_std build, clippy clean, tests pass. Refs #510.