### PR TITLE
feat(#510): R5 tranche — graph-certify GraphScorer::fmm_candidate to Option (certify 21->20)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -813,10 +813,14 @@ pub struct GraphScorer {
 impl GraphScorer {
     /// Build the certifier-side low-rank far-field candidate for this graph.
     /// This deliberately does not alter deployed scoring semantics.
+    ///
+    /// Total: `None` when the low-rank factorization cannot be built from the
+    /// graph parts (the sole path [`crate::fmm::FmmCandidateScorer::from_graph_parts`]
+    /// already reports as `None`) — R5, #510.
     pub fn fmm_candidate(
         &self,
         config: crate::fmm::FmmConfig,
-    ) -> Result<crate::fmm::FmmCandidateScorer, String> {
+    ) -> Option<crate::fmm::FmmCandidateScorer> {
         crate::fmm::FmmCandidateScorer::from_graph_parts(
             &self.regions,
             &self.emissions,
@@ -825,7 +829,6 @@ impl GraphScorer {
             self.vocab,
             config,
         )
-        .ok_or_else(|| "FMM candidate scorer could not be built from the graph parts".to_owned())
     }
 
     /// Enable or disable predicted-cloud (F / ΔT) emissions. Default

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -2737,12 +2737,10 @@ fn load_fmm_candidate(bundle: &Path, artifact_bytes: &[u8]) -> Option<FmmCandida
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(defaults.relative_singular_tolerance);
-    scorer
-        .fmm_candidate(FmmConfig {
-            max_rank,
-            relative_singular_tolerance,
-        })
-        .ok()
+    scorer.fmm_candidate(FmmConfig {
+        max_rank,
+        relative_singular_tolerance,
+    })
 }
 
 /// Load the bundle's corpus record stream for the S6 in-distribution


### PR DESCRIPTION
## R5 tranche (#510): graph-certify `GraphScorer::fmm_candidate` → `Option`

`GraphScorer::fmm_candidate` builds the certifier-side low-rank far-field
candidate. Its only construction path, `FmmCandidateScorer::from_graph_parts`,
already reports failure as `None` (R5 tranche #561) — the wrapper merely
re-wrapped that `None` into a `Result<_, String>` with a synthetic message.
Drop the wrapper and return **`Option<FmmCandidateScorer>`** directly.

The sole caller (`tests/bdd.rs::load_fmm_candidate`, itself `Option`-returning)
drops its now-redundant `.ok()`.

### Audit
`graph-certify` audit-limits: **21 → 20**. No sanctioned error types introduced
— pure removal of a `Result<_, String>`.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy`
(graph-certify, all-targets), graph-certify lib + `fwda_roundtrip` suites — all
green.

### Remaining graph-certify (after this)
5 sites in `score.rs` (gate-C cluster + `recover_from_artifact`) and 15 in
`score_runtime.rs` — the interconnected `GraphScorer` scoring engine, converted
in coherent clusters next (the `from_artifact` + `verify_witness_replay` cluster,
then the `score_candidates`/`score_step` scoring path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
