### PR TITLE
feat(#510): R5 tranche 3g — core compiler + convert_r4g1 to total ops

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -297,18 +297,18 @@ impl RecordedRepresentation {
     /// optional `<records>.hidden` sidecar may exist, but is deliberately not
     /// read: the production compiler's input contract is the portable corpus
     /// record stream itself.
-    pub fn from_corpus(corpus: &Corpus, vocab: usize) -> Result<Self, String> {
+    pub fn from_corpus(corpus: &Corpus, vocab: usize) -> Option<Self> {
         if vocab == 0 {
-            return Err("recorded compile requires a non-zero vocabulary size".to_owned());
+            return None;
         }
         if vocab > u32::MAX as usize {
-            return Err("recorded compile vocabulary exceeds u32 token ids".to_owned());
+            return None;
         }
         if corpus.input.len() != corpus.n
             || corpus.top_tokens.len() != corpus.n
             || corpus.top_weights.len() != corpus.n
         {
-            return Err("recorded corpus arrays do not match the record count".to_owned());
+            return None;
         }
         let mut sums = vec![0.0f64; vocab * D];
         let mut counts = vec![0u64; vocab];
@@ -375,7 +375,7 @@ impl RecordedRepresentation {
         for value in &rows {
             hasher.update(&value.to_le_bytes());
         }
-        Ok(Self {
+        Some(Self {
             rows,
             vocab,
             kappa: format!("blake3:{}", hasher.finalize().to_hex()),
@@ -418,17 +418,17 @@ impl RepresentationSource for RecordedRepresentation {
 
 /// Compile directly from a completed recorded corpus without loading a
 /// teacher or invoking any model forward path.
-pub fn compile_recorded(corpus: &Corpus, vocab: usize) -> Result<Compiled, String> {
+pub fn compile_recorded(corpus: &Corpus, vocab: usize) -> Option<Compiled> {
     if corpus.n == 0 || corpus.stories == 0 {
-        return Err("recorded compile requires a non-empty corpus".to_owned());
+        return None;
     }
     if corpus.input.len() != corpus.n {
-        return Err("corpus input/record count mismatch".to_owned());
+        return None;
     }
     let source = RecordedRepresentation::from_corpus(corpus, vocab)?;
     let source_kappa = source.kappa().to_owned();
     let source_bytes = source.rows.len() * std::mem::size_of::<f32>();
-    Ok(compile_from_representation(
+    Some(compile_from_representation(
         &source,
         &source_kappa,
         source_bytes,

--- a/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
+++ b/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
@@ -183,23 +183,20 @@ pub fn convert(
     store: &Store,
     store_container: &[u8],
     calibration: Option<&HammingCalibrationReport>,
-) -> Result<(Vec<u8>, ConversionReport), String> {
+) -> Option<(Vec<u8>, ConversionReport)> {
     // Input shape honesty: the artifact must carry the 4 × 256 × 36-byte
     // class signature books the ROUT section is built from.
     if !artifacts.token_codes.len().is_multiple_of(STAGES) {
-        return Err("token code table is not a whole number of stages".to_owned());
+        return None;
     }
-    let vocab = u32::try_from(artifacts.token_codes.len() / STAGES)
-        .map_err(|_| "vocabulary exceeds u32 token ids".to_owned())?;
+    let vocab = u32::try_from(artifacts.token_codes.len() / STAGES).ok()?;
     if artifacts.class_sigs.len() != STAGES
         || artifacts
             .class_sigs
             .iter()
             .any(|sigs| sigs.len() != K * SIG_BYTES)
     {
-        return Err(format!(
-            "class signature books must be {STAGES} × {K} × {SIG_BYTES} bytes"
-        ));
+        return None;
     }
 
     // Radii: calibration where present, the 288 default elsewhere.
@@ -294,10 +291,8 @@ pub fn convert(
     let mut root_prior_entries = 0u32;
     if let Some(dist) = store.first().and_then(|level| level.get(&[][..])) {
         for (&token, &count) in dist {
-            let token = i32::try_from(token)
-                .map_err(|_| format!("root prior token {token} exceeds i32 storage"))?;
-            let count = i32::try_from(count)
-                .map_err(|_| format!("root prior count {count} exceeds i32 storage"))?;
+            let token = i32::try_from(token).ok()?;
+            let count = i32::try_from(count).ok()?;
             emit.extend_from_slice(&token.to_le_bytes());
             emit.extend_from_slice(&count.to_le_bytes());
             root_prior_entries += 1;
@@ -401,9 +396,7 @@ pub fn convert(
     builder.add_section(SectionId::ROUT, 0, &rout);
     builder.add_section(SectionId::EMIT, 0, &emit);
     builder.add_section(SectionId::EXCT, 0, &exct);
-    let bytes = builder
-        .build()
-        .map_err(|error| format!("R4G1 serialization failed: {error}"))?;
+    let bytes = builder.build().ok()?;
 
     let report = ConversionReport {
         node_count: NODE_COUNT,
@@ -417,7 +410,7 @@ pub fn convert(
         max_emission_entries: DEFAULT_MAX_EMISSION_ENTRIES,
         artifact_bytes: bytes.len(),
     };
-    Ok((bytes, report))
+    Some((bytes, report))
 }
 
 /// Serialize the fixed 224-byte HEAD prefix (v0 draft line, RFC §4.1).

--- a/crates/uor-r4-graph-cli/src/convert_r4g1.rs
+++ b/crates/uor-r4-graph-cli/src/convert_r4g1.rs
@@ -60,7 +60,11 @@ pub fn run(args: &[String]) -> Result<(), String> {
         &store,
         &store_bytes,
         calibration.as_ref(),
-    )?;
+    )
+    .ok_or_else(|| {
+        "R4G1 conversion failed: token codes, vocabulary, or class-signature books are malformed"
+            .to_string()
+    })?;
 
     // Fail closed: the converter must never emit an artifact its own
     // two-stage validator or the integrity CIDs reject.

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2491,7 +2491,8 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), String> {
         "recorded compile: {} records, {} stories, vocabulary {} (no teacher loaded)",
         corpus.n, corpus.stories, options.vocab_size
     );
-    let artifacts = compiler::compile_recorded(&corpus, options.vocab_size)?;
+    let artifacts = compiler::compile_recorded(&corpus, options.vocab_size)
+        .ok_or_else(|| "recorded compile failed: empty corpus or invalid vocabulary".to_string())?;
     let calibration = compiler::calibrate_hamming_regions(&artifacts, &corpus);
     let hierarchical =
         compiler::induce_hierarchical_codes(&artifacts.token_codes, options.vocab_size, &corpus);


### PR DESCRIPTION
Continues **core** (issue #510): the recorded-corpus compile entry points and the R4G1 converter.

- `RecordedRepresentation::from_corpus` → `Option<Self>`, `compile_recorded` → `Option<Compiled>`. A recorded corpus either compiles or it does not — a zero/oversized vocabulary or corpus arrays disagreeing with the record count yield `None`.
- `convert_r4g1::convert` → `Option<(Vec<u8>, ConversionReport)>`. Malformed token codes, an over-u32 vocabulary, wrong-shape class-signature books, or a serialization failure yield `None`.

Callers: the graph-cli recorded-compile and R4G1-convert commands map `None` to their own `String` context via `ok_or_else`; tests use `.expect`/`.unwrap`.

`audit-limits`: core `compiler.rs` and `convert_r4g1.rs` report zero unsanctioned errors. Build / clippy (`-D warnings`) / fmt clean; all workspace test targets compile.

Note: two categories remain in core for follow-up tranches — the serde `serialize`/`deserialize` helpers (`Result<S::Ok, S::Error>`, a serde trait contract the gate should carve out) and the legacy `scenarios.rs` `io::Result` I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)