### PR TITLE
feat(#597): versioned source snapshot manifest with root κ

### DIFF
--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -174,6 +174,13 @@ pub struct CompileRequest {
     pub work_dir: PathBuf,
     /// Stage knobs.
     pub options: CompileOptions,
+    /// Root κ of the #597 source-snapshot manifest
+    /// (`source_manifest.json`) describing `source_dir`, when the caller
+    /// has computed it (the root crate's `model::source_manifest_kappa`).
+    /// Passed through to the cover stage so `compile_report.json` binds
+    /// the snapshot identity; `None` leaves legacy reports unchanged.
+    /// This crate never computes the κ itself (no uor-addr dependency).
+    pub source_manifest_kappa: Option<String>,
 }
 
 /// How to resume an incomplete compile.
@@ -449,7 +456,7 @@ fn stage_a_flags(request: &CompileRequest) -> Vec<String> {
 fn stage_b_flags(request: &CompileRequest, cover_out: &Path) -> Vec<String> {
     let options = &request.options;
     let work = &request.work_dir;
-    vec![
+    let mut flags = vec![
         "--corpus-meta".to_owned(),
         work.join("corpus.meta").display().to_string(),
         "--corpus-recs".to_owned(),
@@ -466,7 +473,13 @@ fn stage_b_flags(request: &CompileRequest, cover_out: &Path) -> Vec<String> {
         options.memory_budget_mb.to_string(),
         "--out".to_owned(),
         cover_out.display().to_string(),
-    ]
+    ];
+    // #597: thread the source-snapshot manifest root κ into the cover
+    // stage so the emitted compile_report.json binds the snapshot.
+    if let Some(kappa) = &request.source_manifest_kappa {
+        flags.extend(["--source-manifest-kappa".to_owned(), kappa.clone()]);
+    }
+    flags
 }
 
 fn stage_c_flags(request: &CompileRequest, cover_out: &Path, scored_out: &Path) -> Vec<String> {
@@ -499,4 +512,34 @@ fn stage_c_flags(request: &CompileRequest, cover_out: &Path, scored_out: &Path) 
         "--out".to_owned(),
         scored_out.display().to_string(),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(source_manifest_kappa: Option<String>) -> CompileRequest {
+        CompileRequest {
+            source_dir: PathBuf::from("source"),
+            work_dir: PathBuf::from("work"),
+            options: CompileOptions::default(),
+            source_manifest_kappa,
+        }
+    }
+
+    /// #597 plumbing seam: a request carrying the source-snapshot
+    /// manifest root κ forwards it to the cover stage (whose report field
+    /// it populates); an absent κ adds no flag, so legacy invocations are
+    /// byte-identical.
+    #[test]
+    fn source_manifest_kappa_is_threaded_into_cover_stage_flags() {
+        let kappa = format!("blake3:{}", "7".repeat(64));
+        let with = stage_b_flags(&request(Some(kappa.clone())), Path::new("cover"));
+        assert!(with
+            .windows(2)
+            .any(|pair| pair == ["--source-manifest-kappa", kappa.as_str()]));
+        let without = stage_b_flags(&request(None), Path::new("cover"));
+        assert!(!without.iter().any(|flag| flag == "--source-manifest-kappa"));
+        assert_eq!(with.len(), without.len() + 2);
+    }
 }

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -157,6 +157,7 @@ fn request(source: PathBuf, work: PathBuf) -> CompileRequest {
         source_dir: source,
         work_dir: work,
         options: CompileOptions::default(),
+        source_manifest_kappa: None,
     }
 }
 
@@ -250,6 +251,7 @@ fn e2e_compile_then_engine_load() {
                 target: 2_000,
                 ..CompileOptions::default()
             },
+            source_manifest_kappa: None,
         },
         &mut |event| {
             events += 1;

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -614,6 +614,10 @@ struct CoverOptions {
     entropy_gain_bits: f64,
     radius_quantile: u32,
     output: PathBuf,
+    /// Root κ of the #597 source-snapshot manifest of the teacher source
+    /// (`--source-manifest-kappa`), carried verbatim into the cover
+    /// report. This crate never computes the κ (no uor-addr dependency).
+    source_manifest_kappa: Option<String>,
 }
 
 fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailable> {
@@ -630,6 +634,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         entropy_gain_bits: cover::DEFAULT_SPLIT_ENTROPY_GAIN_BITS,
         radius_quantile: cover::RADIUS_QUANTILE_NUMERATOR,
         output: PathBuf::from("cover"),
+        source_manifest_kappa: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -706,6 +711,9 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                 }
             }
             "--out" => options.output = PathBuf::from(value),
+            "--source-manifest-kappa" => {
+                options.source_manifest_kappa = Some(value.clone());
+            }
             _ => {
                 return Err(SourceUnavailable::new(format!(
                     "unknown cover option: {flag}"
@@ -870,7 +878,7 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
             "a token or count exceeded the i32 R4G1 wire bound: {bound}"
         ))
     })?;
-    let report = cover::build_report(
+    let mut report = cover::build_report(
         &config,
         &induced,
         cover::ReportData {
@@ -882,6 +890,9 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
             artifact: Some((&artifact_bytes, info)),
         },
     );
+    // #597: bind the source-snapshot identity into the cover report when
+    // the caller passed it (`--source-manifest-kappa`).
+    report.source_manifest_kappa = options.source_manifest_kappa.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("cover.r4g1");
@@ -3093,6 +3104,22 @@ mod tests {
         assert_eq!(options.target, 1000);
         assert_eq!(options.sequence_length, 64);
         assert_eq!(source_slug(&options), "smollm2-135m-instruct");
+    }
+
+    /// #597 plumbing seam: the cover stage accepts and carries the
+    /// source-snapshot manifest root κ (populated into the cover report),
+    /// and leaves it unset when the flag is absent.
+    #[test]
+    fn cover_options_carry_the_source_manifest_kappa() {
+        let kappa = format!("blake3:{}", "7".repeat(64));
+        let args = ["--source-manifest-kappa".to_owned(), kappa.clone()];
+        let options = parse_cover_options(&args).expect("valid cover options");
+        assert_eq!(
+            options.source_manifest_kappa.as_deref(),
+            Some(kappa.as_str())
+        );
+        let defaults = parse_cover_options(&[]).expect("default cover options");
+        assert_eq!(defaults.source_manifest_kappa, None);
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2516,6 +2516,13 @@ pub fn emit_r4g1(
 #[derive(Debug, Clone, Serialize)]
 pub struct CoverReport {
     pub schema: u32,
+    /// Root κ of the #597 source-snapshot manifest
+    /// (`source_manifest.json`) the teacher inputs were derived from,
+    /// when the invoking pipeline knows it. Optional so every legacy
+    /// report and its bytes stay unchanged; callers set the public field
+    /// after [`build_report`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_manifest_kappa: Option<String>,
     pub config: CoverReportConfig,
     pub inputs: CoverReportInputs,
     pub objective: CoverReportObjective,
@@ -2730,6 +2737,9 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
     );
     CoverReport {
         schema: 2,
+        // #597: populated by callers that hold the source-snapshot
+        // manifest root κ; the induction stages do not see the snapshot.
+        source_manifest_kappa: None,
         config: CoverReportConfig {
             depths: config.depths,
             k0: config.k0,

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -45,6 +45,11 @@ pub struct GraphCompileOptions {
     pub memory_budget_mb: u64,
     pub jobs: Option<usize>,
     pub output: PathBuf,
+    /// Root κ of the #597 source-snapshot manifest of the teacher source
+    /// (`--source-manifest-kappa`), carried verbatim into the compile
+    /// report. This crate never computes the κ itself (no uor-addr
+    /// dependency); callers that hold the snapshot pass the string.
+    pub source_manifest_kappa: Option<String>,
 }
 
 /// Parse graph-compile CLI arguments. `None` when the arguments do not name a
@@ -64,6 +69,7 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
         memory_budget_mb: induction::DEFAULT_MEMORY_BUDGET_MB,
         jobs: None,
         output: PathBuf::from("r4g1_output"),
+        source_manifest_kappa: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -102,6 +108,9 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
                 options.jobs = Some(j);
             }
             "--out" => options.output = PathBuf::from(value),
+            "--source-manifest-kappa" => {
+                options.source_manifest_kappa = Some(value.clone());
+            }
             _ => return None,
         }
         index += 2;
@@ -211,7 +220,7 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
             "a token or count exceeded the i32 R4G1 wire bound: {bound}"
         ))
     })?;
-    let report = induction::build_report(
+    let mut report = induction::build_report(
         &config,
         &induced,
         induction::ReportData {
@@ -223,6 +232,9 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
             artifact: Some((&artifact_bytes, info)),
         },
     );
+    // #597: bind the source-snapshot identity into the compile report when
+    // the caller passed it (`--source-manifest-kappa`).
+    report.source_manifest_kappa = options.source_manifest_kappa.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("compiled.r4g1");
@@ -254,6 +266,10 @@ pub struct ObserveOptions {
     pub target: usize,
     pub shards: u8,
     pub sequence_length: usize,
+    /// Root κ of the #597 source-snapshot manifest of the teacher source
+    /// (`--source-manifest-kappa`), recorded in the observation manifest.
+    /// Carried as an opaque string; this crate never computes it.
+    pub source_manifest_kappa: Option<String>,
 }
 
 /// Parse observe CLI arguments. `None` when the arguments do not name a valid
@@ -269,6 +285,7 @@ pub fn parse_observe_options(args: &[String]) -> Option<ObserveOptions> {
         target: 20_000,
         shards: 3,
         sequence_length: 128,
+        source_manifest_kappa: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -289,6 +306,9 @@ pub fn parse_observe_options(args: &[String]) -> Option<ObserveOptions> {
             }
             "--sequence-length" => {
                 options.sequence_length = value.parse().ok()?;
+            }
+            "--source-manifest-kappa" => {
+                options.source_manifest_kappa = Some(value.clone());
             }
             _ => return None,
         }
@@ -317,6 +337,15 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
             )?;
             Box::new(o)
         };
+
+    // #597: record the source-snapshot identity in the observation
+    // manifest before the sharded run opens it (idempotent, atomic; the
+    // run's own writer loads and preserves the stored field).
+    if let Some(kappa) = &options.source_manifest_kappa {
+        let mut writer =
+            observation::ObservationShardWriter::open(&options.output, options.shards)?;
+        writer.set_source_manifest_kappa(kappa)?;
+    }
 
     observation::observe_sharded(
         &mut *oracle,

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -249,6 +249,13 @@ pub struct ObservationManifest {
     /// of the D3 manifest; absent for teacher-generated streams).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_cid: Option<String>,
+    /// Root κ of the #597 source-snapshot manifest
+    /// (`source_manifest.json`) of the teacher source the observations
+    /// were generated from, when the producing pipeline knows it.
+    /// Optional with a serde default so every legacy manifest stays
+    /// readable and legacy manifest bytes are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_manifest_kappa: Option<String>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -262,6 +269,7 @@ impl ObservationManifest {
             shard_bits,
             partition_rule: None,
             input_cid: None,
+            source_manifest_kappa: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -380,6 +388,16 @@ impl ObservationShardWriter {
     pub fn set_input_cid(&mut self, cid: &str) -> Result<(), SourceUnavailable> {
         if self.manifest.input_cid.as_deref() != Some(cid) {
             self.manifest.input_cid = Some(cid.to_owned());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Record the #597 source-snapshot manifest root κ of the teacher
+    /// source in the observation manifest (idempotent, atomic store).
+    pub fn set_source_manifest_kappa(&mut self, kappa: &str) -> Result<(), SourceUnavailable> {
+        if self.manifest.source_manifest_kappa.as_deref() != Some(kappa) {
+            self.manifest.source_manifest_kappa = Some(kappa.to_owned());
             self.manifest.store(&self.dir)?;
         }
         Ok(())

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -1019,6 +1019,42 @@ fn objective_decomposition_and_tie_breaking_are_deterministic() {
     );
 }
 
+/// #597 plumbing seam: `build_report` leaves the source-snapshot κ unset
+/// (legacy report bytes carry no such key), and a caller that binds it —
+/// as `compile` does from `--source-manifest-kappa` — gets it serialized
+/// into the report JSON.
+#[test]
+fn report_serializes_source_manifest_kappa_only_when_bound() {
+    let (observations, _) = synthetic_observations();
+    let config = synthetic_config();
+    let induced = induce_synthetic(&observations, &config);
+    let reference = cover::ReferenceClassifier::freeze(&induced.cover);
+    let story = vec![0u32; observations.len()];
+    let edges = cover::build_edges(&induced.cover, &reference, &observations, &story);
+    let mut report = cover::build_report(
+        &config,
+        &induced,
+        cover::ReportData {
+            reference: &reference,
+            train: &observations,
+            held_out: &observations,
+            edges: &edges,
+            recall: Vec::new(),
+            artifact: None,
+        },
+    );
+    assert_eq!(report.source_manifest_kappa, None);
+    let legacy_json = serde_json::to_string(&report).expect("report serializes");
+    assert!(
+        !legacy_json.contains("source_manifest_kappa"),
+        "an unbound κ must leave legacy report bytes unchanged"
+    );
+    let kappa = format!("blake3:{}", "7".repeat(64));
+    report.source_manifest_kappa = Some(kappa.clone());
+    let bound_json = serde_json::to_string(&report).expect("report serializes");
+    assert!(bound_json.contains(&format!("\"source_manifest_kappa\":\"{kappa}\"")));
+}
+
 #[test]
 fn kmeans_recovers_tight_clusters_at_any_batch_size() {
     let (observations, _) = synthetic_observations();

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -405,6 +405,64 @@ fn llama_oracle_exposes_hidden_state_and_canonical_top_k() {
 
 // ------------------------------------------------------------------ CLI --
 
+/// #597 plumbing seam: `--source-manifest-kappa` parses into the observe
+/// options, and the writer setter persists the κ into the observation
+/// manifest atomically and idempotently across reopen.
+#[test]
+fn source_manifest_kappa_parses_and_persists_in_the_manifest() {
+    let kappa = format!("blake3:{}", "7".repeat(64));
+    let args: Vec<String> = [
+        "--checkpoint",
+        "/tmp/does-not-need-to-exist-for-parsing",
+        "--source-manifest-kappa",
+        kappa.as_str(),
+    ]
+    .map(str::to_owned)
+    .to_vec();
+    let options = uor_r4_graph_compiler::parse_observe_options(&args).expect("valid options");
+    assert_eq!(
+        options.source_manifest_kappa.as_deref(),
+        Some(kappa.as_str())
+    );
+    // The compile parser accepts the same flag.
+    let compile_args: Vec<String> = ["--source-manifest-kappa", kappa.as_str()]
+        .map(str::to_owned)
+        .to_vec();
+    let compile_options =
+        uor_r4_graph_compiler::parse_options(&compile_args).expect("valid options");
+    assert_eq!(
+        compile_options.source_manifest_kappa.as_deref(),
+        Some(kappa.as_str())
+    );
+
+    let dir = unique_path("observe-source-kappa");
+    let mut writer = ObservationShardWriter::open(&dir, 2).expect("writer");
+    assert_eq!(writer.manifest().source_manifest_kappa, None);
+    writer
+        .set_source_manifest_kappa(&kappa)
+        .expect("set and store");
+    // Idempotent: re-setting the recorded value does not rewrite.
+    writer
+        .set_source_manifest_kappa(&kappa)
+        .expect("idempotent set");
+    drop(writer);
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(
+        manifest.source_manifest_kappa.as_deref(),
+        Some(kappa.as_str())
+    );
+    // A reopened writer (as `observe_sharded` does after the CLI pre-set)
+    // preserves the stored κ.
+    let reopened = ObservationShardWriter::open(&dir, 2).expect("reopen");
+    assert_eq!(
+        reopened.manifest().source_manifest_kappa.as_deref(),
+        Some(kappa.as_str())
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn observe_cli_writes_shards_and_resumes_without_rewriting() {
     if std::fs::metadata(LEGACY_CHECKPOINT).is_err() {

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -60,6 +60,40 @@ The downloader prints the repository and destination immediately, streams the
 `hf` process, and emits a heartbeat every two seconds with file count, bytes,
 and elapsed time.
 
+#### Source-snapshot manifest (#597)
+
+After a successful download the downloader writes `source_manifest.json`
+(schema `uor-r4-source-manifest/1`) into the snapshot directory. It binds the
+whole snapshot in one canonical document: repository, immutable revision,
+license (SPDX identifier when known; the license *file* is always digested),
+compiler version, source-execution mode (`offline-compiler-input`), and every
+admitted file's path, byte length, and raw `blake3:<hex>` digest —
+`*.safetensors`, `*.json` (including `model.safetensors.index.json`),
+`*.model`, `merges.txt`, `LICENSE*`, and `README*`; the manifest excludes
+itself. The file list is sorted by path byte order and the serialization is
+deterministic, so rebuilding from the same directory reproduces identical
+bytes. The manifest's root κ is the canonical-JSON address of those bytes
+(`uor_addr::json::address_blake3`), so it uniquely identifies the exact
+snapshot; the programmatic surface is `build_source_manifest` /
+`write_source_manifest` / `read_source_manifest` / `source_manifest_kappa` in
+`src/model.rs`.
+
+The root κ threads into downstream provenance as an opaque string: the cover
+stages (`transformerless cover`, `graph-compile`) and the observe driver
+accept `--source-manifest-kappa`, recording it as the optional
+`source_manifest_kappa` field of the cover/compile report and the observation
+manifest; `uor-r4-api`'s `CompileRequest.source_manifest_kappa` forwards it to
+the cover stage; and the HTTP server's compile job binds it automatically when
+the downloaded snapshot carries a `source_manifest.json`. Legacy inputs
+without a manifest compile exactly as before, with the field absent.
+
+**Migration note.** Descriptor κs minted before #597 with
+`source_kappa_scope = "model.safetensors"` (e.g. `source_kappa` in
+`models/smollm2-135m-instruct.json`) are weight-only identities: they cover
+the `model.safetensors` bytes and nothing else. They are NOT relabeled and do
+not become snapshot identities; the snapshot-wide identity is only the
+`source_manifest.json` root κ described above.
+
 ### 2. Compile the source
 
 Compile an already downloaded directory:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::fmt;
 use std::io::{self, BufRead, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uor_r4_graph_cli as transformerless_command;
 use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError};
@@ -484,9 +484,29 @@ fn download(args: &DownloadArgs) -> Result<(), RunError> {
         revision: args.revision.clone(),
         name: args.name.clone(),
         output: args.output.clone(),
+        license: descriptor_license(&args.name, &args.repository, &args.revision),
     })?;
     println!("{}", path.display());
     Ok(())
+}
+
+/// SPDX license identifier from the pinned `models/<name>.json`
+/// descriptor, forwarded into the #597 source-snapshot manifest — only
+/// when the descriptor pins exactly the requested repository and
+/// revision. Any miss (no descriptor, malformed JSON, different pin)
+/// yields `None`; the snapshot's license file is digested either way.
+fn descriptor_license(name: &str, repository: &str, revision: &str) -> Option<String> {
+    let bytes = std::fs::read(Path::new("models").join(format!("{name}.json"))).ok()?;
+    let descriptor: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    if descriptor.get("repository")?.as_str()? != repository
+        || descriptor.get("revision")?.as_str()? != revision
+    {
+        return None;
+    }
+    descriptor
+        .get("license")?
+        .as_str()
+        .map(|license| license.to_owned())
 }
 
 fn import(args: &ImportArgs) -> Result<(), RunError> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,18 @@ use std::time::{Duration, Instant};
 
 const MANIFEST_SCHEMA: u32 = 1;
 
+/// Schema tag of the versioned source-snapshot manifest (#597).
+pub const SOURCE_MANIFEST_SCHEMA: &str = "uor-r4-source-manifest/1";
+
+/// File name the source-snapshot manifest is written under inside a
+/// snapshot directory. The manifest is excluded from its own file list.
+pub const SOURCE_MANIFEST_FILE_NAME: &str = "source_manifest.json";
+
+/// The only source-execution mode this stack ships today: the downloaded
+/// open-weight snapshot is executed exclusively as an offline compiler
+/// input (the teacher forward pass); the deployed runtime never runs it.
+pub const SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT: &str = "offline-compiler-input";
+
 /// Default CID-manifest name selected when neither CLI nor environment chooses one.
 pub const DEFAULT_CHAT_MODEL: &str = "smollm2-135m-instruct";
 
@@ -106,6 +118,9 @@ pub enum ModelError {
     },
     SourceNotCompiled(PathBuf),
     CompiledNotImported(PathBuf),
+    UnsupportedSourceManifestSchema(String),
+    NonPortableSnapshotPath(PathBuf),
+    ManifestAddressing(String),
 }
 
 impl fmt::Display for ModelError {
@@ -171,6 +186,19 @@ impl fmt::Display for ModelError {
                 formatter,
                 "compiled transformerless bundle found at {} but it has no imported manifest; direct local chat may load it, or use `cargo run -- import --help` to attach a quality attestation and persist a named manifest",
                 path.display()
+            ),
+            Self::UnsupportedSourceManifestSchema(schema) => write!(
+                formatter,
+                "unsupported source-snapshot manifest schema '{schema}'; expected '{SOURCE_MANIFEST_SCHEMA}'"
+            ),
+            Self::NonPortableSnapshotPath(path) => write!(
+                formatter,
+                "snapshot file path is not portable UTF-8: {}",
+                path.display()
+            ),
+            Self::ManifestAddressing(reason) => write!(
+                formatter,
+                "source-snapshot manifest could not be κ-addressed: {reason}"
             ),
         }
     }
@@ -478,6 +506,11 @@ pub struct SourceDownload {
     /// Destination directory. When omitted, uses
     /// `<model-store>/sources/<name>`.
     pub output: Option<PathBuf>,
+    /// SPDX license identifier recorded in the #597 source-snapshot
+    /// manifest, when the caller knows it (e.g. from a pinned
+    /// `models/*.json` descriptor). `None` leaves the manifest's license
+    /// field null; the license *file* is digested either way.
+    pub license: Option<String>,
 }
 
 /// Download a pinned model source into the local compiler-input cache.
@@ -512,6 +545,22 @@ pub fn download_source(source: &SourceDownload) -> Result<PathBuf, ModelError> {
         "download complete: {} files, {}",
         stats.files,
         ByteCount(stats.bytes)
+    );
+    // #597: bind the whole admitted snapshot in one canonical,
+    // schema-versioned manifest with a root κ.
+    let manifest = build_source_manifest(
+        &destination,
+        &SourceSnapshotInfo {
+            repository: source.repository.clone(),
+            revision: source.revision.clone(),
+            license: source.license.clone(),
+            source_execution_mode: SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT.to_owned(),
+        },
+    )?;
+    let manifest_kappa = write_source_manifest(&destination, &manifest)?;
+    eprintln!(
+        "source manifest: {SOURCE_MANIFEST_FILE_NAME} ({} admitted files), root κ {manifest_kappa}",
+        manifest.files.len()
     );
     Ok(destination)
 }
@@ -646,6 +695,224 @@ fn valid_repository(repository: &str) -> bool {
     )
 }
 
+// --------------------------------------------------------------------------
+// #597: versioned source-snapshot manifest.
+//
+// One canonical, schema-versioned manifest binds ALL open-weight model
+// semantics of a downloaded snapshot: repository, immutable revision,
+// license, compiler/adapter version, source-execution mode, and every
+// admitted file's path + byte length + blake3 digest. Its root κ is the
+// canonical-JSON address of the manifest bytes
+// (`uor_addr::json::address_blake3`), so the κ uniquely identifies the
+// exact snapshot. Pre-#597 descriptor κs with
+// `source_kappa_scope = "model.safetensors"` remain weight-only
+// identities and are NOT relabeled.
+
+/// One admitted file of a source snapshot: path relative to the snapshot
+/// root (`/`-separated), byte length, and raw `blake3:<hex>` digest of
+/// the file bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceManifestFile {
+    pub path: String,
+    pub bytes: u64,
+    pub kappa: String,
+}
+
+/// The versioned source-snapshot manifest (#597). Field order is the
+/// canonical serialization order; `files` is sorted by path byte order in
+/// the canonical form. `license` is the SPDX identifier when the caller
+/// knows it (`null` otherwise; the license *file* is always digested in
+/// `files` when present).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceManifest {
+    pub schema: String,
+    pub repository: String,
+    pub revision: String,
+    pub license: Option<String>,
+    pub compiler_version: String,
+    pub source_execution_mode: String,
+    pub files: Vec<SourceManifestFile>,
+}
+
+/// Snapshot-level provenance the directory walk cannot derive by itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSnapshotInfo {
+    pub repository: String,
+    pub revision: String,
+    /// SPDX license identifier, when known to the caller.
+    pub license: Option<String>,
+    /// How the snapshot is executed; today always
+    /// [`SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT`].
+    pub source_execution_mode: String,
+}
+
+/// Whether a file name is admitted into the snapshot manifest. Mirrors
+/// exactly what [`download_source`] admits: `*.safetensors` (including
+/// sharded weights), `*.json` (config, tokenizer, chat template,
+/// generation config, `model.safetensors.index.json`), `*.model` +
+/// `merges.txt` (tokenizer files), `LICENSE*`, and `README*`. The
+/// manifest never lists itself.
+fn admitted_source_file(name: &str) -> bool {
+    if name == SOURCE_MANIFEST_FILE_NAME {
+        return false;
+    }
+    let extension = Path::new(name).extension().and_then(|ext| ext.to_str());
+    matches!(extension, Some("safetensors" | "json" | "model"))
+        || name == "merges.txt"
+        || name.starts_with("LICENSE")
+        || name.starts_with("README")
+}
+
+/// Build the source-snapshot manifest of a local snapshot directory by
+/// walking its admitted files (hidden entries such as the `hf` CLI's
+/// `.cache` metadata are skipped). Files are digested with raw blake3
+/// and listed sorted by path byte order.
+pub fn build_source_manifest(
+    snapshot_dir: &Path,
+    info: &SourceSnapshotInfo,
+) -> Result<SourceManifest, ModelError> {
+    let mut files = Vec::new();
+    collect_admitted_files(snapshot_dir, snapshot_dir, &mut files)?;
+    files.sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
+    Ok(SourceManifest {
+        schema: SOURCE_MANIFEST_SCHEMA.to_owned(),
+        repository: info.repository.clone(),
+        revision: info.revision.clone(),
+        license: info.license.clone(),
+        compiler_version: env!("CARGO_PKG_VERSION").to_owned(),
+        source_execution_mode: info.source_execution_mode.clone(),
+        files,
+    })
+}
+
+fn collect_admitted_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut Vec<SourceManifestFile>,
+) -> Result<(), ModelError> {
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            return Err(ModelError::NonPortableSnapshotPath(path));
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_admitted_files(root, &path, files)?;
+        } else if file_type.is_file() && admitted_source_file(name) {
+            let relative = relative_manifest_path(root, &path)?;
+            let (bytes, kappa) = file_length_and_kappa(&path)?;
+            files.push(SourceManifestFile {
+                path: relative,
+                bytes,
+                kappa,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn relative_manifest_path(root: &Path, path: &Path) -> Result<String, ModelError> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| ModelError::NonPortableSnapshotPath(path.to_path_buf()))?;
+    let mut portable = String::new();
+    for component in relative.components() {
+        let Some(part) = component.as_os_str().to_str() else {
+            return Err(ModelError::NonPortableSnapshotPath(path.to_path_buf()));
+        };
+        if !portable.is_empty() {
+            portable.push('/');
+        }
+        portable.push_str(part);
+    }
+    Ok(portable)
+}
+
+/// Streamed raw blake3 of one file's bytes plus its length, as
+/// `blake3:<hex>` (per-file digests stay raw, unlike the manifest root κ).
+fn file_length_and_kappa(path: &Path) -> Result<(u64, String), ModelError> {
+    use std::io::Read as _;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 65_536];
+    let mut length = 0u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        length += read as u64;
+        hasher.update(&buffer[..read]);
+    }
+    Ok((length, format!("blake3:{}", hasher.finalize().to_hex())))
+}
+
+/// Canonical manifest bytes: stable field order (struct declaration
+/// order, which `serde_json::to_vec` preserves), `files` sorted by path
+/// byte order, no floats. Two manifests describing the same snapshot
+/// serialize to identical bytes regardless of file insertion order.
+pub fn canonical_source_manifest_bytes(manifest: &SourceManifest) -> Result<Vec<u8>, ModelError> {
+    if manifest.schema != SOURCE_MANIFEST_SCHEMA {
+        return Err(ModelError::UnsupportedSourceManifestSchema(
+            manifest.schema.clone(),
+        ));
+    }
+    let mut canonical = manifest.clone();
+    canonical
+        .files
+        .sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
+    Ok(serde_json::to_vec(&canonical)?)
+}
+
+/// Root κ of a source-snapshot manifest: the canonical-JSON blake3
+/// address (`uor_addr::json::address_blake3`) of the canonical manifest
+/// bytes. This κ uniquely identifies the exact snapshot — any admitted
+/// byte change, file addition/removal, or provenance change relabels it.
+pub fn source_manifest_kappa(manifest: &SourceManifest) -> Result<String, ModelError> {
+    let bytes = canonical_source_manifest_bytes(manifest)?;
+    match uor_addr::json::address_blake3(&bytes) {
+        Ok(outcome) => Ok(outcome.address.to_string()),
+        // Unreachable for serde-produced JSON; kept to honor the
+        // no-panic-on-recoverable-paths convention.
+        Err(failure) => Err(ModelError::ManifestAddressing(format!("{failure:?}"))),
+    }
+}
+
+/// Parse and schema-gate source-snapshot manifest bytes. Any `schema`
+/// value other than [`SOURCE_MANIFEST_SCHEMA`] is rejected.
+pub fn parse_source_manifest(bytes: &[u8]) -> Result<SourceManifest, ModelError> {
+    let manifest: SourceManifest = serde_json::from_slice(bytes)?;
+    if manifest.schema != SOURCE_MANIFEST_SCHEMA {
+        return Err(ModelError::UnsupportedSourceManifestSchema(manifest.schema));
+    }
+    Ok(manifest)
+}
+
+/// Read the source-snapshot manifest of a snapshot directory.
+pub fn read_source_manifest(snapshot_dir: &Path) -> Result<SourceManifest, ModelError> {
+    parse_source_manifest(&std::fs::read(
+        snapshot_dir.join(SOURCE_MANIFEST_FILE_NAME),
+    )?)
+}
+
+/// Write the canonical manifest as `source_manifest.json` inside the
+/// snapshot directory (the manifest excludes itself from its file list)
+/// and return the manifest root κ.
+pub fn write_source_manifest(
+    snapshot_dir: &Path,
+    manifest: &SourceManifest,
+) -> Result<String, ModelError> {
+    let bytes = canonical_source_manifest_bytes(manifest)?;
+    let kappa = source_manifest_kappa(manifest)?;
+    std::fs::write(snapshot_dir.join(SOURCE_MANIFEST_FILE_NAME), bytes)?;
+    Ok(kappa)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -710,6 +977,7 @@ mod tests {
             revision: "a".repeat(40),
             name: "model".to_owned(),
             output: None,
+            license: None,
         };
         let command = build_download_command(&source, Path::new("models/model"));
         let arguments: Vec<_> = command
@@ -769,6 +1037,164 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, ModelError::CompiledNotImported(path) if path == compiled));
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    fn snapshot_info() -> SourceSnapshotInfo {
+        SourceSnapshotInfo {
+            repository: "org/model".to_owned(),
+            revision: "a".repeat(40),
+            license: Some("Apache-2.0".to_owned()),
+            source_execution_mode: SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT.to_owned(),
+        }
+    }
+
+    /// A manifest value constructed directly (no directory walk).
+    fn in_memory_manifest(files: Vec<SourceManifestFile>) -> SourceManifest {
+        let info = snapshot_info();
+        SourceManifest {
+            schema: SOURCE_MANIFEST_SCHEMA.to_owned(),
+            repository: info.repository,
+            revision: info.revision,
+            license: info.license,
+            compiler_version: env!("CARGO_PKG_VERSION").to_owned(),
+            source_execution_mode: info.source_execution_mode,
+            files,
+        }
+    }
+
+    /// A unique temp snapshot directory populated with one file per
+    /// admitted downloader pattern plus two files that must be excluded.
+    fn snapshot_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "uor-r4-source-manifest-{tag}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        for (name, contents) in [
+            ("model.safetensors", "weights"),
+            ("model.safetensors.index.json", "{\"weight_map\":{}}"),
+            ("config.json", "{\"hidden_size\":576}"),
+            ("tokenizer.json", "{\"model\":{}}"),
+            ("tokenizer.model", "sentencepiece"),
+            ("merges.txt", "a b"),
+            ("LICENSE", "Apache License 2.0"),
+            ("README.md", "# model"),
+            ("nested/extra.json", "{}"),
+            ("notes.txt", "not admitted"),
+            (".gitattributes", "hidden, not admitted"),
+        ] {
+            std::fs::write(dir.join(name), contents).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn canonical_manifest_bytes_are_insertion_order_independent() {
+        let file = |path: &str| SourceManifestFile {
+            path: path.to_owned(),
+            bytes: 1,
+            kappa: format!("blake3:{}", "2".repeat(64)),
+        };
+        let forward =
+            in_memory_manifest(vec![file("a.json"), file("b.safetensors"), file("z.model")]);
+        let mut reversed = forward.clone();
+        reversed.files.reverse();
+        assert_eq!(
+            canonical_source_manifest_bytes(&forward).unwrap(),
+            canonical_source_manifest_bytes(&reversed).unwrap()
+        );
+        assert_eq!(
+            source_manifest_kappa(&forward).unwrap(),
+            source_manifest_kappa(&reversed).unwrap()
+        );
+    }
+
+    #[test]
+    fn manifest_covers_every_admitted_file_exactly_once_and_excludes_itself() {
+        let dir = snapshot_dir("coverage");
+        let manifest = build_source_manifest(&dir, &snapshot_info()).unwrap();
+        write_source_manifest(&dir, &manifest).unwrap();
+        // Rebuild AFTER the manifest file exists on disk: it must not
+        // admit itself.
+        let rebuilt = build_source_manifest(&dir, &snapshot_info()).unwrap();
+        let paths: Vec<&str> = rebuilt.files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            [
+                "LICENSE",
+                "README.md",
+                "config.json",
+                "merges.txt",
+                "model.safetensors",
+                "model.safetensors.index.json",
+                "nested/extra.json",
+                "tokenizer.json",
+                "tokenizer.model",
+            ],
+            "sorted by path byte order, each admitted file exactly once"
+        );
+        assert!(!paths.contains(&SOURCE_MANIFEST_FILE_NAME));
+        assert!(!paths.contains(&"notes.txt"));
+        assert!(!paths.contains(&".gitattributes"));
+        for file in &rebuilt.files {
+            assert_eq!(
+                file.bytes,
+                std::fs::metadata(dir.join(&file.path)).unwrap().len()
+            );
+            assert!(file.kappa.starts_with("blake3:") && file.kappa.len() == 71);
+        }
+        assert_eq!(rebuilt, read_source_manifest(&dir).unwrap());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn double_build_is_deterministic_in_bytes_and_kappa() {
+        let dir = snapshot_dir("determinism");
+        let first = build_source_manifest(&dir, &snapshot_info()).unwrap();
+        let second = build_source_manifest(&dir, &snapshot_info()).unwrap();
+        assert_eq!(
+            canonical_source_manifest_bytes(&first).unwrap(),
+            canonical_source_manifest_bytes(&second).unwrap()
+        );
+        assert_eq!(
+            source_manifest_kappa(&first).unwrap(),
+            source_manifest_kappa(&second).unwrap()
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn tampering_with_one_admitted_byte_changes_the_root_kappa() {
+        let dir = snapshot_dir("tamper");
+        let before =
+            source_manifest_kappa(&build_source_manifest(&dir, &snapshot_info()).unwrap()).unwrap();
+        let target = dir.join("model.safetensors");
+        let mut bytes = std::fs::read(&target).unwrap();
+        bytes[0] ^= 0x01;
+        std::fs::write(&target, bytes).unwrap();
+        let after =
+            source_manifest_kappa(&build_source_manifest(&dir, &snapshot_info()).unwrap()).unwrap();
+        assert_ne!(before, after);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn wrong_manifest_schema_is_rejected() {
+        let mut manifest = in_memory_manifest(Vec::new());
+        let bytes = canonical_source_manifest_bytes(&manifest).unwrap();
+        assert!(parse_source_manifest(&bytes).is_ok());
+        manifest.schema = "uor-r4-source-manifest/999".to_owned();
+        let tampered = serde_json::to_vec(&manifest).unwrap();
+        assert!(matches!(
+            parse_source_manifest(&tampered),
+            Err(ModelError::UnsupportedSourceManifestSchema(schema))
+                if schema == "uor-r4-source-manifest/999"
+        ));
+        assert!(matches!(
+            canonical_source_manifest_bytes(&manifest),
+            Err(ModelError::UnsupportedSourceManifestSchema(_))
+        ));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -189,6 +189,11 @@ struct PinnedSourceManifest {
     repository: String,
     revision: String,
     source_directory: Option<String>,
+    /// SPDX license identifier of the pinned source (#597), forwarded
+    /// into the source-snapshot manifest. Optional so older descriptors
+    /// without the field stay readable.
+    #[serde(default)]
+    license: Option<String>,
 }
 
 impl R4g1CompileStatus {
@@ -1797,7 +1802,7 @@ fn compile_r4g1_bundle(
         }
     }
 
-    let cover_args = vec![
+    let mut cover_args = vec![
         "--corpus-meta".to_owned(),
         corpus_meta.display().to_string(),
         "--corpus-recs".to_owned(),
@@ -1821,6 +1826,13 @@ fn compile_r4g1_bundle(
         "--out".to_owned(),
         cover_output.display().to_string(),
     ];
+    // #597: when compiling from a downloaded snapshot that carries a
+    // source-snapshot manifest, bind its root κ into the cover report.
+    // Opportunistic by design: a legacy snapshot without a manifest (or an
+    // unreadable one) compiles exactly as before, with no κ recorded.
+    if let Some(kappa) = downloaded_source.and_then(source_manifest_kappa_of) {
+        cover_args.extend(["--source-manifest-kappa".to_owned(), kappa]);
+    }
     uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");
@@ -1946,6 +1958,7 @@ fn pinned_huggingface_source() -> Result<SourceDownload, String> {
         revision: manifest.revision,
         name,
         output: manifest.source_directory.map(PathBuf::from),
+        license: manifest.license,
     })
 }
 
@@ -1970,6 +1983,9 @@ fn source_from_model_spec(model: &str) -> Result<SourceDownload, String> {
         revision: revision.to_owned(),
         name: format!("{}-{}", name, &revision[..12]),
         output: None,
+        // A custom owner/repository@revision spec carries no license
+        // metadata; the snapshot's license file is still digested.
+        license: None,
     })
 }
 
@@ -1978,6 +1994,15 @@ fn huggingface_source(model: Option<&str>) -> Result<SourceDownload, String> {
         Some(model) => source_from_model_spec(model),
         None => pinned_huggingface_source(),
     }
+}
+
+/// Root κ of the #597 source-snapshot manifest inside a downloaded
+/// snapshot directory, when one is present and verifiable. Total: any
+/// miss (legacy snapshot, malformed manifest, addressing failure)
+/// resolves to `None` so pre-#597 snapshots keep compiling unchanged.
+fn source_manifest_kappa_of(source: &Path) -> Option<String> {
+    let manifest = crate::model::read_source_manifest(source).ok()?;
+    crate::model::source_manifest_kappa(&manifest).ok()
 }
 
 fn downloaded_source_path(source: &SourceDownload) -> PathBuf {


### PR DESCRIPTION
feat(#597): versioned source snapshot manifest with root kappa

One canonical, schema-versioned manifest (uor-r4-source-manifest/1)
binding repository, immutable revision, license, compiler version,
source-execution mode, and every admitted file (path, bytes, blake3)
for a pinned snapshot. Root kappa = uor_addr::json::address_blake3 over
the canonical bytes (per the #620 decision). download_source emits
source_manifest.json; the kappa threads request->flags->report through
uor-r4-api, graph-compiler compile/observe, graph-cli cover, and the
server auto-binds it when the snapshot carries a manifest. CoverReport
and ObservationManifest gain serde(default) optional fields - legacy
artifacts and fixtures stay byte-identical and readable. License now
populated from the pinned models/*.json descriptor at both call sites.
Tests: canonical ordering, digest coverage, tamper, schema rejection,
deterministic double-build, and every plumbing seam. Migration note in
docs/MODEL_LIFECYCLE.md: pre-#597 weight-only kappas are not relabeled.
