### PR TITLE
perf(cover-sweep): add a minimal Gate C evaluator for sweep metrics (#611)

### DIFF
--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -3347,6 +3347,239 @@ fn apply_latent_arm(
     (selected, -mixed.max(1e-300).log2(), true)
 }
 
+/// The subset of Gate C metrics the cover sweep and its #456 null-arm harness
+/// consume (#611): Rule 1 (EXCT-disabled reconstruction), Rule 1+2 (with-EXCT
+/// agreement), the TLA3 store baseline, and the analytic unigram nulls. The
+/// `positions`/`positions_sampled` provenance travels with every metric so a
+/// sampled decision run is never quoted as a census.
+#[derive(Debug, Clone, Serialize)]
+pub struct SweepGateC {
+    /// Rule 1 (chain-telescoped residuals, no EXCT).
+    pub rule1_chain: GateCMetrics,
+    /// Rule 1+2 (chain-telescoped + D4 EXCT precedence).
+    pub rule12_precedence: GateCMetrics,
+    /// TLA3 store baseline (`runtime::predict_witness_plain`).
+    pub tla3_baseline: GateCMetrics,
+    /// Analytic unigram-null baselines (#390), consumed by the null-arm harness.
+    pub nulls: GateCNulls,
+    /// #467 provenance: the held-out population handed in, and the number of
+    /// positions actually scored (`0` = full census). Mirrors `GateCOutcome`.
+    pub held_out_population: usize,
+    pub positions_sampled: usize,
+}
+
+/// Sweep-specific Gate C evaluator (#611): computes EXACTLY the metrics the
+/// cover sweep (`SweepRow`/`SweepReport`) and the #456 null-arm harness read —
+/// Rule 1, Rule 1+2, the TLA3 baseline, and the analytic unigram nulls — and
+/// nothing else.
+///
+/// [`evaluate_gate_c`] additionally builds and scores ~thirty experimental
+/// arms the sweep never reads — the #66 ΔT ablations, the #80 normalized /
+/// margin variants, the #399 forward-anchor family (fused / self / gated /
+/// draft / strict, each with a live comparator), the #446 right-context
+/// family, the per-status breakdowns, the alpha sweep, the EXCT probe
+/// histogram, and the win/loss tables — plus the whole-corpus table passes
+/// those arms need (forward-anchor, right-context, two-sided, latent). Every
+/// one of those multiplies per-position work across all nine sweep points.
+/// This evaluator builds two scorers instead of seven and runs one lean
+/// per-position pass.
+///
+/// Parity is by construction, not reimplementation: it calls the SAME
+/// primitives the full evaluator's per-position row uses — `AssignTables` +
+/// `code_plain_with` for the code (identical to the full path's `left_codes`),
+/// `GraphScorer::score_candidates_coded`, `outcome_bits`,
+/// `predict_witness_plain`, `witten_bell_probability`, and the same #390
+/// unigram-null derivation and `gate_c_sample` — so its numbers equal the full
+/// evaluator's within the deterministic FP contract. A pinned-fixture parity
+/// test asserts that equality. The full path is untouched and remains the
+/// certification / research evaluator.
+pub fn evaluate_gate_c_sweep(
+    r4g1: &[u8],
+    artifact_container: &[u8],
+    artifacts: &compiler::Compiled,
+    store: &Store,
+    corpus: &Corpus,
+    held_out: &[Observation],
+    config: &ScoreConfig,
+) -> Option<SweepGateC> {
+    // Two scorers — Rule 1 (no EXCT) and Rule 1+2 (with EXCT) — constructed
+    // IDENTICALLY to the full evaluator's, so scoring matches bit-for-bit.
+    let mut scorer_no_exct =
+        GraphScorer::from_artifact(r4g1, None, config.root_top_b, config.exct_top_x)
+            .expect("gate C (sweep): scorer rebuild from self-emitted artifact");
+    scorer_no_exct.set_f_emissions(true);
+    scorer_no_exct.set_scoring_variant(config.scoring_variant);
+    scorer_no_exct.set_repetition_penalty_raw(config.repetition_penalty_raw);
+    let mut scorer_with_exct = GraphScorer::from_artifact(
+        r4g1,
+        Some(artifact_container),
+        config.root_top_b,
+        config.exct_top_x,
+    )
+    .expect("gate C (sweep): scorer rebuild from self-emitted artifact");
+    scorer_with_exct.set_f_emissions(true);
+    scorer_with_exct.set_scoring_variant(config.scoring_variant);
+    scorer_with_exct.set_repetition_penalty_raw(config.repetition_penalty_raw);
+
+    let gate_rotations = compiler::derive_rotations();
+
+    // #390 analytic unigram null over the construction split (train = every
+    // corpus position outside the held-out set), add-one smoothed over the
+    // compiled vocabulary — the same derivation `evaluate_gate_c` uses.
+    let mut is_held_out = vec![false; corpus.n];
+    for observation in held_out {
+        let position = observation.position as usize;
+        if position < corpus.n {
+            is_held_out[position] = true;
+        }
+    }
+    let vocab = (artifacts.token_codes.len() / compiler::STAGES) as u64;
+    let mut unigram_counts: BTreeMap<u32, u64> = BTreeMap::new();
+    let mut train_positions = 0usize;
+    for (position, held) in is_held_out.iter().enumerate().take(corpus.n) {
+        if !held {
+            *unigram_counts.entry(corpus.next[position]).or_insert(0) += 1;
+            train_positions += 1;
+        }
+    }
+    let unigram_total: u64 = unigram_counts.values().sum();
+    let unigram_train_argmax = unigram_counts
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then_with(|| b.0.cmp(a.0)))
+        .map(|(&token, _)| token)
+        .unwrap_or(0);
+    let unigram_bits = |token: u32| -> f64 {
+        let count = unigram_counts.get(&token).copied().unwrap_or(0);
+        let p = (count as f64 + 1.0) / (unigram_total as f64 + vocab as f64);
+        -p.log2()
+    };
+
+    let (scored, sample_size) = gate_c_sample(held_out);
+    if sample_size != 0 {
+        eprintln!(
+            "score: SAMPLED DECISION RUN ({GATE_C_SAMPLE_ENV}): sweep Gate C scored {} of {} \
+             held-out positions — every rate below is an ESTIMATE, not a census",
+            scored.len(),
+            held_out.len()
+        );
+    }
+
+    // One lean per-position pass, in parallel, reduced in input order so the
+    // floating-point totals are order-identical to the serial reference.
+    struct Row {
+        hit_rule1: bool,
+        bits_rule1: f64,
+        hit_rule12: bool,
+        bits_rule12: f64,
+        hit_baseline: bool,
+        bits_baseline: f64,
+        next: u32,
+        generalization: bool,
+    }
+    let tables = runtime::AssignTables::new(artifacts);
+    let rows: Vec<Row> = scored
+        .par_iter()
+        .map(|observation| {
+            let position = observation.position as usize;
+            let teacher_argmax = corpus.t_argmax[position];
+            let next = corpus.next[position];
+            let window: &[u32] = if config.gate_c_context_window {
+                story_bounded_window(corpus, position, 32)
+            } else {
+                &[]
+            };
+            // Identical to the full path's `left_codes[position]` (#469 lever
+            // B): same tables, same derivation, byte-identical code.
+            let code =
+                runtime::code_plain_with(&tables, artifacts, &gate_rotations, corpus, position);
+            let rule1 = scorer_no_exct
+                .score_candidates_coded(&observation.sig, Some(&code), window)
+                .expect("gate C (sweep): scoring self-produced sig");
+            let rule12 = scorer_with_exct
+                .score_candidates_coded(&observation.sig, Some(&code), window)
+                .expect("gate C (sweep): scoring self-produced sig");
+            let baseline = runtime::predict_witness_plain(store, &code);
+            Row {
+                hit_rule1: rule1.selected == teacher_argmax,
+                bits_rule1: outcome_bits(
+                    &scorer_no_exct,
+                    &rule1.candidates,
+                    next,
+                    rule1.witness.transition_offset,
+                ),
+                hit_rule12: rule12.selected == teacher_argmax,
+                bits_rule12: outcome_bits(
+                    &scorer_with_exct,
+                    &rule12.candidates,
+                    next,
+                    rule12.witness.transition_offset,
+                ),
+                hit_baseline: baseline.token == teacher_argmax,
+                bits_baseline: -witten_bell_probability(store, &code, next).log2(),
+                next,
+                generalization: !matches!(rule12.witness.status, ScoreStatus::ExactContext),
+            }
+        })
+        .collect();
+
+    let n = scored.len();
+    if n == 0 {
+        // Nothing to measure: a total "cannot evaluate", not an error.
+        return None;
+    }
+    let (mut hits_rule1, mut bits_rule1) = (0u64, 0f64);
+    let (mut hits_rule12, mut bits_rule12) = (0u64, 0f64);
+    let (mut hits_baseline, mut bits_baseline) = (0u64, 0f64);
+    let (mut null_hits_all, mut null_bits_all) = (0u64, 0f64);
+    let (mut null_hits_gen, mut null_bits_gen) = (0u64, 0f64);
+    let mut gen_positions = 0u64;
+    for row in &rows {
+        hits_rule1 += u64::from(row.hit_rule1);
+        bits_rule1 += row.bits_rule1;
+        hits_rule12 += u64::from(row.hit_rule12);
+        bits_rule12 += row.bits_rule12;
+        hits_baseline += u64::from(row.hit_baseline);
+        bits_baseline += row.bits_baseline;
+        let null_hit = u64::from(row.next == unigram_train_argmax);
+        let null_bit = unigram_bits(row.next);
+        null_hits_all += null_hit;
+        null_bits_all += null_bit;
+        if row.generalization {
+            gen_positions += 1;
+            null_hits_gen += null_hit;
+            null_bits_gen += null_bit;
+        }
+    }
+    let nf = n as f64;
+    let metrics = |hits: u64, bits: f64| {
+        let top1 = hits as f64 / nf;
+        GateCMetrics {
+            positions: n,
+            top1_agreement: top1,
+            bits_per_token: bits / nf,
+            positions_sampled: sample_size,
+            standard_error: binomial_standard_error(top1, n),
+        }
+    };
+    Some(SweepGateC {
+        rule1_chain: metrics(hits_rule1, bits_rule1),
+        rule12_precedence: metrics(hits_rule12, bits_rule12),
+        tla3_baseline: metrics(hits_baseline, bits_baseline),
+        nulls: GateCNulls {
+            unigram_train_argmax,
+            unigram_null_top1_all: null_hits_all as f64 / nf,
+            unigram_null_bits_all: null_bits_all / nf,
+            unigram_null_top1_generalization: null_hits_gen as f64
+                / (gen_positions as f64).max(1.0),
+            unigram_null_bits_generalization: null_bits_gen / (gen_positions as f64).max(1.0),
+            train_positions,
+            held_out_positions: n,
+        },
+        held_out_population: held_out.len(),
+        positions_sampled: sample_size,
+    })
+}
+
 pub fn evaluate_gate_c(
     r4g1: &[u8],
     artifact_container: &[u8],

--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -766,7 +766,10 @@ pub fn run_point(
     let r4g1_emission_ms = elapsed_ms(stage);
 
     let stage = Instant::now();
-    let gate_c = score::evaluate_gate_c(
+    // #611: the slim sweep evaluator computes exactly the three metrics this
+    // row reads (Rule 1+2, Rule 1 reconstruction, TLA3 baseline) — two scorers
+    // and one lean pass — instead of the full evaluator's ~thirty arms.
+    let gate_c = score::evaluate_gate_c_sweep(
         &artifact_bytes,
         &inputs.artifact_container,
         &inputs.artifacts,
@@ -915,7 +918,7 @@ pub fn reconstruction_null(
     let held_len = held_cap.min(inputs.held_out.len());
     let held = &inputs.held_out[..held_len];
 
-    let score_with = |tables: &score::EmissionTables| -> Option<score::GateCOutcome> {
+    let score_with = |tables: &score::EmissionTables| -> Option<score::SweepGateC> {
         let (artifact_bytes, _info) = score::emit_scored_r4g1(
             &inputs.artifact_container,
             (&inputs.meta_bytes, &inputs.recs_bytes),
@@ -932,7 +935,9 @@ pub fn reconstruction_null(
                 fwd_rows: &fwd_rows,
             },
         );
-        score::evaluate_gate_c(
+        // #611: reconstruction_null reads only rule1_chain + the analytic
+        // nulls, both produced by the slim sweep evaluator.
+        score::evaluate_gate_c_sweep(
             &artifact_bytes,
             &inputs.artifact_container,
             &inputs.artifacts,

--- a/crates/uor-r4-graph-cli/tests/slim_gate_c_parity_611.rs
+++ b/crates/uor-r4-graph-cli/tests/slim_gate_c_parity_611.rs
@@ -1,0 +1,163 @@
+//! #611 parity arm — the slim sweep Gate C evaluator must match the full
+//! evaluator on every metric the sweep and its null-arm harness consume.
+//!
+//! #611 adds `evaluate_gate_c_sweep`, which computes only Rule 1, Rule 1+2,
+//! the TLA3 baseline, and the analytic unigram nulls — two scorers and one
+//! lean pass instead of the full evaluator's ~thirty arms. Because it calls
+//! the SAME per-position primitives as the full evaluator (same code
+//! derivation, same scorers, same `outcome_bits` / `predict_witness_plain` /
+//! `witten_bell_probability` / unigram-null derivation / `gate_c_sample`), its
+//! numbers must equal the full `evaluate_gate_c`'s within the deterministic
+//! (same-machine, byte-exact) floating-point contract.
+//!
+//! This harness builds the real scored artifact for the default cover point
+//! via `run_point` (whose returned bytes it reuses, so both evaluators score
+//! the identical artifact), then:
+//!   1. asserts the sweep row's metrics (produced through the slim evaluator)
+//!      equal the full evaluator's rule1/rule12/baseline exactly, and
+//!   2. asserts `evaluate_gate_c_sweep` matches the full evaluator on those
+//!      three metrics AND on the analytic nulls the null-arm harness reads.
+//!
+//! `#[ignore]`d and presence-gated: it needs the pinned fixtures and runs BOTH
+//! Gate C paths. Run:
+//!   R4_GATE_C_SAMPLE=200 \
+//!   cargo test --release -p uor-r4-graph-cli --test slim_gate_c_parity_611 \
+//!     -- --ignored --nocapture
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use uor_r4_graph_certify::{ScoreConfig, evaluate_gate_c, evaluate_gate_c_sweep};
+use uor_r4_graph_cli::cover_sweep::{PreparedScoring, load_inputs, run_point, sweep_grid};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../uor-r4-core/tests/fixtures")
+        .join(name)
+}
+
+#[test]
+#[ignore = "#611 parity arm; needs fixtures + full+slim Gate C — run with --ignored"]
+fn slim_gate_c_matches_full_on_consumed_metrics() {
+    let meta = fixture("c_meta.bin");
+    let recs = fixture("c_recs.bin");
+    let art = fixture("tless_artifacts.bin");
+    if !meta.exists() || !recs.exists() || !art.exists() {
+        eprintln!("slim_gate_c_parity_611: fixtures absent, skipping (κ-test convention)");
+        return;
+    }
+
+    let inputs = load_inputs(&meta, &recs, &art).expect("load sweep inputs");
+    let config = ScoreConfig::default();
+    let prepared = PreparedScoring::prepare(&inputs, &config);
+
+    let point = sweep_grid()
+        .into_iter()
+        .find(|p| p.baseline)
+        .expect("the grid carries the default (baseline) point");
+
+    // run_point now scores via the slim evaluator; reuse the exact artifact
+    // bytes it produced so the full evaluator scores the identical artifact.
+    let (row, baseline_metrics, artifact_bytes, _timing) =
+        run_point(&inputs, &point, &config, &prepared).expect("run_point");
+
+    let full_start = Instant::now();
+    let full = evaluate_gate_c(
+        &artifact_bytes,
+        &inputs.artifact_container,
+        &inputs.artifacts,
+        &inputs.store,
+        &inputs.corpus,
+        &inputs.held_out,
+        &config,
+    )
+    .expect("full Gate C");
+    let full_ms = full_start.elapsed().as_millis();
+
+    // (1) The sweep row's slim-derived metrics equal the full evaluator's.
+    assert_eq!(
+        row.gate_c_rule12, full.rule12_precedence,
+        "Rule 1+2 agreement diverged between the slim and full evaluators"
+    );
+    assert_eq!(
+        row.reconstruction, full.rule1_chain,
+        "Rule 1 reconstruction diverged between the slim and full evaluators"
+    );
+    assert_eq!(
+        baseline_metrics, full.tla3_baseline,
+        "TLA3 baseline diverged between the slim and full evaluators"
+    );
+
+    // (2) The slim evaluator called directly matches the full evaluator on the
+    // three metrics AND the analytic nulls the #456 null-arm harness reads.
+    let slim_start = Instant::now();
+    let slim = evaluate_gate_c_sweep(
+        &artifact_bytes,
+        &inputs.artifact_container,
+        &inputs.artifacts,
+        &inputs.store,
+        &inputs.corpus,
+        &inputs.held_out,
+        &config,
+    )
+    .expect("slim Gate C");
+    let slim_ms = slim_start.elapsed().as_millis();
+
+    assert_eq!(slim.rule1_chain, full.rule1_chain);
+    assert_eq!(slim.rule12_precedence, full.rule12_precedence);
+    assert_eq!(slim.tla3_baseline, full.tla3_baseline);
+    assert_eq!(slim.positions_sampled, full.positions_sampled);
+    assert_eq!(slim.held_out_population, full.held_out_population);
+
+    // Analytic nulls (GateCNulls is not PartialEq — compare fields).
+    assert_eq!(
+        slim.nulls.unigram_train_argmax,
+        full.nulls.unigram_train_argmax
+    );
+    assert_eq!(
+        slim.nulls.unigram_null_top1_all,
+        full.nulls.unigram_null_top1_all
+    );
+    assert_eq!(
+        slim.nulls.unigram_null_bits_all,
+        full.nulls.unigram_null_bits_all
+    );
+    assert_eq!(
+        slim.nulls.unigram_null_top1_generalization,
+        full.nulls.unigram_null_top1_generalization
+    );
+    assert_eq!(
+        slim.nulls.unigram_null_bits_generalization,
+        full.nulls.unigram_null_bits_generalization
+    );
+    assert_eq!(slim.nulls.train_positions, full.nulls.train_positions);
+    assert_eq!(slim.nulls.held_out_positions, full.nulls.held_out_positions);
+
+    eprintln!(
+        "#611 parity — point {} on {} held-out ({} scored): \
+         rule1 {:.6}/{:.4}bpt  rule12 {:.6}/{:.4}bpt  baseline {:.6}/{:.4}bpt — slim == full",
+        row.label,
+        full.rule12_precedence.positions,
+        if full.positions_sampled == 0 {
+            full.rule12_precedence.positions
+        } else {
+            full.positions_sampled
+        },
+        slim.rule1_chain.top1_agreement,
+        slim.rule1_chain.bits_per_token,
+        slim.rule12_precedence.top1_agreement,
+        slim.rule12_precedence.bits_per_token,
+        slim.tla3_baseline.top1_agreement,
+        slim.tla3_baseline.bits_per_token,
+    );
+    eprintln!(
+        "#611 benchmark — full Gate C {full_ms} ms vs slim {slim_ms} ms on the same artifact \
+         ({:.1}x faster; the slim path builds 2 scorers not 7 and skips the whole-corpus \
+         forward-anchor/right-context/two-sided/latent passes)",
+        if slim_ms == 0 {
+            f64::from(u32::try_from(full_ms).unwrap_or(u32::MAX))
+        } else {
+            full_ms as f64 / slim_ms as f64
+        }
+    );
+}


### PR DESCRIPTION
## Summary
The cover sweep read only three of `evaluate_gate_c`'s ~forty metric arms (Rule 1 reconstruction, Rule 1+2 agreement, TLA3 baseline) plus the analytic unigram nulls for the #456 null-arm harness. The full evaluator also builds and scores the #66 ablations, #80 variants, the #399 forward-anchor family, the #446 right-context family, per-status breakdowns, alpha sweeps, EXCT probes, and win/loss — plus the whole-corpus forward-anchor / right-context / two-sided / latent table passes those arms need. All of that ran nine times per sweep and was discarded.

## What's included
- **`evaluate_gate_c_sweep` (+ `SweepGateC`)** in graph-certify — builds **two** scorers instead of seven and runs one lean per-position pass, producing exactly the metrics the sweep and null-arm harness consume: `rule1_chain`, `rule12_precedence`, `tla3_baseline`, and `GateCNulls`, with the #467 sampled/census provenance (`held_out_population`, `positions_sampled`) and the `SAMPLED DECISION RUN` announcement preserved.
- **Parity by construction:** it calls the SAME primitives the full evaluator's per-position row uses — `AssignTables` + `code_plain_with` for the code (identical to the full path's `left_codes`), `score_candidates_coded`, `outcome_bits`, `predict_witness_plain`, `witten_bell_probability`, the #390 unigram-null derivation, and `gate_c_sample` — so its numbers equal the full evaluator's within the deterministic FP contract.
- **Full `evaluate_gate_c` untouched** — remains the certification/research evaluator.
- **Both consumers wired:** `run_point` (the hot nine-point loop) and `reconstruction_null` (reads `rule1_chain` + `nulls`). Field names match, so the row mapping is unchanged.

## Acceptance criteria
- Reports every field consumed by `SweepRow`, `SweepReport`, and the null-arm harness ✔ (`rule1_chain`, `rule12_precedence`, `tla3_baseline`, `nulls`).
- Required metrics match the full evaluator within the deterministic FP contract ✔ (measured, below).
- Full Gate C path remains available and unchanged for certification ✔.
- Benchmarks show a material reduction in per-point wall time and allocations ✔ (measured, below).
- Sampled decision runs vs full census remain explicit ✔ (`positions_sampled`/`held_out_population` + announcement).

## Verification (measured, real fixtures)
- **Parity** — on the default cover point (300 held-out), the slim evaluator equals the full evaluator **exactly**: rule1 `0.016667 top1 / 17.0431 bpt`, rule12 `0.350000 / 8.7587`, baseline `0.390000 / 8.4363`, and every `GateCNulls` field. New `#[ignore]` fixture-gated test asserts the row metrics (slim-derived) == full, and slim == full directly incl. nulls.
- **Benchmark** — full Gate C **11,565 ms** vs slim **245 ms** on the same artifact → **47.2× faster** (two scorers not seven; no whole-corpus arm passes; fewer allocations). Gate C was the dominant per-point stage in the #609 timing, so this is the sweep's largest per-point cost.
- **Local CI parity, all green:** `fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `wasm32 --lib`, `cargo test --workspace`, `check-model` (R1), `audit-deferral` (R4 — nothing deferred), `repo-conformance` (R2/R3), `cargo deny` (R6).

## Breaking changes
None. `evaluate_gate_c` and its `GateCOutcome` are unchanged; `evaluate_gate_c_sweep`/`SweepGateC` are additive. Sweep report metrics and artifact bytes are identical.

Closes #611