### PR TITLE
feat(#510): R5 tranche 5a — graph-compiler quantum_cover + reference_ir to total

### DIFF
--- a/crates/uor-r4-graph-compiler/src/quantum_cover.rs
+++ b/crates/uor-r4-graph-compiler/src/quantum_cover.rs
@@ -13,36 +13,7 @@
 
 use crate::induction::{DEFAULT_SPLIT_ENTROPY_GAIN_BITS, Observation};
 use std::collections::BTreeMap;
-use std::fmt;
 use uor_r4_graph_format::ScoreQ;
-
-/// Errors from density-operator construction (library boundary: no
-/// panics on recoverable inputs).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QuantumCoverError {
-    /// A density operator needs at least one dimension.
-    EmptyDistribution,
-    /// Weights must be finite, non-negative, and sum above zero.
-    NonPositiveWeightSum,
-}
-
-impl fmt::Display for QuantumCoverError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            QuantumCoverError::EmptyDistribution => {
-                write!(f, "density operator requires at least one dimension")
-            }
-            QuantumCoverError::NonPositiveWeightSum => {
-                write!(
-                    f,
-                    "weights must be finite, non-negative, and sum above zero"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for QuantumCoverError {}
 
 /// Diagonal density operator ρ: eigenvalues are a normalized
 /// distribution (trace 1). The maximum-entropy operator (1/n)I is the
@@ -54,41 +25,45 @@ pub struct DensityOperator {
 
 impl DensityOperator {
     /// The maximum-entropy operator ρ = (1/n)I_{n×n} in `dimension`
-    /// dimensions.
-    pub fn max_entropy(dimension: usize) -> Result<Self, QuantumCoverError> {
+    /// dimensions. `None` when `dimension` is zero: an empty distribution is
+    /// not a density operator (R5 — the absence of a product, not an error).
+    pub fn max_entropy(dimension: usize) -> Option<Self> {
         if dimension == 0 {
-            return Err(QuantumCoverError::EmptyDistribution);
+            return None;
         }
         let p = 1.0 / dimension as f32;
-        Ok(Self {
+        Some(Self {
             eigenvalues: vec![p; dimension],
         })
     }
 
-    /// ρ from finite non-negative weights, normalized to trace 1.
-    pub fn from_weights(weights: &[f32]) -> Result<Self, QuantumCoverError> {
+    /// ρ from finite non-negative weights, normalized to trace 1. `None` when
+    /// the weights are empty or do not sum to a finite positive value (no
+    /// density operator exists for them).
+    pub fn from_weights(weights: &[f32]) -> Option<Self> {
         if weights.is_empty() {
-            return Err(QuantumCoverError::EmptyDistribution);
+            return None;
         }
         let sum: f32 = weights.iter().sum();
         if !sum.is_finite() || sum <= 0.0 {
-            return Err(QuantumCoverError::NonPositiveWeightSum);
+            return None;
         }
-        Ok(Self {
+        Some(Self {
             eigenvalues: weights.iter().map(|&w| w / sum).collect(),
         })
     }
 
-    /// ρ from integer occurrence counts, normalized to trace 1.
-    pub fn from_counts(counts: &[u64]) -> Result<Self, QuantumCoverError> {
+    /// ρ from integer occurrence counts, normalized to trace 1. `None` when the
+    /// counts are empty or sum to zero.
+    pub fn from_counts(counts: &[u64]) -> Option<Self> {
         if counts.is_empty() {
-            return Err(QuantumCoverError::EmptyDistribution);
+            return None;
         }
         let sum: u64 = counts.iter().sum();
         if sum == 0 {
-            return Err(QuantumCoverError::NonPositiveWeightSum);
+            return None;
         }
-        Ok(Self {
+        Some(Self {
             eigenvalues: counts.iter().map(|&c| c as f32 / sum as f32).collect(),
         })
     }
@@ -147,8 +122,8 @@ fn member_entropy_nats(observations: &[Observation], members: &[usize]) -> f64 {
     let counts = next_token_counts(observations, members);
     let eigenvalues: Vec<u64> = counts.values().copied().collect();
     match DensityOperator::from_counts(&eigenvalues) {
-        Ok(rho) => f64::from(rho.von_neumann_entropy()),
-        Err(_) => 0.0,
+        Some(rho) => f64::from(rho.von_neumann_entropy()),
+        None => 0.0,
     }
 }
 
@@ -248,23 +223,11 @@ mod tests {
     }
 
     #[test]
-    fn invalid_distributions_are_errors_not_panics() {
-        assert_eq!(
-            DensityOperator::max_entropy(0).unwrap_err(),
-            QuantumCoverError::EmptyDistribution
-        );
-        assert_eq!(
-            DensityOperator::from_weights(&[]).unwrap_err(),
-            QuantumCoverError::EmptyDistribution
-        );
-        assert_eq!(
-            DensityOperator::from_weights(&[0.0, 0.0]).unwrap_err(),
-            QuantumCoverError::NonPositiveWeightSum
-        );
-        assert_eq!(
-            DensityOperator::from_counts(&[0, 0]).unwrap_err(),
-            QuantumCoverError::NonPositiveWeightSum
-        );
+    fn invalid_distributions_are_none_not_panics() {
+        assert!(DensityOperator::max_entropy(0).is_none());
+        assert!(DensityOperator::from_weights(&[]).is_none());
+        assert!(DensityOperator::from_weights(&[0.0, 0.0]).is_none());
+        assert!(DensityOperator::from_counts(&[0, 0]).is_none());
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/reference_compiler_ir.rs
+++ b/crates/uor-r4-graph-compiler/src/reference_compiler_ir.rs
@@ -14,39 +14,6 @@
 //! - Standalone inference engine capable of answering transitions and emissions directly.
 
 use std::collections::HashMap;
-use std::fmt;
-
-/// Errors arising during reference compilation or IR evaluation.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ReferenceCompilerError {
-    /// Empty corpus provided to compiler.
-    EmptyCorpus,
-    /// Invalid state or region identifier.
-    InvalidIdentifier { id: String },
-    /// State transition failure or missing transition edge.
-    TransitionNotFound { src_id: String, action: String },
-    /// Differential comparison divergence above tolerance.
-    DifferentialDivergence { metric: String, delta: f32 },
-}
-
-impl fmt::Display for ReferenceCompilerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EmptyCorpus => write!(f, "Cannot compile empty observation corpus"),
-            Self::InvalidIdentifier { id } => write!(f, "Invalid compiler IR identifier: {id}"),
-            Self::TransitionNotFound { src_id, action } => write!(
-                f,
-                "No transition found in reference IR for state '{src_id}' under action '{action}'"
-            ),
-            Self::DifferentialDivergence { metric, delta } => write!(
-                f,
-                "Differential comparison divergence in metric '{metric}': delta = {delta:.4}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ReferenceCompilerError {}
 
 /// Configuration parameters for the reference compiler objective.
 #[derive(Debug, Clone, PartialEq)]
@@ -175,12 +142,11 @@ pub struct ReferenceCompilerPipeline;
 
 impl ReferenceCompilerPipeline {
     /// Execute full 5-stage compilation over input text observations.
-    pub fn compile(
-        corpus: &[&str],
-        config: &ReferenceCompilerConfig,
-    ) -> Result<ReferenceGraphIr, ReferenceCompilerError> {
+    /// `None` when the corpus is empty: there is no graph to compile from no
+    /// observations (R5 — the absence of a product, not a raised error).
+    pub fn compile(corpus: &[&str], config: &ReferenceCompilerConfig) -> Option<ReferenceGraphIr> {
         if corpus.is_empty() {
-            return Err(ReferenceCompilerError::EmptyCorpus);
+            return None;
         }
 
         // Stage 1: Teacher Probing & Observation Digest
@@ -259,7 +225,7 @@ impl ReferenceCompilerPipeline {
             compilation_timestamp_epoch: 1774350000,
         };
 
-        Ok(ReferenceGraphIr {
+        Some(ReferenceGraphIr {
             provenance,
             observations,
             states,
@@ -275,19 +241,21 @@ impl ReferenceCompilerPipeline {
 pub struct DifferentialCompilerHarness;
 
 impl DifferentialCompilerHarness {
+    /// Compare the reference graph's teacher loss against a baseline. Returns
+    /// `Some(delta)` when the absolute divergence is within `tolerance`, or
+    /// `None` when it diverges past the tolerance (R5 — a measured bound
+    /// crossed is reported as the absence of an in-tolerance result, not a
+    /// raised error).
     pub fn compare(
         ref_graph: &ReferenceGraphIr,
         baseline_teacher_loss: f32,
         tolerance: f32,
-    ) -> Result<f32, ReferenceCompilerError> {
+    ) -> Option<f32> {
         let delta = (ref_graph.objective_report.teacher_loss - baseline_teacher_loss).abs();
         if delta > tolerance {
-            return Err(ReferenceCompilerError::DifferentialDivergence {
-                metric: "teacher_loss".to_string(),
-                delta,
-            });
+            return None;
         }
-        Ok(delta)
+        Some(delta)
     }
 }
 


### PR DESCRIPTION
First of several `uor-r4-graph-compiler` tranches. The crate is the true bottom-up leaf of the remaining R5 work (graph-certify wraps it; api wraps certify's scorer; graph-cli wraps all), so it converts before certify/api/cli. **87 → 82** sites.

## What changed
- **quantum_cover.rs** — remove `QuantumCoverError`. `DensityOperator::{max_entropy, from_weights, from_counts}` → `Option<Self>` (None = empty/degenerate distribution). Internal `member_entropy_nats` match and unit tests follow.
- **reference_compiler_ir.rs** — remove `ReferenceCompilerError`. `ReferenceCompilerPipeline::compile` → `Option<ReferenceGraphIr>` (None = empty corpus); `DifferentialCompilerHarness::compare` → `Option<f32>` (Some(delta) within tolerance, None past it — a measured bound crossed).

No external non-test callers of either error type; `bdd.rs` uses `.expect(...)` which still holds on `Option`.

## Verification
- `cargo build --workspace --all-targets` clean
- `cargo build -p uor-r4-graph-compiler --target wasm32-unknown-unknown` clean (neither module touches host I/O / `SourceUnavailable`)
- quantum_cover + reference_compiler_ir unit tests pass; `clippy -D warnings` clean; `cargo fmt --check` clean
- `audit-deferral` (R4) passes; `audit-limits` graph-compiler **87 → 82**

🤖 Generated with [Claude Code](https://claude.com/claude-code)