### PR TITLE
api: official OpenAI SDK smoke tests + README (#654 phase F)

### DIFF
--- a/profiles/openai/README.md
+++ b/profiles/openai/README.md
@@ -70,6 +70,46 @@ the matrix disagree, if the vendored bytes do not match the pinned blake3, or if
 the `supported` set changes without updating the test — so drift cannot land
 unreviewed.
 
+## SDK compatibility (phase F)
+
+The pinned wire surfaces are verified against the **official OpenAI SDKs**, so a
+caller can point an unmodified SDK at an R4 server by setting its base URL:
+
+| SDK | Version verified | Surfaces |
+| --- | --- | --- |
+| `openai` (Python) | 3.0.0 | chat completions (non-stream + stream), responses |
+| `openai` (JS/TS) | 7.4.0 | chat completions (non-stream + stream), responses |
+
+Two layers of coverage:
+
+- **Deterministic fixtures (CI).** `src/server.rs` bakes the *exact* request
+  bodies these SDKs emit for basic calls and asserts our request DTOs
+  deserialize them, and that our response bodies carry the fields the SDKs read
+  (`choices[].message.content`, `finish_reason`, `usage.*`; and the Responses
+  `output[].content[].text` / `usage.*`). No network or model is needed.
+- **Runnable end-to-end scripts.** `smoke_test.py` and `smoke_test.mjs` drive a
+  live server with the real SDK across all three surfaces. They need a server
+  with a compiled model loaded (a declined cascade has no text to serve), so
+  they are developer-run, not CI:
+
+  ```
+  # Python
+  pip install openai
+  python3 profiles/openai/smoke_test.py --base-url http://127.0.0.1:8080/v1 --model <compiled-model-id>
+
+  # JS/TS
+  npm install openai
+  node profiles/openai/smoke_test.mjs --base-url http://127.0.0.1:8080/v1 --model <compiled-model-id>
+  ```
+
+Because the request DTOs use `#[serde(deny_unknown_fields)]`, an SDK call that
+passes a parameter outside the supported subset (a tool spec, a
+structured-output format, a reasoning control) is rejected with the error
+envelope rather than being silently ignored. This is not an SDK incompatibility:
+the SDKs omit every *unset* optional parameter, so ordinary calls always land
+inside the subset; only an explicitly-passed unsupported parameter fails closed,
+which is the intended "support is never implied by omission" contract.
+
 ## Claim status
 
 Passing the profile proves the tested wire-protocol contract against this

--- a/profiles/openai/smoke_test.mjs
+++ b/profiles/openai/smoke_test.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// #654 phase F — official OpenAI **JS/TS** SDK smoke test against a live R4 server.
+//
+// The JavaScript counterpart to smoke_test.py: it drives the pinned wire
+// surfaces (POST /v1/chat/completions non-streaming and streaming, and
+// POST /v1/responses) with the official `openai` npm package and asserts the SDK
+// round-trips against a running R4 server. Like the Python script it is NOT wired
+// into CI — it needs a server with a compiled model loaded; it is the developer-run
+// companion to the deterministic DTO/response fixtures in src/server.rs.
+//
+// Usage:
+//     npm install openai
+//     node profiles/openai/smoke_test.mjs --base-url http://127.0.0.1:8080/v1 --model <compiled-model-id>
+//
+// --base-url/--model default to the UOR_OPENAI_BASE_URL / UOR_OPENAI_MODEL
+// environment variables. The API key is a placeholder (the R4 server does not
+// authenticate the pinned profile). Exit code 0 = every surface round-tripped.
+
+import OpenAI from "openai";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+function check(label, ok, detail) {
+  console.log(`[${ok ? "PASS" : "FAIL"}] ${label}: ${detail}`);
+  return ok;
+}
+
+const baseURL = arg("base-url", process.env.UOR_OPENAI_BASE_URL || "http://127.0.0.1:8080/v1");
+const model = arg("model", process.env.UOR_OPENAI_MODEL || "uor-r4");
+const client = new OpenAI({ baseURL, apiKey: "sk-uor-r4-smoke", maxRetries: 0 });
+const results = [];
+
+// 1. Chat Completions, non-streaming.
+const chat = await client.chat.completions.create({
+  model,
+  messages: [{ role: "user", content: "Say hi in one word." }],
+});
+const choice = chat.choices[0];
+results.push(
+  check(
+    "chat.completions (non-stream)",
+    Boolean(choice.message.content) && ["stop", "length"].includes(choice.finish_reason),
+    `content=${JSON.stringify(choice.message.content)} finish_reason=${choice.finish_reason} usage.total_tokens=${chat.usage.total_tokens}`,
+  ),
+);
+
+// 2. Chat Completions, streaming (phase D SSE).
+let reconstructed = "";
+let sawRole = false;
+let streamFinish = null;
+const stream = await client.chat.completions.create({
+  model,
+  messages: [{ role: "user", content: "Say hi in one word." }],
+  stream: true,
+});
+for await (const event of stream) {
+  const delta = event.choices[0].delta;
+  if (delta.role) sawRole = true;
+  if (delta.content) reconstructed += delta.content;
+  if (event.choices[0].finish_reason) streamFinish = event.choices[0].finish_reason;
+}
+results.push(
+  check(
+    "chat.completions (stream)",
+    sawRole && ["stop", "length"].includes(streamFinish),
+    `reconstructed=${JSON.stringify(reconstructed)} finish_reason=${streamFinish}`,
+  ),
+);
+
+// 3. Responses.
+const resp = await client.responses.create({ model, input: "Say hi in one word." });
+results.push(
+  check(
+    "responses",
+    Boolean(resp.output_text) && ["completed", "incomplete"].includes(resp.status),
+    `output_text=${JSON.stringify(resp.output_text)} status=${resp.status} usage.total_tokens=${resp.usage.total_tokens}`,
+  ),
+);
+
+const ok = results.every(Boolean);
+console.log(
+  `\n${ok ? "ALL SURFACES ROUND-TRIPPED" : "ONE OR MORE SURFACES FAILED"} (${results.filter(Boolean).length}/${results.length})`,
+);
+process.exit(ok ? 0 : 1);

--- a/profiles/openai/smoke_test.py
+++ b/profiles/openai/smoke_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""#654 phase F — official OpenAI **Python** SDK smoke test against a live R4 server.
+
+This drives the pinned wire surfaces (`POST /v1/chat/completions` non-streaming
+and streaming, and `POST /v1/responses`) with the *official* `openai` package and
+asserts the SDK round-trips: it builds a request our server accepts and parses the
+response our server returns. It is intentionally NOT wired into CI — it needs a
+running server with a compiled model loaded (a declined-by-all cascade has no text
+to serve). It is the developer-run companion to the deterministic DTO/response
+fixtures in `src/server.rs` (which prove the exact SDK-emitted request bytes
+deserialize without a live server).
+
+Usage:
+    pip install openai
+    python3 profiles/openai/smoke_test.py --base-url http://127.0.0.1:8080/v1 --model <compiled-model-id>
+
+`--base-url`/`--model` default to the `UOR_OPENAI_BASE_URL` / `UOR_OPENAI_MODEL`
+environment variables. The API key is a placeholder (the R4 server does not
+authenticate the pinned profile). Exit code 0 = every surface round-tripped.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - operator guidance, not a test path
+    sys.exit("openai package not installed; run `pip install openai` first")
+
+
+def _check(label: str, ok: bool, detail: str) -> bool:
+    print(f"[{'PASS' if ok else 'FAIL'}] {label}: {detail}")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("UOR_OPENAI_BASE_URL", "http://127.0.0.1:8080/v1"),
+    )
+    parser.add_argument("--model", default=os.environ.get("UOR_OPENAI_MODEL", "uor-r4"))
+    args = parser.parse_args()
+
+    client = OpenAI(base_url=args.base_url, api_key="sk-uor-r4-smoke", max_retries=0)
+    results: list[bool] = []
+
+    # 1. Chat Completions, non-streaming.
+    chat = client.chat.completions.create(
+        model=args.model,
+        messages=[{"role": "user", "content": "Say hi in one word."}],
+    )
+    choice = chat.choices[0]
+    results.append(
+        _check(
+            "chat.completions (non-stream)",
+            bool(choice.message.content) and choice.finish_reason in {"stop", "length"},
+            f"content={choice.message.content!r} finish_reason={choice.finish_reason} "
+            f"usage.total_tokens={chat.usage.total_tokens}",
+        )
+    )
+
+    # 2. Chat Completions, streaming (phase D SSE).
+    reconstructed = ""
+    saw_role = False
+    stream_finish = None
+    stream = client.chat.completions.create(
+        model=args.model,
+        messages=[{"role": "user", "content": "Say hi in one word."}],
+        stream=True,
+    )
+    for event in stream:
+        delta = event.choices[0].delta
+        if delta.role:
+            saw_role = True
+        if delta.content:
+            reconstructed += delta.content
+        if event.choices[0].finish_reason:
+            stream_finish = event.choices[0].finish_reason
+    results.append(
+        _check(
+            "chat.completions (stream)",
+            saw_role and stream_finish in {"stop", "length"},
+            f"reconstructed={reconstructed!r} finish_reason={stream_finish}",
+        )
+    )
+
+    # 3. Responses.
+    resp = client.responses.create(model=args.model, input="Say hi in one word.")
+    results.append(
+        _check(
+            "responses",
+            bool(resp.output_text) and resp.status in {"completed", "incomplete"},
+            f"output_text={resp.output_text!r} status={resp.status} "
+            f"usage.total_tokens={resp.usage.total_tokens}",
+        )
+    )
+
+    ok = all(results)
+    print(f"\n{'ALL SURFACES ROUND-TRIPPED' if ok else 'ONE OR MORE SURFACES FAILED'} "
+          f"({sum(results)}/{len(results)})")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/server.rs
+++ b/src/server.rs
@@ -5387,4 +5387,107 @@ mod tests {
             serde_json::from_str(r#"{"input":"hi","tools":[]}"#);
         assert!(unsupported.is_err(), "unsupported param must fail closed");
     }
+
+    // ---- #654 phase F: official OpenAI SDK wire compatibility ----
+    // The fixtures below are the EXACT request bodies emitted by the official
+    // OpenAI Python SDK (3.0.0) and JS SDK (7.4.0) for basic calls, captured
+    // against an echo server. They deserialize into our DTOs unchanged: the SDKs
+    // omit every unset optional param, so a real call always lands inside the
+    // supported subset and `deny_unknown_fields` never trips on an SDK default.
+    // These are the deterministic, CI-safe half of the phase-F smoke coverage;
+    // the runnable end-to-end scripts live in profiles/openai/smoke_test.{py,mjs}.
+
+    #[test]
+    fn sdk_chat_request_fixtures_deserialize() {
+        // Minimal chat.completions.create(model, messages).
+        let minimal: super::VendorChatCompletionsRequest = serde_json::from_str(
+            r#"{"messages":[{"content":"hi","role":"user"}],"model":"uor-r4"}"#,
+        )
+        .expect("minimal SDK chat payload deserializes");
+        assert_eq!(minimal.model.as_deref(), Some("uor-r4"));
+        assert_eq!(minimal.messages.len(), 1);
+        assert!(minimal.stream.is_none());
+
+        // With max_tokens + temperature + a system message.
+        let full: super::VendorChatCompletionsRequest = serde_json::from_str(
+            r#"{"max_tokens":32,"messages":[{"content":"be terse","role":"system"},{"content":"hi","role":"user"}],"model":"uor-r4","temperature":0.5}"#,
+        )
+        .expect("full SDK chat payload deserializes");
+        assert_eq!(full.max_tokens, Some(32));
+        assert_eq!(full.messages.len(), 2);
+
+        // A streaming call adds exactly `stream: true`.
+        let streaming: super::VendorChatCompletionsRequest = serde_json::from_str(
+            r#"{"messages":[{"content":"hi","role":"user"}],"model":"uor-r4","stream":true}"#,
+        )
+        .expect("streaming SDK chat payload deserializes");
+        assert_eq!(streaming.stream, Some(true));
+    }
+
+    #[test]
+    fn sdk_responses_request_fixtures_deserialize() {
+        // Minimal responses.create(model, input).
+        let minimal: super::VendorResponsesRequest =
+            serde_json::from_str(r#"{"input":"hi","model":"uor-r4"}"#)
+                .expect("minimal SDK responses payload deserializes");
+        assert_eq!(minimal.model.as_deref(), Some("uor-r4"));
+        assert!(minimal.input.is_string());
+
+        // With instructions + max_output_tokens.
+        let full: super::VendorResponsesRequest = serde_json::from_str(
+            r#"{"input":"hi","instructions":"be terse","max_output_tokens":32,"model":"uor-r4"}"#,
+        )
+        .expect("full SDK responses payload deserializes");
+        assert_eq!(full.instructions.as_deref(), Some("be terse"));
+        assert_eq!(full.max_output_tokens, Some(32));
+    }
+
+    #[test]
+    fn chat_response_carries_the_fields_the_sdk_reads() {
+        // The SDK reads choices[0].message.{role,content}, choices[0].
+        // finish_reason, usage.{prompt,completion,total}_tokens, and id/object.
+        let resp = super::VendorChatCompletionsResponse {
+            id: "chatcmpl-uor-r4-1".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1,
+            model: "uor-r4".to_string(),
+            choices: vec![super::VendorChoice {
+                index: 0,
+                message: super::VendorChatMessage {
+                    role: "assistant".to_string(),
+                    content: "hi".to_string(),
+                },
+                finish_reason: "stop".to_string(),
+            }],
+            usage: super::VendorUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+            system_fingerprint: Some("uor-r4-r4g1".to_string()),
+            uor_audit: None,
+            cascade_trail: serde_json::json!([]),
+        };
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["object"], "chat.completion");
+        assert_eq!(value["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(value["choices"][0]["message"]["content"], "hi");
+        assert_eq!(value["choices"][0]["finish_reason"], "stop");
+        assert_eq!(value["usage"]["total_tokens"], 2);
+    }
+
+    #[test]
+    fn responses_body_carries_the_fields_the_sdk_reads() {
+        // The SDK's `output_text` accessor reads output[].content[].text where
+        // type == output_text; it also reads usage.{input,output,total}_tokens
+        // and status.
+        let body = super::build_responses_body(dummy_generation("hi", 1, 1), "uor-r4", 64);
+        assert_eq!(body["object"], "response");
+        assert_eq!(body["status"], "completed");
+        assert_eq!(body["output"][0]["content"][0]["type"], "output_text");
+        assert_eq!(body["output"][0]["content"][0]["text"], "hi");
+        assert_eq!(body["usage"]["input_tokens"], 4);
+        assert_eq!(body["usage"]["output_tokens"], 1);
+        assert_eq!(body["usage"]["total_tokens"], 5);
+    }
 }


### PR DESCRIPTION
Refs #654; closes #687 (phase F). Builds on phase E (#686, merged). Verifies the pinned wire surfaces against the **official OpenAI SDKs** and documents it.

## Evidence (captured empirically against the real SDKs)
The Python SDK (3.0.0) and JS SDK (7.4.0) send **only the params explicitly passed** — minimal chat = `{model, messages}`, responses = `{model, input}`, a streaming call adds exactly `stream: true`. So every ordinary call lands inside our supported subset and `deny_unknown_fields` never trips on an SDK default. Both SDKs also **parse our chat + responses response shapes** (including the phase-D SSE stream) cleanly, ignoring the R4 audit extras.

**Verdict:** keep `deny_unknown_fields` strict. A 400 happens only when a caller explicitly passes an unsupported param — the intended fail-closed contract. No DTO relaxation.

## Two coverage layers
- **Deterministic CI fixtures** (`src/server.rs`): the exact SDK-emitted request bodies deserialize into our request DTOs, and our response bodies carry the fields the SDKs read (`choices[].message.content`, `finish_reason`, `usage.*`; responses `output[].content[].text`, `usage.*`, `status`). No network or model needed.
- **Runnable end-to-end scripts** (`profiles/openai/smoke_test.py`, `smoke_test.mjs`): drive a live server with the real SDK across all three surfaces (non-stream chat, stream chat, responses). Developer-run (need a compiled model loaded), not CI. Verified functional against a uor-r4-shaped mock.

`profiles/openai/README.md` gains an **SDK compatibility** section: verified SDKs/versions, both layers, run instructions, and the `deny_unknown_fields` rationale.

## Gates
fmt, clippy `-D warnings`, wasm32 lib build, server lib 51 + bin 6 tests, profile-pin 3, claim-wording, plus `py_compile` / `node --check` on the scripts — all green.

Later: G `/v1` control-route split. Deferred: streaming for `/v1/responses`.