### PR TITLE
feat(#510): R5 tranche — graph-compiler rate-distortion analyzer to total (49→46)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/rate_distortion_compression.rs
+++ b/crates/uor-r4-graph-compiler/src/rate_distortion_compression.rs
@@ -9,53 +9,6 @@
 //! - Rate-Distortion Trade-off Curves: Evaluated depth-wise across progressive projection tiers ($k$).
 //! - Content-Addressed Reproducible Reporting: Generates deterministic rate-distortion reports.
 
-use std::fmt;
-
-/// Errors arising during rate-distortion evaluation or report generation.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CompressionAnalysisError {
-    /// Rate budget exceeded declared limit.
-    RateBudgetExceeded {
-        metric: String,
-        actual: usize,
-        limit: usize,
-    },
-    /// Distortion exceeds acceptable quality threshold.
-    DistortionThresholdExceeded {
-        metric: String,
-        actual: f32,
-        limit: f32,
-    },
-    /// Invalid depth tier configuration.
-    InvalidDepthTier { depth: usize },
-}
-
-impl fmt::Display for CompressionAnalysisError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::RateBudgetExceeded {
-                metric,
-                actual,
-                limit,
-            } => write!(
-                f,
-                "Rate budget exceeded for '{metric}': actual {actual} > limit {limit}"
-            ),
-            Self::DistortionThresholdExceeded {
-                metric,
-                actual,
-                limit,
-            } => write!(
-                f,
-                "Distortion threshold exceeded for '{metric}': actual {actual:.4} > limit {limit:.4}"
-            ),
-            Self::InvalidDepthTier { depth } => write!(f, "Invalid projection depth tier: {depth}"),
-        }
-    }
-}
-
-impl std::error::Error for CompressionAnalysisError {}
-
 /// Rate terms ($R$) measuring resource footprint.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RateMetrics {
@@ -96,35 +49,35 @@ pub struct RateDistortionReport {
 }
 
 impl RateDistortionReport {
-    /// Enforce rate budget limit on maximum artifact size across evaluated points.
-    pub fn validate_rate_budget(&self, max_bytes: usize) -> Result<(), CompressionAnalysisError> {
+    /// Check the rate budget against the maximum artifact size across evaluated
+    /// points. `None` when every point is within `max_bytes`; `Some(reason)`
+    /// naming the first point that exceeds it (R5 — a validator is total, the
+    /// held property is the absence of a violation rather than a raised error).
+    pub fn validate_rate_budget(&self, max_bytes: usize) -> Option<String> {
         for pt in &self.points {
             if pt.rate.artifact_size_bytes > max_bytes {
-                return Err(CompressionAnalysisError::RateBudgetExceeded {
-                    metric: "artifact_size_bytes".to_string(),
-                    actual: pt.rate.artifact_size_bytes,
-                    limit: max_bytes,
-                });
+                return Some(format!(
+                    "rate budget exceeded for 'artifact_size_bytes': actual {} > limit {max_bytes}",
+                    pt.rate.artifact_size_bytes
+                ));
             }
         }
-        Ok(())
+        None
     }
 
-    /// Enforce distortion threshold limit on maximum teacher KL divergence across evaluated points.
-    pub fn validate_distortion_threshold(
-        &self,
-        max_kl: f32,
-    ) -> Result<(), CompressionAnalysisError> {
+    /// Check the distortion threshold against the maximum teacher KL divergence
+    /// across evaluated points. `None` when every point is within `max_kl`;
+    /// `Some(reason)` naming the first point that exceeds it (R5 — total).
+    pub fn validate_distortion_threshold(&self, max_kl: f32) -> Option<String> {
         for pt in &self.points {
             if pt.distortion.teacher_kl_divergence > max_kl {
-                return Err(CompressionAnalysisError::DistortionThresholdExceeded {
-                    metric: "teacher_kl_divergence".to_string(),
-                    actual: pt.distortion.teacher_kl_divergence,
-                    limit: max_kl,
-                });
+                return Some(format!(
+                    "distortion threshold exceeded for 'teacher_kl_divergence': actual {:.4} > limit {max_kl:.4}",
+                    pt.distortion.teacher_kl_divergence
+                ));
             }
         }
-        Ok(())
+        None
     }
 }
 
@@ -135,12 +88,16 @@ impl SemanticCompressionAnalyzer {
     /// Compute rate-distortion metrics across progressive depth tiers $k \in \{1, 2, 4, 8\}$.
     ///
     /// Evaluates rate-distortion tradeoffs measured against corpus parameters and teacher loss.
+    ///
+    /// `None` when `depth_tiers` is empty or contains a zero tier: no report is
+    /// a product of those tiers (R5 — the absence of a product rather than a
+    /// raised error).
     pub fn analyze_rate_distortion(
         corpus_id: &str,
         depth_tiers: &[usize],
-    ) -> Result<RateDistortionReport, CompressionAnalysisError> {
+    ) -> Option<RateDistortionReport> {
         if depth_tiers.is_empty() {
-            return Err(CompressionAnalysisError::InvalidDepthTier { depth: 0 });
+            return None;
         }
 
         let mut points = Vec::new();
@@ -150,7 +107,7 @@ impl SemanticCompressionAnalyzer {
 
         for &k in depth_tiers {
             if k == 0 {
-                return Err(CompressionAnalysisError::InvalidDepthTier { depth: k });
+                return None;
             }
 
             // Rate terms ($R$) scale with depth tier $k$ and corpus observation count
@@ -234,7 +191,7 @@ impl SemanticCompressionAnalyzer {
         }
         let report_id = format!("rd_cid_fnv1a_{fnv_hash:016x}");
 
-        Ok(RateDistortionReport {
+        Some(RateDistortionReport {
             report_id,
             corpus_id: corpus_id.to_string(),
             points,
@@ -281,11 +238,8 @@ mod tests {
         let report =
             SemanticCompressionAnalyzer::analyze_rate_distortion("mini_corpus", &[1, 2, 4, 8])
                 .unwrap();
-        assert!(report.validate_rate_budget(10_000_000).is_ok());
-        assert!(report.validate_distortion_threshold(2.0).is_ok());
-        assert!(matches!(
-            report.validate_rate_budget(100).unwrap_err(),
-            CompressionAnalysisError::RateBudgetExceeded { .. }
-        ));
+        assert!(report.validate_rate_budget(10_000_000).is_none());
+        assert!(report.validate_distortion_threshold(2.0).is_none());
+        assert!(report.validate_rate_budget(100).is_some());
     }
 }

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -75,7 +75,7 @@ struct R4g1World {
     rd_corpus_id: String,
     rd_tiers: Vec<usize>,
     rd_report: Option<uor_r4_graph_compiler::rate_distortion_compression::RateDistortionReport>,
-    rd_error: Option<uor_r4_graph_compiler::rate_distortion_compression::CompressionAnalysisError>,
+    rd_rejected: bool,
     // Graph Invariant Ownership fields (#135)
     inv_matrix: Vec<uor_r4_graph_format::invariant_ownership::InvariantOwnershipEntry>,
     inv_nodes: usize,
@@ -699,9 +699,7 @@ fn bdd_pdf_invalid_claim_error_check(w: &mut R4g1World) {
 // =========================================================================
 // Rate-Distortion Compression BDD Steps (#136)
 // =========================================================================
-use uor_r4_graph_compiler::rate_distortion_compression::{
-    CompressionAnalysisError, SemanticCompressionAnalyzer,
-};
+use uor_r4_graph_compiler::rate_distortion_compression::SemanticCompressionAnalyzer;
 
 #[given("a pinned mini-corpus \"pinned_mini_corpus_01\" and depth tiers [1, 2, 4, 8]")]
 fn bdd_rd_mini_corpus_given(w: &mut R4g1World) {
@@ -713,8 +711,8 @@ fn bdd_rd_mini_corpus_given(w: &mut R4g1World) {
 fn bdd_rd_execute_analysis(w: &mut R4g1World) {
     let res = SemanticCompressionAnalyzer::analyze_rate_distortion(&w.rd_corpus_id, &w.rd_tiers);
     match res {
-        Ok(rep) => w.rd_report = Some(rep),
-        Err(err) => w.rd_error = Some(err),
+        Some(rep) => w.rd_report = Some(rep),
+        None => w.rd_rejected = true,
     }
 }
 
@@ -770,11 +768,10 @@ fn bdd_rd_invalid_tier_given(w: &mut R4g1World) {
 
 #[then("analysis fails with an invalid depth tier error")]
 fn bdd_rd_invalid_tier_error_check(w: &mut R4g1World) {
-    let err = w.rd_error.as_ref().expect("rd error");
-    assert!(matches!(
-        err,
-        CompressionAnalysisError::InvalidDepthTier { .. }
-    ));
+    assert!(
+        w.rd_rejected,
+        "analysis should have rejected the invalid depth tier array (returned None)"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
R5 rearchitecture (#510): convert `rate_distortion_compression.rs` off its `Result<_, CompressionAnalysisError>` surface to total forms. **The module is now fully total (0 sanctioned-violation sites).** The `CompressionAnalysisError` enum, its `Display`/`Error` impls, and `use std::fmt` are removed.

## Surfaces
- `analyze_rate_distortion -> Option<RateDistortionReport>` — `None` when `depth_tiers` is empty or contains a zero tier. No report is a product of those tiers, so it is the absence of a product, not a raised error.
- `validate_rate_budget` / `validate_distortion_threshold -> Option<String>` — `None` when every point holds, `Some(reason)` naming the first violating point. A validator is total; the held property is the absence of a violation. `Option<String>` rather than `ObservedBound` because the distortion threshold compares f32 values that `ObservedBound`'s i64 fields cannot carry, and the two validators share one uniform total surface.

## Ripple (same PR)
`tests/bdd.rs` — the `rd_error` World field is dropped for `rd_rejected: bool`; the execute step matches `Some`/`None`; the invalid-tier step asserts the analyzer returned `None`. The import drops `CompressionAnalysisError`.

## Verification
audit-limits graph-compiler **49 → 46** (rate_distortion_compression.rs 0 sites). 86 lib tests, BDD 100/100, proof-model 24 tests, wasm32 + clippy + fmt clean, audit-deferral clean.

Part of the #510 bottom-up sweep (graph-compiler leaf).
