### PR TITLE
feat(#510): R5 tranche — graph-certify Smoothing::parse to Option (certify 22->21)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -439,26 +439,19 @@ impl Smoothing {
 
     /// Parse a `--smoothing` flag value: `add-one` | `witten-bell` |
     /// `abs-disc:δ` with δ finite and in (0, 1].
-    pub fn parse(value: &str) -> Result<Smoothing, String> {
+    ///
+    /// Total: `None` means the value is not a valid smoothing spec (an
+    /// unknown rule, a non-numeric δ, or a δ outside the finite (0, 1]
+    /// range). The caller supplies the user-facing message (R5, #510).
+    pub fn parse(value: &str) -> Option<Smoothing> {
         match value {
-            "add-one" => Ok(Smoothing::AddOne),
-            "witten-bell" => Ok(Smoothing::WittenBell),
+            "add-one" => Some(Smoothing::AddOne),
+            "witten-bell" => Some(Smoothing::WittenBell),
             _ => {
-                let Some(delta) = value.strip_prefix("abs-disc:") else {
-                    return Err(format!(
-                        "invalid --smoothing value: {value} \
-                         (expected add-one | witten-bell | abs-disc:δ)"
-                    ));
-                };
-                let delta: f64 = delta
-                    .parse()
-                    .map_err(|_| format!("invalid --smoothing abs-disc delta: {delta}"))?;
-                if !delta.is_finite() || delta <= 0.0 || delta > 1.0 {
-                    return Err(format!(
-                        "--smoothing abs-disc delta must be finite and in (0, 1]: {delta}"
-                    ));
-                }
-                Ok(Smoothing::AbsoluteDiscount(delta))
+                let delta = value.strip_prefix("abs-disc:")?;
+                let delta: f64 = delta.parse().ok()?;
+                (delta.is_finite() && delta > 0.0 && delta <= 1.0)
+                    .then_some(Smoothing::AbsoluteDiscount(delta))
             }
         }
     }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -920,7 +920,12 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, String> {
                     .map_err(|_| format!("invalid --witness-sample value: {value}"))?;
             }
             "--smoothing" => {
-                options.smoothing = score::Smoothing::parse(value)?;
+                options.smoothing = score::Smoothing::parse(value).ok_or_else(|| {
+                    format!(
+                        "invalid --smoothing value: {value} \
+                         (expected add-one | witten-bell | abs-disc:δ with δ finite in (0, 1])"
+                    )
+                })?;
             }
             "--scoring-variant" => {
                 options.scoring_variant = match value.as_str() {


### PR DESCRIPTION
## R5 tranche (#510): graph-certify `Smoothing::parse` → `Option`

`Smoothing::parse` parses a `--smoothing` flag value; a parse failure is invalid
user input, not one of the sanctioned conditions. Converts it from
`Result<Smoothing, String>` to **`Option<Smoothing>`** (`None` = not a valid
smoothing spec: unknown rule, non-numeric δ, or δ outside the finite `(0, 1]`
range).

The single caller (graph-cli `parse_score_options`) supplies the user-facing
message via `.ok_or_else(...)`, keeping its own `Result<_, String>` CLI surface
until graph-cli's own R5 tranche.

### Audit
`graph-certify` audit-limits: **22 → 21** (score.rs 6 → 5). No sanctioned error
types introduced — pure removal of a `Result<_, String>`.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy` (certify +
cli, all-targets), and both crates' lib test suites all green.

### Remaining graph-certify (after this)
5 sites in `score.rs` (the gate-C cluster + `recover_from_artifact`) and 16 in
`score_runtime.rs` — all coupled to the `GraphScorer` methods, so they land after
`score_runtime.rs` converts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
