### PR TITLE
feat(#510): R5 tranche — graph-compiler future-state planner to total (44→43)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/future_state_planner.rs
+++ b/crates/uor-r4-graph-compiler/src/future_state_planner.rs
@@ -11,79 +11,6 @@
 
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
-use std::fmt;
-
-/// Errors arising during trajectory planning or constraint evaluation.
-#[derive(Debug, Clone, PartialEq)]
-pub enum PlannerError {
-    /// Initial state violates forbidden region constraint.
-    InitialStateForbidden { state_id: String },
-    /// The requested state does not exist in the state graph.
-    UnknownState { state_id: String },
-    /// No valid plan reaches the goal region within the horizon bound.
-    HorizonExceeded { max_horizon: usize },
-    /// Search frontier exhausted without finding goal region.
-    FrontierExhausted {
-        nodes_expanded: usize,
-        forbidden_states_entered: usize,
-    },
-    /// Transition confidence below uncertainty threshold.
-    UncertainTransition {
-        src_id: String,
-        action: String,
-        confidence: f32,
-    },
-    /// Transition enters forbidden constraint region.
-    ForbiddenStateViolation { state_id: String, region_id: String },
-}
-
-impl fmt::Display for PlannerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InitialStateForbidden { state_id } => {
-                write!(
-                    f,
-                    "Initial state '{state_id}' is inside a forbidden constraint region"
-                )
-            }
-            Self::UnknownState { state_id } => {
-                write!(f, "State '{state_id}' does not exist in the state graph")
-            }
-            Self::HorizonExceeded { max_horizon } => {
-                write!(
-                    f,
-                    "Goal not reached within maximum planning horizon of {max_horizon} steps"
-                )
-            }
-            Self::FrontierExhausted {
-                nodes_expanded,
-                forbidden_states_entered,
-            } => {
-                write!(
-                    f,
-                    "Search frontier exhausted after expanding {nodes_expanded} nodes ({forbidden_states_entered} forbidden states entered)"
-                )
-            }
-            Self::UncertainTransition {
-                src_id,
-                action,
-                confidence,
-            } => write!(
-                f,
-                "Uncertain transition from '{src_id}' under action '{action}' (confidence = {confidence:.2})"
-            ),
-            Self::ForbiddenStateViolation {
-                state_id,
-                region_id,
-            } => write!(
-                f,
-                "State '{state_id}' violates forbidden constraint region '{region_id}'"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for PlannerError {}
 
 /// Graph state node for graph transitions.
 #[derive(Debug, Clone, PartialEq)]
@@ -185,38 +112,31 @@ impl PartialOrd for SearchNode {
 pub struct BoundedGraphPlanner;
 
 impl BoundedGraphPlanner {
-    /// Plan finite action trajectory from start state to goal region avoiding forbidden states.
+    /// Plan finite action trajectory from start state to goal region avoiding
+    /// forbidden states. `None` when no trajectory is a product of these inputs:
+    /// the start state is unknown or forbidden, or no plan reaches the goal
+    /// region within the horizon and frontier bounds (R5 — the absence of a
+    /// product rather than a raised error; the search either yields a plan or
+    /// there is none).
     pub fn plan(
         start_state_id: &str,
         nodes: &[PlannerStateNode],
         edges: &[PlannerEdgeTransition],
         config: &PlannerConfig,
-    ) -> Result<PlanTrajectory, PlannerError> {
+    ) -> Option<PlanTrajectory> {
         let node_map: HashMap<&str, &PlannerStateNode> =
             nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
-        let start_node =
-            node_map
-                .get(start_state_id)
-                .ok_or_else(|| PlannerError::UnknownState {
-                    state_id: start_state_id.to_string(),
-                })?;
+        let start_node = node_map.get(start_state_id)?;
 
         if start_node.is_forbidden {
-            return Err(PlannerError::InitialStateForbidden {
-                state_id: start_state_id.to_string(),
-            });
+            return None;
         }
 
         let mut open_set = BinaryHeap::new();
         let mut visited = HashSet::new();
         let mut rejected_count = 0;
         let mut nodes_expanded = 0;
-        let mut forbidden_states_entered = 0;
-        // Set when any node's expansion is dropped for hitting `max_horizon`; used to
-        // report `HorizonExceeded` rather than a misleading `FrontierExhausted` when the
-        // search would otherwise have continued past the bound.
-        let mut horizon_capped = false;
 
         open_set.push(SearchNode {
             state_id: start_state_id.to_string(),
@@ -235,7 +155,6 @@ impl BoundedGraphPlanner {
                 None => continue,
             };
             if curr_node.is_forbidden {
-                forbidden_states_entered += 1;
                 continue;
             }
             if curr_node.is_goal {
@@ -252,7 +171,7 @@ impl BoundedGraphPlanner {
                     "blake3:plan_{}",
                     blake3::hash(current.state_path.join("->").as_bytes()).to_hex()
                 );
-                return Ok(PlanTrajectory {
+                return Some(PlanTrajectory {
                     state_sequence: current.state_path,
                     action_sequence: current.action_path,
                     total_cost: current.g_cost,
@@ -267,7 +186,6 @@ impl BoundedGraphPlanner {
             }
 
             if current.depth >= config.max_horizon {
-                horizon_capped = true;
                 continue;
             }
 
@@ -321,23 +239,11 @@ impl BoundedGraphPlanner {
             }
 
             if open_set.len() > config.max_frontier_size {
-                return Err(PlannerError::FrontierExhausted {
-                    nodes_expanded,
-                    forbidden_states_entered,
-                });
+                return None;
             }
         }
 
-        if horizon_capped {
-            return Err(PlannerError::HorizonExceeded {
-                max_horizon: config.max_horizon,
-            });
-        }
-
-        Err(PlannerError::FrontierExhausted {
-            nodes_expanded,
-            forbidden_states_entered,
-        })
+        None
     }
 }
 
@@ -424,13 +330,9 @@ mod tests {
         }];
 
         let config = PlannerConfig::default_v1();
-        let err = BoundedGraphPlanner::plan("s0", &nodes, &edges, &config).unwrap_err();
-        match err {
-            PlannerError::FrontierExhausted {
-                forbidden_states_entered,
-                ..
-            } => assert_eq!(forbidden_states_entered, 0),
-            other => panic!("expected FrontierExhausted, got {other:?}"),
-        }
+        // The only path runs through the forbidden intermediate state, so no
+        // trajectory reaches the goal: the planner yields no plan.
+        let plan = BoundedGraphPlanner::plan("s0", &nodes, &edges, &config);
+        assert!(plan.is_none());
     }
 }

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -121,7 +121,7 @@ struct R4g1World {
     plan_nodes: Vec<uor_r4_graph_compiler::future_state_planner::PlannerStateNode>,
     plan_edges: Vec<uor_r4_graph_compiler::future_state_planner::PlannerEdgeTransition>,
     plan_result: Option<uor_r4_graph_compiler::future_state_planner::PlanTrajectory>,
-    plan_error: Option<uor_r4_graph_compiler::future_state_planner::PlannerError>,
+    plan_rejected: bool,
     // Lower Semantic Regions fields (#130)
     lower_bool_region: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweredBooleanRegion>,
     lower_witness: Option<uor_r4_graph_compiler::lower_semantic_regions::LoweringWitnessEntry>,
@@ -1318,7 +1318,7 @@ fn bdd_audit_status_matches(w: &mut R4g1World) {
 // Future State Planner BDD Steps (#131)
 // =========================================================================
 use uor_r4_graph_compiler::future_state_planner::{
-    BoundedGraphPlanner, PlannerConfig, PlannerEdgeTransition, PlannerError, PlannerStateNode,
+    BoundedGraphPlanner, PlannerConfig, PlannerEdgeTransition, PlannerStateNode,
 };
 
 #[given("a start state \"s0\", intermediate state \"s1\", and goal state \"s2\"")]
@@ -1364,10 +1364,9 @@ fn bdd_planner_setup_valid_graph(w: &mut R4g1World) {
 #[when("the bounded graph planner computes a trajectory")]
 fn bdd_planner_compute_trajectory(w: &mut R4g1World) {
     let config = PlannerConfig::default_v1();
-    let res = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config);
-    match res {
-        Ok(t) => w.plan_result = Some(t),
-        Err(e) => w.plan_error = Some(e),
+    match BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config) {
+        Some(t) => w.plan_result = Some(t),
+        None => w.plan_rejected = true,
     }
 }
 
@@ -1420,21 +1419,17 @@ fn bdd_planner_setup_forbidden_intermediate(w: &mut R4g1World) {
 #[when("the bounded graph planner attempts to plan a trajectory through \"s1\"")]
 fn bdd_planner_attempt_forbidden_plan(w: &mut R4g1World) {
     let config = PlannerConfig::default_v1();
-    if let Err(e) = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config) {
-        w.plan_error = Some(e);
+    if BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config).is_none() {
+        w.plan_rejected = true;
     }
 }
 
 #[then("planning fails with a frontier exhausted error and zero forbidden states entered")]
 fn bdd_planner_frontier_exhausted_check(w: &mut R4g1World) {
-    let err = w.plan_error.as_ref().expect("plan error");
-    match err {
-        PlannerError::FrontierExhausted {
-            forbidden_states_entered,
-            ..
-        } => assert_eq!(*forbidden_states_entered, 0),
-        other => panic!("expected FrontierExhausted, got {other:?}"),
-    }
+    assert!(
+        w.plan_rejected,
+        "planning should have yielded no plan (the only path runs through a forbidden state)"
+    );
 }
 
 #[given("a start state \"s0\" marked as forbidden")]
@@ -1451,15 +1446,17 @@ fn bdd_planner_setup_forbidden_start(w: &mut R4g1World) {
 #[when("planning is initiated from \"s0\"")]
 fn bdd_planner_initiate_forbidden_start(w: &mut R4g1World) {
     let config = PlannerConfig::default_v1();
-    if let Err(e) = BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config) {
-        w.plan_error = Some(e);
+    if BoundedGraphPlanner::plan("s0", &w.plan_nodes, &w.plan_edges, &config).is_none() {
+        w.plan_rejected = true;
     }
 }
 
 #[then("planning fails immediately with an initial state forbidden error")]
 fn bdd_planner_initial_forbidden_check(w: &mut R4g1World) {
-    let err = w.plan_error.as_ref().expect("plan error");
-    assert!(matches!(err, PlannerError::InitialStateForbidden { .. }));
+    assert!(
+        w.plan_rejected,
+        "planning should have yielded no plan (the start state is forbidden)"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
R5 rearchitecture (#510): convert `future_state_planner.rs` off its `Result<_, PlannerError>` surface to a total form. **The module is now fully total (0 sanctioned-violation sites).** The `PlannerError` enum, its `Display`/`Error` impls, and `use std::fmt` are removed.

## Surface
`BoundedGraphPlanner::plan(...) -> Option<PlanTrajectory>` — `None` when no trajectory is a product of these inputs: the start state is unknown or forbidden, or no plan reaches the goal within the horizon and frontier bounds. A bounded search either yields a plan or there is none; the former `PlannerError` variants (`UnknownState` / `InitialStateForbidden` / `HorizonExceeded` / `FrontierExhausted`, plus two never-constructed variants) were diagnostic detail, not a sanctioned condition, and collapse to `None`. The diagnostic-only counters `forbidden_states_entered` and `horizon_capped` existed solely for those error returns and are removed.

`plan()` has no production callers — `semantic_emission_decoupling` uses the `PlanTrajectory` struct, not `plan()`; only tests and BDD call it.

## Ripple (same PR)
`tests/bdd.rs` — the `plan_error` World field is dropped for `plan_rejected: bool`; the compute/attempt steps set it on `None`; the two failure assertions check it. The `verify_determinism` differential closure now returns `Option<PlanTrajectory>` (still `PartialEq`, still deterministic). The import drops `PlannerError`.

## Verification
audit-limits graph-compiler **44 → 43** (future_state_planner.rs 0 sites). 86 lib tests, BDD 100/100, proof-model 24 tests, wasm32 + clippy + fmt clean, audit-deferral clean.

Part of the #510 bottom-up sweep (graph-compiler leaf).
