### PR TITLE
feat(#510): R5 tranche — graph-cli convert_r4g1 to SourceUnavailable/panic (graph-cli 12->11)

### DIFF
--- a/crates/uor-r4-graph-cli/src/convert_r4g1.rs
+++ b/crates/uor-r4-graph-cli/src/convert_r4g1.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 use uor_r4_core::transformerless::compiler::{self, HammingCalibrationReport};
 use uor_r4_core::transformerless::convert_r4g1;
 use uor_r4_core::transformerless::runtime;
+use uor_r4_model_source::SourceUnavailable;
 
-pub fn run(args: &[String]) -> Result<(), String> {
+pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
     let mut artifacts_path: Option<PathBuf> = None;
     let mut store_path: Option<PathBuf> = None;
     let mut calibration_path: Option<PathBuf> = None;
@@ -13,42 +14,55 @@ pub fn run(args: &[String]) -> Result<(), String> {
         let flag = &args[index];
         let value = args
             .get(index + 1)
-            .ok_or_else(|| format!("missing value for {flag}"))?;
+            .ok_or_else(|| SourceUnavailable::new(format!("missing value for {flag}")))?;
         match flag.as_str() {
             "--artifacts" => artifacts_path = Some(PathBuf::from(value)),
             "--store" => store_path = Some(PathBuf::from(value)),
             "--calibration" => calibration_path = Some(PathBuf::from(value)),
             "--out" => out_path = Some(PathBuf::from(value)),
-            _ => return Err(format!("unknown convert-r4g1 option: {flag}")),
+            _ => {
+                return Err(SourceUnavailable::new(format!(
+                    "unknown convert-r4g1 option: {flag}"
+                )));
+            }
         }
         index += 2;
     }
-    let artifacts_path = artifacts_path.ok_or("pass --artifacts <TLA container>")?;
-    let store_path = store_path.ok_or("pass --store <TLS1 container>")?;
-    let out_path = out_path.ok_or("pass --out <R4G1 output path>")?;
+    let artifacts_path =
+        artifacts_path.ok_or_else(|| SourceUnavailable::new("pass --artifacts <TLA container>"))?;
+    let store_path =
+        store_path.ok_or_else(|| SourceUnavailable::new("pass --store <TLS1 container>"))?;
+    let out_path =
+        out_path.ok_or_else(|| SourceUnavailable::new("pass --out <R4G1 output path>"))?;
 
-    let artifact_bytes = std::fs::read(&artifacts_path)
-        .map_err(|error| format!("{}: {error}", artifacts_path.display()))?;
+    let artifact_bytes = std::fs::read(&artifacts_path).map_err(|error| {
+        SourceUnavailable::new(format!("{}: {error}", artifacts_path.display()))
+    })?;
     let artifacts = compiler::parse_artifacts(&artifact_bytes).ok_or_else(|| {
-        format!(
+        SourceUnavailable::new(format!(
             "{}: not a TLA3/TLA4/TLA5 artifact container",
             artifacts_path.display()
-        )
+        ))
     })?;
-    let store_bytes =
-        std::fs::read(&store_path).map_err(|error| format!("{}: {error}", store_path.display()))?;
+    let store_bytes = std::fs::read(&store_path)
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", store_path.display())))?;
     // Both store eras are accepted: the current 8-byte-entry TLS1 and
     // the legacy 6-byte-entry (u16 token) variant.
     #[allow(deprecated)]
     let store = runtime::parse_store(&store_bytes)
         .or_else(|| runtime::parse_store_legacy_u16(&store_bytes))
-        .ok_or_else(|| format!("{}: not a TLS1 store (either era)", store_path.display()))?;
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "{}: not a TLS1 store (either era)",
+                store_path.display()
+            ))
+        })?;
     let calibration = match calibration_path {
         Some(path) => {
             let text = std::fs::read_to_string(&path)
-                .map_err(|error| format!("{}: {error}", path.display()))?;
+                .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))?;
             let report: HammingCalibrationReport = serde_json::from_str(&text)
-                .map_err(|error| format!("{}: {error}", path.display()))?;
+                .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))?;
             Some(report)
         }
         None => None,
@@ -62,19 +76,22 @@ pub fn run(args: &[String]) -> Result<(), String> {
         calibration.as_ref(),
     )
     .ok_or_else(|| {
-        "R4G1 conversion failed: token codes, vocabulary, or class-signature books are malformed"
-            .to_string()
+        SourceUnavailable::new(
+            "R4G1 conversion failed: token codes, vocabulary, or class-signature books are malformed",
+        )
     })?;
 
     // Fail closed: the converter must never emit an artifact its own
-    // two-stage validator or the integrity CIDs reject.
+    // two-stage validator or the integrity CIDs reject. A rejection here is
+    // a defect in the converter over bytes it just produced, not a host
+    // condition — so it panics rather than surfacing SourceUnavailable.
     let view = uor_r4_graph_format::GraphView::parse(&bytes)
-        .map_err(|error| format!("converter produced an invalid R4G1 artifact: {error}"))?;
+        .expect("converter produced an invalid R4G1 artifact");
     view.verify_cids()
-        .map_err(|error| format!("converter produced an artifact with bad CIDs: {error}"))?;
+        .expect("converter produced an artifact with bad CIDs");
 
     std::fs::write(&out_path, &bytes)
-        .map_err(|error| format!("{}: {error}", out_path.display()))?;
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", out_path.display())))?;
     println!(
         "convert-r4g1: {} -> {}",
         artifacts_path.display(),

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2809,7 +2809,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
             ),
             Err(_) => println!("source checkpoint not found; see `setup`"),
         },
-        Some("convert-r4g1") => convert_r4g1::run(&args[1..])?,
+        Some("convert-r4g1") => convert_r4g1::run(&args[1..]).map_err(|e| e.to_string())?,
         Some("runtime-corpus") => runtime_corpus::run(&args[1..]).map_err(|e| e.to_string())?,
         Some("cover") => cover_command(&args[1..])?,
         Some("cover-sweep") => {


### PR DESCRIPTION
## R5 tranche — graph-cli convert_r4g1 → SourceUnavailable / panic

Converts the `convert-r4g1` command (TLA + TLS1 → R4G1) to the sanctioned surface.

- **Host input path → `SourceUnavailable`**: CLI arg parse, `fs::read` of the
  artifact/store containers, `parse_artifacts` / `parse_store` rejection,
  calibration `read_to_string` + `serde_json` parse, the `convert()` `None`, and
  the `fs::write` of the output.
- **Self-produced-bytes validation → panic**: the two "fail closed" checks on the
  converter's OWN output (`GraphView::parse` + `verify_cids`) are defects if they
  ever fire, not host conditions, so they now `.expect()`.

`lib.rs` dispatch arm maps `SourceUnavailable` back via `to_string`. `convert_r4g1.rs`
is now at 0.

audit-limits: graph-cli **12 → 11**. Gauntlet green (build/fmt/clippy/test + root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
