### PR TITLE
feat(#510): R5 tranche — api compile.rs CompileError to SourceUnavailable (api 20->15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "uor-r4-graph-cli",
  "uor-r4-graph-compiler",
  "uor-r4-graph-format",
+ "uor-r4-model-source",
 ]
 
 [[package]]

--- a/crates/uor-r4-api/Cargo.toml
+++ b/crates/uor-r4-api/Cargo.toml
@@ -11,6 +11,7 @@ uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format" }
 uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler" }
 uor-r4-graph-certify = { version = "0.1.0", path = "../uor-r4-graph-certify" }
 uor-r4-graph-cli = { version = "0.1.0", path = "../uor-r4-graph-cli" }
+uor-r4-model-source = { version = "0.1.0", path = "../uor-r4-model-source" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Pinned to the workspace-wide blake3 version.

--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -36,6 +36,7 @@ use uor_r4_graph_format::{
     ContractVersion, FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR,
     INFERENCE_OPERATION_CONTRACT_VERSION,
 };
+use uor_r4_model_source::SourceUnavailable;
 
 /// Which compiler stage a progress event or failure belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -235,62 +236,6 @@ pub struct CompileProvenance {
     pub digests: ComponentDigests,
 }
 
-/// Focused compile failures.
-#[derive(Debug)]
-pub enum CompileError {
-    /// The source directory is not a verified local HF-style source.
-    SourceInvalid {
-        /// What is missing or malformed.
-        message: String,
-    },
-    /// Filesystem failure while preparing the work directory or
-    /// collecting outputs.
-    Io {
-        /// The stage whose I/O failed.
-        stage: Stage,
-        /// The underlying I/O error.
-        source: std::io::Error,
-    },
-    /// A compiler stage rejected its inputs or failed mid-run (the
-    /// stage's own message, forwarded verbatim).
-    Stage {
-        /// The failing stage.
-        stage: Stage,
-        /// The stage's error message.
-        message: String,
-    },
-    /// A path derived from the request is not UTF-8 (the stage
-    /// implementations stringify corpus paths).
-    NonUtf8Path {
-        /// The stage that needs the path.
-        stage: Stage,
-        /// The offending path.
-        path: PathBuf,
-    },
-}
-
-impl fmt::Display for CompileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CompileError::SourceInvalid { message } => write!(f, "invalid source: {message}"),
-            CompileError::Io { stage, source } => write!(f, "{stage} stage I/O: {source}"),
-            CompileError::Stage { stage, message } => write!(f, "{stage} stage: {message}"),
-            CompileError::NonUtf8Path { stage, path } => {
-                write!(f, "{stage} stage: path is not UTF-8: {}", path.display())
-            }
-        }
-    }
-}
-
-impl std::error::Error for CompileError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CompileError::Io { source, .. } => Some(source),
-            _ => None,
-        }
-    }
-}
-
 /// Orchestrate the three compiler stages for `request`. Resumable: an
 /// incomplete teacher corpus returns
 /// [`CompileOutcome::Incomplete`] and re-calling with the same request
@@ -298,12 +243,11 @@ impl std::error::Error for CompileError {
 pub fn compile(
     request: &CompileRequest,
     progress: &mut dyn FnMut(ProgressEvent),
-) -> Result<CompileOutcome, CompileError> {
+) -> Result<CompileOutcome, SourceUnavailable> {
     validate_source(&request.source_dir)?;
     let work = &request.work_dir;
-    std::fs::create_dir_all(work).map_err(|source| CompileError::Io {
-        stage: Stage::TeacherBundle,
-        source,
+    std::fs::create_dir_all(work).map_err(|source| {
+        SourceUnavailable::new(format!("{} stage I/O: {source}", Stage::TeacherBundle))
     })?;
     let meta = work.join("corpus.meta");
     let recs = work.join("corpus.records");
@@ -322,9 +266,8 @@ pub fn compile(
             });
         },
     )
-    .map_err(|message| CompileError::Stage {
-        stage: Stage::TeacherBundle,
-        message,
+    .map_err(|message| {
+        SourceUnavailable::new(format!("{} stage: {message}", Stage::TeacherBundle))
     })?;
 
     if !corpus_complete(&meta)? {
@@ -344,12 +287,8 @@ pub fn compile(
         percent: 0,
         label: "Inducing multiresolution cover...",
     });
-    uor_r4_graph_compiler::compile(&stage_b_flags(request, &cover_out)).map_err(|error| {
-        CompileError::Stage {
-            stage: Stage::GraphCover,
-            message: error.to_string(),
-        }
-    })?;
+    uor_r4_graph_compiler::compile(&stage_b_flags(request, &cover_out))
+        .map_err(|error| SourceUnavailable::new(format!("{} stage: {error}", Stage::GraphCover)))?;
     progress(ProgressEvent {
         stage: Stage::GraphCover,
         percent: 100,
@@ -363,10 +302,7 @@ pub fn compile(
         label: "Compiling transitions and emission residuals...",
     });
     uor_r4_graph_cli::score_command(&stage_c_flags(request, &cover_out, &scored_out)).map_err(
-        |message| CompileError::Stage {
-            stage: Stage::Scoring,
-            message,
-        },
+        |message| SourceUnavailable::new(format!("{} stage: {message}", Stage::Scoring)),
     )?;
     progress(ProgressEvent {
         stage: Stage::Scoring,
@@ -380,10 +316,10 @@ pub fn compile(
         Ok(bytes) => Some(bytes),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(source) => {
-            return Err(CompileError::Io {
-                stage: Stage::TeacherBundle,
-                source,
-            })
+            return Err(SourceUnavailable::new(format!(
+                "{} stage I/O: {source}",
+                Stage::TeacherBundle
+            )));
         }
     };
     let score_report = read_stage_file(Stage::Scoring, &scored_out.join("score_report.json"))?;
@@ -416,8 +352,8 @@ pub fn compile(
 /// A verified local HF-style source: `config.json`, `tokenizer.json`,
 /// and at least one `*.safetensors` weight file. Downloading is out of
 /// scope for this crate by design.
-fn validate_source(source: &Path) -> Result<(), CompileError> {
-    let invalid = |message: String| CompileError::SourceInvalid { message };
+fn validate_source(source: &Path) -> Result<(), SourceUnavailable> {
+    let invalid = |message: String| SourceUnavailable::new(format!("invalid source: {message}"));
     let metadata = source
         .metadata()
         .map_err(|error| invalid(format!("{}: {error}", source.display())))?;
@@ -456,28 +392,29 @@ fn validate_source(source: &Path) -> Result<(), CompileError> {
 /// meta, `meta[24] == 1`) without loading the corpus; a missing or
 /// partial meta means the teacher-bundle stage has more generation to
 /// do. This is the ONLY resume signal — no stage stdout is parsed.
-fn corpus_complete(meta: &Path) -> Result<bool, CompileError> {
+fn corpus_complete(meta: &Path) -> Result<bool, SourceUnavailable> {
     match std::fs::read(meta) {
         Ok(bytes) => Ok(bytes.len() == 25 && bytes[24] == 1),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(source) => Err(CompileError::Io {
-            stage: Stage::TeacherBundle,
-            source,
-        }),
+        Err(source) => Err(SourceUnavailable::new(format!(
+            "{} stage I/O: {source}",
+            Stage::TeacherBundle
+        ))),
     }
 }
 
-fn utf8(path: &Path, stage: Stage) -> Result<(), CompileError> {
-    path.to_str()
-        .map(|_| ())
-        .ok_or_else(|| CompileError::NonUtf8Path {
-            stage,
-            path: path.to_path_buf(),
-        })
+fn utf8(path: &Path, stage: Stage) -> Result<(), SourceUnavailable> {
+    path.to_str().map(|_| ()).ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{stage} stage: path is not UTF-8: {}",
+            path.display()
+        ))
+    })
 }
 
-fn read_stage_file(stage: Stage, path: &Path) -> Result<Vec<u8>, CompileError> {
-    std::fs::read(path).map_err(|source| CompileError::Io { stage, source })
+fn read_stage_file(stage: Stage, path: &Path) -> Result<Vec<u8>, SourceUnavailable> {
+    std::fs::read(path)
+        .map_err(|source| SourceUnavailable::new(format!("{stage} stage I/O: {source}")))
 }
 
 fn digest(bytes: &[u8]) -> String {

--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -26,9 +26,8 @@ pub mod engine;
 pub mod serving_eval;
 
 pub use compile::{
-    compile, CompileError, CompileOptions, CompileOutcome, CompileProvenance, CompileRequest,
-    CompiledModel, ComponentDigests, ProgressEvent, QualityProfile, ResumeHint, ScoringOptions,
-    Stage,
+    compile, CompileOptions, CompileOutcome, CompileProvenance, CompileRequest, CompiledModel,
+    ComponentDigests, ProgressEvent, QualityProfile, ResumeHint, ScoringOptions, Stage,
 };
 pub use engine::{
     validate_quality_report, AbiVersion, AbstainOutcome, EngineParts, GenerateStatus,

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use uor_r4_api::compile::{
-    compile, CompileError, CompileOptions, CompileOutcome, CompileRequest, QualityProfile, Stage,
+    compile, CompileOptions, CompileOutcome, CompileRequest, QualityProfile, Stage,
 };
 use uor_r4_api::engine::{AbiVersion, EngineParts, LoadError, PredictOutput, R4Engine};
 use uor_r4_api::Tokenizer;
@@ -176,8 +176,8 @@ fn compile_rejects_missing_source() {
         &mut |_| {},
     );
     match outcome {
-        Err(CompileError::SourceInvalid { .. }) => {}
-        other => panic!("expected SourceInvalid, got {other:?}"),
+        Err(error) => assert!(error.reason.contains("invalid source"), "{error}"),
+        other => panic!("expected an invalid-source failure, got {other:?}"),
     }
     let _ = std::fs::remove_dir_all(&work);
 }
@@ -189,18 +189,14 @@ fn compile_rejects_source_without_required_files() {
     std::fs::write(source.join("config.json"), b"{}").expect("config");
     // tokenizer.json and weights missing.
     match compile(&request(source.clone(), work.clone()), &mut |_| {}) {
-        Err(CompileError::SourceInvalid { message }) => {
-            assert!(message.contains("tokenizer.json"), "{message}");
-        }
-        other => panic!("expected SourceInvalid, got {other:?}"),
+        Err(error) => assert!(error.reason.contains("tokenizer.json"), "{error}"),
+        other => panic!("expected an invalid-source failure, got {other:?}"),
     }
     // Weights still missing after the tokenizer appears.
     std::fs::write(source.join("tokenizer.json"), b"{}").expect("tokenizer");
     match compile(&request(source.clone(), work.clone()), &mut |_| {}) {
-        Err(CompileError::SourceInvalid { message }) => {
-            assert!(message.contains("safetensors"), "{message}");
-        }
-        other => panic!("expected SourceInvalid, got {other:?}"),
+        Err(error) => assert!(error.reason.contains("safetensors"), "{error}"),
+        other => panic!("expected an invalid-source failure, got {other:?}"),
     }
     let _ = std::fs::remove_dir_all(&source);
     let _ = std::fs::remove_dir_all(&work);


### PR DESCRIPTION
## R5 tranche (#510): api `compile.rs` `CompileError` → `SourceUnavailable`

First api-crate tranche. The typed compile orchestrator is host-source machinery:
it validates a local Hugging Face source directory, prepares a work directory,
drives the three compiler stages over the filesystem, and collects their byte
outputs. Every failure is *"the local source or work directory could not produce
a model"* — exactly `SourceUnavailable`. Replaces the composite `CompileError`
enum with it:

- `compile` → `Result<CompileOutcome, SourceUnavailable>`
- `validate_source` / `corpus_complete` / `utf8` / `read_stage_file` →
  `Result<_, SourceUnavailable>`

The former variants fold into the single sanctioned reason string, keeping their
operator-facing detail: `SourceInvalid` → `"invalid source: …"`, `Io` →
`"<stage> stage I/O: …"`, `Stage` → `"<stage> stage: …"` (graph-cover already
yields `SourceUnavailable` from `graph-compiler::compile`), `NonUtf8Path` →
`"<stage> stage: path is not UTF-8: …"`. The `CompileError` enum and its
`Display`/`Error` impls are removed; the crate re-export drops it.

api is a **host-only crate** (it does not build for `wasm32` — its compiler
dependencies are unavailable there), so naming the wasm-gated `SourceUnavailable`
is sound. Adds the `uor-r4-model-source` path dependency.

### Tests
The api integration suite's three `CompileError::SourceInvalid` matches become
`Err(error)` with `error.reason.contains(...)` assertions.

### Audit
api audit-limits: **20 → 15** (compile.rs at 0). With graph-compiler and
graph-certify already at 0, the remaining workspace is api 15 + graph-cli 42.
Remaining api sites are the engine.rs serving surfaces
(`InferenceError` / `LoadError` / `WitnessVerificationError`,
`validate_quality_report`) and `serving_eval.rs`, converted next.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy` (api,
all-targets), and the full api lib + integration test suites — all green.
(api is not a wasm target, so no wasm build applies.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
