### PR TITLE
feat(#510): R5 tranche — graph-certify certificate CBOR + provenance-deletion validator to total (49→44)

### DIFF
--- a/crates/uor-r4-graph-certify/src/fairness_provenance.rs
+++ b/crates/uor-r4-graph-certify/src/fairness_provenance.rs
@@ -88,19 +88,27 @@ impl FairnessAndProvenanceCertificate {
         self.certificate_cid == self.compute_cid()
     }
 
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Serialize to CBOR. Infallible: ciborium serialization of this
+    /// derive-Serialize certificate into an in-memory buffer cannot fail — a
+    /// failure would be a serialization defect, not a property of the data
+    /// (R5 — self-produced bytes are an invariant, not a reported condition).
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
-        Ok(buf)
+        ciborium::into_writer(self, &mut buf)
+            .expect("FairnessAndProvenanceCertificate CBOR serialization is infallible");
+        buf
     }
 
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
-        let cert: FairnessAndProvenanceCertificate =
-            ciborium::from_reader(bytes).map_err(|e| e.to_string())?;
+    /// Parse from CBOR and check the certificate's self-CID. `None` when the
+    /// bytes are not a valid CBOR encoding, or when the recomputed CID does not
+    /// match the embedded one: in either case the bytes are not a valid,
+    /// self-consistent certificate — the absence of a product (R5).
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        let cert: FairnessAndProvenanceCertificate = ciborium::from_reader(bytes).ok()?;
         if !cert.verify_cid() {
-            return Err("FairnessAndProvenanceCertificate CID verification failed".to_string());
+            return None;
         }
-        Ok(cert)
+        Some(cert)
     }
 }
 
@@ -167,31 +175,24 @@ impl FairnessEvaluator {
     }
 
     /// Verify that every provenance edge attributed to `deleted_slice_id` has
-    /// been tombstoned in `graph` (weight forced to 0), returning a witness on
-    /// success or an error describing the first integrity violation.
+    /// been tombstoned in `graph` (weight forced to 0). `Some(witness)` when the
+    /// deletion holds; `None` when it does not — a tombstoned edge id is out of
+    /// bounds, or a referenced edge still carries a non-zero weight. The
+    /// deletion is verified or it is not; an unverified deletion yields no
+    /// witness rather than a raised error (R5).
     pub fn verify_provenance_deletion(
         deleted_slice_id: &str,
         graph: &TransitionGraph,
         tombstoned_edge_ids: &[usize],
-    ) -> Result<ProvenanceDeletionWitness, String> {
+    ) -> Option<ProvenanceDeletionWitness> {
         for &edge_id in tombstoned_edge_ids {
-            let edge = graph.edges.get(edge_id).ok_or_else(|| {
-                format!(
-                    "provenance deletion for slice '{deleted_slice_id}' references edge {edge_id} \
-                     out of bounds (graph has {} edges)",
-                    graph.edges.len()
-                )
-            })?;
+            let edge = graph.edges.get(edge_id)?;
             if edge.weight != 0 {
-                return Err(format!(
-                    "provenance deletion for slice '{deleted_slice_id}' failed: edge {edge_id} \
-                     still has non-zero weight {}",
-                    edge.weight
-                ));
+                return None;
             }
         }
 
-        Ok(ProvenanceDeletionWitness {
+        Some(ProvenanceDeletionWitness {
             deleted_slice_id: deleted_slice_id.to_string(),
             tombstoned_provenance_nodes: tombstoned_edge_ids.len(),
             graph_integrity_verified: true,

--- a/crates/uor-r4-graph-certify/src/performance_certificate.rs
+++ b/crates/uor-r4-graph-certify/src/performance_certificate.rs
@@ -75,19 +75,27 @@ impl PerformanceCertificate {
         self.certificate_cid == self.compute_cid()
     }
 
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Serialize to CBOR. Infallible: ciborium serialization of this
+    /// derive-Serialize certificate into an in-memory buffer cannot fail — a
+    /// failure would be a serialization defect, not a property of the data
+    /// (R5 — self-produced bytes are an invariant, not a reported condition).
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        ciborium::into_writer(self, &mut buf).map_err(|e| e.to_string())?;
-        Ok(buf)
+        ciborium::into_writer(self, &mut buf)
+            .expect("PerformanceCertificate CBOR serialization is infallible");
+        buf
     }
 
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, String> {
-        let cert: PerformanceCertificate =
-            ciborium::from_reader(bytes).map_err(|e| e.to_string())?;
+    /// Parse from CBOR and check the certificate's self-CID. `None` when the
+    /// bytes are not a valid CBOR encoding, or when the recomputed CID does not
+    /// match the embedded one: in either case the bytes are not a valid,
+    /// self-consistent certificate — the absence of a product (R5).
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        let cert: PerformanceCertificate = ciborium::from_reader(bytes).ok()?;
         if !cert.verify_cid() {
-            return Err("PerformanceCertificate CID verification failed".to_string());
+            return None;
         }
-        Ok(cert)
+        Some(cert)
     }
 }
 

--- a/crates/uor-r4-graph-certify/tests/fairness_provenance_test.rs
+++ b/crates/uor-r4-graph-certify/tests/fairness_provenance_test.rs
@@ -87,7 +87,7 @@ fn test_fairness_certificate_cbor_roundtrip() {
 
     let cert = FairnessAndProvenanceCertificate::new(vec![], vec![], witness);
 
-    let cbor_bytes = cert.to_cbor_bytes().expect("serialize CBOR");
+    let cbor_bytes = cert.to_cbor_bytes();
     let decoded =
         FairnessAndProvenanceCertificate::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
 
@@ -99,11 +99,13 @@ fn test_fairness_certificate_cbor_roundtrip() {
 fn test_verify_provenance_deletion_detects_untombstoned_edge() {
     let graph = graph_with_tombstoned_edges(&[0, 7]);
 
-    let err = FairnessEvaluator::verify_provenance_deletion("doc_777", &graph, &[0, 1])
-        .expect_err("edge 1 still has non-zero weight");
-    assert!(err.contains("edge 1"), "unexpected error: {err}");
+    assert!(
+        FairnessEvaluator::verify_provenance_deletion("doc_777", &graph, &[0, 1]).is_none(),
+        "edge 1 still has non-zero weight, so no deletion witness is produced"
+    );
 
-    let err = FairnessEvaluator::verify_provenance_deletion("doc_777", &graph, &[5])
-        .expect_err("edge 5 is out of bounds");
-    assert!(err.contains("out of bounds"), "unexpected error: {err}");
+    assert!(
+        FairnessEvaluator::verify_provenance_deletion("doc_777", &graph, &[5]).is_none(),
+        "edge 5 is out of bounds, so no deletion witness is produced"
+    );
 }

--- a/crates/uor-r4-graph-certify/tests/performance_certificate_test.rs
+++ b/crates/uor-r4-graph-certify/tests/performance_certificate_test.rs
@@ -36,7 +36,7 @@ fn test_performance_certificate_cbor_roundtrip() {
     let ops = OpKernel::default();
     let cert = PerformanceProfiler::profile(1024, 2, ops, 2048);
 
-    let cbor_bytes = cert.to_cbor_bytes().expect("serialize CBOR");
+    let cbor_bytes = cert.to_cbor_bytes();
     let decoded = PerformanceCertificate::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
 
     assert_eq!(cert, decoded);


### PR DESCRIPTION
R5 rearchitecture (#510): second graph-certify tranche. Convert `performance_certificate.rs` and `fairness_provenance.rs` off `Result<_, String>`. **Both modules are now fully sanctioned (0 audit sites).**

## Surfaces
- `to_cbor_bytes(&self) -> Vec<u8>` on both certificates (was `Result`) — a derive-Serialize certificate serialized into an in-memory buffer cannot fail; the `Result` was spurious, so the impossible error path becomes an `.expect()` invariant and the fn is infallible.
- `from_cbor_bytes(bytes) -> Option<Self>` on both (was `Result`) — `None` when the bytes are not a valid CBOR encoding OR the recomputed self-CID does not match the embedded one. Both mean the bytes are not a valid, self-consistent certificate — the absence of a product. The CID check stays; only its raised `String` error becomes `None`. `KappaError`'s variants are graph-format-specific and do not describe a generic certificate CID, so `Option` is the honest total surface here.
- `FairnessEvaluator::verify_provenance_deletion(...) -> Option<ProvenanceDeletionWitness>` (was `Result<_, String>`) — `Some(witness)` when every tombstoned edge is really zeroed; `None` when a tombstoned edge id is out of bounds or a referenced edge still carries a non-zero weight. The deletion is verified or it is not; an unverified deletion yields no witness.

## Ripple
Callers are all in the crate's `tests/`: the serialize `.expect` is dropped (`to_cbor_bytes` now returns `Vec<u8>`), the deserialize `.expect` is kept (valid on `Option`), and the untombstoned-edge test's two `.expect_err` assertions become `.is_none()` assertions.

## Verification
audit-limits graph-certify **49 → 44** (performance_certificate.rs and fairness_provenance.rs now 0 sites). Full workspace build + wasm32 graph-compiler + clippy + fmt clean; graph-certify suite green, BDD 100/100, audit-deferral clean.

Part of the #510 bottom-up sweep — graph-certify.
