### PR TITLE
feat(#510): R5 tranche 3c — core runtime store/code layer to total ops

### DIFF
--- a/crates/uor-r4-core/src/transformerless/code_sidecar.rs
+++ b/crates/uor-r4-core/src/transformerless/code_sidecar.rs
@@ -402,7 +402,7 @@ pub fn build_store_cached(
     let codes = match load_codes(&artifact_kappa, &corpus_kappa, c.n) {
         Some(codes) => codes,
         None => {
-            let codes = runtime::codes_with_threads(art, c, threads)?;
+            let codes = runtime::codes_with_threads(art, c, threads);
             save_codes(&artifact_kappa, &corpus_kappa, &codes);
             codes
         }

--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -1591,25 +1591,25 @@ pub fn store_from_codes(c: &Corpus, codes: &[[u8; STAGES]]) -> Store {
 /// (issue #469 lever A) caches exactly the bytes this returns.
 /// Chunks are joined in chunk-id order, so the result is the serial
 /// `code_plain` sequence regardless of `threads`.
+///
+/// Total: a worker thread panicking is a bug, not a data condition, so the
+/// panic is propagated (there is no partial code sequence to report); every
+/// well-formed input yields the full serial code sequence.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn codes_with_threads(
-    art: &Compiled,
-    c: &Corpus,
-    threads: usize,
-) -> Result<Vec<[u8; STAGES]>, String> {
+pub fn codes_with_threads(art: &Compiled, c: &Corpus, threads: usize) -> Vec<[u8; STAGES]> {
     if threads <= 1 || c.n < 2 {
         let rot = derive_rotations();
-        return Ok((0..c.n)
+        return (0..c.n)
             .map(|i| {
                 let bundle = bundle_plain(art, &rot, c, i);
                 assign_for_bundle(art, &bundle)
             })
-            .collect());
+            .collect();
     }
     let worker_count = threads.min(c.n);
     let chunk_size = c.n.div_ceil(worker_count);
     let mut chunks = Vec::with_capacity(worker_count);
-    std::thread::scope(|scope| -> Result<(), String> {
+    std::thread::scope(|scope| {
         let mut handles = Vec::with_capacity(worker_count);
         for (chunk_id, start) in (0..c.n).step_by(chunk_size).enumerate() {
             let end = (start + chunk_size).min(c.n);
@@ -1629,17 +1629,16 @@ pub fn codes_with_threads(
         for (chunk_id, handle) in handles {
             let codes = handle
                 .join()
-                .map_err(|_| format!("store code worker {chunk_id} panicked"))?;
+                .unwrap_or_else(|_| panic!("store code worker {chunk_id} panicked"));
             chunks.push((chunk_id, codes));
         }
-        Ok(())
-    })?;
+    });
     chunks.sort_by_key(|(chunk_id, _)| *chunk_id);
     let mut codes = Vec::with_capacity(c.n);
     for (_, chunk) in chunks {
         codes.extend(chunk);
     }
-    Ok(codes)
+    codes
 }
 
 /// Parallel code-generation front-end for [`build_store`]. The expensive
@@ -1651,13 +1650,13 @@ pub fn build_store_with_threads(
     art: &Compiled,
     c: &Corpus,
     threads: usize,
-) -> Result<(Store, Vec<[u8; STAGES]>), String> {
+) -> (Store, Vec<[u8; STAGES]>) {
     if threads <= 1 || c.n < 2 {
-        return Ok(build_store(art, c));
+        return build_store(art, c);
     }
-    let codes = codes_with_threads(art, c, threads)?;
+    let codes = codes_with_threads(art, c, threads);
     let store = store_from_codes(c, &codes);
-    Ok((store, codes))
+    (store, codes)
 }
 
 /// The pre-#281 write-time fan-out store (multi-membership writes).
@@ -1807,68 +1806,50 @@ pub fn parse_store_legacy_u16(b: &[u8]) -> Option<Store> {
     Some(store)
 }
 
-/// Errors returned when parsing a store binary in strict u32 mode.
-#[derive(Debug, PartialEq, Eq)]
-pub enum StoreParseError {
-    InvalidFormat,
-    /// Deprecated legacy 16-bit store format detected. Recompile store artifacts using u32 token IDs.
-    LegacyStoreFormatDeprecated,
-}
-
-impl std::fmt::Display for StoreParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StoreParseError::InvalidFormat => write!(f, "invalid TLS1 store binary format"),
-            StoreParseError::LegacyStoreFormatDeprecated => write!(
-                f,
-                "legacy 16-bit TLS1 store format is deprecated; recompile store artifacts using u32 token IDs"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for StoreParseError {}
-
 /// Parse a store binary enforcing strict 32-bit integer (u32) token alignment.
-/// Fails fast with `StoreParseError::LegacyStoreFormatDeprecated` if a legacy 16-bit binary is detected.
-pub fn parse_store_strict_u32(b: &[u8]) -> Result<Store, StoreParseError> {
-    if let Some(store) = parse_store(b) {
-        return Ok(store);
-    }
-    #[allow(deprecated)]
-    if parse_store_legacy_u16(b).is_some() {
-        return Err(StoreParseError::LegacyStoreFormatDeprecated);
-    }
-    Err(StoreParseError::InvalidFormat)
+///
+/// Total: `Some(store)` for a valid u32 TLS1 binary, `None` otherwise — a
+/// binary that is not a valid u32 store is not a product, whether it is
+/// malformed or a deprecated legacy 16-bit encoding. The legacy detector
+/// [`parse_store_legacy_u16`] is retained for callers that want to
+/// distinguish the migration case.
+pub fn parse_store_strict_u32(b: &[u8]) -> Option<Store> {
+    parse_store(b)
 }
 
 /// Scan `models_dir` (e.g. `.uor-models/`) recursively for legacy `.u16` store cache files
 /// or legacy store binaries, removing them to enforce u32 recompilation. Returns the number of files purged.
+///
+/// Total, best-effort: returns the number of legacy files actually removed.
+/// A directory that cannot be enumerated contributes zero, and a file that
+/// cannot be removed is skipped rather than counted — the count is a property
+/// of what the filesystem let the purge do, not a limitation the caller must
+/// handle.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn purge_legacy_store_cache(models_dir: &std::path::Path) -> std::io::Result<usize> {
+pub fn purge_legacy_store_cache(models_dir: &std::path::Path) -> usize {
     if !models_dir.exists() {
-        return Ok(0);
+        return 0;
     }
+    let Ok(entries) = std::fs::read_dir(models_dir) else {
+        return 0;
+    };
     let mut purged = 0usize;
-    let entries = std::fs::read_dir(models_dir)?;
-    for entry in entries {
-        let entry = entry?;
+    for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            purged += purge_legacy_store_cache(&path)?;
-        } else if let Some(ext) = path.extension() {
-            if ext == "u16"
-                || path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|s| s.contains("legacy_u16"))
-            {
-                std::fs::remove_file(&path)?;
-                purged += 1;
-            }
+            purged += purge_legacy_store_cache(&path);
+            continue;
+        }
+        let is_legacy = path.extension().is_some_and(|ext| ext == "u16")
+            || path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|s| s.contains("legacy_u16"));
+        if is_legacy && std::fs::remove_file(&path).is_ok() {
+            purged += 1;
         }
     }
-    Ok(purged)
+    purged
 }
 
 /// κ-label of a store's TLS1 bytes.

--- a/crates/uor-r4-core/tests/code_sidecar.rs
+++ b/crates/uor-r4-core/tests/code_sidecar.rs
@@ -89,7 +89,7 @@ fn sidecar_round_trip_matches_fresh_codes() {
     let mut computed = 0usize;
     let cold = code_sidecar::corpus_codes_cached(&art, &corpus, || {
         computed += 1;
-        runtime::codes_with_threads(&art, &corpus, 2).expect("codes")
+        runtime::codes_with_threads(&art, &corpus, 2)
     });
     assert_eq!(computed, 1, "cold run must compute");
     assert_eq!(cold, expected, "computed codes match code_plain");
@@ -107,8 +107,7 @@ fn sidecar_round_trip_matches_fresh_codes() {
 
     // The store built from read-back codes is byte-identical to the store
     // built by the uncached path.
-    let (reference_store, reference_codes) =
-        runtime::build_store_with_threads(&art, &corpus, 2).expect("reference store");
+    let (reference_store, reference_codes) = runtime::build_store_with_threads(&art, &corpus, 2);
     assert_eq!(reference_codes, expected);
     let (cached_store, cached_codes) =
         code_sidecar::build_store_cached(&art, &corpus, 2).expect("cached store");

--- a/crates/uor-r4-core/tests/store_legacy_test.rs
+++ b/crates/uor-r4-core/tests/store_legacy_test.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use uor_r4_core::transformerless::compiler::STAGES;
 use uor_r4_core::transformerless::runtime::{
-    parse_store_strict_u32, purge_legacy_store_cache, store_bytes, Store, StoreParseError,
+    parse_store_strict_u32, purge_legacy_store_cache, store_bytes, Store,
 };
 
 #[allow(deprecated)]
@@ -31,10 +31,7 @@ fn build_legacy_u16_store_bytes() -> Vec<u8> {
 #[test]
 fn test_parse_store_strict_u32_rejects_legacy_u16_binary() {
     let legacy_bytes = build_legacy_u16_store_bytes();
-    assert_eq!(
-        parse_store_strict_u32(&legacy_bytes),
-        Err(StoreParseError::LegacyStoreFormatDeprecated)
-    );
+    assert!(parse_store_strict_u32(&legacy_bytes).is_none());
 }
 
 #[test]
@@ -65,7 +62,7 @@ fn test_purge_legacy_store_cache() {
     assert!(legacy_file.exists());
     assert!(valid_file.exists());
 
-    let purged = purge_legacy_store_cache(&tmp_dir).expect("purge legacy store cache");
+    let purged = purge_legacy_store_cache(&tmp_dir);
     assert_eq!(purged, 1);
     assert!(!legacy_file.exists());
     assert!(valid_file.exists());

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2498,8 +2498,7 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), String> {
     let threads = std::thread::available_parallelism()
         .map(|count| count.get().min(8))
         .unwrap_or(1);
-    let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads)
-        .map_err(|error| format!("parallel recorded store build failed: {error}"))?;
+    let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads);
 
     std::fs::create_dir_all(&options.output).map_err(|error| error.to_string())?;
     std::fs::write(

--- a/crates/uor-r4-graph-cli/src/runtime_corpus.rs
+++ b/crates/uor-r4-graph-cli/src/runtime_corpus.rs
@@ -241,7 +241,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
     )
     .ok_or_else(|| "runtime corpus failed its own round-trip validation".to_owned())?;
     let threads = options.threads.min(final_corpus.n.max(1));
-    let (rebuilt_store, _) = runtime::build_store_with_threads(&art, &final_corpus, threads)?;
+    let (rebuilt_store, _) = runtime::build_store_with_threads(&art, &final_corpus, threads);
     let rebuilt_store_bytes = runtime::store_bytes(&rebuilt_store);
     fs::write(options.output.join("tless_artifacts.bin"), &artifact_bytes)
         .map_err(|error| error.to_string())?;


### PR DESCRIPTION
Continues **core** (issue #510): the store-parse and parallel code/store generation in `uor-r4-core::transformerless::runtime`. Follows region_store (#526) and the TransitionGraph cluster (#527).

- `parse_store_strict_u32` → `Option<Store>` (None = not a valid u32 TLS1 store, whether malformed or a deprecated legacy 16-bit encoding). `StoreParseError` removed; the legacy detector `parse_store_legacy_u16` is **retained** (R4) for callers that want to distinguish the migration case.
- `codes_with_threads` → `Vec<[u8; STAGES]>` and `build_store_with_threads` → `(Store, Vec<[u8; STAGES]>)`: a worker thread panicking is a bug, not a data condition, so the panic is propagated (there is no partial code sequence to report) and the functions are total.
- `purge_legacy_store_cache` → `usize`: total, best-effort — an unenumerable directory contributes zero and an unremovable file is skipped.

Callers adapted (drop `?`/`.map_err`/`.expect` on the now-total returns): `code_sidecar::build_store_cached`, graph-cli `runtime_corpus` + recorded-store build, and the code_sidecar / store_legacy tests. `build_store_cached` keeps its own `String` `Result` (its own code_sidecar tranche).

`audit-limits`: core `runtime.rs` reports **zero** unsanctioned errors. Build / clippy (`-D warnings`) / fmt clean; all workspace test targets compile; store_legacy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)