### PR TITLE
feat(#510): R5 tranche — graph-certify CBOR round-trip helpers to total (53→49)

### DIFF
--- a/crates/uor-r4-graph-certify/src/predictive_sufficiency.rs
+++ b/crates/uor-r4-graph-certify/src/predictive_sufficiency.rs
@@ -54,14 +54,21 @@ impl RateDistortionReport {
             .collect()
     }
 
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Serialize to CBOR. Infallible: the report's fields are plain scalars,
+    /// so ciborium serialization into an in-memory buffer cannot fail — a
+    /// failure would be a serialization defect, not a property of the data
+    /// (R5 — self-produced bytes are an invariant, not a reported condition).
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
-        Ok(buf)
+        ciborium::into_writer(self, &mut buf)
+            .expect("RateDistortionReport CBOR serialization is infallible for its scalar fields");
+        buf
     }
 
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
-        ciborium::from_reader(bytes).map_err(|e| e.to_string())
+    /// Parse from CBOR. `None` when the bytes are not a valid CBOR encoding of
+    /// this report (R5 — the absence of a product rather than a raised error).
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        ciborium::from_reader(bytes).ok()
     }
 }
 

--- a/crates/uor-r4-graph-certify/src/shortlist_evaluator.rs
+++ b/crates/uor-r4-graph-certify/src/shortlist_evaluator.rs
@@ -24,14 +24,21 @@ pub struct ShortlistRecallReport {
 }
 
 impl ShortlistRecallReport {
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Serialize to CBOR. Infallible: the report's fields are plain scalars,
+    /// so ciborium serialization into an in-memory buffer cannot fail — a
+    /// failure would be a serialization defect, not a property of the data
+    /// (R5 — self-produced bytes are an invariant, not a reported condition).
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
-        Ok(buf)
+        ciborium::into_writer(self, &mut buf)
+            .expect("ShortlistRecallReport CBOR serialization is infallible for its scalar fields");
+        buf
     }
 
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
-        ciborium::from_reader(bytes).map_err(|e| e.to_string())
+    /// Parse from CBOR. `None` when the bytes are not a valid CBOR encoding of
+    /// this report (R5 — the absence of a product rather than a raised error).
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        ciborium::from_reader(bytes).ok()
     }
 }
 

--- a/crates/uor-r4-graph-certify/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-graph-certify/tests/predictive_sufficiency_test.rs
@@ -106,7 +106,7 @@ fn test_rate_distortion_report_cbor_roundtrip() {
     assert_eq!(curve[0].1, 1.25);
     assert_eq!(curve[1].1, 0.05);
 
-    let cbor_bytes = report.to_cbor_bytes().expect("serialize CBOR");
+    let cbor_bytes = report.to_cbor_bytes();
     let decoded = RateDistortionReport::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
     assert_eq!(report, decoded);
 }

--- a/crates/uor-r4-graph-certify/tests/shortlist_evaluator_test.rs
+++ b/crates/uor-r4-graph-certify/tests/shortlist_evaluator_test.rs
@@ -63,7 +63,7 @@ fn test_shortlist_recall_report_cbor_roundtrip() {
     let references = vec![1];
     let report = ShortlistEvaluator::evaluate(&shortlists, &references, &[10], &[10], 0.95);
 
-    let cbor_bytes = report.to_cbor_bytes().expect("serialize CBOR");
+    let cbor_bytes = report.to_cbor_bytes();
     let decoded = ShortlistRecallReport::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
     assert_eq!(report, decoded);
 }


### PR DESCRIPTION
R5 rearchitecture (#510): first graph-certify tranche. Convert the CBOR serialize/deserialize pair on `ShortlistRecallReport` (`shortlist_evaluator.rs`) and `RateDistortionReport` (`predictive_sufficiency.rs`) off `Result<_, String>`. **Both modules are now fully sanctioned (0 audit sites).**

## Surfaces
- `to_cbor_bytes(&self) -> Vec<u8>` (was `Result`) — the reports' fields are plain scalars, so ciborium serialization into an in-memory buffer cannot fail. The `Result` was spurious; a failure would be a serialization defect, so the one impossible error path becomes an `.expect()` invariant and the fn is infallible.
- `from_cbor_bytes(bytes) -> Option<Self>` (was `Result`) — the bytes may not be a valid CBOR encoding of the report: the absence of a product, reported as `None`.

Both types' CBOR fns have only test callers (all in the crate's `tests/`), which use `.expect("serialize/deserialize CBOR")`; the serialize `.expect` is dropped (`to_cbor_bytes` now returns `Vec<u8>` directly) and the deserialize `.expect` is kept (valid on `Option`).

## Verification
audit-limits graph-certify **53 → 49** (shortlist_evaluator.rs and predictive_sufficiency.rs now 0 sites). Full workspace build + wasm32 graph-compiler + clippy + fmt clean; graph-certify test suite green, BDD 100/100, audit-deferral clean.

Part of the #510 bottom-up sweep — graph-certify (graph-compiler is already fully sanctioned).
