### PR TITLE
feat(#510): R5 tranche — graph-certify gate-C cluster + recover to total; graph-certify at 0

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1807,13 +1807,25 @@ pub fn emit_scored_r4g1(
 /// re-induced inputs by construction (deterministic double-run).
 pub fn recover_from_artifact(
     r4g1: &[u8],
-) -> Result<(Vec<RegionParams>, Vec<StructuralEdge>), String> {
-    let view = uor_r4_graph_format::GraphView::parse(r4g1)
-        .map_err(|error| format!("invalid cover artifact: {error}"))?;
-    view.verify_cids()
-        .map_err(|error| format!("cover artifact has bad CIDs: {error}"))?;
-    let regions = regions_from_view(&view)
-        .ok_or_else(|| "cover artifact is missing its scoring regions".to_owned())?;
+) -> Result<(Vec<RegionParams>, Vec<StructuralEdge>), uor_r4_graph_format::NotAProduct> {
+    // The `--cover` bytes are an external file: validated as a product. A
+    // structural failure is a `NotAProduct` (parse propagates one directly);
+    // a CID mismatch is folded through its `FormatError` bridge; a view that
+    // parses and verifies but cannot yield scoring regions is reported as a
+    // missing NODE section (R5, #510).
+    let view = uor_r4_graph_format::GraphView::parse(r4g1)?;
+    view.verify_cids().map_err(|kappa| {
+        uor_r4_graph_format::NotAProduct::new(
+            uor_r4_graph_format::ObjectKind::Graph,
+            kappa.as_format(),
+        )
+    })?;
+    let regions = regions_from_view(&view).ok_or_else(|| {
+        uor_r4_graph_format::NotAProduct::new(
+            uor_r4_graph_format::ObjectKind::Graph,
+            uor_r4_graph_format::FormatError::MissingNodeSection,
+        )
+    })?;
     let structural = structural_edges_from_view(&view);
     Ok((regions, structural))
 }
@@ -2701,7 +2713,7 @@ fn generate_greedy_repetition_rate(
     rotations: &[usize; compiler::WINDOW + 1],
     seed: &[u32],
     tokens_to_generate: usize,
-) -> Result<f64, String> {
+) -> f64 {
     let mut window = [0u32; compiler::WINDOW];
     let mut recent_tokens = std::collections::VecDeque::with_capacity(32);
     let seed_len = seed.len();
@@ -2749,7 +2761,7 @@ fn generate_greedy_repetition_rate(
         recent_tokens.push_back(token);
     }
 
-    Ok(duplicate_count as f64 / tokens_to_generate as f64)
+    duplicate_count as f64 / tokens_to_generate as f64
 }
 
 fn baseline_greedy_repetition_rate(
@@ -3337,7 +3349,7 @@ pub fn evaluate_gate_c(
     corpus: &Corpus,
     held_out: &[Observation],
     config: &ScoreConfig,
-) -> Result<GateCOutcome, String> {
+) -> Option<GateCOutcome> {
     // #471: every whole-corpus pass below announces its own cost, and the
     // arm groups this run was told not to build are resolved up front so the
     // skip is one decision read in one place.
@@ -3751,7 +3763,7 @@ pub fn evaluate_gate_c(
         .par_iter()
         .enumerate()
         .map(|(index, observation)| evaluate_gate_c_row(index, observation, &context))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Vec<_>>();
     phases.mark(&format!("scoring {} positions", scored.len()));
     for row in rows {
         hits_legacy += u64::from(row.hits[0]);
@@ -4004,7 +4016,8 @@ pub fn evaluate_gate_c(
     }
     let n = scored.len();
     if n == 0 {
-        return Err("held-out split is empty; cannot evaluate".to_owned());
+        // Nothing to measure: a total "cannot evaluate" answer, not an error.
+        return None;
     }
     let nf = n as f64;
     let metrics = |hits: u64, bits: f64| {
@@ -4380,13 +4393,8 @@ pub fn evaluate_gate_c(
         let pos = obs.position as usize;
         if pos >= 32 && corpus.story[pos] == corpus.story[pos - 32] {
             let seed = &corpus.input[pos - 32..pos];
-            graph_rep_sum += generate_greedy_repetition_rate(
-                &scorer_with_exct,
-                artifacts,
-                &rotations,
-                seed,
-                64,
-            )?;
+            graph_rep_sum +=
+                generate_greedy_repetition_rate(&scorer_with_exct, artifacts, &rotations, seed, 64);
             baseline_rep_sum +=
                 baseline_greedy_repetition_rate(store, artifacts, &rotations, seed, 64);
             probe_count += 1;
@@ -4406,7 +4414,7 @@ pub fn evaluate_gate_c(
 
     phases.mark("reduction, per-status rollups and replay probes");
     phases.total();
-    Ok(outcome)
+    Some(outcome)
 }
 
 /// The `score_report.json` document. Schema history: 1 = the three-set
@@ -4703,7 +4711,7 @@ fn evaluate_gate_c_row(
     index: usize,
     observation: &Observation,
     context: &GateCContext<'_>,
-) -> Result<GateCRow, String> {
+) -> GateCRow {
     let position = observation.position as usize;
     let teacher_argmax = context.corpus.t_argmax[position];
     let next = context.corpus.next[position];
@@ -5308,7 +5316,7 @@ fn evaluate_gate_c_row(
         )
         .is_some();
 
-    Ok(GateCRow {
+    GateCRow {
         hits,
         bits,
         status_index,
@@ -5380,7 +5388,7 @@ fn evaluate_gate_c_row(
         hit_latent_shuffled: latent_shuffled_selected == teacher_argmax,
         bits_latent_shuffled,
         latent_shuffled_live,
-    })
+    }
 }
 
 /// Gate C table (graph_no_exct/graph_with_exct/tla3_baseline); 2 = the

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -495,7 +495,8 @@ pub fn run_point(
         &inputs.corpus,
         &inputs.held_out,
         score_config,
-    )?;
+    )
+    .ok_or_else(|| "gate C could not evaluate an empty held-out split".to_owned())?;
 
     let cover = &induced.cover;
     let mut per_depth = vec![0u32; cover.max_depth];
@@ -651,6 +652,7 @@ pub fn reconstruction_null(
             held,
             score_config,
         )
+        .ok_or_else(|| "gate C could not evaluate an empty held-out split".to_owned())
     };
 
     let real_gate = score_with(&emissions)?;

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1113,7 +1113,8 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
                 path.display(),
                 repro::container_kappa(&bytes)
             );
-            let (regions, structural) = score::recover_from_artifact(&bytes)?;
+            let (regions, structural) =
+                score::recover_from_artifact(&bytes).map_err(|error| error.to_string())?;
             eprintln!(
                 "score: recovered {} regions from {}",
                 regions.len(),
@@ -1207,7 +1208,8 @@ pub fn score_command(args: &[String]) -> Result<(), String> {
         &corpus,
         &held_out,
         &config,
-    )?;
+    )
+    .ok_or_else(|| "gate C could not evaluate an empty held-out split".to_owned())?;
     // The "gate c phase:" lines above break this phase down further (#471);
     // here it is one line so the score-level total stays complete.
     phases.mark("gate c evaluation");


### PR DESCRIPTION
## R5 tranche (#510): graph-certify gate-C cluster + recover → total — **graph-certify at 0**

Converts the last five graph-certify `Result` surfaces, all in `score.rs`:

- **`generate_greedy_repetition_rate` → `f64`.** Mirrors
  `baseline_greedy_repetition_rate` (already bare); its scorer call became a
  self-produced-defect `.expect` in #567, so the wrapper `Result` carried nothing.
- **`evaluate_gate_c_row` → `GateCRow`.** With its scorer calls already `.expect`
  (#567), no fallible operation remained; the per-row Rayon map now collects into
  a plain `Vec`.
- **`evaluate_gate_c` → `Option<GateCOutcome>`.** The one real failure is an empty
  held-out split (nothing to measure) → `None`; the six self-produced scorer
  rebuilds stay `.expect`, and the greedy/row calls are now infallible.
- **`recover_from_artifact` → `Result<_, NotAProduct>`.** The `--cover` bytes are
  an external product: `GraphView::parse` propagates `NotAProduct` directly, a CID
  mismatch folds through `KappaError::as_format`, and a view that parses and
  verifies but yields no scoring regions is reported as a missing NODE section.

Callers adapted: graph-cli `cover_sweep` (×2) and `score_command` map the `Option`
to their `Result` CLI surface via `.ok_or_else`; the `--cover` path maps
`NotAProduct` via `.to_string()`.

### Audit — milestone
`graph-certify` audit-limits: **5 → 0**. Combined with #568 (`score_runtime.rs`
`step_*` → `Option`, already merged), **the entire graph-certify crate now names
only sanctioned `Result` surfaces** (`NotAProduct` / `ObservedBound` /
`KappaError` / `SourceUnavailable`) or total forms. Verified locally by rebasing
onto the #568 base: `audit-limits` reports zero graph-certify sites. Remaining
workspace: api (20), graph-cli (42).

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy` (certify +
cli, all-targets), `wasm32-unknown-unknown` build of graph-certify, and the
graph-certify lib / `fwda_roundtrip` / graph-cli lib / `status_policy` (+census)
suites — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
