### PR TITLE
serving/#639-3b: SentencePiece nmt_nfkc normalizer + register (sentencepiece-unigram, 1)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/hf_bpe.rs
+++ b/crates/uor-r4-core/src/transformerless/hf_bpe.rs
@@ -723,11 +723,12 @@ impl TokenizerAdapter {
     /// Registry version of the byte-level BPE adapter currently
     /// implemented (the post-#242/#253 verified behavior).
     pub const HF_BYTE_BPE_VERSION: u32 = 1;
-    /// Recorded follow-up family (#601 non-goal): SentencePiece/Unigram
-    /// tokenizers are recognized by name and rejected by
-    /// [`adapter_constructor`] until a versioned adapter exists — never
-    /// approximated with the byte-level BPE rule.
+    /// SentencePiece/Unigram adapter family (#639-3). Implemented by
+    /// [`super::sentencepiece::SentencePieceUnigramTokenizer`]: precompiled
+    /// charsmap normalization + Unigram Viterbi segmentation.
     pub const SENTENCEPIECE_UNIGRAM_FAMILY: &'static str = "sentencepiece-unigram";
+    /// Registry version of the SentencePiece/Unigram adapter (#639-3b).
+    pub const SENTENCEPIECE_UNIGRAM_VERSION: u32 = 1;
 
     /// Canonical serialization of the adapter identity: a fixed line
     /// format (format tag then `key=value\n` per field, pre-tokenizer
@@ -819,10 +820,12 @@ impl TokenizerModel for HfBpeTokenizer {
 pub type AdapterConstructor = fn(&[u8]) -> Option<Box<dyn TokenizerModel>>;
 
 /// The versioned tokenizer-adapter registry (#601): map `(family,
-/// version)` to the constructor that implements it. Every pair outside
-/// the registry — including the recorded
-/// [`TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY`] follow-up — is
-/// refused by name on the sanctioned
+/// version)` to the constructor that implements it. Registered families are
+/// `hf-byte-bpe/1` ([`HfBpeTokenizer`]) and, since #639-3b,
+/// `sentencepiece-unigram/1`
+/// ([`super::sentencepiece::SentencePieceUnigramTokenizer`]). Every pair
+/// outside the registry — including a bumped version of a registered family —
+/// is refused by name on the sanctioned
 /// [`uor_r4_model_source::SourceUnavailable`] surface
 /// (`SourceIngestKind::UnknownTokenizerAdapter`), matching the module's
 /// existing host-ingestion convention ([`HfBpeTokenizer::from_dir`])
@@ -840,6 +843,14 @@ pub fn adapter_constructor(
                     .map(|tokenizer| Box::new(tokenizer) as Box<dyn TokenizerModel>)
             })
         }
+        (
+            TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY,
+            TokenizerAdapter::SENTENCEPIECE_UNIGRAM_VERSION,
+        ) => Ok(|bytes| {
+            super::sentencepiece::SentencePieceUnigramTokenizer::from_spiece_bytes(bytes)
+                .ok()
+                .map(|tokenizer| Box::new(tokenizer) as Box<dyn TokenizerModel>)
+        }),
         _ => Err(
             uor_r4_model_source::SourceIngestKind::UnknownTokenizerAdapter {
                 family: family.to_owned(),

--- a/crates/uor-r4-core/src/transformerless/sentencepiece.rs
+++ b/crates/uor-r4-core/src/transformerless/sentencepiece.rs
@@ -8,15 +8,14 @@
 //! minimal protobuf reader, and implements the Unigram best-path
 //! segmentation (Viterbi) over **already-normalized** text.
 //!
-//! What this module deliberately does NOT do: the SentencePiece
-//! normalization (`nmt_nfkc` precompiled charsmap, dummy-prefix and
-//! whitespace escaping), the `(sentencepiece-unigram, 1)` registry entry,
-//! and the [`super::hf_bpe::TokenizerModel`] / [`super::hf_bpe::TokenizerKind`]
-//! wiring all land in #639-3b. Because the normalizer is not yet
-//! implemented, nothing here is registered or reachable from a driver, so
-//! no not-yet-faithful path is ever exposed to a caller. The encode entry
-//! point is named [`UnigramModel::encode_normalized`] to make that
-//! precondition explicit.
+//! Since #639-3b this module also carries the [`Normalizer`] (the
+//! `nmt_nfkc` precompiled-charsmap folding + dummy-prefix/whitespace rules)
+//! and [`SentencePieceUnigramTokenizer`], which composes the normalizer with
+//! the Viterbi core into a [`super::hf_bpe::TokenizerModel`] registered under
+//! `(sentencepiece-unigram, 1)`. The `UnigramModel::encode_normalized` entry
+//! point still operates on already-normalized text; the tokenizer's
+//! `encode` normalizes first. Selecting this adapter from the observe/serve
+//! drivers (the `TokenizerKind` wiring) is the remaining follow-up.
 //!
 //! Refuse-by-name, never approximate: a non-Unigram `model_type`, a
 //! `byte_fallback` source (no pinned byte-fallback source exists yet), a
@@ -26,6 +25,8 @@
 use std::collections::HashMap;
 
 use uor_r4_model_source::SourceUnavailable;
+
+use super::hf_bpe::{TokenizerAdapter, TokenizerAdapterPolicy, TokenizerModel};
 
 /// The whitespace meta symbol SentencePiece escapes spaces to (`▁`,
 /// U+2581). Pieces carry it literally; [`UnigramModel::decode`] maps it
@@ -323,6 +324,350 @@ impl UnigramModel {
         }
         let spaced = surface.replace(WHITESPACE_META, " ");
         spaced.strip_prefix(' ').unwrap_or(&spaced).to_owned()
+    }
+}
+
+// ============================ #639-3b: normalizer + adapter ===============
+
+/// Darts-clone double-array unit accessors (the trie encoding
+/// `precompiled_charsmap` uses). A unit is a `u32`.
+fn darts_has_leaf(unit: u32) -> bool {
+    (unit >> 8) & 1 == 1
+}
+fn darts_value(unit: u32) -> u32 {
+    unit & 0x7fff_ffff
+}
+fn darts_offset(unit: u32) -> u32 {
+    (unit >> 10) << ((unit & 0x200) >> 6)
+}
+
+/// The SentencePiece text normalizer: applies the `precompiled_charsmap`
+/// (a Darts double-array trie of longest-match byte-sequence replacements —
+/// e.g. NFKC folding for `nmt_nfkc`) then the whitespace rules
+/// (`add_dummy_prefix`, escape space → `▁`, collapse/strip extra
+/// whitespace). This reproduces `sentencepiece`'s `Normalizer::Normalize`
+/// byte-for-byte; the algorithm and the pinned T5 `nmt_nfkc` charsmap were
+/// validated against the reference library before this port.
+#[derive(Debug)]
+pub struct Normalizer {
+    /// Declared normalizer name (provenance only; the charsmap drives
+    /// behavior).
+    name: String,
+    /// Darts-clone double-array trie units.
+    trie: Vec<u32>,
+    /// Null-separated normalized replacement strings; a trie value is a byte
+    /// offset into this blob (offset 0 is the empty string).
+    normalized: Vec<u8>,
+    add_dummy_prefix: bool,
+    remove_extra_whitespaces: bool,
+    escape_whitespaces: bool,
+}
+
+impl Normalizer {
+    /// Parse the `NormalizerSpec` (`ModelProto` field 3) from raw
+    /// `spiece.model` bytes and decode its `precompiled_charsmap`.
+    ///
+    /// Fails closed via [`SourceUnavailable`] when the model carries no
+    /// `NormalizerSpec`, when a `normalization_rule_tsv` is present (custom
+    /// rules are refused, never approximated), or when the
+    /// `precompiled_charsmap` is absent or malformed — only
+    /// precompiled-charsmap normalizers are supported.
+    pub fn from_spiece_bytes(bytes: &[u8]) -> Result<Self, SourceUnavailable> {
+        // Locate the normalizer_spec sub-message (ModelProto field 3).
+        let mut reader = ProtoReader::new(bytes);
+        let mut spec: Option<&[u8]> = None;
+        while !reader.is_empty() {
+            let (field, wire) = reader
+                .read_tag()
+                .ok_or_else(|| SourceUnavailable::new("spiece.model: truncated field tag"))?;
+            if (field, wire) == (3, WIRE_LEN) {
+                spec = Some(reader.read_len_delim().ok_or_else(|| {
+                    SourceUnavailable::new("spiece.model: truncated normalizer_spec")
+                })?);
+            } else {
+                reader
+                    .skip_field(wire)
+                    .ok_or_else(|| SourceUnavailable::new("spiece.model: unreadable field"))?;
+            }
+        }
+        let spec =
+            spec.ok_or_else(|| SourceUnavailable::new("spiece.model: no normalizer_spec"))?;
+
+        // NormalizerSpec fields: name(1), precompiled_charsmap(2 bytes),
+        // add_dummy_prefix(3), remove_extra_whitespaces(4),
+        // escape_whitespaces(5), normalization_rule_tsv(6). Booleans default
+        // to true (the SentencePiece proto defaults).
+        let mut name = String::new();
+        let mut charsmap: Option<&[u8]> = None;
+        let mut add_dummy_prefix = true;
+        let mut remove_extra_whitespaces = true;
+        let mut escape_whitespaces = true;
+        let mut reader = ProtoReader::new(spec);
+        while !reader.is_empty() {
+            let (field, wire) = reader
+                .read_tag()
+                .ok_or_else(|| SourceUnavailable::new("normalizer_spec: truncated field tag"))?;
+            match (field, wire) {
+                (1, WIRE_LEN) => {
+                    let raw = reader
+                        .read_len_delim()
+                        .ok_or_else(|| SourceUnavailable::new("normalizer_spec: truncated name"))?;
+                    name = std::str::from_utf8(raw)
+                        .map_err(|_| SourceUnavailable::new("normalizer_spec: non-UTF-8 name"))?
+                        .to_owned();
+                }
+                (2, WIRE_LEN) => {
+                    charsmap = Some(reader.read_len_delim().ok_or_else(|| {
+                        SourceUnavailable::new("normalizer_spec: truncated precompiled_charsmap")
+                    })?);
+                }
+                (3, WIRE_VARINT) => {
+                    add_dummy_prefix = reader.read_varint().ok_or_else(|| {
+                        SourceUnavailable::new("normalizer_spec: truncated add_dummy_prefix")
+                    })? != 0;
+                }
+                (4, WIRE_VARINT) => {
+                    remove_extra_whitespaces = reader.read_varint().ok_or_else(|| {
+                        SourceUnavailable::new(
+                            "normalizer_spec: truncated remove_extra_whitespaces",
+                        )
+                    })? != 0;
+                }
+                (5, WIRE_VARINT) => {
+                    escape_whitespaces = reader.read_varint().ok_or_else(|| {
+                        SourceUnavailable::new("normalizer_spec: truncated escape_whitespaces")
+                    })? != 0;
+                }
+                (6, WIRE_LEN) => {
+                    let tsv = reader.read_len_delim().ok_or_else(|| {
+                        SourceUnavailable::new("normalizer_spec: truncated normalization_rule_tsv")
+                    })?;
+                    if !tsv.is_empty() {
+                        return Err(SourceUnavailable::new(
+                            "normalizer_spec: normalization_rule_tsv is not interpreted — refused \
+                             rather than approximated",
+                        ));
+                    }
+                }
+                _ => reader
+                    .skip_field(wire)
+                    .ok_or_else(|| SourceUnavailable::new("normalizer_spec: unreadable field"))?,
+            }
+        }
+
+        let charsmap = charsmap.filter(|blob| !blob.is_empty()).ok_or_else(|| {
+            SourceUnavailable::new(
+                "normalizer_spec: no precompiled_charsmap — only precompiled-charsmap normalizers \
+                 are supported",
+            )
+        })?;
+        // Charsmap layout: [u32 LE trie_blob_size][trie: u32 units][normalized
+        // blob: null-separated strings].
+        if charsmap.len() < 4 {
+            return Err(SourceUnavailable::new(
+                "normalizer_spec: precompiled_charsmap shorter than its trie-size header",
+            ));
+        }
+        let trie_size =
+            u32::from_le_bytes([charsmap[0], charsmap[1], charsmap[2], charsmap[3]]) as usize;
+        if !trie_size.is_multiple_of(4) || 4usize.saturating_add(trie_size) > charsmap.len() {
+            return Err(SourceUnavailable::new(
+                "normalizer_spec: precompiled_charsmap trie size is malformed",
+            ));
+        }
+        let trie: Vec<u32> = charsmap[4..4 + trie_size]
+            .chunks_exact(4)
+            .map(|chunk| u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+        let normalized = charsmap[4 + trie_size..].to_vec();
+
+        Ok(Self {
+            name,
+            trie,
+            normalized,
+            add_dummy_prefix,
+            remove_extra_whitespaces,
+            escape_whitespaces,
+        })
+    }
+
+    /// Darts `commonPrefixSearch`: the LONGEST key prefix present in the
+    /// trie, as `(value offset into the normalized blob, matched byte
+    /// length)`. `None` when no prefix matches.
+    fn longest_match(&self, key: &[u8]) -> Option<(usize, usize)> {
+        let mut best: Option<(usize, usize)> = None;
+        let mut node_pos = 0usize;
+        let mut unit = *self.trie.first()?;
+        node_pos ^= darts_offset(unit) as usize;
+        for (i, &byte) in key.iter().enumerate() {
+            node_pos ^= byte as usize;
+            unit = *self.trie.get(node_pos)?;
+            if (unit & 0xff) as u8 != byte {
+                break;
+            }
+            node_pos ^= darts_offset(unit) as usize;
+            if darts_has_leaf(unit) {
+                let leaf = *self.trie.get(node_pos)?;
+                best = Some((darts_value(leaf) as usize, i + 1));
+            }
+        }
+        best
+    }
+
+    /// The null-terminated normalized replacement string at `offset`.
+    fn replacement(&self, offset: usize) -> Option<&[u8]> {
+        let rest = self.normalized.get(offset..)?;
+        let end = rest.iter().position(|&b| b == 0)?;
+        Some(&rest[..end])
+    }
+
+    /// Apply the `precompiled_charsmap` with greedy longest match; bytes with
+    /// no matching prefix are copied through unchanged.
+    fn apply_charsmap(&self, input: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(input.len());
+        let mut i = 0;
+        while i < input.len() {
+            if let Some((value, len)) = self.longest_match(&input[i..]) {
+                if let Some(replacement) = self.replacement(value) {
+                    out.extend_from_slice(replacement);
+                    i += len;
+                    continue;
+                }
+            }
+            out.push(input[i]);
+            i += 1;
+        }
+        out
+    }
+
+    /// Normalize raw text to the `▁`-escaped surface form the Unigram Viterbi
+    /// consumes — reproducing `sentencepiece`'s `Normalize`: charsmap folding,
+    /// then whitespace escaping/collapsing, then the dummy prefix (added only
+    /// when the result is non-empty).
+    pub fn normalize(&self, text: &str) -> String {
+        let mapped = self.apply_charsmap(text.as_bytes());
+        let mapped = String::from_utf8_lossy(&mapped);
+
+        let space = if self.escape_whitespaces {
+            WHITESPACE_META
+        } else {
+            ' '
+        };
+        let mut out = String::with_capacity(mapped.len() + WHITESPACE_META.len_utf8());
+        let mut prev_space = self.remove_extra_whitespaces;
+        for ch in mapped.chars() {
+            if ch == ' ' {
+                if self.remove_extra_whitespaces && prev_space {
+                    continue;
+                }
+                out.push(space);
+                prev_space = true;
+            } else {
+                out.push(ch);
+                prev_space = false;
+            }
+        }
+        if self.remove_extra_whitespaces && out.ends_with(space) {
+            out.pop();
+        }
+        if self.add_dummy_prefix && !out.is_empty() {
+            out.insert(0, space);
+        }
+        out
+    }
+}
+
+/// The registered SentencePiece Unigram tokenizer (#639-3b): raw text →
+/// [`Normalizer`] → [`UnigramModel`] Viterbi → token ids, exposed as a
+/// [`TokenizerModel`] under the `(sentencepiece-unigram, 1)` registry entry.
+#[derive(Debug)]
+pub struct SentencePieceUnigramTokenizer {
+    model: UnigramModel,
+    normalizer: Normalizer,
+    tokenizer_cid: String,
+}
+
+impl SentencePieceUnigramTokenizer {
+    /// Build from raw `spiece.model` bytes: the Unigram model, its
+    /// normalizer, and the `blake3` content address of the definition.
+    pub fn from_spiece_bytes(bytes: &[u8]) -> Result<Self, SourceUnavailable> {
+        let model = UnigramModel::from_spiece_bytes(bytes)?;
+        let normalizer = Normalizer::from_spiece_bytes(bytes)?;
+        let tokenizer_cid = format!("blake3:{}", blake3::hash(bytes).to_hex());
+        Ok(Self {
+            model,
+            normalizer,
+            tokenizer_cid,
+        })
+    }
+
+    /// Canonical listing digest + count of the non-Normal pieces (control,
+    /// unknown, user-defined, unused) — sorted by id, each
+    /// `<id>:<byte length>:<content>\n` — mirroring the byte-level BPE
+    /// added-token digest so provenance distinguishes vocabularies.
+    fn special_tokens(&self) -> (u32, String) {
+        let mut listing = Vec::new();
+        let mut count = 0u32;
+        for (id, kind) in self.model.types.iter().enumerate() {
+            if *kind != PieceType::Normal {
+                let content = &self.model.surfaces[id];
+                listing.extend_from_slice(format!("{id}:{}:", content.len()).as_bytes());
+                listing.extend_from_slice(content.as_bytes());
+                listing.push(b'\n');
+                count += 1;
+            }
+        }
+        (count, format!("blake3:{}", blake3::hash(&listing).to_hex()))
+    }
+}
+
+impl TokenizerModel for SentencePieceUnigramTokenizer {
+    fn encode(&self, text: &str) -> Vec<u32> {
+        self.model
+            .encode_normalized(&self.normalizer.normalize(text))
+    }
+
+    fn encode_lossy(&self, text: &str) -> (Vec<u32>, u64) {
+        // Unmatched characters map to `<unk>` (a real id), so the id stream
+        // represents every input; no characters are dropped.
+        (self.encode(text), 0)
+    }
+
+    fn decode(&self, ids: &[u32]) -> String {
+        self.model.decode(ids)
+    }
+
+    fn vocab_size(&self) -> usize {
+        self.model.vocab_size()
+    }
+
+    fn adapter(&self) -> TokenizerAdapter {
+        let (added_tokens_count, added_tokens_digest) = self.special_tokens();
+        let policy = TokenizerAdapterPolicy {
+            normalizer: format!("sentencepiece-precompiled-charsmap({})", self.normalizer.name),
+            pre_tokenizers: vec![format!(
+                "sentencepiece-whitespace(add_dummy_prefix={},escape_meta={},remove_extra_whitespaces={})",
+                self.normalizer.add_dummy_prefix,
+                self.normalizer.escape_whitespaces,
+                self.normalizer.remove_extra_whitespaces,
+            )],
+            // Non-byte-fallback: an unmatched span becomes a single `<unk>`.
+            byte_fallback: "unknown-token".to_owned(),
+            added_tokens_count,
+            added_tokens_digest,
+            bos: "none".to_owned(),
+            eos: "none".to_owned(),
+            chat_template_policy: "not-interpreted".to_owned(),
+        };
+        let mut adapter = TokenizerAdapter {
+            family: TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY.to_owned(),
+            version: TokenizerAdapter::SENTENCEPIECE_UNIGRAM_VERSION,
+            tokenizer_cid: self.tokenizer_cid.clone(),
+            policy,
+            adapter_digest: String::new(),
+        };
+        adapter.adapter_digest = adapter.declared_digest();
+        adapter
     }
 }
 

--- a/crates/uor-r4-core/tests/sentencepiece_unigram.rs
+++ b/crates/uor-r4-core/tests/sentencepiece_unigram.rs
@@ -19,7 +19,50 @@
 
 use std::path::PathBuf;
 
-use uor_r4_core::transformerless::sentencepiece::UnigramModel;
+use uor_r4_core::transformerless::hf_bpe::{adapter_constructor, TokenizerAdapter};
+use uor_r4_core::transformerless::sentencepiece::{SentencePieceUnigramTokenizer, UnigramModel};
+
+/// #639-3b full-pipeline fixtures: raw text → the reference `sentencepiece`
+/// token ids (from `google-t5/t5-base` revision `a9723ea7…`). Unlike the
+/// `FIXTURES` above (which pre-normalize to isolate the Viterbi), these feed
+/// RAW text through the whole adapter — normalizer (precompiled charsmap +
+/// whitespace) then Viterbi — so they exercise the charsmap folding:
+/// fullwidth (Ａ→A, ①②③→123, ＵＯＲ), ligatures (ﬁ→fi, ﬀﬃ), fractions (½),
+/// Roman numerals (Ⅻ), squared forms (㍿), tabs/newlines, whitespace
+/// collapse, and CJK/emoji → `<unk>`.
+const RAW_FIXTURES: &[(&str, &[u32])] = &[
+    ("Hello world", &[8774, 296]),
+    ("Hello  world", &[8774, 296]),
+    ("The quick brown fox.", &[37, 1704, 4216, 3, 20400, 5]),
+    ("café", &[11949]),
+    ("naïve résumé", &[3, 29, 9, 2, 162, 1417, 4078, 154]),
+    (
+        "ﬁ ligature and ½ fraction",
+        &[361, 3, 17140, 2693, 11, 209, 2, 357, 12211],
+    ),
+    ("ｆｕｌｌｗｉｄｔｈ", &[423, 12018, 189]),
+    ("emoji 😀 test", &[3, 15, 51, 21892, 3, 2, 794]),
+    ("日本語のテキスト", &[3, 2]),
+    (" leading and  double   spaces ", &[1374, 11, 1486, 4856]),
+    ("H2O molecule", &[454, 357, 667, 3, 23098]),
+    ("MixedCASE Text", &[28024, 254, 17892, 5027]),
+    ("A🎉B🎉C", &[71, 2, 279, 2, 254]),
+    (
+        "Numbers: 12345 and 6.7",
+        &[7720, 7, 10, 3, 14574, 2128, 11, 3, 29045],
+    ),
+    ("Ａ１２３", &[71, 14574]),
+    ("①②③", &[3, 14574]),
+    ("ＵＯＲ", &[412, 2990]),
+    ("\tTab\nNL", &[10456, 3, 18207]),
+    ("Ⅻ roman", &[3, 4, 196, 196, 3408]),
+    ("㍿ square", &[3, 2, 2812]),
+    ("½+¼", &[209, 2, 357, 18446, 2, 591]),
+    (
+        "ﬀ ﬃ ligatures",
+        &[3, 89, 89, 3, 89, 89, 23, 3, 17140, 10471],
+    ),
+];
 
 /// Workspace root: `CARGO_MANIFEST_DIR` is `<root>/crates/uor-r4-core`.
 fn repo_root() -> PathBuf {
@@ -114,4 +157,78 @@ fn real_t5_unigram_encode_is_deterministic() {
         let second = model.encode_normalized(normalized);
         assert_eq!(first, second, "encode is deterministic for {normalized:?}");
     }
+}
+
+#[test]
+fn real_t5_sentencepiece_adapter_matches_reference_ids() {
+    let Some(bytes) = spiece_bytes() else {
+        return;
+    };
+    let tokenizer =
+        SentencePieceUnigramTokenizer::from_spiece_bytes(&bytes).expect("T5 spiece.model parses");
+
+    use uor_r4_core::transformerless::hf_bpe::TokenizerModel;
+    for (text, expected) in RAW_FIXTURES {
+        let ids = tokenizer.encode(text);
+        assert_eq!(
+            ids, *expected,
+            "full adapter (normalizer + Viterbi) must reproduce the reference ids for {text:?}"
+        );
+        // Determinism: a second encode is byte-identical.
+        assert_eq!(
+            tokenizer.encode(text),
+            ids,
+            "encode is deterministic for {text:?}"
+        );
+    }
+
+    // The declared adapter identity binds the right family/version/CID.
+    let adapter = tokenizer.adapter();
+    assert_eq!(
+        adapter.family,
+        TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY
+    );
+    assert_eq!(
+        adapter.version,
+        TokenizerAdapter::SENTENCEPIECE_UNIGRAM_VERSION
+    );
+    assert_eq!(
+        adapter.tokenizer_cid,
+        format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+        "tokenizer_cid is the blake3 of the spiece.model bytes"
+    );
+    assert_eq!(
+        adapter.adapter_digest,
+        adapter.declared_digest(),
+        "adapter_digest is the declared-identity digest"
+    );
+}
+
+#[test]
+fn registry_resolves_sentencepiece_unigram_1() {
+    // #639-3b: the family that was refused-by-name now resolves to the real
+    // Unigram adapter.
+    let constructor = adapter_constructor(
+        TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY,
+        TokenizerAdapter::SENTENCEPIECE_UNIGRAM_VERSION,
+    )
+    .expect("sentencepiece-unigram/1 is registered");
+    // Malformed bytes stay total (None, not a panic).
+    assert!(constructor(b"not a spiece.model").is_none());
+
+    let Some(bytes) = spiece_bytes() else {
+        return;
+    };
+    use uor_r4_core::transformerless::hf_bpe::TokenizerModel;
+    let via_registry = constructor(&bytes).expect("registry constructor parses the real model");
+    let direct = SentencePieceUnigramTokenizer::from_spiece_bytes(&bytes).expect("direct parse");
+    assert_eq!(via_registry.adapter(), direct.adapter());
+    assert_eq!(
+        via_registry.encode("Hello world"),
+        direct.encode("Hello world")
+    );
+    assert_eq!(
+        via_registry.encode("Ａ１２３ ﬁ ½"),
+        vec![71, 14574, 361, 209, 2, 357]
+    );
 }

--- a/crates/uor-r4-core/tests/tokenizer_adapter.rs
+++ b/crates/uor-r4-core/tests/tokenizer_adapter.rs
@@ -362,12 +362,13 @@ fn registry_resolves_hf_byte_bpe_1() {
 
 #[test]
 fn registry_refuses_unknown_family_and_version_by_name() {
-    // The recorded SentencePiece/Unigram follow-up family is rejected
-    // explicitly (bounded rejection, #601 non-goal), as is any unknown
-    // (family, version) pair — including a bumped hf-byte-bpe version.
+    // Any unknown (family, version) pair is rejected by name — including a
+    // bumped version of a REGISTERED family (hf-byte-bpe/2, sentencepiece-
+    // unigram/2), so a future behavioral change must arrive as a new
+    // registry entry rather than silently reusing the current one.
     for (family, version) in [
-        (TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 1u32),
-        (TokenizerAdapter::HF_BYTE_BPE_FAMILY, 2),
+        (TokenizerAdapter::HF_BYTE_BPE_FAMILY, 2u32),
+        (TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 2),
         ("mystery-tokenizer", 1),
     ] {
         let error = adapter_constructor(family, version)
@@ -387,12 +388,10 @@ fn registry_refuses_unknown_family_and_version_by_name() {
             "reason names the family: {error}"
         );
     }
-    // The rejection message records the follow-up path by name.
-    let error = adapter_constructor(TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 1)
-        .expect_err("sentencepiece-unigram has no adapter yet");
+    // sentencepiece-unigram/1 is now REGISTERED (#639-3b), not refused.
     assert!(
-        error.reason.contains("sentencepiece-unigram"),
-        "follow-up family is named: {error}"
+        adapter_constructor(TokenizerAdapter::SENTENCEPIECE_UNIGRAM_FAMILY, 1).is_ok(),
+        "sentencepiece-unigram/1 resolves to the real Unigram adapter"
     );
 }
 

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -280,9 +280,9 @@ in-place edit.
 A versioned registry maps `(family, version)` to the constructor
 (`hf_bpe::adapter_constructor`); an unknown pair fails closed with the
 focused `SourceIngestKind::UnknownTokenizerAdapter` rather than being
-guessed. SentencePiece/Unigram is the recorded follow-up family
-(`sentencepiece-unigram`): recognized by name, rejected until a versioned
-adapter for it exists, never approximated with the byte-level BPE rule.
+guessed. The registered families are `hf-byte-bpe/1` and, since #639-3b,
+`sentencepiece-unigram/1` (below); a bumped version of either is still
+refused by name, never approximated.
 
 Since #639-2 the constructor yields a boxed `TokenizerModel` — the
 object-safe encode/decode/`adapter` surface a resolved family provides —
@@ -335,10 +335,29 @@ the `models/gpt2-124m.json` layout. This slice is descriptor + pin only —
 no adapter and no `(family, version)` registry entry yet, so
 `crates/uor-r4-core/tests/t5_tokenizer_pin.rs` binds bytes to κ (well-formed
 in CI; presence-gated on the real `spiece.model` reproducing the pin), not a
-tokenizer identity. The registry generalization (639-2), the real Unigram
-encode/decode adapter registering `(sentencepiece-unigram, 1)` (639-3), and
-differential fixtures (639-4) follow; until 639-3 lands the family stays
-refused-by-name as described above.
+tokenizer identity. The registry generalization (639-2) and the real Unigram
+encode/decode adapter registering `(sentencepiece-unigram, 1)` (639-3b,
+below) followed; comprehensive differential fixtures (639-4) come next.
+
+**SentencePiece/Unigram adapter (#639-3b).** `sentencepiece-unigram/1` is
+now a real registered family
+(`transformerless::sentencepiece::SentencePieceUnigramTokenizer`), built
+from the pinned `spiece.model` bytes. It composes two pure-Rust pieces, both
+validated byte-for-byte against the reference `sentencepiece` library before
+landing: a `Normalizer` that applies the `NormalizerSpec`'s
+`precompiled_charsmap` — a Darts double-array trie of longest-match byte
+replacements (NFKC folding: fullwidth → ASCII, ﬁ → fi, ½ → 1⁄2, Roman
+numerals, …) — then the dummy-prefix / `▁`-escape / whitespace-collapse
+rules; and a `UnigramModel` that runs the Viterbi best-path segmentation
+over the normalized surface (per-character `<unk>` for unmatched spans,
+consecutive unknowns collapsed). Refuse-by-name is preserved: a non-Unigram
+`model_type`, a `byte_fallback` source, a `normalization_rule_tsv`, or an
+absent `precompiled_charsmap` each fail closed on `SourceUnavailable` rather
+than being approximated. The adapter binds the `blake3` of `spiece.model` as
+its `tokenizer_cid`. The module and the registry arm are host/compile-side
+(`#[cfg(not(target_arch = "wasm32"))]`); wiring this adapter into the
+`TokenizerKind` selection the observe/serve drivers use is the remaining
+follow-up.
 
 #### Attention operator identity (#602)
 


### PR DESCRIPTION
Second half of #639-3. Closes #715. Builds on the #639-3a Viterbi core. **No CID change; no dependency/Cargo.lock change.**

Makes `sentencepiece-unigram/1` a real registered tokenizer family, so a pinned `spiece.model` encodes raw text → ids faithfully.

## Changes
- **`Normalizer`** (pure Rust, `transformerless::sentencepiece`): parses the `NormalizerSpec` (`ModelProto` field 3) and applies the `precompiled_charsmap` — a Darts double-array trie of longest-match byte replacements (NFKC folding) — then the dummy-prefix / `▁`-escape / whitespace-collapse rules. Reproduces `sentencepiece`'s `Normalize` byte-for-byte.
- **`SentencePieceUnigramTokenizer`** = `Normalizer` + `UnigramModel` Viterbi, implementing `TokenizerModel`; `encode` normalizes then segments. Binds `blake3(spiece.model)` as `tokenizer_cid`; derives a `TokenizerAdapter` identity.
- **Registers `(sentencepiece-unigram, 1)`** in `hf_bpe::adapter_constructor`, replacing refuse-by-name. Refuse-by-name preserved via `SourceUnavailable`: non-Unigram `model_type`, `byte_fallback`, `normalization_rule_tsv`, or absent `precompiled_charsmap` each fail closed.
- Docs: `MODEL_LIFECYCLE.md` tokenizer section — the family is now live.

## Validation
Both the normalizer and the full pipeline were validated **against the reference `sentencepiece` library** before porting. The presence-gated test reproduces the reference token ids on the real pinned T5 `spiece.model` across **22 raw-text fixtures** spanning the charsmap cases — fullwidth (Ａ→A, ①②③→123, ＵＯＲ), ligatures (ﬁ→fi, ﬀﬃ), fractions (½), Roman numerals (Ⅻ), squared forms (㍿), tab/newline, whitespace collapse, CJK/emoji → `<unk>` — plus determinism and the registry-resolution path. The `hf-byte-bpe/1` regression + consumer-agreement seams stay green. Verified in the cloud with the real snapshot; Mac transfer verified. Full local gates: `fmt` + `clippy --workspace --all-targets --all-features -D warnings` + wasm32 lib build + R1–R5 register conformance + tokenizer suites.

## Deferred / non-goals
Wiring this adapter into the `TokenizerKind` selection the observe/serve drivers use is a focused follow-up (kept out so the adapter lands fully tested first). Comprehensive differential fixtures are #639-4. No change to `hf-byte-bpe/1`, the legacy tokenizer, or any pinned artifact. Host/compile-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)