### PR TITLE
feat(#510): R5 tranche 5b — graph-compiler induction cover ops to total

### DIFF
--- a/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
+++ b/crates/uor-r4-graph-certify/tests/capacity_scaling.rs
@@ -953,8 +953,7 @@ fn capacity_scaling() {
     let (train_positions, _held) = induction::split_positions(&corpus);
     let started = Instant::now();
     let observations =
-        induction::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads)
-            .expect("train observations");
+        induction::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads);
     println!(
         "\n  train observations: {} (built once in {:.1}s, shared by FWDA/NGRAM and COVER)",
         observations.len(),

--- a/crates/uor-r4-graph-certify/tests/cover_scaling.rs
+++ b/crates/uor-r4-graph-certify/tests/cover_scaling.rs
@@ -459,15 +459,13 @@ fn cover_scaling() {
         &corpus,
         &train_pos,
         threads as usize,
-    )
-    .expect("train observations");
+    );
     let held_obs = induction::build_observations_with_threads(
         &artifacts,
         &corpus,
         &held_pos,
         threads as usize,
-    )
-    .expect("held-out observations");
+    );
     println!(
         "  observations built in {:.1}s: {} train, {} held-out",
         build_started.elapsed().as_secs_f64(),

--- a/crates/uor-r4-graph-certify/tests/m1_induced_forward.rs
+++ b/crates/uor-r4-graph-certify/tests/m1_induced_forward.rs
@@ -139,8 +139,7 @@ fn m1_induced_forward() {
     let train_pos: Vec<usize> = (0..c.n).filter(|&i| is_constr(c.story[i])).collect();
     let held_pos: Vec<usize> = (0..c.n).filter(|&i| !is_constr(c.story[i])).collect();
 
-    let train_obs = induction::build_observations_with_threads(&art, &c, &train_pos, 2)
-        .expect("train observations");
+    let train_obs = induction::build_observations_with_threads(&art, &c, &train_pos, 2);
     println!("train observations built: {}", train_obs.len());
 
     let config = CoverConfig {
@@ -199,8 +198,7 @@ fn m1_induced_forward() {
     }
 
     // ---- held-out routing + eval ----
-    let held_obs =
-        induction::build_observations_with_threads(&art, &c, &held_pos, 2).expect("held obs");
+    let held_obs = induction::build_observations_with_threads(&art, &c, &held_pos, 2);
     let mut unigram: BTreeMap<u32, u64> = BTreeMap::new();
     for &i in &train_pos {
         *unigram.entry(c.next[i]).or_default() += 1;

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -431,7 +431,8 @@ pub fn run_point(
         &point.config,
         &inputs.artifact_kappa,
         &inputs.corpus_kappa,
-    )?;
+    )
+    .ok_or_else(|| "cover induction needs at least one train observation".to_owned())?;
     let reference = cover::ReferenceClassifier::freeze(&induced.cover);
     let recall = cover::evaluate_held_out(
         &inputs.artifacts,
@@ -587,7 +588,8 @@ pub fn reconstruction_null(
         &point.config,
         &inputs.artifact_kappa,
         &inputs.corpus_kappa,
-    )?;
+    )
+    .ok_or_else(|| "cover induction needs at least one train observation".to_owned())?;
     let reference = cover::ReferenceClassifier::freeze(&induced.cover);
     let edges = cover::build_edges(
         &induced.cover,

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -664,14 +664,15 @@ pub fn cover_command(args: &[String]) -> Result<(), String> {
         &corpus,
         &train_positions,
         config.threads as usize,
-    )?;
+    );
     let held_out = cover::build_observations_with_threads(
         &artifacts,
         &corpus,
         &held_out_positions,
         config.threads as usize,
-    )?;
-    let induced = cover::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)?;
+    );
+    let induced = cover::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)
+        .ok_or_else(|| "cover induction needs at least one train observation".to_owned())?;
     let reference = cover::ReferenceClassifier::freeze(&induced.cover);
     eprintln!(
         "cover: {} regions across {} depth(s); evaluating held-out routing recall...",
@@ -1083,9 +1084,9 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         .map(|count| count.get().min(8))
         .unwrap_or(1);
     let train =
-        cover::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads)?;
+        cover::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads);
     let held_out =
-        cover::build_observations_with_threads(&artifacts, &corpus, &held_out_positions, threads)?;
+        cover::build_observations_with_threads(&artifacts, &corpus, &held_out_positions, threads);
     phases.mark("inputs + observations (load, split, observe)");
 
     // Region parameters + structural edges: recovered from a previously
@@ -1122,7 +1123,8 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
                 &cover::CoverConfig::default(),
                 &artifact_kappa,
                 &corpus_kappa,
-            )?;
+            )
+            .ok_or_else(|| "cover induction needs at least one train observation".to_owned())?;
             let reference = cover::ReferenceClassifier::freeze(&induced.cover);
             let edges = cover::build_edges(&induced.cover, &reference, &train, &corpus.story);
             let n_reg = induced.cover.regions.len();

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -675,13 +675,13 @@ pub fn build_observations_with_threads(
     corpus: &Corpus,
     positions: &[usize],
     threads: usize,
-) -> Result<Vec<Observation>, String> {
+) -> Vec<Observation> {
     if positions.is_empty() {
-        return Ok(Vec::new());
+        return Vec::new();
     }
     let worker_count = threads.max(1).min(positions.len());
     if worker_count == 1 {
-        return Ok(build_observations_serial(art, corpus, positions));
+        return build_observations_serial(art, corpus, positions);
     }
     let chunk_size = positions.len().div_ceil(worker_count);
     let mut chunks = Vec::with_capacity(worker_count);
@@ -694,19 +694,21 @@ pub fn build_observations_with_threads(
             ));
         }
         for (chunk_id, handle) in handles {
-            let observations = handle.join().map_err(|_| {
-                format!("observation worker {chunk_id} panicked during cover compilation")
-            })?;
+            // A worker panic propagates as a panic (total): the observation
+            // build has no reportable condition of its own (R5), and a
+            // panicked worker is a defect, not a limitation the model sanctions.
+            let observations = handle.join().unwrap_or_else(|_| {
+                panic!("observation worker {chunk_id} panicked during cover compilation")
+            });
             chunks.push((chunk_id, observations));
         }
-        Ok::<(), String>(())
-    })?;
+    });
     chunks.sort_by_key(|(chunk_id, _)| *chunk_id);
     let mut observations = Vec::with_capacity(positions.len());
     for (_, mut chunk) in chunks {
         observations.append(&mut chunk);
     }
-    Ok(observations)
+    observations
 }
 
 fn build_observations_serial(
@@ -1669,9 +1671,11 @@ pub fn induce_cover(
     config: &CoverConfig,
     artifact_kappa: &str,
     corpus_kappa: &str,
-) -> Result<InducedCover, String> {
+) -> Option<InducedCover> {
     if observations.is_empty() {
-        return Err("cover induction needs at least one train observation".to_owned());
+        // No train observations: there is no cover to induce (R5 — the absence
+        // of a product, reported as `None`, not a raised error).
+        return None;
     }
     let n = observations.len();
     let regions_budget = config.effective_regions_budget(n);
@@ -1874,7 +1878,7 @@ pub fn induce_cover(
     }
 
     let max_depth = regions.iter().map(|r| r.depth as usize).max().unwrap_or(1);
-    Ok(InducedCover {
+    Some(InducedCover {
         cover: Cover {
             regions,
             max_depth,

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -175,7 +175,8 @@ pub fn compile(args: &[String]) -> Result<(), String> {
     let (train_positions, held_out_positions) = induction::split_positions(&corpus);
     let train = induction::build_observations(&artifacts, &corpus, &train_positions);
     let held_out = induction::build_observations(&artifacts, &corpus, &held_out_positions);
-    let induced = induction::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)?;
+    let induced = induction::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)
+        .ok_or_else(|| "cover induction needs at least one train observation".to_owned())?;
     let reference = induction::ReferenceClassifier::freeze(&induced.cover);
     eprintln!(
         "graph-compiler: {} regions across {} depth(s); evaluating held-out routing recall...",

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -397,8 +397,7 @@ fn cover_induction_is_deterministic_across_repeats_and_worker_counts() {
     let serial = cover::build_observations(&artifacts, &corpus, &positions);
     for threads in [1usize, 2, 3, 5, 8, 64] {
         let parallel =
-            cover::build_observations_with_threads(&artifacts, &corpus, &positions, threads)
-                .expect("observation workers succeed");
+            cover::build_observations_with_threads(&artifacts, &corpus, &positions, threads);
         assert_eq!(
             parallel.len(),
             serial.len(),


### PR DESCRIPTION
Second `uor-r4-graph-compiler` tranche. **82 → 80.** Two standalone cover-induction entry points go total; `emit_r4g1` stays `Result` for now (it wraps `routing::synthesize_routing_program`, part of the still-unconverted executor cluster).

## What changed
- `build_observations_with_threads` → `Vec<Observation>` (was `Result<_,String>`). Its only failure was a worker-thread panic, which now propagates as a panic — a panicked worker is a defect, not a reportable limitation (R5), matching the core runtime thread-worker pattern.
- `induce_cover` → `Option<InducedCover>` (None = no train observations).

Callers adapted (signatures ripple across crates; their own surfaces unchanged): graph-compiler `lib.rs` + graph-cli (`lib.rs`, `cover_sweep.rs`) still return `Result<_,String>`, so `induce_cover` callers map `None` via `.ok_or_else(...)?`; `build_observations_with_threads` callers drop `?`/`.expect(...)` (graph-cli + the graph-compiler/graph-certify test suites). `induce_cover` callers using `.expect()/.unwrap()` are unchanged (both work on `Option`).

## Verification
- `cargo build --workspace --all-targets` clean
- `cargo build -p uor-r4-graph-compiler --target wasm32-unknown-unknown` clean (TRAP A — no host I/O / `SourceUnavailable`)
- induction unit + integration tests pass; `clippy -D warnings` clean (graph-compiler + graph-cli); `cargo fmt --check` clean
- `audit-deferral` (R4) passes; `audit-limits` graph-compiler **82 → 80**

🤖 Generated with [Claude Code](https://claude.com/claude-code)