### PR TITLE
serving/#655-A: matrix-operation census + source-level CI guard

### DIFF
--- a/crates/uor-r4-model-source/tests/matrix_operation_census.rs
+++ b/crates/uor-r4-model-source/tests/matrix_operation_census.rs
@@ -1,0 +1,159 @@
+//! #655 sub-A — matrix-operation census guard.
+//!
+//! The production chain must contain no project-owned conventional library-BLAS
+//! matrix operation outside the single sanctioned teacher site. The teacher's
+//! `cblas_sgemv`/`cblas_sgemm` reach system Accelerate through
+//! `#[link(name = "Accelerate", kind = "framework")]` + `extern "C"` — an FFI
+//! symbol, not a crate dependency — so the crate/manifest audits
+//! (`uor-r4-graph-compiler::dependency_audit`, `uor-r4-proof-model::inference_audit`)
+//! cannot see it. This source scan closes that gap: it fails CI if a
+//! library-BLAS matrix token appears in any production-chain crate `src/`
+//! outside `uor-r4-model-source/src/lib.rs`.
+//!
+//! This is the census baseline (no behavior/CID change). #655-B then replaces
+//! the sanctioned site itself with the pinned `uor-matmul` surface and tightens
+//! this guard to zero library-BLAS anywhere.
+//!
+//! The full classified inventory (including the hand-rolled fallbacks this
+//! mechanical guard does not keyword-match) lives in
+//! `docs/matrix_operation_census.md`.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+
+/// Library-BLAS / external matrix-multiply markers. These name a conventional
+/// matrix backend by symbol or crate; none has a non-matrix meaning, so any
+/// occurrence in production `src/` is a real conventional-GEMM site. Bare
+/// `sgemm`/`sgemv` are intentionally excluded — they appear as backticked words
+/// in doc comments; the `cblas_` FFI prefix is the load-bearing token.
+const BLAS_MATRIX_MARKERS: &[&str] =
+    &["cblas_", "matrixmultiply", "openblas", "dgemm", "intel_mkl"];
+
+/// Files allowed to contain a library-BLAS matrix marker today, by path suffix:
+///
+/// - the teacher (Llama) executor's Accelerate fast path — the one production
+///   *use* of a library-BLAS matrix symbol (#655-B removes it; when it does,
+///   `sanctioned_file_still_owns_blas` forces this allowlist updated);
+/// - the two dependency/manifest audits, which enumerate forbidden BLAS crate
+///   names as denylist *data* so those crates can never enter the tree — the
+///   opposite of performing a matrix operation.
+const SANCTIONED_SUFFIXES: &[&str] = &[
+    "uor-r4-model-source/src/lib.rs",
+    "uor-r4-graph-compiler/src/dependency_audit.rs",
+    "uor-r4-proof-model/src/inference_audit.rs",
+];
+
+/// Workspace root: `CARGO_MANIFEST_DIR` = `<root>/crates/uor-r4-model-source`.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+/// Every production-chain crate `src/` plus the root serving crate's `src/`.
+/// Only `src/` trees are scanned, so this test file (under `tests/`) and its
+/// own marker literals are never self-flagged.
+fn production_src_roots(root: &Path) -> Vec<PathBuf> {
+    let mut roots = vec![root.join("src")];
+    if let Ok(entries) = std::fs::read_dir(root.join("crates")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                roots.push(path.join("src"));
+            }
+        }
+    }
+    roots
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name == "target" || name == ".git" {
+                continue;
+            }
+            rust_sources(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn is_sanctioned(path: &Path) -> bool {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    SANCTIONED_SUFFIXES
+        .iter()
+        .any(|suffix| normalized.ends_with(suffix))
+}
+
+#[test]
+fn no_conventional_blas_matrix_op_outside_the_sanctioned_teacher_site() {
+    let root = workspace_root();
+    let mut files = Vec::new();
+    for r in production_src_roots(&root) {
+        rust_sources(&r, &mut files);
+    }
+    assert!(
+        files.len() > 20,
+        "census scan found only {} files; path resolution is wrong",
+        files.len()
+    );
+
+    let mut leaks: Vec<String> = Vec::new();
+    for file in &files {
+        if is_sanctioned(file) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (lineno, line) in text.lines().enumerate() {
+            for marker in BLAS_MATRIX_MARKERS {
+                if line.contains(marker) {
+                    leaks.push(format!(
+                        "{}:{}: conventional library-BLAS matrix marker `{marker}` — migrate to \
+                         uor-matmul (#655-B) or record + classify it in docs/matrix_operation_census.md",
+                        file.display(),
+                        lineno + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        leaks.is_empty(),
+        "conventional library-BLAS matrix operations leaked into the production chain \
+         ({} occurrences):\n{}",
+        leaks.len(),
+        leaks.join("\n")
+    );
+    eprintln!(
+        "matrix-operation census: {} production source files scanned, 0 unsanctioned library-BLAS matrix ops",
+        files.len()
+    );
+}
+
+/// The sanctioned teacher site is expected to still own the library-BLAS matrix
+/// FFI until #655-B migrates it. If this fails, the allowlist above is stale
+/// (the site moved or was replaced) and must be updated together with the
+/// census doc — a conventional GEMM must never become silently unsanctioned.
+#[test]
+fn sanctioned_file_still_owns_blas() {
+    let root = workspace_root();
+    let lib = root.join("crates/uor-r4-model-source/src/lib.rs");
+    let text = std::fs::read_to_string(&lib).expect("read the teacher executor source");
+    assert!(
+        text.contains("cblas_"),
+        "the sanctioned teacher site {} no longer contains a `cblas_` matrix FFI — update the \
+         census guard allowlist and docs/matrix_operation_census.md (likely #655-B landed)",
+        lib.display()
+    );
+}

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -1,0 +1,82 @@
+# Matrix-operation census (production chain)
+
+Issue #655 sub-A. This is the generated ownership report for every matrix-like
+operation reachable in the production chain
+`uor-r4-model-source → source/graph compiler → certifier → bundle → graph/TLA runtime → API adapters`.
+
+Each site is classified as one of:
+
+- **eliminated-at-compile** — no matrix operation runs in deployed inference;
+  the table-native R4G1/TLA runtime routes over compiled tables under the P-4
+  zero-multiply/divide/float contract.
+- **uor-matmul-owned** — the operation is performed by the pinned
+  `uor-matmul` exact/coded surface (`b13c98449948174f590e337c4dc25dfc394a07d0`).
+- **conventional-to-migrate** — a project-owned conventional BLAS / hand-rolled
+  matrix implementation that must be replaced by `uor-matmul` (or eliminated)
+  under #655-B. No such site may remain reachable in the production chain once B
+  lands.
+- **dev-only-oracle** — a differential-verification oracle that must be
+  structurally unreachable from the release build/serve path.
+
+The CI guard (`crates/uor-r4-model-source/tests/matrix_operation_census.rs`)
+enforces the mechanically-detectable half of this census: no library-BLAS
+matrix FFI/crate (`cblas_*`, `matrixmultiply`, `openblas`, `dgemm`) may appear
+in any production-chain crate `src/` outside the sanctioned teacher site below.
+The crate/manifest audits (`uor-r4-graph-compiler::dependency_audit`,
+`uor-r4-proof-model::inference_audit`) remain the guard for forbidden BLAS/GPU
+*crate dependencies*; this census closes the FFI-symbol gap those cannot see.
+
+## Deployed inference — eliminated-at-compile
+
+| Component | Matrix operation | Classification |
+|---|---|---|
+| `uor-r4-graph-runtime` (R4G1 engine) | none — byte-oriented table lookups, typed D4 policy, bounded witness replay; P-4 forbids multiply/divide/remainder/float in the runtime kernel | eliminated-at-compile |
+| `uor-r4-graph-format` | none — container parse/verify only | eliminated-at-compile |
+| `uor-r4-api` (`R4Engine`) | none — adapts the table-native runtime to the request/response contract | eliminated-at-compile |
+
+Deployed inference performs no matrix multiplication. This is the property
+#655's P-4 clause protects and does not need migration.
+
+## Compile / observe teacher — conventional-to-migrate (targets of #655-B)
+
+The teacher/source executors run at observe/compile time (teacher-forcing to
+generate the corpus and oracle logits). They are **not** deployed inference, but
+they are inside the production chain (`model-source → compiler`), so their
+conventional arithmetic is a migration target for #655-B.
+
+| Site | Operation | Backend today | Classification |
+|---|---|---|---|
+| `uor-r4-model-source/src/lib.rs` `matmul` | matrix–vector (`W·x`) | hand-rolled f32 loop | conventional-to-migrate |
+| `uor-r4-model-source/src/lib.rs` `matmul_fast` (macOS) | matrix–vector | Accelerate `cblas_sgemv` FFI | conventional-to-migrate |
+| `uor-r4-model-source/src/lib.rs` `matmul_fast` (non-macOS) | matrix–vector | hand-rolled (`dot_fast`) | conventional-to-migrate |
+| `uor-r4-model-source/src/lib.rs` `matmul_batched` (macOS) | matrix–matrix (`X·Wᵀ`) | Accelerate `cblas_sgemm` FFI | conventional-to-migrate |
+| `uor-r4-model-source/src/lib.rs` `matmul_batched` (non-macOS) | matrix–matrix | hand-rolled (`dot_fast` reuse) | conventional-to-migrate |
+| `uor-r4-model-source/src/lib.rs` `dot`/`dot_fast` | dot product | hand-rolled f32 | conventional-to-migrate |
+| `uor-r4-model-source/src/gpt2.rs` GPT-2 executor | Conv1D `x@W`, attention accumulation (reuses `matmul_batched`) | hand-rolled + shared matmul | conventional-to-migrate |
+
+The library-BLAS FFI declaration lives once, in
+`uor-r4-model-source/src/lib.rs` (`#[link(name = "Accelerate", kind = "framework")]`
+→ `cblas_sgemv`, `cblas_sgemm`). That file is the **only** sanctioned location
+for a `cblas_*` symbol; the CI guard fails if one appears anywhere else in the
+production chain.
+
+## Out of census scope
+
+| Site | Why |
+|---|---|
+| `uor-r4-core/src/transformerless/compiler.rs:60` `vvexpf` (Accelerate vForce) | vector `exp`, not a matrix operation. Teacher-side softmax backend, disabled under canonical math. If a later issue wants full Accelerate removal it is tracked there, not here. |
+
+## Dev-only oracles
+
+`uor-matmul-core` is currently pinned as a **dev-dependency** parity oracle in
+`crates/uor-r4-graph-cli/Cargo.toml` (`rev = b13c9844`). #655-B promotes it to
+the production arithmetic owner and makes any dev-only comparison oracle
+structurally unreachable from release compilation/serving.
+
+## Status
+
+- #655-A (this): census + guard landed. No behavior or CID change.
+- #655-B: replace every `conventional-to-migrate` site with the pinned
+  `uor-matmul` exact/coded surface (or eliminate it), delete duplicate local
+  arithmetic, and extend the P-4 audit to the pinned dependency source. That is
+  the first CID-changing step (new artifact era + κ re-pin, pre-approved).


### PR DESCRIPTION
Closes #698. First sub-issue of #655 (serving epic). No behavior or CID change.

## What
- **`docs/matrix_operation_census.md`** — the generated ownership report for every matrix-like operation in the production `model-source → compiler → certifier → bundle → runtime → API` chain, classified `eliminated-at-compile` / `uor-matmul-owned` / `conventional-to-migrate` / `dev-only-oracle`. Deployed R4G1/TLA inference is eliminated-at-compile (P-4 zero-multiply/float); the `model-source` teacher GEMM sites (`cblas_sgemv`/`cblas_sgemm` FFI + hand-rolled fallbacks) are the `conventional-to-migrate` targets for #655-B.
- **`crates/uor-r4-model-source/tests/matrix_operation_census.rs`** — a source-level CI guard.

## Why a source scan
The teacher reaches system Accelerate through `#[link(name = "Accelerate", kind = "framework")]` + `extern "C"` — an FFI **symbol**, not a crate dependency — so `dependency_audit` (Cargo.lock crates) and `inference_audit` (manifest deps) structurally cannot see it. The scan closes that gap: it fails CI if a library-BLAS matrix marker (`cblas_*`, `matrixmultiply`, `openblas`, `dgemm`, `intel_mkl`) appears in any production-chain crate `src/` outside the one sanctioned teacher site. The two audit files are allowlisted — they enumerate forbidden BLAS crate names as **denylist data**, the opposite of a matrix op. A second guard asserts the sanctioned site still owns the FFI, so when #655-B removes it the allowlist + census doc are forced to update in lockstep.

## Verification
- Scan passes: 155 production `src/` files, 0 unsanctioned library-BLAS matrix ops.
- Positive control: a planted `cblas_` in `uor-r4-graph-runtime/src/lib.rs` fails the guard with a `file:line` message (reverted).
- `cargo fmt --check`, `cargo clippy -p uor-r4-model-source --all-targets`: clean.

## Scope
No matrix op is replaced and no uor-matmul is wired here — that is #655-B (the first CID-changing step). Hand-rolled fallbacks are inventoried in the doc; the mechanical guard covers the additively-detectable library-BLAS class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)