### PR TITLE
feat(#510): R5 tranche — graph-certify regions_from_view to Option (certify 18->17)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1812,7 +1812,8 @@ pub fn recover_from_artifact(
         .map_err(|error| format!("invalid cover artifact: {error}"))?;
     view.verify_cids()
         .map_err(|error| format!("cover artifact has bad CIDs: {error}"))?;
-    let regions = regions_from_view(&view)?;
+    let regions = regions_from_view(&view)
+        .ok_or_else(|| "cover artifact is missing its scoring regions".to_owned())?;
     let structural = structural_edges_from_view(&view);
     Ok((regions, structural))
 }

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -214,14 +214,18 @@ impl RegionParams {
 /// a region is the source of its refinement edge (the root maps to
 /// `None`); a region without a refinement parent maps to `None` as well
 /// (every emitted region has exactly one).
-pub fn regions_from_view(view: &GraphView) -> Result<Vec<RegionParams>, String> {
-    let head = view.head().ok_or("artifact carries no HEAD section")?;
-    let rout = view
-        .section(SectionId::ROUT)
-        .ok_or("artifact carries no ROUT section")?;
+///
+/// Total: `None` when the view — already parse- and CID-validated by the
+/// caller — lacks a section the recovery needs (HEAD, ROUT), declares zero
+/// nodes, is missing a node record inside its declared count, or points a
+/// prototype window outside ROUT. Every such case means the bytes are not a
+/// scorer's graph (R5, #510).
+pub fn regions_from_view(view: &GraphView) -> Option<Vec<RegionParams>> {
+    let head = view.head()?;
+    let rout = view.section(SectionId::ROUT)?;
     let node_count = head.node_count();
     if node_count == 0 {
-        return Err("HEAD declares zero nodes".to_owned());
+        return None;
     }
     // Parents from refinement edges (dst node -> src node).
     let mut parent_of: BTreeMap<u32, u32> = BTreeMap::new();
@@ -234,13 +238,9 @@ pub fn regions_from_view(view: &GraphView) -> Result<Vec<RegionParams>, String> 
     let mut regions = Vec::with_capacity((node_count - 1) as usize);
     let mut node_index = 1u32;
     while node_index < node_count {
-        let node = view
-            .node(node_index)
-            .ok_or("node record missing within declared count")?;
+        let node = view.node(node_index)?;
         let start = (node.prototype_word_start as usize) << 3;
-        let window = rout
-            .get(start..start + signature_bytes)
-            .ok_or("prototype window outside ROUT")?;
+        let window = rout.get(start..start + signature_bytes)?;
         let mut sig = [0u8; SIG_BYTES];
         sig.copy_from_slice(window);
         let parent =
@@ -256,7 +256,7 @@ pub fn regions_from_view(view: &GraphView) -> Result<Vec<RegionParams>, String> 
         });
         node_index += 1;
     }
-    Ok(regions)
+    Some(regions)
 }
 
 /// One structural edge recovered from the canonical array (E_r/E_o with
@@ -895,7 +895,7 @@ impl GraphScorer {
                 head.fallback_policies(),
             );
         let graph_cid = view.header().artifact_cid.0;
-        let regions = regions_from_view(&view).ok()?;
+        let regions = regions_from_view(&view)?;
         let max_depth = regions.iter().map(|r| r.depth as usize).max().unwrap_or(0);
 
         let mut forward_by_src: BTreeMap<u32, Vec<EdgeUse>> = BTreeMap::new();


### PR DESCRIPTION
## R5 tranche (#510): graph-certify `regions_from_view` → `Option`

`regions_from_view` recovers region parameters from a view the caller has already
parse- and CID-validated. Its failure branches — a missing HEAD or ROUT section,
zero declared nodes, a node record missing inside the declared count, or a
prototype window pointing outside ROUT — all mean the bytes are not a scorer's
graph, so convert `Result<Vec<RegionParams>, String>` to
**`Option<Vec<RegionParams>>`**.

### Callers adapted
- `GraphScorer::from_artifact` (already `Option`-returning) drops its `.ok()`
  bridge → `regions_from_view(&view)?`.
- `score::recover_from_artifact` (still `Result<_, String>`, the `--cover` CLI
  path) maps `None` via `.ok_or_else(...)`.

### Audit
`graph-certify` audit-limits: **18 → 17** (score_runtime.rs 13 → 12). No
sanctioned error types introduced — pure removal of a `Result<_, String>`.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy`
(graph-certify, all-targets), graph-certify lib / `fwda_roundtrip` /
`status_policy` (+census) suites — all green.

### Remaining graph-certify (after this)
12 sites: the `score_runtime.rs` scoring path (`score_candidates`,
`score_candidates_coded`, `probe_code`, `score_candidates_infill`/`legacy`,
`two_pass_infill_generate`, `infill_fill`, and the `step_*` streaming methods)
plus the score.rs gate-C cluster + `recover_from_artifact`. Converted next in
coherent clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
