### PR TITLE
feat(#510): R5 tranche 2 — host-ingestion boundary; model-source to sanctioned surface

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -400,21 +400,19 @@ impl RepresentationSource for RecordedRepresentation {
         "recorded-corpus-tokenizer-v1"
     }
 
-    fn read_embedding_rows(
-        &self,
-        range: std::ops::Range<usize>,
-        output: &mut [f32],
-    ) -> Result<(), String> {
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()> {
+        // Total: `None` when the caller's range or buffer cannot be served
+        // (both are properties of the caller's chosen instantiation).
         if range.start > range.end || range.end > self.vocab {
-            return Err("recorded representation row range is out of bounds".to_owned());
+            return None;
         }
         let count = range.end - range.start;
         let width = count * D;
         if output.len() < width {
-            return Err("recorded representation output buffer too small".to_owned());
+            return None;
         }
         output[..width].copy_from_slice(&self.rows[range.start * D..range.end * D]);
-        Ok(())
+        Some(())
     }
 }
 

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -916,9 +916,9 @@ mod tests {
             &self,
             _range: std::ops::Range<usize>,
             output: &mut [f32],
-        ) -> Result<(), String> {
+        ) -> Option<()> {
             output.fill(0.0);
-            Ok(())
+            Some(())
         }
     }
 

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -300,15 +300,11 @@ impl RepresentationSource for FakeOracle {
     fn tokenizer_address(&self) -> &str {
         "fake-tokenizer"
     }
-    fn read_embedding_rows(
-        &self,
-        range: std::ops::Range<usize>,
-        output: &mut [f32],
-    ) -> Result<(), String> {
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()> {
         for (i, value) in output.iter_mut().enumerate() {
             *value = (range.start + i) as f32;
         }
-        Ok(())
+        Some(())
     }
 }
 

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -785,11 +785,11 @@ pub trait RepresentationSource {
     fn vocab_size(&self) -> usize;
     fn source_dimension(&self) -> usize;
     fn tokenizer_address(&self) -> &str;
-    fn read_embedding_rows(
-        &self,
-        range: std::ops::Range<usize>,
-        output: &mut [f32],
-    ) -> Result<(), String>;
+    /// Copy the embedding rows in `range` into `output`. Total: returns
+    /// `None` when the caller's `output` buffer cannot hold the requested
+    /// rows (a property of the caller's chosen instantiation), `Some(())`
+    /// once the rows are written.
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()>;
 }
 
 pub trait BehaviorSource {
@@ -917,20 +917,16 @@ impl RepresentationSource for LlamaOracle {
     fn tokenizer_address(&self) -> &str {
         "local-llama-tokenizer"
     }
-    fn read_embedding_rows(
-        &self,
-        range: std::ops::Range<usize>,
-        output: &mut [f32],
-    ) -> Result<(), String> {
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()> {
         let d = self.model.cfg.dim;
         let count = range.end - range.start;
         if output.len() < count * d {
-            return Err("output buffer too small".to_string());
+            return None;
         }
         let start_offset = self.model.emb + range.start * d;
         let end_offset = self.model.emb + range.end * d;
         output[..count * d].copy_from_slice(&self.model.w[start_offset..end_offset]);
-        Ok(())
+        Some(())
     }
 }
 
@@ -1023,9 +1019,66 @@ pub struct HuggingFaceLlamaOracle {
     fast_matmul: bool,
 }
 
+/// The sanctioned host-ingestion boundary error (R5).
+///
+/// A declared external source artifact — a teacher directory, its
+/// `model.safetensors`, `config.json`, or a named tensor within — could not be
+/// ingested into a valid teacher at construction. This is the host-side
+/// analogue of graph-format's `NotAProduct`: the only reportable condition is
+/// that the requested object does not exist as a valid product, reported at
+/// construction. It carries the operator-facing diagnostic (which file, which
+/// tensor, what dtype) rather than discarding it.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct SourceUnavailable {
+    /// Human-facing description of why the source could not be ingested.
+    pub reason: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SourceUnavailable {
+    /// Construct from any displayable reason.
+    pub fn new(reason: impl std::fmt::Display) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl std::fmt::Display for SourceUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "source unavailable: {}", self.reason)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl std::error::Error for SourceUnavailable {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<std::io::Error> for SourceUnavailable {
+    fn from(error: std::io::Error) -> Self {
+        Self::new(error)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<serde_json::Error> for SourceUnavailable {
+    fn from(error: serde_json::Error) -> Self {
+        Self::new(error)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<safetensors::SafeTensorError> for SourceUnavailable {
+    fn from(error: safetensors::SafeTensorError) -> Self {
+        Self::new(error)
+    }
+}
+
 impl HuggingFaceLlamaOracle {
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn load(source: impl AsRef<std::path::Path>) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load(source: impl AsRef<std::path::Path>) -> Result<Self, SourceUnavailable> {
         Self::load_inner(source, None)
     }
 
@@ -1037,9 +1090,11 @@ impl HuggingFaceLlamaOracle {
     pub fn load_with_sequence_length(
         source: impl AsRef<std::path::Path>,
         sequence_length: usize,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, SourceUnavailable> {
         if sequence_length == 0 {
-            return Err("teacher sequence length must be greater than zero".into());
+            return Err(SourceUnavailable::new(
+                "teacher sequence length must be greater than zero",
+            ));
         }
         Self::load_inner(source, Some(sequence_length))
     }
@@ -1058,7 +1113,7 @@ impl HuggingFaceLlamaOracle {
     fn load_inner(
         source: impl AsRef<std::path::Path>,
         sequence_length: Option<usize>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, SourceUnavailable> {
         let source = source.as_ref();
         let config: HuggingFaceConfig =
             serde_json::from_slice(&std::fs::read(source.join("config.json"))?)?;
@@ -1170,7 +1225,7 @@ fn append_layers(
     layers: usize,
     suffix: &str,
     out: &mut Vec<f32>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), SourceUnavailable> {
     for layer in 0..layers {
         append_tensor(tensors, &format!("model.layers.{layer}.{suffix}"), out)?;
     }
@@ -1182,10 +1237,13 @@ fn append_tensor(
     tensors: &safetensors::SafeTensors<'_>,
     name: &str,
     out: &mut Vec<f32>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), SourceUnavailable> {
     let tensor = tensors.tensor(name)?;
     if tensor.dtype() != safetensors::Dtype::BF16 {
-        return Err(format!("tensor {name} is {:?}, expected BF16", tensor.dtype()).into());
+        return Err(SourceUnavailable::new(format!(
+            "tensor {name} is {:?}, expected BF16",
+            tensor.dtype()
+        )));
     }
     for bytes in tensor.data().chunks_exact(2) {
         let bits = u16::from_le_bytes([bytes[0], bytes[1]]);
@@ -1204,20 +1262,16 @@ impl RepresentationSource for HuggingFaceLlamaOracle {
     fn tokenizer_address(&self) -> &str {
         "huggingface-tokenizer"
     }
-    fn read_embedding_rows(
-        &self,
-        range: std::ops::Range<usize>,
-        output: &mut [f32],
-    ) -> Result<(), String> {
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()> {
         let d = self.model.cfg.dim;
         let count = range.end - range.start;
         if output.len() < count * d {
-            return Err("output buffer too small".to_string());
+            return None;
         }
         let start_offset = self.model.emb + range.start * d;
         let end_offset = self.model.emb + range.end * d;
         output[..count * d].copy_from_slice(&self.model.w[start_offset..end_offset]);
-        Ok(())
+        Some(())
     }
 }
 

--- a/crates/uor-r4-model-source/src/progress.rs
+++ b/crates/uor-r4-model-source/src/progress.rs
@@ -75,7 +75,10 @@ impl Drop for Progress {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn read_file(path: impl AsRef<Path>, label: &'static str) -> io::Result<Vec<u8>> {
+pub fn read_file(
+    path: impl AsRef<Path>,
+    label: &'static str,
+) -> Result<Vec<u8>, crate::SourceUnavailable> {
     let path = path.as_ref();
     let total = usize::try_from(std::fs::metadata(path)?.len()).unwrap_or(usize::MAX);
     let mut progress = Progress::new(label, total);

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -123,7 +123,19 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
     let sources = shipped_sources(root)?;
     // The only error type a shipped crate may name, plus the declaration check at
     // a declared boundary, which is not the operation failing.
-    let sanctioned = ["NotAProduct", "ObservedBound", "KappaError"];
+    //
+    // `SourceUnavailable` is the host-ingestion analogue: the teacher-loading
+    // boundary (uor-r4 #510) reports exactly one condition — a declared external
+    // source artifact (model directory, safetensors, config, or a named tensor)
+    // could not be ingested into a valid teacher at construction. It is the
+    // host-side counterpart of `NotAProduct`, not a runtime limitation, so it is
+    // sanctioned here alongside the graph substrate's three.
+    let sanctioned = [
+        "NotAProduct",
+        "ObservedBound",
+        "KappaError",
+        "SourceUnavailable",
+    ];
 
     let mut violations = Vec::new();
     for src in &sources {


### PR DESCRIPTION
Fourth R5 step (issue #510): opens the **host-ingestion boundary** and converts the teacher loader (`uor-r4-model-source`) off ad-hoc `Box<dyn Error>` / `String` results. The graph substrate (graph-format + graph-runtime) is now fully on the sanctioned surface via #518–#524; this begins the host-tooling layer.

## Decision: a host-boundary sanctioned type
`model-source` is a std, float-heavy teacher (a run.c forward-pass port) that ingests external HuggingFace safetensors. Its errors — missing model dir, safetensors dtype mismatch, corrupt `config.json` — have no honest representation in the graph substrate's `NotAProduct` (which wraps a graph-*wire* `FormatError` like `BadMagic`); `model-source` doesn't even depend on graph-format. So rather than pollute the wire contract, this introduces one host-side sanctioned error.

`SourceUnavailable { reason }` — the host-side analogue of `NotAProduct`. It reports exactly one condition: *a declared external source artifact could not be ingested into a valid teacher at construction*. `From<io::Error / serde_json::Error / safetensors::SafeTensorError>` keeps `?` ergonomic and **preserves the operator diagnostic** (which file, which tensor, what dtype). It is registered in the `xtask audit-limits` allowlist alongside the substrate's three.

## Conversions
- `HuggingFaceLlamaOracle::{load, load_with_sequence_length, load_inner}`, `append_tensor`, `append_layers`, `progress::read_file` → `Result<_, SourceUnavailable>`.
- `RepresentationSource::read_embedding_rows` → `Option<()>` (None = the caller's range/buffer cannot be served — a property of the caller's chosen instantiation). All implementors updated (LlamaOracle, HuggingFaceLlamaOracle, core's recorded representation, compiler test/observation fakes); callers use `.unwrap()`/`.expect()`, unchanged.

## Verification
- `audit-limits`: model-source now reports **zero** unsanctioned errors.
- Build / clippy (`-D warnings`) / fmt clean; all workspace test targets compile; `recorded_representation` and `observe` integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)