### PR TITLE
feat(#600): explicit source/compiled geometry + versioned projection

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -618,6 +618,12 @@ struct CoverOptions {
     /// (`--source-manifest-kappa`), carried verbatim into the cover
     /// report. This crate never computes the κ (no uor-addr dependency).
     source_manifest_kappa: Option<String>,
+    /// #600 typed geometry-projection record of the teacher source
+    /// (`--geometry-projection`, a JSON serialization of
+    /// [`uor_r4_model_source::geometry::GeometryProjection`]), carried
+    /// into the cover report. This crate never derives the record itself;
+    /// the pipeline that held the oracle passes it.
+    geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
 }
 
 fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailable> {
@@ -635,6 +641,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         radius_quantile: cover::RADIUS_QUANTILE_NUMERATOR,
         output: PathBuf::from("cover"),
         source_manifest_kappa: None,
+        geometry: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -713,6 +720,11 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
             "--out" => options.output = PathBuf::from(value),
             "--source-manifest-kappa" => {
                 options.source_manifest_kappa = Some(value.clone());
+            }
+            "--geometry-projection" => {
+                options.geometry = Some(serde_json::from_str(value).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid --geometry-projection value: {error}"))
+                })?);
             }
             _ => {
                 return Err(SourceUnavailable::new(format!(
@@ -893,6 +905,9 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     // #597: bind the source-snapshot identity into the cover report when
     // the caller passed it (`--source-manifest-kappa`).
     report.source_manifest_kappa = options.source_manifest_kappa.clone();
+    // #600: bind the teacher's geometry-projection record when the caller
+    // passed it (`--geometry-projection`).
+    report.geometry = options.geometry.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("cover.r4g1");
@@ -3120,6 +3135,25 @@ mod tests {
         );
         let defaults = parse_cover_options(&[]).expect("default cover options");
         assert_eq!(defaults.source_manifest_kappa, None);
+    }
+
+    /// #600 plumbing seam: the cover stage accepts the typed
+    /// geometry-projection record as JSON (populated into the cover
+    /// report), leaves it unset when the flag is absent, and refuses
+    /// malformed JSON by name on the sanctioned error surface.
+    #[test]
+    fn cover_options_carry_the_geometry_projection() {
+        let record = uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+        let json = serde_json::to_string(&record).expect("record serializes");
+        let args = ["--geometry-projection".to_owned(), json];
+        let options = parse_cover_options(&args).expect("valid cover options");
+        assert_eq!(options.geometry.as_ref(), Some(&record));
+        let defaults = parse_cover_options(&[]).expect("default cover options");
+        assert_eq!(defaults.geometry, None);
+        let error =
+            parse_cover_options(&["--geometry-projection".to_owned(), "{not json".to_owned()])
+                .expect_err("malformed record is not a product");
+        assert!(error.reason.contains("--geometry-projection"));
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2523,6 +2523,14 @@ pub struct CoverReport {
     /// after [`build_report`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_manifest_kappa: Option<String>,
+    /// #600 typed record of the source→compiled geometry projection the
+    /// teacher applied while producing the compiled inputs (e.g.
+    /// `bucket-average/1`, 576→288 for the pinned SmolLM2-135M), when the
+    /// invoking pipeline knows it (`--geometry-projection`). Optional so
+    /// every legacy report and its bytes stay unchanged when unset;
+    /// callers set the public field after [`build_report`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
     pub config: CoverReportConfig,
     pub inputs: CoverReportInputs,
     pub objective: CoverReportObjective,
@@ -2740,6 +2748,9 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
         // #597: populated by callers that hold the source-snapshot
         // manifest root κ; the induction stages do not see the snapshot.
         source_manifest_kappa: None,
+        // #600: populated by callers that hold the teacher's geometry
+        // projection record; the induction stages do not see the teacher.
+        geometry: None,
         config: CoverReportConfig {
             depths: config.depths,
             k0: config.k0,

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -50,6 +50,12 @@ pub struct GraphCompileOptions {
     /// report. This crate never computes the κ itself (no uor-addr
     /// dependency); callers that hold the snapshot pass the string.
     pub source_manifest_kappa: Option<String>,
+    /// #600 typed geometry-projection record of the teacher source
+    /// (`--geometry-projection`, a JSON serialization of
+    /// [`uor_r4_model_source::geometry::GeometryProjection`]), carried
+    /// into the compile report. This crate never derives the record
+    /// itself; the pipeline that held the oracle passes it.
+    pub geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
 }
 
 /// Parse graph-compile CLI arguments. `None` when the arguments do not name a
@@ -70,6 +76,7 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
         jobs: None,
         output: PathBuf::from("r4g1_output"),
         source_manifest_kappa: None,
+        geometry: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -110,6 +117,9 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
             "--out" => options.output = PathBuf::from(value),
             "--source-manifest-kappa" => {
                 options.source_manifest_kappa = Some(value.clone());
+            }
+            "--geometry-projection" => {
+                options.geometry = Some(serde_json::from_str(value).ok()?);
             }
             _ => return None,
         }
@@ -235,6 +245,9 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     // #597: bind the source-snapshot identity into the compile report when
     // the caller passed it (`--source-manifest-kappa`).
     report.source_manifest_kappa = options.source_manifest_kappa.clone();
+    // #600: bind the teacher's geometry-projection record when the caller
+    // passed it (`--geometry-projection`).
+    report.geometry = options.geometry.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("compiled.r4g1");
@@ -338,13 +351,21 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
             Box::new(o)
         };
 
-    // #597: record the source-snapshot identity in the observation
-    // manifest before the sharded run opens it (idempotent, atomic; the
-    // run's own writer loads and preserves the stored field).
-    if let Some(kappa) = &options.source_manifest_kappa {
+    // #597: record the source-snapshot identity — and, since #600, the
+    // typed geometry-projection record the oracle itself declares — in
+    // the observation manifest before the sharded run opens it
+    // (idempotent, atomic; the run's own writer loads and preserves the
+    // stored fields).
+    let geometry = oracle.geometry_projection();
+    if options.source_manifest_kappa.is_some() || geometry.is_some() {
         let mut writer =
             observation::ObservationShardWriter::open(&options.output, options.shards)?;
-        writer.set_source_manifest_kappa(kappa)?;
+        if let Some(kappa) = &options.source_manifest_kappa {
+            writer.set_source_manifest_kappa(kappa)?;
+        }
+        if let Some(geometry) = &geometry {
+            writer.set_geometry(geometry)?;
+        }
     }
 
     observation::observe_sharded(

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -37,6 +37,7 @@ use uor_r4_core::transformerless::compiler;
 use uor_r4_model_source::SourceUnavailable;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::TeacherOracle;
+use uor_r4_model_source::geometry::GeometryProjection;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::progress::Progress;
 
@@ -256,6 +257,14 @@ pub struct ObservationManifest {
     /// readable and legacy manifest bytes are unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_manifest_kappa: Option<String>,
+    /// #600 typed record of the source→compiled geometry projection the
+    /// teacher oracle applied while producing these observations (e.g.
+    /// `bucket-average/1`, 576→288 for the pinned SmolLM2-135M), when the
+    /// producing pipeline's oracle declares one. Optional with a serde
+    /// default so every legacy manifest stays readable and legacy
+    /// manifest bytes are unchanged when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geometry: Option<GeometryProjection>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -270,6 +279,7 @@ impl ObservationManifest {
             partition_rule: None,
             input_cid: None,
             source_manifest_kappa: None,
+            geometry: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -398,6 +408,16 @@ impl ObservationShardWriter {
     pub fn set_source_manifest_kappa(&mut self, kappa: &str) -> Result<(), SourceUnavailable> {
         if self.manifest.source_manifest_kappa.as_deref() != Some(kappa) {
             self.manifest.source_manifest_kappa = Some(kappa.to_owned());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Record the #600 typed geometry-projection record of the teacher
+    /// oracle in the observation manifest (idempotent, atomic store).
+    pub fn set_geometry(&mut self, geometry: &GeometryProjection) -> Result<(), SourceUnavailable> {
+        if self.manifest.geometry.as_ref() != Some(geometry) {
+            self.manifest.geometry = Some(geometry.clone());
             self.manifest.store(&self.dir)?;
         }
         Ok(())

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -767,7 +767,9 @@ fn commit_article(
 enum Prepared {
     Done(ObservationReport),
     Ready {
-        writer: ObservationShardWriter,
+        /// Boxed: the manifest-carrying writer dominates the variant size
+        /// (clippy::large_enum_variant since the #600 geometry record).
+        writer: Box<ObservationShardWriter>,
         checkpoint: Checkpoint,
         articles_total: u64,
         stories_path: PathBuf,
@@ -885,7 +887,7 @@ fn prepare_text_observation(
     }
 
     Ok(Prepared::Ready {
-        writer,
+        writer: Box::new(writer),
         checkpoint,
         articles_total,
         stories_path,
@@ -928,6 +930,14 @@ pub fn observe_text_corpus(
                 stories_path,
             } => (writer, checkpoint, articles_total, stories_path),
         };
+
+    // #600: record the typed geometry-projection record the teacher
+    // oracle declares (the source→compiled reduction its embedding
+    // surface applies), when it declares one. Idempotent and atomic;
+    // legacy manifests without the field remain byte-identical.
+    if let Some(geometry) = oracles[0].geometry_projection() {
+        writer.set_geometry(&geometry)?;
+    }
 
     let workers = oracles.len();
     let seq_len = oracles[0].seq_len();

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -1055,6 +1055,47 @@ fn report_serializes_source_manifest_kappa_only_when_bound() {
     assert!(bound_json.contains(&format!("\"source_manifest_kappa\":\"{kappa}\"")));
 }
 
+/// #600 plumbing seam: `build_report` leaves the geometry-projection
+/// record unset (legacy report bytes carry no such key), and a caller
+/// that binds it — as `compile` does from `--geometry-projection` — gets
+/// the full typed record, digest included, serialized into the report.
+#[test]
+fn report_serializes_geometry_projection_only_when_bound() {
+    let (observations, _) = synthetic_observations();
+    let config = synthetic_config();
+    let induced = induce_synthetic(&observations, &config);
+    let reference = cover::ReferenceClassifier::freeze(&induced.cover);
+    let story = vec![0u32; observations.len()];
+    let edges = cover::build_edges(&induced.cover, &reference, &observations, &story);
+    let mut report = cover::build_report(
+        &config,
+        &induced,
+        cover::ReportData {
+            reference: &reference,
+            train: &observations,
+            held_out: &observations,
+            edges: &edges,
+            recall: Vec::new(),
+            artifact: None,
+        },
+    );
+    assert_eq!(report.geometry, None);
+    let legacy_json = serde_json::to_string(&report).expect("report serializes");
+    assert!(
+        !legacy_json.contains("\"geometry\""),
+        "an unbound record must leave legacy report bytes unchanged"
+    );
+    let record = uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+    report.geometry = Some(record.clone());
+    let bound_json = serde_json::to_string(&report).expect("report serializes");
+    assert!(bound_json.contains("\"id\":\"bucket-average\""));
+    assert!(bound_json.contains("\"source_width\":576"));
+    assert!(bound_json.contains(&format!(
+        "\"implementation_digest\":\"{}\"",
+        record.implementation_digest
+    )));
+}
+
 #[test]
 fn kmeans_recovers_tight_clusters_at_any_batch_size() {
     let (observations, _) = synthetic_observations();

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -10,6 +10,7 @@ use uor_r4_graph_compiler::observation::{
     merge_probability_metadata, merge_shards, message_bits_per_token, sample_id, shard_file_name,
     shard_of,
 };
+use uor_r4_model_source::geometry::GeometryProjection;
 use uor_r4_model_source::{BehaviorSource, LlamaOracle, RepresentationSource, TeacherOracle};
 
 const LEGACY_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
@@ -461,6 +462,113 @@ fn source_manifest_kappa_parses_and_persists_in_the_manifest() {
         Some(kappa.as_str())
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// #600 plumbing seam: `--geometry-projection` parses a typed
+/// [`GeometryProjection`] into the compile options, the writer setter
+/// persists it into the observation manifest atomically and idempotently
+/// across reopen, and an unset record leaves legacy manifest bytes
+/// unchanged (no `geometry` key at all).
+#[test]
+fn geometry_projection_parses_and_persists_in_the_manifest() {
+    let record = GeometryProjection::bucket_average(576, 288);
+    let json = serde_json::to_string(&record).expect("record serializes");
+
+    // The compile parser accepts the typed record as JSON.
+    let compile_args: Vec<String> = ["--geometry-projection", json.as_str()]
+        .map(str::to_owned)
+        .to_vec();
+    let compile_options =
+        uor_r4_graph_compiler::parse_options(&compile_args).expect("valid options");
+    assert_eq!(compile_options.geometry.as_ref(), Some(&record));
+    // Malformed JSON is not a product of the arguments.
+    let bad_args: Vec<String> = ["--geometry-projection", "{not json"]
+        .map(str::to_owned)
+        .to_vec();
+    assert!(uor_r4_graph_compiler::parse_options(&bad_args).is_none());
+
+    let dir = unique_path("observe-geometry");
+    let mut writer = ObservationShardWriter::open(&dir, 2).expect("writer");
+    assert_eq!(writer.manifest().geometry, None);
+    // Legacy bytes: an unset record serializes no `geometry` key.
+    let legacy_json = serde_json::to_string(writer.manifest()).expect("manifest serializes");
+    assert!(
+        !legacy_json.contains("geometry"),
+        "an unset record must leave legacy manifest bytes unchanged"
+    );
+    // And a legacy manifest without the key still deserializes (None).
+    let legacy: ObservationManifest =
+        serde_json::from_str(&legacy_json).expect("legacy manifest deserializes");
+    assert_eq!(legacy.geometry, None);
+
+    writer.set_geometry(&record).expect("set and store");
+    // Idempotent: re-setting the recorded value does not rewrite.
+    writer.set_geometry(&record).expect("idempotent set");
+    drop(writer);
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.geometry.as_ref(), Some(&record));
+    // Round trip: the persisted record parses back bit-for-bit, digest
+    // included.
+    assert_eq!(
+        manifest.geometry.as_ref().map(|g| &g.implementation_digest),
+        Some(&record.implementation_digest)
+    );
+    // A reopened writer (as `observe_sharded` does after the pre-set)
+    // preserves the stored record.
+    let reopened = ObservationShardWriter::open(&dir, 2).expect("reopen");
+    assert_eq!(reopened.manifest().geometry.as_ref(), Some(&record));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// #600: the legacy checkpoint oracle declares no projection (its dim IS
+/// the source width), while the Hugging Face adapter declares
+/// `bucket-average/1` — asserted here structurally via the trait default.
+#[test]
+fn trait_geometry_projection_defaults_to_none() {
+    struct Plain;
+    impl RepresentationSource for Plain {
+        fn vocab_size(&self) -> usize {
+            4
+        }
+        fn source_dimension(&self) -> usize {
+            8
+        }
+        fn tokenizer_address(&self) -> &str {
+            "plain"
+        }
+        fn read_embedding_rows(
+            &self,
+            _range: std::ops::Range<usize>,
+            _output: &mut [f32],
+        ) -> Option<()> {
+            Some(())
+        }
+    }
+    impl BehaviorSource for Plain {
+        fn reset(&mut self) {}
+        fn step(&mut self, _token: usize, _pos: usize, _logits: &mut [f32]) {}
+    }
+    impl TeacherOracle for Plain {
+        fn vocab(&self) -> usize {
+            4
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+        fn seq_len(&self) -> usize {
+            8
+        }
+        fn kappa(&self) -> String {
+            "blake3:plain".to_owned()
+        }
+        fn source_bytes(&self) -> usize {
+            0
+        }
+        fn embedding(&self, _token: usize, _out: &mut [f32]) {}
+    }
+    assert_eq!(Plain.geometry_projection(), None);
 }
 
 #[test]

--- a/crates/uor-r4-model-source/src/geometry.rs
+++ b/crates/uor-r4-model-source/src/geometry.rs
@@ -1,0 +1,402 @@
+//! Source→compiled geometry projections (#600): the typed, versioned
+//! record of how a teacher's source embedding width is reduced to the
+//! compiled geometry, plus the named implementations themselves.
+//!
+//! Before #600 the reduction was hidden inside
+//! `HuggingFaceLlamaOracle::embedding` — the pinned 576-wide SmolLM2 rows
+//! were bucket-averaged down to the legacy compiled width D=288 with no
+//! record of the algorithm, its parameters, or its version anywhere in the
+//! produced provenance. A change to that code could silently alter
+//! observations and downstream artifact κs. This module makes the
+//! projection explicit:
+//!
+//! - [`GeometryProjection`] is the serializable record `{id, version,
+//!   source_width, compiled_width, params, implementation_digest}` carried
+//!   by the compile report and the observation manifest.
+//! - [`bucket_average_project`] is the free, deterministic implementation
+//!   of `bucket-average/1` — the exact arithmetic (iteration order,
+//!   sequential f32 sum, one divide per bucket) the oracle has always
+//!   used, factored out unchanged.
+//! - [`projection_implementation`] is the versioned registry mapping
+//!   `(id, version)` to an implementation; an unknown pair is refused by
+//!   name on the sanctioned [`SourceUnavailable`](crate::SourceUnavailable)
+//!   surface rather than guessed.
+//!
+//! **Implementation digest.** `implementation_digest` is the blake3 of the
+//! [canonical serialization](GeometryProjection::canonical_bytes) of the
+//! algorithm's *declared parameters* plus a stable algorithm tag — NOT a
+//! hash of the source code text. Source text is a fragile identity: a
+//! rename, comment, or formatting pass would change it while the computed
+//! function stays bit-identical. The declared parameters + versioned tag
+//! are the algorithm's contract; the unit tests in this module pin the
+//! implementation to that declaration, so a behavioral change must bump
+//! the version (a new registry entry) instead of silently drifting.
+
+use serde::{Deserialize, Serialize};
+
+/// The legacy compiled geometry width (the transformerless compiler's
+/// `D = 288`). The Hugging Face teacher adapter reports this as its
+/// [`TeacherOracle::dim`](crate::TeacherOracle::dim) and projects source
+/// embedding rows down to it.
+pub const COMPILED_WIDTH: u32 = 288;
+
+/// Declared parameters of a projection algorithm — the bucket layout,
+/// including the remainder policy for non-divisible widths, and the
+/// reduction order. These strings are stable machine tokens (they enter
+/// the canonical digest serialization byte-for-byte), documented on
+/// [`GeometryProjectionParams::bucket_average`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeometryProjectionParams {
+    /// How source columns are grouped into buckets.
+    #[serde(default)]
+    pub bucket_layout: String,
+    /// What happens when `compiled_width` does not divide `source_width`.
+    #[serde(default)]
+    pub remainder_policy: String,
+    /// The reduction applied to each bucket, including its order.
+    #[serde(default)]
+    pub accumulation: String,
+}
+
+impl GeometryProjectionParams {
+    /// The declared parameters of `bucket-average/1`:
+    ///
+    /// - `bucket_layout = "contiguous-floor-boundaries"` — output index
+    ///   `i` averages the contiguous source slice
+    ///   `[floor(i·S/C), floor((i+1)·S/C))` for source width `S` and
+    ///   compiled width `C`.
+    /// - `remainder_policy = "floor-spread"` — when `C` does not divide
+    ///   `S`, the floor boundaries spread the remainder `S mod C` across
+    ///   the buckets whose scaled boundary crosses an extra integer, so
+    ///   bucket sizes differ by at most one and every source column
+    ///   belongs to exactly one bucket. `S < C` (which would make some
+    ///   buckets empty) is refused by [`bucket_average_project`].
+    /// - `accumulation = "sequential-f32-sum-then-mean"` — each bucket is
+    ///   summed left-to-right in f32 and divided once by the bucket
+    ///   length (the exact legacy arithmetic order).
+    pub fn bucket_average() -> Self {
+        Self {
+            bucket_layout: "contiguous-floor-boundaries".to_owned(),
+            remainder_policy: "floor-spread".to_owned(),
+            accumulation: "sequential-f32-sum-then-mean".to_owned(),
+        }
+    }
+}
+
+/// The typed, versioned record of one source→compiled geometry projection
+/// (#600). Serialized (all fields serde-defaulted) into the cover/compile
+/// report and the observation manifest wherever the projection is known,
+/// so a geometry change is visible in provenance instead of silent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeometryProjection {
+    /// Registry id of the projection algorithm (e.g. `"bucket-average"`).
+    #[serde(default)]
+    pub id: String,
+    /// Registry version of the algorithm. A behavioral change is a new
+    /// version, never an in-place edit.
+    #[serde(default)]
+    pub version: u32,
+    /// Source embedding width the projection reads (e.g. 576 for the
+    /// pinned SmolLM2-135M).
+    #[serde(default)]
+    pub source_width: u32,
+    /// Compiled width the projection writes (the legacy geometry
+    /// [`COMPILED_WIDTH`] = 288).
+    #[serde(default)]
+    pub compiled_width: u32,
+    /// The algorithm's declared parameters (bucket layout, remainder
+    /// policy, accumulation order).
+    #[serde(default)]
+    pub params: GeometryProjectionParams,
+    /// `blake3:<hex>` of [`GeometryProjection::canonical_bytes`] — the
+    /// declared parameters + stable algorithm tag, not source code text
+    /// (see the module docs for why).
+    #[serde(default)]
+    pub implementation_digest: String,
+}
+
+impl GeometryProjection {
+    /// Registry id of the bucket-average projection.
+    pub const BUCKET_AVERAGE_ID: &'static str = "bucket-average";
+    /// Registry version of the bucket-average projection currently
+    /// implemented by [`bucket_average_project`].
+    pub const BUCKET_AVERAGE_VERSION: u32 = 1;
+
+    /// The `bucket-average/1` record for a concrete width pair — the
+    /// projection [`bucket_average_project`] implements and the Hugging
+    /// Face teacher adapter has always applied (576→288 for the pinned
+    /// SmolLM2-135M).
+    pub fn bucket_average(source_width: u32, compiled_width: u32) -> Self {
+        let mut record = Self {
+            id: Self::BUCKET_AVERAGE_ID.to_owned(),
+            version: Self::BUCKET_AVERAGE_VERSION,
+            source_width,
+            compiled_width,
+            params: GeometryProjectionParams::bucket_average(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Canonical serialization of the record's declared identity: a fixed
+    /// line format (format tag, id, version, widths, parameters, each
+    /// `key=value\n`). Byte-stable by construction — field order and
+    /// separators are fixed here, not derived from any serializer — so
+    /// the digest over these bytes is reproducible everywhere.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "uor-r4-geometry-projection/1\n\
+             id={}\n\
+             version={}\n\
+             source_width={}\n\
+             compiled_width={}\n\
+             param.bucket_layout={}\n\
+             param.remainder_policy={}\n\
+             param.accumulation={}\n",
+            self.id,
+            self.version,
+            self.source_width,
+            self.compiled_width,
+            self.params.bucket_layout,
+            self.params.remainder_policy,
+            self.params.accumulation,
+        )
+        .into_bytes()
+    }
+
+    /// The implementation digest this record's declared parameters imply:
+    /// `blake3:<hex>` over [`GeometryProjection::canonical_bytes`].
+    pub fn declared_digest(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.canonical_bytes()).to_hex())
+    }
+}
+
+/// A projection implementation: reads one source-width row, writes one
+/// compiled-width row. Deterministic and free of hidden state.
+pub type ProjectionFn = fn(&[f32], &mut [f32]);
+
+/// The `bucket-average/1` implementation, factored verbatim out of the
+/// Hugging Face oracle's `embedding` (#600): output index `i` is the mean
+/// of the contiguous source slice `[floor(i·S/C), floor((i+1)·S/C))`,
+/// summed left-to-right in f32 and divided once by the bucket length. The
+/// iteration order and arithmetic are bit-identical to the pre-#600 code.
+///
+/// `row.len() < out.len()` would make some buckets empty (a mean over
+/// nothing); it is refused with the legacy panic message rather than
+/// producing NaNs. `out.len() == 0` writes nothing.
+pub fn bucket_average_project(row: &[f32], out: &mut [f32]) {
+    let source_width = row.len();
+    assert!(
+        source_width >= out.len(),
+        "source dimension is smaller than runtime geometry"
+    );
+    let compiled_width = out.len();
+    for (index, value) in out.iter_mut().enumerate() {
+        let start = index * source_width / compiled_width;
+        let end = (index + 1) * source_width / compiled_width;
+        let bucket = &row[start..end];
+        *value = bucket.iter().sum::<f32>() / bucket.len() as f32;
+    }
+}
+
+/// The versioned projection registry (#600): map `(id, version)` to the
+/// implementation that computes it. Every pair outside the registry is
+/// refused by name on the sanctioned [`SourceUnavailable`] surface
+/// ([`SourceIngestKind::UnknownGeometryProjection`]) — never guessed,
+/// never approximated by a "closest" version.
+///
+/// [`SourceUnavailable`]: crate::SourceUnavailable
+/// [`SourceIngestKind::UnknownGeometryProjection`]: crate::SourceIngestKind::UnknownGeometryProjection
+#[cfg(not(target_arch = "wasm32"))]
+pub fn projection_implementation(
+    id: &str,
+    version: u32,
+) -> Result<ProjectionFn, crate::SourceUnavailable> {
+    match (id, version) {
+        (GeometryProjection::BUCKET_AVERAGE_ID, GeometryProjection::BUCKET_AVERAGE_VERSION) => {
+            Ok(bucket_average_project)
+        }
+        _ => Err(crate::SourceIngestKind::UnknownGeometryProjection {
+            id: id.to_owned(),
+            version,
+        }
+        .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference bucket layout, written independently of the projection:
+    /// bucket sizes under the floor rule.
+    fn bucket_sizes(source_width: usize, compiled_width: usize) -> Vec<usize> {
+        (0..compiled_width)
+            .map(|index| {
+                (index + 1) * source_width / compiled_width - index * source_width / compiled_width
+            })
+            .collect()
+    }
+
+    fn ramp(len: usize) -> Vec<f32> {
+        (0..len)
+            .map(|index| ((index * 37 % 101) as f32 - 50.0) / 8.0)
+            .collect()
+    }
+
+    #[test]
+    fn divisible_projection_is_the_exact_pairwise_mean() {
+        // 576 → 288: every bucket is exactly two adjacent columns.
+        let row = ramp(576);
+        let mut out = vec![0f32; 288];
+        bucket_average_project(&row, &mut out);
+        for (index, &value) in out.iter().enumerate() {
+            let expected = (row[2 * index] + row[2 * index + 1]) / 2.0;
+            assert_eq!(value.to_bits(), expected.to_bits(), "bucket {index}");
+        }
+    }
+
+    #[test]
+    fn non_divisible_projection_spreads_the_remainder_by_floor_boundaries() {
+        // 577 → 288: remainder 1; the floor rule gives 287 buckets of two
+        // columns and one bucket (the last) of three.
+        let sizes = bucket_sizes(577, 288);
+        assert_eq!(sizes.iter().sum::<usize>(), 577, "every column is used");
+        assert!(sizes.iter().all(|&s| s == 2 || s == 3));
+        assert_eq!(sizes.iter().filter(|&&s| s == 3).count(), 1);
+        assert_eq!(sizes[287], 3, "floor boundaries put the wide bucket last");
+
+        let row = ramp(577);
+        let mut out = vec![0f32; 288];
+        bucket_average_project(&row, &mut out);
+        let mut start = 0usize;
+        for (index, (&value, &size)) in out.iter().zip(&sizes).enumerate() {
+            let bucket = &row[start..start + size];
+            let expected = bucket.iter().sum::<f32>() / bucket.len() as f32;
+            assert_eq!(value.to_bits(), expected.to_bits(), "bucket {index}");
+            start += size;
+        }
+
+        // A wider remainder: 700 → 288 spreads 124 three-column buckets
+        // among 164 two-column buckets, positions fixed by the floor rule.
+        let sizes = bucket_sizes(700, 288);
+        assert_eq!(sizes.iter().sum::<usize>(), 700);
+        assert_eq!(sizes.iter().filter(|&&s| s == 3).count(), 700 - 2 * 288);
+    }
+
+    #[test]
+    fn equal_widths_project_to_identity_singleton_buckets() {
+        // Short (single-column) buckets: S == C is the identity mean.
+        let row = ramp(288);
+        let mut out = vec![0f32; 288];
+        bucket_average_project(&row, &mut out);
+        for (index, &value) in out.iter().enumerate() {
+            let expected = row[index] / 1.0;
+            assert_eq!(value.to_bits(), expected.to_bits(), "bucket {index}");
+        }
+    }
+
+    #[test]
+    fn empty_compiled_row_writes_nothing() {
+        let row = ramp(16);
+        let mut out: Vec<f32> = Vec::new();
+        bucket_average_project(&row, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "source dimension is smaller than runtime geometry")]
+    fn a_source_narrower_than_the_compiled_width_is_refused() {
+        // 100 → 288 would make buckets empty (NaN means); the legacy
+        // guard refuses it instead.
+        let row = ramp(100);
+        let mut out = vec![0f32; 288];
+        bucket_average_project(&row, &mut out);
+    }
+
+    #[test]
+    fn double_projection_is_bit_deterministic() {
+        let row = ramp(577);
+        let mut first = vec![0f32; 288];
+        let mut second = vec![0f32; 288];
+        bucket_average_project(&row, &mut first);
+        bucket_average_project(&row, &mut second);
+        let first_bits: Vec<u32> = first.iter().map(|v| v.to_bits()).collect();
+        let second_bits: Vec<u32> = second.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(first_bits, second_bits);
+    }
+
+    #[test]
+    fn canonical_serialization_is_byte_stable() {
+        // The canonical form is pinned byte-for-byte: any drift in field
+        // order, separators, or parameter tokens fails here, which is the
+        // point — the digest identity must not move silently.
+        let record = GeometryProjection::bucket_average(576, COMPILED_WIDTH);
+        let pinned = "uor-r4-geometry-projection/1\n\
+                      id=bucket-average\n\
+                      version=1\n\
+                      source_width=576\n\
+                      compiled_width=288\n\
+                      param.bucket_layout=contiguous-floor-boundaries\n\
+                      param.remainder_policy=floor-spread\n\
+                      param.accumulation=sequential-f32-sum-then-mean\n";
+        assert_eq!(record.canonical_bytes(), pinned.as_bytes());
+        // The digest is the blake3 of exactly those pinned bytes (declared
+        // parameters + algorithm tag, not source code text).
+        let expected = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
+        assert_eq!(record.implementation_digest, expected);
+        assert_eq!(record.declared_digest(), expected);
+        // Rebuilding the record reproduces the digest bit-for-bit.
+        let again = GeometryProjection::bucket_average(576, COMPILED_WIDTH);
+        assert_eq!(record, again);
+    }
+
+    #[test]
+    fn record_round_trips_through_serde_json() {
+        let record = GeometryProjection::bucket_average(576, 288);
+        let json = serde_json::to_string(&record).expect("serializes");
+        let back: GeometryProjection = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(record, back);
+        // Serde-defaulted fields: a legacy/partial document still parses.
+        let partial: GeometryProjection =
+            serde_json::from_str("{\"id\":\"bucket-average\"}").expect("defaults fill in");
+        assert_eq!(partial.id, "bucket-average");
+        assert_eq!(partial.version, 0);
+        assert_eq!(partial.params, GeometryProjectionParams::default());
+    }
+
+    #[test]
+    fn registry_resolves_bucket_average_1() {
+        let projection = projection_implementation(
+            GeometryProjection::BUCKET_AVERAGE_ID,
+            GeometryProjection::BUCKET_AVERAGE_VERSION,
+        )
+        .expect("registered implementation");
+        let row = ramp(576);
+        let mut via_registry = vec![0f32; 288];
+        let mut direct = vec![0f32; 288];
+        projection(&row, &mut via_registry);
+        bucket_average_project(&row, &mut direct);
+        assert_eq!(via_registry, direct);
+    }
+
+    #[test]
+    fn registry_refuses_unknown_id_and_version_by_name() {
+        for (id, version) in [("bucket-average", 2u32), ("mystery-projection", 1)] {
+            let error = projection_implementation(id, version)
+                .expect_err("unknown (id, version) is not a product");
+            match &error.kind {
+                crate::SourceIngestKind::UnknownGeometryProjection {
+                    id: got_id,
+                    version: got_version,
+                } => {
+                    assert_eq!(got_id, id);
+                    assert_eq!(*got_version, version);
+                }
+                other => panic!("wrong failure class: {other:?}"),
+            }
+            assert!(error.reason.contains(id), "reason names the id: {error}");
+        }
+    }
+}

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -7,6 +7,7 @@
 //! optimized CPU matrix-vector backend.
 
 pub mod conformance;
+pub mod geometry;
 pub mod progress;
 pub struct Config {
     pub dim: usize,
@@ -1153,6 +1154,16 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
     /// Copy the embedding row of `token` into `out` (len == dim).
     fn embedding(&self, token: usize, out: &mut [f32]);
 
+    /// The #600 typed record of the source→compiled geometry projection
+    /// this oracle applies inside [`TeacherOracle::embedding`], when it
+    /// applies one. `None` means embedding rows pass through at the
+    /// source width ([`TeacherOracle::dim`] ==
+    /// [`RepresentationSource::source_dimension`]); the default keeps
+    /// every existing oracle unaffected.
+    fn geometry_projection(&self) -> Option<geometry::GeometryProjection> {
+        None
+    }
+
     /// Optional compiler-only trace surface (graph-compiler plan §5 Phase
     /// 2): the final hidden state (post-final-rmsnorm activation) of the
     /// last `step`, if the oracle retains it. Defaults to `None` so
@@ -1665,6 +1676,17 @@ pub enum SourceIngestKind {
         /// What `config.json` actually contains.
         actual: String,
     },
+    /// #600 geometry registry: a caller named a source→compiled geometry
+    /// projection `(id, version)` outside the versioned registry
+    /// ([`geometry::projection_implementation`]), so no implementation
+    /// exists to interpret it. Refused by name, never approximated by a
+    /// "closest" algorithm or version.
+    UnknownGeometryProjection {
+        /// The requested projection algorithm id.
+        id: String,
+        /// The requested projection version.
+        version: u32,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1729,6 +1751,13 @@ impl std::fmt::Display for SourceIngestKind {
                 "config.json feature {feature} is outside the adapter's declared support: \
                  adapter declares {declared}, configuration has {actual} \
                  (rejected before any observation)"
+            ),
+            Self::UnknownGeometryProjection { id, version } => write!(
+                f,
+                "geometry projection {id}/{version} is not in the versioned projection \
+                 registry (known: {}/{})",
+                geometry::GeometryProjection::BUCKET_AVERAGE_ID,
+                geometry::GeometryProjection::BUCKET_AVERAGE_VERSION,
             ),
         }
     }
@@ -2543,7 +2572,9 @@ impl TeacherOracle for HuggingFaceLlamaOracle {
         self.model.cfg.vocab
     }
     fn dim(&self) -> usize {
-        288
+        // The compiled geometry this adapter presents (D = 288), not the
+        // source width; `embedding` projects rows down to it (#600).
+        geometry::COMPILED_WIDTH as usize
     }
     fn seq_len(&self) -> usize {
         self.model.cfg.seq_len
@@ -2563,17 +2594,15 @@ impl TeacherOracle for HuggingFaceLlamaOracle {
     fn embedding(&self, token: usize, out: &mut [f32]) {
         let dim = self.model.cfg.dim;
         let row = &self.model.w[self.model.emb + token * dim..self.model.emb + (token + 1) * dim];
-        assert!(
-            dim >= out.len(),
-            "source dimension is smaller than runtime geometry"
-        );
-        let output_dimensions = out.len();
-        for (index, value) in out.iter_mut().enumerate() {
-            let start = index * dim / output_dimensions;
-            let end = (index + 1) * dim / output_dimensions;
-            let bucket = &row[start..end];
-            *value = bucket.iter().sum::<f32>() / bucket.len() as f32;
-        }
+        // #600: the explicitly named `bucket-average/1` projection — the
+        // exact arithmetic this method always performed, factored into
+        // the versioned geometry module (see `geometry_projection`).
+        geometry::bucket_average_project(row, out);
+    }
+    fn geometry_projection(&self) -> Option<geometry::GeometryProjection> {
+        u32::try_from(self.model.cfg.dim).ok().map(|source_width| {
+            geometry::GeometryProjection::bucket_average(source_width, geometry::COMPILED_WIDTH)
+        })
     }
     fn hidden_state(&self) -> Option<&[f32]> {
         Some(&self.state.x)

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -206,6 +206,51 @@ Interactive terminals show progress bars. Redirected output receives periodic
 allocate; the allocation-free guarantee applies to the deployed prediction hot
 path, which uses fixed and caller-owned buffers.
 
+#### Geometry and projection identity (#600)
+
+The teacher adapter distinguishes two widths: the **source geometry**
+(`source_dimension()`, the `hidden_size` declared by `config.json` — 576 for
+the pinned SmolLM2-135M) and the **compiled geometry** it presents to the
+transformerless compiler (`dim()`, the legacy `D = 288`). The reduction
+between them is an explicit, versioned algorithm, not an implementation
+detail: `uor-r4-model-source::geometry` names the current one
+`bucket-average/1` (output index `i` averages the contiguous source slice
+`[floor(i·S/C), floor((i+1)·S/C))`; non-divisible widths spread the
+remainder by the floor boundaries so bucket sizes differ by at most one;
+each bucket is summed left-to-right in f32 and divided once — the exact
+arithmetic the adapter has always used, factored into the free deterministic
+function `bucket_average_project`). A versioned registry maps
+`(id, version)` to the implementation (`projection_implementation`); an
+unknown pair fails closed with the focused
+`SourceIngestKind::UnknownGeometryProjection` rather than being guessed.
+
+The typed record — `GeometryProjection { id, version, source_width,
+compiled_width, params, implementation_digest }` — threads into provenance
+the same way the #597 manifest κ does: the observe drivers record it in the
+observation manifest automatically whenever the oracle declares one, the
+cover stages (`transformerless cover`, `graph-compile`) accept
+`--geometry-projection <json>` and bind it as the optional `geometry` field
+of the cover/compile report, and the HTTP server's compile job binds it
+opportunistically from the downloaded snapshot's declared `hidden_size`.
+The `implementation_digest` is the blake3 of a canonical, byte-stable
+serialization of the algorithm's declared parameters plus a stable
+algorithm tag — deliberately not a hash of source code text, which would
+churn under refactors that leave the arithmetic bit-identical; the unit
+tests pin the implementation to the declaration, so a behavioral change
+must arrive as a new registry version. The record rides the report/manifest
+provenance sidecars; artifact container bytes (TLA/R4G1) are unchanged, so
+every previously pinned artifact κ remains valid.
+
+**Migration note.** Reports and observation manifests produced before #600
+carry no `geometry` field; absent metadata marks the implicit legacy era.
+For teacher inputs produced by the Hugging Face adapter — where
+bucket-averaging 576→288 was the sole historical behavior for the pinned
+SmolLM2-135M — an absent record may be *interpreted* as `bucket-average/1`
+at 576→288. This is an interpretation rule for readers, not a relabeling:
+legacy documents are not rewritten, and inputs from the legacy checkpoint
+oracle (whose source width is already 288, no projection) carry no such
+implication.
+
 ### 3. Compile the holographic graph
 
 The graph compiler turns the retained observation corpus and TLA artifact

--- a/src/server.rs
+++ b/src/server.rs
@@ -1833,6 +1833,13 @@ fn compile_r4g1_bundle(
     if let Some(kappa) = downloaded_source.and_then(source_manifest_kappa_of) {
         cover_args.extend(["--source-manifest-kappa".to_owned(), kappa]);
     }
+    // #600: bind the typed geometry-projection record the teacher adapter
+    // applies (bucket-average/1, hidden_size→288) into the cover report,
+    // when the downloaded snapshot declares its width. Opportunistic like
+    // the #597 binding above: a miss compiles exactly as before.
+    if let Some(geometry) = downloaded_source.and_then(geometry_projection_of) {
+        cover_args.extend(["--geometry-projection".to_owned(), geometry]);
+    }
     uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");
@@ -2003,6 +2010,27 @@ fn huggingface_source(model: Option<&str>) -> Result<SourceDownload, String> {
 fn source_manifest_kappa_of(source: &Path) -> Option<String> {
     let manifest = crate::model::read_source_manifest(source).ok()?;
     crate::model::source_manifest_kappa(&manifest).ok()
+}
+
+/// JSON serialization of the #600 geometry-projection record the teacher
+/// adapter applies for a downloaded snapshot: `bucket-average/1` from the
+/// snapshot's declared `hidden_size` down to the compiled width (288).
+/// Total: any miss (no `config.json`, no numeric `hidden_size`, a source
+/// narrower than the compiled width) resolves to `None` so such inputs
+/// keep compiling unchanged with no record bound.
+fn geometry_projection_of(source: &Path) -> Option<String> {
+    let config: serde_json::Value =
+        serde_json::from_slice(&fs::read(source.join("config.json")).ok()?).ok()?;
+    let hidden_size = u32::try_from(config.get("hidden_size")?.as_u64()?).ok()?;
+    let compiled_width = uor_r4_model_source::geometry::COMPILED_WIDTH;
+    if hidden_size < compiled_width {
+        return None;
+    }
+    let record = uor_r4_model_source::geometry::GeometryProjection::bucket_average(
+        hidden_size,
+        compiled_width,
+    );
+    serde_json::to_string(&record).ok()
 }
 
 fn downloaded_source_path(source: &SourceDownload) -> PathBuf {


### PR DESCRIPTION
feat(#600): explicit source/compiled geometry + versioned projection

The hidden 576->288 bucket-average becomes the named, versioned
projection bucket-average/1: a free deterministic function
(bucket_average_project) with identical iteration order and arithmetic,
a typed GeometryProjection record (id, version, widths, params,
implementation digest = blake3 over the pinned parameter declaration -
not source text, documented why), and a registry that refuses unknown
(id,version) via the sanctioned error surface. TeacherOracle gains a
defaulted geometry_projection() (HF oracle overrides). Provenance rides
the #597 seams: flag -> options -> CoverReport + ObservationManifest
(serde(default) additive; legacy bytes unchanged when unset); observe
paths bind automatically from the oracle; server binds opportunistically.
Artifact CONTAINER bytes deliberately untouched: binding the record
into TLA/R4G1 bytes cannot be additive (PROV section is defined but
never emitted; emitting breaks existing readers) and would move kappas
of fresh identical compiles - the era decision is filed separately
rather than chosen silently. All kappa/rebuild/era fixtures green
without re-pin (deterministic_rebuild --include-ignored reproduces the
pinned container byte-identically). 15 new tests incl. non-divisible
widths and canonical-serialization byte stability. Docs section +
migration note (absent metadata = legacy-era interpretation, not
relabeling).
