### PR TITLE
feat(#515): PR-2 — compile-gate core and graph-runtime dormant modules (default OFF)

### DIFF
--- a/crates/uor-r4-core/Cargo.toml
+++ b/crates/uor-r4-core/Cargo.toml
@@ -20,6 +20,8 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 libm = "0.2"
 
 [features]
+endomorphism = []
+lie-jordan = ["endomorphism"]
 # Measurement-only surface for the #330 isolated dot-scan microbenchmark.
 # Off by default: it exposes no deployed prediction-path behavior, only a
 # read-only handle onto the already-built SIMD dot tables.

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -23,7 +23,9 @@
 // fs-dependent functions are cfg-gated per item (see those files).
 pub mod bott_fock;
 pub mod cd_space;
+#[cfg(feature = "endomorphism")]
 pub mod endomorphism;
+#[cfg(feature = "lie-jordan")]
 pub mod lie_jordan;
 pub mod region_store;
 

--- a/crates/uor-r4-graph-runtime/Cargo.toml
+++ b/crates/uor-r4-graph-runtime/Cargo.toml
@@ -19,3 +19,6 @@ harness = false
 [[bench]]
 name = "session_signature"
 harness = false
+
+[features]
+packed-routing = []

--- a/crates/uor-r4-graph-runtime/src/lib.rs
+++ b/crates/uor-r4-graph-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate alloc;
 
 pub mod engine;
+#[cfg(feature = "packed-routing")]
 pub mod packed_kernels;
 pub mod patch_chain;
 pub mod routing;


### PR DESCRIPTION
## #515 PR-2 — compile-gate core & graph-runtime dormant modules

Fourth tranche of preserve-and-gate. Modules the build proves are off the serving path are now behind **default-off** cargo features:

- **uor-r4-core**: `lie_jordan` (`lie-jordan`) + its operator algebra `endomorphism` (`endomorphism`). Coupled (endomorphism is referenced only by lie_jordan), so `lie-jordan = ["endomorphism"]`.
- **uor-r4-graph-runtime**: `packed_kernels` (`packed-routing`) — the placeholder ROUT-bytecode / typed-transition evaluators (`packed-routing-dormant`).

Default build + test-compile exclude them; `--all-features` compiles all and its lib tests pass (32 core + 13 runtime); clippy clean at `--all-features`.

### Build-test correction — three modules are actually wired
Left **un-gated** (gating breaks the default build — the proof they're on-path). Claims are untouched in this PR; a later pass will refine their wording:

- `bott_fock`, `cd_space` — reachable from shipped `graph-cli` via the `cd-compile` / `quantum-eval` subcommands. Dormant in the *scoring* path (the accurate part of their claims) but compiled into the CLI.
- `patch_chain` — held by `R4G1Runtime` (`crate::patch_chain::PatchChain`), on the serving runtime path.

No ledger/CONFORMANCE change here. Refs #515.
