### PR TITLE
feat(#601): versioned tokenizer adapters + differential source fixtures

### DIFF
--- a/crates/uor-r4-core/src/transformerless/hf_bpe.rs
+++ b/crates/uor-r4-core/src/transformerless/hf_bpe.rs
@@ -31,6 +31,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
+use serde::{Deserialize, Serialize};
+
 use super::scenarios::Tokenizer;
 
 /// Upper bound on cached pre-token encodings (bounds memory on adversarial
@@ -268,7 +270,11 @@ impl HfBpeTokenizer {
     }
 
     /// Raw decoded bytes of `ids` (before any lossy UTF-8 conversion).
-    fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
+    /// Public since #601: differential fixtures and consumer-agreement
+    /// tests compare token content at the byte level, where a token
+    /// holding a partial UTF-8 sequence keeps its true bytes instead of
+    /// the replacement character.
+    pub fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
         let mut bytes = Vec::new();
         for &id in ids {
             let Some(token) = self.vocab.get(id as usize) else {
@@ -310,6 +316,63 @@ impl HfBpeTokenizer {
     /// Content address of the raw `tokenizer.json` bytes: `blake3:<hex>`.
     pub fn address(&self) -> String {
         self.address.clone()
+    }
+
+    /// The versioned adapter-identity record (#601) this tokenizer
+    /// implements: family `hf-byte-bpe` version 1, the `tokenizer.json`
+    /// content address, and the encode/decode policy the parsed
+    /// configuration selects. Host/compile-side metadata only — the
+    /// encode/decode hot paths never call this.
+    pub fn adapter(&self) -> TokenizerAdapter {
+        // Canonical added-token summary: entries sorted by id, each as
+        // `<id>:<byte length>:<content bytes>\n` (length-prefixed, so no
+        // content byte can be confused with a separator).
+        let mut entries: Vec<(u32, &str)> = self
+            .added_tokens
+            .iter()
+            .map(|(content, id)| (*id, content.as_str()))
+            .collect();
+        entries.sort_by_key(|(id, _)| *id);
+        let mut listing = Vec::new();
+        for (id, content) in &entries {
+            listing.extend_from_slice(format!("{id}:{}:", content.len()).as_bytes());
+            listing.extend_from_slice(content.as_bytes());
+            listing.push(b'\n');
+        }
+        let mut pre_tokenizers = Vec::new();
+        if let Some(individual) = self.digits_individual {
+            pre_tokenizers.push(format!("digits(individual_digits={individual})"));
+        }
+        pre_tokenizers.push(format!(
+            "byte-level(add_prefix_space={})",
+            self.add_prefix_space
+        ));
+        let policy = TokenizerAdapterPolicy {
+            // This adapter applies no normalizer; parsing accepts the
+            // configuration as-is and never rewrites input text.
+            normalizer: "none".to_owned(),
+            pre_tokenizers,
+            // The GPT-2 byte alphabet covers all 256 byte values, so
+            // every input byte is encodable: encoding is total.
+            byte_fallback: "byte-level-alphabet".to_owned(),
+            added_tokens_count: entries.len() as u32,
+            added_tokens_digest: format!("blake3:{}", blake3::hash(&listing).to_hex()),
+            // No BOS/EOS insertion: encode adds no tokens beyond the
+            // input (the pinned SmolLM2 post-processor is null; see
+            // `HfBpeTokenizer::encode`).
+            bos: "none".to_owned(),
+            eos: "none".to_owned(),
+            chat_template_policy: "not-interpreted".to_owned(),
+        };
+        let mut record = TokenizerAdapter {
+            family: TokenizerAdapter::HF_BYTE_BPE_FAMILY.to_owned(),
+            version: TokenizerAdapter::HF_BYTE_BPE_VERSION,
+            tokenizer_cid: self.address.clone(),
+            policy,
+            adapter_digest: String::new(),
+        };
+        record.adapter_digest = record.declared_digest();
+        record
     }
 
     /// Split text on added-token occurrences, leftmost-longest.
@@ -581,6 +644,168 @@ fn pre_tokenize(text: &str) -> Vec<&str> {
     pieces
 }
 
+/// Declared encode/decode policy of a versioned tokenizer adapter
+/// (#601). Every field is a stable machine token entering the canonical
+/// digest serialization byte-for-byte, mirroring the #600
+/// `GeometryProjectionParams` convention.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenizerAdapterPolicy {
+    /// Normalizer the adapter applies before pre-tokenization
+    /// (`"none"`: this adapter never rewrites input text).
+    #[serde(default)]
+    pub normalizer: String,
+    /// Pre-tokenizer steps in application order, e.g.
+    /// `digits(individual_digits=true)` then
+    /// `byte-level(add_prefix_space=false)`.
+    #[serde(default)]
+    pub pre_tokenizers: Vec<String>,
+    /// How bytes outside merged tokens are represented
+    /// (`"byte-level-alphabet"`: the GPT-2 byte alphabet covers all 256
+    /// byte values, so encoding is total).
+    #[serde(default)]
+    pub byte_fallback: String,
+    /// Number of added (special) tokens matched atomically before
+    /// pre-tokenization.
+    #[serde(default)]
+    pub added_tokens_count: u32,
+    /// `blake3:<hex>` over the canonical added-token listing (entries
+    /// sorted by id, each `<id>:<byte length>:<content>\n`).
+    #[serde(default)]
+    pub added_tokens_digest: String,
+    /// BOS insertion policy (`"none"`: encode inserts no BOS token).
+    #[serde(default)]
+    pub bos: String,
+    /// EOS insertion policy (`"none"`: encode inserts no EOS token).
+    #[serde(default)]
+    pub eos: String,
+    /// Chat-template handling (`"not-interpreted"`: any
+    /// `chat_template` in the source snapshot is provenance-pinned by
+    /// the tokenizer CID but never executed by this adapter).
+    #[serde(default)]
+    pub chat_template_policy: String,
+}
+
+/// The typed, versioned tokenizer-adapter identity record (#601),
+/// mirroring the #600 `GeometryProjection` pattern: `{family, version,
+/// tokenizer_cid, policy, adapter_digest}` with a canonical
+/// serialization and a digest over it, carried by provenance surfaces
+/// (the observation manifest) wherever the producing pipeline knows its
+/// tokenizer. A behavioral change to an adapter family is a new
+/// version — a new registry entry — never an in-place edit.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenizerAdapter {
+    /// Registry family id (e.g. [`TokenizerAdapter::HF_BYTE_BPE_FAMILY`]).
+    #[serde(default)]
+    pub family: String,
+    /// Registry version of the family's implementation.
+    #[serde(default)]
+    pub version: u32,
+    /// Content address of the raw tokenizer definition bytes
+    /// (`blake3:<hex>` of `tokenizer.json`, exactly how tokenizer CIDs
+    /// are formed today by [`HfBpeTokenizer::address`]).
+    #[serde(default)]
+    pub tokenizer_cid: String,
+    /// The declared encode/decode policy.
+    #[serde(default)]
+    pub policy: TokenizerAdapterPolicy,
+    /// `blake3:<hex>` of [`TokenizerAdapter::canonical_bytes`] — the
+    /// declared identity, not source code text (renames and formatting
+    /// must not move the digest; a behavioral change must bump
+    /// `version` instead).
+    #[serde(default)]
+    pub adapter_digest: String,
+}
+
+impl TokenizerAdapter {
+    /// Registry family of the Hugging Face byte-level BPE adapter
+    /// implemented by [`HfBpeTokenizer`].
+    pub const HF_BYTE_BPE_FAMILY: &'static str = "hf-byte-bpe";
+    /// Registry version of the byte-level BPE adapter currently
+    /// implemented (the post-#242/#253 verified behavior).
+    pub const HF_BYTE_BPE_VERSION: u32 = 1;
+    /// Recorded follow-up family (#601 non-goal): SentencePiece/Unigram
+    /// tokenizers are recognized by name and rejected by
+    /// [`adapter_constructor`] until a versioned adapter exists — never
+    /// approximated with the byte-level BPE rule.
+    pub const SENTENCEPIECE_UNIGRAM_FAMILY: &'static str = "sentencepiece-unigram";
+
+    /// Canonical serialization of the adapter identity: a fixed line
+    /// format (format tag then `key=value\n` per field, pre-tokenizer
+    /// steps joined with `,`). Byte-stable by construction — field
+    /// order and separators are fixed here, not derived from any
+    /// serializer — so the digest over these bytes is reproducible
+    /// everywhere.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "uor-r4-tokenizer-adapter/1\n\
+             family={}\n\
+             version={}\n\
+             tokenizer_cid={}\n\
+             policy.normalizer={}\n\
+             policy.pre_tokenizers={}\n\
+             policy.byte_fallback={}\n\
+             policy.added_tokens_count={}\n\
+             policy.added_tokens_digest={}\n\
+             policy.bos={}\n\
+             policy.eos={}\n\
+             policy.chat_template_policy={}\n",
+            self.family,
+            self.version,
+            self.tokenizer_cid,
+            self.policy.normalizer,
+            self.policy.pre_tokenizers.join(","),
+            self.policy.byte_fallback,
+            self.policy.added_tokens_count,
+            self.policy.added_tokens_digest,
+            self.policy.bos,
+            self.policy.eos,
+            self.policy.chat_template_policy,
+        )
+        .into_bytes()
+    }
+
+    /// The adapter digest this record's declared identity implies:
+    /// `blake3:<hex>` over [`TokenizerAdapter::canonical_bytes`].
+    pub fn declared_digest(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.canonical_bytes()).to_hex())
+    }
+}
+
+/// A registered adapter constructor: parse raw tokenizer definition
+/// bytes into the family's tokenizer. Total in the module's existing
+/// convention ([`HfBpeTokenizer::from_tokenizer_json_bytes`]): `None`
+/// when the bytes are not the shape the family requires.
+pub type AdapterConstructor = fn(&[u8]) -> Option<HfBpeTokenizer>;
+
+/// The versioned tokenizer-adapter registry (#601): map `(family,
+/// version)` to the constructor that implements it. Every pair outside
+/// the registry — including the recorded
+/// [`TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY`] follow-up — is
+/// refused by name on the sanctioned
+/// [`uor_r4_model_source::SourceUnavailable`] surface
+/// (`SourceIngestKind::UnknownTokenizerAdapter`), matching the module's
+/// existing host-ingestion convention ([`HfBpeTokenizer::from_dir`])
+/// and the #600 geometry registry: never guessed, never approximated
+/// by a "closest" family or version.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn adapter_constructor(
+    family: &str,
+    version: u32,
+) -> Result<AdapterConstructor, uor_r4_model_source::SourceUnavailable> {
+    match (family, version) {
+        (TokenizerAdapter::HF_BYTE_BPE_FAMILY, TokenizerAdapter::HF_BYTE_BPE_VERSION) => {
+            Ok(HfBpeTokenizer::from_tokenizer_json_bytes)
+        }
+        _ => Err(
+            uor_r4_model_source::SourceIngestKind::UnknownTokenizerAdapter {
+                family: family.to_owned(),
+                version,
+            }
+            .into(),
+        ),
+    }
+}
+
 /// Tokenizer selector for observation drivers: the legacy llama2.c
 /// tokenizer keeps its exact behavior (κ-pinned baselines), the HF path
 /// uses the teacher's real byte-level BPE when `tokenizer.json` exists.
@@ -617,6 +842,18 @@ impl TokenizerKind {
         match self {
             TokenizerKind::Legacy(tokenizer) => tokenizer.vocab.len(),
             TokenizerKind::HfBpe(tokenizer) => tokenizer.vocab_size(),
+        }
+    }
+
+    /// The versioned adapter-identity record (#601) this selection
+    /// resolves to: `Some` for the HF byte-level BPE path, `None` for
+    /// the legacy llama2.c tokenizer, which predates adapter records
+    /// and stays exactly as-is (its κ-pinned baselines and manifest
+    /// bytes are unchanged when no adapter is recorded).
+    pub fn adapter(&self) -> Option<TokenizerAdapter> {
+        match self {
+            TokenizerKind::Legacy(_) => None,
+            TokenizerKind::HfBpe(tokenizer) => Some(tokenizer.adapter()),
         }
     }
 }

--- a/crates/uor-r4-core/tests/tokenizer_adapter.rs
+++ b/crates/uor-r4-core/tests/tokenizer_adapter.rs
@@ -1,0 +1,529 @@
+//! Versioned tokenizer adapters and differential source fixtures
+//! (issue #601).
+//!
+//! Three suites:
+//!
+//! 1. **Adapter identity** — the typed [`TokenizerAdapter`] record derived
+//!    from a parsed `tokenizer.json`: pinned canonical serialization,
+//!    digest, serde round-trip, and the versioned `(family, version)`
+//!    registry with its explicit unknown-family rejection (including the
+//!    recorded `sentencepiece-unigram` follow-up).
+//! 2. **Differential fixtures** — table-driven encode/decode witnesses
+//!    against a full-byte-alphabet fixture tokenizer. The Hugging Face
+//!    source snapshot is not present in this environment, so the expected
+//!    token ids are pinned constants derived from the CURRENT verified
+//!    behavior (the post-#242/#253 implementation, whose segmentation the
+//!    existing `hf_bpe_tokenizer.rs` witnesses established against the
+//!    teacher's rule). They are the differential baseline: any encode or
+//!    decode drift fails these tables.
+//! 3. **Consumer agreement** — the observation, evaluation, serving-prompt,
+//!    and exported-runtime-tokenizer selection seams resolve the same
+//!    adapter identity, token ids, and decode bytes for the same input.
+
+use std::path::PathBuf;
+
+use uor_r4_core::transformerless::hf_bpe::{
+    adapter_constructor, HfBpeTokenizer, TokenizerAdapter, TokenizerKind,
+};
+use uor_r4_core::transformerless::scenarios;
+
+// =====================================================================
+// Fixture: a byte-level BPE tokenizer with the FULL 256-symbol GPT-2
+// byte alphabet (id = byte value), 13 merged tokens (dense ids
+// 256..=268), and three added tokens. Multi-byte input without a merge
+// (CJK, emoji) therefore encodes to its raw byte values — analytically
+// checkable AND pinned.
+// =====================================================================
+
+/// Merged-token contents, id = 256 + index.
+const MERGED: [&str; 13] = [
+    "he", "ll", "hell", "hello", "Ġw", "Ġwo", "Ġwor", "Ġworl", "Ġworld", "Ã©", "12", "ab", "bc",
+];
+
+/// Ordered merges (rank = position). Note "b c" (rank 11) outranks
+/// "a b" (rank 12): the discriminating rank-order configuration.
+const MERGES: [&str; 13] = [
+    "h e", "l l", "he ll", "hell o", "Ġ w", "Ġw o", "Ġwo r", "Ġwor l", "Ġworl d", "Ã ©", "1 2",
+    "b c", "a b",
+];
+
+const ADDED: [(u32, &str); 3] = [(269, "<|bos|>"), (270, "<|eos|>"), (271, "<|end|>")];
+
+/// Independent re-derivation of the GPT-2 byte→unicode table (printable
+/// latin-1 bytes map to themselves, the remaining 68 bytes to U+0100..
+/// in ascending order), written from the published rule rather than the
+/// implementation under test.
+fn byte_symbol(byte: u8) -> char {
+    let printable = |b: u8| (b'!'..=b'~').contains(&b) || (0xA1..=0xAC).contains(&b) || b >= 0xAE;
+    if printable(byte) {
+        char::from_u32(u32::from(byte)).expect("latin-1 codepoint")
+    } else {
+        let extra = (0..byte).filter(|&b| !printable(b)).count() as u32;
+        char::from_u32(256 + extra).expect("fallback codepoint")
+    }
+}
+
+/// Serialize the fixture `tokenizer.json`. `digits` selects the
+/// SmolLM2-shaped pre-tokenizer sequence (`Digits{individual_digits:
+/// true}` then `ByteLevel`); otherwise plain `ByteLevel`.
+fn fixture_json(digits: bool) -> Vec<u8> {
+    let mut vocab = serde_json::Map::new();
+    for byte in 0u8..=255 {
+        vocab.insert(byte_symbol(byte).to_string(), serde_json::json!(byte));
+    }
+    for (index, token) in MERGED.iter().enumerate() {
+        vocab.insert((*token).to_string(), serde_json::json!(256 + index));
+    }
+    let pre_tokenizer = if digits {
+        serde_json::json!({"type": "Sequence", "pretokenizers": [
+            {"type": "Digits", "individual_digits": true},
+            {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true}
+        ]})
+    } else {
+        serde_json::json!({"type": "ByteLevel", "add_prefix_space": false})
+    };
+    let added: Vec<serde_json::Value> = ADDED
+        .iter()
+        .map(|(id, content)| serde_json::json!({"id": id, "content": content, "special": true}))
+        .collect();
+    serde_json::to_vec(&serde_json::json!({
+        "added_tokens": added,
+        "pre_tokenizer": pre_tokenizer,
+        "model": {"type": "BPE", "vocab": vocab, "merges": MERGES.to_vec()}
+    }))
+    .expect("fixture serializes")
+}
+
+fn fixture_tokenizer(digits: bool) -> HfBpeTokenizer {
+    HfBpeTokenizer::from_tokenizer_json_bytes(&fixture_json(digits))
+        .expect("fixture tokenizer.json parses")
+}
+
+// =====================================================================
+// Suite 2: differential encode/decode fixtures.
+// =====================================================================
+
+struct Case {
+    name: &'static str,
+    text: &'static str,
+    /// Pinned expected ids: the current verified behavior recorded as
+    /// the differential baseline (see module docs).
+    ids: &'static [u32],
+}
+
+/// Cases against the SmolLM2-shaped fixture (Digits + ByteLevel).
+const DIGITS_CASES: [Case; 12] = [
+    Case {
+        name: "ascii merges",
+        text: "hello world",
+        ids: &[259, 264],
+    },
+    Case {
+        name: "ascii whitespace run keeps last space for the next word",
+        text: "hello  world",
+        ids: &[259, 32, 264],
+    },
+    Case {
+        name: "contraction binds without a preceding space",
+        text: "it's",
+        ids: &[105, 116, 39, 115],
+    },
+    Case {
+        name: "merge RANK order beats lowest-token-id greedy",
+        text: "abc",
+        ids: &[97, 268],
+    },
+    Case {
+        name: "accented letter merges through its byte-level symbols",
+        text: "héllo",
+        ids: &[104, 265, 257, 111],
+    },
+    Case {
+        name: "CJK falls back to per-byte tokens",
+        text: "中文",
+        ids: &[228, 184, 173, 230, 150, 135],
+    },
+    Case {
+        name: "emoji falls back to per-byte tokens",
+        text: "🙂",
+        ids: &[240, 159, 153, 130],
+    },
+    Case {
+        name: "emoji ZWJ sequence stays one pre-token of raw bytes",
+        text: "👩\u{200d}💻",
+        ids: &[240, 159, 145, 169, 226, 128, 141, 240, 159, 146, 187],
+    },
+    Case {
+        name: "byte fallback for a bare latin-1 character",
+        text: "ÿ",
+        ids: &[195, 191],
+    },
+    Case {
+        name: "added token matched atomically",
+        text: "hello<|end|>hello",
+        ids: &[259, 271, 259],
+    },
+    Case {
+        name: "explicit BOS/EOS text maps to added tokens; none are auto-inserted",
+        text: "<|bos|>hello<|eos|>",
+        ids: &[269, 259, 270],
+    },
+    Case {
+        name: "Digits isolates every digit (no merge crosses a digit boundary)",
+        text: "hello 12",
+        ids: &[259, 32, 49, 50],
+    },
+];
+
+#[test]
+fn differential_fixture_encode_and_round_trip_decode() {
+    let tokenizer = fixture_tokenizer(true);
+    for case in &DIGITS_CASES {
+        let ids = tokenizer.encode(case.text);
+        assert_eq!(ids, case.ids, "encode drift on case {:?}", case.name);
+        // Round-trip: decoded text and RAW decoded bytes both reproduce
+        // the input exactly (byte-level BPE is total; add_prefix_space
+        // is false in the fixture).
+        assert_eq!(
+            tokenizer.decode(&ids),
+            case.text,
+            "decode drift on case {:?}",
+            case.name
+        );
+        assert_eq!(
+            tokenizer.decode_bytes(&ids),
+            case.text.as_bytes(),
+            "decode-bytes drift on case {:?}",
+            case.name
+        );
+        // encode_lossy replaces nothing: the byte alphabet is total.
+        let (lossy_ids, replaced) = tokenizer.encode_lossy(case.text);
+        assert_eq!(lossy_ids, ids);
+        assert_eq!(replaced, 0, "case {:?}", case.name);
+    }
+}
+
+#[test]
+fn no_bos_or_eos_is_auto_inserted() {
+    let tokenizer = fixture_tokenizer(true);
+    let ids = tokenizer.encode("hello");
+    assert_eq!(ids, vec![259], "no BOS/EOS wraps a plain encode");
+}
+
+#[test]
+fn digits_pre_tokenization_boundaries_differ_from_plain_byte_level() {
+    let digits = fixture_tokenizer(true);
+    let plain = fixture_tokenizer(false);
+    // Same merges table; only the Digits step separates them. The "1 2"
+    // merge applies without Digits and is blocked by it.
+    assert_eq!(plain.encode("12"), vec![266]);
+    assert_eq!(digits.encode("12"), vec![49, 50]);
+    assert_eq!(plain.encode("hello 12"), vec![259, 32, 266]);
+    assert_eq!(digits.encode("hello 12"), vec![259, 32, 49, 50]);
+    // Individual digits split even inside letter/digit alternation.
+    assert_eq!(digits.encode("a1b2"), vec![97, 49, 98, 50]);
+}
+
+#[test]
+fn partial_utf8_token_decodes_its_true_bytes() {
+    let tokenizer = fixture_tokenizer(true);
+    // Token id 255 is the single byte 0xFF — not valid UTF-8 alone. The
+    // raw byte surface keeps it exact; the string surface is lossy.
+    assert_eq!(tokenizer.decode_bytes(&[255]), vec![0xFF]);
+    assert_eq!(tokenizer.decode(&[255]), "\u{FFFD}");
+    assert_eq!(tokenizer.token_byte_lengths()[255], 1);
+}
+
+// =====================================================================
+// Suite 1: adapter identity, canonical serialization, registry.
+// =====================================================================
+
+/// Independent recomputation of the canonical added-token listing
+/// digest: entries sorted by id, each `<id>:<byte length>:<content>\n`.
+fn expected_added_tokens_digest() -> String {
+    let mut listing = Vec::new();
+    for (id, content) in ADDED {
+        listing.extend_from_slice(format!("{id}:{}:", content.len()).as_bytes());
+        listing.extend_from_slice(content.as_bytes());
+        listing.push(b'\n');
+    }
+    format!("blake3:{}", blake3::hash(&listing).to_hex())
+}
+
+#[test]
+fn adapter_record_is_pinned_and_canonically_serialized() {
+    let bytes = fixture_json(true);
+    let tokenizer = HfBpeTokenizer::from_tokenizer_json_bytes(&bytes).expect("fixture parses");
+    let adapter = tokenizer.adapter();
+
+    assert_eq!(adapter.family, TokenizerAdapter::HF_BYTE_BPE_FAMILY);
+    assert_eq!(adapter.family, "hf-byte-bpe");
+    assert_eq!(adapter.version, TokenizerAdapter::HF_BYTE_BPE_VERSION);
+    assert_eq!(adapter.version, 1);
+    // tokenizer_cid is the blake3 of the raw tokenizer.json bytes —
+    // exactly how tokenizer CIDs are formed today (HfBpeTokenizer::address).
+    let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    assert_eq!(adapter.tokenizer_cid, cid);
+    assert_eq!(adapter.tokenizer_cid, tokenizer.address());
+
+    // Pinned policy tokens.
+    assert_eq!(adapter.policy.normalizer, "none");
+    assert_eq!(
+        adapter.policy.pre_tokenizers,
+        vec![
+            "digits(individual_digits=true)".to_owned(),
+            "byte-level(add_prefix_space=false)".to_owned(),
+        ]
+    );
+    assert_eq!(adapter.policy.byte_fallback, "byte-level-alphabet");
+    assert_eq!(adapter.policy.added_tokens_count, 3);
+    assert_eq!(
+        adapter.policy.added_tokens_digest,
+        expected_added_tokens_digest()
+    );
+    assert_eq!(adapter.policy.bos, "none");
+    assert_eq!(adapter.policy.eos, "none");
+    assert_eq!(adapter.policy.chat_template_policy, "not-interpreted");
+
+    // Canonical serialization is pinned byte-for-byte: any drift in
+    // field order, separators, or policy tokens fails here — the digest
+    // identity must not move silently.
+    let pinned = format!(
+        "uor-r4-tokenizer-adapter/1\n\
+         family=hf-byte-bpe\n\
+         version=1\n\
+         tokenizer_cid={cid}\n\
+         policy.normalizer=none\n\
+         policy.pre_tokenizers=digits(individual_digits=true),byte-level(add_prefix_space=false)\n\
+         policy.byte_fallback=byte-level-alphabet\n\
+         policy.added_tokens_count=3\n\
+         policy.added_tokens_digest={added}\n\
+         policy.bos=none\n\
+         policy.eos=none\n\
+         policy.chat_template_policy=not-interpreted\n",
+        added = expected_added_tokens_digest(),
+    );
+    assert_eq!(adapter.canonical_bytes(), pinned.as_bytes());
+    let expected_digest = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
+    assert_eq!(adapter.adapter_digest, expected_digest);
+    assert_eq!(adapter.declared_digest(), expected_digest);
+
+    // Rebuilding the record reproduces it bit-for-bit.
+    assert_eq!(tokenizer.adapter(), adapter);
+}
+
+#[test]
+fn adapter_record_round_trips_through_serde_json() {
+    let adapter = fixture_tokenizer(true).adapter();
+    let json = serde_json::to_string(&adapter).expect("serializes");
+    let back: TokenizerAdapter = serde_json::from_str(&json).expect("deserializes");
+    assert_eq!(adapter, back);
+    // Serde-defaulted fields: a legacy/partial document still parses.
+    let partial: TokenizerAdapter =
+        serde_json::from_str("{\"family\":\"hf-byte-bpe\"}").expect("defaults fill in");
+    assert_eq!(partial.family, "hf-byte-bpe");
+    assert_eq!(partial.version, 0);
+    assert_eq!(partial.policy.pre_tokenizers, Vec::<String>::new());
+}
+
+#[test]
+fn pre_tokenizer_variant_changes_the_adapter_digest() {
+    // Same vocabulary/merges, different pre-tokenizer policy → distinct
+    // adapter identity AND distinct tokenizer CID.
+    let digits = fixture_tokenizer(true).adapter();
+    let plain = fixture_tokenizer(false).adapter();
+    assert_ne!(digits.adapter_digest, plain.adapter_digest);
+    assert_ne!(digits.tokenizer_cid, plain.tokenizer_cid);
+    assert_eq!(
+        plain.policy.pre_tokenizers,
+        vec!["byte-level(add_prefix_space=false)".to_owned()]
+    );
+}
+
+#[test]
+fn registry_resolves_hf_byte_bpe_1() {
+    let constructor = adapter_constructor(
+        TokenizerAdapter::HF_BYTE_BPE_FAMILY,
+        TokenizerAdapter::HF_BYTE_BPE_VERSION,
+    )
+    .expect("registered constructor");
+    let bytes = fixture_json(true);
+    let via_registry = constructor(&bytes).expect("registry constructor parses the fixture");
+    let direct = HfBpeTokenizer::from_tokenizer_json_bytes(&bytes).expect("direct parse");
+    assert_eq!(via_registry.adapter(), direct.adapter());
+    assert_eq!(
+        via_registry.encode("hello world"),
+        direct.encode("hello world")
+    );
+    // The constructor stays total in the module's existing convention:
+    // malformed bytes are None, not a panic.
+    assert!(constructor(b"not json").is_none());
+}
+
+#[test]
+fn registry_refuses_unknown_family_and_version_by_name() {
+    // The recorded SentencePiece/Unigram follow-up family is rejected
+    // explicitly (bounded rejection, #601 non-goal), as is any unknown
+    // (family, version) pair — including a bumped hf-byte-bpe version.
+    for (family, version) in [
+        (TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 1u32),
+        (TokenizerAdapter::HF_BYTE_BPE_FAMILY, 2),
+        ("mystery-tokenizer", 1),
+    ] {
+        let error = adapter_constructor(family, version)
+            .expect_err("unknown (family, version) is not a product");
+        match &error.kind {
+            uor_r4_model_source::SourceIngestKind::UnknownTokenizerAdapter {
+                family: got_family,
+                version: got_version,
+            } => {
+                assert_eq!(got_family, family);
+                assert_eq!(*got_version, version);
+            }
+            other => panic!("wrong failure class: {other:?}"),
+        }
+        assert!(
+            error.reason.contains(family),
+            "reason names the family: {error}"
+        );
+    }
+    // The rejection message records the follow-up path by name.
+    let error = adapter_constructor(TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 1)
+        .expect_err("sentencepiece-unigram has no adapter yet");
+    assert!(
+        error.reason.contains("sentencepiece-unigram"),
+        "follow-up family is named: {error}"
+    );
+}
+
+// =====================================================================
+// Suite 3: consumer agreement across tokenizer selection seams.
+// =====================================================================
+
+fn unique_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "uor-r4-i601-{name}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create fixture dir");
+    dir
+}
+
+/// The four consumer paths resolve their tokenizer at these seams:
+///
+/// - **observation path** (`uor-r4-graph-cli::observe_text_command` and
+///   `observe_text_batched_command`): `TokenizerKind::HfBpe(Box::new(
+///   HfBpeTokenizer::from_dir(&options.source)?))` when the snapshot has
+///   a `tokenizer.json` — asserted below by building exactly that value.
+/// - **evaluation path** (`uor-r4-graph-cli::evaluate_report`):
+///   `HfBpeTokenizer::from_dir(&options.source).ok()` — asserted below
+///   by building exactly that value.
+/// - **serving prompt path** (`src/server.rs::load_serving_hf_tokenizer`):
+///   `HfBpeTokenizer::from_dir(dir)` into `SERVING_HF_TOKENIZER` —
+///   asserted below at the same `from_dir` seam (the server's static is
+///   private to the binary crate, so the selection expression is
+///   exercised, not the static).
+/// - **exported runtime tokenizer path** (`observe-text` exports
+///   `tokenizer.bin` via `export_hf_bytelevel_tokenizer_with_lengths`;
+///   `uor-r4-api::R4Engine::load` pins its blake3 against the graph
+///   head's `tokenizer_cid` and serving decode falls back to the legacy
+///   `scenarios::Tokenizer` over it): asserted below by exporting,
+///   reloading with the legacy loader, and comparing per-id decode
+///   bytes. Encode agreement is NOT asserted for the legacy fallback —
+///   its greedy segmentation is the recorded #242/#285 serving
+///   difference — the runtime path consumes this table for id-space
+///   decode, which must and does agree.
+#[test]
+fn consumer_paths_agree_on_adapter_identity_token_ids_and_decode_bytes() {
+    let dir = unique_dir("consumer-agreement");
+    let json_bytes = fixture_json(true);
+    std::fs::write(dir.join("tokenizer.json"), &json_bytes).expect("write tokenizer.json");
+
+    // Observation-path selection (graph-cli observe-text, serial and
+    // batched drivers use this identical expression).
+    let observation = TokenizerKind::HfBpe(Box::new(
+        HfBpeTokenizer::from_dir(&dir).expect("observation-path tokenizer loads"),
+    ));
+    // Evaluation-path selection (graph-cli evaluate_report).
+    let evaluation = HfBpeTokenizer::from_dir(&dir).expect("evaluation-path tokenizer loads");
+    // Serving-prompt-path selection (src/server.rs load_serving_hf_tokenizer).
+    let serving = HfBpeTokenizer::from_dir(&dir).expect("serving-path tokenizer loads");
+
+    // Adapter identity: all three HF selections resolve the same record,
+    // and its CID is the blake3 of the tokenizer bytes — the same CID
+    // rule `R4Engine::load` verifies tokenizer bytes against.
+    let observation_adapter = observation
+        .adapter()
+        .expect("the HF observation path declares an adapter");
+    assert_eq!(observation_adapter, evaluation.adapter());
+    assert_eq!(observation_adapter, serving.adapter());
+    assert_eq!(
+        observation_adapter.tokenizer_cid,
+        format!("blake3:{}", blake3::hash(&json_bytes).to_hex())
+    );
+    assert_eq!(
+        observation_adapter.adapter_digest,
+        observation_adapter.declared_digest()
+    );
+
+    // Token ids and decode bytes agree across the encode seams.
+    for case in &DIGITS_CASES {
+        let ids = observation.encode(case.text);
+        assert_eq!(ids, evaluation.encode(case.text), "case {:?}", case.name);
+        assert_eq!(ids, serving.encode(case.text), "case {:?}", case.name);
+        assert_eq!(
+            evaluation.decode_bytes(&ids),
+            case.text.as_bytes(),
+            "case {:?}",
+            case.name
+        );
+        assert_eq!(observation.decode(&ids), case.text, "case {:?}", case.name);
+        assert_eq!(serving.decode(&ids), case.text, "case {:?}", case.name);
+    }
+
+    // Exported runtime tokenizer: the compiled tokenizer.bin carries the
+    // same id space — per-id decode bytes and byte lengths agree with
+    // the HF adapter over the whole exported vocabulary (added tokens
+    // are not part of model.vocab and are not exported).
+    let lengths = scenarios::export_hf_bytelevel_tokenizer_with_lengths(
+        dir.join("tokenizer.json"),
+        dir.join("tokenizer.bin"),
+    )
+    .expect("runtime tokenizer export");
+    let runtime = scenarios::Tokenizer::try_load(dir.join("tokenizer.bin"))
+        .expect("exported runtime tokenizer loads");
+    assert_eq!(runtime.vocab.len(), 256 + MERGED.len());
+    let hf_lengths = evaluation.token_byte_lengths();
+    for (id, piece) in runtime.vocab.iter().enumerate() {
+        let hf_bytes = evaluation.decode_bytes(&[id as u32]);
+        assert_eq!(piece, &hf_bytes, "runtime decode bytes drift at id {id}");
+        assert_eq!(
+            lengths[id] as usize,
+            piece.len(),
+            "exported length at id {id}"
+        );
+        assert_eq!(hf_lengths[id], lengths[id], "byte-length table at id {id}");
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The legacy llama2.c selection declares NO adapter: its κ-pinned
+/// baselines predate adapter records, and manifests written through it
+/// stay byte-identical (the #601 provenance field remains unset).
+#[test]
+fn legacy_selection_declares_no_adapter() {
+    let dir = unique_dir("legacy-none");
+    // Minimal legacy tokenizer.bin: i32 length-prefixed pieces.
+    let mut bytes = Vec::new();
+    for piece in [&b" "[..], b"a", b"b"] {
+        bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+        bytes.extend_from_slice(piece);
+    }
+    let path = dir.join("tokenizer.bin");
+    std::fs::write(&path, bytes).expect("write legacy tokenizer");
+    let legacy = scenarios::Tokenizer::try_load(&path).expect("legacy tokenizer loads");
+    assert!(TokenizerKind::Legacy(legacy).adapter().is_none());
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -33,6 +33,7 @@ use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_core::transformerless::compiler;
+use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::SourceUnavailable;
 #[cfg(not(target_arch = "wasm32"))]
@@ -265,6 +266,15 @@ pub struct ObservationManifest {
     /// manifest bytes are unchanged when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub geometry: Option<GeometryProjection>,
+    /// #601 typed record of the versioned tokenizer adapter the
+    /// producing pipeline segmented these observations with (family,
+    /// version, tokenizer CID, encode/decode policy, adapter digest),
+    /// when the pipeline's tokenizer declares one (the HF byte-level
+    /// BPE path; the legacy llama2.c tokenizer declares none).
+    /// Optional with a serde default so every legacy manifest stays
+    /// readable and legacy manifest bytes are unchanged when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokenizer_adapter: Option<TokenizerAdapter>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -280,6 +290,7 @@ impl ObservationManifest {
             input_cid: None,
             source_manifest_kappa: None,
             geometry: None,
+            tokenizer_adapter: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -418,6 +429,20 @@ impl ObservationShardWriter {
     pub fn set_geometry(&mut self, geometry: &GeometryProjection) -> Result<(), SourceUnavailable> {
         if self.manifest.geometry.as_ref() != Some(geometry) {
             self.manifest.geometry = Some(geometry.clone());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Record the #601 typed tokenizer-adapter identity record of the
+    /// producing pipeline's tokenizer in the observation manifest
+    /// (idempotent, atomic store).
+    pub fn set_tokenizer_adapter(
+        &mut self,
+        adapter: &TokenizerAdapter,
+    ) -> Result<(), SourceUnavailable> {
+        if self.manifest.tokenizer_adapter.as_ref() != Some(adapter) {
+            self.manifest.tokenizer_adapter = Some(adapter.clone());
             self.manifest.store(&self.dir)?;
         }
         Ok(())

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -939,6 +939,14 @@ pub fn observe_text_corpus(
         writer.set_geometry(&geometry)?;
     }
 
+    // #601: record the versioned tokenizer-adapter identity this pass
+    // segments with, when the selected tokenizer declares one (the HF
+    // byte-level BPE path; the legacy llama2.c tokenizer declares none,
+    // so legacy manifests remain byte-identical). Idempotent and atomic.
+    if let Some(adapter) = tokenizer.adapter() {
+        writer.set_tokenizer_adapter(&adapter)?;
+    }
+
     let workers = oracles.len();
     let seq_len = oracles[0].seq_len();
     let mut progress = Progress::new("text observations", articles_total as usize);
@@ -1161,6 +1169,12 @@ pub fn observe_text_corpus_batched(
                 stories_path,
             } => (writer, checkpoint, articles_total, stories_path),
         };
+
+    // #601: same tokenizer-adapter provenance as the serial driver — the
+    // batched path segments with the identical `TokenizerKind` selection.
+    if let Some(adapter) = tokenizer.adapter() {
+        writer.set_tokenizer_adapter(&adapter)?;
+    }
 
     let seq_len = oracle.seq_len();
     let mut progress = Progress::new("text observations", articles_total as usize);

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -522,6 +522,69 @@ fn geometry_projection_parses_and_persists_in_the_manifest() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// #601 provenance seam: the writer setter persists the typed
+/// [`TokenizerAdapter`] record into the observation manifest atomically
+/// and idempotently across reopen, and an unset record leaves legacy
+/// manifest bytes unchanged (no `tokenizer_adapter` key at all) — the
+/// legacy llama2.c selection never sets one, so its historical bytes and
+/// existing tokenizer CIDs stay valid.
+#[test]
+fn tokenizer_adapter_persists_in_the_manifest() {
+    let tokenizer_json = r#"{
+        "pre_tokenizer": {"type": "ByteLevel", "add_prefix_space": false},
+        "model": {"type": "BPE", "vocab": {"a": 0, "b": 1, "ab": 2}, "merges": ["a b"]}
+    }"#;
+    let record = uor_r4_core::transformerless::hf_bpe::HfBpeTokenizer::from_tokenizer_json_bytes(
+        tokenizer_json.as_bytes(),
+    )
+    .expect("fixture tokenizer parses")
+    .adapter();
+
+    let dir = unique_path("observe-tokenizer-adapter");
+    let mut writer = ObservationShardWriter::open(&dir, 2).expect("writer");
+    assert_eq!(writer.manifest().tokenizer_adapter, None);
+    // Legacy bytes: an unset record serializes no `tokenizer_adapter` key.
+    let legacy_json = serde_json::to_string(writer.manifest()).expect("manifest serializes");
+    assert!(
+        !legacy_json.contains("tokenizer_adapter"),
+        "an unset record must leave legacy manifest bytes unchanged"
+    );
+    // And a legacy manifest without the key still deserializes (None).
+    let legacy: ObservationManifest =
+        serde_json::from_str(&legacy_json).expect("legacy manifest deserializes");
+    assert_eq!(legacy.tokenizer_adapter, None);
+
+    writer
+        .set_tokenizer_adapter(&record)
+        .expect("set and store");
+    // Idempotent: re-setting the recorded value does not rewrite.
+    writer
+        .set_tokenizer_adapter(&record)
+        .expect("idempotent set");
+    drop(writer);
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.tokenizer_adapter.as_ref(), Some(&record));
+    // Round trip: the persisted record parses back bit-for-bit, digest
+    // included.
+    assert_eq!(
+        manifest
+            .tokenizer_adapter
+            .as_ref()
+            .map(|a| &a.adapter_digest),
+        Some(&record.adapter_digest)
+    );
+    // A reopened writer (as the observe-text drivers do after the
+    // pre-set) preserves the stored record.
+    let reopened = ObservationShardWriter::open(&dir, 2).expect("reopen");
+    assert_eq!(
+        reopened.manifest().tokenizer_adapter.as_ref(),
+        Some(&record)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// #600: the legacy checkpoint oracle declares no projection (its dim IS
 /// the source width), while the Hugging Face adapter declares
 /// `bucket-average/1` — asserted here structurally via the trait default.

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -1687,6 +1687,19 @@ pub enum SourceIngestKind {
         /// The requested projection version.
         version: u32,
     },
+    /// #601 tokenizer-adapter registry: a caller named a tokenizer
+    /// adapter `(family, version)` outside the versioned registry
+    /// (`uor_r4_core::transformerless::hf_bpe::adapter_constructor`),
+    /// so no constructor exists to interpret it. Refused by name, never
+    /// approximated by a "closest" family or version; in particular the
+    /// recorded `sentencepiece-unigram` follow-up family is rejected
+    /// here until a versioned adapter for it exists.
+    UnknownTokenizerAdapter {
+        /// The requested adapter family.
+        family: String,
+        /// The requested adapter version.
+        version: u32,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1758,6 +1771,13 @@ impl std::fmt::Display for SourceIngestKind {
                  registry (known: {}/{})",
                 geometry::GeometryProjection::BUCKET_AVERAGE_ID,
                 geometry::GeometryProjection::BUCKET_AVERAGE_VERSION,
+            ),
+            Self::UnknownTokenizerAdapter { family, version } => write!(
+                f,
+                "tokenizer adapter {family}/{version} is not in the versioned adapter \
+                 registry (known: hf-byte-bpe/1; sentencepiece-unigram is the recorded \
+                 follow-up family and stays rejected until its adapter is implemented, \
+                 never approximated)"
             ),
         }
     }

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -251,6 +251,50 @@ legacy documents are not rewritten, and inputs from the legacy checkpoint
 oracle (whose source width is already 288, no projection) carry no such
 implication.
 
+#### Versioned tokenizer adapters (#601)
+
+The tokenizer a pipeline segments with is a typed, versioned identity, not
+an implementation detail. `uor-r4-core::transformerless::hf_bpe` derives a
+`TokenizerAdapter { family, version, tokenizer_cid, policy,
+adapter_digest }` record from every parsed `tokenizer.json`
+(`HfBpeTokenizer::adapter()`, selected through `TokenizerKind::adapter()`):
+family `hf-byte-bpe` version 1 is the post-#242/#253 byte-level BPE, the
+`tokenizer_cid` is the blake3 of the raw `tokenizer.json` bytes (the same
+CID rule used everywhere today), and the policy block names the applied
+normalizer (`none`), the pre-tokenizer steps in order (e.g.
+`digits(individual_digits=true)` then
+`byte-level(add_prefix_space=false)`), the byte-fallback mechanism
+(`byte-level-alphabet` — the GPT-2 byte alphabet makes encoding total), an
+added-token count + canonical digest, BOS/EOS insertion (`none`; the
+pinned post-processor is null), and the chat-template policy
+(`not-interpreted`). The `adapter_digest` is the blake3 of a canonical,
+byte-stable serialization of that declared identity — like the #600
+geometry digest, deliberately not a hash of source code text; a
+behavioral change must arrive as a new registry version, never an
+in-place edit.
+
+A versioned registry maps `(family, version)` to the constructor
+(`hf_bpe::adapter_constructor`); an unknown pair fails closed with the
+focused `SourceIngestKind::UnknownTokenizerAdapter` rather than being
+guessed. SentencePiece/Unigram is the recorded follow-up family
+(`sentencepiece-unigram`): recognized by name, rejected until a versioned
+adapter for it exists, never approximated with the byte-level BPE rule.
+
+The record threads into provenance the same way the #597 manifest κ and
+the #600 geometry record do: the observe-text drivers (serial and
+batched) record it in the observation manifest automatically whenever the
+selected tokenizer declares one (`tokenizer_adapter`, an optional
+serde-defaulted field — manifests written through the legacy llama2.c
+tokenizer carry no field and stay byte-identical, and every existing
+tokenizer CID remains valid). Differential source fixtures
+(`crates/uor-r4-core/tests/tokenizer_adapter.rs`) pin the current
+verified encode/decode behavior — ASCII, accents, CJK, emoji incl. ZWJ
+sequences, byte fallback, added tokens, BOS/EOS handling, digit
+boundaries, raw-byte round trips — as the baseline any drift fails
+against, and a consumer-agreement test asserts the observation,
+evaluation, serving-prompt, and exported-runtime-tokenizer selection
+seams resolve the same adapter identity, token ids, and decode bytes.
+
 ### 3. Compile the holographic graph
 
 The graph compiler turns the retained observation corpus and TLA artifact


### PR DESCRIPTION
feat(#601): versioned tokenizer adapters + differential source fixtures

The existing TokenizerKind/HfBpeTokenizer surface becomes a versioned
adapter boundary - no parallel API. TokenizerAdapter record (family
hf-byte-bpe/1, tokenizer_cid = the existing blake3-of-bytes rule,
policy incl. pre-tokenizers, byte fallback, added-tokens digest,
BOS/EOS, chat-template not-interpreted) with a declared-identity digest
over pinned canonical bytes (the #600 rationale). Registry refuses
unknown (family,version) by name through the sanctioned surface
(UnknownTokenizerAdapter kind); sentencepiece-unigram is a recognized-
but-rejected family with a follow-up issue. Differential fixtures: a
full-256-byte-alphabet tokenizer with pinned expected ids/bytes across
ASCII merges, Unicode (CJK, emoji ZWJ), byte fallback, added tokens,
BOS/EOS, digits-boundary differentials - pinning the post-#242/#253
verified behavior as the baseline so any drift fails. Consumer
agreement asserted across observation, evaluation, serving-selection,
and exported-runtime-tokenizer seams (ids + raw decode bytes + one
adapter identity). ObservationManifest.tokenizer_adapter serde(default)
auto-populated on observe-text paths; legacy bytes unchanged when
unset; legacy llama2.c tokenizer and historical kappas untouched.
11+1 new tests; no new deps; wasm-clean. Docs section added.
