### PR TITLE
feat(#510): R5 1b(iv) — r4g1 realization to total Option (graph-format done)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1171,9 +1171,10 @@ impl R4Engine {
         let token_rows = u32::try_from(artifacts.token_codes.len() / STAGES)
             .map_err(|_| LoadError::TeacherTooLarge)?;
         let artifact_kappa = r4g1::artifact_kappa(parts.graph)
-            .map_err(|error| LoadError::Scorer(error.to_string()))?;
-        let node_section_kappa = r4g1::section_kappa(parts.graph, SectionId::NODE)
-            .map_err(|error| LoadError::Scorer(error.to_string()))?;
+            .ok_or_else(|| LoadError::Scorer("R4G1 artifact is not addressable".to_string()))?;
+        // The graph is known addressable here (artifact_kappa succeeded), so a
+        // `None` is a genuinely absent NODE section, kept as such.
+        let node_section_kappa = r4g1::section_kappa(parts.graph, SectionId::NODE);
 
         Ok(Self {
             artifacts,

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1184,7 +1184,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         },
     )?;
     let graph_kappa = uor_r4_graph_format::r4g1::artifact_kappa(&artifact_bytes)
-        .map_err(|error| format!("cannot address emitted R4G1 artifact: {error}"))?;
+        .ok_or_else(|| "cannot address emitted R4G1 artifact".to_string())?;
     phases.mark("R4G1 artifact emission");
 
     eprintln!("score: running Gate C evaluation [========================] 100%");

--- a/crates/uor-r4-graph-format/src/r4g1.rs
+++ b/crates/uor-r4-graph-format/src/r4g1.rs
@@ -24,30 +24,6 @@ pub const REALIZATION_VERSION: u64 = 1;
 /// Stable realization discriminator included in every skeleton.
 pub const REALIZATION_NAME: &str = "r4g1";
 
-/// Failure while validating or addressing an R4G1 artifact.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RealizationError {
-    /// The container is not a valid R4G1 artifact.
-    InvalidArtifact(crate::NotAProduct),
-    /// A CID did not reproduce.
-    CidMismatch(crate::KappaError),
-    /// The generated skeleton was not accepted by the CBOR realization.
-    AddressingFailed,
-}
-
-impl core::fmt::Display for RealizationError {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidArtifact(error) => write!(formatter, "invalid R4G1 artifact: {error}"),
-            Self::CidMismatch(error) => write!(formatter, "R4G1 CID mismatch: {error}"),
-            Self::AddressingFailed => write!(formatter, "uor-addr rejected the R4G1 skeleton"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for RealizationError {}
-
 /// A section's representation-level address.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SectionAddress {
@@ -71,9 +47,14 @@ pub struct R4G1Address {
 }
 
 /// Address a validated R4G1 container using its canonical section skeleton.
-pub fn address(bytes: &[u8]) -> Result<R4G1Address, RealizationError> {
-    let view = GraphView::parse(bytes).map_err(RealizationError::InvalidArtifact)?;
-    view.verify_cids().map_err(RealizationError::CidMismatch)?;
+///
+/// Total (R5): `None` means the bytes do not yield an address — they are not a
+/// valid R4G1 artifact, their CIDs do not reproduce, or the CBOR realization
+/// rejected the skeleton. The specific reason is recoverable by calling
+/// [`GraphView::parse`] and [`GraphView::verify_cids`] directly.
+pub fn address(bytes: &[u8]) -> Option<R4G1Address> {
+    let view = GraphView::parse(bytes).ok()?;
+    view.verify_cids().ok()?;
 
     let mut sections = Vec::with_capacity(view.sections().len());
     for section in view.sections() {
@@ -88,31 +69,32 @@ pub fn address(bytes: &[u8]) -> Result<R4G1Address, RealizationError> {
 
     let skeleton = artifact_skeleton(&sections);
     let artifact_kappa = address_cbor(&skeleton)?;
-    Ok(R4G1Address {
+    Some(R4G1Address {
         artifact_kappa,
         sections,
         skeleton,
     })
 }
 
-/// Return only the representation-level artifact κ-label.
-pub fn artifact_kappa(bytes: &[u8]) -> Result<String, RealizationError> {
-    Ok(address(bytes)?.artifact_kappa)
+/// Return only the representation-level κ-label; `None` if not addressable.
+pub fn artifact_kappa(bytes: &[u8]) -> Option<String> {
+    Some(address(bytes)?.artifact_kappa)
 }
 
-/// Return the representation-level κ-label for one section.
-pub fn section_kappa(bytes: &[u8], id: SectionId) -> Result<Option<String>, RealizationError> {
-    Ok(address(bytes)?
+/// Return the representation-level κ-label for one section; `None` if the
+/// artifact is not addressable or the section is absent.
+pub fn section_kappa(bytes: &[u8], id: SectionId) -> Option<String> {
+    address(bytes)?
         .sections
         .into_iter()
         .find(|section| section.id == id)
-        .map(|section| section.kappa))
+        .map(|section| section.kappa)
 }
 
-fn address_cbor(skeleton: &[u8]) -> Result<String, RealizationError> {
+fn address_cbor(skeleton: &[u8]) -> Option<String> {
     uor_addr::cbor::address_blake3(skeleton)
         .map(|outcome| outcome.address.to_string())
-        .map_err(|_| RealizationError::AddressingFailed)
+        .ok()
 }
 
 fn section_skeleton(id: SectionId, flags: u32, payload: &[u8]) -> Vec<u8> {

--- a/crates/uor-r4-graph-format/tests/realization.rs
+++ b/crates/uor-r4-graph-format/tests/realization.rs
@@ -62,18 +62,13 @@ fn payload_changes_change_the_section_and_artifact_addresses() {
 
 #[test]
 fn malformed_or_tampered_artifacts_are_rejected() {
-    assert!(matches!(
-        r4g1::address(b"not an R4G1 artifact"),
-        Err(r4g1::RealizationError::InvalidArtifact(_))
-    ));
+    // Not a valid artifact -> not addressable.
+    assert!(r4g1::address(b"not an R4G1 artifact").is_none());
 
     let mut tampered = sample(3, false);
     let last = tampered.len() - 1;
     tampered[last] ^= 1;
     // Flipping a content byte leaves the structure valid but breaks the
-    // artifact CID, so the failure is now the sanctioned kappa condition.
-    assert!(matches!(
-        r4g1::address(&tampered),
-        Err(r4g1::RealizationError::CidMismatch(_))
-    ));
+    // artifact CID, so it is likewise not addressable.
+    assert!(r4g1::address(&tampered).is_none());
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -966,7 +966,7 @@ fn active_artifact_cid() -> Option<String> {
         }
     }
     let bytes = std::fs::read(path).ok()?;
-    let cid = uor_r4_graph_format::r4g1::artifact_kappa(&bytes).ok()?;
+    let cid = uor_r4_graph_format::r4g1::artifact_kappa(&bytes)?;
     *guard = Some((path.to_path_buf(), mtime, cid.clone()));
     Some(cid)
 }


### PR DESCRIPTION
The realization layer composite RealizationError (parse→NotAProduct, CID→KappaError, uor-addr rejection) cannot be one sanctioned error per Result. Per the approved total-ops direction, r4g1 address/artifact_kappa/section_kappa/address_cbor become total Option (None = not addressable); the reason stays recoverable via GraphView::parse/verify_cids. RealizationError removed. Callers (api engine, graph-cli emission, root server cid cache) and the realization test updated. Last graph-format R5 file — with #520/#521/#522 it takes graph-format to 0. Full workspace builds, std+no_std, clippy clean, tests pass. Refs #510.