### PR TITLE
model-source: GPT-2 batched executor for batched observe (#667 item 2b)

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -44,9 +44,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use uor_r4_core::transformerless::hf_bpe::{HfBpeTokenizer, TokenizerKind};
 use uor_r4_core::transformerless::scenarios as core_scenarios;
-use uor_r4_model_source::{
-    BehaviorSource, HuggingFaceLlamaOracle, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle,
-};
+use uor_r4_model_source::{BehaviorSource, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle};
 
 const DEFAULT_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
 const DEFAULT_TOKENIZER: &str = "/tmp/ref/tokenizer.bin";
@@ -498,15 +496,15 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
 /// up to `--batch` articles teacher-forced per forward. Produces the same
 /// records as the serial path for identical logits.
 fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), SourceUnavailable> {
-    // #657: the batched observation path scores through `BatchedTeacher`,
-    // whose per-sequence `State` is the Llama batched state — GPT-2 has no
-    // batched executor yet (that is #657 item 2), so this path stays
-    // Llama-only until then rather than dispatching over `Teacher`.
-    let oracle =
-        HuggingFaceLlamaOracle::load_with_sequence_length(&options.source, options.sequence_length)
-            .map_err(|error| {
-                SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
-            })?;
+    // #657 item 2b: the batched observation path now dispatches over
+    // `Teacher`, so a GPT-2 source runs on its own batched executor
+    // (`Gpt2State`) instead of the Llama-only path. Both concrete oracles
+    // implement `BatchedTeacher`; the generic `observe_text_corpus_batched`
+    // is monomorphized per architecture.
+    let teacher = Teacher::load_with_sequence_length(&options.source, options.sequence_length)
+        .map_err(|error| {
+            SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
+        })?;
     eprintln!("exporting tokenizer...");
     let token_byte_lengths =
         uor_r4_core::transformerless::scenarios::export_hf_bytelevel_tokenizer_with_lengths(
@@ -528,17 +526,30 @@ fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), Sour
         )
     };
     eprintln!("observing with batch {}", options.batch);
-    let report = observe_text::observe_text_corpus_batched(
-        &oracle,
-        options.batch,
-        options.seconds,
-        &tokenizer,
-        Some(&token_byte_lengths),
-        &options.input,
-        &options.output,
-        options.shards,
-        true,
-    )
+    let report = match teacher {
+        Teacher::Llama(oracle) => observe_text::observe_text_corpus_batched(
+            &oracle,
+            options.batch,
+            options.seconds,
+            &tokenizer,
+            Some(&token_byte_lengths),
+            &options.input,
+            &options.output,
+            options.shards,
+            true,
+        ),
+        Teacher::Gpt2(oracle) => observe_text::observe_text_corpus_batched(
+            &oracle,
+            options.batch,
+            options.seconds,
+            &tokenizer,
+            Some(&token_byte_lengths),
+            &options.input,
+            &options.output,
+            options.shards,
+            true,
+        ),
+    }
     .map_err(SourceUnavailable::new)?;
     finish_observe_text_report(&report, &options.output)
 }

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -51,10 +51,10 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use uor_r4_core::transformerless::hf_bpe::TokenizerKind;
+use uor_r4_model_source::BatchedTeacher;
 use uor_r4_model_source::SourceUnavailable;
 use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::progress::Progress;
-use uor_r4_model_source::{BatchedTeacher, State};
 
 /// Authoritative per-article checkpoint file name within an observation
 /// directory.
@@ -1156,8 +1156,8 @@ struct BatchSlot {
 /// path from the serial (`sgemv`) one — both are teacher data, not the pinned
 /// legacy proof.
 #[allow(clippy::too_many_arguments)]
-pub fn observe_text_corpus_batched(
-    oracle: &dyn BatchedTeacher,
+pub fn observe_text_corpus_batched<T: BatchedTeacher>(
+    oracle: &T,
     batch: usize,
     budget_s: u64,
     tokenizer: &TokenizerKind,
@@ -1199,7 +1199,7 @@ pub fn observe_text_corpus_batched(
     let mut ordinal = 0u64;
     let mut budget_hit = false;
     // One reusable state per slot, all sharing the oracle's single weight copy.
-    let mut states: Vec<State> = (0..batch).map(|_| oracle.new_state()).collect();
+    let mut states: Vec<T::State> = (0..batch).map(|_| oracle.new_state()).collect();
 
     'groups: loop {
         let mut slots: Vec<BatchSlot> = Vec::with_capacity(batch);
@@ -1246,7 +1246,9 @@ pub fn observe_text_corpus_batched(
             break;
         }
         let active = slots.len();
-        states[..active].iter_mut().for_each(State::reset);
+        for state in states[..active].iter_mut() {
+            oracle.reset_state(state);
+        }
         let max_len = slots.iter().map(|s| s.positions).max().unwrap_or(0);
 
         for pos in 0..max_len {
@@ -1270,7 +1272,7 @@ pub fn observe_text_corpus_batched(
                     let token = slot.tokens[pos];
                     let next = slot.tokens[pos + 1];
                     let (encoded, advanced) = encode_position(
-                        &mut states[i].logits,
+                        oracle.logits_mut(&mut states[i]),
                         story,
                         pos,
                         token,
@@ -1346,7 +1348,7 @@ mod tests {
     };
     use std::time::{SystemTime, UNIX_EPOCH};
     use uor_r4_core::transformerless::scenarios::Tokenizer;
-    use uor_r4_model_source::{BehaviorSource, RepresentationSource};
+    use uor_r4_model_source::{BehaviorSource, RepresentationSource, State};
 
     const SHARD_BITS: u8 = 2;
     const SHARD_COUNT: u32 = 1 << SHARD_BITS;
@@ -2185,8 +2187,15 @@ mod tests {
     }
 
     impl BatchedTeacher for FakeBatchedOracle {
+        type State = State;
         fn new_state(&self) -> State {
             State::new(&self.cfg)
+        }
+        fn reset_state(&self, state: &mut State) {
+            state.reset();
+        }
+        fn logits_mut<'a>(&self, state: &'a mut State) -> &'a mut [f32] {
+            &mut state.logits
         }
         fn seq_len(&self) -> usize {
             FAKE_SEQ_LEN

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -302,6 +302,43 @@ fn conv1d(x: &[f32], w: &[f32], bias: &[f32], out_dim: usize, out: &mut [f32]) {
     }
 }
 
+/// Batched Conv1D: `b` input vectors of length `in_dim` through weight
+/// `[in_dim, out_dim]` → `b` output vectors of length `out_dim`, both in
+/// sequence-major layout (`b * in_dim` in, `b * out_dim` out). Each weight
+/// row `w[i * out_dim..]` is read once per input index `i` and reused
+/// across all `b` sequences — the memory-amortization that lifts batched
+/// teacher inference off the per-token bandwidth wall — while every output
+/// accumulates over `i` in the SAME order, with the same bias
+/// initialization and the same bit-neutral zero-input skip, as the serial
+/// [`conv1d`]. So `conv1d_batched` is bit-identical to calling `conv1d` on
+/// each sequence separately.
+fn conv1d_batched(
+    out: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    bias: &[f32],
+    out_dim: usize,
+    in_dim: usize,
+    b: usize,
+) {
+    for bi in 0..b {
+        out[bi * out_dim..(bi + 1) * out_dim].copy_from_slice(&bias[..out_dim]);
+    }
+    for i in 0..in_dim {
+        let row = &w[i * out_dim..(i + 1) * out_dim];
+        for bi in 0..b {
+            let xi = x[bi * in_dim + i];
+            if xi == 0.0 {
+                continue;
+            }
+            let ob = &mut out[bi * out_dim..(bi + 1) * out_dim];
+            for o in 0..out_dim {
+                ob[o] += xi * row[o];
+            }
+        }
+    }
+}
+
 /// Recurrent decode state: per-layer key/value caches, the working
 /// residual, the final hidden state, and the last step's logits.
 pub struct Gpt2State {
@@ -468,13 +505,10 @@ impl Gpt2 {
         inner: &mut [f32],
         mlp_out: &mut [f32],
         request: Option<&crate::TraceCaptureRequest<'_>>,
-        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+        sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
     ) {
         let d = self.cfg.n_embd;
-        let hs = self.cfg.head_size();
-        let scale = 1.0 / (hs as f32).sqrt();
         let layer = &self.layers[l];
-        let seq = self.cfg.seq_len;
 
         // --- attention ---
         layer_norm(
@@ -485,6 +519,53 @@ impl Gpt2 {
             normed,
         );
         conv1d(normed, &layer.c_attn_w, &layer.c_attn_b, 3 * d, qkv);
+        self.block_attention(st, l, pos, qkv, attn, request, sinks);
+        conv1d(attn, &layer.c_proj_w, &layer.c_proj_b, d, proj);
+        for (xi, &p) in st.x.iter_mut().zip(&proj[..d]) {
+            *xi += p;
+        }
+
+        // --- MLP ---
+        layer_norm(
+            &st.x,
+            &layer.ln2_w,
+            &layer.ln2_b,
+            self.cfg.layer_norm_eps,
+            normed,
+        );
+        conv1d(normed, &layer.fc_w, &layer.fc_b, self.cfg.n_inner, inner);
+        for v in inner.iter_mut() {
+            *v = gelu_new(*v);
+        }
+        conv1d(inner, &layer.mlp_w, &layer.mlp_b, d, mlp_out);
+        for (xi, &m) in st.x.iter_mut().zip(&mlp_out[..d]) {
+            *xi += m;
+        }
+    }
+
+    /// The per-sequence attention sub-block shared by [`Gpt2::block_forward`]
+    /// (serial) and [`Gpt2::forward_batch`] (batched): cache this position's
+    /// k/v from the fused `qkv` projection, then for each head compute the
+    /// scaled dot-product scores, the max-subtracted softmax (normalized in
+    /// place), and the value aggregation into `attn`. Optional #603 taps
+    /// (q/k/v and the per-head weights) fire for a requested layer. Sharing
+    /// it keeps the serial and batched executors bit-identical by
+    /// construction.
+    #[allow(clippy::too_many_arguments)]
+    fn block_attention(
+        &self,
+        st: &mut Gpt2State,
+        l: usize,
+        pos: usize,
+        qkv: &[f32],
+        attn: &mut [f32],
+        request: Option<&crate::TraceCaptureRequest<'_>>,
+        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+    ) {
+        let d = self.cfg.n_embd;
+        let hs = self.cfg.head_size();
+        let scale = 1.0 / (hs as f32).sqrt();
+        let seq = self.cfg.seq_len;
         // store this position's k, v (thirds 1 and 2 of the fused qkv).
         let base = (l * seq + pos) * d;
         st.k_cache[base..base + d].copy_from_slice(&qkv[d..2 * d]);
@@ -549,26 +630,148 @@ impl Gpt2 {
                 }
             }
         }
-        conv1d(attn, &layer.c_proj_w, &layer.c_proj_b, d, proj);
-        for (xi, &p) in st.x.iter_mut().zip(&proj[..d]) {
-            *xi += p;
+    }
+
+    /// Batched forward: advance `states.len()` independent sequences by one
+    /// position each — sequence `bi` steps `tokens[bi]` at `positions[bi]`
+    /// against its own k/v cache in `states[bi]`. The projection Conv1Ds
+    /// (`c_attn`, `c_proj`, `fc`, `mlp`) run once over the whole batch via
+    /// the amortized [`conv1d_batched`], and the tied lm-head reuses each
+    /// `wte` row across the batch — the same memory-amortization Llama's
+    /// `forward_batch` gets from `matmul_batched`. Every per-sequence op
+    /// (embedding, LayerNorm, attention via the shared
+    /// [`Gpt2::block_attention`], GELU, residual) mirrors [`Gpt2::forward`]
+    /// and keeps the serial accumulation order, so this is bit-identical to
+    /// calling `forward` on each sequence.
+    // Sequence-major index loops are deliberate here: the accumulation order
+    // must match the serial `forward` byte-for-byte, and the offsets index
+    // several stacked scratch buffers in lockstep.
+    #[allow(clippy::needless_range_loop)]
+    pub fn forward_batch(&self, states: &mut [Gpt2State], tokens: &[usize], positions: &[usize]) {
+        let d = self.cfg.n_embd;
+        let inner_dim = self.cfg.n_inner;
+        let b = states.len();
+        debug_assert_eq!(tokens.len(), b);
+        debug_assert_eq!(positions.len(), b);
+        if b == 0 {
+            return;
         }
 
-        // --- MLP ---
-        layer_norm(
-            &st.x,
-            &layer.ln2_w,
-            &layer.ln2_b,
-            self.cfg.layer_norm_eps,
-            normed,
-        );
-        conv1d(normed, &layer.fc_w, &layer.fc_b, self.cfg.n_inner, inner);
-        for v in inner.iter_mut() {
-            *v = gelu_new(*v);
+        let mut normed = vec![0.0f32; b * d];
+        let mut qkv = vec![0.0f32; b * 3 * d];
+        let mut attn = vec![0.0f32; b * d];
+        let mut proj = vec![0.0f32; b * d];
+        let mut inner = vec![0.0f32; b * inner_dim];
+        let mut mlp_out = vec![0.0f32; b * d];
+
+        // token + learned absolute position embedding, per sequence.
+        for bi in 0..b {
+            let (token, pos) = (tokens[bi], positions[bi]);
+            let x = &mut states[bi].x;
+            for i in 0..d {
+                x[i] = self.wte[token * d + i] + self.wpe[pos * d + i];
+            }
         }
-        conv1d(inner, &layer.mlp_w, &layer.mlp_b, d, mlp_out);
-        for (xi, &m) in st.x.iter_mut().zip(&mlp_out[..d]) {
-            *xi += m;
+
+        for l in 0..self.cfg.n_layer {
+            let layer = &self.layers[l];
+            for bi in 0..b {
+                layer_norm(
+                    &states[bi].x,
+                    &layer.ln1_w,
+                    &layer.ln1_b,
+                    self.cfg.layer_norm_eps,
+                    &mut normed[bi * d..(bi + 1) * d],
+                );
+            }
+            conv1d_batched(
+                &mut qkv,
+                &normed,
+                &layer.c_attn_w,
+                &layer.c_attn_b,
+                3 * d,
+                d,
+                b,
+            );
+            for bi in 0..b {
+                self.block_attention(
+                    &mut states[bi],
+                    l,
+                    positions[bi],
+                    &qkv[bi * 3 * d..(bi + 1) * 3 * d],
+                    &mut attn[bi * d..(bi + 1) * d],
+                    None,
+                    None,
+                );
+            }
+            conv1d_batched(&mut proj, &attn, &layer.c_proj_w, &layer.c_proj_b, d, d, b);
+            for bi in 0..b {
+                let x = &mut states[bi].x;
+                for i in 0..d {
+                    x[i] += proj[bi * d + i];
+                }
+            }
+            for bi in 0..b {
+                layer_norm(
+                    &states[bi].x,
+                    &layer.ln2_w,
+                    &layer.ln2_b,
+                    self.cfg.layer_norm_eps,
+                    &mut normed[bi * d..(bi + 1) * d],
+                );
+            }
+            conv1d_batched(
+                &mut inner,
+                &normed,
+                &layer.fc_w,
+                &layer.fc_b,
+                inner_dim,
+                d,
+                b,
+            );
+            for v in inner.iter_mut() {
+                *v = gelu_new(*v);
+            }
+            conv1d_batched(
+                &mut mlp_out,
+                &inner,
+                &layer.mlp_w,
+                &layer.mlp_b,
+                d,
+                inner_dim,
+                b,
+            );
+            for bi in 0..b {
+                let x = &mut states[bi].x;
+                for i in 0..d {
+                    x[i] += mlp_out[bi * d + i];
+                }
+            }
+        }
+
+        // final ln_f into each state's hidden, then the tied lm-head with
+        // each wte row reused across the batch (naive sequential dot per
+        // sequence — bit-identical to `finish_forward`).
+        for bi in 0..b {
+            let st = &mut states[bi];
+            layer_norm(
+                &st.x,
+                &self.ln_f_w,
+                &self.ln_f_b,
+                self.cfg.layer_norm_eps,
+                &mut st.hidden,
+            );
+        }
+        for v in 0..self.cfg.vocab {
+            let row = &self.wte[v * d..(v + 1) * d];
+            for bi in 0..b {
+                let st = &mut states[bi];
+                let mut acc = 0.0f32;
+                for i in 0..d {
+                    acc += st.hidden[i] * row[i];
+                }
+                st.logits[v] = acc;
+            }
         }
     }
 }
@@ -796,6 +999,89 @@ mod tests {
         }
     }
 
+    /// #667: GPT-2's batched forward is bit-identical to advancing each
+    /// sequence through the serial `forward` — the amortized conv1d/lm-head
+    /// keep the serial accumulation order, and each sequence reads its own
+    /// `positions[bi]` and k/v cache. Covers a lockstep batch (all at the
+    /// same position) and a divergent batch (each sequence at a different
+    /// position).
+    #[test]
+    #[allow(clippy::needless_range_loop)]
+    fn forward_batch_matches_serial_forward() {
+        let dir = fixture_dir();
+        let model = Gpt2::load(&dir, None).expect("load tiny gpt2 snapshot");
+        let steps = 4.min(model.cfg.seq_len).max(1);
+        let vocab = model.cfg.vocab;
+        let seqs: [Vec<usize>; 3] = [
+            (0..steps).map(|i| i % vocab).collect(),
+            (0..steps).map(|i| (i * 2 + 1) % vocab).collect(),
+            (0..steps).map(|i| (i * 3 + 2) % vocab).collect(),
+        ];
+
+        // Serial reference: each sequence's logits at each position.
+        let mut serial: Vec<Vec<Vec<f32>>> = Vec::new();
+        for seq in &seqs {
+            let mut st = Gpt2State::new(&model.cfg);
+            st.reset();
+            let mut per_pos = Vec::new();
+            for (pos, &tok) in seq.iter().enumerate() {
+                model.forward(&mut st, tok, pos, &[], &mut |_, _| {});
+                per_pos.push(st.logits.clone());
+            }
+            serial.push(per_pos);
+        }
+
+        let fresh = || {
+            let mut s = Gpt2State::new(&model.cfg);
+            s.reset();
+            s
+        };
+        let bits = |xs: &[f32]| -> Vec<u32> { xs.iter().map(|v| v.to_bits()).collect() };
+
+        // Lockstep: advance all three together, position by position.
+        {
+            let mut states: Vec<Gpt2State> = (0..seqs.len()).map(|_| fresh()).collect();
+            for pos in 0..steps {
+                let tokens: Vec<usize> = seqs.iter().map(|s| s[pos]).collect();
+                let positions = vec![pos; seqs.len()];
+                model.forward_batch(&mut states, &tokens, &positions);
+                for (b, st) in states.iter().enumerate() {
+                    assert_eq!(
+                        bits(&st.logits),
+                        bits(&serial[b][pos]),
+                        "lockstep batched seq {b} pos {pos} equals serial"
+                    );
+                }
+            }
+        }
+
+        // Divergent positions in one batch: seq b targets a different pos.
+        if steps >= 3 {
+            let targets = [2usize, 1, 0];
+            let mut states: Vec<Gpt2State> = (0..seqs.len()).map(|_| fresh()).collect();
+            // Pre-fill each state's k/v cache serially up to its target - 1.
+            for (b, &target) in targets.iter().enumerate() {
+                for pos in 0..target {
+                    model.forward(&mut states[b], seqs[b][pos], pos, &[], &mut |_, _| {});
+                }
+            }
+            let tokens: Vec<usize> = targets
+                .iter()
+                .enumerate()
+                .map(|(b, &t)| seqs[b][t])
+                .collect();
+            let positions = targets.to_vec();
+            model.forward_batch(&mut states, &tokens, &positions);
+            for (b, &target) in targets.iter().enumerate() {
+                assert_eq!(
+                    bits(&states[b].logits),
+                    bits(&serial[b][target]),
+                    "divergent batched seq {b} pos {target} equals serial"
+                );
+            }
+        }
+    }
+
     /// Loading a snapshot whose config declares a non-GPT-2 architecture is
     /// refused at the #599 gate before any weight is read.
     #[test]
@@ -990,6 +1276,28 @@ impl crate::TeacherOracle for HuggingFaceGpt2Oracle {
             .forward_capturing_trace(&mut self.state, token, pos, request, sinks);
         logits.copy_from_slice(&self.state.logits);
         true
+    }
+}
+
+impl crate::BatchedTeacher for HuggingFaceGpt2Oracle {
+    type State = Gpt2State;
+    fn new_state(&self) -> Gpt2State {
+        Gpt2State::new(&self.model.cfg)
+    }
+    fn reset_state(&self, state: &mut Gpt2State) {
+        state.reset();
+    }
+    fn logits_mut<'a>(&self, state: &'a mut Gpt2State) -> &'a mut [f32] {
+        &mut state.logits
+    }
+    fn seq_len(&self) -> usize {
+        self.model.cfg.seq_len
+    }
+    fn vocab(&self) -> usize {
+        self.model.cfg.vocab
+    }
+    fn forward_batch_into(&self, states: &mut [Gpt2State], tokens: &[usize], positions: &[usize]) {
+        self.model.forward_batch(states, tokens, positions);
     }
 }
 

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -2485,20 +2485,38 @@ fn required_llama_tensors(cfg: &Config, tie_word_embeddings: bool) -> Vec<Tensor
 /// (the deployed teacher) and mockable for tests, so the batched observe driver
 /// need not name a concrete oracle.
 pub trait BatchedTeacher {
+    /// The per-sequence decode state this teacher advances. Generic so a
+    /// non-Llama architecture (GPT-2) can carry its own state through the
+    /// same batched observe driver instead of the Llama `State`.
+    type State;
     /// A fresh per-sequence state for this teacher.
-    fn new_state(&self) -> State;
+    fn new_state(&self) -> Self::State;
+    /// Reset a state to begin a new sequence (zero its caches/buffers).
+    fn reset_state(&self, state: &mut Self::State);
+    /// Mutable view of the logits the last
+    /// [`BatchedTeacher::forward_batch_into`] left in `state` — the observe
+    /// driver encodes each position in place.
+    fn logits_mut<'a>(&self, state: &'a mut Self::State) -> &'a mut [f32];
     /// Maximum context length (teacher-forced positions per article).
     fn seq_len(&self) -> usize;
     /// Vocabulary size (logits length).
     fn vocab(&self) -> usize;
     /// Advance `states.len()` sequences one position each: sequence `b` steps
-    /// `tokens[b]` at `positions[b]`, leaving its logits in `states[b].logits`.
-    fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]);
+    /// `tokens[b]` at `positions[b]`, leaving its logits reachable through
+    /// [`BatchedTeacher::logits_mut`].
+    fn forward_batch_into(&self, states: &mut [Self::State], tokens: &[usize], positions: &[usize]);
 }
 
 impl BatchedTeacher for HuggingFaceLlamaOracle {
+    type State = State;
     fn new_state(&self) -> State {
         State::new(&self.model.cfg)
+    }
+    fn reset_state(&self, state: &mut State) {
+        state.reset();
+    }
+    fn logits_mut<'a>(&self, state: &'a mut State) -> &'a mut [f32] {
+        &mut state.logits
     }
     fn seq_len(&self) -> usize {
         self.model.cfg.seq_len


### PR DESCRIPTION
Second half of #657 item 2. **Closes #667** (item 2a landed in #674). Stacked on #674, rebased onto main after it merged.

## Problem
`observe_text_corpus_batched` ran through `BatchedTeacher`, whose `forward_batch_into(&self, states: &mut [State], …)` **hardcoded Llama's concrete `State`**. GPT-2 has its own `Gpt2State`, so batched compile-corpus observation was Llama-only; GPT-2 had no batched executor.

## Change
- **`BatchedTeacher` generalized** with an associated `type State` plus `reset_state` / `logits_mut` accessors, so the driver no longer names a concrete state. The Llama impl is behaviorally unchanged.
- **`Gpt2::forward_batch`** — advances N independent sequences one position each. The four projection Conv1Ds run once over the batch via a new **`conv1d_batched`** (each weight row read once across the batch, with the *same* per-output accumulation order and bit-neutral zero-skip as the serial `conv1d`), and the tied lm-head reuses each `wte` row across the batch (naive sequential dot). The per-sequence attention is the shared **`block_attention`** factored out of `block_forward`, so serial and batched are **bit-identical by construction**.
- **`impl BatchedTeacher for HuggingFaceGpt2Oracle`** (`State = Gpt2State`).
- **`observe_text_corpus_batched` is now generic** over `T: BatchedTeacher`; the graph-cli caller **dispatches Llama vs GPT-2 on the `Teacher` enum**, so a GPT-2 source's compile-corpus observation uses the batched path.

## Regression gates
- `forward_batch_matches_serial_forward` — GPT-2 batched == serial `forward` **bit-for-bit** (`to_bits`), for a lockstep batch (all at the same position) and a divergent batch (each sequence at a different position, own k/v cache).
- `batched_matches_serial_byte_for_byte` (graph-compiler) — the Llama batched **driver** still produces byte-identical records to the serial driver through the generalized trait.
- Tiny + real numpy GPT-2 parity and the #603 trace tests unchanged.

## Verification (local, pre-push)
- `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- `cargo build --target wasm32-unknown-unknown --lib` (clean)
- `cargo test -p uor-r4-model-source --lib` (68 pass), `-p uor-r4-graph-compiler` (all pass incl the byte-for-byte batched test), `-p uor-r4-graph-cli`
- Register conformance R1–R5. No new dependencies.

With this, #657's item 2 is complete; only item 5 (the full compile→certify canary, #670) remains before the umbrella #657 closes.