### PR TITLE
feat(#510): R5 tranche 1c — graph-runtime to total ops

### DIFF
--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -2,28 +2,9 @@ use crate::runtime_state::RuntimeState;
 use crate::runtime_state::SemanticStateSlot;
 use crate::status::ResolutionStatus;
 use crate::vp_tree::{MIN_ROUTE_INDEX_NODES, VpTree};
-use core::fmt;
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_graph_format::{CODE_OP_HALT, OP_CLEAR_SLOT, OP_SHIFT_SLOTS, OP_UPDATE_SLOT};
-use uor_r4_graph_format::{FormatError, GraphView, SectionId};
-
-/// Errors during graph step execution.
-#[derive(Debug)]
-pub enum RuntimeError {
-    Format(FormatError),
-    InvalidNode,
-    Patch(alloc::borrow::Cow<'static, str>),
-}
-
-impl fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Format(e) => write!(f, "Format error: {:?}", e),
-            Self::InvalidNode => write!(f, "Invalid node reference in graph"),
-            Self::Patch(msg) => write!(f, "Patch error: {}", msg),
-        }
-    }
-}
+use uor_r4_graph_format::{GraphView, NotAProduct, SectionId};
 
 /// Multiplication-free zero-allocation prediction runtime wrapping an R4G1 borrowed `PatchChain`.
 ///
@@ -95,8 +76,8 @@ fn best_context_entry(
 
 impl<'a> R4G1Runtime<'a> {
     /// Create a new R4G1 runtime by running two-stage validation over `bytes`.
-    pub fn parse(bytes: &'a [u8]) -> Result<Self, FormatError> {
-        let view = GraphView::parse(bytes).map_err(|e| e.reason)?;
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, NotAProduct> {
+        let view = GraphView::parse(bytes)?;
         let route_index = (view.node_count().unwrap_or(0) >= MIN_ROUTE_INDEX_NODES)
             .then(|| VpTree::from_graph(&view))
             .flatten();
@@ -107,11 +88,16 @@ impl<'a> R4G1Runtime<'a> {
     }
 
     /// Appends a patch epoch to the runtime's chain.
-    pub fn try_push_patch(&mut self, patch_bytes: &'a [u8]) -> Result<(), RuntimeError> {
-        let view = GraphView::parse(patch_bytes).map_err(|e| RuntimeError::Format(e.reason))?;
-        self.chain
-            .try_push_patch(view)
-            .map_err(|e| RuntimeError::Patch(alloc::borrow::Cow::Borrowed(e)))
+    ///
+    /// Total verdict: `None` on success, `Some(reason)` when the patch is
+    /// rejected — either because `patch_bytes` is not a valid R4G1 artifact
+    /// or because the chain-precedence rules reject it (see
+    /// [`crate::patch_chain::PatchChain::try_push_patch`]).
+    pub fn try_push_patch(&mut self, patch_bytes: &'a [u8]) -> Option<&'static str> {
+        let Ok(view) = GraphView::parse(patch_bytes) else {
+            return Some("patch bytes are not a valid R4G1 artifact");
+        };
+        self.chain.try_push_patch(view)
     }
 
     /// One ROUT probe: query `sig` against the per-node prototypes/masks
@@ -186,17 +172,20 @@ impl<'a> R4G1Runtime<'a> {
     }
 
     /// Single deterministic, allocation-free step of the graph runtime.
+    ///
+    /// Total: every input yields a `(token, status)` pair — an empty graph
+    /// resolves to `(0, BackedOff)` rather than an error.
     pub fn step(
         &self,
         state: &mut RuntimeState,
         token: u32,
         _witness: &mut [u8],
-    ) -> Result<(u32, ResolutionStatus), RuntimeError> {
+    ) -> (u32, ResolutionStatus) {
         state.record_token(token);
 
         let num_nodes = self.node_count();
         if num_nodes == 0 {
-            return Ok((0, ResolutionStatus::BackedOff));
+            return (0, ResolutionStatus::BackedOff);
         }
 
         let context = state.token().as_slice();
@@ -216,7 +205,7 @@ impl<'a> R4G1Runtime<'a> {
             Self::execute_state_updates(state, code_bytes);
         }
 
-        Ok((pred_token, status))
+        (pred_token, status)
     }
 
     /// Execute the bytecode program in the CODE section to update semantic states.

--- a/crates/uor-r4-graph-runtime/src/lib.rs
+++ b/crates/uor-r4-graph-runtime/src/lib.rs
@@ -13,5 +13,5 @@ pub mod status;
 
 mod vp_tree;
 
-pub use engine::{R4G1Runtime, RuntimeError};
+pub use engine::R4G1Runtime;
 pub use status::ResolutionStatus;

--- a/crates/uor-r4-graph-runtime/src/packed_kernels.rs
+++ b/crates/uor-r4-graph-runtime/src/packed_kernels.rs
@@ -15,7 +15,6 @@
 //! 8. Immutable patch-chain delta application (`apply_patch_chain`).
 //! 9. Complete zero-allocation prediction step (`evaluate_no_alloc_predict_step`).
 
-use crate::engine::RuntimeError;
 use crate::runtime_state::RuntimeState;
 use core::cmp::Ordering;
 use uor_r4_graph_format::{GraphView, ScoreQ};
@@ -93,18 +92,11 @@ impl<const TOP_K: usize> StepOutput<TOP_K> {
 /// # TODO(open: packed-routing-dormant)
 /// Declared placeholder — ROUT bytecode interpretation over the graph's routing
 /// section is not yet wired; registered `open` in model/ledger.toml behind its
-/// activation gate (#159 Phase 2). Validates `max_steps` and returns 0 as the
-/// pre-declared route-target placeholder; unreferenced by the serving path.
-pub fn evaluate_routing_program(
-    _view: &GraphView<'_>,
-    _start_pc: usize,
-    max_steps: usize,
-) -> Result<u32, RuntimeError> {
-    if max_steps == 0 {
-        return Err(RuntimeError::InvalidNode);
-    }
+/// activation gate (#159 Phase 2). Total: returns 0 as the pre-declared
+/// route-target placeholder for every input; unreferenced by the serving path.
+pub fn evaluate_routing_program(_view: &GraphView<'_>, _start_pc: usize, _max_steps: usize) -> u32 {
     // TODO(open: packed-routing-dormant, #159 Phase 2): walk view.routing_section() / ROUT opcodes up to max_steps.
-    Ok(0)
+    0
 }
 
 /// Kernel 2: Bounded active-frontier expansion and eviction.
@@ -169,15 +161,11 @@ pub fn accumulate_candidate_shortlist<const C: usize>(
 /// # TODO(open: packed-routing-dormant)
 /// Declared placeholder — graph-edge traversal using the `action_mask` is not
 /// yet wired; registered `open` in model/ledger.toml behind its activation gate
-/// (#159 Phase 2). Returns `src_node + 1` as the pre-declared placeholder
-/// successor; unreferenced by the serving path.
-pub fn evaluate_typed_transition(
-    _view: &GraphView<'_>,
-    src_node: u32,
-    _action_mask: u64,
-) -> Result<u32, RuntimeError> {
+/// (#159 Phase 2). Total: returns `src_node + 1` as the pre-declared
+/// placeholder successor; unreferenced by the serving path.
+pub fn evaluate_typed_transition(_view: &GraphView<'_>, src_node: u32, _action_mask: u64) -> u32 {
     // TODO(open: packed-routing-dormant, #159 Phase 2): look up outgoing edges from src_node filtered by action_mask.
-    Ok(src_node.saturating_add(1))
+    src_node.saturating_add(1)
 }
 
 /// Kernel 5: Hazard constraint evaluator (returns true if candidate is safe / non-hazard).
@@ -232,13 +220,13 @@ pub fn evaluate_no_alloc_predict_step<const N: usize, const C: usize, const K: u
     state: &mut RuntimeState,
     token: u32,
     output: &mut StepOutput<K>,
-) -> Result<u32, RuntimeError> {
+) -> u32 {
     state.record_token(token);
 
     let node_count = view.node_count().unwrap_or(0);
     if node_count == 0 {
         output.count = 0;
-        return Ok(0);
+        return 0;
     }
 
     let mut frontier = PackedFrontier::<N>::new();
@@ -261,9 +249,9 @@ pub fn evaluate_no_alloc_predict_step<const N: usize, const C: usize, const K: u
     // decode_canonical_topk sets output.count = candidates.len().min(K), so
     // output.count == 0 whenever candidate_count == 0 or K == 0.
     if output.count == 0 {
-        return Ok(0);
+        return 0;
     }
-    Ok(output.predictions[0].0)
+    output.predictions[0].0
 }
 
 #[cfg(test)]

--- a/crates/uor-r4-graph-runtime/src/patch_chain.rs
+++ b/crates/uor-r4-graph-runtime/src/patch_chain.rs
@@ -24,11 +24,13 @@ impl<'a> PatchChain<'a> {
     /// Tries to append a patch epoch to the chain.
     ///
     /// Validates deterministic newest-valid precedence and rejects forks
-    /// (the patch's parent CID must match the current chain tip).
-    pub fn try_push_patch(&mut self, patch: GraphView<'a>) -> Result<(), &'static str> {
-        let parent_cid = patch
-            .patch_parent_cid()
-            .ok_or("Patch has no PTCH section or parent CID")?;
+    /// (the patch's parent CID must match the current chain tip). Total
+    /// verdict: `None` when the patch is appended, `Some(reason)` when it is
+    /// rejected.
+    pub fn try_push_patch(&mut self, patch: GraphView<'a>) -> Option<&'static str> {
+        let Some(parent_cid) = patch.patch_parent_cid() else {
+            return Some("Patch has no PTCH section or parent CID");
+        };
 
         let expected_parent = if let Some(last) = self.patches.last() {
             last.header().artifact_cid
@@ -38,16 +40,16 @@ impl<'a> PatchChain<'a> {
 
         // Chain validation: fork rejection unless compacted.
         if parent_cid != expected_parent {
-            return Err("Fork rejection: parent CID does not match tip of the chain");
+            return Some("Fork rejection: parent CID does not match tip of the chain");
         }
 
         // Bounded layer limits: force compaction if we exceed 8 layers.
         if self.patches.len() >= 8 {
-            return Err("Compaction required: chain length exceeds 8 uncompacted layers");
+            return Some("Compaction required: chain length exceeds 8 uncompacted layers");
         }
 
         self.patches.push(patch);
-        Ok(())
+        None
     }
 
     /// Checks whether a node ID is tombstoned by any patch in the chain.

--- a/crates/uor-r4-graph-runtime/src/routing.rs
+++ b/crates/uor-r4-graph-runtime/src/routing.rs
@@ -1,15 +1,16 @@
-use crate::engine::RuntimeError;
-use uor_r4_graph_format::{FormatError, GraphView, SectionId};
+use uor_r4_graph_format::{GraphView, SectionId};
 use uor_r4_graph_format::{OP_HALT, OP_JMP_FWD, OP_LEAF, OP_TEST_POPCOUNT_LE};
 
-pub fn evaluate_route<'a>(
-    view: &GraphView<'a>,
-    signature: &[u64],
-) -> Result<&'a [u8], RuntimeError> {
-    let head = view.head().ok_or(RuntimeError::InvalidNode)?;
+/// Evaluate the ROUT bytecode program, returning the resolved shortlist slice.
+///
+/// Total verdict: `Some(slice)` on a well-formed traversal (the empty slice
+/// when there is no ROUT section), `None` when the program is malformed —
+/// an absent head, an out-of-bounds field, or an unknown opcode.
+pub fn evaluate_route<'a>(view: &GraphView<'a>, signature: &[u64]) -> Option<&'a [u8]> {
+    let head = view.head()?;
     let rout_bytes = view.section(SectionId::ROUT).unwrap_or(&[]);
     if rout_bytes.is_empty() {
-        return Ok(&[]);
+        return Some(&[]);
     }
 
     // Scan for HALT to find the shortlist table start
@@ -25,12 +26,8 @@ pub fn evaluate_route<'a>(
             OP_TEST_POPCOUNT_LE => scan_pc += 12,
             OP_JMP_FWD => scan_pc += 3,
             OP_LEAF => scan_pc += 7,
-            _ => {
-                return Err(RuntimeError::Format(FormatError::UnknownRoutingOp {
-                    offset: scan_pc as u32,
-                    opcode: op,
-                }));
-            }
+            // Unknown opcode at `scan_pc`: the ROUT program is malformed.
+            _ => return None,
         }
     }
 
@@ -50,23 +47,15 @@ pub fn evaluate_route<'a>(
 
         match opcode {
             OP_HALT => {
-                return Ok(table); // Return the entire table as fallback
+                return Some(table); // Return the entire table as fallback
             }
             OP_TEST_POPCOUNT_LE => {
                 if pc + 12 > rout_bytes.len() {
-                    return Err(RuntimeError::InvalidNode);
+                    return None;
                 }
                 let word = rout_bytes[pc + 1] as usize;
-                let mask = u64::from_le_bytes(
-                    rout_bytes[pc + 2..pc + 10]
-                        .try_into()
-                        .map_err(|_| RuntimeError::InvalidNode)?,
-                );
-                let threshold = u16::from_le_bytes(
-                    rout_bytes[pc + 10..pc + 12]
-                        .try_into()
-                        .map_err(|_| RuntimeError::InvalidNode)?,
-                );
+                let mask = u64::from_le_bytes(rout_bytes[pc + 2..pc + 10].try_into().ok()?);
+                let threshold = u16::from_le_bytes(rout_bytes[pc + 10..pc + 12].try_into().ok()?);
 
                 let popcount = if word < signature.len() {
                     (signature[word] & mask).count_ones() as u16
@@ -86,7 +75,7 @@ pub fn evaluate_route<'a>(
                             OP_TEST_POPCOUNT_LE => 12,
                             OP_JMP_FWD => 3,
                             OP_LEAF => 7,
-                            _ => return Err(RuntimeError::InvalidNode),
+                            _ => return None,
                         };
                         pc += skip_size;
                     }
@@ -94,17 +83,13 @@ pub fn evaluate_route<'a>(
             }
             OP_JMP_FWD => {
                 if pc + 3 > rout_bytes.len() {
-                    return Err(RuntimeError::InvalidNode);
+                    return None;
                 }
-                let delta_ops = u16::from_le_bytes(
-                    rout_bytes[pc + 1..pc + 3]
-                        .try_into()
-                        .map_err(|_| RuntimeError::InvalidNode)?,
-                );
+                let delta_ops = u16::from_le_bytes(rout_bytes[pc + 1..pc + 3].try_into().ok()?);
                 pc += 3;
                 for _ in 0..delta_ops {
                     if pc >= rout_bytes.len() {
-                        return Err(RuntimeError::InvalidNode);
+                        return None;
                     }
                     let skip_op = rout_bytes[pc];
                     let skip_size = match skip_op {
@@ -112,33 +97,27 @@ pub fn evaluate_route<'a>(
                         OP_TEST_POPCOUNT_LE => 12,
                         OP_JMP_FWD => 3,
                         OP_LEAF => 7,
-                        _ => return Err(RuntimeError::InvalidNode),
+                        _ => return None,
                     };
                     pc += skip_size;
                 }
             }
             OP_LEAF => {
                 if pc + 7 > rout_bytes.len() {
-                    return Err(RuntimeError::InvalidNode);
+                    return None;
                 }
-                let shortlist_start = u32::from_le_bytes(
-                    rout_bytes[pc + 1..pc + 5]
-                        .try_into()
-                        .map_err(|_| RuntimeError::InvalidNode)?,
-                ) as usize;
-                let shortlist_len = u16::from_le_bytes(
-                    rout_bytes[pc + 5..pc + 7]
-                        .try_into()
-                        .map_err(|_| RuntimeError::InvalidNode)?,
-                ) as usize;
+                let shortlist_start =
+                    u32::from_le_bytes(rout_bytes[pc + 1..pc + 5].try_into().ok()?) as usize;
+                let shortlist_len =
+                    u16::from_le_bytes(rout_bytes[pc + 5..pc + 7].try_into().ok()?) as usize;
                 if shortlist_start + shortlist_len > table.len() {
-                    return Err(RuntimeError::InvalidNode);
+                    return None;
                 }
-                return Ok(&table[shortlist_start..shortlist_start + shortlist_len]);
+                return Some(&table[shortlist_start..shortlist_start + shortlist_len]);
             }
-            _ => return Err(RuntimeError::InvalidNode),
+            _ => return None,
         }
     }
 
-    Ok(table)
+    Some(table)
 }

--- a/crates/uor-r4-graph-runtime/src/scoring.rs
+++ b/crates/uor-r4-graph-runtime/src/scoring.rs
@@ -61,11 +61,6 @@ pub struct TypedContribution {
     pub value: ScoreQ,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AccumulatorError {
-    DuplicateEvidenceId(u32),
-}
-
 /// Sort contributions into canonical accumulation order.
 pub fn sort_contributions_canonical(contributions: &mut [TypedContribution]) {
     contributions.sort_by_key(|c| (c.kind as u8, c.evidence_id));
@@ -74,24 +69,21 @@ pub fn sort_contributions_canonical(contributions: &mut [TypedContribution]) {
 /// Reference fixed-point accumulator.
 ///
 /// The order is the provided slice order; callers should canonicalize first via
-/// [`sort_contributions_canonical`].
-pub fn accumulate_reference(
-    base: ScoreQ,
-    contributions: &[TypedContribution],
-) -> Result<ScoreQ, AccumulatorError> {
+/// [`sort_contributions_canonical`]. Total: `Some(total)` for a well-formed
+/// contribution set, `None` when any evidence id is duplicated (each canonical
+/// evidence may contribute at most once).
+pub fn accumulate_reference(base: ScoreQ, contributions: &[TypedContribution]) -> Option<ScoreQ> {
     let mut total = base;
     for (index, contribution) in contributions.iter().enumerate() {
         if contributions[..index]
             .iter()
             .any(|prior| prior.evidence_id == contribution.evidence_id)
         {
-            return Err(AccumulatorError::DuplicateEvidenceId(
-                contribution.evidence_id,
-            ));
+            return None;
         }
         total = total.saturating_add(contribution.value);
     }
-    Ok(total)
+    Some(total)
 }
 
 /// Canonical deterministic top-1 selector:
@@ -110,8 +102,8 @@ pub fn select_best(candidates: &[(u32, OrderedScore)]) -> Option<(u32, OrderedSc
 #[cfg(test)]
 mod tests {
     use super::{
-        AccumulatorError, OrderedScore, ResidualKind, ScoreSentinel, TypedContribution,
-        accumulate_reference, select_best, sort_contributions_canonical,
+        OrderedScore, ResidualKind, ScoreSentinel, TypedContribution, accumulate_reference,
+        select_best, sort_contributions_canonical,
     };
     use uor_r4_graph_format::ScoreQ;
 
@@ -124,6 +116,7 @@ mod tests {
         }];
         let max_total = accumulate_reference(ScoreQ::MAX, &contributions).expect("accumulate");
         assert_eq!(max_total, ScoreQ::MAX);
+        // (Option::expect on the total accumulator: None == duplicate id.)
 
         let negative = [TypedContribution {
             evidence_id: 1,
@@ -175,8 +168,8 @@ mod tests {
                 value: ScoreQ::from_raw(5),
             },
         ];
-        let err = accumulate_reference(ScoreQ::ZERO, &contributions).expect_err("duplicate");
-        assert_eq!(err, AccumulatorError::DuplicateEvidenceId(3));
+        // Duplicate evidence id 3 → the total accumulator rejects with None.
+        assert_eq!(accumulate_reference(ScoreQ::ZERO, &contributions), None);
     }
 
     #[test]
@@ -199,8 +192,8 @@ mod tests {
             },
         ];
         sort_contributions_canonical(&mut contributions);
-        let err = accumulate_reference(ScoreQ::ZERO, &contributions).expect_err("duplicate");
-        assert_eq!(err, AccumulatorError::DuplicateEvidenceId(3));
+        // The canonical sort surfaces the non-adjacent duplicate id 3 → None.
+        assert_eq!(accumulate_reference(ScoreQ::ZERO, &contributions), None);
     }
 
     #[test]


### PR DESCRIPTION
Third R5 tranche (issue #510): converts `uor-r4-graph-runtime` to the sanctioned error surface. Continues the bottom-up march after graph-format (#518, #520, #521, #522, #523).

## What changes
The crate's private `RuntimeError` / `AccumulatorError` enums are removed. Every function either becomes **total** or narrows to a **sanctioned** type (`NotAProduct` / `ObservedBound` / `KappaError`):

- `engine::R4G1Runtime::parse` → `Result<Self, NotAProduct>` (was `FormatError`; now propagates the sanctioned parse verdict directly).
- `engine::R4G1Runtime::try_push_patch` → `Option<&'static str>` (None = pushed, Some = rejection reason; a non-parsing patch folds to a rejection reason).
- `engine::R4G1Runtime::step` → `(u32, ResolutionStatus)` — the `Result` was never `Err`; an empty graph resolves to `(0, BackedOff)`.
- `patch_chain::PatchChain::try_push_patch` → `Option<&'static str>`.
- `routing::evaluate_route` → `Option<&'a [u8]>` (None = malformed ROUT program: absent head, out-of-bounds field, or unknown opcode).
- `scoring::accumulate_reference` → `Option<ScoreQ>` (None = duplicate evidence id); `AccumulatorError` removed.
- Dormant packed kernels (`evaluate_routing_program`, `evaluate_typed_transition`, `evaluate_no_alloc_predict_step`) → total `u32`.

## Dormant mechanisms preserved
Per the preserve-and-gate policy (#515), no mechanism is deleted. The `packed-routing-dormant` markers and their `open` ledger claims are kept intact for later activation; only the arbitrary `max_steps == 0` guard (an unsanctioned limit) is dropped.

## Verification
- `cargo build`/`test`/`clippy`/`--no-default-features` (no_std) all green for the crate and workspace.
- `xtask audit-deferral` clean; graph-runtime no longer appears in the `audit-limits` inventory.
- No external code depended on `RuntimeError` (only a re-export and a certify test comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)