### PR TITLE
research: run Octeract route-trace screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "ciborium",
+ "libm",
  "rayon",
  "serde",
  "uor-r4-core",

--- a/crates/uor-r4-graph-certify/Cargo.toml
+++ b/crates/uor-r4-graph-certify/Cargo.toml
@@ -15,6 +15,7 @@ uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler" }
 serde = { version = "1.0", features = ["derive"] }
 ciborium = "0.2"
 blake3 = "1.5"
+libm = "0.2"
 rayon = "1.10.0"
 
 [dev-dependencies]

--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -15,6 +15,8 @@ pub mod frame_consistency;
 pub mod holographic_encoding;
 pub mod long_context;
 pub mod octeract;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod octeract_trace_screen;
 #[cfg(feature = "patch-lifecycle")]
 pub mod patch_lifecycle;
 pub mod performance_certificate;

--- a/crates/uor-r4-graph-certify/src/octeract_trace_screen.rs
+++ b/crates/uor-r4-graph-certify/src/octeract_trace_screen.rs
@@ -1,0 +1,2834 @@
+//! Deterministic Octeract route-trace collision/reachability screen (#661/#722).
+//!
+//! This host-side certifier consumes the existing `full/1` trace and
+//! `route-fit/1` products. It neither reads a fixture implicitly nor defines a
+//! new fit, packed operator, artifact section, or serving path. Synthetic
+//! inputs exercise instrument conformance only; empirical candidate verdicts
+//! require an explicitly supplied, completely identified real trace.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use uor_r4_core::transformerless::compiler::xorshift;
+use uor_r4_core::transformerless::hf_bpe::adapter_constructor;
+use uor_r4_graph_compiler::observation::ObservationManifest;
+use uor_r4_graph_compiler::route_fit::{
+    fit_method_spec, fit_route_codes, route_fit_v1_parameter_labels, FitManifest, FittedRouteCodes,
+    RouteFitMethod, RouteTraceCorpus, FIT_MANIFEST_FORMAT,
+};
+use uor_r4_graph_compiler::trace_profile::{
+    profile_spec, TraceCaptureBounds, FULL_PROFILE, PROFILE_VERSION,
+};
+use uor_r4_graph_format::route_attention::{
+    build_route_attention_instance, RouteOpCensus, ROUTE_CODE_BITS, ROUTE_CODE_BYTES,
+    ROUTE_MAX_CANDIDATES,
+};
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_model_source::attention::{operator_spec, AttentionOperatorSpec};
+use uor_r4_model_source::geometry::{projection_implementation, GeometryProjection};
+
+use crate::frame_consistency::{frame_control_default, FrameControl};
+use crate::octeract::{
+    distance_from_oriented, folded_class, masked_byte_distance, masked_weight_lower_bound,
+    oriented_class, BlockDistance, OCTERACT_CYPHER_SOURCE, OCTERACT_VALIDATION_SOURCE,
+};
+use crate::route_attention::{run_packed, RouteAttentionReference, RouteSelection};
+use crate::route_fit_report::StageVerdict;
+
+/// Canonical pre-inspection contract tag.
+pub const OCTERACT_TRACE_CONTRACT_FORMAT: &str = "uor-r4-octeract-trace-screen-contract/1";
+/// Canonical report-envelope tag.
+pub const OCTERACT_TRACE_REPORT_FORMAT: &str = "uor-r4-octeract-trace-screen/1";
+/// Occupancy-matched fold-null seed locked by #722.
+pub const OCCUPANCY_MATCHED_FOLD_SEED: u64 = 0x661B_0001;
+/// Shuffled-key-block null seed locked by #722.
+pub const SHUFFLED_BLOCK_SEED: u64 = 0x661B_0002;
+/// Layer selected before trace inspection.
+pub const SCREEN_LAYER: u32 = 0;
+/// Head selected before trace inspection.
+pub const SCREEN_HEAD: u32 = 0;
+/// Full-byte relation mask.
+pub const SCREEN_MASK: [u8; ROUTE_CODE_BYTES] = [0xff; ROUTE_CODE_BYTES];
+
+const ARM_V1: &str = "v1-baseline";
+const ARM_WEIGHT9: &str = "weight9-control";
+const ARM_FOLD5: &str = "octeract-fold5";
+const ARM_ORIENTED: &str = "octeract-oriented-control";
+const ARM_PREFILTER: &str = "octeract-prefilter";
+const ARM_LOWER_BOUND: &str = "safe-lower-bound-control";
+const NULL_OCCUPANCY: &str = "occupancy-matched-fold-null";
+const NULL_SHUFFLED_BLOCK: &str = "shuffled-block-null";
+const NULL_DERANGED_SUPPORT: &str = "deranged-support-null";
+/// Initial registry id for structural-only evidence.
+pub const INSTRUMENT_CONFORMANCE_EVIDENCE_ID: &str = "instrument-conformance";
+/// Initial registry version for structural-only evidence.
+pub const INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION: u32 = 1;
+/// Number of bijections of the five folded-shell anchor identities.
+pub const ANCHOR_RELABELINGS: u32 = 120;
+
+/// Whether supplied evidence may carry empirical candidate verdicts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TraceKind {
+    /// A completely identified, pinned real `full/1` trace.
+    #[serde(rename = "pinned-real")]
+    PinnedReal,
+    /// A synthetic/manual fixture usable only for structural conformance.
+    #[serde(rename = "instrument-conformance")]
+    InstrumentConformance,
+}
+
+/// Opaque registry record authorizing one evidence class. A caller cannot
+/// manufacture or relabel this value: records are obtained only through
+/// [`registered_trace_evidence`]. Future empirical records must pin every
+/// decoded observation/fit identity represented by the private fields below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TraceEvidenceRecord {
+    id: &'static str,
+    version: u32,
+    kind: TraceKind,
+    observation_identity_bundle_digest: Option<&'static str>,
+    records_kappa: Option<&'static str>,
+    trace_kappa: Option<&'static str>,
+    fit_manifest_kappa: Option<&'static str>,
+    fitted_params_kappa: Option<&'static str>,
+}
+
+impl TraceEvidenceRecord {
+    /// Stable registry id.
+    pub const fn id(self) -> &'static str {
+        self.id
+    }
+
+    /// Registry version.
+    pub const fn version(self) -> u32 {
+        self.version
+    }
+
+    /// Evidence class authorized by this registry record.
+    pub const fn kind(self) -> TraceKind {
+        self.kind
+    }
+
+    /// Canonical digest of the complete registry record, including explicit
+    /// absence markers for identity pins.
+    pub fn declared_digest(self) -> String {
+        fn field(value: Option<&str>) -> String {
+            value.map_or_else(|| "absent".to_owned(), |value| format!("present:{value}"))
+        }
+        let kind = match self.kind {
+            TraceKind::PinnedReal => "pinned-real",
+            TraceKind::InstrumentConformance => "instrument-conformance",
+        };
+        let bytes = format!(
+            "uor-r4-octeract-trace-evidence/1\nid={}\nversion={}\nkind={}\nobservation={}\nrecords={}\ntrace={}\nfit-manifest={}\nfitted-params={}\n",
+            self.id,
+            self.version,
+            kind,
+            field(self.observation_identity_bundle_digest),
+            field(self.records_kappa),
+            field(self.trace_kappa),
+            field(self.fit_manifest_kappa),
+            field(self.fitted_params_kappa),
+        );
+        format!("blake3:{}", blake3::hash(bytes.as_bytes()).to_hex())
+    }
+}
+
+/// Resolve an evidence record through the closed #722 registry. The initial
+/// registry intentionally contains no empirical record: a real trace becomes
+/// eligible only when its exact observation and fit identities are pinned in
+/// a reviewed follow-up, never by caller-selected [`TraceKind`] or adapter
+/// spelling.
+const fn instrument_trace_evidence() -> TraceEvidenceRecord {
+    TraceEvidenceRecord {
+        id: INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+        version: INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+        kind: TraceKind::InstrumentConformance,
+        observation_identity_bundle_digest: None,
+        records_kappa: None,
+        trace_kappa: None,
+        fit_manifest_kappa: None,
+        fitted_params_kappa: None,
+    }
+}
+
+pub fn registered_trace_evidence(id: &str, version: u32) -> Option<TraceEvidenceRecord> {
+    match (id, version) {
+        (INSTRUMENT_CONFORMANCE_EVIDENCE_ID, INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION) => {
+            Some(instrument_trace_evidence())
+        }
+        _ => None,
+    }
+}
+
+/// Explicit input boundary. Source/operator provenance is accepted only via
+/// the authoritative observation manifest whose identity-bundle digest the
+/// decoded corpus carries. It is never inferred from
+/// `FitManifest::operator_identity` (which identifies the target dormant
+/// operator) or supplied as a free-floating digest/spec.
+#[derive(Debug, Clone, Copy)]
+pub struct OcteractTraceInput<'a> {
+    pub corpus: &'a RouteTraceCorpus,
+    pub fitted: &'a FittedRouteCodes,
+    pub fit_manifest: &'a FitManifest,
+    pub observation_manifest: Option<&'a ObservationManifest>,
+    /// Closed registry evidence record. In the initial #722 release this can
+    /// authorize structural instrument conformance only.
+    pub evidence: TraceEvidenceRecord,
+}
+
+/// Final branch selected by the locked #722 decision rules.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScreenDisposition {
+    /// At least one promotable Octeract arm cleared every locked gate.
+    #[serde(rename = "advance")]
+    Advance,
+    /// A valid real screen ran and no promotable arm cleared.
+    #[serde(rename = "stop-negative")]
+    StopNegative,
+    /// Real evidence or a valid frame/instrument was absent.
+    #[default]
+    #[serde(rename = "UNAVAILABLE")]
+    Unavailable,
+}
+
+/// One arm/null declaration serialized in the contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArmContract {
+    /// Stable arm id.
+    pub id: String,
+    /// Whether this arm can advance #661.
+    pub can_advance: bool,
+    /// Locked score and tie semantics.
+    pub rule: String,
+}
+
+/// One closed evidence-registry declaration serialized in the preinspection
+/// contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceEvidenceContractRecord {
+    pub id: String,
+    pub version: u32,
+    pub kind: TraceKind,
+    pub declared_digest: String,
+}
+
+/// Locked numerical thresholds.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScreenThresholds {
+    /// Direct fold oracle and realized Jaccard margin above V1.
+    pub direct_jaccard_margin: f64,
+    /// Minimum prefilter recall of the full V1 selection.
+    pub prefilter_v1_recall: f64,
+    /// Maximum exact-refinement fraction on work-eligible steps.
+    pub prefilter_refinement_fraction: f64,
+}
+
+/// Complete #722 screen contract, constructed without reading support labels.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OcteractTraceContract {
+    /// [`OCTERACT_TRACE_CONTRACT_FORMAT`].
+    pub format: String,
+    /// Fixed layer.
+    pub layer: u32,
+    /// Fixed head.
+    pub head: u32,
+    /// Fixed route-code width.
+    pub code_bits: u32,
+    /// Natural byte-block count.
+    pub blocks: u32,
+    /// Fixed full-byte mask.
+    pub mask: Vec<u8>,
+    /// Stable candidate/tie rule.
+    pub candidate_rule: String,
+    /// `M=min(8, trace support cap)`.
+    pub selection_width_rule: String,
+    /// Direct-arm eligibility.
+    pub eligible_step_rule: String,
+    /// Fixed-order aggregation.
+    pub aggregation: String,
+    /// Arms in canonical order.
+    pub arms: Vec<ArmContract>,
+    /// Null arms in canonical order.
+    pub nulls: Vec<ArmContract>,
+    /// Historical weighted-Hamming comparison owner; cited, never rerun or
+    /// relabeled as an Octeract arm.
+    pub prior_weighted_hamming_row: String,
+    /// Locked null seeds.
+    pub occupancy_seed: u64,
+    /// Locked shuffled-block seed.
+    pub shuffled_block_seed: u64,
+    /// Derived fixed nonidentity key-block permutation, serialized so a future
+    /// RNG implementation change cannot silently move the null.
+    pub shuffled_block_permutation: Vec<u8>,
+    /// Locked thresholds.
+    pub thresholds: ScreenThresholds,
+    /// Frame policy.
+    pub frame_rule: String,
+    /// Five anchors are labels only; every bijective relabeling must preserve
+    /// class-only results.
+    pub anchor_relabel_rule: String,
+    /// Closed evidence-registry policy.
+    pub evidence_registry_rule: String,
+    /// Initial closed registry, in stable order.
+    pub evidence_registry: Vec<TraceEvidenceContractRecord>,
+    /// Evidence/absence policy.
+    pub unavailable_rule: String,
+    /// Positive branch.
+    pub decision_positive: String,
+    /// Negative branch.
+    pub decision_negative: String,
+    /// Unavailable branch.
+    pub decision_unavailable: String,
+}
+
+/// Identity bundle bound by a report. `None` is typed absence, never an empty
+/// digest pretending to be evidence.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScreenIdentities {
+    /// #720 primary-source SHA-256.
+    pub octeract_source_sha256: String,
+    /// #720 validation-roadmap SHA-256.
+    pub validation_source_sha256: String,
+    /// #603 observation identity-bundle digest.
+    pub observation_identity_bundle_digest: Option<String>,
+    /// Exact observation input CID (#603 identity bundle component).
+    pub observation_input_cid: Option<String>,
+    /// #597 source-manifest file binding from the observation manifest. This
+    /// is intentionally distinct from `source_snapshot`.
+    pub source_manifest_kappa: Option<String>,
+    /// Merged observation-record κ.
+    pub records_kappa: Option<String>,
+    /// Merged trace-sidecar κ.
+    pub trace_kappa: Option<String>,
+    /// Declared trace-profile digest.
+    pub trace_profile_digest: Option<String>,
+    /// `route-fit/1` declared digest.
+    pub route_fit_digest: Option<String>,
+    /// Fit-manifest κ.
+    pub fit_manifest_kappa: Option<String>,
+    /// Fitted-parameter κ.
+    pub fitted_params_kappa: Option<String>,
+    /// Source snapshot identity.
+    pub source_snapshot: Option<String>,
+    /// Declared observation source-to-compiled geometry digest.
+    pub source_geometry_digest: Option<String>,
+    /// Raw tokenizer-definition CID from the typed observation adapter.
+    pub tokenizer_cid: Option<String>,
+    /// Raw declared adapter digest from the typed observation adapter.
+    pub tokenizer_adapter_digest: Option<String>,
+    /// Tokenizer identity.
+    pub tokenizer: Option<String>,
+    /// Adapter identity.
+    pub adapter: Option<String>,
+    /// Target dormant `r4-route-attention/1` digest from the fit manifest.
+    pub target_operator_digest: Option<String>,
+    /// Teacher/source attention-operator digest, supplied explicitly.
+    pub source_attention_operator_digest: Option<String>,
+    /// Compiler identity.
+    pub compiler: Option<String>,
+    /// Closed evidence-registry id, absent only when no input was supplied.
+    pub trace_evidence_id: Option<String>,
+    /// Closed evidence-registry version.
+    pub trace_evidence_version: Option<u32>,
+    /// Evidence class encoded by the registry record.
+    pub trace_evidence_kind: Option<TraceKind>,
+    /// Digest of the complete registry record.
+    pub trace_evidence_digest: Option<String>,
+}
+
+/// Fixed finite counts for an arm/null.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScreenCounts {
+    pub eligible_stories: u64,
+    pub eligible_steps: u64,
+    pub candidates: u64,
+    pub teacher_support_entries: u64,
+}
+
+/// Exact and folded occupancy, pooled and by natural byte block.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct OccupancyMetrics {
+    pub exact_weight: Vec<u64>,
+    pub folded_shell: Vec<u64>,
+    pub exact_weight_per_block: Vec<Vec<u64>>,
+    pub folded_shell_per_block: Vec<Vec<u64>>,
+    pub exact_entropy_bits: f64,
+    pub folded_entropy_bits: f64,
+}
+
+/// Fold-only occupancy for a null that transforms categorical shell labels
+/// but has no exact-distance representation of its own.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct FoldOccupancyMetrics {
+    pub folded_shell: Vec<u64>,
+    pub folded_shell_per_block: Vec<Vec<u64>>,
+    pub folded_entropy_bits: f64,
+}
+
+/// Selection-quality measurements under a locked stable tie rule.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SelectionMetrics {
+    pub mean_teacher_recall: f64,
+    pub mean_teacher_jaccard: f64,
+    pub score_support_mi_bits: f64,
+    pub pooled_block_class_support_mi_bits: f64,
+    pub per_block_class_support_mi_bits: Vec<f64>,
+}
+
+/// Complete-signature collision measurements.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CollisionMetrics {
+    pub complete_fold_signature_groups: u64,
+    pub exact_collision_pairs: u64,
+    pub complement_collision_pairs: u64,
+    pub lossy_signature_groups: u64,
+    pub group_size_distribution: Vec<(u32, u64)>,
+    pub within_group_membership_disagreements: u64,
+}
+
+/// Fold shortlist classification counts.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShortlistMetrics {
+    pub false_positives: u64,
+    pub false_negatives: u64,
+}
+
+/// V1-refinement work and fidelity for the prefilter arm.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PrefilterMetrics {
+    pub work_eligible_steps: u64,
+    pub mean_v1_recall: f64,
+    pub mean_v1_jaccard: f64,
+    pub exact_refinement_candidates: u64,
+    pub total_candidates: u64,
+    pub exact_refinement_fraction: f64,
+    pub exact_refinement_candidates_avoided: u64,
+    pub occupancy_null_teacher_jaccard: f64,
+    pub shuffled_block_null_teacher_jaccard: f64,
+    pub deranged_support_null_teacher_jaccard: f64,
+}
+
+/// Safe lower-bound tightness and exact-evaluation work.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LowerBoundMetrics {
+    pub candidates: u64,
+    pub tight_candidates: u64,
+    pub tight_fraction: f64,
+    pub exact_evaluations: u64,
+    pub exact_evaluations_avoided: u64,
+}
+
+/// Optimistic signature-only reachability ceiling.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct OracleMetrics {
+    pub mean_max_recall: f64,
+    pub mean_max_jaccard: f64,
+}
+
+/// Measurements shared by the bounded evaluation domain, rather than copied
+/// into unrelated arm/null rows.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScreenSharedMetrics {
+    /// Matched-support base domain used by the direct/control rows. Rows with
+    /// a narrowed or transformed domain carry their own counts separately.
+    pub counts: ScreenCounts,
+    pub occupancy: OccupancyMetrics,
+}
+
+/// Measurements carried by one arm/null. `None` is explicit non-applicability,
+/// so prefilter, lower-bound, collision, and oracle measurements cannot be
+/// mistaken for measurements of unrelated rows.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ArmMetrics {
+    /// Exact row domain. `None` means the row did not run.
+    pub counts: Option<ScreenCounts>,
+    pub occupancy: Option<OccupancyMetrics>,
+    pub fold_occupancy: Option<FoldOccupancyMetrics>,
+    pub selection: Option<SelectionMetrics>,
+    pub collisions: Option<CollisionMetrics>,
+    pub shortlist: Option<ShortlistMetrics>,
+    pub prefilter: Option<PrefilterMetrics>,
+    pub lower_bound: Option<LowerBoundMetrics>,
+    pub oracle: Option<OracleMetrics>,
+}
+
+/// One evaluated arm or null.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArmReport {
+    pub id: String,
+    pub can_advance: bool,
+    pub verdict: StageVerdict,
+    pub reason: String,
+    pub metrics: ArmMetrics,
+}
+
+/// Frame/instrument checks before any empirical negative is accepted.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScreenControls {
+    pub v1_scalar_operator_exact: bool,
+    pub weight9_exact: bool,
+    pub oriented_exact: bool,
+    pub lower_bound_exact: bool,
+    pub anchor_relabel_invariant: bool,
+    pub anchor_relabels_checked: u32,
+    pub matched_pair_mean_jaccard: f64,
+    pub frame: String,
+    pub deranged_support_transformation_distinct: bool,
+    pub deranged_support_observably_distinct: bool,
+    pub occupancy_null_transformation_distinct: bool,
+    pub occupancy_null_result_distinct: bool,
+    pub shuffled_block_null_transformation_distinct: bool,
+    pub shuffled_block_null_result_distinct: bool,
+    pub instrument_valid: bool,
+}
+
+/// Canonical #722 report envelope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OcteractTraceReport {
+    /// [`OCTERACT_TRACE_REPORT_FORMAT`].
+    pub format: String,
+    /// Locked contract embedded verbatim.
+    pub contract: OcteractTraceContract,
+    /// Evidence class requested by the caller.
+    pub trace_kind: TraceKind,
+    /// Bound identities, with typed absence.
+    pub identities: ScreenIdentities,
+    /// Structural/frame controls.
+    pub controls: ScreenControls,
+    /// Domain counts/base occupancy shared by all rows.
+    pub shared_metrics: ScreenSharedMetrics,
+    /// Candidate/control arms, fixed contract order.
+    pub arms: Vec<ArmReport>,
+    /// Null rows, fixed contract order.
+    pub nulls: Vec<ArmReport>,
+    /// Locked branch outcome.
+    pub disposition: ScreenDisposition,
+    /// Exact reason for the branch.
+    pub disposition_reason: String,
+    /// Hash over the canonical payload with this field empty. The final
+    /// envelope bytes include this non-self-referential identity.
+    pub payload_kappa: String,
+}
+
+/// Candidate id and scalar score under one locked relation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScoredCandidate {
+    pub candidate: u32,
+    pub score: u32,
+}
+
+/// Prefilter result for one step.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrefilterStep {
+    pub shortlist: Vec<u32>,
+    pub selected: Vec<ScoredCandidate>,
+    pub exact_refinement_candidates: u32,
+    pub exact_refinement_candidates_avoided: u32,
+}
+
+/// Safe-lower-bound result for one step.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LowerBoundStep {
+    pub lower_bounds: Vec<u32>,
+    pub selected: Vec<ScoredCandidate>,
+    pub exact_evaluations: u32,
+    pub exact_evaluations_avoided: u32,
+    pub tight_candidates: u32,
+}
+
+/// Every exact/control score and selection needed to test one bounded step.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StepScores {
+    pub exact_scores: Vec<u32>,
+    pub weight9_scores: Vec<u32>,
+    pub folded_scores: Vec<u32>,
+    pub oriented_scores: Vec<u32>,
+    pub v1_selected: Vec<ScoredCandidate>,
+    pub weight9_selected: Vec<ScoredCandidate>,
+    pub folded_selected: Vec<ScoredCandidate>,
+    pub oriented_selected: Vec<ScoredCandidate>,
+    pub prefilter: PrefilterStep,
+    pub lower_bound: LowerBoundStep,
+    pub fold_classes: Vec<[u8; ROUTE_CODE_BYTES]>,
+    pub weight9_blocks: Vec<[u8; ROUTE_CODE_BYTES]>,
+    pub oriented_weights: Vec<[u8; ROUTE_CODE_BYTES]>,
+}
+
+/// One complete fold-signature group in ascending candidate order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CollisionGroup {
+    pub candidate_ids: Vec<u32>,
+    pub teacher_membership: Vec<bool>,
+}
+
+/// Exact bounded oracle result for one step.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OracleStep {
+    pub max_teacher_hits: u32,
+    pub selected_slots: u32,
+}
+
+/// Inputs to the public pure verdict classifier.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CandidateGate {
+    pub controls_pass: bool,
+    pub frame_score: f64,
+    pub deranged_distinct: bool,
+    pub gate_pass: bool,
+}
+
+/// Pure candidate verdict classifier. Synthetic evidence never becomes an
+/// empirical PASS/FAIL; a prior structural stop produces NOT_RUN.
+pub fn classify_candidate_arm(
+    kind: TraceKind,
+    gate: CandidateGate,
+    prior_stop: bool,
+) -> StageVerdict {
+    if prior_stop {
+        return StageVerdict::NotRun;
+    }
+    if !gate.controls_pass
+        || !gate.deranged_distinct
+        || frame_control_default(gate.frame_score).is_frame_mismatch()
+    {
+        return StageVerdict::Unavailable;
+    }
+    if kind == TraceKind::InstrumentConformance {
+        return StageVerdict::NotRun;
+    }
+    if gate.gate_pass {
+        StageVerdict::Pass
+    } else {
+        StageVerdict::Fail
+    }
+}
+
+/// The complete locked contract. This function consumes no trace/support
+/// input, so its bytes necessarily predate label inspection.
+pub fn preregistered_octeract_trace_contract() -> OcteractTraceContract {
+    let arm = |id: &str, can_advance: bool, rule: &str| ArmContract {
+        id: id.to_owned(),
+        can_advance,
+        rule: rule.to_owned(),
+    };
+    let instrument_evidence = instrument_trace_evidence();
+    OcteractTraceContract {
+        format: OCTERACT_TRACE_CONTRACT_FORMAT.to_owned(),
+        layer: SCREEN_LAYER,
+        head: SCREEN_HEAD,
+        code_bits: ROUTE_CODE_BITS as u32,
+        blocks: ROUTE_CODE_BYTES as u32,
+        mask: SCREEN_MASK.to_vec(),
+        candidate_rule: "causal-prefix-position-ascending; stable ascending-(score,candidate-index)"
+            .to_owned(),
+        selection_width_rule: "M=min(8,trace-support-cap)".to_owned(),
+        eligible_step_rule: "candidate-count>M".to_owned(),
+        aggregation: "fixed-story-position-candidate-block-order; arithmetic-mean-per-step; row-counts-own-consumed-domain; shared-counts-are-matched-base-domain"
+            .to_owned(),
+        arms: vec![
+            arm(
+                ARM_V1,
+                false,
+                "sum-36-full-mask-xor-popcounts; packed/reference/scalar exact identity",
+            ),
+            arm(
+                ARM_WEIGHT9,
+                false,
+                "preserve-each-byte-distance-0..8-and-sum; exact-V1-control",
+            ),
+            arm(
+                ARM_FOLD5,
+                true,
+                "sum-per-byte-min(distance,8-distance); no-anchor-integer-scoring",
+            ),
+            arm(
+                ARM_ORIENTED,
+                false,
+                "preserve-folded-shell-and-high-side; reconstruct-and-sum; exact-V1-control",
+            ),
+            arm(
+                ARM_PREFILTER,
+                true,
+                "P=floor(3N/4); first-P-by-fold5; exact-V1-refine; only-P>=M-enters-work",
+            ),
+            arm(
+                ARM_LOWER_BOUND,
+                false,
+                "ascending-index; skip-later-exact-only-when-L>=current-worst-selected-distance",
+            ),
+        ],
+        nulls: vec![
+            arm(
+                NULL_OCCUPANCY,
+                false,
+                "within-(story,step,block)-permutation-of-observed-fold5-labels; step-seed=0x661B0001-XOR-(story<<32)-XOR-step",
+            ),
+            arm(
+                NULL_SHUFFLED_BLOCK,
+                false,
+                "one-seeded-fixed-nonidentity-permutation-of-36-key-byte-indices",
+            ),
+            arm(
+                NULL_DERANGED_SUPPORT,
+                false,
+                "cyclic-next-position-support-within-sequence",
+            ),
+        ],
+        prior_weighted_hamming_row:
+            "issue-310-prior-weighted-Hamming-row-cite-when-budgets-comparable-do-not-rerun"
+                .to_owned(),
+        occupancy_seed: OCCUPANCY_MATCHED_FOLD_SEED,
+        shuffled_block_seed: SHUFFLED_BLOCK_SEED,
+        shuffled_block_permutation: shuffled_block_permutation(SHUFFLED_BLOCK_SEED).to_vec(),
+        thresholds: ScreenThresholds {
+            direct_jaccard_margin: 0.03,
+            prefilter_v1_recall: 0.95,
+            prefilter_refinement_fraction: 0.75,
+        },
+        frame_rule: "V1-vs-teacher-support-mean-jaccard-through-frame_control_default; deranged-support-must-be-observably-distinct"
+            .to_owned(),
+        anchor_relabel_rule:
+            "all-five-shell-label-bijections-preserve-class-only-scores-selections-and-groups"
+                .to_owned(),
+        evidence_registry_rule: "closed-registry-record-kind-must-match-request; empirical-record-must-pin-observation-records-trace-fit-manifest-and-fitted-params; initial-registry-has-instrument-conformance-only; registry-expansion-requires-new-contract-and-report-format-version"
+            .to_owned(),
+        evidence_registry: vec![TraceEvidenceContractRecord {
+            id: instrument_evidence.id().to_owned(),
+            version: instrument_evidence.version(),
+            kind: instrument_evidence.kind(),
+            declared_digest: instrument_evidence.declared_digest(),
+        }],
+        unavailable_rule: "missing-or-incomplete-real-trace/lane/identity/domain-or-frame-is-UNAVAILABLE-never-zero-FAIL-or-vacuous-PASS"
+            .to_owned(),
+        decision_positive:
+            "create-661-C-with-only-clearing-Octeract-arms-at-most-two-remain-dormant"
+                .to_owned(),
+        decision_negative:
+            "preserve-negative-report-no-one-head-child-trigger-bounded-classification-cache-fallback"
+                .to_owned(),
+        decision_unavailable:
+            "preserve-typed-unavailable-create-neither-one-head-nor-negative-only-fallback"
+                .to_owned(),
+    }
+}
+
+fn bounded_block(distance: u8) -> BlockDistance {
+    match BlockDistance::new(distance, 8) {
+        Some(block) => block,
+        None => unreachable!("a full-byte Hamming distance is always in 0..=8"),
+    }
+}
+
+fn selected_from_scores(scores: &[u32], m: usize) -> Vec<ScoredCandidate> {
+    let mut ranked: Vec<ScoredCandidate> = scores
+        .iter()
+        .enumerate()
+        .map(|(candidate, &score)| ScoredCandidate {
+            candidate: candidate as u32,
+            score,
+        })
+        .collect();
+    ranked.sort_by_key(|entry| (entry.score, entry.candidate));
+    ranked.truncate(m);
+    ranked
+}
+
+fn exact_score(query: &[u8; ROUTE_CODE_BYTES], key: &[u8; ROUTE_CODE_BYTES]) -> u32 {
+    query
+        .iter()
+        .zip(key)
+        .map(|(&query_byte, &key_byte)| {
+            u32::from(masked_byte_distance(query_byte, key_byte, u8::MAX))
+        })
+        .sum()
+}
+
+/// Independent weight-9 representation: one exact distance `d_b in 0..=8`
+/// per byte block, computed directly from XOR popcount rather than through the
+/// V1 scalar helper or the oriented representation.
+fn weight9_blocks(
+    query: &[u8; ROUTE_CODE_BYTES],
+    key: &[u8; ROUTE_CODE_BYTES],
+) -> [u8; ROUTE_CODE_BYTES] {
+    let mut blocks = [0u8; ROUTE_CODE_BYTES];
+    for (slot, (&query_byte, &key_byte)) in query.iter().zip(key).enumerate() {
+        blocks[slot] = (query_byte ^ key_byte).count_ones() as u8;
+    }
+    blocks
+}
+
+fn fold_classes(
+    query: &[u8; ROUTE_CODE_BYTES],
+    key: &[u8; ROUTE_CODE_BYTES],
+) -> [u8; ROUTE_CODE_BYTES] {
+    let mut classes = [0u8; ROUTE_CODE_BYTES];
+    for (slot, (&query_byte, &key_byte)) in query.iter().zip(key).enumerate() {
+        let distance = masked_byte_distance(query_byte, key_byte, u8::MAX);
+        classes[slot] = folded_class(bounded_block(distance));
+    }
+    classes
+}
+
+fn oriented_weights(
+    query: &[u8; ROUTE_CODE_BYTES],
+    key: &[u8; ROUTE_CODE_BYTES],
+) -> [u8; ROUTE_CODE_BYTES] {
+    let mut weights = [0u8; ROUTE_CODE_BYTES];
+    for (slot, (&query_byte, &key_byte)) in query.iter().zip(key).enumerate() {
+        let distance = masked_byte_distance(query_byte, key_byte, u8::MAX);
+        weights[slot] = distance_from_oriented(oriented_class(bounded_block(distance)));
+    }
+    weights
+}
+
+fn prefilter_step(exact_scores: &[u32], folded_scores: &[u32], m: usize) -> PrefilterStep {
+    let n = exact_scores.len();
+    let p = (3 * n) / 4;
+    if p < m {
+        return PrefilterStep::default();
+    }
+    let mut fold_rank: Vec<(u32, u32)> = folded_scores
+        .iter()
+        .enumerate()
+        .map(|(candidate, &score)| (score, candidate as u32))
+        .collect();
+    fold_rank.sort_unstable();
+    let shortlist: Vec<u32> = fold_rank
+        .into_iter()
+        .take(p)
+        .map(|(_, candidate)| candidate)
+        .collect();
+    let mut selected: Vec<ScoredCandidate> = shortlist
+        .iter()
+        .map(|&candidate| ScoredCandidate {
+            candidate,
+            score: exact_scores[candidate as usize],
+        })
+        .collect();
+    selected.sort_by_key(|entry| (entry.score, entry.candidate));
+    selected.truncate(m);
+    PrefilterStep {
+        shortlist,
+        selected,
+        exact_refinement_candidates: p as u32,
+        exact_refinement_candidates_avoided: (n - p) as u32,
+    }
+}
+
+fn lower_bound_step(
+    query: &[u8; ROUTE_CODE_BYTES],
+    keys: &[[u8; ROUTE_CODE_BYTES]],
+    exact_scores: &[u32],
+    m: usize,
+) -> LowerBoundStep {
+    let mut lower_bounds = Vec::with_capacity(keys.len());
+    let mut selected = Vec::<ScoredCandidate>::with_capacity(m);
+    let mut exact_evaluations = 0u32;
+    let mut avoided = 0u32;
+    let mut tight = 0u32;
+    for (candidate, key) in keys.iter().enumerate() {
+        let lower: u32 = query
+            .iter()
+            .zip(key)
+            .map(|(&query_byte, &key_byte)| {
+                u32::from(masked_weight_lower_bound(query_byte, key_byte, u8::MAX))
+            })
+            .sum();
+        lower_bounds.push(lower);
+        let exact = exact_scores[candidate];
+        if lower == exact {
+            tight += 1;
+        }
+        if selected.len() == m {
+            let worst = selected[m - 1].score;
+            // Candidate indices arrive strictly ascending. On equality this
+            // later candidate loses the stable V1 tie and can be skipped.
+            if lower >= worst {
+                avoided += 1;
+                continue;
+            }
+        }
+        exact_evaluations += 1;
+        selected.push(ScoredCandidate {
+            candidate: candidate as u32,
+            score: exact,
+        });
+        selected.sort_by_key(|entry| (entry.score, entry.candidate));
+        selected.truncate(m);
+    }
+    LowerBoundStep {
+        lower_bounds,
+        selected,
+        exact_evaluations,
+        exact_evaluations_avoided: avoided,
+        tight_candidates: tight,
+    }
+}
+
+/// Score one bounded step under every exact/folded/control relation. Invalid
+/// instance shapes do not construct a result (R5).
+pub fn score_octeract_step(
+    query: &[u8; ROUTE_CODE_BYTES],
+    keys: &[[u8; ROUTE_CODE_BYTES]],
+    m: usize,
+) -> Option<StepScores> {
+    if keys.is_empty() || keys.len() > ROUTE_MAX_CANDIDATES || m == 0 || m > keys.len().min(8) {
+        return None;
+    }
+    let mut exact_scores = Vec::with_capacity(keys.len());
+    let mut weight9_scores = Vec::with_capacity(keys.len());
+    let mut folded_scores = Vec::with_capacity(keys.len());
+    let mut oriented_scores = Vec::with_capacity(keys.len());
+    let mut all_fold_classes = Vec::with_capacity(keys.len());
+    let mut all_weight9_blocks = Vec::with_capacity(keys.len());
+    let mut all_oriented_weights = Vec::with_capacity(keys.len());
+    for key in keys {
+        let exact = exact_score(query, key);
+        let weight9 = weight9_blocks(query, key);
+        let classes = fold_classes(query, key);
+        let oriented = oriented_weights(query, key);
+        exact_scores.push(exact);
+        weight9_scores.push(weight9.iter().map(|&value| u32::from(value)).sum());
+        folded_scores.push(classes.iter().map(|&value| u32::from(value)).sum());
+        oriented_scores.push(oriented.iter().map(|&value| u32::from(value)).sum());
+        all_fold_classes.push(classes);
+        all_weight9_blocks.push(weight9);
+        all_oriented_weights.push(oriented);
+    }
+    let v1_selected = selected_from_scores(&exact_scores, m);
+    let weight9_selected = selected_from_scores(&weight9_scores, m);
+    let folded_selected = selected_from_scores(&folded_scores, m);
+    let oriented_selected = selected_from_scores(&oriented_scores, m);
+    let prefilter = prefilter_step(&exact_scores, &folded_scores, m);
+    let lower_bound = lower_bound_step(query, keys, &exact_scores, m);
+    Some(StepScores {
+        exact_scores,
+        weight9_scores,
+        folded_scores,
+        oriented_scores,
+        v1_selected,
+        weight9_selected,
+        folded_selected,
+        oriented_selected,
+        prefilter,
+        lower_bound,
+        fold_classes: all_fold_classes,
+        weight9_blocks: all_weight9_blocks,
+        oriented_weights: all_oriented_weights,
+    })
+}
+
+fn signature_groups(classes: &[[u8; ROUTE_CODE_BYTES]]) -> Vec<Vec<u32>> {
+    let mut groups = BTreeMap::<[u8; ROUTE_CODE_BYTES], Vec<u32>>::new();
+    for (candidate, &signature) in classes.iter().enumerate() {
+        groups.entry(signature).or_default().push(candidate as u32);
+    }
+    let mut memberships: Vec<Vec<u32>> = groups.into_values().collect();
+    memberships.sort();
+    memberships
+}
+
+fn next_permutation(values: &mut [u8; 5]) -> bool {
+    let Some(pivot) = (0..values.len() - 1)
+        .rev()
+        .find(|&index| values[index] < values[index + 1])
+    else {
+        return false;
+    };
+    let successor = (pivot + 1..values.len())
+        .rev()
+        .find(|&index| values[pivot] < values[index])
+        .unwrap_or(pivot + 1);
+    values.swap(pivot, successor);
+    values[pivot + 1..].reverse();
+    true
+}
+
+/// Exhaustively verify the #720 anchor-label invariant for all `5! = 120`
+/// bijections. Relabeled identities are resolved through the relabeled anchor
+/// table (not interpreted as numeric weights), then scores, stable selections,
+/// and complete-signature collision groups are compared to the canonical row.
+fn anchor_relabel_control_result(scores: &StepScores, m: usize) -> (bool, u32) {
+    if scores.fold_classes.is_empty()
+        || m == 0
+        || m > scores.fold_classes.len().min(8)
+        || scores
+            .fold_classes
+            .iter()
+            .flatten()
+            .any(|&class| class >= 5)
+    {
+        return (false, 0);
+    }
+    let canonical_scores: Vec<u32> = scores
+        .fold_classes
+        .iter()
+        .map(|classes| classes.iter().map(|&value| u32::from(value)).sum())
+        .collect();
+    if canonical_scores != scores.folded_scores
+        || selected_from_scores(&canonical_scores, m) != scores.folded_selected
+    {
+        return (false, 0);
+    }
+    let canonical_groups = signature_groups(&scores.fold_classes);
+    let mut permutation = [0u8, 1, 2, 3, 4];
+    let mut checked = 0u32;
+    loop {
+        let relabeled: Vec<[u8; ROUTE_CODE_BYTES]> = scores
+            .fold_classes
+            .iter()
+            .map(|classes| {
+                let mut row = [0u8; ROUTE_CODE_BYTES];
+                for (block, &class) in classes.iter().enumerate() {
+                    row[block] = permutation[usize::from(class)];
+                }
+                row
+            })
+            .collect();
+        if signature_groups(&relabeled) != canonical_groups {
+            return (false, checked);
+        }
+        let mut inverse = [0u8; 5];
+        for (class, &label) in permutation.iter().enumerate() {
+            inverse[usize::from(label)] = class as u8;
+        }
+        let decoded_scores: Vec<u32> = relabeled
+            .iter()
+            .map(|classes| {
+                classes
+                    .iter()
+                    .map(|&label| u32::from(inverse[usize::from(label)]))
+                    .sum()
+            })
+            .collect();
+        if decoded_scores != canonical_scores
+            || selected_from_scores(&decoded_scores, m) != scores.folded_selected
+        {
+            return (false, checked);
+        }
+        checked += 1;
+        if !next_permutation(&mut permutation) {
+            break;
+        }
+    }
+    (checked == ANCHOR_RELABELINGS, checked)
+}
+
+/// Public boolean form of the exhaustive anchor control.
+pub fn exhaustive_anchor_relabel_control(scores: &StepScores, m: usize) -> bool {
+    anchor_relabel_control_result(scores, m).0
+}
+
+/// Deterministically permute each block's observed fold labels across the
+/// causal candidate indices, preserving five-class occupancy exactly.
+pub fn occupancy_matched_fold_null(
+    classes: &[[u8; ROUTE_CODE_BYTES]],
+    seed: u64,
+) -> Vec<[u8; ROUTE_CODE_BYTES]> {
+    let mut output = classes.to_vec();
+    let mut stream = seed;
+    for block in 0..ROUTE_CODE_BYTES {
+        let mut labels: Vec<u8> = classes.iter().map(|row| row[block]).collect();
+        for index in (1..labels.len()).rev() {
+            let draw = xorshift(&mut stream) as usize;
+            labels.swap(index, draw % (index + 1));
+        }
+        for (row, label) in output.iter_mut().zip(labels) {
+            row[block] = label;
+        }
+    }
+    output
+}
+
+/// Derive the fixed non-identity 36-key-byte permutation used by the shuffled
+/// block null.
+pub fn shuffled_block_permutation(seed: u64) -> [u8; ROUTE_CODE_BYTES] {
+    let mut permutation = [0u8; ROUTE_CODE_BYTES];
+    for (index, slot) in permutation.iter_mut().enumerate() {
+        *slot = index as u8;
+    }
+    let mut stream = seed;
+    for index in (1..permutation.len()).rev() {
+        let draw = xorshift(&mut stream) as usize;
+        permutation.swap(index, draw % (index + 1));
+    }
+    if permutation
+        .iter()
+        .enumerate()
+        .all(|(index, &value)| usize::from(value) == index)
+    {
+        permutation.rotate_left(1);
+    }
+    permutation
+}
+
+/// #605 cyclic one-position support derangement within one sequence.
+pub fn deranged_supports(supports: &[Vec<u32>]) -> Vec<Vec<u32>> {
+    if supports.is_empty() {
+        return Vec::new();
+    }
+    (0..supports.len())
+        .map(|position| supports[(position + 1) % supports.len()].clone())
+        .collect()
+}
+
+/// Exact bounded collision-oracle optimization. Distinct complete signatures
+/// may be ordered arbitrarily; candidates within a signature retain ascending
+/// index, and at most one final signature may be partial.
+pub fn collision_oracle(groups: &[CollisionGroup], m: usize) -> Option<OracleStep> {
+    let total: usize = groups.iter().map(|group| group.candidate_ids.len()).sum();
+    if m == 0 || m > 8 || total < m || total > ROUTE_MAX_CANDIDATES {
+        return None;
+    }
+    let mut all_candidates = Vec::with_capacity(total);
+    for group in groups {
+        if group.candidate_ids.is_empty()
+            || group.candidate_ids.len() != group.teacher_membership.len()
+            || !group.candidate_ids.windows(2).all(|pair| pair[0] < pair[1])
+        {
+            return None;
+        }
+        all_candidates.extend_from_slice(&group.candidate_ids);
+    }
+    all_candidates.sort_unstable();
+    if all_candidates.windows(2).any(|pair| pair[0] == pair[1]) {
+        return None;
+    }
+
+    fn whole_group_dp(groups: &[CollisionGroup], omitted: Option<usize>, m: usize) -> Vec<i32> {
+        let mut dp = vec![-1i32; m + 1];
+        dp[0] = 0;
+        for (index, group) in groups.iter().enumerate() {
+            if Some(index) == omitted {
+                continue;
+            }
+            let width = group.candidate_ids.len();
+            if width > m {
+                continue;
+            }
+            let hits = group
+                .teacher_membership
+                .iter()
+                .filter(|&&member| member)
+                .count() as i32;
+            let previous = dp.clone();
+            for used in 0..=m.saturating_sub(width) {
+                if previous[used] >= 0 {
+                    dp[used + width] = dp[used + width].max(previous[used] + hits);
+                }
+            }
+        }
+        dp
+    }
+
+    let mut best = whole_group_dp(groups, None, m)[m];
+    for (partial_index, partial) in groups.iter().enumerate() {
+        let dp = whole_group_dp(groups, Some(partial_index), m);
+        let mut prefix_hits = vec![0i32; partial.candidate_ids.len() + 1];
+        for (index, &member) in partial.teacher_membership.iter().enumerate() {
+            prefix_hits[index + 1] = prefix_hits[index] + i32::from(member);
+        }
+        for (used, &hits) in dp.iter().enumerate() {
+            if hits < 0 || used >= m {
+                continue;
+            }
+            let take = (m - used).min(partial.candidate_ids.len());
+            if used + take == m {
+                best = best.max(hits + prefix_hits[take]);
+            }
+        }
+    }
+    if best < 0 {
+        None
+    } else {
+        Some(OracleStep {
+            max_teacher_hits: best as u32,
+            selected_slots: m as u32,
+        })
+    }
+}
+
+fn serialize_report(report: &OcteractTraceReport) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    ciborium::into_writer(report, &mut bytes)
+        .expect("bounded Octeract trace report serializes to canonical bytes");
+    bytes
+}
+
+fn canonical_payload_bytes(report: &OcteractTraceReport) -> Vec<u8> {
+    let mut payload = report.clone();
+    payload.payload_kappa.clear();
+    serialize_report(&payload)
+}
+
+/// Non-self-referential payload identity: blake3 over canonical report bytes
+/// with the `payload_kappa` field empty.
+pub fn octeract_trace_payload_kappa(report: &OcteractTraceReport) -> String {
+    format!(
+        "blake3:{}",
+        blake3::hash(&canonical_payload_bytes(report)).to_hex()
+    )
+}
+
+/// Canonical final envelope bytes. The payload identity is recomputed before
+/// serialization so caller mutation of that derived field cannot fork bytes.
+pub fn canonical_octeract_trace_report_bytes(report: &OcteractTraceReport) -> Vec<u8> {
+    let mut envelope = report.clone();
+    envelope.payload_kappa = octeract_trace_payload_kappa(&envelope);
+    serialize_report(&envelope)
+}
+
+/// Final envelope κ over bytes which include the separately defined payload
+/// identity.
+pub fn octeract_trace_report_kappa(report: &OcteractTraceReport) -> String {
+    format!(
+        "blake3:{}",
+        blake3::hash(&canonical_octeract_trace_report_bytes(report)).to_hex()
+    )
+}
+
+#[derive(Clone)]
+struct MetricAccumulator {
+    steps: u64,
+    recall_sum: f64,
+    jaccard_sum: f64,
+    score_joint: BTreeMap<(u32, bool), u64>,
+    class_joint: Vec<BTreeMap<(u32, bool), u64>>,
+}
+
+struct OccupancyAccumulator {
+    exact_weight: Vec<u64>,
+    folded_shell: Vec<u64>,
+    exact_weight_per_block: Vec<Vec<u64>>,
+    folded_shell_per_block: Vec<Vec<u64>>,
+}
+
+impl OccupancyAccumulator {
+    fn new() -> Self {
+        Self {
+            exact_weight: vec![0; 9],
+            folded_shell: vec![0; 5],
+            exact_weight_per_block: vec![vec![0; 9]; ROUTE_CODE_BYTES],
+            folded_shell_per_block: vec![vec![0; 5]; ROUTE_CODE_BYTES],
+        }
+    }
+
+    fn record_fold(&mut self, classes: &[[u8; ROUTE_CODE_BYTES]]) {
+        for row in classes {
+            for (block, &class) in row.iter().enumerate() {
+                self.folded_shell[usize::from(class)] += 1;
+                self.folded_shell_per_block[block][usize::from(class)] += 1;
+            }
+        }
+    }
+
+    fn record_exact_and_fold(
+        &mut self,
+        exact: &[[u8; ROUTE_CODE_BYTES]],
+        classes: &[[u8; ROUTE_CODE_BYTES]],
+    ) {
+        if exact.len() != classes.len() {
+            return;
+        }
+        self.record_fold(classes);
+        for row in exact {
+            for (block, &distance) in row.iter().enumerate() {
+                self.exact_weight[usize::from(distance)] += 1;
+                self.exact_weight_per_block[block][usize::from(distance)] += 1;
+            }
+        }
+    }
+
+    fn finish(self) -> OccupancyMetrics {
+        OccupancyMetrics {
+            exact_entropy_bits: entropy(&self.exact_weight),
+            folded_entropy_bits: entropy(&self.folded_shell),
+            exact_weight: self.exact_weight,
+            folded_shell: self.folded_shell,
+            exact_weight_per_block: self.exact_weight_per_block,
+            folded_shell_per_block: self.folded_shell_per_block,
+        }
+    }
+
+    fn finish_fold(self) -> FoldOccupancyMetrics {
+        FoldOccupancyMetrics {
+            folded_entropy_bits: entropy(&self.folded_shell),
+            folded_shell: self.folded_shell,
+            folded_shell_per_block: self.folded_shell_per_block,
+        }
+    }
+}
+
+impl MetricAccumulator {
+    fn new() -> Self {
+        Self {
+            steps: 0,
+            recall_sum: 0.0,
+            jaccard_sum: 0.0,
+            score_joint: BTreeMap::new(),
+            class_joint: vec![BTreeMap::new(); ROUTE_CODE_BYTES],
+        }
+    }
+
+    fn record(
+        &mut self,
+        scores: &[u32],
+        classes: &[[u8; ROUTE_CODE_BYTES]],
+        selected: &[ScoredCandidate],
+        teacher: &[u32],
+    ) {
+        let selected_ids: Vec<u32> = selected.iter().map(|entry| entry.candidate).collect();
+        self.recall_sum += recall(&selected_ids, teacher);
+        self.jaccard_sum += jaccard(&selected_ids, teacher);
+        self.steps += 1;
+        for (candidate, (&score, block_classes)) in scores.iter().zip(classes).enumerate() {
+            let member = teacher.contains(&(candidate as u32));
+            *self.score_joint.entry((score, member)).or_default() += 1;
+            for (block, &class) in block_classes.iter().enumerate() {
+                *self.class_joint[block]
+                    .entry((u32::from(class), member))
+                    .or_default() += 1;
+            }
+        }
+    }
+
+    fn finish(&self) -> SelectionMetrics {
+        let denominator = self.steps as f64;
+        let per_block: Vec<f64> = self.class_joint.iter().map(mutual_information).collect();
+        let mut pooled = BTreeMap::new();
+        for block in &self.class_joint {
+            for (&key, &count) in block {
+                *pooled.entry(key).or_default() += count;
+            }
+        }
+        SelectionMetrics {
+            mean_teacher_recall: if self.steps == 0 {
+                0.0
+            } else {
+                self.recall_sum / denominator
+            },
+            mean_teacher_jaccard: if self.steps == 0 {
+                0.0
+            } else {
+                self.jaccard_sum / denominator
+            },
+            score_support_mi_bits: mutual_information(&self.score_joint),
+            pooled_block_class_support_mi_bits: mutual_information(&pooled),
+            per_block_class_support_mi_bits: per_block,
+        }
+    }
+}
+
+fn intersection_count(left: &[u32], right: &[u32]) -> usize {
+    left.iter().filter(|value| right.contains(value)).count()
+}
+
+fn recall(selected: &[u32], teacher: &[u32]) -> f64 {
+    if teacher.is_empty() {
+        0.0
+    } else {
+        intersection_count(selected, teacher) as f64 / teacher.len() as f64
+    }
+}
+
+fn jaccard(left: &[u32], right: &[u32]) -> f64 {
+    if left.is_empty() && right.is_empty() {
+        return 0.0;
+    }
+    let intersection = intersection_count(left, right);
+    let union = left.len() + right.len() - intersection;
+    intersection as f64 / union as f64
+}
+
+fn mutual_information(joint: &BTreeMap<(u32, bool), u64>) -> f64 {
+    let total: u64 = joint.values().sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let mut by_score = BTreeMap::<u32, u64>::new();
+    let mut by_membership = [0u64; 2];
+    for (&(score, member), &count) in joint {
+        *by_score.entry(score).or_default() += count;
+        by_membership[usize::from(member)] += count;
+    }
+    let total_f = total as f64;
+    let mut information = 0.0;
+    for (&(score, member), &count) in joint {
+        if count == 0 {
+            continue;
+        }
+        let p_xy = count as f64 / total_f;
+        let p_x = by_score[&score] as f64 / total_f;
+        let p_y = by_membership[usize::from(member)] as f64 / total_f;
+        information += p_xy * libm::log2(p_xy / (p_x * p_y));
+    }
+    information
+}
+
+fn entropy(counts: &[u64]) -> f64 {
+    let total: u64 = counts.iter().sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let total_f = total as f64;
+    counts
+        .iter()
+        .filter(|&&count| count != 0)
+        .map(|&count| {
+            let probability = count as f64 / total_f;
+            -probability * libm::log2(probability)
+        })
+        .sum()
+}
+
+fn choose_two(value: usize) -> u64 {
+    if value < 2 {
+        0
+    } else {
+        (value as u64 * (value as u64 - 1)) / 2
+    }
+}
+
+fn selection_ids(selected: &[ScoredCandidate]) -> Vec<u32> {
+    selected.iter().map(|entry| entry.candidate).collect()
+}
+
+fn route_seam_matches(
+    query: &[u8; ROUTE_CODE_BYTES],
+    keys: &[[u8; ROUTE_CODE_BYTES]],
+    m: usize,
+    scalar: &[ScoredCandidate],
+) -> bool {
+    let contributions = vec![ScoreQ::ZERO; keys.len()];
+    let instance =
+        match build_route_attention_instance(&SCREEN_MASK, keys, &contributions, m as u32) {
+            Ok(bytes) => bytes,
+            Err(_) => return false,
+        };
+    let (packed, _) = match run_packed(&instance, &[*query]) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let reference = match RouteAttentionReference::from_instance_bytes(&instance) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let mut census = RouteOpCensus::default();
+    let reference_step = reference.reference_step(query, &mut census);
+    let expected: Vec<RouteSelection> = scalar
+        .iter()
+        .map(|entry| RouteSelection {
+            candidate: entry.candidate,
+            distance: entry.score,
+        })
+        .collect();
+    packed.len() == 1
+        && packed[0].selected == expected
+        && reference_step.selected == expected
+        && packed[0].selected == reference_step.selected
+}
+
+enum InputCheck<'a> {
+    Ready {
+        input: OcteractTraceInput<'a>,
+        lane_index: usize,
+        source_operator_digest: Option<String>,
+    },
+    Unavailable(String),
+}
+
+fn nonempty(value: &Option<String>) -> bool {
+    value.as_ref().is_some_and(|value| !value.is_empty())
+}
+
+fn canonical_blake3(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("blake3:") else {
+        return false;
+    };
+    hex.len() == 64
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_input<'a>(input: OcteractTraceInput<'a>, kind: TraceKind) -> InputCheck<'a> {
+    let corpus = input.corpus;
+    let fitted = input.fitted;
+    let manifest = input.fit_manifest;
+
+    let registered_evidence =
+        registered_trace_evidence(input.evidence.id(), input.evidence.version());
+
+    let profile = &corpus.trace_profile;
+    let registered_profile = match profile_spec(
+        &profile.id,
+        profile.version,
+        &TraceCaptureBounds {
+            layer_indices: corpus.declared_layers.clone(),
+            support_size: corpus.support_size,
+        },
+    ) {
+        Ok(record) => record,
+        Err(_) => {
+            return InputCheck::Unavailable(
+                "trace profile is not a registered bounded record".to_owned(),
+            );
+        }
+    };
+    let qkv_layers = profile
+        .qkv_lane
+        .as_ref()
+        .map(|lane| lane.layer_indices.as_slice());
+    let support_lane = profile.attention_support_lane.as_ref();
+    if &registered_profile != profile
+        || profile.id != FULL_PROFILE
+        || profile.version != PROFILE_VERSION
+        || qkv_layers != Some(corpus.declared_layers.as_slice())
+        || support_lane.map(|lane| lane.layer_indices.as_slice())
+            != Some(corpus.declared_layers.as_slice())
+        || support_lane.map(|lane| lane.support_size) != Some(corpus.support_size)
+    {
+        return InputCheck::Unavailable(
+            "required pinned full/1 q/k and attention-support lanes are absent or misaligned"
+                .to_owned(),
+        );
+    }
+    let Some(lane_index) = corpus
+        .declared_layers
+        .iter()
+        .position(|&layer| layer == SCREEN_LAYER)
+    else {
+        return InputCheck::Unavailable("declared trace lacks layer 0".to_owned());
+    };
+    if corpus.geometry.layers == 0
+        || corpus.geometry.heads <= SCREEN_HEAD as usize
+        || corpus.geometry.kv_heads == 0
+        || corpus.geometry.residual_width == 0
+        || !corpus
+            .geometry
+            .heads
+            .is_multiple_of(corpus.geometry.kv_heads)
+        || !corpus
+            .geometry
+            .residual_width
+            .is_multiple_of(corpus.geometry.heads)
+        || corpus.declared_layers.is_empty()
+        || corpus.declared_layers.iter().any(|&layer| {
+            usize::try_from(layer).map_or(true, |layer| layer >= corpus.geometry.layers)
+        })
+    {
+        return InputCheck::Unavailable(
+            "trace geometry has a zero/out-of-range dimension or non-integral head/kv dimensions"
+                .to_owned(),
+        );
+    }
+    if fitted
+        .heads
+        .windows(2)
+        .any(|pair| (pair[0].layer, pair[0].head) >= (pair[1].layer, pair[1].head))
+        || fitted
+            .heads
+            .iter()
+            .filter(|head| head.layer == SCREEN_LAYER && head.head == SCREEN_HEAD)
+            .count()
+            != 1
+    {
+        return InputCheck::Unavailable(
+            "route-fit head table is not uniquely ordered by (layer, head)".to_owned(),
+        );
+    }
+    let Some(head) = fitted.head(SCREEN_LAYER, SCREEN_HEAD) else {
+        return InputCheck::Unavailable("route-fit/1 lacks layer 0 head 0".to_owned());
+    };
+    if head.thresholds.len() != ROUTE_CODE_BITS
+        || head.thresholds.iter().any(|value| !value.is_finite())
+    {
+        return InputCheck::Unavailable(
+            "route-fit/1 head thresholds are incomplete or non-finite".to_owned(),
+        );
+    }
+    let expected_m = corpus.support_size.min(8);
+    if expected_m == 0 || fitted.top_m != expected_m {
+        return InputCheck::Unavailable(
+            "route-fit selection width disagrees with min(8, trace support cap)".to_owned(),
+        );
+    }
+    if head.query_codes.len() != corpus.stories.len()
+        || head.key_codes.len() != corpus.stories.len()
+    {
+        return InputCheck::Unavailable(
+            "route-fit story tables are not aligned to RouteTraceCorpus".to_owned(),
+        );
+    }
+    if corpus
+        .stories
+        .windows(2)
+        .any(|pair| pair[0].story >= pair[1].story)
+    {
+        return InputCheck::Unavailable(
+            "trace stories are not in unique ascending story-id order".to_owned(),
+        );
+    }
+    let Some(kv_product) = corpus
+        .geometry
+        .residual_width
+        .checked_mul(corpus.geometry.kv_heads)
+    else {
+        return InputCheck::Unavailable("trace kv-width arithmetic overflowed".to_owned());
+    };
+    if !kv_product.is_multiple_of(corpus.geometry.heads) {
+        return InputCheck::Unavailable("trace kv-width is not integral".to_owned());
+    }
+    let kv_width = kv_product / corpus.geometry.heads;
+    let decoded_records: usize = corpus.stories.iter().map(|story| story.steps.len()).sum();
+    if corpus.records != decoded_records {
+        return InputCheck::Unavailable(
+            "RouteTraceCorpus record count disagrees with decoded stories".to_owned(),
+        );
+    }
+    for (story_index, story) in corpus.stories.iter().enumerate() {
+        if story.steps.is_empty()
+            || story.steps.len() > ROUTE_MAX_CANDIDATES
+            || story.tokens.len() != story.steps.len()
+            || head.query_codes[story_index].len() != story.steps.len()
+            || head.key_codes[story_index].len() != story.steps.len()
+        {
+            return InputCheck::Unavailable(
+                "route-fit/trace story tables are empty, out of bounds, or misaligned".to_owned(),
+            );
+        }
+        for (position, step) in story.steps.iter().enumerate() {
+            if step.pos as usize != position
+                || step.input_token != story.tokens[position]
+                || step.q_rows.len() != corpus.declared_layers.len()
+                || step.k_rows.len() != corpus.declared_layers.len()
+                || step
+                    .q_rows
+                    .iter()
+                    .any(|row| row.len() != corpus.geometry.residual_width)
+                || step.k_rows.iter().any(|row| row.len() != kv_width)
+                || step
+                    .q_rows
+                    .iter()
+                    .chain(&step.k_rows)
+                    .flatten()
+                    .any(|value| !value.is_finite())
+                || step.supports.len() <= lane_index
+                || step.supports[lane_index].len() <= SCREEN_HEAD as usize
+            {
+                return InputCheck::Unavailable(
+                    "trace position, q/k lanes, or attention-support alignment is incomplete"
+                        .to_owned(),
+                );
+            }
+            let support = &step.supports[lane_index][SCREEN_HEAD as usize];
+            let mut ids: Vec<u32> = support.iter().map(|&(candidate, _)| candidate).collect();
+            ids.sort_unstable();
+            if ids.windows(2).any(|pair| pair[0] == pair[1])
+                || ids.iter().any(|&candidate| candidate as usize > position)
+                || support
+                    .iter()
+                    .any(|&(_, weight)| !weight.is_finite() || weight < 0.0)
+                || support.windows(2).any(|pair| pair[0].1 < pair[1].1)
+                || u32::try_from(position + 1).map_or(true, |candidate_count| {
+                    candidate_count > expected_m && ids.len() != expected_m as usize
+                })
+            {
+                return InputCheck::Unavailable(
+                    "teacher top-M support is duplicate, non-causal, non-finite, out of order, or incomplete"
+                        .to_owned(),
+                );
+            }
+        }
+    }
+    if !corpus
+        .stories
+        .iter()
+        .any(|story| story.steps.len() as u32 > expected_m)
+    {
+        return InputCheck::Unavailable(
+            "trace has no eligible candidate_count > M step".to_owned(),
+        );
+    }
+
+    let registered_fit = match fit_method_spec(&fitted.method.id, fitted.method.version) {
+        Ok(record) => record,
+        Err(_) => {
+            return InputCheck::Unavailable(
+                "fitted route method is not a registered route-fit record".to_owned(),
+            );
+        }
+    };
+    let profile_digest = profile.declared_digest();
+    if manifest.format != FIT_MANIFEST_FORMAT
+        || manifest.parameters != route_fit_v1_parameter_labels()
+        || manifest.trace.as_deref() != Some(corpus.trace_kappa.as_str())
+        || manifest.corpus.as_deref() != Some(corpus.records_kappa.as_str())
+        || manifest
+            .trace_profile
+            .as_ref()
+            .map(|record| record.declared_digest())
+            != Some(profile_digest)
+        || registered_fit != RouteFitMethod::route_fit_v1()
+        || registered_fit != fitted.method
+        || manifest.method != registered_fit
+        || manifest.method.declared_digest() != fitted.method.declared_digest()
+    {
+        return InputCheck::Unavailable(
+            "trace/record/profile/route-fit identities do not agree".to_owned(),
+        );
+    }
+    let Some(fit_geometry) = manifest.geometry.as_ref() else {
+        return InputCheck::Unavailable("route-fit geometry identity is absent".to_owned());
+    };
+    let Ok(source_width) = u32::try_from(corpus.geometry.residual_width) else {
+        return InputCheck::Unavailable(
+            "trace source width does not fit the registered geometry record".to_owned(),
+        );
+    };
+    let Ok(route_width) = u32::try_from(ROUTE_CODE_BITS) else {
+        return InputCheck::Unavailable("route width does not fit u32".to_owned());
+    };
+    let expected_fit_geometry =
+        GeometryProjection::bucket_average(source_width.max(route_width), route_width);
+    if projection_implementation(&fit_geometry.id, fit_geometry.version).is_err()
+        || fit_geometry != &expected_fit_geometry
+        || manifest.geometry_identity.as_deref()
+            != Some(expected_fit_geometry.declared_digest().as_str())
+    {
+        return InputCheck::Unavailable(
+            "route-fit geometry record/digest is unregistered or inconsistent".to_owned(),
+        );
+    }
+    let Some(target_operator) = manifest.operator.as_ref() else {
+        return InputCheck::Unavailable(
+            "target r4-route-attention/1 identity is absent".to_owned(),
+        );
+    };
+    let target_registered = match operator_spec(&target_operator.id, target_operator.version) {
+        Ok(record) => record,
+        Err(_) => {
+            return InputCheck::Unavailable(
+                "target attention operator is not a registered record".to_owned(),
+            );
+        }
+    };
+    if &target_registered != target_operator
+        || target_operator.id != AttentionOperatorSpec::R4_ROUTE_ID
+        || target_operator.version != AttentionOperatorSpec::R4_ROUTE_VERSION
+        || manifest.operator_identity.as_deref() != Some(target_operator.declared_digest().as_str())
+    {
+        return InputCheck::Unavailable(
+            "target attention operator record/digest is tampered or not r4-route-attention/1"
+                .to_owned(),
+        );
+    }
+
+    let source_operator_digest = match input.observation_manifest {
+        None => None,
+        Some(observation) => {
+            if observation.identity_bundle_digest() != corpus.identity_bundle_digest
+                || observation.trace_profile.as_ref() != Some(profile)
+                || observation.total_records != corpus.records as u64
+            {
+                return InputCheck::Unavailable(
+                    "observation manifest identity bundle/profile/record count does not bind the decoded trace"
+                        .to_owned(),
+                );
+            }
+            if let Some(geometry) = observation.geometry.as_ref() {
+                let registered_geometry = GeometryProjection::bucket_average(
+                    geometry.source_width,
+                    geometry.compiled_width,
+                );
+                if projection_implementation(&geometry.id, geometry.version).is_err()
+                    || geometry != &registered_geometry
+                    || geometry.source_width != source_width
+                    || geometry.compiled_width != route_width
+                {
+                    return InputCheck::Unavailable(
+                        "observation geometry is not the registered corpus-source-to-288 record"
+                            .to_owned(),
+                    );
+                }
+            } else if kind == TraceKind::PinnedReal {
+                return InputCheck::Unavailable(
+                    "authoritative observation manifest has no geometry record".to_owned(),
+                );
+            }
+            if let Some(adapter) = observation.tokenizer_adapter.as_ref() {
+                if adapter_constructor(&adapter.family, adapter.version).is_err()
+                    || !canonical_blake3(&adapter.tokenizer_cid)
+                    || !canonical_blake3(&adapter.adapter_digest)
+                    || adapter.adapter_digest != adapter.declared_digest()
+                {
+                    return InputCheck::Unavailable(
+                        "observation tokenizer adapter record is unknown, noncanonical, or tampered"
+                            .to_owned(),
+                    );
+                }
+            }
+            for value in [
+                observation.input_cid.as_deref(),
+                observation.source_manifest_kappa.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if !canonical_blake3(value) {
+                    return InputCheck::Unavailable(
+                        "observation manifest carries a noncanonical content identity".to_owned(),
+                    );
+                }
+            }
+            match observation.attention_operator.as_ref() {
+                None => None,
+                Some(source_operator) => {
+                    let registered =
+                        match operator_spec(&source_operator.id, source_operator.version) {
+                            Ok(record) => record,
+                            Err(_) => {
+                                return InputCheck::Unavailable(
+                                    "source attention operator is not a registered record"
+                                        .to_owned(),
+                                );
+                            }
+                        };
+                    if &registered != source_operator
+                        || source_operator.id == AttentionOperatorSpec::R4_ROUTE_ID
+                    {
+                        return InputCheck::Unavailable(
+                            "source attention operator record is tampered or names the target operator"
+                                .to_owned(),
+                        );
+                    }
+                    Some(source_operator.declared_digest())
+                }
+            }
+        }
+    };
+
+    if kind == TraceKind::PinnedReal {
+        let Some(observation) = input.observation_manifest else {
+            return InputCheck::Unavailable(
+                "pinned real trace lacks its authoritative observation manifest".to_owned(),
+            );
+        };
+        if source_operator_digest.is_none()
+            || !nonempty(&manifest.source_snapshot)
+            || !nonempty(&manifest.tokenizer)
+            || !nonempty(&manifest.adapter)
+            || !nonempty(&manifest.compiler)
+            || corpus.identity_bundle_digest.is_empty()
+            || corpus.records_kappa.is_empty()
+            || corpus.trace_kappa.is_empty()
+            || !nonempty(&observation.source_manifest_kappa)
+            || !nonempty(&observation.input_cid)
+            || observation.geometry.is_none()
+            || observation.tokenizer_adapter.is_none()
+        {
+            return InputCheck::Unavailable(
+                "pinned real trace lacks a complete source/tokenizer/adapter/source-operator/corpus/profile/record/trace identity"
+                    .to_owned(),
+                );
+        }
+        let tokenizer = match observation.tokenizer_adapter.as_ref() {
+            Some(adapter) => adapter,
+            None => {
+                return InputCheck::Unavailable(
+                    "pinned real trace lost its required tokenizer adapter".to_owned(),
+                )
+            }
+        };
+        let tokenizer_adapter_digest = tokenizer.declared_digest();
+        if manifest.tokenizer.as_deref() != Some(tokenizer_adapter_digest.as_str()) {
+            return InputCheck::Unavailable(
+                "route-fit tokenizer identity does not match the observation tokenizer adapter"
+                    .to_owned(),
+            );
+        }
+        for value in [
+            manifest.source_snapshot.as_deref(),
+            manifest.tokenizer.as_deref(),
+            observation.input_cid.as_deref(),
+            observation.source_manifest_kappa.as_deref(),
+            Some(corpus.identity_bundle_digest.as_str()),
+            Some(corpus.records_kappa.as_str()),
+            Some(corpus.trace_kappa.as_str()),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if !canonical_blake3(value) {
+                return InputCheck::Unavailable(
+                    "pinned real trace carries a noncanonical content identity".to_owned(),
+                );
+            }
+        }
+        let Some(registered_evidence) = registered_evidence else {
+            return InputCheck::Unavailable(
+                "trace evidence is not a registered #722 evidence-kind record".to_owned(),
+            );
+        };
+        if registered_evidence != input.evidence
+            || registered_evidence.kind() != TraceKind::PinnedReal
+        {
+            return InputCheck::Unavailable(
+                "evidence-kind registry mismatch: caller-selected TraceKind cannot relabel evidence"
+                    .to_owned(),
+            );
+        }
+        let fit_manifest_kappa = manifest.kappa();
+        let fitted_params_kappa = fitted.kappa();
+        if registered_evidence.observation_identity_bundle_digest
+            != Some(corpus.identity_bundle_digest.as_str())
+            || registered_evidence.records_kappa != Some(corpus.records_kappa.as_str())
+            || registered_evidence.trace_kappa != Some(corpus.trace_kappa.as_str())
+            || registered_evidence.fit_manifest_kappa != Some(fit_manifest_kappa.as_str())
+            || registered_evidence.fitted_params_kappa != Some(fitted_params_kappa.as_str())
+        {
+            return InputCheck::Unavailable(
+                "registered empirical evidence identities do not exactly bind observation, records, trace, fit manifest, and fitted parameters"
+                    .to_owned(),
+            );
+        }
+        // `FittedRouteCodes` is a typed artifact but its fields are public for
+        // fixture construction. Recompute route-fit/1 at the empirical
+        // boundary so a fabricated code table cannot borrow a pinned κ.
+        match fit_route_codes(corpus) {
+            Ok(recomputed) if &recomputed == fitted => {}
+            Ok(_) | Err(_) => {
+                return InputCheck::Unavailable(
+                    "fitted route codes do not recompute exactly under registered route-fit/1"
+                        .to_owned(),
+                );
+            }
+        }
+    } else if registered_evidence != Some(input.evidence)
+        || input.evidence.kind() != TraceKind::InstrumentConformance
+    {
+        return InputCheck::Unavailable(
+            "instrument trace evidence is not the full registered evidence-kind record".to_owned(),
+        );
+    }
+    InputCheck::Ready {
+        input,
+        lane_index,
+        source_operator_digest,
+    }
+}
+
+fn report_identities(
+    input: Option<OcteractTraceInput<'_>>,
+    source_operator_digest: Option<String>,
+) -> ScreenIdentities {
+    let mut identities = ScreenIdentities {
+        octeract_source_sha256: OCTERACT_CYPHER_SOURCE.sha256.to_owned(),
+        validation_source_sha256: OCTERACT_VALIDATION_SOURCE.sha256.to_owned(),
+        ..ScreenIdentities::default()
+    };
+    let Some(input) = input else {
+        return identities;
+    };
+    identities.observation_identity_bundle_digest =
+        Some(input.corpus.identity_bundle_digest.clone());
+    identities.observation_input_cid = input
+        .observation_manifest
+        .and_then(|manifest| manifest.input_cid.clone());
+    identities.source_manifest_kappa = input
+        .observation_manifest
+        .and_then(|manifest| manifest.source_manifest_kappa.clone());
+    identities.records_kappa = Some(input.corpus.records_kappa.clone());
+    identities.trace_kappa = Some(input.corpus.trace_kappa.clone());
+    identities.trace_profile_digest = Some(input.corpus.trace_profile.declared_digest());
+    identities.route_fit_digest = Some(input.fitted.method.declared_digest());
+    identities.fit_manifest_kappa = Some(input.fit_manifest.kappa());
+    identities.fitted_params_kappa = Some(input.fitted.kappa());
+    identities.source_snapshot = input.fit_manifest.source_snapshot.clone();
+    identities.source_geometry_digest = input
+        .observation_manifest
+        .and_then(|manifest| manifest.geometry.as_ref())
+        .map(GeometryProjection::declared_digest);
+    identities.tokenizer_cid = input
+        .observation_manifest
+        .and_then(|manifest| manifest.tokenizer_adapter.as_ref())
+        .map(|adapter| adapter.tokenizer_cid.clone());
+    identities.tokenizer_adapter_digest = input
+        .observation_manifest
+        .and_then(|manifest| manifest.tokenizer_adapter.as_ref())
+        .map(|adapter| adapter.adapter_digest.clone());
+    identities.tokenizer = input.fit_manifest.tokenizer.clone();
+    identities.adapter = input.fit_manifest.adapter.clone();
+    identities.target_operator_digest = input.fit_manifest.operator_identity.clone();
+    identities.source_attention_operator_digest = source_operator_digest;
+    identities.compiler = input.fit_manifest.compiler.clone();
+    identities.trace_evidence_id = Some(input.evidence.id().to_owned());
+    identities.trace_evidence_version = Some(input.evidence.version());
+    identities.trace_evidence_kind = Some(input.evidence.kind());
+    identities.trace_evidence_digest = Some(input.evidence.declared_digest());
+    identities
+}
+
+fn unavailable_report(
+    contract: OcteractTraceContract,
+    kind: TraceKind,
+    identities: ScreenIdentities,
+    reason: String,
+) -> OcteractTraceReport {
+    let mut arms = Vec::with_capacity(contract.arms.len());
+    for (index, declaration) in contract.arms.iter().enumerate() {
+        arms.push(ArmReport {
+            id: declaration.id.clone(),
+            can_advance: declaration.can_advance,
+            verdict: if index == 0 {
+                StageVerdict::Unavailable
+            } else {
+                StageVerdict::NotRun
+            },
+            reason: if index == 0 {
+                reason.clone()
+            } else {
+                "NOT_RUN after unavailable prerequisite/instrument".to_owned()
+            },
+            metrics: ArmMetrics::default(),
+        });
+    }
+    let nulls = contract
+        .nulls
+        .iter()
+        .map(|declaration| ArmReport {
+            id: declaration.id.clone(),
+            can_advance: false,
+            verdict: StageVerdict::NotRun,
+            reason: "NOT_RUN after unavailable prerequisite/instrument".to_owned(),
+            metrics: ArmMetrics::default(),
+        })
+        .collect();
+    let mut report = OcteractTraceReport {
+        format: OCTERACT_TRACE_REPORT_FORMAT.to_owned(),
+        contract,
+        trace_kind: kind,
+        identities,
+        controls: ScreenControls {
+            frame: "UNAVAILABLE".to_owned(),
+            ..ScreenControls::default()
+        },
+        shared_metrics: ScreenSharedMetrics::default(),
+        arms,
+        nulls,
+        disposition: ScreenDisposition::Unavailable,
+        disposition_reason: reason,
+        payload_kappa: String::new(),
+    };
+    report.payload_kappa = octeract_trace_payload_kappa(&report);
+    report
+}
+
+fn arm_report(
+    id: &str,
+    can_advance: bool,
+    verdict: StageVerdict,
+    reason: &str,
+    metrics: ArmMetrics,
+) -> ArmReport {
+    ArmReport {
+        id: id.to_owned(),
+        can_advance,
+        verdict,
+        reason: reason.to_owned(),
+        metrics,
+    }
+}
+
+/// Execute the locked screen over an explicitly supplied trace/fit/manifest.
+/// `None` emits a deterministic typed-UNAVAILABLE report and never searches
+/// the filesystem or silently selects a fixture.
+pub fn run_octeract_trace_screen(
+    input: Option<OcteractTraceInput<'_>>,
+    kind: TraceKind,
+) -> OcteractTraceReport {
+    let contract = preregistered_octeract_trace_contract();
+    let Some(supplied) = input else {
+        return unavailable_report(
+            contract,
+            kind,
+            report_identities(None, None),
+            "required explicitly supplied pinned full/1 trace input is absent".to_owned(),
+        );
+    };
+    let checked = validate_input(supplied, kind);
+    let (input, lane_index, source_operator_digest) = match checked {
+        InputCheck::Ready {
+            input,
+            lane_index,
+            source_operator_digest,
+        } => (input, lane_index, source_operator_digest),
+        InputCheck::Unavailable(reason) => {
+            return unavailable_report(
+                contract,
+                kind,
+                report_identities(Some(supplied), None),
+                reason,
+            );
+        }
+    };
+    let identities = report_identities(Some(input), source_operator_digest);
+    let Some(head) = input.fitted.head(SCREEN_LAYER, SCREEN_HEAD) else {
+        return unavailable_report(
+            contract,
+            kind,
+            identities,
+            "validated route-fit input lost layer 0 head 0".to_owned(),
+        );
+    };
+    let m = input.fitted.top_m as usize;
+
+    let mut exact_weight = vec![0u64; 9];
+    let mut folded_shell = vec![0u64; 5];
+    let mut exact_per_block = vec![vec![0u64; 9]; ROUTE_CODE_BYTES];
+    let mut fold_per_block = vec![vec![0u64; 5]; ROUTE_CODE_BYTES];
+    let mut eligible_story = BTreeMap::<u32, ()>::new();
+    let mut counts = ScreenCounts::default();
+    let mut prefilter_eligible_story = BTreeMap::<u32, ()>::new();
+    let mut prefilter_counts = ScreenCounts::default();
+    let mut deranged_counts = ScreenCounts::default();
+    let mut collision = CollisionMetrics::default();
+    let mut group_sizes = BTreeMap::<u32, u64>::new();
+    let mut oracle_recall_sum = 0.0;
+    let mut oracle_jaccard_sum = 0.0;
+    let mut oracle_steps = 0u64;
+    let mut shortlist = ShortlistMetrics::default();
+    let mut prefilter = PrefilterMetrics::default();
+    let mut lower = LowerBoundMetrics::default();
+    let mut occupancy_null_occupancy = OccupancyAccumulator::new();
+    let mut shuffled_null_occupancy = OccupancyAccumulator::new();
+
+    let mut v1 = MetricAccumulator::new();
+    let mut weight9 = MetricAccumulator::new();
+    let mut fold5 = MetricAccumulator::new();
+    let mut oriented = MetricAccumulator::new();
+    let mut prefilter_selection = MetricAccumulator::new();
+    let mut lower_selection = MetricAccumulator::new();
+    let mut occupancy_null = MetricAccumulator::new();
+    let mut shuffled_null = MetricAccumulator::new();
+    let mut deranged_null = MetricAccumulator::new();
+    let mut frame_deranged = MetricAccumulator::new();
+    let mut prefilter_occupancy_null = MetricAccumulator::new();
+    let mut prefilter_shuffled_null = MetricAccumulator::new();
+    let mut prefilter_deranged_null = MetricAccumulator::new();
+
+    let permutation = shuffled_block_permutation(SHUFFLED_BLOCK_SEED);
+    let mut scalar_operator_exact = true;
+    let mut weight9_exact = true;
+    let mut oriented_exact = true;
+    let mut lower_bound_exact = true;
+    let mut anchor_relabel_invariant = true;
+    let mut anchor_relabels_checked = 0u32;
+    let mut occupancy_null_transformation_distinct = false;
+    let mut occupancy_null_result_distinct = false;
+    let mut shuffled_block_null_transformation_distinct = false;
+    let mut shuffled_block_null_result_distinct = false;
+    let mut deranged_support_transformation_distinct = false;
+
+    for (story_index, story) in input.corpus.stories.iter().enumerate() {
+        let story_supports: Vec<Vec<u32>> = story
+            .steps
+            .iter()
+            .map(|step| {
+                step.supports[lane_index][SCREEN_HEAD as usize]
+                    .iter()
+                    .map(|&(candidate, _)| candidate)
+                    .collect()
+            })
+            .collect();
+        let deranged = deranged_supports(&story_supports);
+        for position in 0..story.steps.len() {
+            let query = &head.query_codes[story_index][position];
+            let keys = &head.key_codes[story_index][..=position];
+            let step_m = m.min(keys.len());
+            let Some(scored) = score_octeract_step(query, keys, step_m) else {
+                scalar_operator_exact = false;
+                continue;
+            };
+            scalar_operator_exact &= route_seam_matches(query, keys, step_m, &scored.v1_selected);
+            weight9_exact &= scored.weight9_blocks == scored.oriented_weights
+                && scored.weight9_scores == scored.exact_scores
+                && scored.weight9_selected == scored.v1_selected;
+            oriented_exact &= scored.oriented_scores == scored.exact_scores
+                && scored.oriented_selected == scored.v1_selected;
+            lower_bound_exact &= scored.lower_bound.selected == scored.v1_selected
+                && scored
+                    .lower_bound
+                    .lower_bounds
+                    .iter()
+                    .zip(&scored.exact_scores)
+                    .all(|(&bound, &exact)| bound <= exact);
+
+            if keys.len() <= m {
+                continue;
+            }
+            let (step_anchor_invariant, step_relabels_checked) =
+                anchor_relabel_control_result(&scored, step_m);
+            anchor_relabel_invariant &= step_anchor_invariant;
+            anchor_relabels_checked = anchor_relabels_checked.max(step_relabels_checked);
+            eligible_story.insert(story.story, ());
+            counts.eligible_steps += 1;
+            counts.candidates += keys.len() as u64;
+            let teacher = &story_supports[position];
+            counts.teacher_support_entries += teacher.len() as u64;
+            deranged_counts.eligible_steps += 1;
+            deranged_counts.candidates += keys.len() as u64;
+            deranged_counts.teacher_support_entries += deranged[position].len() as u64;
+
+            for (candidate, classes) in scored.fold_classes.iter().enumerate() {
+                for (block, &class) in classes.iter().enumerate() {
+                    let distance = usize::from(scored.weight9_blocks[candidate][block]);
+                    exact_weight[distance] += 1;
+                    folded_shell[class as usize] += 1;
+                    exact_per_block[block][distance] += 1;
+                    fold_per_block[block][class as usize] += 1;
+                }
+            }
+
+            v1.record(
+                &scored.exact_scores,
+                &scored.oriented_weights,
+                &scored.v1_selected,
+                teacher,
+            );
+            weight9.record(
+                &scored.weight9_scores,
+                &scored.weight9_blocks,
+                &scored.weight9_selected,
+                teacher,
+            );
+            fold5.record(
+                &scored.folded_scores,
+                &scored.fold_classes,
+                &scored.folded_selected,
+                teacher,
+            );
+            oriented.record(
+                &scored.oriented_scores,
+                &scored.oriented_weights,
+                &scored.oriented_selected,
+                teacher,
+            );
+            let lower_classes: Vec<[u8; ROUTE_CODE_BYTES]> = keys
+                .iter()
+                .map(|key| {
+                    let mut classes = [0u8; ROUTE_CODE_BYTES];
+                    for (block, (&query_byte, &key_byte)) in query.iter().zip(key).enumerate() {
+                        classes[block] = masked_weight_lower_bound(query_byte, key_byte, u8::MAX);
+                    }
+                    classes
+                })
+                .collect();
+            lower_selection.record(
+                &scored.lower_bound.lower_bounds,
+                &lower_classes,
+                &scored.lower_bound.selected,
+                teacher,
+            );
+
+            let v1_ids = selection_ids(&scored.v1_selected);
+
+            let occupancy_classes = occupancy_matched_fold_null(
+                &scored.fold_classes,
+                OCCUPANCY_MATCHED_FOLD_SEED ^ (u64::from(story.story) << 32) ^ position as u64,
+            );
+            let occupancy_scores: Vec<u32> = occupancy_classes
+                .iter()
+                .map(|classes| classes.iter().map(|&value| u32::from(value)).sum())
+                .collect();
+            let occupancy_selected = selected_from_scores(&occupancy_scores, m);
+            occupancy_null_transformation_distinct |= occupancy_classes != scored.fold_classes;
+            occupancy_null_result_distinct |= occupancy_scores != scored.folded_scores
+                || occupancy_selected != scored.folded_selected;
+            occupancy_null_occupancy.record_fold(&occupancy_classes);
+            occupancy_null.record(
+                &occupancy_scores,
+                &occupancy_classes,
+                &occupancy_selected,
+                teacher,
+            );
+
+            let mut shuffled_classes = Vec::with_capacity(keys.len());
+            let mut shuffled_blocks = Vec::with_capacity(keys.len());
+            for key in keys {
+                let mut classes = [0u8; ROUTE_CODE_BYTES];
+                let mut blocks = [0u8; ROUTE_CODE_BYTES];
+                for block in 0..ROUTE_CODE_BYTES {
+                    let distance = masked_byte_distance(
+                        query[block],
+                        key[usize::from(permutation[block])],
+                        u8::MAX,
+                    );
+                    blocks[block] = distance;
+                    classes[block] = folded_class(bounded_block(distance));
+                }
+                shuffled_blocks.push(blocks);
+                shuffled_classes.push(classes);
+            }
+            let shuffled_scores: Vec<u32> = shuffled_classes
+                .iter()
+                .map(|classes| classes.iter().map(|&value| u32::from(value)).sum())
+                .collect();
+            let shuffled_selected = selected_from_scores(&shuffled_scores, m);
+            shuffled_block_null_transformation_distinct |= permutation
+                .iter()
+                .enumerate()
+                .any(|(index, &value)| index != usize::from(value))
+                && (shuffled_blocks != scored.weight9_blocks
+                    || shuffled_classes != scored.fold_classes);
+            shuffled_block_null_result_distinct |= shuffled_scores != scored.folded_scores
+                || shuffled_selected != scored.folded_selected;
+            shuffled_null_occupancy.record_exact_and_fold(&shuffled_blocks, &shuffled_classes);
+            shuffled_null.record(
+                &shuffled_scores,
+                &shuffled_classes,
+                &shuffled_selected,
+                teacher,
+            );
+            deranged_null.record(
+                &scored.folded_scores,
+                &scored.fold_classes,
+                &scored.folded_selected,
+                &deranged[position],
+            );
+            deranged_support_transformation_distinct |=
+                deranged[position].as_slice() != teacher.as_slice();
+            frame_deranged.record(
+                &scored.exact_scores,
+                &scored.oriented_weights,
+                &scored.v1_selected,
+                &deranged[position],
+            );
+
+            if !scored.prefilter.shortlist.is_empty() {
+                prefilter_eligible_story.insert(story.story, ());
+                prefilter_counts.eligible_steps += 1;
+                prefilter_counts.candidates += keys.len() as u64;
+                prefilter_counts.teacher_support_entries += teacher.len() as u64;
+                prefilter.work_eligible_steps += 1;
+                prefilter.total_candidates += keys.len() as u64;
+                prefilter.exact_refinement_candidates +=
+                    u64::from(scored.prefilter.exact_refinement_candidates);
+                prefilter.exact_refinement_candidates_avoided +=
+                    u64::from(scored.prefilter.exact_refinement_candidates_avoided);
+                let selected = selection_ids(&scored.prefilter.selected);
+                prefilter.mean_v1_recall += recall(&selected, &v1_ids);
+                prefilter.mean_v1_jaccard += jaccard(&selected, &v1_ids);
+                prefilter_selection.record(
+                    &scored.folded_scores,
+                    &scored.fold_classes,
+                    &scored.prefilter.selected,
+                    teacher,
+                );
+                let occupancy_prefilter =
+                    prefilter_step(&scored.exact_scores, &occupancy_scores, m);
+                prefilter_occupancy_null.record(
+                    &occupancy_scores,
+                    &occupancy_classes,
+                    &occupancy_prefilter.selected,
+                    teacher,
+                );
+                let shuffled_prefilter = prefilter_step(&scored.exact_scores, &shuffled_scores, m);
+                prefilter_shuffled_null.record(
+                    &shuffled_scores,
+                    &shuffled_classes,
+                    &shuffled_prefilter.selected,
+                    teacher,
+                );
+                prefilter_deranged_null.record(
+                    &scored.folded_scores,
+                    &scored.fold_classes,
+                    &scored.prefilter.selected,
+                    &deranged[position],
+                );
+                let shortlist_ids = &scored.prefilter.shortlist;
+                for candidate in 0..keys.len() as u32 {
+                    let in_v1 = v1_ids.contains(&candidate);
+                    let in_shortlist = shortlist_ids.contains(&candidate);
+                    shortlist.false_positives += u64::from(in_shortlist && !in_v1);
+                    shortlist.false_negatives += u64::from(in_v1 && !in_shortlist);
+                }
+            }
+            lower.candidates += keys.len() as u64;
+            lower.tight_candidates += u64::from(scored.lower_bound.tight_candidates);
+            lower.exact_evaluations += u64::from(scored.lower_bound.exact_evaluations);
+            lower.exact_evaluations_avoided +=
+                u64::from(scored.lower_bound.exact_evaluations_avoided);
+
+            let mut fold_groups = BTreeMap::<[u8; ROUTE_CODE_BYTES], Vec<usize>>::new();
+            let mut exact_groups = BTreeMap::<[u8; ROUTE_CODE_BYTES], Vec<usize>>::new();
+            for candidate in 0..keys.len() {
+                fold_groups
+                    .entry(scored.fold_classes[candidate])
+                    .or_default()
+                    .push(candidate);
+                exact_groups
+                    .entry(scored.oriented_weights[candidate])
+                    .or_default()
+                    .push(candidate);
+            }
+            collision.exact_collision_pairs += exact_groups
+                .values()
+                .map(|members| choose_two(members.len()))
+                .sum::<u64>();
+            let mut oracle_groups = Vec::with_capacity(fold_groups.len());
+            for members in fold_groups.values() {
+                if members.len() > 1 {
+                    collision.complete_fold_signature_groups += 1;
+                    *group_sizes.entry(members.len() as u32).or_default() += 1;
+                }
+                let mut lossy = false;
+                for left in 0..members.len() {
+                    for right in left + 1..members.len() {
+                        if scored.oriented_weights[members[left]]
+                            != scored.oriented_weights[members[right]]
+                        {
+                            collision.complement_collision_pairs += 1;
+                            lossy = true;
+                        }
+                        let left_member = teacher.contains(&(members[left] as u32));
+                        let right_member = teacher.contains(&(members[right] as u32));
+                        collision.within_group_membership_disagreements +=
+                            u64::from(left_member != right_member);
+                    }
+                }
+                collision.lossy_signature_groups += u64::from(lossy);
+                oracle_groups.push(CollisionGroup {
+                    candidate_ids: members.iter().map(|&value| value as u32).collect(),
+                    teacher_membership: members
+                        .iter()
+                        .map(|&value| teacher.contains(&(value as u32)))
+                        .collect(),
+                });
+            }
+            if let Some(oracle) = collision_oracle(&oracle_groups, m) {
+                let hits = oracle.max_teacher_hits as usize;
+                oracle_recall_sum += if teacher.is_empty() {
+                    0.0
+                } else {
+                    hits as f64 / teacher.len() as f64
+                };
+                oracle_jaccard_sum += hits as f64 / (m + teacher.len() - hits) as f64;
+                oracle_steps += 1;
+            }
+        }
+    }
+    counts.eligible_stories = eligible_story.len() as u64;
+    deranged_counts.eligible_stories = counts.eligible_stories;
+    prefilter_counts.eligible_stories = prefilter_eligible_story.len() as u64;
+
+    let occupancy = OccupancyMetrics {
+        exact_entropy_bits: entropy(&exact_weight),
+        folded_entropy_bits: entropy(&folded_shell),
+        exact_weight,
+        folded_shell,
+        exact_weight_per_block: exact_per_block,
+        folded_shell_per_block: fold_per_block,
+    };
+    let occupancy_null_occupancy = occupancy_null_occupancy.finish_fold();
+    let shuffled_null_occupancy = shuffled_null_occupancy.finish();
+    collision.group_size_distribution = group_sizes.into_iter().collect();
+    if prefilter.work_eligible_steps != 0 {
+        let denominator = prefilter.work_eligible_steps as f64;
+        prefilter.mean_v1_recall /= denominator;
+        prefilter.mean_v1_jaccard /= denominator;
+    }
+    if prefilter.total_candidates != 0 {
+        prefilter.exact_refinement_fraction =
+            prefilter.exact_refinement_candidates as f64 / prefilter.total_candidates as f64;
+    }
+    if lower.candidates != 0 {
+        lower.tight_fraction = lower.tight_candidates as f64 / lower.candidates as f64;
+    }
+    let prefilter_occupancy_null_selection = prefilter_occupancy_null.finish();
+    let prefilter_shuffled_null_selection = prefilter_shuffled_null.finish();
+    let prefilter_deranged_null_selection = prefilter_deranged_null.finish();
+    prefilter.occupancy_null_teacher_jaccard =
+        prefilter_occupancy_null_selection.mean_teacher_jaccard;
+    prefilter.shuffled_block_null_teacher_jaccard =
+        prefilter_shuffled_null_selection.mean_teacher_jaccard;
+    prefilter.deranged_support_null_teacher_jaccard =
+        prefilter_deranged_null_selection.mean_teacher_jaccard;
+    let oracle = OracleMetrics {
+        mean_max_recall: if oracle_steps == 0 {
+            0.0
+        } else {
+            oracle_recall_sum / oracle_steps as f64
+        },
+        mean_max_jaccard: if oracle_steps == 0 {
+            0.0
+        } else {
+            oracle_jaccard_sum / oracle_steps as f64
+        },
+    };
+    let shared_metrics = ScreenSharedMetrics {
+        counts: counts.clone(),
+        occupancy,
+    };
+
+    let v1_selection = v1.finish();
+    let weight_selection = weight9.finish();
+    let fold_selection = fold5.finish();
+    let oriented_selection = oriented.finish();
+    let prefilter_arm_selection = prefilter_selection.finish();
+    let lower_arm_selection = lower_selection.finish();
+    let occupancy_null_selection = occupancy_null.finish();
+    let shuffled_null_selection = shuffled_null.finish();
+    let deranged_null_selection = deranged_null.finish();
+    let frame_deranged_selection = frame_deranged.finish();
+
+    let frame = frame_control_default(v1_selection.mean_teacher_jaccard);
+    let deranged_distinct =
+        (v1_selection.mean_teacher_jaccard - frame_deranged_selection.mean_teacher_jaccard).abs()
+            > crate::frame_consistency::FRAME_CONTROL_EPSILON;
+    anchor_relabel_invariant &= anchor_relabels_checked == ANCHOR_RELABELINGS;
+    let structural_controls = scalar_operator_exact
+        && weight9_exact
+        && oriented_exact
+        && lower_bound_exact
+        && anchor_relabel_invariant
+        && v1.steps != 0;
+    let all_nulls_nonvacuous = deranged_support_transformation_distinct
+        && deranged_distinct
+        && occupancy_null_transformation_distinct
+        && occupancy_null_result_distinct
+        && shuffled_block_null_transformation_distinct
+        && shuffled_block_null_result_distinct;
+    let instrument_valid =
+        structural_controls && frame == FrameControl::Framed && all_nulls_nonvacuous;
+    let controls = ScreenControls {
+        v1_scalar_operator_exact: scalar_operator_exact,
+        weight9_exact,
+        oriented_exact,
+        lower_bound_exact,
+        anchor_relabel_invariant,
+        anchor_relabels_checked,
+        matched_pair_mean_jaccard: v1_selection.mean_teacher_jaccard,
+        frame: match frame {
+            FrameControl::Framed => "FRAMED".to_owned(),
+            FrameControl::MismatchSuspected => {
+                "UNAVAILABLE(frame/instrument mismatch suspected)".to_owned()
+            }
+        },
+        deranged_support_transformation_distinct,
+        deranged_support_observably_distinct: deranged_distinct,
+        occupancy_null_transformation_distinct,
+        occupancy_null_result_distinct,
+        shuffled_block_null_transformation_distinct,
+        shuffled_block_null_result_distinct,
+        instrument_valid,
+    };
+    if !instrument_valid {
+        let reason = "UNAVAILABLE(frame/instrument mismatch suspected): V1/weight9/oriented/lower/anchor identity, matched-pair frame, or a null anti-vacuity control failed";
+        let mut report = unavailable_report(contract, kind, identities, reason.to_owned());
+        report.controls = controls;
+        report.shared_metrics = shared_metrics.clone();
+        report.arms = vec![
+            arm_report(
+                ARM_V1,
+                false,
+                StageVerdict::Unavailable,
+                reason,
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    selection: Some(v1_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                ARM_WEIGHT9,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    selection: Some(weight_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                ARM_FOLD5,
+                true,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    selection: Some(fold_selection),
+                    collisions: Some(collision),
+                    oracle: Some(oracle),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                ARM_ORIENTED,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    selection: Some(oriented_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                ARM_PREFILTER,
+                true,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(prefilter_counts.clone()),
+                    selection: Some(prefilter_arm_selection),
+                    shortlist: Some(shortlist),
+                    prefilter: Some(prefilter),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                ARM_LOWER_BOUND,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    selection: Some(lower_arm_selection),
+                    lower_bound: Some(lower),
+                    ..ArmMetrics::default()
+                },
+            ),
+        ];
+        report.nulls = vec![
+            arm_report(
+                NULL_OCCUPANCY,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    fold_occupancy: Some(occupancy_null_occupancy),
+                    selection: Some(occupancy_null_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                NULL_SHUFFLED_BLOCK,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(counts.clone()),
+                    occupancy: Some(shuffled_null_occupancy),
+                    selection: Some(shuffled_null_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+            arm_report(
+                NULL_DERANGED_SUPPORT,
+                false,
+                StageVerdict::NotRun,
+                "NOT_RUN after unavailable frame/instrument",
+                ArmMetrics {
+                    counts: Some(deranged_counts.clone()),
+                    selection: Some(deranged_null_selection),
+                    ..ArmMetrics::default()
+                },
+            ),
+        ];
+        report.payload_kappa = octeract_trace_payload_kappa(&report);
+        return report;
+    }
+
+    let baseline_jaccard = v1_selection.mean_teacher_jaccard;
+    let null_max = occupancy_null_selection
+        .mean_teacher_jaccard
+        .max(shuffled_null_selection.mean_teacher_jaccard)
+        .max(deranged_null_selection.mean_teacher_jaccard);
+    let prefilter_null_max = prefilter_occupancy_null_selection
+        .mean_teacher_jaccard
+        .max(prefilter_shuffled_null_selection.mean_teacher_jaccard)
+        .max(prefilter_deranged_null_selection.mean_teacher_jaccard);
+    let direct_gate = oracle.mean_max_jaccard
+        >= baseline_jaccard + contract.thresholds.direct_jaccard_margin
+        && fold_selection.mean_teacher_jaccard
+            >= baseline_jaccard + contract.thresholds.direct_jaccard_margin
+        && fold_selection.mean_teacher_jaccard > null_max;
+    let prefilter_gate = prefilter.work_eligible_steps != 0
+        && prefilter.mean_v1_recall >= contract.thresholds.prefilter_v1_recall
+        && prefilter.exact_refinement_fraction <= contract.thresholds.prefilter_refinement_fraction
+        && prefilter_arm_selection.mean_teacher_jaccard > prefilter_null_max;
+    let classifier_gate = |gate_pass| CandidateGate {
+        controls_pass: structural_controls,
+        frame_score: baseline_jaccard,
+        deranged_distinct,
+        gate_pass,
+    };
+    let direct_verdict = classify_candidate_arm(kind, classifier_gate(direct_gate), false);
+    let prefilter_verdict = classify_candidate_arm(kind, classifier_gate(prefilter_gate), false);
+    let control_verdict = if kind == TraceKind::InstrumentConformance {
+        StageVerdict::NotRun
+    } else {
+        StageVerdict::Pass
+    };
+    let control_reason = if kind == TraceKind::InstrumentConformance {
+        "instrument-conformance metric recorded; empirical verdict is NOT_RUN"
+    } else {
+        "structural conformance control passed"
+    };
+    let candidate_reason = |verdict: StageVerdict, passed: bool| match verdict {
+        StageVerdict::Pass => "valid pinned-real arm cleared every locked gate",
+        StageVerdict::Fail if passed => "valid pinned-real arm reached a contradictory gate state",
+        StageVerdict::Fail => {
+            "valid pinned-real arm missed at least one locked reachability/null/fidelity/work gate"
+        }
+        StageVerdict::Unavailable => "UNAVAILABLE(frame/instrument mismatch suspected)",
+        StageVerdict::NotRun => "instrument-conformance only; empirical PASS/FAIL is NOT_RUN",
+    };
+    let arms = vec![
+        arm_report(
+            ARM_V1,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                selection: Some(v1_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            ARM_WEIGHT9,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                selection: Some(weight_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            ARM_FOLD5,
+            true,
+            direct_verdict,
+            candidate_reason(direct_verdict, direct_gate),
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                selection: Some(fold_selection),
+                collisions: Some(collision),
+                oracle: Some(oracle),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            ARM_ORIENTED,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                selection: Some(oriented_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            ARM_PREFILTER,
+            true,
+            prefilter_verdict,
+            candidate_reason(prefilter_verdict, prefilter_gate),
+            ArmMetrics {
+                counts: Some(prefilter_counts),
+                selection: Some(prefilter_arm_selection),
+                shortlist: Some(shortlist),
+                prefilter: Some(prefilter),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            ARM_LOWER_BOUND,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                selection: Some(lower_arm_selection),
+                lower_bound: Some(lower),
+                ..ArmMetrics::default()
+            },
+        ),
+    ];
+    let nulls = vec![
+        arm_report(
+            NULL_OCCUPANCY,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts.clone()),
+                fold_occupancy: Some(occupancy_null_occupancy),
+                selection: Some(occupancy_null_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            NULL_SHUFFLED_BLOCK,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(counts),
+                occupancy: Some(shuffled_null_occupancy),
+                selection: Some(shuffled_null_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+        arm_report(
+            NULL_DERANGED_SUPPORT,
+            false,
+            control_verdict,
+            control_reason,
+            ArmMetrics {
+                counts: Some(deranged_counts),
+                selection: Some(deranged_null_selection),
+                ..ArmMetrics::default()
+            },
+        ),
+    ];
+    let (disposition, disposition_reason) = if kind == TraceKind::InstrumentConformance {
+        (
+            ScreenDisposition::Unavailable,
+            "instrument-conformance completed; required pinned real trace row remains UNAVAILABLE"
+                .to_owned(),
+        )
+    } else if direct_verdict == StageVerdict::Pass || prefilter_verdict == StageVerdict::Pass {
+        (
+            ScreenDisposition::Advance,
+            "at least one promotable Octeract arm cleared every locked gate".to_owned(),
+        )
+    } else {
+        (
+            ScreenDisposition::StopNegative,
+            "valid pinned-real screen ran and no promotable Octeract arm cleared".to_owned(),
+        )
+    };
+    let mut report = OcteractTraceReport {
+        format: OCTERACT_TRACE_REPORT_FORMAT.to_owned(),
+        contract,
+        trace_kind: kind,
+        identities,
+        controls,
+        shared_metrics,
+        arms,
+        nulls,
+        disposition,
+        disposition_reason,
+        payload_kappa: String::new(),
+    };
+    report.payload_kappa = octeract_trace_payload_kappa(&report);
+    report
+}

--- a/crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs
+++ b/crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs
@@ -1,0 +1,1714 @@
+//! #661/#722 Octeract route-trace screen conformance.
+//!
+//! These fixtures are deliberately small, deterministic, and certifier-only.
+//! They exercise the locked screen and its null instruments without presenting
+//! synthetic observations as evidence about a real checkpoint.
+
+use std::collections::BTreeMap;
+
+use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
+use uor_r4_graph_certify::octeract_trace_screen::{
+    canonical_octeract_trace_report_bytes, classify_candidate_arm, collision_oracle,
+    deranged_supports, exhaustive_anchor_relabel_control, occupancy_matched_fold_null,
+    octeract_trace_payload_kappa, octeract_trace_report_kappa,
+    preregistered_octeract_trace_contract, registered_trace_evidence, run_octeract_trace_screen,
+    score_octeract_step, shuffled_block_permutation, CandidateGate, CollisionGroup,
+    OcteractTraceInput, ScoredCandidate, ScreenDisposition, TraceKind, ANCHOR_RELABELINGS,
+    INSTRUMENT_CONFORMANCE_EVIDENCE_ID, INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+    OCCUPANCY_MATCHED_FOLD_SEED, OCTERACT_TRACE_CONTRACT_FORMAT, OCTERACT_TRACE_REPORT_FORMAT,
+    SHUFFLED_BLOCK_SEED,
+};
+use uor_r4_graph_certify::route_fit_report::StageVerdict;
+use uor_r4_graph_compiler::observation::ObservationManifest;
+use uor_r4_graph_compiler::route_fit::{
+    synthetic_fit_manifest, FittedRouteCodes, HeadCodes, RouteFitMethod, RouteTraceCorpus,
+    StepTrace, StoryTrace,
+};
+use uor_r4_graph_compiler::trace_profile::TraceProfile;
+use uor_r4_graph_format::route_attention::ROUTE_CODE_BYTES;
+use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::geometry::GeometryProjection;
+use uor_r4_model_source::TraceCaptureGeometry;
+
+const TEST_STEPS: usize = 12;
+const TEST_TOP_M: u32 = 2;
+
+struct Fixture {
+    corpus: RouteTraceCorpus,
+    fitted: FittedRouteCodes,
+    manifest: uor_r4_graph_compiler::route_fit::FitManifest,
+}
+
+fn digest(label: &str) -> String {
+    format!("blake3:{}", blake3::hash(label.as_bytes()).to_hex())
+}
+
+fn code_with(first: u8, second: u8) -> [u8; ROUTE_CODE_BYTES] {
+    let mut code = [0u8; ROUTE_CODE_BYTES];
+    code[0] = first;
+    code[1] = second;
+    code
+}
+
+/// One 12-step, one-head `full/1` fixture. Key XOR deltas include exact ties
+/// and complement-fold pairs (1/7 and 2/6). The nonuniform shared query base
+/// preserves those distances while making the shuffled-block null observable.
+/// Teacher supports follow the exact V1 winners on eligible steps, which gives
+/// the frame and derangement controls a non-vacuous signal.
+fn fixture() -> Fixture {
+    let profile = TraceProfile::full(&[0], TEST_TOP_M);
+    let geometry = TraceCaptureGeometry {
+        layers: 1,
+        heads: 1,
+        kv_heads: 1,
+        residual_width: 288,
+    };
+    let query_code: [u8; ROUTE_CODE_BYTES] =
+        core::array::from_fn(|block| (block as u8).wrapping_mul(37).wrapping_add(11));
+    let distance_codes = [
+        code_with(0x00, 0x00), // D=0, F=0
+        code_with(0x01, 0x00), // D=1, F=1
+        code_with(0x02, 0x00), // D=1, F=1 (V1 tie, index loses)
+        code_with(0xfe, 0x00), // D=7, F=1 (complement-fold collision)
+        code_with(0x03, 0x00), // D=2, F=2
+        code_with(0xfc, 0x00), // D=6, F=2 (complement-fold collision)
+        code_with(0x0f, 0x00), // D=4, F=4 (equator)
+        code_with(0x00, 0x01), // D=1 in a second block
+        code_with(0x00, 0x02), // D=1 in a second block (tie)
+        code_with(0xff, 0x00), // D=8, F=0
+        code_with(0x00, 0xff), // D=8 in a second block, F=0
+        code_with(0x55, 0xaa), // D=8, F=8
+    ];
+    let keys = distance_codes
+        .map(|distance| core::array::from_fn(|block| query_code[block] ^ distance[block]));
+    let queries = vec![vec![query_code; TEST_STEPS]];
+    let key_codes = vec![keys.to_vec()];
+
+    let mut steps = Vec::with_capacity(TEST_STEPS);
+    for pos in 0..TEST_STEPS {
+        let support = match pos {
+            0 => vec![(0, 1.0)],
+            1 => vec![(0, 0.75), (1, 0.25)],
+            _ => vec![(0, 0.6), (1, 0.4)],
+        };
+        steps.push(StepTrace {
+            pos: pos as u32,
+            input_token: pos as u32,
+            next: (pos + 1) as u32,
+            top_tokens: [0, 1, 2, 3, 4, 5, 6, 7],
+            target_logprob_nats: -1.0,
+            q_rows: vec![vec![0.0; 288]],
+            k_rows: vec![vec![0.0; 288]],
+            supports: vec![vec![support]],
+        });
+    }
+    let corpus = RouteTraceCorpus {
+        geometry,
+        declared_layers: vec![0],
+        support_size: TEST_TOP_M,
+        trace_profile: profile,
+        stories: vec![StoryTrace {
+            story: 0,
+            tokens: (0..TEST_STEPS as u32).collect(),
+            steps,
+        }],
+        records: TEST_STEPS,
+        records_kappa: digest("#722-test-records"),
+        trace_kappa: digest("#722-test-trace"),
+        identity_bundle_digest: digest("#722-test-observation-identities"),
+    };
+    let fitted = FittedRouteCodes {
+        method: RouteFitMethod::route_fit_v1(),
+        top_m: TEST_TOP_M,
+        heads: vec![HeadCodes {
+            layer: 0,
+            head: 0,
+            thresholds: vec![0.0; 288],
+            query_codes: queries,
+            key_codes,
+        }],
+    };
+    let mut manifest = synthetic_fit_manifest(&corpus, &digest("#722-test-source"))
+        .expect("registered route-fit/operator identities");
+    // The fixture can be offered as a fully identified pinned-real shape in
+    // negative/control tests. TraceKind still decides whether rows are
+    // empirical or instrument-conformance; identity spelling alone cannot
+    // promote a synthetic row.
+    manifest.tokenizer = Some(digest("#722-test-tokenizer"));
+    Fixture {
+        corpus,
+        fitted,
+        manifest,
+    }
+}
+
+/// A second shape in which the full bounded screen has four eligible steps
+/// (`N=9..=12`, `M=8`) but the locked `P=floor(3N/4)` prefilter can run only
+/// for `N=11,12`. This makes row-domain accounting observably different from
+/// copying the shared counts into the prefilter row.
+fn prefilter_subset_fixture() -> Fixture {
+    let mut fixture = fixture();
+    fixture.corpus.support_size = 8;
+    fixture.corpus.trace_profile = TraceProfile::full(&[0], 8);
+    fixture.fitted.top_m = 8;
+    for (position, step) in fixture.corpus.stories[0].steps.iter_mut().enumerate() {
+        let candidates: Vec<u32> = if position < 8 {
+            (0..=position as u32).collect()
+        } else {
+            vec![0, 1, 2, 4, 5, 6, 7, 8]
+        };
+        let support = candidates
+            .iter()
+            .map(|&candidate| (candidate, 1.0 / candidates.len() as f32))
+            .collect();
+        step.supports = vec![vec![support]];
+    }
+    let source_snapshot = fixture
+        .manifest
+        .source_snapshot
+        .clone()
+        .expect("synthetic teacher snapshot identity");
+    fixture.manifest = synthetic_fit_manifest(&fixture.corpus, &source_snapshot)
+        .expect("registered route-fit/operator identities");
+    fixture
+}
+
+fn screen_input<'a>(
+    fixture: &'a Fixture,
+    observation_manifest: Option<&'a ObservationManifest>,
+) -> OcteractTraceInput<'a> {
+    OcteractTraceInput {
+        corpus: &fixture.corpus,
+        fitted: &fixture.fitted,
+        fit_manifest: &fixture.manifest,
+        observation_manifest,
+        evidence: registered_trace_evidence(
+            INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+            INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+        )
+        .expect("registered structural evidence"),
+    }
+}
+
+fn bound_observation(fixture: &mut Fixture) -> ObservationManifest {
+    let mut tokenizer = TokenizerAdapter {
+        family: TokenizerAdapter::HF_BYTE_BPE_FAMILY.to_owned(),
+        version: TokenizerAdapter::HF_BYTE_BPE_VERSION,
+        tokenizer_cid: digest("#722-test-tokenizer-definition"),
+        ..TokenizerAdapter::default()
+    };
+    tokenizer.adapter_digest = tokenizer.declared_digest();
+
+    let mut observation = ObservationManifest::new(0);
+    observation.input_cid = Some(digest("#722-test-input-corpus"));
+    observation.source_manifest_kappa = Some(digest("#722-test-source-manifest"));
+    observation.geometry = Some(GeometryProjection::bucket_average(288, 288));
+    observation.tokenizer_adapter = Some(tokenizer.clone());
+    observation.attention_operator = Some(AttentionOperatorSpec::standard());
+    observation.trace_profile = Some(fixture.corpus.trace_profile.clone());
+    observation.total_records = fixture.corpus.records as u64;
+
+    fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+    fixture.manifest.tokenizer = Some(tokenizer.declared_digest());
+    observation
+}
+
+fn real_shaped_fixture() -> (Fixture, ObservationManifest) {
+    let mut fixture = fixture();
+    fixture.manifest.adapter = Some("pinned-real-test-adapter/1".to_owned());
+    let observation = bound_observation(&mut fixture);
+    (fixture, observation)
+}
+
+fn assert_unavailable(report: &uor_r4_graph_certify::octeract_trace_screen::OcteractTraceReport) {
+    assert_eq!(report.disposition, ScreenDisposition::Unavailable);
+    assert_eq!(report.arms[0].verdict, StageVerdict::Unavailable);
+    assert!(report.arms[1..]
+        .iter()
+        .all(|arm| arm.verdict == StageVerdict::NotRun));
+    assert!(report
+        .arms
+        .iter()
+        .all(|arm| !matches!(arm.verdict, StageVerdict::Pass | StageVerdict::Fail)));
+}
+
+#[test]
+fn verdict_classifier_keeps_all_four_states_distinct_and_synthetic_nonempirical() {
+    let gate = CandidateGate {
+        controls_pass: true,
+        frame_score: 1.0,
+        deranged_distinct: true,
+        gate_pass: true,
+    };
+    assert_eq!(
+        classify_candidate_arm(TraceKind::PinnedReal, gate, false),
+        StageVerdict::Pass
+    );
+    assert_eq!(
+        classify_candidate_arm(
+            TraceKind::PinnedReal,
+            CandidateGate {
+                gate_pass: false,
+                ..gate
+            },
+            false,
+        ),
+        StageVerdict::Fail
+    );
+    assert_eq!(
+        classify_candidate_arm(
+            TraceKind::PinnedReal,
+            CandidateGate {
+                frame_score: 0.0,
+                ..gate
+            },
+            false,
+        ),
+        StageVerdict::Unavailable,
+        "a frame mismatch is absence, never an empirical negative"
+    );
+    assert_eq!(
+        classify_candidate_arm(TraceKind::PinnedReal, gate, true),
+        StageVerdict::NotRun
+    );
+    for gate_pass in [false, true] {
+        assert_eq!(
+            classify_candidate_arm(
+                TraceKind::InstrumentConformance,
+                CandidateGate { gate_pass, ..gate },
+                false,
+            ),
+            StageVerdict::NotRun,
+            "synthetic evidence can exercise the instrument but cannot become PASS/FAIL"
+        );
+    }
+}
+
+#[test]
+fn contract_is_frozen_before_labels_and_only_two_arms_can_advance() {
+    let first = preregistered_octeract_trace_contract();
+    let second = preregistered_octeract_trace_contract();
+    assert_eq!(first, second);
+    assert_eq!(first.format, OCTERACT_TRACE_CONTRACT_FORMAT);
+    assert_eq!((first.layer, first.head), (0, 0));
+    assert_eq!((first.code_bits, first.blocks), (288, 36));
+    assert_eq!(first.mask, vec![0xff; ROUTE_CODE_BYTES]);
+    assert_eq!(first.occupancy_seed, OCCUPANCY_MATCHED_FOLD_SEED);
+    assert_eq!(first.shuffled_block_seed, SHUFFLED_BLOCK_SEED);
+    assert_eq!(first.thresholds.direct_jaccard_margin, 0.03);
+    assert_eq!(first.thresholds.prefilter_v1_recall, 0.95);
+    assert_eq!(first.thresholds.prefilter_refinement_fraction, 0.75);
+    assert!(first
+        .aggregation
+        .contains("row-counts-own-consumed-domain; shared-counts-are-matched-base-domain"));
+    let evidence = registered_trace_evidence(
+        INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+        INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+    )
+    .expect("registered structural evidence");
+    assert_eq!(first.evidence_registry.len(), 1);
+    assert_eq!(first.evidence_registry[0].id, evidence.id());
+    assert_eq!(first.evidence_registry[0].version, evidence.version());
+    assert_eq!(first.evidence_registry[0].kind, evidence.kind());
+    assert_eq!(
+        first.evidence_registry[0].declared_digest,
+        evidence.declared_digest()
+    );
+    assert!(first
+        .evidence_registry_rule
+        .contains("registry-expansion-requires-new-contract-and-report-format-version"));
+    let advancing: Vec<&str> = first
+        .arms
+        .iter()
+        .filter(|arm| arm.can_advance)
+        .map(|arm| arm.id.as_str())
+        .collect();
+    assert_eq!(advancing, vec!["octeract-fold5", "octeract-prefilter"]);
+    assert!(first.nulls.iter().all(|null| !null.can_advance));
+
+    let mut first_bytes = Vec::new();
+    ciborium::into_writer(&first, &mut first_bytes).expect("contract serializes");
+    let mut second_bytes = Vec::new();
+    ciborium::into_writer(&second, &mut second_bytes).expect("contract serializes");
+    assert_eq!(first_bytes, second_bytes);
+}
+
+#[test]
+fn absent_real_trace_is_canonical_typed_unavailable_and_never_searched() {
+    let first = run_octeract_trace_screen(None, TraceKind::PinnedReal);
+    let second = run_octeract_trace_screen(None, TraceKind::PinnedReal);
+    assert_eq!(first, second);
+    assert_eq!(first.format, OCTERACT_TRACE_REPORT_FORMAT);
+    assert_eq!(first.disposition, ScreenDisposition::Unavailable);
+    assert!(first.disposition_reason.contains("explicitly supplied"));
+    assert_eq!(first.arms[0].verdict, StageVerdict::Unavailable);
+    assert!(first.arms[1..]
+        .iter()
+        .all(|arm| arm.verdict == StageVerdict::NotRun));
+    assert!(first
+        .nulls
+        .iter()
+        .all(|null| null.verdict == StageVerdict::NotRun));
+    assert_eq!(first.controls.frame, "UNAVAILABLE");
+    assert_eq!(first.identities.observation_identity_bundle_digest, None);
+    assert_eq!(first.identities.source_attention_operator_digest, None);
+    assert_eq!(first.payload_kappa, octeract_trace_payload_kappa(&first));
+    assert_eq!(
+        canonical_octeract_trace_report_bytes(&first),
+        canonical_octeract_trace_report_bytes(&second)
+    );
+    assert_eq!(
+        octeract_trace_report_kappa(&first),
+        octeract_trace_report_kappa(&second)
+    );
+    assert_eq!(canonical_octeract_trace_report_bytes(&first).len(), 6_587);
+    assert_eq!(
+        first.payload_kappa,
+        "blake3:8b8c3bdc41f04ac2d6b9a15ef843f5064fae92e8b6bfe57cafbc6803eca7c5a2"
+    );
+    assert_eq!(
+        octeract_trace_report_kappa(&first),
+        "blake3:eab7b1bb12d9508d9815da0c4fbac248eab8b93b8258e717829542e41ac75e5e"
+    );
+
+    // The final byte function recomputes the non-self-referential payload
+    // identity, so mutating only the cached derived field cannot fork bytes.
+    let mut stale = first.clone();
+    stale.payload_kappa = "blake3:stale-caller-cache".to_owned();
+    assert_eq!(
+        canonical_octeract_trace_report_bytes(&stale),
+        canonical_octeract_trace_report_bytes(&first)
+    );
+}
+
+#[test]
+fn instrument_report_is_deterministic_comprehensive_and_nonpromoting() {
+    let mut fixture = fixture();
+    let observation = bound_observation(&mut fixture);
+    let first = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::InstrumentConformance,
+    );
+    let second = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::InstrumentConformance,
+    );
+    assert_eq!(first, second);
+    assert_eq!(first.disposition, ScreenDisposition::Unavailable);
+    assert!(first.disposition_reason.contains("instrument-conformance"));
+    assert_eq!(first.payload_kappa, octeract_trace_payload_kappa(&first));
+    assert_eq!(
+        canonical_octeract_trace_report_bytes(&first),
+        canonical_octeract_trace_report_bytes(&second)
+    );
+    assert_eq!(
+        octeract_trace_report_kappa(&first),
+        octeract_trace_report_kappa(&second)
+    );
+
+    assert!(first.controls.instrument_valid);
+    assert!(first.controls.v1_scalar_operator_exact);
+    assert!(first.controls.weight9_exact);
+    assert!(first.controls.oriented_exact);
+    assert!(first.controls.lower_bound_exact);
+    assert!(first.controls.anchor_relabel_invariant);
+    assert_eq!(first.controls.anchor_relabels_checked, ANCHOR_RELABELINGS);
+    assert!(first.controls.deranged_support_transformation_distinct);
+    assert!(first.controls.deranged_support_observably_distinct);
+    assert!(first.controls.occupancy_null_transformation_distinct);
+    assert!(first.controls.occupancy_null_result_distinct);
+    assert!(first.controls.shuffled_block_null_transformation_distinct);
+    assert!(first.controls.shuffled_block_null_result_distinct);
+    assert_eq!(first.controls.frame, "FRAMED");
+
+    assert_eq!(first.arms.len(), 6);
+    assert_eq!(first.nulls.len(), 3);
+    assert!(first.arms.iter().all(|arm| {
+        arm.verdict == StageVerdict::NotRun && arm.reason.contains("instrument-conformance")
+    }));
+    assert!(first.nulls.iter().all(|null| {
+        !null.can_advance
+            && null.verdict == StageVerdict::NotRun
+            && null.reason.contains("instrument-conformance")
+    }));
+
+    let shared = &first.shared_metrics;
+    assert_eq!(shared.counts.eligible_stories, 1);
+    assert_eq!(shared.counts.eligible_steps, 10);
+    assert_eq!(shared.counts.candidates, 75);
+    assert_eq!(shared.counts.teacher_support_entries, 20);
+    assert!(first
+        .arms
+        .iter()
+        .chain(&first.nulls)
+        .all(|row| row.metrics.counts.is_some()));
+    for row in [
+        &first.arms[0],
+        &first.arms[1],
+        &first.arms[2],
+        &first.arms[3],
+        &first.arms[5],
+        &first.nulls[0],
+        &first.nulls[1],
+    ] {
+        assert_eq!(
+            row.metrics.counts.as_ref(),
+            Some(&shared.counts),
+            "{}",
+            row.id
+        );
+    }
+    let prefilter_counts = first.arms[4]
+        .metrics
+        .counts
+        .as_ref()
+        .expect("prefilter owns its work-eligible domain");
+    assert_eq!(prefilter_counts.eligible_stories, 1);
+    assert_eq!(prefilter_counts.eligible_steps, 10);
+    assert_eq!(prefilter_counts.candidates, 75);
+    assert_eq!(prefilter_counts.teacher_support_entries, 20);
+    let deranged_counts = first.nulls[2]
+        .metrics
+        .counts
+        .as_ref()
+        .expect("deranged-support null owns its transformed-label domain");
+    assert_eq!(deranged_counts.eligible_stories, 1);
+    assert_eq!(deranged_counts.eligible_steps, 10);
+    assert_eq!(deranged_counts.candidates, 75);
+    assert_eq!(
+        deranged_counts.teacher_support_entries, 19,
+        "the cyclic derangement ends with the one-entry position-0 support"
+    );
+    assert_eq!(shared.occupancy.exact_weight.iter().sum::<u64>(), 75 * 36);
+    assert_eq!(shared.occupancy.folded_shell.iter().sum::<u64>(), 75 * 36);
+    assert_eq!(shared.occupancy.exact_weight_per_block.len(), 36);
+    assert_eq!(shared.occupancy.folded_shell_per_block.len(), 36);
+    assert!(shared.occupancy.exact_entropy_bits.is_finite());
+    assert!(shared.occupancy.folded_entropy_bits.is_finite());
+    assert!(shared.occupancy.exact_entropy_bits > 0.0);
+    assert!(shared.occupancy.folded_entropy_bits > 0.0);
+
+    let v1 = &first.arms[0].metrics;
+    assert!(first
+        .arms
+        .iter()
+        .all(|row| row.metrics.fold_occupancy.is_none()));
+    let v1_selection = v1.selection.as_ref().expect("V1 owns selection metrics");
+    assert!(v1_selection.mean_teacher_jaccard > 0.0);
+    assert!(v1_selection.score_support_mi_bits.is_finite());
+    assert!(v1_selection.pooled_block_class_support_mi_bits.is_finite());
+    assert_eq!(v1_selection.per_block_class_support_mi_bits.len(), 36);
+    assert!(v1_selection
+        .per_block_class_support_mi_bits
+        .iter()
+        .all(|value| value.is_finite()));
+    assert!(v1.occupancy.is_none());
+    assert!(v1.collisions.is_none());
+    assert!(v1.shortlist.is_none());
+    assert!(v1.prefilter.is_none());
+    assert!(v1.lower_bound.is_none());
+    assert!(v1.oracle.is_none());
+
+    let weight9 = &first.arms[1].metrics;
+    assert!(weight9.selection.is_some());
+    assert!(weight9.occupancy.is_none());
+    assert!(weight9.collisions.is_none());
+    assert!(weight9.shortlist.is_none());
+    assert!(weight9.prefilter.is_none());
+    assert!(weight9.lower_bound.is_none());
+    assert!(weight9.oracle.is_none());
+
+    let fold5 = &first.arms[2].metrics;
+    assert!(fold5.selection.is_some());
+    let collisions = fold5
+        .collisions
+        .as_ref()
+        .expect("fold5 owns collision metrics");
+    assert!(collisions.exact_collision_pairs > 0);
+    assert!(collisions.complement_collision_pairs > 0);
+    assert!(collisions.complete_fold_signature_groups > 0);
+    assert!(collisions.lossy_signature_groups > 0);
+    assert!(!collisions.group_size_distribution.is_empty());
+    let oracle = fold5.oracle.as_ref().expect("fold5 owns oracle metrics");
+    assert!(oracle.mean_max_recall.is_finite());
+    assert!(oracle.mean_max_jaccard.is_finite());
+    assert!(fold5.occupancy.is_none());
+    assert!(fold5.shortlist.is_none());
+    assert!(fold5.prefilter.is_none());
+    assert!(fold5.lower_bound.is_none());
+
+    let oriented = &first.arms[3].metrics;
+    assert!(oriented.selection.is_some());
+    assert!(oriented.occupancy.is_none());
+    assert!(oriented.collisions.is_none());
+    assert!(oriented.shortlist.is_none());
+    assert!(oriented.prefilter.is_none());
+    assert!(oriented.lower_bound.is_none());
+    assert!(oriented.oracle.is_none());
+
+    let prefilter = &first.arms[4].metrics;
+    assert!(prefilter.selection.is_some());
+    let shortlist = prefilter
+        .shortlist
+        .as_ref()
+        .expect("prefilter owns shortlist metrics");
+    assert!(shortlist.false_positives > 0);
+    assert_eq!(
+        shortlist.false_negatives, 0,
+        "the main fixture retains V1 inside P; the separate adversary pins the failure case"
+    );
+    let prefilter_metrics = prefilter
+        .prefilter
+        .as_ref()
+        .expect("prefilter owns work/fidelity metrics");
+    assert!(prefilter_metrics.work_eligible_steps > 0);
+    assert!(prefilter_metrics.exact_refinement_candidates_avoided > 0);
+    assert!(prefilter_metrics.exact_refinement_fraction.is_finite());
+    assert!(prefilter_metrics.mean_v1_recall.is_finite());
+    assert!(prefilter_metrics.mean_v1_jaccard.is_finite());
+    assert!(prefilter.occupancy.is_none());
+    assert!(prefilter.collisions.is_none());
+    assert!(prefilter.lower_bound.is_none());
+    assert!(prefilter.oracle.is_none());
+
+    let lower = &first.arms[5].metrics;
+    assert!(lower.selection.is_some());
+    let lower_metrics = lower
+        .lower_bound
+        .as_ref()
+        .expect("lower-bound control owns work metrics");
+    assert!(lower_metrics.exact_evaluations_avoided > 0);
+    assert!(lower_metrics.tight_fraction.is_finite());
+    assert!(lower.occupancy.is_none());
+    assert!(lower.collisions.is_none());
+    assert!(lower.shortlist.is_none());
+    assert!(lower.prefilter.is_none());
+    assert!(lower.oracle.is_none());
+
+    let occupancy_null = &first.nulls[0].metrics;
+    let occupancy_null_occupancy = occupancy_null
+        .fold_occupancy
+        .as_ref()
+        .expect("occupancy null owns its realized occupancy");
+    assert_eq!(
+        occupancy_null_occupancy.folded_shell.iter().sum::<u64>(),
+        75 * 36
+    );
+    assert_eq!(
+        occupancy_null_occupancy.folded_shell_per_block.len(),
+        ROUTE_CODE_BYTES
+    );
+    assert!(occupancy_null.occupancy.is_none());
+    assert!(occupancy_null.selection.is_some());
+    assert!(occupancy_null.collisions.is_none());
+    assert!(occupancy_null.shortlist.is_none());
+    assert!(occupancy_null.prefilter.is_none());
+    assert!(occupancy_null.lower_bound.is_none());
+    assert!(occupancy_null.oracle.is_none());
+
+    let shuffled_null = &first.nulls[1].metrics;
+    let shuffled_occupancy = shuffled_null
+        .occupancy
+        .as_ref()
+        .expect("shuffled-block null owns its realized occupancy");
+    assert_eq!(shuffled_occupancy.exact_weight.iter().sum::<u64>(), 75 * 36);
+    assert_eq!(shuffled_occupancy.folded_shell.iter().sum::<u64>(), 75 * 36);
+    assert!(shuffled_null.selection.is_some());
+    assert!(shuffled_null.fold_occupancy.is_none());
+    assert!(shuffled_null.collisions.is_none());
+    assert!(shuffled_null.shortlist.is_none());
+    assert!(shuffled_null.prefilter.is_none());
+    assert!(shuffled_null.lower_bound.is_none());
+    assert!(shuffled_null.oracle.is_none());
+
+    let deranged_null = &first.nulls[2].metrics;
+    assert!(deranged_null.selection.is_some());
+    assert!(deranged_null.occupancy.is_none());
+    assert!(deranged_null.fold_occupancy.is_none());
+    assert!(deranged_null.collisions.is_none());
+    assert!(deranged_null.shortlist.is_none());
+    assert!(deranged_null.prefilter.is_none());
+    assert!(deranged_null.lower_bound.is_none());
+    assert!(deranged_null.oracle.is_none());
+
+    assert_eq!(
+        first
+            .identities
+            .observation_identity_bundle_digest
+            .as_deref(),
+        Some(fixture.corpus.identity_bundle_digest.as_str())
+    );
+    assert_eq!(
+        first.identities.records_kappa.as_deref(),
+        Some(fixture.corpus.records_kappa.as_str())
+    );
+    assert_eq!(
+        first.identities.trace_kappa.as_deref(),
+        Some(fixture.corpus.trace_kappa.as_str())
+    );
+    assert_eq!(
+        first.identities.route_fit_digest.as_deref(),
+        Some(fixture.fitted.method.declared_digest().as_str())
+    );
+    assert_eq!(
+        first.identities.fitted_params_kappa.as_deref(),
+        Some(fixture.fitted.kappa().as_str())
+    );
+    assert_eq!(
+        first.identities.fit_manifest_kappa.as_deref(),
+        Some(fixture.manifest.kappa().as_str())
+    );
+    assert_eq!(
+        first.identities.source_snapshot.as_deref(),
+        fixture.manifest.source_snapshot.as_deref()
+    );
+    assert_eq!(
+        first.identities.source_manifest_kappa.as_deref(),
+        observation.source_manifest_kappa.as_deref()
+    );
+    assert_ne!(
+        first.identities.source_snapshot, first.identities.source_manifest_kappa,
+        "teacher weight snapshot kappa and #597 source-manifest binding are distinct identities"
+    );
+    assert_eq!(
+        first.identities.observation_input_cid.as_deref(),
+        observation.input_cid.as_deref()
+    );
+    assert_eq!(
+        first.identities.source_geometry_digest.as_deref(),
+        observation
+            .geometry
+            .as_ref()
+            .map(GeometryProjection::declared_digest)
+            .as_deref()
+    );
+    assert_eq!(
+        first.identities.tokenizer_cid.as_deref(),
+        observation
+            .tokenizer_adapter
+            .as_ref()
+            .map(|adapter| adapter.tokenizer_cid.as_str())
+    );
+    assert_eq!(
+        first.identities.tokenizer_adapter_digest.as_deref(),
+        observation
+            .tokenizer_adapter
+            .as_ref()
+            .map(|adapter| adapter.adapter_digest.as_str())
+    );
+    assert_eq!(
+        first.identities.target_operator_digest,
+        fixture.manifest.operator_identity
+    );
+    assert_eq!(
+        first.identities.source_attention_operator_digest.as_deref(),
+        Some(
+            observation
+                .attention_operator
+                .as_ref()
+                .expect("source operator")
+                .declared_digest()
+                .as_str()
+        )
+    );
+    assert_ne!(
+        first.identities.target_operator_digest, first.identities.source_attention_operator_digest,
+        "the target dormant operator must never be relabeled as the teacher source operator"
+    );
+    let evidence = registered_trace_evidence(
+        INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+        INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+    )
+    .expect("registered structural evidence");
+    assert_eq!(
+        first.identities.trace_evidence_id.as_deref(),
+        Some(evidence.id())
+    );
+    assert_eq!(
+        first.identities.trace_evidence_version,
+        Some(evidence.version())
+    );
+    assert_eq!(first.identities.trace_evidence_kind, Some(evidence.kind()));
+    assert_eq!(
+        first.identities.trace_evidence_digest,
+        Some(evidence.declared_digest())
+    );
+}
+
+#[test]
+fn prefilter_counts_only_its_work_eligible_domain() {
+    let fixture = prefilter_subset_fixture();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, None)),
+        TraceKind::InstrumentConformance,
+    );
+    assert!(report.controls.instrument_valid);
+    assert_eq!(report.shared_metrics.counts.eligible_stories, 1);
+    assert_eq!(report.shared_metrics.counts.eligible_steps, 4);
+    assert_eq!(report.shared_metrics.counts.candidates, 42);
+    assert_eq!(report.shared_metrics.counts.teacher_support_entries, 32);
+
+    assert!(report
+        .arms
+        .iter()
+        .chain(&report.nulls)
+        .all(|row| row.metrics.counts.is_some()));
+    for row in [
+        &report.arms[0],
+        &report.arms[1],
+        &report.arms[2],
+        &report.arms[3],
+        &report.arms[5],
+        &report.nulls[0],
+        &report.nulls[1],
+    ] {
+        assert_eq!(
+            row.metrics.counts.as_ref(),
+            Some(&report.shared_metrics.counts),
+            "{}",
+            row.id
+        );
+    }
+
+    let prefilter = &report.arms[4].metrics;
+    let counts = prefilter
+        .counts
+        .as_ref()
+        .expect("prefilter owns a narrowed row domain");
+    assert_eq!(counts.eligible_stories, 1);
+    assert_eq!(counts.eligible_steps, 2);
+    assert_eq!(counts.candidates, 23);
+    assert_eq!(counts.teacher_support_entries, 16);
+    let work = prefilter
+        .prefilter
+        .as_ref()
+        .expect("prefilter work metrics");
+    assert_eq!(work.work_eligible_steps, counts.eligible_steps);
+    assert_eq!(work.total_candidates, counts.candidates);
+
+    let deranged = report.nulls[2]
+        .metrics
+        .counts
+        .as_ref()
+        .expect("deranged-support null owns transformed counts");
+    assert_eq!(deranged.eligible_stories, 1);
+    assert_eq!(deranged.eligible_steps, 4);
+    assert_eq!(deranged.candidates, 42);
+    assert_eq!(deranged.teacher_support_entries, 25);
+}
+
+#[test]
+fn known_synthetic_adapter_cannot_be_relabelled_pinned_real() {
+    let mut fixture = fixture();
+    let observation = bound_observation(&mut fixture);
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("evidence-kind"));
+    assert!(report.disposition_reason.contains("cannot relabel"));
+}
+
+#[test]
+fn closed_evidence_registry_prevents_arbitrary_synthetic_identity_relabeling() {
+    let evidence = registered_trace_evidence(
+        INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+        INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION,
+    )
+    .expect("the structural evidence record is registered");
+    assert_eq!(evidence.id(), INSTRUMENT_CONFORMANCE_EVIDENCE_ID);
+    assert_eq!(evidence.version(), INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION);
+    assert_eq!(evidence.kind(), TraceKind::InstrumentConformance);
+    assert!(evidence.declared_digest().starts_with("blake3:"));
+    assert!(registered_trace_evidence("pinned-real", 1).is_none());
+    assert!(registered_trace_evidence(
+        INSTRUMENT_CONFORMANCE_EVIDENCE_ID,
+        INSTRUMENT_CONFORMANCE_EVIDENCE_VERSION + 1
+    )
+    .is_none());
+    assert!(registered_trace_evidence("invented-real-corpus", 1).is_none());
+
+    let mut fixture = fixture();
+    fixture.manifest.source_snapshot = Some(digest("relabelled-teacher-weight-snapshot"));
+    fixture.manifest.adapter = Some("arbitrarily-relabelled-real-adapter/999".to_owned());
+    fixture.manifest.compiler = Some("arbitrarily-relabelled-real-compiler/999".to_owned());
+    fixture.corpus.records_kappa = digest("relabelled-records");
+    fixture.corpus.trace_kappa = digest("relabelled-trace");
+    fixture.manifest.corpus = Some(fixture.corpus.records_kappa.clone());
+    fixture.manifest.trace = Some(fixture.corpus.trace_kappa.clone());
+
+    let mut observation = bound_observation(&mut fixture);
+    observation.input_cid = Some(digest("relabelled-input-cid"));
+    observation.source_manifest_kappa = Some(digest("relabelled-source-manifest"));
+    let tokenizer = observation
+        .tokenizer_adapter
+        .as_mut()
+        .expect("fixture tokenizer");
+    tokenizer.tokenizer_cid = digest("relabelled-tokenizer-definition");
+    tokenizer.adapter_digest = tokenizer.declared_digest();
+    fixture.manifest.tokenizer = Some(tokenizer.declared_digest());
+    fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("evidence-kind"));
+    assert!(report.disposition_reason.contains("cannot relabel"));
+    assert!(report
+        .arms
+        .iter()
+        .chain(&report.nulls)
+        .all(|row| !matches!(row.verdict, StageVerdict::Pass | StageVerdict::Fail)));
+    assert_eq!(
+        report.identities.trace_evidence_kind,
+        Some(TraceKind::InstrumentConformance)
+    );
+    assert_eq!(
+        report.identities.trace_evidence_id.as_deref(),
+        Some(evidence.id())
+    );
+    assert_eq!(
+        report.identities.trace_evidence_version,
+        Some(evidence.version())
+    );
+    assert_eq!(
+        report.identities.trace_evidence_digest.as_deref(),
+        Some(evidence.declared_digest().as_str())
+    );
+}
+
+#[test]
+fn pinned_real_requires_the_authoritative_manifest_and_exact_bundle_binding() {
+    let (fixture, observation) = real_shaped_fixture();
+    let missing =
+        run_octeract_trace_screen(Some(screen_input(&fixture, None)), TraceKind::PinnedReal);
+    assert_unavailable(&missing);
+    assert!(missing
+        .disposition_reason
+        .contains("authoritative observation manifest"));
+
+    let mut mismatched = observation.clone();
+    mismatched.input_cid = Some(digest("different-corpus"));
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&mismatched))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("does not bind"));
+
+    let (mut fixture, mut wrong_profile) = real_shaped_fixture();
+    wrong_profile.trace_profile = Some(TraceProfile::full(&[0], TEST_TOP_M + 1));
+    fixture.corpus.identity_bundle_digest = wrong_profile.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&wrong_profile))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("does not bind"));
+
+    let (fixture, mut wrong_records) = real_shaped_fixture();
+    wrong_records.total_records += 1;
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&wrong_records))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("does not bind"));
+}
+
+#[test]
+fn pinned_real_rejects_unknown_or_tampered_source_provenance_records() {
+    let (mut fixture, mut tampered_operator) = real_shaped_fixture();
+    tampered_operator
+        .attention_operator
+        .as_mut()
+        .expect("source operator")
+        .params
+        .score_scale = "tampered-after-capture".to_owned();
+    fixture.corpus.identity_bundle_digest = tampered_operator.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&tampered_operator))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("tampered"));
+
+    let (mut fixture, mut unknown_operator) = real_shaped_fixture();
+    let operator = unknown_operator
+        .attention_operator
+        .as_mut()
+        .expect("source operator");
+    operator.id = "unregistered-source-attention".to_owned();
+    operator.version = 99;
+    operator.implementation_digest = operator.declared_digest();
+    fixture.corpus.identity_bundle_digest = unknown_operator.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&unknown_operator))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report
+        .disposition_reason
+        .contains("not a registered record"));
+
+    let (mut fixture, mut tampered_tokenizer) = real_shaped_fixture();
+    tampered_tokenizer
+        .tokenizer_adapter
+        .as_mut()
+        .expect("tokenizer adapter")
+        .adapter_digest = digest("wrong-adapter-digest");
+    fixture.corpus.identity_bundle_digest = tampered_tokenizer.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&tampered_tokenizer))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(
+        report.disposition_reason.contains("tokenizer adapter"),
+        "{}",
+        report.disposition_reason
+    );
+
+    let (mut fixture, mut unknown_tokenizer) = real_shaped_fixture();
+    let tokenizer = unknown_tokenizer
+        .tokenizer_adapter
+        .as_mut()
+        .expect("tokenizer adapter");
+    tokenizer.family = "unregistered-tokenizer".to_owned();
+    tokenizer.version = 99;
+    tokenizer.adapter_digest = tokenizer.declared_digest();
+    fixture.corpus.identity_bundle_digest = unknown_tokenizer.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&unknown_tokenizer))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(
+        report.disposition_reason.contains("tokenizer adapter"),
+        "{}",
+        report.disposition_reason
+    );
+
+    let (mut fixture, mut tampered_geometry) = real_shaped_fixture();
+    tampered_geometry
+        .geometry
+        .as_mut()
+        .expect("source geometry")
+        .id = "unregistered-geometry".to_owned();
+    fixture.corpus.identity_bundle_digest = tampered_geometry.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&tampered_geometry))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(
+        report.disposition_reason.contains("geometry"),
+        "{}",
+        report.disposition_reason
+    );
+}
+
+#[test]
+fn supplied_observation_requires_input_cid_and_matching_source_geometry() {
+    let mut input_fixture = fixture();
+    let mut missing_input = bound_observation(&mut input_fixture);
+    missing_input.input_cid = None;
+    input_fixture.corpus.identity_bundle_digest = missing_input.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&input_fixture, Some(&missing_input))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(
+        !report.disposition_reason.contains("evidence-kind"),
+        "{}",
+        report.disposition_reason
+    );
+
+    let mut geometry_fixture = fixture();
+    let mut mismatched_geometry = bound_observation(&mut geometry_fixture);
+    mismatched_geometry.geometry = Some(GeometryProjection::bucket_average(576, 288));
+    geometry_fixture.corpus.identity_bundle_digest = mismatched_geometry.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&geometry_fixture, Some(&mismatched_geometry))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(
+        report.disposition_reason.contains("geometry"),
+        "{}",
+        report.disposition_reason
+    );
+}
+
+#[test]
+fn teacher_snapshot_and_source_manifest_kappas_are_distinct_and_canonical() {
+    let mut valid_fixture = fixture();
+    let observation = bound_observation(&mut valid_fixture);
+    assert_ne!(
+        valid_fixture.manifest.source_snapshot,
+        observation.source_manifest_kappa
+    );
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&valid_fixture, Some(&observation))),
+        TraceKind::InstrumentConformance,
+    );
+    assert!(report.controls.instrument_valid);
+    assert_eq!(
+        report.identities.source_snapshot,
+        valid_fixture.manifest.source_snapshot
+    );
+    assert_eq!(
+        report.identities.source_manifest_kappa,
+        observation.source_manifest_kappa
+    );
+
+    for malformed in [None, Some("not-a-canonical-kappa".to_owned())] {
+        let mut snapshot_fixture = fixture();
+        let observation = bound_observation(&mut snapshot_fixture);
+        snapshot_fixture.manifest.source_snapshot = malformed.clone();
+        let report = run_octeract_trace_screen(
+            Some(screen_input(&snapshot_fixture, Some(&observation))),
+            TraceKind::PinnedReal,
+        );
+        assert_unavailable(&report);
+        assert!(
+            !report.disposition_reason.contains("evidence-kind"),
+            "{}",
+            report.disposition_reason
+        );
+
+        let mut manifest_fixture = fixture();
+        let mut observation = bound_observation(&mut manifest_fixture);
+        observation.source_manifest_kappa = malformed.clone();
+        manifest_fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+        let report = run_octeract_trace_screen(
+            Some(screen_input(&manifest_fixture, Some(&observation))),
+            TraceKind::PinnedReal,
+        );
+        assert_unavailable(&report);
+        assert!(
+            !report.disposition_reason.contains("evidence-kind"),
+            "{}",
+            report.disposition_reason
+        );
+    }
+}
+
+#[test]
+fn target_operator_identity_is_separate_and_tamper_evident() {
+    let (mut fixture, observation) = real_shaped_fixture();
+    fixture
+        .manifest
+        .operator
+        .as_mut()
+        .expect("target operator")
+        .params
+        .score_scale = "tampered-target-score".to_owned();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report
+        .disposition_reason
+        .contains("target attention operator"));
+    assert_eq!(report.identities.source_attention_operator_digest, None);
+    assert_ne!(
+        fixture.manifest.operator_identity,
+        observation
+            .attention_operator
+            .as_ref()
+            .map(AttentionOperatorSpec::declared_digest)
+    );
+}
+
+#[test]
+fn pinned_real_rejects_fit_manifest_format_and_provenance_label_drift() {
+    let (mut fixture, observation) = real_shaped_fixture();
+    fixture.manifest.format = "uor-r4-route-fit-manifest/99".to_owned();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("route-fit identities"));
+
+    let (mut fixture, observation) = real_shaped_fixture();
+    fixture.manifest.parameters[0].class = "source".to_owned();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("route-fit identities"));
+}
+
+#[test]
+fn malformed_capture_geometry_is_unavailable_without_panicking() {
+    let mut cases = vec![
+        (
+            "zero layers",
+            TraceCaptureGeometry {
+                layers: 0,
+                heads: 1,
+                kv_heads: 1,
+                residual_width: 288,
+            },
+        ),
+        (
+            "zero heads",
+            TraceCaptureGeometry {
+                layers: 1,
+                heads: 0,
+                kv_heads: 1,
+                residual_width: 288,
+            },
+        ),
+        (
+            "zero kv heads",
+            TraceCaptureGeometry {
+                layers: 1,
+                heads: 1,
+                kv_heads: 0,
+                residual_width: 288,
+            },
+        ),
+        (
+            "zero residual width",
+            TraceCaptureGeometry {
+                layers: 1,
+                heads: 1,
+                kv_heads: 1,
+                residual_width: 0,
+            },
+        ),
+        (
+            "nondivisible kv width",
+            TraceCaptureGeometry {
+                layers: 1,
+                heads: 2,
+                kv_heads: 1,
+                residual_width: 289,
+            },
+        ),
+        (
+            "kv width multiplication overflow",
+            TraceCaptureGeometry {
+                layers: 1,
+                heads: 1,
+                kv_heads: 2,
+                residual_width: usize::MAX,
+            },
+        ),
+    ];
+    #[cfg(target_pointer_width = "64")]
+    cases.push((
+        "u32-truncating source width",
+        TraceCaptureGeometry {
+            layers: 1,
+            heads: 1,
+            kv_heads: 1,
+            residual_width: u32::MAX as usize + 1,
+        },
+    ));
+
+    for (case, geometry) in cases {
+        let mut fixture = fixture();
+        fixture.corpus.geometry = geometry;
+        let report = run_octeract_trace_screen(
+            Some(screen_input(&fixture, None)),
+            TraceKind::InstrumentConformance,
+        );
+        assert_unavailable(&report);
+        assert!(
+            !report.disposition_reason.is_empty(),
+            "{case}: {}",
+            report.disposition_reason
+        );
+    }
+}
+
+#[test]
+fn fully_bound_unregistered_shape_still_cannot_claim_an_empirical_decision() {
+    let (fixture, observation) = real_shaped_fixture();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::PinnedReal,
+    );
+    assert_unavailable(&report);
+    assert!(report.disposition_reason.contains("evidence-kind"));
+    assert!(report.disposition_reason.contains("cannot relabel"));
+    assert!(report
+        .arms
+        .iter()
+        .chain(&report.nulls)
+        .all(|row| !matches!(row.verdict, StageVerdict::Pass | StageVerdict::Fail)));
+    assert_ne!(
+        report.identities.target_operator_digest,
+        report.identities.source_attention_operator_digest
+    );
+    assert_ne!(
+        report.identities.source_snapshot,
+        report.identities.source_manifest_kappa
+    );
+}
+
+#[test]
+fn scalar_v1_ties_weight9_and_oriented_controls_are_exact() {
+    let query = [0u8; ROUTE_CODE_BYTES];
+    let keys = [
+        code_with(0x01, 0),
+        code_with(0x02, 0),
+        code_with(0x03, 0),
+        code_with(0x07, 0),
+    ];
+    let scores = score_octeract_step(&query, &keys, 2).expect("bounded step");
+    assert_eq!(scores.exact_scores, vec![1, 1, 2, 3]);
+    assert_eq!(scores.weight9_scores, scores.exact_scores);
+    assert_eq!(scores.oriented_scores, scores.exact_scores);
+    assert_eq!(scores.weight9_selected, scores.v1_selected);
+    assert_eq!(scores.oriented_selected, scores.v1_selected);
+    assert_eq!(
+        scores.v1_selected,
+        vec![
+            ScoredCandidate {
+                candidate: 0,
+                score: 1,
+            },
+            ScoredCandidate {
+                candidate: 1,
+                score: 1,
+            },
+        ],
+        "equal distances retain ascending candidate order"
+    );
+    assert_eq!(scores.lower_bound.selected, scores.v1_selected);
+
+    assert!(score_octeract_step(&query, &[], 1).is_none());
+    assert!(score_octeract_step(&query, &keys, 0).is_none());
+    assert!(score_octeract_step(&query, &keys, 5).is_none());
+}
+
+#[test]
+fn weight9_materializes_blocks_and_scores_independently_of_fold5() {
+    let query = [0u8; ROUTE_CODE_BYTES];
+    let mut distributed = [0u8; ROUTE_CODE_BYTES];
+    distributed[..8].fill(0x01);
+    let concentrated = code_with(0xff, 0x00);
+
+    // Both candidates have exact/weight9 score 8, but their block values and
+    // fold5 scores differ. Placing the distributed candidate first makes the
+    // stable exact tie select candidate 0 while fold5 selects candidate 1.
+    // This catches a weight9 control implemented by reusing fold5 values.
+    let scored = score_octeract_step(&query, &[distributed, concentrated], 1)
+        .expect("bounded discriminating adversary");
+    assert_eq!(scored.exact_scores, vec![8, 8]);
+    assert_eq!(scored.weight9_scores, vec![8, 8]);
+    assert_eq!(scored.folded_scores, vec![8, 0]);
+    assert_eq!(scored.weight9_blocks[0][..8], [1u8; 8]);
+    assert!(scored.weight9_blocks[0][8..]
+        .iter()
+        .all(|&value| value == 0));
+    assert_eq!(scored.weight9_blocks[1][0], 8);
+    assert!(scored.weight9_blocks[1][1..]
+        .iter()
+        .all(|&value| value == 0));
+    assert_eq!(
+        scored.weight9_scores,
+        scored
+            .weight9_blocks
+            .iter()
+            .map(|blocks| blocks.iter().map(|&value| u32::from(value)).sum())
+            .collect::<Vec<u32>>()
+    );
+    assert_eq!(scored.weight9_selected, scored.v1_selected);
+    assert_eq!(scored.weight9_selected[0].candidate, 0);
+    assert_eq!(scored.folded_selected[0].candidate, 1);
+}
+
+#[test]
+fn fold_complement_adversaries_and_prefilter_outcomes_are_explicit() {
+    let fixture = fixture();
+    let head = fixture.fitted.head(0, 0).expect("fixture head");
+    let query = &head.query_codes[0][0];
+    let keys = &head.key_codes[0];
+    let scores = score_octeract_step(query, keys, TEST_TOP_M as usize).expect("bounded step");
+
+    // Distance 1 and distance 7 are the same fold shell while the oriented
+    // representation reconstructs both exact weights.
+    assert_eq!(scores.fold_classes[1], scores.fold_classes[3]);
+    assert_ne!(scores.exact_scores[1], scores.exact_scores[3]);
+    assert_eq!(scores.oriented_weights[1][0], 1);
+    assert_eq!(scores.oriented_weights[3][0], 7);
+    assert_eq!(scores.oriented_scores, scores.exact_scores);
+    assert_ne!(scores.folded_selected, scores.v1_selected);
+
+    // N=12 => P=floor(3N/4)=9. The true exact winners survive this
+    // shortlist, so refinement reproduces V1 at exactly the 0.75 work cap.
+    assert_eq!(scores.prefilter.shortlist.len(), 9);
+    assert_eq!(scores.prefilter.selected, scores.v1_selected);
+    assert_eq!(scores.prefilter.exact_refinement_candidates, 9);
+    assert_eq!(scores.prefilter.exact_refinement_candidates_avoided, 3);
+
+    // Adversarial tie: six early distance-8 keys have fold score zero and
+    // crowd the exact distance-0/1 winners out of P=6. This is a valid
+    // fidelity failure, not a reason to tune P after inspection.
+    let key_from_delta =
+        |delta: [u8; ROUTE_CODE_BYTES]| core::array::from_fn(|block| query[block] ^ delta[block]);
+    let mut bad_keys = vec![key_from_delta(code_with(0xff, 0)); 6];
+    bad_keys.push(key_from_delta(code_with(0x00, 0)));
+    bad_keys.push(key_from_delta(code_with(0x01, 0)));
+    let bad = score_octeract_step(query, &bad_keys, 2).expect("bounded adversary");
+    assert_eq!(
+        bad.v1_selected
+            .iter()
+            .map(|entry| entry.candidate)
+            .collect::<Vec<_>>(),
+        vec![6, 7]
+    );
+    assert_eq!(bad.prefilter.shortlist, vec![0, 1, 2, 3, 4, 5]);
+    assert_eq!(
+        bad.prefilter
+            .selected
+            .iter()
+            .map(|entry| entry.candidate)
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    let no_work = score_octeract_step(query, &bad_keys[..2], 2).expect("bounded no-work step");
+    assert!(no_work.prefilter.shortlist.is_empty());
+    assert_eq!(no_work.prefilter.exact_refinement_candidates, 0);
+}
+
+#[test]
+fn safe_lower_bound_skips_equal_later_ties_without_changing_v1() {
+    let query = [0u8; ROUTE_CODE_BYTES];
+    let keys = [
+        code_with(0x00, 0),
+        code_with(0x01, 0),
+        code_with(0x02, 0),
+        code_with(0x03, 0),
+    ];
+    let scores = score_octeract_step(&query, &keys, 2).expect("bounded step");
+    assert_eq!(scores.lower_bound.selected, scores.v1_selected);
+    assert_eq!(scores.lower_bound.lower_bounds, scores.exact_scores);
+    assert_eq!(scores.lower_bound.exact_evaluations, 2);
+    assert_eq!(scores.lower_bound.exact_evaluations_avoided, 2);
+    assert_eq!(
+        scores.lower_bound.lower_bounds[2], scores.v1_selected[1].score,
+        "candidate 2 is an equal-distance later tie and may be skipped safely"
+    );
+}
+
+#[test]
+fn nulls_are_deterministic_occupancy_preserving_and_nonidentity() {
+    let fixture = fixture();
+    let head = fixture.fitted.head(0, 0).expect("fixture head");
+    let scores = score_octeract_step(
+        &head.query_codes[0][0],
+        &head.key_codes[0],
+        TEST_TOP_M as usize,
+    )
+    .expect("bounded step");
+    assert!(exhaustive_anchor_relabel_control(
+        &scores,
+        TEST_TOP_M as usize
+    ));
+    let first = occupancy_matched_fold_null(&scores.fold_classes, OCCUPANCY_MATCHED_FOLD_SEED);
+    let second = occupancy_matched_fold_null(&scores.fold_classes, OCCUPANCY_MATCHED_FOLD_SEED);
+    assert_eq!(first, second);
+    assert_ne!(first, scores.fold_classes);
+    for block in 0..ROUTE_CODE_BYTES {
+        let mut original: Vec<u8> = scores.fold_classes.iter().map(|row| row[block]).collect();
+        let mut permuted: Vec<u8> = first.iter().map(|row| row[block]).collect();
+        original.sort_unstable();
+        permuted.sort_unstable();
+        assert_eq!(permuted, original, "block {block} occupancy");
+    }
+
+    let permutation = shuffled_block_permutation(SHUFFLED_BLOCK_SEED);
+    assert_eq!(permutation, shuffled_block_permutation(SHUFFLED_BLOCK_SEED));
+    assert!(
+        permutation
+            .iter()
+            .enumerate()
+            .any(|(index, &value)| index != usize::from(value)),
+        "the block null is required to be nonidentity"
+    );
+    let mut sorted = permutation;
+    sorted.sort_unstable();
+    assert_eq!(
+        sorted,
+        core::array::from_fn::<_, ROUTE_CODE_BYTES, _>(|index| index as u8)
+    );
+    let query: [u8; ROUTE_CODE_BYTES] = core::array::from_fn(|index| index as u8);
+    let aligned = query;
+    let shuffled: [u8; ROUTE_CODE_BYTES] =
+        core::array::from_fn(|index| aligned[usize::from(permutation[index])]);
+    let aligned_score = score_octeract_step(&query, &[aligned], 1).expect("aligned step");
+    let shuffled_score = score_octeract_step(&query, &[shuffled], 1).expect("shuffled step");
+    assert_eq!(aligned_score.exact_scores, vec![0]);
+    assert!(shuffled_score.exact_scores[0] > 0);
+
+    let supports = vec![vec![0, 1], vec![2, 3], vec![4, 5]];
+    assert_eq!(
+        deranged_supports(&supports),
+        vec![vec![2, 3], vec![4, 5], vec![0, 1]]
+    );
+    assert_ne!(deranged_supports(&supports), supports);
+}
+
+#[test]
+fn a_vacuous_occupancy_null_makes_the_screen_unavailable() {
+    let mut fixture = fixture();
+    let query = fixture.fitted.heads[0].query_codes[0][0];
+    fixture.fitted.heads[0].key_codes[0].fill(query);
+
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, None)),
+        TraceKind::InstrumentConformance,
+    );
+    assert!(!report.controls.occupancy_null_transformation_distinct);
+    assert!(!report.controls.occupancy_null_result_distinct);
+    assert_unavailable(&report);
+    assert!(report.arms[1..]
+        .iter()
+        .all(|row| row.verdict == StageVerdict::NotRun));
+    assert!(report
+        .nulls
+        .iter()
+        .all(|row| row.verdict == StageVerdict::NotRun));
+}
+
+#[test]
+fn a_vacuous_shuffled_block_null_makes_the_screen_unavailable() {
+    let mut fixture = fixture();
+    fixture.fitted.heads[0].query_codes[0].fill([0u8; ROUTE_CODE_BYTES]);
+    let uniform_bytes = [
+        0x00, 0x01, 0x03, 0x05, 0x06, 0x09, 0x0a, 0x0c, 0x0f, 0x17, 0x1b, 0x1d,
+    ];
+    for (key, value) in fixture.fitted.heads[0].key_codes[0]
+        .iter_mut()
+        .zip(uniform_bytes)
+    {
+        key.fill(value);
+    }
+
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, None)),
+        TraceKind::InstrumentConformance,
+    );
+    assert!(!report.controls.shuffled_block_null_transformation_distinct);
+    assert!(!report.controls.shuffled_block_null_result_distinct);
+    assert_unavailable(&report);
+    assert!(report.arms[1..]
+        .iter()
+        .all(|row| row.verdict == StageVerdict::NotRun));
+    assert!(report
+        .nulls
+        .iter()
+        .all(|row| row.verdict == StageVerdict::NotRun));
+}
+
+#[test]
+fn every_bijective_anchor_relabel_preserves_fold_signature_groups() {
+    let fixture = fixture();
+    let head = fixture.fitted.head(0, 0).expect("fixture head");
+    let scores = score_octeract_step(
+        &head.query_codes[0][0],
+        &head.key_codes[0],
+        TEST_TOP_M as usize,
+    )
+    .expect("bounded step");
+    fn next_permutation(values: &mut [u8]) -> bool {
+        let Some(pivot) = (0..values.len().saturating_sub(1))
+            .rev()
+            .find(|&index| values[index] < values[index + 1])
+        else {
+            return false;
+        };
+        let successor = (pivot + 1..values.len())
+            .rev()
+            .find(|&index| values[pivot] < values[index])
+            .expect("a pivot has a successor");
+        values.swap(pivot, successor);
+        values[pivot + 1..].reverse();
+        true
+    }
+
+    fn selected(scores: &[u32], m: usize) -> Vec<ScoredCandidate> {
+        let mut ranked: Vec<_> = scores
+            .iter()
+            .enumerate()
+            .map(|(candidate, &score)| ScoredCandidate {
+                candidate: candidate as u32,
+                score,
+            })
+            .collect();
+        ranked.sort_unstable_by_key(|entry| (entry.score, entry.candidate));
+        ranked.truncate(m);
+        ranked
+    }
+
+    fn signature_groups(
+        rows: &[[u8; ROUTE_CODE_BYTES]],
+    ) -> BTreeMap<[u8; ROUTE_CODE_BYTES], Vec<u32>> {
+        let mut groups = BTreeMap::new();
+        for (candidate, row) in rows.iter().copied().enumerate() {
+            groups
+                .entry(row)
+                .or_insert_with(Vec::new)
+                .push(candidate as u32);
+        }
+        groups
+    }
+
+    let expected_scores: Vec<u32> = scores
+        .fold_classes
+        .iter()
+        .map(|row| row.iter().map(|&class| u32::from(class)).sum())
+        .collect();
+    assert_eq!(expected_scores, scores.folded_scores);
+    let expected_selected = selected(&expected_scores, TEST_TOP_M as usize);
+    assert_eq!(expected_selected, scores.folded_selected);
+    let expected_groups = signature_groups(&scores.fold_classes);
+
+    let symbols = [0u8, 127, 189, 217, 225];
+    let mut permutation = [0u8, 1, 2, 3, 4];
+    let mut checked = 0u32;
+    loop {
+        let encoded: Vec<[u8; ROUTE_CODE_BYTES]> = scores
+            .fold_classes
+            .iter()
+            .map(|row| row.map(|class| symbols[permutation[class as usize] as usize]))
+            .collect();
+        let mut inverse = [0u8; 256];
+        for (class, &permuted_class) in permutation.iter().enumerate() {
+            inverse[symbols[permuted_class as usize] as usize] = class as u8;
+        }
+        let decoded: Vec<[u8; ROUTE_CODE_BYTES]> = encoded
+            .iter()
+            .map(|row| row.map(|label| inverse[label as usize]))
+            .collect();
+        let decoded_scores: Vec<u32> = decoded
+            .iter()
+            .map(|row| row.iter().map(|&class| u32::from(class)).sum())
+            .collect();
+
+        assert_eq!(decoded, scores.fold_classes);
+        assert_eq!(decoded_scores, scores.folded_scores);
+        assert_eq!(
+            selected(&decoded_scores, TEST_TOP_M as usize),
+            expected_selected
+        );
+        assert_eq!(signature_groups(&decoded), expected_groups);
+        checked += 1;
+        if !next_permutation(&mut permutation) {
+            break;
+        }
+    }
+    assert_eq!(checked, 120, "all 5! anchor bijections are exercised");
+}
+
+fn brute_force_oracle(groups: &[CollisionGroup], m: usize) -> u32 {
+    fn visit(
+        groups: &[CollisionGroup],
+        m: usize,
+        order: &mut Vec<usize>,
+        used: &mut [bool],
+        best: &mut u32,
+    ) {
+        if order.len() == groups.len() {
+            let hits = order
+                .iter()
+                .flat_map(|&index| groups[index].teacher_membership.iter().copied())
+                .take(m)
+                .filter(|&member| member)
+                .count() as u32;
+            *best = (*best).max(hits);
+            return;
+        }
+        for index in 0..groups.len() {
+            if !used[index] {
+                used[index] = true;
+                order.push(index);
+                visit(groups, m, order, used, best);
+                order.pop();
+                used[index] = false;
+            }
+        }
+    }
+
+    let mut best = 0;
+    visit(
+        groups,
+        m,
+        &mut Vec::new(),
+        &mut vec![false; groups.len()],
+        &mut best,
+    );
+    best
+}
+
+fn groups_from_masks(total: usize, boundaries: usize, memberships: usize) -> Vec<CollisionGroup> {
+    let mut groups = Vec::new();
+    let mut start = 0;
+    for candidate in 0..total {
+        let ends_group = candidate + 1 == total || (boundaries & (1 << candidate)) != 0;
+        if ends_group {
+            groups.push(CollisionGroup {
+                candidate_ids: (start..=candidate).map(|value| value as u32).collect(),
+                teacher_membership: (start..=candidate)
+                    .map(|value| (memberships & (1 << value)) != 0)
+                    .collect(),
+            });
+            start = candidate + 1;
+        }
+    }
+    groups
+}
+
+#[test]
+fn collision_oracle_matches_bruteforce_over_exhaustive_small_domains() {
+    for total in 1..=6usize {
+        for boundaries in 0..(1usize << total.saturating_sub(1)) {
+            for memberships in 0..(1usize << total) {
+                let groups = groups_from_masks(total, boundaries, memberships);
+                for m in 1..=total.min(3) {
+                    let oracle = collision_oracle(&groups, m).expect("bounded oracle domain");
+                    assert_eq!(oracle.selected_slots, m as u32);
+                    assert_eq!(
+                        oracle.max_teacher_hits,
+                        brute_force_oracle(&groups, m),
+                        "total={total} boundaries={boundaries:#x} memberships={memberships:#x} m={m}"
+                    );
+                }
+            }
+        }
+    }
+
+    let malformed = CollisionGroup {
+        candidate_ids: vec![1, 0],
+        teacher_membership: vec![true, false],
+    };
+    assert!(collision_oracle(std::slice::from_ref(&malformed), 1).is_none());
+    let duplicate_across_groups = [
+        CollisionGroup {
+            candidate_ids: vec![0, 2],
+            teacher_membership: vec![true, false],
+        },
+        CollisionGroup {
+            candidate_ids: vec![1, 2],
+            teacher_membership: vec![false, true],
+        },
+    ];
+    assert!(
+        collision_oracle(&duplicate_across_groups, 2).is_none(),
+        "one candidate cannot occupy two complete-signature groups"
+    );
+    assert!(collision_oracle(&[], 0).is_none());
+}

--- a/docs/octeract_attention_661.md
+++ b/docs/octeract_attention_661.md
@@ -169,3 +169,147 @@ prefilter/refine and the safe lower bound, occupancy-matched and shuffled-block
 nulls, and the #647 frame control. Missing real trace/corpus prerequisites are
 recorded as `UNAVAILABLE`, never as zero or a negative quality verdict. At most
 two candidates may advance; no packed or long run begins before that decision.
+
+## 2026-08-14 - Phase B route-trace screen record (#722)
+
+### Frozen screen contract
+
+**Definition** Phase B is the certifier-side
+`uor-r4-octeract-trace-screen-contract/1` contract and
+`uor-r4-octeract-trace-screen/1` report. It fixes layer 0/head 0, 288 route bits
+as 36 natural bytes, the current full mask, causal candidates in ascending
+index order, stable ascending `(score,candidate-index)` ties, selection width
+`M = min(8, trace support cap)`, and only steps with more than `M` candidates.
+The full contract is embedded in every report before any support labels are
+read.
+
+The fixed rows are:
+
+| Row | Role | Relation / work rule | May advance |
+|---|---|---|---|
+| V1 baseline | frame and operator control | sum 36 full-byte XOR popcounts; existing packed/reference route-attention selection | no |
+| `weight9` | representation control | independently materialize each exact byte distance in `0..=8`, then sum | no |
+| `octeract-fold5` | direct candidate | sum the 36 complement-folded shell classes | yes |
+| `octeract-oriented` | representation control | retain shell plus high-side orientation, reconstruct every exact byte distance, then sum | no |
+| `octeract-prefilter` | prefilter candidate | shortlist the first `floor(3N/4)` fold-ranked candidates, then refine with V1 | yes |
+| safe lower bound | pruning control | skip a later exact distance only when its weight-difference lower bound cannot beat the current stable-tie worst selection | no |
+
+The fixed nulls are the occupancy-matched fold null with seed `0x661B0001`,
+the single nonidentity 36-block permutation with seed `0x661B0002`, and the
+cyclic deranged-support null. The direct-fold gate requires a mean Jaccard
+improvement of at least `0.03` over V1 and strict separation from every
+applicable null. The prefilter gate requires at least `0.95` V1-selection
+recall, at most `0.75` exact-refinement fraction, at least one work-eligible
+step, and strict null separation.
+
+**Guarantee** Status: **Structural**. Only `octeract-fold5` and
+`octeract-prefilter` can produce an advance disposition. Synthetic or manually
+constructed evidence is registry-limited to `instrument-conformance` and can
+produce neither empirical `PASS` nor empirical `FAIL`. The initial closed
+evidence registry has no `pinned-real` entry. Adding one requires new contract
+and report format versions rather than changing either `/1` record in place.
+Evidence:
+[`octeract_trace_screen_661.rs`](../crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs).
+
+### Provenance and instrument controls
+
+The report repeats both Phase A source identities:
+
+| Bound source | SHA-256 |
+|---|---|
+| Octeract Cypher paper | `44bab09a20253437aeef43057ae316fcded5b00fd9f6b180f83843f06d2bbb3c` |
+| validation roadmap | `5322c519fa872ca836e2ad23d523ecf655defedd3dd17589ba290dec62a93a5e` |
+
+A future empirical evidence record must additionally bind one authoritative
+#603 observation identity bundle and its input CID, #597 source-manifest
+identity, source geometry and tokenizer-adapter records, registered source
+attention operator, merged records and trace kappas, `full/1` profile,
+`route-fit/1` method, fit manifest, fitted parameters, target
+`r4-route-attention/1`, source snapshot, adapter, and compiler identities. The
+teacher source snapshot kappa and #597 source-manifest kappa are separate
+fields; neither is substituted for the other.
+
+**Guarantee** Status: **Structural**. Input validation recomputes registered
+records and full record equality, checks observation/trace/fit alignment before
+scoring, and returns typed `UNAVAILABLE` for malformed geometry, missing lanes,
+unknown records, incomplete identities, or an unregistered evidence class.
+The empirical path also recomputes `route-fit/1` and requires its complete
+output to equal the supplied fitted artifact. Publicly constructible metadata
+cannot promote a synthetic bundle by changing an adapter string or requested
+trace kind. Evidence:
+[`octeract_trace_screen_661.rs`](../crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs).
+
+The same executable evidence covers V1 packed/reference/scalar identity,
+independent `weight9` materialization, oriented reconstruction, fold and
+complement adversaries, prefilter fidelity and no-work cases, safe lower-bound
+ties, all 120 shell-label bijections, deterministic and nonvacuous nulls,
+malformed-geometry no-panic behavior, and exhaustive small-domain comparison
+of the bounded collision oracle with brute force. The report keeps common base
+occupancy once and gives every arm/null its own consumed-domain counts. That
+distinction is material: the conformance fixture's matched rows consume 20
+support entries while the cyclic deranged-support row consumes 19; a separate
+`M=8` fixture has base counts `1/4/42/32` for
+stories/steps/candidates/support entries but prefilter work-domain counts
+`1/2/23/16`. Typed optional fields likewise keep row-specific selection,
+collision, oracle, shortlist, prefilter, lower-bound, and transformed-null
+occupancy metrics at their actual owners.
+
+### Availability and canonical disposition
+
+No registered pinned-real `full/1` evidence record or corresponding exact
+observation/records/trace/fit bundle was delivered by #603-#606 or present in
+the configured local fixture inventory. The only local corpus manifest was the
+Simple Wiki corpus input; it is not a `full/1` route-trace evidence bundle and
+was not substituted. Phase B therefore exercised the explicit missing-input
+branch rather than generating a checkpoint, searching for an approximate
+fixture, or relabeling the synthetic #605 conformance data.
+
+**Empirical Criterion** Status: **Unproven**. No real support labels were
+available, so no attention-quality, collision-ceiling, null-separation, or
+prefilter-work result is claimed.
+
+The canonical missing-real report is:
+
+| Field | Frozen value |
+|---|---|
+| trace kind | `pinned-real` |
+| reason | `required explicitly supplied pinned full/1 trace input is absent` |
+| report bytes | 6,587 |
+| payload kappa | `blake3:8b8c3bdc41f04ac2d6b9a15ef843f5064fae92e8b6bfe57cafbc6803eca7c5a2` |
+| final envelope kappa | `blake3:eab7b1bb12d9508d9815da0c4fbac248eab8b93b8258e717829542e41ac75e5e` |
+| disposition | `UNAVAILABLE` |
+
+| Arm / null | Verdict | Reason |
+|---|---|---|
+| V1 baseline | `UNAVAILABLE` | required explicitly supplied pinned `full/1` trace input is absent |
+| `weight9` | `NOT_RUN` | unavailable prerequisite/instrument |
+| `octeract-fold5` | `NOT_RUN` | unavailable prerequisite/instrument |
+| `octeract-oriented` | `NOT_RUN` | unavailable prerequisite/instrument |
+| `octeract-prefilter` | `NOT_RUN` | unavailable prerequisite/instrument |
+| safe lower bound | `NOT_RUN` | unavailable prerequisite/instrument |
+| occupancy-matched fold null | `NOT_RUN` | unavailable prerequisite/instrument |
+| shuffled-block null | `NOT_RUN` | unavailable prerequisite/instrument |
+| deranged-support null | `NOT_RUN` | unavailable prerequisite/instrument |
+
+Repeated construction produces identical canonical bytes, payload kappa, and
+final envelope kappa. Typed absent identities remain absent; the two Phase A
+source hashes and the complete preregistered contract remain present.
+
+### Decision and compatibility
+
+The locked unavailable branch applies: create neither #661-C nor the
+negative-only classification/cache fallback. The Octeract attention mechanism
+remains dormant and unavailable unless a later, separately reviewed issue
+delivers and registers one exact real evidence bundle under new contract and
+report versions.
+
+The #310 weighted-Hamming experiment is cited, not rerun: its A-W rows recovered
+about 5% of the A-f32 gap, below the preregistered 25% shipping bar, and shipped
+nothing runtime-side. That negative sign-space result is context, not Octeract
+evidence.
+
+No fit method, attention-operator registry entry, packed instance, graph
+format, runtime kernel, artifact, serving path, default, historical Phase A
+record, or existing kappa fixture changes in Phase B. The added `libm` use is
+certifier-only and makes entropy/MI report arithmetic independent of a native
+`f64::log2` implementation; it does not enter the deployed integer runtime.


### PR DESCRIPTION
## Summary

- freeze the preregistered Octeract route-trace screen contract and canonical report schema for #661-B
- implement the collision/reachability arms, three typed nulls, exact collision oracle, fail-closed input validation, and closed evidence registry
- append the Phase B evidence record without changing the deployed runtime, attention operator, or artifact format

## Result

No registered pinned-real `full/1` route-trace evidence exists, so the empirical screen terminates canonically as `UNAVAILABLE`; synthetic/manual rows remain instrument-conformance evidence and cannot be promoted to empirical PASS/FAIL.

- canonical report: 6,587 bytes
- payload kappa: `blake3:8b8c3bdc41f04ac2d6b9a15ef843f5064fae92e8b6bfe57cafbc6803eca7c5a2`
- final envelope kappa: `blake3:eab7b1bb12d9508d9815da0c4fbac248eab8b93b8258e717829542e41ac75e5e`
- disposition: retain the mechanism as dormant/unavailable; do not open #661-C or activate the negative-only fallback

Every evaluated arm/null owns the counts for the domain it actually consumed. The discriminating fixtures pin the narrower prefilter domain and the deranged-support cardinality separately from the matched base domain.

## Verification

- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all --check`
- `cargo check -p uor-r4-graph-format --no-default-features`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`
- `cargo test -p uor-r4-graph-certify --test octeract_trace_screen_661 --offline` (24 passed)
- non-vacuous canonical Gate E with `/tmp/ref/out/model.bin` present (3 passed)
- `cargo deny check bans`
- `python3 scripts/check_claim_wording.py`
- `cargo run -q -p xtask -- check-model`
- `cargo test -q -p repo-conformance`
- `cargo run -q -p xtask -- audit-deferral`
- `cargo run -q -p xtask -- audit-limits`
- `git diff --check`

Closes #722
References #661
