### PR TITLE
serving/#639-2: generalize the tokenizer-adapter registry beyond HfBpeTokenizer

### DIFF
--- a/crates/uor-r4-core/src/transformerless/hf_bpe.rs
+++ b/crates/uor-r4-core/src/transformerless/hf_bpe.rs
@@ -771,11 +771,52 @@ impl TokenizerAdapter {
     }
 }
 
-/// A registered adapter constructor: parse raw tokenizer definition
-/// bytes into the family's tokenizer. Total in the module's existing
-/// convention ([`HfBpeTokenizer::from_tokenizer_json_bytes`]): `None`
-/// when the bytes are not the shape the family requires.
-pub type AdapterConstructor = fn(&[u8]) -> Option<HfBpeTokenizer>;
+/// The behavior a registered tokenizer family provides once resolved
+/// from the versioned adapter registry (#639-2): encode/decode plus the
+/// versioned identity it declares. Object-safe by construction, so
+/// [`adapter_constructor`] can hand back a `Box<dyn TokenizerModel>` for
+/// any family — a family can encode and decode without being an
+/// [`HfBpeTokenizer`]. `hf-byte-bpe/1` implements it by delegating to its
+/// inherent methods, so its behavior is byte-unchanged; the recorded
+/// SentencePiece/Unigram follow-up (#639-3) implements the same trait
+/// rather than a new concrete return type.
+pub trait TokenizerModel {
+    /// Encode text to token ids (the family's exact encode path).
+    fn encode(&self, text: &str) -> Vec<u32>;
+    /// Lossy encode: ids plus the count of characters the family could not
+    /// represent (zero for lossless families such as byte-level BPE).
+    fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64);
+    /// Decode ids to lossy-UTF-8 text.
+    fn decode(&self, ids: &[u32]) -> String;
+    /// Number of id slots (max assigned id + 1).
+    fn vocab_size(&self) -> usize;
+    /// The versioned adapter-identity record (#601) this family declares.
+    fn adapter(&self) -> TokenizerAdapter;
+}
+
+impl TokenizerModel for HfBpeTokenizer {
+    fn encode(&self, text: &str) -> Vec<u32> {
+        HfBpeTokenizer::encode(self, text)
+    }
+    fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64) {
+        HfBpeTokenizer::encode_lossy(self, text)
+    }
+    fn decode(&self, ids: &[u32]) -> String {
+        HfBpeTokenizer::decode(self, ids)
+    }
+    fn vocab_size(&self) -> usize {
+        HfBpeTokenizer::vocab_size(self)
+    }
+    fn adapter(&self) -> TokenizerAdapter {
+        HfBpeTokenizer::adapter(self)
+    }
+}
+
+/// A registered adapter constructor: parse raw tokenizer definition bytes
+/// into the family's [`TokenizerModel`]. Total in the module's existing
+/// convention ([`HfBpeTokenizer::from_tokenizer_json_bytes`]): `None` when
+/// the bytes are not the shape the family requires.
+pub type AdapterConstructor = fn(&[u8]) -> Option<Box<dyn TokenizerModel>>;
 
 /// The versioned tokenizer-adapter registry (#601): map `(family,
 /// version)` to the constructor that implements it. Every pair outside
@@ -794,7 +835,10 @@ pub fn adapter_constructor(
 ) -> Result<AdapterConstructor, uor_r4_model_source::SourceUnavailable> {
     match (family, version) {
         (TokenizerAdapter::HF_BYTE_BPE_FAMILY, TokenizerAdapter::HF_BYTE_BPE_VERSION) => {
-            Ok(HfBpeTokenizer::from_tokenizer_json_bytes)
+            Ok(|bytes| {
+                HfBpeTokenizer::from_tokenizer_json_bytes(bytes)
+                    .map(|tokenizer| Box::new(tokenizer) as Box<dyn TokenizerModel>)
+            })
         }
         _ => Err(
             uor_r4_model_source::SourceIngestKind::UnknownTokenizerAdapter {

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -284,6 +284,16 @@ guessed. SentencePiece/Unigram is the recorded follow-up family
 (`sentencepiece-unigram`): recognized by name, rejected until a versioned
 adapter for it exists, never approximated with the byte-level BPE rule.
 
+Since #639-2 the constructor yields a boxed `TokenizerModel` — the
+object-safe encode/decode/`adapter` surface a resolved family provides —
+so a registered family can encode and decode without being an
+`HfBpeTokenizer`. `hf-byte-bpe/1` implements the trait by delegating to
+its inherent methods, so its behavior is byte-unchanged (the
+`registry_resolves_hf_byte_bpe_1` regression check asserts the registry
+path's `adapter()` and `encode()` match a directly-constructed tokenizer);
+the SentencePiece/Unigram family implements the same trait when its adapter
+lands (#639-3), rather than widening the constructor's concrete return.
+
 The record threads into provenance the same way the #597 manifest κ and
 the #600 geometry record do: the observe-text drivers (serial and
 batched) record it in the observation manifest automatically whenever the


### PR DESCRIPTION
Second slice of #639. Closes #707. Introduces the abstraction so a registered tokenizer family can encode/decode **without being an `HfBpeTokenizer`**, setting up the real SentencePiece Unigram adapter (639-3). **`hf-byte-bpe/1` behavior byte-unchanged.** No CID change.

## Changes
- New `pub trait TokenizerModel` in `transformerless::hf_bpe` — the object-safe `encode`/`encode_lossy`/`decode`/`vocab_size`/`adapter` surface a resolved family provides. `impl TokenizerModel for HfBpeTokenizer` delegates to its inherent methods (zero behavior change).
- `AdapterConstructor` widened to `fn(&[u8]) -> Option<Box<dyn TokenizerModel>>`; `adapter_constructor`'s `hf-byte-bpe/1` arm boxes the tokenizer. Every other `(family, version)` stays refused-by-name (`UnknownTokenizerAdapter`).
- `docs/MODEL_LIFECYCLE.md`: registry paragraph updated.

## Regression gate
The existing `registry_resolves_hf_byte_bpe_1` test passes **unchanged** — it asserts the registry-built tokenizer's `adapter()` and `encode()` are identical to a directly-constructed `HfBpeTokenizer`, now through the boxed `TokenizerModel` seam. Full `tokenizer_adapter` differential fixtures + the consumer-agreement (observation/eval/serving/export) seams green. Verified in cloud: `fmt` + `clippy --workspace --all-targets --all-features -D warnings` + tokenizer suites + **wasm32 lib build** all green; Mac transfer byte-verified.

## Deferred to 639-3 (deliberately)
The `TokenizerKind` runtime variant for the new family is added in 639-3 alongside the actual Unigram constructor + graph-cli selection, so the variant is genuinely constructed on the real path (a never-constructed variant would trip the wasm32 lib build's `-D warnings`).

## Non-goals
No Unigram algorithm yet; `sentencepiece-unigram` stays refused-by-name until 639-3. No change to the legacy llama2.c tokenizer or any κ-pinned artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)