### PR TITLE
feat(#602): versioned source attention operator specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Anything else is served as a static file from the working directory; `/` serves
 | `transformerless` | Allocation-free table-native codebook retrieval, sub-millisecond on CPU |
 | `r4g1` | The validated R4G1 graph scorer; needs a loaded `score.r4g1` |
 | `attention` | Standard scaled dot-product attention on the loaded teacher (up to 256 tokens) |
-| `r4-attention` | Experimental 4D Spin(4) softmax-free attention (~25% faster on CPU by bypassing softmax exponents) |
+| `r4-attention` | Experimental teacher attention variant (#602 operator `experimental-r4-source-attention/1`: a 4-wide-chunked dot product with the same softmax selector as `attention`; never measured against it — see `docs/deferral_record_2026_08_05.md`) |
 | `geometric` | Route purely geometrically and decode from manifold resonance |
 
 Omitting `engine` runs the **full cascade, r4g1-first** — it does *not* mean

--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -479,6 +479,16 @@ fn stage_b_flags(request: &CompileRequest, cover_out: &Path) -> Vec<String> {
     if let Some(kappa) = &request.source_manifest_kappa {
         flags.extend(["--source-manifest-kappa".to_owned(), kappa.clone()]);
     }
+    // #602: this request holds the teacher's `r4_attention` switch, which
+    // maps to exactly one registered attention operator
+    // (`standard-source-attention/1` off,
+    // `experimental-r4-source-attention/1` on); thread the typed record
+    // into the cover stage so compile_report.json binds the operator the
+    // teacher actually ran.
+    let operator = uor_r4_model_source::attention::operator_for_r4_switch(options.r4_attention);
+    if let Ok(json) = serde_json::to_string(&operator) {
+        flags.extend(["--attention-operator".to_owned(), json]);
+    }
     flags
 }
 
@@ -541,5 +551,33 @@ mod tests {
         let without = stage_b_flags(&request(None), Path::new("cover"));
         assert!(!without.iter().any(|flag| flag == "--source-manifest-kappa"));
         assert_eq!(with.len(), without.len() + 2);
+    }
+
+    /// #602 plumbing seam: the request's boolean `r4_attention` switch is
+    /// forwarded to the cover stage as the typed record of exactly the
+    /// registered operator the teacher ran — `standard-source-attention/1`
+    /// when off (the default), `experimental-r4-source-attention/1` when
+    /// on.
+    #[test]
+    fn attention_operator_is_threaded_into_cover_stage_flags() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        let flag_value = |flags: &[String]| -> AttentionOperatorSpec {
+            let index = flags
+                .iter()
+                .position(|flag| flag == "--attention-operator")
+                .expect("flag present");
+            serde_json::from_str(&flags[index + 1]).expect("typed record round-trips")
+        };
+
+        let standard = stage_b_flags(&request(None), Path::new("cover"));
+        assert_eq!(flag_value(&standard), AttentionOperatorSpec::standard());
+
+        let mut experimental_request = request(None);
+        experimental_request.options.r4_attention = true;
+        let experimental = stage_b_flags(&experimental_request, Path::new("cover"));
+        assert_eq!(
+            flag_value(&experimental),
+            AttentionOperatorSpec::experimental_r4()
+        );
     }
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -624,6 +624,13 @@ struct CoverOptions {
     /// into the cover report. This crate never derives the record itself;
     /// the pipeline that held the oracle passes it.
     geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
+    /// #602 typed attention-operator record of the teacher source
+    /// (`--attention-operator`, a JSON serialization of
+    /// [`uor_r4_model_source::attention::AttentionOperatorSpec`]),
+    /// carried into the cover report. This crate never derives the
+    /// record itself; the pipeline that held the oracle (or its
+    /// `r4_attention` switch) passes it.
+    attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
 }
 
 fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailable> {
@@ -642,6 +649,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         output: PathBuf::from("cover"),
         source_manifest_kappa: None,
         geometry: None,
+        attention_operator: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -725,6 +733,14 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                 options.geometry = Some(serde_json::from_str(value).map_err(|error| {
                     SourceUnavailable::new(format!("invalid --geometry-projection value: {error}"))
                 })?);
+            }
+            "--attention-operator" => {
+                options.attention_operator =
+                    Some(serde_json::from_str(value).map_err(|error| {
+                        SourceUnavailable::new(format!(
+                            "invalid --attention-operator value: {error}"
+                        ))
+                    })?);
             }
             _ => {
                 return Err(SourceUnavailable::new(format!(
@@ -908,6 +924,9 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     // #600: bind the teacher's geometry-projection record when the caller
     // passed it (`--geometry-projection`).
     report.geometry = options.geometry.clone();
+    // #602: bind the teacher's attention-operator record when the caller
+    // passed it (`--attention-operator`).
+    report.attention_operator = options.attention_operator.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("cover.r4g1");
@@ -3154,6 +3173,30 @@ mod tests {
             parse_cover_options(&["--geometry-projection".to_owned(), "{not json".to_owned()])
                 .expect_err("malformed record is not a product");
         assert!(error.reason.contains("--geometry-projection"));
+    }
+
+    /// #602 plumbing seam: the cover stage accepts the typed
+    /// attention-operator record as JSON (populated into the cover
+    /// report), leaves it unset when the flag is absent (the legacy
+    /// interpretation), and refuses malformed JSON by name on the
+    /// sanctioned error surface.
+    #[test]
+    fn cover_options_carry_the_attention_operator() {
+        for record in [
+            uor_r4_model_source::attention::AttentionOperatorSpec::standard(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4(),
+        ] {
+            let json = serde_json::to_string(&record).expect("record serializes");
+            let args = ["--attention-operator".to_owned(), json];
+            let options = parse_cover_options(&args).expect("valid cover options");
+            assert_eq!(options.attention_operator.as_ref(), Some(&record));
+        }
+        let defaults = parse_cover_options(&[]).expect("default cover options");
+        assert_eq!(defaults.attention_operator, None);
+        let error =
+            parse_cover_options(&["--attention-operator".to_owned(), "{not json".to_owned()])
+                .expect_err("malformed record is not a product");
+        assert!(error.reason.contains("--attention-operator"));
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2531,6 +2531,16 @@ pub struct CoverReport {
     /// callers set the public field after [`build_report`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
+    /// #602 typed record of the source attention operator the teacher
+    /// computed while producing the compiled inputs
+    /// (`standard-source-attention/1`, or
+    /// `experimental-r4-source-attention/1` when the `r4_attention`
+    /// switch was on), when the invoking pipeline knows it
+    /// (`--attention-operator`). Optional so every legacy report and
+    /// its bytes stay unchanged when unset; callers set the public
+    /// field after [`build_report`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
     pub config: CoverReportConfig,
     pub inputs: CoverReportInputs,
     pub objective: CoverReportObjective,
@@ -2748,9 +2758,11 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
         // #597: populated by callers that hold the source-snapshot
         // manifest root κ; the induction stages do not see the snapshot.
         source_manifest_kappa: None,
-        // #600: populated by callers that hold the teacher's geometry
-        // projection record; the induction stages do not see the teacher.
+        // #600/#602: populated by callers that hold the teacher's geometry
+        // projection record and attention-operator record; the induction
+        // stages do not see the teacher.
         geometry: None,
+        attention_operator: None,
         config: CoverReportConfig {
             depths: config.depths,
             k0: config.k0,

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -56,6 +56,13 @@ pub struct GraphCompileOptions {
     /// into the compile report. This crate never derives the record
     /// itself; the pipeline that held the oracle passes it.
     pub geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
+    /// #602 typed attention-operator record of the teacher source
+    /// (`--attention-operator`, a JSON serialization of
+    /// [`uor_r4_model_source::attention::AttentionOperatorSpec`]),
+    /// carried into the compile report. This crate never derives the
+    /// record itself; the pipeline that held the oracle (or its
+    /// `r4_attention` switch) passes it.
+    pub attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
 }
 
 /// Parse graph-compile CLI arguments. `None` when the arguments do not name a
@@ -77,6 +84,7 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
         output: PathBuf::from("r4g1_output"),
         source_manifest_kappa: None,
         geometry: None,
+        attention_operator: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -120,6 +128,9 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
             }
             "--geometry-projection" => {
                 options.geometry = Some(serde_json::from_str(value).ok()?);
+            }
+            "--attention-operator" => {
+                options.attention_operator = Some(serde_json::from_str(value).ok()?);
             }
             _ => return None,
         }
@@ -248,6 +259,9 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     // #600: bind the teacher's geometry-projection record when the caller
     // passed it (`--geometry-projection`).
     report.geometry = options.geometry.clone();
+    // #602: bind the teacher's attention-operator record when the caller
+    // passed it (`--attention-operator`).
+    report.attention_operator = options.attention_operator.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("compiled.r4g1");
@@ -351,13 +365,15 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
             Box::new(o)
         };
 
-    // #597: record the source-snapshot identity — and, since #600, the
-    // typed geometry-projection record the oracle itself declares — in
-    // the observation manifest before the sharded run opens it
-    // (idempotent, atomic; the run's own writer loads and preserves the
-    // stored fields).
+    // #597: record the source-snapshot identity — and, since #600/#602,
+    // the typed geometry-projection and attention-operator records the
+    // oracle itself declares — in the observation manifest before the
+    // sharded run opens it (idempotent, atomic; the run's own writer
+    // loads and preserves the stored fields).
     let geometry = oracle.geometry_projection();
-    if options.source_manifest_kappa.is_some() || geometry.is_some() {
+    let attention_operator = oracle.attention_operator_spec();
+    if options.source_manifest_kappa.is_some() || geometry.is_some() || attention_operator.is_some()
+    {
         let mut writer =
             observation::ObservationShardWriter::open(&options.output, options.shards)?;
         if let Some(kappa) = &options.source_manifest_kappa {
@@ -365,6 +381,9 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
         }
         if let Some(geometry) = &geometry {
             writer.set_geometry(geometry)?;
+        }
+        if let Some(operator) = &attention_operator {
+            writer.set_attention_operator(operator)?;
         }
     }
 

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -38,6 +38,7 @@ use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
 use uor_r4_model_source::SourceUnavailable;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::TeacherOracle;
+use uor_r4_model_source::attention::AttentionOperatorSpec;
 use uor_r4_model_source::geometry::GeometryProjection;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::progress::Progress;
@@ -275,6 +276,17 @@ pub struct ObservationManifest {
     /// readable and legacy manifest bytes are unchanged when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokenizer_adapter: Option<TokenizerAdapter>,
+    /// #602 typed record of the source attention operator the teacher
+    /// oracle computed while producing these observations
+    /// (`standard-source-attention/1`, or
+    /// `experimental-r4-source-attention/1` when the `r4_attention`
+    /// switch was on), when the producing pipeline's oracle declares
+    /// one. `None` marks the legacy interpretation documented in
+    /// `docs/MODEL_LIFECYCLE.md`. Optional with a serde default so
+    /// every legacy manifest stays readable and legacy manifest bytes
+    /// are unchanged when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_operator: Option<AttentionOperatorSpec>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -291,6 +303,7 @@ impl ObservationManifest {
             source_manifest_kappa: None,
             geometry: None,
             tokenizer_adapter: None,
+            attention_operator: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
@@ -443,6 +456,20 @@ impl ObservationShardWriter {
     ) -> Result<(), SourceUnavailable> {
         if self.manifest.tokenizer_adapter.as_ref() != Some(adapter) {
             self.manifest.tokenizer_adapter = Some(adapter.clone());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
+    /// Record the #602 typed attention-operator identity record of the
+    /// teacher oracle in the observation manifest (idempotent, atomic
+    /// store).
+    pub fn set_attention_operator(
+        &mut self,
+        operator: &AttentionOperatorSpec,
+    ) -> Result<(), SourceUnavailable> {
+        if self.manifest.attention_operator.as_ref() != Some(operator) {
+            self.manifest.attention_operator = Some(operator.clone());
             self.manifest.store(&self.dir)?;
         }
         Ok(())

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -939,6 +939,15 @@ pub fn observe_text_corpus(
         writer.set_geometry(&geometry)?;
     }
 
+    // #602: record the typed attention-operator identity the teacher
+    // oracle's source executor computes (the boolean `r4_attention`
+    // switch resolved to its registered operator id), when the oracle
+    // declares one. Idempotent and atomic; legacy manifests without the
+    // field remain byte-identical.
+    if let Some(operator) = oracles[0].attention_operator_spec() {
+        writer.set_attention_operator(&operator)?;
+    }
+
     // #601: record the versioned tokenizer-adapter identity this pass
     // segments with, when the selected tokenizer declares one (the HF
     // byte-level BPE path; the legacy llama2.c tokenizer declares none,

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -585,9 +585,67 @@ fn tokenizer_adapter_persists_in_the_manifest() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// #602 provenance seam: the writer setter persists the typed
+/// [`AttentionOperatorSpec`] record into the observation manifest
+/// atomically and idempotently across reopen, and an unset record leaves
+/// legacy manifest bytes unchanged (no `attention_operator` key at all)
+/// — oracles that predate the record never set one, so their historical
+/// bytes stay valid (the documented legacy interpretation).
+#[test]
+fn attention_operator_persists_in_the_manifest() {
+    use uor_r4_model_source::attention::AttentionOperatorSpec;
+    let record = AttentionOperatorSpec::standard();
+
+    let dir = unique_path("observe-attention-operator");
+    let mut writer = ObservationShardWriter::open(&dir, 2).expect("writer");
+    assert_eq!(writer.manifest().attention_operator, None);
+    // Legacy bytes: an unset record serializes no `attention_operator` key.
+    let legacy_json = serde_json::to_string(writer.manifest()).expect("manifest serializes");
+    assert!(
+        !legacy_json.contains("attention_operator"),
+        "an unset record must leave legacy manifest bytes unchanged"
+    );
+    // And a legacy manifest without the key still deserializes (None).
+    let legacy: ObservationManifest =
+        serde_json::from_str(&legacy_json).expect("legacy manifest deserializes");
+    assert_eq!(legacy.attention_operator, None);
+
+    writer
+        .set_attention_operator(&record)
+        .expect("set and store");
+    // Idempotent: re-setting the recorded value does not rewrite.
+    writer
+        .set_attention_operator(&record)
+        .expect("idempotent set");
+    drop(writer);
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.attention_operator.as_ref(), Some(&record));
+    // Round trip: the persisted record parses back bit-for-bit, digest
+    // included.
+    assert_eq!(
+        manifest
+            .attention_operator
+            .as_ref()
+            .map(|operator| &operator.implementation_digest),
+        Some(&record.implementation_digest)
+    );
+    // A reopened writer (as the observe drivers do after the pre-set)
+    // preserves the stored record.
+    let reopened = ObservationShardWriter::open(&dir, 2).expect("reopen");
+    assert_eq!(
+        reopened.manifest().attention_operator.as_ref(),
+        Some(&record)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// #600: the legacy checkpoint oracle declares no projection (its dim IS
 /// the source width), while the Hugging Face adapter declares
 /// `bucket-average/1` — asserted here structurally via the trait default.
+/// #602 mirrors the pattern for the attention operator: an oracle that
+/// declares nothing carries the documented legacy interpretation.
 #[test]
 fn trait_geometry_projection_defaults_to_none() {
     struct Plain;
@@ -632,6 +690,7 @@ fn trait_geometry_projection_defaults_to_none() {
         fn embedding(&self, _token: usize, _out: &mut [f32]) {}
     }
     assert_eq!(Plain.geometry_projection(), None);
+    assert_eq!(Plain.attention_operator_spec(), None);
 }
 
 #[test]

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -1,0 +1,843 @@
+//! Source attention operator specification (#602): the typed, versioned
+//! record of the attention operator a source teacher computes, plus the
+//! factored reference implementations themselves.
+//!
+//! Before #602 the teacher's attention operator was a boolean
+//! (`Config::r4_attention`) selecting between two in-line loop bodies in
+//! `Llama::layer_forward`/`Llama::forward_batch`, and the experimental
+//! branch was described in stale wording that #515's audit records as not
+//! matching its control flow. This module makes the operator identity
+//! explicit and truthful:
+//!
+//! - [`AttentionOperatorSpec`] is the serializable record `{id, version,
+//!   projections, positional_action, compatibility_relation,
+//!   selector_normalization, value_aggregation, output_projection,
+//!   runtime_state, tie_breaking, permitted_operation_class, params}`
+//!   carried by the observation manifest and the cover/compile report.
+//! - [`standard_head_attention_weights`] and
+//!   [`head_attention_value_aggregate`] are the free, deterministic
+//!   reference implementations of `standard-source-attention/1` — the
+//!   exact arithmetic (iteration order, sequential f32 folds, one divide
+//!   per score) the teacher has always used, factored out unchanged.
+//! - [`experimental_r4_head_attention_weights`] is the factored
+//!   experimental branch, recorded under the honest id
+//!   `experimental-r4-source-attention/1` with its ACTUAL computation
+//!   (see below) — not the historical description.
+//! - [`operator_spec`] is the versioned registry mapping `(id, version)`
+//!   to a spec; an unknown pair is refused by name on the sanctioned
+//!   [`SourceUnavailable`](crate::SourceUnavailable) surface rather than
+//!   guessed.
+//!
+//! **Truthful inventory of the two branches** (read from
+//! `Llama::layer_forward` / `Llama::forward_batch`; the unit tests below
+//! pin every claim):
+//!
+//! Both branches share: dense per-layer f32 `wq`/`wk`/`wv` projections
+//! with grouped-query key/value sharing (head `h` reads kv head
+//! `h / kv_mul` where `kv_mul = n_heads / n_kv_heads`); RoPE rotation of
+//! q and k applied before any score (interleaved-pair or split-half
+//! layout is a source-config property, not an operator property); a
+//! growing KV cache attending the full prefix `0..=pos`; value
+//! aggregation as a position-ascending weighted sum `out[i] +=
+//! att[t] * v_t[i]`; and a dense per-layer f32 `wo` output projection.
+//! Both branches normalize scores with the SAME selector,
+//! `softmax_with_mode`: subtract the maximum score (first maximum on
+//! ties — value-identical, since only the maximum's value enters), then
+//! `exp` each shifted score (`libm::expf` in canonical mode, `f32::exp`
+//! otherwise) and divide by the sum. Neither branch performs an argmax
+//! or any selection needing a tie-break beyond that stabilizer.
+//!
+//! They differ ONLY in the compatibility relation:
+//!
+//! - **standard**: `score(t) = (Σ_{i<H} q[i]·k_t[i]) / sqrt(H)` for head
+//!   width `H`, accumulated as a single sequential f32 left fold over
+//!   every head dimension.
+//! - **experimental**: `score(t) = (Σ_{c<⌊H/4⌋} Σ_{j<4}
+//!   q[4c+j]·k_t[4c+j]) / sqrt(H)` — the dot product computed in 4-wide
+//!   chunks (each chunk a left-to-right 4-term fold, chunk subtotals
+//!   then summed), which is still a dot product followed by the same
+//!   softmax. **Remainder policy**: the trailing `H mod 4` q/k
+//!   dimensions are never read by the score (dropped), while the scale
+//!   divides by `sqrt(H)` over the FULL head width and value aggregation
+//!   still uses every head dimension. For `H < 4` no chunk exists, every
+//!   score is 0, and the softmax yields uniform weights over the prefix.
+//!   For `H` divisible by 4 the same terms are scored but the chunked
+//!   accumulation order can differ from the standard single fold in the
+//!   last bits.
+//!
+//! **Implementation digest.** As with the #600 geometry record and the
+//! #601 tokenizer-adapter record, `implementation_digest` is the blake3
+//! of the [canonical serialization](AttentionOperatorSpec::canonical_bytes)
+//! of the operator's *declared identity* — NOT a hash of source code
+//! text, which would churn under refactors that leave the arithmetic
+//! bit-identical. The unit tests pin the implementations to the
+//! declarations, so a behavioral change must bump the version (a new
+//! registry entry) instead of silently drifting.
+//!
+//! **Boundary note.** These specs describe HOST-SIDE source-teacher
+//! computation (f32 dot products, exp, division). They are provenance
+//! records, distinct from — and outside — the deployed inference
+//! operation contract
+//! (`docs/transformerless/INFERENCE_OPERATION_CONTRACT.md`), which
+//! forbids floating-point arithmetic on the deployed hot path and
+//! explicitly excludes teacher execution. #602 defines no target
+//! (deployed) operator.
+
+use serde::{Deserialize, Serialize};
+
+/// Declared parameters of an attention operator — head selection, score
+/// scale, score-width policy (which head dimensions the compatibility
+/// relation reads), remainder policy for non-divisible head widths, and
+/// the score accumulation order. These strings are stable machine tokens
+/// (they enter the canonical digest serialization byte-for-byte),
+/// documented on [`AttentionOperatorParams::standard`] and
+/// [`AttentionOperatorParams::experimental_r4`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttentionOperatorParams {
+    /// How a query head selects its key/value head (grouped query).
+    #[serde(default)]
+    pub head_selection: String,
+    /// The scale applied to every raw score.
+    #[serde(default)]
+    pub score_scale: String,
+    /// Which head dimensions the compatibility relation reads.
+    #[serde(default)]
+    pub score_width_policy: String,
+    /// What happens to head dimensions outside the scored width.
+    #[serde(default)]
+    pub remainder_policy: String,
+    /// The f32 accumulation order of one score.
+    #[serde(default)]
+    pub score_accumulation: String,
+}
+
+impl AttentionOperatorParams {
+    /// The declared parameters of `standard-source-attention/1`:
+    ///
+    /// - `head_selection = "grouped-query-kv-head-h-div-kv-mul"` — head
+    ///   `h` reads kv head `h / kv_mul`, `kv_mul = n_heads / n_kv_heads`.
+    /// - `score_scale = "divide-by-sqrt-full-head-size"` — one divide by
+    ///   `sqrt(H)` per score, `H` the full head width.
+    /// - `score_width_policy = "full-head-width"` — every head dimension
+    ///   enters the dot product.
+    /// - `remainder_policy = "none-every-head-dimension-scored"` — there
+    ///   is no unscored remainder at any head width.
+    /// - `score_accumulation = "sequential-f32-left-fold"` — one running
+    ///   f32 sum over `i = 0..H` in order.
+    pub fn standard() -> Self {
+        Self {
+            head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
+            score_scale: "divide-by-sqrt-full-head-size".to_owned(),
+            score_width_policy: "full-head-width".to_owned(),
+            remainder_policy: "none-every-head-dimension-scored".to_owned(),
+            score_accumulation: "sequential-f32-left-fold".to_owned(),
+        }
+    }
+
+    /// The declared parameters of `experimental-r4-source-attention/1`
+    /// — the ACTUAL computation of the `r4_attention` branch:
+    ///
+    /// - `head_selection = "grouped-query-kv-head-h-div-kv-mul"` — same
+    ///   as standard.
+    /// - `score_scale = "divide-by-sqrt-full-head-size"` — the divide
+    ///   uses the FULL head width `H` even though only `4·⌊H/4⌋`
+    ///   dimensions are scored.
+    /// - `score_width_policy = "chunks-of-4-floor-head-size-div-4"` —
+    ///   the dot product reads dimensions `0..4·⌊H/4⌋` in 4-wide chunks.
+    /// - `remainder_policy = "truncate-trailing-head-size-mod-4-dims-from-score"`
+    ///   — the trailing `H mod 4` q/k dimensions never enter any score
+    ///   (value aggregation still uses all `H` dimensions); `H < 4`
+    ///   scores 0 everywhere, so the softmax is uniform.
+    /// - `score_accumulation = "per-4-chunk-left-fold-then-chunk-sum"` —
+    ///   each chunk is a left-to-right 4-term f32 fold; chunk subtotals
+    ///   are then summed in chunk order.
+    pub fn experimental_r4() -> Self {
+        Self {
+            head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
+            score_scale: "divide-by-sqrt-full-head-size".to_owned(),
+            score_width_policy: "chunks-of-4-floor-head-size-div-4".to_owned(),
+            remainder_policy: "truncate-trailing-head-size-mod-4-dims-from-score".to_owned(),
+            score_accumulation: "per-4-chunk-left-fold-then-chunk-sum".to_owned(),
+        }
+    }
+}
+
+/// The typed, versioned record of one source attention operator (#602).
+/// Serialized (all fields serde-defaulted) into the observation manifest
+/// and the cover/compile report wherever the operator is known, so an
+/// operator change is visible in provenance instead of silent. `None`
+/// wherever the record is carried means the legacy interpretation
+/// documented in `docs/MODEL_LIFECYCLE.md` (produced before #602; for
+/// teacher paths the default-off switch always computed
+/// `standard-source-attention/1`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttentionOperatorSpec {
+    /// Registry id of the operator (e.g. `"standard-source-attention"`).
+    #[serde(default)]
+    pub id: String,
+    /// Registry version of the operator. A behavioral change is a new
+    /// version, never an in-place edit.
+    #[serde(default)]
+    pub version: u32,
+    /// The projections producing q/k/v from the normalized residual.
+    #[serde(default)]
+    pub projections: String,
+    /// The positional action applied before scoring.
+    #[serde(default)]
+    pub positional_action: String,
+    /// The compatibility relation between a query and a cached key.
+    #[serde(default)]
+    pub compatibility_relation: String,
+    /// The selector/normalization turning raw scores into weights —
+    /// exactly what `softmax_with_mode` computes, per mode.
+    #[serde(default)]
+    pub selector_normalization: String,
+    /// How weighted values are aggregated into the head output.
+    #[serde(default)]
+    pub value_aggregation: String,
+    /// The projection producing the layer output from head outputs.
+    #[serde(default)]
+    pub output_projection: String,
+    /// The recurrent state the operator reads and extends.
+    #[serde(default)]
+    pub runtime_state: String,
+    /// Deterministic tie-breaking discipline.
+    #[serde(default)]
+    pub tie_breaking: String,
+    /// The operation class the operator is permitted to use — host-side
+    /// source f32; NOT the deployed inference contract's integer set.
+    #[serde(default)]
+    pub permitted_operation_class: String,
+    /// The operator's declared parameters (head selection, scale, score
+    /// width, remainder policy, accumulation order).
+    #[serde(default)]
+    pub params: AttentionOperatorParams,
+    /// `blake3:<hex>` of [`AttentionOperatorSpec::canonical_bytes`] —
+    /// the declared identity, not source code text (see the module docs
+    /// for why).
+    #[serde(default)]
+    pub implementation_digest: String,
+}
+
+impl AttentionOperatorSpec {
+    /// Registry id of the standard scaled-dot-product source operator.
+    pub const STANDARD_ID: &'static str = "standard-source-attention";
+    /// Registry version of the standard operator currently implemented
+    /// by [`standard_head_attention_weights`] +
+    /// [`head_attention_value_aggregate`].
+    pub const STANDARD_VERSION: u32 = 1;
+    /// Registry id of the experimental `r4_attention`-gated operator,
+    /// named for what it computes (a chunked dot product with the same
+    /// softmax selector), not for the historical description.
+    pub const EXPERIMENTAL_R4_ID: &'static str = "experimental-r4-source-attention";
+    /// Registry version of the experimental operator currently
+    /// implemented by [`experimental_r4_head_attention_weights`] +
+    /// [`head_attention_value_aggregate`].
+    pub const EXPERIMENTAL_R4_VERSION: u32 = 1;
+
+    /// The `standard-source-attention/1` record — the operator the
+    /// default-off `r4_attention` switch has always computed.
+    pub fn standard() -> Self {
+        let mut record = Self {
+            id: Self::STANDARD_ID.to_owned(),
+            version: Self::STANDARD_VERSION,
+            projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
+            positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
+            compatibility_relation: "scaled-dot-product".to_owned(),
+            selector_normalization: "softmax-max-subtracted-exp-then-sum-normalize".to_owned(),
+            value_aggregation: "position-ascending-weighted-sum-of-values".to_owned(),
+            output_projection: "per-layer-dense-f32-wo".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class: "host-source-f32".to_owned(),
+            params: AttentionOperatorParams::standard(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// The `experimental-r4-source-attention/1` record — the ACTUAL
+    /// computation of the `r4_attention = true` branch: a 4-wide-chunked
+    /// dot product (truncating the trailing `head_size mod 4`
+    /// dimensions from the score) followed by the SAME max-subtracted
+    /// softmax the standard operator uses.
+    pub fn experimental_r4() -> Self {
+        let mut record = Self {
+            id: Self::EXPERIMENTAL_R4_ID.to_owned(),
+            version: Self::EXPERIMENTAL_R4_VERSION,
+            projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
+            positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
+            compatibility_relation: "chunked-4-wide-dot-product".to_owned(),
+            selector_normalization: "softmax-max-subtracted-exp-then-sum-normalize".to_owned(),
+            value_aggregation: "position-ascending-weighted-sum-of-values".to_owned(),
+            output_projection: "per-layer-dense-f32-wo".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class: "host-source-f32".to_owned(),
+            params: AttentionOperatorParams::experimental_r4(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Canonical serialization of the record's declared identity: a
+    /// fixed line format (format tag, id, version, operator fields,
+    /// parameters, each `key=value\n`). Byte-stable by construction —
+    /// field order and separators are fixed here, not derived from any
+    /// serializer — so the digest over these bytes is reproducible
+    /// everywhere.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "uor-r4-attention-operator/1\n\
+             id={}\n\
+             version={}\n\
+             projections={}\n\
+             positional_action={}\n\
+             compatibility_relation={}\n\
+             selector_normalization={}\n\
+             value_aggregation={}\n\
+             output_projection={}\n\
+             runtime_state={}\n\
+             tie_breaking={}\n\
+             permitted_operation_class={}\n\
+             param.head_selection={}\n\
+             param.score_scale={}\n\
+             param.score_width_policy={}\n\
+             param.remainder_policy={}\n\
+             param.score_accumulation={}\n",
+            self.id,
+            self.version,
+            self.projections,
+            self.positional_action,
+            self.compatibility_relation,
+            self.selector_normalization,
+            self.value_aggregation,
+            self.output_projection,
+            self.runtime_state,
+            self.tie_breaking,
+            self.permitted_operation_class,
+            self.params.head_selection,
+            self.params.score_scale,
+            self.params.score_width_policy,
+            self.params.remainder_policy,
+            self.params.score_accumulation,
+        )
+        .into_bytes()
+    }
+
+    /// The implementation digest this record's declared identity
+    /// implies: `blake3:<hex>` over
+    /// [`AttentionOperatorSpec::canonical_bytes`].
+    pub fn declared_digest(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.canonical_bytes()).to_hex())
+    }
+}
+
+/// The typed record the boolean `Config::r4_attention` switch selects:
+/// `false` has always computed `standard-source-attention/1`, `true` the
+/// `experimental-r4-source-attention/1` branch. This is the one boundary
+/// mapping from the legacy switch to the versioned operator identity.
+pub fn operator_for_r4_switch(r4_attention: bool) -> AttentionOperatorSpec {
+    if r4_attention {
+        AttentionOperatorSpec::experimental_r4()
+    } else {
+        AttentionOperatorSpec::standard()
+    }
+}
+
+/// The versioned operator registry (#602): map `(id, version)` to the
+/// spec that names it. Every pair outside the registry is refused by
+/// name on the sanctioned [`SourceUnavailable`] surface
+/// ([`SourceIngestKind::UnknownAttentionOperator`]) — never guessed,
+/// never approximated by a "closest" operator or version.
+///
+/// [`SourceUnavailable`]: crate::SourceUnavailable
+/// [`SourceIngestKind::UnknownAttentionOperator`]: crate::SourceIngestKind::UnknownAttentionOperator
+#[cfg(not(target_arch = "wasm32"))]
+pub fn operator_spec(
+    id: &str,
+    version: u32,
+) -> Result<AttentionOperatorSpec, crate::SourceUnavailable> {
+    match (id, version) {
+        (AttentionOperatorSpec::STANDARD_ID, AttentionOperatorSpec::STANDARD_VERSION) => {
+            Ok(AttentionOperatorSpec::standard())
+        }
+        (
+            AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+            AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+        ) => Ok(AttentionOperatorSpec::experimental_r4()),
+        _ => Err(crate::SourceIngestKind::UnknownAttentionOperator {
+            id: id.to_owned(),
+            version,
+        }
+        .into()),
+    }
+}
+
+/// The `standard-source-attention/1` weight computation, factored
+/// verbatim out of `Llama::layer_forward`/`Llama::forward_batch` (#602):
+/// fill `att` (one slot per cached position `t = 0..att.len()`) with the
+/// softmax-normalized scaled dot products of `q` against the cached keys.
+/// `keys` is the layer's key-cache region; position `t`'s key head starts
+/// at `t * key_stride + key_offset` (grouped query: `key_offset =
+/// (h / kv_mul) * head_size`). Iteration order and arithmetic — one
+/// sequential f32 left fold per score over the FULL head width, one
+/// divide by `sqrt(head_size)`, then the shared max-subtracted softmax —
+/// are bit-identical to the pre-#602 in-line loop. Deterministic and
+/// free of hidden state; `canonical` selects the D2 libm math path
+/// exactly as the executor does.
+pub fn standard_head_attention_weights(
+    att: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    canonical: bool,
+) {
+    let head_size = q.len();
+    for (t, attention) in att.iter_mut().enumerate() {
+        let k = &keys[t * key_stride + key_offset..][..head_size];
+        let mut score = 0.0f32;
+        for i in 0..head_size {
+            score += q[i] * k[i];
+        }
+        score /= crate::sqrtf(head_size as f32, canonical);
+        *attention = score;
+    }
+    crate::softmax_with_mode(att, canonical);
+}
+
+/// The `experimental-r4-source-attention/1` weight computation, factored
+/// verbatim out of the `r4_attention` branch (#602): the dot product is
+/// computed in 4-wide chunks over dimensions `0..4*(head_size/4)` — the
+/// trailing `head_size mod 4` q/k dimensions are never read — divided by
+/// `sqrt(head_size)` over the FULL head width, then normalized by the
+/// SAME max-subtracted softmax as the standard operator. For
+/// `head_size < 4` every score is 0 and the weights are uniform.
+/// Iteration order and arithmetic are bit-identical to the pre-#602
+/// in-line loop. Still gated by `Config::r4_attention` at both call
+/// sites; factoring changes no selection.
+pub fn experimental_r4_head_attention_weights(
+    att: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    canonical: bool,
+) {
+    let head_size = q.len();
+    for (t, attention) in att.iter_mut().enumerate() {
+        let k = &keys[t * key_stride + key_offset..][..head_size];
+        let mut head_score = 0.0f32;
+        let chunks = head_size / 4;
+        for chunk_idx in 0..chunks {
+            let q_chunk = &q[chunk_idx * 4..(chunk_idx + 1) * 4];
+            let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
+            head_score += q_chunk[0] * k_chunk[0]
+                + q_chunk[1] * k_chunk[1]
+                + q_chunk[2] * k_chunk[2]
+                + q_chunk[3] * k_chunk[3];
+        }
+        head_score /= crate::sqrtf(head_size as f32, canonical);
+        *attention = head_score;
+    }
+    crate::softmax_with_mode(att, canonical);
+}
+
+/// The value aggregation both operators share, factored verbatim out of
+/// the executor (#602): zero `out` (one head width), then accumulate the
+/// position-ascending weighted sum `out[i] += att[t] * v_t[i]` over the
+/// cached values. `values` is the layer's value-cache region; position
+/// `t`'s value head starts at `t * value_stride + value_offset`. Every
+/// head dimension participates regardless of the scoring operator's
+/// width policy. Arithmetic order is bit-identical to the pre-#602
+/// in-line loop.
+pub fn head_attention_value_aggregate(
+    out: &mut [f32],
+    att: &[f32],
+    values: &[f32],
+    value_offset: usize,
+    value_stride: usize,
+) {
+    let head_size = out.len();
+    out.iter_mut().for_each(|v| *v = 0.0);
+    for (t, &attention) in att.iter().enumerate() {
+        let v = &values[t * value_stride + value_offset..][..head_size];
+        for i in 0..head_size {
+            out[i] += attention * v[i];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ramp(len: usize, seed: usize) -> Vec<f32> {
+        (0..len)
+            .map(|index| (((index * 37 + seed * 13) % 101) as f32 - 50.0) / 8.0)
+            .collect()
+    }
+
+    /// Independent softmax reference: max-subtracted exp then divide by
+    /// the sum, written apart from the implementation under test.
+    fn softmax_reference(scores: &[f32]) -> Vec<f32> {
+        let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let exps: Vec<f32> = scores.iter().map(|s| (s - max).exp()).collect();
+        let sum: f32 = exps.iter().sum();
+        exps.iter().map(|e| e / sum).collect()
+    }
+
+    /// A key/value cache region for `positions` positions with
+    /// `kv_heads` heads of width `head_size` each.
+    fn cache(positions: usize, kv_heads: usize, head_size: usize, seed: usize) -> Vec<f32> {
+        ramp(positions * kv_heads * head_size, seed)
+    }
+
+    #[test]
+    fn standard_weights_score_every_dimension_divisible_width() {
+        // Divisible head width (H = 8): the score is the full-width dot
+        // product over sqrt(H), softmax-normalized.
+        let head_size = 8;
+        let positions = 5;
+        let q = ramp(head_size, 1);
+        let keys = cache(positions, 2, head_size, 2);
+        let kv_stride = 2 * head_size;
+        let key_offset = head_size; // second kv head
+        let mut att = vec![0f32; positions];
+        standard_head_attention_weights(&mut att, &q, &keys, key_offset, kv_stride, false);
+
+        let mut raw = vec![0f32; positions];
+        for (t, slot) in raw.iter_mut().enumerate() {
+            let k = &keys[t * kv_stride + key_offset..][..head_size];
+            let mut score = 0.0f32;
+            for i in 0..head_size {
+                score += q[i] * k[i];
+            }
+            *slot = score / (head_size as f32).sqrt();
+        }
+        let expected = softmax_reference(&raw);
+        for (index, (&got, &want)) in att.iter().zip(&expected).enumerate() {
+            assert!((got - want).abs() <= 1e-6, "position {index}");
+        }
+        let total: f32 = att.iter().sum();
+        assert!((total - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn standard_weights_have_no_remainder_at_non_divisible_width() {
+        // Non-divisible head width (H = 6, H mod 4 = 2): the standard
+        // operator has NO remainder policy — every dimension is scored,
+        // pinned by perturbing the trailing dimension and observing the
+        // weights move.
+        let head_size = 6;
+        let positions = 4;
+        let q = ramp(head_size, 3);
+        let keys = cache(positions, 1, head_size, 4);
+        let mut att = vec![0f32; positions];
+        standard_head_attention_weights(&mut att, &q, &keys, 0, head_size, false);
+
+        let mut q_perturbed = q.clone();
+        q_perturbed[head_size - 1] += 1.0;
+        let mut att_perturbed = vec![0f32; positions];
+        standard_head_attention_weights(
+            &mut att_perturbed,
+            &q_perturbed,
+            &keys,
+            0,
+            head_size,
+            false,
+        );
+        assert_ne!(
+            att, att_perturbed,
+            "the trailing head dimension must enter the standard score"
+        );
+    }
+
+    #[test]
+    fn experimental_weights_truncate_the_trailing_mod_4_dimensions() {
+        // The measured remainder policy of the r4_attention branch: at
+        // H = 6 only dimensions 0..4 (one 4-wide chunk) enter any
+        // score. Perturbing q[4], q[5], k[4], k[5] leaves the produced
+        // weights bit-identical; perturbing q[3] moves them.
+        let head_size = 6;
+        let positions = 4;
+        let q = ramp(head_size, 5);
+        let keys = cache(positions, 1, head_size, 6);
+        let mut att = vec![0f32; positions];
+        experimental_r4_head_attention_weights(&mut att, &q, &keys, 0, head_size, false);
+
+        let mut q_tail = q.clone();
+        q_tail[4] += 3.0;
+        q_tail[5] -= 2.0;
+        let mut keys_tail = keys.clone();
+        for t in 0..positions {
+            keys_tail[t * head_size + 4] += 1.5;
+            keys_tail[t * head_size + 5] += 2.5;
+        }
+        let mut att_tail = vec![0f32; positions];
+        experimental_r4_head_attention_weights(
+            &mut att_tail,
+            &q_tail,
+            &keys_tail,
+            0,
+            head_size,
+            false,
+        );
+        let bits: Vec<u32> = att.iter().map(|v| v.to_bits()).collect();
+        let tail_bits: Vec<u32> = att_tail.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(
+            bits, tail_bits,
+            "trailing head_size mod 4 dimensions must never enter the experimental score"
+        );
+
+        let mut q_head = q.clone();
+        q_head[3] += 1.0;
+        let mut att_head = vec![0f32; positions];
+        experimental_r4_head_attention_weights(&mut att_head, &q_head, &keys, 0, head_size, false);
+        assert_ne!(att, att_head, "scored dimensions must move the weights");
+    }
+
+    #[test]
+    fn experimental_scale_still_divides_by_sqrt_full_head_size() {
+        // H = 6 scores only 4 dimensions but divides by sqrt(6), not
+        // sqrt(4): pinned against an independent computation.
+        let head_size = 6;
+        let positions = 3;
+        let q = ramp(head_size, 7);
+        let keys = cache(positions, 1, head_size, 8);
+        let mut att = vec![0f32; positions];
+        experimental_r4_head_attention_weights(&mut att, &q, &keys, 0, head_size, false);
+
+        let mut raw = vec![0f32; positions];
+        for (t, slot) in raw.iter_mut().enumerate() {
+            let k = &keys[t * head_size..][..head_size];
+            let mut score = 0.0f32;
+            for i in 0..4 {
+                score += q[i] * k[i];
+            }
+            *slot = score / (head_size as f32).sqrt();
+        }
+        let expected = softmax_reference(&raw);
+        for (index, (&got, &want)) in att.iter().zip(&expected).enumerate() {
+            assert!((got - want).abs() <= 1e-6, "position {index}");
+        }
+    }
+
+    #[test]
+    fn experimental_weights_are_uniform_below_chunk_width() {
+        // H < 4: no chunk exists, every score is 0, and the selector —
+        // still a softmax, never bypassed — yields uniform weights.
+        let head_size = 3;
+        let positions = 5;
+        let q = ramp(head_size, 9);
+        let keys = cache(positions, 1, head_size, 10);
+        let mut att = vec![0f32; positions];
+        experimental_r4_head_attention_weights(&mut att, &q, &keys, 0, head_size, false);
+        for (index, &weight) in att.iter().enumerate() {
+            assert!(
+                (weight - 1.0 / positions as f32).abs() <= 1e-6,
+                "position {index}: {weight}"
+            );
+        }
+    }
+
+    #[test]
+    fn both_operators_normalize_with_the_same_softmax() {
+        // The honest selector statement: BOTH branches apply the same
+        // max-subtracted softmax. At a divisible width the two weight
+        // vectors agree to tolerance (same scored terms, different fold
+        // grouping), and both sum to 1.
+        let head_size = 8;
+        let positions = 6;
+        let q = ramp(head_size, 11);
+        let keys = cache(positions, 1, head_size, 12);
+        let mut standard = vec![0f32; positions];
+        let mut experimental = vec![0f32; positions];
+        standard_head_attention_weights(&mut standard, &q, &keys, 0, head_size, false);
+        experimental_r4_head_attention_weights(&mut experimental, &q, &keys, 0, head_size, false);
+        for (index, (&s, &e)) in standard.iter().zip(&experimental).enumerate() {
+            assert!((s - e).abs() <= 1e-5, "position {index}: {s} vs {e}");
+        }
+        let sum_s: f32 = standard.iter().sum();
+        let sum_e: f32 = experimental.iter().sum();
+        assert!((sum_s - 1.0).abs() < 1e-5);
+        assert!((sum_e - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn value_aggregation_uses_every_dimension_in_position_order() {
+        let head_size = 6;
+        let positions = 4;
+        let att = softmax_reference(&ramp(positions, 13));
+        let values = cache(positions, 2, head_size, 14);
+        let value_stride = 2 * head_size;
+        let value_offset = head_size;
+        let mut out = vec![7.0f32; head_size]; // pre-dirtied: must be zeroed
+        head_attention_value_aggregate(&mut out, &att, &values, value_offset, value_stride);
+        for i in 0..head_size {
+            let mut expected = 0.0f32;
+            for (t, &weight) in att.iter().enumerate() {
+                expected += weight * values[t * value_stride + value_offset + i];
+            }
+            assert_eq!(out[i].to_bits(), expected.to_bits(), "dimension {i}");
+        }
+    }
+
+    #[test]
+    fn weight_functions_are_bit_deterministic() {
+        let head_size = 6;
+        let positions = 5;
+        let q = ramp(head_size, 15);
+        let keys = cache(positions, 1, head_size, 16);
+        for weights in [
+            standard_head_attention_weights as fn(&mut [f32], &[f32], &[f32], usize, usize, bool),
+            experimental_r4_head_attention_weights,
+        ] {
+            let mut first = vec![0f32; positions];
+            let mut second = vec![0f32; positions];
+            weights(&mut first, &q, &keys, 0, head_size, false);
+            weights(&mut second, &q, &keys, 0, head_size, false);
+            let first_bits: Vec<u32> = first.iter().map(|v| v.to_bits()).collect();
+            let second_bits: Vec<u32> = second.iter().map(|v| v.to_bits()).collect();
+            assert_eq!(first_bits, second_bits);
+        }
+    }
+
+    #[test]
+    fn canonical_serialization_is_byte_stable() {
+        // The canonical forms are pinned byte-for-byte: any drift in
+        // field order, separators, or parameter tokens fails here — the
+        // digest identity must not move silently.
+        let standard = AttentionOperatorSpec::standard();
+        let pinned_standard = "uor-r4-attention-operator/1\n\
+             id=standard-source-attention\n\
+             version=1\n\
+             projections=per-layer-dense-f32-wq-wk-wv\n\
+             positional_action=rope-rotation-of-q-and-k-before-scoring\n\
+             compatibility_relation=scaled-dot-product\n\
+             selector_normalization=softmax-max-subtracted-exp-then-sum-normalize\n\
+             value_aggregation=position-ascending-weighted-sum-of-values\n\
+             output_projection=per-layer-dense-f32-wo\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32\n\
+             param.head_selection=grouped-query-kv-head-h-div-kv-mul\n\
+             param.score_scale=divide-by-sqrt-full-head-size\n\
+             param.score_width_policy=full-head-width\n\
+             param.remainder_policy=none-every-head-dimension-scored\n\
+             param.score_accumulation=sequential-f32-left-fold\n";
+        assert_eq!(standard.canonical_bytes(), pinned_standard.as_bytes());
+        let expected = format!(
+            "blake3:{}",
+            blake3::hash(pinned_standard.as_bytes()).to_hex()
+        );
+        assert_eq!(standard.implementation_digest, expected);
+        assert_eq!(standard.declared_digest(), expected);
+
+        let experimental = AttentionOperatorSpec::experimental_r4();
+        let pinned_experimental = "uor-r4-attention-operator/1\n\
+             id=experimental-r4-source-attention\n\
+             version=1\n\
+             projections=per-layer-dense-f32-wq-wk-wv\n\
+             positional_action=rope-rotation-of-q-and-k-before-scoring\n\
+             compatibility_relation=chunked-4-wide-dot-product\n\
+             selector_normalization=softmax-max-subtracted-exp-then-sum-normalize\n\
+             value_aggregation=position-ascending-weighted-sum-of-values\n\
+             output_projection=per-layer-dense-f32-wo\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32\n\
+             param.head_selection=grouped-query-kv-head-h-div-kv-mul\n\
+             param.score_scale=divide-by-sqrt-full-head-size\n\
+             param.score_width_policy=chunks-of-4-floor-head-size-div-4\n\
+             param.remainder_policy=truncate-trailing-head-size-mod-4-dims-from-score\n\
+             param.score_accumulation=per-4-chunk-left-fold-then-chunk-sum\n";
+        assert_eq!(
+            experimental.canonical_bytes(),
+            pinned_experimental.as_bytes()
+        );
+        assert_eq!(
+            experimental.declared_digest(),
+            experimental.implementation_digest
+        );
+        assert_ne!(
+            standard.implementation_digest, experimental.implementation_digest,
+            "the two operators are distinct identities"
+        );
+        // Rebuilding reproduces the records bit-for-bit.
+        assert_eq!(standard, AttentionOperatorSpec::standard());
+        assert_eq!(experimental, AttentionOperatorSpec::experimental_r4());
+    }
+
+    #[test]
+    fn record_round_trips_through_serde_json() {
+        for record in [
+            AttentionOperatorSpec::standard(),
+            AttentionOperatorSpec::experimental_r4(),
+        ] {
+            let json = serde_json::to_string(&record).expect("serializes");
+            let back: AttentionOperatorSpec = serde_json::from_str(&json).expect("deserializes");
+            assert_eq!(record, back);
+        }
+        // Serde-defaulted fields: a legacy/partial document still parses.
+        let partial: AttentionOperatorSpec =
+            serde_json::from_str("{\"id\":\"standard-source-attention\"}").expect("defaults fill");
+        assert_eq!(partial.id, "standard-source-attention");
+        assert_eq!(partial.version, 0);
+        assert_eq!(partial.params, AttentionOperatorParams::default());
+    }
+
+    #[test]
+    fn switch_maps_to_exactly_the_two_registered_operators() {
+        assert_eq!(
+            operator_for_r4_switch(false),
+            AttentionOperatorSpec::standard()
+        );
+        assert_eq!(
+            operator_for_r4_switch(true),
+            AttentionOperatorSpec::experimental_r4()
+        );
+    }
+
+    #[test]
+    fn registry_resolves_both_operators() {
+        let standard = operator_spec(
+            AttentionOperatorSpec::STANDARD_ID,
+            AttentionOperatorSpec::STANDARD_VERSION,
+        )
+        .expect("registered standard operator");
+        assert_eq!(standard, AttentionOperatorSpec::standard());
+        let experimental = operator_spec(
+            AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+            AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+        )
+        .expect("registered experimental operator");
+        assert_eq!(experimental, AttentionOperatorSpec::experimental_r4());
+    }
+
+    #[test]
+    fn registry_refuses_unknown_id_and_version_by_name() {
+        for (id, version) in [
+            ("standard-source-attention", 2u32),
+            ("experimental-r4-source-attention", 9),
+            ("mystery-attention", 1),
+        ] {
+            let error =
+                operator_spec(id, version).expect_err("unknown (id, version) is not a product");
+            match &error.kind {
+                crate::SourceIngestKind::UnknownAttentionOperator {
+                    id: got_id,
+                    version: got_version,
+                } => {
+                    assert_eq!(got_id, id);
+                    assert_eq!(*got_version, version);
+                }
+                other => panic!("wrong failure class: {other:?}"),
+            }
+            assert!(error.reason.contains(id), "reason names the id: {error}");
+        }
+    }
+}

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -6,6 +6,7 @@
 //! the original reduction order; native Hugging Face compilation may use an
 //! optimized CPU matrix-vector backend.
 
+pub mod attention;
 pub mod conformance;
 pub mod geometry;
 pub mod progress;
@@ -93,7 +94,7 @@ impl State {
 }
 
 #[inline]
-fn sqrtf(value: f32, canonical: bool) -> f32 {
+pub(crate) fn sqrtf(value: f32, canonical: bool) -> f32 {
     if canonical {
         libm::sqrtf(value)
     } else {
@@ -161,7 +162,7 @@ fn rmsnorm_inplace_with_mode(x: &mut [f32], weight: &[f32], canonical: bool) {
     }
 }
 
-fn softmax_with_mode(x: &mut [f32], canonical: bool) {
+pub(crate) fn softmax_with_mode(x: &mut [f32], canonical: bool) {
     let mut max_val = x[0];
     for &value in x.iter().skip(1) {
         if value > max_val {
@@ -793,57 +794,47 @@ impl Llama {
             }
 
             // multihead attention (serial over heads; per-head work is
-            // independent of order).
+            // independent of order). The per-head weight computation and
+            // value aggregation are the free #602 reference functions in
+            // [`attention`], factored out of this loop unchanged; the
+            // `r4_attention` switch selects between exactly the two
+            // registered operators (`standard-source-attention/1` and
+            // `experimental-r4-source-attention/1`, a chunked dot
+            // product with the same softmax selector).
             for h in 0..c.n_heads {
                 let q = &st.q[h * head_size..(h + 1) * head_size];
                 let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                let kv_head_offset = (h / kv_mul) * head_size;
 
                 if c.r4_attention {
-                    // Compute R4 4D Spin(4) quaternionic alignment
-                    for (t, attention) in att.iter_mut().enumerate() {
-                        let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                            [..head_size];
-
-                        let mut head_score = 0.0f32;
-                        let chunks = head_size / 4;
-                        for chunk_idx in 0..chunks {
-                            let q_chunk = &q[chunk_idx * 4..(chunk_idx + 1) * 4];
-                            let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
-                            let dot_4d = q_chunk[0] * k_chunk[0]
-                                + q_chunk[1] * k_chunk[1]
-                                + q_chunk[2] * k_chunk[2]
-                                + q_chunk[3] * k_chunk[3];
-                            head_score += dot_4d;
-                        }
-                        head_score /= sqrtf(head_size as f32, self.canonical_math);
-                        *attention = head_score;
-                    }
-                    softmax_with_mode(att, self.canonical_math);
+                    attention::experimental_r4_head_attention_weights(
+                        att,
+                        q,
+                        &st.key_cache[loff..],
+                        kv_head_offset,
+                        kv_dim,
+                        self.canonical_math,
+                    );
                 } else {
-                    // Standard Llama scaled dot-product attention
-                    for (t, attention) in att.iter_mut().enumerate() {
-                        let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                            [..head_size];
-                        let mut score = 0.0f32;
-                        for i in 0..head_size {
-                            score += q[i] * k[i];
-                        }
-                        score /= sqrtf(head_size as f32, self.canonical_math);
-                        *attention = score;
-                    }
-                    softmax_with_mode(att, self.canonical_math);
+                    attention::standard_head_attention_weights(
+                        att,
+                        q,
+                        &st.key_cache[loff..],
+                        kv_head_offset,
+                        kv_dim,
+                        self.canonical_math,
+                    );
                 }
 
+                let att = &st.att[h * c.seq_len..h * c.seq_len + pos + 1];
                 let xb = &mut st.xb[h * head_size..(h + 1) * head_size];
-                xb.iter_mut().for_each(|v| *v = 0.0);
-                for (t, &attention) in att.iter().enumerate() {
-                    let v = &st.value_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                        [..head_size];
-                    let a = attention;
-                    for i in 0..head_size {
-                        xb[i] += a * v[i];
-                    }
-                }
+                attention::head_attention_value_aggregate(
+                    xb,
+                    att,
+                    &st.value_cache[loff..],
+                    kv_head_offset,
+                    kv_dim,
+                );
             }
 
             matmul(
@@ -1021,49 +1012,41 @@ impl Llama {
                     }
                 }
 
+                // Same #602 reference functions as the serial
+                // [`Llama::layer_forward`] path: the `r4_attention`
+                // switch selects between the two registered operators.
                 for h in 0..c.n_heads {
                     let qh = &qb[h * head_size..(h + 1) * head_size];
                     let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                    let kv_head_offset = (h / kv_mul) * head_size;
                     if c.r4_attention {
-                        for (t, attention) in att.iter_mut().enumerate() {
-                            let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                                [..head_size];
-                            let mut head_score = 0.0f32;
-                            let chunks = head_size / 4;
-                            for chunk_idx in 0..chunks {
-                                let q_chunk = &qh[chunk_idx * 4..(chunk_idx + 1) * 4];
-                                let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
-                                head_score += q_chunk[0] * k_chunk[0]
-                                    + q_chunk[1] * k_chunk[1]
-                                    + q_chunk[2] * k_chunk[2]
-                                    + q_chunk[3] * k_chunk[3];
-                            }
-                            head_score /= sqrtf(head_size as f32, self.canonical_math);
-                            *attention = head_score;
-                        }
-                        softmax_with_mode(att, self.canonical_math);
+                        attention::experimental_r4_head_attention_weights(
+                            att,
+                            qh,
+                            &st.key_cache[loff..],
+                            kv_head_offset,
+                            kv_dim,
+                            self.canonical_math,
+                        );
                     } else {
-                        for (t, attention) in att.iter_mut().enumerate() {
-                            let k = &st.key_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                                [..head_size];
-                            let mut score = 0.0f32;
-                            for i in 0..head_size {
-                                score += qh[i] * k[i];
-                            }
-                            score /= sqrtf(head_size as f32, self.canonical_math);
-                            *attention = score;
-                        }
-                        softmax_with_mode(att, self.canonical_math);
+                        attention::standard_head_attention_weights(
+                            att,
+                            qh,
+                            &st.key_cache[loff..],
+                            kv_head_offset,
+                            kv_dim,
+                            self.canonical_math,
+                        );
                     }
+                    let att = &st.att[h * c.seq_len..h * c.seq_len + pos + 1];
                     let outh = &mut out[h * head_size..(h + 1) * head_size];
-                    outh.iter_mut().for_each(|v| *v = 0.0);
-                    for (t, &attention) in att.iter().enumerate() {
-                        let v = &st.value_cache[loff + t * kv_dim + (h / kv_mul) * head_size..]
-                            [..head_size];
-                        for i in 0..head_size {
-                            outh[i] += attention * v[i];
-                        }
-                    }
+                    attention::head_attention_value_aggregate(
+                        outh,
+                        att,
+                        &st.value_cache[loff..],
+                        kv_head_offset,
+                        kv_dim,
+                    );
                 }
             }
 
@@ -1161,6 +1144,21 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
     /// [`RepresentationSource::source_dimension`]); the default keeps
     /// every existing oracle unaffected.
     fn geometry_projection(&self) -> Option<geometry::GeometryProjection> {
+        None
+    }
+
+    /// The #602 typed record of the attention operator this oracle's
+    /// source executor computes during [`BehaviorSource::step`], when the
+    /// oracle declares one. The boolean `r4_attention` switch maps to
+    /// exactly the two registered operators
+    /// (`standard-source-attention/1` when off,
+    /// `experimental-r4-source-attention/1` when on — see
+    /// [`attention::operator_for_r4_switch`]). `None` means the oracle
+    /// predates the record (the legacy interpretation documented in
+    /// `docs/MODEL_LIFECYCLE.md`); the default keeps every existing
+    /// oracle unaffected, mirroring
+    /// [`TeacherOracle::geometry_projection`].
+    fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
         None
     }
 
@@ -1700,6 +1698,17 @@ pub enum SourceIngestKind {
         /// The requested adapter version.
         version: u32,
     },
+    /// #602 attention-operator registry: a caller named a source
+    /// attention operator `(id, version)` outside the versioned registry
+    /// ([`attention::operator_spec`]), so no specification exists to
+    /// interpret it. Refused by name, never approximated by a "closest"
+    /// operator or version.
+    UnknownAttentionOperator {
+        /// The requested operator id.
+        id: String,
+        /// The requested operator version.
+        version: u32,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1778,6 +1787,15 @@ impl std::fmt::Display for SourceIngestKind {
                  registry (known: hf-byte-bpe/1; sentencepiece-unigram is the recorded \
                  follow-up family and stays rejected until its adapter is implemented, \
                  never approximated)"
+            ),
+            Self::UnknownAttentionOperator { id, version } => write!(
+                f,
+                "attention operator {id}/{version} is not in the versioned operator \
+                 registry (known: {}/{} and {}/{})",
+                attention::AttentionOperatorSpec::STANDARD_ID,
+                attention::AttentionOperatorSpec::STANDARD_VERSION,
+                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
             ),
         }
     }
@@ -2342,12 +2360,18 @@ impl HuggingFaceLlamaOracle {
         Self::load_inner(source, Some(sequence_length))
     }
 
-    /// Enable or disable experimental R4 Spin(4) softmax-free attention calculation.
+    /// Enable or disable the experimental attention variant
+    /// (`experimental-r4-source-attention/1`, #602): a 4-wide-chunked
+    /// dot product — truncating the trailing `head_size mod 4`
+    /// dimensions from the score — followed by the same softmax the
+    /// standard operator applies. Despite the flag's historical name it
+    /// is neither quaternionic nor softmax-bypassing (#515 audit).
     pub fn set_r4_attention(&mut self, enable: bool) {
         self.model.cfg.r4_attention = enable;
     }
 
-    /// Check if experimental R4 Spin(4) attention is enabled.
+    /// Check if the experimental attention variant
+    /// (`experimental-r4-source-attention/1`) is enabled.
     pub fn r4_attention(&self) -> bool {
         self.model.cfg.r4_attention
     }
@@ -2623,6 +2647,14 @@ impl TeacherOracle for HuggingFaceLlamaOracle {
         u32::try_from(self.model.cfg.dim).ok().map(|source_width| {
             geometry::GeometryProjection::bucket_average(source_width, geometry::COMPILED_WIDTH)
         })
+    }
+    fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
+        // #602: the boolean switch maps to exactly the two registered
+        // operators — this is the one boundary where the legacy flag
+        // becomes a versioned identity.
+        Some(attention::operator_for_r4_switch(
+            self.model.cfg.r4_attention,
+        ))
     }
     fn hidden_state(&self) -> Option<&[f32]> {
         Some(&self.state.x)

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -172,9 +172,13 @@ cargo run --release -- compile \
 
 `--revision` must be a full 40-character commit hash. `--seconds` limits the
 teacher-generation work performed by one invocation, while `--target` is the
-teacher-token goal. `--r4-attention` enables the experimental 4D softmax-free
-Spin(4) attention geometry during teacher generation (omitting this flag runs
-standard scaled dot-product attention). Hugging Face compilation defaults to
+teacher-token goal. `--r4-attention` selects the experimental teacher
+attention variant during generation — the #602 operator
+`experimental-r4-source-attention/1`, a 4-wide-chunked dot product with the
+same softmax selector as the standard operator (see "Attention operator
+identity (#602)" below; omitting this flag runs the standard
+`standard-source-attention/1` scaled dot-product operator, the default
+everywhere). Hugging Face compilation defaults to
 20,000 tokens and 128-token teacher stories. The bounded story length keeps
 attention cost and KV memory proportional to the eight-token deployed runtime
 window; increase `--target` or `--sequence-length` explicitly for quality
@@ -294,6 +298,100 @@ boundaries, raw-byte round trips — as the baseline any drift fails
 against, and a consumer-agreement test asserts the observation,
 evaluation, serving-prompt, and exported-runtime-tokenizer selection
 seams resolve the same adapter identity, token ids, and decode bytes.
+
+#### Attention operator identity (#602)
+
+The attention operator the source teacher computes is a typed, versioned
+identity, not a boolean. `uor-r4-model-source::attention` defines
+`AttentionOperatorSpec { id, version, projections, positional_action,
+compatibility_relation, selector_normalization, value_aggregation,
+output_projection, runtime_state, tie_breaking,
+permitted_operation_class, params }` with the same canonical-bytes +
+declared-identity digest discipline as the #600 geometry and #601
+tokenizer records (blake3 over a pinned line format of the declared
+identity — deliberately not a hash of source code text; a behavioral
+change must arrive as a new registry version). A versioned registry maps
+`(id, version)` to the spec (`attention::operator_spec`); an unknown
+pair fails closed with the focused
+`SourceIngestKind::UnknownAttentionOperator` rather than being guessed.
+
+**Truthful operator inventory.** Two operators are registered, and they
+are exactly the two branches the teacher's `r4_attention` switch selects
+between (`attention::operator_for_r4_switch` is the one boundary mapping
+from the legacy boolean to the versioned identity):
+
+- `standard-source-attention/1` (the switch off — the default
+  everywhere): dense per-layer f32 `wq`/`wk`/`wv` projections with
+  grouped-query key/value sharing (head `h` reads kv head `h / kv_mul`);
+  RoPE rotation of q and k before scoring (interleaved vs. split-half
+  layout is a source-config property); compatibility relation
+  `score(t) = (Σ_{i<H} q[i]·k_t[i]) / sqrt(H)` accumulated as one
+  sequential f32 left fold over the full head width `H` (no remainder at
+  any width); selector `softmax_with_mode` — subtract the maximum score
+  (first maximum on ties, value-identical since only the maximum's value
+  enters), `exp` each shifted score (`libm::expf` in D2 canonical mode,
+  `f32::exp` otherwise), divide by the sum; value aggregation as a
+  position-ascending weighted sum over the full growing-KV-cache prefix;
+  dense f32 `wo` output projection. No argmax or selection happens
+  inside the operator, so no further tie-break exists.
+- `experimental-r4-source-attention/1` (the switch on): identical in
+  every respect EXCEPT the compatibility relation, which computes the
+  dot product in 4-wide chunks over dimensions `0..4·⌊H/4⌋` (each chunk
+  a left-to-right 4-term fold, chunk subtotals then summed).
+  **Remainder policy, measured from the code and pinned by unit tests:**
+  the trailing `H mod 4` q/k dimensions never enter any score (dropped),
+  the scale still divides by `sqrt(H)` over the full head width, and
+  value aggregation still uses every head dimension; for `H < 4` no
+  chunk exists, every score is 0, and the softmax yields uniform
+  weights. The selector is the SAME max-subtracted softmax as the
+  standard operator — the historical description of this branch did not
+  match its control flow (#515 audit; see the dated correction in
+  `docs/deferral_record_2026_08_05.md`), and the registry id names what
+  it computes. The branch remains shipped, selectable, default-off, and
+  unmeasured; #602 changes no selection and activates nothing.
+
+The reference implementations are free deterministic functions factored
+verbatim out of the executor (`standard_head_attention_weights`,
+`experimental_r4_head_attention_weights`,
+`head_attention_value_aggregate`) — iteration order and arithmetic
+unchanged, the same discipline as #600's `bucket_average_project` and
+#599's `layer_forward` factoring, with the existing bit-exactness parity
+tests (e.g. `forward_batch_matches_serial_forward`) guarding the
+executor path and unit tests pinning divisible and non-divisible head
+widths.
+
+The record threads into provenance the same way the #597 manifest κ,
+the #600 geometry record, and the #601 tokenizer record do: the observe
+drivers record it in the observation manifest automatically whenever
+the oracle declares one (`attention_operator`, an optional
+serde-defaulted field; `TeacherOracle::attention_operator_spec()`
+defaults to `None`, and the legacy checkpoint oracle declares none, so
+legacy manifest bytes are unchanged); the cover stages
+(`transformerless cover`, `graph-compile`) accept
+`--attention-operator <json>` and bind it as the optional
+`attention_operator` field of the cover/compile report; the typed
+compile API derives it from its `r4_attention` option; and the HTTP
+server's compile job binds the standard record (its teacher stage never
+enables the experimental switch). An absent record marks the implicit
+legacy era: documents produced before #602 are not rewritten, and — the
+switch having been default-off everywhere — a reader may *interpret* an
+absent record on teacher-produced inputs as `standard-source-attention/1`
+unless the producing invocation is known to have passed
+`--r4-attention`. **Honesty item:** the score/certify report structs in
+`uor-r4-graph-certify` carry no attention-operator field — that stage
+reads corpus, cover, and artifact bytes with no teacher oracle in reach
+(the #597 source κ and #600 geometry records are likewise absent there),
+so #602 records the gap instead of inventing plumbing; an
+operator-specific experiment should thread the record through the cover
+report it already consumes.
+
+**Boundary note.** These specs describe HOST-SIDE source-teacher
+computation (f32 dot products, `exp`, division). The deployed inference
+operation contract
+(`docs/transformerless/INFERENCE_OPERATION_CONTRACT.md`) is a distinct,
+unchanged surface: it forbids floating-point arithmetic on the deployed
+hot path and explicitly excludes teacher execution. #602 defines no
+target (deployed) operator and changes no runtime contract.
 
 ### 3. Compile the holographic graph
 

--- a/docs/deferral_record_2026_08_05.md
+++ b/docs/deferral_record_2026_08_05.md
@@ -30,6 +30,22 @@ and teacher bits/token. If the A/B records zero-or-negative, the engine
 becomes a #410-style removal candidate; until the A/B exists, the flag stays
 shipped and off.
 
+**Correction 2026-08-12 (#602).** The description above is retained as the
+historical record, but its characterization of the variant does not match
+the control flow (#515's audit recorded the mismatch): the branch is
+neither quaternionic nor a softmax bypass. What it actually computes — as
+factored, specified, and unit-test-pinned by #602
+(`uor-r4-model-source::attention`, documented in
+`docs/MODEL_LIFECYCLE.md` "Attention operator identity (#602)") — is a
+4-wide-chunked dot product over the leading `4·⌊H/4⌋` head dimensions
+(the trailing `H mod 4` dimensions never enter any score, the scale still
+divides by `sqrt(H)`, and heads narrower than 4 score uniformly),
+followed by the SAME max-subtracted softmax the standard operator
+applies. Its versioned identity is `experimental-r4-source-attention/1`
+(the standard arm is `standard-source-attention/1`); the deferral
+disposition, activation condition, and default-off status above are
+unchanged.
+
 ## bott_fock context store — tracking re-pointed from #234 to #424
 
 `docs/r4_furey_quantum_geometric_plan.md` records `bott_fock.rs` (the O(1)

--- a/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
+++ b/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
@@ -68,6 +68,14 @@ This contract does **not** restrict:
 
 Compilation and training are explicitly unrestricted by this contract.
 
+Note (non-normative cross-reference, #602): the source attention operator
+specifications in `uor-r4-model-source::attention`
+(`standard-source-attention/1`, `experimental-r4-source-attention/1`) are
+host-side provenance records of teacher execution — an activity this
+section already excludes. They are distinct from this deployed contract,
+describe floating-point source computation the deployed hot path never
+performs, and change none of the operation lists or obligations above.
+
 ## 5) Activity ownership map
 
 Each in-scope activity has a crate/module owner:

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,9 @@ struct CompileArgs {
     /// Teacher context allocation and story length.
     #[arg(long, default_value_t = 128)]
     sequence_length: usize,
-    /// Enable experimental R4 Spin(4) softmax-free attention during compilation.
+    /// Enable the experimental teacher attention variant (#602 operator
+    /// `experimental-r4-source-attention/1`: a 4-wide-chunked dot product with
+    /// the same softmax selector as the standard operator) during compilation.
     #[arg(long, default_value_t = false)]
     r4_attention: bool,
     /// Force exact scalar CPU math instead of Apple Accelerate / SIMD hardware matrix acceleration.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1840,6 +1840,15 @@ fn compile_r4g1_bundle(
     if let Some(geometry) = downloaded_source.and_then(geometry_projection_of) {
         cover_args.extend(["--geometry-projection".to_owned(), geometry]);
     }
+    // #602: the server compile job never passes `--r4-attention` to the
+    // teacher stage above, so the teacher ran exactly the registered
+    // `standard-source-attention/1` operator; bind its typed record into
+    // the cover report.
+    if let Ok(operator) =
+        serde_json::to_string(&uor_r4_model_source::attention::AttentionOperatorSpec::standard())
+    {
+        cover_args.extend(["--attention-operator".to_owned(), operator]);
+    }
     uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");


### PR DESCRIPTION
feat(#602): versioned source attention operator specification

Truthful operator inventory made typed and versioned: AttentionOperatorSpec
(new attention.rs beside geometry.rs) with canonical bytes + declared-
identity digest. Two registered operators: standard-source-attention/1
(scaled dot product, full head width) and experimental-r4-source-
attention/1 - the r4_attention branch recorded as it actually computes:
chunked-4-wide dot product, softmax IDENTICAL to standard (max-subtract
exp sum-normalize - not a bypass), trailing H mod 4 q/k dims truncated
from scores (perturbation-tested), scale still sqrt(full H). Stale
Spin(4)/softmax-free wording corrected in README (false 250.000000aster
claim removed), CLI help, doc comments; dated correction appended to
the deferral record (history retained); non-normative cross-ref in
INFERENCE_OPERATION_CONTRACT.md (contract untouched). Registry refuses
unknown (id,version) via sanctioned surface (R5). Boolean switch maps
to operator ids at the oracle (TeacherOracle default None, legacy
interpretation documented). Identity carried on the #597/#600/#601
seams: ObservationManifest auto-populated, CoverReport via
--attention-operator flag, api stage_b + server bind naturally;
certify-side gap recorded as honesty item (no oracle seam there,
consistent with prior fields). Standard + experimental per-head
attention factored into free deterministic functions, arithmetic
untouched (bit-exact forward_batch parity green). 13 new tests incl.
non-divisible head widths. No dormant activation; #515 gates untouched.
