### PR TITLE
feat(#510): R5 tranche 3h — scenarios tokenizer encode/decode to total ops

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1214,13 +1214,13 @@ impl R4Engine {
     /// available. (The tokenizer's BPE path allocates an intermediate
     /// `String`; text helpers sit outside the allocation-free step path.)
     pub fn encode_text_into(&self, text: &str, out: &mut [u32]) -> Option<usize> {
-        self.tokenizer.as_ref()?.encode_into(text, out).ok()
+        self.tokenizer.as_ref()?.encode_into(text, out)
     }
 
     /// Decode tokens with the bundle-matched tokenizer when one is
     /// available.
     pub fn decode_tokens_into(&self, tokens: &[u32], out: &mut [u8]) -> Option<usize> {
-        self.tokenizer.as_ref()?.decode_into(tokens, out).ok()
+        self.tokenizer.as_ref()?.decode_into(tokens, out)
     }
 }
 

--- a/crates/uor-r4-core/src/transformerless/scenarios.rs
+++ b/crates/uor-r4-core/src/transformerless/scenarios.rs
@@ -302,12 +302,14 @@ impl Tokenizer {
     ///
     /// Note: the BPE path allocates an intermediate `String` for byte-level
     /// remapping, so this is not fully allocation-free.
-    pub fn encode_into(&self, text: &str, out: &mut [u32]) -> io::Result<usize> {
-        let capacity_error = || io::Error::new(io::ErrorKind::InvalidInput, "token buffer full");
+    /// Total: `Some(count)` of tokens written, `None` when `out` cannot hold
+    /// the encoding (a property of the caller's buffer) or the text needs a
+    /// byte fallback the tokenizer lacks.
+    pub fn encode_into(&self, text: &str, out: &mut [u32]) -> Option<usize> {
         let is_llama_bos = self.vocab.get(1).is_some_and(|v| v == b"<s>");
         let mut len = 0usize;
         if is_llama_bos {
-            *out.get_mut(len).ok_or_else(capacity_error)? = 1;
+            *out.get_mut(len)? = 1;
             len += 1;
         }
 
@@ -346,19 +348,19 @@ impl Tokenizer {
                 }
 
                 if let Some(id) = matched_id {
-                    *out.get_mut(len).ok_or_else(capacity_error)? = id;
+                    *out.get_mut(len)? = id;
                     len += 1;
                     i += matched_len;
                 } else {
                     let b = bytes[i];
                     if let Some(&id) = self.map.get(&[b][..]) {
-                        *out.get_mut(len).ok_or_else(capacity_error)? = id;
+                        *out.get_mut(len)? = id;
                         len += 1;
                     }
                     i += 1;
                 }
             }
-            return Ok(len);
+            return Some(len);
         }
 
         for ch in std::iter::once(' ').chain(text.chars()) {
@@ -368,19 +370,14 @@ impl Tokenizer {
                 Some(&id) => id,
                 None => {
                     for byte in bytes {
-                        let id = self.map.get(&[*byte][..]).copied().ok_or_else(|| {
-                            io::Error::new(
-                                io::ErrorKind::InvalidInput,
-                                "tokenizer has no byte fallback",
-                            )
-                        })?;
-                        *out.get_mut(len).ok_or_else(capacity_error)? = id;
+                        let id = self.map.get(&[*byte][..]).copied()?;
+                        *out.get_mut(len)? = id;
                         len += 1;
                     }
                     continue;
                 }
             };
-            *out.get_mut(len).ok_or_else(capacity_error)? = token;
+            *out.get_mut(len)? = token;
             len += 1;
         }
         loop {
@@ -411,7 +408,7 @@ impl Tokenizer {
                 None => break,
             }
         }
-        Ok(len)
+        Some(len)
     }
 
     pub fn decode(&self, toks: &[u32]) -> String {
@@ -436,17 +433,16 @@ impl Tokenizer {
     ///
     /// Note: this delegates to `decode`, which allocates an intermediate
     /// `Vec`/`String`, so this is not allocation-free.
-    pub fn decode_into(&self, toks: &[u32], out: &mut [u8]) -> io::Result<usize> {
+    /// Total: `Some(count)` of bytes written, `None` when `out` cannot hold
+    /// the decoded text.
+    pub fn decode_into(&self, toks: &[u32], out: &mut [u8]) -> Option<usize> {
         let decoded = self.decode(toks);
         let bytes = decoded.as_bytes();
         if bytes.len() > out.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "decoded output buffer full",
-            ));
+            return None;
         }
         out[..bytes.len()].copy_from_slice(bytes);
-        Ok(bytes.len())
+        Some(bytes.len())
     }
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -34,7 +34,8 @@ pub enum ChatError {
     InvalidArtifacts,
     /// The graded store container was invalid.
     InvalidStore,
-    /// Generation produced no tokens or could not be decoded.
+    /// Generation produced no tokens, or the question/answer could not be
+    /// tokenized or decoded into its caller-owned buffer.
     EmptyGeneration,
     /// Generation entered a repeated-token loop and was rejected.
     RepetitiveGeneration,
@@ -277,7 +278,9 @@ fn hologram_answer(
     max_tokens: usize,
 ) -> Result<ChatAnswer, ChatError> {
     let mut question_tokens = [0u32; MAX_CHAT_HISTORY];
-    let question_count = tokenizer.encode_into(question, &mut question_tokens)?;
+    let question_count = tokenizer
+        .encode_into(question, &mut question_tokens)
+        .ok_or(ChatError::EmptyGeneration)?;
     let question_tokens = if *history_len == 0 {
         &question_tokens[..question_count]
     } else {
@@ -396,7 +399,9 @@ fn hologram_answer(
                 return Err(ChatError::EmptyGeneration);
             }
             let mut answer_bytes = [0u8; MAX_ANSWER_BYTES];
-            let answer_len = tokenizer.decode_into(generated, &mut answer_bytes)?;
+            let answer_len = tokenizer
+                .decode_into(generated, &mut answer_bytes)
+                .ok_or(ChatError::EmptyGeneration)?;
             let text = String::from_utf8_lossy(&answer_bytes[..answer_len])
                 .trim()
                 .to_owned();
@@ -436,7 +441,9 @@ fn hologram_answer(
         return Err(ChatError::EmptyGeneration);
     }
     let mut answer_bytes = [0u8; MAX_ANSWER_BYTES];
-    let answer_len = tokenizer.decode_into(generated, &mut answer_bytes)?;
+    let answer_len = tokenizer
+        .decode_into(generated, &mut answer_bytes)
+        .ok_or(ChatError::EmptyGeneration)?;
     let text = String::from_utf8_lossy(&answer_bytes[..answer_len])
         .trim()
         .to_owned();

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -184,12 +184,12 @@ impl R4g1State {
 
     /// Encode with the bundle-matched tokenizer when one is available.
     pub fn encode_into(&self, text: &str, out: &mut [u32]) -> Option<usize> {
-        self.tokenizer.as_ref()?.encode_into(text, out).ok()
+        self.tokenizer.as_ref()?.encode_into(text, out)
     }
 
     /// Decode with the bundle-matched tokenizer when one is available.
     pub fn decode_into(&self, tokens: &[u32], out: &mut [u8]) -> Option<usize> {
-        self.tokenizer.as_ref()?.decode_into(tokens, out).ok()
+        self.tokenizer.as_ref()?.decode_into(tokens, out)
     }
 
     /// Score one token window using the validated graph artifact.

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -591,7 +591,7 @@ pub fn tless_tokenize(text: &str) -> Option<Vec<u32>> {
 
 /// Tokenize into caller-owned storage without allocating.
 pub fn tless_tokenize_into(text: &str, out: &mut [u32]) -> Option<usize> {
-    with_tokenizer(|tokenizer| tokenizer.encode_into(text, out).ok()).flatten()
+    with_tokenizer(|tokenizer| tokenizer.encode_into(text, out)).flatten()
 }
 
 /// Detokenize token ids with the bound tokenizer.
@@ -601,7 +601,7 @@ pub fn tless_detokenize(tokens: &[u32]) -> Option<String> {
 
 /// Detokenize into caller-owned byte storage without allocating.
 pub fn tless_detokenize_into(tokens: &[u32], out: &mut [u8]) -> Option<usize> {
-    with_tokenizer(|tokenizer| tokenizer.decode_into(tokens, out).ok()).flatten()
+    with_tokenizer(|tokenizer| tokenizer.decode_into(tokens, out)).flatten()
 }
 
 /// Index a token stream into the bound graded store as additional evidence


### PR DESCRIPTION
Converts the legacy tokenizer's buffer-writing encode/decode off `io::Result`.

- `Tokenizer::encode_into` → `Option<usize>` and `decode_into` → `Option<usize>`. These returned `io::Result<usize>` only to signal "caller buffer full" (or a missing byte fallback) — a property of the caller's chosen `out` slice, never an I/O condition. Total now: `Some(count)` written, `None` when the buffer cannot hold the result. The κ-pinned encoding/decoding behavior is unchanged.

Callers updated to the `Option` surface: api `encode_text_into`/`decode_tokens_into` drop the redundant `.ok()`; root `tless_uor` and `r4g1` wrappers drop `.ok()`; `chat` maps `None` to `ChatError::EmptyGeneration` (doc broadened).

The host-ingestion legs of `scenarios.rs` (`try_load` / `from_bytes` / the HF export helpers) remain for a follow-up tranche using the `SourceUnavailable` boundary.

Build / clippy (`-D warnings`) / fmt clean; all workspace test targets compile; api suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)