### PR TITLE
feat(#510): R5 tranche — graph-certify score_candidates path to Option (certify 17->10)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -681,7 +681,11 @@ impl R4Engine {
             let outcome = self
                 .scorer
                 .score_candidates_coded(sig, input_code, recent_tokens)
-                .map_err(InferenceError::Scorer)?;
+                .ok_or_else(|| {
+                    InferenceError::Scorer(
+                        "scorer produced no candidates for the probe signature".to_owned(),
+                    )
+                })?;
             Ok(ScoredProbe {
                 token: outcome.selected,
                 status: outcome.witness.status,
@@ -707,7 +711,11 @@ impl R4Engine {
         let _ = top_m;
         self.scorer
             .score_candidates_coded(sig, input_code, recent_tokens)
-            .map_err(InferenceError::Scorer)
+            .ok_or_else(|| {
+                InferenceError::Scorer(
+                    "scorer produced no candidates for the probe signature".to_owned(),
+                )
+            })
     }
 
     /// The D4 policy decision for one input signature: score at the

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -2727,8 +2727,9 @@ fn generate_greedy_repetition_rate(
         for (i, &t) in recent_tokens.iter().enumerate() {
             recent_array[i] = t;
         }
-        let outcome =
-            scorer.score_candidates_coded(&sig, Some(&code), &recent_array[..recent_len])?;
+        let outcome = scorer
+            .score_candidates_coded(&sig, Some(&code), &recent_array[..recent_len])
+            .expect("gate C: scoring self-produced sig");
         let token = outcome.selected;
 
         if recent_tokens.contains(&token) {
@@ -4727,33 +4728,32 @@ fn evaluate_gate_c_row(
 
     let legacy = context
         .scorer_with_exct
-        .score_candidates_legacy(&observation.sig)?;
-    let rule1 =
-        context
-            .scorer_no_exct
-            .score_candidates_coded(&observation.sig, Some(&code), window)?;
-    let rule12 =
-        context
-            .scorer_with_exct
-            .score_candidates_coded(&observation.sig, Some(&code), window)?;
-    let rule1_no_f = context.scorer_no_exct_no_f.score_candidates_coded(
-        &observation.sig,
-        Some(&code),
-        window,
-    )?;
-    let rule12_no_f = context.scorer_with_exct_no_f.score_candidates_coded(
-        &observation.sig,
-        Some(&code),
-        window,
-    )?;
-    let normalized =
-        context
-            .scorer_normalized
-            .score_candidates_coded(&observation.sig, Some(&code), window)?;
-    let margin =
-        context
-            .scorer_margin
-            .score_candidates_coded(&observation.sig, Some(&code), window)?;
+        .score_candidates_legacy(&observation.sig)
+        .expect("gate C: scoring self-produced sig");
+    let rule1 = context
+        .scorer_no_exct
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
+    let rule12 = context
+        .scorer_with_exct
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
+    let rule1_no_f = context
+        .scorer_no_exct_no_f
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
+    let rule12_no_f = context
+        .scorer_with_exct_no_f
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
+    let normalized = context
+        .scorer_normalized
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
+    let margin = context
+        .scorer_margin
+        .score_candidates_coded(&observation.sig, Some(&code), window)
+        .expect("gate C: scoring self-produced sig");
     let baseline = runtime::predict_witness_plain(context.store, &code);
 
     let hits = [
@@ -5092,11 +5092,10 @@ fn evaluate_gate_c_row(
             } else {
                 &[]
             };
-            let anchor_outcome = context.scorer_with_exct.score_candidates_coded(
-                &anchor_sig,
-                Some(&anchor_code),
-                anchor_window,
-            )?;
+            let anchor_outcome = context
+                .scorer_with_exct
+                .score_candidates_coded(&anchor_sig, Some(&anchor_code), anchor_window)
+                .expect("gate C: scoring self-produced sig");
             let anchor_hat = anchor_outcome.selected;
             anchor_hat_correct = Some(anchor_hat == anchor);
             if let Some(fwd_row) = context.fwd_table.get(&(lookahead, anchor_hat)) {
@@ -5161,11 +5160,14 @@ fn evaluate_gate_c_row(
                 );
                 let draft_sig = runtime::sig_plain(context.artifacts, &draft_bundle);
                 let draft_code = runtime::assign_for_bundle(context.artifacts, &draft_bundle);
-                let draft_outcome = context.scorer_with_exct.score_candidates_coded(
-                    &draft_sig,
-                    Some(&draft_code),
-                    &draft_recent[..draft_recent_len],
-                )?;
+                let draft_outcome = context
+                    .scorer_with_exct
+                    .score_candidates_coded(
+                        &draft_sig,
+                        Some(&draft_code),
+                        &draft_recent[..draft_recent_len],
+                    )
+                    .expect("gate C: scoring self-produced sig");
                 pending = draft_outcome.selected;
                 draft_anchor = pending;
                 draft_gate = draft_outcome.witness.status == ScoreStatus::ExactContext;

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -1151,7 +1151,7 @@ impl GraphScorer {
         &self,
         sig: &[u8; SIG_BYTES],
         recent_tokens: &[u32],
-    ) -> Result<ScoreOutcome, String> {
+    ) -> Option<ScoreOutcome> {
         self.score_candidates_coded(sig, None, recent_tokens)
     }
 
@@ -1164,15 +1164,13 @@ impl GraphScorer {
         art: &Compiled,
         sig: &[u8; SIG_BYTES],
         input_code: Option<&[u8; STAGES]>,
-    ) -> Result<[u8; STAGES], String> {
+    ) -> Option<[u8; STAGES]> {
         match input_code {
-            Some(code) => Ok(*code),
-            None if art.dot_cb.is_empty() => Ok(runtime::assign_plain(art, sig)),
-            None => Err(
-                "TLA6 artifact: the EXCT probe requires the assigned graded code \
-                 (witness contract, #243 Phase C option A)"
-                    .to_owned(),
-            ),
+            Some(code) => Some(*code),
+            None if art.dot_cb.is_empty() => Some(runtime::assign_plain(art, sig)),
+            // TLA6 artifact without a caller code: the sig cannot reconstruct
+            // the dot-metric graded code (witness contract, #243 Phase C A).
+            None => None,
         }
     }
 
@@ -1185,7 +1183,7 @@ impl GraphScorer {
         sig: &[u8; SIG_BYTES],
         input_code: Option<&[u8; STAGES]>,
         recent_tokens: &[u32],
-    ) -> Result<ScoreOutcome, String> {
+    ) -> Option<ScoreOutcome> {
         let recent_tokens = if recent_tokens.len() > 32 {
             &recent_tokens[recent_tokens.len() - 32..]
         } else {
@@ -1226,7 +1224,7 @@ impl GraphScorer {
                 candidate_count: candidates.len() as u32,
                 census,
             };
-            return Ok(ScoreOutcome {
+            return Some(ScoreOutcome {
                 selected,
                 selected_score,
                 candidates,
@@ -1530,7 +1528,7 @@ impl GraphScorer {
             ranked_candidates.push((token, score, contributions));
         }
         if ranked_candidates.is_empty() {
-            return Err("scoring produced an empty candidate set".to_owned());
+            return None;
         }
 
         // Canonical argmax: highest score, then the lowest token id
@@ -1576,7 +1574,7 @@ impl GraphScorer {
             candidate_count,
             census: k,
         };
-        Ok(ScoreOutcome {
+        Some(ScoreOutcome {
             selected,
             selected_score,
             candidates: candidates_out,
@@ -1633,13 +1631,13 @@ impl GraphScorer {
         input_code: Option<&[u8; STAGES]>,
         recent_tokens: &[u32],
         next_anchor: Option<(u32, u8)>,
-    ) -> Result<ScoreOutcome, String> {
+    ) -> Option<ScoreOutcome> {
         let base = self.score_candidates_coded(sig, input_code, recent_tokens)?;
         let Some((anchor, distance)) = next_anchor else {
-            return Ok(base);
+            return Some(base);
         };
         let Some(row) = self.fwd_rows.get(&(distance, anchor)) else {
-            return Ok(base);
+            return Some(base);
         };
         let floor_base = self
             .root_floor
@@ -1664,13 +1662,13 @@ impl GraphScorer {
             }
         }
         let Some((selected, selected_score)) = best else {
-            return Ok(base);
+            return Some(base);
         };
         let mut outcome = base;
         outcome.selected = selected;
         outcome.selected_score = selected_score;
         outcome.candidates = fused.into_iter().collect();
-        Ok(outcome)
+        Some(outcome)
     }
 
     /// The pre-#64 Σ-over-cloud formula `S(v) = B(v) + Σ_{n∈A} ΔE(n,v) +
@@ -1680,7 +1678,7 @@ impl GraphScorer {
     /// semantics; emits no replayable witness. The active cloud uses the
     /// same ReferenceClassifier semantics the old formula scored
     /// (nearest-region fallback included).
-    pub fn score_candidates_legacy(&self, sig: &[u8; SIG_BYTES]) -> Result<LegacyOutcome, String> {
+    pub fn score_candidates_legacy(&self, sig: &[u8; SIG_BYTES]) -> Option<LegacyOutcome> {
         let mut k = OpKernel::default();
 
         // Active cloud A: top-M memberships at each depth.
@@ -1781,7 +1779,7 @@ impl GraphScorer {
             ranked_candidates.push((token, score));
         }
         if ranked_candidates.is_empty() {
-            return Err("scoring produced an empty candidate set".to_owned());
+            return None;
         }
         let mut best_index = 0usize;
         for (index, &(_, score)) in ranked_candidates.iter().enumerate() {
@@ -1790,7 +1788,7 @@ impl GraphScorer {
             }
         }
         let (selected, selected_score) = ranked_candidates[best_index];
-        Ok(LegacyOutcome {
+        Some(LegacyOutcome {
             selected,
             selected_score,
             candidates: ranked_candidates,
@@ -2506,7 +2504,7 @@ pub fn two_pass_infill_generate(
     rotations: &[usize; compiler::WINDOW + 1],
     seed: &[u32],
     tokens_to_generate: usize,
-) -> Result<TwoPassGeneration, String> {
+) -> Option<TwoPassGeneration> {
     let seed_len = seed.len();
 
     // ---- Pass 1: greedy draft, recording per-position context. ----
@@ -2586,7 +2584,7 @@ pub fn two_pass_infill_generate(
         }
     }
 
-    Ok(TwoPassGeneration {
+    Some(TwoPassGeneration {
         draft,
         final_tokens,
         changed_positions,
@@ -2642,7 +2640,7 @@ pub fn infill_fill(
     artifacts: &Compiled,
     rotations: &[usize; compiler::WINDOW + 1],
     skeleton: &[Option<u32>],
-) -> Result<Vec<u32>, String> {
+) -> Option<Vec<u32>> {
     let mut window = [0u32; compiler::WINDOW];
     let mut w_len = 0usize;
     let mut recent_tokens = std::collections::VecDeque::with_capacity(32);
@@ -2678,7 +2676,7 @@ pub fn infill_fill(
         }
         recent_tokens.push_back(token);
     }
-    Ok(filled)
+    Some(filled)
 }
 
 /// Rejection reasons of the independent witness-replay verifier
@@ -2812,8 +2810,12 @@ pub fn verify_witness_replay(
         witness.input_code.as_ref(),
         &witness.context_tokens,
     ) {
-        Ok(outcome) => outcome,
-        Err(e) => return Some(ReplayError::Artifact(e)),
+        Some(outcome) => outcome,
+        None => {
+            return Some(ReplayError::Artifact(
+                "score_candidates_coded produced no outcome on replay".to_owned(),
+            ));
+        }
     };
     let recomputed = &outcome.witness;
 

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2638,7 +2638,8 @@ pub fn graph_infill_command(args: &[String]) -> Result<(), String> {
     .ok_or_else(|| "could not build scorer from R4G1 artifact".to_owned())?;
     let rotations = runtime::derive_rotations();
 
-    let filled = score_runtime::infill_fill(&scorer, &artifacts, &rotations, &skeleton)?;
+    let filled = score_runtime::infill_fill(&scorer, &artifacts, &rotations, &skeleton)
+        .ok_or_else(|| "infill fill produced no tokens".to_owned())?;
 
     let free_positions = skeleton.iter().filter(|slot| slot.is_none()).count();
     let live_fwd_positions = skeleton


### PR DESCRIPTION
## R5 tranche (#510): graph-certify `score_candidates` path → `Option`

Converts the witness-emitting candidate-scoring path in `score_runtime.rs` to a
total surface. Each function scores a signature against a validated
`GraphScorer`; a failure means no candidate distribution could be produced (an
empty candidate set, an unresolvable TLA6 graded code, or a propagated inner
`None`) — a total "no outcome" answer, not one of the sanctioned error
conditions.

- `score_candidates` / `score_candidates_coded` / `score_candidates_infill` →
  `Option<ScoreOutcome>`
- `score_candidates_legacy` → `Option<LegacyOutcome>`
- `probe_code` → `Option<[u8; STAGES]>`
- `two_pass_infill_generate` → `Option<TwoPassGeneration>`
- `infill_fill` → `Option<Vec<u32>>`

### Callers adapted in-PR
- **score.rs gate-C** rebuilds score the just-emitted self-produced artifact and
  its own observation sigs → `None` is a defect → `.expect("gate C: scoring
  self-produced sig")` (these fns keep their `Result` surface until the gate-C
  conversion; `.expect` is forward-safe).
- **`verify_witness_replay`** (already `Option<ReplayError>`) maps a `None`
  outcome to `ReplayError::Artifact`.
- **api engine** serving (score + witness paths) maps `None` to
  `InferenceError::Scorer` via `.ok_or_else(...)`.
- **graph-cli** `graph_infill` maps `None` to its own `Result` via
  `.ok_or_else(...)`.
- The `fwda_roundtrip` / `router_reconnect` / `status_policy` test call sites are
  unchanged — they already use `Option`-compatible `.expect(...)` / `.unwrap()`.

### Audit
`graph-certify` audit-limits: **17 → 10** (score_runtime.rs 12 → 5). Remaining
score_runtime sites are the `step_*` streaming methods; score.rs keeps its
gate-C cluster + `recover_from_artifact`. No sanctioned error types introduced —
pure removal of `Result<_, String>`.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy` (certify +
cli + api, all-targets), `wasm32-unknown-unknown` build of graph-certify, and the
graph-certify lib / `fwda_roundtrip` / api lib / `status_policy` (+census) suites
— all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
