### PR TITLE
feat(#603): versioned TeacherTrace profiles + content-addressed trace sidecars

### DIFF
--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -28,6 +28,7 @@ pub mod routing;
 pub mod semantic_emission_decoupling;
 pub mod semantic_state;
 pub mod stage_dag;
+pub mod trace_profile;
 
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
@@ -297,6 +298,18 @@ pub struct ObserveOptions {
     /// (`--source-manifest-kappa`), recorded in the observation manifest.
     /// Carried as an opaque string; this crate never computes it.
     pub source_manifest_kappa: Option<String>,
+    /// #603 teacher-trace profile (`--trace-profile <id>` or
+    /// `<id>/<version>`), resolved through the versioned registry
+    /// ([`trace_profile::profile_spec`]) at run time. `None` — the
+    /// default everywhere — is the minimal profile: exactly today's
+    /// observation bytes. Richer profiles are strictly opt-in.
+    pub trace_profile: Option<(String, u32)>,
+    /// Declared capture layer indices for the richer #603 lanes
+    /// (`--trace-layers <csv>`; bounded by the registry).
+    pub trace_layers: Vec<u32>,
+    /// Declared per-head attention-support cap (`--trace-support <n>`;
+    /// bounded by the registry).
+    pub trace_support: u32,
 }
 
 /// Parse observe CLI arguments. `None` when the arguments do not name a valid
@@ -313,6 +326,9 @@ pub fn parse_observe_options(args: &[String]) -> Option<ObserveOptions> {
         shards: 3,
         sequence_length: 128,
         source_manifest_kappa: None,
+        trace_profile: None,
+        trace_layers: Vec::new(),
+        trace_support: trace_profile::PRIMARY_TOP_K,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -336,6 +352,22 @@ pub fn parse_observe_options(args: &[String]) -> Option<ObserveOptions> {
             }
             "--source-manifest-kappa" => {
                 options.source_manifest_kappa = Some(value.clone());
+            }
+            "--trace-profile" => {
+                // `<id>` (registry version 1) or `<id>/<version>`.
+                options.trace_profile = Some(match value.split_once('/') {
+                    Some((id, version)) => (id.to_owned(), version.parse().ok()?),
+                    None => (value.clone(), trace_profile::PROFILE_VERSION),
+                });
+            }
+            "--trace-layers" => {
+                options.trace_layers = value
+                    .split(',')
+                    .map(|index| index.trim().parse().ok())
+                    .collect::<Option<Vec<u32>>>()?;
+            }
+            "--trace-support" => {
+                options.trace_support = value.parse().ok()?;
             }
             _ => return None,
         }
@@ -387,13 +419,40 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
         }
     }
 
-    observation::observe_sharded(
-        &mut *oracle,
-        options.seconds,
-        options.target,
-        options.shards,
-        &options.output,
-        None,
-    )?;
+    // #603: resolve the opt-in teacher-trace profile through the
+    // versioned registry — an unknown (profile, version) or unbounded
+    // declaration is refused by name, never guessed. No flag means the
+    // minimal profile: exactly today's observation bytes.
+    match &options.trace_profile {
+        None => {
+            observation::observe_sharded(
+                &mut *oracle,
+                options.seconds,
+                options.target,
+                options.shards,
+                &options.output,
+                None,
+            )?;
+        }
+        Some((id, version)) => {
+            let profile = trace_profile::profile_spec(
+                id,
+                *version,
+                &trace_profile::TraceCaptureBounds {
+                    layer_indices: options.trace_layers.clone(),
+                    support_size: options.trace_support,
+                },
+            )?;
+            observation::observe_sharded_traced(
+                &mut *oracle,
+                options.seconds,
+                options.target,
+                options.shards,
+                &options.output,
+                None,
+                &profile,
+            )?;
+        }
+    }
     Ok(())
 }

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -23,6 +23,9 @@
 //! A rerun skips completed shards and regenerates only missing/incomplete
 //! ones, continuing the stream from the checkpoint.
 
+#[cfg(not(target_arch = "wasm32"))]
+use crate::trace_profile::SUPPORT_ABSENT_MARKER;
+use crate::trace_profile::TraceProfile;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 #[cfg(not(target_arch = "wasm32"))]
@@ -42,6 +45,8 @@ use uor_r4_model_source::attention::AttentionOperatorSpec;
 use uor_r4_model_source::geometry::GeometryProjection;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::progress::Progress;
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::{TraceCaptureRequest, TraceCaptureSinks};
 
 /// Observation record width: the v4 corpus record layout (story, next,
 /// top-8 tokens, top-8 weights, span, byte anchors) — see
@@ -234,6 +239,12 @@ pub struct ShardEntry {
     /// metadata was captured for this shard.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub probability_kappa: Option<String>,
+    /// Content κ of the aligned #603 teacher-trace sidecar
+    /// (`<shard>.trace`), when a non-minimal trace profile captured
+    /// richer lanes for this shard. Absent for the minimal profile, so
+    /// legacy manifest bytes are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_kappa: Option<String>,
 }
 
 /// Manifest of an observation shard directory: the fan-out, the completed
@@ -287,6 +298,21 @@ pub struct ObservationManifest {
     /// are unchanged when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_operator: Option<AttentionOperatorSpec>,
+    /// #603 typed record of the teacher-trace profile the producing pass
+    /// captured under (which lanes, which declared layer indices, which
+    /// caps), when a non-minimal profile was active. `None` marks the
+    /// minimal profile — exactly today's surface, the implicit legacy
+    /// era — so every legacy manifest stays readable and legacy manifest
+    /// bytes are unchanged when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_profile: Option<TraceProfile>,
+    /// Width in bytes of one #603 trace-sidecar row for this directory
+    /// (a pure function of the trace profile's declared bounds and the
+    /// oracle's capture geometry, pinned at the first traced write so
+    /// resume and merge validate alignment). Absent for the minimal
+    /// profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_row_bytes: Option<u64>,
     #[serde(default)]
     pub completed: BTreeMap<u32, ShardEntry>,
     #[serde(default)]
@@ -304,9 +330,81 @@ impl ObservationManifest {
             geometry: None,
             tokenizer_adapter: None,
             attention_operator: None,
+            trace_profile: None,
+            trace_row_bytes: None,
             completed: BTreeMap::new(),
             total_records: 0,
         }
+    }
+
+    /// Canonical serialization of the manifest's identity BUNDLE (#603):
+    /// the five identity fields (`input_cid`, `source_manifest_kappa`,
+    /// `geometry` #600, `tokenizer_adapter` #601, `attention_operator`
+    /// #602) plus the #603 `trace_profile`, in that fixed order, one
+    /// line per component. Absence is part of the digest input as an
+    /// EXPLICIT marker: an unset component serializes as
+    /// `<name>=absent`, a set component as `<name>=present:<value>`
+    /// (the raw string for the κ/CID fields, the declared-identity
+    /// digest recomputed from the typed records) — so an absent field is
+    /// never confusable with an empty or zero one, and the digest is a
+    /// pure function of the field values regardless of the order they
+    /// were set in.
+    pub fn identity_bundle_bytes(&self) -> Vec<u8> {
+        fn line(text: &mut String, name: &str, value: Option<String>) {
+            match value {
+                None => text.push_str(&format!("{name}=absent\n")),
+                Some(value) => text.push_str(&format!("{name}=present:{value}\n")),
+            }
+        }
+        let mut text = String::from("uor-r4-observation-identity-bundle/1\n");
+        line(&mut text, "input_cid", self.input_cid.clone());
+        line(
+            &mut text,
+            "source_manifest_kappa",
+            self.source_manifest_kappa.clone(),
+        );
+        line(
+            &mut text,
+            "geometry",
+            self.geometry
+                .as_ref()
+                .map(|record| record.declared_digest()),
+        );
+        line(
+            &mut text,
+            "tokenizer_adapter",
+            self.tokenizer_adapter
+                .as_ref()
+                .map(|record| record.declared_digest()),
+        );
+        line(
+            &mut text,
+            "attention_operator",
+            self.attention_operator
+                .as_ref()
+                .map(|record| record.declared_digest()),
+        );
+        line(
+            &mut text,
+            "trace_profile",
+            self.trace_profile
+                .as_ref()
+                .map(|record| record.declared_digest()),
+        );
+        text.into_bytes()
+    }
+
+    /// The identity-bundle digest: `blake3:<hex>` over
+    /// [`ObservationManifest::identity_bundle_bytes`]. This is the ONE
+    /// stable bundle identity of an observation corpus's provenance
+    /// seam: it moves when any component changes, is independent of the
+    /// order components were recorded in, and distinguishes an absent
+    /// component from an empty one.
+    pub fn identity_bundle_digest(&self) -> String {
+        format!(
+            "blake3:{}",
+            blake3::hash(&self.identity_bundle_bytes()).to_hex()
+        )
     }
 
     /// Number of shards in the configured fan-out (2^shard_bits).
@@ -341,10 +439,17 @@ impl ObservationManifest {
     }
 }
 
+/// Name of one shard's #603 trace sidecar: `<shard file>.trace`,
+/// mirroring the `.prob` probability sidecar naming.
+pub fn trace_sidecar_name(shard_bits: u8, shard: u32) -> String {
+    format!("{}.trace", shard_file_name(shard_bits, shard))
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 struct ShardHandle {
     file: BufWriter<fs::File>,
     probability: Option<BufWriter<fs::File>>,
+    trace: Option<BufWriter<fs::File>>,
 }
 
 /// Spills observation records into per-shard files with a κ-pinned
@@ -475,6 +580,20 @@ impl ObservationShardWriter {
         Ok(())
     }
 
+    /// Record the #603 typed teacher-trace-profile record of the
+    /// producing pass in the observation manifest (idempotent, atomic
+    /// store), mirroring
+    /// [`ObservationShardWriter::set_geometry`]/[`ObservationShardWriter::set_tokenizer_adapter`].
+    /// The minimal profile is never recorded — absence marks it — so
+    /// legacy manifest bytes are unchanged for every minimal pass.
+    pub fn set_trace_profile(&mut self, profile: &TraceProfile) -> Result<(), SourceUnavailable> {
+        if self.manifest.trace_profile.as_ref() != Some(profile) {
+            self.manifest.trace_profile = Some(profile.clone());
+            self.manifest.store(&self.dir)?;
+        }
+        Ok(())
+    }
+
     /// Pending per-shard partition counts (records written so far via
     /// [`ObservationShardWriter::write_record_in_partition`] plus any
     /// counts restored by [`ObservationShardWriter::restore_partition_counts`]).
@@ -543,6 +662,7 @@ impl ObservationShardWriter {
             self.handles[index] = Some(ShardHandle {
                 file: BufWriter::new(file),
                 probability: None,
+                trace: None,
             });
         }
         let handle = self.handles[index]
@@ -616,6 +736,79 @@ impl ObservationShardWriter {
         Ok(true)
     }
 
+    /// Append an observation record, its aligned probability metadata,
+    /// and its aligned #603 trace-sidecar row (the richer lanes of a
+    /// non-minimal trace profile, assembled by the traced observe
+    /// driver). The first traced write pins the row width in the
+    /// manifest; every later row must match it, and finalization
+    /// validates that every non-empty shard has a complete, aligned
+    /// trace sidecar rather than silently publishing partial lanes. The
+    /// primary shard record bytes are written through the unchanged v4
+    /// path — richer lanes never alter them.
+    pub fn write_record_with_probability_and_trace(
+        &mut self,
+        record: &[u8; RECORD_SIZE],
+        probability: ProbabilityMetadata,
+        trace_row: &[u8],
+        shard: u32,
+    ) -> Result<bool, SourceUnavailable> {
+        if trace_row.is_empty() {
+            return Err(invalid_input(
+                "a trace-sidecar row must be non-empty; minimal passes use \
+                 write_record_with_probability instead"
+                    .to_owned(),
+            ));
+        }
+        if self.is_complete(shard) {
+            return Ok(false);
+        }
+        match self.manifest.trace_row_bytes {
+            Some(width) if width != trace_row.len() as u64 => {
+                return Err(invalid_input(format!(
+                    "trace row is {} bytes but the manifest pins {width}-byte rows; \
+                     the trace profile or capture geometry cannot change mid-corpus",
+                    trace_row.len()
+                )));
+            }
+            None => {
+                self.manifest.trace_row_bytes = Some(trace_row.len() as u64);
+                self.manifest.store(&self.dir)?;
+            }
+            Some(_) => {}
+        }
+        let written = self.write_record_with_probability(record, probability, shard)?;
+        if !written {
+            return Ok(false);
+        }
+        let index = shard as usize;
+        let path = self
+            .dir
+            .join(trace_sidecar_name(self.manifest.shard_bits, shard));
+        let handle = self.handles[index]
+            .as_mut()
+            .ok_or_else(|| invalid_data(format!("shard {shard} handle was not opened")))?;
+        if handle.trace.is_none() {
+            let file = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)?;
+            let existing = file.metadata()?.len();
+            if existing % trace_row.len() as u64 != 0 {
+                return Err(invalid_data(format!(
+                    "trace sidecar {} has a torn row",
+                    path.display()
+                )));
+            }
+            handle.trace = Some(BufWriter::new(file));
+        }
+        handle
+            .trace
+            .as_mut()
+            .expect("trace handle opened above")
+            .write_all(trace_row)?;
+        Ok(true)
+    }
+
     /// Probability-sidecar variant of
     /// [`ObservationShardWriter::write_record_in_partition`].
     pub fn write_record_with_probability_in_partition(
@@ -642,6 +835,9 @@ impl ObservationShardWriter {
             if let Some(probability) = handle.probability.as_mut() {
                 probability.flush()?;
             }
+            if let Some(trace) = handle.trace.as_mut() {
+                trace.flush()?;
+            }
         }
         Ok(())
     }
@@ -663,6 +859,9 @@ impl ObservationShardWriter {
             handle.file.flush()?;
             if let Some(probability) = handle.probability.as_mut() {
                 probability.flush()?;
+            }
+            if let Some(trace) = handle.trace.as_mut() {
+                trace.flush()?;
             }
         }
         let path = self.shard_path(shard);
@@ -696,6 +895,36 @@ impl ObservationShardWriter {
         } else {
             None
         };
+        let trace_path = self
+            .dir
+            .join(trace_sidecar_name(self.manifest.shard_bits, shard));
+        let trace_kappa = if trace_path.exists() {
+            let row_bytes = self.manifest.trace_row_bytes.ok_or_else(|| {
+                invalid_data(format!(
+                    "trace sidecar {} exists but the manifest pins no row width",
+                    trace_path.display()
+                ))
+            })?;
+            let trace_length = fs::metadata(&trace_path)?.len();
+            let records = length / RECORD_SIZE as u64;
+            if trace_length != records * row_bytes {
+                return Err(invalid_data(format!(
+                    "trace sidecar {} has {} bytes for {} records of {}-byte rows",
+                    trace_path.display(),
+                    trace_length,
+                    records,
+                    row_bytes
+                )));
+            }
+            Some(file_kappa(&trace_path)?)
+        } else if self.manifest.trace_row_bytes.is_some() && length != 0 {
+            return Err(invalid_data(format!(
+                "shard {shard} has records but no trace sidecar; the trace \
+                 profile cannot change mid-corpus"
+            )));
+        } else {
+            None
+        };
         let entry = ShardEntry {
             records: length / RECORD_SIZE as u64,
             kappa: file_kappa(&path)?,
@@ -703,6 +932,7 @@ impl ObservationShardWriter {
                 .partitions_active
                 .then_some(self.partition_counts[shard as usize]),
             probability_kappa,
+            trace_kappa,
         };
         self.manifest.total_records = self.manifest.total_records.saturating_add(entry.records);
         self.manifest.completed.insert(shard, entry);
@@ -885,6 +1115,106 @@ pub fn reconcile_probability_pair(
     Ok(())
 }
 
+/// Merge aligned #603 trace-sidecar rows in the same deterministic shard
+/// order as [`merge_shards`]. The result depends only on shard contents,
+/// never on completion order; rows are returned as raw bytes (the lane
+/// layout is declared by the manifest's `trace_profile` and
+/// `trace_row_bytes`).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn merge_trace_rows(dir: impl AsRef<Path>) -> Result<Vec<u8>, SourceUnavailable> {
+    let dir = dir.as_ref();
+    let manifest = ObservationManifest::load(dir)?
+        .ok_or_else(|| invalid_data(format!("no observation manifest in {}", dir.display())))?;
+    let row_bytes = manifest.trace_row_bytes.ok_or_else(|| {
+        invalid_data(format!(
+            "{} has no trace sidecars (minimal trace profile)",
+            dir.display()
+        ))
+    })?;
+    let mut merged = Vec::new();
+    for shard in 0..manifest.shard_count() {
+        let Some(entry) = manifest.completed.get(&shard) else {
+            continue;
+        };
+        if entry.trace_kappa.is_none() {
+            if entry.records == 0 {
+                continue;
+            }
+            return Err(invalid_data(format!("shard {shard} has no trace sidecar")));
+        }
+        let path = dir.join(trace_sidecar_name(manifest.shard_bits, shard));
+        let bytes = fs::read(&path)?;
+        if bytes.len() as u64 != entry.records * row_bytes {
+            return Err(invalid_data(format!(
+                "trace sidecar {} is not aligned",
+                path.display()
+            )));
+        }
+        merged.extend_from_slice(&bytes);
+    }
+    Ok(merged)
+}
+
+/// Reconcile a generation-path record/probability/trace triple after a
+/// crash between the buffered writes of one position: the common record
+/// prefix of the three files is the recoverable prefix (the #603
+/// extension of [`reconcile_probability_pair`], applied when the
+/// manifest pins a trace row width). Records without trace rows are
+/// refused — a corpus cannot silently change trace profile mid-stream.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn reconcile_trace_triple(
+    dir: impl AsRef<Path>,
+    shard_bits: u8,
+    shard: u32,
+    trace_row_bytes: u64,
+) -> Result<(), SourceUnavailable> {
+    let dir = dir.as_ref();
+    reconcile_probability_pair(dir, shard_bits, shard)?;
+    let record_path = dir.join(shard_file_name(shard_bits, shard));
+    let record_length = match fs::metadata(&record_path) {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let trace_path = dir.join(trace_sidecar_name(shard_bits, shard));
+    let trace_length = match fs::metadata(&trace_path) {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if record_length == 0 {
+                return Ok(());
+            }
+            return Err(invalid_data(format!(
+                "shard {shard} has records but no trace sidecar; the trace \
+                 profile cannot change mid-corpus"
+            )));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let records = (record_length / RECORD_SIZE as u64).min(trace_length / trace_row_bytes.max(1));
+    let targets = [
+        (record_path, records * RECORD_SIZE as u64),
+        (
+            dir.join(format!("{}.prob", shard_file_name(shard_bits, shard))),
+            records * PROBABILITY_METADATA_SIZE as u64,
+        ),
+        (trace_path, records * trace_row_bytes),
+    ];
+    for (path, expected) in targets {
+        let length = match fs::metadata(&path) {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if length > expected {
+            fs::OpenOptions::new()
+                .write(true)
+                .open(&path)?
+                .set_len(expected)?;
+        }
+    }
+    Ok(())
+}
+
 /// Outcome of one [`observe_sharded`] invocation.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -902,6 +1232,214 @@ pub struct ObserveSummary {
     pub done: bool,
 }
 
+/// The bounded per-step capture state of one traced observation pass
+/// (#603): the resolved lane plan of a non-minimal [`TraceProfile`]
+/// against one oracle's declared capture geometry, and the assembly
+/// buffer for one trace-sidecar row. Lane order within a row is fixed
+/// and documented: per-layer residuals (ascending declared layers), the
+/// final-hidden state (#95 lane), q/k/v rows (ascending declared
+/// layers, q then k then v), then attention support (ascending declared
+/// layers, heads ascending, S fixed slots of `(u32 position, f32
+/// weight)` — unfilled slots carry the explicit
+/// [`SUPPORT_ABSENT_MARKER`], never zeros). All values little-endian
+/// f32/u32 bytes; the row width is a pure function of (profile,
+/// geometry), pinned into the manifest at the first write.
+#[cfg(not(target_arch = "wasm32"))]
+struct TraceCapture {
+    profile: TraceProfile,
+    residual_layers: Vec<usize>,
+    qkv_layers: Vec<usize>,
+    attention_layers: Vec<usize>,
+    support: usize,
+    final_hidden: bool,
+    residual_width: usize,
+    row_bytes: usize,
+    row: Vec<u8>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TraceCapture {
+    /// Resolve `profile` against `oracle`'s declared capture geometry.
+    /// Refused — never zero-filled — when the oracle exposes no capture
+    /// surface, no hidden state for a declared final-hidden lane, or a
+    /// declared layer index outside its layer range.
+    fn new(profile: &TraceProfile, oracle: &dyn TeacherOracle) -> Result<Self, SourceUnavailable> {
+        let geometry = oracle.trace_capture_geometry().ok_or_else(|| {
+            invalid_input(format!(
+                "trace profile {}/{} needs the oracle's bounded capture surface, \
+                 but this oracle declares none; richer lanes are refused, not zero-filled",
+                profile.id, profile.version
+            ))
+        })?;
+        let resolve = |indices: &[u32], lane: &str| -> Result<Vec<usize>, SourceUnavailable> {
+            let mut resolved = Vec::with_capacity(indices.len());
+            for &index in indices {
+                if index as usize >= geometry.layers {
+                    return Err(invalid_input(format!(
+                        "{lane} capture layer {index} is outside the oracle's {} layers",
+                        geometry.layers
+                    )));
+                }
+                resolved.push(index as usize);
+            }
+            Ok(resolved)
+        };
+        let (residual_layers, final_hidden) = match &profile.layer_lane {
+            Some(lane) => (resolve(&lane.layer_indices, "residual")?, lane.final_hidden),
+            None => (Vec::new(), false),
+        };
+        if final_hidden && oracle.hidden_state().is_none() {
+            return Err(invalid_input(format!(
+                "trace profile {}/{} declares the final-hidden lane, but this \
+                 oracle retains no hidden state; the lane is refused, not zero-filled",
+                profile.id, profile.version
+            )));
+        }
+        let qkv_layers = match &profile.qkv_lane {
+            Some(lane) => resolve(&lane.layer_indices, "q/k/v")?,
+            None => Vec::new(),
+        };
+        let (attention_layers, support) = match &profile.attention_support_lane {
+            Some(lane) => (
+                resolve(&lane.layer_indices, "attention-support")?,
+                lane.support_size as usize,
+            ),
+            None => (Vec::new(), 0),
+        };
+        let kv_width = geometry.residual_width * geometry.kv_heads / geometry.heads;
+        let row_bytes = residual_layers.len() * geometry.residual_width * 4
+            + usize::from(final_hidden) * geometry.residual_width * 4
+            + qkv_layers.len() * (geometry.residual_width + 2 * kv_width) * 4
+            + attention_layers.len() * geometry.heads * support * 8;
+        if row_bytes == 0 {
+            return Err(invalid_input(format!(
+                "trace profile {}/{} declares no captured bytes; use the minimal profile",
+                profile.id, profile.version
+            )));
+        }
+        Ok(Self {
+            profile: profile.clone(),
+            residual_layers,
+            qkv_layers,
+            attention_layers,
+            support,
+            final_hidden,
+            residual_width: geometry.residual_width,
+            row_bytes,
+            row: Vec::with_capacity(row_bytes),
+        })
+    }
+
+    /// One traced teacher step: capture the declared lanes through the
+    /// oracle's exact-executor capture path and assemble this position's
+    /// trace-sidecar row into `self.row`. Deterministic: the row is a
+    /// pure function of (oracle state, token, pos, profile).
+    fn step(
+        &mut self,
+        oracle: &mut dyn TeacherOracle,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+    ) -> Result<(), SourceUnavailable> {
+        let mut residual_bytes: Vec<u8> = Vec::new();
+        let mut qkv_bytes: Vec<u8> = Vec::new();
+        let mut attention_bytes: Vec<u8> = Vec::new();
+        let support = self.support;
+        let captured = {
+            let mut residual_sink = |_layer: usize, x: &[f32]| {
+                for value in x {
+                    residual_bytes.extend_from_slice(&value.to_le_bytes());
+                }
+            };
+            let mut qkv_sink = |_layer: usize, q: &[f32], k: &[f32], v: &[f32]| {
+                for vector in [q, k, v] {
+                    for value in vector {
+                        qkv_bytes.extend_from_slice(&value.to_le_bytes());
+                    }
+                }
+            };
+            let mut attention_sink = |_layer: usize, _head: usize, att: &[f32]| {
+                // Bounded top-S support: positions ordered by descending
+                // weight, ties to the lower position (the same canonical
+                // tie-break as the top-k trace surface).
+                let mut order: Vec<u32> = (0..att.len() as u32).collect();
+                order.sort_by(|a, b| {
+                    att[*b as usize]
+                        .total_cmp(&att[*a as usize])
+                        .then_with(|| a.cmp(b))
+                });
+                for slot in 0..support {
+                    match order.get(slot) {
+                        Some(&position) => {
+                            attention_bytes.extend_from_slice(&position.to_le_bytes());
+                            attention_bytes
+                                .extend_from_slice(&att[position as usize].to_le_bytes());
+                        }
+                        None => {
+                            // Fewer prefix positions than the cap: mark
+                            // the slot explicitly absent — never a
+                            // zero-filled entry.
+                            attention_bytes.extend_from_slice(&SUPPORT_ABSENT_MARKER.to_le_bytes());
+                            attention_bytes.extend_from_slice(&SUPPORT_ABSENT_MARKER.to_le_bytes());
+                        }
+                    }
+                }
+            };
+            oracle.step_with_trace_capture(
+                token,
+                pos,
+                logits,
+                &TraceCaptureRequest {
+                    residual_layers: &self.residual_layers,
+                    qkv_layers: &self.qkv_layers,
+                    attention_layers: &self.attention_layers,
+                },
+                &mut TraceCaptureSinks {
+                    residual: &mut residual_sink,
+                    qkv: &mut qkv_sink,
+                    attention: &mut attention_sink,
+                },
+            )
+        };
+        if !captured {
+            return Err(invalid_input(format!(
+                "trace profile {}/{} needs the oracle's exact-executor capture \
+                 step, but this oracle performs only plain steps; richer lanes \
+                 are refused, not zero-filled",
+                self.profile.id, self.profile.version
+            )));
+        }
+        self.row.clear();
+        self.row.extend_from_slice(&residual_bytes);
+        if self.final_hidden {
+            let hidden = oracle.hidden_state().ok_or_else(|| {
+                invalid_data("oracle hidden state disappeared mid-pass".to_owned())
+            })?;
+            if hidden.len() != self.residual_width {
+                return Err(invalid_data(format!(
+                    "hidden state is {} wide, expected the capture geometry's {}",
+                    hidden.len(),
+                    self.residual_width
+                )));
+            }
+            for value in hidden {
+                self.row.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+        self.row.extend_from_slice(&qkv_bytes);
+        self.row.extend_from_slice(&attention_bytes);
+        if self.row.len() != self.row_bytes {
+            return Err(invalid_data(format!(
+                "assembled trace row is {} bytes, expected {} — the oracle's \
+                 captures do not match its declared geometry",
+                self.row.len(),
+                self.row_bytes
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Run the teacher generation of `compile_hugging_face`'s corpus step,
 /// spilling v4 records plus aligned probability metadata into content-addressed
 /// shards instead of one
@@ -911,6 +1449,10 @@ pub struct ObserveSummary {
 /// window is the existing 8-token window of fed tokens. Resume: a rerun
 /// continues the stream from `state.bin`, skips shards the manifest marks
 /// complete, and appends to the incomplete ones.
+///
+/// This is the minimal trace profile: byte-for-byte today's records,
+/// sidecars, and manifest (no `trace_profile` field is recorded). Richer
+/// #603 profiles are opt-in through [`observe_sharded_traced`].
 #[cfg(not(target_arch = "wasm32"))]
 pub fn observe_sharded(
     oracle: &mut dyn TeacherOracle,
@@ -920,9 +1462,112 @@ pub fn observe_sharded(
     out: &Path,
     token_byte_lengths: Option<&[u32]>,
 ) -> Result<ObserveSummary, SourceUnavailable> {
+    observe_sharded_inner(
+        oracle,
+        budget_s,
+        target,
+        shard_bits,
+        out,
+        token_byte_lengths,
+        None,
+    )
+}
+
+/// [`observe_sharded`] under an explicit #603 teacher-trace profile: the
+/// SAME pipeline (same deterministic stream, records, sharding,
+/// checkpointing, and resume), extended — when the profile is not
+/// minimal — with one aligned trace-sidecar row per record carrying the
+/// declared richer lanes, captured through the oracle's exact-executor
+/// capture step within the profile's declared bounds. Passing the
+/// minimal profile is exactly [`observe_sharded`]. Deterministic: the
+/// same inputs and profile produce byte-identical shard and sidecar
+/// bytes; a corpus's profile is pinned in its manifest and cannot change
+/// mid-stream.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn observe_sharded_traced(
+    oracle: &mut dyn TeacherOracle,
+    budget_s: u64,
+    target: usize,
+    shard_bits: u8,
+    out: &Path,
+    token_byte_lengths: Option<&[u32]>,
+    profile: &TraceProfile,
+) -> Result<ObserveSummary, SourceUnavailable> {
+    let trace = if profile.is_minimal() {
+        None
+    } else {
+        Some(TraceCapture::new(profile, oracle)?)
+    };
+    observe_sharded_inner(
+        oracle,
+        budget_s,
+        target,
+        shard_bits,
+        out,
+        token_byte_lengths,
+        trace,
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn observe_sharded_inner(
+    oracle: &mut dyn TeacherOracle,
+    budget_s: u64,
+    target: usize,
+    shard_bits: u8,
+    out: &Path,
+    token_byte_lengths: Option<&[u32]>,
+    mut trace: Option<TraceCapture>,
+) -> Result<ObserveSummary, SourceUnavailable> {
     let mut writer = ObservationShardWriter::open(out, shard_bits)?;
+    // #603 profile pinning: a corpus is captured under ONE profile. A
+    // recorded profile must match the requested one (minimal requests
+    // refuse traced corpora and vice versa once bytes exist); a fresh
+    // traced pass records its profile before any record is written.
+    let recorded = writer.manifest().trace_profile.clone();
+    let has_prior_state = out.join(STATE_FILE).exists() || !writer.manifest().completed.is_empty();
+    match (&recorded, trace.as_ref()) {
+        (None, None) => {}
+        (Some(recorded), Some(trace)) if *recorded == trace.profile => {}
+        (None, Some(trace)) => {
+            if has_prior_state {
+                return Err(invalid_input(format!(
+                    "{} was captured under the minimal trace profile; profile \
+                     {}/{} cannot be introduced mid-corpus",
+                    out.display(),
+                    trace.profile.id,
+                    trace.profile.version
+                )));
+            }
+            writer.set_trace_profile(&trace.profile)?;
+        }
+        (Some(recorded), Some(trace)) => {
+            return Err(invalid_input(format!(
+                "{} is pinned to trace profile {}/{}; requested {}/{}",
+                out.display(),
+                recorded.id,
+                recorded.version,
+                trace.profile.id,
+                trace.profile.version
+            )));
+        }
+        (Some(recorded), None) => {
+            return Err(invalid_input(format!(
+                "{} is pinned to trace profile {}/{}; pass the same profile to resume",
+                out.display(),
+                recorded.id,
+                recorded.version
+            )));
+        }
+    }
+    let trace_row_bytes = writer.manifest().trace_row_bytes;
     for shard in 0..writer.manifest().shard_count() {
-        reconcile_probability_pair(out, shard_bits, shard)?;
+        match (trace.as_ref(), trace_row_bytes) {
+            (Some(_), Some(row_bytes)) => {
+                reconcile_trace_triple(out, shard_bits, shard, row_bytes)?;
+            }
+            _ => reconcile_probability_pair(out, shard_bits, shard)?,
+        }
     }
     let state_path = out.join(STATE_FILE);
     let (mut n, mut stories, mut rng, mut done) = match fs::read(&state_path) {
@@ -967,7 +1612,10 @@ pub fn observe_sharded(
         window.clear();
         for pos in 0..seq_len {
             progress.set(n as usize);
-            oracle.step(token, pos, &mut logits);
+            match trace.as_mut() {
+                None => oracle.step(token, pos, &mut logits),
+                Some(trace) => trace.step(oracle, token, pos, &mut logits)?,
+            }
             let (next, top_tokens, top_weights, stats) =
                 compiler::softmax_top8_sample_with_stats(&mut logits, &mut rng);
             window.push(token as u32);
@@ -988,16 +1636,22 @@ pub fn observe_sharded(
                 (span_start, span_end),
                 (byte_start, byte_end),
             );
-            if writer.write_record_with_probability(
-                &record,
-                ProbabilityMetadata {
-                    target_logprob_nats: stats.target_logprob_nats,
-                    entropy_bits: stats.entropy_bits,
-                    top8_mass: stats.top8_mass,
-                    target_rank: stats.target_rank,
-                },
-                shard,
-            )? {
+            let probability = ProbabilityMetadata {
+                target_logprob_nats: stats.target_logprob_nats,
+                entropy_bits: stats.entropy_bits,
+                top8_mass: stats.top8_mass,
+                target_rank: stats.target_rank,
+            };
+            let wrote = match trace.as_ref() {
+                None => writer.write_record_with_probability(&record, probability, shard)?,
+                Some(trace) => writer.write_record_with_probability_and_trace(
+                    &record,
+                    probability,
+                    &trace.row,
+                    shard,
+                )?,
+            };
+            if wrote {
                 written += 1;
             } else {
                 skipped += 1;

--- a/crates/uor-r4-graph-compiler/src/trace_profile.rs
+++ b/crates/uor-r4-graph-compiler/src/trace_profile.rs
@@ -1,0 +1,562 @@
+//! Deterministic versioned teacher-trace profiles (#603): the typed
+//! `uor-r4-teacher-trace/1` record naming exactly which observation lanes
+//! a pass captures and their bounds, so trace richness, boundedness,
+//! profile identity, absence semantics, and source/provenance
+//! dependencies travel as ONE stable bundle on the observation manifest
+//! (see [`crate::observation::ObservationManifest::identity_bundle_digest`]).
+//!
+//! Four profiles are registered, every one an extension of the existing
+//! observation pipeline — no second pipeline exists:
+//!
+//! - `minimal/1` — exactly today's surface: the v4 88-byte records
+//!   (bounded token / top-8 / probability rows) plus the aligned
+//!   probability sidecar. No richer lane; a minimal pass writes bytes
+//!   and manifests byte-identical to a pre-#603 pass (the manifest
+//!   carries NO `trace_profile` field for it — absence marks the
+//!   implicit legacy era, exactly like the #597/#600/#601/#602 fields).
+//! - `layer/1` — minimal plus the per-layer residual lane at declared
+//!   layer indices and the final-hidden lane (the post-final-rmsnorm
+//!   hidden state, `TeacherOracle::hidden_state`). **Measurement record
+//!   (#95):** the final-hidden lane was measured NEGATIVE for the cover
+//!   compiler — 2.8% vs 31.7% Gate C top-1 when used as the cover
+//!   observation vector (merged #95). The lane is preserved here as a
+//!   recorded capture for measurement, NOT adopted for fitting; adopting
+//!   any richer profile for fitting requires a separate measured issue.
+//! - `attention-support/1` — minimal plus the attention-support lane:
+//!   per-head top-S attention weights, captured ONLY for declared layer
+//!   indices and within the declared support cap (tapped from the #602
+//!   factored per-head weight functions through the exact executor).
+//! - `full/1` — minimal plus all richer lanes: per-layer residuals,
+//!   final hidden, current-position q/k/v rows, and attention support.
+//!
+//! Richer lanes live in a per-shard SIDE-CAR file (`shard-NN.bin.trace`,
+//! same deterministic partitioning, content addressing, and manifest
+//! registration as the `.prob` sidecar), so the primary 88-byte shard
+//! record format stays era-stable: the v4 record bytes never change for
+//! any profile. Absent lanes are absent — never zero-filled: a profile
+//! that does not declare a lane produces no bytes for it, and a padding
+//! slot inside the bounded attention-support rows is written as the
+//! explicit absence marker [`SUPPORT_ABSENT_MARKER`], never as a
+//! zero-valued entry.
+//!
+//! Identity follows the #600/#601/#602 discipline: the profile's
+//! declared identity has a canonical pinned-line serialization
+//! ([`TraceProfile::canonical_bytes`]) and a blake3 declared-identity
+//! digest ([`TraceProfile::declared_digest`]) — deliberately not a hash
+//! of source code text; a behavioral change must arrive as a new
+//! registry version, never an in-place edit. The versioned registry
+//! ([`profile_spec`]) maps `(profile, version)` to the record and
+//! refuses every unknown pair by name on the sanctioned
+//! [`SourceUnavailable`](uor_r4_model_source::SourceUnavailable) surface
+//! — the same type this crate's manifest/parse failures already use —
+//! rather than guessing.
+
+use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::SourceUnavailable;
+
+/// Format tag of the canonical serialization (and the version prefix of
+/// every registered profile identity).
+pub const TRACE_PROFILE_FORMAT: &str = "uor-r4-teacher-trace/1";
+
+/// Registry id of the profile capturing exactly today's surface.
+pub const MINIMAL_PROFILE: &str = "minimal";
+/// Registry id of the per-layer residual + final-hidden profile.
+pub const LAYER_PROFILE: &str = "layer";
+/// Registry id of the bounded attention-support profile.
+pub const ATTENTION_SUPPORT_PROFILE: &str = "attention-support";
+/// Registry id of the all-lanes profile.
+pub const FULL_PROFILE: &str = "full";
+/// Registry version shared by the four registered profiles.
+pub const PROFILE_VERSION: u32 = 1;
+
+/// Bound of the primary lane's top-k row — the v4 record's top-8, fixed
+/// for every registered profile (the primary record format never
+/// changes).
+pub const PRIMARY_TOP_K: u32 = 8;
+
+/// Maximum number of declarable capture layer indices per lane.
+pub const MAX_TRACE_LAYERS: usize = 64;
+
+/// Maximum declarable per-head attention-support cap.
+pub const MAX_SUPPORT_SIZE: u32 = 64;
+
+/// Explicit absence marker for an unfilled slot inside a bounded
+/// attention-support row (fewer prefix positions than the declared cap):
+/// both the u32 position field and the u32 weight-bits field carry this
+/// marker. Absence is marked, never zero-filled — a real entry at
+/// position 0 with weight 0.0 is distinguishable from an absent slot.
+pub const SUPPORT_ABSENT_MARKER: u32 = u32::MAX;
+
+/// The per-layer residual lane declaration: which post-layer residual
+/// streams are captured, and whether the final-hidden (#95) lane rides
+/// along.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LayerLane {
+    /// Declared post-layer capture indices, ascending and deduplicated.
+    #[serde(default)]
+    pub layer_indices: Vec<u32>,
+    /// Whether the post-final-rmsnorm hidden state
+    /// (`TeacherOracle::hidden_state`) is captured. This is the #95
+    /// lane, measured NEGATIVE for the cover compiler (2.8% vs 31.7%
+    /// Gate C top-1, merged #95) — preserved as a recorded measurement
+    /// capture, not adopted for fitting.
+    #[serde(default)]
+    pub final_hidden: bool,
+}
+
+/// The current-position q/k/v lane declaration (rotated query plus the
+/// key/value cache rows the #602 operators consumed), `full/1` only.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QkvLane {
+    /// Declared capture indices, ascending and deduplicated.
+    #[serde(default)]
+    pub layer_indices: Vec<u32>,
+}
+
+/// The attention-support lane declaration: per-head top-S attention
+/// weights for declared layer indices, within the declared cap.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttentionSupportLane {
+    /// Declared capture indices, ascending and deduplicated.
+    #[serde(default)]
+    pub layer_indices: Vec<u32>,
+    /// Per-head support cap S: at most S `(position, weight)` entries
+    /// per head per declared layer per step, ordered by descending
+    /// weight (ties to the lower position). `1..=MAX_SUPPORT_SIZE`.
+    #[serde(default)]
+    pub support_size: u32,
+}
+
+/// The typed, versioned record of one teacher-trace profile (#603):
+/// which lanes a pass captures and their bounds. Serialized (all fields
+/// serde-defaulted, lanes as `Option` — absence is absence, never a
+/// zero-filled default) into the observation manifest whenever a
+/// non-minimal profile is active; a minimal pass carries NO record, so
+/// legacy manifest bytes are unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceProfile {
+    /// Registry id (`minimal`, `layer`, `attention-support`, `full`).
+    #[serde(default)]
+    pub id: String,
+    /// Registry version. A behavioral change is a new version, never an
+    /// in-place edit.
+    #[serde(default)]
+    pub version: u32,
+    /// Bound of the primary lane's top-k row (always
+    /// [`PRIMARY_TOP_K`]; the v4 record format is era-stable).
+    #[serde(default)]
+    pub top_k: u32,
+    /// Per-layer residual + final-hidden lane; `None` = not captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layer_lane: Option<LayerLane>,
+    /// Current-position q/k/v lane; `None` = not captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qkv_lane: Option<QkvLane>,
+    /// Bounded attention-support lane; `None` = not captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention_support_lane: Option<AttentionSupportLane>,
+    /// `blake3:<hex>` of [`TraceProfile::canonical_bytes`] — the
+    /// declared identity, not source code text (#600/#601/#602
+    /// discipline).
+    #[serde(default)]
+    pub declared_digest: String,
+}
+
+fn normalized(indices: &[u32]) -> Vec<u32> {
+    let mut indices = indices.to_vec();
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
+fn indices_line(indices: &[u32]) -> String {
+    indices
+        .iter()
+        .map(|index| index.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+impl TraceProfile {
+    /// The `minimal/1` record: exactly today's surface, no richer lane.
+    pub fn minimal() -> Self {
+        let mut record = Self {
+            id: MINIMAL_PROFILE.to_owned(),
+            version: PROFILE_VERSION,
+            top_k: PRIMARY_TOP_K,
+            layer_lane: None,
+            qkv_lane: None,
+            attention_support_lane: None,
+            declared_digest: String::new(),
+        };
+        record.declared_digest = record.declared_digest();
+        record
+    }
+
+    /// The `layer/1` record over `layer_indices` (sorted, deduplicated;
+    /// the final-hidden #95 lane is always declared with it).
+    pub fn layer(layer_indices: &[u32]) -> Self {
+        let mut record = Self {
+            id: LAYER_PROFILE.to_owned(),
+            version: PROFILE_VERSION,
+            top_k: PRIMARY_TOP_K,
+            layer_lane: Some(LayerLane {
+                layer_indices: normalized(layer_indices),
+                final_hidden: true,
+            }),
+            qkv_lane: None,
+            attention_support_lane: None,
+            declared_digest: String::new(),
+        };
+        record.declared_digest = record.declared_digest();
+        record
+    }
+
+    /// The `attention-support/1` record over `layer_indices` with the
+    /// per-head support cap `support_size`.
+    pub fn attention_support(layer_indices: &[u32], support_size: u32) -> Self {
+        let mut record = Self {
+            id: ATTENTION_SUPPORT_PROFILE.to_owned(),
+            version: PROFILE_VERSION,
+            top_k: PRIMARY_TOP_K,
+            layer_lane: None,
+            qkv_lane: None,
+            attention_support_lane: Some(AttentionSupportLane {
+                layer_indices: normalized(layer_indices),
+                support_size,
+            }),
+            declared_digest: String::new(),
+        };
+        record.declared_digest = record.declared_digest();
+        record
+    }
+
+    /// The `full/1` record: every richer lane over the same declared
+    /// `layer_indices`, attention support capped at `support_size`.
+    pub fn full(layer_indices: &[u32], support_size: u32) -> Self {
+        let indices = normalized(layer_indices);
+        let mut record = Self {
+            id: FULL_PROFILE.to_owned(),
+            version: PROFILE_VERSION,
+            top_k: PRIMARY_TOP_K,
+            layer_lane: Some(LayerLane {
+                layer_indices: indices.clone(),
+                final_hidden: true,
+            }),
+            qkv_lane: Some(QkvLane {
+                layer_indices: indices.clone(),
+            }),
+            attention_support_lane: Some(AttentionSupportLane {
+                layer_indices: indices,
+                support_size,
+            }),
+            declared_digest: String::new(),
+        };
+        record.declared_digest = record.declared_digest();
+        record
+    }
+
+    /// Whether this is the minimal profile: no richer lane declared —
+    /// the pass writes exactly today's bytes and records nothing in the
+    /// manifest.
+    pub fn is_minimal(&self) -> bool {
+        self.layer_lane.is_none()
+            && self.qkv_lane.is_none()
+            && self.attention_support_lane.is_none()
+    }
+
+    /// Canonical serialization of the record's declared identity: a
+    /// fixed line format (format tag, id, version, bounds, one
+    /// `key=value\n` per field) with EXPLICIT absence markers — an
+    /// undeclared lane serializes as `<lane>=absent`, a declared lane as
+    /// `<lane>=present` followed by its bound lines, so absence is part
+    /// of the digest input and distinct from any empty declaration.
+    /// Byte-stable by construction: field order and separators are fixed
+    /// here, not derived from any serializer.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut text = format!(
+            "{TRACE_PROFILE_FORMAT}\nid={}\nversion={}\ntop_k={}\n",
+            self.id, self.version, self.top_k
+        );
+        match &self.layer_lane {
+            None => text.push_str("layer_lane=absent\n"),
+            Some(lane) => {
+                text.push_str("layer_lane=present\n");
+                text.push_str(&format!(
+                    "layer_lane.layer_indices={}\nlayer_lane.final_hidden={}\n",
+                    indices_line(&lane.layer_indices),
+                    lane.final_hidden
+                ));
+            }
+        }
+        match &self.qkv_lane {
+            None => text.push_str("qkv_lane=absent\n"),
+            Some(lane) => {
+                text.push_str("qkv_lane=present\n");
+                text.push_str(&format!(
+                    "qkv_lane.layer_indices={}\n",
+                    indices_line(&lane.layer_indices)
+                ));
+            }
+        }
+        match &self.attention_support_lane {
+            None => text.push_str("attention_support_lane=absent\n"),
+            Some(lane) => {
+                text.push_str("attention_support_lane=present\n");
+                text.push_str(&format!(
+                    "attention_support_lane.layer_indices={}\nattention_support_lane.support_size={}\n",
+                    indices_line(&lane.layer_indices),
+                    lane.support_size
+                ));
+            }
+        }
+        text.into_bytes()
+    }
+
+    /// The declared-identity digest: `blake3:<hex>` over
+    /// [`TraceProfile::canonical_bytes`].
+    pub fn declared_digest(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.canonical_bytes()).to_hex())
+    }
+}
+
+/// Capture bounds a caller declares when resolving a profile through the
+/// registry: the layer indices the richer lanes capture at and the
+/// per-head attention-support cap. Ignored by profiles whose lanes do
+/// not use them (`minimal/1` uses neither).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCaptureBounds {
+    /// Declared capture layer indices (at most [`MAX_TRACE_LAYERS`]).
+    pub layer_indices: Vec<u32>,
+    /// Per-head attention-support cap (`1..=MAX_SUPPORT_SIZE` where the
+    /// profile declares the lane).
+    pub support_size: u32,
+}
+
+impl Default for TraceCaptureBounds {
+    fn default() -> Self {
+        Self {
+            layer_indices: Vec::new(),
+            support_size: PRIMARY_TOP_K,
+        }
+    }
+}
+
+/// The versioned profile registry (#603): map `(profile, version)` plus
+/// the caller-declared bounds to the typed record. Every pair outside
+/// the registry — and every unbounded declaration — is refused by name
+/// on the sanctioned [`SourceUnavailable`] surface (the same type this
+/// crate reports manifest/parse failures on), never guessed and never
+/// approximated by a "closest" profile or version.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn profile_spec(
+    id: &str,
+    version: u32,
+    bounds: &TraceCaptureBounds,
+) -> Result<TraceProfile, SourceUnavailable> {
+    if bounds.layer_indices.len() > MAX_TRACE_LAYERS {
+        return Err(SourceUnavailable::new(format!(
+            "trace profile {id}/{version} declares {} capture layers, more than the bound {MAX_TRACE_LAYERS}",
+            bounds.layer_indices.len()
+        )));
+    }
+    let bounded_support = |lane: &str| -> Result<u32, SourceUnavailable> {
+        if bounds.support_size == 0 || bounds.support_size > MAX_SUPPORT_SIZE {
+            return Err(SourceUnavailable::new(format!(
+                "trace profile {id}/{version} {lane} support cap {} is outside 1..={MAX_SUPPORT_SIZE}",
+                bounds.support_size
+            )));
+        }
+        Ok(bounds.support_size)
+    };
+    let declared_layers = |lane: &str| -> Result<&[u32], SourceUnavailable> {
+        if bounds.layer_indices.is_empty() {
+            return Err(SourceUnavailable::new(format!(
+                "trace profile {id}/{version} {lane} declares no capture layer indices; \
+                 declare the bounded layer list explicitly"
+            )));
+        }
+        Ok(&bounds.layer_indices)
+    };
+    match (id, version) {
+        (MINIMAL_PROFILE, PROFILE_VERSION) => Ok(TraceProfile::minimal()),
+        (LAYER_PROFILE, PROFILE_VERSION) => Ok(TraceProfile::layer(&bounds.layer_indices)),
+        (ATTENTION_SUPPORT_PROFILE, PROFILE_VERSION) => Ok(TraceProfile::attention_support(
+            declared_layers("attention-support lane")?,
+            bounded_support("attention-support lane")?,
+        )),
+        (FULL_PROFILE, PROFILE_VERSION) => Ok(TraceProfile::full(
+            declared_layers("richer lanes")?,
+            bounded_support("attention-support lane")?,
+        )),
+        _ => Err(SourceUnavailable::new(format!(
+            "unknown teacher-trace profile ({id}, {version}); registered: \
+             {MINIMAL_PROFILE}/{PROFILE_VERSION}, {LAYER_PROFILE}/{PROFILE_VERSION}, \
+             {ATTENTION_SUPPORT_PROFILE}/{PROFILE_VERSION}, {FULL_PROFILE}/{PROFILE_VERSION}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_serialization_is_byte_stable() {
+        // Pinned byte-for-byte: any drift in field order, separators, or
+        // absence markers fails here — profile identity must not move
+        // silently.
+        let minimal = TraceProfile::minimal();
+        let pinned_minimal = "uor-r4-teacher-trace/1\n\
+             id=minimal\n\
+             version=1\n\
+             top_k=8\n\
+             layer_lane=absent\n\
+             qkv_lane=absent\n\
+             attention_support_lane=absent\n";
+        assert_eq!(minimal.canonical_bytes(), pinned_minimal.as_bytes());
+        let expected = format!(
+            "blake3:{}",
+            blake3::hash(pinned_minimal.as_bytes()).to_hex()
+        );
+        assert_eq!(minimal.declared_digest, expected);
+        assert_eq!(minimal.declared_digest(), expected);
+
+        let full = TraceProfile::full(&[2, 0, 2], 4);
+        let pinned_full = "uor-r4-teacher-trace/1\n\
+             id=full\n\
+             version=1\n\
+             top_k=8\n\
+             layer_lane=present\n\
+             layer_lane.layer_indices=0,2\n\
+             layer_lane.final_hidden=true\n\
+             qkv_lane=present\n\
+             qkv_lane.layer_indices=0,2\n\
+             attention_support_lane=present\n\
+             attention_support_lane.layer_indices=0,2\n\
+             attention_support_lane.support_size=4\n";
+        assert_eq!(full.canonical_bytes(), pinned_full.as_bytes());
+        assert_eq!(full.declared_digest, full.declared_digest());
+
+        // The four registered profiles are four distinct identities.
+        let digests = [
+            TraceProfile::minimal().declared_digest,
+            TraceProfile::layer(&[0]).declared_digest,
+            TraceProfile::attention_support(&[0], 4).declared_digest,
+            TraceProfile::full(&[0], 4).declared_digest,
+        ];
+        for (i, a) in digests.iter().enumerate() {
+            for b in digests.iter().skip(i + 1) {
+                assert_ne!(a, b);
+            }
+        }
+        // Bounds are identity: a different layer list or support cap is
+        // a different declared digest.
+        assert_ne!(
+            TraceProfile::layer(&[0]).declared_digest,
+            TraceProfile::layer(&[1]).declared_digest
+        );
+        assert_ne!(
+            TraceProfile::attention_support(&[0], 4).declared_digest,
+            TraceProfile::attention_support(&[0], 8).declared_digest
+        );
+    }
+
+    #[test]
+    fn absent_lane_is_not_an_empty_declaration() {
+        // Absence semantics in the digest input: an undeclared lane and
+        // a declared-but-empty lane are different identities.
+        let absent = TraceProfile::minimal();
+        let mut empty = TraceProfile::minimal();
+        empty.layer_lane = Some(LayerLane {
+            layer_indices: Vec::new(),
+            final_hidden: false,
+        });
+        assert_ne!(absent.declared_digest(), empty.declared_digest());
+    }
+
+    #[test]
+    fn record_round_trips_through_serde_json_and_absent_lanes_serialize_no_key() {
+        for record in [
+            TraceProfile::minimal(),
+            TraceProfile::layer(&[0, 3]),
+            TraceProfile::attention_support(&[1], 4),
+            TraceProfile::full(&[0, 1], 2),
+        ] {
+            let json = serde_json::to_string(&record).expect("serializes");
+            let back: TraceProfile = serde_json::from_str(&json).expect("deserializes");
+            assert_eq!(record, back);
+        }
+        // Absence stays absence on the wire: no lane keys at all.
+        let minimal_json = serde_json::to_string(&TraceProfile::minimal()).expect("serializes");
+        assert!(!minimal_json.contains("layer_lane"));
+        assert!(!minimal_json.contains("qkv_lane"));
+        assert!(!minimal_json.contains("attention_support_lane"));
+        // Serde-defaulted fields: a partial document still parses.
+        let partial: TraceProfile =
+            serde_json::from_str("{\"id\":\"minimal\"}").expect("defaults fill");
+        assert_eq!(partial.id, "minimal");
+        assert_eq!(partial.version, 0);
+        assert_eq!(partial.layer_lane, None);
+    }
+
+    #[test]
+    fn registry_resolves_the_four_profiles() {
+        let bounds = TraceCaptureBounds {
+            layer_indices: vec![0, 2],
+            support_size: 4,
+        };
+        assert_eq!(
+            profile_spec(MINIMAL_PROFILE, 1, &bounds).expect("minimal"),
+            TraceProfile::minimal()
+        );
+        assert_eq!(
+            profile_spec(LAYER_PROFILE, 1, &bounds).expect("layer"),
+            TraceProfile::layer(&[0, 2])
+        );
+        assert_eq!(
+            profile_spec(ATTENTION_SUPPORT_PROFILE, 1, &bounds).expect("attention-support"),
+            TraceProfile::attention_support(&[0, 2], 4)
+        );
+        assert_eq!(
+            profile_spec(FULL_PROFILE, 1, &bounds).expect("full"),
+            TraceProfile::full(&[0, 2], 4)
+        );
+    }
+
+    #[test]
+    fn registry_refuses_unknown_and_unbounded_by_name() {
+        let bounds = TraceCaptureBounds {
+            layer_indices: vec![0],
+            support_size: 4,
+        };
+        for (id, version) in [("minimal", 2u32), ("layer", 9), ("mystery-trace", 1)] {
+            let error = profile_spec(id, version, &bounds)
+                .expect_err("unknown (profile, version) is not a product");
+            assert!(error.reason.contains(id), "reason names the id: {error}");
+        }
+        // Unbounded declarations are refused, not clamped.
+        let unbounded_support = TraceCaptureBounds {
+            layer_indices: vec![0],
+            support_size: MAX_SUPPORT_SIZE + 1,
+        };
+        assert!(profile_spec(FULL_PROFILE, 1, &unbounded_support).is_err());
+        let zero_support = TraceCaptureBounds {
+            layer_indices: vec![0],
+            support_size: 0,
+        };
+        assert!(profile_spec(ATTENTION_SUPPORT_PROFILE, 1, &zero_support).is_err());
+        let no_layers = TraceCaptureBounds {
+            layer_indices: Vec::new(),
+            support_size: 4,
+        };
+        assert!(profile_spec(ATTENTION_SUPPORT_PROFILE, 1, &no_layers).is_err());
+        assert!(profile_spec(FULL_PROFILE, 1, &no_layers).is_err());
+        let too_many = TraceCaptureBounds {
+            layer_indices: (0..=MAX_TRACE_LAYERS as u32).collect(),
+            support_size: 4,
+        };
+        assert!(profile_spec(LAYER_PROFILE, 1, &too_many).is_err());
+    }
+}

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -7,11 +7,16 @@ use std::collections::BTreeSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uor_r4_graph_compiler::observation::{
     ObservationManifest, ObservationShardWriter, ProbabilityMetadata, RECORD_SIZE,
-    merge_probability_metadata, merge_shards, message_bits_per_token, sample_id, shard_file_name,
-    shard_of,
+    merge_probability_metadata, merge_shards, merge_trace_rows, message_bits_per_token,
+    observe_sharded, observe_sharded_traced, sample_id, shard_file_name, shard_of,
+    trace_sidecar_name,
 };
+use uor_r4_graph_compiler::trace_profile::{SUPPORT_ABSENT_MARKER, TraceProfile};
 use uor_r4_model_source::geometry::GeometryProjection;
-use uor_r4_model_source::{BehaviorSource, LlamaOracle, RepresentationSource, TeacherOracle};
+use uor_r4_model_source::{
+    BehaviorSource, LlamaOracle, RepresentationSource, TeacherOracle, TraceCaptureGeometry,
+    TraceCaptureRequest, TraceCaptureSinks,
+};
 
 const LEGACY_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
 
@@ -754,4 +759,569 @@ fn observe_cli_writes_shards_and_resumes_without_rewriting() {
     assert_eq!(merge_shards(&dir).expect("merge 2"), merged1);
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ----------------------------------------------- teacher trace (#603) --
+
+/// #603 provenance seam: the writer setter persists the typed
+/// [`TraceProfile`] record into the observation manifest atomically and
+/// idempotently across reopen, and an unset record leaves legacy
+/// manifest bytes unchanged (no `trace_profile` / `trace_row_bytes`
+/// keys at all) — minimal passes never set one, so their historical
+/// bytes stay valid (absence marks the minimal profile).
+#[test]
+fn trace_profile_persists_in_the_manifest() {
+    let record = TraceProfile::layer(&[0, 2]);
+
+    let dir = unique_path("observe-trace-profile");
+    let mut writer = ObservationShardWriter::open(&dir, 2).expect("writer");
+    assert_eq!(writer.manifest().trace_profile, None);
+    // Legacy bytes: an unset record serializes no trace keys.
+    let legacy_json = serde_json::to_string(writer.manifest()).expect("manifest serializes");
+    assert!(
+        !legacy_json.contains("trace_profile") && !legacy_json.contains("trace_row_bytes"),
+        "an unset record must leave legacy manifest bytes unchanged"
+    );
+    // And a legacy manifest without the keys still deserializes (None).
+    let legacy: ObservationManifest =
+        serde_json::from_str(&legacy_json).expect("legacy manifest deserializes");
+    assert_eq!(legacy.trace_profile, None);
+    assert_eq!(legacy.trace_row_bytes, None);
+
+    writer.set_trace_profile(&record).expect("set and store");
+    // Idempotent: re-setting the recorded value does not rewrite.
+    writer.set_trace_profile(&record).expect("idempotent set");
+    drop(writer);
+    let manifest = ObservationManifest::load(&dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.trace_profile.as_ref(), Some(&record));
+    // Round trip: the persisted record parses back bit-for-bit, digest
+    // included.
+    assert_eq!(
+        manifest
+            .trace_profile
+            .as_ref()
+            .map(|profile| &profile.declared_digest),
+        Some(&record.declared_digest)
+    );
+    // A reopened writer preserves the stored record.
+    let reopened = ObservationShardWriter::open(&dir, 2).expect("reopen");
+    assert_eq!(reopened.manifest().trace_profile.as_ref(), Some(&record));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// #603 bundle identity: `identity_bundle_digest` moves when ANY of the
+/// six components changes, is independent of the order the components
+/// were recorded in, and distinguishes an ABSENT component from an
+/// empty one (absence is an explicit marker in the digest input, never
+/// a zero/default value).
+#[test]
+fn identity_bundle_digest_covers_components_order_and_absence() {
+    use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+    let base = ObservationManifest::new(2);
+    let mut digests = vec![base.identity_bundle_digest()];
+
+    let mut with_input = base.clone();
+    with_input.input_cid = Some(format!("blake3:{}", "1".repeat(64)));
+    digests.push(with_input.identity_bundle_digest());
+
+    let mut with_source = base.clone();
+    with_source.source_manifest_kappa = Some(format!("blake3:{}", "2".repeat(64)));
+    digests.push(with_source.identity_bundle_digest());
+
+    let mut with_geometry = base.clone();
+    with_geometry.geometry = Some(GeometryProjection::bucket_average(576, 288));
+    digests.push(with_geometry.identity_bundle_digest());
+
+    let mut with_operator = base.clone();
+    with_operator.attention_operator = Some(AttentionOperatorSpec::standard());
+    digests.push(with_operator.identity_bundle_digest());
+
+    let mut with_profile = base.clone();
+    with_profile.trace_profile = Some(TraceProfile::layer(&[0]));
+    digests.push(with_profile.identity_bundle_digest());
+
+    // Every single-component change is a distinct bundle identity.
+    for (i, a) in digests.iter().enumerate() {
+        for (j, b) in digests.iter().enumerate().skip(i + 1) {
+            assert_ne!(a, b, "digests {i} and {j} collide");
+        }
+    }
+    // A component VALUE change moves the digest too.
+    let mut with_other_profile = base.clone();
+    with_other_profile.trace_profile = Some(TraceProfile::layer(&[1]));
+    assert_ne!(
+        with_profile.identity_bundle_digest(),
+        with_other_profile.identity_bundle_digest()
+    );
+
+    // Absent is NOT empty: an empty-string κ is a different identity
+    // from an unset one.
+    let mut with_empty = base.clone();
+    with_empty.source_manifest_kappa = Some(String::new());
+    assert_ne!(
+        base.identity_bundle_digest(),
+        with_empty.identity_bundle_digest()
+    );
+    assert_ne!(
+        with_source.identity_bundle_digest(),
+        with_empty.identity_bundle_digest()
+    );
+
+    // Set-order independence, through the persisted writer path.
+    let geometry = GeometryProjection::bucket_average(576, 288);
+    let cid = format!("blake3:{}", "3".repeat(64));
+    let dir_a = unique_path("bundle-order-a");
+    let mut writer = ObservationShardWriter::open(&dir_a, 2).expect("writer a");
+    writer.set_input_cid(&cid).expect("cid first");
+    writer.set_geometry(&geometry).expect("geometry second");
+    drop(writer);
+    let dir_b = unique_path("bundle-order-b");
+    let mut writer = ObservationShardWriter::open(&dir_b, 2).expect("writer b");
+    writer.set_geometry(&geometry).expect("geometry first");
+    writer.set_input_cid(&cid).expect("cid second");
+    drop(writer);
+    let manifest_a = ObservationManifest::load(&dir_a)
+        .expect("io a")
+        .expect("manifest a");
+    let manifest_b = ObservationManifest::load(&dir_b)
+        .expect("io b")
+        .expect("manifest b");
+    assert_eq!(
+        manifest_a.identity_bundle_digest(),
+        manifest_b.identity_bundle_digest(),
+        "the bundle digest must not depend on field-set order"
+    );
+    for dir in [&dir_a, &dir_b] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+/// A deterministic capture-capable oracle: logits, hidden state, and
+/// every trace lane are pure functions of (token, pos), so two runs
+/// under the same profile must produce byte-identical shards and
+/// sidecars.
+struct FakeTraceOracle {
+    hidden: Vec<f32>,
+}
+
+impl FakeTraceOracle {
+    const LAYERS: usize = 2;
+    const HEADS: usize = 2;
+    const KV_HEADS: usize = 1;
+    const WIDTH: usize = 4;
+
+    fn new() -> Self {
+        Self {
+            hidden: vec![0.0; Self::WIDTH],
+        }
+    }
+
+    fn fill_logits(token: usize, pos: usize, logits: &mut [f32]) {
+        for (i, logit) in logits.iter_mut().enumerate() {
+            *logit = ((token * 31 + pos * 17 + i * 7) % 23) as f32 / 4.0;
+        }
+    }
+}
+
+impl RepresentationSource for FakeTraceOracle {
+    fn vocab_size(&self) -> usize {
+        16
+    }
+    fn source_dimension(&self) -> usize {
+        Self::WIDTH
+    }
+    fn tokenizer_address(&self) -> &str {
+        "fake-trace-tokenizer"
+    }
+    fn read_embedding_rows(
+        &self,
+        _range: std::ops::Range<usize>,
+        output: &mut [f32],
+    ) -> Option<()> {
+        output.fill(0.0);
+        Some(())
+    }
+}
+
+impl BehaviorSource for FakeTraceOracle {
+    fn reset(&mut self) {
+        self.hidden.fill(0.0);
+    }
+    fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]) {
+        Self::fill_logits(token, pos, logits);
+        for (j, value) in self.hidden.iter_mut().enumerate() {
+            *value = (token * 3 + pos * 5 + j) as f32 / 8.0;
+        }
+    }
+}
+
+impl TeacherOracle for FakeTraceOracle {
+    fn vocab(&self) -> usize {
+        16
+    }
+    fn dim(&self) -> usize {
+        Self::WIDTH
+    }
+    fn seq_len(&self) -> usize {
+        6
+    }
+    fn kappa(&self) -> String {
+        "blake3:fake-trace".to_string()
+    }
+    fn source_bytes(&self) -> usize {
+        0
+    }
+    fn embedding(&self, _token: usize, out: &mut [f32]) {
+        out.fill(0.0);
+    }
+    fn hidden_state(&self) -> Option<&[f32]> {
+        Some(&self.hidden)
+    }
+    fn trace_capture_geometry(&self) -> Option<TraceCaptureGeometry> {
+        Some(TraceCaptureGeometry {
+            layers: Self::LAYERS,
+            heads: Self::HEADS,
+            kv_heads: Self::KV_HEADS,
+            residual_width: Self::WIDTH,
+        })
+    }
+    fn step_with_trace_capture(
+        &mut self,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) -> bool {
+        self.step(token, pos, logits);
+        let kv_width = Self::WIDTH * Self::KV_HEADS / Self::HEADS;
+        for layer in 0..Self::LAYERS {
+            if request.attention_layers.contains(&layer) {
+                for head in 0..Self::HEADS {
+                    let mut att: Vec<f32> = (0..=pos)
+                        .map(|t| (t + head * 2 + layer * 3 + token % 5 + 1) as f32)
+                        .collect();
+                    let total: f32 = att.iter().sum();
+                    att.iter_mut().for_each(|w| *w /= total);
+                    (sinks.attention)(layer, head, &att);
+                }
+            }
+            if request.qkv_layers.contains(&layer) {
+                let q: Vec<f32> = (0..Self::WIDTH)
+                    .map(|i| (layer * 7 + token + pos * 2 + i) as f32 / 3.0)
+                    .collect();
+                let k: Vec<f32> = (0..kv_width)
+                    .map(|i| (layer * 11 + token * 2 + pos + i) as f32 / 5.0)
+                    .collect();
+                let v: Vec<f32> = (0..kv_width)
+                    .map(|i| (layer * 13 + token + pos + i) as f32 / 7.0)
+                    .collect();
+                (sinks.qkv)(layer, &q, &k, &v);
+            }
+            if request.residual_layers.contains(&layer) {
+                let residual: Vec<f32> = (0..Self::WIDTH)
+                    .map(|i| (layer * 17 + token * 5 + pos * 3 + i) as f32 / 9.0)
+                    .collect();
+                (sinks.residual)(layer, &residual);
+            }
+        }
+        true
+    }
+}
+
+fn traced_run_bytes(dir: &std::path::Path, shard_bits: u8) -> Vec<Vec<u8>> {
+    let manifest = ObservationManifest::load(dir)
+        .expect("manifest io")
+        .expect("manifest present");
+    let mut files = Vec::new();
+    for shard in 0..manifest.shard_count() {
+        let name = shard_file_name(shard_bits, shard);
+        files.push(std::fs::read(dir.join(&name)).expect("shard bytes"));
+        files.push(std::fs::read(dir.join(format!("{name}.prob"))).expect("prob bytes"));
+        let trace = dir.join(trace_sidecar_name(shard_bits, shard));
+        files.push(if trace.exists() {
+            std::fs::read(&trace).expect("trace bytes")
+        } else {
+            Vec::new()
+        });
+    }
+    files
+}
+
+/// #603 determinism: the same inputs and profile produce byte-identical
+/// shard, probability-sidecar, and trace-sidecar bytes across two
+/// independent full runs; the trace sidecar is aligned (one fixed-width
+/// row per record), registered per shard in the manifest with its own
+/// κ, and merge order is canonical. A rerun over the complete corpus
+/// rewrites nothing.
+#[test]
+fn traced_observation_is_deterministic_and_aligned() {
+    let profile = TraceProfile::full(&[0, 1], 3);
+    const SHARDS: u8 = 2;
+    const TARGET: usize = 40;
+
+    let run = |dir: &std::path::Path| {
+        let mut oracle = FakeTraceOracle::new();
+        let summary = observe_sharded_traced(&mut oracle, 30, TARGET, SHARDS, dir, None, &profile)
+            .expect("traced run");
+        assert!(summary.done, "target must be reached");
+    };
+    let dir_a = unique_path("traced-a");
+    let dir_b = unique_path("traced-b");
+    run(&dir_a);
+    run(&dir_b);
+    assert_eq!(
+        traced_run_bytes(&dir_a, SHARDS),
+        traced_run_bytes(&dir_b, SHARDS),
+        "double run must be byte-identical"
+    );
+
+    let manifest = ObservationManifest::load(&dir_a)
+        .expect("manifest io")
+        .expect("manifest present");
+    assert_eq!(manifest.trace_profile.as_ref(), Some(&profile));
+    // Row width is the pure lane sum for this oracle's geometry:
+    // residuals 2×4×4 + final hidden 4×4 + qkv 2×(4+2+2)×4 + support
+    // 2 layers × 2 heads × 3 slots × 8.
+    let expected_row = (2 * 4 * 4 + 4 * 4 + 2 * 8 * 4 + 2 * 2 * 3 * 8) as u64;
+    assert_eq!(manifest.trace_row_bytes, Some(expected_row));
+    for (shard, entry) in &manifest.completed {
+        if entry.records == 0 {
+            continue;
+        }
+        let trace_kappa = entry
+            .trace_kappa
+            .as_ref()
+            .unwrap_or_else(|| panic!("shard {shard} trace κ"));
+        let bytes =
+            std::fs::read(dir_a.join(trace_sidecar_name(SHARDS, *shard))).expect("trace bytes");
+        assert_eq!(bytes.len() as u64, entry.records * expected_row);
+        assert_eq!(*trace_kappa, kappa_of(&bytes));
+    }
+    let merged_trace = merge_trace_rows(&dir_a).expect("merge trace");
+    assert_eq!(
+        merged_trace.len() as u64,
+        manifest.total_records * expected_row
+    );
+    assert_eq!(
+        merged_trace,
+        merge_trace_rows(&dir_b).expect("merge trace b")
+    );
+    // Bounded support with explicit absence: position 0 has fewer prefix
+    // positions than the cap, so marker slots must exist in the lane —
+    // and they are the documented marker, not zeros.
+    let marker = SUPPORT_ABSENT_MARKER.to_le_bytes();
+    let marker_slot: Vec<u8> = [marker, marker].concat();
+    assert!(
+        merged_trace
+            .windows(marker_slot.len())
+            .any(|window| window == marker_slot),
+        "unfilled support slots must carry the explicit absence marker"
+    );
+
+    // Rerun: complete corpus, nothing rewritten.
+    let mut oracle = FakeTraceOracle::new();
+    let summary = observe_sharded_traced(&mut oracle, 30, TARGET, SHARDS, &dir_a, None, &profile)
+        .expect("resume over complete corpus");
+    assert!(summary.done);
+    assert_eq!(summary.written, 0);
+    assert_eq!(
+        traced_run_bytes(&dir_a, SHARDS),
+        traced_run_bytes(&dir_b, SHARDS)
+    );
+
+    for dir in [&dir_a, &dir_b] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+/// #603 crash-safe resume for the trace sidecar, at the writer level
+/// (extending the `shard_spill_manifest_resume_and_merge` discipline):
+/// an interrupted pass whose writer is dropped without finalizing
+/// resumes from the on-disk prefix and converges to the exact bytes of
+/// a single-pass run — records, probability rows, and trace rows.
+#[test]
+fn trace_sidecar_resumes_from_partial_writes() {
+    const TRACE_ROW: usize = 24;
+    let records = synth_records();
+    let probability = |i: usize| ProbabilityMetadata {
+        target_logprob_nats: -0.25 - i as f32,
+        entropy_bits: 1.0 + i as f32,
+        top8_mass: 0.5,
+        target_rank: i as u16,
+    };
+    let trace_row = |i: usize| -> Vec<u8> {
+        (0..TRACE_ROW)
+            .map(|j| ((i * 13 + j * 5) % 251) as u8)
+            .collect()
+    };
+    let write_all = |writer: &mut ObservationShardWriter, range: std::ops::Range<usize>| {
+        for i in range {
+            assert!(
+                writer
+                    .write_record_with_probability_and_trace(
+                        &records[i],
+                        probability(i),
+                        &trace_row(i),
+                        record_shard(i),
+                    )
+                    .expect("traced write")
+            );
+        }
+    };
+
+    // Single pass: the reference bytes.
+    let dir_single = unique_path("trace-resume-single");
+    let mut writer = ObservationShardWriter::open(&dir_single, SHARD_BITS).expect("open single");
+    write_all(&mut writer, 0..records.len());
+    writer.finalize_all().expect("finalize single");
+    let reference_trace = merge_trace_rows(&dir_single).expect("merge single");
+    let reference_records = merge_shards(&dir_single).expect("merge records single");
+
+    // Interrupted pass: half the records, writer dropped without
+    // finalizing (the manifest keeps the pinned row width), then a
+    // resumed writer appends the remainder and finalizes.
+    let dir_resumed = unique_path("trace-resume-partial");
+    {
+        let mut writer =
+            ObservationShardWriter::open(&dir_resumed, SHARD_BITS).expect("open partial");
+        write_all(&mut writer, 0..records.len() / 2);
+        writer.flush().expect("flush partial");
+    }
+    let mut writer = ObservationShardWriter::open(&dir_resumed, SHARD_BITS).expect("reopen");
+    assert_eq!(
+        writer.manifest().trace_row_bytes,
+        Some(TRACE_ROW as u64),
+        "the pinned row width survives the crash"
+    );
+    // A row of the wrong width is refused mid-corpus: the profile and
+    // capture geometry are pinned by the manifest's row width.
+    assert!(
+        writer
+            .write_record_with_probability_and_trace(
+                &records[0],
+                probability(0),
+                &[0u8; TRACE_ROW + 8],
+                record_shard(0),
+            )
+            .is_err()
+    );
+    write_all(&mut writer, records.len() / 2..records.len());
+    writer.finalize_all().expect("finalize resumed");
+    assert_eq!(
+        merge_shards(&dir_resumed).expect("merge records resumed"),
+        reference_records
+    );
+    assert_eq!(
+        merge_trace_rows(&dir_resumed).expect("merge resumed"),
+        reference_trace,
+        "a resumed traced pass must converge to the single-pass bytes"
+    );
+
+    for dir in [&dir_single, &dir_resumed] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+/// #603 absence stays absence: richer profiles are REFUSED — never
+/// zero-filled — when the oracle has no capture surface; a corpus is
+/// pinned to one profile (minimal cannot become traced mid-corpus and
+/// vice versa); and the default minimal path records no trace fields at
+/// all, byte-identical to a pre-#603 pass.
+#[test]
+fn trace_profiles_are_refused_not_zero_filled_and_pinned_per_corpus() {
+    // An oracle without the capture surface refuses richer profiles.
+    let dir = unique_path("trace-refused");
+    let mut plain = FakeOracle { dim: 4, vocab: 8 };
+    let error =
+        observe_sharded_traced(&mut plain, 5, 16, 2, &dir, None, &TraceProfile::layer(&[0]))
+            .expect_err("no capture surface is a refusal, not zeros");
+    assert!(
+        error.reason.contains("capture"),
+        "reason names the gap: {error}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // Minimal through the traced entry point IS the minimal path: same
+    // bytes as observe_sharded, no trace fields in the manifest.
+    let dir_minimal = unique_path("trace-minimal");
+    let dir_plain = unique_path("trace-plain");
+    let mut oracle = FakeTraceOracle::new();
+    observe_sharded_traced(
+        &mut oracle,
+        30,
+        24,
+        2,
+        &dir_minimal,
+        None,
+        &TraceProfile::minimal(),
+    )
+    .expect("minimal traced run");
+    let mut oracle = FakeTraceOracle::new();
+    observe_sharded(&mut oracle, 30, 24, 2, &dir_plain, None).expect("plain run");
+    assert_eq!(
+        traced_run_bytes(&dir_minimal, 2),
+        traced_run_bytes(&dir_plain, 2),
+        "the minimal profile is exactly today's bytes"
+    );
+    let manifest = ObservationManifest::load(&dir_minimal)
+        .expect("io")
+        .expect("manifest");
+    assert_eq!(manifest.trace_profile, None);
+    assert_eq!(manifest.trace_row_bytes, None);
+
+    // Profile pinning: a minimal corpus refuses a traced resume, and a
+    // traced corpus refuses a minimal (or different-profile) resume.
+    let mut oracle = FakeTraceOracle::new();
+    assert!(
+        observe_sharded_traced(
+            &mut oracle,
+            30,
+            24,
+            2,
+            &dir_plain,
+            None,
+            &TraceProfile::layer(&[0]),
+        )
+        .is_err(),
+        "a profile cannot be introduced mid-corpus"
+    );
+    let dir_traced = unique_path("trace-pinned");
+    let mut oracle = FakeTraceOracle::new();
+    observe_sharded_traced(
+        &mut oracle,
+        30,
+        24,
+        2,
+        &dir_traced,
+        None,
+        &TraceProfile::layer(&[0]),
+    )
+    .expect("traced run");
+    let mut oracle = FakeTraceOracle::new();
+    assert!(
+        observe_sharded(&mut oracle, 30, 24, 2, &dir_traced, None).is_err(),
+        "a traced corpus refuses a minimal resume"
+    );
+    let mut oracle = FakeTraceOracle::new();
+    assert!(
+        observe_sharded_traced(
+            &mut oracle,
+            30,
+            24,
+            2,
+            &dir_traced,
+            None,
+            &TraceProfile::layer(&[1]),
+        )
+        .is_err(),
+        "a traced corpus refuses a different profile"
+    );
+
+    for dir in [&dir_minimal, &dir_plain, &dir_traced] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -706,6 +706,63 @@ impl Llama {
         self.finish_forward(st, fast_matmul);
     }
 
+    /// One forward step with the #603 teacher-trace lanes captured at
+    /// declared layer indices. This IS the exact executor — the same
+    /// [`Llama::layer_forward`]/[`Llama::finish_forward`] path `forward`
+    /// and `forward_capturing` take, so a traced step and a plain step
+    /// produce identical bits; the taps only READ state the layer body
+    /// already produced. Bounded by construction: each lane copies out
+    /// only its declared layer indices, once per step.
+    ///
+    /// Taps, all read after `layer_forward(l)` returns:
+    ///
+    /// - residual: `st.x` (the post-layer residual stream, the same slice
+    ///   `forward_capturing` sinks);
+    /// - q/k/v: `st.q` (the current position's RoPE-rotated query) and the
+    ///   layer's key/value cache rows at `pos` — the exact vectors the
+    ///   #602 attention operators consumed;
+    /// - attention support: per head `h`, the softmax-normalized weights
+    ///   `st.att[h*seq_len .. h*seq_len+pos+1]` the #602 factored per-head
+    ///   weight functions just produced for layer `l`. Read before the
+    ///   next layer overwrites the shared buffer.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn forward_capturing_trace(
+        &self,
+        st: &mut State,
+        token: usize,
+        pos: usize,
+        fast_matmul: bool,
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) {
+        let dim = self.cfg.dim;
+        let kv_dim = self.cfg.dim * self.cfg.n_kv_heads / self.cfg.n_heads;
+        st.x.copy_from_slice(&self.w[self.emb + token * dim..self.emb + (token + 1) * dim]);
+        for l in 0..self.cfg.n_layers {
+            self.layer_forward(st, l, pos, fast_matmul);
+            if request.attention_layers.contains(&l) {
+                for h in 0..self.cfg.n_heads {
+                    (sinks.attention)(
+                        l,
+                        h,
+                        &st.att[h * self.cfg.seq_len..h * self.cfg.seq_len + pos + 1],
+                    );
+                }
+            }
+            if request.qkv_layers.contains(&l) {
+                let loff = l * self.cfg.seq_len * kv_dim;
+                let k = &st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                let v = &st.value_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                (sinks.qkv)(l, &st.q, k, v);
+            }
+            if request.residual_layers.contains(&l) {
+                (sinks.residual)(l, &st.x);
+            }
+        }
+        self.finish_forward(st, fast_matmul);
+    }
+
     /// One transformer layer of the exact forward step, factored out of
     /// [`Llama::forward`] so the #599 conformance runner can observe the
     /// residual stream at declared layer indices through the very same
@@ -1113,6 +1170,64 @@ pub trait BehaviorSource {
     fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]);
 }
 
+/// The bounded dimensions a trace-capturing oracle exposes for the #603
+/// teacher-trace lanes: how many layers exist (bounding the declarable
+/// layer indices), how many attention heads and kv heads each layer has
+/// (bounding the attention-support and k/v lane widths), and the width of
+/// the residual stream the capture taps (`cfg.dim`, the SOURCE width — for
+/// the Hugging Face adapter this is 576, not the compiled 288 that
+/// [`TeacherOracle::dim`] presents).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TraceCaptureGeometry {
+    /// Number of transformer layers (declared capture indices must be
+    /// strictly below this).
+    pub layers: usize,
+    /// Attention heads per layer.
+    pub heads: usize,
+    /// Key/value heads per layer (grouped query).
+    pub kv_heads: usize,
+    /// Residual-stream width of the captured `st.x` / q vectors (the
+    /// source `cfg.dim`). K/v rows are
+    /// `residual_width * kv_heads / heads` wide.
+    pub residual_width: usize,
+}
+
+/// Which layer indices each #603 trace lane captures during one
+/// [`TeacherOracle::step_with_trace_capture`]. Empty slices capture
+/// nothing for that lane; indices outside the model's layer range are
+/// never matched (the caller validates them against
+/// [`TraceCaptureGeometry::layers`] up front).
+#[derive(Debug, Clone, Copy)]
+pub struct TraceCaptureRequest<'a> {
+    /// Post-layer residual-stream capture indices.
+    pub residual_layers: &'a [usize],
+    /// Current-position q/k/v capture indices.
+    pub qkv_layers: &'a [usize],
+    /// Per-head attention-weight capture indices.
+    pub attention_layers: &'a [usize],
+}
+
+/// `(layer, post-layer residual stream)` sink of one traced step.
+pub type ResidualSink<'a> = dyn FnMut(usize, &[f32]) + 'a;
+/// `(layer, rotated q at the current position, k cache row, v cache
+/// row)` sink of one traced step.
+pub type QkvSink<'a> = dyn FnMut(usize, &[f32], &[f32], &[f32]) + 'a;
+/// `(layer, head, softmax weights over positions 0..=pos)` sink of one
+/// traced step.
+pub type AttentionSupportSink<'a> = dyn FnMut(usize, usize, &[f32]) + 'a;
+
+/// The capture sinks one traced step feeds. Each is called only for the
+/// declared layer indices, in ascending layer order (heads ascending
+/// within a layer for the attention sink), once per step.
+pub struct TraceCaptureSinks<'a, 'b> {
+    /// See [`ResidualSink`].
+    pub residual: &'a mut ResidualSink<'b>,
+    /// See [`QkvSink`].
+    pub qkv: &'a mut QkvSink<'b>,
+    /// See [`AttentionSupportSink`].
+    pub attention: &'a mut AttentionSupportSink<'b>,
+}
+
 /// The TWO-SURFACE interface every source architecture must expose to the
 /// compiler: the embedding table (representation) and a sequential
 /// next-token forward (behavior). The compiler is written against this
@@ -1179,6 +1294,38 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
     fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
         let _ = (k, out);
         0
+    }
+
+    /// Optional compiler-only #603 trace-capture surface: the bounded
+    /// capture dimensions this oracle exposes, when it supports the
+    /// traced step. `None` means the oracle has no bounded per-layer
+    /// capture path (richer trace profiles must be refused, never
+    /// zero-filled); the default keeps every existing oracle unaffected,
+    /// mirroring [`TeacherOracle::hidden_state`].
+    fn trace_capture_geometry(&self) -> Option<TraceCaptureGeometry> {
+        None
+    }
+
+    /// Optional compiler-only #603 trace-capture step: one forward step
+    /// with the declared lanes captured through the exact executor path
+    /// (`Llama::forward_capturing_trace`, the #599 `forward_capturing`
+    /// discipline extended with the q/k/v and per-head attention taps).
+    /// Returns `true` when the oracle captured through its executor;
+    /// the default performs a plain [`BehaviorSource::step`] and returns
+    /// `false` — the caller must treat `false` as "this oracle has no
+    /// capture surface" and refuse the richer profile rather than emit
+    /// absent lanes as zeros.
+    fn step_with_trace_capture(
+        &mut self,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) -> bool {
+        let _ = (request, sinks);
+        self.step(token, pos, logits);
+        false
     }
 }
 
@@ -1308,6 +1455,30 @@ impl TeacherOracle for LlamaOracle {
     }
     fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
         top_k_from_logits(&self.state.logits, k, out, self.model.canonical_math)
+    }
+    fn trace_capture_geometry(&self) -> Option<TraceCaptureGeometry> {
+        Some(TraceCaptureGeometry {
+            layers: self.model.cfg.n_layers,
+            heads: self.model.cfg.n_heads,
+            kv_heads: self.model.cfg.n_kv_heads,
+            residual_width: self.model.cfg.dim,
+        })
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    fn step_with_trace_capture(
+        &mut self,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) -> bool {
+        // Same matmul selection as `step` (the legacy exact scalar path),
+        // so a traced step and a plain step produce identical bits.
+        self.model
+            .forward_capturing_trace(&mut self.state, token, pos, false, request, sinks);
+        logits.copy_from_slice(&self.state.logits);
+        true
     }
 }
 
@@ -2662,6 +2833,37 @@ impl TeacherOracle for HuggingFaceLlamaOracle {
     fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
         top_k_from_logits(&self.state.logits, k, out, self.model.canonical_math)
     }
+    fn trace_capture_geometry(&self) -> Option<TraceCaptureGeometry> {
+        Some(TraceCaptureGeometry {
+            layers: self.model.cfg.n_layers,
+            heads: self.model.cfg.n_heads,
+            kv_heads: self.model.cfg.n_kv_heads,
+            residual_width: self.model.cfg.dim,
+        })
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    fn step_with_trace_capture(
+        &mut self,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) -> bool {
+        // This oracle's own matmul selection, exactly as
+        // `step_with_layer_capture` (#599) delegates it, so a traced
+        // step and a plain step produce identical bits.
+        self.model.forward_capturing_trace(
+            &mut self.state,
+            token,
+            pos,
+            self.fast_matmul,
+            request,
+            sinks,
+        );
+        logits.copy_from_slice(&self.state.logits);
+        true
+    }
 }
 
 /// Backward-compatible name for the first supported Hugging Face model.
@@ -2859,6 +3061,77 @@ mod tests {
         };
         model.rebuild_rope_cache();
         model
+    }
+
+    /// #603: the traced forward IS the exact executor — a
+    /// `forward_capturing_trace` stream produces bit-identical logits and
+    /// hidden state to a plain `forward` stream, and its taps are bounded
+    /// to the declared layer indices: residuals once per declared layer,
+    /// q/k/v rows at the current position, and per-head attention weights
+    /// that are softmax-normalized over the prefix (each head's captured
+    /// row sums to 1 and has `pos + 1` entries).
+    #[test]
+    fn forward_capturing_trace_matches_plain_forward_with_bounded_taps() {
+        let model = tiny_llama();
+        let tokens = [1usize, 3, 5, 2, 7];
+        let kv_dim = model.cfg.dim * model.cfg.n_kv_heads / model.cfg.n_heads;
+
+        let mut plain = State::new(&model.cfg);
+        plain.reset();
+        let mut traced = State::new(&model.cfg);
+        traced.reset();
+        let request = TraceCaptureRequest {
+            residual_layers: &[1],
+            qkv_layers: &[0],
+            attention_layers: &[1],
+        };
+        for (pos, &token) in tokens.iter().enumerate() {
+            model.forward(&mut plain, token, pos, false);
+
+            let mut residuals: Vec<(usize, Vec<f32>)> = Vec::new();
+            let mut qkv: Vec<(usize, usize, usize, usize)> = Vec::new();
+            let mut attention: Vec<(usize, usize, Vec<f32>)> = Vec::new();
+            let mut residual_sink = |layer: usize, x: &[f32]| residuals.push((layer, x.to_vec()));
+            let mut qkv_sink = |layer: usize, q: &[f32], k: &[f32], v: &[f32]| {
+                qkv.push((layer, q.len(), k.len(), v.len()));
+            };
+            let mut attention_sink = |layer: usize, head: usize, att: &[f32]| {
+                attention.push((layer, head, att.to_vec()))
+            };
+            model.forward_capturing_trace(
+                &mut traced,
+                token,
+                pos,
+                false,
+                &request,
+                &mut TraceCaptureSinks {
+                    residual: &mut residual_sink,
+                    qkv: &mut qkv_sink,
+                    attention: &mut attention_sink,
+                },
+            );
+
+            let plain_bits: Vec<u32> = plain.logits.iter().map(|v| v.to_bits()).collect();
+            let traced_bits: Vec<u32> = traced.logits.iter().map(|v| v.to_bits()).collect();
+            assert_eq!(plain_bits, traced_bits, "logits diverged at pos {pos}");
+            let plain_x: Vec<u32> = plain.x.iter().map(|v| v.to_bits()).collect();
+            let traced_x: Vec<u32> = traced.x.iter().map(|v| v.to_bits()).collect();
+            assert_eq!(plain_x, traced_x, "hidden state diverged at pos {pos}");
+
+            // Bounded taps: exactly the declared layers, once per step.
+            assert_eq!(residuals.len(), 1);
+            assert_eq!(residuals[0].0, 1);
+            assert_eq!(residuals[0].1.len(), model.cfg.dim);
+            assert_eq!(qkv, vec![(0, model.cfg.dim, kv_dim, kv_dim)]);
+            assert_eq!(attention.len(), model.cfg.n_heads);
+            for (head, (layer, got_head, att)) in attention.iter().enumerate() {
+                assert_eq!(*layer, 1);
+                assert_eq!(*got_head, head);
+                assert_eq!(att.len(), pos + 1, "prefix-bounded weights");
+                let total: f32 = att.iter().sum();
+                assert!((total - 1.0).abs() < 1e-5, "head {head} not normalized");
+            }
+        }
     }
 
     /// forward_batch over B sequences, stepped position by position, must

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -393,6 +393,107 @@ unchanged surface: it forbids floating-point arithmetic on the deployed
 hot path and explicitly excludes teacher execution. #602 defines no
 target (deployed) operator and changes no runtime contract.
 
+#### Teacher trace profiles (#603)
+
+What an observation pass captures — its trace richness, boundedness,
+profile identity, absence semantics, and source/provenance dependencies —
+is a typed, versioned identity, not an implicit property of the run.
+`uor-r4-graph-compiler::trace_profile` defines
+`TraceProfile { id, version, top_k, layer_lane, qkv_lane,
+attention_support_lane, declared_digest }` (`uor-r4-teacher-trace/1`)
+with the same canonical-bytes + declared-identity digest discipline as
+the #600 geometry, #601 tokenizer, and #602 attention records (blake3
+over a pinned line format of the declared identity, with EXPLICIT
+absence markers — an undeclared lane serializes as `<lane>=absent`, so
+absence is part of the digest input and distinct from an empty
+declaration). A versioned registry maps `(profile, version)` plus the
+caller-declared bounds to the record (`trace_profile::profile_spec`);
+an unknown pair — and any unbounded declaration (no layer list, a
+support cap outside `1..=64`, more than 64 layer indices) — is refused
+by name on the sanctioned error surface rather than guessed.
+
+Four profiles are registered, every one an extension of the existing
+observation pipeline (no second pipeline exists), each declaring exactly
+which lanes it captures and their bounds (layer index list, top-k size,
+per-head support cap):
+
+- `minimal/1` — **the default everywhere**: exactly today's surface,
+  the v4 88-byte records (bounded token / top-8 / probability rows)
+  plus the aligned `.prob` sidecar. A minimal pass writes bytes and a
+  manifest byte-identical to a pre-#603 pass: no `trace_profile` field
+  is recorded — absence marks the minimal profile, the implicit legacy
+  era, exactly like the #597/#600/#601/#602 fields.
+- `layer/1` — minimal plus the per-layer residual lane at declared
+  layer indices and the final-hidden lane (the post-final-rmsnorm
+  hidden state, `TeacherOracle::hidden_state()`). **Measurement record
+  (merged #95):** the final-hidden lane was measured NEGATIVE for the
+  cover compiler — 2.8% vs 31.7% Gate C top-1 when the hidden state was
+  used as the cover observation vector. The lane is preserved here as a
+  recorded capture for measurement, not adopted for fitting and not
+  deleted; adopting ANY richer profile for fitting requires a separate
+  measured issue.
+- `attention-support/1` — minimal plus per-head attention support:
+  the top-S `(position, weight)` pairs of each head's softmax weights,
+  captured ONLY for declared layer indices and within the declared cap
+  S (tapped from the #602 factored per-head weight functions through
+  the exact executor path).
+- `full/1` — minimal plus all richer lanes: per-layer residuals, final
+  hidden, current-position q/k/v rows, and attention support.
+
+**Sidecar, not record change.** The v4 88-byte observation record is a
+fixed-width era-stable byte format and cannot carry optional per-layer
+f32 lanes without a byte-format change, so richer lanes live in a
+per-shard side-car file (`shard-NN.bin.trace`, one fixed-width row per
+record), following the probability sidecar's existing pattern: the same
+deterministic content-addressed partitioning, crash-safe
+append/reconcile/resume, per-shard κ registration in the manifest
+(`ShardEntry::trace_kappa`), and canonical ascending-shard merge
+(`merge_trace_rows`). The primary shard bytes are identical for every
+profile. Lane order within a row is fixed (residuals ascending declared
+layers, final hidden, q/k/v, attention support), values are
+little-endian f32/u32, and the row width — a pure function of (profile,
+capture geometry) — is pinned in the manifest (`trace_row_bytes`) at
+the first traced write, so a profile or geometry change mid-corpus is
+refused. Absence stays absence: an undeclared lane produces no bytes,
+an oracle without the bounded capture surface refuses richer profiles
+(`SourceUnavailable`, never zero-filled lanes), and an unfilled
+attention-support slot (fewer prefix positions than the cap) carries
+the explicit `SUPPORT_ABSENT_MARKER` (`0xFFFFFFFF` in both fields),
+never a zero-valued entry.
+
+**Bundle identity.** The manifest's identity seam is ONE stable bundle:
+`ObservationManifest::identity_bundle_digest()` computes a canonical
+blake3 over the five existing identity fields (`input_cid`,
+`source_manifest_kappa` #597, `geometry` #600, `tokenizer_adapter`
+#601, `attention_operator` #602) plus the #603 `trace_profile`, in a
+fixed order with explicit `absent` / `present:<value>` markers per
+component — so the digest moves when any component changes, is
+independent of the order the fields were recorded in, and an absent
+component is never confusable with an empty or zero one.
+
+**Capture plumbing, bounded.** Richer lanes are captured through the
+surfaces that already exist: the #599 `forward_capturing` discipline
+extended as `TeacherOracle::step_with_trace_capture` (the exact
+executor path — a traced step and a plain step produce identical bits,
+pinned by unit test), the `hidden_state()` hook for the #95 lane, and
+the #602 factored per-head attention functions as the natural tap for
+the support lane. Captures copy out only the declared layer indices,
+once per step. Determinism is tested by double-run byte comparison:
+the same inputs and profile produce byte-identical shard and sidecar
+bytes.
+
+**No default change.** The default profile is `minimal` on every path;
+richer profiles are strictly opt-in on the generation observe path via
+`observe --trace-profile <id[/version]> --trace-layers <csv>
+[--trace-support <n>]` (graph-compiler CLI), mirroring how
+`--source-manifest-kappa` flows, or programmatically via
+`observation::observe_sharded_traced`. The from-text observe drivers
+(serial and batched) remain minimal-only: they carry the manifest
+seam (`set_trace_profile` exists on the shard writer) but no capture
+wiring — richer text-path capture is a recorded follow-up, not
+invented plumbing. Existing fixtures, corpora, and manifests are
+unchanged.
+
 ### 3. Compile the holographic graph
 
 The graph compiler turns the retained observation corpus and TLA artifact


### PR DESCRIPTION
feat(#603): versioned TeacherTrace profiles + content-addressed trace sidecars

Four bounded profiles under uor-r4-teacher-trace/1 (minimal = exactly
today, never recorded; layer incl. the #95 lane; attention-support;
full) as typed records with pinned canonical bytes + declared digests;
registry refuses unknown or unbounded declarations via graph-compilers
existing sanctioned surface. Richer lanes ride NEW .trace sidecars
copying the .prob pattern (v4 records are a fixed 88-byte layout - no
additive in-record path), with per-shard kappa registration, canonical
merge, torn-row checks, crash-safe resume, and pinned row width; absent
support slots carry an explicit 0xFFFFFFFF marker - absence is never
zero-filled. ObservationManifest gains trace_profile/trace_row_bytes
(serde default) and identity_bundle_digest(): one blake3 over the six
identity components (#597 manifest kappa, input CID, #600 geometry,
#601 tokenizer, #602 operator, trace profile) with explicit
absent/present markers - the issues one stable bundle. Capture taps
the #599 forward_capturing path and #602 factored per-head weights,
bounded to declared indices; traced step bit-identical to plain step
(tested). Default stays minimal everywhere; #95s negative measurement
(2.8% vs 31.7%) cited as the recorded reason richer profiles are
opt-in and fitting adoption needs its own measured issue. From-text
batched drivers remain minimal-only (no BatchedTeacher capture surface
- recorded follow-up, not invented). 127 suites green; no new deps.
