### PR TITLE
serving/#639-1: pin T5 SentencePiece Unigram source descriptor + κ-verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ manifold_cache_rust.json
 !.uor-models/corpora/
 .uor-models/corpora/*/*
 !.uor-models/corpora/*/manifest.json
+# #639-1: local T5 SentencePiece source (spiece.model), pinned by κ in
+# models/t5-base-tokenizer.json; the bytes stay local like other sources.
+.uor-models/sources/t5-base-tokenizer/
 uor_standards/
 crates/uor-r4-graph-format/fuzz/target/
 pkg/

--- a/crates/uor-r4-core/tests/t5_tokenizer_pin.rs
+++ b/crates/uor-r4-core/tests/t5_tokenizer_pin.rs
@@ -1,0 +1,127 @@
+//! #639-1: the pinned T5 SentencePiece Unigram source in
+//! `models/t5-base-tokenizer.json`.
+//!
+//! Casey chose T5 (`google-t5/t5-base`, revision `a9723ea7…`) as the
+//! `sentencepiece-unigram` source for the #639 tokenizer adapter. This
+//! descriptor pins `spiece.model` by its blake3 κ so the later slices
+//! (639-2 registry generalization, 639-3 the real Unigram adapter, 639-4
+//! differential fixtures) build against a fixed, verifiable input rather
+//! than whatever a fresh download happens to return.
+//!
+//! This slice is descriptor + pin only — there is no adapter yet, so the
+//! test binds bytes to κ, not a `(family, version)` record. That binding
+//! arrives with the adapter in 639-3.
+//!
+//! Two-state coverage (mirrors `gpt2_tokenizer_pin.rs`, #669):
+//! - [`t5_tokenizer_pin_is_well_formed`] runs in CI: the pin is present
+//!   and structurally valid, no snapshot required.
+//! - [`real_t5_spiece_matches_the_pin`] is presence-gated (#599
+//!   three-state) on the real `spiece.model`, a dev/local input that never
+//!   downloads in CI: when present it must reproduce the pin byte-for-byte;
+//!   when absent it reports UNAVAILABLE and passes vacuously — never a
+//!   silent skip of a real failure.
+
+use std::path::PathBuf;
+
+/// Workspace root: `CARGO_MANIFEST_DIR` is `<root>/crates/uor-r4-core`.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn t5_descriptor() -> serde_json::Value {
+    let path = repo_root().join("models").join("t5-base-tokenizer.json");
+    let bytes = std::fs::read(&path).unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+    serde_json::from_slice(&bytes).expect("models/t5-base-tokenizer.json parses")
+}
+
+/// CI-run: the source pin is present and well-formed — a `blake3:<64 hex>`
+/// address scoped to `spiece.model` with the pinned byte length, the
+/// `sentencepiece-unigram` family, the pinned HF repo/revision, and the
+/// Apache-2.0 license. Runs without the snapshot.
+#[test]
+fn t5_tokenizer_pin_is_well_formed() {
+    let descriptor = t5_descriptor();
+
+    assert_eq!(
+        descriptor["repository"].as_str(),
+        Some("google-t5/t5-base"),
+        "the source repository is pinned"
+    );
+    assert_eq!(
+        descriptor["revision"].as_str(),
+        Some("a9723ea7f1b39c1eae772870f3b547bf6ef7e6c1"),
+        "the source revision is pinned"
+    );
+    assert_eq!(
+        descriptor["tokenizer_family"].as_str(),
+        Some("sentencepiece-unigram"),
+        "the tokenizer family is recorded for 639-3"
+    );
+    assert_eq!(
+        descriptor["license"].as_str(),
+        Some("Apache-2.0"),
+        "the license permitting the pin is captured with the descriptor"
+    );
+
+    let kappa = descriptor["tokenizer_kappa"]
+        .as_str()
+        .expect("tokenizer_kappa is pinned");
+    let hex = kappa
+        .strip_prefix("blake3:")
+        .expect("tokenizer_kappa is a blake3 address");
+    assert_eq!(hex.len(), 64, "blake3 hex is 64 chars: {kappa}");
+    assert!(
+        hex.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "tokenizer_kappa is hex: {kappa}"
+    );
+    assert_eq!(
+        descriptor["tokenizer_kappa_scope"].as_str(),
+        Some("spiece.model"),
+        "the pin is scoped to the spiece.model file"
+    );
+    assert_eq!(
+        descriptor["tokenizer_bytes"].as_u64(),
+        Some(791_656),
+        "the tokenizer byte length is pinned"
+    );
+}
+
+/// Presence-gated: the real pinned `spiece.model` reproduces the pinned
+/// `tokenizer_kappa` byte-for-byte, and its length matches the pin.
+/// UNAVAILABLE (vacuous pass) when the snapshot is absent.
+#[test]
+fn real_t5_spiece_matches_the_pin() {
+    let descriptor = t5_descriptor();
+    let kappa = descriptor["tokenizer_kappa"]
+        .as_str()
+        .expect("tokenizer_kappa is pinned")
+        .to_owned();
+    let expected_bytes = descriptor["tokenizer_bytes"]
+        .as_u64()
+        .expect("tokenizer_bytes is pinned");
+    let source_dir = descriptor["source_directory"]
+        .as_str()
+        .expect("source_directory is declared");
+    let spiece = repo_root().join(source_dir).join("spiece.model");
+    if !spiece.is_file() {
+        eprintln!(
+            "UNAVAILABLE: real T5 spiece.model absent at {} — presence-gated pin check skipped",
+            spiece.display()
+        );
+        return;
+    }
+
+    let bytes = std::fs::read(&spiece).expect("read spiece.model");
+    assert_eq!(
+        bytes.len() as u64,
+        expected_bytes,
+        "the snapshot spiece.model byte length must match the pin"
+    );
+    let measured = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    assert_eq!(
+        measured, kappa,
+        "the snapshot spiece.model κ must reproduce the pin in models/t5-base-tokenizer.json"
+    );
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -315,6 +315,21 @@ is well-formed in CI and, presence-gated on the real snapshot (never a CI
 download), that the on-disk `tokenizer.json` reproduces the pin and the
 `hf-byte-bpe/1` adapter built from it carries that same CID.
 
+**SentencePiece/Unigram source pin (#639-1).** The recorded
+`sentencepiece-unigram` follow-up family (above) gets its pinned source
+ahead of the adapter: `models/t5-base-tokenizer.json` pins the
+`google-t5/t5-base` (revision `a9723ea7…`, Apache-2.0) `spiece.model` by
+`tokenizer_kappa` / `tokenizer_bytes` / `tokenizer_kappa_scope =
+spiece.model`, with `tokenizer_family = sentencepiece-unigram`, mirroring
+the `models/gpt2-124m.json` layout. This slice is descriptor + pin only —
+no adapter and no `(family, version)` registry entry yet, so
+`crates/uor-r4-core/tests/t5_tokenizer_pin.rs` binds bytes to κ (well-formed
+in CI; presence-gated on the real `spiece.model` reproducing the pin), not a
+tokenizer identity. The registry generalization (639-2), the real Unigram
+encode/decode adapter registering `(sentencepiece-unigram, 1)` (639-3), and
+differential fixtures (639-4) follow; until 639-3 lands the family stays
+refused-by-name as described above.
+
 #### Attention operator identity (#602)
 
 The attention operator the source teacher computes is a typed, versioned

--- a/models/t5-base-tokenizer.json
+++ b/models/t5-base-tokenizer.json
@@ -1,0 +1,10 @@
+{
+  "repository": "google-t5/t5-base",
+  "revision": "a9723ea7f1b39c1eae772870f3b547bf6ef7e6c1",
+  "tokenizer_family": "sentencepiece-unigram",
+  "tokenizer_kappa": "blake3:18af7072534a34d626ca166c92f5e37c7ccfcd6ce6877c3c25d325bc8201090d",
+  "tokenizer_bytes": 791656,
+  "tokenizer_kappa_scope": "spiece.model",
+  "license": "Apache-2.0",
+  "source_directory": ".uor-models/sources/t5-base-tokenizer"
+}


### PR DESCRIPTION
First slice of #639 (SentencePiece/Unigram tokenizer adapter). Closes #705. **No CID change.**

Records the pinned Unigram source so the later slices build against a fixed, κ-verified input:
639-2 registry generalization → 639-3 the real Unigram adapter → 639-4 differential fixtures.

## Changes
- **`models/t5-base-tokenizer.json`** — source descriptor mirroring `models/gpt2-124m.json` (#669): repo `google-t5/t5-base`, revision `a9723ea7f1b39c1eae772870f3b547bf6ef7e6c1`, `spiece.model` κ `blake3:18af7072…` / 791656 bytes / scope `spiece.model`, `tokenizer_family: sentencepiece-unigram`, `license: Apache-2.0`.
- **`crates/uor-r4-core/tests/t5_tokenizer_pin.rs`** — CI well-formedness check + a #599 presence-gated κ-verify that reproduces the pin byte-for-byte from the real `spiece.model` and is UNAVAILABLE/vacuous when the snapshot is absent.
- **`.gitignore`** — keep the local T5 source dir out of the tree like other sources.
- **`docs/MODEL_LIFECYCLE.md`** — document the source pin next to the GPT-2 pin; the `sentencepiece-unigram` family stays refused-by-name until 639-3.

## Verification
Pin verified in the cloud against the live HF revision: 791656 bytes, blake3 `18af7072…`, sha256 `d60acb12…` — all match. Presence-gated test **ran for real** against the downloaded `spiece.model` (passed); on the Mac (no snapshot) it reports UNAVAILABLE and vacuous-passes. `cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -D warnings` green.

## Non-goals
No change to `hf-byte-bpe/1`, the legacy llama2.c tokenizer, or any κ-pinned artifact. Registry generalization and the real Unigram algorithm follow in 639-2/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)