### PR TITLE
feat(#510): R5 tranche 3b — core TransitionGraph cluster to total ops

### DIFF
--- a/crates/uor-r4-core/src/transformerless/graph_patch.rs
+++ b/crates/uor-r4-core/src/transformerless/graph_patch.rs
@@ -95,12 +95,16 @@ impl GraphPatch {
     }
 
     /// Apply patch to a transition graph in-place.
-    pub fn apply(&self, graph: &mut TransitionGraph) -> Result<(), String> {
+    ///
+    /// Total: `None` on success, `Some(reason)` when an index is out of
+    /// bounds, an added-edge id disagrees, or the post-patch graph violates
+    /// Theorem 7.
+    pub fn apply(&self, graph: &mut TransitionGraph) -> Option<String> {
         // Update ScoreQ residuals
         for &(edge_idx, ref score) in &self.residual_updates {
             let edge_idx = edge_idx as usize;
             if edge_idx >= graph.edges.len() {
-                return Err(format!(
+                return Some(format!(
                     "Residual update edge index {} out of bounds",
                     edge_idx
                 ));
@@ -113,7 +117,7 @@ impl GraphPatch {
             let new_id =
                 graph.add_edge_with_score(edge.src, edge.dst, edge.weight, edge.score, edge.kind);
             if new_id != edge.id {
-                return Err(format!(
+                return Some(format!(
                     "Added edge ID mismatch: patch has {}, graph assigned {}",
                     edge.id, new_id
                 ));
@@ -124,7 +128,7 @@ impl GraphPatch {
         for &tombstone_idx in &self.tombstone_edge_ids {
             let tombstone_idx = tombstone_idx as usize;
             if tombstone_idx >= graph.edges.len() {
-                return Err(format!(
+                return Some(format!(
                     "Tombstone edge index {} out of bounds",
                     tombstone_idx
                 ));
@@ -133,28 +137,30 @@ impl GraphPatch {
         }
 
         // Rebuild reverse index and verify Theorem 7
-        graph
-            .build_reverse_index()
-            .map_err(|e| format!("Post-patch reverse index rebuild failed: {}", e))?;
-        graph
-            .verify_theorem_7()
-            .map_err(|e| format!("Post-patch Theorem 7 verification failed: {}", e))?;
-
-        Ok(())
-    }
-
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
-        let mut buf = Vec::new();
-        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
-        Ok(buf)
-    }
-
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
-        let patch: GraphPatch = ciborium::from_reader(bytes).map_err(|e| e.to_string())?;
-        if !patch.verify_cid() {
-            return Err("GraphPatch CID verification failed".to_string());
+        if let Some(reason) = graph.build_reverse_index() {
+            return Some(format!("Post-patch reverse index rebuild failed: {reason}"));
         }
-        Ok(patch)
+        if let Some(reason) = graph.verify_theorem_7() {
+            return Some(format!(
+                "Post-patch Theorem 7 verification failed: {reason}"
+            ));
+        }
+
+        None
+    }
+
+    pub fn to_cbor_bytes(&self) -> Option<Vec<u8>> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(self, &mut buf).ok()?;
+        Some(buf)
+    }
+
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        let patch: GraphPatch = ciborium::from_reader(bytes).ok()?;
+        if !patch.verify_cid() {
+            return None;
+        }
+        Some(patch)
     }
 }
 
@@ -162,31 +168,32 @@ pub struct Theorem11Verifier;
 
 impl Theorem11Verifier {
     /// Verify Theorem 11 for retained routes: parent and patched scores must match.
+    ///
+    /// Total: `None` when Theorem 11 holds for every retained route,
+    /// `Some(reason)` naming the first failure.
     pub fn verify_theorem_11(
         parent: &TransitionGraph,
         patched: &TransitionGraph,
         map: &RouteTranslationMap,
-    ) -> Result<(), String> {
-        parent
-            .verify_theorem_7()
-            .map_err(|e| format!("Parent graph Theorem 7 failed: {}", e))?;
-        patched
-            .verify_theorem_7()
-            .map_err(|e| format!("Patched graph Theorem 7 failed: {}", e))?;
+    ) -> Option<String> {
+        if let Some(reason) = parent.verify_theorem_7() {
+            return Some(format!("Parent graph Theorem 7 failed: {reason}"));
+        }
+        if let Some(reason) = patched.verify_theorem_7() {
+            return Some(format!("Patched graph Theorem 7 failed: {reason}"));
+        }
 
         for (&parent_route_id, mapping) in &map.mappings {
             if let RouteMapping::Retained(patched_id) = mapping {
-                let parent_edge = parent
-                    .edges
-                    .get(parent_route_id as usize)
-                    .ok_or_else(|| format!("Parent route ID {} missing", parent_route_id))?;
-                let patched_edge = patched
-                    .edges
-                    .get(*patched_id as usize)
-                    .ok_or_else(|| format!("Patched route ID {} missing", patched_id))?;
+                let Some(parent_edge) = parent.edges.get(parent_route_id as usize) else {
+                    return Some(format!("Parent route ID {} missing", parent_route_id));
+                };
+                let Some(patched_edge) = patched.edges.get(*patched_id as usize) else {
+                    return Some(format!("Patched route ID {} missing", patched_id));
+                };
 
                 if parent_edge.score != patched_edge.score {
-                    return Err(format!(
+                    return Some(format!(
                         "Theorem 11 score mismatch for route {}: parent {:?} != patched {:?}",
                         parent_route_id, parent_edge.score, patched_edge.score
                     ));
@@ -194,6 +201,6 @@ impl Theorem11Verifier {
             }
         }
 
-        Ok(())
+        None
     }
 }

--- a/crates/uor-r4-core/src/transformerless/transitions.rs
+++ b/crates/uor-r4-core/src/transformerless/transitions.rs
@@ -72,7 +72,10 @@ impl TransitionGraph {
     }
 
     /// Build and sort the reverse edge index $E_b$, validating Theorem 7 consistency.
-    pub fn build_reverse_index(&mut self) -> Result<(), &'static str> {
+    ///
+    /// Total: builds the index, then returns the Theorem 7 verdict — `None`
+    /// when consistent, `Some(reason)` when the rebuilt index violates it.
+    pub fn build_reverse_index(&mut self) -> Option<&'static str> {
         let mut edge_ids: Vec<u32> = (0..self.edges.len() as u32).collect();
         // Sort edge IDs by (dst, src, kind, id)
         edge_ids.sort_by_key(|&id| {
@@ -102,42 +105,45 @@ impl TransitionGraph {
     /// Verify Theorem 7 consistency:
     /// For every dst node, all reverse index entries in its slice MUST refer to
     /// valid canonical edge IDs whose destination equals dst.
-    pub fn verify_theorem_7(&self) -> Result<(), &'static str> {
+    ///
+    /// Total: `None` when the reverse index is consistent, `Some(reason)`
+    /// naming the first violation found.
+    pub fn verify_theorem_7(&self) -> Option<&'static str> {
         if self.edges.is_empty() {
-            return Ok(());
+            return None;
         }
         if self.reverse_index.len() != self.edges.len() {
-            return Err("Theorem 7 violation: reverse index does not cover all edges");
+            return Some("Theorem 7 violation: reverse index does not cover all edges");
         }
         let total_count: usize = self.reverse_offsets.values().map(|&(_, c)| c).sum();
         if total_count != self.reverse_index.len() {
-            return Err("Theorem 7 violation: reverse offsets do not cover reverse index");
+            return Some("Theorem 7 violation: reverse offsets do not cover reverse index");
         }
         for &edge_id in &self.reverse_index {
             if edge_id as usize >= self.edges.len() {
-                return Err("Theorem 7 violation: invalid canonical edge ID in reverse index");
+                return Some("Theorem 7 violation: invalid canonical edge ID in reverse index");
             }
         }
         for i in 1..self.reverse_index.len() {
             let prev_dst = self.edges[self.reverse_index[i - 1] as usize].dst;
             let cur_dst = self.edges[self.reverse_index[i] as usize].dst;
             if prev_dst > cur_dst {
-                return Err("Theorem 7 violation: reverse index not sorted by dst");
+                return Some("Theorem 7 violation: reverse index not sorted by dst");
             }
         }
         for (&dst, &(start, count)) in &self.reverse_offsets {
             if start + count > self.reverse_index.len() {
-                return Err("Theorem 7 violation: reverse index range out of bounds");
+                return Some("Theorem 7 violation: reverse index range out of bounds");
             }
             for i in start..start + count {
                 let edge_id = self.reverse_index[i];
                 let edge = &self.edges[edge_id as usize];
                 if edge.dst != dst {
-                    return Err("Theorem 7 violation: reverse index target mismatched edge dst");
+                    return Some("Theorem 7 violation: reverse index target mismatched edge dst");
                 }
             }
         }
-        Ok(())
+        None
     }
 }
 
@@ -150,7 +156,7 @@ pub fn compile_transitions_from_corpus<F>(
     corpus: &Corpus,
     region_assigner: F,
     max_transitions_per_node: usize,
-) -> Result<TransitionGraph, &'static str>
+) -> Option<TransitionGraph>
 where
     F: Fn(u32) -> u32,
 {
@@ -159,7 +165,7 @@ where
     // Iterate over sequential positions in the corpus
     let n = corpus.n;
     if corpus.story.len() < n || corpus.input.len() < n || corpus.next.len() < n {
-        return Err("corpus vectors shorter than corpus.n");
+        return None;
     }
     if n > 1 {
         for i in 0..(n - 1) {
@@ -194,7 +200,10 @@ where
         }
     }
 
-    // Build and verify Theorem 7 reverse index
-    graph.build_reverse_index()?;
-    Ok(graph)
+    // Build and verify Theorem 7 reverse index; a violation means the corpus
+    // did not yield a consistent graph.
+    if graph.build_reverse_index().is_some() {
+        return None;
+    }
+    Some(graph)
 }

--- a/crates/uor-r4-core/tests/deterministic_rebuild_test.rs
+++ b/crates/uor-r4-core/tests/deterministic_rebuild_test.rs
@@ -98,6 +98,6 @@ fn test_deterministic_transition_graph_rebuild() {
         g1.reverse_offsets, g2.reverse_offsets,
         "Reverse offset maps must match"
     );
-    assert!(g1.verify_theorem_7().is_ok());
-    assert!(g2.verify_theorem_7().is_ok());
+    assert!(g1.verify_theorem_7().is_none());
+    assert!(g2.verify_theorem_7().is_none());
 }

--- a/crates/uor-r4-core/tests/graph_patch_test.rs
+++ b/crates/uor-r4-core/tests/graph_patch_test.rs
@@ -9,9 +9,10 @@ fn test_graph_patch_application_and_theorem_11() {
     let mut base_graph = TransitionGraph::new();
     base_graph.add_edge_with_score(10, 20, 5, ScoreQ::from_raw(100), EdgeKind::Forward);
     base_graph.add_edge_with_score(30, 20, 8, ScoreQ::from_raw(200), EdgeKind::Forward);
-    base_graph
-        .build_reverse_index()
-        .expect("build base reverse index");
+    assert!(
+        base_graph.build_reverse_index().is_none(),
+        "build base reverse index"
+    );
 
     let new_edge = Edge {
         id: 2,
@@ -39,13 +40,15 @@ fn test_graph_patch_application_and_theorem_11() {
     assert!(patch.verify_cid());
 
     let mut patched_graph = base_graph.clone();
-    assert!(patch.apply(&mut patched_graph).is_ok());
+    assert!(patch.apply(&mut patched_graph).is_none());
 
     assert_eq!(patched_graph.edges.len(), 3);
     assert_eq!(patched_graph.edges[2].dst, 40);
 
     // Verify Theorem 11
-    assert!(Theorem11Verifier::verify_theorem_11(&base_graph, &patched_graph, &route_map).is_ok());
+    assert!(
+        Theorem11Verifier::verify_theorem_11(&base_graph, &patched_graph, &route_map).is_none()
+    );
 }
 
 #[test]

--- a/crates/uor-r4-core/tests/transitions_test.rs
+++ b/crates/uor-r4-core/tests/transitions_test.rs
@@ -14,10 +14,10 @@ fn test_transition_graph_manual_edges_and_theorem_7() {
     assert_eq!(e1, 1);
     assert_eq!(e2, 2);
 
-    graph.build_reverse_index().expect("build reverse index");
+    assert!(graph.build_reverse_index().is_none(), "build reverse index");
 
     // Theorem 7 verification
-    assert!(graph.verify_theorem_7().is_ok());
+    assert!(graph.verify_theorem_7().is_none());
 
     // Verify reverse index for dst = 20
     let &(start, count) = graph
@@ -56,7 +56,7 @@ fn test_compile_transitions_from_synthetic_corpus() {
         compile_transitions_from_corpus(&corpus, region_assigner, 10).expect("compile transitions");
 
     // Verify Theorem 7
-    assert!(graph.verify_theorem_7().is_ok());
+    assert!(graph.verify_theorem_7().is_none());
 
     // Check transition counts
     // 100 -> 200 appears twice => region 10 -> region 20 weight 2
@@ -102,5 +102,5 @@ fn test_bounded_transitions_per_node() {
         2,
         "bounded to max 2 transitions per node"
     );
-    assert!(graph.verify_theorem_7().is_ok());
+    assert!(graph.verify_theorem_7().is_none());
 }

--- a/crates/uor-r4-proof-model/src/theorem7_proof.rs
+++ b/crates/uor-r4-proof-model/src/theorem7_proof.rs
@@ -4,7 +4,7 @@ use uor_r4_core::transformerless::transitions::TransitionGraph;
 
 /// Formally verify Theorem 7 reverse index consistency on a TransitionGraph.
 pub fn verify_theorem_7_proof(graph: &TransitionGraph) -> Result<(), String> {
-    graph
-        .verify_theorem_7()
-        .map_err(|e| format!("Theorem 7 proof failed: {}", e))
+    graph.verify_theorem_7().map_or(Ok(()), |reason| {
+        Err(format!("Theorem 7 proof failed: {reason}"))
+    })
 }

--- a/crates/uor-r4-proof-model/tests/proof_model_tests.rs
+++ b/crates/uor-r4-proof-model/tests/proof_model_tests.rs
@@ -52,7 +52,7 @@ fn test_theorem7_proof_verification() {
     let mut graph = TransitionGraph::new();
     graph.add_edge(1, 2, 10, EdgeKind::Forward);
     graph.add_edge(3, 2, 15, EdgeKind::Forward);
-    graph.build_reverse_index().expect("build reverse index");
+    assert!(graph.build_reverse_index().is_none(), "build reverse index");
 
     assert!(theorem7_proof::verify_theorem_7_proof(&graph).is_ok());
 }


### PR DESCRIPTION
Continues **core** (issue #510): the transition-graph construction, patch, and theorem verifiers (`uor-r4-core` `transitions.rs` + `graph_patch.rs`) to the sanctioned surface. Follows region_store (#526).

All were `String` / `&'static str` `Result`s; each is now total:

**transitions.rs**
- `verify_theorem_7` → `Option<&'static str>` (None = consistent, Some = the first violation — message preserved)
- `build_reverse_index` → `Option<&'static str>` (builds the index, forwards the Theorem 7 verdict)
- `compile_transitions_from_corpus` → `Option<TransitionGraph>` (None = the corpus did not yield a consistent graph)

**graph_patch.rs**
- `GraphPatch::apply` → `Option<String>`; `to_cbor_bytes` → `Option<Vec<u8>>`; `from_cbor_bytes` → `Option<Self>`; `Theorem11Verifier::verify_theorem_11` → `Option<String>`. Dynamic diagnostics preserved in the `Some` arm.

**proof-model**: `theorem7_proof::verify_theorem_7_proof` keeps its `Result` signature (its own tranche) via a `map_or` adapter over the new `Option`.

Tests: `.is_ok()` → `.is_none()` and the `build_reverse_index` success checks → `assert!(...is_none())`, since `None` is now the success verdict.

Build / clippy (`-D warnings`) / fmt clean; transitions / graph_patch / deterministic_rebuild / proof-model suites green; `audit-limits` no longer flags either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)