### PR TITLE
fix(cover-sweep): R5 audit-limits — drop the io::Result closure in checkpoint save (#613 follow-up)

### DIFF
--- a/crates/uor-r4-graph-cli/src/cover_sweep.rs
+++ b/crates/uor-r4-graph-cli/src/cover_sweep.rs
@@ -1252,19 +1252,32 @@ fn save_point_checkpoint(
         baseline: output.1.clone(),
         timing: output.2.clone(),
     };
-    let result = (|| -> std::io::Result<()> {
-        std::fs::create_dir_all(dir)?;
-        let tmp_path = dir.join(format!("point-{index:02}.json.tmp"));
-        let json = serde_json::to_vec_pretty(&checkpoint).map_err(std::io::Error::other)?;
-        std::fs::write(&tmp_path, &json)?;
-        std::fs::rename(&tmp_path, checkpoint_path(dir, index))?;
-        Ok(())
-    })();
-    if let Err(error) = result {
+    // Best-effort persistence, handled inline: each fallible step warns and
+    // returns rather than propagating an error. (The R5 audit forbids a
+    // shipped signature that returns an unsanctioned `Result`, so this does
+    // not wrap the I/O in a `Result`-typed helper — a persistence failure is
+    // not a limitation the model reports; the point was computed correctly.)
+    let warn = |what: &str, error: &dyn std::fmt::Display| {
         eprintln!(
-            "cover-sweep: WARNING could not persist checkpoint for point {index} ({}): {error}",
+            "cover-sweep: WARNING could not persist checkpoint for point {index} ({}): \
+             {what}: {error}",
             point.label
         );
+    };
+    let json = match serde_json::to_vec_pretty(&checkpoint) {
+        Ok(json) => json,
+        Err(error) => return warn("serialize", &error),
+    };
+    if let Err(error) = std::fs::create_dir_all(dir) {
+        return warn("create dir", &error);
+    }
+    let tmp_path = dir.join(format!("point-{index:02}.json.tmp"));
+    if let Err(error) = std::fs::write(&tmp_path, &json) {
+        return warn("write tmp", &error);
+    }
+    // Atomic rename into place: a reader sees a complete file or nothing.
+    if let Err(error) = std::fs::rename(&tmp_path, checkpoint_path(dir, index)) {
+        warn("rename", &error);
     }
 }
 


### PR DESCRIPTION
## Summary
#613 (PR #665) merged with `save_point_checkpoint` wrapping its I/O in a `(|| -> std::io::Result<()> { … })()` closure. The **R5** register-conformance gate (`xtask audit-limits`) forbids a shipped signature returning an unsanctioned error type — only `NotAProduct` / `ObservedBound` / `KappaError` / `SourceUnavailable` (plus serde/framework carve-outs) are allowed — so `io::Result<()>` trips it. That gate now **fails the register conformance job on `main`**, so this is a fast follow-up to unbreak it.

## What changed
Rewrote the persistence as inline best-effort steps: each fallible call (`to_vec_pretty`, `create_dir_all`, `write`, atomic `rename`) warns and returns on error, with **no `Result`-typed helper**. Behavior is unchanged — same tmp-file + atomic-rename, same warn-and-continue on failure.

## Why it slipped through
The register conformance job runs R1/R2/R3/**R5**/R6, but my local gate set had been running R1/R4/R2-R3/R6 and omitted **R5 `audit-limits`**. Added to the checklist going forward.

## Verification (local, matches the register conformance job)
- **R5** `cargo run -q -p xtask -- audit-limits`: *no shipped crate returns an unsanctioned error*.
- `fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `wasm32 --lib`, and the `cover_sweep` unit tests (7 passed, incl. the checkpoint round-trip / mismatch / atomic-write guards) all green.

Refs #613