### PR TITLE
feat(#510): R5 tranche 5d — graph-compiler executor cluster to total

### DIFF
--- a/crates/uor-r4-graph-certify/src/certificate.rs
+++ b/crates/uor-r4-graph-certify/src/certificate.rs
@@ -136,26 +136,24 @@ impl Certificate {
         claim_fragments: &[EmpiricalClaim],
         threads: usize,
     ) -> Result<Vec<EmpiricalClaim>, String> {
+        // The compiler executor is now total (infallible worker closure; a
+        // worker panic propagates). Fragment cloning cannot fail, so this
+        // helper never reports an error — it keeps its `Result` surface until
+        // graph-certify's own R5 conversion.
         let indices: Vec<usize> = (0..claim_fragments.len()).collect();
-        if threads == 1 {
-            return SequentialExecutor::new()
-                .map(&indices, |&idx| Ok(claim_fragments[idx].clone()))
-                .map_err(|e| e.to_string());
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            RayonExecutor::new(threads)
-                .and_then(|executor| {
-                    executor.map(&indices, |&idx| Ok(claim_fragments[idx].clone()))
-                })
-                .map_err(|e| e.to_string())
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            SequentialExecutor::new()
-                .map(&indices, |&idx| Ok(claim_fragments[idx].clone()))
-                .map_err(|e| e.to_string())
-        }
+        let claims = if threads == 1 {
+            SequentialExecutor::new().map(&indices, |&idx| claim_fragments[idx].clone())
+        } else {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                RayonExecutor::new(threads).map(&indices, |&idx| claim_fragments[idx].clone())
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                SequentialExecutor::new().map(&indices, |&idx| claim_fragments[idx].clone())
+            }
+        };
+        Ok(claims)
     }
 
     fn canonical_sort_and_dedup_claims(claims: &mut Vec<EmpiricalClaim>) {

--- a/crates/uor-r4-graph-compiler/src/executor.rs
+++ b/crates/uor-r4-graph-compiler/src/executor.rs
@@ -6,56 +6,22 @@
 //!
 //! Enforces:
 //! - Positional output mapping (`map` result index matches input index).
-//! - Deterministic error aggregation (returns the error from the lowest input index).
-//! - Worker panic containment (`std::panic::catch_unwind` converted to `CompileError::ExecutionPanic`).
-
-use std::any::Any;
-use std::fmt;
-
-/// Typed compilation error taxonomy for compiler executors.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CompileError {
-    /// Worker closure returned an explicit error message.
-    WorkerError { input_index: usize, message: String },
-    /// Worker closure panicked during execution.
-    ExecutionPanic {
-        input_index: usize,
-        panic_message: String,
-    },
-    /// Executor configuration error.
-    InvalidConfiguration(String),
-}
-
-impl fmt::Display for CompileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::WorkerError {
-                input_index,
-                message,
-            } => {
-                write!(f, "Worker error at index {input_index}: {message}")
-            }
-            Self::ExecutionPanic {
-                input_index,
-                panic_message,
-            } => {
-                write!(f, "Worker panic at index {input_index}: {panic_message}")
-            }
-            Self::InvalidConfiguration(msg) => write!(f, "Executor configuration error: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for CompileError {}
+//! - Worker panic propagation: `map` is total over an infallible worker
+//!   closure, so the only way a worker can fail is to panic, and a panic is a
+//!   defect that propagates (re-raised in the calling thread), never a
+//!   sanctioned reportable condition (R5). There is no error surface to
+//!   aggregate.
 
 /// Abstract compiler task executor.
 pub trait CompilerExecutor: Send + Sync {
-    /// Execute function `f` over each item in `inputs`, returning mapped outputs in positional order.
-    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Result<Vec<O>, CompileError>
+    /// Execute function `f` over each item in `inputs`, returning mapped outputs
+    /// in positional order. Total: `f` is infallible and the mapping cannot
+    /// report an error; a worker panic propagates.
+    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Vec<O>
     where
         I: Sync,
         O: Send,
-        F: Fn(&I) -> Result<O, String> + Sync;
+        F: Fn(&I) -> O + Sync;
 }
 
 /// Normative sequential reference executor (zero concurrency).
@@ -69,33 +35,13 @@ impl SequentialExecutor {
 }
 
 impl CompilerExecutor for SequentialExecutor {
-    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Result<Vec<O>, CompileError>
+    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Vec<O>
     where
         I: Sync,
         O: Send,
-        F: Fn(&I) -> Result<O, String> + Sync,
+        F: Fn(&I) -> O + Sync,
     {
-        let mut results = Vec::with_capacity(inputs.len());
-        for (idx, item) in inputs.iter().enumerate() {
-            let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(item)));
-            match res {
-                Ok(Ok(out)) => results.push(out),
-                Ok(Err(msg)) => {
-                    return Err(CompileError::WorkerError {
-                        input_index: idx,
-                        message: msg,
-                    });
-                }
-                Err(panic_err) => {
-                    let msg = extract_panic_message(&*panic_err);
-                    return Err(CompileError::ExecutionPanic {
-                        input_index: idx,
-                        panic_message: msg,
-                    });
-                }
-            }
-        }
-        Ok(results)
+        inputs.iter().map(&f).collect()
     }
 }
 
@@ -108,7 +54,11 @@ pub struct RayonExecutor {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl RayonExecutor {
-    pub fn new(num_threads: usize) -> Result<Self, CompileError> {
+    /// Build an executor over a dedicated `ThreadPool` of `num_threads`
+    /// (0 = the host's available parallelism). Total: a thread-pool that will
+    /// not build is a host defect (cannot spawn threads), so it propagates as a
+    /// panic rather than a sanctioned condition (R5).
+    pub fn new(num_threads: usize) -> Self {
         let threads = if num_threads == 0 {
             std::thread::available_parallelism()
                 .map(|n| n.get())
@@ -120,11 +70,11 @@ impl RayonExecutor {
             .num_threads(threads)
             .thread_name(|i| format!("uor-r4-compiler-{i}"))
             .build()
-            .map_err(|e| CompileError::InvalidConfiguration(e.to_string()))?;
-        Ok(Self {
+            .unwrap_or_else(|e| panic!("uor-r4 compiler thread pool construction failed: {e}"));
+        Self {
             pool,
             num_threads: threads,
-        })
+        }
     }
 
     pub fn num_threads(&self) -> usize {
@@ -134,56 +84,22 @@ impl RayonExecutor {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl CompilerExecutor for RayonExecutor {
-    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Result<Vec<O>, CompileError>
+    fn map<I, O, F>(&self, inputs: &[I], f: F) -> Vec<O>
     where
         I: Sync,
         O: Send,
-        F: Fn(&I) -> Result<O, String> + Sync,
+        F: Fn(&I) -> O + Sync,
     {
         if inputs.is_empty() {
-            return Ok(Vec::new());
+            return Vec::new();
         }
-
-        let raw_results: Vec<Result<Result<O, String>, Box<dyn Any + Send>>> =
-            self.pool.install(|| {
-                use rayon::prelude::*;
-                inputs
-                    .par_iter()
-                    .map(|item| std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(item))))
-                    .collect()
-            });
-
-        let mut outputs = Vec::with_capacity(inputs.len());
-        for (idx, res) in raw_results.into_iter().enumerate() {
-            match res {
-                Ok(Ok(val)) => outputs.push(val),
-                Ok(Err(msg)) => {
-                    return Err(CompileError::WorkerError {
-                        input_index: idx,
-                        message: msg,
-                    });
-                }
-                Err(panic_err) => {
-                    let msg = extract_panic_message(&*panic_err);
-                    return Err(CompileError::ExecutionPanic {
-                        input_index: idx,
-                        panic_message: msg,
-                    });
-                }
-            }
-        }
-
-        Ok(outputs)
-    }
-}
-
-fn extract_panic_message(err: &(dyn Any + Send)) -> String {
-    if let Some(s) = err.downcast_ref::<&'static str>() {
-        s.to_string()
-    } else if let Some(s) = err.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "unknown worker panic".to_string()
+        // `par_iter().map(..).collect()` preserves positional order, and rayon
+        // re-raises a worker panic in this thread on `collect` — the total
+        // panic-propagation contract above.
+        self.pool.install(|| {
+            use rayon::prelude::*;
+            inputs.par_iter().map(&f).collect()
+        })
     }
 }
 
@@ -192,74 +108,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sequential_executor_mapping_and_panic_containment() {
+    fn test_sequential_executor_mapping_and_panic_propagation() {
         let exec = SequentialExecutor::new();
         let inputs = vec![1, 2, 3, 4, 5];
-        let res = exec.map(&inputs, |&x| Ok(x * 10)).unwrap();
+        let res = exec.map(&inputs, |&x| x * 10);
         assert_eq!(res, vec![10, 20, 30, 40, 50]);
 
-        let err = exec
-            .map(&inputs, |&x| {
-                if x == 3 {
-                    Err("x is 3".to_string())
-                } else {
-                    Ok(x)
-                }
-            })
-            .unwrap_err();
-        assert_eq!(
-            err,
-            CompileError::WorkerError {
-                input_index: 2,
-                message: "x is 3".to_string()
-            }
-        );
-
-        let panic_err = exec
-            .map(&inputs, |&x| {
-                if x == 2 {
-                    panic!("simulated panic");
-                } else {
-                    Ok(x)
-                }
-            })
-            .unwrap_err();
-        assert_eq!(
-            panic_err,
-            CompileError::ExecutionPanic {
-                input_index: 1,
-                panic_message: "simulated panic".to_string()
-            }
-        );
+        // A worker panic propagates (total map): catch it to assert it aborts
+        // the whole mapping rather than being folded into a reported error.
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            exec.map(
+                &inputs,
+                |&x| if x == 2 { panic!("simulated panic") } else { x },
+            )
+        }));
+        assert!(panicked.is_err());
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_rayon_executor_mapping_equivalence_and_panic_containment() {
+    fn test_rayon_executor_mapping_equivalence_and_panic_propagation() {
         let seq_exec = SequentialExecutor::new();
-        let par_exec = RayonExecutor::new(4).unwrap();
+        let par_exec = RayonExecutor::new(4);
         assert_eq!(par_exec.num_threads(), 4);
 
         let inputs: Vec<u32> = (1..=100).collect();
-        let seq_out = seq_exec.map(&inputs, |&x| Ok(x * x + 7)).unwrap();
-        let par_out = par_exec.map(&inputs, |&x| Ok(x * x + 7)).unwrap();
+        let seq_out = seq_exec.map(&inputs, |&x| x * x + 7);
+        let par_out = par_exec.map(&inputs, |&x| x * x + 7);
         assert_eq!(seq_out, par_out);
 
-        let panic_err = par_exec
-            .map(&inputs, |&x| {
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            par_exec.map(&inputs, |&x| {
                 if x == 42 {
-                    panic!("rayon worker panic");
+                    panic!("rayon worker panic")
                 } else {
-                    Ok(x)
+                    x
                 }
             })
-            .unwrap_err();
-        assert_eq!(
-            panic_err,
-            CompileError::ExecutionPanic {
-                input_index: 41,
-                panic_message: "rayon worker panic".to_string()
-            }
-        );
+        }));
+        assert!(panicked.is_err());
     }
 }

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2292,7 +2292,7 @@ pub fn emit_r4g1(
         forward_len[dst] += 1;
     }
 
-    let mut rout = crate::routing::synthesize_routing_program(cover, observations)?;
+    let mut rout = crate::routing::synthesize_routing_program(cover, observations);
     while !rout.len().is_multiple_of(8) {
         rout.push(0x00);
     }

--- a/crates/uor-r4-graph-compiler/src/pack.rs
+++ b/crates/uor-r4-graph-compiler/src/pack.rs
@@ -35,7 +35,6 @@ struct EmissionFragment {
 /// and align emission blocks to 64-byte cache lines.
 pub fn pack_emission_tables(region_emissions: &[Vec<u8>]) -> PackedEmissionTable {
     pack_emission_tables_with_threads(region_emissions, 1)
-        .expect("pack_emission_tables with a sequential executor must not fail")
 }
 
 /// Deduplicate emission tables with bounded parallel fragment preparation and
@@ -43,14 +42,12 @@ pub fn pack_emission_tables(region_emissions: &[Vec<u8>]) -> PackedEmissionTable
 pub fn pack_emission_tables_with_threads(
     region_emissions: &[Vec<u8>],
     threads: usize,
-) -> Result<PackedEmissionTable, String> {
+) -> PackedEmissionTable {
     let indices: Vec<usize> = (0..region_emissions.len()).collect();
-    let mut fragments = map_with_threads(&indices, threads, |&idx| {
-        Ok(EmissionFragment {
-            region_index: idx,
-            table: region_emissions[idx].clone(),
-        })
-    })?;
+    let mut fragments = map_with_threads(&indices, threads, |&idx| EmissionFragment {
+        region_index: idx,
+        table: region_emissions[idx].clone(),
+    });
     fragments.sort_by_key(|fragment| fragment.region_index);
 
     let mut packed_bytes = Vec::new();
@@ -82,34 +79,28 @@ pub fn pack_emission_tables_with_threads(
 
     pad_to_cache_line(&mut packed_bytes);
 
-    Ok(PackedEmissionTable {
+    PackedEmissionTable {
         bytes: packed_bytes,
         ranges,
-    })
+    }
 }
 
-fn map_with_threads<I, O, F>(inputs: &[I], threads: usize, map_fn: F) -> Result<Vec<O>, String>
+fn map_with_threads<I, O, F>(inputs: &[I], threads: usize, map_fn: F) -> Vec<O>
 where
     I: Sync,
     O: Send,
-    F: Fn(&I) -> Result<O, String> + Sync,
+    F: Fn(&I) -> O + Sync,
 {
     if threads == 1 {
-        return SequentialExecutor::new()
-            .map(inputs, map_fn)
-            .map_err(|e| e.to_string());
+        return SequentialExecutor::new().map(inputs, map_fn);
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        RayonExecutor::new(threads)
-            .and_then(|executor| executor.map(inputs, map_fn))
-            .map_err(|e| e.to_string())
+        RayonExecutor::new(threads).map(inputs, map_fn)
     }
     #[cfg(target_arch = "wasm32")]
     {
-        SequentialExecutor::new()
-            .map(inputs, map_fn)
-            .map_err(|e| e.to_string())
+        SequentialExecutor::new().map(inputs, map_fn)
     }
 }
 
@@ -147,9 +138,9 @@ mod tests {
             vec![9, 8, 7, 6],
             vec![0, 0, 1, 1, 2, 2, 3, 3],
         ];
-        let seq = pack_emission_tables_with_threads(&tables, 1).unwrap();
-        let par2 = pack_emission_tables_with_threads(&tables, 2).unwrap();
-        let par4 = pack_emission_tables_with_threads(&tables, 4).unwrap();
+        let seq = pack_emission_tables_with_threads(&tables, 1);
+        let par2 = pack_emission_tables_with_threads(&tables, 2);
+        let par4 = pack_emission_tables_with_threads(&tables, 4);
         assert_eq!(seq, par2);
         assert_eq!(seq, par4);
     }
@@ -157,8 +148,8 @@ mod tests {
     #[test]
     fn test_pack_emission_tables_threads_zero_matches_sequential() {
         let tables = vec![vec![1, 2, 3], vec![4, 5], vec![1, 2, 3], vec![]];
-        let seq = pack_emission_tables_with_threads(&tables, 1).unwrap();
-        let auto = pack_emission_tables_with_threads(&tables, 0).unwrap();
+        let seq = pack_emission_tables_with_threads(&tables, 1);
+        let auto = pack_emission_tables_with_threads(&tables, 0);
         assert_eq!(seq, auto);
     }
 }

--- a/crates/uor-r4-graph-compiler/src/reproducibility.rs
+++ b/crates/uor-r4-graph-compiler/src/reproducibility.rs
@@ -23,19 +23,6 @@ pub struct ReproducibilityReport {
     pub parallel_hashes: Vec<(usize, String)>,
 }
 
-/// Errors returned when reproducibility verification fails.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReproducibilityError {
-    /// Parallel output at a specific thread count differed from sequential output.
-    ByteMismatch {
-        thread_count: usize,
-        expected_hash: String,
-        actual_hash: String,
-    },
-    /// Compiler execution failed during reproducibility sweep.
-    ExecutionFailed(String),
-}
-
 /// Harness for verifying canonical artifact byte equality under compiler parallelism.
 pub struct ParallelReproducibilityHarness;
 
@@ -45,21 +32,24 @@ impl ParallelReproducibilityHarness {
         blake3::hash(bytes).to_hex().to_string()
     }
 
-    /// Execute reproducibility verification across a thread count sweep.
-    pub fn verify_reproducibility<I, F>(
-        inputs: &[I],
-        map_fn: F,
-    ) -> Result<ReproducibilityReport, ReproducibilityError>
+    /// Execute reproducibility verification across a thread count sweep. Total:
+    /// always produces a [`ReproducibilityReport`]; `is_byte_identical` is
+    /// `false` when any tested thread count's output diverges from the
+    /// sequential reference (R5 — a measured byte mismatch is a report, not a
+    /// raised error). The mapping closure is infallible; a worker panic
+    /// propagates.
+    pub fn verify_reproducibility<I, F>(inputs: &[I], map_fn: F) -> ReproducibilityReport
     where
         I: Sync + Send,
-        F: Fn(&I) -> Result<Vec<u8>, String> + Sync + Send,
+        F: Fn(&I) -> Vec<u8> + Sync + Send,
     {
         // 1. Sequential reference run
         let seq_exec = SequentialExecutor::new();
-        let seq_chunks = seq_exec
+        let seq_bytes: Vec<u8> = seq_exec
             .map(inputs, &map_fn)
-            .map_err(|e| ReproducibilityError::ExecutionFailed(format!("{e:?}")))?;
-        let seq_bytes: Vec<u8> = seq_chunks.into_iter().flatten().collect();
+            .into_iter()
+            .flatten()
+            .collect();
         let seq_hash = Self::compute_digest(&seq_bytes);
 
         #[cfg(target_arch = "wasm32")]
@@ -69,23 +59,23 @@ impl ParallelReproducibilityHarness {
         let thread_counts = vec![1, 2, 4];
 
         let mut parallel_hashes = Vec::new();
+        let mut is_byte_identical = true;
 
         for &threads in &thread_counts {
             let par_bytes: Vec<u8> = if threads == 1 {
-                let exec = SequentialExecutor::new();
-                let chunks = exec
+                SequentialExecutor::new()
                     .map(inputs, &map_fn)
-                    .map_err(|e| ReproducibilityError::ExecutionFailed(format!("{e:?}")))?;
-                chunks.into_iter().flatten().collect()
+                    .into_iter()
+                    .flatten()
+                    .collect()
             } else {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
-                    let exec = RayonExecutor::new(threads)
-                        .map_err(|e| ReproducibilityError::ExecutionFailed(format!("{e:?}")))?;
-                    let chunks = exec
+                    RayonExecutor::new(threads)
                         .map(inputs, &map_fn)
-                        .map_err(|e| ReproducibilityError::ExecutionFailed(format!("{e:?}")))?;
-                    chunks.into_iter().flatten().collect()
+                        .into_iter()
+                        .flatten()
+                        .collect()
                 }
                 #[cfg(target_arch = "wasm32")]
                 {
@@ -94,22 +84,19 @@ impl ParallelReproducibilityHarness {
             };
 
             let par_hash = Self::compute_digest(&par_bytes);
+            parallel_hashes.push((threads, par_hash.clone()));
             if par_hash != seq_hash {
-                return Err(ReproducibilityError::ByteMismatch {
-                    thread_count: threads,
-                    expected_hash: seq_hash,
-                    actual_hash: par_hash,
-                });
+                is_byte_identical = false;
+                break;
             }
-            parallel_hashes.push((threads, par_hash));
         }
 
-        Ok(ReproducibilityReport {
-            is_byte_identical: true,
+        ReproducibilityReport {
+            is_byte_identical,
             thread_counts_tested: thread_counts,
             sequential_hash: seq_hash,
             parallel_hashes,
-        })
+        }
     }
 }
 
@@ -188,9 +175,8 @@ mod tests {
     fn test_reproducibility_harness_positive_sweep() {
         let inputs = vec![10u32, 20u32, 30u32, 40u32];
         let report = ParallelReproducibilityHarness::verify_reproducibility(&inputs, |&x| {
-            Ok(x.to_le_bytes().to_vec())
-        })
-        .unwrap();
+            x.to_le_bytes().to_vec()
+        });
 
         assert!(report.is_byte_identical);
         assert!(!report.thread_counts_tested.is_empty());
@@ -206,13 +192,13 @@ mod tests {
         // Intentionally non-deterministic reduction function that depends on call order
         let result = ParallelReproducibilityHarness::verify_reproducibility(&inputs, |_| {
             let c = CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            Ok(vec![c as u8])
+            vec![c as u8]
         });
 
-        // The harness must detect nondeterminism (or report byte mismatch)
+        // The harness must detect nondeterminism by reporting a byte mismatch
         // when outputs differ across runs.
         assert!(
-            result.is_err() || !result.as_ref().unwrap().is_byte_identical,
+            !result.is_byte_identical,
             "Harness failed to detect non-deterministic reduction"
         );
     }

--- a/crates/uor-r4-graph-compiler/src/residual.rs
+++ b/crates/uor-r4-graph-compiler/src/residual.rs
@@ -32,20 +32,15 @@ pub fn quantize_logprobs_with_threads(
     tokens: &[u32],
     logprobs: &[f32],
     threads: usize,
-) -> Result<Vec<QuantizedResidual>, String> {
-    if tokens.len() != logprobs.len() {
-        return Err(format!(
-            "token/logprob length mismatch: {} vs {}",
-            tokens.len(),
-            logprobs.len()
-        ));
-    }
-    let indices: Vec<usize> = (0..tokens.len()).collect();
-    map_with_threads(&indices, threads, |&idx| {
-        Ok(QuantizedResidual {
-            token: tokens[idx],
-            score: ScoreQ::from_logprob(logprobs[idx]),
-        })
+) -> Vec<QuantizedResidual> {
+    // Total: quantize over the common prefix, truncating on any length mismatch
+    // exactly as the single-threaded `quantize_logprobs` does (a mismatch is a
+    // property of the caller's inputs, not a sanctioned condition).
+    let n = tokens.len().min(logprobs.len());
+    let indices: Vec<usize> = (0..n).collect();
+    map_with_threads(&indices, threads, |&idx| QuantizedResidual {
+        token: tokens[idx],
+        score: ScoreQ::from_logprob(logprobs[idx]),
     })
 }
 
@@ -56,7 +51,6 @@ pub fn compute_residual_deltas(
     parent_residuals: &[QuantizedResidual],
 ) -> Vec<QuantizedResidual> {
     compute_residual_deltas_with_threads(child_residuals, parent_residuals, 1)
-        .expect("compute_residual_deltas with a sequential executor must not fail")
 }
 
 /// Compute residual delta corrections with canonical key ordering and bounded
@@ -65,7 +59,7 @@ pub fn compute_residual_deltas_with_threads(
     child_residuals: &[QuantizedResidual],
     parent_residuals: &[QuantizedResidual],
     threads: usize,
-) -> Result<Vec<QuantizedResidual>, String> {
+) -> Vec<QuantizedResidual> {
     let child_canonical = canonicalize_residuals(child_residuals);
     let parent_by_token = canonicalize_residuals(parent_residuals)
         .into_iter()
@@ -77,10 +71,10 @@ pub fn compute_residual_deltas_with_threads(
             .get(&child.token)
             .copied()
             .unwrap_or(ScoreQ::ZERO);
-        Ok(QuantizedResidual {
+        QuantizedResidual {
             token: child.token,
             score: child.score.saturating_sub(parent_score),
-        })
+        }
     })
 }
 
@@ -95,28 +89,22 @@ fn canonicalize_residuals(residuals: &[QuantizedResidual]) -> Vec<QuantizedResid
     canonical
 }
 
-fn map_with_threads<I, O, F>(inputs: &[I], threads: usize, map_fn: F) -> Result<Vec<O>, String>
+fn map_with_threads<I, O, F>(inputs: &[I], threads: usize, map_fn: F) -> Vec<O>
 where
     I: Sync,
     O: Send,
-    F: Fn(&I) -> Result<O, String> + Sync,
+    F: Fn(&I) -> O + Sync,
 {
     if threads == 1 {
-        return SequentialExecutor::new()
-            .map(inputs, map_fn)
-            .map_err(|e| e.to_string());
+        return SequentialExecutor::new().map(inputs, map_fn);
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        RayonExecutor::new(threads)
-            .and_then(|executor| executor.map(inputs, map_fn))
-            .map_err(|e| e.to_string())
+        RayonExecutor::new(threads).map(inputs, map_fn)
     }
     #[cfg(target_arch = "wasm32")]
     {
-        SequentialExecutor::new()
-            .map(inputs, map_fn)
-            .map_err(|e| e.to_string())
+        SequentialExecutor::new().map(inputs, map_fn)
     }
 }
 
@@ -145,9 +133,9 @@ mod tests {
         let tokens = vec![10, 11, 12, 13, 14, 15];
         let logprobs = vec![-0.1, -0.7, -1.3, -2.2, -0.4, -9.9];
 
-        let seq = quantize_logprobs_with_threads(&tokens, &logprobs, 1).unwrap();
-        let par2 = quantize_logprobs_with_threads(&tokens, &logprobs, 2).unwrap();
-        let par4 = quantize_logprobs_with_threads(&tokens, &logprobs, 4).unwrap();
+        let seq = quantize_logprobs_with_threads(&tokens, &logprobs, 1);
+        let par2 = quantize_logprobs_with_threads(&tokens, &logprobs, 2);
+        let par4 = quantize_logprobs_with_threads(&tokens, &logprobs, 4);
 
         assert_eq!(seq, par2);
         assert_eq!(seq, par4);
@@ -169,8 +157,8 @@ mod tests {
         let tokens = vec![10, 11, 12, 13, 14, 15];
         let logprobs = vec![-0.1, -0.7, -1.3, -2.2, -0.4, -9.9];
 
-        let seq = quantize_logprobs_with_threads(&tokens, &logprobs, 1).unwrap();
-        let auto = quantize_logprobs_with_threads(&tokens, &logprobs, 0).unwrap();
+        let seq = quantize_logprobs_with_threads(&tokens, &logprobs, 1);
+        let auto = quantize_logprobs_with_threads(&tokens, &logprobs, 0);
         assert_eq!(seq, auto);
     }
 
@@ -201,8 +189,8 @@ mod tests {
             },
         ];
 
-        let seq = compute_residual_deltas_with_threads(&child, &parent, 1).unwrap();
-        let par = compute_residual_deltas_with_threads(&child, &parent, 4).unwrap();
+        let seq = compute_residual_deltas_with_threads(&child, &parent, 1);
+        let par = compute_residual_deltas_with_threads(&child, &parent, 4);
         assert_eq!(seq, par);
         assert_eq!(seq.len(), 2);
         assert_eq!(seq[0].token, 5);

--- a/crates/uor-r4-graph-compiler/src/routing.rs
+++ b/crates/uor-r4-graph-compiler/src/routing.rs
@@ -207,18 +207,16 @@ fn evaluate_batched<E: CompilerExecutor>(
     candidates: &[RoutingCandidate],
     observations: &[Observation],
     batch_size: usize,
-) -> Result<Vec<CandidateEvaluation>, String> {
+) -> Vec<CandidateEvaluation> {
     let mut out = Vec::with_capacity(candidates.len());
     let chunk = batch_size.max(1);
     for batch in candidates.chunks(chunk) {
-        let mut evaluated = executor
-            .map(batch, |candidate| {
-                Ok(evaluate_candidate(candidate, observations))
-            })
-            .map_err(|e| format!("routing candidate evaluation failed: {e}"))?;
+        let mut evaluated = executor.map(batch, |candidate| {
+            evaluate_candidate(candidate, observations)
+        });
         out.append(&mut evaluated);
     }
-    Ok(out)
+    out
 }
 
 fn derive_candidates(cover: &Cover, observations: &[Observation]) -> Vec<RoutingCandidate> {
@@ -284,10 +282,10 @@ fn choose_best_for_threads(
     cover: &Cover,
     observations: &[Observation],
     threads: usize,
-) -> Result<CandidateEvaluation, String> {
+) -> CandidateEvaluation {
     let candidates = derive_candidates(cover, observations);
     if candidates.is_empty() {
-        return Ok(CandidateEvaluation {
+        return CandidateEvaluation {
             key: CandidateKey {
                 tap_set: vec![],
                 polynomial_id: 0,
@@ -305,43 +303,42 @@ fn choose_best_for_threads(
                 cache_cost: 0,
             },
             bytecode: vec![OP_HALT],
-        });
+        };
     }
 
     let worker_threads = threads.max(1);
     let total_budget_bytes = 512usize * 1024 * 1024;
-    let budget = CompilerMemoryBudget::derive(total_budget_bytes, worker_threads).map_err(|e| {
-        format!("failed to derive routing memory budget for {worker_threads} threads: {e}")
-    })?;
+    // A fixed 512 MiB budget over >=1 worker is always above the compiler
+    // minimum, so this derivation cannot fail here.
+    let budget = CompilerMemoryBudget::derive(total_budget_bytes, worker_threads)
+        .expect("routing memory budget: 512 MiB over >=1 worker is above the compiler minimum");
     let batch_size = budget.max_in_flight_tasks.clamp(1, candidates.len());
 
     let evaluations = if worker_threads == 1 {
         let seq = SequentialExecutor::new();
-        evaluate_batched(&seq, &candidates, observations, batch_size)?
+        evaluate_batched(&seq, &candidates, observations, batch_size)
     } else {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let par = RayonExecutor::new(worker_threads)
-                .map_err(|e| format!("failed to create routing executor: {e}"))?;
-            evaluate_batched(&par, &candidates, observations, batch_size)?
+            let par = RayonExecutor::new(worker_threads);
+            evaluate_batched(&par, &candidates, observations, batch_size)
         }
         #[cfg(target_arch = "wasm32")]
         {
             let seq = SequentialExecutor::new();
-            evaluate_batched(&seq, &candidates, observations, batch_size)?
+            evaluate_batched(&seq, &candidates, observations, batch_size)
         }
     };
-    reduce_best(evaluations.into_iter()).ok_or_else(|| "routing candidate set was empty".to_owned())
+    // `candidates` is non-empty here (the early return above handles the empty
+    // case), so the reduction always yields a best candidate.
+    reduce_best(evaluations.into_iter()).expect("non-empty candidate set yields a best candidate")
 }
 
-pub fn synthesize_routing_program(
-    cover: &Cover,
-    observations: &[Observation],
-) -> Result<Vec<u8>, String> {
+pub fn synthesize_routing_program(cover: &Cover, observations: &[Observation]) -> Vec<u8> {
     let threads = std::thread::available_parallelism()
         .map(|n| n.get().min(4))
         .unwrap_or(1);
-    choose_best_for_threads(cover, observations, threads).map(|best| best.bytecode)
+    choose_best_for_threads(cover, observations, threads).bytecode
 }
 
 pub fn benchmark_candidate_scaling(
@@ -490,9 +487,9 @@ mod tests {
     fn winner_is_identical_across_thread_counts() {
         let cover = synthetic_cover();
         let observations = synthetic_observations();
-        let one = choose_best_for_threads(&cover, &observations, 1).expect("best");
-        let two = choose_best_for_threads(&cover, &observations, 2).expect("best");
-        let four = choose_best_for_threads(&cover, &observations, 4).expect("best");
+        let one = choose_best_for_threads(&cover, &observations, 1);
+        let two = choose_best_for_threads(&cover, &observations, 2);
+        let four = choose_best_for_threads(&cover, &observations, 4);
         assert_eq!(one.key, two.key);
         assert_eq!(two.key, four.key);
         assert_eq!(one.bytecode, four.bytecode);

--- a/crates/uor-r4-proof-model/src/structural_guarantees.rs
+++ b/crates/uor-r4-proof-model/src/structural_guarantees.rs
@@ -437,11 +437,10 @@ impl StructuralGuaranteeVerifier {
             )
         };
 
+        // The compiler executor is total (infallible worker closure; a worker
+        // panic propagates), so `map` returns the mapped values directly.
         let inputs = vec![1u32, 2u32, 3u32];
-        let seq_res = match SequentialExecutor::new().map(&inputs, |&x| Ok(x * 2)) {
-            Ok(v) => v,
-            Err(_) => return make_report("sequential_executor_error"),
-        };
+        let seq_res = SequentialExecutor::new().map(&inputs, |&x| x * 2);
         if seq_res != vec![2, 4, 6] {
             return make_report("sequential_positional_order");
         }
@@ -449,14 +448,7 @@ impl StructuralGuaranteeVerifier {
         #[cfg(not(target_arch = "wasm32"))]
         {
             use uor_r4_graph_compiler::executor::RayonExecutor;
-            let rayon = match RayonExecutor::new(2) {
-                Ok(r) => r,
-                Err(_) => return make_report("rayon_executor_init"),
-            };
-            let par_res = match rayon.map(&inputs, |&x| Ok(x * 2)) {
-                Ok(v) => v,
-                Err(_) => return make_report("rayon_executor_error"),
-            };
+            let par_res = RayonExecutor::new(2).map(&inputs, |&x| x * 2);
             if par_res != seq_res {
                 return make_report("sequential_rayon_equivalence");
             }
@@ -469,7 +461,8 @@ impl StructuralGuaranteeVerifier {
             verified: true,
             details: "Compiler executor verified: SequentialExecutor positional order correct; \
                       RayonExecutor output is bit-identical to SequentialExecutor (non-wasm32); \
-                      panic containment and deterministic error aggregation covered by unit + BDD suites."
+                      the executor is total over an infallible worker closure and propagates a \
+                      worker panic (covered by unit + BDD suites)."
                 .to_string(),
         }
     }
@@ -524,19 +517,12 @@ impl StructuralGuaranteeVerifier {
         use uor_r4_graph_compiler::reproducibility::ParallelReproducibilityHarness;
         let obl_id = obligation_id.into();
 
+        // The harness is total: it always produces a report whose
+        // `is_byte_identical` carries the finding.
         let inputs = vec![100u32, 200u32, 300u32, 400u32];
-        let report = match ParallelReproducibilityHarness::verify_reproducibility(&inputs, |&x| {
-            Ok(x.to_le_bytes().to_vec())
-        }) {
-            Ok(report) => report,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "parallel reproducibility harness failed to run",
-                );
-            }
-        };
+        let report = ParallelReproducibilityHarness::verify_reproducibility(&inputs, |&x| {
+            x.to_le_bytes().to_vec()
+        });
 
         if !report.is_byte_identical {
             return ProofVerificationReport::unverified(

--- a/features/suites/compiler_executor.feature
+++ b/features/suites/compiler_executor.feature
@@ -8,13 +8,6 @@ Feature: Deterministic compiler executor abstraction
     Then both mapped output vectors are positionally identical
 
   @RF-02 @build
-  Scenario: Aggregate errors deterministically by lowest input index
-    Given a batch of integer input items where item 3 returns a worker error
-    When mapped by the Rayon parallel multicore compiler executor
-    Then execution returns a worker error at input index 2
-
-  @RF-02 @build
-  Scenario: Contain worker panics without aborting the host process
+  Scenario: A worker panic propagates to the caller
     Given a batch of integer input items where item 5 panics
-    When mapped by the Rayon parallel multicore compiler executor
-    Then execution returns a worker panic error at input index 4
+    Then mapping the batch propagates the worker panic

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -2174,26 +2174,20 @@ fn bdd_exec_inputs_given(w: &mut R4g1World, count: usize) {
 #[when("mapped by the sequential reference compiler executor")]
 fn bdd_exec_seq_when(w: &mut R4g1World) {
     let exec = SequentialExecutor::new();
-    w.exec_seq_out = exec
-        .map(&w.exec_inputs, |&x| Ok(x * 2 + 1))
-        .expect("seq map");
+    w.exec_seq_out = exec.map(&w.exec_inputs, |&x| x * 2 + 1);
 }
 
 #[when("mapped by the Rayon parallel multicore compiler executor")]
 fn bdd_exec_par_when(w: &mut R4g1World) {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let exec = RayonExecutor::new(4).expect("rayon exec");
-        w.exec_par_out = exec
-            .map(&w.exec_inputs, |&x| Ok(x * 2 + 1))
-            .expect("par map");
+        let exec = RayonExecutor::new(4);
+        w.exec_par_out = exec.map(&w.exec_inputs, |&x| x * 2 + 1);
     }
     #[cfg(target_arch = "wasm32")]
     {
         let exec = SequentialExecutor::new();
-        w.exec_par_out = exec
-            .map(&w.exec_inputs, |&x| Ok(x * 2 + 1))
-            .expect("par map");
+        w.exec_par_out = exec.map(&w.exec_inputs, |&x| x * 2 + 1);
     }
 }
 
@@ -2202,65 +2196,31 @@ fn bdd_exec_vectors_identical_then(w: &mut R4g1World) {
     assert_eq!(w.exec_seq_out, w.exec_par_out);
 }
 
-#[given(expr = "a batch of integer input items where item {int} returns a worker error")]
-fn bdd_exec_err_input_given(w: &mut R4g1World, err_item: i32) {
-    w.exec_inputs = vec![1, 2, err_item, 4, 5];
-}
-
-#[then(expr = "execution returns a worker error at input index {int}")]
-fn bdd_exec_err_index_then(w: &mut R4g1World, expected_idx: usize) {
-    #[cfg(not(target_arch = "wasm32"))]
-    let exec = RayonExecutor::new(4).expect("rayon exec");
-    #[cfg(target_arch = "wasm32")]
-    let exec = SequentialExecutor::new();
-
-    let err = exec
-        .map(&w.exec_inputs, |&x| {
-            if x == 3 {
-                Err("simulated worker error".to_string())
-            } else {
-                Ok(x)
-            }
-        })
-        .unwrap_err();
-
-    assert_eq!(
-        err,
-        uor_r4_graph_compiler::executor::CompileError::WorkerError {
-            input_index: expected_idx,
-            message: "simulated worker error".to_string()
-        }
-    );
-}
-
 #[given(expr = "a batch of integer input items where item {int} panics")]
 fn bdd_exec_panic_input_given(w: &mut R4g1World, panic_item: i32) {
     w.exec_inputs = vec![1, 2, 3, 4, panic_item];
 }
 
-#[then(expr = "execution returns a worker panic error at input index {int}")]
-fn bdd_exec_panic_index_then(w: &mut R4g1World, expected_idx: usize) {
+#[then("mapping the batch propagates the worker panic")]
+fn bdd_exec_panic_propagates_then(w: &mut R4g1World) {
+    // The compiler executor is total over an infallible worker closure; a
+    // worker panic is a defect that propagates to the caller (re-raised in this
+    // thread) rather than being folded into a reported error (R5).
     #[cfg(not(target_arch = "wasm32"))]
-    let exec = RayonExecutor::new(4).expect("rayon exec");
+    let exec = RayonExecutor::new(4);
     #[cfg(target_arch = "wasm32")]
     let exec = SequentialExecutor::new();
 
-    let err = exec
-        .map(&w.exec_inputs, |&x| {
-            if x == 5 {
-                panic!("simulated panic");
-            } else {
-                Ok(x)
-            }
-        })
-        .unwrap_err();
-
-    assert_eq!(
-        err,
-        uor_r4_graph_compiler::executor::CompileError::ExecutionPanic {
-            input_index: expected_idx,
-            panic_message: "simulated panic".to_string()
-        }
+    let inputs = w.exec_inputs.clone();
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        exec.map(
+            &inputs,
+            |&x| if x == 5 { panic!("simulated panic") } else { x },
+        )
+    }));
+    assert!(
+        panicked.is_err(),
+        "a worker panic must propagate to the caller"
     );
 }
 
@@ -2359,9 +2319,8 @@ fn bdd_reproducibility_eval_when(_w: &mut R4g1World, _t1: usize, _t2: usize, _t3
 #[then("all thread count outputs produce 100% bit-identical byte digests")]
 fn bdd_reproducibility_eval_then(w: &mut R4g1World) {
     let report = ParallelReproducibilityHarness::verify_reproducibility(&w.exec_inputs, |&x| {
-        Ok(x.to_le_bytes().to_vec())
-    })
-    .expect("harness pass");
+        x.to_le_bytes().to_vec()
+    });
 
     assert!(report.is_byte_identical);
 }


### PR DESCRIPTION
The largest `uor-r4-graph-compiler` piece: make the compiler executor total, which flows through every parallel-map consumer. **79 → 59.**

## What changed
- **executor.rs** — remove `CompileError`. `CompilerExecutor::map` → `fn map<I,O,F>(&self, inputs, f) -> Vec<O> where F: Fn(&I)->O + Sync`: the worker closure is infallible (no `WorkerError`), and a worker panic **propagates** (Sequential maps directly; Rayon's `par_iter().map().collect()` re-raises the panic in the caller) rather than being contained into an `ExecutionPanic` variant. `RayonExecutor::new -> Self` (a pool that won't build is a host defect → panic). Under R5 a worker panic is a defect that propagates, never a sanctioned condition.
- **Consumers** made total (drop `Result<_,String>`): `residual.rs`, `pack.rs`, `routing.rs` (`synthesize_routing_program` et al. — the fixed 512 MiB budget and non-empty candidate set are documented invariants, hence `.expect`), `reproducibility.rs` (`verify_reproducibility -> ReproducibilityReport`; `is_byte_identical` carries a mismatch; `ReproducibilityError` removed). `induction.rs` `emit_r4g1` drops the `?` on the now-total routing (it stays `Result` — its other legs are a later tranche).
- **Ripple**: graph-certify `certificate.rs` (adapts to the total executor, keeps its own `Result` for now); proof-model `verify_compiler_executor_compliance` / `verify_parallel_reproducibility_compliance`; `tests/bdd.rs` + `features/suites/compiler_executor.feature` — the worker-error scenario is removed (no fallible worker) and the panic scenario now asserts the panic **propagates** (`catch_unwind`).

## Verification
- `cargo build --workspace --all-targets` clean; `cargo build -p uor-r4-graph-compiler -p uor-r4-graph-certify --target wasm32-unknown-unknown` clean (Rayon is cfg-not-wasm; wasm uses Sequential)
- graph-compiler 86 lib tests + proof-model 18 lib tests pass; **BDD 100/100 scenarios, 333/333 steps**; `clippy -D warnings` clean; `cargo fmt --check` clean
- `audit-deferral` (R4) passes; `audit-limits` graph-compiler **79 → 59**

🤖 Generated with [Claude Code](https://claude.com/claude-code)