### PR TITLE
research: freeze Octeract byte-map conformance

### DIFF
--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -14,6 +14,7 @@ pub mod frame_consistency;
 #[cfg(feature = "holographic-encoding")]
 pub mod holographic_encoding;
 pub mod long_context;
+pub mod octeract;
 #[cfg(feature = "patch-lifecycle")]
 pub mod patch_lifecycle;
 pub mod performance_certificate;

--- a/crates/uor-r4-graph-certify/src/octeract.rs
+++ b/crates/uor-r4-graph-certify/src/octeract.rs
@@ -1,0 +1,261 @@
+//! Finite Octeract byte-map conformance primitives (#661/#720).
+//!
+//! This module owns only the independently executable byte algebra needed by
+//! the #661 research screen. It is certifier-side, referenced by no serving
+//! path, and does not define or mutate an attention operator. In particular,
+//! the five published anchor integers are labels of equivalence classes, not
+//! similarity scores.
+
+/// Provenance fields for one supplied research input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceIdentity {
+    /// Document title embedded in the supplied PDF metadata.
+    pub metadata_title: &'static str,
+    /// Title displayed on the first page, normalized to one line.
+    pub displayed_title: &'static str,
+    /// Local filename under which the input was supplied.
+    pub filename: &'static str,
+    /// Exact file length in bytes at the #720 source audit.
+    pub byte_len: u64,
+    /// Lowercase SHA-256 of the exact supplied bytes.
+    pub sha256: &'static str,
+    /// SPDX-style license audit result. No license was found in either input.
+    pub license: &'static str,
+    /// Redistribution status derived from the absent license grant.
+    pub redistribution: &'static str,
+    /// Provenance known to the repository.
+    pub provenance: &'static str,
+    /// Date on which the local bytes and metadata were audited.
+    pub audited_on: &'static str,
+}
+
+/// The primary Octeract paper supplied to #661.
+pub const OCTERACT_CYPHER_SOURCE: SourceIdentity = SourceIdentity {
+    metadata_title: "The Octeract Cypher: Coarse-Graining and Categorical Adjunctions in 8-Bit Phase Space Collapses",
+    displayed_title: "The Octeract Cypher: Coarse-Graining and Categorical Adjunctions in 8-Bit Phase Space Collapses",
+    filename: "Octeract_Cypher_Paper.pdf",
+    byte_len: 54_969,
+    sha256: "44bab09a20253437aeef43057ae316fcded5b00fd9f6b180f83843f06d2bbb3c",
+    license: "NOASSERTION",
+    redistribution: "not-authorized",
+    provenance: "supplied-out-of-band-to-repository-maintainer",
+    audited_on: "2026-08-14",
+};
+
+/// The validation/formalization roadmap supplied to #661.
+pub const OCTERACT_VALIDATION_SOURCE: SourceIdentity = SourceIdentity {
+    metadata_title: "Validating Octeract Cypher Mathlib",
+    displayed_title: "Formal Validation and Mechanized Verification of the Octeract Cypher: A Base-2 Kaprekar Adjunction Framework",
+    filename: "Validating Octeract Cypher Mathlib.pdf",
+    byte_len: 262_762,
+    sha256: "5322c519fa872ca836e2ad23d523ecf655defedd3dd17589ba290dec62a93a5e",
+    license: "NOASSERTION",
+    redistribution: "not-authorized",
+    provenance: "supplied-out-of-band-to-repository-maintainer",
+    audited_on: "2026-08-14",
+};
+
+/// The five outputs of the 8-bit sort/subtract map, indexed by canonical
+/// folded shell `min(k, 8-k)`.
+pub const OCTERACT_ANCHORS: [u8; 5] = [0, 127, 189, 217, 225];
+
+/// Hamming weight of one byte. Values outside `0..=8` do not construct this
+/// object, so the closed-form operation itself is total (R5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ByteWeight(u8);
+
+impl ByteWeight {
+    /// Construct a byte weight exactly when `value` is in `0..=8`.
+    pub const fn new(value: u8) -> Option<Self> {
+        if value <= 8 {
+            Some(Self(value))
+        } else {
+            None
+        }
+    }
+
+    /// Return the validated weight.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+/// Hamming distance together with the caller-declared active width of one
+/// byte block. Invalid pairs do not construct this object, leaving folding
+/// total over every admitted instantiation (R5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockDistance {
+    distance: u8,
+    active_bits: u8,
+}
+
+impl BlockDistance {
+    /// Construct a bounded block distance when `distance <= active_bits <= 8`.
+    pub const fn new(distance: u8, active_bits: u8) -> Option<Self> {
+        if active_bits <= 8 && distance <= active_bits {
+            Some(Self {
+                distance,
+                active_bits,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Return the exact Hamming distance.
+    pub const fn distance(self) -> u8 {
+        self.distance
+    }
+
+    /// Return the caller-declared number of active bits.
+    pub const fn active_bits(self) -> u8 {
+        self.active_bits
+    }
+}
+
+/// One of the five folded shells of a complete byte. Values outside `0..=4`
+/// do not construct this object, so anchor lookup is total (R5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FullByteShell(u8);
+
+impl FullByteShell {
+    /// Construct a full-byte folded shell exactly when `value` is in `0..=4`.
+    pub const fn new(value: u8) -> Option<Self> {
+        if value <= 4 {
+            Some(Self(value))
+        } else {
+            None
+        }
+    }
+
+    /// Return the folded shell index.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+/// Canonical folded class together with the orientation needed to recover the
+/// unfurled Hamming distance exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OrientedClass {
+    /// `min(distance, active_bits - distance)`.
+    shell: u8,
+    /// `true` exactly when `distance > active_bits / 2`.
+    high_side: bool,
+    /// Number of active bits in the block.
+    active_bits: u8,
+}
+
+impl OrientedClass {
+    /// Construct a canonical oriented class. A high-side spelling of an
+    /// even-width equator is non-canonical and therefore does not construct.
+    pub const fn new(shell: u8, high_side: bool, active_bits: u8) -> Option<Self> {
+        if active_bits > 8 || shell > active_bits / 2 {
+            return None;
+        }
+        if high_side && active_bits.is_multiple_of(2) && shell == active_bits / 2 {
+            return None;
+        }
+        Some(Self {
+            shell,
+            high_side,
+            active_bits,
+        })
+    }
+
+    /// Return the folded shell.
+    pub const fn shell(self) -> u8 {
+        self.shell
+    }
+
+    /// Return whether this is the high-distance member of the folded pair.
+    pub const fn high_side(self) -> bool {
+        self.high_side
+    }
+
+    /// Return the caller-declared active width.
+    pub const fn active_bits(self) -> u8 {
+        self.active_bits
+    }
+}
+
+/// Direct oracle from the defining construction: split a byte into eight
+/// binary digits, sort the digits, interpret the ascending and descending
+/// arrangements, and subtract. This intentionally does not call
+/// [`octeract_closed_form`] or `count_ones`.
+pub fn octeract_sort_subtract(value: u8) -> u8 {
+    let mut digits = [0u8; 8];
+    for (index, digit) in digits.iter_mut().enumerate() {
+        *digit = (value >> index) & 1;
+    }
+    digits.sort_unstable();
+
+    let mut ascending = 0u8;
+    let mut descending = 0u8;
+    for &digit in &digits {
+        ascending = (ascending << 1) | digit;
+    }
+    for &digit in digits.iter().rev() {
+        descending = (descending << 1) | digit;
+    }
+    descending - ascending
+}
+
+/// Closed-form 8-bit map evaluated from a bounded Hamming weight:
+/// `257 - (2^(8-k) + 2^k)`.
+pub fn octeract_closed_form_from_weight(weight: ByteWeight) -> u8 {
+    let weight = weight.get();
+    let output = 257u16 - (1u16 << (8 - weight)) - (1u16 << weight);
+    output as u8
+}
+
+/// Closed-form 8-bit map evaluated from the input byte's Hamming weight.
+pub fn octeract_closed_form(value: u8) -> u8 {
+    // Every u8 weight is in 0..=8, so this expression is total without a
+    // recoverable error branch.
+    let weight = value.count_ones();
+    let output = 257u16 - (1u16 << (8 - weight)) - (1u16 << weight);
+    output as u8
+}
+
+/// Fold a bounded block distance through complement symmetry.
+pub fn folded_class(block: BlockDistance) -> u8 {
+    block.distance.min(block.active_bits - block.distance)
+}
+
+/// Fold a bounded block distance while retaining the orientation that makes
+/// the representation lossless with respect to ordinary block weight.
+pub fn oriented_class(block: BlockDistance) -> OrientedClass {
+    OrientedClass {
+        shell: folded_class(block),
+        high_side: block.distance > block.active_bits / 2,
+        active_bits: block.active_bits,
+    }
+}
+
+/// Recover the exact distance from a canonical oriented class.
+pub fn distance_from_oriented(class: OrientedClass) -> u8 {
+    if class.high_side {
+        class.active_bits - class.shell
+    } else {
+        class.shell
+    }
+}
+
+/// Map one full-byte folded shell to the paper's published anchor label.
+pub fn anchor_for_shell(shell: FullByteShell) -> u8 {
+    OCTERACT_ANCHORS[shell.get() as usize]
+}
+
+/// Masked byte Hamming distance used by the current route relation.
+pub fn masked_byte_distance(query: u8, key: u8, mask: u8) -> u8 {
+    ((query ^ key) & mask).count_ones() as u8
+}
+
+/// Safe weight lower bound for masked byte Hamming distance:
+/// `abs(wt(q AND m) - wt(k AND m)) <= d_H(q,k;m)`.
+pub fn masked_weight_lower_bound(query: u8, key: u8, mask: u8) -> u8 {
+    let query_weight = (query & mask).count_ones() as u8;
+    let key_weight = (key & mask).count_ones() as u8;
+    query_weight.abs_diff(key_weight)
+}

--- a/crates/uor-r4-graph-certify/tests/octeract_attention_661.rs
+++ b/crates/uor-r4-graph-certify/tests/octeract_attention_661.rs
@@ -1,0 +1,228 @@
+//! #661/#720 finite Octeract conformance. These tests establish the bounded
+//! byte algebra only; they make no attention-quality or formal-proof claim.
+
+use uor_r4_graph_certify::octeract::{
+    anchor_for_shell, distance_from_oriented, folded_class, masked_byte_distance,
+    masked_weight_lower_bound, octeract_closed_form, octeract_closed_form_from_weight,
+    octeract_sort_subtract, oriented_class, BlockDistance, ByteWeight, FullByteShell,
+    OrientedClass, OCTERACT_ANCHORS, OCTERACT_CYPHER_SOURCE, OCTERACT_VALIDATION_SOURCE,
+};
+
+fn block_distance(distance: u8, active_bits: u8) -> BlockDistance {
+    BlockDistance::new(distance, active_bits).expect("test inputs are bounded byte blocks")
+}
+
+fn byte_shell(shell: u8) -> FullByteShell {
+    FullByteShell::new(shell).expect("test inputs are full-byte shells")
+}
+
+fn byte_weight(weight: u8) -> ByteWeight {
+    ByteWeight::new(weight).expect("test inputs are byte weights")
+}
+
+#[test]
+fn supplied_source_identities_are_exact_and_nonredistributable() {
+    assert_eq!(
+        OCTERACT_CYPHER_SOURCE.metadata_title,
+        OCTERACT_CYPHER_SOURCE.displayed_title
+    );
+    assert_eq!(OCTERACT_CYPHER_SOURCE.filename, "Octeract_Cypher_Paper.pdf");
+    assert_eq!(OCTERACT_CYPHER_SOURCE.byte_len, 54_969);
+    assert_eq!(
+        OCTERACT_CYPHER_SOURCE.sha256,
+        "44bab09a20253437aeef43057ae316fcded5b00fd9f6b180f83843f06d2bbb3c"
+    );
+    assert_eq!(OCTERACT_VALIDATION_SOURCE.byte_len, 262_762);
+    assert_eq!(
+        OCTERACT_VALIDATION_SOURCE.metadata_title,
+        "Validating Octeract Cypher Mathlib"
+    );
+    assert_eq!(
+        OCTERACT_VALIDATION_SOURCE.displayed_title,
+        "Formal Validation and Mechanized Verification of the Octeract Cypher: A Base-2 Kaprekar Adjunction Framework"
+    );
+    assert_eq!(
+        OCTERACT_VALIDATION_SOURCE.filename,
+        "Validating Octeract Cypher Mathlib.pdf"
+    );
+    assert_eq!(
+        OCTERACT_VALIDATION_SOURCE.sha256,
+        "5322c519fa872ca836e2ad23d523ecf655defedd3dd17589ba290dec62a93a5e"
+    );
+    for source in [OCTERACT_CYPHER_SOURCE, OCTERACT_VALIDATION_SOURCE] {
+        assert_eq!(source.license, "NOASSERTION");
+        assert_eq!(source.redistribution, "not-authorized");
+        assert_eq!(
+            source.provenance,
+            "supplied-out-of-band-to-repository-maintainer"
+        );
+        assert_eq!(source.audited_on, "2026-08-14");
+    }
+}
+
+#[test]
+fn direct_oracle_closed_form_and_published_map_agree_exhaustively() {
+    // The paper's named equal-weight example: both arrangements have four
+    // ones and therefore route to the same published anchor.
+    assert_eq!(octeract_sort_subtract(0b1010_1010), 225);
+    assert_eq!(octeract_sort_subtract(0b1111_0000), 225);
+
+    let published = [0u8, 127, 189, 217, 225, 217, 189, 127, 0];
+    for (weight, &expected) in published.iter().enumerate() {
+        assert_eq!(
+            octeract_closed_form_from_weight(byte_weight(weight as u8)),
+            expected
+        );
+    }
+    assert_eq!(ByteWeight::new(9), None);
+
+    let mut observed = [false; 256];
+    for value in u8::MIN..=u8::MAX {
+        let direct = octeract_sort_subtract(value);
+        let closed = octeract_closed_form(value);
+        assert_eq!(direct, closed, "input {value:#04x}");
+        observed[direct as usize] = true;
+
+        // Complement symmetry and one-step idempotency are finite facts over
+        // the complete byte domain, including both endpoint weights.
+        assert_eq!(closed, octeract_closed_form(!value));
+        assert_eq!(closed, octeract_closed_form(closed));
+
+        let weight = value.count_ones() as u8;
+        let shell = folded_class(block_distance(weight, 8));
+        assert_eq!(closed, anchor_for_shell(byte_shell(shell)));
+    }
+    let outputs: Vec<u8> = observed
+        .iter()
+        .enumerate()
+        .filter_map(|(value, &present)| present.then_some(value as u8))
+        .collect();
+    assert_eq!(outputs, OCTERACT_ANCHORS);
+}
+
+#[test]
+fn all_full_mask_pairs_obey_fold_orientation_and_safe_bound() {
+    let mut complement_collisions = 0u64;
+    for query in u8::MIN..=u8::MAX {
+        for key in u8::MIN..=u8::MAX {
+            let difference = query ^ key;
+            let distance = masked_byte_distance(query, key, u8::MAX);
+            let block = block_distance(distance, 8);
+            let shell = folded_class(block);
+            let oriented = oriented_class(block);
+            assert_eq!(distance_from_oriented(oriented), distance);
+            assert_eq!(
+                octeract_sort_subtract(difference),
+                anchor_for_shell(byte_shell(shell))
+            );
+
+            let complement_distance = masked_byte_distance(query, !key, u8::MAX);
+            assert_eq!(complement_distance, 8 - distance);
+            assert_eq!(
+                folded_class(block_distance(complement_distance, 8)),
+                folded_class(block)
+            );
+            if complement_distance != distance {
+                complement_collisions += 1;
+                assert_ne!(
+                    oriented_class(block_distance(complement_distance, 8)),
+                    oriented_class(block)
+                );
+            }
+
+            let lower = masked_weight_lower_bound(query, key, u8::MAX);
+            assert!(lower <= distance);
+        }
+    }
+    // Exactly the C(8,4) * 256 equator pairs do not change distance
+    // under key complementation; every other pair is a lossy fold collision.
+    assert_eq!(complement_collisions, 65_536 - 70 * 256);
+}
+
+#[test]
+fn partial_masks_and_wide_block_composition_are_bounded_and_nonvacuous() {
+    // Exhaust the complete canonical oriented state space, including every
+    // active width not represented by the fixed mask sample below.
+    let mut canonical_states = 0u8;
+    for active_bits in 0..=8u8 {
+        for distance in 0..=active_bits {
+            let class = oriented_class(block_distance(distance, active_bits));
+            assert_eq!(distance_from_oriented(class), distance);
+            canonical_states += 1;
+        }
+    }
+    assert_eq!(canonical_states, 45);
+
+    const MASKS: [u8; 8] = [0x00, 0x01, 0x0f, 0x33, 0x55, 0xaa, 0xfe, 0xff];
+    let mut strict_lower_bounds = 0u64;
+    for mask in MASKS {
+        let active_bits = mask.count_ones() as u8;
+        for query in u8::MIN..=u8::MAX {
+            for key in u8::MIN..=u8::MAX {
+                let distance = masked_byte_distance(query, key, mask);
+                let lower = masked_weight_lower_bound(query, key, mask);
+                assert!(distance <= active_bits);
+                assert!(lower <= distance);
+                if lower < distance {
+                    strict_lower_bounds += 1;
+                }
+                let class = oriented_class(block_distance(distance, active_bits));
+                assert_eq!(distance_from_oriented(class), distance);
+            }
+        }
+    }
+    assert!(
+        strict_lower_bounds > 100_000,
+        "the bound is not an equality"
+    );
+
+    // Fixed 288-bit example: summing the 36 ordinary block weights and
+    // reconstructing those weights from oriented shells are exactly the same
+    // relation. The unoriented fold is deliberately lossy.
+    let mut exact_sum = 0u16;
+    let mut reconstructed_sum = 0u16;
+    let mut folded_sum = 0u16;
+    for block in 0..36u8 {
+        let query = block.wrapping_mul(73).rotate_left(1);
+        let key = block.wrapping_mul(29).wrapping_add(0x5a);
+        let distance = masked_byte_distance(query, key, u8::MAX);
+        exact_sum += u16::from(distance);
+        reconstructed_sum += u16::from(distance_from_oriented(oriented_class(block_distance(
+            distance, 8,
+        ))));
+        folded_sum += u16::from(folded_class(block_distance(distance, 8)));
+    }
+    assert_eq!(exact_sum, reconstructed_sum);
+    assert_ne!(exact_sum, folded_sum);
+}
+
+#[test]
+fn anchor_integers_are_only_a_bijective_shell_relabeling() {
+    let arbitrary_labels = [91u8, 4, 250, 33, 118];
+    for left in 0..=8u8 {
+        for right in 0..=8u8 {
+            let left_shell = folded_class(block_distance(left, 8));
+            let right_shell = folded_class(block_distance(right, 8));
+            assert_eq!(
+                anchor_for_shell(byte_shell(left_shell))
+                    == anchor_for_shell(byte_shell(right_shell)),
+                arbitrary_labels[left_shell as usize] == arbitrary_labels[right_shell as usize]
+            );
+        }
+    }
+}
+
+#[test]
+fn malformed_bounded_classes_fail_closed() {
+    assert_eq!(BlockDistance::new(9, 8), None);
+    assert_eq!(BlockDistance::new(0, 9), None);
+    assert_eq!(FullByteShell::new(5), None);
+    assert_eq!(OrientedClass::new(4, true, 8), None);
+    assert_eq!(OrientedClass::new(3, false, 4), None);
+
+    let canonical = OrientedClass::new(3, true, 8).expect("high-side shell is canonical");
+    assert_eq!(canonical.shell(), 3);
+    assert!(canonical.high_side());
+    assert_eq!(canonical.active_bits(), 8);
+    assert_eq!(distance_from_oriented(canonical), 5);
+}

--- a/docs/octeract_attention_661.md
+++ b/docs/octeract_attention_661.md
@@ -1,0 +1,171 @@
+# Octeract route-attention investigation (#661)
+
+This record is append-only evidence for the bounded investigation in #661. It
+does not activate an operator or change a serving path. Phase A is owned by
+#720; the trace ceiling and disposition remain a later, separately gated
+phase.
+
+## 2026-08-14 - Phase A source and conformance record (#720)
+
+### Source boundary
+
+The two research inputs were supplied out of band to the repository
+maintainer. They are not repository artifacts. The audit found no license or
+redistribution grant in either PDF's text or metadata, so the repository uses
+`license: NOASSERTION` and `redistribution: not-authorized`. Neither PDF, its
+figures, nor extended source prose may be committed without a separate grant.
+Only independently stated definitions, executable tests, and analysis appear
+here.
+
+| Input | Local identity | Exact bytes | SHA-256 | Provenance / license |
+|---|---|---:|---|---|
+| *The Octeract Cypher: Coarse-Graining and Categorical Adjunctions in 8-Bit Phase Space Collapses* | `Octeract_Cypher_Paper.pdf`; 8 pages; PDF title metadata present | 54,969 | `44bab09a20253437aeef43057ae316fcded5b00fd9f6b180f83843f06d2bbb3c` | supplied out of band; `NOASSERTION`; redistribution not authorized |
+| Metadata title *Validating Octeract Cypher Mathlib*; displayed title *Formal Validation and Mechanized Verification of the Octeract Cypher: A Base-2 Kaprekar Adjunction Framework* | `Validating Octeract Cypher Mathlib.pdf`; 12 pages | 262,762 | `5322c519fa872ca836e2ad23d523ecf655defedd3dd17589ba290dec62a93a5e` | supplied out of band; `NOASSERTION`; redistribution not authorized |
+
+Audit date: 2026-08-14. The same identity fields are pinned as data in
+`uor_r4_graph_certify::octeract`.
+
+### Finite definitions used by the investigation
+
+**Definition** Direct byte map. Split a byte into eight binary digits, sort
+the digits once in ascending and descending order, interpret both arrangements
+as bytes, and subtract the ascending value from the descending value. The
+certifier's direct oracle implements those steps without calling `count_ones`
+or the closed form.
+
+**Definition** Closed form. For a validated byte Hamming weight
+`k in 0..=8`, the independent algebraic implementation is
+
+```text
+K8(k) = 257 - (2^(8-k) + 2^k).
+```
+
+The complete weight map is:
+
+| `k` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `K8(k)` | 0 | 127 | 189 | 217 | 225 | 217 | 189 | 127 | 0 |
+
+**Definition** Class identity. For a relation block with `B` active bits and
+masked Hamming distance `d`, the canonical complement-folded class is
+`min(d, B-d)`. On a full byte this has five values. The integers
+`0/127/189/217/225` are a bijective labeling of those five values; they have no
+declared ordering or metric meaning for attention.
+
+**Definition** Oriented class. The folded class plus the predicate
+`d > floor(B/2)` reconstructs `d` exactly (the even-width equator has only its
+canonical low-side spelling). Consequently, oriented folding is an alternate
+representation of ordinary block weight, not a new relation by itself.
+
+### Page/claim/owner map
+
+Page numbers refer to the supplied files above, not to any republished copy.
+
+| Source location | Independently stated proposal | Classification | R4 owner / consequence |
+|---|---|---|---|
+| Cypher paper pp. 2-3, sections 2.1-2.3; validation pp. 2-3, sections 2-3 | Binary state, Hamming weight, sorted forms, and the closed form | `directly-applicable` | Certifier conformance oracle in `uor-r4-graph-certify::octeract` |
+| Cypher paper p. 4, section 2.4 | Factorization through Hamming weight | `directly-applicable` after correcting the claim that the weight-to-output map is injective | The finite map is many-to-one under `k <-> 8-k`; no attention semantics follow from factorization alone |
+| Cypher paper p. 5, section 3.3; validation pp. 3-5, section 4 | Five outputs and one-step idempotency | `directly-applicable` as finite byte facts | Exhaustive #720 tests; endpoints are handled explicitly |
+| Cypher paper pp. 5-6, section 4.1; validation pp. 6-7, section 6.1 | Complement/equator symmetry | `directly-applicable` as a bounded finite identity | Exhaustive #720 tests; no attention-quality consequence is inferred |
+| Validation pp. 5-6, section 5 | 6.1824-bit loss under a uniform distribution on all bytes | `already-covered` as an arithmetic consequence, not an R4 measurement | #661-B must measure actual route-trace occupancy and information; the uniform-byte number is not a baseline |
+| Cypher pp. 6-7, section 4; validation pp. 7-8, section 6 | Complement/equator order duality described as a Galois connection | `adaptable-hypothesis` | The bounded complement map is an order duality; it is not, by that fact alone, the deployed `K8` relation or a complete attention operator |
+| Validation pp. 8-10, section 7 | Suggested Lean/mathlib declarations | `incompatible` with a proof claim in their supplied form | The declarations contain `sorry` and are a roadmap. #653 is the existing proof-integration owner; #720 introduces no second registry or toolchain |
+| Both conclusions/applications (Cypher pp. 7-8; validation p. 11) | Routing, stabilization, self-correction, and pipeline benefits | `adaptable-hypothesis` only | #661's locked collision/ceiling/null experiment owns any empirical disposition; no product or quality claim is imported |
+
+### Corrections and bounded claim status
+
+**Guarantee** Status: **Structural**. On the complete byte domain, the direct
+sort/subtract implementation equals the independent closed form, identifies
+complementary weights, has exactly the five outputs in the table above, and is
+idempotent after one application. The oriented class round-trips every one of
+the 45 canonical `(active width, distance)` states. Evidence:
+[`octeract_attention_661.rs`](../crates/uor-r4-graph-certify/tests/octeract_attention_661.rs).
+
+1. The weight-to-output map is not injective: complementary weights have the
+   same output.
+2. The non-trivial output-weight identity applies only for `0 < k < 8`.
+   Both endpoint weights map to zero. Idempotency itself still holds at the
+   endpoints.
+3. This record does not adopt the source's Galois label as a property of `K8`
+   or of the complete deployed attention operator. At `k = 0`, for example,
+   complement weight is 8 while `K8(0)` has weight 0.
+4. The validation PDF's Lean snippets contain admitted goals. This record makes
+   no machine-proof claim and relies only on exhaustive finite execution for
+   the byte-domain facts.
+5. The source's entropy row assumes uniformly sampled bytes. #720 does not
+   adopt it as evidence about teacher support, real route-code occupancy,
+   language quality, or useful pruning on R4 traces.
+
+### Math-to-operator boundary
+
+**Definition** Candidate placement. The source material supplies only a
+possible compatibility relation or prefilter. It does not supply the rest of
+the versioned #602 operator:
+
+| #602 field | #720 finding |
+|---|---|
+| projections | absent; current `route-fit/1` Q/K code construction remains the later baseline |
+| positional action | absent |
+| compatibility relation | relation-first hypothesis `fold(popcount((q XOR key) AND mask))`; encode-first and prefilter/refine are distinct candidates and may not be conflated |
+| selector | absent; current bounded `(distance, candidate-index)` selection is not implied by the papers |
+| aggregation | absent |
+| output projection | absent |
+| state | absent |
+| tie behavior | absent |
+
+Other existing Hamming consumers remain separate owners: the packed
+route-attention relation, graph-runtime route probing/VP-tree distance, and the
+legacy transformerless assignment/index path. The f64 router produces the
+288-bit session signature but does not perform the Hamming comparison. A later
+classification-only fallback, if the attention screen stops negative, belongs
+at those comparison seats and may not silently alter them.
+
+### Executable Phase A evidence
+
+**Guarantee** Status: **Structural**. For every masked byte pair exercised by
+the declared exhaustive/representative domains, the weight difference is a
+lower bound on masked Hamming distance. Full-byte oriented folds reconstruct
+ordinary block weight, while unoriented folds deliberately identify
+complementary distances. Evidence:
+[`octeract_attention_661.rs`](../crates/uor-r4-graph-certify/tests/octeract_attention_661.rs).
+
+`crates/uor-r4-graph-certify/tests/octeract_attention_661.rs` checks:
+
+- all 256 byte inputs against independently coded direct and closed-form maps;
+- the exact five outputs, both endpoints, complement symmetry, and one-step
+  idempotency;
+- all 65,536 full-mask `(query,key)` byte pairs;
+- the 47,616 non-equator pairs whose exact distances collide after key
+  complementation (the 17,920 distance-4 pairs are the equator);
+- all 45 canonical oriented states, five-anchor relabel invariance, and the
+  paper's named `10101010` / `11110000` example;
+- the safe lower bound
+  `abs(wt(q AND m)-wt(key AND m)) <= wt((q XOR key) AND m)` across eight
+  deterministic masks and every byte pair; and
+- a deterministic 36-byte composition showing ordinary block weights and
+  oriented folds reconstruct the same 288-bit Hamming sum while the
+  unoriented fold is lossy.
+
+Malformed weights, widths, distances, shells, and non-canonical equator
+encodings do not construct the corresponding bounded value types; operations
+over admitted values are total. No serving, graph-format, runtime,
+operator-registry, fit-method, artifact, or kappa byte changes in this phase.
+
+### Next gate (not run in Phase A)
+
+**Empirical Criterion** Status: **Unproven** until #661-B runs. An
+Octeract-derived attention arm advances only under the parent issue's locked
+trace-ceiling, null, frame, and promotion rules on a pinned fixture.
+
+The next child must freeze and run #661's predeclared cheap screen over the
+existing #603-shaped trace surface. `weight9` and oriented folding are controls:
+when their 36 block weights are summed, they reproduce current V1 Hamming.
+`fold5` is the lossy candidate. A folded/lower-bound prefilter can report only a
+theoretical pruning ceiling against the current flat-scan `RAT1`; it cannot
+claim runtime byte savings without a new indexed representation.
+
+The screen must include packed V1, fold5, oriented/weight controls,
+prefilter/refine and the safe lower bound, occupancy-matched and shuffled-block
+nulls, and the #647 frame control. Missing real trace/corpus prerequisites are
+recorded as `UNAVAILABLE`, never as zero or a negative quality verdict. At most
+two candidates may advance; no packed or long run begins before that decision.


### PR DESCRIPTION
## Summary

- bind the two supplied Octeract research inputs by exact metadata/displayed title, filename, byte size, SHA-256, provenance, audit date, and `NOASSERTION` license state without redistributing either PDF
- add an independent digit-sort/subtract oracle and a separate closed-form byte map
- make valid byte weights, block distances, shells, and oriented classes explicit bounded value types whose admitted operations are total
- exhaust the complete byte and full-mask pair domains, partial masks, all 45 canonical oriented states, anchor relabeling, and deterministic 288-bit composition
- document source corrections and keep the result certifier-only: no operator, runtime, artifact, default, or kappa mutation

## Evidence

- all 256 bytes reproduce the published five-output map
- all 65,536 full-mask pairs satisfy the folded/oriented relations
- 47,616 non-equator complement pairs collide under the lossy fold; 17,920 equator pairs do not
- the partial-mask lower bound is strict in 213,862 cases
- the deterministic 288-bit example reconstructs exact distance 146; the lossy fold totals 106

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo test --workspace --offline`
- `cargo check -p uor-r4-graph-format --no-default-features`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`
- `TLESS_CANONICAL_DETERMINISTIC=1 cargo test -p uor-r4-core --release --offline --test kappa_reproduction -- --ignored` (3/3, non-vacuous `/tmp/ref/out/model.bin`)
- `cargo run -q -p xtask -- check-model`
- `cargo run -q -p xtask -- audit-deferral`
- `cargo run -q -p xtask -- audit-limits`
- `cargo test -q -p repo-conformance`
- `cargo deny check bans`
- `python3 scripts/check_claim_wording.py`
- `git diff --check`

Closes #720.
References #661.
