### PR TITLE
ci: move D2 canonical-differential off the merge queue (push + nightly) + cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,15 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
+  schedule:
+    # Nightly D2 canonical-differential acceptance (07:00 UTC). The D2 jobs
+    # below run on push-to-main + this schedule + workflow_dispatch, NOT in
+    # the merge queue (merge_group) — they are not required checks and their
+    # ~hour-long corpus compile does not belong on the merge critical path
+    # (issue #713). The nightly run recompiles unconditionally (cache bypass)
+    # so it re-verifies determinism against runner/toolchain drift, not only
+    # source changes.
+    - cron: '0 7 * * *'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -337,7 +346,11 @@ jobs:
   # macOS-pinned kappa reproduction and does not repin a shipped fixture.
   d2-differential:
     name: D2 canonical differential (${{ matrix.os }})
-    if: github.event_name != 'pull_request'
+    # Off the merge queue (issue #713): runs on push-to-main (post-merge),
+    # the nightly schedule, and manual dispatch — NOT on merge_group or
+    # pull_request. D2 is not a required check, so it never gated a merge;
+    # keeping its ~hour corpus compile off every speculative merge is the fix.
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -364,7 +377,25 @@ jobs:
           key: d2-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: d2-${{ runner.os }}-
 
+      # Cache the compiled D2 manifest (the artifact the compare job consumes),
+      # so an unchanged compile path skips the ~hour corpus compile. The key is
+      # deliberately CONSERVATIVE — any first-party Rust source, Cargo.lock, or
+      # the D2 script busts it — so a cache hit can never mask a change to the
+      # compiled bytes. (A narrower, compile-path-scoped key is unsafe here: the
+      # teacher/compiler and unrelated code share crates, and Rust builds are
+      # not byte-reproducible, so it could silently skip a real determinism
+      # regression.) Cross-OS byte equality is still asserted by the compare
+      # job on the restored manifests. The nightly schedule bypasses the cache
+      # (below) to re-verify against runner/toolchain drift, not only source.
+      - name: Restore cached D2 manifest
+        id: d2_manifest_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/d2-manifest.json
+          key: d2-manifest-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'src/**/*.rs', 'crates/**/*.rs', 'scripts/d2_differential_compile.sh') }}
+
       - name: Run canonical differential compile
+        if: steps.d2_manifest_cache.outputs.cache-hit != 'true' || github.event_name == 'schedule'
         env:
           D2_SOURCE_DIR: ${{ runner.temp }}/d2-source
           D2_OUTPUT_DIR: ${{ runner.temp }}/d2-output
@@ -381,7 +412,7 @@ jobs:
 
   d2-differential-compare:
     name: D2 differential equality
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: d2-differential
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Closes #713.

The D2 acceptance jobs (`d2-differential` matrix + `d2-differential-compare`) download SmolLM2-135M and run `r4 compile --target 1000` on Linux + macOS, then byte-compare for cross-OS determinism. They ran on `merge_group`, so **every merge-queue speculative build paid the full corpus compile** (queue builds up to 5 in parallel). Since #703 (the uor-matmul exact-GEMM teacher) that compile is ~50–58 min and climbing. D2 is **not a required check** — it never gated a merge, it just burned ~an hour of runner time per queued PR.

## Change
- **Move D2 off the merge queue**: `d2-differential` + `d2-differential-compare` now run on **push-to-main + a nightly cron (07:00 UTC) + workflow_dispatch**, not on `merge_group`/`pull_request`. Every merge is fast again; determinism is still verified on `main` within ~1h of each merge (revertable) and nightly.
- **Cache the D2 manifest**, keyed conservatively on `hashFiles('Cargo.lock', 'src/**/*.rs', 'crates/**/*.rs', 'scripts/d2_differential_compile.sh')`, so an unchanged compile path skips the corpus compile. Broad key on purpose — a narrower, compile-path-scoped key is unsafe (the teacher/compiler and unrelated code share crates, and Rust builds aren't byte-reproducible, so it could silently mask a determinism regression). The nightly run bypasses the cache to re-verify against runner/toolchain drift.

## Verification / notes
- YAML parse + `actionlint` clean (0 errors).
- D2 is not a required status check (required set: `fmt / clippy / tests / no_std / κ`, `cargo audit`, `fuzz smoke`, `wasm-pack`, `Gate C trend`), so removing it from the queue cannot wedge merges.
- This PR does not exercise D2 on its own PR/queue run (D2 no longer runs there) — expected; its required checks run and gate as usual.
- Trade-off: determinism detection moves pre-merge → post-merge on `main`, for a rarely-regressing, easily-reverted property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)