### PR TITLE
feat(#531): batched teacher inference — ~15x faster corpus-scale observe

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -289,6 +289,7 @@ struct ObserveTextOptions {
     shards: u8,
     sequence_length: usize,
     workers: usize,
+    batch: usize,
 }
 
 fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, SourceUnavailable> {
@@ -302,6 +303,7 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
         shards: 4,
         sequence_length: 128,
         workers: 1,
+        batch: 1,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -354,6 +356,16 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
                     ));
                 }
             }
+            "--batch" => {
+                // Articles teacher-forced together per forward (Hugging Face
+                // teacher only). One shared weight copy; the throughput lever.
+                options.batch = value.parse().map_err(|_| {
+                    SourceUnavailable::new(format!("invalid --batch value: {value}"))
+                })?;
+                if options.batch == 0 {
+                    return Err(SourceUnavailable::new("--batch must be greater than zero"));
+                }
+            }
             _ => {
                 return Err(SourceUnavailable::new(format!(
                     "unknown observe-text option: {flag}"
@@ -376,6 +388,17 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
     );
     let options = parse_observe_text_options(args)?;
     std::fs::create_dir_all(&options.output)?;
+    // Batched teacher path: one shared weight copy, B articles per forward. This
+    // is the throughput lever (measured ~15× at batch 32) and supersedes
+    // --workers for the Hugging Face teacher.
+    if options.batch > 1 {
+        if options.checkpoint.is_some() {
+            return Err(SourceUnavailable::new(
+                "--batch is only supported for the Hugging Face teacher, not a legacy --checkpoint",
+            ));
+        }
+        return observe_text_batched_command(&options);
+    }
     let token_byte_lengths: Vec<u32>;
     let tokenizer: TokenizerKind;
     let oracle: Box<dyn TeacherOracle + Send> = if let Some(checkpoint) = &options.checkpoint {
@@ -475,6 +498,60 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         true,
     )
     .map_err(SourceUnavailable::new)?;
+    finish_observe_text_report(&report, &options.output)
+}
+
+/// Observe-text with a batched Hugging Face teacher: one shared weight copy,
+/// up to `--batch` articles teacher-forced per forward. Produces the same
+/// records as the serial path for identical logits.
+fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), SourceUnavailable> {
+    let oracle =
+        HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, options.sequence_length)
+            .map_err(|error| {
+                SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
+            })?;
+    eprintln!("exporting tokenizer...");
+    let token_byte_lengths =
+        uor_r4_core::transformerless::scenarios::export_hf_bytelevel_tokenizer_with_lengths(
+            options.source.join("tokenizer.json"),
+            options.output.join("tokenizer.bin"),
+        )
+        .map_err(SourceUnavailable::new)?;
+    let tokenizer_json = options.source.join("tokenizer.json");
+    let tokenizer = if tokenizer_json.is_file() {
+        TokenizerKind::HfBpe(Box::new(
+            HfBpeTokenizer::from_dir(&options.source).map_err(|error| {
+                SourceUnavailable::new(format!("{}: {error}", tokenizer_json.display()))
+            })?,
+        ))
+    } else {
+        TokenizerKind::Legacy(
+            scenarios::Tokenizer::try_load(options.output.join("tokenizer.bin"))
+                .map_err(SourceUnavailable::new)?,
+        )
+    };
+    eprintln!("observing with batch {}", options.batch);
+    let report = observe_text::observe_text_corpus_batched(
+        &oracle,
+        options.batch,
+        options.seconds,
+        &tokenizer,
+        Some(&token_byte_lengths),
+        &options.input,
+        &options.output,
+        options.shards,
+        true,
+    )
+    .map_err(SourceUnavailable::new)?;
+    finish_observe_text_report(&report, &options.output)
+}
+
+/// Print the observe-text report and, when the corpus is complete, persist the
+/// merged record stream. Shared by the serial/pool and batched entry points.
+fn finish_observe_text_report(
+    report: &observe_text::ObservationReport,
+    output: &std::path::Path,
+) -> Result<(), SourceUnavailable> {
     println!(
         "observe-text: {} records across {}/{} shards ({} written this run)",
         report.records, report.shards_completed, report.shard_count, report.written
@@ -502,12 +579,15 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
     if report.done {
         // Persist the merged record stream: Gate C consumes it as
         // --corpus-recs with state.bin as --corpus-meta (issue #72).
-        let merged = observe::merge_shards(&options.output).map_err(SourceUnavailable::new)?;
-        let merged_path = options.output.join("merged.bin");
+        let merged = observe::merge_shards(output).map_err(SourceUnavailable::new)?;
+        let merged_path = output.join("merged.bin");
         std::fs::write(&merged_path, &merged)?;
         println!(
             "observe-text complete: merged κ {} at {}",
-            report.merged_kappa.expect("done reports merged κ"),
+            report
+                .merged_kappa
+                .as_deref()
+                .expect("done reports merged κ"),
             merged_path.display()
         );
     } else {
@@ -515,7 +595,7 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             "text observation corpus is not complete ({}/{} articles); rerun the same command to resume {}",
             report.articles_completed,
             report.articles_total,
-            options.output.display()
+            output.display()
         );
     }
     Ok(())

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -54,6 +54,7 @@ use uor_r4_core::transformerless::hf_bpe::TokenizerKind;
 use uor_r4_model_source::SourceUnavailable;
 use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::progress::Progress;
+use uor_r4_model_source::{BatchedTeacher, State};
 
 /// Authoritative per-article checkpoint file name within an observation
 /// directory.
@@ -577,6 +578,81 @@ struct ArticleProduced {
     replaced: u64,
 }
 
+/// One encoded teacher-forced position: its record, the shard it routes to, and
+/// the aligned probability sidecar.
+struct EncodedPosition {
+    shard: u32,
+    record: [u8; RECORD_SIZE],
+    metadata: observe::ProbabilityMetadata,
+}
+
+/// Encode the observation record at one teacher-forced position from that
+/// position's `logits`. Pushes `token` onto `window` (trimmed to the context
+/// width), routes by the content-addressed sample id, and returns the record
+/// plus the advanced story byte offset. Shared by the serial and batched
+/// drivers so both emit identical records for identical logits. The sampled
+/// token is discarded — every recorded field is deterministic from
+/// `(logits, token, next)`.
+#[allow(clippy::too_many_arguments)]
+fn encode_position(
+    logits: &mut [f32],
+    story: u32,
+    pos: usize,
+    token: u32,
+    next: u32,
+    window: &mut Vec<u32>,
+    story_byte_offset: u32,
+    token_byte_lengths: Option<&[u32]>,
+    shard_bits: u8,
+    rng: &mut u64,
+) -> (EncodedPosition, u32) {
+    let (_sampled, top_tokens, top_weights, sampled_stats) =
+        compiler::softmax_top8_sample_with_stats(logits, rng);
+    let stats = compiler::TokenProbabilityStats::from_normalized(
+        logits,
+        next as usize,
+        &top_tokens,
+        sampled_stats.top8_mass,
+    );
+    window.push(token);
+    if window.len() > compiler::WINDOW {
+        window.remove(0);
+    }
+    let id = observe::sample_id(window);
+    let shard = observe::shard_of(&id, shard_bits);
+    let span_start = pos as u32;
+    let span_end = span_start.saturating_add(1);
+    let (byte_start, byte_end) =
+        compiler::byte_anchors(token_byte_lengths, story_byte_offset, next as usize);
+    let record = compiler::encode_v4_record(
+        story,
+        next,
+        &top_tokens,
+        &top_weights,
+        (span_start, span_end),
+        (byte_start, byte_end),
+    );
+    let metadata = observe::ProbabilityMetadata {
+        target_logprob_nats: stats.target_logprob_nats,
+        entropy_bits: stats.entropy_bits,
+        top8_mass: stats.top8_mass,
+        target_rank: stats.target_rank,
+    };
+    let advanced = if token_byte_lengths.is_some() {
+        byte_end
+    } else {
+        story_byte_offset
+    };
+    (
+        EncodedPosition {
+            shard,
+            record,
+            metadata,
+        },
+        advanced,
+    )
+}
+
 /// Teacher-force one article and return its record stream. The sampled token
 /// is discarded (see the module docs): every recorded field is a deterministic
 /// function of `(article tokens, model)`, so this is independent of worker,
@@ -607,46 +683,21 @@ fn produce_article_records(
     for pos in 0..positions {
         let token = tokens[pos];
         oracle.step(token as usize, pos, &mut logits);
-        let (_sampled, top_tokens, top_weights, sampled_stats) =
-            compiler::softmax_top8_sample_with_stats(&mut logits, rng);
         let next = tokens[pos + 1];
-        let stats = compiler::TokenProbabilityStats::from_normalized(
-            &logits,
-            next as usize,
-            &top_tokens,
-            sampled_stats.top8_mass,
-        );
-        window.push(token);
-        if window.len() > compiler::WINDOW {
-            window.remove(0);
-        }
-        let id = observe::sample_id(&window);
-        let shard = observe::shard_of(&id, shard_bits);
-        let span_start = pos as u32;
-        let span_end = span_start.saturating_add(1);
-        let (byte_start, byte_end) =
-            compiler::byte_anchors(token_byte_lengths, story_byte_offset, next as usize);
-        let record = compiler::encode_v4_record(
+        let (encoded, advanced) = encode_position(
+            &mut logits,
             story,
+            pos,
+            token,
             next,
-            &top_tokens,
-            &top_weights,
-            (span_start, span_end),
-            (byte_start, byte_end),
+            &mut window,
+            story_byte_offset,
+            token_byte_lengths,
+            shard_bits,
+            rng,
         );
-        records.push((
-            shard,
-            record,
-            observe::ProbabilityMetadata {
-                target_logprob_nats: stats.target_logprob_nats,
-                entropy_bits: stats.entropy_bits,
-                top8_mass: stats.top8_mass,
-                target_rank: stats.target_rank,
-            },
-        ));
-        if token_byte_lengths.is_some() {
-            story_byte_offset = byte_end;
-        }
+        records.push((encoded.shard, encoded.record, encoded.metadata));
+        story_byte_offset = advanced;
     }
     Ok(ArticleProduced {
         ordinal,
@@ -711,32 +762,28 @@ fn commit_article(
     Ok(())
 }
 
-/// Observe a text corpus with a pool of `oracles` teacher instances. Articles
-/// are teacher-forced and mutually independent (the sampled token is discarded;
-/// every recorded field is a deterministic function of the article tokens and
-/// the model), so a batch of up to `oracles.len()` articles is produced in
-/// parallel — one worker thread per oracle — and then committed on this thread
-/// in ascending article ordinal. Because the shard writer appends in call
-/// order, the committed shard bytes are identical to a single-oracle pass.
-///
-/// A single-oracle pool (`oracles.len() == 1`) runs entirely on this thread and
-/// threads `checkpoint.rng` exactly as the original in-line loop did, so it is
-/// byte-for-byte unchanged including the committed checkpoint.
-#[allow(clippy::too_many_arguments)]
-pub fn observe_text_corpus(
-    oracles: &mut [Box<dyn TeacherOracle + Send>],
-    budget_s: u64,
-    tokenizer: &TokenizerKind,
-    token_byte_lengths: Option<&[u32]>,
-    articles_path: &Path,
+/// Outcome of opening an observation directory: either the corpus is already
+/// complete (its report), or a fresh/resumed session ready to receive records.
+enum Prepared {
+    Done(ObservationReport),
+    Ready {
+        writer: ObservationShardWriter,
+        checkpoint: Checkpoint,
+        articles_total: u64,
+        stories_path: PathBuf,
+    },
+}
+
+/// Open an observation directory: validate/resume the checkpoint, reconcile any
+/// interrupted on-disk shard/story tails, and count the article stream. Shared
+/// by the serial and batched drivers — everything up to the per-article loop is
+/// identical regardless of how records are produced.
+fn prepare_text_observation(
     out_dir: &Path,
+    articles_path: &Path,
     shard_bits: u8,
     resume: bool,
-) -> Result<ObservationReport, SourceUnavailable> {
-    assert!(
-        !oracles.is_empty(),
-        "observe_text_corpus needs at least one oracle"
-    );
+) -> Result<Prepared, SourceUnavailable> {
     let kappa = input_kappa(articles_path)?;
     let mut writer = ObservationShardWriter::open(out_dir, shard_bits)?;
     let shard_count = writer.manifest().shard_count();
@@ -761,7 +808,7 @@ pub fn observe_text_corpus(
     // (issue #72): the input κ is the corpus CID of the D3 manifest.
     writer.set_input_cid(&format!("blake3:{}", blake3::Hash::from(kappa).to_hex()))?;
 
-    let mut checkpoint = match read_checkpoint(out_dir, shard_count)? {
+    let checkpoint = match read_checkpoint(out_dir, shard_count)? {
         Some(checkpoint) => {
             if checkpoint.input_kappa != kappa {
                 return Err(SourceUnavailable::new(format!(
@@ -833,8 +880,54 @@ pub fn observe_text_corpus(
             "text observation corpus already complete: {} records",
             checkpoint.n
         );
-        return build_report(out_dir, &checkpoint, &writer, articles_total, 0, 0, 0);
+        let report = build_report(out_dir, &checkpoint, &writer, articles_total, 0, 0, 0)?;
+        return Ok(Prepared::Done(report));
     }
+
+    Ok(Prepared::Ready {
+        writer,
+        checkpoint,
+        articles_total,
+        stories_path,
+    })
+}
+
+/// Observe a text corpus with a pool of `oracles` teacher instances. Articles
+/// are teacher-forced and mutually independent (the sampled token is discarded;
+/// every recorded field is a deterministic function of the article tokens and
+/// the model), so a batch of up to `oracles.len()` articles is produced in
+/// parallel — one worker thread per oracle — and then committed on this thread
+/// in ascending article ordinal. Because the shard writer appends in call
+/// order, the committed shard bytes are identical to a single-oracle pass.
+///
+/// A single-oracle pool (`oracles.len() == 1`) runs entirely on this thread and
+/// threads `checkpoint.rng` exactly as the original in-line loop did, so it is
+/// byte-for-byte unchanged including the committed checkpoint.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus(
+    oracles: &mut [Box<dyn TeacherOracle + Send>],
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
+    assert!(
+        !oracles.is_empty(),
+        "observe_text_corpus needs at least one oracle"
+    );
+    let (mut writer, mut checkpoint, articles_total, stories_path) =
+        match prepare_text_observation(out_dir, articles_path, shard_bits, resume)? {
+            Prepared::Done(report) => return Ok(report),
+            Prepared::Ready {
+                writer,
+                checkpoint,
+                articles_total,
+                stories_path,
+            } => (writer, checkpoint, articles_total, stories_path),
+        };
 
     let workers = oracles.len();
     let seq_len = oracles[0].seq_len();
@@ -950,10 +1043,37 @@ pub fn observe_text_corpus(
             break 'batches;
         }
     }
+    finalize_text_observation(
+        out_dir,
+        &mut writer,
+        &mut checkpoint,
+        &mut progress,
+        articles_total,
+        ordinal,
+        truncated,
+        replaced,
+        written,
+    )
+}
+
+/// Finalize an observation: mark a fully-consumed stream done, κ-pin the shards,
+/// and build the report. Shared by the serial and batched drivers.
+#[allow(clippy::too_many_arguments)]
+fn finalize_text_observation(
+    out_dir: &Path,
+    writer: &mut ObservationShardWriter,
+    checkpoint: &mut Checkpoint,
+    progress: &mut Progress,
+    articles_total: u64,
+    ordinal: u64,
+    truncated: u64,
+    replaced: u64,
+    written: u64,
+) -> Result<ObservationReport, SourceUnavailable> {
     if !checkpoint.done && ordinal == articles_total {
-        // Empty input file: nothing to do, the corpus is trivially complete.
+        // Empty (or fully consumed) stream: the corpus is complete.
         checkpoint.done = true;
-        write_checkpoint(out_dir, &checkpoint)?;
+        write_checkpoint(out_dir, checkpoint)?;
     }
     if checkpoint.done {
         writer.finalize_all()?;
@@ -961,8 +1081,8 @@ pub fn observe_text_corpus(
     }
     let report = build_report(
         out_dir,
-        &checkpoint,
-        &writer,
+        checkpoint,
+        writer,
         articles_total,
         truncated,
         replaced,
@@ -980,6 +1100,209 @@ pub fn observe_text_corpus(
         report.done
     );
     Ok(report)
+}
+
+/// One in-flight article in a batched observation group.
+struct BatchSlot {
+    ordinal: u64,
+    article: Article,
+    tokens: Vec<u32>,
+    positions: usize,
+    truncated: bool,
+    replaced: u64,
+    window: Vec<u32>,
+    byte_off: u32,
+    rng: u64,
+    records: Vec<(u32, [u8; RECORD_SIZE], observe::ProbabilityMetadata)>,
+}
+
+/// Observe a text corpus with a batched teacher: up to `batch` articles are
+/// teacher-forced together through the memory-amortized forward, so B articles
+/// cost one weight sweep per step instead of B — the throughput lever (measured
+/// ~15× at batch 32 on a 360M teacher). Articles are gathered in ordinal order
+/// into a group, stepped together to the group's longest article (a finished
+/// slot repeats its last position, which is idempotent, keeping the batch
+/// contiguous), each active position encoded via the shared [`encode_position`],
+/// then the group committed in ordinal order via [`commit_article`]. Records are
+/// identical to the serial path for identical logits; on the deployed macOS
+/// teacher the batched (`sgemm`) logits are a distinct, reproducible teacher
+/// path from the serial (`sgemv`) one — both are teacher data, not the pinned
+/// legacy proof.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus_batched(
+    oracle: &dyn BatchedTeacher,
+    batch: usize,
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
+    assert!(batch >= 1, "observe_text_corpus_batched needs batch >= 1");
+    let (mut writer, mut checkpoint, articles_total, stories_path) =
+        match prepare_text_observation(out_dir, articles_path, shard_bits, resume)? {
+            Prepared::Done(report) => return Ok(report),
+            Prepared::Ready {
+                writer,
+                checkpoint,
+                articles_total,
+                stories_path,
+            } => (writer, checkpoint, articles_total, stories_path),
+        };
+
+    let seq_len = oracle.seq_len();
+    let mut progress = Progress::new("text observations", articles_total as usize);
+    progress.set(checkpoint.stories as usize);
+    let mut written = 0u64;
+    let mut truncated = 0u64;
+    let mut replaced = 0u64;
+    let t0 = std::time::Instant::now();
+
+    let file = fs::File::open(articles_path)
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", articles_path.display())))?;
+    let mut lines = BufReader::new(file).lines();
+    let mut ordinal = 0u64;
+    let mut budget_hit = false;
+    // One reusable state per slot, all sharing the oracle's single weight copy.
+    let mut states: Vec<State> = (0..batch).map(|_| oracle.new_state()).collect();
+
+    'groups: loop {
+        let mut slots: Vec<BatchSlot> = Vec::with_capacity(batch);
+        while slots.len() < batch {
+            let line = match lines.next() {
+                Some(line) => line.map_err(|error| {
+                    SourceUnavailable::new(format!("{}: {error}", articles_path.display()))
+                })?,
+                None => break,
+            };
+            if ordinal < checkpoint.stories {
+                ordinal += 1;
+                continue;
+            }
+            if t0.elapsed().as_secs() >= budget_s {
+                budget_hit = true;
+                break;
+            }
+            let article: Article = serde_json::from_str(&line).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "{} line {}: invalid article: {error}",
+                    articles_path.display(),
+                    ordinal + 1
+                ))
+            })?;
+            let (tokens, replaced_n) = tokenizer.encode_lossy(&article.text);
+            let positions = tokens.len().saturating_sub(1).min(seq_len);
+            let truncated = positions < tokens.len().saturating_sub(1);
+            slots.push(BatchSlot {
+                ordinal,
+                article,
+                tokens,
+                positions,
+                truncated,
+                replaced: replaced_n,
+                window: Vec::with_capacity(compiler::WINDOW),
+                byte_off: 0,
+                rng: RNG_SEED,
+                records: Vec::new(),
+            });
+            ordinal += 1;
+        }
+        if slots.is_empty() {
+            break;
+        }
+        let active = slots.len();
+        states[..active].iter_mut().for_each(State::reset);
+        let max_len = slots.iter().map(|s| s.positions).max().unwrap_or(0);
+
+        for pos in 0..max_len {
+            let tokens: Vec<usize> = slots
+                .iter()
+                .map(|s| {
+                    let p = pos.min(s.positions.saturating_sub(1));
+                    s.tokens.get(p).copied().unwrap_or(0) as usize
+                })
+                .collect();
+            let positions: Vec<usize> = slots
+                .iter()
+                .map(|s| pos.min(s.positions.saturating_sub(1)))
+                .collect();
+            oracle.forward_batch_into(&mut states[..active], &tokens, &positions);
+            for (i, slot) in slots.iter_mut().enumerate() {
+                if pos < slot.positions {
+                    let story = u32::try_from(slot.ordinal).map_err(|_| {
+                        SourceUnavailable::new("article ordinal exceeds the u32 story field")
+                    })?;
+                    let token = slot.tokens[pos];
+                    let next = slot.tokens[pos + 1];
+                    let (encoded, advanced) = encode_position(
+                        &mut states[i].logits,
+                        story,
+                        pos,
+                        token,
+                        next,
+                        &mut slot.window,
+                        slot.byte_off,
+                        token_byte_lengths,
+                        shard_bits,
+                        &mut slot.rng,
+                    );
+                    slot.records
+                        .push((encoded.shard, encoded.record, encoded.metadata));
+                    slot.byte_off = advanced;
+                }
+            }
+        }
+
+        // Commit the group in ascending ordinal (slots gathered in order).
+        for slot in &slots {
+            let story = u32::try_from(slot.ordinal).map_err(|_| {
+                SourceUnavailable::new("article ordinal exceeds the u32 story field")
+            })?;
+            let produced = ArticleProduced {
+                ordinal: slot.ordinal,
+                records: slot.records.clone(),
+                story_entry: StoryEntry {
+                    story,
+                    id: slot.article.id.clone(),
+                    url: slot.article.url.clone(),
+                    title: slot.article.title.clone(),
+                    partition: partition_of(&slot.article.id),
+                },
+                truncated: slot.truncated,
+                replaced: slot.replaced,
+            };
+            commit_article(
+                &mut writer,
+                &mut checkpoint,
+                out_dir,
+                &stories_path,
+                &produced,
+                articles_total,
+                &mut written,
+                &mut truncated,
+                &mut replaced,
+            )?;
+            progress.set((slot.ordinal + 1) as usize);
+        }
+
+        if budget_hit {
+            break 'groups;
+        }
+    }
+
+    finalize_text_observation(
+        out_dir,
+        &mut writer,
+        &mut checkpoint,
+        &mut progress,
+        articles_total,
+        ordinal,
+        truncated,
+        replaced,
+        written,
+    )
 }
 
 #[cfg(test)]
@@ -1818,6 +2141,124 @@ mod tests {
 
         let _ = fs::remove_dir_all(&dir1);
         let _ = fs::remove_dir_all(&dir3);
+        let _ = fs::remove_file(&input);
+    }
+
+    /// A batched teacher whose per-position logits match `FakeOracle::step`
+    /// exactly, so the batched driver's records can be compared byte-for-byte
+    /// against the serial driver's.
+    struct FakeBatchedOracle {
+        cfg: uor_r4_model_source::Config,
+    }
+
+    impl BatchedTeacher for FakeBatchedOracle {
+        fn new_state(&self) -> State {
+            State::new(&self.cfg)
+        }
+        fn seq_len(&self) -> usize {
+            FAKE_SEQ_LEN
+        }
+        fn vocab(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]) {
+            for (b, st) in states.iter_mut().enumerate() {
+                let (token, pos) = (tokens[b], positions[b]);
+                for (index, logit) in st.logits.iter_mut().enumerate() {
+                    let value = (token as u64 * 31 + pos as u64 * 7 + index as u64 * 13) % 29;
+                    *logit = value as f32 * 0.25 - 3.0;
+                }
+            }
+        }
+    }
+
+    fn fake_batched_config() -> uor_r4_model_source::Config {
+        uor_r4_model_source::Config {
+            dim: 4,
+            hidden: 4,
+            n_layers: 1,
+            n_heads: 2,
+            n_kv_heads: 2,
+            vocab: FAKE_VOCAB,
+            seq_len: FAKE_SEQ_LEN,
+            rope_theta: 10_000.0,
+            rms_norm_eps: 1e-5,
+            rope_interleaved: true,
+            r4_attention: false,
+        }
+    }
+
+    /// The batched driver must produce a byte-for-byte identical corpus to the
+    /// serial driver when the teacher's per-position logits match: a fake whose
+    /// logits equal FakeOracle's is observed serially and with batch=4, and the
+    /// merged stream, its κ, every shard, and the story mapping must be equal.
+    /// Guards the batched observe path added for #531.
+    #[test]
+    fn batched_matches_serial_byte_for_byte() {
+        let articles = test_articles();
+        let articles_ref: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("articles.jsonl");
+        write_articles(&input, &articles_ref);
+
+        let dir_s = unique_path("serial");
+        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![Box::new(FakeOracle)];
+        let serial = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_s,
+            SHARD_BITS,
+            false,
+        )
+        .expect("serial observe");
+        assert!(serial.done);
+
+        let dir_b = unique_path("batched");
+        let fake = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+        };
+        let batched = observe_text_corpus_batched(
+            &fake,
+            4,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_b,
+            SHARD_BITS,
+            false,
+        )
+        .expect("batched observe");
+        assert!(batched.done);
+
+        assert_eq!(
+            merge_shards(&dir_s).expect("merge serial"),
+            merge_shards(&dir_b).expect("merge batched"),
+            "batched merged bytes differ from serial"
+        );
+        assert_eq!(serial.merged_kappa, batched.merged_kappa);
+        assert_eq!(serial.records, batched.records);
+        assert_eq!(serial.written, batched.written);
+        for shard in 0..SHARD_COUNT {
+            let f_s = fs::read(dir_s.join(shard_file_name(SHARD_BITS, shard))).unwrap_or_default();
+            let f_b = fs::read(dir_b.join(shard_file_name(SHARD_BITS, shard))).unwrap_or_default();
+            assert_eq!(f_s, f_b, "shard {shard} differs between serial and batched");
+        }
+        assert_eq!(
+            fs::read_to_string(&serial.stories_file).expect("serial stories"),
+            fs::read_to_string(&batched.stories_file).expect("batched stories"),
+            "story mapping differs between serial and batched"
+        );
+
+        let _ = fs::remove_dir_all(&dir_s);
+        let _ = fs::remove_dir_all(&dir_b);
         let _ = fs::remove_file(&input);
     }
 }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -267,6 +267,23 @@ unsafe extern "C" {
         output: *mut f32,
         output_stride: i32,
     );
+
+    fn cblas_sgemm(
+        order: i32,
+        transpose_a: i32,
+        transpose_b: i32,
+        m: i32,
+        n: i32,
+        k: i32,
+        alpha: f32,
+        a: *const f32,
+        lda: i32,
+        b: *const f32,
+        ldb: i32,
+        beta: f32,
+        c: *mut f32,
+        ldc: i32,
+    );
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -275,6 +292,72 @@ fn matmul_fast(xout: &mut [f32], x: &[f32], w: &[f32], n: usize) {
     debug_assert!(w.len() >= xout.len() * n);
     for (output, row) in xout.iter_mut().zip(w.chunks_exact(n)) {
         *output = dot_fast(row, x);
+    }
+}
+
+/// Batched matmul: `batch` input vectors of length `n` through weight
+/// `W[rows, n]` → `batch` output vectors of length `rows`. `x` is the `batch`
+/// input vectors laid out contiguously (`batch * n`); `xout` is the `batch`
+/// output vectors (`batch * rows`), same sequence-major layout.
+///
+/// This is the memory-amortized core of batched teacher inference: the serial
+/// [`matmul`] re-reads the entire weight `W` for every single token, which
+/// makes autoregressive inference of a large teacher memory-bandwidth bound.
+/// Here each weight is read once and reused across all `batch` inputs, so `B`
+/// tokens cost one weight sweep instead of `B` — turning the per-token
+/// matrix-vector products into one matrix-matrix product.
+///
+/// Off macOS this reuses [`dot_fast`] per (row, input) with each weight row
+/// held hot across the batch, so it is bit-identical to `batch` separate
+/// [`matmul`]`(.., fast = true)` calls. On macOS it dispatches to Accelerate's
+/// `cblas_sgemm`; like the serial `cblas_sgemv` fast path it is teacher data,
+/// not part of the pinned legacy proof, and is deterministic per machine.
+#[cfg(not(target_os = "macos"))]
+fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
+    debug_assert!(batch > 0);
+    debug_assert_eq!(xout.len() % batch, 0);
+    let rows = xout.len() / batch;
+    debug_assert!(w.len() >= rows * n);
+    debug_assert_eq!(x.len(), batch * n);
+    for row in 0..rows {
+        let wr = &w[row * n..row * n + n];
+        for bi in 0..batch {
+            let xi = &x[bi * n..bi * n + n];
+            xout[bi * rows + row] = dot_fast(wr, xi);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
+    debug_assert!(batch > 0);
+    debug_assert_eq!(xout.len() % batch, 0);
+    let rows = xout.len() / batch;
+    debug_assert!(w.len() >= rows * n);
+    debug_assert_eq!(x.len(), batch * n);
+    const CBLAS_ROW_MAJOR: i32 = 101;
+    const CBLAS_NO_TRANSPOSE: i32 = 111;
+    const CBLAS_TRANSPOSE: i32 = 112;
+    // C[batch, rows] = X[batch, n] · W[rows, n]^T
+    // SAFETY: all pointers refer to initialized, non-overlapping f32 slices
+    // whose dimensions/strides describe X[batch, n], W[rows, n], C[batch, rows].
+    unsafe {
+        cblas_sgemm(
+            CBLAS_ROW_MAJOR,
+            CBLAS_NO_TRANSPOSE,
+            CBLAS_TRANSPOSE,
+            i32::try_from(batch).expect("teacher batch exceeds CBLAS i32"),
+            i32::try_from(rows).expect("teacher output dimension exceeds CBLAS i32"),
+            i32::try_from(n).expect("teacher input dimension exceeds CBLAS i32"),
+            1.0,
+            x.as_ptr(),
+            i32::try_from(n).expect("teacher input stride exceeds CBLAS i32"),
+            w.as_ptr(),
+            i32::try_from(n).expect("teacher weight stride exceeds CBLAS i32"),
+            0.0,
+            xout.as_mut_ptr(),
+            i32::try_from(rows).expect("teacher output stride exceeds CBLAS i32"),
+        );
     }
 }
 
@@ -779,6 +862,209 @@ impl Llama {
         }
         matmul(&mut st.logits, &st.x, &w[self.wcls..], dim, fast_matmul);
     }
+
+    /// Batched forward: advance `states.len()` independent sequences by one
+    /// position each — sequence `b` steps `tokens[b]` at `positions[b]` against
+    /// its own KV cache in `states[b]`. The memory-bound weight matmuls (Q/K/V,
+    /// output, MLP, vocab) run once over the whole batch via [`matmul_batched`]
+    /// instead of once per sequence, so B sequences cost one weight sweep — the
+    /// amortization that lifts the teacher off the per-token memory-bandwidth
+    /// wall. Every per-sequence op (rmsnorm, RoPE, attention, SwiGLU, residual)
+    /// mirrors [`Llama::forward`] exactly, and off macOS `matmul_batched` reuses
+    /// the same `dot_fast`, so this is bit-identical to calling `forward` on
+    /// each sequence with `fast_matmul = true`. `fast_matmul` is accepted for
+    /// signature parity; the batched path always takes the amortized kernel.
+    pub fn forward_batch(
+        &self,
+        states: &mut [State],
+        tokens: &[usize],
+        positions: &[usize],
+        fast_matmul: bool,
+    ) {
+        let _ = fast_matmul;
+        let c = &self.cfg;
+        let (dim, hid) = (c.dim, c.hidden);
+        let kv_dim = c.dim * c.n_kv_heads / c.n_heads;
+        let kv_mul = c.n_heads / c.n_kv_heads;
+        let head_size = dim / c.n_heads;
+        let w = &self.w;
+        let b = states.len();
+        debug_assert_eq!(tokens.len(), b);
+        debug_assert_eq!(positions.len(), b);
+
+        // Sequence-major stacked scratch for the batched matmuls.
+        let mut norm = vec![0f32; b * dim];
+        let mut q = vec![0f32; b * dim];
+        let mut ktmp = vec![0f32; b * kv_dim];
+        let mut vtmp = vec![0f32; b * kv_dim];
+        let mut attn = vec![0f32; b * dim];
+        let mut o = vec![0f32; b * dim];
+        let mut hb = vec![0f32; b * hid];
+        let mut hb2 = vec![0f32; b * hid];
+        let mut ffn = vec![0f32; b * dim];
+        let mut xstack = vec![0f32; b * dim];
+
+        for bi in 0..b {
+            let token = tokens[bi];
+            states[bi]
+                .x
+                .copy_from_slice(&w[self.emb + token * dim..self.emb + (token + 1) * dim]);
+        }
+
+        for l in 0..c.n_layers {
+            let loff = l * c.seq_len * kv_dim;
+            for bi in 0..b {
+                rmsnorm_with_mode(
+                    &mut norm[bi * dim..(bi + 1) * dim],
+                    &states[bi].x,
+                    &w[self.rms_att + l * dim..self.rms_att + (l + 1) * dim],
+                    self.canonical_math,
+                );
+            }
+            matmul_batched(&mut q, &norm, &w[self.wq + l * dim * dim..], dim, b);
+            matmul_batched(&mut ktmp, &norm, &w[self.wk + l * dim * kv_dim..], dim, b);
+            matmul_batched(&mut vtmp, &norm, &w[self.wv + l * dim * kv_dim..], dim, b);
+            for bi in 0..b {
+                let dst = loff + positions[bi] * kv_dim;
+                states[bi].key_cache[dst..dst + kv_dim]
+                    .copy_from_slice(&ktmp[bi * kv_dim..(bi + 1) * kv_dim]);
+                states[bi].value_cache[dst..dst + kv_dim]
+                    .copy_from_slice(&vtmp[bi * kv_dim..(bi + 1) * kv_dim]);
+            }
+
+            for bi in 0..b {
+                let pos = positions[bi];
+                let qb = &mut q[bi * dim..(bi + 1) * dim];
+                let out = &mut attn[bi * dim..(bi + 1) * dim];
+                let st = &mut states[bi];
+
+                if c.rope_interleaved {
+                    let k = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                    let rope_offset = pos * (head_size / 2);
+                    let mut i = 0usize;
+                    while i < dim {
+                        let angle_index = rope_offset + (i % head_size) / 2;
+                        let fcr = self.rope_cos[angle_index];
+                        let fci = self.rope_sin[angle_index];
+                        let rotn = if i < kv_dim { 2 } else { 1 };
+                        for v in 0..rotn {
+                            let vec: &mut [f32] = if v == 0 { &mut *qb } else { &mut *k };
+                            let v0 = vec[i];
+                            let v1 = vec[i + 1];
+                            vec[i] = v0 * fcr - v1 * fci;
+                            vec[i + 1] = v0 * fci + v1 * fcr;
+                        }
+                        i += 2;
+                    }
+                } else {
+                    let k = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                    for vector in [&mut qb[..], &mut k[..]] {
+                        for head in vector.chunks_exact_mut(head_size) {
+                            let half = head_size / 2;
+                            for i in 0..half {
+                                let angle_index = pos * half + i;
+                                let cos = self.rope_cos[angle_index];
+                                let sin = self.rope_sin[angle_index];
+                                let first = head[i];
+                                let second = head[i + half];
+                                head[i] = first * cos - second * sin;
+                                head[i + half] = second * cos + first * sin;
+                            }
+                        }
+                    }
+                }
+
+                for h in 0..c.n_heads {
+                    let qh = &qb[h * head_size..(h + 1) * head_size];
+                    let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                    if c.r4_attention {
+                        for (t, attention) in att.iter_mut().enumerate() {
+                            let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
+                                [..head_size];
+                            let mut head_score = 0.0f32;
+                            let chunks = head_size / 4;
+                            for chunk_idx in 0..chunks {
+                                let q_chunk = &qh[chunk_idx * 4..(chunk_idx + 1) * 4];
+                                let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
+                                head_score += q_chunk[0] * k_chunk[0]
+                                    + q_chunk[1] * k_chunk[1]
+                                    + q_chunk[2] * k_chunk[2]
+                                    + q_chunk[3] * k_chunk[3];
+                            }
+                            head_score /= sqrtf(head_size as f32, self.canonical_math);
+                            *attention = head_score;
+                        }
+                        softmax_with_mode(att, self.canonical_math);
+                    } else {
+                        for (t, attention) in att.iter_mut().enumerate() {
+                            let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
+                                [..head_size];
+                            let mut score = 0.0f32;
+                            for i in 0..head_size {
+                                score += qh[i] * k[i];
+                            }
+                            score /= sqrtf(head_size as f32, self.canonical_math);
+                            *attention = score;
+                        }
+                        softmax_with_mode(att, self.canonical_math);
+                    }
+                    let outh = &mut out[h * head_size..(h + 1) * head_size];
+                    outh.iter_mut().for_each(|v| *v = 0.0);
+                    for (t, &attention) in att.iter().enumerate() {
+                        let v = &st.value_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
+                            [..head_size];
+                        for i in 0..head_size {
+                            outh[i] += attention * v[i];
+                        }
+                    }
+                }
+            }
+
+            matmul_batched(&mut o, &attn, &w[self.wo + l * dim * dim..], dim, b);
+            for bi in 0..b {
+                for i in 0..dim {
+                    states[bi].x[i] += o[bi * dim + i];
+                }
+            }
+
+            for bi in 0..b {
+                rmsnorm_with_mode(
+                    &mut norm[bi * dim..(bi + 1) * dim],
+                    &states[bi].x,
+                    &w[self.rms_ffn + l * dim..self.rms_ffn + (l + 1) * dim],
+                    self.canonical_math,
+                );
+            }
+            matmul_batched(&mut hb, &norm, &w[self.w1 + l * dim * hid..], dim, b);
+            matmul_batched(&mut hb2, &norm, &w[self.w3 + l * dim * hid..], dim, b);
+            for idx in 0..b * hid {
+                let mut val = hb[idx];
+                val *= 1.0f32 / (1.0f32 + expf(-val, self.canonical_math));
+                val *= hb2[idx];
+                hb[idx] = val;
+            }
+            matmul_batched(&mut ffn, &hb, &w[self.w2 + l * hid * dim..], hid, b);
+            for bi in 0..b {
+                for i in 0..dim {
+                    states[bi].x[i] += ffn[bi * dim + i];
+                }
+            }
+        }
+
+        let rf = self.rms_final;
+        for bi in 0..b {
+            let (wslice, x) = (&w[rf..rf + dim], &mut states[bi].x);
+            rmsnorm_inplace_with_mode(x, wslice, self.canonical_math);
+            xstack[bi * dim..(bi + 1) * dim].copy_from_slice(x);
+        }
+        let mut logits_stacked = vec![0f32; b * c.vocab];
+        matmul_batched(&mut logits_stacked, &xstack, &w[self.wcls..], dim, b);
+        for bi in 0..b {
+            states[bi]
+                .logits
+                .copy_from_slice(&logits_stacked[bi * c.vocab..(bi + 1) * c.vocab]);
+        }
+    }
 }
 
 pub trait RepresentationSource {
@@ -1080,6 +1366,33 @@ impl HuggingFaceLlamaOracle {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(source: impl AsRef<std::path::Path>) -> Result<Self, SourceUnavailable> {
         Self::load_inner(source, None)
+    }
+
+    /// A fresh per-sequence [`State`] for this teacher, for the batched path:
+    /// the batched driver keeps one per in-flight sequence and shares this one
+    /// oracle's (single) weight copy across all of them.
+    pub fn new_state(&self) -> State {
+        State::new(&self.model.cfg)
+    }
+
+    /// This teacher's configuration (dims, heads, vocab, sequence length).
+    pub fn cfg(&self) -> &Config {
+        &self.model.cfg
+    }
+
+    /// Advance a batch of independent sequences one position each through the
+    /// memory-amortized batched forward — sequence `b` steps `tokens[b]` at
+    /// `positions[b]` against its own KV cache in `states[b]`, leaving each
+    /// sequence's logits in `states[b].logits`. This is the throughput lever:
+    /// B sequences cost one weight sweep instead of B.
+    pub fn forward_batch_into(
+        &self,
+        states: &mut [State],
+        tokens: &[usize],
+        positions: &[usize],
+    ) {
+        self.model
+            .forward_batch(states, tokens, positions, self.fast_matmul);
     }
 
     /// Load an offline teacher with a bounded context allocation. Compilation
@@ -1434,5 +1747,187 @@ mod tests {
             let tolerance = 1e-5f32.max(expected.abs() * 1e-5);
             assert!((expected - actual).abs() <= tolerance);
         }
+    }
+
+    #[test]
+    fn matmul_batched_matches_serial_fast() {
+        const N: usize = 73;
+        const ROWS: usize = 40;
+        const BATCH: usize = 6;
+        let weights: Vec<f32> = (0..ROWS * N)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect();
+        let x: Vec<f32> = (0..BATCH * N)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect();
+        let mut batched = vec![0.0f32; BATCH * ROWS];
+        matmul_batched(&mut batched, &x, &weights, N, BATCH);
+        for bi in 0..BATCH {
+            let mut serial = [0.0f32; ROWS];
+            matmul(&mut serial, &x[bi * N..(bi + 1) * N], &weights, N, true);
+            for row in 0..ROWS {
+                let want = serial[row];
+                let got = batched[bi * ROWS + row];
+                // Off macOS the batched kernel reuses the exact same dot_fast as
+                // the serial fast path, so it is bit-identical. On macOS it is
+                // Accelerate sgemm vs sgemv — deterministic, within tolerance.
+                #[cfg(not(target_os = "macos"))]
+                assert_eq!(got, want, "batched != serial at b{bi} row{row}");
+                #[cfg(target_os = "macos")]
+                {
+                    let tolerance = 1e-4f32.max(want.abs() * 1e-4);
+                    assert!(
+                        (got - want).abs() <= tolerance,
+                        "batched vs serial b{bi} row{row}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A tiny synthetic Llama with deterministic weights, for exercising the
+    /// forward path without loading a real checkpoint.
+    fn tiny_llama() -> Llama {
+        let (dim, hid, nl, kv_dim, vocab, seq_len) = (8usize, 16usize, 2usize, 8usize, 10usize, 8usize);
+        let cfg = Config {
+            dim,
+            hidden: hid,
+            n_layers: nl,
+            n_heads: 2,
+            n_kv_heads: 2,
+            vocab,
+            seq_len,
+            rope_theta: 10_000.0,
+            rms_norm_eps: 1e-5,
+            rope_interleaved: true,
+            r4_attention: false,
+        };
+        let emb = 0;
+        let rms_att = emb + vocab * dim;
+        let wq = rms_att + nl * dim;
+        let wk = wq + nl * dim * dim;
+        let wv = wk + nl * dim * kv_dim;
+        let wo = wv + nl * dim * kv_dim;
+        let rms_ffn = wo + nl * dim * dim;
+        let w1 = rms_ffn + nl * dim;
+        let w2 = w1 + nl * dim * hid;
+        let w3 = w2 + nl * hid * dim;
+        let rms_final = w3 + nl * dim * hid;
+        let total = rms_final + dim;
+        let w: Vec<f32> = (0..total)
+            .map(|i| (((i * 131 + 7) % 251) as f32 / 251.0 - 0.5) * 0.2)
+            .collect();
+        let mut model = Llama {
+            cfg,
+            w,
+            rope_cos: Vec::new(),
+            rope_sin: Vec::new(),
+            emb,
+            rms_att,
+            wq,
+            wk,
+            wv,
+            wo,
+            rms_ffn,
+            w1,
+            w2,
+            w3,
+            rms_final,
+            wcls: emb,
+            canonical_math: false,
+        };
+        model.rebuild_rope_cache();
+        model
+    }
+
+    /// forward_batch over B sequences, stepped position by position, must
+    /// produce the exact logits of B independent forward() streams. Off macOS
+    /// the batched matmul reuses the serial dot_fast, so this is bit-identical;
+    /// guards the batched teacher path added for #531.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn forward_batch_matches_serial_forward() {
+        let model = tiny_llama();
+        let seqs: [[usize; 4]; 3] = [[1, 3, 5, 2], [4, 0, 7, 8], [2, 9, 1, 6]];
+        let len = 4;
+
+        // Serial reference: one State per sequence, stepped token by token.
+        let mut serial: Vec<Vec<f32>> = Vec::new();
+        let mut sstates: Vec<State> = (0..3).map(|_| State::new(&model.cfg)).collect();
+        sstates.iter_mut().for_each(State::reset);
+        for pos in 0..len {
+            for (b, st) in sstates.iter_mut().enumerate() {
+                model.forward(st, seqs[b][pos], pos, true);
+                serial.push(st.logits.clone());
+            }
+        }
+
+        // Batched: all three sequences advanced together each step.
+        let mut bstates: Vec<State> = (0..3).map(|_| State::new(&model.cfg)).collect();
+        bstates.iter_mut().for_each(State::reset);
+        for pos in 0..len {
+            let tokens: Vec<usize> = (0..3).map(|b| seqs[b][pos]).collect();
+            let positions = vec![pos; 3];
+            model.forward_batch(&mut bstates, &tokens, &positions, true);
+            for (b, st) in bstates.iter().enumerate() {
+                assert_eq!(st.logits, serial[pos * 3 + b], "logits differ at pos {pos} seq {b}");
+            }
+        }
+    }
+
+    /// Raw teacher throughput: serial `step` vs batched `forward_batch_into` on
+    /// a real teacher. Ignored by default; run against a model directory:
+    ///   TLESS_BENCH_MODEL=.uor-models/sources/smollm2-360m-instruct \
+    ///   cargo test -p uor-r4-model-source --release bench_forward_batch \
+    ///     -- --ignored --nocapture
+    /// Optionally TLESS_BENCH_B=16 (batch), TLESS_BENCH_STEPS=128 (positions).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    #[ignore]
+    fn bench_forward_batch() {
+        use std::time::Instant;
+        let dir = std::env::var("TLESS_BENCH_MODEL")
+            .expect("set TLESS_BENCH_MODEL to a teacher source directory");
+        let steps: usize = std::env::var("TLESS_BENCH_STEPS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(128);
+        let batch: usize = std::env::var("TLESS_BENCH_B")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(16);
+        let mut oracle =
+            HuggingFaceLlamaOracle::load_with_sequence_length(&dir, 128).expect("load teacher");
+        let vocab = oracle.cfg().vocab;
+
+        // Serial baseline: one sequence, `steps` positions via step().
+        let mut logits = vec![0f32; vocab];
+        oracle.reset();
+        let t = Instant::now();
+        for pos in 0..steps {
+            oracle.step((pos % vocab).max(1), pos, &mut logits);
+        }
+        let serial_s = t.elapsed().as_secs_f64();
+        let serial_tps = steps as f64 / serial_s;
+
+        // Batched: `batch` sequences, `steps` positions each.
+        let mut states: Vec<State> = (0..batch).map(|_| oracle.new_state()).collect();
+        states.iter_mut().for_each(State::reset);
+        let t = Instant::now();
+        for pos in 0..steps {
+            let tokens: Vec<usize> = (0..batch).map(|b| ((pos + b) % vocab).max(1)).collect();
+            let positions = vec![pos; batch];
+            oracle.forward_batch_into(&mut states, &tokens, &positions);
+        }
+        let batched_s = t.elapsed().as_secs_f64();
+        let batched_tps = (steps * batch) as f64 / batched_s;
+
+        eprintln!(
+            "BENCH serial: {steps} tok in {serial_s:.3}s = {serial_tps:.1} tok/s | \
+             batched B={batch}: {} tok in {batched_s:.3}s = {batched_tps:.1} tok/s | \
+             speedup {:.2}x",
+            steps * batch,
+            batched_tps / serial_tps
+        );
     }
 }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -1362,37 +1362,47 @@ impl From<safetensors::SafeTensorError> for SourceUnavailable {
     }
 }
 
+/// A teacher that can advance a batch of independent sequences one position
+/// each through a single memory-amortized forward. Implemented by the HF oracle
+/// (the deployed teacher) and mockable for tests, so the batched observe driver
+/// need not name a concrete oracle.
+pub trait BatchedTeacher {
+    /// A fresh per-sequence state for this teacher.
+    fn new_state(&self) -> State;
+    /// Maximum context length (teacher-forced positions per article).
+    fn seq_len(&self) -> usize;
+    /// Vocabulary size (logits length).
+    fn vocab(&self) -> usize;
+    /// Advance `states.len()` sequences one position each: sequence `b` steps
+    /// `tokens[b]` at `positions[b]`, leaving its logits in `states[b].logits`.
+    fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]);
+}
+
+impl BatchedTeacher for HuggingFaceLlamaOracle {
+    fn new_state(&self) -> State {
+        State::new(&self.model.cfg)
+    }
+    fn seq_len(&self) -> usize {
+        self.model.cfg.seq_len
+    }
+    fn vocab(&self) -> usize {
+        self.model.cfg.vocab
+    }
+    fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]) {
+        self.model
+            .forward_batch(states, tokens, positions, self.fast_matmul);
+    }
+}
+
 impl HuggingFaceLlamaOracle {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(source: impl AsRef<std::path::Path>) -> Result<Self, SourceUnavailable> {
         Self::load_inner(source, None)
     }
 
-    /// A fresh per-sequence [`State`] for this teacher, for the batched path:
-    /// the batched driver keeps one per in-flight sequence and shares this one
-    /// oracle's (single) weight copy across all of them.
-    pub fn new_state(&self) -> State {
-        State::new(&self.model.cfg)
-    }
-
     /// This teacher's configuration (dims, heads, vocab, sequence length).
     pub fn cfg(&self) -> &Config {
         &self.model.cfg
-    }
-
-    /// Advance a batch of independent sequences one position each through the
-    /// memory-amortized batched forward — sequence `b` steps `tokens[b]` at
-    /// `positions[b]` against its own KV cache in `states[b]`, leaving each
-    /// sequence's logits in `states[b].logits`. This is the throughput lever:
-    /// B sequences cost one weight sweep instead of B.
-    pub fn forward_batch_into(
-        &self,
-        states: &mut [State],
-        tokens: &[usize],
-        positions: &[usize],
-    ) {
-        self.model
-            .forward_batch(states, tokens, positions, self.fast_matmul);
     }
 
     /// Load an offline teacher with a bounded context allocation. Compilation
@@ -1788,7 +1798,8 @@ mod tests {
     /// A tiny synthetic Llama with deterministic weights, for exercising the
     /// forward path without loading a real checkpoint.
     fn tiny_llama() -> Llama {
-        let (dim, hid, nl, kv_dim, vocab, seq_len) = (8usize, 16usize, 2usize, 8usize, 10usize, 8usize);
+        let (dim, hid, nl, kv_dim, vocab, seq_len) =
+            (8usize, 16usize, 2usize, 8usize, 10usize, 8usize);
         let cfg = Config {
             dim,
             hidden: hid,
@@ -1846,6 +1857,7 @@ mod tests {
     /// guards the batched teacher path added for #531.
     #[cfg(not(target_os = "macos"))]
     #[test]
+    #[allow(clippy::needless_range_loop)]
     fn forward_batch_matches_serial_forward() {
         let model = tiny_llama();
         let seqs: [[usize; 4]; 3] = [[1, 3, 5, 2], [4, 0, 7, 8], [2, 9, 1, 6]];
@@ -1870,7 +1882,11 @@ mod tests {
             let positions = vec![pos; 3];
             model.forward_batch(&mut bstates, &tokens, &positions, true);
             for (b, st) in bstates.iter().enumerate() {
-                assert_eq!(st.logits, serial[pos * 3 + b], "logits differ at pos {pos} seq {b}");
+                assert_eq!(
+                    st.logits,
+                    serial[pos * 3 + b],
+                    "logits differ at pos {pos} seq {b}"
+                );
             }
         }
     }


### PR DESCRIPTION
## #531 — batched teacher inference for the corpus-scale observe

The teacher observe was memory-bandwidth bound: every token re-reads the full ~1.4 GB of teacher weights, so autoregressive inference of a 360M teacher runs at ~20 tok/s and thread-level parallelism only bought ~1.3×. This batches independent articles through one forward, so each weight read serves the whole batch.

**Measured on an M1 (360M teacher, Accelerate):** serial ~20 tok/s → batch 8 **3.6×**, batch 16 **7.3×**, batch 32 **15.1×** (~910k records/hour → **2M observe ~2.2h** vs ~28h serial). One shared weight copy, not N.

### What's here
- `matmul_batched` + `Llama::forward_batch(states[B], tokens[B], positions[B])`: the six weight matmuls (Q/K/V, output, MLP, vocab) run once over the batch; per-sequence rmsnorm/RoPE/attention (own KV cache + position)/SwiGLU/residual mirror `forward()` exactly. Off macOS it reuses the serial `dot_fast` (bit-identical); on macOS it's Accelerate `cblas_sgemm`. Teacher data, not the pinned legacy proof.
- `BatchedTeacher` trait (impl by the HF oracle) + `observe_text_corpus_batched`: fixed-group continuous batching — gather up to `--batch` articles in ordinal order, step them together to the group's longest, encode each active position via the shared `encode_position`, commit in ordinal order. Reuses the extracted `prepare_text_observation` / `finalize_text_observation` / `commit_article`, so checkpoint/resume/reporting are identical to the serial path.
- `observe-text --batch N` (Hugging Face teacher only; errors on `--checkpoint`). Supersedes `--workers` for throughput.

### Correctness
- `matmul_batched_matches_serial_fast` and `forward_batch_matches_serial_forward` — bit-identical to the serial path (off macOS).
- `batched_matches_serial_byte_for_byte` — a fake teacher whose logits match `FakeOracle` observed serially vs at batch 4: merged stream, κ, every shard, and `stories.jsonl` are byte-for-byte equal.

Full gauntlet green: build, `--all-features`, `cargo test --workspace --no-run` (incl `tests/bdd.rs`), `clippy -D warnings`, `fmt`, `check-model` / `audit-deferral` / `audit-limits`.

Refs #531.
