### PR TITLE
feat(#510): R5 tranche 5c — graph-compiler monograph validator to total

### DIFF
--- a/crates/uor-r4-graph-compiler/src/monograph.rs
+++ b/crates/uor-r4-graph-compiler/src/monograph.rs
@@ -8,43 +8,10 @@
 //! - Traceability link validation connecting implementation modules to proof matrix entries.
 //! - Verification of explicit non-goals and claim-wording boundaries.
 
-use std::fmt;
-
-/// Errors arising during monograph validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MonographValidationError {
-    /// Required section missing from formal monograph.
-    MissingSection { section_title: String },
-    /// Implementation module traceability link broken or unreferenced.
-    MissingTraceabilityLink { module_name: String },
-    /// Non-goal disavowal missing from problem statement section.
-    MissingNonGoalDisavowal { non_goal: String },
-}
-
-impl fmt::Display for MonographValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::MissingSection { section_title } => {
-                write!(
-                    f,
-                    "Formal monograph missing required section: '{section_title}'"
-                )
-            }
-            Self::MissingTraceabilityLink { module_name } => write!(
-                f,
-                "Traceability link missing for implementation module: '{module_name}'"
-            ),
-            Self::MissingNonGoalDisavowal { non_goal } => write!(
-                f,
-                "Monograph missing explicit non-goal disavowal for: '{non_goal}'"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for MonographValidationError {}
-
-/// Monograph validation report metrics.
+/// Monograph validation report metrics. `verified` is `true` only when every
+/// required section, module traceability link, and non-goal disavowal is
+/// present; otherwise the count fields report how many of each were found (R5 —
+/// a failed validation is a measured report, not a raised error).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonographValidationReport {
     pub total_sections_verified: usize,
@@ -57,10 +24,10 @@ pub struct MonographValidationReport {
 pub struct MonographTraceabilityVerifier;
 
 impl MonographTraceabilityVerifier {
-    /// Validate full formal monograph markdown text.
-    pub fn validate_monograph_text(
-        content: &str,
-    ) -> Result<MonographValidationReport, MonographValidationError> {
+    /// Validate full formal monograph markdown text. Total: always produces a
+    /// [`MonographValidationReport`]; `verified` is `true` only when every
+    /// required section, module link, and non-goal disavowal is present.
+    pub fn validate_monograph_text(content: &str) -> MonographValidationReport {
         let required_sections = [
             "Section 1: Problem Statement and Non-Goals",
             "Section 2: Semantic State Spaces and Holographic Projections",
@@ -104,42 +71,29 @@ impl MonographTraceabilityVerifier {
             "No Floating-Point Runtime Hot Path",
         ];
 
-        let mut sections_count = 0;
-        for sec in &required_sections {
-            if !content.contains(sec) {
-                return Err(MonographValidationError::MissingSection {
-                    section_title: sec.to_string(),
-                });
-            }
-            sections_count += 1;
-        }
+        let sections_count = required_sections
+            .iter()
+            .filter(|sec| content.contains(**sec))
+            .count();
+        let modules_count = required_modules
+            .iter()
+            .filter(|mod_name| content.contains(**mod_name))
+            .count();
+        let non_goals_count = required_non_goals
+            .iter()
+            .filter(|ng| content.contains(**ng))
+            .count();
 
-        let mut modules_count = 0;
-        for mod_name in &required_modules {
-            if !content.contains(mod_name) {
-                return Err(MonographValidationError::MissingTraceabilityLink {
-                    module_name: mod_name.to_string(),
-                });
-            }
-            modules_count += 1;
-        }
+        let verified = sections_count == required_sections.len()
+            && modules_count == required_modules.len()
+            && non_goals_count == required_non_goals.len();
 
-        let mut non_goals_count = 0;
-        for ng in &required_non_goals {
-            if !content.contains(ng) {
-                return Err(MonographValidationError::MissingNonGoalDisavowal {
-                    non_goal: ng.to_string(),
-                });
-            }
-            non_goals_count += 1;
-        }
-
-        Ok(MonographValidationReport {
+        MonographValidationReport {
             total_sections_verified: sections_count,
             total_modules_linked: modules_count,
             non_goals_disavowed: non_goals_count,
-            verified: true,
-        })
+            verified,
+        }
     }
 }
 
@@ -150,7 +104,7 @@ mod tests {
     #[test]
     fn test_monograph_validation_passes() {
         let content = include_str!("../../../docs/hologram_r4_formal_monograph.md");
-        let report = MonographTraceabilityVerifier::validate_monograph_text(content).unwrap();
+        let report = MonographTraceabilityVerifier::validate_monograph_text(content);
 
         assert_eq!(report.total_sections_verified, 19);
         assert_eq!(report.total_modules_linked, 12);

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -104,7 +104,6 @@ struct R4g1World {
     // Formal Monograph fields (#133)
     monograph_text: String,
     monograph_report: Option<uor_r4_graph_compiler::monograph::MonographValidationReport>,
-    monograph_error: Option<uor_r4_graph_compiler::monograph::MonographValidationError>,
     // Expand Proof Model fields (#132)
     proof_report: Option<uor_r4_proof_model::structural_guarantees::ProofVerificationReport>,
     proof_nodes: Vec<u32>,
@@ -987,7 +986,7 @@ fn bdd_decouple_contradictory_error_check(w: &mut R4g1World) {
 // =========================================================================
 // Formal Monograph BDD Steps (#133)
 // =========================================================================
-use uor_r4_graph_compiler::monograph::{MonographTraceabilityVerifier, MonographValidationError};
+use uor_r4_graph_compiler::monograph::MonographTraceabilityVerifier;
 
 #[given("the living formal monograph document")]
 fn bdd_given_monograph_doc(w: &mut R4g1World) {
@@ -996,11 +995,11 @@ fn bdd_given_monograph_doc(w: &mut R4g1World) {
 
 #[when("audited by the monograph traceability verifier")]
 fn bdd_validate_monograph_step(w: &mut R4g1World) {
-    let res = MonographTraceabilityVerifier::validate_monograph_text(&w.monograph_text);
-    match res {
-        Ok(rep) => w.monograph_report = Some(rep),
-        Err(err) => w.monograph_error = Some(err),
-    }
+    // Total validation: always produces a report; `verified` and the count
+    // fields carry the finding.
+    w.monograph_report = Some(MonographTraceabilityVerifier::validate_monograph_text(
+        &w.monograph_text,
+    ));
 }
 
 #[then("all 19 monograph sections are verified present")]
@@ -1033,11 +1032,11 @@ fn bdd_given_missing_section(w: &mut R4g1World) {
 
 #[then("validation fails with a missing section error")]
 fn bdd_missing_section_error_check(w: &mut R4g1World) {
-    let err = w.monograph_error.as_ref().expect("monograph error");
-    assert!(matches!(
-        err,
-        MonographValidationError::MissingSection { .. }
-    ));
+    // Total validation: a missing section is reported as not-verified with a
+    // section count below the required 19, not a raised error.
+    let rep = w.monograph_report.as_ref().expect("monograph report");
+    assert!(!rep.verified);
+    assert!(rep.total_sections_verified < 19);
 }
 
 #[given("a monograph draft missing non-goal \"No Human-Level Reasoning Claim\"")]
@@ -1048,11 +1047,11 @@ fn bdd_given_missing_non_goal(w: &mut R4g1World) {
 
 #[then("validation fails with a missing non-goal error")]
 fn bdd_missing_non_goal_error_check(w: &mut R4g1World) {
-    let err = w.monograph_error.as_ref().expect("monograph error");
-    assert!(matches!(
-        err,
-        MonographValidationError::MissingNonGoalDisavowal { .. }
-    ));
+    // Total validation: a missing non-goal disavowal is reported as
+    // not-verified with fewer than the 3 required disavowals present.
+    let rep = w.monograph_report.as_ref().expect("monograph report");
+    assert!(!rep.verified);
+    assert!(rep.non_goals_disavowed < 3);
 }
 
 // =========================================================================


### PR DESCRIPTION
Third `uor-r4-graph-compiler` tranche. **80 → 79.** `monograph.rs` is a validator; under R5 it reports completeness as a value, not a raised error.

- `validate_monograph_text` → `MonographValidationReport` directly (was `Result<_, MonographValidationError>`). Counts present sections / module links / non-goal disavowals without early return; `verified` is true only when all three counts equal their required lengths. `MonographValidationError` removed.
- bdd steps rewritten (World's `monograph_error` field dropped): the missing-section / missing-non-goal scenarios assert the report is not-verified with a count below the required total.

## Verification
- `cargo build --workspace --all-targets` clean; `cargo build -p uor-r4-graph-compiler --target wasm32-unknown-unknown` clean (TRAP A — pure text validation)
- monograph unit test passes; **BDD 101/101 scenarios, 337/337 steps** pass; `clippy -D warnings` clean; `cargo fmt --check` clean
- `audit-limits` graph-compiler **80 → 79**

🤖 Generated with [Claude Code](https://claude.com/claude-code)