### PR TITLE
feat(#510): carve serde Serialize/Deserialize contracts out of audit-limits

### DIFF
--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -147,6 +147,17 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
             if sanctioned.iter().any(|s| tail.contains(s)) {
                 continue;
             }
+            // serde's `Serialize`/`Deserialize` contract is not the model's
+            // error surface: a `Serializer::serialize_*`-shaped helper returns
+            // `Result<S::Ok, S::Error>` and a `Deserialize::deserialize`-shaped
+            // helper returns `Result<T, D::Error>`, where the error is the
+            // *data format's* (the caller's serde impl), not a limitation this
+            // model reports. These associated-type signatures are fixed by the
+            // trait and cannot name a sanctioned type, so they are carved out
+            // exactly like a sanctioned return.
+            if tail.contains("S::Ok") || tail.contains("S::Error") || tail.contains("D::Error") {
+                continue;
+            }
             violations.push(format!("{}:{line_no}:{}", src.rel, line.trim()));
         }
     }


### PR DESCRIPTION
The `audit-limits` gate (R5) flags any shipped-crate `Result<...>` whose error is not a sanctioned type. serde's `Serialize`/`Deserialize` contract is a **false positive**: a `Serializer::serialize`-shaped helper must return `Result<S::Ok, S::Error>` and a `Deserialize::deserialize`-shaped helper must return `Result<T, D::Error>`, where the error is the *data format's* (the caller's serde impl), not a limitation this model reports. Those signatures are fixed by the trait and cannot name a sanctioned type — no conversion could ever satisfy the gate.

Carve them out like a sanctioned return: a `Result<...>` tail containing `S::Ok`, `S::Error`, or `D::Error` is a serde associated-type contract, not the model's error surface. This clears the `#[serde(with)]` helpers (core `endomorphism.rs`, router's f64-vector codecs, …) without loosening the gate for any real error return.

Unblocks the path to a zero-violation `audit-limits` and closing #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)