### PR TITLE
serving/#655-B2: migrate Llama teacher weight matmuls to uor-matmul exact GEMM

### DIFF
--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -188,339 +188,54 @@ pub(crate) fn softmax_with_mode(x: &mut [f32], canonical: bool) {
     }
 }
 
-/// W (d,n) @ x (n,) -> xout (d,). The exact path preserves the original C
-/// reduction order for certificate reproduction. Hugging Face compilation
-/// may select the optimized CPU path because those source logits are teacher
-/// data rather than part of the pinned legacy proof.
-///
-/// Note: a row-parallel (rayon fork-join) variant of this exact path was
-/// measured 2026-07-31 and REVERTED — per-matmul fork-join costs ~1.5 ms of
-/// worker-scheduling latency on a load-average->100 development machine,
-/// ~10× slower end-to-end than the serial loop below (recorded negative
-/// result, issue #310). Parallelism in corpus generation must be
-/// story-level (a new corpus era) or not at all.
-fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, fast: bool) {
-    if fast {
-        return matmul_fast(xout, x, w, n);
-    }
+/// W (d,n) @ x (n,) -> xout (d,), computed by the pinned `uor-matmul` exact
+/// GEMM (#655-B2). `gemm_float` accumulates every product into a complete
+/// accumulator and rounds once, so the result is the correctly-rounded exact
+/// dot product — byte-identical across targets (no per-machine Accelerate
+/// variance), which is what teacher-side κ reproduction needs. The former
+/// `fast` (Accelerate BLAS `sgemv`) / hand-rolled canonical paths are gone;
+/// `_fast` is retained in the signature only so callers need not change.
+fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, _fast: bool) {
+    // xout[d] = W[d, n] · x[n]  ==>  C[d, 1] = A[d, n] · B[n, 1].
     let d = xout.len();
-    // Four rows in flight hide FP add latency while retaining each row's
-    // strictly sequential accumulation chain and therefore its exact bits.
-    let mut i = 0usize;
-    while i + 4 <= d {
-        let r0 = &w[i * n..i * n + n];
-        let r1 = &w[(i + 1) * n..(i + 1) * n + n];
-        let r2 = &w[(i + 2) * n..(i + 2) * n + n];
-        let r3 = &w[(i + 3) * n..(i + 3) * n + n];
-        let (mut v0, mut v1, mut v2, mut v3) = (0.0f32, 0.0f32, 0.0f32, 0.0f32);
-        for j in 0..n {
-            let xj = x[j];
-            v0 += r0[j] * xj;
-            v1 += r1[j] * xj;
-            v2 += r2[j] * xj;
-            v3 += r3[j] * xj;
-        }
-        xout[i] = v0;
-        xout[i + 1] = v1;
-        xout[i + 2] = v2;
-        xout[i + 3] = v3;
-        i += 4;
-    }
-    while i < d {
-        let mut value = 0.0f32;
-        let row = &w[i * n..i * n + n];
-        for j in 0..n {
-            value += row[j] * x[j];
-        }
-        xout[i] = value;
-        i += 1;
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn matmul_fast(xout: &mut [f32], x: &[f32], w: &[f32], n: usize) {
-    const CBLAS_ROW_MAJOR: i32 = 101;
-    const CBLAS_NO_TRANSPOSE: i32 = 111;
-    debug_assert!(w.len() >= xout.len() * n);
-    // SAFETY: all pointers refer to initialized, non-overlapping f32 slices;
-    // their dimensions and strides describe W[xout.len(), n] and x[n].
-    unsafe {
-        cblas_sgemv(
-            CBLAS_ROW_MAJOR,
-            CBLAS_NO_TRANSPOSE,
-            i32::try_from(xout.len()).expect("teacher output dimension exceeds CBLAS i32"),
-            i32::try_from(n).expect("teacher input dimension exceeds CBLAS i32"),
-            1.0,
-            w.as_ptr(),
-            i32::try_from(n).expect("teacher stride exceeds CBLAS i32"),
-            x.as_ptr(),
-            1,
-            0.0,
-            xout.as_mut_ptr(),
-            1,
-        );
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[link(name = "Accelerate", kind = "framework")]
-unsafe extern "C" {
-    fn cblas_sgemv(
-        order: i32,
-        transpose: i32,
-        rows: i32,
-        columns: i32,
-        alpha: f32,
-        matrix: *const f32,
-        leading_dimension: i32,
-        vector: *const f32,
-        vector_stride: i32,
-        beta: f32,
-        output: *mut f32,
-        output_stride: i32,
-    );
-
-    fn cblas_sgemm(
-        order: i32,
-        transpose_a: i32,
-        transpose_b: i32,
-        m: i32,
-        n: i32,
-        k: i32,
-        alpha: f32,
-        a: *const f32,
-        lda: i32,
-        b: *const f32,
-        ldb: i32,
-        beta: f32,
-        c: *mut f32,
-        ldc: i32,
-    );
-}
-
-#[cfg(not(target_os = "macos"))]
-fn matmul_fast(xout: &mut [f32], x: &[f32], w: &[f32], n: usize) {
-    debug_assert_eq!(x.len(), n);
-    debug_assert!(w.len() >= xout.len() * n);
-    for (output, row) in xout.iter_mut().zip(w.chunks_exact(n)) {
-        *output = dot_fast(row, x);
-    }
+    let mut pa = vec![uor_matmul::PackedCode::default(); n];
+    let mut pb = vec![uor_matmul::PackedCode::default(); n];
+    uor_matmul::slice::gemm_float(d, n, 1, w, x, xout, &mut pa, &mut pb)
+        .expect("teacher matrix-vector product is total over finite f32 operands");
 }
 
 /// Batched matmul: `batch` input vectors of length `n` through weight
-/// `W[rows, n]` → `batch` output vectors of length `rows`. `x` is the `batch`
-/// input vectors laid out contiguously (`batch * n`); `xout` is the `batch`
-/// output vectors (`batch * rows`), same sequence-major layout.
-///
-/// This is the memory-amortized core of batched teacher inference: the serial
-/// [`matmul`] re-reads the entire weight `W` for every single token, which
-/// makes autoregressive inference of a large teacher memory-bandwidth bound.
-/// Here each weight is read once and reused across all `batch` inputs, so `B`
-/// tokens cost one weight sweep instead of `B` — turning the per-token
-/// matrix-vector products into one matrix-matrix product.
-///
-/// Off macOS this reuses [`dot_fast`] per (row, input) with each weight row
-/// held hot across the batch, so it is bit-identical to `batch` separate
-/// [`matmul`]`(.., fast = true)` calls. On macOS it dispatches to Accelerate's
-/// `cblas_sgemm`; like the serial `cblas_sgemv` fast path it is teacher data,
-/// not part of the pinned legacy proof, and is deterministic per machine.
-#[cfg(not(target_os = "macos"))]
+/// `W[rows, n]` → `batch` output vectors of length `rows`, laid out
+/// sequence-major (`x` is `batch * n`, `xout` is `batch * rows`). Computes
+/// `C[batch, rows] = X[batch, n] · W[rows, n]ᵀ` with the pinned `uor-matmul`
+/// exact GEMM (#655-B2), replacing the former Accelerate BLAS `sgemm` /
+/// hand-rolled `dot_fast` reuse. Byte-identical across targets, so the batched
+/// teacher path reproduces the serial [`matmul`] exactly on every machine.
 fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
     debug_assert!(batch > 0);
     debug_assert_eq!(xout.len() % batch, 0);
     let rows = xout.len() / batch;
     debug_assert!(w.len() >= rows * n);
     debug_assert_eq!(x.len(), batch * n);
-    for row in 0..rows {
-        let wr = &w[row * n..row * n + n];
-        for bi in 0..batch {
-            let xi = &x[bi * n..bi * n + n];
-            xout[bi * rows + row] = dot_fast(wr, xi);
+    // gemm_float is C = A·B (no transpose), so transpose W[rows, n] → Wt[n, rows]
+    // and compute X[batch, n] · Wt[n, rows] into the sequence-major `xout`.
+    let mut wt = vec![0f32; n * rows];
+    for r in 0..rows {
+        for j in 0..n {
+            wt[j * rows + r] = w[r * n + j];
         }
     }
+    let mut pa = vec![uor_matmul::PackedCode::default(); n];
+    let mut pb = vec![uor_matmul::PackedCode::default(); n * rows];
+    uor_matmul::slice::gemm_float(batch, n, rows, x, &wt, xout, &mut pa, &mut pb)
+        .expect("batched teacher product is total over finite f32 operands");
 }
 
-#[cfg(target_os = "macos")]
-fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
-    debug_assert!(batch > 0);
-    debug_assert_eq!(xout.len() % batch, 0);
-    let rows = xout.len() / batch;
-    debug_assert!(w.len() >= rows * n);
-    debug_assert_eq!(x.len(), batch * n);
-    const CBLAS_ROW_MAJOR: i32 = 101;
-    const CBLAS_NO_TRANSPOSE: i32 = 111;
-    const CBLAS_TRANSPOSE: i32 = 112;
-    // C[batch, rows] = X[batch, n] · W[rows, n]^T
-    // SAFETY: all pointers refer to initialized, non-overlapping f32 slices
-    // whose dimensions/strides describe X[batch, n], W[rows, n], C[batch, rows].
-    unsafe {
-        cblas_sgemm(
-            CBLAS_ROW_MAJOR,
-            CBLAS_NO_TRANSPOSE,
-            CBLAS_TRANSPOSE,
-            i32::try_from(batch).expect("teacher batch exceeds CBLAS i32"),
-            i32::try_from(rows).expect("teacher output dimension exceeds CBLAS i32"),
-            i32::try_from(n).expect("teacher input dimension exceeds CBLAS i32"),
-            1.0,
-            x.as_ptr(),
-            i32::try_from(n).expect("teacher input stride exceeds CBLAS i32"),
-            w.as_ptr(),
-            i32::try_from(n).expect("teacher weight stride exceeds CBLAS i32"),
-            0.0,
-            xout.as_mut_ptr(),
-            i32::try_from(rows).expect("teacher output stride exceeds CBLAS i32"),
-        );
-    }
-}
-
-#[cfg(all(not(target_os = "macos"), target_arch = "aarch64"))]
-fn dot_fast(weights: &[f32], values: &[f32]) -> f32 {
-    // NEON is part of the AArch64 architecture baseline.
-    // SAFETY: the helper only performs unaligned loads within these equal-size
-    // slices, and its required target feature is always present on AArch64.
-    unsafe { dot_neon(weights, values) }
-}
-
-#[cfg(all(target_arch = "aarch64", any(not(target_os = "macos"), test)))]
-#[target_feature(enable = "neon")]
-unsafe fn dot_neon(weights: &[f32], values: &[f32]) -> f32 {
-    use core::arch::aarch64::{vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32, vld1q_f32};
-
-    debug_assert_eq!(weights.len(), values.len());
-    let mut sums = [vdupq_n_f32(0.0); 4];
-    let mut index = 0usize;
-    while index + 16 <= weights.len() {
-        for (lane, sum) in sums.iter_mut().enumerate() {
-            let offset = index + lane * 4;
-            // SAFETY: the loop condition guarantees four readable values from
-            // each pointer, and NEON's vld1q instruction permits unaligned data.
-            let (weight, value) = unsafe {
-                (
-                    vld1q_f32(weights.as_ptr().add(offset)),
-                    vld1q_f32(values.as_ptr().add(offset)),
-                )
-            };
-            *sum = vfmaq_f32(*sum, weight, value);
-        }
-        index += 16;
-    }
-    let combined = vaddq_f32(vaddq_f32(sums[0], sums[1]), vaddq_f32(sums[2], sums[3]));
-    let mut result = vaddvq_f32(combined);
-    for (&weight, &value) in weights[index..].iter().zip(&values[index..]) {
-        result += weight * value;
-    }
-    result
-}
-
-#[cfg(all(not(target_os = "macos"), target_arch = "x86_64"))]
-fn dot_fast(weights: &[f32], values: &[f32]) -> f32 {
-    if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
-        // SAFETY: runtime detection above establishes both target features;
-        // the helper bounds every unaligned load to the input slices.
-        unsafe { dot_avx2_fma(weights, values) }
-    } else {
-        dot_portable(weights, values)
-    }
-}
-
-#[cfg(all(not(target_os = "macos"), target_arch = "x86_64"))]
-#[target_feature(enable = "avx2,fma")]
-unsafe fn dot_avx2_fma(weights: &[f32], values: &[f32]) -> f32 {
-    use core::arch::x86_64::{
-        _mm256_add_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_setzero_ps, _mm256_storeu_ps,
-    };
-
-    debug_assert_eq!(weights.len(), values.len());
-    let mut sums = [_mm256_setzero_ps(); 4];
-    let mut index = 0usize;
-    while index + 32 <= weights.len() {
-        for (lane, sum) in sums.iter_mut().enumerate() {
-            let offset = index + lane * 8;
-            // SAFETY: the loop condition guarantees eight readable values
-            // from each pointer; loadu explicitly supports unaligned data.
-            let (weight, value) = unsafe {
-                (
-                    _mm256_loadu_ps(weights.as_ptr().add(offset)),
-                    _mm256_loadu_ps(values.as_ptr().add(offset)),
-                )
-            };
-            *sum = _mm256_fmadd_ps(weight, value, *sum);
-        }
-        index += 32;
-    }
-    let combined = _mm256_add_ps(
-        _mm256_add_ps(sums[0], sums[1]),
-        _mm256_add_ps(sums[2], sums[3]),
-    );
-    let mut lanes = [0.0f32; 8];
-    // SAFETY: `lanes` has room for all eight values written by the intrinsic.
-    unsafe { _mm256_storeu_ps(lanes.as_mut_ptr(), combined) };
-    let mut result = lanes.into_iter().sum::<f32>();
-    for (&weight, &value) in weights[index..].iter().zip(&values[index..]) {
-        result += weight * value;
-    }
-    result
-}
-
-#[cfg(all(
-    not(target_os = "macos"),
-    not(any(target_arch = "aarch64", target_arch = "x86_64"))
-))]
-fn dot_fast(weights: &[f32], values: &[f32]) -> f32 {
-    dot_portable(weights, values)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn dot_portable(weights: &[f32], values: &[f32]) -> f32 {
-    debug_assert_eq!(weights.len(), values.len());
-    let mut partial = [0.0f32; 8];
-    let mut weight_chunks = weights.chunks_exact(8);
-    let mut input_chunks = values.chunks_exact(8);
-    for (weight_chunk, value_chunk) in weight_chunks.by_ref().zip(input_chunks.by_ref()) {
-        for lane in 0..8 {
-            partial[lane] += weight_chunk[lane] * value_chunk[lane];
-        }
-    }
-    let mut result = partial.into_iter().sum::<f32>();
-    for (&weight, &value) in weight_chunks
-        .remainder()
-        .iter()
-        .zip(input_chunks.remainder())
-    {
-        result += weight * value;
-    }
-    result
-}
-
-#[allow(dead_code)]
-#[cfg(target_os = "macos")]
+/// The teacher's matrix-operation backend, for the "teacher model ready"
+/// diagnostic. Since #655-B2 every teacher weight matmul is the pinned,
+/// portable `uor-matmul` exact GEMM — no per-machine SIMD/Accelerate path.
 fn fast_matmul_backend() -> &'static str {
-    "Apple Accelerate CPU SIMD"
-}
-
-#[allow(dead_code)]
-#[cfg(all(not(target_os = "macos"), target_arch = "aarch64"))]
-fn fast_matmul_backend() -> &'static str {
-    "AArch64 NEON CPU"
-}
-
-#[allow(dead_code)]
-#[cfg(all(not(target_os = "macos"), target_arch = "x86_64"))]
-fn fast_matmul_backend() -> &'static str {
-    if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
-        "x86-64 AVX2/FMA CPU"
-    } else {
-        "portable CPU"
-    }
-}
-
-#[allow(dead_code)]
-#[cfg(all(
-    not(target_os = "macos"),
-    not(any(target_arch = "aarch64", target_arch = "x86_64"))
-))]
-fn fast_matmul_backend() -> &'static str {
-    "portable CPU"
+    "uor-matmul exact GEMM"
 }
 
 impl Llama {

--- a/crates/uor-r4-model-source/tests/matrix_operation_census.rs
+++ b/crates/uor-r4-model-source/tests/matrix_operation_census.rs
@@ -1,21 +1,22 @@
-//! #655 sub-A — matrix-operation census guard.
+//! #655 — matrix-operation census guard.
 //!
 //! The production chain must contain no project-owned conventional library-BLAS
-//! matrix operation outside the single sanctioned teacher site. The teacher's
-//! `cblas_sgemv`/`cblas_sgemm` reach system Accelerate through
-//! `#[link(name = "Accelerate", kind = "framework")]` + `extern "C"` — an FFI
-//! symbol, not a crate dependency — so the crate/manifest audits
+//! matrix operation. Crate/manifest audits
 //! (`uor-r4-graph-compiler::dependency_audit`, `uor-r4-proof-model::inference_audit`)
-//! cannot see it. This source scan closes that gap: it fails CI if a
-//! library-BLAS matrix token appears in any production-chain crate `src/`
-//! outside `uor-r4-model-source/src/lib.rs`.
+//! catch forbidden BLAS/GPU *crate dependencies*, but a `cblas_*` reached through
+//! `#[link(name = "Accelerate")]` + `extern "C"` is an FFI *symbol*, not a crate
+//! dependency, so those audits cannot see it. This source scan closes that gap:
+//! it fails CI if a library-BLAS matrix token appears in any production-chain
+//! crate `src/` (only the two audit files, which list such names as denylist
+//! data, are exempt).
 //!
-//! This is the census baseline (no behavior/CID change). #655-B then replaces
-//! the sanctioned site itself with the pinned `uor-matmul` surface and tightens
-//! this guard to zero library-BLAS anywhere.
+//! Since #655-B2 the teacher's `cblas_sgemv`/`cblas_sgemm` are gone — its weight
+//! matmuls are the pinned `uor-matmul` exact GEMM — so the guard now enforces
+//! zero library-BLAS use anywhere in the production chain.
 //!
-//! The full classified inventory (including the hand-rolled fallbacks this
-//! mechanical guard does not keyword-match) lives in
+//! The full classified inventory (including the remaining hand-rolled GPT-2
+//! `conv1d` / attention accumulations this mechanical guard does not
+//! keyword-match, tracked for a follow-up) lives in
 //! `docs/matrix_operation_census.md`.
 #![cfg(not(target_arch = "wasm32"))]
 
@@ -29,16 +30,13 @@ use std::path::{Path, PathBuf};
 const BLAS_MATRIX_MARKERS: &[&str] =
     &["cblas_", "matrixmultiply", "openblas", "dgemm", "intel_mkl"];
 
-/// Files allowed to contain a library-BLAS matrix marker today, by path suffix:
-///
-/// - the teacher (Llama) executor's Accelerate fast path — the one production
-///   *use* of a library-BLAS matrix symbol (#655-B removes it; when it does,
-///   `sanctioned_file_still_owns_blas` forces this allowlist updated);
-/// - the two dependency/manifest audits, which enumerate forbidden BLAS crate
-///   names as denylist *data* so those crates can never enter the tree — the
-///   opposite of performing a matrix operation.
+/// Files allowed to contain a library-BLAS matrix marker today, by path suffix.
+/// Since #655-B2 the teacher's Accelerate `cblas_*` FFI is gone — every teacher
+/// weight matmul is the pinned `uor-matmul` exact GEMM — so no production *use*
+/// site remains sanctioned. Only the two dependency/manifest audits are listed:
+/// they enumerate forbidden BLAS crate names as denylist *data* so those crates
+/// can never enter the tree — the opposite of performing a matrix operation.
 const SANCTIONED_SUFFIXES: &[&str] = &[
-    "uor-r4-model-source/src/lib.rs",
     "uor-r4-graph-compiler/src/dependency_audit.rs",
     "uor-r4-proof-model/src/inference_audit.rs",
 ];
@@ -141,19 +139,20 @@ fn no_conventional_blas_matrix_op_outside_the_sanctioned_teacher_site() {
     );
 }
 
-/// The sanctioned teacher site is expected to still own the library-BLAS matrix
-/// FFI until #655-B migrates it. If this fails, the allowlist above is stale
-/// (the site moved or was replaced) and must be updated together with the
-/// census doc — a conventional GEMM must never become silently unsanctioned.
+/// Since #655-B2, the teacher executor must own NO library-BLAS matrix FFI: its
+/// weight matmuls are the pinned `uor-matmul` exact GEMM. If a `cblas_*` symbol
+/// reappears here it is a regression to a conventional matrix backend, which the
+/// main scan above would also catch (the file is no longer sanctioned) — this
+/// asserts it directly at the teacher site for a clearer failure.
 #[test]
-fn sanctioned_file_still_owns_blas() {
+fn teacher_site_owns_no_blas_matrix_ffi() {
     let root = workspace_root();
     let lib = root.join("crates/uor-r4-model-source/src/lib.rs");
     let text = std::fs::read_to_string(&lib).expect("read the teacher executor source");
     assert!(
-        text.contains("cblas_"),
-        "the sanctioned teacher site {} no longer contains a `cblas_` matrix FFI — update the \
-         census guard allowlist and docs/matrix_operation_census.md (likely #655-B landed)",
+        !text.contains("cblas_"),
+        "the teacher site {} reintroduced a `cblas_` matrix FFI — teacher matmuls must stay \
+         uor-matmul-owned (#655-B2)",
         lib.display()
     );
 }

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -37,28 +37,53 @@ The crate/manifest audits (`uor-r4-graph-compiler::dependency_audit`,
 Deployed inference performs no matrix multiplication. This is the property
 #655's P-4 clause protects and does not need migration.
 
-## Compile / observe teacher — conventional-to-migrate (targets of #655-B)
+## Compile / observe teacher
 
 The teacher/source executors run at observe/compile time (teacher-forcing to
 generate the corpus and oracle logits). They are **not** deployed inference, but
 they are inside the production chain (`model-source → compiler`), so their
 conventional arithmetic is a migration target for #655-B.
 
+### uor-matmul-owned (migrated by #655-B2)
+
+The shared Llama teacher **weight matmuls** now call the pinned `uor-matmul`
+exact GEMM (`uor_matmul::slice::gemm_float`). The Accelerate `cblas_sgemv` /
+`cblas_sgemm` FFI and all hand-rolled SIMD dot helpers are removed. GPT-2's
+tied lm-head reuses `matmul_batched`, so it is migrated too. The result is
+correctly-rounded exact and byte-identical across targets (no per-machine
+Accelerate variance) — a determinism improvement for teacher-side κ.
+
+| Site | Operation | Backend | Classification |
+|---|---|---|---|
+| `uor-r4-model-source/src/lib.rs` `matmul` | matrix–vector (`W·x`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
+| `uor-r4-model-source/src/lib.rs` `matmul_batched` | matrix–matrix (`X·Wᵀ`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
+
+No `cblas_*` symbol remains anywhere in the production chain; the CI guard now
+enforces zero library-BLAS use (only the two dependency-audit files, which list
+BLAS crate names as denylist data, are exempt).
+
+### conventional-to-migrate (remaining — #655-B3)
+
+GPT-2 keeps its own hand-rolled f32 arithmetic, a separate follow-up:
+
 | Site | Operation | Backend today | Classification |
 |---|---|---|---|
-| `uor-r4-model-source/src/lib.rs` `matmul` | matrix–vector (`W·x`) | hand-rolled f32 loop | conventional-to-migrate |
-| `uor-r4-model-source/src/lib.rs` `matmul_fast` (macOS) | matrix–vector | Accelerate `cblas_sgemv` FFI | conventional-to-migrate |
-| `uor-r4-model-source/src/lib.rs` `matmul_fast` (non-macOS) | matrix–vector | hand-rolled (`dot_fast`) | conventional-to-migrate |
-| `uor-r4-model-source/src/lib.rs` `matmul_batched` (macOS) | matrix–matrix (`X·Wᵀ`) | Accelerate `cblas_sgemm` FFI | conventional-to-migrate |
-| `uor-r4-model-source/src/lib.rs` `matmul_batched` (non-macOS) | matrix–matrix | hand-rolled (`dot_fast` reuse) | conventional-to-migrate |
-| `uor-r4-model-source/src/lib.rs` `dot`/`dot_fast` | dot product | hand-rolled f32 | conventional-to-migrate |
-| `uor-r4-model-source/src/gpt2.rs` GPT-2 executor | Conv1D `x@W`, attention accumulation (reuses `matmul_batched`) | hand-rolled + shared matmul | conventional-to-migrate |
+| `uor-r4-model-source/src/gpt2.rs` `conv1d` / `conv1d_batched` | Conv1D `x@W` | hand-rolled f32 | conventional-to-migrate |
+| `uor-r4-model-source/src/{lib.rs,gpt2.rs}` attention scoring | per-head `Q·K` / `·V` accumulation | hand-rolled f32 | conventional-to-migrate |
 
-The library-BLAS FFI declaration lives once, in
-`uor-r4-model-source/src/lib.rs` (`#[link(name = "Accelerate", kind = "framework")]`
-→ `cblas_sgemv`, `cblas_sgemm`). That file is the **only** sanctioned location
-for a `cblas_*` symbol; the CI guard fails if one appears anywhere else in the
-production chain.
+These are not library-BLAS (no `cblas_*`), so the mechanical guard does not flag
+them; they are tracked here for #655-B3.
+
+## Teacher-arithmetic era (#655-B2)
+
+Switching the teacher weight matmuls from Accelerate/hand-rolled f32 to the exact
+`uor-matmul` GEMM changes teacher output bytes, so compiled artifacts produced
+after B2 have different CIDs than pre-B2 ones. This is recorded by the teacher's
+own κ (blake3 over teacher output), which changes accordingly, and surfaced in
+the "teacher model ready" diagnostic (`matmul=uor-matmul exact GEMM`). No test
+pins a pre-B2 teacher-derived κ as a constant (verified across the full suite),
+so no fixture re-pin is required; post-B2 CIDs are a new teacher-arithmetic era
+and are never retroactively assigned to pre-B2 artifacts.
 
 ## Out of census scope
 
@@ -66,17 +91,24 @@ production chain.
 |---|---|
 | `uor-r4-core/src/transformerless/compiler.rs:60` `vvexpf` (Accelerate vForce) | vector `exp`, not a matrix operation. Teacher-side softmax backend, disabled under canonical math. If a later issue wants full Accelerate removal it is tracked there, not here. |
 
-## Dev-only oracles
+## uor-matmul as a production dependency
 
-`uor-matmul-core` is currently pinned as a **dev-dependency** parity oracle in
-`crates/uor-r4-graph-cli/Cargo.toml` (`rev = b13c9844`). #655-B promotes it to
-the production arithmetic owner and makes any dev-only comparison oracle
-structurally unreachable from release compilation/serving.
+`uor-matmul` (`rev = b13c9844`) is a **production dependency** of
+`uor-r4-model-source` (promoted from the dev-only parity pin in
+`crates/uor-r4-graph-cli`, #622 → #655-B1). It is `no_std`, `forbid(unsafe)`,
+zero-heap. It enters only the **compile-time teacher**, not the deployed R4G1
+runtime kernel, so it adds nothing to the P-4 deployed-inference audit surface;
+the crate-dependency audits confirm it pulls in no BLAS/GPU crate.
 
 ## Status
 
-- #655-A (this): census + guard landed. No behavior or CID change.
-- #655-B: replace every `conventional-to-migrate` site with the pinned
-  `uor-matmul` exact/coded surface (or eliminate it), delete duplicate local
-  arithmetic, and extend the P-4 audit to the pinned dependency source. That is
-  the first CID-changing step (new artifact era + κ re-pin, pre-approved).
+- #655-A: census + guard landed (#699). No behavior/CID change.
+- #655-B1: `uor-matmul` promoted to production dep + exact-matmul parity harness
+  (#701). No behavior/CID change.
+- #655-B2 (this): Llama teacher weight matmuls (`matmul`, `matmul_batched`;
+  GPT-2 lm-head reuse included) migrated to `uor_matmul::slice::gemm_float`;
+  `cblas_*` FFI + SIMD dot helpers removed; census guard tightened to zero
+  library-BLAS. Teacher-arithmetic era change (see above); no fixture re-pin
+  required.
+- #655-B3: migrate GPT-2 `conv1d` / `conv1d_batched` and the attention-scoring
+  accumulations (`Q·K` / `·V`) — the remaining hand-rolled f32 matrix ops.


### PR DESCRIPTION
Closes #702. Second half of #655 sub-B — the arithmetic migration, scoped by the #700/#701 dry-run to exactly what was proven safe. **Net −254 lines.**

## What
- `matmul` (matrix–vector) and `matmul_batched` (matrix–matrix) in the shared Llama teacher now call `uor_matmul::slice::gemm_float` (pinned exact GEMM). GPT-2's tied lm-head reuses `matmul_batched`, so it's migrated too.
- Removed: the Accelerate `#[link]` FFI (`cblas_sgemv`/`cblas_sgemm`), both `matmul_fast` variants, the hand-rolled canonical loop, and every SIMD dot helper. `fast_matmul_backend()` collapses to one returning `"uor-matmul exact GEMM"`.
- Census guard tightened to zero library-BLAS anywhere (teacher site de-sanctioned + asserted `cblas_*`-free). Census doc updated.

## Why it's safe — the #700 dry-run
`gemm_float` is correctly-rounded exact and **byte-identical across targets** (a determinism improvement — the teacher is now macOS == Linux/CI reproducible, not per-machine). With the switch in place the full κ-sensitive suite passes: model-source (incl. 27 numpy-parity), graph-compiler observe/induction/reproducibility/route_fit, graph-certify (29), and serving **BDD 100 scenarios / 333 steps** (incl. teacher-label replay + the P-4 census). Two full GPT-2 124M compiles are **byte-identical**. Compile cost ~+37% model-source, ~100s/124M compile — modest.

**No fixture re-pin required:** no test pins a pre-B2 teacher-derived κ as a constant. Post-B2 CIDs are a new teacher-arithmetic era, recorded by the teacher's own κ and the "teacher model ready" diagnostic, never retroactively assigned to pre-B2 artifacts (pre-approved).

## P-4
`uor-matmul` enters only the compile-time teacher, not the deployed R4G1 runtime kernel, so the P-4 deployed-inference audit surface is unchanged; dependency audits confirm no BLAS/GPU crate enters the tree.

## Verified
macOS: builds, census guard + numpy parity pass (Accelerate removal confirmed). Linux: full model-source suite, downstream κ suites, 124M canary — all green. `fmt` + `clippy --workspace --all-targets` clean.

## Follows: #655-B3
GPT-2 `conv1d`/`conv1d_batched` + attention scoring (`Q·K` / `·V`) — the remaining hand-rolled f32 matrix ops (not library-BLAS; tracked in the census doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)