### PR TITLE
model-source: dispatch the compile path over TeacherOracle by architecture (#657 item 1)

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -45,7 +45,7 @@ use std::path::{Path, PathBuf};
 use uor_r4_core::transformerless::hf_bpe::{HfBpeTokenizer, TokenizerKind};
 use uor_r4_core::transformerless::scenarios as core_scenarios;
 use uor_r4_model_source::{
-    BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, SourceUnavailable, TeacherOracle,
+    BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle,
 };
 
 const DEFAULT_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
@@ -231,7 +231,7 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
         Box::new(LlamaOracle::load(path))
     } else {
-        let oracle = HuggingFaceLlamaOracle::load_with_sequence_length(
+        let oracle = Teacher::load_with_sequence_length(
             &options.source,
             options.sequence_length,
         )
@@ -425,7 +425,7 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
         Box::new(LlamaOracle::load(path))
     } else {
-        let oracle = HuggingFaceLlamaOracle::load_with_sequence_length(
+        let oracle = Teacher::load_with_sequence_length(
             &options.source,
             options.sequence_length,
         )
@@ -473,7 +473,7 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             Box::new(LlamaOracle::load(path))
         } else {
             Box::new(
-                HuggingFaceLlamaOracle::load_with_sequence_length(
+                Teacher::load_with_sequence_length(
                     &options.source,
                     options.sequence_length,
                 )
@@ -505,6 +505,10 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
 /// up to `--batch` articles teacher-forced per forward. Produces the same
 /// records as the serial path for identical logits.
 fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), SourceUnavailable> {
+    // #657: the batched observation path scores through `BatchedTeacher`,
+    // whose per-sequence `State` is the Llama batched state — GPT-2 has no
+    // batched executor yet (that is #657 item 2), so this path stays
+    // Llama-only until then rather than dispatching over `Teacher`.
     let oracle =
         HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, options.sequence_length)
             .map_err(|error| {
@@ -2174,7 +2178,7 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     // of the no-BOS arms.
     let oracle_sequence_length = options.sequence_length + usize::from(options.bos);
     let mut oracle =
-        HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, oracle_sequence_length)
+        Teacher::load_with_sequence_length(&options.source, oracle_sequence_length)
             .map_err(|error| {
                 SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
             })?;
@@ -2642,7 +2646,7 @@ where
         .to_str()
         .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
     let mut oracle =
-        HuggingFaceLlamaOracle::load_with_sequence_length(&source, options.sequence_length)
+        Teacher::load_with_sequence_length(&source, options.sequence_length)
             .map_err(|error| {
                 SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
             })?;

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -231,11 +231,8 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
         Box::new(LlamaOracle::load(path))
     } else {
-        let oracle = Teacher::load_with_sequence_length(
-            &options.source,
-            options.sequence_length,
-        )
-        .map_err(|error| {
+        let oracle = Teacher::load_with_sequence_length(&options.source, options.sequence_length)
+            .map_err(|error| {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
         eprintln!("exporting tokenizer...");
@@ -425,11 +422,8 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
         Box::new(LlamaOracle::load(path))
     } else {
-        let oracle = Teacher::load_with_sequence_length(
-            &options.source,
-            options.sequence_length,
-        )
-        .map_err(|error| {
+        let oracle = Teacher::load_with_sequence_length(&options.source, options.sequence_length)
+            .map_err(|error| {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
         eprintln!("exporting tokenizer...");
@@ -473,13 +467,12 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             Box::new(LlamaOracle::load(path))
         } else {
             Box::new(
-                Teacher::load_with_sequence_length(
-                    &options.source,
-                    options.sequence_length,
-                )
-                .map_err(|error| {
-                    SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
-                })?,
+                Teacher::load_with_sequence_length(&options.source, options.sequence_length)
+                    .map_err(|error| {
+                        SourceUnavailable::new(format!(
+                            "failed to load Hugging Face model: {error}"
+                        ))
+                    })?,
             )
         };
         pool.push(extra);
@@ -2177,11 +2170,10 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     // causal over cached positions); it does not change the arithmetic
     // of the no-BOS arms.
     let oracle_sequence_length = options.sequence_length + usize::from(options.bos);
-    let mut oracle =
-        Teacher::load_with_sequence_length(&options.source, oracle_sequence_length)
-            .map_err(|error| {
-                SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
-            })?;
+    let mut oracle = Teacher::load_with_sequence_length(&options.source, oracle_sequence_length)
+        .map_err(|error| {
+            SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
+        })?;
     let mut teacher_logits = vec![0f32; oracle.vocab()];
     let artifacts_bytes = std::fs::read(&artifacts_path)?;
     let tokenizer_bytes = std::fs::read(&tokenizer_path)?;
@@ -2646,10 +2638,9 @@ where
         .to_str()
         .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
     let mut oracle =
-        Teacher::load_with_sequence_length(&source, options.sequence_length)
-            .map_err(|error| {
-                SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
-            })?;
+        Teacher::load_with_sequence_length(&source, options.sequence_length).map_err(|error| {
+            SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
+        })?;
     if options.r4_attention {
         oracle.set_r4_attention(true);
     }

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -391,7 +391,7 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
             let o = uor_r4_model_source::LlamaOracle::load(ckpt.to_str().unwrap());
             Box::new(o)
         } else {
-            let o = uor_r4_model_source::HuggingFaceLlamaOracle::load_with_sequence_length(
+            let o = uor_r4_model_source::Teacher::load_with_sequence_length(
                 options.source.as_ref().unwrap(),
                 options.sequence_length,
             )?;

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -12,9 +12,13 @@ pub mod geometry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gpt2;
 pub mod progress;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod teacher;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use gpt2::HuggingFaceGpt2Oracle;
+#[cfg(not(target_arch = "wasm32"))]
+pub use teacher::Teacher;
 pub struct Config {
     pub dim: usize,
     pub hidden: usize,

--- a/crates/uor-r4-model-source/src/teacher.rs
+++ b/crates/uor-r4-model-source/src/teacher.rs
@@ -79,11 +79,13 @@ fn family_for_model_type(model_type: Option<&str>) -> Result<Family, SourceUnava
 /// Read `<source>/config.json` and resolve its family.
 fn detect_family(source: &Path) -> Result<Family, SourceUnavailable> {
     let config_path = source.join("config.json");
-    let text = std::fs::read_to_string(&config_path).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", config_path.display()))
-    })?;
+    let text = std::fs::read_to_string(&config_path)
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", config_path.display())))?;
     let config: serde_json::Value = serde_json::from_str(&text).map_err(|error| {
-        SourceUnavailable::new(format!("{}: not valid JSON: {error}", config_path.display()))
+        SourceUnavailable::new(format!(
+            "{}: not valid JSON: {error}",
+            config_path.display()
+        ))
     })?;
     family_for_model_type(config.get("model_type").and_then(|value| value.as_str()))
 }
@@ -246,5 +248,60 @@ mod tests {
         ));
         assert!(family_for_model_type(Some("mistral")).is_err());
         assert!(family_for_model_type(Some("")).is_err());
+    }
+
+    // #657 regression gate: routing a Llama/SmolLM2 source through `Teacher`
+    // must be behaviorally identical to the concrete `HuggingFaceLlamaOracle`
+    // — same κ/geometry and bit-identical forward logits — so a compile
+    // through the dispatched path is byte-unchanged (the compile is
+    // deterministic; identical oracle behavior ⇒ identical artifact bytes).
+    // Presence-gated on local weights; `#[ignore]` (loads a 135M checkpoint):
+    //   R4_TEACHER_PARITY_SOURCE=/abs/path/to/smollm2-135m-instruct \
+    //   cargo test -p uor-r4-model-source --release teacher_llama_matches -- --ignored --nocapture
+    #[test]
+    #[ignore = "#657 SmolLM2 parity; needs local weights — run with --ignored + R4_TEACHER_PARITY_SOURCE"]
+    fn teacher_llama_matches_direct_oracle_on_smollm2() {
+        let source = std::env::var("R4_TEACHER_PARITY_SOURCE")
+            .unwrap_or_else(|_| ".uor-models/sources/smollm2-135m-instruct".to_owned());
+        if !std::path::Path::new(&source).join("config.json").is_file() {
+            eprintln!("teacher parity: source absent at {source}, skipping (κ-test convention)");
+            return;
+        }
+        let seq = 8;
+        let mut via_enum = Teacher::load_with_sequence_length(&source, seq).expect("Teacher::load");
+        let mut direct =
+            HuggingFaceLlamaOracle::load_with_sequence_length(&source, seq).expect("direct load");
+
+        assert!(
+            matches!(via_enum, Teacher::Llama(_)),
+            "a llama-family source must route to Teacher::Llama"
+        );
+        assert_eq!(via_enum.kappa(), direct.kappa(), "source κ diverged");
+        assert_eq!(via_enum.vocab(), direct.vocab());
+        assert_eq!(via_enum.dim(), direct.dim());
+        assert_eq!(via_enum.seq_len(), direct.seq_len());
+
+        // One forward step from BOS must yield bit-identical logits.
+        let vocab = via_enum.vocab();
+        let (mut le, mut ld) = (vec![0f32; vocab], vec![0f32; vocab]);
+        let bos = via_enum.bos_token();
+        via_enum.reset();
+        direct.reset();
+        via_enum.step(bos, 0, &mut le);
+        direct.step(bos, 0, &mut ld);
+        let bit_identical = le
+            .iter()
+            .zip(ld.iter())
+            .all(|(a, b)| a.to_bits() == b.to_bits());
+        assert!(
+            bit_identical,
+            "forward logits diverged between Teacher::Llama and the direct oracle"
+        );
+        eprintln!(
+            "#657 parity — Teacher::Llama == HuggingFaceLlamaOracle on {source} \
+             (κ {}, vocab {vocab}, {} logits bit-identical)",
+            via_enum.kappa(),
+            le.len()
+        );
     }
 }

--- a/crates/uor-r4-model-source/src/teacher.rs
+++ b/crates/uor-r4-model-source/src/teacher.rs
@@ -1,0 +1,250 @@
+//! Architecture-keyed teacher dispatch (#657 item 1).
+//!
+//! The compile and serving paths bind a single teacher type. Before this
+//! module that type was the concrete [`HuggingFaceLlamaOracle`], so only the
+//! Llama family could be compiled. [`Teacher`] is the architecture-neutral
+//! carrier: an enum over the registered source oracles that implements the
+//! full [`TeacherOracle`] surface by delegating to whichever variant it holds,
+//! plus a factory ([`Teacher::load`] / [`Teacher::load_with_sequence_length`])
+//! that reads the source `config.json`'s `model_type` and constructs the right
+//! oracle — keyed by the #599 family declarations
+//! ([`crate::conformance::AdapterFeatures`]).
+//!
+//! An **enum**, not `Box<dyn TeacherOracle>`, because the two oracles expose
+//! genuinely divergent inherent surfaces (e.g. `cfg()` returns `&Config` for
+//! Llama and `&Gpt2Config` for GPT-2 — different types that cannot share one
+//! trait method): a caller that needs an architecture-specific capability
+//! matches on the variant, while the shared [`TeacherOracle`] surface is
+//! delegated. The Llama variant delegates to the identical executor, so an
+//! existing Llama/SmolLM2 compile is byte-unchanged.
+//!
+//! Family-specific policy stays confined to `uor-r4-model-source` (the
+//! architecture-neutral boundary): this module names families only through
+//! the conformance declarations and the two oracle constructors.
+
+use std::path::Path;
+
+use crate::conformance::AdapterFeatures;
+use crate::{
+    BehaviorSource, HuggingFaceGpt2Oracle, HuggingFaceLlamaOracle, RepresentationSource,
+    SourceUnavailable, TeacherOracle, TraceCaptureGeometry, TraceCaptureRequest, TraceCaptureSinks,
+};
+
+/// A loaded source teacher of a known architecture. Implements the entire
+/// [`TeacherOracle`] surface by delegating to the held oracle; construct with
+/// the architecture-keyed [`Teacher::load`] / [`Teacher::load_with_sequence_length`].
+pub enum Teacher {
+    /// A Llama-family Hugging Face teacher (the pre-#657 default).
+    Llama(HuggingFaceLlamaOracle),
+    /// A GPT-2-family Hugging Face teacher (#607).
+    Gpt2(HuggingFaceGpt2Oracle),
+}
+
+/// The registered source families, resolved from `config.json`'s `model_type`.
+enum Family {
+    Llama,
+    Gpt2,
+}
+
+/// Resolve a family from a `model_type` label (pure — testable without a
+/// snapshot). An **absent** `model_type` resolves to Llama: every caller
+/// before #657 loaded [`HuggingFaceLlamaOracle`] unconditionally, so this
+/// preserves that exact behavior (and keeps Llama/SmolLM2 compiles unchanged).
+/// A known label routes to its family; any other label fails closed rather
+/// than being approximated by a family that does not execute it.
+fn family_for_model_type(model_type: Option<&str>) -> Result<Family, SourceUnavailable> {
+    let Some(label) = model_type else {
+        return Ok(Family::Llama);
+    };
+    if AdapterFeatures::huggingface_gpt2()
+        .model_types
+        .iter()
+        .any(|known| known == label)
+    {
+        return Ok(Family::Gpt2);
+    }
+    if AdapterFeatures::huggingface_llama()
+        .model_types
+        .iter()
+        .any(|known| known == label)
+    {
+        return Ok(Family::Llama);
+    }
+    Err(SourceUnavailable::new(format!(
+        "config.json model_type {label:?} has no registered teacher family \
+         (expected one of the #599 families: llama, gpt2)"
+    )))
+}
+
+/// Read `<source>/config.json` and resolve its family.
+fn detect_family(source: &Path) -> Result<Family, SourceUnavailable> {
+    let config_path = source.join("config.json");
+    let text = std::fs::read_to_string(&config_path).map_err(|error| {
+        SourceUnavailable::new(format!("{}: {error}", config_path.display()))
+    })?;
+    let config: serde_json::Value = serde_json::from_str(&text).map_err(|error| {
+        SourceUnavailable::new(format!("{}: not valid JSON: {error}", config_path.display()))
+    })?;
+    family_for_model_type(config.get("model_type").and_then(|value| value.as_str()))
+}
+
+impl Teacher {
+    /// Load the architecture-appropriate teacher from a snapshot directory,
+    /// keyed by `config.json`'s `model_type`.
+    pub fn load(source: impl AsRef<Path>) -> Result<Self, SourceUnavailable> {
+        Self::dispatch(source.as_ref(), None)
+    }
+
+    /// Load with a bounded teacher context (the compile path's short
+    /// trajectories), keyed by `config.json`'s `model_type`.
+    pub fn load_with_sequence_length(
+        source: impl AsRef<Path>,
+        sequence_length: usize,
+    ) -> Result<Self, SourceUnavailable> {
+        Self::dispatch(source.as_ref(), Some(sequence_length))
+    }
+
+    fn dispatch(source: &Path, sequence_length: Option<usize>) -> Result<Self, SourceUnavailable> {
+        match detect_family(source)? {
+            Family::Llama => Ok(Self::Llama(match sequence_length {
+                Some(len) => HuggingFaceLlamaOracle::load_with_sequence_length(source, len)?,
+                None => HuggingFaceLlamaOracle::load(source)?,
+            })),
+            Family::Gpt2 => Ok(Self::Gpt2(match sequence_length {
+                Some(len) => HuggingFaceGpt2Oracle::load_with_sequence_length(source, len)?,
+                None => HuggingFaceGpt2Oracle::load(source)?,
+            })),
+        }
+    }
+
+    /// Toggle the experimental #602 R4 route-attention operator. Llama maps
+    /// this to its two registered operators (`standard-source-attention/1`
+    /// off, `experimental-r4-source-attention/1` on). GPT-2 has no such
+    /// switch — its learned-absolute operator is a separate registry entry
+    /// (#657 item 3) — so the toggle is a documented no-op there rather than
+    /// silently reinterpreting a Llama switch it does not execute.
+    pub fn set_r4_attention(&mut self, enable: bool) {
+        match self {
+            Self::Llama(oracle) => oracle.set_r4_attention(enable),
+            Self::Gpt2(_) => {}
+        }
+    }
+
+    /// The held teacher as a `&dyn TeacherOracle` (shared delegation target).
+    fn as_oracle(&self) -> &dyn TeacherOracle {
+        match self {
+            Self::Llama(oracle) => oracle,
+            Self::Gpt2(oracle) => oracle,
+        }
+    }
+
+    /// The held teacher as a `&mut dyn TeacherOracle` (mutable delegation).
+    fn as_oracle_mut(&mut self) -> &mut dyn TeacherOracle {
+        match self {
+            Self::Llama(oracle) => oracle,
+            Self::Gpt2(oracle) => oracle,
+        }
+    }
+}
+
+impl RepresentationSource for Teacher {
+    fn vocab_size(&self) -> usize {
+        self.as_oracle().vocab_size()
+    }
+    fn source_dimension(&self) -> usize {
+        self.as_oracle().source_dimension()
+    }
+    fn tokenizer_address(&self) -> &str {
+        self.as_oracle().tokenizer_address()
+    }
+    fn read_embedding_rows(&self, range: std::ops::Range<usize>, output: &mut [f32]) -> Option<()> {
+        self.as_oracle().read_embedding_rows(range, output)
+    }
+}
+
+impl BehaviorSource for Teacher {
+    fn reset(&mut self) {
+        self.as_oracle_mut().reset();
+    }
+    fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]) {
+        self.as_oracle_mut().step(token, pos, logits);
+    }
+}
+
+impl TeacherOracle for Teacher {
+    fn vocab(&self) -> usize {
+        self.as_oracle().vocab()
+    }
+    fn dim(&self) -> usize {
+        self.as_oracle().dim()
+    }
+    fn seq_len(&self) -> usize {
+        self.as_oracle().seq_len()
+    }
+    fn bos_token(&self) -> usize {
+        self.as_oracle().bos_token()
+    }
+    fn eos_token(&self) -> usize {
+        self.as_oracle().eos_token()
+    }
+    fn kappa(&self) -> String {
+        self.as_oracle().kappa()
+    }
+    fn source_bytes(&self) -> usize {
+        self.as_oracle().source_bytes()
+    }
+    fn embedding(&self, token: usize, out: &mut [f32]) {
+        self.as_oracle().embedding(token, out);
+    }
+    fn geometry_projection(&self) -> Option<crate::geometry::GeometryProjection> {
+        self.as_oracle().geometry_projection()
+    }
+    fn attention_operator_spec(&self) -> Option<crate::attention::AttentionOperatorSpec> {
+        self.as_oracle().attention_operator_spec()
+    }
+    fn hidden_state(&self) -> Option<&[f32]> {
+        self.as_oracle().hidden_state()
+    }
+    fn top_k(&self, k: usize, out: &mut [(u32, f32)]) -> usize {
+        self.as_oracle().top_k(k, out)
+    }
+    fn trace_capture_geometry(&self) -> Option<TraceCaptureGeometry> {
+        self.as_oracle().trace_capture_geometry()
+    }
+    fn step_with_trace_capture(
+        &mut self,
+        token: usize,
+        pos: usize,
+        logits: &mut [f32],
+        request: &TraceCaptureRequest<'_>,
+        sinks: &mut TraceCaptureSinks<'_, '_>,
+    ) -> bool {
+        self.as_oracle_mut()
+            .step_with_trace_capture(token, pos, logits, request, sinks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #657: the architecture router. An absent model_type stays Llama (the
+    // pre-#657 default, so existing compiles are unchanged); the two declared
+    // families route to themselves; an unregistered label fails closed rather
+    // than being run by a family that does not execute it. Pure — runs in CI
+    // without any snapshot.
+    #[test]
+    fn model_type_routes_to_the_declared_family() {
+        assert!(matches!(family_for_model_type(None), Ok(Family::Llama)));
+        assert!(matches!(
+            family_for_model_type(Some("llama")),
+            Ok(Family::Llama)
+        ));
+        assert!(matches!(
+            family_for_model_type(Some("gpt2")),
+            Ok(Family::Gpt2)
+        ));
+        assert!(family_for_model_type(Some("mistral")).is_err());
+        assert!(family_for_model_type(Some("")).is_err());
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -245,7 +245,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     let start_time = Instant::now();
     let router = Arc::new(Mutex::new(UorR4Router::new(0.85)));
     let tless: Arc<Mutex<Option<tless_uor::TlessState>>> = Arc::new(Mutex::new(None));
-    let oracle: Arc<Mutex<Option<uor_r4_model_source::HuggingFaceLlamaOracle>>> =
+    let oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>> =
         Arc::new(Mutex::new(None));
 
     let last_model = std::fs::read_to_string(".uor-models/last_model_name.txt").unwrap_or_default();
@@ -266,7 +266,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
             "[*] Loading full Llama teacher oracle from {} for attention-based generation...",
             path
         );
-        match uor_r4_model_source::HuggingFaceLlamaOracle::load(path) {
+        match uor_r4_model_source::Teacher::load(path) {
             Ok(o) => {
                 println!(
                     "[+] Successfully loaded full Llama teacher model ({})!",
@@ -745,7 +745,7 @@ fn load_serving_hf_tokenizer(dir: &std::path::Path) {
 }
 
 fn generate_attention_text(
-    oracle: &mut uor_r4_model_source::HuggingFaceLlamaOracle,
+    oracle: &mut uor_r4_model_source::Teacher,
     prompt: &str,
     max_tokens: usize,
 ) -> Option<(String, usize)> {
@@ -1265,7 +1265,7 @@ fn transformerless_tier(
 /// the readability gate — pinned attention modes get the same gate as the
 /// cascade tier.
 fn attention_tier(
-    oracle: &mut Option<uor_r4_model_source::HuggingFaceLlamaOracle>,
+    oracle: &mut Option<uor_r4_model_source::Teacher>,
     prompt: &str,
     max_tokens: usize,
     r4_attention: bool,
@@ -1329,7 +1329,7 @@ fn run_serving_cascade(
     router: &mut UorR4Router,
     r4g1: &Arc<Mutex<Option<R4g1State>>>,
     tless: &Arc<Mutex<Option<tless_uor::TlessState>>>,
-    oracle: &mut Option<uor_r4_model_source::HuggingFaceLlamaOracle>,
+    oracle: &mut Option<uor_r4_model_source::Teacher>,
     prompt: &str,
     identity: &str,
     max_tokens: usize,
@@ -2092,7 +2092,7 @@ fn handle_connection(
     r4g1: Arc<Mutex<Option<R4g1State>>>,
     r4g1_compile: Arc<Mutex<R4g1CompileStatus>>,
     hf_download: Arc<Mutex<HuggingFaceDownloadStatus>>,
-    oracle: Arc<Mutex<Option<uor_r4_model_source::HuggingFaceLlamaOracle>>>,
+    oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>>,
     cli: Arc<ServerConfig>,
     start_time: Instant,
 ) {
@@ -2243,7 +2243,7 @@ fn handle_connection(
             .join("model.safetensors")
             .exists()
         {
-            match uor_r4_model_source::HuggingFaceLlamaOracle::load(&oracle_source) {
+            match uor_r4_model_source::Teacher::load(&oracle_source) {
                 Ok(o) => {
                     println!(
                         "[+] Successfully reloaded teacher oracle model for '{}'",

--- a/src/server.rs
+++ b/src/server.rs
@@ -245,8 +245,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     let start_time = Instant::now();
     let router = Arc::new(Mutex::new(UorR4Router::new(0.85)));
     let tless: Arc<Mutex<Option<tless_uor::TlessState>>> = Arc::new(Mutex::new(None));
-    let oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>> =
-        Arc::new(Mutex::new(None));
+    let oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>> = Arc::new(Mutex::new(None));
 
     let last_model = std::fs::read_to_string(".uor-models/last_model_name.txt").unwrap_or_default();
     let last_model_name = last_model.trim();


### PR DESCRIPTION
## Summary
Delivers **item 1** of #657 — the architecture dispatch enabler. The compile and serving paths bound the concrete `HuggingFaceLlamaOracle`, so only the Llama family could be compiled. This introduces `Teacher`, an architecture-keyed enum that carries either family and dispatches on the source's `config.json` `model_type`, so a GPT-2 source is loaded and compiled through the same path — with the Llama/SmolLM2 path **byte-unchanged**.

## Design — enum, not `Box<dyn TeacherOracle>`
`Teacher { Llama(HuggingFaceLlamaOracle), Gpt2(HuggingFaceGpt2Oracle) }` implements the full `TeacherOracle` surface (RepresentationSource + BehaviorSource + TeacherOracle) by delegating to the held variant via `as_oracle()`/`as_oracle_mut()`. An enum is required because the oracles' **inherent** surfaces diverge — `cfg()` returns `&Config` for Llama and `&Gpt2Config` for GPT-2, different types that cannot share one trait method — so a caller matches on the variant for architecture-specific needs while the shared surface is delegated.

- **Factory:** `Teacher::load` / `load_with_sequence_length` read `config.json` `model_type` and construct the right oracle, keyed by the #599 conformance family declarations: absent or `llama` → Llama (the pre-#657 default), `gpt2` → GPT-2, any other label **fails closed** with `SourceUnavailable` rather than being approximated by a family that does not execute it.
- **`set_r4_attention`:** delegates for Llama; a documented no-op for GPT-2 (its learned-absolute operator is the separate #668 registry entry, not the Llama r4 switch).
- Family-specific policy stays confined to `uor-r4-model-source` (the architecture-neutral boundary).

## Migrated (all TeacherOracle trait-surface sites)
graph-cli (`observe_command`, `observe_text_command` + worker pool, `compile_hugging_face_with_progress`), graph-compiler (`observe`), and the server (oracle slot `Arc<Mutex<Option<Teacher>>>`, loader, handler signatures).

**Deliberately not migrated:** `observe_text_batched_command` scores through `BatchedTeacher`, whose per-sequence `State` **is** the Llama batched state; GPT-2 has no batched executor yet (that is **#667**, item 2), so this path stays Llama-only and is documented as such rather than approximated.

## Verification (measured)
- **SmolLM2 byte-parity (the regression gate):** a presence-gated test proves loading SmolLM2 through `Teacher` is behaviorally identical to the concrete oracle — routes to `Teacher::Llama`, same source κ (`blake3:12d2cd8…`), same vocab/dim/seq_len, and a forward step from BOS yields **all 49,152 logits bit-identical**. The compile is deterministic, so identical oracle behavior ⇒ byte-identical artifacts.
- **Routing unit test** (CI, no weights): absent/`llama` → Llama, `gpt2` → GPT-2, unregistered label → error.
- **Full local gate set, all green:** `fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, **R5 `audit-limits`**, `wasm32 --lib`, `cargo test --workspace`, `check-model` (R1), `audit-deferral` (R4), `repo-conformance` (R2/R3), `cargo deny` (R6).

## Scope / follow-ups
This is the dispatch enabler only; #657's end-to-end GPT-2 compile acceptance also needs items 2–5, now filed as sub-issues: **#667** (GPT-2 #603 trace-capture + batched executor), **#668** (GPT-2 learned-absolute attention operator), **#669** (GPT-2 tokenizer identity), **#670** (full compile→certify canary). #657 stays open as the umbrella.

Refs #657