### PR TITLE
feat(#510): R5 tranche — graph-certify certificate.rs to total

### DIFF
--- a/crates/uor-r4-graph-certify/src/certificate.rs
+++ b/crates/uor-r4-graph-certify/src/certificate.rs
@@ -47,14 +47,6 @@ pub struct Certificate {
     pub attestation: ProtocolAttestation,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CertificateError {
-    SerializationError(String),
-    DeserializationError(String),
-    CidMismatch { expected: String, actual: String },
-    AttestationFailed(String),
-}
-
 impl Certificate {
     // Args mirror the schema's CID fields one-to-one (issue #20); a params
     // struct can replace them if the schema grows further.
@@ -100,13 +92,10 @@ impl Certificate {
         claim_fragments: &[EmpiricalClaim],
         attestation: ProtocolAttestation,
         threads: usize,
-    ) -> Result<Self, CertificateError> {
-        let mut claims = Self::claims_from_fragments_with_threads(claim_fragments, threads)
-            .map_err(|e| {
-                CertificateError::SerializationError(format!("claim-fragment assembly failed: {e}"))
-            })?;
+    ) -> Self {
+        let mut claims = Self::claims_from_fragments_with_threads(claim_fragments, threads);
         Self::canonical_sort_and_dedup_claims(&mut claims);
-        Ok(Self::new(
+        Self::new(
             source_cid,
             corpus_cid,
             graph_cid,
@@ -115,7 +104,7 @@ impl Certificate {
             benchmark_cid,
             claims,
             attestation,
-        ))
+        )
     }
 
     /// Compute self-referential BLAKE3 CID (hex format) over certificate content.
@@ -132,16 +121,16 @@ impl Certificate {
         format!("kappa:blake3:{}", hasher.finalize().to_hex())
     }
 
+    /// Assemble claims from fragments across `threads` workers. Total: the
+    /// compiler executor is infallible (the worker closure only clones a
+    /// fragment; a worker panic propagates), so this never reports an error
+    /// (R5 — graph-compiler's scorer/executor dependency is already total).
     fn claims_from_fragments_with_threads(
         claim_fragments: &[EmpiricalClaim],
         threads: usize,
-    ) -> Result<Vec<EmpiricalClaim>, String> {
-        // The compiler executor is now total (infallible worker closure; a
-        // worker panic propagates). Fragment cloning cannot fail, so this
-        // helper never reports an error — it keeps its `Result` surface until
-        // graph-certify's own R5 conversion.
+    ) -> Vec<EmpiricalClaim> {
         let indices: Vec<usize> = (0..claim_fragments.len()).collect();
-        let claims = if threads == 1 {
+        if threads == 1 {
             SequentialExecutor::new().map(&indices, |&idx| claim_fragments[idx].clone())
         } else {
             #[cfg(not(target_arch = "wasm32"))]
@@ -152,8 +141,7 @@ impl Certificate {
             {
                 SequentialExecutor::new().map(&indices, |&idx| claim_fragments[idx].clone())
             }
-        };
-        Ok(claims)
+        }
     }
 
     fn canonical_sort_and_dedup_claims(claims: &mut Vec<EmpiricalClaim>) {
@@ -188,55 +176,54 @@ impl Certificate {
         self.certificate_cid == computed
     }
 
-    /// Validate structural attestation requirements (Gate K).
-    pub fn verify_attestation(&self) -> Result<(), CertificateError> {
+    /// Validate structural attestation requirements (Gate K). `None` when the
+    /// attestation holds; `Some(reason)` naming the first failure — a self-CID
+    /// mismatch or an unverified attestation flag. A validator is total; the
+    /// held property is the absence of a failure rather than a raised error
+    /// (R5).
+    pub fn verify_attestation(&self) -> Option<String> {
         if !self.verify_cid() {
-            return Err(CertificateError::CidMismatch {
-                expected: self.compute_cid(),
-                actual: self.certificate_cid.clone(),
-            });
+            return Some(format!(
+                "certificate CID mismatch: expected {}, found {}",
+                self.compute_cid(),
+                self.certificate_cid
+            ));
         }
         if !self.attestation.deterministic_canonical_mode {
-            return Err(CertificateError::AttestationFailed(
-                "deterministic canonical mode not verified".to_string(),
-            ));
+            return Some("deterministic canonical mode not verified".to_string());
         }
         if !self.attestation.zero_allocation_verified {
-            return Err(CertificateError::AttestationFailed(
-                "zero allocation check failed".to_string(),
-            ));
+            return Some("zero allocation check failed".to_string());
         }
         if !self.attestation.no_multiply_verified {
-            return Err(CertificateError::AttestationFailed(
-                "no multiply check failed".to_string(),
-            ));
+            return Some("no multiply check failed".to_string());
         }
         if !self.attestation.theorem_7_reverse_index_verified {
-            return Err(CertificateError::AttestationFailed(
-                "Theorem 7 reverse index check failed".to_string(),
-            ));
+            return Some("Theorem 7 reverse index check failed".to_string());
         }
-        Ok(())
+        None
     }
 
-    /// Serialize certificate to CBOR bytes.
-    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, CertificateError> {
+    /// Serialize certificate to CBOR bytes. Infallible: ciborium serialization
+    /// of this derive-Serialize certificate into an in-memory buffer cannot
+    /// fail — a failure would be a serialization defect, not a property of the
+    /// data (R5 — self-produced bytes are an invariant).
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         ciborium::into_writer(self, &mut buf)
-            .map_err(|e| CertificateError::SerializationError(e.to_string()))?;
-        Ok(buf)
+            .expect("Certificate CBOR serialization is infallible");
+        buf
     }
 
-    /// Deserialize certificate from CBOR bytes.
-    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, CertificateError> {
-        let cert: Certificate = ciborium::from_reader(bytes)
-            .map_err(|e| CertificateError::DeserializationError(e.to_string()))?;
+    /// Deserialize certificate from CBOR bytes and check its self-CID. `None`
+    /// when the bytes are not a valid CBOR encoding, or when the recomputed CID
+    /// does not match: in either case the bytes are not a valid, self-consistent
+    /// certificate — the absence of a product (R5).
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Option<Self> {
+        let cert: Certificate = ciborium::from_reader(bytes).ok()?;
         if !cert.verify_cid() {
-            return Err(CertificateError::CidMismatch {
-                expected: cert.compute_cid(),
-                actual: cert.certificate_cid,
-            });
+            return None;
         }
-        Ok(cert)
+        Some(cert)
     }
 }

--- a/crates/uor-r4-graph-certify/tests/certificate_test.rs
+++ b/crates/uor-r4-graph-certify/tests/certificate_test.rs
@@ -37,7 +37,7 @@ fn test_certificate_cid_computation_and_verification() {
         "Certificate CID must carry kappa scheme prefix"
     );
     assert!(
-        cert.verify_attestation().is_ok(),
+        cert.verify_attestation().is_none(),
         "Structural attestation checks must pass"
     );
 }
@@ -71,7 +71,7 @@ fn test_certificate_cbor_roundtrip() {
         attestation,
     );
 
-    let cbor_bytes = cert.to_cbor_bytes().expect("serialize CBOR");
+    let cbor_bytes = cert.to_cbor_bytes();
     assert!(!cbor_bytes.is_empty());
 
     let decoded = Certificate::from_cbor_bytes(&cbor_bytes).expect("deserialize CBOR");
@@ -98,7 +98,7 @@ fn test_certificate_attestation_failure() {
     );
 
     assert!(
-        cert.verify_attestation().is_err(),
+        cert.verify_attestation().is_some(),
         "Attestation check must fail when zero_allocation_verified is false"
     );
 }
@@ -153,8 +153,8 @@ fn test_deterministic_certificate_rebuild() {
         "Certificate CIDs must match"
     );
     assert_eq!(
-        cert1.to_cbor_bytes().unwrap(),
-        cert2.to_cbor_bytes().unwrap(),
+        cert1.to_cbor_bytes(),
+        cert2.to_cbor_bytes(),
         "Certificate CBOR bytes must be byte-identical"
     );
 }
@@ -206,8 +206,7 @@ fn test_parallel_claim_fragment_assembly_is_canonical_and_thread_invariant() {
         &fragments,
         attestation.clone(),
         1,
-    )
-    .unwrap();
+    );
     let cert_par = Certificate::new_from_claim_fragments(
         "kappa:blake3:src",
         "kappa:blake3:corpus",
@@ -218,8 +217,7 @@ fn test_parallel_claim_fragment_assembly_is_canonical_and_thread_invariant() {
         &fragments,
         attestation,
         4,
-    )
-    .unwrap();
+    );
 
     assert_eq!(cert_seq.claims.len(), 2);
     assert_eq!(cert_seq, cert_par);
@@ -263,8 +261,7 @@ fn test_parallel_claim_fragment_threads_zero_matches_sequential() {
         &fragments,
         attestation.clone(),
         1,
-    )
-    .unwrap();
+    );
     let cert_auto = Certificate::new_from_claim_fragments(
         "kappa:blake3:src",
         "kappa:blake3:corpus",
@@ -275,8 +272,7 @@ fn test_parallel_claim_fragment_threads_zero_matches_sequential() {
         &fragments,
         attestation,
         0,
-    )
-    .unwrap();
+    );
 
     assert_eq!(cert_seq, cert_auto);
 }


### PR DESCRIPTION
R5 rearchitecture (#510): convert `certificate.rs` off `Result` / `CertificateError`, dropping the `CertificateError` enum entirely. **The module is now fully sanctioned (0 audit sites).**

## Surfaces
- `claims_from_fragments_with_threads -> Vec<EmpiricalClaim>` (was `Result<_, String>`) — the module comment already noted it never reports an error now that the compiler executor is total (the worker closure only clones a fragment; a worker panic propagates). Dropped the spurious `Result`.
- `new_from_claim_fragments -> Self` (was `Result<Self, CertificateError>`) — its only error path was the now-infallible claims helper, so the constructor is infallible.
- `verify_attestation -> Option<String>` (was `Result<(), CertificateError>`) — a Gate-K validator. `None` when the attestation holds; `Some(reason)` naming the first failure — self-CID mismatch or an unverified attestation flag. Mixed CID + flag failures, so `Option<String>` is the total validator surface.
- `to_cbor_bytes -> Vec<u8>` infallible (`.expect`); `from_cbor_bytes -> Option<Self>` (`None` on invalid bytes OR self-CID mismatch), same pattern as the other certificates.

`CertificateError` enum removed (`SerializationError`/`DeserializationError`/`CidMismatch`/`AttestationFailed` all gone).

## Ripple
Callers are all in `certificate_test`: `new_from_claim_fragments` `.unwrap()` dropped; `verify_attestation` `.is_ok()` → `.is_none()` and `.is_err()` → `.is_some()`; `to_cbor_bytes` `.expect`/`.unwrap` dropped; `from_cbor_bytes` `.expect` kept (valid on `Option`).

## Verification
audit-limits graph-certify certificate.rs now 0 sites. Full workspace build + wasm32 graph-compiler + clippy + fmt clean; graph-certify suite green (certificate test 6/6), BDD 100/100, audit-deferral clean.

Part of the #510 bottom-up sweep — graph-certify.
