### PR TITLE
feat(#510): R5 tranche 4a — router to the sanctioned surface

### DIFF
--- a/crates/uor-r4-router/src/benchmark.rs
+++ b/crates/uor-r4-router/src/benchmark.rs
@@ -70,21 +70,19 @@ fn evaluate_geometry<G: SemanticGeometry>(
     let mut recall_sum = 0.0;
 
     for (obj, gt_id) in queries {
-        if let Ok(grounded) = geometry.ground(obj) {
-            if let Ok(coords) = geometry.encode(&grounded) {
-                if let Ok(routes) = geometry.soft_route(&coords, 3) {
-                    // Check if ground truth maps to axis in routes
-                    let mut matched = false;
-                    for route in &routes {
-                        if route.axis as usize == *gt_id {
-                            matched = true;
-                            break;
-                        }
-                    }
-                    if matched {
-                        recall_sum += 1.0;
-                    }
+        if let Some(grounded) = geometry.ground(obj) {
+            let coords = geometry.encode(&grounded);
+            let routes = geometry.soft_route(&coords, 3);
+            // Check if ground truth maps to axis in routes
+            let mut matched = false;
+            for route in &routes {
+                if route.axis as usize == *gt_id {
+                    matched = true;
+                    break;
                 }
+            }
+            if matched {
+                recall_sum += 1.0;
             }
         }
     }

--- a/crates/uor-r4-router/src/fallback.rs
+++ b/crates/uor-r4-router/src/fallback.rs
@@ -251,76 +251,50 @@ impl FallbackRouter {
 
     /// Execute inference generation with automatic fallback cascading.
     ///
-    /// Evaluates `primary_fn`. If `primary_fn` returns `EngineStatus::Success`, returns the result directly.
-    /// If `primary_fn` returns `UnmappedRegion` or `Pathological`, logs a `tracing::info!` fallback event
-    /// and invokes `secondary_fn`, returning a clean `FallbackResult`.
+    /// Evaluates `primary_fn`. If it returns [`EngineStatus::Success`], returns
+    /// that result directly. For any other status (`UnmappedRegion`,
+    /// `Pathological`, `Failed`, `Abstained`) it logs a `tracing::info!`
+    /// fallback event and invokes `secondary_fn`, returning a clean
+    /// [`FallbackResult`].
+    ///
+    /// Each engine closure returns an [`EngineResponse`] directly: the outcome
+    /// — success or otherwise — is carried in the response's own
+    /// [`EngineStatus`], not a separate error channel. A failed engine reports
+    /// `EngineStatus::Failed` with its explanatory text, so there is no bound
+    /// on how an engine may report (R5 — the closures are total).
     pub fn execute<FPrimary, FSecondary>(
         &self,
         mut primary_fn: FPrimary,
         mut secondary_fn: FSecondary,
     ) -> FallbackResult
     where
-        FPrimary: FnMut() -> Result<EngineResponse, String>,
-        FSecondary: FnMut() -> Result<EngineResponse, String>,
+        FPrimary: FnMut() -> EngineResponse,
+        FSecondary: FnMut() -> EngineResponse,
     {
-        match primary_fn() {
-            Ok(res) if res.status == EngineStatus::Success => FallbackResult {
-                text: res.text,
+        let primary_res = primary_fn();
+        if primary_res.status == EngineStatus::Success {
+            return FallbackResult {
+                text: primary_res.text,
                 primary_status: EngineStatus::Success,
                 fallback_triggered: false,
-                active_engine: res.engine,
-                tokens_generated: res.tokens_generated,
-            },
-            Ok(primary_res) => {
-                tracing::info!(
-                    target: "uor_r4_router::fallback",
-                    primary = %self.primary_name,
-                    secondary = %self.secondary_name,
-                    primary_status = %primary_res.status,
-                    "Primary engine status requiring fallback; cascading to secondary engine"
-                );
-                match secondary_fn() {
-                    Ok(sec_res) => FallbackResult {
-                        text: sec_res.text,
-                        primary_status: primary_res.status,
-                        fallback_triggered: true,
-                        active_engine: sec_res.engine,
-                        tokens_generated: sec_res.tokens_generated,
-                    },
-                    Err(err) => FallbackResult {
-                        text: format!("Fallback engine error: {err}"),
-                        primary_status: primary_res.status,
-                        fallback_triggered: true,
-                        active_engine: self.secondary_name.clone(),
-                        tokens_generated: 0,
-                    },
-                }
-            }
-            Err(err) => {
-                tracing::info!(
-                    target: "uor_r4_router::fallback",
-                    primary = %self.primary_name,
-                    secondary = %self.secondary_name,
-                    error = %err,
-                    "Primary engine returned error; cascading to secondary fallback engine"
-                );
-                match secondary_fn() {
-                    Ok(sec_res) => FallbackResult {
-                        text: sec_res.text,
-                        primary_status: EngineStatus::Failed,
-                        fallback_triggered: true,
-                        active_engine: sec_res.engine,
-                        tokens_generated: sec_res.tokens_generated,
-                    },
-                    Err(sec_err) => FallbackResult {
-                        text: format!("Primary error: {err}; Secondary error: {sec_err}"),
-                        primary_status: EngineStatus::Failed,
-                        fallback_triggered: true,
-                        active_engine: self.secondary_name.clone(),
-                        tokens_generated: 0,
-                    },
-                }
-            }
+                active_engine: primary_res.engine,
+                tokens_generated: primary_res.tokens_generated,
+            };
+        }
+        tracing::info!(
+            target: "uor_r4_router::fallback",
+            primary = %self.primary_name,
+            secondary = %self.secondary_name,
+            primary_status = %primary_res.status,
+            "Primary engine status requiring fallback; cascading to secondary engine"
+        );
+        let sec_res = secondary_fn();
+        FallbackResult {
+            text: sec_res.text,
+            primary_status: primary_res.status,
+            fallback_triggered: true,
+            active_engine: sec_res.engine,
+            tokens_generated: sec_res.tokens_generated,
         }
     }
 }
@@ -333,13 +307,11 @@ mod tests {
     fn test_fallback_router_primary_success() {
         let router = FallbackRouter::default();
         let res = router.execute(
-            || {
-                Ok(EngineResponse {
-                    text: "Primary clean output".to_string(),
-                    status: EngineStatus::Success,
-                    engine: "r4g1-graph".to_string(),
-                    tokens_generated: 10,
-                })
+            || EngineResponse {
+                text: "Primary clean output".to_string(),
+                status: EngineStatus::Success,
+                engine: "r4g1-graph".to_string(),
+                tokens_generated: 10,
             },
             || panic!("secondary should not be called"),
         );
@@ -354,21 +326,17 @@ mod tests {
     fn test_fallback_router_unmapped_region_triggers_fallback() {
         let router = FallbackRouter::default();
         let res = router.execute(
-            || {
-                Ok(EngineResponse {
-                    text: "".to_string(),
-                    status: EngineStatus::UnmappedRegion,
-                    engine: "r4g1-graph".to_string(),
-                    tokens_generated: 0,
-                })
+            || EngineResponse {
+                text: "".to_string(),
+                status: EngineStatus::UnmappedRegion,
+                engine: "r4g1-graph".to_string(),
+                tokens_generated: 0,
             },
-            || {
-                Ok(EngineResponse {
-                    text: "Secondary fallback output".to_string(),
-                    status: EngineStatus::Success,
-                    engine: "transformerless-tla5".to_string(),
-                    tokens_generated: 8,
-                })
+            || EngineResponse {
+                text: "Secondary fallback output".to_string(),
+                status: EngineStatus::Success,
+                engine: "transformerless-tla5".to_string(),
+                tokens_generated: 8,
             },
         );
 
@@ -382,21 +350,17 @@ mod tests {
     fn test_fallback_router_pathological_loop_triggers_fallback() {
         let router = FallbackRouter::default();
         let res = router.execute(
-            || {
-                Ok(EngineResponse {
-                    text: "Loop detected".to_string(),
-                    status: EngineStatus::Pathological,
-                    engine: "r4g1-graph".to_string(),
-                    tokens_generated: 2,
-                })
+            || EngineResponse {
+                text: "Loop detected".to_string(),
+                status: EngineStatus::Pathological,
+                engine: "r4g1-graph".to_string(),
+                tokens_generated: 2,
             },
-            || {
-                Ok(EngineResponse {
-                    text: "Secondary fallback recovery".to_string(),
-                    status: EngineStatus::Success,
-                    engine: "transformerless-tla5".to_string(),
-                    tokens_generated: 12,
-                })
+            || EngineResponse {
+                text: "Secondary fallback recovery".to_string(),
+                status: EngineStatus::Success,
+                engine: "transformerless-tla5".to_string(),
+                tokens_generated: 12,
             },
         );
 

--- a/crates/uor-r4-router/src/geometry.rs
+++ b/crates/uor-r4-router/src/geometry.rs
@@ -27,28 +27,26 @@ pub struct Operator {
     pub space_cid: KappaLabel,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum GeometryError {
-    InvalidObject,
-    EncodingFailed,
-    RouteResolutionFailed,
-    OperatorMismatch,
-}
-
 pub trait SemanticGeometry {
     fn space_manifest(&self) -> KappaLabel;
-    fn ground(&self, object: &TypedObject) -> Result<GroundedSemantics, GeometryError>;
-    fn encode(&self, grounded: &GroundedSemantics) -> Result<FacetCoordinates, GeometryError>;
-    fn soft_route(
-        &self,
-        coordinates: &FacetCoordinates,
-        max_routes: usize,
-    ) -> Result<Vec<WeightedRoute>, GeometryError>;
+    /// Ground a typed object into semantics. `None` when the object carries no
+    /// content to ground: not a limitation of the geometry, but the absence of
+    /// an object to place (R5 — the only reportable condition is "no product").
+    fn ground(&self, object: &TypedObject) -> Option<GroundedSemantics>;
+    /// Encode grounded semantics into facet coordinates. Total: every grounded
+    /// vector has coordinates.
+    fn encode(&self, grounded: &GroundedSemantics) -> FacetCoordinates;
+    /// Soft-route coordinates to weighted routes. Total: the empty coordinate
+    /// set routes to the empty (or single fallback) route list, never an error.
+    fn soft_route(&self, coordinates: &FacetCoordinates, max_routes: usize) -> Vec<WeightedRoute>;
+    /// Apply an operator to a route. `None` when this geometry does not carry
+    /// the requested operator — the (route, operator) product does not exist
+    /// here, not a fault.
     fn apply_operator(
         &self,
         route: &WeightedRoute,
         operator: &Operator,
-    ) -> Result<Vec<WeightedRoute>, GeometryError>;
+    ) -> Option<Vec<WeightedRoute>>;
 }
 
 // 1. Spectral Geometry (Heuristic Baseline)
@@ -63,9 +61,9 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
         self.space_cid.clone()
     }
 
-    fn ground(&self, object: &TypedObject) -> Result<GroundedSemantics, GeometryError> {
+    fn ground(&self, object: &TypedObject) -> Option<GroundedSemantics> {
         if object.content.is_empty() {
-            return Err(GeometryError::InvalidObject);
+            return None;
         }
         let mut v = vec![0.0; 1024];
         if let Some(state) = self.active_state {
@@ -104,13 +102,13 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
         } else {
             v[..512].copy_from_slice(&vec![1.0 / (512.0f64).sqrt(); 512]);
         }
-        Ok(GroundedSemantics {
+        Some(GroundedSemantics {
             vsa_vector: v.iter().map(|&x| x as f32).collect(),
             roles: vec!["spectral-role".to_string()],
         })
     }
 
-    fn encode(&self, grounded: &GroundedSemantics) -> Result<FacetCoordinates, GeometryError> {
+    fn encode(&self, grounded: &GroundedSemantics) -> FacetCoordinates {
         let active_state: Vec<f64> = grounded.vsa_vector[..512]
             .iter()
             .map(|&x| x as f64)
@@ -155,16 +153,12 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
                 .collect(),
         );
 
-        Ok(FacetCoordinates {
+        FacetCoordinates {
             coordinates: coords,
-        })
+        }
     }
 
-    fn soft_route(
-        &self,
-        coordinates: &FacetCoordinates,
-        _max_routes: usize,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    fn soft_route(&self, coordinates: &FacetCoordinates, _max_routes: usize) -> Vec<WeightedRoute> {
         let window_idx = coordinates
             .coordinates
             .get("window")
@@ -197,18 +191,18 @@ impl<'a> SemanticGeometry for SpectralGeometry<'a> {
                 score: 1.0,
             });
         }
-        Ok(routes)
+        routes
     }
 
     fn apply_operator(
         &self,
         route: &WeightedRoute,
         operator: &Operator,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    ) -> Option<Vec<WeightedRoute>> {
         if operator.name == "identity" {
-            Ok(vec![route.clone()])
+            Some(vec![route.clone()])
         } else {
-            Err(GeometryError::OperatorMismatch)
+            None
         }
     }
 }
@@ -223,9 +217,9 @@ impl SemanticGeometry for VsaGeometry {
         self.space_cid.clone()
     }
 
-    fn ground(&self, object: &TypedObject) -> Result<GroundedSemantics, GeometryError> {
+    fn ground(&self, object: &TypedObject) -> Option<GroundedSemantics> {
         if object.content.is_empty() {
-            return Err(GeometryError::InvalidObject);
+            return None;
         }
         // #496: ground the VSA hypervector from the zeta word-sum CONTENT signal
         // (the same multiplication-free construction `SpectralGeometry::ground`
@@ -271,13 +265,13 @@ impl SemanticGeometry for VsaGeometry {
                 *target = uniform;
             }
         }
-        Ok(GroundedSemantics {
+        Some(GroundedSemantics {
             vsa_vector: float_vec,
             roles: vec!["grounded-vsa-role".to_string()],
         })
     }
 
-    fn encode(&self, grounded: &GroundedSemantics) -> Result<FacetCoordinates, GeometryError> {
+    fn encode(&self, grounded: &GroundedSemantics) -> FacetCoordinates {
         let mut coords = HashMap::new();
         // Induce simple path codes by binning the grounded VSA dimensions
         let mut type_path = Vec::new();
@@ -287,16 +281,12 @@ impl SemanticGeometry for VsaGeometry {
         }
         coords.insert("type".to_string(), type_path);
         coords.insert("entity".to_string(), vec![100, 200]);
-        Ok(FacetCoordinates {
+        FacetCoordinates {
             coordinates: coords,
-        })
+        }
     }
 
-    fn soft_route(
-        &self,
-        coordinates: &FacetCoordinates,
-        max_routes: usize,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    fn soft_route(&self, coordinates: &FacetCoordinates, max_routes: usize) -> Vec<WeightedRoute> {
         let mut routes = Vec::new();
         for (facet, path) in &coordinates.coordinates {
             let axis = match facet.as_str() {
@@ -310,18 +300,18 @@ impl SemanticGeometry for VsaGeometry {
                 score: 0.95,
             });
         }
-        Ok(routes.into_iter().take(max_routes).collect())
+        routes.into_iter().take(max_routes).collect()
     }
 
     fn apply_operator(
         &self,
         route: &WeightedRoute,
         operator: &Operator,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    ) -> Option<Vec<WeightedRoute>> {
         if operator.name == "vsa-identity" {
-            Ok(vec![route.clone()])
+            Some(vec![route.clone()])
         } else {
-            Err(GeometryError::OperatorMismatch)
+            None
         }
     }
 }
@@ -338,26 +328,22 @@ mod tests {
             active_state: Some(&state),
             identity: Some("test-session"),
         };
-        let first = geometry
-            .encode(
-                &geometry
-                    .ground(&TypedObject {
-                        object_type: "query".to_string(),
-                        content: "prime factorization and zeta spectrum".to_string(),
-                    })
-                    .expect("first query grounds"),
-            )
-            .expect("first query encodes");
-        let second = geometry
-            .encode(
-                &geometry
-                    .ground(&TypedObject {
-                        object_type: "query".to_string(),
-                        content: "oceanic climate satellites and rainfall".to_string(),
-                    })
-                    .expect("second query grounds"),
-            )
-            .expect("second query encodes");
+        let first = geometry.encode(
+            &geometry
+                .ground(&TypedObject {
+                    object_type: "query".to_string(),
+                    content: "prime factorization and zeta spectrum".to_string(),
+                })
+                .expect("first query grounds"),
+        );
+        let second = geometry.encode(
+            &geometry
+                .ground(&TypedObject {
+                    object_type: "query".to_string(),
+                    content: "oceanic climate satellites and rainfall".to_string(),
+                })
+                .expect("second query grounds"),
+        );
 
         assert_ne!(
             first.coordinates.get("window"),

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -6,9 +6,7 @@ use crate::geometry::SemanticGeometry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::f64::consts::PI;
-use std::fmt;
 use std::sync::OnceLock;
-use uor_r4_core::semantic::WeightedRoute;
 use uor_r4_core::*;
 use wasm_bindgen::prelude::*;
 
@@ -163,32 +161,6 @@ pub struct CoordinateProvenance {
     pub projection_kappa: String,
     pub vocabulary_kappa: String,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ProvenanceError {
-    Missing {
-        sentence: String,
-    },
-    Mismatch {
-        sentence: String,
-        axis: &'static str,
-    },
-}
-
-impl fmt::Display for ProvenanceError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Missing { sentence } => {
-                write!(formatter, "missing coordinate provenance for {sentence:?}")
-            }
-            Self::Mismatch { sentence, axis } => {
-                write!(formatter, "{axis} provenance mismatch for {sentence:?}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for ProvenanceError {}
 
 fn uor_json_address(value: &serde_json::Value) -> String {
     let bytes = match serde_json::to_vec(value) {
@@ -1262,8 +1234,12 @@ impl UorR4Router {
         serde_json::to_string(self).unwrap_or_default()
     }
 
-    /// Imports a JSON string and restores the router system database
-    pub fn import_state(&mut self, json_str: &str) -> Result<(), JsValue> {
+    /// Imports a JSON string and restores the router system database. Returns
+    /// `true` when the string is a valid serialized router state and was
+    /// applied, `false` when it could not be parsed. Import is total: a
+    /// malformed input is the absence of a state to restore, reported as
+    /// `false`, not a thrown JS error (R5).
+    pub fn import_state(&mut self, json_str: &str) -> bool {
         match serde_json::from_str::<Self>(json_str) {
             Ok(mut imported) => {
                 for (word, &prime) in &imported.word_primes {
@@ -1274,12 +1250,9 @@ impl UorR4Router {
                 // Rebuild transitions dynamically
                 imported.rebuild_transitions();
                 *self = imported;
-                Ok(())
+                true
             }
-            Err(e) => Err(JsValue::from_str(&format!(
-                "Failed to parse router state JSON: {}",
-                e
-            ))),
+            Err(_) => false,
         }
     }
 
@@ -1735,7 +1708,7 @@ impl UorR4Router {
             content: text.to_string(),
         };
 
-        let grounded = geometry.ground(&obj).unwrap_or_else(|_| {
+        let grounded = geometry.ground(&obj).unwrap_or_else(|| {
             let mut v = vec![0.0; 1024];
             v[..512].copy_from_slice(active_state);
             geometry::GroundedSemantics {
@@ -1744,19 +1717,9 @@ impl UorR4Router {
             }
         });
 
-        let coords = geometry.encode(&grounded).unwrap_or_else(|_| {
-            let mut h = HashMap::new();
-            h.insert("window".to_string(), vec![1]);
-            geometry::FacetCoordinates { coordinates: h }
-        });
+        let coords = geometry.encode(&grounded);
 
-        let routes = geometry.soft_route(&coords, 16).unwrap_or_else(|_| {
-            vec![WeightedRoute {
-                axis: 1,
-                path: vec![1],
-                score: 1.0,
-            }]
-        });
+        let routes = geometry.soft_route(&coords, 16);
 
         let routed_idx = routes
             .iter()
@@ -2115,10 +2078,9 @@ impl UorR4Router {
             object_type: "sentence".to_string(),
             content: s_clean.to_string(),
         };
-        if let Ok(grounded) = geom.ground(&obj) {
-            if let Ok(coords) = geom.encode(&grounded) {
-                self.index_semantic_object(item_id, &coords);
-            }
+        if let Some(grounded) = geom.ground(&obj) {
+            let coords = geom.encode(&grounded);
+            self.index_semantic_object(item_id, &coords);
             // #496 real facet-index: store the item's VSA hypervector for
             // precomputed scoring, and index it under its salient content
             // dimensions (the high-recall, content-addressed candidate set).
@@ -2138,36 +2100,26 @@ impl UorR4Router {
     /// Recompute and verify provenance for every indexed sentence in one
     /// identity scope. This is deliberately outside the prediction kernel;
     /// callers may use it as an integrity check before serving a retrieval.
-    pub fn verify_corpus_provenance(&self, identity: &str) -> Result<usize, ProvenanceError> {
+    /// Returns the count of verified items, or `None` if any indexed sentence
+    /// is missing provenance or its recorded κ disagrees with the recomputed
+    /// source/projection/vocabulary provenance (R5 — a failed integrity check
+    /// is the absence of a verified count, not a reported error class).
+    pub fn verify_corpus_provenance(&self, identity: &str) -> Option<usize> {
         let items = self.corpus_items_for(identity);
         for item in &items {
-            let provenance = item
-                .provenance
-                .as_ref()
-                .ok_or_else(|| ProvenanceError::Missing {
-                    sentence: item.sentence.clone(),
-                })?;
+            let provenance = item.provenance.as_ref()?;
             if provenance.source_kappa != source_provenance(&item.sentence) {
-                return Err(ProvenanceError::Mismatch {
-                    sentence: item.sentence.clone(),
-                    axis: "source",
-                });
+                return None;
             }
             if provenance.projection_kappa != projection_provenance() {
-                return Err(ProvenanceError::Mismatch {
-                    sentence: item.sentence.clone(),
-                    axis: "projection",
-                });
+                return None;
             }
             if provenance.vocabulary_kappa != vocabulary_provenance(&self.word_primes, &item.words)
             {
-                return Err(ProvenanceError::Mismatch {
-                    sentence: item.sentence.clone(),
-                    axis: "vocabulary",
-                });
+                return None;
             }
         }
-        Ok(items.len())
+        Some(items.len())
     }
 
     fn retrieve_geometric_resonance(
@@ -2328,9 +2280,8 @@ impl UorR4Router {
             content: text.to_string(),
         };
 
-        let grounded = match geom.ground(&obj) {
-            Ok(g) => g,
-            Err(_) => return Vec::new(),
+        let Some(grounded) = geom.ground(&obj) else {
+            return Vec::new();
         };
         let query_vsa: Vec<f64> = grounded.vsa_vector.iter().map(|&x| x as f64).collect();
 
@@ -2374,7 +2325,6 @@ impl UorR4Router {
                             object_type: "query".to_string(),
                             content: item.sentence.clone(),
                         })
-                        .ok()
                     })
                     .map(|c| {
                         let cand: Vec<f64> = c.vsa_vector.iter().map(|&x| x as f64).collect();
@@ -2411,10 +2361,7 @@ impl UorR4Router {
         geom: &geometry::VsaGeometry,
         grounded: &geometry::GroundedSemantics,
     ) -> Vec<u64> {
-        let coords = match geom.encode(grounded) {
-            Ok(c) => c,
-            Err(_) => return Vec::new(),
-        };
+        let coords = geom.encode(grounded);
         let mut working_coords = coords.clone();
         let mut candidate_ids = Vec::new();
         loop {
@@ -3089,9 +3036,8 @@ pub struct DihedralInfo {
 }
 
 #[wasm_bindgen(start)]
-pub fn init_wasm() -> Result<(), JsValue> {
+pub fn init_wasm() {
     console_error_panic_hook::set_once();
-    Ok(())
 }
 
 impl UorR4Router {
@@ -3250,8 +3196,14 @@ impl UorR4Router {
         })
     }
 
-    pub fn import_state_native(&mut self, json_str: &str) -> Result<(), serde_json::Error> {
-        let mut imported: Self = serde_json::from_str(json_str)?;
+    /// Native counterpart of [`Self::import_state`]. Returns `true` when the
+    /// JSON is a valid serialized router state and was applied, `false` when it
+    /// could not be parsed (R5 — total import surface).
+    pub fn import_state_native(&mut self, json_str: &str) -> bool {
+        let mut imported: Self = match serde_json::from_str(json_str) {
+            Ok(value) => value,
+            Err(_) => return false,
+        };
         for (word, &prime) in &imported.word_primes {
             let vec = get_word_vector(prime as usize);
             imported.vocab_vectors.insert(word.clone(), vec);
@@ -3259,7 +3211,7 @@ impl UorR4Router {
         imported.max_prime = imported.word_primes.values().max().copied().unwrap_or(0);
         imported.rebuild_transitions();
         *self = imported;
-        Ok(())
+        true
     }
 
     pub fn inject_thought_stream_native(&mut self, content: &str) -> ThoughtStream {
@@ -3438,9 +3390,10 @@ mod tests {
         assert!(!exported.is_empty(), "export_state must produce JSON");
 
         let mut restored = UorR4Router::new(0.5);
-        restored
-            .import_state_native(&exported)
-            .expect("exported state must re-import cleanly");
+        assert!(
+            restored.import_state_native(&exported),
+            "exported state must re-import cleanly"
+        );
         assert_eq!(
             restored.get_vocab_size(),
             router.get_vocab_size(),

--- a/crates/uor-r4-router/tests/multi_facet_routing.rs
+++ b/crates/uor-r4-router/tests/multi_facet_routing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use uor_r4_core::semantic::{KappaLabel, WeightedRoute};
 use uor_r4_router::geometry::{
-    FacetCoordinates, GeometryError, GroundedSemantics, Operator, SemanticGeometry, TypedObject,
+    FacetCoordinates, GroundedSemantics, Operator, SemanticGeometry, TypedObject,
 };
 
 pub struct MockGeometry {
@@ -13,29 +13,25 @@ impl SemanticGeometry for MockGeometry {
         self.space_cid.clone()
     }
 
-    fn ground(&self, object: &TypedObject) -> Result<GroundedSemantics, GeometryError> {
+    fn ground(&self, object: &TypedObject) -> Option<GroundedSemantics> {
         if object.content.is_empty() {
-            return Err(GeometryError::InvalidObject);
+            return None;
         }
-        Ok(GroundedSemantics {
+        Some(GroundedSemantics {
             vsa_vector: vec![0.5; 1024],
             roles: vec!["subject".to_string()],
         })
     }
 
-    fn encode(&self, _grounded: &GroundedSemantics) -> Result<FacetCoordinates, GeometryError> {
+    fn encode(&self, _grounded: &GroundedSemantics) -> FacetCoordinates {
         let mut coordinates = HashMap::new();
         coordinates.insert("type".to_string(), vec![1, 2, 3]);
         coordinates.insert("entity".to_string(), vec![10, 20, 30, 40]);
         coordinates.insert("relation".to_string(), vec![5, 6]);
-        Ok(FacetCoordinates { coordinates })
+        FacetCoordinates { coordinates }
     }
 
-    fn soft_route(
-        &self,
-        coordinates: &FacetCoordinates,
-        max_routes: usize,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    fn soft_route(&self, coordinates: &FacetCoordinates, max_routes: usize) -> Vec<WeightedRoute> {
         let mut routes = Vec::new();
         if let Some(path) = coordinates.coordinates.get("type") {
             routes.push(WeightedRoute {
@@ -51,18 +47,18 @@ impl SemanticGeometry for MockGeometry {
                 score: 0.8,
             });
         }
-        Ok(routes.into_iter().take(max_routes).collect())
+        routes.into_iter().take(max_routes).collect()
     }
 
     fn apply_operator(
         &self,
         route: &WeightedRoute,
         operator: &Operator,
-    ) -> Result<Vec<WeightedRoute>, GeometryError> {
+    ) -> Option<Vec<WeightedRoute>> {
         if operator.name == "identity" {
-            Ok(vec![route.clone()])
+            Some(vec![route.clone()])
         } else {
-            Err(GeometryError::OperatorMismatch)
+            None
         }
     }
 }
@@ -81,14 +77,14 @@ fn test_mock_geometry_grounding_and_routing() {
     let grounded = geom.ground(&obj).unwrap();
     assert_eq!(grounded.roles, vec!["subject"]);
 
-    let coords = geom.encode(&grounded).unwrap();
+    let coords = geom.encode(&grounded);
     assert_eq!(coords.coordinates.get("type").unwrap(), &vec![1, 2, 3]);
     assert_eq!(
         coords.coordinates.get("entity").unwrap(),
         &vec![10, 20, 30, 40]
     );
 
-    let routes = geom.soft_route(&coords, 5).unwrap();
+    let routes = geom.soft_route(&coords, 5);
     assert_eq!(routes.len(), 2);
     assert_eq!(routes[0].axis, 1);
     assert_eq!(routes[0].path, vec![1, 2, 3]);

--- a/crates/uor-r4-router/tests/provenance.rs
+++ b/crates/uor-r4-router/tests/provenance.rs
@@ -20,7 +20,7 @@ fn indexed_coordinates_are_populated_and_verifiable() {
     assert!(provenance.source_kappa.starts_with("sha256:"));
     assert!(provenance.projection_kappa.starts_with("sha256:"));
     assert!(provenance.vocabulary_kappa.starts_with("sha256:"));
-    assert_eq!(router.verify_corpus_provenance(ID), Ok(1));
+    assert_eq!(router.verify_corpus_provenance(ID), Some(1));
 
     let retrieved = router.get_top_resonances_native("distant stars", ID, 1);
     assert_eq!(retrieved.len(), 1);
@@ -36,5 +36,5 @@ fn content_free_measurement_arm_still_records_provenance() {
     // Content-free indexing is still an intentionally supported measurement
     // arm, but it now records provenance as well; verification must not be
     // silently skipped for that path.
-    assert_eq!(router.verify_corpus_provenance(ID), Ok(1));
+    assert_eq!(router.verify_corpus_provenance(ID), Some(1));
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -366,14 +366,14 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     {
         let mut r = router.lock().unwrap();
         if let Ok(cache_data) = std::fs::read_to_string(&cli.manifold_cache) {
-            if let Err(e) = r.import_state_native(&cache_data) {
-                tracing::warn!(error = %e, path = %cli.manifold_cache, "failed to load manifold cache");
-            } else {
+            if r.import_state_native(&cache_data) {
                 let total = r.get_total_indexed_sentences();
                 println!(
                     "[+] Successfully loaded manifold cache from {}. Sentences indexed: {}",
                     cli.manifold_cache, total
                 );
+            } else {
+                tracing::warn!(path = %cli.manifold_cache, "failed to load manifold cache: not a valid serialized router state");
             }
         } else {
             tracing::info!(path = %cli.manifold_cache, "no manifold cache found; initializing a new manifold");
@@ -3168,11 +3168,11 @@ fn handle_connection(
                 return;
             }
         };
-        if let Err(e) = router_guard.import_state_native(&state_str) {
+        if !router_guard.import_state_native(&state_str) {
             send_json_response(
                 stream,
                 400,
-                &format!("{{\"error\":\"Import failed: {}\"}}", e),
+                "{\"error\":\"Import failed: not a valid serialized router state\"}",
             );
             return;
         }
@@ -3933,8 +3933,11 @@ struct CliAnswer {
 fn load_cli_router(cli: &ServerConfig) -> UorR4Router {
     let mut router = UorR4Router::new(0.85);
     if let Ok(cache_data) = std::fs::read_to_string(&cli.manifold_cache) {
-        if let Err(e) = router.import_state_native(&cache_data) {
-            eprintln!("[!] failed to load {}: {}", cli.manifold_cache, e);
+        if !router.import_state_native(&cache_data) {
+            eprintln!(
+                "[!] failed to load {}: not a valid serialized router state",
+                cli.manifold_cache
+            );
         }
     }
     // The geometric router needs at least one vocabulary manifold. A fresh CLI

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -113,6 +113,13 @@ fn effective_lines(text: &str) -> Vec<(usize, &str)> {
     out
 }
 
+/// Net angle-bracket depth change of `s`: `<` opens a generic, `>` closes one.
+/// Used to rejoin a `Result<...>` return type that rustfmt wrapped across
+/// several lines, so the whole error type is visible to the sanctioned checks.
+fn angle_delta(s: &str) -> i32 {
+    s.matches('<').count() as i32 - s.matches('>').count() as i32
+}
+
 /// R5: no arbitrary limitation. Every bound is a property of the caller's
 /// chosen instantiation, never of the code.
 ///
@@ -139,11 +146,30 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
 
     let mut violations = Vec::new();
     for src in &sources {
-        for (line_no, line) in effective_lines(&src.text) {
+        let lines = effective_lines(&src.text);
+        for (idx, &(line_no, line)) in lines.iter().enumerate() {
             let Some(pos) = line.find("Result<") else {
                 continue;
             };
-            let tail = &line[pos..];
+            // The return type may wrap across lines: rustfmt puts a long
+            // associated type on its own lines and leaves `-> Result<` with the
+            // error type below it (an external-trait `forward` impl does this).
+            // Join continuation lines until the `Result<...>` generic closes, so
+            // a sanctioned or external-contract error type on a following line is
+            // seen by the checks below instead of read as a bare `Result<` with
+            // no sanctioned type --- a false positive the single-line scan cannot
+            // avoid.
+            let mut tail = line[pos..].to_string();
+            let mut depth = angle_delta(&line[pos + "Result".len()..]);
+            let mut j = idx + 1;
+            while depth > 0 && j < lines.len() && j < idx + 16 {
+                let cont = lines[j].1;
+                tail.push(' ');
+                tail.push_str(cont);
+                depth += angle_delta(cont);
+                j += 1;
+            }
+            let tail = tail.as_str();
             if sanctioned.iter().any(|s| tail.contains(s)) {
                 continue;
             }
@@ -156,6 +182,18 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
             // trait and cannot name a sanctioned type, so they are carved out
             // exactly like a sanctioned return.
             if tail.contains("S::Ok") || tail.contains("S::Error") || tail.contains("D::Error") {
+                continue;
+            }
+            // The uor_foundation SDK's enforcement and pipeline traits fix their
+            // own error surfaces the same way serde does. An `axis!`-declared
+            // `route_query` must return `Result<usize, ShapeViolation>`, and a
+            // `PrismModel::forward` impl must return
+            // `Result<Grounded<..>, PipelineFailure>`. Both error types are the
+            // framework's shape-conformance reports at a declared host boundary
+            // --- the caller's external contract, not a limitation this model
+            // imposes --- and neither signature can name a sanctioned type, so
+            // they are carved out exactly like the serde associated types.
+            if tail.contains("ShapeViolation") || tail.contains("PipelineFailure") {
                 continue;
             }
             violations.push(format!("{}:{line_no}:{}", src.rel, line.trim()));


### PR DESCRIPTION
Part of the #510 R5 rearchitecture. Converts `uor-r4-router` to the sanctioned Result<> surface, clearing all 21 audit-limits violations for the crate.

## What changed
- **geometry.rs** — remove `GeometryError`; `SemanticGeometry` is now total: `ground → Option`, `encode → FacetCoordinates`, `soft_route → Vec<WeightedRoute>`, `apply_operator → Option`. Callers in benchmark.rs/lib.rs follow.
- **lib.rs** — `verify_corpus_provenance → Option<usize>` (`ProvenanceError` removed); `import_state`/`import_state_native → bool` (total import); `init_wasm → ()` (`#[wasm_bindgen(start)]` never failed). Server + test callers updated.
- **fallback.rs** — `FallbackRouter::execute` closures `FnMut() -> EngineResponse` (total) instead of `Result<_, String>`; outcome rides in `EngineResponse.status`. Legacy mechanism kept (R4), surface totalized (R5).
- **xtask/src/audit.rs** — teach audit-limits multiline `Result<...>` return types (rustfmt wraps long ones, leaving a bare `-> Result<` the single-line scan mis-flags); carve out the two `uor_foundation` SDK contract error types (`ShapeViolation` from an `axis!` `route_query`, `PipelineFailure` from a `PrismModel::forward` impl) — external trait-fixed surfaces, the serde-carveout analogue.

## Verification
- `cargo build --workspace --all-targets` — clean
- router tests pass; `clippy -D warnings` clean (router/xtask/root); `cargo fmt --check` clean
- `wasm32-unknown-unknown` check clean; `audit-deferral` (R4) passes
- `audit-limits` router violations: **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)