### PR TITLE
feat(#510): R5 tranche 3f — core code_sidecar to total ops

### DIFF
--- a/crates/uor-r4-core/src/transformerless/code_sidecar.rs
+++ b/crates/uor-r4-core/src/transformerless/code_sidecar.rs
@@ -176,34 +176,11 @@ pub fn sidecar_bytes(artifact_kappa: &str, corpus_kappa: &str, codes: &[[u8; STA
     b
 }
 
-/// Why a sidecar was not usable. Reported in the provenance log so a MISS
-/// is never mysterious.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SidecarReject {
-    Magic,
-    Version(u32),
-    Stages(u32),
-    RecordCount(u64),
-    ArtifactKappa(String),
-    CorpusKappa(String),
-    Truncated,
-    Digest,
-}
-
-impl std::fmt::Display for SidecarReject {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SidecarReject::Magic => write!(f, "not an {} container", MAGIC.escape_ascii()),
-            SidecarReject::Version(v) => write!(f, "version {v} (expected {VERSION})"),
-            SidecarReject::Stages(s) => write!(f, "stages {s} (expected {STAGES})"),
-            SidecarReject::RecordCount(n) => write!(f, "record count {n} does not match corpus"),
-            SidecarReject::ArtifactKappa(k) => write!(f, "artifact κ {k} does not match"),
-            SidecarReject::CorpusKappa(k) => write!(f, "corpus κ {k} does not match"),
-            SidecarReject::Truncated => write!(f, "truncated or over-long container"),
-            SidecarReject::Digest => write!(f, "code-block digest mismatch"),
-        }
-    }
-}
+// R5 (#510): a sidecar either verifies into the exact code block or it does
+// not — magic/version/stages/record-count/κ/digest are all properties of the
+// bytes on disk, so `parse_sidecar` is total (`None` = not a usable sidecar)
+// and the former `SidecarReject` enum is removed. The provenance log still
+// names the path and κs on a MISS.
 
 fn read_u16(b: &[u8], at: usize) -> Option<usize> {
     let raw = b.get(at..at + 2)?;
@@ -217,61 +194,46 @@ pub fn parse_sidecar(
     artifact_kappa: &str,
     corpus_kappa: &str,
     records: usize,
-) -> Result<Vec<[u8; STAGES]>, SidecarReject> {
+) -> Option<Vec<[u8; STAGES]>> {
     if bytes.len() < HEADER_FIXED || &bytes[0..4] != MAGIC {
-        return Err(SidecarReject::Magic);
+        return None;
     }
     let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
     if version != VERSION {
-        return Err(SidecarReject::Version(version));
+        return None;
     }
     let stages = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
     if stages as usize != STAGES {
-        return Err(SidecarReject::Stages(stages));
+        return None;
     }
     let count = u64::from_le_bytes(bytes[12..20].try_into().unwrap());
     if count != records as u64 {
-        return Err(SidecarReject::RecordCount(count));
+        return None;
     }
     let mut offset = HEADER_FIXED;
-    let art_len = read_u16(bytes, offset).ok_or(SidecarReject::Truncated)?;
+    let art_len = read_u16(bytes, offset)?;
     offset += 2;
-    let art_key = bytes
-        .get(offset..offset + art_len)
-        .ok_or(SidecarReject::Truncated)?;
+    let art_key = bytes.get(offset..offset + art_len)?;
     offset += art_len;
-    let corpus_len = read_u16(bytes, offset).ok_or(SidecarReject::Truncated)?;
+    let corpus_len = read_u16(bytes, offset)?;
     offset += 2;
-    let corpus_key = bytes
-        .get(offset..offset + corpus_len)
-        .ok_or(SidecarReject::Truncated)?;
+    let corpus_key = bytes.get(offset..offset + corpus_len)?;
     offset += corpus_len;
     if art_key != artifact_kappa.as_bytes() {
-        return Err(SidecarReject::ArtifactKappa(
-            String::from_utf8_lossy(art_key).into_owned(),
-        ));
+        return None;
     }
     if corpus_key != corpus_kappa.as_bytes() {
-        return Err(SidecarReject::CorpusKappa(
-            String::from_utf8_lossy(corpus_key).into_owned(),
-        ));
+        return None;
     }
-    let digest = bytes
-        .get(offset..offset + DIGEST_BYTES)
-        .ok_or(SidecarReject::Truncated)?
-        .to_vec();
+    let digest = bytes.get(offset..offset + DIGEST_BYTES)?.to_vec();
     offset += DIGEST_BYTES;
-    let packed_len = records
-        .checked_mul(STAGES)
-        .ok_or(SidecarReject::RecordCount(count))?;
-    let packed = bytes
-        .get(offset..offset + packed_len)
-        .ok_or(SidecarReject::Truncated)?;
+    let packed_len = records.checked_mul(STAGES)?;
+    let packed = bytes.get(offset..offset + packed_len)?;
     if offset + packed_len != bytes.len() {
-        return Err(SidecarReject::Truncated);
+        return None;
     }
     if blake3::hash(packed).as_bytes()[..] != digest[..] {
-        return Err(SidecarReject::Digest);
+        return None;
     }
     let mut codes = Vec::with_capacity(records);
     for chunk in packed.chunks_exact(STAGES) {
@@ -279,7 +241,7 @@ pub fn parse_sidecar(
         code.copy_from_slice(chunk);
         codes.push(code);
     }
-    Ok(codes)
+    Some(codes)
 }
 
 /// Read the sidecar at [`codes_path`] and verify it against the given keys.
@@ -303,7 +265,7 @@ pub fn load_codes(
         }
     };
     match parse_sidecar(&bytes, artifact_kappa, corpus_kappa, records) {
-        Ok(codes) => {
+        Some(codes) => {
             eprintln!(
                 "code sidecar: LOADED {path} ({} records, {} bytes, artifact κ \
                  {artifact_kappa}, corpus κ {corpus_kappa})",
@@ -312,9 +274,10 @@ pub fn load_codes(
             );
             Some(codes)
         }
-        Err(reason) => {
+        None => {
             eprintln!(
-                "code sidecar: MISS {path} ({reason}); computing {records} record codes \
+                "code sidecar: MISS {path} (failed a magic/version/stages/count/κ/digest \
+                 check); computing {records} record codes \
                  (artifact κ {artifact_kappa}, corpus κ {corpus_kappa})"
             );
             None
@@ -365,8 +328,8 @@ pub fn build_store_cached(
     art: &Compiled,
     c: &Corpus,
     _threads: usize,
-) -> Result<(runtime::Store, Vec<[u8; STAGES]>), String> {
-    Ok(runtime::build_store(art, c))
+) -> (runtime::Store, Vec<[u8; STAGES]>) {
+    runtime::build_store(art, c)
 }
 
 /// Per-record codes for a whole corpus: served from the sidecar when it
@@ -397,7 +360,7 @@ pub fn build_store_cached(
     art: &Compiled,
     c: &Corpus,
     threads: usize,
-) -> Result<(runtime::Store, Vec<[u8; STAGES]>), String> {
+) -> (runtime::Store, Vec<[u8; STAGES]>) {
     let (artifact_kappa, corpus_kappa) = sidecar_keys(art, c);
     let codes = match load_codes(&artifact_kappa, &corpus_kappa, c.n) {
         Some(codes) => codes,
@@ -408,5 +371,5 @@ pub fn build_store_cached(
         }
     };
     let store = runtime::store_from_codes(c, &codes);
-    Ok((store, codes))
+    (store, codes)
 }

--- a/crates/uor-r4-core/tests/code_sidecar.rs
+++ b/crates/uor-r4-core/tests/code_sidecar.rs
@@ -14,9 +14,7 @@
 //! environment (`R4_CODES_PATH`); every rejection case exercises the pure
 //! parser, so the suite is parallel-safe within this test binary.
 
-use uor_r4_core::transformerless::code_sidecar::{
-    self, parse_sidecar, sidecar_bytes, SidecarReject,
-};
+use uor_r4_core::transformerless::code_sidecar::{self, parse_sidecar, sidecar_bytes};
 use uor_r4_core::transformerless::compiler::{self, Compiled, Corpus, STAGES};
 use uor_r4_core::transformerless::runtime;
 
@@ -109,8 +107,7 @@ fn sidecar_round_trip_matches_fresh_codes() {
     // built by the uncached path.
     let (reference_store, reference_codes) = runtime::build_store_with_threads(&art, &corpus, 2);
     assert_eq!(reference_codes, expected);
-    let (cached_store, cached_codes) =
-        code_sidecar::build_store_cached(&art, &corpus, 2).expect("cached store");
+    let (cached_store, cached_codes) = code_sidecar::build_store_cached(&art, &corpus, 2);
     assert_eq!(cached_codes, expected);
     assert_eq!(
         runtime::store_bytes(&cached_store),
@@ -143,10 +140,7 @@ fn a_mismatched_artifact_kappa_is_rejected() {
     let codes = good_codes();
     let bytes = sidecar_bytes("blake3:art-A", "blake3:corpus", &codes);
     let got = parse_sidecar(&bytes, "blake3:art-B", "blake3:corpus", codes.len());
-    assert!(
-        matches!(got, Err(SidecarReject::ArtifactKappa(_))),
-        "{got:?}"
-    );
+    assert!(got.is_none(), "{got:?}");
 }
 
 #[test]
@@ -154,7 +148,7 @@ fn a_mismatched_corpus_kappa_is_rejected() {
     let codes = good_codes();
     let bytes = sidecar_bytes("blake3:art", "blake3:corpus-A", &codes);
     let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus-B", codes.len());
-    assert!(matches!(got, Err(SidecarReject::CorpusKappa(_))), "{got:?}");
+    assert!(got.is_none(), "{got:?}");
 }
 
 #[test]
@@ -163,13 +157,13 @@ fn a_truncated_container_is_rejected() {
     let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
     for cut in [0usize, 4, 12, 24, 60, bytes.len() - 1] {
         let got = parse_sidecar(&bytes[..cut], "blake3:art", "blake3:corpus", codes.len());
-        assert!(got.is_err(), "prefix of {cut} bytes must not load");
+        assert!(got.is_none(), "prefix of {cut} bytes must not load");
     }
     // Over-long is rejected too: the header must account for every byte.
     let mut extended = bytes.clone();
     extended.push(0);
     let got = parse_sidecar(&extended, "blake3:art", "blake3:corpus", codes.len());
-    assert!(matches!(got, Err(SidecarReject::Truncated)), "{got:?}");
+    assert!(got.is_none(), "{got:?}");
 }
 
 #[test]
@@ -179,7 +173,7 @@ fn a_wrong_stage_count_is_rejected() {
     let wrong = (STAGES as u32) + 1;
     bytes[8..12].copy_from_slice(&wrong.to_le_bytes());
     let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len());
-    assert!(matches!(got, Err(SidecarReject::Stages(_))), "{got:?}");
+    assert!(got.is_none(), "{got:?}");
 }
 
 #[test]
@@ -187,7 +181,7 @@ fn a_wrong_record_count_is_rejected() {
     let codes = good_codes();
     let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
     let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len() + 1);
-    assert!(matches!(got, Err(SidecarReject::RecordCount(_))), "{got:?}");
+    assert!(got.is_none(), "{got:?}");
 }
 
 #[test]
@@ -196,16 +190,10 @@ fn a_wrong_magic_or_version_is_rejected() {
     let bytes = sidecar_bytes("blake3:art", "blake3:corpus", &codes);
     let mut foreign = bytes.clone();
     foreign[0..4].copy_from_slice(b"TLA7");
-    assert!(matches!(
-        parse_sidecar(&foreign, "blake3:art", "blake3:corpus", codes.len()),
-        Err(SidecarReject::Magic)
-    ));
+    assert!(parse_sidecar(&foreign, "blake3:art", "blake3:corpus", codes.len()).is_none());
     let mut future = bytes;
     future[4..8].copy_from_slice(&(code_sidecar::VERSION + 1).to_le_bytes());
-    assert!(matches!(
-        parse_sidecar(&future, "blake3:art", "blake3:corpus", codes.len()),
-        Err(SidecarReject::Version(_))
-    ));
+    assert!(parse_sidecar(&future, "blake3:art", "blake3:corpus", codes.len()).is_none());
 }
 
 #[test]
@@ -215,7 +203,7 @@ fn a_corrupted_code_block_is_rejected() {
     let last = bytes.len() - 1;
     bytes[last] ^= 0xff;
     let got = parse_sidecar(&bytes, "blake3:art", "blake3:corpus", codes.len());
-    assert!(matches!(got, Err(SidecarReject::Digest)), "{got:?}");
+    assert!(got.is_none(), "{got:?}");
 }
 
 /// The corpus key changes when the corpus content changes, so a sidecar

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1143,7 +1143,7 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
     // #469 lever A: per-record codes come from the κ-keyed sidecar when one
     // verifies against this artifact κ and corpus κ, and are written back
     // when it does not. Store bytes are identical on both branches.
-    let (store, _) = code_sidecar::build_store_cached(&artifacts, &corpus, threads)?;
+    let (store, _) = code_sidecar::build_store_cached(&artifacts, &corpus, threads);
     let tls1 = runtime::store_bytes(&store);
     // The "code sidecar: HIT/MISS/WROTE/LOADED" line above is inside this
     // phase: a cold miss recomputes every record code (#469 lever A), which is


### PR DESCRIPTION
Continues **core** (issue #510): the per-record graded-code sidecar (`uor-r4-core::transformerless::code_sidecar`).

- `parse_sidecar` → `Option<Vec<[u8; STAGES]>>`. A sidecar either verifies into the exact code block or it does not; magic / version / stages / record-count / κ / digest are all properties of the bytes on disk, so the eight-variant `SidecarReject` enum is removed and every check yields `None`. `load_codes` still logs a greppable MISS line with the path and κs.
- `build_store_cached` (wasm + native) → `(Store, Vec<[u8; STAGES]>)`. After #528 made `codes_with_threads` total, this had no remaining error path. The graph-cli caller drops its `?`.

Tests: the per-variant rejection assertions become `is_none()` — the safety property (a stale/foreign/truncated/corrupted sidecar never loads) is preserved; the variant distinction is the R5 diagnostic trade-off.

`audit-limits`: `code_sidecar.rs` reports **zero** unsanctioned errors. Build / clippy (`-D warnings`) / fmt clean; the code_sidecar test target compiles and is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)