### PR TITLE
graph-compiler: make cover.r4g1 emission byte-reproducible (#694)

### DIFF
--- a/crates/uor-r4-graph-cli/tests/gpt2_compile_canary_670.rs
+++ b/crates/uor-r4-graph-cli/tests/gpt2_compile_canary_670.rs
@@ -24,9 +24,9 @@
 //! rows — the source-manifest κ (#597), the geometry projection (#600), and the
 //! learned-absolute attention operator (#602) the GPT-2 oracle declares — with
 //! held-out routing recall measured (Gate C) and the induced cover
-//! deterministic across runs. (The serialized R4G1 embeds a per-run
-//! HashMap-seeded provenance digest, so the *induced structure* — regions and
-//! recall — is the reproducibility invariant, not the raw artifact bytes.)
+//! deterministic across runs — byte-for-byte: since #694 the emission shortlist
+//! is BTreeMap-ordered with a total-order tie-break, so `cover.r4g1` reproduces
+//! bit-identically (no per-run HashMap-seeded ordering reaches the wire).
 //!
 //! This canary is additive: it adds no SmolLM2 path, so SmolLM2 compiles
 //! byte-unchanged.
@@ -268,10 +268,11 @@ fn gpt2_cover_certifies_source_parity_rows() {
     );
 
     // Deterministic induction: a second run over the same compiled teacher
-    // induces the identical cover — same regions and same held-out recall.
-    // (The serialized R4G1 carries a provenance digest seeded per-run by the
-    // std HashMap's random state, so raw artifact bytes are not the invariant;
-    // the induced structure is.)
+    // induces the identical cover, serialized to byte-identical R4G1. Since #694
+    // the emission shortlist is BTreeMap-ordered with a total-order (weight desc,
+    // token asc) tie-break, so no per-run HashMap seed reaches the wire and the
+    // artifact — including its content-addressed section CIDs — reproduces bit
+    // for bit. The report's structure (recall + regions) is checked below too.
     cover_command(&cover_args(
         &compiled,
         &cover_b,
@@ -282,9 +283,8 @@ fn gpt2_cover_certifies_source_parity_rows() {
     .expect("cover induction (second run)");
     let bytes_b = std::fs::read(cover_b.join("cover.r4g1")).expect("read second-run cover.r4g1");
     assert_eq!(
-        bytes_a.len(),
-        bytes_b.len(),
-        "the induced R4G1 has a stable size across runs"
+        bytes_a, bytes_b,
+        "the induced R4G1 is byte-identical across runs (#694)"
     );
     let report_b: serde_json::Value = serde_json::from_slice(
         &std::fs::read(cover_b.join("cover_report.json")).expect("read second cover_report.json"),

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2340,9 +2340,12 @@ pub fn emit_r4g1(
 
     for (index, _) in cover.regions.iter().enumerate() {
         let i = 1 + index;
-        let mut freq: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
-        let mut bigram_freq: std::collections::HashMap<(u32, u32), u32> =
-            std::collections::HashMap::new();
+        // BTreeMaps (not HashMaps): the emission shortlist is serialized to the
+        // wire, so its ordering must be seed-independent. std HashMap iteration
+        // is per-instance random-seeded; BTreeMap iterates in key order, making
+        // the pre-sort candidate order — and thus cover.r4g1 — reproducible (#694).
+        let mut freq: BTreeMap<u32, u32> = BTreeMap::new();
+        let mut bigram_freq: BTreeMap<(u32, u32), u32> = BTreeMap::new();
         for &obs_idx in &cover.members[index] {
             if let Some(obs) = observations.get(obs_idx) {
                 let prev_token = obs.prev;
@@ -2351,8 +2354,7 @@ pub fn emit_r4g1(
                 *bigram_freq.entry((prev_token, next_token)).or_insert(0) += 1;
             }
         }
-        let mut candidate_weights: std::collections::HashMap<u32, u32> =
-            std::collections::HashMap::new();
+        let mut candidate_weights: BTreeMap<u32, u32> = BTreeMap::new();
         for (&next_token, &count) in &freq {
             let mut weight = count * 10;
             for (&(prev, next), &bcount) in &bigram_freq {
@@ -2362,8 +2364,12 @@ pub fn emit_r4g1(
             }
             candidate_weights.insert(next_token, weight);
         }
+        // Total-order shortlist: weight descending, then token id ascending as a
+        // deterministic tie-break. A weight-only key leaves equal-weight tokens
+        // (and the token kept at the 64-candidate truncation boundary) resolved
+        // by the map's iteration order — which must not reach the wire (#694).
         let mut sorted: Vec<_> = candidate_weights.into_iter().collect();
-        sorted.sort_by_key(|&(_, weight)| std::cmp::Reverse(weight));
+        sorted.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         sorted.truncate(64); // max E = 64
 
         let start_in_remainder = (emit.len() - 4) as u32;


### PR DESCRIPTION
Closes #694.

## Problem
`emit_r4g1` built the per-region emission shortlist in `std::collections::HashMap` (`freq`, `bigram_freq`, `candidate_weights`) and sorted it with `sort_by_key(|&(_, w)| Reverse(w))` — a **weight-only** key. HashMap iteration is per-instance random-seeded, and `Reverse(weight)` is not a total order, so equal-weight tokens (and the token kept at the 64-candidate `truncate(64)` boundary) were ordered by per-run HashMap state. That perturbed the EMIT section bytes and flipped the artifact's content-addressed section CID, so `cover.r4g1` was not byte-reproducible across runs — the ~32-byte section-CID diff #694 reported.

The HEAD digests (teacher_cid, corpus_construction_cid, compiler-version) and the induced region structure / held-out recall were already deterministic; only the emission ordering leaked a seed to the wire.

## Fix
- Build `freq` / `bigram_freq` / `candidate_weights` as `BTreeMap` (key-order iteration).
- Sort the shortlist by a **total order**: weight descending, then token id ascending — so both ordering and the truncation boundary are seed-independent.

No behavior change beyond determinism: weights are unchanged (sums are order-independent), and the same top-64 tokens are emitted, now in a stable order.

## Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets`: clean.
- `cargo test -p uor-r4-graph-compiler`: 144 tests pass.
- Real cover pipeline over the pinned GPT-2 snapshot, two runs (incl. a fresh process): `cover.r4g1` reproduces κ `blake3:aa591432…` **bit for bit**.
- The #670 increment-2 canary (`gpt2_cover_certifies_source_parity_rows`) is tightened from a size + structural-determinism check to a **byte-exact** `assert_eq!(bytes_a, bytes_b)`; presence-gated, so it stays a vacuous UNAVAILABLE pass in CI where the snapshot is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)