### PR TITLE
model-source: register the GPT-2 learned-absolute attention operator (#668)

### DIFF
--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -203,6 +203,33 @@ impl AttentionOperatorParams {
             score_accumulation: "per-byte-popcount-table-add-left-fold".to_owned(),
         }
     }
+
+    /// The declared parameters of `learned-absolute-source-attention/1`
+    /// (#668) — the ACTUAL computation of the GPT-2 executor
+    /// (`crate::gpt2::Gpt2Model::layer_forward`):
+    ///
+    /// - `head_selection = "multi-head-identity-kv-head-equals-query-head"`
+    ///   — GPT-2 is plain multi-head (kv heads == query heads); head `h`
+    ///   reads its own `h`-th head slice, with no grouped-query sharing.
+    /// - `score_scale = "multiply-by-reciprocal-sqrt-full-head-size"` —
+    ///   the executor precomputes `scale = 1/sqrt(head_size)` once and
+    ///   multiplies every score by it, distinct from the standard
+    ///   operator's per-score divide by `sqrt(head_size)`.
+    /// - `score_width_policy = "full-head-width"` — every head dimension
+    ///   enters the dot product.
+    /// - `remainder_policy = "none-every-head-dimension-scored"` — there
+    ///   is no unscored remainder at any head width.
+    /// - `score_accumulation = "sequential-f32-left-fold"` — one running
+    ///   f32 sum over `i = 0..head_size` in order.
+    pub fn learned_absolute() -> Self {
+        Self {
+            head_selection: "multi-head-identity-kv-head-equals-query-head".to_owned(),
+            score_scale: "multiply-by-reciprocal-sqrt-full-head-size".to_owned(),
+            score_width_policy: "full-head-width".to_owned(),
+            remainder_policy: "none-every-head-dimension-scored".to_owned(),
+            score_accumulation: "sequential-f32-left-fold".to_owned(),
+        }
+    }
 }
 
 /// The typed, versioned record of one source attention operator (#602).
@@ -287,6 +314,16 @@ impl AttentionOperatorSpec {
     /// `uor-r4-graph-certify::route_attention` (reference) and
     /// `uor-r4-graph-runtime::route_attention` (packed lowering).
     pub const R4_ROUTE_VERSION: u32 = 1;
+    /// Registry id of the GPT-2-family source operator (#668): a scaled
+    /// dot product with the SAME max-subtracted softmax as the standard
+    /// operator, but learned absolute positions (no RoPE) and GPT-2's
+    /// fused-`c_attn`/`c_proj` Conv1D projections. Named for its
+    /// positional action, the field that distinguishes it from
+    /// `standard-source-attention`.
+    pub const LEARNED_ABSOLUTE_ID: &'static str = "learned-absolute-source-attention";
+    /// Registry version of the learned-absolute operator currently
+    /// computed by the GPT-2 executor (`crate::gpt2::Gpt2Model`).
+    pub const LEARNED_ABSOLUTE_VERSION: u32 = 1;
 
     /// The `standard-source-attention/1` record — the operator the
     /// default-off `r4_attention` switch has always computed.
@@ -373,6 +410,54 @@ impl AttentionOperatorSpec {
             permitted_operation_class: "deployed-integer-xor-popcount-add-compare-table-read"
                 .to_owned(),
             params: AttentionOperatorParams::r4_route_attention(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// The `learned-absolute-source-attention/1` record (#668) — the
+    /// GPT-2-family source operator computed by the executor in
+    /// [`crate::gpt2`] (`Gpt2Model::layer_forward`), the way
+    /// `r4-route-attention/1`'s record names an operator whose
+    /// implementation lives outside this module. Truthful inventory of
+    /// what the GPT-2 executor computes, read from `layer_forward` (the
+    /// presence-gated numpy canary and the tiny-fixture parity test pin
+    /// the arithmetic):
+    ///
+    /// - `projections`: the fused `c_attn` Conv1D `[n_embd, 3·n_embd]`
+    ///   applied as `x @ W + b` (no transpose), split into q/k/v thirds,
+    ///   WITH bias — unlike Llama's separate biasless `wq`/`wk`/`wv`.
+    /// - `positional_action`: NONE on q/k before scoring. GPT-2 adds a
+    ///   learned absolute position embedding (`wpe`) to the input
+    ///   residual; no rotation touches q or k, unlike RoPE. This is the
+    ///   field that makes reusing `standard-source-attention/1` a false
+    ///   record.
+    /// - `compatibility_relation`: `scaled-dot-product`, a single
+    ///   sequential f32 left fold over the FULL head width, scaled by a
+    ///   precomputed `1/sqrt(head_size)` (multiply, not divide).
+    /// - `selector_normalization`: the SAME max-subtracted softmax the
+    ///   standard operator uses.
+    /// - `value_aggregation`: position-ascending weighted sum of values.
+    /// - `output_projection`: the `c_proj` Conv1D `[n_embd, n_embd]` with
+    ///   bias.
+    /// - head selection is plain multi-head (kv heads == query heads);
+    ///   no grouped-query arithmetic exists.
+    pub fn learned_absolute_source_attention() -> Self {
+        let mut record = Self {
+            id: Self::LEARNED_ABSOLUTE_ID.to_owned(),
+            version: Self::LEARNED_ABSOLUTE_VERSION,
+            projections: "fused-c-attn-conv1d-qkv-with-bias".to_owned(),
+            positional_action: "none-learned-absolute-positions-added-to-input-embeddings"
+                .to_owned(),
+            compatibility_relation: "scaled-dot-product".to_owned(),
+            selector_normalization: "softmax-max-subtracted-exp-then-sum-normalize".to_owned(),
+            value_aggregation: "position-ascending-weighted-sum-of-values".to_owned(),
+            output_projection: "dense-c-proj-conv1d-with-bias".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class: "host-source-f32".to_owned(),
+            params: AttentionOperatorParams::learned_absolute(),
             implementation_digest: String::new(),
         };
         record.implementation_digest = record.declared_digest();
@@ -469,6 +554,10 @@ pub fn operator_spec(
         (AttentionOperatorSpec::R4_ROUTE_ID, AttentionOperatorSpec::R4_ROUTE_VERSION) => {
             Ok(AttentionOperatorSpec::r4_route_attention_v1())
         }
+        (
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+        ) => Ok(AttentionOperatorSpec::learned_absolute_source_attention()),
         _ => Err(crate::SourceIngestKind::UnknownAttentionOperator {
             id: id.to_owned(),
             version,
@@ -879,6 +968,7 @@ mod tests {
             AttentionOperatorSpec::standard(),
             AttentionOperatorSpec::experimental_r4(),
             AttentionOperatorSpec::r4_route_attention_v1(),
+            AttentionOperatorSpec::learned_absolute_source_attention(),
         ] {
             let json = serde_json::to_string(&record).expect("serializes");
             let back: AttentionOperatorSpec = serde_json::from_str(&json).expect("deserializes");
@@ -931,6 +1021,15 @@ mod tests {
         )
         .expect("registered target route operator");
         assert_eq!(target, AttentionOperatorSpec::r4_route_attention_v1());
+        let learned = operator_spec(
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+        )
+        .expect("registered learned-absolute operator");
+        assert_eq!(
+            learned,
+            AttentionOperatorSpec::learned_absolute_source_attention()
+        );
     }
 
     #[test]
@@ -984,10 +1083,70 @@ mod tests {
     }
 
     #[test]
+    fn learned_absolute_canonical_serialization_is_byte_stable() {
+        // #668: the GPT-2-family operator's declared identity, pinned
+        // byte-for-byte. Any drift in a field token is a version bump,
+        // never a silent edit.
+        let learned = AttentionOperatorSpec::learned_absolute_source_attention();
+        let pinned = "uor-r4-attention-operator/1\n\
+             id=learned-absolute-source-attention\n\
+             version=1\n\
+             projections=fused-c-attn-conv1d-qkv-with-bias\n\
+             positional_action=none-learned-absolute-positions-added-to-input-embeddings\n\
+             compatibility_relation=scaled-dot-product\n\
+             selector_normalization=softmax-max-subtracted-exp-then-sum-normalize\n\
+             value_aggregation=position-ascending-weighted-sum-of-values\n\
+             output_projection=dense-c-proj-conv1d-with-bias\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32\n\
+             param.head_selection=multi-head-identity-kv-head-equals-query-head\n\
+             param.score_scale=multiply-by-reciprocal-sqrt-full-head-size\n\
+             param.score_width_policy=full-head-width\n\
+             param.remainder_policy=none-every-head-dimension-scored\n\
+             param.score_accumulation=sequential-f32-left-fold\n";
+        assert_eq!(learned.canonical_bytes(), pinned.as_bytes());
+        let expected = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
+        assert_eq!(learned.implementation_digest, expected);
+        assert_eq!(learned.declared_digest(), expected);
+
+        // It shares the standard operator's compatibility relation and
+        // softmax selector, but is a DISTINCT identity: the positional
+        // action and projections differ, so the declared digest differs.
+        let standard = AttentionOperatorSpec::standard();
+        assert_eq!(
+            learned.compatibility_relation,
+            standard.compatibility_relation
+        );
+        assert_eq!(
+            learned.selector_normalization,
+            standard.selector_normalization
+        );
+        assert_ne!(
+            learned.positional_action, standard.positional_action,
+            "GPT-2 uses learned absolute positions, not RoPE"
+        );
+        assert_ne!(
+            learned.implementation_digest, standard.implementation_digest,
+            "learned-absolute is a distinct operator identity"
+        );
+        assert_ne!(
+            learned.implementation_digest,
+            AttentionOperatorSpec::experimental_r4().implementation_digest
+        );
+        // Rebuilding reproduces the record bit-for-bit.
+        assert_eq!(
+            learned,
+            AttentionOperatorSpec::learned_absolute_source_attention()
+        );
+    }
+
+    #[test]
     fn registry_refuses_unknown_id_and_version_by_name() {
         for (id, version) in [
             ("standard-source-attention", 2u32),
             ("experimental-r4-source-attention", 9),
+            ("learned-absolute-source-attention", 2),
             ("mystery-attention", 1),
         ] {
             let error =

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -583,6 +583,43 @@ mod tests {
         }
     }
 
+    /// #668: the GPT-2 oracle reports the truthful learned-absolute
+    /// operator record, and it resolves through the versioned registry.
+    /// Its positional action is NOT RoPE, so it is a distinct identity
+    /// from `standard-source-attention/1` — reusing that record would be
+    /// a false operator identity.
+    #[test]
+    fn gpt2_oracle_reports_learned_absolute_operator() {
+        use crate::attention::{operator_spec, AttentionOperatorSpec};
+        use crate::TeacherOracle;
+
+        let oracle = HuggingFaceGpt2Oracle::load(fixture_dir()).expect("load tiny gpt2 oracle");
+        let spec = oracle
+            .attention_operator_spec()
+            .expect("gpt2 oracle declares an attention operator");
+
+        assert_eq!(
+            spec,
+            AttentionOperatorSpec::learned_absolute_source_attention()
+        );
+        assert_eq!(spec.id, AttentionOperatorSpec::LEARNED_ABSOLUTE_ID);
+        assert_eq!(
+            spec.version,
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION
+        );
+
+        // Resolvable through the registry it is registered in.
+        let resolved = operator_spec(&spec.id, spec.version).expect("registered operator");
+        assert_eq!(resolved, spec);
+
+        // A distinct identity from the RoPE standard operator: the
+        // positional action is the discriminating field, and the digest
+        // over the declared identity differs accordingly.
+        let standard = AttentionOperatorSpec::standard();
+        assert_ne!(spec.positional_action, standard.positional_action);
+        assert_ne!(spec.implementation_digest, standard.implementation_digest);
+    }
+
     /// Loading a snapshot whose config declares a non-GPT-2 architecture is
     /// refused at the #599 gate before any weight is read.
     #[test]
@@ -737,15 +774,13 @@ impl crate::TeacherOracle for HuggingFaceGpt2Oracle {
             })
     }
     fn attention_operator_spec(&self) -> Option<crate::attention::AttentionOperatorSpec> {
-        // Deliberately absent, not defaulted by omission: the only
-        // registered #602 operator (`standard-source-attention/1`) declares
-        // `rope-rotation-of-q-and-k-before-scoring` as its positional
-        // action, which GPT-2 (learned absolute positions) does not perform.
-        // Recording it would be a false operator identity. Registering a
-        // learned-absolute operator and wiring it here is scoped future
-        // work in issue #657; until it exists this stays absent rather than
-        // misdeclared.
-        None
+        // #668: the truthful GPT-2 operator record. `Gpt2Model::layer_forward`
+        // (this module) is its implementation — a scaled dot product with the
+        // standard max-subtracted softmax, but learned absolute positions (no
+        // RoPE on q/k) and GPT-2's fused-`c_attn`/`c_proj` Conv1D projections.
+        // Reusing `standard-source-attention/1` would misdeclare the positional
+        // action, so this is its own registered `(id, version)`.
+        Some(crate::attention::AttentionOperatorSpec::learned_absolute_source_attention())
     }
     fn hidden_state(&self) -> Option<&[f32]> {
         Some(&self.state.hidden)

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -315,10 +315,13 @@ change must arrive as a new registry version). A versioned registry maps
 pair fails closed with the focused
 `SourceIngestKind::UnknownAttentionOperator` rather than being guessed.
 
-**Truthful operator inventory.** Two operators are registered, and they
-are exactly the two branches the teacher's `r4_attention` switch selects
-between (`attention::operator_for_r4_switch` is the one boundary mapping
-from the legacy boolean to the versioned identity):
+**Truthful operator inventory.** Two source operators map to the
+teacher's `r4_attention` switch — they are exactly the two branches it
+selects between (`attention::operator_for_r4_switch` is the one boundary
+mapping from the legacy boolean to the versioned identity); a third
+source operator (`learned-absolute-source-attention/1`, #668) is
+registered for the GPT-2 family and selected by architecture rather than
+the switch:
 
 - `standard-source-attention/1` (the switch off — the default
   everywhere): dense per-layer f32 `wq`/`wk`/`wv` projections with
@@ -349,6 +352,28 @@ from the legacy boolean to the versioned identity):
   `docs/deferral_record_2026_08_05.md`), and the registry id names what
   it computes. The branch remains shipped, selectable, default-off, and
   unmeasured; #602 changes no selection and activates nothing.
+- `learned-absolute-source-attention/1` (#668, the GPT-2 family —
+  declared by the oracle's architecture, never reached through the
+  `r4_attention` switch): the SAME scaled-dot-product compatibility
+  relation and max-subtracted softmax selector as the standard operator,
+  but a truthfully distinct identity in the fields GPT-2 differs on. Its
+  projections are the fused `c_attn` Conv1D `[n_embd, 3·n_embd]` applied
+  as `x @ W + b` (split into q/k/v thirds, with bias) and its output is
+  the `c_proj` Conv1D with bias — not Llama's separate biasless
+  `wq`/`wk`/`wv`/`wo`. Its positional action is NONE on q/k: GPT-2 adds a
+  learned absolute position embedding (`wpe`) to the input residual and
+  nothing rotates q or k, so recording RoPE would be a false identity —
+  the field that forbids reusing `standard-source-attention/1`. Head
+  selection is plain multi-head (kv heads == query heads, no
+  grouped-query), and the score is scaled by a precomputed
+  `1/sqrt(head_size)` (a multiply, distinct from the standard operator's
+  per-score divide). Its implementation is the GPT-2 executor
+  (`gpt2::Gpt2Model::layer_forward`), pinned by the presence-gated numpy
+  canary and the committed tiny-fixture parity test — the same
+  implementation-lives-elsewhere discipline as the #604 target operator;
+  the GPT-2 oracle declares it via `attention_operator_spec`, so a
+  compiled GPT-2 bundle carries a truthful operator row (feeding the #606
+  certificate) instead of a misdeclared RoPE one.
 
 The reference implementations are free deterministic functions factored
 verbatim out of the executor (`standard_head_attention_weights`,


### PR DESCRIPTION
Follow-up to #657 (item 3). Closes #668.

## Problem
`HuggingFaceGpt2Oracle::attention_operator_spec` returned `None` by design: the only registered operator, `standard-source-attention/1`, declares `positional_action = rope-rotation-of-q-and-k-before-scoring`, which GPT-2 does **not** do (learned absolute positions). Recording it would be a false operator identity, so the GPT-2 certificate operator row (#606) was absent rather than misdeclared.

## Change
Register a new versioned source operator `learned-absolute-source-attention/1` in `uor-r4-model-source::attention`, and wire the GPT-2 oracle to it.

The record is a **truthful inventory** read from the executor (`gpt2::Gpt2Model::layer_forward`), following the same implementation-lives-elsewhere discipline the #604 target operator uses:

- **projections**: fused `c_attn` Conv1D `[n_embd, 3·n_embd]` applied as `x @ W + b`, split into q/k/v thirds, **with bias** (not Llama's separate biasless `wq`/`wk`/`wv`).
- **positional_action**: NONE on q/k — GPT-2 adds a learned absolute position embedding (`wpe`) to the input residual; nothing rotates q or k. This is the field that forbids reusing `standard-source-attention/1`.
- **compatibility_relation / selector**: the same `scaled-dot-product` + max-subtracted softmax as the standard operator.
- **output_projection**: `c_proj` Conv1D with bias.
- **head selection**: plain multi-head (kv heads == query heads, no grouped-query).
- **score_scale**: precomputed `1/sqrt(head_size)` **multiply** (distinct from the standard per-score divide).

The versioned registry (`operator_spec`) still refuses unknown `(id, version)` on the sanctioned `UnknownAttentionOperator` surface. `MODEL_LIFECYCLE.md`'s operator inventory is updated in lockstep.

## Regression gate
**SmolLM2/Llama is byte-unchanged**: the Llama oracle still returns `operator_for_r4_switch`, and the two source operators + the #604 target operator are untouched. The GPT-2 tiny-fixture numpy parity test is unchanged and green — the executor arithmetic is not modified, only its provenance record is now declared.

## Verification (all local, pre-push)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- `cargo build --target wasm32-unknown-unknown --lib` (clean)
- `cargo test -p uor-r4-model-source`: 66 lib + 15 attention tests pass, including:
  - `attention::learned_absolute_canonical_serialization_is_byte_stable` — pins the canonical bytes + blake3 declared-identity digest, distinct from the other operators.
  - `attention::registry_resolves_all_registered_operators` / `registry_refuses_unknown_id_and_version_by_name` — extended for the new `(id, 1)` and its unknown `(id, 2)`.
  - `gpt2::gpt2_oracle_reports_learned_absolute_operator` — the oracle reports the record and it round-trips through the registry (loaded from the committed tiny fixture).
- Register conformance R1–R5: `check-model`, `repo-conformance`, `audit-deferral`, `audit-limits` all green. No new dependencies (R6/cargo-deny dep-neutral).

Claim discipline unchanged: this makes the operator record truthful; it does not compile or certify GPT-2 (items 2/4/5 remain: #667, #669, #670).