### PR TITLE
feat(#510): R5 tranche — api engine load LoadError to SourceUnavailable (api 2->1)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -119,6 +119,7 @@ use uor_r4_graph_format::{
     ContractVersion, FormatError, GraphView, ObservedBound, FORMAT_VERSION_MAJOR,
     FORMAT_VERSION_MINOR, INFERENCE_OPERATION_CONTRACT_VERSION,
 };
+use uor_r4_model_source::SourceUnavailable;
 
 /// The resolution status of a scored prediction. Alias of the production
 /// scorer's [`ScoreStatus`] — no second definition of the status space.
@@ -160,62 +161,6 @@ impl AbiVersion {
             format_minor: FORMAT_VERSION_MINOR,
             contract: INFERENCE_OPERATION_CONTRACT_VERSION,
             api_crate_version: env!("CARGO_PKG_VERSION"),
-        }
-    }
-}
-
-/// Focused load-time failures of [`R4Engine::load`].
-#[derive(Debug)]
-pub enum LoadError {
-    /// The graph bytes failed the format crate's two-stage structural
-    /// validation or CID verification.
-    InvalidGraph(FormatError),
-    /// The signature artifact is not a TLA3/TLA4/TLA5 teacher container.
-    InvalidSignatureArtifact,
-    /// The score report bytes are not well-formed JSON.
-    InvalidScoreReport(String),
-    /// The tokenizer bytes are not a well-formed binary tokenizer.
-    InvalidTokenizer,
-    /// The graph's Rule 1+2 quality digresses from the declared quality
-    /// basis (see [`validate_quality_report`]).
-    QualityGate(String),
-    /// The production scorer rejected the validated parts.
-    Scorer(String),
-    /// The teacher token table exceeds the u32 token-id space.
-    TeacherTooLarge,
-    /// The loaded tokenizer CID does not match the R4G1 header's tokenizer_cid.
-    TokenizerCidMismatch { expected: String, actual: String },
-}
-
-impl fmt::Display for LoadError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LoadError::InvalidGraph(error) => write!(f, "invalid R4G1 graph: {error}"),
-            LoadError::InvalidSignatureArtifact => {
-                write!(f, "not a TLA3/TLA4/TLA5 teacher artifact")
-            }
-            LoadError::InvalidScoreReport(message) => {
-                write!(f, "invalid score report: {message}")
-            }
-            LoadError::InvalidTokenizer => write!(f, "invalid tokenizer bytes"),
-            LoadError::QualityGate(message) => write!(f, "{message}"),
-            LoadError::Scorer(message) => write!(f, "{message}"),
-            LoadError::TeacherTooLarge => write!(f, "teacher token table too large"),
-            LoadError::TokenizerCidMismatch { expected, actual } => {
-                write!(
-                    f,
-                    "tokenizer_cid mismatch: header expected {expected}, loaded {actual}"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for LoadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            LoadError::InvalidGraph(error) => Some(error),
-            _ => None,
         }
     }
 }
@@ -1073,34 +1018,45 @@ impl R4Engine {
     /// supplies the compressed token rows used to derive input
     /// signatures. EXCT is not enabled because its reference
     /// implementation performs probe-time floating-point quantization.
-    pub fn load(parts: EngineParts<'_>) -> Result<Self, LoadError> {
-        // Fail fast with a typed format error before any scorer state is
-        // built (the scorer re-validates internally; this surfaces the
-        // format crate's focused error at the library boundary).
-        let view = GraphView::parse(parts.graph).map_err(|e| LoadError::InvalidGraph(e.reason))?;
-        view.verify_cids()
-            .map_err(|k| LoadError::InvalidGraph(k.as_format()))?;
+    pub fn load(parts: EngineParts<'_>) -> Result<Self, SourceUnavailable> {
+        // Fail fast with the format crate's focused reason before any scorer
+        // state is built (the scorer re-validates internally). Every part is
+        // an external byte source; a malformed part is reported as a
+        // SourceUnavailable with the specific diagnostic preserved. Failures
+        // that operate on the already-parsed-and-CID-verified graph (scorer
+        // rebuild, step state, addressability) are self-produced defects and
+        // panic (R5, #510).
+        let view = GraphView::parse(parts.graph)
+            .map_err(|e| SourceUnavailable::new(format!("invalid R4G1 graph: {}", e.reason)))?;
+        view.verify_cids().map_err(|k| {
+            SourceUnavailable::new(format!("invalid R4G1 graph: {}", k.as_format()))
+        })?;
         if let Some(tokenizer_bytes) = parts.tokenizer {
             let expected = view
                 .head()
-                .ok_or(FormatError::MissingHead)
-                .map_err(LoadError::InvalidGraph)?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "invalid R4G1 graph: {}",
+                        FormatError::MissingHead
+                    ))
+                })?
                 .tokenizer_cid();
             let actual = blake3::hash(tokenizer_bytes);
             if expected.0 != [0u8; 32] && expected.0 != *actual.as_bytes() {
-                return Err(LoadError::TokenizerCidMismatch {
-                    expected: format!("blake3:{}", blake3::Hash::from(expected.0).to_hex()),
-                    actual: format!("blake3:{actual}"),
-                });
+                return Err(SourceUnavailable::new(format!(
+                    "tokenizer_cid mismatch: header expected blake3:{}, loaded blake3:{actual}",
+                    blake3::Hash::from(expected.0).to_hex()
+                )));
             }
         }
         let artifacts = compiler::parse_artifacts(parts.signature_artifact)
-            .ok_or(LoadError::InvalidSignatureArtifact)?;
+            .ok_or_else(|| SourceUnavailable::new("not a TLA3/TLA4/TLA5 teacher artifact"))?;
         let score_report = parts
             .score_report
             .map(|bytes| {
-                serde_json::from_slice::<serde_json::Value>(bytes)
-                    .map_err(|error| LoadError::InvalidScoreReport(error.to_string()))
+                serde_json::from_slice::<serde_json::Value>(bytes).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid score report: {error}"))
+                })
             })
             .transpose()?;
         let root_top_b = score_report
@@ -1126,30 +1082,29 @@ impl R4Engine {
             root_top_b,
             exct_top_x,
         )
-        .ok_or_else(|| {
-            LoadError::Scorer(
-                "signature artifact is not a scorer (parse, CID, or teacher_cid)".to_owned(),
-            )
-        })?;
+        .expect("engine load: scorer rebuild from the parsed and CID-verified graph bytes");
         if let Some(report) = score_report.as_ref() {
             if let Some(message) = validate_quality_report(report) {
-                return Err(LoadError::QualityGate(message));
+                return Err(SourceUnavailable::new(message));
             }
         }
         let tokenizer = parts
             .tokenizer
-            .map(|bytes| Tokenizer::from_bytes(bytes).ok_or(LoadError::InvalidTokenizer))
+            .map(|bytes| {
+                Tokenizer::from_bytes(bytes)
+                    .ok_or_else(|| SourceUnavailable::new("invalid tokenizer bytes"))
+            })
             .transpose()?;
 
         let policy = StatusPolicy::from_report(score_report.as_ref());
         let step_supported = !scorer.has_legacy_exct();
-        let step = scorer.step_state(WIDENED_TOP_M).ok_or_else(|| {
-            LoadError::Scorer("scorer does not support a deployed step state".to_owned())
-        })?;
+        let step = scorer
+            .step_state(WIDENED_TOP_M)
+            .expect("engine load: scorer built from a validated graph supports a step state");
         let token_rows = u32::try_from(artifacts.token_codes.len() / STAGES)
-            .map_err(|_| LoadError::TeacherTooLarge)?;
+            .map_err(|_| SourceUnavailable::new("teacher token table too large"))?;
         let artifact_kappa = r4g1::artifact_kappa(parts.graph)
-            .ok_or_else(|| LoadError::Scorer("R4G1 artifact is not addressable".to_string()))?;
+            .expect("engine load: the validated R4G1 artifact is addressable");
         // The graph is known addressable here (artifact_kappa succeeded), so a
         // `None` is a genuinely absent NODE section, kept as such.
         let node_section_kappa = r4g1::section_kappa(parts.graph, SectionId::NODE);
@@ -1301,17 +1256,5 @@ mod tests {
         let decoded: InferenceResponse =
             serde_json::from_str(&json).expect("deserialize InferenceResponse");
         assert_eq!(res, decoded);
-    }
-
-    #[test]
-    fn test_load_error_tokenizer_cid_mismatch_display() {
-        let err = LoadError::TokenizerCidMismatch {
-            expected: "blake3:1111".to_string(),
-            actual: "blake3:2222".to_string(),
-        };
-        assert_eq!(
-            err.to_string(),
-            "tokenizer_cid mismatch: header expected blake3:1111, loaded blake3:2222"
-        );
     }
 }

--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -31,7 +31,7 @@ pub use compile::{
 };
 pub use engine::{
     validate_quality_report, AbiVersion, AbstainOutcome, EngineParts, GenerateStatus,
-    InferenceRequest, InferenceResponse, InferenceWitness, LoadError, PolicyCounters, PolicyStatus,
+    InferenceRequest, InferenceResponse, InferenceWitness, PolicyCounters, PolicyStatus,
     PredictDecision, PredictOutcome, PredictOutput, R4Engine, ResolutionStatus, StatusAction,
     StatusPolicy, WitnessVerificationError,
 };
@@ -41,3 +41,7 @@ pub use engine::{
 // and decode against the same vocabulary the bundle was compiled with.
 pub use uor_r4_core::transformerless::scenarios::Tokenizer;
 pub use uor_r4_graph_certify::ScoreStatus;
+// The sanctioned host-source failure type `compile` and `R4Engine::load`
+// return (R5): re-exported so consumers name it without depending on
+// `uor-r4-model-source` directly.
+pub use uor_r4_model_source::SourceUnavailable;

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use uor_r4_api::compile::{
     compile, CompileOptions, CompileOutcome, CompileRequest, QualityProfile, Stage,
 };
-use uor_r4_api::engine::{AbiVersion, EngineParts, LoadError, PredictOutput, R4Engine};
+use uor_r4_api::engine::{AbiVersion, EngineParts, PredictOutput, R4Engine};
 use uor_r4_api::Tokenizer;
 use uor_r4_graph_format::{
     FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR, INFERENCE_OPERATION_CONTRACT_VERSION,
@@ -90,14 +90,17 @@ fn engine_load_rejects_garbage_graph() {
         score_report: None,
     };
     match R4Engine::load(parts) {
-        Err(LoadError::InvalidGraph(_)) => {}
-        other => panic!("expected InvalidGraph, got {}", outcome_label(other)),
+        Err(error) => assert!(error.reason.contains("invalid R4G1 graph"), "{error}"),
+        other => panic!(
+            "expected an invalid-graph failure, got {}",
+            outcome_label(other)
+        ),
     }
 }
 
 #[test]
 fn engine_load_rejects_garbage_score_report_after_valid_graph_shape() {
-    // A graph that fails structural parse still reports InvalidGraph
+    // A graph that fails structural parse still reports the graph failure
     // before the score report is examined (fail-fast order).
     let parts = EngineParts {
         graph: &[],
@@ -106,12 +109,15 @@ fn engine_load_rejects_garbage_score_report_after_valid_graph_shape() {
         score_report: Some(b"{not json"),
     };
     match R4Engine::load(parts) {
-        Err(LoadError::InvalidGraph(_)) => {}
-        other => panic!("expected InvalidGraph, got {}", outcome_label(other)),
+        Err(error) => assert!(error.reason.contains("invalid R4G1 graph"), "{error}"),
+        other => panic!(
+            "expected an invalid-graph failure, got {}",
+            outcome_label(other)
+        ),
     }
 }
 
-fn outcome_label(result: Result<R4Engine, LoadError>) -> String {
+fn outcome_label(result: Result<R4Engine, uor_r4_api::SourceUnavailable>) -> String {
     match result {
         Ok(_) => "Ok(engine)".to_owned(),
         Err(error) => format!("Err({error})"),
@@ -130,9 +136,10 @@ fn engine_errors_implement_std_error() {
         Err(error) => error,
         Ok(_) => panic!("garbage graph must fail"),
     };
-    // Display is non-empty and the wrapped FormatError is chained.
+    // The sanctioned SourceUnavailable is a leaf std::error::Error: its full
+    // diagnostic is carried inline in Display, with no wrapped source.
     assert!(!error.to_string().is_empty());
-    assert!(error.source().is_some());
+    assert!(error.source().is_none());
 }
 
 #[test]
@@ -282,12 +289,14 @@ fn e2e_compile_then_engine_load() {
         score_report: Some(&model.score_report),
     });
     match mismatch_result {
-        Err(LoadError::TokenizerCidMismatch { expected, actual }) => {
-            assert!(expected.starts_with("blake3:"));
-            assert!(actual.starts_with("blake3:"));
+        Err(error) => {
+            // The sanctioned reason carries both the header-expected and the
+            // loaded tokenizer CIDs.
+            assert!(error.reason.contains("tokenizer_cid mismatch"), "{error}");
+            assert_eq!(error.reason.matches("blake3:").count(), 2, "{error}");
         }
         other => panic!(
-            "expected TokenizerCidMismatch, got {}",
+            "expected a tokenizer_cid mismatch, got {}",
             outcome_label(other)
         ),
     }

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -33,9 +33,7 @@
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
-use uor_r4_api::engine::{
-    EngineParts, InferenceWitness, LoadError, R4Engine, WitnessVerificationError,
-};
+use uor_r4_api::engine::{EngineParts, InferenceWitness, R4Engine, WitnessVerificationError};
 use uor_r4_core::transformerless::compiler::SIG_BYTES;
 use uor_r4_core::transformerless::scenarios::Tokenizer;
 
@@ -166,11 +164,17 @@ impl R4g1State {
             tokenizer: None,
             score_report: score_report.as_deref(),
         })
-        .map_err(|error| match error {
-            LoadError::InvalidSignatureArtifact | LoadError::TeacherTooLarge => {
-                format!("{}: {error}", teacher_path.display())
-            }
-            other => format!("{}: {other}", graph_path.display()),
+        .map_err(|error| {
+            // The engine loader now returns a single sanctioned
+            // SourceUnavailable whose reason names the failing part; attribute
+            // teacher-artifact reasons to the teacher path, the rest to the
+            // graph path.
+            let path = if error.reason.contains("teacher") {
+                teacher_path.display()
+            } else {
+                graph_path.display()
+            };
+            format!("{path}: {error}")
         })?;
         let tokenizer = teacher_path
             .parent()


### PR DESCRIPTION
## R5 tranche (#510): api engine `load` `LoadError` → `SourceUnavailable`

`R4Engine::load` ingests four heterogeneous external byte-part sources — the R4G1
graph, the teacher artifact, the score report, and the tokenizer — into a
deployable engine. Every load-time failure means one of those source parts is not
usable, which is exactly `SourceUnavailable`; its free-form reason carries each
specific diagnostic the composite `LoadError` enum used to name. Replaces
`LoadError` with `Result<Self, SourceUnavailable>`:

- graph parse / `verify_cids` / missing HEAD / tokenizer_cid mismatch →
  `SourceUnavailable`
- teacher artifact / score-report JSON / tokenizer bytes invalid →
  `SourceUnavailable`
- teacher token table exceeding u32 → `SourceUnavailable`
- quality-gate digression (`validate_quality_report` `Option`, #571) →
  `SourceUnavailable(message)`

Failures on the already-parsed-and-CID-verified graph — the scorer rebuild, the
deployed step state, and R4G1 addressability — are **self-produced defects**, so
they now `.expect(...)` (panic) rather than fabricating a load error.

The `LoadError` enum and its `Display`/`Error` impls are removed; the crate now
re-exports `SourceUnavailable` (which `compile` already returns), so consumers
name the sanctioned type without depending on `uor-r4-model-source` directly.

### Callers adapted
- The root `r4g1` loader attributes teacher-part reasons to the teacher path and
  the rest to the graph path via the reason string.
- The api tests match on `error.reason` (a leaf `std::error::Error`, no source
  chain); the obsolete `LoadError` Display unit test is removed.
- `serving_eval` keeps its own `ServingEvalError::Load { message }` (it
  stringifies the error) until its R5 conversion.

### Audit
api audit-limits: **2 → 1** (only `serving_eval.rs` remains). `SourceUnavailable`
is sanctioned. After the next PR (serving_eval) api hits 0.

### Gauntlet
`cargo fmt --check`, `cargo build --workspace --all-targets`, `clippy` (api,
all-targets), the api lib + integration suites, `status_policy` (+census), and the
full root-package `bdd` suite (100 scenarios / 333 steps) — all green. (api is not
a wasm target.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
