### PR TITLE
feat(#510): R5 tranche 3i — scenarios host-ingestion; core now zero

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -34,7 +34,6 @@
 //! defaults.
 
 use std::fmt;
-use std::io;
 
 use serde::{Deserialize, Serialize};
 use uor_r4_core::transformerless::compiler::{self, Compiled, SIG_BYTES, STAGES, WINDOW};
@@ -176,7 +175,7 @@ pub enum LoadError {
     /// The score report bytes are not well-formed JSON.
     InvalidScoreReport(String),
     /// The tokenizer bytes are not a well-formed binary tokenizer.
-    InvalidTokenizer(io::Error),
+    InvalidTokenizer,
     /// The graph's Rule 1+2 quality digresses from the declared quality
     /// basis (see [`validate_quality_report`]).
     QualityGate(String),
@@ -198,7 +197,7 @@ impl fmt::Display for LoadError {
             LoadError::InvalidScoreReport(message) => {
                 write!(f, "invalid score report: {message}")
             }
-            LoadError::InvalidTokenizer(error) => write!(f, "invalid tokenizer bytes: {error}"),
+            LoadError::InvalidTokenizer => write!(f, "invalid tokenizer bytes"),
             LoadError::QualityGate(message) => write!(f, "{message}"),
             LoadError::Scorer(message) => write!(f, "{message}"),
             LoadError::TeacherTooLarge => write!(f, "teacher token table too large"),
@@ -216,7 +215,6 @@ impl std::error::Error for LoadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             LoadError::InvalidGraph(error) => Some(error),
-            LoadError::InvalidTokenizer(error) => Some(error),
             _ => None,
         }
     }
@@ -1160,7 +1158,7 @@ impl R4Engine {
         }
         let tokenizer = parts
             .tokenizer
-            .map(|bytes| Tokenizer::from_bytes(bytes).map_err(LoadError::InvalidTokenizer))
+            .map(|bytes| Tokenizer::from_bytes(bytes).ok_or(LoadError::InvalidTokenizer))
             .transpose()?;
 
         let policy = StatusPolicy::from_report(score_report.as_ref());

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -54,18 +54,18 @@ fn tokenizer_from_bytes_rejects_truncated() {
         .into_iter()
         .chain(*b"a")
         .collect::<Vec<_>>();
-    let error = match Tokenizer::from_bytes(&bytes) {
-        Err(error) => error,
-        Ok(_) => panic!("truncated token must fail"),
-    };
-    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    // from_bytes is total: a truncated token yields None.
+    assert!(
+        Tokenizer::from_bytes(&bytes).is_none(),
+        "truncated token must fail"
+    );
 
     // Negative length.
     let bytes = (-1i32).to_le_bytes().to_vec();
-    assert!(Tokenizer::from_bytes(&bytes).is_err());
+    assert!(Tokenizer::from_bytes(&bytes).is_none());
 
     // Trailing partial length field.
-    assert!(Tokenizer::from_bytes(&[0u8, 1]).is_err());
+    assert!(Tokenizer::from_bytes(&[0u8, 1]).is_none());
 }
 
 // ---------------------------------------------------------- abi version --

--- a/crates/uor-r4-core/src/transformerless/scenarios.rs
+++ b/crates/uor-r4-core/src/transformerless/scenarios.rs
@@ -86,6 +86,7 @@ pub fn export_hf_bytelevel_tokenizer_with_lengths(
     Ok(lengths)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn hf_bytelevel_tokens(
     source: impl AsRef<Path>,
 ) -> Result<Vec<Vec<u8>>, uor_r4_model_source::SourceUnavailable> {
@@ -116,6 +117,7 @@ fn hf_bytelevel_tokens(
     Ok(tokens)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn bytelevel_inverse() -> BTreeMap<char, u8> {
     let mut bytes: Vec<u8> = (b'!'..=b'~')
         .chain(0xA1..=0xAC)

--- a/crates/uor-r4-core/src/transformerless/scenarios.rs
+++ b/crates/uor-r4-core/src/transformerless/scenarios.rs
@@ -56,7 +56,7 @@ pub fn format_instruct_chat_prompt(system_prompt: Option<&str>, user_prompt: &st
 pub fn export_hf_bytelevel_tokenizer(
     source: impl AsRef<Path>,
     destination: impl AsRef<Path>,
-) -> io::Result<()> {
+) -> Result<(), uor_r4_model_source::SourceUnavailable> {
     export_hf_bytelevel_tokenizer_with_lengths(source, destination).map(|_| ())
 }
 
@@ -66,15 +66,15 @@ pub fn export_hf_bytelevel_tokenizer(
 pub fn export_hf_bytelevel_tokenizer_with_lengths(
     source: impl AsRef<Path>,
     destination: impl AsRef<Path>,
-) -> io::Result<Vec<u32>> {
+) -> Result<Vec<u32>, uor_r4_model_source::SourceUnavailable> {
     let tokens = hf_bytelevel_tokens(source)?;
     let lengths = tokens
         .iter()
         .map(|token| {
             u32::try_from(token.len())
-                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "token too long"))
+                .map_err(|_| uor_r4_model_source::SourceUnavailable::new("token too long"))
         })
-        .collect::<io::Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>, uor_r4_model_source::SourceUnavailable>>()?;
     let mut bytes = Vec::new();
     for token in tokens {
         let length = i32::try_from(token.len())
@@ -86,23 +86,24 @@ pub fn export_hf_bytelevel_tokenizer_with_lengths(
     Ok(lengths)
 }
 
-fn hf_bytelevel_tokens(source: impl AsRef<Path>) -> io::Result<Vec<Vec<u8>>> {
-    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(source)?)
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+fn hf_bytelevel_tokens(
+    source: impl AsRef<Path>,
+) -> Result<Vec<Vec<u8>>, uor_r4_model_source::SourceUnavailable> {
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(source)?)?;
     let vocab = value
         .pointer("/model/vocab")
         .and_then(serde_json::Value::as_object)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing BPE vocabulary"))?;
+        .ok_or_else(|| uor_r4_model_source::SourceUnavailable::new("missing BPE vocabulary"))?;
     let mut tokens = vec![Vec::new(); vocab.len()];
     let byte_map = bytelevel_inverse();
     for (piece, id) in vocab {
         let id = id
             .as_u64()
             .and_then(|value| usize::try_from(value).ok())
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid token id"))?;
+            .ok_or_else(|| uor_r4_model_source::SourceUnavailable::new("invalid token id"))?;
         let output = tokens
             .get_mut(id)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "sparse token ids"))?;
+            .ok_or_else(|| uor_r4_model_source::SourceUnavailable::new("sparse token ids"))?;
         for ch in piece.chars() {
             if let Some(byte) = byte_map.get(&ch) {
                 output.push(*byte);
@@ -159,7 +160,9 @@ pub struct Tokenizer {
 impl Tokenizer {
     /// Load and validate a tokenizer without panicking on malformed input.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn try_load(path: impl AsRef<Path>) -> io::Result<Self> {
+    pub fn try_load(
+        path: impl AsRef<Path>,
+    ) -> Result<Self, uor_r4_model_source::SourceUnavailable> {
         let path_ref = path.as_ref();
 
         // 1. Try loading vocab.json if present in the target or parent directories
@@ -199,36 +202,30 @@ impl Tokenizer {
 
         // 2. Fall back to binary tokenizer.bin format
         let bytes = std::fs::read(path_ref)?;
-        Self::from_bytes(&bytes)
+        Self::from_bytes(&bytes).ok_or_else(|| {
+            uor_r4_model_source::SourceUnavailable::new(format!(
+                "{}: not a valid tokenizer.bin",
+                path_ref.display()
+            ))
+        })
     }
 
     /// Parse a tokenizer from in-memory bytes in the binary tokenizer.bin
     /// format (per token: i32 little-endian length, then the token bytes).
     /// Split from [`try_load`](Self::try_load) so library consumers can
     /// validate a bundled tokenizer without filesystem access.
-    pub fn from_bytes(bytes: &[u8]) -> io::Result<Self> {
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
         let mut vocab = Vec::new();
         let mut offset = 0usize;
         while offset < bytes.len() {
-            let length_bytes = bytes.get(offset..offset + 4).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "truncated tokenizer length")
-            })?;
-            let length = i32::from_le_bytes(
-                length_bytes
-                    .try_into()
-                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
-            );
+            let length_bytes = bytes.get(offset..offset + 4)?;
+            let length = i32::from_le_bytes(length_bytes.try_into().ok()?);
             offset += 4;
             if length < 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "negative token length",
-                ));
+                return None;
             }
             let length = length as usize;
-            let token = bytes.get(offset..offset + length).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "truncated tokenizer token")
-            })?;
+            let token = bytes.get(offset..offset + length)?;
             vocab.push(token.to_vec());
             offset += length;
         }
@@ -237,7 +234,7 @@ impl Tokenizer {
             let id = index as u32;
             map.entry(token.clone()).or_insert(id);
         }
-        Ok(Tokenizer { vocab, map })
+        Some(Tokenizer { vocab, map })
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -160,7 +160,8 @@ impl ChatEngineBuilder {
                 model_store.get(&manifest.tokenizer)?
             };
         let tokenizer_path = write_tokenizer_cache(&manifest.tokenizer.cid, &tokenizer_bytes)?;
-        let tokenizer = Tokenizer::try_load(&tokenizer_path)?;
+        let tokenizer = Tokenizer::try_load(&tokenizer_path)
+            .map_err(|error| ChatError::Io(std::io::Error::other(error.reason)))?;
         tracing::info!(
             model = %manifest.name,
             source_model = %manifest.source_model,
@@ -211,7 +212,8 @@ fn build_local_compiled_engine(
     let store_object = model_store.put(&store_bytes)?;
     let tokenizer_object = model_store.put(&tokenizer_bytes)?;
     let tokenizer_path = write_tokenizer_cache(&tokenizer_object.cid, &tokenizer_bytes)?;
-    let tokenizer = Tokenizer::try_load(&tokenizer_path)?;
+    let tokenizer = Tokenizer::try_load(&tokenizer_path)
+        .map_err(|error| ChatError::Io(std::io::Error::other(error.reason)))?;
     tracing::warn!(
         model = reference,
         directory = %directory.display(),


### PR DESCRIPTION
Finishes **core's** R5 conversion: the legacy tokenizer's file/parse boundary. After this, `uor-r4-core` reports **zero** unsanctioned errors under `audit-limits`.

- `Tokenizer::from_bytes` → `Option<Self>` (parsing the runtime `tokenizer.bin` format; a truncated/negative length or truncated token → `None`).
- `Tokenizer::try_load` → `Result<Self, uor_r4_model_source::SourceUnavailable>` — the host-ingestion boundary: an `fs::read` failure (via `From<io::Error>`) or a `tokenizer.bin` that `from_bytes` rejects reports `SourceUnavailable` with the path. The `vocab.json` probe path is unchanged.
- `export_hf_bytelevel_tokenizer` / `_with_lengths` / `hf_bytelevel_tokens` → `Result<_, SourceUnavailable>` — ingesting an external HF `vocab.json` and writing the runtime table; read/parse failure, missing vocab, or an over-long token reports `SourceUnavailable`. Written-file behavior unchanged.

Ripple: api `LoadError::InvalidTokenizer` drops its `io::Error` payload (uses `ok_or`, Display → "invalid tokenizer bytes", `Error::source` arm removed; test asserts `None`); chat maps `try_load`'s `SourceUnavailable` back through `ChatError::Io`; r4g1's `.ok()`/`load` are unaffected.

Build / clippy (`-D warnings`) / fmt clean; all workspace test targets compile; api suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)