### PR TITLE
ci: isolate Kani from native matmul dependencies

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -25,5 +25,14 @@ jobs:
       - name: Verify Proof Status Matrix
         run: cargo test -p uor-r4-proof-model
 
+      - name: Verify Kani dependency boundary
+        run: |
+          dependency_tree="$(cargo tree -p uor-r4-proof-model --no-default-features --edges normal --prefix none)"
+          echo "$dependency_tree"
+          if grep -Eq '^(uor-r4-(core|model-source|graph-(certify|compiler))|uor-matmul([^[:alnum:]]|$))' <<<"$dependency_tree"; then
+            echo "Kani dependency boundary includes compiler or native-matmul crates" >&2
+            exit 1
+          fi
+
       - name: Run Kani proofs
-        run: cargo kani -p uor-r4-proof-model
+        run: cargo kani -p uor-r4-proof-model --no-default-features --lib

--- a/crates/uor-r4-proof-model/Cargo.toml
+++ b/crates/uor-r4-proof-model/Cargo.toml
@@ -5,12 +5,30 @@ version = "0.1.0"
 edition = "2021"
 description = "Executable proof specification and formal verification harness for the R4 holographic graph compiler"
 
+[features]
+default = ["full-model"]
+full-model = [
+    "dep:serde",
+    "dep:uor-r4-core",
+    "dep:uor-r4-graph-certify",
+    "dep:uor-r4-graph-compiler",
+    "uor-r4-graph-format/std",
+]
+
 [dependencies]
-uor-r4-core = { version = "0.1.0", path = "../uor-r4-core" }
-uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format" }
+uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format", default-features = false }
 uor-r4-graph-runtime = { version = "0.1.0", path = "../uor-r4-graph-runtime" }
-uor-r4-graph-certify = { version = "0.1.0", path = "../uor-r4-graph-certify" }
-uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler" }
-serde = { version = "1.0", features = ["derive"] }
+uor-r4-core = { version = "0.1.0", path = "../uor-r4-core", optional = true }
+uor-r4-graph-certify = { version = "0.1.0", path = "../uor-r4-graph-certify", optional = true }
+uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
+[[test]]
+name = "proof_matrix_audit"
+path = "tests/proof_matrix_audit.rs"
+required-features = ["full-model"]
 
+[[test]]
+name = "proof_model_tests"
+path = "tests/proof_model_tests.rs"
+required-features = ["full-model"]

--- a/crates/uor-r4-proof-model/README.md
+++ b/crates/uor-r4-proof-model/README.md
@@ -30,10 +30,18 @@ Property tests and production test-suites call the `verify_*` functions
 directly (see `tests/proof_model_tests.rs`); the proof matrix is the
 machine-readable registry of what is proven, assumed, and still open.
 
+The default `full-model` feature enables that complete executable-spec surface.
+Kani runs with `--no-default-features`, which retains only the harnesses over
+`uor-r4-graph-format` and `uor-r4-graph-runtime`. This keeps native teacher and
+compiler dependencies outside the bounded-model-checking graph; Kani never
+suppresses or skips their assembly.
+
 ## Conventions
 
 - Mirrors the runtime's integer-only semantics — proofs are stated over the
   normative scalar kernel, not floating-point compiler internals.
 - Findings are reported as `Result<_, String>` with the violated invariant in
   the message; no panics in verification paths.
-- Depends only on `uor-r4-core` (for the structures under proof) and serde.
+- The default executable specification depends on core, compiler, certifier,
+  format, runtime, and serde surfaces. The isolated Kani graph depends only on
+  format and runtime.

--- a/crates/uor-r4-proof-model/src/kani_proofs.rs
+++ b/crates/uor-r4-proof-model/src/kani_proofs.rs
@@ -1,4 +1,8 @@
 #![allow(unexpected_cfgs)]
+
+#[cfg(all(kani, feature = "full-model"))]
+compile_error!("Kani proofs must run with --no-default-features");
+
 #[cfg(kani)]
 mod kani_proofs {
     use kani::any;
@@ -10,8 +14,8 @@ mod kani_proofs {
         let a = ScoreQ::from_raw(any::<i32>());
         let b = ScoreQ::from_raw(any::<i32>());
 
-        // This should not panic
-        let _ = a.raw().saturating_add(b.raw());
+        let sum = a.saturating_add(b);
+        assert_eq!(sum.raw(), a.raw().saturating_add(b.raw()));
     }
 
     #[kani::proof]

--- a/crates/uor-r4-proof-model/src/lib.rs
+++ b/crates/uor-r4-proof-model/src/lib.rs
@@ -1,11 +1,19 @@
 //! uor-r4-proof-model: Executable proof specification and formal verification harness.
 
+#[cfg(feature = "full-model")]
 pub mod allocation_proof;
+#[cfg(feature = "full-model")]
 pub mod deterministic_topk_proof;
+#[cfg(feature = "full-model")]
 pub mod inference_audit;
 pub mod kani_proofs;
+#[cfg(feature = "full-model")]
 pub mod pdf_traceability;
+#[cfg(feature = "full-model")]
 pub mod proof_matrix;
+#[cfg(feature = "full-model")]
 pub mod range_bounds_proof;
+#[cfg(feature = "full-model")]
 pub mod structural_guarantees;
+#[cfg(feature = "full-model")]
 pub mod theorem7_proof;


### PR DESCRIPTION
## Summary

- split `uor-r4-proof-model` into a default-on full executable-spec surface and a minimal Kani surface
- keep only `uor-r4-graph-format` and `uor-r4-graph-runtime` in the Kani dependency graph
- fail CI if compiler, certifier, model-source, core, or `uor-matmul` re-enters that graph
- make Kani select only the library target with default features disabled
- make the ScoreQ proof exercise `ScoreQ::saturating_add` itself and assert its semantics

## Root cause

The proof crate unconditionally depended on `uor-r4-core`, which now reaches `uor-r4-model-source -> uor-matmul-kernels`. Kani rejects that crate's global assembly before either proof harness runs. Suppressing global assembly would weaken the verification result, even though neither harness needs the teacher/compiler stack.

## Impact

Normal builds and proof-matrix tests retain the complete API through the default `full-model` feature. Kani now compiles only the integer format/runtime surfaces used by its two harnesses and does not ignore unsupported assembly.

## Validation

- `cargo kani -p uor-r4-proof-model --no-default-features --lib` — 2/2 harnesses verified; runtime-state checks and the ScoreQ semantic assertion pass
- `cargo test -p uor-r4-proof-model --offline` — 25 tests pass
- `cargo test -p uor-r4-proof-model --no-default-features --offline` — minimal library profile passes
- default and minimal-profile package clippy with `-D warnings` — pass
- both graph-format no_std ladder commands — pass
- `cargo fmt --check`, claim-wording gate, and `git diff --check` — pass
- broader Apple-aarch64 workspace test/clippy reach pre-existing stale `dot_neon` test code and a fixture-enabled one-second observation assumption; both are recorded on #704 and are outside this diff

Closes #712

Generated with Codex
