### PR TITLE
feat(#515): PR-2 — compile-gate graph-certify dormant surfaces (default OFF)

### DIFF
--- a/crates/uor-r4-graph-certify/Cargo.toml
+++ b/crates/uor-r4-graph-certify/Cargo.toml
@@ -21,3 +21,16 @@ rayon = "1.10.0"
 # The original f64 geometric router — measurement harnesses only
 # (issue #421 M-R1 reconnection), never the deployed scoring path.
 uor-r4-router = { version = "0.1.0", path = "../uor-r4-router" }
+
+[features]
+# #515 preserve-and-gate: dormant research/certificate surfaces retained off the
+# serving path, registered as `open` claims in model/ledger.toml and compile-
+# toggled here (default OFF) so they stay buildable (CI builds --all-features)
+# without bit-rotting. Per-mechanism granularity — one feature per claim. The
+# shipped default build is byte-identical whether or not these are enabled.
+anti-degeneracy = []
+fairness-provenance = []
+holographic-encoding = []
+patch-lifecycle = []
+predictive-sufficiency = []
+shortlist-evaluator = []

--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "anti-degeneracy")]
 pub mod anti_degeneracy;
 pub mod certificate;
 #[cfg(not(target_arch = "wasm32"))]
@@ -6,15 +7,20 @@ pub mod certify;
 pub mod compare;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod compiler_scaling;
+#[cfg(feature = "fairness-provenance")]
 pub mod fairness_provenance;
 pub mod fmm;
+#[cfg(feature = "holographic-encoding")]
 pub mod holographic_encoding;
 pub mod long_context;
+#[cfg(feature = "patch-lifecycle")]
 pub mod patch_lifecycle;
 pub mod performance_certificate;
+#[cfg(feature = "predictive-sufficiency")]
 pub mod predictive_sufficiency;
 pub mod score;
 pub mod score_runtime;
+#[cfg(feature = "shortlist-evaluator")]
 pub mod shortlist_evaluator;
 
 pub use fmm::*;

--- a/crates/uor-r4-graph-certify/tests/anti_degeneracy_test.rs
+++ b/crates/uor-r4-graph-certify/tests/anti_degeneracy_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "anti-degeneracy")]
 use uor_r4_graph_certify::anti_degeneracy::{
     MdlObjective, ParaphraseEvaluator, PerturbationKind, PerturbationSuite, PolysemyEvaluator,
     SemanticCoherenceCertificate,

--- a/crates/uor-r4-graph-certify/tests/fairness_provenance_test.rs
+++ b/crates/uor-r4-graph-certify/tests/fairness_provenance_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "fairness-provenance")]
 use uor_r4_core::transformerless::score_q::ScoreQ;
 use uor_r4_core::transformerless::transitions::{EdgeKind, TransitionGraph};
 use uor_r4_graph_certify::fairness_provenance::{

--- a/crates/uor-r4-graph-certify/tests/holographic_encoding_test.rs
+++ b/crates/uor-r4-graph-certify/tests/holographic_encoding_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "holographic-encoding")]
 use uor_r4_graph_certify::holographic_encoding::{
     AblationProtocol, DivergenceMetric, HolographicEncodingCertificate,
     HolographicEncodingEvaluator, HolographicProbeReport, Projection, ProjectionMetadata,

--- a/crates/uor-r4-graph-certify/tests/predictive_sufficiency_test.rs
+++ b/crates/uor-r4-graph-certify/tests/predictive_sufficiency_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "predictive-sufficiency")]
 use uor_r4_core::transformerless::runtime::OpKernel;
 use uor_r4_graph_certify::predictive_sufficiency::{
     DivergencePoint, GraphDepth, PredictiveSufficiencyEvaluator, RateDistortionReport,

--- a/crates/uor-r4-graph-certify/tests/shortlist_evaluator_test.rs
+++ b/crates/uor-r4-graph-certify/tests/shortlist_evaluator_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "shortlist-evaluator")]
 use uor_r4_graph_certify::shortlist_evaluator::{ShortlistEvaluator, ShortlistRecallReport};
 
 #[test]


### PR DESCRIPTION
## #515 PR-2 — compile-gate graph-certify dormant surfaces

Second tranche of the preserve-and-gate work. The six off-serving-path
`graph-certify` mechanisms registered as `open` ledger claims in #590 are now
behind **default-off** cargo features, one per claim:

| feature | module | ledger claim |
|---|---|---|
| `anti-degeneracy` | `anti_degeneracy` | `anti-degeneracy-dormant` |
| `fairness-provenance` | `fairness_provenance` | `fairness-provenance-dormant` |
| `holographic-encoding` | `holographic_encoding` | `holographic-encoding-dormant` |
| `patch-lifecycle` | `patch_lifecycle` | `patch-overlay-dormant` |
| `predictive-sufficiency` | `predictive_sufficiency` | `predictive-sufficiency-dormant` |
| `shortlist-evaluator` | `shortlist_evaluator` | `shortlist-evaluator-dormant` |

### Dormancy is proven by the build
- **default** workspace build compiles and links with none of these modules; their five dedicated integration test files (`#![cfg(feature = ...)]`) reduce to 0 cases.
- **`--all-features`** compiles all six and runs their 20 tests (4+4+6+3+3), clippy clean both ways.
- The shipped default artifact is byte-identical whether or not these features are enabled.

On-path certify surfaces (`certificate`, `certify`, `compare`, `fmm`, `performance_certificate`, `score`, `score_runtime`) are untouched.

Refs #515.
