### PR TITLE
feat(#510): R5 tranche — graph-cli run() dispatcher to SourceUnavailable; graph-cli at 0 (1->0)

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -2797,7 +2797,7 @@ pub fn graph_command(args: &[String]) -> Result<(), SourceUnavailable> {
     }
 }
 
-pub fn run(args: &[String]) -> Result<(), String> {
+pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
     match args.first().map(|s| s.as_str()) {
         Some("setup") => setup(),
         Some("gen") => {
@@ -2814,12 +2814,10 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 let art = compiler::compile(&oracle, &c);
                 compiler::save_artifacts(&art);
             } else {
-                compile_hugging_face(&args[1..]).map_err(|e| e.to_string())?;
+                compile_hugging_face(&args[1..])?;
             }
         }
-        Some("compile-recorded") => {
-            compile_recorded_corpus(&args[1..]).map_err(|e| e.to_string())?
-        }
+        Some("compile-recorded") => compile_recorded_corpus(&args[1..])?,
         Some("store") => {
             let c = compiler::load_corpus()
                 .expect("corpus incomplete: run `transformerless gen` first");
@@ -2835,9 +2833,9 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 runtime::store_kappa(&store)
             );
         }
-        Some("evaluate-report") => evaluate_report(&args[1..]).map_err(|e| e.to_string())?,
-        Some("observe") => observe_command(&args[1..]).map_err(|e| e.to_string())?,
-        Some("observe-text") => observe_text_command(&args[1..]).map_err(|e| e.to_string())?,
+        Some("evaluate-report") => evaluate_report(&args[1..])?,
+        Some("observe") => observe_command(&args[1..])?,
+        Some("observe-text") => observe_text_command(&args[1..])?,
         Some("scenarios") => {
             let mut oracle = LlamaOracle::load(DEFAULT_CHECKPOINT);
             scenarios::scenarios(&mut oracle);
@@ -2850,15 +2848,13 @@ pub fn run(args: &[String]) -> Result<(), String> {
             ),
             Err(_) => println!("source checkpoint not found; see `setup`"),
         },
-        Some("convert-r4g1") => convert_r4g1::run(&args[1..]).map_err(|e| e.to_string())?,
-        Some("runtime-corpus") => runtime_corpus::run(&args[1..]).map_err(|e| e.to_string())?,
-        Some("cover") => cover_command(&args[1..]).map_err(|e| e.to_string())?,
-        Some("cover-sweep") => {
-            cover_sweep::cover_sweep_command(&args[1..]).map_err(|e| e.to_string())?
-        }
-        Some("recommend-scale") => recommend_scale::run(&args[1..]).map_err(|e| e.to_string())?,
-        Some("score") => score_command(&args[1..]).map_err(|e| e.to_string())?,
-        Some("graph") => graph_command(&args[1..]).map_err(|e| e.to_string())?,
+        Some("convert-r4g1") => convert_r4g1::run(&args[1..])?,
+        Some("runtime-corpus") => runtime_corpus::run(&args[1..])?,
+        Some("cover") => cover_command(&args[1..])?,
+        Some("cover-sweep") => cover_sweep::cover_sweep_command(&args[1..])?,
+        Some("recommend-scale") => recommend_scale::run(&args[1..])?,
+        Some("score") => score_command(&args[1..])?,
+        Some("graph") => graph_command(&args[1..])?,
         Some("cd-compile") => cd_compile_command(&args[1..]),
         Some("quantum-eval") => quantum_eval_command(&args[1..]),
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,8 @@ fn compile(args: &CompileArgs) -> Result<(), RunError> {
             "--out".to_owned(),
             output.display().to_string(),
         ];
-        return transformerless_command::run(&values).map_err(RunError::Command);
+        return transformerless_command::run(&values)
+            .map_err(|error| RunError::Command(error.to_string()));
     }
     let mut values = Vec::new();
     if let Some(source) = &args.source {
@@ -550,7 +551,7 @@ fn evaluate_report(args: &EvaluateReportArgs) -> Result<(), RunError> {
 fn run_core(name: &str, arguments: &[String]) -> Result<(), RunError> {
     let mut values = vec![name.to_owned()];
     values.extend_from_slice(arguments);
-    transformerless_command::run(&values).map_err(RunError::Command)
+    transformerless_command::run(&values).map_err(|error| RunError::Command(error.to_string()))
 }
 
 /// Default location of the reference teacher checkpoint used by `certify`/`compare`.
@@ -647,12 +648,13 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         Some(Command::Scenarios) => run_core("scenarios", &[]),
         Some(Command::TeacherKappa) => run_core("teacher-kappa", &[]),
         Some(Command::Transformerless { args }) => {
-            transformerless_command::run(args).map_err(RunError::Command)
+            transformerless_command::run(args).map_err(|error| RunError::Command(error.to_string()))
         }
         Some(Command::Graph { args }) => {
             let mut values = vec!["graph".to_owned()];
             values.extend_from_slice(args);
-            transformerless_command::run(&values).map_err(RunError::Command)
+            transformerless_command::run(&values)
+                .map_err(|error| RunError::Command(error.to_string()))
         }
         Some(Command::GraphCompile { args }) => uor_r4_graph_compiler::compile(args)
             .map_err(|error| RunError::Command(error.to_string())),


### PR DESCRIPTION
## R5 tranche — graph-cli run() dispatcher → SourceUnavailable; graph-cli at 0

The final graph-cli site. Now that every command `run()` dispatches to returns a
sanctioned surface (`SourceUnavailable`, or `()` for the infallible demo
commands), `run()` itself becomes `Result<(), SourceUnavailable>`: the 12 per-arm
`.map_err(|e| e.to_string())` wrappers are dropped so each arm propagates its
`SourceUnavailable` via `?`; the `setup`/`gen`/`compile-native`/`store`/
`scenarios`/`teacher-kappa`/`cd-compile`/`quantum-eval`/help arms (which return
`()`) are unchanged.

Root edits: `src/main.rs`'s four `transformerless_command::run(...)` call sites
map `SourceUnavailable` back to `RunError::Command` via `to_string`.

audit-limits: graph-cli **1 → 0**. The **whole-repo audit is now clean**: every
shipped crate's `Result` error surface names only the four sanctioned types —
`NotAProduct` / `ObservedBound` / `KappaError` / `SourceUnavailable`. Gauntlet
green: graph-cli + root + api build, fmt/clippy/test; `xtask audit-limits` reports
"no shipped crate returns an unsanctioned error (R5)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
