### PR TITLE
ci(#515): guard dormant modules with an --all-features build + gated-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,3 +489,51 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
+
+  # #515 preserve-and-gate: the dormant mechanisms retained off the serving path
+  # are compiled behind default-off cargo features (one per `open` ledger claim).
+  # The shipped default build never touches them, so a normal `cargo build` /
+  # nextest run cannot catch bit-rot in a dormant module or its gated tests.
+  # This job turns every feature ON and (a) does a real codegen+link build so the
+  # gated code cannot silently stop compiling, and (b) EXECUTES the gated tests
+  # (the default nextest run in `gates` uses default features, so those tests
+  # never otherwise run). It runs only in merge_group / push — NOT pull_request —
+  # so it stays off the PR author's wait path and runs in parallel with `gates`
+  # in the queue (which is bounded by the heavier κ-reproduction / trend ladder,
+  # so this adds no wall-clock to the binding verdict). Promoting it to a
+  # required status check is a repo-admin branch-protection toggle.
+  all-features:
+    name: all-features build + gated dormant tests (#515)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      - name: cargo build --workspace --all-features
+        run: cargo build --workspace --all-features
+
+      - name: cargo test --workspace --all-features (runs the dormant-mechanism gated tests)
+        run: cargo test --workspace --all-features
+
+  # PR-context companion to `all-features` (same name), so the check resolves on
+  # pull_request while the real all-features build + gated tests run once, in the
+  # queue. Mirrors wasm-pr-stub / fuzz-smoke-pr-stub (issue #240).
+  all-features-pr-stub:
+    name: all-features build + gated dormant tests (#515)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'Deferred to the merge queue - the real --all-features build + gated dormant tests run on the speculative merge.'"


### PR DESCRIPTION
## #515 PR-2 — CI guard so dormant modules can't bit-rot

The preserve-and-gate work compiles each dormant mechanism behind a **default-off** cargo feature, so the shipped default build and the `gates` nextest run (default features) never touch that code. `gates` already type-checks every feature via `clippy --all-targets --all-features`, but it never **runs** the gated tests and does no codegen/link of the feature-on build.

New **`all-features`** job:
- `cargo build --workspace --all-features` — real codegen + link of every gated module.
- `cargo test --workspace --all-features` — executes the gated dormant-mechanism tests that default nextest skips.

Runs only on `merge_group` / `push` (not `pull_request`), in **parallel** with `gates` in the queue — whose binding verdict is bounded by the heavier κ-reproduction / trend ladder — so it adds no wall-clock to the author's wait. A same-named `pull_request` stub keeps the check resolving in both contexts (mirrors `wasm-pr-stub` / `fuzz-smoke-pr-stub`, #240).

Promoting it to a required status check is a repo-admin branch-protection toggle.

Refs #515.
