### PR TITLE
feat(#510): R5 tranche — graph-compiler behavioral probes to total (43→41)

### DIFF
--- a/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
+++ b/crates/uor-r4-graph-compiler/src/behavioral_probes.rs
@@ -13,65 +13,6 @@
 //! - Probe harness evaluating sensitivity and invariance scores with anti-memorization guards.
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
-
-/// Errors arising during behavioral probe creation or evaluation.
-#[derive(Debug, Clone, PartialEq)]
-pub enum BehavioralProbeError {
-    /// Affected span range is out of bounds for the source observation string.
-    SpanOutOfBounds {
-        start: usize,
-        end: usize,
-        len: usize,
-    },
-    /// Invalid probe outputs (empty or dimension mismatch).
-    InvalidOutputDimensions {
-        baseline_len: usize,
-        intervention_len: usize,
-    },
-    /// Surface memorization guard detected non-generalizing table lookup.
-    MemorizationDetected { probe_id: String },
-    /// Probe execution failed expected relation assertion.
-    AssertionFailed {
-        probe_id: String,
-        expected: String,
-        actual: String,
-    },
-}
-
-impl fmt::Display for BehavioralProbeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::SpanOutOfBounds { start, end, len } => {
-                write!(
-                    f,
-                    "Probe span [{start}..{end}] out of bounds for observation length {len}"
-                )
-            }
-            Self::InvalidOutputDimensions {
-                baseline_len,
-                intervention_len,
-            } => write!(
-                f,
-                "Output dimension mismatch: baseline {baseline_len}, intervention {intervention_len}"
-            ),
-            Self::MemorizationDetected { probe_id } => write!(
-                f,
-                "Anti-memorization guard failed for probe '{probe_id}': surface lookup detected"
-            ),
-            Self::AssertionFailed {
-                probe_id,
-                expected,
-                actual,
-            } => write!(
-                f,
-                "Probe '{probe_id}' assertion failed: expected {expected}, actual {actual}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for BehavioralProbeError {}
 
 /// Controlled intervention kind applied to observation context $x$.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -119,7 +60,11 @@ pub struct InterventionRecord {
 }
 
 impl InterventionRecord {
-    /// Create and validate a new intervention record.
+    /// Create and validate a new intervention record. `None` when the record is
+    /// not a product of these inputs: the affected span is out of bounds for the
+    /// observation, or the baseline/intervention outputs are empty or of
+    /// mismatched dimension (R5 — the absence of a product rather than a raised
+    /// error).
     pub fn new(
         source_observation: impl Into<String>,
         kind: InterventionKind,
@@ -127,21 +72,14 @@ impl InterventionRecord {
         expected_relation: ExpectedRelation,
         baseline_output: Vec<f32>,
         intervention_output: Vec<f32>,
-    ) -> Result<Self, BehavioralProbeError> {
+    ) -> Option<Self> {
         let obs = source_observation.into();
         let (start, end) = affected_span;
         if start > end || end > obs.len() {
-            return Err(BehavioralProbeError::SpanOutOfBounds {
-                start,
-                end,
-                len: obs.len(),
-            });
+            return None;
         }
         if baseline_output.len() != intervention_output.len() || baseline_output.is_empty() {
-            return Err(BehavioralProbeError::InvalidOutputDimensions {
-                baseline_len: baseline_output.len(),
-                intervention_len: intervention_output.len(),
-            });
+            return None;
         }
 
         // Content-addressed ID: blake3 over the observation, intervention
@@ -161,7 +99,7 @@ impl InterventionRecord {
         }
         let id = format!("probe_blake3:{}", hasher.finalize().to_hex());
 
-        Ok(Self {
+        Some(Self {
             id,
             source_observation: obs,
             kind,
@@ -198,20 +136,24 @@ pub struct BehavioralProbeHarness;
 
 impl BehavioralProbeHarness {
     /// Evaluate a set of intervention records against expectation relations.
+    /// Total: the anti-memorization guard's verdict is carried in the report's
+    /// `memorization_check_passed` field rather than raised as an error (R5 — a
+    /// validator reports the held property; a tripped guard is `false`, not a
+    /// failure to produce a report).
     pub fn evaluate_suite(
         probes: &[InterventionRecord],
         invariance_tolerance: f32,
         sensitivity_threshold: f32,
-    ) -> Result<BehavioralProbeReport, BehavioralProbeError> {
+    ) -> BehavioralProbeReport {
         if probes.is_empty() {
-            return Ok(BehavioralProbeReport {
+            return BehavioralProbeReport {
                 total_probes: 0,
                 invariant_passed: 0,
                 sensitive_passed: 0,
                 invariance_score: 1.0,
                 sensitivity_score: 1.0,
                 memorization_check_passed: true,
-            });
+            };
         }
 
         let mut inv_count = 0;
@@ -253,27 +195,23 @@ impl BehavioralProbeHarness {
         // Anti-memorization guard check: any Sensitive GoalChange/ContextAblation probe
         // whose divergence falls below the sensitivity threshold indicates the model is
         // memorizing surface form without understanding state dynamics.
-        if let Some(probe) = probes.iter().find(|probe| {
+        let memorization_check_passed = !probes.iter().any(|probe| {
             probe.expected_relation == ExpectedRelation::Sensitive
                 && matches!(
                     probe.kind,
                     InterventionKind::GoalChange | InterventionKind::ContextAblation
                 )
                 && probe.output_divergence() < sensitivity_threshold
-        }) {
-            return Err(BehavioralProbeError::MemorizationDetected {
-                probe_id: probe.id.clone(),
-            });
-        }
+        });
 
-        Ok(BehavioralProbeReport {
+        BehavioralProbeReport {
             total_probes: probes.len(),
             invariant_passed: inv_passed,
             sensitive_passed: sens_passed,
             invariance_score,
             sensitivity_score,
-            memorization_check_passed: true,
-        })
+            memorization_check_passed,
+        }
     }
 }
 
@@ -319,7 +257,7 @@ mod tests {
         )
         .unwrap();
 
-        let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5).unwrap();
+        let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5);
 
         assert_eq!(report.total_probes, 2);
         assert_eq!(report.invariance_score, 1.0);
@@ -340,10 +278,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5).unwrap_err();
-        assert!(matches!(
-            err,
-            BehavioralProbeError::MemorizationDetected { .. }
-        ));
+        let report = BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5);
+        assert!(!report.memorization_check_passed);
     }
 }

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -138,8 +138,7 @@ struct R4g1World {
     // Behavioral Probe fields (#128)
     probe_baseline_obs: String,
     probe_suite_report: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeReport>,
-    probe_suite_error: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeError>,
-    probe_record_error: Option<uor_r4_graph_compiler::behavioral_probes::BehavioralProbeError>,
+    probe_record_rejected: bool,
     // Semantic State Space fields (#124)
     state_s0: Option<uor_r4_graph_compiler::semantic_state::SemanticState>,
     state_eval_res: Option<
@@ -1644,8 +1643,7 @@ fn bdd_diff_comparison_passes(w: &mut R4g1World) {
 // Behavioral Probes BDD Steps (#128)
 // =========================================================================
 use uor_r4_graph_compiler::behavioral_probes::{
-    BehavioralProbeError, BehavioralProbeHarness, ExpectedRelation, InterventionKind,
-    InterventionRecord,
+    BehavioralProbeHarness, ExpectedRelation, InterventionKind, InterventionRecord,
 };
 
 #[given("a baseline observation \"Context text sample\"")]
@@ -1676,7 +1674,7 @@ fn bdd_evaluate_probes(w: &mut R4g1World) {
     )
     .unwrap();
 
-    let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5).unwrap();
+    let report = BehavioralProbeHarness::evaluate_suite(&[p_inv, p_sens], 0.05, 0.5);
     w.probe_suite_report = Some(report);
 }
 
@@ -1705,9 +1703,7 @@ fn bdd_zero_divergence_sensitive_probe(w: &mut R4g1World) {
     )
     .unwrap();
 
-    if let Err(e) = BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5) {
-        w.probe_suite_error = Some(e);
-    }
+    w.probe_suite_report = Some(BehavioralProbeHarness::evaluate_suite(&[p_mem], 0.05, 0.5));
 }
 
 #[when("the probe suite is evaluated by the behavioral harness")]
@@ -1715,11 +1711,11 @@ fn bdd_harness_eval_step(_w: &mut R4g1World) {}
 
 #[then("evaluation fails with a memorization detected error")]
 fn bdd_memorization_error_check(w: &mut R4g1World) {
-    let err = w.probe_suite_error.as_ref().expect("suite error");
-    assert!(matches!(
-        err,
-        BehavioralProbeError::MemorizationDetected { .. }
-    ));
+    let report = w.probe_suite_report.as_ref().expect("report");
+    assert!(
+        !report.memorization_check_passed,
+        "the anti-memorization guard should have failed (memorization_check_passed = false)"
+    );
 }
 
 #[given("an observation of length 15")]
@@ -1727,22 +1723,26 @@ fn bdd_observation_len_15(_w: &mut R4g1World) {}
 
 #[when("an intervention record is created with span [0..20]")]
 fn bdd_create_out_of_bounds_span(w: &mut R4g1World) {
-    if let Err(e) = InterventionRecord::new(
+    if InterventionRecord::new(
         "Short 15 char!!",
         InterventionKind::ContextAblation,
         (0, 20),
         ExpectedRelation::Invariant,
         vec![1.0],
         vec![1.0],
-    ) {
-        w.probe_record_error = Some(e);
+    )
+    .is_none()
+    {
+        w.probe_record_rejected = true;
     }
 }
 
 #[then("record creation fails with a span out of bounds error")]
 fn bdd_span_out_of_bounds_check(w: &mut R4g1World) {
-    let err = w.probe_record_error.as_ref().expect("record error");
-    assert!(matches!(err, BehavioralProbeError::SpanOutOfBounds { .. }));
+    assert!(
+        w.probe_record_rejected,
+        "record creation should have rejected the out-of-bounds span (returned None)"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
R5 rearchitecture (#510): convert `behavioral_probes.rs` off its `Result<_, BehavioralProbeError>` surface to total forms. **The module is now fully total (0 sanctioned-violation sites).** The `BehavioralProbeError` enum, its `Display`/`Error` impls, and `use std::fmt` are removed.

## Surfaces
- `InterventionRecord::new(...) -> Option<Self>` — `None` when the record is not a product of these inputs: the affected span is out of bounds for the observation, or the baseline/intervention outputs are empty or of mismatched dimension. Both former variants (`SpanOutOfBounds`, `InvalidOutputDimensions`) collapse to `None`.
- `BehavioralProbeHarness::evaluate_suite(...) -> BehavioralProbeReport` (was `Result`) — the anti-memorization guard's verdict is now carried in the report's existing `memorization_check_passed` bool rather than raised as an error. A validator reports the held property; a tripped guard is `false`, not a failure to produce a report. The report is always produced with the computed invariance/sensitivity scores. The never-constructed `AssertionFailed` variant goes with the enum.

`evaluate_suite` / `InterventionRecord::new` have no production callers (graph-certify's `anti_memorization_passed` / `HolographicProbeReport` are unrelated types); only tests and BDD call them.

## Ripple (same PR)
`tests/bdd.rs` — the `probe_suite_error` World field is dropped (the memorization scenario now stores the report and asserts `!memorization_check_passed`) and `probe_record_error` becomes `probe_record_rejected: bool`. The import drops `BehavioralProbeError`.

## Verification
audit-limits graph-compiler **43 → 41** (behavioral_probes.rs 0 sites). 86 lib tests, BDD 100/100, proof-model 24 tests, wasm32 + clippy + fmt clean, audit-deferral clean.

Part of the #510 bottom-up sweep (graph-compiler leaf).
