### PR TITLE
feat(#510): R5 tranche — graph-compiler config/audit cluster to total (56→50)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/dependency_audit.rs
+++ b/crates/uor-r4-graph-compiler/src/dependency_audit.rs
@@ -5,40 +5,6 @@
 //! Audits workspace lockfiles, crate manifests, and default feature flags to verify
 //! that no GPU, tensor, or BLAS accelerator dependencies enter the compiler tree.
 
-use core::fmt;
-
-/// Errors emitted during compiler dependency auditing.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CompilerDependencyAuditError {
-    /// Forbidden GPU or accelerator crate detected in dependency tree.
-    ForbiddenCrateDetected {
-        crate_name: String,
-        matched_pattern: String,
-    },
-    /// Default GPU feature flag detected in workspace manifest.
-    DefaultGpuFeatureDetected { feature_name: String },
-}
-
-impl fmt::Display for CompilerDependencyAuditError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ForbiddenCrateDetected {
-                crate_name,
-                matched_pattern,
-            } => write!(
-                f,
-                "Forbidden crate '{crate_name}' detected matching denylist pattern '{matched_pattern}'"
-            ),
-            Self::DefaultGpuFeatureDetected { feature_name } => write!(
-                f,
-                "Forbidden default GPU feature '{feature_name}' detected in workspace manifest"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for CompilerDependencyAuditError {}
-
 /// Audit report produced by `CompilerDependencyAuditor`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompilerDependencyAuditReport {
@@ -99,10 +65,11 @@ impl CompilerDependencyAuditor {
         None
     }
 
-    /// Audit a Cargo.lock string for forbidden GPU/tensor/BLAS crates.
-    pub fn audit_lockfile_contents(
-        lockfile_str: &str,
-    ) -> Result<usize, CompilerDependencyAuditError> {
+    /// Audit a Cargo.lock string for forbidden GPU/tensor/BLAS crates. `Some`
+    /// with the count of audited packages when the tree is clean, `None` when a
+    /// forbidden crate is present (R5 — a failed audit is the absence of a clean
+    /// count, a measured report rather than a raised error).
+    pub fn audit_lockfile_contents(lockfile_str: &str) -> Option<usize> {
         let mut audited_count = 0;
         for line in lockfile_str.lines() {
             let trimmed = line.trim();
@@ -113,21 +80,18 @@ impl CompilerDependencyAuditor {
                     .trim_matches('"')
                     .to_lowercase();
 
-                if let Some(matched_pattern) = Self::matches_forbidden_rule(&crate_name) {
-                    return Err(CompilerDependencyAuditError::ForbiddenCrateDetected {
-                        crate_name,
-                        matched_pattern: matched_pattern.to_string(),
-                    });
+                if Self::matches_forbidden_rule(&crate_name).is_some() {
+                    return None;
                 }
             }
         }
-        Ok(audited_count)
+        Some(audited_count)
     }
 
-    /// Audit a Cargo.toml string for forbidden default features.
-    pub fn audit_workspace_features(
-        manifest_str: &str,
-    ) -> Result<usize, CompilerDependencyAuditError> {
+    /// Audit a Cargo.toml string for forbidden default features. `Some` with the
+    /// count of audited default-feature lines when clean, `None` when a
+    /// forbidden default feature is present (R5).
+    pub fn audit_workspace_features(manifest_str: &str) -> Option<usize> {
         let mut audited_count = 0;
         let mut in_default_features = false;
 
@@ -146,14 +110,12 @@ impl CompilerDependencyAuditor {
                 let lower = trimmed.to_lowercase();
                 for &pattern in Self::FORBIDDEN_FEATURE_PATTERNS {
                     if lower.contains(pattern) {
-                        return Err(CompilerDependencyAuditError::DefaultGpuFeatureDetected {
-                            feature_name: pattern.to_string(),
-                        });
+                        return None;
                     }
                 }
             }
         }
-        Ok(audited_count)
+        Some(audited_count)
     }
 }
 
@@ -195,11 +157,7 @@ version = "0.1.0"
 name = "cust"
 version = "0.3.0"
 "#;
-        let err = CompilerDependencyAuditor::audit_lockfile_contents(sample_lockfile).unwrap_err();
-        assert!(matches!(
-            err,
-            CompilerDependencyAuditError::ForbiddenCrateDetected { .. }
-        ));
+        assert!(CompilerDependencyAuditor::audit_lockfile_contents(sample_lockfile).is_none());
     }
 
     #[test]
@@ -209,11 +167,7 @@ version = "0.3.0"
 name = "tch"
 version = "0.14.0"
 "#;
-        let err = CompilerDependencyAuditor::audit_lockfile_contents(sample_lockfile).unwrap_err();
-        assert!(matches!(
-            err,
-            CompilerDependencyAuditError::ForbiddenCrateDetected { .. }
-        ));
+        assert!(CompilerDependencyAuditor::audit_lockfile_contents(sample_lockfile).is_none());
     }
 
     #[test]
@@ -233,10 +187,6 @@ gpu-experimental = []
 [features]
 default = ["gpu", "alloc"]
 "#;
-        let err = CompilerDependencyAuditor::audit_workspace_features(manifest).unwrap_err();
-        assert!(matches!(
-            err,
-            CompilerDependencyAuditError::DefaultGpuFeatureDetected { .. }
-        ));
+        assert!(CompilerDependencyAuditor::audit_workspace_features(manifest).is_none());
     }
 }

--- a/crates/uor-r4-graph-compiler/src/jobs_config.rs
+++ b/crates/uor-r4-graph-compiler/src/jobs_config.rs
@@ -4,7 +4,6 @@
 //! typed error validation, and dedicated custom Rayon thread pool construction.
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// Precedence source of resolved compiler jobs configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -16,37 +15,6 @@ pub enum JobsConfigSource {
     /// Default policy (`min(logical_cpus, 8)`).
     DefaultPolicy,
 }
-
-/// Errors returned when parsing or validating jobs configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum JobsConfigError {
-    /// Passing 0 worker threads is forbidden.
-    ZeroJobsForbidden,
-    /// Thread count string failed decimal integer parsing.
-    InvalidJobCount { value: String },
-    /// Custom thread pool construction failed.
-    ThreadPoolBuildFailed { reason: String },
-}
-
-impl fmt::Display for JobsConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JobsConfigError::ZeroJobsForbidden => {
-                write!(f, "Jobs configuration error: thread count 0 is forbidden")
-            }
-            JobsConfigError::InvalidJobCount { value } => write!(
-                f,
-                "Jobs configuration error: invalid thread count '{value}'"
-            ),
-            JobsConfigError::ThreadPoolBuildFailed { reason } => write!(
-                f,
-                "Jobs configuration error: failed to build dedicated thread pool: {reason}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for JobsConfigError {}
 
 /// Compiler jobs and thread-pool configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,17 +47,18 @@ impl CompilerJobsConfig {
         cpus.min(8)
     }
 
-    /// Resolve configuration following precedence: CLI (`--jobs`) > Env (`R4_COMPILER_THREADS`) > Default.
-    pub fn resolve(
-        cli_jobs: Option<usize>,
-        env_val: Option<&str>,
-    ) -> Result<Self, JobsConfigError> {
+    /// Resolve configuration following precedence: CLI (`--jobs`) > Env
+    /// (`R4_COMPILER_THREADS`) > Default. `None` when the requested count is not
+    /// a valid configuration — a CLI/env value of 0, or an env string that is
+    /// not a decimal integer (R5 — the absence of a valid config, not a raised
+    /// error). An empty/absent env value falls through to the default policy.
+    pub fn resolve(cli_jobs: Option<usize>, env_val: Option<&str>) -> Option<Self> {
         // Tier 1: CLI argument
         if let Some(jobs) = cli_jobs {
             if jobs == 0 {
-                return Err(JobsConfigError::ZeroJobsForbidden);
+                return None;
             }
-            return Ok(CompilerJobsConfig {
+            return Some(CompilerJobsConfig {
                 jobs,
                 thread_name_prefix: "r4-compile".to_string(),
                 source: JobsConfigSource::CliArg,
@@ -100,16 +69,11 @@ impl CompilerJobsConfig {
         if let Some(env_str) = env_val {
             let trimmed = env_str.trim();
             if !trimmed.is_empty() {
-                let parsed: usize =
-                    trimmed
-                        .parse()
-                        .map_err(|_| JobsConfigError::InvalidJobCount {
-                            value: trimmed.to_string(),
-                        })?;
+                let parsed: usize = trimmed.parse().ok()?;
                 if parsed == 0 {
-                    return Err(JobsConfigError::ZeroJobsForbidden);
+                    return None;
                 }
-                return Ok(CompilerJobsConfig {
+                return Some(CompilerJobsConfig {
                     jobs: parsed,
                     thread_name_prefix: "r4-compile".to_string(),
                     source: JobsConfigSource::EnvVar,
@@ -118,20 +82,21 @@ impl CompilerJobsConfig {
         }
 
         // Tier 3: Default policy
-        Ok(CompilerJobsConfig::default())
+        Some(CompilerJobsConfig::default())
     }
 
     /// Build a dedicated named Rayon thread pool owned by the compiler context.
+    /// Total: a thread pool that will not build is a host defect (cannot spawn
+    /// threads), so it propagates as a panic rather than a sanctioned condition
+    /// (R5), matching [`crate::executor::RayonExecutor::new`].
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn build_dedicated_thread_pool(&self) -> Result<rayon::ThreadPool, JobsConfigError> {
+    pub fn build_dedicated_thread_pool(&self) -> rayon::ThreadPool {
         let prefix = self.thread_name_prefix.clone();
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.jobs)
             .thread_name(move |idx| format!("{prefix}-{idx}"))
             .build()
-            .map_err(|e| JobsConfigError::ThreadPoolBuildFailed {
-                reason: format!("{e:?}"),
-            })
+            .unwrap_or_else(|e| panic!("compiler dedicated thread pool construction failed: {e:?}"))
     }
 }
 
@@ -162,20 +127,9 @@ mod tests {
 
     #[test]
     fn test_jobs_config_rejects_zero_and_invalid() {
-        assert_eq!(
-            CompilerJobsConfig::resolve(Some(0), None),
-            Err(JobsConfigError::ZeroJobsForbidden)
-        );
-        assert_eq!(
-            CompilerJobsConfig::resolve(None, Some("0")),
-            Err(JobsConfigError::ZeroJobsForbidden)
-        );
-        assert_eq!(
-            CompilerJobsConfig::resolve(None, Some("invalid_num")),
-            Err(JobsConfigError::InvalidJobCount {
-                value: "invalid_num".to_string()
-            })
-        );
+        assert_eq!(CompilerJobsConfig::resolve(Some(0), None), None);
+        assert_eq!(CompilerJobsConfig::resolve(None, Some("0")), None);
+        assert_eq!(CompilerJobsConfig::resolve(None, Some("invalid_num")), None);
     }
 
     #[test]
@@ -186,7 +140,7 @@ mod tests {
             thread_name_prefix: "test-compile".to_string(),
             source: JobsConfigSource::CliArg,
         };
-        let pool = config.build_dedicated_thread_pool().unwrap();
+        let pool = config.build_dedicated_thread_pool();
         assert_eq!(pool.current_num_threads(), 2);
     }
 }

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -120,10 +120,11 @@ pub fn compile(args: &[String]) -> Result<(), String> {
     let options = parse_options(args)?;
     let env_jobs = std::env::var("R4_COMPILER_THREADS").ok();
     let jobs_config = jobs_config::CompilerJobsConfig::resolve(options.jobs, env_jobs.as_deref())
-        .map_err(|e| e.to_string())?;
-    let _pool = jobs_config
-        .build_dedicated_thread_pool()
-        .map_err(|e| e.to_string())?;
+        .ok_or_else(|| {
+        "invalid worker thread count (--jobs / R4_COMPILER_THREADS must be a positive integer)"
+            .to_owned()
+    })?;
+    let _pool = jobs_config.build_dedicated_thread_pool();
     eprintln!(
         "graph-compiler: initialized dedicated thread pool ({} workers, source: {:?})",
         jobs_config.jobs, jobs_config.source

--- a/crates/uor-r4-graph-compiler/src/memory_budget.rs
+++ b/crates/uor-r4-graph-compiler/src/memory_budget.rs
@@ -4,7 +4,6 @@
 //! bounded in-flight backpressure limiting, and typed `BudgetExceeded` error handling.
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -26,58 +25,6 @@ pub struct StageMemoryEstimate {
     pub per_shard_buffer_bytes: usize,
 }
 
-/// Errors returned during memory budget calculation or runtime backpressure allocation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MemoryBudgetError {
-    /// Provided memory budget is below the mandatory minimum threshold.
-    BudgetTooSmall {
-        required_minimum_bytes: usize,
-        provided_bytes: usize,
-    },
-    /// Stage or worker allocation exceeded the allocated memory budget.
-    BudgetExceeded {
-        stage_id: String,
-        allocated_bytes: usize,
-        budget_bytes: usize,
-    },
-    /// Backpressure queue capacity reached maximum limit.
-    BackpressureLimitReached {
-        capacity: usize,
-        current_in_flight: usize,
-    },
-}
-
-impl fmt::Display for MemoryBudgetError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MemoryBudgetError::BudgetTooSmall {
-                required_minimum_bytes,
-                provided_bytes,
-            } => write!(
-                f,
-                "Memory budget error: provided budget {provided_bytes} bytes is below required minimum {required_minimum_bytes} bytes"
-            ),
-            MemoryBudgetError::BudgetExceeded {
-                stage_id,
-                allocated_bytes,
-                budget_bytes,
-            } => write!(
-                f,
-                "Memory budget error: stage '{stage_id}' requested {allocated_bytes} bytes exceeding budget {budget_bytes} bytes"
-            ),
-            MemoryBudgetError::BackpressureLimitReached {
-                capacity,
-                current_in_flight,
-            } => write!(
-                f,
-                "Memory budget error: in-flight task limit reached ({current_in_flight}/{capacity})"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for MemoryBudgetError {}
-
 /// Concurrency-aware compiler memory budget configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompilerMemoryBudget {
@@ -97,18 +44,15 @@ impl CompilerMemoryBudget {
         MINIMUM_COMPILER_BUDGET_BYTES + (worker_threads * DEFAULT_PER_WORKER_SCRATCH_BYTES)
     }
 
-    /// Derive concurrency-aware memory budget configuration ($PeakRSS \le Budget$).
-    pub fn derive(
-        total_budget_bytes: usize,
-        worker_threads: usize,
-    ) -> Result<Self, MemoryBudgetError> {
+    /// Derive concurrency-aware memory budget configuration ($PeakRSS \le
+    /// Budget$). `None` when `total_budget_bytes` is below the minimum this
+    /// worker count requires (R5 — the requested budget is not a valid
+    /// configuration, the absence of a product rather than a raised error).
+    pub fn derive(total_budget_bytes: usize, worker_threads: usize) -> Option<Self> {
         let threads = worker_threads.max(1);
         let min_required = Self::min_supported_budget_bytes(threads);
         if total_budget_bytes < min_required {
-            return Err(MemoryBudgetError::BudgetTooSmall {
-                required_minimum_bytes: min_required,
-                provided_bytes: total_budget_bytes,
-            });
+            return None;
         }
 
         let worker_scratch_total = threads * DEFAULT_PER_WORKER_SCRATCH_BYTES;
@@ -117,7 +61,7 @@ impl CompilerMemoryBudget {
         let per_task_estimate = 512 * 1024; // 512 KB per task buffer
         let max_in_flight_tasks = (available_for_in_flight / per_task_estimate).max(threads * 2);
 
-        Ok(CompilerMemoryBudget {
+        Some(CompilerMemoryBudget {
             total_budget_bytes,
             max_in_flight_tasks,
             per_worker_scratch_bytes: DEFAULT_PER_WORKER_SCRATCH_BYTES,
@@ -142,15 +86,14 @@ impl InFlightBackpressureLimiter {
         }
     }
 
-    /// Attempt to acquire a slot for an in-flight task. Returns a RAII guard.
-    pub fn try_acquire(&self) -> Result<BackpressureGuard, MemoryBudgetError> {
+    /// Attempt to acquire a slot for an in-flight task. Returns a RAII guard, or
+    /// `None` when the limiter is already at capacity (R5 — the requested slot
+    /// is not available, reported as `None` rather than a raised error).
+    pub fn try_acquire(&self) -> Option<BackpressureGuard> {
         let mut curr = self.current_in_flight.load(Ordering::Relaxed);
         loop {
             if curr >= self.capacity {
-                return Err(MemoryBudgetError::BackpressureLimitReached {
-                    capacity: self.capacity,
-                    current_in_flight: curr,
-                });
+                return None;
             }
             match self.current_in_flight.compare_exchange_weak(
                 curr,
@@ -159,7 +102,7 @@ impl InFlightBackpressureLimiter {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    return Ok(BackpressureGuard {
+                    return Some(BackpressureGuard {
                         current_in_flight: Arc::clone(&self.current_in_flight),
                     });
                 }
@@ -207,8 +150,7 @@ mod tests {
     #[test]
     fn test_budget_derivation_too_small() {
         let too_small = 10 * 1024 * 1024; // 10 MiB
-        let err = CompilerMemoryBudget::derive(too_small, 4).unwrap_err();
-        assert!(matches!(err, MemoryBudgetError::BudgetTooSmall { .. }));
+        assert!(CompilerMemoryBudget::derive(too_small, 4).is_none());
     }
 
     #[test]
@@ -218,14 +160,7 @@ mod tests {
         let g2 = limiter.try_acquire().unwrap();
         assert_eq!(limiter.current_in_flight(), 2);
 
-        let err = limiter.try_acquire().unwrap_err();
-        assert!(matches!(
-            err,
-            MemoryBudgetError::BackpressureLimitReached {
-                capacity: 2,
-                current_in_flight: 2
-            }
-        ));
+        assert!(limiter.try_acquire().is_none());
 
         drop(g1);
         assert_eq!(limiter.current_in_flight(), 1);

--- a/crates/uor-r4-proof-model/src/structural_guarantees.rs
+++ b/crates/uor-r4-proof-model/src/structural_guarantees.rs
@@ -550,40 +550,31 @@ impl StructuralGuaranteeVerifier {
     pub fn verify_compiler_jobs_config_compliance(
         obligation_id: impl Into<String>,
     ) -> ProofVerificationReport {
-        use uor_r4_graph_compiler::jobs_config::{
-            CompilerJobsConfig, JobsConfigError, JobsConfigSource,
-        };
+        use uor_r4_graph_compiler::jobs_config::{CompilerJobsConfig, JobsConfigSource};
         let obl_id = obligation_id.into();
 
         // 1. Check CLI precedence over Env and Default
-        let cli_res = match CompilerJobsConfig::resolve(Some(4), Some("16")) {
-            Ok(cli_res) => cli_res,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "compiler jobs config: CLI-precedence resolution failed",
-                );
-            }
+        let Some(cli_res) = CompilerJobsConfig::resolve(Some(4), Some("16")) else {
+            return ProofVerificationReport::unverified(
+                obl_id,
+                StructuralObligationKind::Determinism,
+                "compiler jobs config: CLI-precedence resolution failed",
+            );
         };
         let prec_ok = cli_res.jobs == 4 && cli_res.source == JobsConfigSource::CliArg;
 
         // 2. Check Env precedence over Default
-        let env_res = match CompilerJobsConfig::resolve(None, Some("6")) {
-            Ok(env_res) => env_res,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "compiler jobs config: env-precedence resolution failed",
-                );
-            }
+        let Some(env_res) = CompilerJobsConfig::resolve(None, Some("6")) else {
+            return ProofVerificationReport::unverified(
+                obl_id,
+                StructuralObligationKind::Determinism,
+                "compiler jobs config: env-precedence resolution failed",
+            );
         };
         let env_ok = env_res.jobs == 6 && env_res.source == JobsConfigSource::EnvVar;
 
-        // 3. Check invalid rejection (0 jobs)
-        let zero_rejected =
-            CompilerJobsConfig::resolve(Some(0), None) == Err(JobsConfigError::ZeroJobsForbidden);
+        // 3. Check invalid rejection (0 jobs): resolve reports no valid config.
+        let zero_rejected = CompilerJobsConfig::resolve(Some(0), None).is_none();
 
         if !prec_ok || !env_ok || !zero_rejected {
             return ProofVerificationReport::unverified(
@@ -612,43 +603,34 @@ impl StructuralGuaranteeVerifier {
         obligation_id: impl Into<String>,
     ) -> ProofVerificationReport {
         use uor_r4_graph_compiler::memory_budget::{
-            CompilerMemoryBudget, InFlightBackpressureLimiter, MemoryBudgetError,
+            CompilerMemoryBudget, InFlightBackpressureLimiter,
         };
         let obl_id = obligation_id.into();
 
         // 1. Derivation check for valid budget
-        let valid_budget = match CompilerMemoryBudget::derive(256 * 1024 * 1024, 4) {
-            Ok(valid_budget) => valid_budget,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "compiler memory budget: valid-budget derivation failed",
-                );
-            }
+        let Some(valid_budget) = CompilerMemoryBudget::derive(256 * 1024 * 1024, 4) else {
+            return ProofVerificationReport::unverified(
+                obl_id,
+                StructuralObligationKind::Determinism,
+                "compiler memory budget: valid-budget derivation failed",
+            );
         };
         let valid_ok = valid_budget.worker_threads == 4 && valid_budget.max_in_flight_tasks >= 1;
 
-        // 2. Rejection check for budget below minimum
-        let too_small_err = CompilerMemoryBudget::derive(10 * 1024 * 1024, 4);
-        let rejection_ok = matches!(too_small_err, Err(MemoryBudgetError::BudgetTooSmall { .. }));
+        // 2. Rejection check for budget below minimum: derivation reports no
+        //    valid budget.
+        let rejection_ok = CompilerMemoryBudget::derive(10 * 1024 * 1024, 4).is_none();
 
         // 3. Backpressure capacity check
         let limiter = InFlightBackpressureLimiter::new(1);
-        let _g1 = match limiter.try_acquire() {
-            Ok(guard) => guard,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "compiler memory budget: initial backpressure acquire failed",
-                );
-            }
+        let Some(_g1) = limiter.try_acquire() else {
+            return ProofVerificationReport::unverified(
+                obl_id,
+                StructuralObligationKind::Determinism,
+                "compiler memory budget: initial backpressure acquire failed",
+            );
         };
-        let cap_ok = matches!(
-            limiter.try_acquire(),
-            Err(MemoryBudgetError::BackpressureLimitReached { .. })
-        );
+        let cap_ok = limiter.try_acquire().is_none();
 
         if !valid_ok || !rejection_ok || !cap_ok {
             return ProofVerificationReport::unverified(
@@ -772,9 +754,7 @@ impl StructuralGuaranteeVerifier {
     pub fn verify_compiler_dependency_audit_compliance(
         obligation_id: impl Into<String>,
     ) -> ProofVerificationReport {
-        use uor_r4_graph_compiler::dependency_audit::{
-            CompilerDependencyAuditError, CompilerDependencyAuditor,
-        };
+        use uor_r4_graph_compiler::dependency_audit::CompilerDependencyAuditor;
         let obl_id = obligation_id.into();
 
         // 1. Clean lockfile audit check
@@ -786,28 +766,24 @@ version = "0.1.0"
 name = "rayon"
 version = "1.10.0"
 "#;
-        let clean_count = match CompilerDependencyAuditor::audit_lockfile_contents(sample_clean) {
-            Ok(clean_count) => clean_count,
-            Err(_) => {
-                return ProofVerificationReport::unverified(
-                    obl_id,
-                    StructuralObligationKind::Determinism,
-                    "compiler dependency audit: clean lockfile failed to audit",
-                );
-            }
+        let Some(clean_count) = CompilerDependencyAuditor::audit_lockfile_contents(sample_clean)
+        else {
+            return ProofVerificationReport::unverified(
+                obl_id,
+                StructuralObligationKind::Determinism,
+                "compiler dependency audit: clean lockfile failed to audit",
+            );
         };
         let clean_ok = clean_count == 2;
 
-        // 2. Denylisted crate rejection check
+        // 2. Denylisted crate rejection check: the audit reports no clean count.
         let sample_cuda = r#"
 [[package]]
 name = "cust"
 version = "0.3.0"
 "#;
-        let rejection_ok = matches!(
-            CompilerDependencyAuditor::audit_lockfile_contents(sample_cuda),
-            Err(CompilerDependencyAuditError::ForbiddenCrateDetected { .. })
-        );
+        let rejection_ok =
+            CompilerDependencyAuditor::audit_lockfile_contents(sample_cuda).is_none();
 
         if !clean_ok || !rejection_ok {
             return ProofVerificationReport::unverified(

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -163,29 +163,14 @@ struct R4g1World {
     // Compiler Jobs Config fields (#168)
     jobs_cli: Option<usize>,
     jobs_env: Option<String>,
-    jobs_config_res: Option<
-        Result<
-            uor_r4_graph_compiler::jobs_config::CompilerJobsConfig,
-            uor_r4_graph_compiler::jobs_config::JobsConfigError,
-        >,
-    >,
+    jobs_config_res: Option<Option<uor_r4_graph_compiler::jobs_config::CompilerJobsConfig>>,
     // Compiler Memory Budget fields (#169)
     mem_req_bytes: usize,
     mem_req_threads: usize,
-    mem_budget_res: Option<
-        Result<
-            uor_r4_graph_compiler::memory_budget::CompilerMemoryBudget,
-            uor_r4_graph_compiler::memory_budget::MemoryBudgetError,
-        >,
-    >,
+    mem_budget_res: Option<Option<uor_r4_graph_compiler::memory_budget::CompilerMemoryBudget>>,
     limiter_capacity: usize,
     limiter_guard1: Option<uor_r4_graph_compiler::memory_budget::BackpressureGuard>,
-    limiter_acq2_res: Option<
-        Result<
-            uor_r4_graph_compiler::memory_budget::BackpressureGuard,
-            uor_r4_graph_compiler::memory_budget::MemoryBudgetError,
-        >,
-    >,
+    limiter_acq2_res: Option<Option<uor_r4_graph_compiler::memory_budget::BackpressureGuard>>,
     // Parallel Observation Shards fields (#170)
     obs_raw_items: Vec<String>,
     obs_chunk_size: usize,
@@ -2388,7 +2373,7 @@ fn bdd_cover_edge_fragments_then(_w: &mut R4g1World) {
 // =========================================================================
 // Feature: Compiler thread-pool, jobs configuration, and oversubscription policy (#168)
 // =========================================================================
-use uor_r4_graph_compiler::jobs_config::{CompilerJobsConfig, JobsConfigError, JobsConfigSource};
+use uor_r4_graph_compiler::jobs_config::{CompilerJobsConfig, JobsConfigSource};
 
 #[given(
     expr = "a compiler jobs configuration request with CLI argument {int} and environment variable {string}"
@@ -2437,29 +2422,21 @@ fn bdd_jobs_eval_then(w: &mut R4g1World, expected_jobs: usize, expected_source: 
 
 #[then("resolution fails with a zero jobs forbidden error")]
 fn bdd_jobs_zero_error_then(w: &mut R4g1World) {
+    // Total resolution: a 0-jobs request has no valid config (`None`).
     let res = w.jobs_config_res.as_ref().expect("jobs_config_res present");
-    assert_eq!(
-        res.as_ref().err(),
-        Some(&JobsConfigError::ZeroJobsForbidden)
-    );
+    assert!(res.is_none(), "0 jobs must not resolve to a config");
 }
 
 #[then(expr = "resolution fails with an invalid job count error for {string}")]
-fn bdd_jobs_invalid_error_then(w: &mut R4g1World, expected_val: String) {
+fn bdd_jobs_invalid_error_then(w: &mut R4g1World, _expected_val: String) {
+    // Total resolution: an unparseable job count has no valid config (`None`).
     let res = w.jobs_config_res.as_ref().expect("jobs_config_res present");
-    assert_eq!(
-        res.as_ref().err(),
-        Some(&JobsConfigError::InvalidJobCount {
-            value: expected_val
-        })
-    );
+    assert!(res.is_none(), "an invalid job count must not resolve");
 }
 // =========================================================================
 // Feature: Compiler memory-budget and backpressure model for multicore compilation (#169)
 // =========================================================================
-use uor_r4_graph_compiler::memory_budget::{
-    CompilerMemoryBudget, InFlightBackpressureLimiter, MemoryBudgetError,
-};
+use uor_r4_graph_compiler::memory_budget::{CompilerMemoryBudget, InFlightBackpressureLimiter};
 
 #[given(expr = "a memory budget request of {int} bytes for {int} worker threads")]
 fn bdd_memory_budget_request_given(w: &mut R4g1World, req_bytes: usize, req_threads: usize) {
@@ -2493,11 +2470,9 @@ fn bdd_memory_budget_eval_then(
 
 #[then("memory budget derivation fails with a budget too small error")]
 fn bdd_memory_budget_too_small_then(w: &mut R4g1World) {
+    // Total derivation: a below-minimum budget has no valid config (`None`).
     let res = w.mem_budget_res.as_ref().expect("mem_budget_res present");
-    assert!(matches!(
-        res.as_ref().err(),
-        Some(MemoryBudgetError::BudgetTooSmall { .. })
-    ));
+    assert!(res.is_none(), "a below-minimum budget must not derive");
 }
 
 #[given(expr = "an in-flight backpressure limiter with capacity {int}")]
@@ -2508,8 +2483,7 @@ fn bdd_limiter_given(w: &mut R4g1World, capacity: usize) {
 #[when("2 task slot acquisitions are attempted sequentially")]
 fn bdd_limiter_acquisitions_when(w: &mut R4g1World) {
     let limiter = InFlightBackpressureLimiter::new(w.limiter_capacity);
-    let g1 = limiter.try_acquire();
-    w.limiter_guard1 = g1.ok();
+    w.limiter_guard1 = limiter.try_acquire();
     w.limiter_acq2_res = Some(limiter.try_acquire());
 }
 
@@ -2518,11 +2492,9 @@ fn bdd_limiter_acquisitions_when(w: &mut R4g1World) {
 )]
 fn bdd_limiter_acquisitions_then(w: &mut R4g1World) {
     assert!(w.limiter_guard1.is_some());
+    // Total try_acquire: at capacity the second acquisition yields `None`.
     let acq2 = w.limiter_acq2_res.as_ref().expect("acq2 present");
-    assert!(matches!(
-        acq2.as_ref().err(),
-        Some(MemoryBudgetError::BackpressureLimitReached { .. })
-    ));
+    assert!(acq2.is_none(), "the 2nd acquisition must fail at capacity");
 }
 
 // =========================================================================


### PR DESCRIPTION
R5 rearchitecture (#510): convert the compiler config/audit surface so `Result` names only sanctioned types. The fallible-but-not-error cases become the absence of a product.

## Modules converted
- **jobs_config.rs** — `CompilerJobsConfig::resolve` → `Option<Self>` (None on 0-jobs or unparseable env); `build_dedicated_thread_pool` → `ThreadPool` or **panic** (host-resource construction defect). `JobsConfigError` removed.
- **memory_budget.rs** — `CompilerMemoryBudget::derive` → `Option<Self>` (None below minimum); `InFlightBackpressureLimiter::try_acquire` → `Option<BackpressureGuard>` (None at capacity). `MemoryBudgetError` removed (incl. unused `BudgetExceeded`).
- **dependency_audit.rs** — `audit_lockfile_contents` / `audit_workspace_features` → `Option<usize>` (None on a forbidden crate/feature). Audit error removed.

## Ripple (same PR)
- **proof-model structural_guarantees.rs** — the three `verify_compiler_*` fns use let-Some-else / `.is_none()` instead of `matches!`/`Err` checks.
- **graph-compiler lib.rs** `compile()` — `resolve()?` adapts via `ok_or_else`; the dedicated pool is now infallible.
- **tests/bdd.rs** — World fields to `Option<Option<_>>`; steps assert `.is_none()`.

## Verification
audit-limits graph-compiler **56 → 50**. 86 lib tests, BDD 100/100, proof-model 24 tests, wasm32 + clippy + fmt clean, audit-deferral clean.

Part of the #510 bottom-up sweep (graph-compiler leaf first).