### PR TITLE
serving: bind source attention provenance (#704 A1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ r4 import --name N --source-model M --capability continuation|instruction-chat \
           --artifacts F --store F --tokenizer F [--evaluation-report F]
 ```
 
+Source compiles write `attention_operator.json` beside `corpus.meta` and
+`corpus.records`. The registry-validated sidecar binds the source-attention
+operator that produced the rows; resume fails closed when an existing payload
+has a missing or different binding. `compile-recorded` propagates an explicit
+operator from an observation manifest, while a genuinely absent historical
+record retains the documented implicit `standard-source-attention/1` meaning.
+
 **Graph pipeline**
 
 ```bash
@@ -264,6 +271,7 @@ r4 transformerless cover        [--corpus-meta M] [--corpus-recs R] [--artifacts
 r4 transformerless cover-sweep  [...]
 r4 transformerless score        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out DIR]
 r4 transformerless convert-r4g1 --artifacts TLA --store TLS1 --out R4G1
+r4 transformerless copy-recorded-attention --corpus-meta M --corpus-recs R --out attention_operator.json
 r4 transformerless compile-recorded --corpus-meta M --corpus-recs R --vocab-size N --out DIR
 r4 graph infill --artifact score.r4g1 --skeleton 12,_,_,_,99,_,_,_,7
 ```

--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -293,6 +293,7 @@ pub fn compile(
         SourceUnavailable::new(format!("{} stage: {message}", Stage::TeacherBundle))
     })?;
     let tokenizer_adapter = read_stage_a_tokenizer_adapter(work, &preflight_tokenizer_adapter)?;
+    let attention_operator = uor_r4_graph_cli::compiled_attention_operator(work)?;
 
     if !corpus_complete(&meta)? {
         return Ok(CompileOutcome::Incomplete {
@@ -311,7 +312,7 @@ pub fn compile(
         percent: 0,
         label: "Inducing multiresolution cover...",
     });
-    uor_r4_graph_compiler::compile(&stage_b_flags(request, &cover_out))
+    uor_r4_graph_compiler::compile(&stage_b_flags(request, &cover_out, &attention_operator)?)
         .map_err(|error| SourceUnavailable::new(format!("{} stage: {error}", Stage::GraphCover)))?;
     progress(ProgressEvent {
         stage: Stage::GraphCover,
@@ -579,7 +580,11 @@ fn stage_a_flags(request: &CompileRequest) -> Vec<String> {
     flags
 }
 
-fn stage_b_flags(request: &CompileRequest, cover_out: &Path) -> Vec<String> {
+fn stage_b_flags(
+    request: &CompileRequest,
+    cover_out: &Path,
+    operator: &uor_r4_model_source::attention::AttentionOperatorSpec,
+) -> Result<Vec<String>, SourceUnavailable> {
     let options = &request.options;
     let work = &request.work_dir;
     let mut flags = vec![
@@ -607,17 +612,15 @@ fn stage_b_flags(request: &CompileRequest, cover_out: &Path) -> Vec<String> {
     if let Some(kappa) = &request.source_manifest_kappa {
         flags.extend(["--source-manifest-kappa".to_owned(), kappa.clone()]);
     }
-    // #602: this request holds the teacher's `r4_attention` switch, which
-    // maps to exactly one registered attention operator
-    // (`standard-source-attention/1` off,
-    // `experimental-r4-source-attention/1` on); thread the typed record
-    // into the cover stage so compile_report.json binds the operator the
-    // teacher actually ran.
-    let operator = uor_r4_model_source::attention::operator_for_r4_switch(options.r4_attention);
-    if let Ok(json) = serde_json::to_string(&operator) {
-        flags.extend(["--attention-operator".to_owned(), json]);
-    }
-    flags
+    // #602/#704: the registry-validated stage-A binding is authoritative.
+    // Reconstructing identity from the request boolean would mislabel an
+    // auto-detected GPT-2 teacher as standard attention and could relabel a
+    // resumed corpus from another arithmetic era.
+    let json = serde_json::to_string(operator).map_err(|error| {
+        SourceUnavailable::new(format!("attention-operator binding serialization: {error}"))
+    })?;
+    flags.extend(["--attention-operator".to_owned(), json]);
+    Ok(flags)
 }
 
 fn stage_c_flags(request: &CompileRequest, cover_out: &Path, scored_out: &Path) -> Vec<String> {
@@ -685,8 +688,9 @@ mod tests {
     fn deployed_tokenizer_is_threaded_into_cover_and_score_stages() {
         let request = request(None);
         let expected = request.work_dir.join("tokenizer.bin").display().to_string();
+        let operator = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
         for flags in [
-            stage_b_flags(&request, Path::new("cover")),
+            stage_b_flags(&request, Path::new("cover"), &operator).expect("cover flags"),
             stage_c_flags(&request, Path::new("cover"), Path::new("scored")),
         ] {
             assert!(
@@ -818,20 +822,21 @@ mod tests {
     #[test]
     fn source_manifest_kappa_is_threaded_into_cover_stage_flags() {
         let kappa = format!("blake3:{}", "7".repeat(64));
-        let with = stage_b_flags(&request(Some(kappa.clone())), Path::new("cover"));
+        let operator = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
+        let with = stage_b_flags(&request(Some(kappa.clone())), Path::new("cover"), &operator)
+            .expect("flags");
         assert!(with
             .windows(2)
             .any(|pair| pair == ["--source-manifest-kappa", kappa.as_str()]));
-        let without = stage_b_flags(&request(None), Path::new("cover"));
+        let without = stage_b_flags(&request(None), Path::new("cover"), &operator).expect("flags");
         assert!(!without.iter().any(|flag| flag == "--source-manifest-kappa"));
         assert_eq!(with.len(), without.len() + 2);
     }
 
-    /// #602 plumbing seam: the request's boolean `r4_attention` switch is
-    /// forwarded to the cover stage as the typed record of exactly the
-    /// registered operator the teacher ran — `standard-source-attention/1`
-    /// when off (the default), `experimental-r4-source-attention/1` when
-    /// on.
+    /// #602/#704 plumbing seam: stage B forwards the registry-validated
+    /// stage-A binding independently of the request switch. In particular,
+    /// an auto-detected GPT-2 teacher remains learned-absolute rather than
+    /// being relabelled standard because `r4_attention` is false.
     #[test]
     fn attention_operator_is_threaded_into_cover_stage_flags() {
         use uor_r4_model_source::attention::AttentionOperatorSpec;
@@ -843,15 +848,19 @@ mod tests {
             serde_json::from_str(&flags[index + 1]).expect("typed record round-trips")
         };
 
-        let standard = stage_b_flags(&request(None), Path::new("cover"));
-        assert_eq!(flag_value(&standard), AttentionOperatorSpec::standard());
-
-        let mut experimental_request = request(None);
-        experimental_request.options.r4_attention = true;
-        let experimental = stage_b_flags(&experimental_request, Path::new("cover"));
-        assert_eq!(
-            flag_value(&experimental),
-            AttentionOperatorSpec::experimental_r4()
-        );
+        for (mut request, operator) in [
+            (request(None), AttentionOperatorSpec::standard()),
+            (request(None), AttentionOperatorSpec::experimental_r4()),
+            (
+                request(None),
+                AttentionOperatorSpec::learned_absolute_source_attention(),
+            ),
+        ] {
+            // Deliberately contradict the supplied record where possible:
+            // the stage-A binding, not this policy bit, is authoritative.
+            request.options.r4_attention = operator == AttentionOperatorSpec::standard();
+            let flags = stage_b_flags(&request, Path::new("cover"), &operator).expect("flags");
+            assert_eq!(flag_value(&flags), operator);
+        }
     }
 }

--- a/crates/uor-r4-core/src/transformerless/hf_bpe.rs
+++ b/crates/uor-r4-core/src/transformerless/hf_bpe.rs
@@ -706,6 +706,7 @@ fn pre_tokenize(text: &str) -> Vec<&str> {
 /// digest serialization byte-for-byte, mirroring the #600
 /// `GeometryProjectionParams` convention.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenizerAdapterPolicy {
     /// Normalizer the adapter applies before pre-tokenization
     /// (`"none"`: this adapter never rewrites input text).
@@ -750,6 +751,7 @@ pub struct TokenizerAdapterPolicy {
 /// tokenizer. A behavioral change to an adapter family is a new
 /// version — a new registry entry — never an in-place edit.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenizerAdapter {
     /// Registry family id (e.g. [`TokenizerAdapter::HF_BYTE_BPE_FAMILY`]).
     #[serde(default)]

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -49,7 +49,10 @@ use uor_r4_core::transformerless::hf_bpe::{
 };
 use uor_r4_core::transformerless::scenarios as core_scenarios;
 use uor_r4_core::transformerless::scenarios::RuntimeTokenizerDecodeTable;
-use uor_r4_model_source::{BehaviorSource, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle};
+use uor_r4_model_source::{
+    BehaviorSource, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle,
+    attention::AttentionOperatorSpec,
+};
 
 const DEFAULT_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
 const DEFAULT_TOKENIZER: &str = "/tmp/ref/tokenizer.bin";
@@ -59,7 +62,14 @@ const DEFAULT_HF_COMPILED_PATH: &str = ".uor-models/compiled/smollm2-135m-instru
 const DEFAULT_HF_EVALUATION_REPORT: &str = "instruction-eval.json";
 const DEFAULT_TEXT_CORPUS: &str = ".uor-models/corpora/simple-wiki-20231101/articles.jsonl";
 const TOKENIZER_ADAPTER_FILE: &str = "tokenizer_adapter.json";
+/// Compile-directory binding for the source attention operator that produced
+/// `corpus.meta` / `corpus.records`.
+pub const ATTENTION_OPERATOR_BINDING_FILE: &str = "attention_operator.json";
+// Pre-#602 corpora computed the immutable standard-source-attention/1
+// operator even after the registry's current source version advances.
+const LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION: u32 = 1;
 static TOKENIZER_ADAPTER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static ATTENTION_OPERATOR_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn is_blake3_cid(value: &str) -> bool {
     value.len() == "blake3:".len() + 64
@@ -202,6 +212,441 @@ fn require_matching_compile_tokenizer_adapter(
     )))
 }
 
+#[derive(Default)]
+struct CompileOutputPayloadInventory {
+    first_present: Option<&'static str>,
+}
+
+// Union of the named leaves mutated by source and recorded compilation.
+// Identity sidecars are validated separately by their strict readers and are
+// published atomically; every other output is inventoried here before either
+// identity can take an exact-resume fast path.
+const COMPILE_OUTPUT_MUTABLE_FILES: [&str; 9] = [
+    "tokenizer.bin",
+    "corpus.meta",
+    "corpus.records",
+    "corpus.records.hidden",
+    "tless_artifacts.bin",
+    "tless_store.bin",
+    "hamming_calibration.json",
+    "hierarchical_codes.json",
+    "space_manifest.json",
+];
+
+const SOURCE_CORPUS_META_BYTES: usize = 25;
+const SOURCE_CORPUS_RECORD_BYTES: u64 = 48;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SourceCompileResumePlan {
+    records_committed_bytes: Option<u64>,
+    hidden_committed_bytes: Option<u64>,
+}
+
+/// Inspect every mutable compile-output leaf without following it. Binding
+/// equality does not make a directory, symlink, or special file safe for the
+/// subsequent tokenizer export / corpus resume path.
+fn compile_output_payload_inventory(
+    output: &Path,
+) -> Result<CompileOutputPayloadInventory, SourceUnavailable> {
+    match std::fs::symlink_metadata(output) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "compile output root {} is not a real directory; symlinks, files, and special entries are refused",
+                output.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CompileOutputPayloadInventory::default());
+        }
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "compile output root {} cannot be inspected: {error}",
+                output.display()
+            )));
+        }
+    }
+
+    let mut inventory = CompileOutputPayloadInventory::default();
+    for name in COMPILE_OUTPUT_MUTABLE_FILES {
+        let path = output.join(name);
+        match std::fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                if inventory.first_present.is_none() {
+                    inventory.first_present = Some(name);
+                }
+            }
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{} exists but is not a regular file; refusing compile-output mutation through a directory, symlink, or special file",
+                    path.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{} cannot be inspected: {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(inventory)
+}
+
+fn readable_regular_file_len(path: &Path, label: &str) -> Result<u64, SourceUnavailable> {
+    let file = std::fs::File::open(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} {} cannot be read: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} {} cannot be inspected after open: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "{label} {} is not a regular file",
+            path.display()
+        )));
+    }
+    Ok(metadata.len())
+}
+
+fn require_truncatable_if_needed(
+    path: &Path,
+    current_bytes: u64,
+    committed_bytes: u64,
+    label: &str,
+) -> Result<(), SourceUnavailable> {
+    if current_bytes == committed_bytes {
+        return Ok(());
+    }
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map(|_| ())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} {} has an uncommitted tail but cannot be opened for recovery: {error}",
+                path.display()
+            ))
+        })
+}
+
+fn validate_source_v3_committed_records(
+    bytes: &[u8],
+    records: usize,
+    stories: u64,
+) -> Result<(), SourceUnavailable> {
+    let committed = records
+        .checked_mul(SOURCE_CORPUS_RECORD_BYTES as usize)
+        .ok_or_else(|| {
+            SourceUnavailable::new("source corpus v3 committed record length overflows")
+        })?;
+    let committed = bytes.get(..committed).ok_or_else(|| {
+        SourceUnavailable::new("source corpus v3 committed prefix is shorter than declared")
+    })?;
+    let mut previous_story = None;
+    for (index, row) in committed
+        .chunks_exact(SOURCE_CORPUS_RECORD_BYTES as usize)
+        .enumerate()
+    {
+        let word = |offset: usize| {
+            u32::from_le_bytes(
+                row[offset..offset + 4]
+                    .try_into()
+                    .expect("fixed v3 word range"),
+            )
+        };
+        let story = word(0);
+        if u64::from(story) >= stories || previous_story.is_some_and(|prior| story < prior) {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus record {index} is not a monotone in-range v3 story row"
+            )));
+        }
+        previous_story = Some(story);
+        let weight_sum = u64::from(word(20)) + u64::from(word(24)) + u64::from(word(28));
+        if weight_sum != 100 {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus record {index} has v3 top-weight sum {weight_sum}, expected 100"
+            )));
+        }
+        let span_start = word(32);
+        let span_end = word(36);
+        if span_end != span_start.saturating_add(1) {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus record {index} has invalid v3 token span {span_start}..{span_end}"
+            )));
+        }
+        let byte_start = word(40);
+        let byte_end = word(44);
+        if !((byte_start == u32::MAX && byte_end == u32::MAX) || byte_start <= byte_end) {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus record {index} has invalid v3 byte anchors {byte_start}..{byte_end}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the source generator's 25-byte checkpoint and the record/hidden
+/// streams it commits at story boundaries. This is read-only and runs before
+/// either provenance sidecar or tokenizer output can be published.
+///
+/// A missing hidden stream remains compatible with an already-complete
+/// historical corpus because the core loader treats hidden rows as optional.
+/// An incomplete historical corpus cannot resume under a hidden-producing
+/// oracle: that would create a suffix with no rows for the old prefix. Once a
+/// hidden stream is present, its committed prefix is checked against the
+/// *actual* loaded oracle's hidden width; an interrupted tail is recovered
+/// alongside the record tail before generation resumes.
+fn preflight_source_compile_resume(
+    output: &Path,
+    hidden_row_bytes: Option<usize>,
+    target: usize,
+) -> Result<SourceCompileResumePlan, SourceUnavailable> {
+    // This also rejects a symlink output root and every nonregular mutable
+    // leaf, independently of whether both identity sidecars already match.
+    let _ = compile_output_payload_inventory(output)?;
+    let meta_path = output.join("corpus.meta");
+    let records_path = output.join("corpus.records");
+    let hidden_path = output.join("corpus.records.hidden");
+    let meta_present = strict_regular_file_if_present(&meta_path, "source corpus metadata")?;
+    let records_present = strict_regular_file_if_present(&records_path, "source corpus records")?;
+    let hidden_present =
+        strict_regular_file_if_present(&hidden_path, "source corpus hidden stream")?;
+
+    match (meta_present, records_present) {
+        (false, false) if !hidden_present => return Ok(SourceCompileResumePlan::default()),
+        (false, false) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} exists without corpus.meta/corpus.records; refusing an orphan hidden resume stream before mutation",
+                hidden_path.display()
+            )));
+        }
+        (true, false) | (false, true) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} must contain corpus.meta and corpus.records together; one-sided source corpus resume refused before mutation",
+                output.display()
+            )));
+        }
+        (true, true) => {}
+    }
+
+    let meta = std::fs::read(&meta_path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "source corpus metadata {} cannot be read: {error}",
+            meta_path.display()
+        ))
+    })?;
+    if meta.len() != SOURCE_CORPUS_META_BYTES {
+        return Err(SourceUnavailable::new(format!(
+            "source corpus metadata {} is {} bytes, expected exactly {SOURCE_CORPUS_META_BYTES}; refusing a false-fresh resume before mutation",
+            meta_path.display(),
+            meta.len()
+        )));
+    }
+    let records = u64::from_le_bytes(
+        meta[0..8]
+            .try_into()
+            .map_err(|_| SourceUnavailable::new("invalid source corpus record count"))?,
+    );
+    usize::try_from(records).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "source corpus metadata {} declares {records} records, which cannot be represented on this host",
+            meta_path.display()
+        ))
+    })?;
+    let stories = u64::from_le_bytes(
+        meta[8..16]
+            .try_into()
+            .map_err(|_| SourceUnavailable::new("invalid source corpus story count"))?,
+    );
+    u32::try_from(stories).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "source corpus metadata {} declares {stories} stories, exceeding the u32 story-id wire range",
+            meta_path.display()
+        ))
+    })?;
+    let done = meta[24];
+    if !matches!(done, 0 | 1) {
+        return Err(SourceUnavailable::new(format!(
+            "source corpus metadata {} has invalid done byte {}; expected 0 or 1",
+            meta_path.display(),
+            done
+        )));
+    }
+
+    let record_bytes = std::fs::read(&records_path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "source corpus records {} cannot be read: {error}",
+            records_path.display()
+        ))
+    })?;
+    let records_len = u64::try_from(record_bytes.len()).map_err(|_| {
+        SourceUnavailable::new("source corpus record stream is too large for its wire length")
+    })?;
+    // The required tokenizer+operator bindings cannot predate the current
+    // source generator, whose only write layout is v3/48. Missing-sidecar
+    // 32/12-byte legacy outputs are already refused at the identity boundary;
+    // do not ambiguously reinterpret a long legacy crash tail as v3 here.
+    let records_committed_bytes =
+        records
+            .checked_mul(SOURCE_CORPUS_RECORD_BYTES)
+            .ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "source corpus metadata {} overflows the 48-byte v3 record layout",
+                    meta_path.display()
+                ))
+            })?;
+    // n=0 authoritatively commits the empty prefix. Any bytes after it were
+    // written before the first story checkpoint and are therefore a crash
+    // tail, not an inferable legacy format; recovery truncates them to zero.
+    if records_len < records_committed_bytes {
+        return Err(SourceUnavailable::new(format!(
+            "source corpus records {} is {records_len} bytes, shorter than the {records_committed_bytes}-byte v3 prefix committed for {records} records",
+            records_path.display()
+        )));
+    }
+    validate_source_v3_committed_records(
+        &record_bytes,
+        usize::try_from(records).expect("host-size record count validated above"),
+        stories,
+    )?;
+    require_truncatable_if_needed(
+        &records_path,
+        records_len,
+        records_committed_bytes,
+        "source corpus records",
+    )?;
+
+    let hidden_committed_bytes = if hidden_present {
+        let hidden_len = readable_regular_file_len(&hidden_path, "source corpus hidden stream")?;
+        let committed = match hidden_row_bytes {
+            Some(row_bytes) if row_bytes != 0 => records
+                .checked_mul(row_bytes as u64)
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "source corpus hidden prefix overflows for {records} records at {row_bytes} bytes per oracle row"
+                    ))
+                })?,
+            Some(_) if records == 0 && hidden_len == 0 => 0,
+            Some(_) => {
+                return Err(SourceUnavailable::new(
+                    "loaded teacher exposes a zero-width hidden row for a nonempty hidden corpus",
+                ));
+            }
+            None if hidden_len == 0 => 0,
+            None => {
+                return Err(SourceUnavailable::new(format!(
+                    "source corpus hidden stream {} has {hidden_len} bytes, but the loaded teacher exposes no hidden-state row layout",
+                    hidden_path.display()
+                )));
+            }
+        };
+        if hidden_len < committed {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus hidden stream {} is {hidden_len} bytes, shorter than the {committed}-byte prefix committed for {records} records by the loaded teacher",
+                hidden_path.display()
+            )));
+        }
+        require_truncatable_if_needed(
+            &hidden_path,
+            hidden_len,
+            committed,
+            "source corpus hidden stream",
+        )?;
+        Some(committed)
+    } else if hidden_row_bytes.is_some()
+        && records != 0
+        && !(done == 1
+            && records
+                >= u64::try_from(target).map_err(|_| {
+                    SourceUnavailable::new("source compile target does not fit the corpus wire")
+                })?)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "source corpus has {records} committed records but no hidden stream; historical hidden absence is compatible only for an already-complete corpus, because resuming generation would create an unverifiable partial hidden suffix"
+        )));
+    } else {
+        None
+    };
+
+    Ok(SourceCompileResumePlan {
+        records_committed_bytes: Some(records_committed_bytes),
+        hidden_committed_bytes,
+    })
+}
+
+fn truncate_source_compile_resume_file(
+    path: &Path,
+    committed_bytes: u64,
+    label: &str,
+) -> Result<(), SourceUnavailable> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} {} cannot be reinspected: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "{label} {} stopped being a regular file before recovery",
+            path.display()
+        )));
+    }
+    if metadata.len() < committed_bytes {
+        return Err(SourceUnavailable::new(format!(
+            "{label} {} shrank to {} bytes before recovery, below its {committed_bytes}-byte committed prefix",
+            path.display(),
+            metadata.len()
+        )));
+    }
+    if metadata.len() == committed_bytes {
+        return Ok(());
+    }
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} {} cannot be opened for recovery: {error}",
+                path.display()
+            ))
+        })?;
+    file.set_len(committed_bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} {} cannot be truncated to its committed {committed_bytes}-byte prefix: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn reconcile_source_compile_resume(
+    output: &Path,
+    plan: &SourceCompileResumePlan,
+) -> Result<(), SourceUnavailable> {
+    if let Some(committed) = plan.records_committed_bytes {
+        truncate_source_compile_resume_file(
+            &output.join("corpus.records"),
+            committed,
+            "source corpus records",
+        )?;
+    }
+    if let Some(committed) = plan.hidden_committed_bytes {
+        truncate_source_compile_resume_file(
+            &output.join("corpus.records.hidden"),
+            committed,
+            "source corpus hidden stream",
+        )?;
+    }
+    Ok(())
+}
+
 /// Bind a resumable compiler output to the exact full adapter identity before
 /// `tokenizer.bin`, `corpus.meta`, or `corpus.records` can be changed.
 fn pin_compile_tokenizer_adapter(
@@ -209,40 +654,24 @@ fn pin_compile_tokenizer_adapter(
     requested: &TokenizerAdapter,
 ) -> Result<(), SourceUnavailable> {
     validate_tokenizer_adapter_record(requested)?;
+    let inventory = compile_output_payload_inventory(output)?;
     let sidecar = output.join(TOKENIZER_ADAPTER_FILE);
-    if let Some(recorded) = read_compile_tokenizer_adapter(output)? {
+    let recorded = read_compile_tokenizer_adapter(output)?;
+    if let Some(recorded) = recorded {
         return require_matching_compile_tokenizer_adapter(output, requested, &recorded);
     }
 
-    // A pre-#718 compiler corpus has no adapter identity. Non-empty tokenizer
-    // or corpus files make that absence an incompatible legacy era; never
-    // relabel those bytes merely because the current source happens to parse.
-    for name in ["tokenizer.bin", "corpus.meta", "corpus.records"] {
-        let path = output.join(name);
-        match std::fs::symlink_metadata(&path) {
-            Ok(metadata) if !metadata.file_type().is_file() => {
-                return Err(SourceUnavailable::new(format!(
-                    "{} exists but is not a regular file; refusing to infer an empty compiler payload through a directory, symlink, or special file",
-                    path.display()
-                )));
-            }
-            Ok(metadata) if metadata.len() != 0 => {
-                return Err(SourceUnavailable::new(format!(
-                    "{} has no {TOKENIZER_ADAPTER_FILE} but already contains {name} payload; refusing to relabel legacy/unpinned compiler bytes as {}/{} before mutation",
-                    output.display(),
-                    requested.family,
-                    requested.version
-                )));
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(SourceUnavailable::new(format!(
-                    "{}: {error}",
-                    path.display()
-                )));
-            }
-        }
+    // A pre-#718 compiler corpus has no adapter identity. Any recognized
+    // output leaf, including a zero-byte torn create, makes that absence an
+    // incompatible legacy era; never relabel it merely because the current
+    // source happens to parse.
+    if let Some(name) = inventory.first_present {
+        return Err(SourceUnavailable::new(format!(
+            "{} has no {TOKENIZER_ADAPTER_FILE} but already contains {name} payload; refusing to relabel legacy/unpinned compiler bytes as {}/{} before mutation",
+            output.display(),
+            requested.family,
+            requested.version
+        )));
     }
 
     std::fs::create_dir_all(output).map_err(SourceUnavailable::new)?;
@@ -312,6 +741,321 @@ fn pin_compile_tokenizer_adapter(
     }
 }
 
+/// Read-only half of [`pin_compile_tokenizer_adapter`]. Source-driven compile
+/// runs use this together with the attention-operator preflight so a conflict
+/// in either identity is found before either sidecar is published.
+fn preflight_compile_tokenizer_adapter(
+    output: &Path,
+    requested: &TokenizerAdapter,
+) -> Result<(), SourceUnavailable> {
+    validate_tokenizer_adapter_record(requested)?;
+    let inventory = compile_output_payload_inventory(output)?;
+    let recorded = read_compile_tokenizer_adapter(output)?;
+    if let Some(recorded) = recorded {
+        return require_matching_compile_tokenizer_adapter(output, requested, &recorded);
+    }
+
+    if let Some(name) = inventory.first_present {
+        return Err(SourceUnavailable::new(format!(
+            "{} has no {TOKENIZER_ADAPTER_FILE} but already contains {name} payload; refusing to relabel legacy/unpinned compiler bytes as {}/{} before mutation",
+            output.display(),
+            requested.family,
+            requested.version
+        )));
+    }
+    Ok(())
+}
+
+/// Return `false` only for a genuinely absent path. Every present directory
+/// entry must itself be a regular file: symlinks (including links to regular
+/// files), directories, and special files are provenance errors.
+fn strict_regular_file_if_present(path: &Path, context: &str) -> Result<bool, SourceUnavailable> {
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(SourceUnavailable::new(format!(
+            "{context} {} cannot be inspected: {error}",
+            path.display()
+        ))),
+        Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+        Ok(_) => Err(SourceUnavailable::new(format!(
+            "{context} {} is present but is not a regular file; symlinks, directories, and special files are refused",
+            path.display()
+        ))),
+    }
+}
+
+fn validate_attention_operator(
+    recorded: &AttentionOperatorSpec,
+    context: &str,
+) -> Result<AttentionOperatorSpec, SourceUnavailable> {
+    let registered = uor_r4_model_source::attention::operator_spec(&recorded.id, recorded.version)
+        .map_err(|mut error| {
+            error.reason = format!("{context}: {}", error.reason);
+            error
+        })?;
+    if !matches!(
+        registered.id.as_str(),
+        AttentionOperatorSpec::STANDARD_ID
+            | AttentionOperatorSpec::EXPERIMENTAL_R4_ID
+            | AttentionOperatorSpec::LEARNED_ABSOLUTE_ID
+    ) {
+        return Err(SourceUnavailable::new(format!(
+            "{context} names {}/{} from the operator registry, but it is not a source-teacher attention operator",
+            registered.id, registered.version
+        )));
+    }
+    if recorded != &registered {
+        return Err(SourceUnavailable::new(format!(
+            "{context} does not match registered attention operator {}/{}",
+            recorded.id, recorded.version
+        )));
+    }
+    Ok(registered)
+}
+
+fn validate_attention_operator_json(
+    value: &serde_json::Value,
+    context: &str,
+) -> Result<AttentionOperatorSpec, SourceUnavailable> {
+    let recorded: AttentionOperatorSpec =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context}: malformed attention-operator record: {error}"
+            ))
+        })?;
+    let registered = validate_attention_operator(&recorded, context)?;
+    let registered_json = serde_json::to_value(&registered).map_err(SourceUnavailable::new)?;
+    if value != &registered_json {
+        return Err(SourceUnavailable::new(format!(
+            "{context} is not the full registered attention-operator record; missing, unknown, or noncanonical fields are refused"
+        )));
+    }
+    Ok(registered)
+}
+
+fn read_optional_compiled_attention_operator(
+    output: &Path,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+    if !strict_regular_file_if_present(&path, "attention-operator binding")? {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: unreadable attention-operator binding: {error}",
+            path.display()
+        ))
+    })?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: malformed attention-operator binding: {error}",
+            path.display()
+        ))
+    })?;
+    validate_attention_operator_json(&value, &path.display().to_string()).map(Some)
+}
+
+/// Read and registry-validate a compile directory's attention-operator
+/// binding. A missing sidecar is an error on this source-driven/API seam; use
+/// [`recorded_corpus_attention_operator`] when legacy absence is meaningful.
+pub fn compiled_attention_operator(
+    output: &Path,
+) -> Result<AttentionOperatorSpec, SourceUnavailable> {
+    read_optional_compiled_attention_operator(output)?.ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{}: missing teacher attention-operator binding",
+            output.join(ATTENTION_OPERATOR_BINDING_FILE).display()
+        ))
+    })
+}
+
+/// Read-only compatibility check for an output directory's arithmetic-era
+/// binding. Returns `true` when the exact binding already exists.
+fn preflight_compiled_attention_operator(
+    output: &Path,
+    requested: &AttentionOperatorSpec,
+) -> Result<bool, SourceUnavailable> {
+    let requested =
+        validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
+    let inventory = compile_output_payload_inventory(output)?;
+    let recorded = read_optional_compiled_attention_operator(output)?;
+    if let Some(recorded) = recorded {
+        if recorded != requested {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to attention operator {}/{} (digest {}); requested {}/{} (digest {}); use a fresh output directory for the new teacher-arithmetic era",
+                output.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        return Ok(true);
+    }
+    if let Some(name) = inventory.first_present {
+        return Err(SourceUnavailable::new(format!(
+            "{} contains {name} payload without {ATTENTION_OPERATOR_BINDING_FILE}; it belongs to the implicit legacy attention era and cannot resume under {}/{}; use a fresh output directory",
+            output.display(),
+            requested.id,
+            requested.version,
+        )));
+    }
+    Ok(false)
+}
+
+fn require_matching_compiled_attention_operator(
+    output: &Path,
+    requested: &AttentionOperatorSpec,
+    recorded: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    if recorded == requested {
+        return Ok(());
+    }
+    Err(SourceUnavailable::new(format!(
+        "{} is pinned to attention operator {}/{} (digest {}); requested {}/{} (digest {}); incompatible compile resume refused before mutation",
+        output.display(),
+        recorded.id,
+        recorded.version,
+        recorded.declared_digest(),
+        requested.id,
+        requested.version,
+        requested.declared_digest(),
+    )))
+}
+
+fn publish_attention_operator_binding(
+    output: &Path,
+    requested: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    let requested =
+        validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
+    if let Some(recorded) = read_optional_compiled_attention_operator(output)? {
+        return require_matching_compiled_attention_operator(output, &requested, &recorded);
+    }
+
+    std::fs::create_dir_all(output).map_err(SourceUnavailable::new)?;
+    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
+    bytes.push(b'\n');
+    let temporary = loop {
+        let sequence = ATTENTION_OPERATOR_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = output.join(format!(
+            ".{ATTENTION_OPERATOR_BINDING_FILE}.{}.{}.tmp",
+            std::process::id(),
+            sequence
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(&bytes).and_then(|()| file.sync_all()) {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(SourceUnavailable::new(format!(
+                        "{}: {error}",
+                        candidate.display()
+                    )));
+                }
+                drop(file);
+                break candidate;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{}: {error}",
+                    candidate.display()
+                )));
+            }
+        }
+    };
+
+    // `hard_link` is an atomic no-clobber publish. A racing loser accepts the
+    // winner only after a strict re-read and full-record equality check.
+    match std::fs::hard_link(&temporary, &path) {
+        Ok(()) => {
+            std::fs::remove_file(&temporary).map_err(|error| {
+                SourceUnavailable::new(format!("{}: {error}", temporary.display()))
+            })?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = std::fs::remove_file(&temporary);
+            let recorded = read_optional_compiled_attention_operator(output)?.ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "{} appeared during attention-operator publication but is now absent",
+                    path.display()
+                ))
+            })?;
+            require_matching_compiled_attention_operator(output, &requested, &recorded)
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&temporary);
+            Err(SourceUnavailable::new(format!(
+                "attention-operator sidecar publish {} -> {}: {error}",
+                temporary.display(),
+                path.display()
+            )))
+        }
+    }
+}
+
+fn bind_compiled_attention_operator(
+    output: &Path,
+    requested: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    let requested =
+        validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
+    if preflight_compiled_attention_operator(output, &requested)? {
+        return Ok(());
+    }
+    publish_attention_operator_binding(output, &requested)
+}
+
+fn pin_compile_identities(
+    output: &Path,
+    tokenizer: &TokenizerAdapter,
+    attention_operator: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    // Both checks are deliberately read-only. Do not let the successful half
+    // of a mismatched identity pair mutate a resumable output.
+    preflight_compile_tokenizer_adapter(output, tokenizer)?;
+    preflight_compiled_attention_operator(output, attention_operator)?;
+    pin_compile_tokenizer_adapter(output, tokenizer)?;
+    bind_compiled_attention_operator(output, attention_operator)
+}
+
+/// Recorded compilation has no tokenizer authority: its input is already a
+/// token-id corpus, not a tokenizer package. Preserving either a source
+/// compiler's adapter claim or its runtime table would produce a bundle that
+/// looks bound to a token space the recorded path never verified.
+fn preflight_recorded_compile_output(output: &Path) -> Result<(), SourceUnavailable> {
+    const FORBIDDEN_RECORDED_OUTPUT_LEAVES: [&str; 3] = [
+        "tokenizer.bin",
+        "corpus.records.hidden",
+        "space_manifest.json",
+    ];
+    let _ = compile_output_payload_inventory(output)?;
+    if read_compile_tokenizer_adapter(output)?.is_some() {
+        return Err(SourceUnavailable::new(format!(
+            "recorded compile output {} contains {TOKENIZER_ADAPTER_FILE}, but compile-recorded has no tokenizer authority; use a fresh recorded-only output directory",
+            output.display()
+        )));
+    }
+    for name in FORBIDDEN_RECORDED_OUTPUT_LEAVES {
+        let path = output.join(name);
+        if strict_regular_file_if_present(&path, "recorded compile unsupported leaf")? {
+            return Err(SourceUnavailable::new(format!(
+                "recorded compile output {} contains {name}, which compile-recorded cannot verify or reproduce; use a fresh recorded-only output directory",
+                output.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct CompileOptions {
     model: Option<String>,
@@ -331,6 +1075,52 @@ struct RecordedCompileOptions {
     corpus_recs: PathBuf,
     vocab_size: usize,
     output: PathBuf,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CopyRecordedAttentionOptions {
+    corpus_meta: PathBuf,
+    corpus_recs: PathBuf,
+    output: PathBuf,
+}
+
+fn parse_copy_recorded_attention_options(
+    args: &[String],
+) -> Result<CopyRecordedAttentionOptions, SourceUnavailable> {
+    let mut corpus_meta = None;
+    let mut corpus_recs = None;
+    let mut output = None;
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| SourceUnavailable::new(format!("missing value for {flag}")))?;
+        match flag.as_str() {
+            "--corpus-meta" => corpus_meta = Some(PathBuf::from(value)),
+            "--corpus-recs" => corpus_recs = Some(PathBuf::from(value)),
+            "--out" => output = Some(PathBuf::from(value)),
+            _ => {
+                return Err(SourceUnavailable::new(format!(
+                    "unknown copy-recorded-attention option: {flag}"
+                )));
+            }
+        }
+        index += 2;
+    }
+    let output = output.ok_or_else(|| SourceUnavailable::new("--out is required"))?;
+    if output.file_name() != Some(std::ffi::OsStr::new(ATTENTION_OPERATOR_BINDING_FILE)) {
+        return Err(SourceUnavailable::new(format!(
+            "--out must name {ATTENTION_OPERATOR_BINDING_FILE} exactly"
+        )));
+    }
+    Ok(CopyRecordedAttentionOptions {
+        corpus_meta: corpus_meta
+            .ok_or_else(|| SourceUnavailable::new("--corpus-meta is required"))?,
+        corpus_recs: corpus_recs
+            .ok_or_else(|| SourceUnavailable::new("--corpus-recs is required"))?,
+        output,
+    })
 }
 
 fn parse_recorded_compile_options(
@@ -513,27 +1303,320 @@ fn parse_observe_options(args: &[String]) -> Result<ObserveOptions, SourceUnavai
     Ok(options)
 }
 
-/// Pin the tokenizer identity before a resumable observation command writes
-/// `tokenizer.bin` or reconciles any partial shard tail. The writer performs
-/// the registry/digest checks and refuses adapterless payload relabeling.
-fn pin_observation_tokenizer_before_output(
+fn read_optional_observation_manifest(
+    output: &Path,
+) -> Result<Option<observe::ObservationManifest>, SourceUnavailable> {
+    let path = output.join(observe::MANIFEST_FILE);
+    if !strict_regular_file_if_present(&path, "observation manifest")? {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: unreadable observation manifest: {error}",
+            path.display()
+        ))
+    })?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: malformed observation manifest: {error}",
+            path.display()
+        ))
+    })?;
+    if let Some(operator) = value.get("attention_operator") {
+        validate_attention_operator_json(operator, &path.display().to_string())?;
+    }
+    let parsed: observe::ObservationManifest = serde_json::from_value(value).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: malformed observation manifest: {error}",
+            path.display()
+        ))
+    })?;
+    // Delegate the authoritative registry checks for geometry, tokenizer,
+    // attention, and trace records to the graph-compiler boundary. The raw
+    // operator check above additionally refuses unknown nested claims before
+    // serde can discard them.
+    let validated = observe::ObservationManifest::load(output)?.ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{} disappeared during observation-manifest validation",
+            path.display()
+        ))
+    })?;
+    if validated != parsed {
+        return Err(SourceUnavailable::new(format!(
+            "{} changed during observation-manifest validation",
+            path.display()
+        )));
+    }
+    Ok(Some(validated))
+}
+
+fn observation_payload_exists(
+    output: &Path,
+    manifest: Option<&observe::ObservationManifest>,
+) -> Result<bool, SourceUnavailable> {
+    let mut has_payload = manifest
+        .is_some_and(|manifest| manifest.total_records != 0 || !manifest.completed.is_empty());
+
+    let payload_file_is_present = |path: &Path| match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+        Ok(_) => Err(SourceUnavailable::new(format!(
+            "observation payload path {} is not a regular file; refusing provenance mutation",
+            path.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(SourceUnavailable::new(format!(
+            "{} cannot be inspected: {error}",
+            path.display()
+        ))),
+    };
+
+    for name in [
+        observe::STATE_FILE,
+        "merged.bin",
+        "committed.bin",
+        ".committed.bin.tmp",
+        "stories.jsonl",
+        "tokenizer.bin",
+    ] {
+        if payload_file_is_present(&output.join(name))? {
+            has_payload = true;
+        }
+    }
+    // Scan the inventory rather than deriving names from the requested
+    // fan-out. A stripped or stale manifest can under-declare the shards that
+    // already exist; every shard/probability/trace payload is arithmetic-era
+    // evidence even when its index lies outside the current fan-out.
+    let entries = match std::fs::read_dir(output) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(has_payload),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "observation directory {} cannot be inspected: {error}",
+                output.display()
+            )));
+        }
+    };
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            SourceUnavailable::new(format!(
+                "observation directory {} cannot be inspected: {error}",
+                output.display()
+            ))
+        })?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Some(stem) = name.strip_prefix("shard-") else {
+            continue;
+        };
+        let numeric_index = [".bin", ".bin.prob", ".bin.trace"]
+            .into_iter()
+            .find_map(|suffix| stem.strip_suffix(suffix));
+        if numeric_index.is_some_and(|index| {
+            !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit())
+        }) && payload_file_is_present(&entry.path())?
+        {
+            has_payload = true;
+        }
+    }
+    Ok(has_payload)
+}
+
+/// Validate the tokenizer and operator halves of an observation identity
+/// without opening a writer. Any conflict therefore leaves both manifest
+/// fields and `tokenizer.bin` unchanged.
+fn preflight_observation_identities(
     output: &Path,
     shard_bits: u8,
-    requested: Option<&TokenizerAdapter>,
+    tokenizer: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
 ) -> Result<(), SourceUnavailable> {
-    let mut writer = observe::ObservationShardWriter::open(output, shard_bits)?;
-    match (writer.manifest().tokenizer_adapter.as_ref(), requested) {
-        (Some(recorded), None) => Err(SourceUnavailable::new(format!(
-            "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested the adapterless legacy tokenizer; incompatible resume refused before mutation",
-            output.display(),
-            recorded.family,
-            recorded.version,
-            recorded.tokenizer_cid,
-            recorded.adapter_digest,
-        ))),
-        (_, Some(adapter)) => writer.set_tokenizer_adapter(adapter),
-        (None, None) => Ok(()),
+    if let Some(tokenizer) = tokenizer {
+        validate_tokenizer_adapter_record(tokenizer)?;
     }
+    let requested_operator = attention_operator
+        .map(|operator| {
+            validate_attention_operator(operator, "teacher-declared attention operator")
+        })
+        .transpose()?;
+    let manifest = read_optional_observation_manifest(output)?;
+    if let Some(manifest) = &manifest {
+        if manifest.shard_bits != shard_bits {
+            return Err(SourceUnavailable::new(format!(
+                "manifest shard_bits {} does not match requested {shard_bits}",
+                manifest.shard_bits
+            )));
+        }
+        if let Some(recorded) = &manifest.tokenizer_adapter {
+            validate_tokenizer_adapter_record(recorded).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "{}: {}",
+                    output.join(observe::MANIFEST_FILE).display(),
+                    error.reason
+                ))
+            })?;
+        }
+        if let Some(recorded) = &manifest.attention_operator {
+            validate_attention_operator(
+                recorded,
+                &output.join(observe::MANIFEST_FILE).display().to_string(),
+            )?;
+        }
+    }
+    // Inventory every payload entry even when the two recorded identities
+    // match. This is the last read-only boundary before tokenizer export and
+    // writer construction, so a shard/probability/trace symlink or other
+    // nonregular entry must fail before either operation can follow it.
+    let payload_exists = observation_payload_exists(output, manifest.as_ref())?;
+
+    match (
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.tokenizer_adapter.as_ref()),
+        tokenizer,
+    ) {
+        (Some(recorded), Some(requested)) if recorded == requested => {}
+        (Some(recorded), Some(requested)) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested {}/{} (CID {}, digest {}); incompatible resume refused before mutation",
+                output.display(),
+                recorded.family,
+                recorded.version,
+                recorded.tokenizer_cid,
+                recorded.adapter_digest,
+                requested.family,
+                requested.version,
+                requested.tokenizer_cid,
+                requested.adapter_digest,
+            )));
+        }
+        (Some(recorded), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested the adapterless legacy tokenizer; incompatible resume refused before mutation",
+                output.display(),
+                recorded.family,
+                recorded.version,
+                recorded.tokenizer_cid,
+                recorded.adapter_digest,
+            )));
+        }
+        (None, _) => {}
+    }
+
+    match (
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.attention_operator.as_ref()),
+        requested_operator.as_ref(),
+    ) {
+        (Some(recorded), Some(requested)) if recorded == requested => {}
+        (Some(recorded), Some(requested)) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to attention operator {}/{} (digest {}); requested {}/{} (digest {}); incompatible observation resume refused before mutation",
+                output.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        (Some(recorded), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to attention operator {}/{} but the requested oracle declares no operator; use a fresh output directory for the legacy arithmetic era",
+                output.display(),
+                recorded.id,
+                recorded.version,
+            )));
+        }
+        (None, Some(requested)) if payload_exists => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has no recorded attention operator but already contains observation payload; refusing to relabel legacy rows as {}/{} before mutation",
+                output.display(),
+                requested.id,
+                requested.version,
+            )));
+        }
+        (None, _) => {}
+    }
+    Ok(())
+}
+
+fn pin_raw_observation_identities_before_output(
+    session: &observe::ObservationSession,
+    tokenizer: Option<&TokenizerAdapter>,
+    geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    preflight_observation_identities(
+        session.dir(),
+        session.shard_bits(),
+        tokenizer,
+        attention_operator,
+    )?;
+    let operator = attention_operator
+        .map(|operator| {
+            validate_attention_operator(operator, "teacher-declared attention operator")
+        })
+        .transpose()?;
+    // The lower boundary joins geometry with tokenizer/operator on the same
+    // locked snapshot. Run its full read-only pass before publishing any
+    // identity, then repeat and pin the whole bundle while this session stays
+    // live through tokenizer export, reconciliation, and row writes.
+    observe::preflight_observation_identities_in_session(
+        session,
+        None,
+        geometry,
+        tokenizer,
+        operator.as_ref(),
+        None,
+    )?;
+    observe::pin_observation_identities_in_session(
+        session,
+        None,
+        geometry,
+        tokenizer,
+        operator.as_ref(),
+        None,
+    )
+}
+
+fn pin_text_observation_identities_before_output(
+    session: &observe::ObservationSession,
+    input: &Path,
+    tokenizer: Option<&TokenizerAdapter>,
+    geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    preflight_observation_identities(
+        session.dir(),
+        session.shard_bits(),
+        tokenizer,
+        attention_operator,
+    )?;
+    let operator = attention_operator
+        .map(|operator| {
+            validate_attention_operator(operator, "teacher-declared attention operator")
+        })
+        .transpose()?;
+    observe_text::preflight_text_observation_in_session(
+        session,
+        input,
+        true,
+        geometry,
+        operator.as_ref(),
+        tokenizer,
+    )?;
+    observe_text::pin_text_observation_identities_in_session(
+        session,
+        input,
+        true,
+        geometry,
+        operator.as_ref(),
+        tokenizer,
+    )
 }
 
 /// Observation pipeline v2 (plan §5 Phase 2): the same teacher generation
@@ -545,16 +1628,18 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
         "warning: debug builds make teacher generation much slower; use `cargo run --release -- observe ...`"
     );
     let options = parse_observe_options(args)?;
-    let token_byte_lengths: Option<Vec<u32>>;
-    let mut oracle: Box<dyn TeacherOracle> = if let Some(checkpoint) = &options.checkpoint {
+    let (adapter, runtime_table, mut oracle): (
+        Option<TokenizerAdapter>,
+        Option<RuntimeTokenizerDecodeTable>,
+        Box<dyn TeacherOracle>,
+    ) = if let Some(checkpoint) = &options.checkpoint {
         // Legacy llama2.c checkpoint: no HF tokenizer tree, so byte
         // anchors stay at the v3 "unknown" value.
-        token_byte_lengths = None;
         let path = checkpoint
             .to_str()
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
-        pin_observation_tokenizer_before_output(&options.output, options.shards, None)?;
-        Box::new(LlamaOracle::load(path))
+        let oracle = LlamaOracle::load(path);
+        (None, None, Box::new(oracle))
     } else {
         let tokenizer =
             resolve_source_tokenizer(&options.source, options.tokenizer_adapter.as_ref())?;
@@ -566,22 +1651,36 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
         let adapter = tokenizer.adapter();
-        pin_observation_tokenizer_before_output(&options.output, options.shards, adapter.as_ref())?;
+        (adapter, Some(runtime_table), Box::new(oracle))
+    };
+    // Resolve every source input before opening the resumable output. The one
+    // session acquired here then spans the full identity/export/run/finalize
+    // lifetime.
+    let session = observe::ObservationSession::acquire(&options.output, options.shards)?;
+    let geometry = oracle.geometry_projection();
+    let attention_operator = oracle.attention_operator_spec();
+    pin_raw_observation_identities_before_output(
+        &session,
+        adapter.as_ref(),
+        geometry.as_ref(),
+        attention_operator.as_ref(),
+    )?;
+    let token_byte_lengths = if let Some(runtime_table) = runtime_table.as_ref() {
         eprintln!("exporting tokenizer...");
         let export = core_scenarios::export_runtime_tokenizer_table(
-            &runtime_table,
-            options.output.join("tokenizer.bin"),
+            runtime_table,
+            session.dir().join("tokenizer.bin"),
         )
         .map_err(SourceUnavailable::new)?;
-        token_byte_lengths = export.source_byte_lengths;
-        Box::new(oracle)
+        export.source_byte_lengths
+    } else {
+        None
     };
-    let summary = observe::observe_sharded(
+    let summary = observe::observe_sharded_in_session(
+        &session,
         oracle.as_mut(),
         options.seconds,
         options.target,
-        options.shards,
-        &options.output,
         token_byte_lengths.as_deref(),
     )
     .map_err(SourceUnavailable::new)?;
@@ -589,8 +1688,8 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
         // Persist the merged record stream so Gate C can consume it as
         // --corpus-recs with state.bin as --corpus-meta (same convention
         // as the from-text driver, issue #75).
-        let merged = observe::merge_shards(&options.output).map_err(SourceUnavailable::new)?;
-        let merged_path = options.output.join("merged.bin");
+        let merged = observe::merge_shards(session.dir()).map_err(SourceUnavailable::new)?;
+        let merged_path = session.dir().join("merged.bin");
         std::fs::write(&merged_path, &merged)?;
         println!(
             "observe complete: {} records at {}",
@@ -603,6 +1702,7 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
             options.output.display()
         );
     }
+    drop(session);
     Ok(())
 }
 
@@ -734,18 +1834,16 @@ fn resolve_registered_observation_tokenizer(
     Ok((tokenizer, runtime_table))
 }
 
-fn pin_and_export_observation_tokenizer(
-    tokenizer: &TokenizerKind,
+fn export_observation_tokenizer_in_session(
+    session: &observe::ObservationSession,
     runtime_table: &RuntimeTokenizerDecodeTable,
-    output: &Path,
-    shard_bits: u8,
 ) -> Result<Option<Vec<u32>>, SourceUnavailable> {
-    let adapter = tokenizer.adapter();
-    pin_observation_tokenizer_before_output(output, shard_bits, adapter.as_ref())?;
     eprintln!("exporting tokenizer...");
-    let export =
-        core_scenarios::export_runtime_tokenizer_table(runtime_table, output.join("tokenizer.bin"))
-            .map_err(SourceUnavailable::new)?;
+    let export = core_scenarios::export_runtime_tokenizer_table(
+        runtime_table,
+        session.dir().join("tokenizer.bin"),
+    )
+    .map_err(SourceUnavailable::new)?;
     Ok(export.source_byte_lengths)
 }
 
@@ -770,9 +1868,12 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         }
         return observe_text_batched_command(&options);
     }
-    let token_byte_lengths: Option<Vec<u32>>;
-    let tokenizer: TokenizerKind;
-    let oracle: Box<dyn TeacherOracle + Send> = if let Some(checkpoint) = &options.checkpoint {
+    let (tokenizer, runtime_table, mut token_byte_lengths, oracle): (
+        TokenizerKind,
+        Option<RuntimeTokenizerDecodeTable>,
+        Option<Vec<u32>>,
+        Box<dyn TeacherOracle + Send>,
+    ) = if let Some(checkpoint) = &options.checkpoint {
         // Legacy llama2.c checkpoint: the companion tokenizer is the
         // scoreless tokenizer.bin fetched by `setup` (overridable with
         // --tokenizer); its piece byte lengths anchor records into the
@@ -785,18 +1886,19 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         let legacy = scenarios::Tokenizer::try_load(&tokenizer_path).map_err(|error| {
             SourceUnavailable::new(format!("{}: {error}", tokenizer_path.display()))
         })?;
-        token_byte_lengths = Some(
+        let token_byte_lengths = Some(
             legacy
                 .vocab
                 .iter()
                 .map(|piece| piece.len() as u32)
                 .collect(),
         );
-        tokenizer = TokenizerKind::Legacy(legacy);
+        let tokenizer = TokenizerKind::Legacy(legacy);
         let path = checkpoint
             .to_str()
             .ok_or_else(|| SourceUnavailable::new("checkpoint path is not UTF-8"))?;
-        Box::new(LlamaOracle::load(path))
+        let oracle = LlamaOracle::load(path);
+        (tokenizer, None, token_byte_lengths, Box::new(oracle))
     } else {
         let (resolved_tokenizer, runtime_table) = resolve_registered_observation_tokenizer(
             &options.source,
@@ -806,14 +1908,12 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
             .map_err(|error| {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
-        token_byte_lengths = pin_and_export_observation_tokenizer(
-            &resolved_tokenizer,
-            &runtime_table,
-            &options.output,
-            options.shards,
-        )?;
-        tokenizer = resolved_tokenizer;
-        Box::new(oracle)
+        (
+            resolved_tokenizer,
+            Some(runtime_table),
+            None,
+            Box::new(oracle),
+        )
     };
     // Build the worker pool: the oracle loaded above plus `workers - 1` more
     // identical teacher instances, so up to `workers` articles are observed in
@@ -838,21 +1938,50 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         };
         pool.push(extra);
     }
+    let geometry = pool[0].geometry_projection();
+    let attention_operator = pool[0].attention_operator_spec();
+    for (worker, oracle) in pool.iter().enumerate().skip(1) {
+        if oracle.geometry_projection() != geometry {
+            return Err(SourceUnavailable::new(format!(
+                "observe-text worker {worker} loaded a different source geometry before output; refusing a mixed teacher pool"
+            )));
+        }
+        if oracle.attention_operator_spec() != attention_operator {
+            return Err(SourceUnavailable::new(format!(
+                "observe-text worker {worker} loaded a different attention operator before output; refusing a mixed teacher pool"
+            )));
+        }
+    }
+    // All potentially fallible teacher/tokenizer loading is complete before
+    // the locked output session publishes identities or tokenizer bytes.
+    let session = observe::ObservationSession::acquire(&options.output, options.shards)?;
+    let adapter = tokenizer.adapter();
+    pin_text_observation_identities_before_output(
+        &session,
+        &options.input,
+        adapter.as_ref(),
+        geometry.as_ref(),
+        attention_operator.as_ref(),
+    )?;
+    if let Some(runtime_table) = runtime_table.as_ref() {
+        token_byte_lengths = export_observation_tokenizer_in_session(&session, runtime_table)?;
+    }
     if options.workers > 1 {
         eprintln!("observing with {} teacher workers", options.workers);
     }
-    let report = observe_text::observe_text_corpus(
+    let report = observe_text::observe_text_corpus_in_session(
+        &session,
         &mut pool,
         options.seconds,
         &tokenizer,
         token_byte_lengths.as_deref(),
         &options.input,
-        &options.output,
-        options.shards,
         true,
     )
     .map_err(SourceUnavailable::new)?;
-    finish_observe_text_report(&report, &options.output)
+    let result = finish_observe_text_report(&report, session.dir());
+    drop(session);
+    result
 }
 
 /// Observe-text with a batched Hugging Face teacher: one shared weight copy,
@@ -872,39 +2001,45 @@ fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), Sour
         .map_err(|error| {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
-    let token_byte_lengths = pin_and_export_observation_tokenizer(
-        &tokenizer,
-        &runtime_table,
-        &options.output,
-        options.shards,
+    let session = observe::ObservationSession::acquire(&options.output, options.shards)?;
+    let adapter = tokenizer.adapter();
+    let geometry = teacher.geometry_projection();
+    let attention_operator = teacher.attention_operator_spec();
+    pin_text_observation_identities_before_output(
+        &session,
+        &options.input,
+        adapter.as_ref(),
+        geometry.as_ref(),
+        attention_operator.as_ref(),
     )?;
+    let token_byte_lengths = export_observation_tokenizer_in_session(&session, &runtime_table)?;
     eprintln!("observing with batch {}", options.batch);
     let report = match teacher {
-        Teacher::Llama(oracle) => observe_text::observe_text_corpus_batched(
+        Teacher::Llama(oracle) => observe_text::observe_text_corpus_batched_in_session(
+            &session,
             &oracle,
             options.batch,
             options.seconds,
             &tokenizer,
             token_byte_lengths.as_deref(),
             &options.input,
-            &options.output,
-            options.shards,
             true,
         ),
-        Teacher::Gpt2(oracle) => observe_text::observe_text_corpus_batched(
+        Teacher::Gpt2(oracle) => observe_text::observe_text_corpus_batched_in_session(
+            &session,
             &oracle,
             options.batch,
             options.seconds,
             &tokenizer,
             token_byte_lengths.as_deref(),
             &options.input,
-            &options.output,
-            options.shards,
             true,
         ),
     }
     .map_err(SourceUnavailable::new)?;
-    finish_observe_text_report(&report, &options.output)
+    let result = finish_observe_text_report(&report, session.dir());
+    drop(session);
+    result
 }
 
 /// Print the observe-text report and, when the corpus is complete, persist the
@@ -1099,12 +2234,13 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                 })?);
             }
             "--attention-operator" => {
-                options.attention_operator =
-                    Some(serde_json::from_str(value).map_err(|error| {
-                        SourceUnavailable::new(format!(
-                            "invalid --attention-operator value: {error}"
-                        ))
-                    })?);
+                let recorded: serde_json::Value = serde_json::from_str(value).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid --attention-operator value: {error}"))
+                })?;
+                options.attention_operator = Some(validate_attention_operator_json(
+                    &recorded,
+                    "--attention-operator",
+                )?);
             }
             _ => {
                 return Err(SourceUnavailable::new(format!(
@@ -2632,6 +3768,7 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         &tokenizer_adapter,
         &recorded_adapter,
     )?;
+    let recorded_attention_operator = compiled_attention_operator(&options.compiled)?;
     let report_path = options
         .report
         .clone()
@@ -2677,6 +3814,28 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         .map_err(|error| {
             SourceUnavailable::new(format!("failed to load Hugging Face model: {error}"))
         })?;
+    oracle.set_r4_attention(
+        recorded_attention_operator.id == AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+    );
+    let actual_attention_operator = oracle.attention_operator_spec().ok_or_else(|| {
+        SourceUnavailable::new("evaluation teacher declares no attention operator")
+    })?;
+    let actual_attention_operator = validate_attention_operator(
+        &actual_attention_operator,
+        "evaluation teacher attention operator",
+    )?;
+    if actual_attention_operator != recorded_attention_operator {
+        return Err(SourceUnavailable::new(format!(
+            "{} is pinned to attention operator {}/{} (digest {}), but the loaded evaluation teacher computes {}/{} (digest {}); evaluation refused before replay",
+            options.compiled.display(),
+            recorded_attention_operator.id,
+            recorded_attention_operator.version,
+            recorded_attention_operator.declared_digest(),
+            actual_attention_operator.id,
+            actual_attention_operator.version,
+            actual_attention_operator.declared_digest(),
+        )));
+    }
     let mut teacher_logits = vec![0f32; oracle.vocab()];
     let artifacts_bytes = std::fs::read(&artifacts_path)?;
 
@@ -3125,7 +4284,6 @@ where
         .clone()
         .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
     eprintln!("compiler output: {}", output.display());
-    pin_compile_tokenizer_adapter(&output, &tokenizer_adapter)?;
     let meta = output.join("corpus.meta");
     let records = output.join("corpus.records");
     let meta = meta
@@ -3141,6 +4299,30 @@ where
     if options.r4_attention {
         oracle.set_r4_attention(true);
     }
+    let attention_operator = oracle.attention_operator_spec().ok_or_else(|| {
+        SourceUnavailable::new("Hugging Face teacher declares no attention operator")
+    })?;
+    // Keep every identity and corpus-resume check read-only until the whole
+    // bundle has been accepted. In particular, malformed regular metadata
+    // must not be mistaken for a fresh corpus after either sidecar is pinned.
+    preflight_compile_tokenizer_adapter(&output, &tokenizer_adapter)?;
+    preflight_compiled_attention_operator(&output, &attention_operator)?;
+    let hidden_row_bytes = oracle
+        .hidden_state()
+        .map(|hidden| {
+            hidden
+                .len()
+                .checked_mul(std::mem::size_of::<f32>())
+                .ok_or_else(|| {
+                    SourceUnavailable::new("loaded teacher hidden-state row byte length overflows")
+                })
+        })
+        .transpose()?;
+    let resume = preflight_source_compile_resume(&output, hidden_row_bytes, options.target)?;
+    // A story checkpoint commits records and hidden rows together. Normalize
+    // both interrupted tails before the core generator reopens either stream.
+    reconcile_source_compile_resume(&output, &resume)?;
+    pin_compile_identities(&output, &tokenizer_adapter, &attention_operator)?;
     progress(5, "Exporting tokenizer...");
     eprintln!("exporting tokenizer...");
     let tokenizer_export = core_scenarios::export_runtime_tokenizer_table(
@@ -3254,12 +4436,194 @@ where
     Ok(())
 }
 
+/// Resolve the arithmetic era accompanying a canonically paired recorded
+/// corpus. Observation directories carry it in `manifest.json`; compile
+/// directories carry the extracted sidecar. `None` means both records are
+/// genuinely absent and preserves the documented pre-#602 interpretation.
+/// Every present record is registry-validated and two present sources must
+/// agree exactly. Provenance is inherited only by the canonical compiled
+/// (`corpus.meta` / `corpus.records`) or observation (`state.bin` /
+/// `merged.bin`) pair. Arbitrarily named files remain compatible only when
+/// both provenance entries are genuinely absent.
+pub fn recorded_corpus_attention_operator(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    fn canonical_parent(path: &Path, label: &str) -> Result<PathBuf, SourceUnavailable> {
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} {} cannot be inspected: {error}",
+                path.display()
+            ))
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(SourceUnavailable::new(format!(
+                "{label} {} is not a regular non-symlink file",
+                path.display()
+            )));
+        }
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let canonical = std::fs::canonicalize(parent).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} parent {} cannot be resolved: {error}",
+                parent.display()
+            ))
+        })?;
+        let parent_metadata = std::fs::metadata(&canonical).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} parent {} cannot be inspected: {error}",
+                canonical.display()
+            ))
+        })?;
+        if !parent_metadata.is_dir() {
+            return Err(SourceUnavailable::new(format!(
+                "{label} parent {} is not a directory",
+                canonical.display()
+            )));
+        }
+        Ok(canonical)
+    }
+
+    fn is_canonical_pair(corpus_meta: &Path, corpus_records: &Path) -> bool {
+        let names = (corpus_meta.file_name(), corpus_records.file_name());
+        matches!(
+            names,
+            (Some(meta), Some(records))
+                if (meta == std::ffi::OsStr::new("corpus.meta")
+                    && records == std::ffi::OsStr::new("corpus.records"))
+                    || (meta == std::ffi::OsStr::new(observe::STATE_FILE)
+                        && records == std::ffi::OsStr::new("merged.bin"))
+        )
+    }
+
+    let meta_root = canonical_parent(corpus_meta, "corpus metadata")?;
+    let records_root = canonical_parent(corpus_records, "corpus records")?;
+    if meta_root != records_root {
+        return Err(SourceUnavailable::new(format!(
+            "corpus.meta and corpus.records have different canonical parent roots ({} versus {}); no cryptographic cross-directory pairing exists",
+            meta_root.display(),
+            records_root.display()
+        )));
+    }
+    let root = meta_root;
+    let sidecar = read_optional_compiled_attention_operator(&root)?;
+    let manifest_path = root.join(observe::MANIFEST_FILE);
+    let manifest = read_optional_observation_manifest(&root)?;
+    let manifest_present = manifest.is_some();
+    let manifest_operator = manifest
+        .and_then(|manifest| manifest.attention_operator)
+        .map(|recorded| {
+            validate_attention_operator(&recorded, &manifest_path.display().to_string())
+        })
+        .transpose()?;
+
+    if (sidecar.is_some() || manifest_present) && !is_canonical_pair(corpus_meta, corpus_records) {
+        return Err(SourceUnavailable::new(format!(
+            "recorded-corpus provenance in {} applies only to the canonical corpus.meta/corpus.records or state.bin/merged.bin pair; refusing to attach it to {}/{}",
+            root.display(),
+            corpus_meta.display(),
+            corpus_records.display(),
+        )));
+    }
+
+    if let Some(sidecar) = sidecar.as_ref()
+        && manifest_present
+        && manifest_operator.is_none()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{} declares attention operator {}/{} but present {} records the legacy operatorless era; refusing conflicting recorded-corpus provenance",
+            root.join(ATTENTION_OPERATOR_BINDING_FILE).display(),
+            sidecar.id,
+            sidecar.version,
+            manifest_path.display(),
+        )));
+    }
+
+    match (sidecar, manifest_operator) {
+        (Some(sidecar), Some(manifest)) if sidecar != manifest => {
+            Err(SourceUnavailable::new(format!(
+                "{} and {} declare different attention operators ({}/{} digest {} versus {}/{} digest {})",
+                root.join(ATTENTION_OPERATOR_BINDING_FILE).display(),
+                manifest_path.display(),
+                sidecar.id,
+                sidecar.version,
+                sidecar.declared_digest(),
+                manifest.id,
+                manifest.version,
+                manifest.declared_digest(),
+            )))
+        }
+        (Some(sidecar), _) => Ok(Some(sidecar)),
+        (None, Some(manifest)) => Ok(Some(manifest)),
+        (None, None) => Ok(None),
+    }
+}
+
+/// Copy only the registry-exact source-attention provenance of a recorded
+/// corpus. This tooling seam deliberately delegates all source pairing and
+/// manifest validation to [`recorded_corpus_attention_operator`] instead of
+/// reinterpreting observation JSON in a shell/Python helper.
+pub fn copy_recorded_attention(args: &[String]) -> Result<(), SourceUnavailable> {
+    let options = parse_copy_recorded_attention_options(args)?;
+    let resolved = recorded_corpus_attention_operator(&options.corpus_meta, &options.corpus_recs)?;
+    match resolved {
+        Some(operator) => {
+            let parent = options
+                .output
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            match std::fs::symlink_metadata(parent) {
+                Ok(metadata) if metadata.file_type().is_dir() => {}
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "attention-operator destination parent {} is not a real directory",
+                        parent.display()
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "attention-operator destination parent {} cannot be inspected: {error}",
+                        parent.display()
+                    )));
+                }
+            }
+            publish_attention_operator_binding(parent, &operator)
+        }
+        None => match std::fs::symlink_metadata(&options.output) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(SourceUnavailable::new(format!(
+                "legacy recorded corpus destination {} cannot be inspected: {error}",
+                options.output.display()
+            ))),
+            Ok(_) => Err(SourceUnavailable::new(format!(
+                "recorded corpus has no attention-operator provenance, but destination {} is present; refusing to preserve or relabel a stale binding",
+                options.output.display()
+            ))),
+        },
+    }
+}
+
 /// Compile a completed recorded corpus without loading or executing a
 /// transformer. This is the observation-first production path; teacher
 /// capture remains available through `observe`/`compile` as an explicitly
 /// separate offline step.
 pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable> {
     let options = parse_recorded_compile_options(args)?;
+    preflight_recorded_compile_output(&options.output)?;
+    let attention_operator =
+        match recorded_corpus_attention_operator(&options.corpus_meta, &options.corpus_recs)? {
+            Some(recorded) => recorded,
+            None => uor_r4_model_source::attention::operator_spec(
+                AttentionOperatorSpec::STANDARD_ID,
+                LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
+            )?,
+        };
+    preflight_compiled_attention_operator(&options.output, &attention_operator)?;
     let meta = options
         .corpus_meta
         .to_str()
@@ -3290,7 +4654,7 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         .unwrap_or(1);
     let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads);
 
-    std::fs::create_dir_all(&options.output)?;
+    bind_compiled_attention_operator(&options.output, &attention_operator)?;
     std::fs::write(
         options.output.join("tless_artifacts.bin"),
         compiler::artifact_bytes(&artifacts),
@@ -3477,6 +4841,7 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
             }
         }
         Some("compile-recorded") => compile_recorded_corpus(&args[1..])?,
+        Some("copy-recorded-attention") => copy_recorded_attention(&args[1..])?,
         Some("store") => {
             let c = compiler::load_corpus()
                 .expect("corpus incomplete: run `transformerless gen` first");
@@ -3521,6 +4886,7 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
                 "R4 transformerless — compile a mul-free table artifact\n\
                  commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
                  recorded compile (no transformer): compile-recorded --corpus-meta <META> --corpus-recs <RECS> --vocab-size <N> --out <DIR>\n\
+                 recorded provenance copy: copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N]\n\
@@ -3674,6 +5040,96 @@ mod tests {
         entries
     }
 
+    fn attention_operator_temp_entries(path: &Path) -> Vec<String> {
+        let prefix = format!(".{ATTENTION_OPERATOR_BINDING_FILE}.");
+        let mut entries: Vec<String> = std::fs::read_dir(path)
+            .expect("read test directory")
+            .map(|entry| {
+                entry
+                    .expect("directory entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(&prefix) && name.ends_with(".tmp"))
+            .collect();
+        entries.sort();
+        entries
+    }
+
+    fn write_observation_manifest(path: &Path, manifest: &observe::ObservationManifest) {
+        std::fs::create_dir_all(path).expect("observation directory");
+        std::fs::write(
+            path.join(observe::MANIFEST_FILE),
+            serde_json::to_vec_pretty(manifest).expect("serialize observation manifest"),
+        )
+        .expect("write observation manifest");
+    }
+
+    fn corpus_markers(path: &Path) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(path).expect("corpus directory");
+        let meta = path.join("corpus.meta");
+        let records = path.join("corpus.records");
+        std::fs::write(&meta, b"meta marker").expect("metadata marker");
+        std::fs::write(&records, b"records marker").expect("records marker");
+        (meta, records)
+    }
+
+    fn observation_corpus_markers(path: &Path) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(path).expect("observation directory");
+        let state = path.join(observe::STATE_FILE);
+        let merged = path.join("merged.bin");
+        std::fs::write(&state, b"state marker").expect("state marker");
+        std::fs::write(&merged, b"merged marker").expect("merged marker");
+        (state, merged)
+    }
+
+    fn source_resume_meta(records: u64, done: u8) -> Vec<u8> {
+        let mut meta = Vec::with_capacity(SOURCE_CORPUS_META_BYTES);
+        meta.extend_from_slice(&records.to_le_bytes());
+        meta.extend_from_slice(&1u64.to_le_bytes());
+        meta.extend_from_slice(&0x5EEDu64.to_le_bytes());
+        meta.push(done);
+        meta
+    }
+
+    fn source_v3_record(story: u32, position: u32) -> [u8; 48] {
+        compiler::encode_v3_record(
+            story,
+            7,
+            &[7, 8, 9],
+            &[70, 20, 10],
+            (position, position + 1),
+            (position, position + 1),
+        )
+    }
+
+    fn source_v2_record(story: u32) -> [u8; 32] {
+        let mut record = [0u8; 32];
+        record[0..4].copy_from_slice(&story.to_le_bytes());
+        record[4..8].copy_from_slice(&7u32.to_le_bytes());
+        for (index, token) in [7u32, 8, 9].into_iter().enumerate() {
+            let offset = 8 + index * 4;
+            record[offset..offset + 4].copy_from_slice(&token.to_le_bytes());
+        }
+        for (index, weight) in [70u32, 20, 10].into_iter().enumerate() {
+            let offset = 20 + index * 4;
+            record[offset..offset + 4].copy_from_slice(&weight.to_le_bytes());
+        }
+        record
+    }
+
+    fn copy_recorded_attention_args(meta: &Path, records: &Path, output: &Path) -> Vec<String> {
+        vec![
+            "--corpus-meta".to_owned(),
+            meta.to_string_lossy().into_owned(),
+            "--corpus-recs".to_owned(),
+            records.to_string_lossy().into_owned(),
+            "--out".to_owned(),
+            output.to_string_lossy().into_owned(),
+        ]
+    }
+
     #[test]
     fn parses_parametric_hugging_face_compile() {
         let args = [
@@ -3756,6 +5212,7 @@ mod tests {
         for record in [
             uor_r4_model_source::attention::AttentionOperatorSpec::standard(),
             uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_source_attention(),
         ] {
             let json = serde_json::to_string(&record).expect("record serializes");
             let args = ["--attention-operator".to_owned(), json];
@@ -3768,6 +5225,41 @@ mod tests {
             parse_cover_options(&["--attention-operator".to_owned(), "{not json".to_owned()])
                 .expect_err("malformed record is not a product");
         assert!(error.reason.contains("--attention-operator"));
+
+        let mut altered = AttentionOperatorSpec::standard();
+        altered.output_projection.push_str("-tampered");
+        altered.implementation_digest = altered.declared_digest();
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&altered).expect("serialize altered record"),
+        ])
+        .expect_err("registry-divergent record is not a product");
+        assert!(error.reason.contains("does not match registered"));
+
+        let target = AttentionOperatorSpec::r4_route_attention_v1();
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&target).expect("serialize target record"),
+        ])
+        .expect_err("a deployed target operator is not source provenance");
+        assert!(
+            error
+                .reason
+                .contains("not a source-teacher attention operator")
+        );
+
+        let mut with_extra =
+            serde_json::to_value(AttentionOperatorSpec::standard()).expect("operator JSON");
+        with_extra
+            .as_object_mut()
+            .expect("operator object")
+            .insert("unregistered_claim".to_owned(), serde_json::json!(true));
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&with_extra).expect("serialize extended record"),
+        ])
+        .expect_err("unknown provenance fields are refused");
+        assert!(error.reason.contains("unregistered_claim"));
     }
 
     #[test]
@@ -4127,6 +5619,1444 @@ mod tests {
         assert_eq!(directory_bytes(&output), before);
         assert!(!output.join(TOKENIZER_ADAPTER_FILE).exists());
         let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_sidecar_is_exact_atomic_and_idempotent() {
+        let output = unique_cli_test_path("compile-attention-fresh");
+        let operator = AttentionOperatorSpec::learned_absolute_source_attention();
+        bind_compiled_attention_operator(&output, &operator).expect("fresh operator pin");
+        let sidecar = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let bytes_before = std::fs::read(&sidecar).expect("sidecar bytes");
+        assert_eq!(bytes_before.last(), Some(&b'\n'));
+        assert_eq!(
+            compiled_attention_operator(&output).expect("registry-validated read"),
+            operator
+        );
+        bind_compiled_attention_operator(&output, &operator).expect("idempotent operator pin");
+        assert_eq!(
+            std::fs::read(&sidecar).expect("reread sidecar"),
+            bytes_before
+        );
+        assert!(attention_operator_temp_entries(&output).is_empty());
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_publish_is_concurrent_and_no_clobber() {
+        let output = unique_cli_test_path("compile-attention-concurrent");
+        let operator = AttentionOperatorSpec::standard();
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let output = output.clone();
+            let operator = operator.clone();
+            threads.push(std::thread::spawn(move || {
+                bind_compiled_attention_operator(&output, &operator)
+            }));
+        }
+        for thread in threads {
+            thread
+                .join()
+                .expect("publisher thread")
+                .expect("same operator publisher");
+        }
+        assert_eq!(
+            compiled_attention_operator(&output).expect("published sidecar"),
+            operator
+        );
+        assert!(attention_operator_temp_entries(&output).is_empty());
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_concurrent_conflict_accepts_only_the_exact_winner() {
+        let output = unique_cli_test_path("compile-attention-concurrent-conflict");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+        let mut threads = Vec::new();
+        for index in 0..16 {
+            let output = output.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            let operator = if index % 2 == 0 {
+                AttentionOperatorSpec::standard()
+            } else {
+                AttentionOperatorSpec::experimental_r4()
+            };
+            let requested = operator.clone();
+            threads.push((
+                requested,
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    bind_compiled_attention_operator(&output, &operator)
+                }),
+            ));
+        }
+        let results: Vec<_> = threads
+            .into_iter()
+            .map(|(requested, thread)| (requested, thread.join().expect("publisher thread")))
+            .collect();
+        let winner = compiled_attention_operator(&output).expect("one exact winner");
+        for (requested, result) in results {
+            if requested == winner {
+                result.expect("an exact racing loser accepts the winner");
+            } else {
+                let error = result.expect_err("a different racing loser is refused");
+                assert!(error.reason.contains("pinned to attention operator"));
+            }
+        }
+        assert!(attention_operator_temp_entries(&output).is_empty());
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_uses_unique_temporary_names() {
+        let output = unique_cli_test_path("compile-attention-unique-temp");
+        std::fs::create_dir_all(&output).expect("output directory");
+        let historical_fixed_temp = output.join(format!(".{ATTENTION_OPERATOR_BINDING_FILE}.tmp"));
+        std::fs::write(&historical_fixed_temp, b"do not replace").expect("park fixed temp");
+        bind_compiled_attention_operator(&output, &AttentionOperatorSpec::standard())
+            .expect("unique publisher ignores a parked fixed-name temp");
+        assert_eq!(
+            std::fs::read(&historical_fixed_temp).expect("fixed temp preserved"),
+            b"do not replace"
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_reader_distinguishes_absent_from_present_invalid() {
+        let missing = unique_cli_test_path("compile-attention-missing");
+        let error = compiled_attention_operator(&missing).expect_err("missing binding is explicit");
+        assert!(
+            error
+                .reason
+                .contains("missing teacher attention-operator binding")
+        );
+
+        let malformed = unique_cli_test_path("compile-attention-malformed");
+        std::fs::create_dir_all(&malformed).expect("output directory");
+        std::fs::write(
+            malformed.join(ATTENTION_OPERATOR_BINDING_FILE),
+            b"{not json",
+        )
+        .expect("malformed binding");
+        let error = compiled_attention_operator(&malformed)
+            .expect_err("a malformed present binding is not absence");
+        assert!(
+            error
+                .reason
+                .contains("malformed attention-operator binding")
+        );
+
+        let directory = unique_cli_test_path("compile-attention-directory");
+        std::fs::create_dir_all(directory.join(ATTENTION_OPERATOR_BINDING_FILE))
+            .expect("directory binding");
+        let error = compiled_attention_operator(&directory)
+            .expect_err("a directory binding is not absence");
+        assert!(error.reason.contains("not a regular file"));
+
+        let _ = std::fs::remove_dir_all(malformed);
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_attention_operator_reader_rejects_all_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let output = unique_cli_test_path("compile-attention-symlink");
+        std::fs::create_dir_all(&output).expect("output directory");
+        let target = output.join("operator-target.json");
+        std::fs::write(
+            &target,
+            serde_json::to_vec_pretty(&AttentionOperatorSpec::standard())
+                .expect("serialize target"),
+        )
+        .expect("write target");
+        symlink(&target, output.join(ATTENTION_OPERATOR_BINDING_FILE)).expect("binding symlink");
+        let error = compiled_attention_operator(&output)
+            .expect_err("even a resolving provenance symlink is refused");
+        assert!(error.reason.contains("not a regular file"));
+
+        let dangling = unique_cli_test_path("compile-attention-dangling");
+        std::fs::create_dir_all(&dangling).expect("output directory");
+        symlink(
+            "missing-target",
+            dangling.join(ATTENTION_OPERATOR_BINDING_FILE),
+        )
+        .expect("dangling binding symlink");
+        let error = compiled_attention_operator(&dangling)
+            .expect_err("a dangling provenance symlink is refused");
+        assert!(error.reason.contains("not a regular file"));
+
+        let _ = std::fs::remove_dir_all(output);
+        let _ = std::fs::remove_dir_all(dangling);
+    }
+
+    #[test]
+    fn compile_attention_operator_reader_requires_registry_exactness() {
+        let output = unique_cli_test_path("compile-attention-registry");
+        std::fs::create_dir_all(&output).expect("output directory");
+        let mut altered = AttentionOperatorSpec::standard();
+        altered.output_projection.push_str("-tampered");
+        altered.implementation_digest = altered.declared_digest();
+        std::fs::write(
+            output.join(ATTENTION_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&altered).expect("altered record JSON"),
+        )
+        .expect("write altered binding");
+        let error = compiled_attention_operator(&output)
+            .expect_err("self-consistent but non-registry record is refused");
+        assert!(error.reason.contains("does not match registered"));
+
+        let mut unknown = AttentionOperatorSpec::standard();
+        unknown.version = u32::MAX;
+        unknown.implementation_digest = unknown.declared_digest();
+        std::fs::write(
+            output.join(ATTENTION_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&unknown).expect("unknown record JSON"),
+        )
+        .expect("write unknown binding");
+        let error = compiled_attention_operator(&output)
+            .expect_err("unregistered operator version is refused");
+        assert!(error.reason.contains(&u32::MAX.to_string()));
+        assert!(matches!(
+            error.kind,
+            uor_r4_model_source::SourceIngestKind::UnknownAttentionOperator { version, .. }
+                if version == u32::MAX
+        ));
+
+        std::fs::write(
+            output.join(ATTENTION_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&AttentionOperatorSpec::r4_route_attention_v1())
+                .expect("target record JSON"),
+        )
+        .expect("write target binding");
+        let error = compiled_attention_operator(&output)
+            .expect_err("a deployed target operator is not source provenance");
+        assert!(
+            error
+                .reason
+                .contains("not a source-teacher attention operator")
+        );
+
+        let mut with_extra =
+            serde_json::to_value(AttentionOperatorSpec::standard()).expect("operator JSON");
+        with_extra
+            .as_object_mut()
+            .expect("operator object")
+            .insert("unregistered_claim".to_owned(), serde_json::json!(true));
+        std::fs::write(
+            output.join(ATTENTION_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&with_extra).expect("extended record JSON"),
+        )
+        .expect("write extended binding");
+        let error = compiled_attention_operator(&output)
+            .expect_err("unknown provenance fields are refused");
+        assert!(error.reason.contains("unregistered_claim"));
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_refuses_to_relabel_legacy_corpus_payload() {
+        let output = unique_cli_test_path("compile-attention-legacy-corpus");
+        std::fs::create_dir_all(&output).expect("output directory");
+        std::fs::write(output.join("corpus.records"), b"legacy teacher rows")
+            .expect("legacy corpus payload");
+        let before = directory_bytes(&output);
+        let error = bind_compiled_attention_operator(&output, &AttentionOperatorSpec::standard())
+            .expect_err("an operatorless corpus cannot be relabelled");
+        assert!(error.reason.contains("implicit legacy attention era"));
+        assert_eq!(directory_bytes(&output), before);
+        assert!(!output.join(ATTENTION_OPERATOR_BINDING_FILE).exists());
+        assert!(attention_operator_temp_entries(&output).is_empty());
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_identity_preflights_refuse_zero_byte_unbound_payload_entries() {
+        for payload_name in ["tokenizer.bin", "corpus.meta"] {
+            let output = unique_cli_test_path(&format!(
+                "compile-zero-byte-{}",
+                payload_name.replace('.', "-")
+            ));
+            std::fs::create_dir_all(&output).expect("output directory");
+            std::fs::write(output.join(payload_name), []).expect("zero-byte payload entry");
+            let before = directory_bytes(&output);
+            let tokenizer = fixture_adapter(payload_name);
+            let operator = AttentionOperatorSpec::standard();
+
+            for error in [
+                preflight_compile_tokenizer_adapter(&output, &tokenizer)
+                    .expect_err("zero-byte entry is tokenizer-era evidence"),
+                preflight_compiled_attention_operator(&output, &operator)
+                    .expect_err("zero-byte entry is operator-era evidence"),
+                pin_compile_identities(&output, &tokenizer, &operator)
+                    .expect_err("joint pin cannot relabel a torn output"),
+            ] {
+                assert!(error.reason.contains(payload_name));
+            }
+            assert_eq!(directory_bytes(&output), before);
+            assert!(!output.join(TOKENIZER_ADAPTER_FILE).exists());
+            assert!(!output.join(ATTENTION_OPERATOR_BINDING_FILE).exists());
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn compile_attention_operator_preflight_is_joint_before_either_sidecar_mutates() {
+        let operator_first = unique_cli_test_path("compile-joint-operator-first");
+        bind_compiled_attention_operator(&operator_first, &AttentionOperatorSpec::standard())
+            .expect("initial operator");
+        let operator_before = directory_bytes(&operator_first);
+        let error = pin_compile_identities(
+            &operator_first,
+            &fixture_adapter("fresh-tokenizer"),
+            &AttentionOperatorSpec::experimental_r4(),
+        )
+        .expect_err("operator mismatch rejects before tokenizer publication");
+        assert!(error.reason.contains("is pinned to attention operator"));
+        assert_eq!(directory_bytes(&operator_first), operator_before);
+        assert!(!operator_first.join(TOKENIZER_ADAPTER_FILE).exists());
+
+        let tokenizer_first = unique_cli_test_path("compile-joint-tokenizer-first");
+        let first = fixture_adapter("first-tokenizer");
+        pin_compile_tokenizer_adapter(&tokenizer_first, &first).expect("initial tokenizer");
+        let tokenizer_before = directory_bytes(&tokenizer_first);
+        let error = pin_compile_identities(
+            &tokenizer_first,
+            &fixture_adapter("different-tokenizer"),
+            &AttentionOperatorSpec::standard(),
+        )
+        .expect_err("tokenizer mismatch rejects before operator publication");
+        assert!(error.reason.contains("incompatible compile resume"));
+        assert_eq!(directory_bytes(&tokenizer_first), tokenizer_before);
+        assert!(
+            !tokenizer_first
+                .join(ATTENTION_OPERATOR_BINDING_FILE)
+                .exists()
+        );
+
+        let _ = std::fs::remove_dir_all(operator_first);
+        let _ = std::fs::remove_dir_all(tokenizer_first);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_exact_identity_resume_rejects_payload_symlinks_without_following() {
+        use std::os::unix::fs::symlink;
+
+        for payload_name in [
+            "corpus.records",
+            "corpus.records.hidden",
+            "tokenizer.bin",
+            "tless_artifacts.bin",
+        ] {
+            for resolving in [true, false] {
+                let link_kind = if resolving { "resolving" } else { "dangling" };
+                let output = unique_cli_test_path(&format!(
+                    "compile-exact-{}-{}",
+                    payload_name.replace('.', "-"),
+                    link_kind
+                ));
+                let tokenizer = fixture_adapter(&format!("{payload_name}-{link_kind}"));
+                let operator = AttentionOperatorSpec::standard();
+                pin_compile_identities(&output, &tokenizer, &operator)
+                    .expect("publish exact identity pair");
+                let tokenizer_sidecar = output.join(TOKENIZER_ADAPTER_FILE);
+                let operator_sidecar = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+                let tokenizer_sidecar_before =
+                    std::fs::read(&tokenizer_sidecar).expect("tokenizer sidecar");
+                let operator_sidecar_before =
+                    std::fs::read(&operator_sidecar).expect("operator sidecar");
+
+                let external_target = unique_cli_test_path(&format!(
+                    "compile-external-{}-{}",
+                    payload_name.replace('.', "-"),
+                    link_kind
+                ));
+                let external_bytes = b"external bytes must remain unchanged";
+                if resolving {
+                    std::fs::write(&external_target, external_bytes).expect("external target");
+                }
+                let payload = output.join(payload_name);
+                symlink(&external_target, &payload).expect("payload symlink");
+
+                for error in [
+                    preflight_compile_tokenizer_adapter(&output, &tokenizer)
+                        .expect_err("tokenizer preflight must reject payload symlink"),
+                    preflight_compiled_attention_operator(&output, &operator)
+                        .expect_err("operator preflight must reject payload symlink"),
+                    pin_compile_identities(&output, &tokenizer, &operator)
+                        .expect_err("joint exact resume must reject payload symlink"),
+                ] {
+                    assert!(error.reason.contains("not a regular file"));
+                }
+                assert_eq!(
+                    std::fs::read(&tokenizer_sidecar).expect("tokenizer sidecar"),
+                    tokenizer_sidecar_before
+                );
+                assert_eq!(
+                    std::fs::read(&operator_sidecar).expect("operator sidecar"),
+                    operator_sidecar_before
+                );
+                assert_eq!(
+                    std::fs::read_link(&payload).expect("payload link target"),
+                    external_target
+                );
+                if resolving {
+                    assert_eq!(
+                        std::fs::read(&external_target).expect("external target"),
+                        external_bytes
+                    );
+                    std::fs::remove_file(&external_target).expect("remove external target");
+                } else {
+                    assert!(!external_target.exists());
+                }
+                let _ = std::fs::remove_dir_all(output);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_resume_rejects_symlink_output_root_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let real_root = unique_cli_test_path("compile-real-output-root");
+        let output_link = unique_cli_test_path("compile-output-root-symlink");
+        let tokenizer = fixture_adapter("root-symlink");
+        let operator = AttentionOperatorSpec::standard();
+        pin_compile_identities(&real_root, &tokenizer, &operator)
+            .expect("publish exact identity pair");
+        let external_artifact = real_root.join("tless_artifacts.bin");
+        let sentinel = b"external artifact sentinel must remain unchanged";
+        std::fs::write(&external_artifact, sentinel).expect("external artifact sentinel");
+        let tokenizer_sidecar_before =
+            std::fs::read(real_root.join(TOKENIZER_ADAPTER_FILE)).expect("tokenizer sidecar");
+        let operator_sidecar_before =
+            std::fs::read(real_root.join(ATTENTION_OPERATOR_BINDING_FILE))
+                .expect("operator sidecar");
+        symlink(&real_root, &output_link).expect("output-root symlink");
+
+        for error in [
+            preflight_compile_tokenizer_adapter(&output_link, &tokenizer)
+                .expect_err("tokenizer preflight must reject a symlink output root"),
+            preflight_compiled_attention_operator(&output_link, &operator)
+                .expect_err("operator preflight must reject a symlink output root"),
+            pin_compile_identities(&output_link, &tokenizer, &operator)
+                .expect_err("joint resume must reject a symlink output root"),
+        ] {
+            assert!(error.reason.contains("is not a real directory"));
+        }
+        assert_eq!(
+            std::fs::read(&external_artifact).expect("external artifact sentinel"),
+            sentinel
+        );
+        assert_eq!(
+            std::fs::read(real_root.join(TOKENIZER_ADAPTER_FILE)).expect("tokenizer sidecar"),
+            tokenizer_sidecar_before
+        );
+        assert_eq!(
+            std::fs::read(real_root.join(ATTENTION_OPERATOR_BINDING_FILE))
+                .expect("operator sidecar"),
+            operator_sidecar_before
+        );
+        assert_eq!(
+            std::fs::read_link(&output_link).expect("output-root link target"),
+            real_root
+        );
+
+        std::fs::remove_file(&output_link).expect("remove output-root symlink");
+        let _ = std::fs::remove_dir_all(real_root);
+    }
+
+    #[test]
+    fn source_compile_resume_rejects_malformed_checkpoint_before_any_output_mutation() {
+        let mut too_many_stories = source_resume_meta(0, 0);
+        too_many_stories[8..16].copy_from_slice(&(u64::from(u32::MAX) + 1).to_le_bytes());
+        for (case, meta, expected) in [
+            ("empty", Vec::new(), "expected exactly"),
+            ("truncated", vec![0u8; 24], "expected exactly"),
+            (
+                "invalid-done",
+                source_resume_meta(1, 2),
+                "invalid done byte",
+            ),
+            ("story-overflow", too_many_stories, "exceeding the u32"),
+        ] {
+            let output = unique_cli_test_path(&format!("source-resume-{case}"));
+            let tokenizer = fixture_adapter(case);
+            let operator = AttentionOperatorSpec::standard();
+            pin_compile_identities(&output, &tokenizer, &operator)
+                .expect("publish exact identity pair");
+            std::fs::write(output.join("corpus.meta"), meta).expect("metadata fixture");
+            let records = b"committed record sentinel must remain byte-identical";
+            std::fs::write(output.join("corpus.records"), records).expect("record fixture");
+            let before = directory_bytes(&output);
+
+            let error = preflight_source_compile_resume(&output, Some(16), 2)
+                .expect_err("malformed checkpoint must fail closed");
+            assert!(error.reason.contains(expected), "{}", error.reason);
+            assert_eq!(directory_bytes(&output), before);
+            assert_eq!(
+                std::fs::read(output.join("corpus.records")).expect("record sentinel"),
+                records
+            );
+            let _ = std::fs::remove_dir_all(output);
+        }
+
+        for missing in ["corpus.meta", "corpus.records"] {
+            let output = unique_cli_test_path(&format!(
+                "source-resume-missing-{}",
+                missing.replace('.', "-")
+            ));
+            let tokenizer = fixture_adapter(missing);
+            pin_compile_identities(&output, &tokenizer, &AttentionOperatorSpec::standard())
+                .expect("publish exact identity pair");
+            if missing != "corpus.meta" {
+                std::fs::write(output.join("corpus.meta"), source_resume_meta(1, 0))
+                    .expect("metadata fixture");
+            }
+            if missing != "corpus.records" {
+                std::fs::write(output.join("corpus.records"), vec![7u8; 48])
+                    .expect("records fixture");
+            }
+            let before = directory_bytes(&output);
+            let error = preflight_source_compile_resume(&output, Some(16), 2)
+                .expect_err("one-sided resume must fail closed");
+            assert!(error.reason.contains("one-sided"));
+            assert_eq!(directory_bytes(&output), before);
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn source_compile_resume_reconciles_record_and_hidden_tails_at_actual_oracle_width() {
+        let output = unique_cli_test_path("source-resume-tail-recovery");
+        let tokenizer = fixture_adapter("tail-recovery");
+        pin_compile_identities(&output, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(output.join("corpus.meta"), source_resume_meta(2, 0))
+            .expect("metadata fixture");
+        let mut records = source_v3_record(0, 0).to_vec();
+        records.extend_from_slice(&source_v3_record(0, 1));
+        records.extend_from_slice(b"partial-record-tail");
+        std::fs::write(output.join("corpus.records"), &records).expect("record fixture");
+        // The loaded-oracle seam reports 16 bytes per hidden row here. Two
+        // committed rows plus a partial third model an interrupted story.
+        let mut hidden = vec![5u8; 32];
+        hidden.extend_from_slice(b"partial");
+        std::fs::write(output.join("corpus.records.hidden"), &hidden).expect("hidden fixture");
+
+        let plan = preflight_source_compile_resume(&output, Some(16), 10)
+            .expect("valid crash tails are recoverable");
+        assert_eq!(plan.records_committed_bytes, Some(96));
+        assert_eq!(plan.hidden_committed_bytes, Some(32));
+        reconcile_source_compile_resume(&output, &plan).expect("recover both streams");
+        assert_eq!(
+            std::fs::metadata(output.join("corpus.records"))
+                .expect("records metadata")
+                .len(),
+            96
+        );
+        assert_eq!(
+            std::fs::metadata(output.join("corpus.records.hidden"))
+                .expect("hidden metadata")
+                .len(),
+            32
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn source_compile_resume_never_reinterprets_a_long_legacy_tail_as_v3() {
+        let output = unique_cli_test_path("source-resume-legacy-width-ambiguity");
+        let tokenizer = fixture_adapter("legacy-width-ambiguity");
+        pin_compile_identities(&output, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(output.join("corpus.meta"), source_resume_meta(2, 0))
+            .expect("metadata fixture");
+        let mut legacy = source_v2_record(0).to_vec();
+        legacy.extend_from_slice(&source_v2_record(0));
+        legacy.extend_from_slice(&[0xA5; 40]); // 104 bytes: longer than 2 * 48.
+        std::fs::write(output.join("corpus.records"), &legacy).expect("legacy record fixture");
+        let before = directory_bytes(&output);
+
+        let error = preflight_source_compile_resume(&output, None, 10)
+            .expect_err("a long v2 tail is not evidence of a v3 committed prefix");
+        assert!(error.reason.contains("invalid v3 token span"));
+        assert_eq!(directory_bytes(&output), before);
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("legacy bytes"),
+            legacy
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn source_compile_zero_checkpoint_recovers_only_the_authoritative_empty_prefix() {
+        let output = unique_cli_test_path("source-resume-zero-checkpoint");
+        let tokenizer = fixture_adapter("zero-checkpoint");
+        pin_compile_identities(&output, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(output.join("corpus.meta"), source_resume_meta(0, 0))
+            .expect("zero checkpoint");
+        std::fs::write(
+            output.join("corpus.records"),
+            b"uncommitted bytes before the first story checkpoint",
+        )
+        .expect("uncommitted record tail");
+
+        let plan = preflight_source_compile_resume(&output, None, 10)
+            .expect("n=0 makes every record byte an uncommitted tail");
+        assert_eq!(plan.records_committed_bytes, Some(0));
+        reconcile_source_compile_resume(&output, &plan).expect("truncate empty prefix");
+        assert_eq!(
+            std::fs::metadata(output.join("corpus.records"))
+                .expect("records metadata")
+                .len(),
+            0
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn source_compile_resume_keeps_legacy_missing_hidden_optional_but_refuses_short_present_hidden()
+    {
+        let historical = unique_cli_test_path("source-resume-no-hidden");
+        let tokenizer = fixture_adapter("no-hidden");
+        pin_compile_identities(&historical, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(historical.join("corpus.meta"), source_resume_meta(1, 1))
+            .expect("metadata fixture");
+        std::fs::write(historical.join("corpus.records"), source_v3_record(0, 0))
+            .expect("records fixture");
+        let plan = preflight_source_compile_resume(&historical, Some(16), 1)
+            .expect("completed historical absent hidden stream remains compatible");
+        assert_eq!(plan.hidden_committed_bytes, None);
+
+        let incomplete = unique_cli_test_path("source-resume-no-hidden-incomplete");
+        let tokenizer = fixture_adapter("no-hidden-incomplete");
+        pin_compile_identities(&incomplete, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(incomplete.join("corpus.meta"), source_resume_meta(1, 0))
+            .expect("metadata fixture");
+        std::fs::write(incomplete.join("corpus.records"), source_v3_record(0, 0))
+            .expect("records fixture");
+        let before = directory_bytes(&incomplete);
+        let error = preflight_source_compile_resume(&incomplete, Some(16), 10)
+            .expect_err("resuming would create a partial hidden suffix");
+        assert!(error.reason.contains("already-complete corpus"));
+        assert_eq!(directory_bytes(&incomplete), before);
+
+        let short = unique_cli_test_path("source-resume-short-hidden");
+        let tokenizer = fixture_adapter("short-hidden");
+        pin_compile_identities(&short, &tokenizer, &AttentionOperatorSpec::standard())
+            .expect("publish exact identity pair");
+        std::fs::write(short.join("corpus.meta"), source_resume_meta(1, 0))
+            .expect("metadata fixture");
+        std::fs::write(short.join("corpus.records"), source_v3_record(0, 0))
+            .expect("records fixture");
+        std::fs::write(short.join("corpus.records.hidden"), vec![9u8; 15])
+            .expect("short hidden fixture");
+        let before = directory_bytes(&short);
+        let error = preflight_source_compile_resume(&short, Some(16), 10)
+            .expect_err("short committed hidden prefix is torn");
+        assert!(error.reason.contains("shorter than the 16-byte prefix"));
+        assert_eq!(directory_bytes(&short), before);
+
+        let _ = std::fs::remove_dir_all(historical);
+        let _ = std::fs::remove_dir_all(incomplete);
+        let _ = std::fs::remove_dir_all(short);
+    }
+
+    #[test]
+    fn recorded_compile_refuses_unsupported_source_bundle_leaves_before_mutation() {
+        for case in ["adapter", "table", "hidden", "space-manifest"] {
+            let output = unique_cli_test_path(&format!("recorded-output-stale-{case}"));
+            if case == "adapter" {
+                pin_compile_tokenizer_adapter(&output, &fixture_adapter("stale-recorded"))
+                    .expect("stale adapter fixture");
+            }
+            bind_compiled_attention_operator(&output, &AttentionOperatorSpec::standard())
+                .expect("exact attention binding");
+            if case == "table" {
+                std::fs::write(
+                    output.join("tokenizer.bin"),
+                    b"stale tokenizer table sentinel",
+                )
+                .expect("stale tokenizer table");
+            }
+            if case == "hidden" {
+                std::fs::write(
+                    output.join("corpus.records.hidden"),
+                    b"stale teacher hidden-row sentinel",
+                )
+                .expect("stale hidden stream");
+            }
+            if case == "space-manifest" {
+                std::fs::write(
+                    output.join("space_manifest.json"),
+                    b"stale semantic-space manifest sentinel",
+                )
+                .expect("stale space manifest");
+            }
+            std::fs::write(
+                output.join("tless_artifacts.bin"),
+                b"prior artifact sentinel",
+            )
+            .expect("prior artifact");
+            let before = directory_bytes(&output);
+
+            let error = preflight_recorded_compile_output(&output)
+                .expect_err("recorded compile cannot preserve tokenizer provenance");
+            assert!(
+                error.reason.contains("no tokenizer authority")
+                    || error.reason.contains("cannot verify or reproduce")
+            );
+            assert_eq!(directory_bytes(&output), before);
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn observation_attention_operator_preflight_is_joint_and_rejects_legacy_relabeling() {
+        let operator_conflict = unique_cli_test_path("observe-joint-operator-conflict");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+        write_observation_manifest(&operator_conflict, &manifest);
+        let operator_session =
+            observe::ObservationSession::acquire(&operator_conflict, 1).expect("session");
+        let manifest_path = operator_conflict.join(observe::MANIFEST_FILE);
+        let bytes_before = std::fs::read(&manifest_path).expect("manifest bytes");
+        let error = pin_raw_observation_identities_before_output(
+            &operator_session,
+            Some(&fixture_adapter("would-have-been-published")),
+            None,
+            Some(&AttentionOperatorSpec::experimental_r4()),
+        )
+        .expect_err("operator conflict rejects before tokenizer pin");
+        assert!(error.reason.contains("is pinned to attention operator"));
+        assert_eq!(
+            std::fs::read(&manifest_path).expect("manifest bytes"),
+            bytes_before
+        );
+        assert!(!operator_conflict.join("tokenizer.bin").exists());
+
+        let tokenizer_conflict = unique_cli_test_path("observe-joint-tokenizer-conflict");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.tokenizer_adapter = Some(fixture_adapter("recorded"));
+        write_observation_manifest(&tokenizer_conflict, &manifest);
+        let tokenizer_session =
+            observe::ObservationSession::acquire(&tokenizer_conflict, 1).expect("session");
+        let manifest_path = tokenizer_conflict.join(observe::MANIFEST_FILE);
+        let bytes_before = std::fs::read(&manifest_path).expect("manifest bytes");
+        let error = pin_raw_observation_identities_before_output(
+            &tokenizer_session,
+            Some(&fixture_adapter("requested")),
+            None,
+            Some(&AttentionOperatorSpec::standard()),
+        )
+        .expect_err("tokenizer conflict rejects before operator pin");
+        assert!(error.reason.contains("pinned to tokenizer adapter"));
+        assert_eq!(
+            std::fs::read(&manifest_path).expect("manifest bytes"),
+            bytes_before
+        );
+
+        let legacy = unique_cli_test_path("observe-attention-legacy-payload");
+        let manifest = observe::ObservationManifest::new(1);
+        write_observation_manifest(&legacy, &manifest);
+        std::fs::write(legacy.join(observe::STATE_FILE), b"legacy state").expect("legacy payload");
+        let legacy_session = observe::ObservationSession::acquire(&legacy, 1).expect("session");
+        let before = directory_bytes(&legacy);
+        let error = pin_raw_observation_identities_before_output(
+            &legacy_session,
+            None,
+            None,
+            Some(&AttentionOperatorSpec::standard()),
+        )
+        .expect_err("operatorless legacy rows cannot be relabelled");
+        assert!(error.reason.contains("refusing to relabel legacy rows"));
+        assert_eq!(directory_bytes(&legacy), before);
+
+        drop(operator_session);
+        drop(tokenizer_session);
+        drop(legacy_session);
+        let _ = std::fs::remove_dir_all(operator_conflict);
+        let _ = std::fs::remove_dir_all(tokenizer_conflict);
+        let _ = std::fs::remove_dir_all(legacy);
+    }
+
+    #[test]
+    fn raw_observation_geometry_conflict_is_refused_before_tokenizer_export() {
+        let output = unique_cli_test_path("observe-raw-geometry-preflight");
+        let adapter = fixture_adapter("raw-geometry");
+        let operator = AttentionOperatorSpec::standard();
+        let recorded_geometry =
+            uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+        let requested_geometry =
+            uor_r4_model_source::geometry::GeometryProjection::bucket_average(768, 288);
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.tokenizer_adapter = Some(adapter.clone());
+        manifest.attention_operator = Some(operator.clone());
+        manifest.geometry = Some(recorded_geometry);
+        write_observation_manifest(&output, &manifest);
+        std::fs::write(output.join("tokenizer.bin"), b"existing tokenizer sentinel")
+            .expect("tokenizer sentinel");
+        let session = observe::ObservationSession::acquire(&output, 1).expect("session");
+        let before = directory_bytes(&output);
+
+        let error = pin_raw_observation_identities_before_output(
+            &session,
+            Some(&adapter),
+            Some(&requested_geometry),
+            Some(&operator),
+        )
+        .expect_err("geometry conflict must precede tokenizer export");
+        assert!(
+            error.reason.contains("pinned to geometry"),
+            "{}",
+            error.reason
+        );
+        assert_eq!(directory_bytes(&output), before);
+        drop(session);
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn text_observation_input_and_geometry_conflicts_precede_serial_and_batched_export() {
+        let output = unique_cli_test_path("observe-text-full-preflight");
+        let input = unique_cli_test_path("observe-text-input-a.jsonl");
+        let other_input = unique_cli_test_path("observe-text-input-b.jsonl");
+        std::fs::write(
+            &input,
+            b"{\"id\":\"a\",\"url\":\"https://example/a\",\"title\":\"A\",\"text\":\"first corpus\"}\n",
+        )
+        .expect("first input");
+        std::fs::write(
+            &other_input,
+            b"{\"id\":\"b\",\"url\":\"https://example/b\",\"title\":\"B\",\"text\":\"different corpus\"}\n",
+        )
+        .expect("second input");
+        let adapter = fixture_adapter("text-preflight");
+        let operator = AttentionOperatorSpec::standard();
+        let recorded_geometry =
+            uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+        let requested_geometry =
+            uor_r4_model_source::geometry::GeometryProjection::bucket_average(768, 288);
+        let session = observe::ObservationSession::acquire(&output, 1).expect("session");
+        pin_text_observation_identities_before_output(
+            &session,
+            &input,
+            Some(&adapter),
+            Some(&recorded_geometry),
+            Some(&operator),
+        )
+        .expect("pin complete text identity bundle");
+        std::fs::write(output.join("tokenizer.bin"), b"existing tokenizer sentinel")
+            .expect("tokenizer sentinel");
+
+        let before_geometry = directory_bytes(&output);
+        let error = pin_text_observation_identities_before_output(
+            &session,
+            &input,
+            Some(&adapter),
+            Some(&requested_geometry),
+            Some(&operator),
+        )
+        .expect_err("serial/batched geometry conflict must precede tokenizer export");
+        assert!(
+            error.reason.contains("pinned to geometry"),
+            "{}",
+            error.reason
+        );
+        assert_eq!(directory_bytes(&output), before_geometry);
+
+        let before_input = directory_bytes(&output);
+        let error = pin_text_observation_identities_before_output(
+            &session,
+            &other_input,
+            Some(&adapter),
+            Some(&recorded_geometry),
+            Some(&operator),
+        )
+        .expect_err("serial/batched input conflict must precede tokenizer export");
+        assert!(error.reason.contains("different input CID"));
+        assert_eq!(directory_bytes(&output), before_input);
+
+        drop(session);
+        let _ = std::fs::remove_dir_all(output);
+        let _ = std::fs::remove_file(input);
+        let _ = std::fs::remove_file(other_input);
+    }
+
+    #[test]
+    fn observation_session_serializes_cross_field_identity_pin_and_rows() {
+        let output = unique_cli_test_path("observe-cross-field-session");
+        let winner_output = output.clone();
+        let (winner_ready_tx, winner_ready_rx) = std::sync::mpsc::channel();
+        let (release_winner_tx, release_winner_rx) = std::sync::mpsc::channel();
+        let winner = std::thread::spawn(move || -> Result<(), String> {
+            let session = observe::ObservationSession::acquire(&winner_output, 1)
+                .map_err(|error| error.reason)?;
+            pin_raw_observation_identities_before_output(
+                &session,
+                None,
+                None,
+                Some(&AttentionOperatorSpec::standard()),
+            )
+            .map_err(|error| error.reason)?;
+            let mut writer = session.writer().map_err(|error| error.reason)?;
+            writer
+                .write_record(&[0u8; observe::RECORD_SIZE], 0)
+                .map_err(|error| error.reason)?;
+            drop(writer);
+            winner_ready_tx
+                .send(())
+                .map_err(|error| error.to_string())?;
+            release_winner_rx
+                .recv()
+                .map_err(|error| error.to_string())?;
+            drop(session);
+            Ok(())
+        });
+        winner_ready_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("winner pins and writes while retaining its session");
+
+        let loser_output = output.clone();
+        let loser_adapter = fixture_adapter("cross-field-loser");
+        let (loser_attempt_tx, loser_attempt_rx) = std::sync::mpsc::channel();
+        let loser = std::thread::spawn(move || -> Result<SourceUnavailable, String> {
+            loser_attempt_tx
+                .send(())
+                .map_err(|error| error.to_string())?;
+            let session = observe::ObservationSession::acquire(&loser_output, 1)
+                .map_err(|error| error.reason)?;
+            let result = pin_raw_observation_identities_before_output(
+                &session,
+                Some(&loser_adapter),
+                None,
+                Some(&AttentionOperatorSpec::experimental_r4()),
+            );
+            drop(session);
+            match result {
+                Ok(()) => Err("incompatible loser unexpectedly pinned identities".to_owned()),
+                Err(error) => Ok(error),
+            }
+        });
+        loser_attempt_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("loser attempts the same session");
+        release_winner_tx.send(()).expect("release winner session");
+        winner
+            .join()
+            .expect("winner thread")
+            .expect("winner session");
+        let loser_error = loser
+            .join()
+            .expect("loser thread")
+            .expect("loser is refused after serialized acquisition");
+        assert!(loser_error.reason.contains("pinned to attention operator"));
+
+        let manifest = read_optional_observation_manifest(&output)
+            .expect("manifest read")
+            .expect("manifest present");
+        assert_eq!(manifest.tokenizer_adapter, None);
+        assert_eq!(
+            manifest.attention_operator,
+            Some(AttentionOperatorSpec::standard())
+        );
+        assert!(!output.join("tokenizer.bin").exists());
+        assert_eq!(
+            std::fs::metadata(output.join(observe::shard_file_name(1, 0)))
+                .expect("winner shard")
+                .len(),
+            observe::RECORD_SIZE as u64
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn observation_preflight_detects_payload_beyond_declared_shard_fanout() {
+        for (case, payload_name) in [
+            ("shard", "shard-99.bin"),
+            ("probability", "shard-99.bin.prob"),
+            ("trace", "shard-99.bin.trace"),
+        ] {
+            let output = unique_cli_test_path(&format!("observe-out-of-fanout-{case}"));
+            let manifest = observe::ObservationManifest::new(1); // only shards 00 and 01
+            write_observation_manifest(&output, &manifest);
+            std::fs::write(output.join(payload_name), b"legacy out-of-fanout payload")
+                .expect("out-of-fanout payload");
+            let before_acquire = directory_bytes(&output);
+            match observe::ObservationSession::acquire(&output, 1) {
+                Ok(session) => {
+                    let before = directory_bytes(&output);
+                    let error = pin_raw_observation_identities_before_output(
+                        &session,
+                        None,
+                        None,
+                        Some(&AttentionOperatorSpec::standard()),
+                    )
+                    .expect_err("out-of-fanout payload cannot be relabelled");
+                    assert!(error.reason.contains("refusing to relabel legacy rows"));
+                    assert_eq!(directory_bytes(&output), before);
+                    drop(session);
+                }
+                Err(error) => {
+                    assert!(error.reason.contains("outside the manifest"));
+                    assert_eq!(directory_bytes(&output), before_acquire);
+                }
+            }
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn observation_preflight_treats_zero_byte_payload_entries_as_era_evidence() {
+        for (case, payload_name) in [("state", observe::STATE_FILE), ("shard", "shard-99.bin")] {
+            let output = unique_cli_test_path(&format!("observe-zero-byte-{case}"));
+            write_observation_manifest(&output, &observe::ObservationManifest::new(1));
+            std::fs::write(output.join(payload_name), []).expect("zero-byte payload entry");
+            let before_acquire = directory_bytes(&output);
+            match observe::ObservationSession::acquire(&output, 1) {
+                Ok(session) => {
+                    let before = directory_bytes(&output);
+                    let error = pin_raw_observation_identities_before_output(
+                        &session,
+                        None,
+                        None,
+                        Some(&AttentionOperatorSpec::standard()),
+                    )
+                    .expect_err("zero-byte payload cannot be relabelled to the current operator");
+                    assert!(error.reason.contains("refusing to relabel legacy rows"));
+                    assert_eq!(directory_bytes(&output), before);
+                    drop(session);
+                }
+                Err(error) => {
+                    assert!(
+                        error.reason.contains("outside the manifest")
+                            || error.reason.contains("state")
+                    );
+                    assert_eq!(directory_bytes(&output), before_acquire);
+                }
+            }
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn observation_matching_identity_preflight_rejects_payload_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        for (case, payload_name) in [
+            ("shard", "shard-00.bin"),
+            ("probability", "shard-00.bin.prob"),
+            ("trace", "shard-00.bin.trace"),
+        ] {
+            let output = unique_cli_test_path(&format!("observe-matching-symlink-{case}"));
+            let mut manifest = observe::ObservationManifest::new(1);
+            manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+            write_observation_manifest(&output, &manifest);
+            let manifest_path = output.join(observe::MANIFEST_FILE);
+            let manifest_before = std::fs::read(&manifest_path).expect("manifest bytes");
+            let target = output.join(format!("{case}-payload-target"));
+            std::fs::write(&target, b"payload target").expect("payload target");
+            symlink(&target, output.join(payload_name)).expect("payload symlink");
+
+            let error = preflight_observation_identities(
+                &output,
+                1,
+                None,
+                Some(&AttentionOperatorSpec::standard()),
+            )
+            .expect_err("matching identities must not bypass payload inventory");
+            assert!(error.reason.contains("not a regular file"));
+            assert_eq!(
+                std::fs::read(&manifest_path).expect("manifest bytes"),
+                manifest_before
+            );
+            assert!(
+                std::fs::symlink_metadata(output.join(payload_name))
+                    .expect("payload metadata")
+                    .file_type()
+                    .is_symlink()
+            );
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn recorded_corpus_attention_operator_reads_both_sources_and_rejects_conflicts() {
+        let sidecar_root = unique_cli_test_path("recorded-attention-sidecar");
+        let sidecar_operator = AttentionOperatorSpec::learned_absolute_source_attention();
+        bind_compiled_attention_operator(&sidecar_root, &sidecar_operator)
+            .expect("sidecar binding");
+        let (meta, records) = corpus_markers(&sidecar_root);
+        assert_eq!(
+            recorded_corpus_attention_operator(&meta, &records).expect("resolve sidecar operator"),
+            Some(sidecar_operator)
+        );
+
+        let manifest_root = unique_cli_test_path("recorded-attention-manifest");
+        let manifest_operator = AttentionOperatorSpec::standard();
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(manifest_operator.clone());
+        write_observation_manifest(&manifest_root, &manifest);
+        let (meta, records) = observation_corpus_markers(&manifest_root);
+        assert_eq!(
+            recorded_corpus_attention_operator(&meta, &records).expect("resolve manifest operator"),
+            Some(manifest_operator)
+        );
+
+        let conflict_root = unique_cli_test_path("recorded-attention-conflict");
+        bind_compiled_attention_operator(&conflict_root, &AttentionOperatorSpec::standard())
+            .expect("sidecar binding");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::experimental_r4());
+        write_observation_manifest(&conflict_root, &manifest);
+        let (meta, records) = corpus_markers(&conflict_root);
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("two provenance sources must agree exactly");
+        assert!(
+            error
+                .reason
+                .contains("declare different attention operators")
+        );
+
+        let operatorless_manifest_root =
+            unique_cli_test_path("recorded-attention-operatorless-manifest-conflict");
+        bind_compiled_attention_operator(
+            &operatorless_manifest_root,
+            &AttentionOperatorSpec::standard(),
+        )
+        .expect("sidecar binding");
+        write_observation_manifest(
+            &operatorless_manifest_root,
+            &observe::ObservationManifest::new(1),
+        );
+        let (meta, records) = observation_corpus_markers(&operatorless_manifest_root);
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("a present operatorless manifest conflicts with a sidecar");
+        assert!(error.reason.contains("legacy operatorless era"));
+
+        let legacy_root = unique_cli_test_path("recorded-attention-legacy");
+        let (meta, records) = corpus_markers(&legacy_root);
+        assert_eq!(
+            recorded_corpus_attention_operator(&meta, &records).expect("legacy absence"),
+            None
+        );
+
+        let _ = std::fs::remove_dir_all(sidecar_root);
+        let _ = std::fs::remove_dir_all(manifest_root);
+        let _ = std::fs::remove_dir_all(conflict_root);
+        let _ = std::fs::remove_dir_all(operatorless_manifest_root);
+        let _ = std::fs::remove_dir_all(legacy_root);
+    }
+
+    #[test]
+    fn recorded_corpus_attention_operator_custom_names_require_legacy_absence() {
+        let legacy_root = unique_cli_test_path("recorded-attention-custom-legacy");
+        std::fs::create_dir_all(&legacy_root).expect("legacy directory");
+        let legacy_meta = legacy_root.join("c_meta.bin");
+        let legacy_records = legacy_root.join("c_recs.bin");
+        std::fs::write(&legacy_meta, b"legacy metadata").expect("legacy metadata");
+        std::fs::write(&legacy_records, b"legacy records").expect("legacy records");
+        assert_eq!(
+            recorded_corpus_attention_operator(&legacy_meta, &legacy_records)
+                .expect("custom legacy pair remains compatible"),
+            None
+        );
+
+        let sidecar_root = unique_cli_test_path("recorded-attention-custom-sidecar");
+        bind_compiled_attention_operator(&sidecar_root, &AttentionOperatorSpec::standard())
+            .expect("sidecar binding");
+        let (canonical_meta, canonical_records) = corpus_markers(&sidecar_root);
+        let alternate_meta = sidecar_root.join("second.meta");
+        let alternate_records = sidecar_root.join("second.records");
+        std::fs::write(&alternate_meta, b"alternate metadata").expect("alternate metadata");
+        std::fs::write(&alternate_records, b"alternate records").expect("alternate records");
+        assert_eq!(
+            recorded_corpus_attention_operator(&canonical_meta, &canonical_records)
+                .expect("canonical pair inherits sidecar"),
+            Some(AttentionOperatorSpec::standard())
+        );
+        let error = recorded_corpus_attention_operator(&alternate_meta, &alternate_records)
+            .expect_err("a sibling pair cannot inherit the canonical pair's sidecar");
+        assert!(error.reason.contains("applies only to the canonical"));
+
+        let manifest_root = unique_cli_test_path("recorded-attention-custom-manifest");
+        write_observation_manifest(&manifest_root, &observe::ObservationManifest::new(1));
+        let alternate_meta = manifest_root.join("second.meta");
+        let alternate_records = manifest_root.join("second.records");
+        std::fs::write(&alternate_meta, b"alternate metadata").expect("alternate metadata");
+        std::fs::write(&alternate_records, b"alternate records").expect("alternate records");
+        let error = recorded_corpus_attention_operator(&alternate_meta, &alternate_records)
+            .expect_err("even an operatorless manifest belongs only to a canonical pair");
+        assert!(error.reason.contains("applies only to the canonical"));
+
+        let _ = std::fs::remove_dir_all(legacy_root);
+        let _ = std::fs::remove_dir_all(sidecar_root);
+        let _ = std::fs::remove_dir_all(manifest_root);
+    }
+
+    #[test]
+    fn recorded_corpus_attention_operator_rejects_malformed_manifest_and_mixed_roots() {
+        let malformed = unique_cli_test_path("recorded-attention-malformed");
+        bind_compiled_attention_operator(&malformed, &AttentionOperatorSpec::standard())
+            .expect("valid sidecar");
+        std::fs::write(malformed.join(observe::MANIFEST_FILE), b"{not json")
+            .expect("malformed manifest");
+        let (meta, records) = corpus_markers(&malformed);
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("a present invalid manifest is not absence");
+        assert!(error.reason.contains("malformed observation manifest"));
+
+        let extended = unique_cli_test_path("recorded-attention-extended-manifest");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+        let mut manifest_json = serde_json::to_value(&manifest).expect("manifest JSON");
+        manifest_json
+            .get_mut("attention_operator")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("operator object")
+            .insert("unregistered_claim".to_owned(), serde_json::json!(true));
+        std::fs::create_dir_all(&extended).expect("extended manifest directory");
+        std::fs::write(
+            extended.join(observe::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest_json).expect("extended manifest JSON"),
+        )
+        .expect("extended manifest");
+        let (meta, records) = corpus_markers(&extended);
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("unknown nested operator claims are refused");
+        assert!(error.reason.contains("unregistered_claim"));
+
+        let meta_root = unique_cli_test_path("recorded-attention-meta-root");
+        let records_root = unique_cli_test_path("recorded-attention-records-root");
+        let (meta, _) = corpus_markers(&meta_root);
+        let (_, records) = corpus_markers(&records_root);
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("mixed corpus roots cannot inherit provenance");
+        assert!(error.reason.contains("different canonical parent roots"));
+
+        let _ = std::fs::remove_dir_all(malformed);
+        let _ = std::fs::remove_dir_all(extended);
+        let _ = std::fs::remove_dir_all(meta_root);
+        let _ = std::fs::remove_dir_all(records_root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recorded_corpus_attention_operator_rejects_corpus_symlink_inputs() {
+        use std::os::unix::fs::symlink;
+
+        for symlinked_entry in ["corpus.meta", "corpus.records"] {
+            let root = unique_cli_test_path(&format!(
+                "recorded-attention-{}-symlink",
+                symlinked_entry.replace('.', "-")
+            ));
+            std::fs::create_dir_all(&root).expect("corpus directory");
+            let meta = root.join("corpus.meta");
+            let records = root.join("corpus.records");
+            let target = root.join(format!("{symlinked_entry}-target"));
+            std::fs::write(&target, b"corpus target").expect("corpus target");
+            if symlinked_entry == "corpus.meta" {
+                symlink(&target, &meta).expect("metadata symlink");
+                std::fs::write(&records, b"records marker").expect("records marker");
+            } else {
+                std::fs::write(&meta, b"metadata marker").expect("metadata marker");
+                symlink(&target, &records).expect("records symlink");
+            }
+
+            let error = recorded_corpus_attention_operator(&meta, &records)
+                .expect_err("corpus symlinks cannot inherit directory provenance");
+            assert!(error.reason.contains("not a regular non-symlink file"));
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recorded_corpus_attention_operator_rejects_manifest_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_cli_test_path("recorded-attention-manifest-symlink");
+        let (meta, records) = corpus_markers(&root);
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+        let target = root.join("manifest-target.json");
+        std::fs::write(
+            &target,
+            serde_json::to_vec_pretty(&manifest).expect("manifest JSON"),
+        )
+        .expect("manifest target");
+        symlink(&target, root.join(observe::MANIFEST_FILE)).expect("manifest symlink");
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("a present manifest symlink is not legacy absence");
+        assert!(error.reason.contains("not a regular file"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn copy_recorded_attention_uses_registry_resolver_and_preserves_true_legacy_absence() {
+        let source = unique_cli_test_path("copy-recorded-attention-source");
+        let operator = AttentionOperatorSpec::learned_absolute_source_attention();
+        bind_compiled_attention_operator(&source, &operator).expect("source binding");
+        let (meta, records) = corpus_markers(&source);
+        let destination = unique_cli_test_path("copy-recorded-attention-destination")
+            .join(ATTENTION_OPERATOR_BINDING_FILE);
+        copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
+            .expect("copy exact source provenance");
+        assert_eq!(
+            compiled_attention_operator(destination.parent().expect("destination parent"))
+                .expect("copied binding"),
+            operator
+        );
+
+        let legacy = unique_cli_test_path("copy-recorded-attention-legacy");
+        let (legacy_meta, legacy_records) = corpus_markers(&legacy);
+        let absent_destination = unique_cli_test_path("copy-recorded-attention-legacy-destination")
+            .join(ATTENTION_OPERATOR_BINDING_FILE);
+        copy_recorded_attention(&copy_recorded_attention_args(
+            &legacy_meta,
+            &legacy_records,
+            &absent_destination,
+        ))
+        .expect("true legacy absence is a no-op");
+        assert!(!absent_destination.exists());
+
+        let stale_parent = unique_cli_test_path("copy-recorded-attention-stale-legacy");
+        std::fs::create_dir_all(&stale_parent).expect("stale destination parent");
+        let stale_destination = stale_parent.join(ATTENTION_OPERATOR_BINDING_FILE);
+        std::fs::write(&stale_destination, b"stale binding").expect("stale destination");
+        let stale_before = std::fs::read(&stale_destination).expect("stale bytes");
+        let error = copy_recorded_attention(&copy_recorded_attention_args(
+            &legacy_meta,
+            &legacy_records,
+            &stale_destination,
+        ))
+        .expect_err("legacy absence cannot retain a stale destination");
+        assert!(
+            error
+                .reason
+                .contains("has no attention-operator provenance")
+        );
+        assert_eq!(
+            std::fs::read(&stale_destination).expect("stale bytes"),
+            stale_before
+        );
+
+        let _ = std::fs::remove_dir_all(source);
+        if let Some(parent) = destination.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+        let _ = std::fs::remove_dir_all(legacy);
+        let _ = std::fs::remove_dir_all(stale_parent);
+    }
+
+    #[test]
+    fn copy_recorded_attention_rejects_malformed_full_manifest_and_custom_pair() {
+        let malformed = unique_cli_test_path("copy-recorded-attention-malformed-manifest");
+        let (meta, records) = observation_corpus_markers(&malformed);
+        let partial_manifest = serde_json::json!({
+            "attention_operator": AttentionOperatorSpec::standard()
+        });
+        std::fs::write(
+            malformed.join(observe::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&partial_manifest).expect("partial manifest JSON"),
+        )
+        .expect("partial manifest");
+        let destination = unique_cli_test_path("copy-recorded-attention-malformed-destination")
+            .join(ATTENTION_OPERATOR_BINDING_FILE);
+        let error =
+            copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
+                .expect_err("partial observation manifest cannot be laundered");
+        assert!(error.reason.contains("manifest"));
+        assert!(!destination.exists());
+
+        let custom = unique_cli_test_path("copy-recorded-attention-custom-pair");
+        bind_compiled_attention_operator(&custom, &AttentionOperatorSpec::standard())
+            .expect("source binding");
+        let custom_meta = custom.join("other.meta");
+        let custom_records = custom.join("other.records");
+        std::fs::write(&custom_meta, b"custom metadata").expect("custom metadata");
+        std::fs::write(&custom_records, b"custom records").expect("custom records");
+        let error = copy_recorded_attention(&copy_recorded_attention_args(
+            &custom_meta,
+            &custom_records,
+            &destination,
+        ))
+        .expect_err("custom pair cannot inherit sibling provenance");
+        assert!(error.reason.contains("applies only to the canonical"));
+        assert!(!destination.exists());
+
+        let _ = std::fs::remove_dir_all(malformed);
+        let _ = std::fs::remove_dir_all(custom);
+    }
+
+    #[test]
+    fn recorded_resolver_and_copy_reject_invalid_non_attention_manifest_identity() {
+        let source = unique_cli_test_path("copy-recorded-attention-invalid-geometry");
+        let (meta, records) = observation_corpus_markers(&source);
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+        let mut geometry =
+            uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+        geometry.implementation_digest = format!("blake3:{}", "0".repeat(64));
+        manifest.geometry = Some(geometry);
+        write_observation_manifest(&source, &manifest);
+        let destination = unique_cli_test_path("copy-recorded-attention-invalid-geometry-dest")
+            .join(ATTENTION_OPERATOR_BINDING_FILE);
+
+        let error = recorded_corpus_attention_operator(&meta, &records)
+            .expect_err("forged geometry invalidates the full manifest");
+        assert!(error.reason.contains("geometry projection"));
+        let error =
+            copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
+                .expect_err("copy cannot launder a forged non-attention identity");
+        assert!(error.reason.contains("geometry projection"));
+        assert!(!destination.exists());
+
+        let _ = std::fs::remove_dir_all(source);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_recorded_attention_rejects_destination_symlink_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let source = unique_cli_test_path("copy-recorded-attention-symlink-source");
+        bind_compiled_attention_operator(&source, &AttentionOperatorSpec::standard())
+            .expect("source binding");
+        let (meta, records) = corpus_markers(&source);
+        let destination_parent =
+            unique_cli_test_path("copy-recorded-attention-symlink-destination");
+        std::fs::create_dir_all(&destination_parent).expect("destination parent");
+        let destination = destination_parent.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let sentinel = unique_cli_test_path("copy-recorded-attention-symlink-sentinel");
+        let sentinel_bytes = b"external sentinel must remain unchanged";
+        std::fs::write(&sentinel, sentinel_bytes).expect("sentinel");
+        symlink(&sentinel, &destination).expect("destination symlink");
+
+        let error =
+            copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
+                .expect_err("destination symlink must be refused");
+        assert!(error.reason.contains("not a regular file"));
+        assert_eq!(std::fs::read(&sentinel).expect("sentinel"), sentinel_bytes);
+        assert!(
+            std::fs::symlink_metadata(&destination)
+                .expect("destination link")
+                .file_type()
+                .is_symlink()
+        );
+
+        let _ = std::fs::remove_dir_all(source);
+        let _ = std::fs::remove_dir_all(destination_parent);
+        let _ = std::fs::remove_file(sentinel);
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -144,7 +144,10 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
                 options.geometry = Some(serde_json::from_str(value).ok()?);
             }
             "--attention-operator" => {
-                options.attention_operator = Some(serde_json::from_str(value).ok()?);
+                let operator: uor_r4_model_source::attention::AttentionOperatorSpec =
+                    serde_json::from_str(value).ok()?;
+                observation::validate_registered_source_attention_operator(&operator).ok()?;
+                options.attention_operator = Some(operator);
             }
             _ => return None,
         }
@@ -511,7 +514,7 @@ fn preflight_recorded_tokenizer_identity(
 /// registered output refuses an adapterless legacy request, while
 /// [`ObservationShardWriter::set_tokenizer_adapter`] refuses to relabel an
 /// adapterless payload and validates the full registered identity.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 fn preflight_observation_tokenizer(
     output: &std::path::Path,
     shard_bits: u8,
@@ -535,7 +538,7 @@ fn preflight_observation_tokenizer(
 /// Read-only resume check for the other source identities this command owns.
 /// A different explicitly requested value is an incompatible observation era;
 /// an omitted optional value preserves a recorded value for legacy callers.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 fn preflight_observation_metadata(
     output: &std::path::Path,
     shard_bits: u8,
@@ -544,63 +547,145 @@ fn preflight_observation_metadata(
     attention_operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
     trace_profile: Option<&trace_profile::TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
-    let Some(recorded) = observation::ObservationManifest::load(output)? else {
-        return Ok(());
-    };
-    if recorded.shard_bits != shard_bits {
+    let existing = observation::ObservationManifest::load(output)?;
+    if let Some(recorded) = existing.as_ref()
+        && recorded.shard_bits != shard_bits
+    {
         return Err(SourceUnavailable::new(format!(
             "manifest shard_bits {} does not match requested {shard_bits}",
             recorded.shard_bits
         )));
     }
-    if let (Some(recorded), Some(requested)) = (
+    let recorded = existing.unwrap_or_else(|| observation::ObservationManifest::new(shard_bits));
+    preflight_observation_metadata_for_manifest(
+        output,
+        &recorded,
+        source_manifest_kappa,
+        geometry,
+        attention_operator,
+        trace_profile,
+    )
+}
+
+/// Joint read-only identity check against a manifest already reloaded under an
+/// [`observation::ObservationSession`] lock.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn preflight_observation_metadata_for_manifest(
+    output: &std::path::Path,
+    recorded: &observation::ObservationManifest,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
+    attention_operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+    trace_profile: Option<&trace_profile::TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    let payload_present =
+        observation::observation_payload_present(output, recorded, "observation-identity")?;
+    if let Some(operator) = recorded.attention_operator.as_ref() {
+        observation::validate_registered_source_attention_operator(operator)?;
+    }
+    if let Some(operator) = attention_operator {
+        observation::validate_registered_source_attention_operator(operator)?;
+    }
+    match (
         recorded.source_manifest_kappa.as_deref(),
         source_manifest_kappa,
-    ) && recorded != requested
-    {
-        return Err(SourceUnavailable::new(format!(
-            "{} is pinned to source manifest κ {recorded}; requested {requested}; incompatible observation resume refused before mutation",
-            output.display()
-        )));
+    ) {
+        (Some(existing), Some(requested)) if existing == requested => {}
+        (Some(existing), Some(requested)) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to source manifest κ {existing}; requested {requested}; incompatible observation resume refused before mutation",
+                output.display()
+            )));
+        }
+        (Some(existing), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to source manifest κ {existing}; requested none; incompatible observation resume refused before mutation",
+                output.display()
+            )));
+        }
+        (None, Some(requested)) if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has payload but no source manifest κ; refusing to relabel it as {requested} before mutation",
+                output.display()
+            )));
+        }
+        _ => {}
     }
-    if let (Some(recorded), Some(requested)) = (recorded.geometry.as_ref(), geometry)
-        && recorded != requested
-    {
-        return Err(SourceUnavailable::new(format!(
-            "{} is pinned to geometry {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
-            output.display(),
-            recorded.id,
-            recorded.version,
-            recorded.declared_digest(),
-            requested.id,
-            requested.version,
-            requested.declared_digest(),
-        )));
+    if let Some(recorded) = recorded.geometry.as_ref() {
+        observation::validate_registered_geometry_projection(recorded)?;
     }
-    if let (Some(recorded), Some(requested)) =
-        (recorded.attention_operator.as_ref(), attention_operator)
-        && recorded != requested
-    {
-        return Err(SourceUnavailable::new(format!(
-            "{} is pinned to attention operator {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
-            output.display(),
-            recorded.id,
-            recorded.version,
-            recorded.declared_digest(),
-            requested.id,
-            requested.version,
-            requested.declared_digest(),
-        )));
+    if let Some(requested) = geometry {
+        observation::validate_registered_geometry_projection(requested)?;
     }
-    let state_exists = match std::fs::symlink_metadata(output.join(observation::STATE_FILE)) {
-        Ok(_) => true,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => return Err(SourceUnavailable::from(error)),
-    };
+    match (recorded.geometry.as_ref(), geometry) {
+        (Some(existing), Some(requested)) if existing == requested => {}
+        (Some(existing), Some(requested)) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to geometry {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version,
+                existing.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        (Some(existing), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to geometry {}/{}; requested pass-through/none; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version
+            )));
+        }
+        (None, Some(requested)) if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has payload but no geometry; refusing to relabel it as {}/{} before mutation",
+                output.display(),
+                requested.id,
+                requested.version
+            )));
+        }
+        _ => {}
+    }
+    match (recorded.attention_operator.as_ref(), attention_operator) {
+        (Some(existing), Some(requested)) if existing != requested => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to attention operator {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version,
+                existing.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        (Some(existing), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to attention operator {}/{} digest {}; the requested producer declares none; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version,
+                existing.declared_digest(),
+            )));
+        }
+        (None, Some(requested)) if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has no recorded attention operator but already contains observation payload from the implicit legacy era; refusing to relabel those bytes as {}/{} digest {} before mutation",
+                output.display(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        _ => {}
+    }
     match (recorded.trace_profile.as_ref(), trace_profile) {
         (None, None) => {}
         (Some(recorded), Some(requested)) if recorded == requested => {}
-        (None, Some(requested)) if state_exists || !recorded.completed.is_empty() => {
+        (None, Some(requested)) if payload_present => {
             return Err(SourceUnavailable::new(format!(
                 "{} was captured under the minimal trace profile; profile {}/{} cannot be introduced mid-corpus; incompatible observation resume refused before mutation",
                 output.display(),
@@ -633,7 +718,7 @@ fn preflight_observation_metadata(
 
 /// Check all already-recorded identities without writing, then make the
 /// tokenizer pin the first mutation of a compatible run.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(clippy::too_many_arguments)]
 fn preflight_observation_identities(
     output: &std::path::Path,
@@ -732,31 +817,31 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
     // loads and preserves the stored fields).
     let geometry = oracle.geometry_projection();
     let attention_operator = oracle.attention_operator_spec();
-    preflight_observation_identities(
-        &options.output,
-        options.shards,
+    let session = observation::ObservationSession::acquire(&options.output, options.shards)?;
+    let tokenizer_adapter = registered_tokenizer
+        .as_ref()
+        .map(|resolved| &resolved.adapter);
+    observation::preflight_observation_identities_in_session(
+        &session,
         options.source_manifest_kappa.as_deref(),
         geometry.as_ref(),
+        tokenizer_adapter,
         attention_operator.as_ref(),
         requested_trace_profile.as_ref(),
-        registered_tokenizer
-            .as_ref()
-            .map(|resolved| &resolved.adapter),
     )?;
-    if options.source_manifest_kappa.is_some() || geometry.is_some() || attention_operator.is_some()
-    {
-        let mut writer =
-            observation::ObservationShardWriter::open(&options.output, options.shards)?;
-        if let Some(kappa) = &options.source_manifest_kappa {
-            writer.set_source_manifest_kappa(kappa)?;
-        }
-        if let Some(geometry) = &geometry {
-            writer.set_geometry(geometry)?;
-        }
-        if let Some(operator) = &attention_operator {
-            writer.set_attention_operator(operator)?;
-        }
-    }
+    observation::preflight_observation_trace_layout_in_session(
+        &session,
+        &*oracle,
+        requested_trace_profile.as_ref(),
+    )?;
+    observation::pin_observation_identities_in_session(
+        &session,
+        options.source_manifest_kappa.as_deref(),
+        geometry.as_ref(),
+        tokenizer_adapter,
+        attention_operator.as_ref(),
+        requested_trace_profile.as_ref(),
+    )?;
 
     // Export only after every recorded source/geometry/attention/tokenizer
     // identity has passed and its setter has completed. The same resolved
@@ -776,22 +861,20 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
     // minimal profile: exactly today's observation bytes.
     match &requested_trace_profile {
         None => {
-            observation::observe_sharded(
+            observation::observe_sharded_in_session(
+                &session,
                 &mut *oracle,
                 options.seconds,
                 options.target,
-                options.shards,
-                &options.output,
                 token_byte_lengths.as_deref(),
             )?;
         }
         Some(profile) => {
-            observation::observe_sharded_traced(
+            observation::observe_sharded_traced_in_session(
+                &session,
                 &mut *oracle,
                 options.seconds,
                 options.target,
-                options.shards,
-                &options.output,
                 token_byte_lengths.as_deref(),
                 profile,
             )?;
@@ -963,6 +1046,68 @@ mod tokenizer_observe_tests {
     }
 
     #[test]
+    fn graph_compile_attention_flag_accepts_only_exact_registry_records() {
+        let standard = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
+        let valid_json = serde_json::to_string(&standard).expect("serialize standard operator");
+        let valid =
+            parse_options(&["--attention-operator", valid_json.as_str()].map(str::to_owned))
+                .expect("exact registry record parses");
+        assert_eq!(valid.attention_operator.as_ref(), Some(&standard));
+        for source in [
+            uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_source_attention(),
+        ] {
+            let json = serde_json::to_string(&source).expect("serialize source operator");
+            let parsed = parse_options(
+                &["--attention-operator", json.as_str()].map(str::to_owned),
+            )
+            .expect("every registered source operator parses");
+            assert_eq!(parsed.attention_operator.as_ref(), Some(&source));
+        }
+
+        let mut tampered = standard.clone();
+        tampered.value_aggregation = "tampered-value-fold".to_owned();
+        let tampered_json = serde_json::to_string(&tampered).expect("serialize tampered record");
+        assert!(
+            parse_options(&["--attention-operator", tampered_json.as_str()].map(str::to_owned))
+                .is_none()
+        );
+
+        let mut unknown = standard;
+        unknown.version = 999;
+        unknown.implementation_digest = unknown.declared_digest();
+        let unknown_json = serde_json::to_string(&unknown).expect("serialize unknown record");
+        assert!(
+            parse_options(&["--attention-operator", unknown_json.as_str()].map(str::to_owned))
+                .is_none()
+        );
+
+        let target = uor_r4_model_source::attention::AttentionOperatorSpec::r4_route_attention_v1();
+        let target_json = serde_json::to_string(&target).expect("serialize target record");
+        assert!(
+            parse_options(&["--attention-operator", target_json.as_str()].map(str::to_owned))
+                .is_none(),
+            "a deployed target operator is not source-teacher provenance"
+        );
+
+        let mut extra_claim: serde_json::Value =
+            serde_json::from_str(&valid_json).expect("parse canonical JSON");
+        extra_claim
+            .as_object_mut()
+            .expect("operator object")
+            .insert(
+                "unregistered_claim".to_owned(),
+                serde_json::Value::Bool(true),
+            );
+        let extra_json = extra_claim.to_string();
+        assert!(
+            parse_options(&["--attention-operator", extra_json.as_str()].map(str::to_owned))
+                .is_none(),
+            "unknown attention claims must fail closed"
+        );
+    }
+
+    #[test]
     fn observe_parser_requires_an_atomic_registered_key_and_rejects_legacy_mix() {
         let valid = parse_observe_options(
             &[
@@ -1075,8 +1220,12 @@ mod tokenizer_observe_tests {
         {
             let mut writer =
                 observation::ObservationShardWriter::open(&output, 2).expect("open pinned writer");
+            let source_kappa = format!(
+                "blake3:{}",
+                blake3::hash(b"original-source-manifest").to_hex()
+            );
             writer
-                .set_source_manifest_kappa("blake3:original")
+                .set_source_manifest_kappa(&source_kappa)
                 .expect("write unrelated provenance");
         }
         std::fs::write(output.join("sentinel.bin"), b"preserve me")
@@ -1152,6 +1301,30 @@ mod tokenizer_observe_tests {
         );
         assert_eq!(directory_bytes(&legacy_output), legacy_before);
 
+        let attention = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
+        let geometry = uor_r4_model_source::geometry::GeometryProjection::bucket_average(576, 288);
+        let requested_source_kappa =
+            format!("blake3:{}", blake3::hash(b"must-not-be-recorded").to_hex());
+        let operator_error = preflight_observation_identities(
+            &legacy_output,
+            2,
+            Some(&requested_source_kappa),
+            Some(&geometry),
+            Some(&attention),
+            None,
+            None,
+        )
+        .expect_err("operatorless payload cannot acquire current identities");
+        assert!(
+            operator_error.reason.contains("no source manifest"),
+            "{operator_error}"
+        );
+        assert_eq!(
+            directory_bytes(&legacy_output),
+            legacy_before,
+            "attention refusal mutated stripped legacy output"
+        );
+
         let _ = std::fs::remove_dir_all(first_source);
         let _ = std::fs::remove_dir_all(second_source);
         let _ = std::fs::remove_dir_all(output);
@@ -1214,6 +1387,22 @@ mod tokenizer_observe_tests {
                 && error.reason.contains("incompatible observation resume")
                 && error.reason.contains("before mutation"),
             "{error}"
+        );
+        assert_eq!(directory_bytes(&output), before);
+
+        let undeclared_error = preflight_observation_identities(
+            &output,
+            2,
+            None,
+            Some(&recorded_geometry),
+            None,
+            Some(&trace),
+            Some(&resolved.adapter),
+        )
+        .expect_err("operatorless producer must not resume explicit output");
+        assert!(
+            undeclared_error.reason.contains("declares none"),
+            "{undeclared_error}"
         );
         assert_eq!(directory_bytes(&output), before);
 

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -20,8 +20,11 @@
 //! `state.bin` checkpoints the deterministic teacher stream at whole-story
 //! boundaries (same 25-byte layout as the corpus meta), and
 //! `manifest.json` records which shards are complete with their content κ.
-//! A rerun skips completed shards and regenerates only missing/incomplete
-//! ones, continuing the stream from the checkpoint.
+//! A rerun skips completed shards and continues incomplete shards after
+//! validating record/sidecar alignment. The raw 25-byte checkpoint does not
+//! carry per-shard committed lengths, so an aligned mid-story tail cannot be
+//! distinguished from committed rows and raw resume is not an exactly-once
+//! recovery claim. The text driver has a separate per-shard checkpoint.
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::trace_profile::SUPPORT_ABSENT_MARKER;
@@ -35,6 +38,8 @@ use std::io::{self, BufWriter, Read, Write};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use uor_r4_core::transformerless::compiler;
 use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
 #[cfg(not(target_arch = "wasm32"))]
@@ -44,7 +49,11 @@ use uor_r4_model_source::SourceUnavailable;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::attention::AttentionOperatorSpec;
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::attention::operator_spec;
 use uor_r4_model_source::geometry::GeometryProjection;
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::geometry::projection_implementation;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::progress::Progress;
 #[cfg(not(target_arch = "wasm32"))]
@@ -123,8 +132,75 @@ pub const MAX_SHARD_BITS: u8 = 8;
 /// Manifest file name within an observation directory.
 pub const MANIFEST_FILE: &str = "manifest.json";
 
+/// Permanent, empty coordination inode used only for an OS-backed exclusive
+/// writer lock. It is not observation payload and is never removed as a lease,
+/// so process death releases the lock without leaving a stale-lock state.
+#[cfg(not(target_arch = "wasm32"))]
+const OBSERVATION_SESSION_LOCK_PREFIX: &str = ".uor-r4-observation-session-";
+
+#[cfg(not(target_arch = "wasm32"))]
+const OBSERVATION_PAYLOAD_FILES: [&str; 7] = [
+    STATE_FILE,
+    "merged.bin",
+    "committed.bin",
+    ".committed.bin.tmp",
+    "stories.jsonl",
+    "stories.tmp",
+    "tokenizer.bin",
+];
+
+#[cfg(not(target_arch = "wasm32"))]
+static MANIFEST_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Generator checkpoint file name within an observation directory.
 pub const STATE_FILE: &str = "state.bin";
+
+#[cfg(not(target_arch = "wasm32"))]
+type ObservationState = (u64, u64, u64, u8);
+
+#[cfg(not(target_arch = "wasm32"))]
+fn read_observation_state(dir: &Path) -> Result<Option<ObservationState>, SourceUnavailable> {
+    let path = dir.join(STATE_FILE);
+    match fs::symlink_metadata(&path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            return Err(invalid_input(format!(
+                "observation checkpoint {} is not a regular file",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+    }
+    let bytes = fs::read(&path)?;
+    if bytes.len() != 25 {
+        return Err(invalid_data(format!(
+            "observation checkpoint {} has {} bytes, expected exactly 25",
+            path.display(),
+            bytes.len()
+        )));
+    }
+    let done = bytes[24];
+    if done > 1 {
+        return Err(invalid_data(format!(
+            "observation checkpoint {} has invalid done byte {done}; expected 0 or 1",
+            path.display()
+        )));
+    }
+    let stories = u64::from_le_bytes(bytes[8..16].try_into().expect("8-byte slice"));
+    if stories > u32::MAX as u64 {
+        return Err(invalid_data(format!(
+            "observation checkpoint {} records {stories} stories, outside the u32 story wire domain",
+            path.display()
+        )));
+    }
+    Ok(Some((
+        u64::from_le_bytes(bytes[0..8].try_into().expect("8-byte slice")),
+        stories,
+        u64::from_le_bytes(bytes[16..24].try_into().expect("8-byte slice")),
+        done,
+    )))
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 fn is_canonical_blake3_address(value: &str) -> bool {
@@ -133,6 +209,136 @@ fn is_canonical_blake3_address(value: &str) -> bool {
         && value["blake3:".len()..]
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Validate that an attention provenance record is exactly one immutable
+/// entry from the source-operator registry. Naming a registered `(id,
+/// version)` is insufficient: every declared field and the implementation
+/// digest must agree with the registry's canonical record.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn validate_registered_source_attention_operator(
+    operator: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    let registered = operator_spec(&operator.id, operator.version)?;
+    if registered != *operator {
+        return Err(invalid_input(format!(
+            "attention operator {}/{} diverges from its immutable registry record; refusing provenance before mutation",
+            operator.id, operator.version
+        )));
+    }
+    let is_source_operator = operator.id == AttentionOperatorSpec::STANDARD_ID
+        || operator.id == AttentionOperatorSpec::EXPERIMENTAL_R4_ID
+        || operator.id == AttentionOperatorSpec::LEARNED_ABSOLUTE_ID;
+    if !is_source_operator {
+        return Err(invalid_input(format!(
+            "registered attention operator {}/{} is not an allowed source teacher operator; refusing source provenance before mutation",
+            operator.id, operator.version
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_registered_tokenizer_adapter(
+    adapter: &TokenizerAdapter,
+) -> Result<(), SourceUnavailable> {
+    adapter_constructor(&adapter.family, adapter.version)?;
+    for (field, value) in [
+        ("tokenizer_cid", adapter.tokenizer_cid.as_str()),
+        ("adapter_digest", adapter.adapter_digest.as_str()),
+    ] {
+        if !is_canonical_blake3_address(value) {
+            return Err(invalid_input(format!(
+                "tokenizer adapter {}/{} has non-canonical {field} {value}; expected lowercase blake3:<64 hex>; refusing provenance before mutation",
+                adapter.family, adapter.version,
+            )));
+        }
+    }
+    let declared_digest = adapter.declared_digest();
+    if adapter.adapter_digest != declared_digest {
+        return Err(invalid_input(format!(
+            "tokenizer adapter {}/{} claims digest {}, but its canonical fields declare {}; refusing inconsistent provenance before mutation",
+            adapter.family, adapter.version, adapter.adapter_digest, declared_digest,
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn validate_registered_geometry_projection(
+    geometry: &GeometryProjection,
+) -> Result<(), SourceUnavailable> {
+    projection_implementation(&geometry.id, geometry.version)?;
+    let registered =
+        GeometryProjection::bucket_average(geometry.source_width, geometry.compiled_width);
+    if registered != *geometry
+        || geometry.compiled_width == 0
+        || geometry.source_width < geometry.compiled_width
+    {
+        return Err(invalid_input(format!(
+            "geometry projection {}/{} diverges from its immutable registry record for {} -> {}; refusing provenance before mutation",
+            geometry.id, geometry.version, geometry.source_width, geometry.compiled_width
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_registered_trace_profile(profile: &TraceProfile) -> Result<(), SourceUnavailable> {
+    let layer_indices = profile
+        .layer_lane
+        .as_ref()
+        .map(|lane| lane.layer_indices.clone())
+        .or_else(|| {
+            profile
+                .qkv_lane
+                .as_ref()
+                .map(|lane| lane.layer_indices.clone())
+        })
+        .or_else(|| {
+            profile
+                .attention_support_lane
+                .as_ref()
+                .map(|lane| lane.layer_indices.clone())
+        })
+        .unwrap_or_default();
+    let support_size = profile
+        .attention_support_lane
+        .as_ref()
+        .map_or(crate::trace_profile::PRIMARY_TOP_K, |lane| {
+            lane.support_size
+        });
+    let registered = crate::trace_profile::profile_spec(
+        &profile.id,
+        profile.version,
+        &crate::trace_profile::TraceCaptureBounds {
+            layer_indices,
+            support_size,
+        },
+    )?;
+    if registered != *profile || profile.is_minimal() {
+        return Err(invalid_input(format!(
+            "trace profile {}/{} diverges from its immutable non-minimal registry record; refusing provenance before mutation",
+            profile.id, profile.version
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_registered_trace_request(profile: &TraceProfile) -> Result<(), SourceUnavailable> {
+    if profile.is_minimal() {
+        if *profile == TraceProfile::minimal() {
+            Ok(())
+        } else {
+            Err(invalid_input(format!(
+                "trace profile {}/{} diverges from the immutable minimal registry record; refusing provenance before mutation",
+                profile.id, profile.version
+            )))
+        }
+    } else {
+        validate_registered_trace_profile(profile)
+    }
 }
 
 /// Content address of one observation sample: blake3 over the
@@ -214,6 +420,7 @@ pub enum RecordPartition {
 
 /// Per-partition record counts of one shard.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PartitionCounts {
     pub construction: u64,
     pub held_out: u64,
@@ -236,6 +443,7 @@ impl PartitionCounts {
 
 /// One completed shard's entry in the observation manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ShardEntry {
     /// Number of observation records in the shard file.
     pub records: u64,
@@ -262,6 +470,7 @@ pub struct ShardEntry {
 /// shards with their content κ, and the total record count across
 /// completed shards.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ObservationManifest {
     pub schema: u32,
     pub shard_bits: u8,
@@ -423,30 +632,544 @@ impl ObservationManifest {
         1u32 << self.shard_bits.min(31)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn validate_loaded_semantics(&self) -> Result<(), SourceUnavailable> {
+        if self.schema != 1 {
+            return Err(invalid_data(format!(
+                "unsupported observation manifest schema {}; expected 1",
+                self.schema
+            )));
+        }
+        if self.shard_bits > MAX_SHARD_BITS {
+            return Err(invalid_data(format!(
+                "observation manifest shard_bits {} exceeds the maximum {MAX_SHARD_BITS}",
+                self.shard_bits
+            )));
+        }
+        if self.trace_profile.is_none() && self.trace_row_bytes.is_some() {
+            return Err(invalid_data(
+                "observation manifest records a trace row width without a trace profile".to_owned(),
+            ));
+        }
+        if self.trace_row_bytes == Some(0) {
+            return Err(invalid_data(
+                "observation manifest records a zero-byte trace row width".to_owned(),
+            ));
+        }
+        if let Some(kappa) = self.source_manifest_kappa.as_deref()
+            && !is_canonical_blake3_address(kappa)
+        {
+            return Err(invalid_data(format!(
+                "observation manifest has non-canonical source manifest κ {kappa}; expected lowercase blake3:<64 hex>"
+            )));
+        }
+        if let Some(cid) = self.input_cid.as_deref()
+            && !is_canonical_blake3_address(cid)
+        {
+            return Err(invalid_data(format!(
+                "observation manifest has non-canonical input CID {cid}; expected lowercase blake3:<64 hex>"
+            )));
+        }
+
+        let shard_count = self.shard_count();
+        let mut total_records = 0u64;
+        for (&shard, entry) in &self.completed {
+            if shard >= shard_count {
+                return Err(invalid_data(format!(
+                    "observation manifest completes shard {shard}, outside its {shard_count}-shard fan-out"
+                )));
+            }
+            for (field, value) in [
+                ("kappa", Some(entry.kappa.as_str())),
+                ("probability_kappa", entry.probability_kappa.as_deref()),
+                ("trace_kappa", entry.trace_kappa.as_deref()),
+            ] {
+                if let Some(value) = value
+                    && !is_canonical_blake3_address(value)
+                {
+                    return Err(invalid_data(format!(
+                        "observation manifest shard {shard} has non-canonical {field} {value}; expected lowercase blake3:<64 hex>"
+                    )));
+                }
+            }
+            if entry.trace_kappa.is_some() && self.trace_profile.is_none() {
+                return Err(invalid_data(format!(
+                    "observation manifest shard {shard} records a trace sidecar without a trace profile"
+                )));
+            }
+            if entry.trace_kappa.is_some() && self.trace_row_bytes.is_none() {
+                return Err(invalid_data(format!(
+                    "observation manifest shard {shard} records a trace sidecar without a trace row width"
+                )));
+            }
+            if let Some(partitions) = entry.partitions {
+                let partition_records = partitions
+                    .construction
+                    .checked_add(partitions.held_out)
+                    .ok_or_else(|| {
+                        invalid_data(format!(
+                            "observation manifest shard {shard} partition counts overflow"
+                        ))
+                    })?;
+                if partition_records != entry.records {
+                    return Err(invalid_data(format!(
+                        "observation manifest shard {shard} partition counts total {partition_records}, but the shard records {}",
+                        entry.records
+                    )));
+                }
+            }
+            total_records = total_records.checked_add(entry.records).ok_or_else(|| {
+                invalid_data("observation manifest completed record count overflows u64".to_owned())
+            })?;
+        }
+        if total_records != self.total_records {
+            return Err(invalid_data(format!(
+                "observation manifest total_records {} does not match completed shard total {total_records}",
+                self.total_records
+            )));
+        }
+        Ok(())
+    }
+
     /// Load the manifest of an observation directory, if present.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(dir: &Path) -> Result<Option<Self>, SourceUnavailable> {
-        match fs::read(dir.join(MANIFEST_FILE)) {
-            Ok(bytes) => serde_json::from_slice(&bytes)
-                .map(Some)
-                .map_err(|error| invalid_data(format!("invalid observation manifest: {error}"))),
+        let path = dir.join(MANIFEST_FILE);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if !metadata.file_type().is_file() => Err(invalid_data(format!(
+                "observation manifest {} is not a regular file; symlinks and non-file entries are refused",
+                path.display()
+            ))),
+            Ok(_) => fs::read(&path)
+                .map_err(SourceUnavailable::from)
+                .and_then(|bytes| {
+                    let manifest: Self = serde_json::from_slice(&bytes).map_err(|error| {
+                        invalid_data(format!("invalid observation manifest: {error}"))
+                    })?;
+                    manifest.validate_loaded_semantics()?;
+                    validate_canonical_shard_payload_names(dir, &manifest)?;
+                    validate_completed_payloads(dir, &manifest)?;
+                    if manifest.trace_profile.is_some()
+                        && manifest.trace_row_bytes.is_none()
+                        && (regular_file_present(&dir.join(STATE_FILE), "trace-layout")?
+                            || observation_shard_payload_present(dir)?)
+                    {
+                        return Err(invalid_data(format!(
+                            "observation manifest records a trace profile but no trace row width despite existing raw stream payload in {}",
+                            dir.display()
+                        )));
+                    }
+                    if let Some(geometry) = manifest.geometry.as_ref() {
+                        validate_registered_geometry_projection(geometry)?;
+                    }
+                    if let Some(adapter) = manifest.tokenizer_adapter.as_ref() {
+                        validate_registered_tokenizer_adapter(adapter)?;
+                    }
+                    if let Some(operator) = manifest.attention_operator.as_ref() {
+                        validate_registered_source_attention_operator(operator)?;
+                    }
+                    if let Some(profile) = manifest.trace_profile.as_ref() {
+                        validate_registered_trace_profile(profile)?;
+                    }
+                    Ok(Some(manifest))
+                }),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(error) => Err(error.into()),
         }
     }
 
-    /// Persist the manifest atomically (write-then-rename). Shard files
-    /// are always flushed before this runs, so a crash loses at most the
-    /// manifest update; the affected shard is then regenerated on the
-    /// next run.
+    /// Persist the manifest atomically (write-then-rename). Shard files are
+    /// flushed before completed entries are published. A lost manifest update
+    /// leaves that shard incomplete; resume validates and appends its existing
+    /// aligned bytes. See the raw checkpoint limitation in the module docs.
     #[cfg(not(target_arch = "wasm32"))]
     fn store(&self, dir: &Path) -> Result<(), SourceUnavailable> {
         let bytes = serde_json::to_vec_pretty(self)
             .map_err(|error| invalid_data(format!("manifest serialization: {error}")))?;
-        let tmp = dir.join(".manifest.json.tmp");
-        fs::write(&tmp, bytes)?;
-        fs::rename(&tmp, dir.join(MANIFEST_FILE))?;
+        let destination = dir.join(MANIFEST_FILE);
+        match fs::symlink_metadata(&destination) {
+            Ok(metadata) if !metadata.file_type().is_file() => {
+                return Err(invalid_input(format!(
+                    "observation manifest {} is not a regular file; refusing atomic replacement",
+                    destination.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+
+        // Each publisher owns a create_new temporary. It never opens or
+        // removes a caller-planted path, and concurrent publishers cannot
+        // clobber one another's bytes before the final atomic rename.
+        for _ in 0..64 {
+            let sequence =
+                MANIFEST_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let tmp = dir.join(format!(
+                ".manifest.json.tmp-{}-{sequence}",
+                std::process::id()
+            ));
+            let mut file = match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error.into()),
+            };
+            let write_result = file.write_all(&bytes).and_then(|()| file.sync_all());
+            drop(file);
+            if let Err(error) = write_result {
+                let _ = fs::remove_file(&tmp);
+                return Err(error.into());
+            }
+            if let Err(error) = fs::rename(&tmp, &destination) {
+                let _ = fs::remove_file(&tmp);
+                return Err(error.into());
+            }
+            return Ok(());
+        }
+        Err(invalid_input(format!(
+            "could not reserve a unique observation-manifest temporary in {}",
+            dir.display()
+        )))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_base_shard_payload_name(name: &str) -> bool {
+    name.strip_prefix("shard-")
+        .and_then(|rest| rest.strip_suffix(".bin"))
+        .is_some_and(|index| !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_shard_payload_name(name: &str) -> bool {
+    let base = name
+        .strip_suffix(".prob")
+        .or_else(|| name.strip_suffix(".trace"))
+        .unwrap_or(name);
+    is_base_shard_payload_name(base)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_canonical_shard_payload_names(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<(), SourceUnavailable> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !is_shard_payload_name(name) {
+            continue;
+        }
+        let (base, suffix) = if let Some(base) = name.strip_suffix(".prob") {
+            (base, ".prob")
+        } else if let Some(base) = name.strip_suffix(".trace") {
+            (base, ".trace")
+        } else {
+            (name, "")
+        };
+        let shard = base
+            .strip_prefix("shard-")
+            .and_then(|rest| rest.strip_suffix(".bin"))
+            .and_then(|index| index.parse::<u32>().ok())
+            .ok_or_else(|| invalid_data(format!("invalid observation shard name {name}")))?;
+        if shard >= manifest.shard_count() {
+            return Err(invalid_data(format!(
+                "observation payload {name} is outside the manifest's {}-shard fan-out",
+                manifest.shard_count()
+            )));
+        }
+        let canonical = format!("{}{suffix}", shard_file_name(manifest.shard_bits, shard));
+        if name != canonical {
+            return Err(invalid_data(format!(
+                "observation payload {name} is a non-canonical numeric alias of {canonical}; refusing ambiguous shard bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_completed_payloads(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<(), SourceUnavailable> {
+    let validate_file = |path: &Path,
+                         expected_bytes: u64,
+                         expected_kappa: &str|
+     -> Result<(), SourceUnavailable> {
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            Ok(_) => {
+                return Err(invalid_data(format!(
+                    "completed observation payload {} is not a regular file",
+                    path.display()
+                )));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Err(invalid_data(format!(
+                    "completed observation payload {} is missing",
+                    path.display()
+                )));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if metadata.len() != expected_bytes {
+            return Err(invalid_data(format!(
+                "completed observation payload {} has {} bytes, but its manifest commits {expected_bytes}",
+                path.display(),
+                metadata.len()
+            )));
+        }
+        let actual_kappa = file_kappa(path)?;
+        if actual_kappa != expected_kappa {
+            return Err(invalid_data(format!(
+                "completed observation payload {} has κ {actual_kappa}, but its manifest commits {expected_kappa}",
+                path.display()
+            )));
+        }
         Ok(())
+    };
+
+    for (&shard, entry) in &manifest.completed {
+        let base_name = shard_file_name(manifest.shard_bits, shard);
+        let base_path = dir.join(&base_name);
+        let base_bytes = entry
+            .records
+            .checked_mul(RECORD_SIZE as u64)
+            .ok_or_else(|| {
+                invalid_data(format!("completed shard {shard} byte length overflows"))
+            })?;
+        validate_file(&base_path, base_bytes, &entry.kappa)?;
+
+        let probability_path = dir.join(format!("{base_name}.prob"));
+        match entry.probability_kappa.as_deref() {
+            Some(kappa) => {
+                let bytes = entry
+                    .records
+                    .checked_mul(PROBABILITY_METADATA_SIZE as u64)
+                    .ok_or_else(|| {
+                        invalid_data(format!(
+                            "completed shard {shard} probability length overflows"
+                        ))
+                    })?;
+                validate_file(&probability_path, bytes, kappa)?;
+            }
+            None if regular_file_present(&probability_path, "completed-shard")? => {
+                return Err(invalid_data(format!(
+                    "completed shard {shard} has an uncommitted probability sidecar"
+                )));
+            }
+            None => {}
+        }
+
+        let trace_path = dir.join(format!("{base_name}.trace"));
+        match entry.trace_kappa.as_deref() {
+            Some(kappa) => {
+                let row_bytes = manifest.trace_row_bytes.ok_or_else(|| {
+                    invalid_data(format!(
+                        "completed traced shard {shard} has no trace row width"
+                    ))
+                })?;
+                let bytes = entry.records.checked_mul(row_bytes).ok_or_else(|| {
+                    invalid_data(format!("completed shard {shard} trace length overflows"))
+                })?;
+                validate_file(&trace_path, bytes, kappa)?;
+            }
+            None if regular_file_present(&trace_path, "completed-shard")? => {
+                return Err(invalid_data(format!(
+                    "completed shard {shard} has an uncommitted trace sidecar"
+                )));
+            }
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_observation_payload_name(name: &str) -> bool {
+    OBSERVATION_PAYLOAD_FILES.contains(&name)
+        || is_manifest_temp_name(name)
+        || name.starts_with("stories.tmp-")
+        || is_shard_payload_name(name)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_manifest_temp_name(name: &str) -> bool {
+    name == ".manifest.json.tmp" || name.starts_with(".manifest.json.tmp-")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn regular_file_present(path: &Path, provenance: &str) -> Result<bool, SourceUnavailable> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+        Ok(_) => Err(invalid_input(format!(
+            "observation payload path {} is not a regular file; refusing {provenance} provenance mutation",
+            path.display()
+        ))),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Validate every entry that a writer may later open, truncate, append, or
+/// atomically replace. This metadata-only pass runs before the coordination
+/// inode can be created so a static symlink/nonregular refusal leaves the
+/// observation directory byte-identical; it is repeated under the lock before
+/// any payload bytes are trusted.
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_observation_entry_types(dir: &Path) -> Result<(), SourceUnavailable> {
+    let manifest_path = dir.join(MANIFEST_FILE);
+    match fs::symlink_metadata(&manifest_path) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(invalid_input(format!(
+                "observation manifest {} is not a regular file; symlinks and non-file entries are refused",
+                manifest_path.display()
+            )));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    match fs::read_dir(dir) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry?;
+                let name = entry.file_name();
+                if name.to_str().is_some_and(is_observation_payload_name) {
+                    let _ = regular_file_present(&entry.path(), "observation")?;
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+/// Discard unpublished manifest-store residue while the caller holds the
+/// observation session lock. A temp file alone cannot establish an arithmetic
+/// era: `store` publishes only at rename, before any row write can proceed.
+/// Zero/truncated bytes are therefore safe crash residue; only a nonregular
+/// entry fails closed so recovery never follows or removes a symlink target.
+#[cfg(not(target_arch = "wasm32"))]
+fn recover_manifest_temp_residue(dir: &Path) -> Result<(), SourceUnavailable> {
+    let mut temporaries = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if !name.to_str().is_some_and(is_manifest_temp_name) {
+            continue;
+        }
+        let path = entry.path();
+        if !fs::symlink_metadata(&path)?.file_type().is_file() {
+            return Err(invalid_input(format!(
+                "observation manifest temporary {} is not a regular file; refusing recovery",
+                path.display()
+            )));
+        }
+        temporaries.push(path);
+    }
+    temporaries.sort();
+    for path in temporaries {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn prepare_observation_root(dir: &Path) -> Result<(), SourceUnavailable> {
+    match fs::symlink_metadata(dir) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => {
+            return Err(invalid_input(format!(
+                "observation output root {} is not a directory; symlink and non-directory roots are refused",
+                dir.display()
+            )));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::create_dir_all(dir)?,
+        Err(error) => return Err(error.into()),
+    }
+    match fs::symlink_metadata(dir) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(invalid_input(format!(
+            "observation output root {} ceased to be a directory",
+            dir.display()
+        ))),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Acquire the process-crash-safe, full-session writer lock. The permanent
+/// empty file is coordination metadata rather than a create/delete lease: the
+/// OS releases its exclusive lock when the `File` guard is dropped, including
+/// after process death, so no stale-lock recovery protocol is needed.
+#[cfg(not(target_arch = "wasm32"))]
+fn acquire_observation_session_lock(dir: &Path) -> Result<fs::File, SourceUnavailable> {
+    // Keep coordination outside the observation directory so even the first
+    // refused resume leaves that directory byte-identical. Hash the canonical
+    // output path so aliases contend on one permanent sibling inode without
+    // exposing arbitrary path bytes in its file name.
+    let canonical = fs::canonicalize(dir)?;
+    let parent = canonical.parent().ok_or_else(|| {
+        invalid_input(format!(
+            "observation output {} has no parent for its coordination lock",
+            canonical.display()
+        ))
+    })?;
+    let digest = blake3::hash(canonical.to_string_lossy().as_bytes());
+    let path = parent.join(format!(
+        "{OBSERVATION_SESSION_LOCK_PREFIX}{}.lock",
+        digest.to_hex()
+    ));
+    let file = loop {
+        match fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => break file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                match fs::symlink_metadata(&path) {
+                    Ok(metadata) if metadata.file_type().is_file() => {}
+                    Ok(_) => {
+                        return Err(invalid_input(format!(
+                            "observation session lock {} is not a regular file; symlinks and non-file entries are refused",
+                            path.display()
+                        )));
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error.into()),
+                }
+                let file = fs::OpenOptions::new().read(true).write(true).open(&path)?;
+                if !file.metadata()?.file_type().is_file() {
+                    return Err(invalid_input(format!(
+                        "observation session lock {} is not a regular file",
+                        path.display()
+                    )));
+                }
+                break file;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    };
+    file.lock()?;
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(file),
+        Ok(_) => Err(invalid_input(format!(
+            "observation session lock {} ceased to be a regular file while acquiring it",
+            path.display()
+        ))),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -454,6 +1177,493 @@ impl ObservationManifest {
 /// mirroring the `.prob` probability sidecar naming.
 pub fn trace_sidecar_name(shard_bits: u8, shard: u32) -> String {
     format!("{}.trace", shard_file_name(shard_bits, shard))
+}
+
+/// Whether an observation directory already contains payload or resumable
+/// state whose tokenizer and attention eras are fixed. This inventory is the
+/// single fail-closed source used by both provenance setters and by their
+/// read-only entry-point preflights.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observation_payload_present(
+    dir: &Path,
+    manifest: &ObservationManifest,
+    provenance: &str,
+) -> Result<bool, SourceUnavailable> {
+    let manifest_has_payload = manifest.total_records != 0 || !manifest.completed.is_empty();
+    let mut files_have_payload = false;
+    // Shards are not the only tokenizer/attention-era evidence. The raw
+    // driver checkpoints its token stream in state.bin; the text driver
+    // additionally checkpoints article progress and story identity; the CLI
+    // can persist a merged record stream and the exact runtime token table in
+    // the same directory. A stripped/torn historical manifest must not make
+    // any of those sessions look fresh. The committed temp is included
+    // because a crash between write and rename is still evidence of an
+    // in-progress tokenizer- and operator-dependent session.
+    for name in OBSERVATION_PAYLOAD_FILES {
+        files_have_payload |= regular_file_present(&dir.join(name), provenance)?;
+    }
+    // Discover shard payload from the directory itself, not from the
+    // manifest/requested fan-out. A stripped manifest combined with a smaller
+    // requested shard_bits must not hide (for example) shard-02.bin or either
+    // of its sidecars from the era check.
+    match fs::read_dir(dir) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry?;
+                let name = entry.file_name();
+                if let Some(name) = name.to_str() {
+                    if is_shard_payload_name(name) || name.starts_with("stories.tmp-") {
+                        files_have_payload |= regular_file_present(&entry.path(), provenance)?;
+                    } else if is_manifest_temp_name(name) {
+                        // Unpublished store residue does not establish an era,
+                        // but it must still be regular before locked recovery.
+                        let _ = regular_file_present(&entry.path(), provenance)?;
+                    }
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    Ok(manifest_has_payload || files_have_payload)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observation_shard_payload_present(dir: &Path) -> Result<bool, SourceUnavailable> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(is_shard_payload_name)
+        {
+            let _ = regular_file_present(&entry.path(), "checkpoint")?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn raw_shard_record_total(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<(bool, u64), SourceUnavailable> {
+    let mut present = false;
+    let mut records = 0u64;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !is_base_shard_payload_name(name) {
+            continue;
+        }
+        present = true;
+        let shard = name
+            .strip_prefix("shard-")
+            .and_then(|rest| rest.strip_suffix(".bin"))
+            .and_then(|index| index.parse::<u32>().ok())
+            .ok_or_else(|| invalid_data(format!("invalid observation shard name {name}")))?;
+        if shard >= manifest.shard_count() {
+            return Err(invalid_data(format!(
+                "observation shard {name} is outside the manifest's {}-shard fan-out",
+                manifest.shard_count()
+            )));
+        }
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if !metadata.file_type().is_file() {
+            return Err(invalid_input(format!(
+                "observation shard {} is not a regular file",
+                entry.path().display()
+            )));
+        }
+        let length = metadata.len();
+        if length % RECORD_SIZE as u64 != 0 {
+            return Err(invalid_data(format!(
+                "observation shard {} has a torn record ({length} bytes)",
+                entry.path().display()
+            )));
+        }
+        records = records
+            .checked_add(length / RECORD_SIZE as u64)
+            .ok_or_else(|| {
+                invalid_data("observation shard record total overflows u64".to_owned())
+            })?;
+    }
+    Ok((present, records))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn raw_recoverable_record_total(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<u64, SourceUnavailable> {
+    let regular_length = |path: &Path| -> Result<Option<u64>, SourceUnavailable> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.len())),
+            Ok(_) => Err(invalid_input(format!(
+                "raw observation payload {} is not a regular file",
+                path.display()
+            ))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    };
+    let mut recoverable = 0u64;
+    for shard in 0..manifest.shard_count() {
+        let base_path = dir.join(shard_file_name(manifest.shard_bits, shard));
+        let probability_path = dir.join(format!(
+            "{}.prob",
+            shard_file_name(manifest.shard_bits, shard)
+        ));
+        let trace_path = dir.join(trace_sidecar_name(manifest.shard_bits, shard));
+        let base_length = regular_length(&base_path)?;
+        let probability_length = regular_length(&probability_path)?;
+        let trace_length = regular_length(&trace_path)?;
+        let Some(base_length) = base_length else {
+            if probability_length.is_some() || trace_length.is_some() {
+                return Err(invalid_data(format!(
+                    "raw observation shard {shard} has a sidecar but no base record file"
+                )));
+            }
+            continue;
+        };
+        if base_length % RECORD_SIZE as u64 != 0 {
+            return Err(invalid_data(format!(
+                "raw observation shard {} has a torn record",
+                base_path.display()
+            )));
+        }
+        let base_records = base_length / RECORD_SIZE as u64;
+        let probability_records = match probability_length {
+            Some(length) if length % PROBABILITY_METADATA_SIZE as u64 == 0 => {
+                length / PROBABILITY_METADATA_SIZE as u64
+            }
+            Some(_) => {
+                return Err(invalid_data(format!(
+                    "raw probability sidecar {} has a torn metadata row",
+                    probability_path.display()
+                )));
+            }
+            None if base_records == 0 => 0,
+            None => {
+                return Err(invalid_data(format!(
+                    "raw observation shard {} has records but no probability sidecar",
+                    base_path.display()
+                )));
+            }
+        };
+        let mut shard_recoverable = base_records.min(probability_records);
+        match (manifest.trace_profile.as_ref(), trace_length) {
+            (None, Some(_)) => {
+                return Err(invalid_data(format!(
+                    "raw observation shard {shard} has a trace sidecar but no trace profile"
+                )));
+            }
+            (None, None) => {}
+            (Some(_), Some(length)) => {
+                let row_bytes = manifest.trace_row_bytes.ok_or_else(|| {
+                    invalid_data("traced raw observation has no pinned trace row width".to_owned())
+                })?;
+                if length % row_bytes != 0 {
+                    return Err(invalid_data(format!(
+                        "raw trace sidecar {} has a torn row",
+                        trace_path.display()
+                    )));
+                }
+                shard_recoverable = shard_recoverable.min(length / row_bytes);
+            }
+            (Some(_), None) if base_records == 0 => {
+                shard_recoverable = 0;
+            }
+            (Some(_), None) => {
+                return Err(invalid_data(format!(
+                    "raw observation shard {} has records but no trace sidecar",
+                    base_path.display()
+                )));
+            }
+        }
+        recoverable = recoverable.checked_add(shard_recoverable).ok_or_else(|| {
+            invalid_data("recoverable raw observation record total overflows u64".to_owned())
+        })?;
+    }
+    Ok(recoverable)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_observation_state(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<Option<ObservationState>, SourceUnavailable> {
+    let state = read_observation_state(dir)?;
+    let (base_shard_present, _) = raw_shard_record_total(dir, manifest)?;
+    let shard_payload_present = base_shard_present || observation_shard_payload_present(dir)?;
+    let merged_present = regular_file_present(&dir.join("merged.bin"), "checkpoint")?;
+    let manifest_stream_evidence = manifest.total_records != 0 || !manifest.completed.is_empty();
+    if state.is_none() && (shard_payload_present || merged_present || manifest_stream_evidence) {
+        return Err(invalid_data(format!(
+            "{} contains raw observation stream evidence but no {STATE_FILE}; refusing to restart from a false fresh state",
+            dir.display()
+        )));
+    }
+    if let Some((n, _, _, _)) = state {
+        let recoverable_records = raw_recoverable_record_total(dir, manifest)?;
+        if recoverable_records < n {
+            return Err(invalid_data(format!(
+                "{} checkpoint records {n} generated rows, but its aligned base/sidecar prefixes retain only {recoverable_records}; refusing lossy resume before mutation",
+                dir.display()
+            )));
+        }
+    }
+    Ok(state)
+}
+
+/// Exclusive coordination guard for one observation output directory.
+///
+/// Hold this value across the complete provenance-pin, tokenizer-export,
+/// reconciliation, generation, checkpoint, and finalization session. Writers
+/// opened through [`ObservationSession::writer`] share the already-acquired OS
+/// lock; the lock is released only after the session and every such writer are
+/// dropped.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct ObservationSession {
+    dir: PathBuf,
+    shard_bits: u8,
+    state: Arc<ObservationSessionState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct ObservationSessionState {
+    _lock: fs::File,
+    writer_active: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct ObservationWriterLease {
+    state: Arc<ObservationSessionState>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for ObservationWriterLease {
+    fn drop(&mut self) {
+        self.state
+            .writer_active
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ObservationSession {
+    /// Acquire the exclusive full-session lock and validate the authoritative
+    /// manifest/payload inventory under it.
+    pub fn acquire(dir: impl AsRef<Path>, shard_bits: u8) -> Result<Self, SourceUnavailable> {
+        if shard_bits > MAX_SHARD_BITS {
+            return Err(invalid_input(format!(
+                "shard_bits {shard_bits} exceeds the writer maximum {MAX_SHARD_BITS}"
+            )));
+        }
+        let dir = dir.as_ref().to_path_buf();
+        prepare_observation_root(&dir)?;
+        validate_observation_entry_types(&dir)?;
+        // Fail static semantic refusals before creating the permanent
+        // coordination inode. This snapshot is only an optimization for
+        // failure atomicity; `load_manifest` repeats it authoritatively after
+        // the lock is acquired.
+        if let Some(manifest) = ObservationManifest::load(&dir)?
+            && manifest.shard_bits != shard_bits
+        {
+            return Err(invalid_input(format!(
+                "manifest shard_bits {} does not match requested {shard_bits}",
+                manifest.shard_bits
+            )));
+        }
+        let state = Arc::new(ObservationSessionState {
+            _lock: acquire_observation_session_lock(&dir)?,
+            writer_active: std::sync::atomic::AtomicBool::new(false),
+        });
+        let session = Self {
+            dir,
+            shard_bits,
+            state,
+        };
+        // Every manifest and payload read that can authorize mutation happens
+        // after lock acquisition. The metadata-only scan above exists solely
+        // to make static nonregular-entry refusal failure-atomic.
+        let _ = session.load_manifest()?;
+        Ok(session)
+    }
+
+    /// Observation output directory protected by this session.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Fan-out pinned by this session.
+    pub fn shard_bits(&self) -> u8 {
+        self.shard_bits
+    }
+
+    /// Open a writer that shares this session's already-held exclusive lock.
+    /// The manifest and payload entry types are reloaded under the lock.
+    pub fn writer(&self) -> Result<ObservationShardWriter, SourceUnavailable> {
+        if self
+            .state
+            .writer_active
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::Acquire,
+                std::sync::atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return Err(invalid_input(format!(
+                "observation session for {} already has a live writer; drop it before opening another",
+                self.dir.display()
+            )));
+        }
+        let lease = ObservationWriterLease {
+            state: Arc::clone(&self.state),
+        };
+        let manifest = self.load_manifest()?;
+        let handles = (0..manifest.shard_count()).map(|_| None).collect();
+        let partition_counts = (0..manifest.shard_count())
+            .map(|_| PartitionCounts::default())
+            .collect();
+        Ok(ObservationShardWriter {
+            dir: self.dir.clone(),
+            manifest,
+            handles,
+            partition_counts,
+            partitions_active: false,
+            _session_lease: lease,
+        })
+    }
+
+    fn load_manifest(&self) -> Result<ObservationManifest, SourceUnavailable> {
+        validate_observation_entry_types(&self.dir)?;
+        let manifest = match ObservationManifest::load(&self.dir)? {
+            Some(manifest) => {
+                if manifest.shard_bits != self.shard_bits {
+                    return Err(invalid_input(format!(
+                        "manifest shard_bits {} does not match requested {}",
+                        manifest.shard_bits, self.shard_bits
+                    )));
+                }
+                manifest
+            }
+            None => ObservationManifest::new(self.shard_bits),
+        };
+        validate_canonical_shard_payload_names(&self.dir, &manifest)?;
+        let _ = observation_payload_present(&self.dir, &manifest, "observation")?;
+        Ok(manifest)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn preflight_writer_identity_bundle(
+    writer: &ObservationShardWriter,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&GeometryProjection>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    trace_profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    writer.preflight_source_manifest_kappa(source_manifest_kappa)?;
+    writer.preflight_geometry(geometry)?;
+    writer.preflight_tokenizer_adapter(tokenizer_adapter)?;
+    writer.preflight_attention_operator(attention_operator)?;
+    writer.preflight_trace_profile(trace_profile)
+}
+
+/// Joint, read-only provenance preflight under a caller-held observation
+/// session. Commands call this before tokenizer export or any identity setter;
+/// the lower driver repeats the checks before reconciliation and row writes.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+pub fn preflight_observation_identities_in_session(
+    session: &ObservationSession,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&GeometryProjection>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    trace_profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    let writer = session.writer()?;
+    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
+    preflight_writer_identity_bundle(
+        &writer,
+        source_manifest_kappa,
+        geometry,
+        tokenizer_adapter,
+        attention_operator,
+        trace_profile,
+    )
+}
+
+/// Resolve the requested trace capture layout against the actual oracle and
+/// compare its row width with the manifest before tokenizer export or any
+/// reconciliation. The richer trace profile alone does not identify capture
+/// geometry, so this is a separate read-only half of the joint preflight.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn preflight_observation_trace_layout_in_session(
+    session: &ObservationSession,
+    oracle: &dyn TeacherOracle,
+    profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    if let Some(profile) = profile {
+        validate_registered_trace_request(profile)?;
+    }
+    let trace = match profile {
+        Some(profile) if !profile.is_minimal() => Some(TraceCapture::new(profile, oracle)?),
+        Some(_) | None => None,
+    };
+    let writer = session.writer()?;
+    writer.preflight_trace_row_bytes(trace.as_ref().map(|trace| trace.row_bytes as u64))
+}
+
+/// Jointly preflight, then publish all present identity records under one
+/// exclusive session. No setter runs until every requested/recorded identity
+/// has passed the read-only bundle check.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+pub fn pin_observation_identities_in_session(
+    session: &ObservationSession,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&GeometryProjection>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    trace_profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    let mut writer = session.writer()?;
+    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
+    preflight_writer_identity_bundle(
+        &writer,
+        source_manifest_kappa,
+        geometry,
+        tokenizer_adapter,
+        attention_operator,
+        trace_profile,
+    )?;
+    if let Some(adapter) = tokenizer_adapter {
+        writer.set_tokenizer_adapter(adapter)?;
+    }
+    if let Some(kappa) = source_manifest_kappa {
+        writer.set_source_manifest_kappa(kappa)?;
+    }
+    if let Some(geometry) = geometry {
+        writer.set_geometry(geometry)?;
+    }
+    if let Some(operator) = attention_operator {
+        writer.set_attention_operator(operator)?;
+    }
+    if let Some(profile) = trace_profile {
+        writer.set_trace_profile(profile)?;
+    }
+    Ok(())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -465,9 +1675,11 @@ struct ShardHandle {
 
 /// Spills observation records into per-shard files with a κ-pinned
 /// manifest. Records may arrive interleaved across shards (routed by
-/// [`shard_of`]); each incomplete shard is appended to, so an interrupted
-/// pass resumes from the bytes already on disk. Completed shards are
-/// never rewritten: writes routed to them are skipped.
+/// [`shard_of`]); each incomplete shard is appended to after its aligned
+/// record/sidecar prefix is validated. Completed shards are never rewritten:
+/// writes routed to them are skipped. Semantic exactly-once recovery is the
+/// caller checkpoint's responsibility; the raw checkpoint limitation is
+/// documented at module scope.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct ObservationShardWriter {
     dir: PathBuf,
@@ -475,6 +1687,9 @@ pub struct ObservationShardWriter {
     handles: Vec<Option<ShardHandle>>,
     partition_counts: Vec<PartitionCounts>,
     partitions_active: bool,
+    // Keep the guard last so buffered shard handles are dropped before this
+    // writer releases its share of the full-session exclusive lock.
+    _session_lease: ObservationWriterLease,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -483,36 +1698,7 @@ impl ObservationShardWriter {
     /// manifest pins the fan-out; requesting a different `shard_bits` for
     /// the same directory is an error.
     pub fn open(dir: impl AsRef<Path>, shard_bits: u8) -> Result<Self, SourceUnavailable> {
-        if shard_bits > MAX_SHARD_BITS {
-            return Err(invalid_input(format!(
-                "shard_bits {shard_bits} exceeds the writer maximum {MAX_SHARD_BITS}"
-            )));
-        }
-        let dir = dir.as_ref().to_path_buf();
-        fs::create_dir_all(&dir)?;
-        let manifest = match ObservationManifest::load(&dir)? {
-            Some(manifest) => {
-                if manifest.shard_bits != shard_bits {
-                    return Err(invalid_input(format!(
-                        "manifest shard_bits {} does not match requested {shard_bits}",
-                        manifest.shard_bits
-                    )));
-                }
-                manifest
-            }
-            None => ObservationManifest::new(shard_bits),
-        };
-        let handles = (0..manifest.shard_count()).map(|_| None).collect();
-        let partition_counts = (0..manifest.shard_count())
-            .map(|_| PartitionCounts::default())
-            .collect();
-        Ok(Self {
-            dir,
-            manifest,
-            handles,
-            partition_counts,
-            partitions_active: false,
-        })
+        ObservationSession::acquire(dir, shard_bits)?.writer()
     }
 
     pub fn manifest(&self) -> &ObservationManifest {
@@ -527,160 +1713,200 @@ impl ObservationShardWriter {
     /// atomically). Idempotent: storing the already-recorded rule is a
     /// no-op and does not rewrite the manifest.
     pub fn set_partition_rule(&mut self, rule: &str) -> Result<(), SourceUnavailable> {
-        if self.manifest.partition_rule.as_deref() != Some(rule) {
-            self.manifest.partition_rule = Some(rule.to_owned());
-            self.manifest.store(&self.dir)?;
+        if self.manifest.partition_rule.as_deref() == Some(rule) {
+            return Ok(());
         }
+        let mut candidate = self.manifest.clone();
+        candidate.partition_rule = Some(rule.to_owned());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
     }
 
     /// Record the input CID in the manifest (idempotent, atomic store).
     pub fn set_input_cid(&mut self, cid: &str) -> Result<(), SourceUnavailable> {
-        if self.manifest.input_cid.as_deref() != Some(cid) {
-            self.manifest.input_cid = Some(cid.to_owned());
-            self.manifest.store(&self.dir)?;
+        if !is_canonical_blake3_address(cid) {
+            return Err(invalid_input(format!(
+                "input CID {cid} is not canonical lowercase blake3:<64 hex>; refusing provenance before mutation"
+            )));
         }
+        if self.manifest.input_cid.as_deref() == Some(cid) {
+            return Ok(());
+        }
+        let mut candidate = self.manifest.clone();
+        candidate.input_cid = Some(cid.to_owned());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
     }
 
-    /// Record the #597 source-snapshot manifest root κ of the teacher
-    /// source in the observation manifest (idempotent, atomic store).
+    /// Read-only symmetric compatibility check for the source-snapshot κ.
+    /// Once payload exists, an absent κ cannot be backfilled and a bound κ
+    /// must be requested exactly.
+    pub fn preflight_source_manifest_kappa(
+        &self,
+        requested: Option<&str>,
+    ) -> Result<(), SourceUnavailable> {
+        for (role, kappa) in [
+            ("recorded", self.manifest.source_manifest_kappa.as_deref()),
+            ("requested", requested),
+        ] {
+            if let Some(kappa) = kappa
+                && !is_canonical_blake3_address(kappa)
+            {
+                return Err(invalid_input(format!(
+                    "{role} source manifest κ {kappa} is not canonical lowercase blake3:<64 hex>; refusing provenance before mutation"
+                )));
+            }
+        }
+        let payload_present =
+            observation_payload_present(&self.dir, &self.manifest, "source-manifest")?;
+        match (self.manifest.source_manifest_kappa.as_deref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to source manifest κ {recorded}; requested {requested}; incompatible observation resume refused before mutation",
+                self.dir.display()
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to source manifest κ {recorded}; the requested producer declares none; incompatible observation resume refused before mutation",
+                self.dir.display()
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded source manifest κ but already contains observation payload; refusing to relabel legacy bytes as {requested} before mutation",
+                self.dir.display()
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
+    /// Record the #597 source-snapshot manifest root κ of the teacher source.
     pub fn set_source_manifest_kappa(&mut self, kappa: &str) -> Result<(), SourceUnavailable> {
-        if self.manifest.source_manifest_kappa.as_deref() != Some(kappa) {
-            self.manifest.source_manifest_kappa = Some(kappa.to_owned());
-            self.manifest.store(&self.dir)?;
+        self.preflight_source_manifest_kappa(Some(kappa))?;
+        if self.manifest.source_manifest_kappa.as_deref() == Some(kappa) {
+            return Ok(());
         }
+        let mut candidate = self.manifest.clone();
+        candidate.source_manifest_kappa = Some(kappa.to_owned());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
     }
 
-    /// Record the #600 typed geometry-projection record of the teacher
-    /// oracle in the observation manifest (idempotent, atomic store).
-    pub fn set_geometry(&mut self, geometry: &GeometryProjection) -> Result<(), SourceUnavailable> {
-        if self.manifest.geometry.as_ref() != Some(geometry) {
-            self.manifest.geometry = Some(geometry.clone());
-            self.manifest.store(&self.dir)?;
+    /// Read-only symmetric compatibility check for source geometry. `None`
+    /// means the pass-through geometry era and is therefore authoritative.
+    pub fn preflight_geometry(
+        &self,
+        requested: Option<&GeometryProjection>,
+    ) -> Result<(), SourceUnavailable> {
+        if let Some(recorded) = self.manifest.geometry.as_ref() {
+            validate_registered_geometry_projection(recorded)?;
         }
+        if let Some(requested) = requested {
+            validate_registered_geometry_projection(requested)?;
+        }
+        let payload_present = observation_payload_present(&self.dir, &self.manifest, "geometry")?;
+        match (self.manifest.geometry.as_ref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to geometry {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to geometry {}/{} digest {}; the requested producer declares pass-through/none; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded geometry but already contains observation payload from the pass-through/legacy era; refusing to relabel those bytes as {}/{} before mutation",
+                self.dir.display(),
+                requested.id,
+                requested.version,
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
+    /// Record the #600 typed geometry-projection record of the teacher oracle.
+    pub fn set_geometry(&mut self, geometry: &GeometryProjection) -> Result<(), SourceUnavailable> {
+        self.preflight_geometry(Some(geometry))?;
+        if self.manifest.geometry.as_ref() == Some(geometry) {
+            return Ok(());
+        }
+        let mut candidate = self.manifest.clone();
+        candidate.geometry = Some(geometry.clone());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
+    }
+
+    /// Read-only compatibility check for the #601 tokenizer era. This is
+    /// symmetric with the attention check so a checkpoint/adapterless producer
+    /// cannot resume bytes pinned to a registered tokenizer.
+    pub fn preflight_tokenizer_adapter(
+        &self,
+        requested: Option<&TokenizerAdapter>,
+    ) -> Result<(), SourceUnavailable> {
+        if let Some(recorded) = self.manifest.tokenizer_adapter.as_ref() {
+            validate_registered_tokenizer_adapter(recorded)?;
+        }
+        if let Some(requested) = requested {
+            validate_registered_tokenizer_adapter(requested)?;
+        }
+        let payload_present = observation_payload_present(&self.dir, &self.manifest, "tokenizer")?;
+        match (self.manifest.tokenizer_adapter.as_ref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested {}/{} (CID {}, digest {}); incompatible resume refused before mutation",
+                self.dir.display(),
+                recorded.family,
+                recorded.version,
+                recorded.tokenizer_cid,
+                recorded.adapter_digest,
+                requested.family,
+                requested.version,
+                requested.tokenizer_cid,
+                requested.adapter_digest,
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested the adapterless legacy tokenizer; incompatible resume refused before mutation",
+                self.dir.display(),
+                recorded.family,
+                recorded.version,
+                recorded.tokenizer_cid,
+                recorded.adapter_digest,
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded tokenizer adapter but already contains observation payload; refusing to relabel legacy/unpinned bytes as {}/{} (CID {}, digest {}) before mutation",
+                self.dir.display(),
+                requested.family,
+                requested.version,
+                requested.tokenizer_cid,
+                requested.adapter_digest,
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
     }
 
     /// Record the #601 typed tokenizer-adapter identity record of the
-    /// producing pipeline's tokenizer in the observation manifest.
-    ///
-    /// An absent record is the explicit legacy/unpinned state. It may be
-    /// pinned only before any observation payload exists; other identity
-    /// metadata does not by itself make the corpus an incompatible era.
-    /// Re-recording the identical adapter is idempotent. Once pinned, however,
-    /// a different adapter is an incompatible resume and is refused before
-    /// either the in-memory manifest or any directory bytes are changed. The
-    /// candidate must name a registered family/version and reproduce its
-    /// canonical digest; its manifest is installed in memory only after the
-    /// atomic store succeeds.
+    /// producing pipeline's tokenizer in the observation manifest. The cloned
+    /// candidate replaces in-memory state only after its atomic store succeeds.
     pub fn set_tokenizer_adapter(
         &mut self,
         adapter: &TokenizerAdapter,
     ) -> Result<(), SourceUnavailable> {
-        // A provenance record is admitted only for an implemented registry
-        // key, and only when its canonical fields reproduce its claimed
-        // digest. This validation precedes every identity/resume branch so a
-        // custom caller cannot persist unknown or internally inconsistent
-        // metadata even in a fresh directory.
-        adapter_constructor(&adapter.family, adapter.version)?;
-        for (field, value) in [
-            ("tokenizer_cid", adapter.tokenizer_cid.as_str()),
-            ("adapter_digest", adapter.adapter_digest.as_str()),
-        ] {
-            if !is_canonical_blake3_address(value) {
-                return Err(invalid_input(format!(
-                    "tokenizer adapter {}/{} has non-canonical {field} {value}; expected lowercase blake3:<64 hex>; refusing provenance before mutation",
-                    adapter.family, adapter.version,
-                )));
-            }
+        self.preflight_tokenizer_adapter(Some(adapter))?;
+        recover_manifest_temp_residue(&self.dir)?;
+        if self.manifest.tokenizer_adapter.as_ref() == Some(adapter) {
+            return Ok(());
         }
-        let declared_digest = adapter.declared_digest();
-        if adapter.adapter_digest != declared_digest {
-            return Err(invalid_input(format!(
-                "tokenizer adapter {}/{} claims digest {}, but its canonical fields \
-                 declare {}; refusing inconsistent provenance before mutation",
-                adapter.family, adapter.version, adapter.adapter_digest, declared_digest,
-            )));
-        }
-
-        match self.manifest.tokenizer_adapter.as_ref() {
-            Some(recorded) if recorded == adapter => return Ok(()),
-            Some(recorded) => {
-                return Err(invalid_input(format!(
-                    "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); \
-                     requested {}/{} (CID {}, digest {}); incompatible resume \
-                     refused before mutation",
-                    self.dir.display(),
-                    recorded.family,
-                    recorded.version,
-                    recorded.tokenizer_cid,
-                    recorded.adapter_digest,
-                    adapter.family,
-                    adapter.version,
-                    adapter.tokenizer_cid,
-                    adapter.adapter_digest,
-                )));
-            }
-            None => {
-                let payload_file_has_bytes = |path: &Path| match fs::symlink_metadata(path) {
-                    Ok(metadata) if metadata.file_type().is_file() => Ok(metadata.len() != 0),
-                    Ok(_) => Err(invalid_input(format!(
-                        "observation payload path {} is not a regular file; refusing \
-                         tokenizer provenance mutation",
-                        path.display()
-                    ))),
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-                    Err(error) => Err(SourceUnavailable::from(error)),
-                };
-                let manifest_has_payload =
-                    self.manifest.total_records != 0 || !self.manifest.completed.is_empty();
-                let mut files_have_payload = false;
-                // Shards are not the only tokenizer-era evidence. The raw
-                // driver checkpoints its token stream in state.bin; the text
-                // driver additionally checkpoints article progress and story
-                // identity; the CLI can persist a merged record stream and
-                // the exact runtime token table in the same directory. A
-                // stripped/torn historical manifest must not make any of
-                // those sessions look fresh. The committed temp is included
-                // because a crash between write and rename is still evidence
-                // of an in-progress tokenizer-dependent session.
-                for name in [
-                    STATE_FILE,
-                    "merged.bin",
-                    "committed.bin",
-                    ".committed.bin.tmp",
-                    "stories.jsonl",
-                    "tokenizer.bin",
-                ] {
-                    files_have_payload |= payload_file_has_bytes(&self.dir.join(name))?;
-                }
-                for shard in 0..self.manifest.shard_count() {
-                    let shard_name = shard_file_name(self.manifest.shard_bits, shard);
-                    for path in [
-                        self.dir.join(&shard_name),
-                        self.dir.join(format!("{shard_name}.prob")),
-                        self.dir.join(format!("{shard_name}.trace")),
-                    ] {
-                        files_have_payload |= payload_file_has_bytes(&path)?;
-                    }
-                }
-                if manifest_has_payload || files_have_payload {
-                    return Err(invalid_input(format!(
-                        "{} has no recorded tokenizer adapter but already contains \
-                         observation payload; refusing to relabel legacy/unpinned bytes as \
-                         {}/{} (CID {}, digest {}) before mutation",
-                        self.dir.display(),
-                        adapter.family,
-                        adapter.version,
-                        adapter.tokenizer_cid,
-                        adapter.adapter_digest,
-                    )));
-                }
-            }
-        }
-
         let mut candidate = self.manifest.clone();
         candidate.tokenizer_adapter = Some(adapter.clone());
         candidate.store(&self.dir)?;
@@ -688,31 +1914,152 @@ impl ObservationShardWriter {
         Ok(())
     }
 
+    /// Read-only compatibility check for the #602 attention-operator era.
+    /// Compatibility is symmetric: an operator-declaring producer cannot
+    /// relabel operatorless legacy payload, and an operatorless producer
+    /// cannot resume a directory pinned to an explicit operator.
+    pub fn preflight_attention_operator(
+        &self,
+        requested: Option<&AttentionOperatorSpec>,
+    ) -> Result<(), SourceUnavailable> {
+        if let Some(recorded) = self.manifest.attention_operator.as_ref() {
+            validate_registered_source_attention_operator(recorded)?;
+        }
+        if let Some(requested) = requested {
+            validate_registered_source_attention_operator(requested)?;
+        }
+        // Always scan for nonregular payload entries, even when the recorded
+        // and requested operators match. Otherwise reconciliation or append
+        // could follow a shard/sidecar symlink and mutate its external target.
+        let payload_present =
+            observation_payload_present(&self.dir, &self.manifest, "attention-operator")?;
+
+        match (self.manifest.attention_operator.as_ref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to attention operator {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to attention operator {}/{} digest {}; the requested producer declares none; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded attention operator but already contains observation payload from the implicit legacy era; refusing to relabel those bytes as {}/{} digest {} before mutation",
+                self.dir.display(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
     /// Record the #602 typed attention-operator identity record of the
-    /// teacher oracle in the observation manifest (idempotent, atomic
-    /// store).
+    /// teacher oracle in the observation manifest (idempotent, atomic store).
+    /// Only an exact immutable registry record can be stored, and the cloned
+    /// candidate replaces in-memory state only after its atomic store succeeds.
     pub fn set_attention_operator(
         &mut self,
         operator: &AttentionOperatorSpec,
     ) -> Result<(), SourceUnavailable> {
-        if self.manifest.attention_operator.as_ref() != Some(operator) {
-            self.manifest.attention_operator = Some(operator.clone());
-            self.manifest.store(&self.dir)?;
+        self.preflight_attention_operator(Some(operator))?;
+        recover_manifest_temp_residue(&self.dir)?;
+        if self.manifest.attention_operator.as_ref() == Some(operator) {
+            return Ok(());
         }
+        let mut candidate = self.manifest.clone();
+        candidate.attention_operator = Some(operator.clone());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
     }
 
-    /// Record the #603 typed teacher-trace-profile record of the
-    /// producing pass in the observation manifest (idempotent, atomic
-    /// store), mirroring
-    /// [`ObservationShardWriter::set_geometry`]/[`ObservationShardWriter::set_tokenizer_adapter`].
-    /// The minimal profile is never recorded — absence marks it — so
-    /// legacy manifest bytes are unchanged for every minimal pass.
-    pub fn set_trace_profile(&mut self, profile: &TraceProfile) -> Result<(), SourceUnavailable> {
-        if self.manifest.trace_profile.as_ref() != Some(profile) {
-            self.manifest.trace_profile = Some(profile.clone());
-            self.manifest.store(&self.dir)?;
+    /// Read-only symmetric compatibility check for the #603 trace-profile
+    /// era. The full payload inventory gates introduction of a richer profile;
+    /// orphan shards and sidecars count just like checkpoints.
+    pub fn preflight_trace_profile(
+        &self,
+        requested: Option<&TraceProfile>,
+    ) -> Result<(), SourceUnavailable> {
+        if let Some(recorded) = self.manifest.trace_profile.as_ref() {
+            validate_registered_trace_profile(recorded)?;
         }
+        if let Some(requested) = requested {
+            validate_registered_trace_profile(requested)?;
+        }
+        let payload_present =
+            observation_payload_present(&self.dir, &self.manifest, "trace-profile")?;
+        match (self.manifest.trace_profile.as_ref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to trace profile {}/{}; requested {}/{}; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                requested.id,
+                requested.version,
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to trace profile {}/{}; requested the minimal/absent profile; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded trace profile but already contains observation payload from the minimal era; refusing to relabel those bytes as {}/{} before mutation",
+                self.dir.display(),
+                requested.id,
+                requested.version,
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
+    fn preflight_trace_row_bytes(&self, requested: Option<u64>) -> Result<(), SourceUnavailable> {
+        match (self.manifest.trace_row_bytes, requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to {recorded}-byte trace rows; the requested oracle/profile resolves to {requested}-byte rows; incompatible trace capture geometry refused before mutation",
+                self.dir.display()
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to {recorded}-byte trace rows; the requested pass has no richer trace rows",
+                self.dir.display()
+            ))),
+            (None, Some(_))
+                if regular_file_present(&self.dir.join(STATE_FILE), "trace-layout")?
+                    || observation_shard_payload_present(&self.dir)? =>
+            {
+                Err(invalid_input(format!(
+                    "{} has traced stream payload but no recorded trace row width; refusing to backfill an impossible capture layout before mutation",
+                    self.dir.display()
+                )))
+            }
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
+    /// Record a non-minimal #603 trace-profile identity after compatibility
+    /// succeeds. The minimal profile remains represented by absence.
+    pub fn set_trace_profile(&mut self, profile: &TraceProfile) -> Result<(), SourceUnavailable> {
+        self.preflight_trace_profile(Some(profile))?;
+        if self.manifest.trace_profile.as_ref() == Some(profile) {
+            return Ok(());
+        }
+        let mut candidate = self.manifest.clone();
+        candidate.trace_profile = Some(profile.clone());
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
         Ok(())
     }
 
@@ -1407,12 +2754,51 @@ pub struct TraceRow {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl TraceRowLayout {
-    /// Resolve the row layout from a trace profile and capture geometry —
-    /// the same widths [`TraceCapture`] pins and every reader expects.
-    pub fn new(
+    fn checked_row_bytes(&self) -> Result<usize, SourceUnavailable> {
+        let residual_bytes = self
+            .residual_layers
+            .checked_add(usize::from(self.final_hidden))
+            .and_then(|lanes| lanes.checked_mul(self.residual_width))
+            .and_then(|width| width.checked_mul(4))
+            .ok_or_else(|| invalid_data("trace residual lane width overflows usize".to_owned()))?;
+        let qkv_vector_width = self
+            .kv_width
+            .checked_mul(2)
+            .and_then(|width| self.residual_width.checked_add(width))
+            .ok_or_else(|| invalid_data("trace q/k/v lane width overflows usize".to_owned()))?;
+        let qkv_bytes = self
+            .qkv_layers
+            .checked_mul(qkv_vector_width)
+            .and_then(|width| width.checked_mul(4))
+            .ok_or_else(|| invalid_data("trace q/k/v bytes overflow usize".to_owned()))?;
+        let attention_bytes = self
+            .attention_layers
+            .checked_mul(self.heads)
+            .and_then(|rows| rows.checked_mul(self.support))
+            .and_then(|slots| slots.checked_mul(8))
+            .ok_or_else(|| invalid_data("trace attention bytes overflow usize".to_owned()))?;
+        residual_bytes
+            .checked_add(qkv_bytes)
+            .and_then(|width| width.checked_add(attention_bytes))
+            .ok_or_else(|| invalid_data("trace row width overflows usize".to_owned()))
+    }
+
+    fn try_new(
         profile: &TraceProfile,
         geometry: &uor_r4_model_source::TraceCaptureGeometry,
-    ) -> Self {
+    ) -> Result<Self, SourceUnavailable> {
+        if geometry.heads == 0
+            || geometry.kv_heads == 0
+            || geometry.residual_width == 0
+            || geometry.kv_heads > geometry.heads
+        {
+            return Err(invalid_input(format!(
+                "invalid trace capture geometry: heads={}, kv_heads={}, residual_width={}",
+                geometry.heads, geometry.kv_heads, geometry.residual_width
+            )));
+        }
+        // Resolve the row layout from a trace profile and capture geometry —
+        // the same widths `TraceCapture` pins and every reader expects.
         let residual_layers = profile
             .layer_lane
             .as_ref()
@@ -1432,12 +2818,38 @@ impl TraceRowLayout {
                 (lane.layer_indices.len(), lane.support_size as usize)
             });
         let residual_width = geometry.residual_width;
-        let kv_width = geometry.residual_width * geometry.kv_heads / geometry.heads;
-        let row_bytes = residual_layers * residual_width * 4
-            + usize::from(final_hidden) * residual_width * 4
-            + qkv_layers * (residual_width + 2 * kv_width) * 4
-            + attention_layers * geometry.heads * support * 8;
-        Self {
+        let kv_numerator = residual_width
+            .checked_mul(geometry.kv_heads)
+            .ok_or_else(|| invalid_input("trace k/v width overflows usize".to_owned()))?;
+        if kv_numerator % geometry.heads != 0 {
+            return Err(invalid_input(
+                "trace capture geometry does not define an integral k/v width".to_owned(),
+            ));
+        }
+        let kv_width = kv_numerator / geometry.heads;
+        let residual_bytes = residual_layers
+            .checked_add(usize::from(final_hidden))
+            .and_then(|lanes| lanes.checked_mul(residual_width))
+            .and_then(|width| width.checked_mul(4))
+            .ok_or_else(|| invalid_input("trace residual lane width overflows usize".to_owned()))?;
+        let qkv_vector_width = kv_width
+            .checked_mul(2)
+            .and_then(|width| residual_width.checked_add(width))
+            .ok_or_else(|| invalid_input("trace q/k/v lane width overflows usize".to_owned()))?;
+        let qkv_bytes = qkv_layers
+            .checked_mul(qkv_vector_width)
+            .and_then(|width| width.checked_mul(4))
+            .ok_or_else(|| invalid_input("trace q/k/v bytes overflow usize".to_owned()))?;
+        let attention_bytes = attention_layers
+            .checked_mul(geometry.heads)
+            .and_then(|rows| rows.checked_mul(support))
+            .and_then(|slots| slots.checked_mul(8))
+            .ok_or_else(|| invalid_input("trace attention bytes overflow usize".to_owned()))?;
+        let row_bytes = residual_bytes
+            .checked_add(qkv_bytes)
+            .and_then(|width| width.checked_add(attention_bytes))
+            .ok_or_else(|| invalid_input("trace row width overflows usize".to_owned()))?;
+        Ok(Self {
             residual_layers,
             final_hidden,
             qkv_layers,
@@ -1447,17 +2859,45 @@ impl TraceRowLayout {
             residual_width,
             kv_width,
             row_bytes,
-        }
+        })
+    }
+
+    /// Resolve the row layout from a trace profile and capture geometry —
+    /// the same widths [`TraceCapture`] pins and every reader expects. Invalid
+    /// external geometry produces a sentinel-width layout; mutation paths use
+    /// the checked constructor and return a focused error instead.
+    pub fn new(
+        profile: &TraceProfile,
+        geometry: &uor_r4_model_source::TraceCaptureGeometry,
+    ) -> Self {
+        Self::try_new(profile, geometry).unwrap_or(Self {
+            residual_layers: 0,
+            final_hidden: false,
+            qkv_layers: 0,
+            attention_layers: 0,
+            heads: geometry.heads,
+            support: 0,
+            residual_width: geometry.residual_width,
+            kv_width: 0,
+            row_bytes: usize::MAX,
+        })
     }
 
     /// Decode one `row_bytes`-long row into its structured lanes. Errors if
     /// the slice length does not match the pinned width.
     pub fn read_row(&self, row: &[u8]) -> Result<TraceRow, SourceUnavailable> {
-        if row.len() != self.row_bytes {
+        let expected_row_bytes = self.checked_row_bytes()?;
+        if self.row_bytes != expected_row_bytes {
+            return Err(invalid_data(format!(
+                "trace layout pins {} row bytes, but its lane fields require {expected_row_bytes}",
+                self.row_bytes
+            )));
+        }
+        if row.len() != expected_row_bytes {
             return Err(invalid_data(format!(
                 "trace row is {} bytes, layout pins {}",
                 row.len(),
-                self.row_bytes
+                expected_row_bytes
             )));
         }
         let read_f32 = |offset: usize| {
@@ -1509,10 +2949,21 @@ impl TraceRowLayout {
                 for slot in 0..self.support {
                     let position = read_u32(offset + slot * 8);
                     let weight_bits = read_u32(offset + slot * 8 + 4);
-                    if position == SUPPORT_ABSENT_MARKER && weight_bits == SUPPORT_ABSENT_MARKER {
-                        // Explicit absence marker: the slot is absent, never
-                        // a zero-valued entry.
-                        continue;
+                    match (
+                        position == SUPPORT_ABSENT_MARKER,
+                        weight_bits == SUPPORT_ABSENT_MARKER,
+                    ) {
+                        (true, true) => {
+                            // Explicit absence marker: the slot is absent,
+                            // never a zero-valued entry.
+                            continue;
+                        }
+                        (true, false) | (false, true) => {
+                            return Err(invalid_data(
+                                "trace support slot has a partial absence marker".to_owned(),
+                            ));
+                        }
+                        (false, false) => {}
                     }
                     entries.push((position, f32::from_bits(weight_bits)));
                 }
@@ -1562,6 +3013,7 @@ impl TraceCapture {
     /// surface, no hidden state for a declared final-hidden lane, or a
     /// declared layer index outside its layer range.
     fn new(profile: &TraceProfile, oracle: &dyn TeacherOracle) -> Result<Self, SourceUnavailable> {
+        validate_registered_trace_profile(profile)?;
         let geometry = oracle.trace_capture_geometry().ok_or_else(|| {
             invalid_input(format!(
                 "trace profile {}/{} needs the oracle's bounded capture surface, \
@@ -1606,7 +3058,7 @@ impl TraceCapture {
         };
         // Single source of truth for the row width — the same layout every
         // reader derives, so the writer and consumers cannot drift.
-        let row_bytes = TraceRowLayout::new(profile, &geometry).row_bytes;
+        let row_bytes = TraceRowLayout::try_new(profile, &geometry)?.row_bytes;
         if row_bytes == 0 {
             return Err(invalid_input(format!(
                 "trace profile {}/{} declares no captured bytes; use the minimal profile",
@@ -1742,9 +3194,12 @@ impl TraceCapture {
 /// append-only corpus file. The teacher stream is the same deterministic
 /// stream (seed 0x5EED, whole-story checkpointing); each record is routed
 /// to `shard_of(sample_id(context_window), shard_bits)`, where the context
-/// window is the existing 8-token window of fed tokens. Resume: a rerun
-/// continues the stream from `state.bin`, skips shards the manifest marks
-/// complete, and appends to the incomplete ones.
+/// window is the existing 8-token window of fed tokens. Resume continues the
+/// stream from a strictly decoded `state.bin`, skips completed shards, and
+/// appends to alignment-validated incomplete shards. Because raw `state.bin`
+/// has no per-shard committed lengths, aligned mid-story tails are not
+/// exactly-once recoverable; use the text driver where transactional
+/// per-shard recovery is required.
 ///
 /// This is the minimal trace profile: byte-for-byte today's records,
 /// sidecars, and manifest (no `trace_profile` field is recorded). Richer
@@ -1766,6 +3221,29 @@ pub fn observe_sharded(
         out,
         token_byte_lengths,
         None,
+        None,
+    )
+}
+
+/// [`observe_sharded`] while retaining a caller-owned exclusive observation
+/// session across earlier identity pinning and tokenizer export.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn observe_sharded_in_session(
+    session: &ObservationSession,
+    oracle: &mut dyn TeacherOracle,
+    budget_s: u64,
+    target: usize,
+    token_byte_lengths: Option<&[u32]>,
+) -> Result<ObserveSummary, SourceUnavailable> {
+    observe_sharded_inner(
+        oracle,
+        budget_s,
+        target,
+        session.shard_bits(),
+        session.dir(),
+        token_byte_lengths,
+        None,
+        Some(session),
     )
 }
 
@@ -1789,6 +3267,7 @@ pub fn observe_sharded_traced(
     token_byte_lengths: Option<&[u32]>,
     profile: &TraceProfile,
 ) -> Result<ObserveSummary, SourceUnavailable> {
+    validate_registered_trace_request(profile)?;
     let trace = if profile.is_minimal() {
         None
     } else {
@@ -1802,10 +3281,41 @@ pub fn observe_sharded_traced(
         out,
         token_byte_lengths,
         trace,
+        None,
+    )
+}
+
+/// [`observe_sharded_traced`] under a caller-owned exclusive observation
+/// session.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn observe_sharded_traced_in_session(
+    session: &ObservationSession,
+    oracle: &mut dyn TeacherOracle,
+    budget_s: u64,
+    target: usize,
+    token_byte_lengths: Option<&[u32]>,
+    profile: &TraceProfile,
+) -> Result<ObserveSummary, SourceUnavailable> {
+    validate_registered_trace_request(profile)?;
+    let trace = if profile.is_minimal() {
+        None
+    } else {
+        Some(TraceCapture::new(profile, oracle)?)
+    };
+    observe_sharded_inner(
+        oracle,
+        budget_s,
+        target,
+        session.shard_bits(),
+        session.dir(),
+        token_byte_lengths,
+        trace,
+        Some(session),
     )
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
 fn observe_sharded_inner(
     oracle: &mut dyn TeacherOracle,
     budget_s: u64,
@@ -1814,29 +3324,47 @@ fn observe_sharded_inner(
     out: &Path,
     token_byte_lengths: Option<&[u32]>,
     mut trace: Option<TraceCapture>,
+    session: Option<&ObservationSession>,
 ) -> Result<ObserveSummary, SourceUnavailable> {
-    let mut writer = ObservationShardWriter::open(out, shard_bits)?;
+    // Resolve and registry-validate the producer's actual arithmetic identity
+    // before even opening a new output directory. The writer then performs the
+    // symmetric resume/payload check before trace reconciliation or any other
+    // stateful operation.
+    let geometry = oracle.geometry_projection();
+    if let Some(geometry) = geometry.as_ref() {
+        validate_registered_geometry_projection(geometry)?;
+    }
+    let attention_operator = oracle.attention_operator_spec();
+    if let Some(operator) = attention_operator.as_ref() {
+        validate_registered_source_attention_operator(operator)?;
+    }
+    let mut writer = match session {
+        Some(session) => session.writer()?,
+        None => ObservationShardWriter::open(out, shard_bits)?,
+    };
+    writer.preflight_geometry(geometry.as_ref())?;
+    writer.preflight_attention_operator(attention_operator.as_ref())?;
+    let restored_state = preflight_observation_state(out, writer.manifest())?;
+    let requested_target = u64::try_from(target).unwrap_or(u64::MAX);
+    if restored_state.is_some_and(|(n, _, _, _)| n < requested_target)
+        && !writer.manifest().completed.is_empty()
+    {
+        return Err(invalid_input(format!(
+            "{} has finalized observation shards at a smaller raw target; extending a finalized corpus would skip rows routed to those shards, so use a fresh output directory",
+            out.display()
+        )));
+    }
     // #603 profile pinning: a corpus is captured under ONE profile. A
     // recorded profile must match the requested one (minimal requests
     // refuse traced corpora and vice versa once bytes exist); a fresh
     // traced pass records its profile before any record is written.
+    writer.preflight_trace_profile(trace.as_ref().map(|trace| &trace.profile))?;
+    writer.preflight_trace_row_bytes(trace.as_ref().map(|trace| trace.row_bytes as u64))?;
     let recorded = writer.manifest().trace_profile.clone();
-    let has_prior_state = out.join(STATE_FILE).exists() || !writer.manifest().completed.is_empty();
-    match (&recorded, trace.as_ref()) {
-        (None, None) => {}
-        (Some(recorded), Some(trace)) if *recorded == trace.profile => {}
-        (None, Some(trace)) => {
-            if has_prior_state {
-                return Err(invalid_input(format!(
-                    "{} was captured under the minimal trace profile; profile \
-                     {}/{} cannot be introduced mid-corpus",
-                    out.display(),
-                    trace.profile.id,
-                    trace.profile.version
-                )));
-            }
-            writer.set_trace_profile(&trace.profile)?;
-        }
+    let trace_profile_to_set = match (&recorded, trace.as_ref()) {
+        (None, None) => None,
+        (Some(recorded), Some(trace)) if *recorded == trace.profile => None,
+        (None, Some(trace)) => Some(trace.profile.clone()),
         (Some(recorded), Some(trace)) => {
             return Err(invalid_input(format!(
                 "{} is pinned to trace profile {}/{}; requested {}/{}",
@@ -1855,6 +3383,17 @@ fn observe_sharded_inner(
                 recorded.version
             )));
         }
+    };
+    // Every identity check above is read-only. Only after all of them agree do
+    // we publish either missing record.
+    if let Some(geometry) = geometry.as_ref() {
+        writer.set_geometry(geometry)?;
+    }
+    if let Some(operator) = attention_operator.as_ref() {
+        writer.set_attention_operator(operator)?;
+    }
+    if let Some(profile) = trace_profile_to_set.as_ref() {
+        writer.set_trace_profile(profile)?;
     }
     let trace_row_bytes = writer.manifest().trace_row_bytes;
     for shard in 0..writer.manifest().shard_count() {
@@ -1866,15 +3405,7 @@ fn observe_sharded_inner(
         }
     }
     let state_path = out.join(STATE_FILE);
-    let (mut n, mut stories, mut rng, mut done) = match fs::read(&state_path) {
-        Ok(bytes) if bytes.len() == 25 => (
-            u64::from_le_bytes(bytes[0..8].try_into().expect("8-byte slice")),
-            u64::from_le_bytes(bytes[8..16].try_into().expect("8-byte slice")),
-            u64::from_le_bytes(bytes[16..24].try_into().expect("8-byte slice")),
-            bytes[24],
-        ),
-        _ => (0, 0, 0x5EED, 0),
-    };
+    let (mut n, mut stories, mut rng, mut done) = restored_state.unwrap_or((0, 0, 0x5EED, 0));
     if (n as usize) < target {
         done = 0;
     }
@@ -2102,5 +3633,1110 @@ mod trace_row_tests {
         // A wrong-length row is rejected, never silently mis-decoded.
         assert!(layout.read_row(&row[..row.len() - 1]).is_err());
         assert!(layout.read_row(&[]).is_err());
+    }
+
+    #[test]
+    fn trace_reader_rejects_inconsistent_layouts_and_partial_absence_markers() {
+        let inconsistent = TraceRowLayout {
+            residual_layers: 1,
+            final_hidden: false,
+            qkv_layers: 0,
+            attention_layers: 0,
+            heads: 1,
+            support: 0,
+            residual_width: 1,
+            kv_width: 1,
+            row_bytes: 0,
+        };
+        let error = inconsistent
+            .read_row(&[])
+            .expect_err("public layout fields must not authorize out-of-bounds decoding");
+        assert!(error.reason.contains("lane fields require"), "{error}");
+
+        let support_layout = TraceRowLayout {
+            residual_layers: 0,
+            final_hidden: false,
+            qkv_layers: 0,
+            attention_layers: 1,
+            heads: 1,
+            support: 1,
+            residual_width: 1,
+            kv_width: 1,
+            row_bytes: 8,
+        };
+        for (label, position, weight_bits) in [
+            ("position-only", SUPPORT_ABSENT_MARKER, 1.0f32.to_bits()),
+            ("weight-only", 0, SUPPORT_ABSENT_MARKER),
+        ] {
+            let mut row = Vec::with_capacity(8);
+            row.extend_from_slice(&position.to_le_bytes());
+            row.extend_from_slice(&weight_bits.to_le_bytes());
+            let error = support_layout
+                .read_row(&row)
+                .expect_err("half of an absence marker must not become a support entry");
+            assert!(
+                error.reason.contains("partial absence marker"),
+                "{label}: {error}"
+            );
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod attention_operator_resume_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Barrier, mpsc};
+    use std::time::Duration;
+
+    static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "uor-r4-attention-resume-{label}-{}-{}",
+                std::process::id(),
+                NEXT_DIR.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn bytes(&self) -> Vec<(String, Vec<u8>)> {
+            let mut files = fs::read_dir(&self.0)
+                .expect("read test directory")
+                .map(|entry| entry.expect("read directory entry").path())
+                .filter(|path| path.is_file())
+                .map(|path| {
+                    (
+                        path.file_name()
+                            .expect("file name")
+                            .to_string_lossy()
+                            .into_owned(),
+                        fs::read(path).expect("read file bytes"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            files.sort_by(|left, right| left.0.cmp(&right.0));
+            files
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_writer_refuses_symlinked_valid_manifest_without_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TestDir::new("manifest-symlink");
+        let target_name = "valid-manifest-target.json";
+        fs::write(
+            dir.path().join(target_name),
+            serde_json::to_vec_pretty(&ObservationManifest::new(1))
+                .expect("serialize valid manifest"),
+        )
+        .expect("write valid manifest target");
+        let link = dir.path().join(MANIFEST_FILE);
+        symlink(target_name, &link).expect("create manifest symlink");
+        let before = dir.bytes();
+        let link_target_before = fs::read_link(&link).expect("read manifest link");
+
+        let error = match ObservationShardWriter::open(dir.path(), 1) {
+            Ok(_) => panic!("public writer followed a manifest symlink"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not a regular file"), "{error}");
+        assert_eq!(dir.bytes(), before, "refusal changed directory bytes");
+        assert_eq!(
+            fs::read_link(&link).expect("reread manifest link"),
+            link_target_before,
+            "refusal replaced the manifest symlink"
+        );
+    }
+
+    #[test]
+    fn public_writer_rejects_unknown_nested_provenance_claims_without_mutation() {
+        for (label, field, mut manifest) in [
+            ("attention", "attention_operator", {
+                let mut manifest = ObservationManifest::new(1);
+                manifest.attention_operator = Some(AttentionOperatorSpec::standard());
+                manifest
+            }),
+            ("geometry", "geometry", {
+                let mut manifest = ObservationManifest::new(1);
+                manifest.geometry = Some(GeometryProjection::bucket_average(4, 2));
+                manifest
+            }),
+            ("tokenizer", "tokenizer_adapter", {
+                let mut manifest = ObservationManifest::new(1);
+                manifest.tokenizer_adapter = Some(test_tokenizer_adapter());
+                manifest
+            }),
+            ("trace", "trace_profile", {
+                let mut manifest = ObservationManifest::new(1);
+                manifest.trace_profile = Some(TraceProfile::layer(&[0]));
+                manifest
+            }),
+        ] {
+            let dir = TestDir::new(&format!("manifest-extra-{label}-claim"));
+            let mut value = serde_json::to_value(&mut manifest).expect("serialize manifest value");
+            value
+                .get_mut(field)
+                .and_then(serde_json::Value::as_object_mut)
+                .expect("nested provenance object")
+                .insert(
+                    "unregistered_claim".to_owned(),
+                    serde_json::Value::Bool(true),
+                );
+            fs::write(
+                dir.path().join(MANIFEST_FILE),
+                serde_json::to_vec_pretty(&value).expect("serialize malformed manifest"),
+            )
+            .expect("write malformed manifest");
+            let before = dir.bytes();
+
+            let error = match ObservationShardWriter::open(dir.path(), 1) {
+                Ok(_) => panic!("writer accepted an unregistered nested {label} claim"),
+                Err(error) => error,
+            };
+            assert!(
+                error.reason.contains("unregistered_claim"),
+                "{label}: {error}"
+            );
+            assert_eq!(
+                dir.bytes(),
+                before,
+                "{label} refusal changed manifest bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn public_writer_rejects_unknown_manifest_semantics_without_mutation() {
+        for (label, mutate) in [
+            (
+                "future-schema",
+                Box::new(|value: &mut serde_json::Value| value["schema"] = 2.into())
+                    as Box<dyn Fn(&mut serde_json::Value)>,
+            ),
+            (
+                "unknown-root-claim",
+                Box::new(|value: &mut serde_json::Value| {
+                    value
+                        .as_object_mut()
+                        .expect("manifest object")
+                        .insert("future_semantics".to_owned(), true.into());
+                }),
+            ),
+            (
+                "out-of-range-fanout",
+                Box::new(|value: &mut serde_json::Value| value["shard_bits"] = 9.into()),
+            ),
+        ] {
+            let dir = TestDir::new(label);
+            let mut value =
+                serde_json::to_value(ObservationManifest::new(1)).expect("serialize manifest");
+            mutate(&mut value);
+            fs::write(
+                dir.path().join(MANIFEST_FILE),
+                serde_json::to_vec_pretty(&value).expect("serialize adversarial manifest"),
+            )
+            .expect("write adversarial manifest");
+            let before = dir.bytes();
+
+            let error = match ObservationShardWriter::open(dir.path(), 1) {
+                Ok(_) => panic!("writer accepted {label}"),
+                Err(error) => error,
+            };
+            assert!(
+                error.reason.contains("schema")
+                    || error.reason.contains("unknown field")
+                    || error.reason.contains("shard_bits"),
+                "{label}: {error}"
+            );
+            assert_eq!(dir.bytes(), before, "{label} refusal changed bytes");
+        }
+
+        let dir = TestDir::new("malformed-recorded-source-kappa");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.source_manifest_kappa = Some("blake3:not-a-digest".to_owned());
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize malformed manifest"),
+        )
+        .expect("write malformed manifest");
+        let before = dir.bytes();
+        let error = match ObservationShardWriter::open(dir.path(), 1) {
+            Ok(_) => panic!("writer accepted malformed recorded source kappa"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("source manifest"), "{error}");
+        assert_eq!(dir.bytes(), before);
+
+        let dir = TestDir::new("malformed-recorded-input-cid");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.input_cid = Some("blake3:not-a-digest".to_owned());
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize malformed manifest"),
+        )
+        .expect("write malformed manifest");
+        let before = dir.bytes();
+        let error = match ObservationShardWriter::open(dir.path(), 1) {
+            Ok(_) => panic!("writer accepted malformed recorded input CID"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("input CID"), "{error}");
+        assert_eq!(dir.bytes(), before);
+
+        let fresh = TestDir::new("malformed-requested-input-cid");
+        let before = fresh.bytes();
+        let mut writer = ObservationShardWriter::open(fresh.path(), 1).expect("open fresh writer");
+        let error = writer
+            .set_input_cid("not-a-cid")
+            .expect_err("malformed requested input CID must fail");
+        assert!(error.reason.contains("input CID"), "{error}");
+        assert_eq!(fresh.bytes(), before);
+    }
+
+    #[test]
+    fn trace_layout_is_fail_closed_before_reconciliation() {
+        let profile = TraceProfile::layer(&[0]);
+        let dir = TestDir::new("trace-width-mismatch");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.trace_profile = Some(profile.clone());
+        manifest.trace_row_bytes = Some(16);
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize traced manifest"),
+        )
+        .expect("write traced manifest");
+        let before = dir.bytes();
+        let writer = ObservationShardWriter::open(dir.path(), 1).expect("open traced writer");
+        let error = writer
+            .preflight_trace_row_bytes(Some(32))
+            .expect_err("different capture geometry must fail before reconciliation");
+        assert!(error.reason.contains("trace rows"), "{error}");
+        assert_eq!(dir.bytes(), before);
+
+        let missing_width = TestDir::new("trace-width-missing-with-payload");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.trace_profile = Some(profile);
+        fs::write(
+            missing_width.path().join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize traced manifest"),
+        )
+        .expect("write traced manifest");
+        fs::write(missing_width.path().join("shard-00.bin"), []).expect("write shard-era evidence");
+        let before = missing_width.bytes();
+        let error = match ObservationShardWriter::open(missing_width.path(), 1) {
+            Ok(_) => panic!("trace profile without row width accepted over shard payload"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("no trace row width"), "{error}");
+        assert_eq!(missing_width.bytes(), before);
+
+        let unregistered = TestDir::new("unregistered-trace-before-capture");
+        let mut adversarial = TraceProfile::attention_support(&[0], 1);
+        adversarial
+            .attention_support_lane
+            .as_mut()
+            .expect("support lane")
+            .support_size = u32::MAX;
+        adversarial.declared_digest = adversarial.declared_digest();
+        let mut oracle = DeclaredOperatorOracle {
+            operator: Some(AttentionOperatorSpec::standard()),
+            geometry: None,
+        };
+        let before = unregistered.bytes();
+        let error = observe_sharded_traced(
+            &mut oracle,
+            60,
+            1,
+            1,
+            unregistered.path(),
+            None,
+            &adversarial,
+        )
+        .expect_err("unregistered trace bounds must fail before capture allocation");
+        assert!(
+            error.reason.contains("support") || error.reason.contains("trace profile"),
+            "{error}"
+        );
+        assert_eq!(unregistered.bytes(), before);
+    }
+
+    #[test]
+    fn public_writer_rejects_target_and_noncanonical_manifest_operators() {
+        for (label, operator) in [
+            (
+                "target-route",
+                AttentionOperatorSpec::r4_route_attention_v1(),
+            ),
+            ("tampered", {
+                let mut operator = AttentionOperatorSpec::standard();
+                operator.value_aggregation = "tampered-value-fold".to_owned();
+                operator
+            }),
+            ("unknown", {
+                let mut operator = AttentionOperatorSpec::standard();
+                operator.version = 999;
+                operator.implementation_digest = operator.declared_digest();
+                operator
+            }),
+        ] {
+            let dir = TestDir::new(label);
+            let mut manifest = ObservationManifest::new(1);
+            manifest.attention_operator = Some(operator);
+            fs::write(
+                dir.path().join(MANIFEST_FILE),
+                serde_json::to_vec_pretty(&manifest).expect("serialize adversarial manifest"),
+            )
+            .expect("write adversarial manifest");
+            let before = dir.bytes();
+
+            let error = match ObservationShardWriter::open(dir.path(), 1) {
+                Ok(_) => panic!("writer accepted {label} source provenance"),
+                Err(error) => error,
+            };
+            assert!(
+                error.reason.contains("attention operator")
+                    || error.reason.contains("unknown attention"),
+                "{label}: {error}"
+            );
+            assert_eq!(dir.bytes(), before, "{label} refusal changed bytes");
+            assert!(
+                !dir.path().join("shard-00.bin").exists(),
+                "{label} refusal created a shard"
+            );
+        }
+    }
+
+    #[test]
+    fn regular_manifest_temp_crash_residue_is_recovered_before_pinning() {
+        let dir = TestDir::new("manifest-temp-recovery");
+        let fixed = dir.path().join(".manifest.json.tmp");
+        let unique = dir.path().join(".manifest.json.tmp-123-7");
+        fs::write(&fixed, []).expect("write zero-byte fixed crash residue");
+        fs::write(&unique, b"{\"schema\":").expect("write truncated unique crash residue");
+
+        let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+        writer
+            .set_attention_operator(&AttentionOperatorSpec::standard())
+            .expect("unpublished regular temps do not establish an era");
+
+        assert!(!fixed.exists(), "fixed crash residue was not recovered");
+        assert!(!unique.exists(), "unique crash residue was not recovered");
+        assert_eq!(
+            writer.manifest().attention_operator.as_ref(),
+            Some(&AttentionOperatorSpec::standard())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn manifest_temp_symlink_is_refused_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TestDir::new("manifest-temp-symlink");
+        let external = TestDir::new("manifest-temp-external");
+        let target = external.path().join("sentinel");
+        fs::write(&target, b"external sentinel").expect("write external target");
+        let link = dir.path().join(".manifest.json.tmp");
+        symlink(&target, &link).expect("plant manifest temp symlink");
+        let before = dir.bytes();
+        let target_before = fs::read(&target).expect("read target before refusal");
+
+        let error = match ObservationShardWriter::open(dir.path(), 1) {
+            Ok(_) => panic!("writer accepted a manifest-temp symlink"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not a regular file"), "{error}");
+        assert_eq!(dir.bytes(), before, "refusal changed directory bytes");
+        assert_eq!(
+            fs::read(&target).expect("read target after refusal"),
+            target_before,
+            "refusal followed the temp symlink"
+        );
+        assert_eq!(fs::read_link(&link).expect("temp symlink remains"), target);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn matching_operator_resume_refuses_shard_symlink_without_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TestDir::new("matching-shard-symlink");
+        let standard = AttentionOperatorSpec::standard();
+        {
+            let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+            writer
+                .set_attention_operator(&standard)
+                .expect("pin standard operator");
+        }
+        let external = TestDir::new("matching-shard-external");
+        let target = external.path().join("sentinel");
+        fs::write(&target, vec![0x5a; RECORD_SIZE * 2]).expect("write external shard target");
+        let link = dir.path().join("shard-00.bin");
+        symlink(&target, &link).expect("plant shard symlink");
+        let before = dir.bytes();
+        let target_before = fs::read(&target).expect("read target before refusal");
+        let mut producer = DeclaredOperatorOracle {
+            operator: Some(standard),
+            geometry: None,
+        };
+
+        let error = observe_sharded(&mut producer, 0, 1, 1, dir.path(), None)
+            .expect_err("matching identity must still reject a shard symlink");
+        assert!(error.reason.contains("not a regular file"), "{error}");
+        assert_eq!(dir.bytes(), before, "refusal changed observation bytes");
+        assert_eq!(
+            fs::read(&target).expect("read target after refusal"),
+            target_before,
+            "refusal followed or truncated the shard symlink"
+        );
+        assert_eq!(fs::read_link(&link).expect("shard symlink remains"), target);
+    }
+
+    #[test]
+    fn setter_accepts_only_exact_registry_records_and_is_failure_atomic() {
+        for (label, operator) in [
+            ("tampered", {
+                let mut operator = AttentionOperatorSpec::standard();
+                operator.value_aggregation = "tampered-value-fold".to_owned();
+                operator
+            }),
+            ("unknown", {
+                let mut operator = AttentionOperatorSpec::standard();
+                operator.version = 999;
+                operator.implementation_digest = operator.declared_digest();
+                operator
+            }),
+            (
+                "target-route",
+                AttentionOperatorSpec::r4_route_attention_v1(),
+            ),
+        ] {
+            let dir = TestDir::new(label);
+            let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+            let error = writer
+                .set_attention_operator(&operator)
+                .expect_err("only exact source provenance may be stored");
+            if label == "target-route" {
+                assert!(error.reason.contains("not an allowed source"), "{error}");
+            }
+            assert!(dir.bytes().is_empty(), "{label} refusal wrote output");
+        }
+
+        for operator in [
+            AttentionOperatorSpec::standard(),
+            AttentionOperatorSpec::experimental_r4(),
+            AttentionOperatorSpec::learned_absolute_source_attention(),
+        ] {
+            let dir = TestDir::new(&operator.id);
+            let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+            writer
+                .set_attention_operator(&operator)
+                .expect("every registered source operator is admissible");
+            assert_eq!(
+                writer.manifest().attention_operator.as_ref(),
+                Some(&operator)
+            );
+        }
+
+        let dir = TestDir::new("registered");
+        let standard = AttentionOperatorSpec::standard();
+        let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+        writer
+            .set_attention_operator(&standard)
+            .expect("pin registered operator");
+        let pinned = dir.bytes();
+        writer
+            .set_attention_operator(&standard)
+            .expect("identical record is idempotent");
+        assert_eq!(dir.bytes(), pinned);
+
+        let error = writer
+            .set_attention_operator(&AttentionOperatorSpec::experimental_r4())
+            .expect_err("different registered era must be refused");
+        assert!(error.reason.contains("incompatible observation resume"));
+        assert_eq!(
+            writer.manifest().attention_operator.as_ref(),
+            Some(&standard)
+        );
+        assert_eq!(dir.bytes(), pinned, "mismatch changed directory bytes");
+    }
+
+    #[test]
+    fn every_tokenizer_era_payload_marker_blocks_attention_relabelling() {
+        let shard = shard_file_name(1, 0);
+        let payload_names = [
+            STATE_FILE.to_owned(),
+            "merged.bin".to_owned(),
+            "committed.bin".to_owned(),
+            ".committed.bin.tmp".to_owned(),
+            "stories.jsonl".to_owned(),
+            "stories.tmp".to_owned(),
+            "stories.tmp-123-0".to_owned(),
+            "tokenizer.bin".to_owned(),
+            shard.clone(),
+            format!("{shard}.prob"),
+            format!("{shard}.trace"),
+        ];
+        for name in payload_names {
+            let dir = TestDir::new(&name.replace('.', "-"));
+            fs::write(dir.path().join(&name), b"legacy payload").expect("write payload marker");
+            let before = dir.bytes();
+            let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+            let error = writer
+                .set_attention_operator(&AttentionOperatorSpec::standard())
+                .expect_err("legacy payload cannot be relabelled");
+            assert!(
+                error.reason.contains("implicit legacy era"),
+                "{name}: {error}"
+            );
+            assert_eq!(dir.bytes(), before, "{name} refusal changed bytes");
+            assert_eq!(writer.manifest().attention_operator, None);
+        }
+
+        let dir = TestDir::new("manifest-count");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.total_records = 1;
+        manifest.store(dir.path()).expect("store legacy manifest");
+        let before = dir.bytes();
+        let error = match ObservationShardWriter::open(dir.path(), 1) {
+            Ok(_) => panic!("inconsistent manifest record count was accepted"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("total_records"), "{error}");
+        assert_eq!(dir.bytes(), before);
+    }
+
+    #[test]
+    fn zero_byte_payload_entries_still_pin_the_legacy_operator_era() {
+        for name in [STATE_FILE, "shard-00.bin"] {
+            let dir = TestDir::new(&format!("zero-{}", name.replace('.', "-")));
+            fs::write(dir.path().join(name), []).expect("write zero-byte crash residue");
+            let before = dir.bytes();
+            let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+
+            let error = writer
+                .set_attention_operator(&AttentionOperatorSpec::standard())
+                .expect_err("payload entry presence must pin the legacy era");
+            assert!(error.reason.contains("implicit legacy era"), "{error}");
+            assert_eq!(dir.bytes(), before, "{name} refusal changed bytes");
+        }
+    }
+
+    #[test]
+    fn stripped_manifest_cannot_hide_out_of_fanout_shard_payload() {
+        // Requested shard_bits=1 implies only shards 00 and 01. These files
+        // came from a wider historical fan-out whose manifest was stripped.
+        for name in ["shard-02.bin", "shard-02.bin.prob", "shard-02.bin.trace"] {
+            let dir = TestDir::new(&format!("hidden-{}", name.replace('.', "-")));
+            fs::write(dir.path().join(name), b"legacy hidden row")
+                .expect("write hidden shard payload");
+            let before = dir.bytes();
+
+            let error = match ObservationShardWriter::open(dir.path(), 1) {
+                Ok(_) => panic!("narrow writer accepted out-of-fanout payload"),
+                Err(error) => error,
+            };
+            assert!(error.reason.contains("outside"), "{error}");
+            assert_eq!(dir.bytes(), before, "{name} refusal changed legacy bytes");
+            assert!(
+                !dir.path().join(MANIFEST_FILE).exists(),
+                "{name} refusal relabelled the stripped manifest"
+            );
+        }
+    }
+
+    fn test_tokenizer_adapter() -> TokenizerAdapter {
+        let mut adapter = TokenizerAdapter {
+            family: TokenizerAdapter::HF_BYTE_BPE_FAMILY.to_owned(),
+            version: TokenizerAdapter::HF_BYTE_BPE_VERSION,
+            tokenizer_cid: format!("blake3:{}", blake3::hash(b"test-tokenizer").to_hex()),
+            policy: Default::default(),
+            adapter_digest: String::new(),
+        };
+        adapter.adapter_digest = adapter.declared_digest();
+        adapter
+    }
+
+    #[test]
+    fn one_session_never_issues_stale_or_concurrent_writers() {
+        let dir = TestDir::new("single-writer-lease");
+        let session = ObservationSession::acquire(dir.path(), 1).expect("acquire session");
+        let adapter = test_tokenizer_adapter();
+        let mut first = session.writer().expect("open first writer");
+        first
+            .set_tokenizer_adapter(&adapter)
+            .expect("pin tokenizer through first writer");
+
+        let error = match session.writer() {
+            Ok(_) => panic!("session issued a stale second writer"),
+            Err(error) => error,
+        };
+        assert!(
+            error.reason.contains("already has a live writer"),
+            "{error}"
+        );
+        drop(first);
+
+        let mut second = session.writer().expect("reload after first writer drops");
+        assert_eq!(
+            second.manifest().tokenizer_adapter.as_ref(),
+            Some(&adapter),
+            "fresh writer did not reload the first identity update"
+        );
+        second
+            .set_attention_operator(&AttentionOperatorSpec::standard())
+            .expect("pin operator without erasing tokenizer");
+        second
+            .write_record(&[0u8; RECORD_SIZE], 0)
+            .expect("write one shard row");
+        second.flush().expect("flush shard row");
+        assert!(
+            session.writer().is_err(),
+            "session issued a same-shard writer while one was live"
+        );
+        drop(second);
+
+        let manifest = ObservationManifest::load(dir.path())
+            .expect("reload manifest")
+            .expect("manifest exists");
+        assert_eq!(manifest.tokenizer_adapter.as_ref(), Some(&adapter));
+        assert_eq!(
+            manifest.attention_operator.as_ref(),
+            Some(&AttentionOperatorSpec::standard())
+        );
+        assert_eq!(
+            fs::metadata(dir.path().join("shard-00.bin"))
+                .expect("shard exists")
+                .len(),
+            RECORD_SIZE as u64
+        );
+    }
+
+    #[test]
+    fn full_session_lock_prevents_cross_field_mixed_era_publication() {
+        let dir = TestDir::new("cross-field-session-race");
+        let session_a = ObservationSession::acquire(dir.path(), 1).expect("acquire session A");
+        let mut writer_a = session_a.writer().expect("open session A writer");
+        let standard = AttentionOperatorSpec::standard();
+        writer_a
+            .preflight_tokenizer_adapter(None)
+            .expect("checkpoint tokenizer half is fresh");
+        writer_a
+            .preflight_attention_operator(Some(&standard))
+            .expect("checkpoint operator half is fresh");
+
+        let barrier = std::sync::Arc::new(Barrier::new(2));
+        let (sender, receiver) = mpsc::channel();
+        let thread_dir = dir.path().to_path_buf();
+        let thread_barrier = std::sync::Arc::clone(&barrier);
+        let adapter = test_tokenizer_adapter();
+        let adapter_for_thread = adapter.clone();
+        let worker = std::thread::spawn(move || {
+            thread_barrier.wait();
+            let result = (|| -> Result<(), SourceUnavailable> {
+                let session_b = ObservationSession::acquire(&thread_dir, 1)?;
+                let mut writer_b = session_b.writer()?;
+                let experimental = AttentionOperatorSpec::experimental_r4();
+                // Jointly check both halves before either setter. Once A has
+                // committed a row, B must fail here and publish nothing.
+                writer_b.preflight_tokenizer_adapter(Some(&adapter_for_thread))?;
+                writer_b.preflight_attention_operator(Some(&experimental))?;
+                writer_b.set_tokenizer_adapter(&adapter_for_thread)?;
+                writer_b.set_attention_operator(&experimental)?;
+                writer_b.write_record(&[1u8; RECORD_SIZE], 0)?;
+                Ok(())
+            })();
+            sender
+                .send(result.map_err(|error| error.reason))
+                .expect("send worker result");
+        });
+        barrier.wait();
+        assert!(
+            receiver.recv_timeout(Duration::from_millis(100)).is_err(),
+            "session B entered while session A still held the OS lock"
+        );
+
+        writer_a
+            .set_attention_operator(&standard)
+            .expect("session A pins standard operator");
+        writer_a
+            .write_record(&[0u8; RECORD_SIZE], 0)
+            .expect("session A writes its row");
+        writer_a.flush().expect("flush session A row");
+        drop(writer_a);
+        drop(session_a);
+
+        let error = receiver
+            .recv_timeout(Duration::from_secs(3))
+            .expect("session B resumes after A drops")
+            .expect_err("session B must refuse the mixed identity pair");
+        assert!(
+            error.contains("tokenizer adapter") || error.contains("attention operator"),
+            "{error}"
+        );
+        worker.join().expect("worker thread joins");
+
+        let manifest = ObservationManifest::load(dir.path())
+            .expect("load final manifest")
+            .expect("manifest exists");
+        assert_eq!(
+            manifest.tokenizer_adapter, None,
+            "loser added its tokenizer"
+        );
+        assert_eq!(manifest.attention_operator.as_ref(), Some(&standard));
+        assert_eq!(
+            fs::metadata(dir.path().join("shard-00.bin"))
+                .expect("winner shard exists")
+                .len(),
+            RECORD_SIZE as u64,
+            "loser appended a row"
+        );
+        assert!(
+            !dir.path().join("tokenizer.bin").exists(),
+            "loser exported tokenizer bytes"
+        );
+    }
+
+    struct DeclaredOperatorOracle {
+        operator: Option<AttentionOperatorSpec>,
+        geometry: Option<GeometryProjection>,
+    }
+
+    impl uor_r4_model_source::RepresentationSource for DeclaredOperatorOracle {
+        fn vocab_size(&self) -> usize {
+            2
+        }
+        fn source_dimension(&self) -> usize {
+            1
+        }
+        fn tokenizer_address(&self) -> &str {
+            "test-tokenizer"
+        }
+        fn read_embedding_rows(
+            &self,
+            _range: std::ops::Range<usize>,
+            output: &mut [f32],
+        ) -> Option<()> {
+            output.fill(0.0);
+            Some(())
+        }
+    }
+
+    impl uor_r4_model_source::BehaviorSource for DeclaredOperatorOracle {
+        fn reset(&mut self) {}
+        fn step(&mut self, _token: usize, _pos: usize, logits: &mut [f32]) {
+            logits.fill(0.0);
+        }
+    }
+
+    impl TeacherOracle for DeclaredOperatorOracle {
+        fn vocab(&self) -> usize {
+            2
+        }
+        fn dim(&self) -> usize {
+            1
+        }
+        fn seq_len(&self) -> usize {
+            1
+        }
+        fn kappa(&self) -> String {
+            "blake3:test-source".to_owned()
+        }
+        fn source_bytes(&self) -> usize {
+            1
+        }
+        fn embedding(&self, _token: usize, out: &mut [f32]) {
+            out.fill(0.0);
+        }
+        fn attention_operator_spec(&self) -> Option<AttentionOperatorSpec> {
+            self.operator.clone()
+        }
+        fn geometry_projection(&self) -> Option<GeometryProjection> {
+            self.geometry.clone()
+        }
+    }
+
+    #[test]
+    fn raw_sharded_path_binds_actual_operator_and_refuses_symmetric_resume() {
+        let dir = TestDir::new("raw-path");
+        let standard = AttentionOperatorSpec::standard();
+        let mut producer = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: None,
+        };
+        observe_sharded(&mut producer, 0, 1, 1, dir.path(), None)
+            .expect("fresh raw path binds the operator before generation");
+        let manifest = ObservationManifest::load(dir.path())
+            .expect("load manifest")
+            .expect("manifest exists");
+        assert_eq!(manifest.attention_operator.as_ref(), Some(&standard));
+        let before = dir.bytes();
+
+        let mut undeclared = DeclaredOperatorOracle {
+            operator: None,
+            geometry: None,
+        };
+        let error = observe_sharded(&mut undeclared, 0, 1, 1, dir.path(), None)
+            .expect_err("explicit-to-none resume must fail");
+        assert!(error.reason.contains("declares none"), "{error}");
+        assert_eq!(dir.bytes(), before);
+
+        let mut different = DeclaredOperatorOracle {
+            operator: Some(AttentionOperatorSpec::experimental_r4()),
+            geometry: None,
+        };
+        observe_sharded(&mut different, 0, 1, 1, dir.path(), None)
+            .expect_err("different explicit era must fail");
+        assert_eq!(dir.bytes(), before);
+    }
+
+    #[test]
+    fn raw_path_binds_geometry_and_refuses_both_absence_directions() {
+        let geometry = GeometryProjection::bucket_average(4, 2);
+        let standard = AttentionOperatorSpec::standard();
+
+        let projected_dir = TestDir::new("raw-geometry-projected");
+        let mut projected = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: Some(geometry.clone()),
+        };
+        observe_sharded(&mut projected, 60, 1, 1, projected_dir.path(), None)
+            .expect("projected raw pass");
+        let projected_manifest = ObservationManifest::load(projected_dir.path())
+            .expect("load projected manifest")
+            .expect("projected manifest exists");
+        assert_eq!(projected_manifest.geometry.as_ref(), Some(&geometry));
+        let projected_before = projected_dir.bytes();
+        let error = observe_sharded(&mut projected, 60, 2, 1, projected_dir.path(), None)
+            .expect_err("a finalized raw corpus cannot be extended in place");
+        assert!(
+            error.reason.contains("finalized observation shards"),
+            "{error}"
+        );
+        assert_eq!(projected_dir.bytes(), projected_before);
+        let mut pass_through = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: None,
+        };
+        let error = observe_sharded(&mut pass_through, 0, 1, 1, projected_dir.path(), None)
+            .expect_err("pass-through geometry cannot resume projected bytes");
+        assert!(error.reason.contains("geometry"), "{error}");
+        assert_eq!(projected_dir.bytes(), projected_before);
+
+        let legacy_dir = TestDir::new("raw-geometry-pass-through");
+        let mut legacy = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: None,
+        };
+        observe_sharded(&mut legacy, 60, 1, 1, legacy_dir.path(), None)
+            .expect("pass-through raw pass");
+        let legacy_before = legacy_dir.bytes();
+        let mut relabel = DeclaredOperatorOracle {
+            operator: Some(standard),
+            geometry: Some(geometry),
+        };
+        let error = observe_sharded(&mut relabel, 0, 1, 1, legacy_dir.path(), None)
+            .expect_err("projected geometry cannot relabel pass-through payload");
+        assert!(error.reason.contains("no recorded geometry"), "{error}");
+        assert_eq!(legacy_dir.bytes(), legacy_before);
+    }
+
+    #[test]
+    fn raw_path_refuses_malformed_present_checkpoint_before_mutation() {
+        for (label, bytes) in [
+            ("zero", Vec::new()),
+            ("truncated", vec![0u8; 24]),
+            ("invalid-done", {
+                let mut bytes = vec![0u8; 25];
+                bytes[24] = 2;
+                bytes
+            }),
+            ("stories-outside-wire-domain", {
+                let mut bytes = vec![0u8; 25];
+                bytes[8..16].copy_from_slice(&u64::MAX.to_le_bytes());
+                bytes
+            }),
+        ] {
+            let dir = TestDir::new(&format!("raw-state-{label}"));
+            {
+                let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+                writer
+                    .set_attention_operator(&AttentionOperatorSpec::standard())
+                    .expect("pin source operator");
+            }
+            fs::write(dir.path().join(STATE_FILE), bytes).expect("write malformed state");
+            let before = dir.bytes();
+            let mut oracle = DeclaredOperatorOracle {
+                operator: Some(AttentionOperatorSpec::standard()),
+                geometry: None,
+            };
+
+            let error = observe_sharded(&mut oracle, 60, 1, 1, dir.path(), None)
+                .expect_err("present malformed checkpoint must not mean fresh");
+            assert!(error.reason.contains("checkpoint"), "{label}: {error}");
+            assert_eq!(dir.bytes(), before, "{label} refusal changed bytes");
+        }
+    }
+
+    #[test]
+    fn raw_state_pairing_is_validated_before_identity_or_reconciliation() {
+        let standard = AttentionOperatorSpec::standard();
+        {
+            let marker = "merged.bin";
+            let dir = TestDir::new("raw-missing-state-stream-evidence");
+            {
+                let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
+                writer
+                    .set_attention_operator(&standard)
+                    .expect("pin operator");
+            }
+            fs::write(dir.path().join(marker), []).expect("write stream evidence");
+            let before = dir.bytes();
+            let mut oracle = DeclaredOperatorOracle {
+                operator: Some(standard.clone()),
+                geometry: None,
+            };
+            let error = observe_sharded(&mut oracle, 60, 1, 1, dir.path(), None)
+                .expect_err("stream evidence without state must fail");
+            assert!(error.reason.contains("no state.bin"), "{error}");
+            assert_eq!(dir.bytes(), before);
+        }
+
+        let missing_rows = TestDir::new("raw-state-missing-rows");
+        {
+            let mut writer =
+                ObservationShardWriter::open(missing_rows.path(), 1).expect("open writer");
+            writer
+                .set_attention_operator(&standard)
+                .expect("pin operator");
+        }
+        let mut state = [0u8; 25];
+        state[0..8].copy_from_slice(&1u64.to_le_bytes());
+        fs::write(missing_rows.path().join(STATE_FILE), state).expect("write valid state");
+        let before = missing_rows.bytes();
+        let mut oracle = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: None,
+        };
+        let error = observe_sharded(&mut oracle, 60, 1, 1, missing_rows.path(), None)
+            .expect_err("checkpoint rows missing from base shards must fail");
+        assert!(error.reason.contains("retain only 0"), "{error}");
+        assert_eq!(missing_rows.bytes(), before);
+
+        for alias_name in ["shard-1.bin", "shard-000.bin"] {
+            let alias = TestDir::new("raw-noncanonical-shard-alias");
+            {
+                let mut writer =
+                    ObservationShardWriter::open(alias.path(), 1).expect("open writer");
+                writer
+                    .set_attention_operator(&standard)
+                    .expect("pin operator");
+            }
+            fs::write(alias.path().join(STATE_FILE), state).expect("write valid state");
+            fs::write(alias.path().join(alias_name), [0u8; RECORD_SIZE])
+                .expect("write numeric alias");
+            let before = alias.bytes();
+            let error = observe_sharded(&mut oracle, 60, 1, 1, alias.path(), None)
+                .expect_err("noncanonical numeric shard aliases must fail");
+            assert!(
+                error.reason.contains("non-canonical numeric alias"),
+                "{error}"
+            );
+            assert_eq!(alias.bytes(), before);
+        }
+
+        let tampered = TestDir::new("raw-completed-same-length-tamper");
+        let mut oracle = DeclaredOperatorOracle {
+            operator: Some(standard.clone()),
+            geometry: None,
+        };
+        observe_sharded(&mut oracle, 60, 1, 1, tampered.path(), None)
+            .expect("complete corpus before tampering");
+        let manifest = ObservationManifest::load(tampered.path())
+            .expect("load completed manifest")
+            .expect("completed manifest exists");
+        let (&shard, _) = manifest
+            .completed
+            .iter()
+            .find(|(_, entry)| entry.records > 0)
+            .expect("fixture completes a non-empty shard");
+        let shard_path = tampered
+            .path()
+            .join(shard_file_name(manifest.shard_bits, shard));
+        let mut shard_bytes = fs::read(&shard_path).expect("completed shard bytes");
+        shard_bytes[0] ^= 0x80;
+        fs::write(&shard_path, shard_bytes).expect("tamper completed shard in place");
+        let before = tampered.bytes();
+        let error = observe_sharded(&mut oracle, 60, 1, 1, tampered.path(), None)
+            .expect_err("same-length completed-shard tampering must fail");
+        assert!(error.reason.contains("manifest commits"), "{error}");
+        assert_eq!(tampered.bytes(), before);
+
+        let completed = TestDir::new("raw-completed-without-state");
+        let mut oracle = DeclaredOperatorOracle {
+            operator: Some(standard),
+            geometry: None,
+        };
+        observe_sharded(&mut oracle, 60, 1, 1, completed.path(), None)
+            .expect("complete raw corpus");
+        fs::remove_file(completed.path().join(STATE_FILE)).expect("remove checkpoint");
+        let before = completed.bytes();
+        let error = observe_sharded(&mut oracle, 60, 1, 1, completed.path(), None)
+            .expect_err("completed manifest without state must fail");
+        assert!(error.reason.contains("no state.bin"), "{error}");
+        assert_eq!(completed.bytes(), before);
+    }
+
+    #[test]
+    fn source_snapshot_kappa_is_symmetric_once_bound_or_payload_exists() {
+        let source_kappa = format!("blake3:{}", blake3::hash(b"source-a").to_hex());
+        let bound_dir = TestDir::new("source-kappa-bound");
+        let mut writer = ObservationShardWriter::open(bound_dir.path(), 1).expect("open writer");
+        writer
+            .set_source_manifest_kappa(&source_kappa)
+            .expect("bind fresh source kappa");
+        let before = bound_dir.bytes();
+        let error = writer
+            .preflight_source_manifest_kappa(None)
+            .expect_err("bound source kappa requires an exact request");
+        assert!(error.reason.contains("declares none"), "{error}");
+        assert_eq!(bound_dir.bytes(), before);
+
+        let legacy_dir = TestDir::new("source-kappa-orphan");
+        fs::write(legacy_dir.path().join("shard-00.bin"), []).expect("write orphan shard");
+        let before = legacy_dir.bytes();
+        let writer = ObservationShardWriter::open(legacy_dir.path(), 1).expect("open legacy");
+        let error = writer
+            .preflight_source_manifest_kappa(Some(&source_kappa))
+            .expect_err("orphan payload cannot acquire a source kappa");
+        assert!(error.reason.contains("no recorded source"), "{error}");
+        assert_eq!(legacy_dir.bytes(), before);
+
+        let malformed_dir = TestDir::new("source-kappa-malformed");
+        let before = malformed_dir.bytes();
+        let mut writer =
+            ObservationShardWriter::open(malformed_dir.path(), 1).expect("open fresh writer");
+        let error = writer
+            .set_source_manifest_kappa("blake3:not-a-digest")
+            .expect_err("malformed requested kappa must fail");
+        assert!(error.reason.contains("not canonical"), "{error}");
+        assert_eq!(malformed_dir.bytes(), before);
     }
 }

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -54,6 +54,8 @@ use uor_r4_core::transformerless::hf_bpe::{TokenizerAdapter, TokenizerKind};
 use uor_r4_model_source::BatchedTeacher;
 use uor_r4_model_source::SourceUnavailable;
 use uor_r4_model_source::TeacherOracle;
+use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::geometry::GeometryProjection;
 use uor_r4_model_source::progress::Progress;
 
 /// Authoritative per-article checkpoint file name within an observation
@@ -82,6 +84,8 @@ const SHARD_ROW_SIZE: usize = 24;
 
 /// Input-pin width: blake3 digest of the articles file.
 const INPUT_KAPPA_SIZE: usize = 32;
+
+static STORIES_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Document-level partition of one article, keyed by its article id:
 /// held-out when `blake3(id as utf-8)[0] % 5 == 0` (the D3 split rule).
@@ -255,6 +259,12 @@ impl Checkpoint {
                 bytes.len()
             )));
         }
+        if bytes[24] > 1 {
+            return Err(SourceUnavailable::new(format!(
+                "committed checkpoint has invalid done byte {}; expected 0 or 1",
+                bytes[24]
+            )));
+        }
         let at = |offset: usize| {
             u64::from_le_bytes(bytes[offset..offset + 8].try_into().expect("8-byte slice"))
         };
@@ -273,6 +283,21 @@ impl Checkpoint {
                     "committed checkpoint has a torn shard length",
                 ));
             }
+            let partition_records = shard
+                .partitions
+                .construction
+                .checked_add(shard.partitions.held_out)
+                .ok_or_else(|| {
+                    SourceUnavailable::new(
+                        "committed checkpoint partition counts overflow the record counter",
+                    )
+                })?;
+            let shard_records = shard.bytes / RECORD_SIZE as u64;
+            if partition_records != shard_records {
+                return Err(SourceUnavailable::new(format!(
+                    "committed checkpoint partition counts {partition_records} do not match the shard length's {shard_records} records"
+                )));
+            }
             shards.push(shard);
             offset += SHARD_ROW_SIZE;
         }
@@ -280,17 +305,19 @@ impl Checkpoint {
             n: at(0),
             stories: at(8),
             rng: at(16),
-            done: bytes[24] != 0,
+            done: bytes[24] == 1,
             input_kappa: bytes[HEADER_SIZE..HEADER_SIZE + INPUT_KAPPA_SIZE]
                 .try_into()
                 .expect("32-byte slice"),
             shards,
         };
-        let committed_records: u64 = checkpoint
-            .shards
-            .iter()
-            .map(|shard| shard.bytes / RECORD_SIZE as u64)
-            .sum();
+        let committed_records = checkpoint.shards.iter().try_fold(0u64, |total, shard| {
+            total
+                .checked_add(shard.bytes / RECORD_SIZE as u64)
+                .ok_or_else(|| {
+                    SourceUnavailable::new("committed checkpoint shard record total overflows u64")
+                })
+        })?;
         if checkpoint.n != committed_records {
             return Err(SourceUnavailable::new(format!(
                 "committed checkpoint records {} do not match the shard lengths {committed_records}",
@@ -319,6 +346,33 @@ fn read_checkpoint(dir: &Path, shard_count: u32) -> Result<Option<Checkpoint>, S
     }
 }
 
+fn state_mirror_needs_repair(
+    dir: &Path,
+    checkpoint: &Checkpoint,
+) -> Result<bool, SourceUnavailable> {
+    let path = dir.join(observe::STATE_FILE);
+    match fs::symlink_metadata(&path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(SourceUnavailable::new(format!(
+            "{}: {error}",
+            path.display()
+        ))),
+        Ok(metadata) if !metadata.file_type().is_file() => Err(SourceUnavailable::new(format!(
+            "{} is not a regular checkpoint mirror",
+            path.display()
+        ))),
+        Ok(_) => fs::read(&path)
+            .map(|bytes| bytes != checkpoint.header())
+            .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display()))),
+    }
+}
+
+fn repair_state_mirror(dir: &Path, checkpoint: &Checkpoint) -> Result<(), SourceUnavailable> {
+    let path = dir.join(observe::STATE_FILE);
+    fs::write(&path, checkpoint.header())
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))
+}
+
 /// Persist the checkpoint: `committed.bin` atomically (write-then-rename),
 /// then the `state.bin` mirror in the 25-byte corpus-meta layout.
 fn write_checkpoint(dir: &Path, checkpoint: &Checkpoint) -> Result<(), SourceUnavailable> {
@@ -337,18 +391,24 @@ fn write_checkpoint(dir: &Path, checkpoint: &Checkpoint) -> Result<(), SourceUna
 /// restarted article never duplicates its records. A file longer than the
 /// checkpoint holds the content-stable tail of an interrupted article and
 /// is truncated; a file shorter than the checkpoint means data loss.
-fn reconcile_shard(
+fn preflight_shard_prefix(
     dir: &Path,
     shard_bits: u8,
     shard: u32,
     committed: u64,
-) -> Result<(), SourceUnavailable> {
+) -> Result<u64, SourceUnavailable> {
     let path = dir.join(observe::shard_file_name(shard_bits, shard));
-    let length = match fs::metadata(&path) {
-        Ok(metadata) => metadata.len(),
+    let length = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => metadata.len(),
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is not a regular observation shard",
+                path.display()
+            )));
+        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             if committed == 0 {
-                return Ok(());
+                return Ok(0);
             }
             return Err(SourceUnavailable::new(format!(
                 "{} is missing but the checkpoint commits {committed} bytes; delete the observation directory and rerun",
@@ -374,6 +434,19 @@ fn reconcile_shard(
             path.display()
         )));
     }
+    Ok(length)
+}
+
+/// Trim one incomplete shard file back to its committed length after every
+/// shard and sidecar has passed the read-only prefix preflight.
+fn reconcile_shard(
+    dir: &Path,
+    shard_bits: u8,
+    shard: u32,
+    committed: u64,
+) -> Result<(), SourceUnavailable> {
+    let path = dir.join(observe::shard_file_name(shard_bits, shard));
+    let length = preflight_shard_prefix(dir, shard_bits, shard, committed)?;
     if length > committed {
         let file = fs::OpenOptions::new()
             .write(true)
@@ -385,14 +458,73 @@ fn reconcile_shard(
     Ok(())
 }
 
-/// Trim `stories.jsonl` back to the committed story count (crash window:
-/// a story line appended just before the checkpoint rename failed).
-fn reconcile_stories(path: &Path, stories: u64) -> Result<(), SourceUnavailable> {
-    let bytes = match fs::read(path) {
-        Ok(bytes) => bytes,
+fn preflight_probability_prefix(
+    dir: &Path,
+    shard_bits: u8,
+    shard: u32,
+    committed_record_bytes: u64,
+) -> Result<(), SourceUnavailable> {
+    let path = dir.join(format!(
+        "{}.prob",
+        observe::shard_file_name(shard_bits, shard)
+    ));
+    let expected =
+        committed_record_bytes / RECORD_SIZE as u64 * observe::PROBABILITY_METADATA_SIZE as u64;
+    let length = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => metadata.len(),
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is not a regular probability sidecar",
+                path.display()
+            )));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if expected == 0 {
+                return Ok(());
+            }
+            return Err(SourceUnavailable::new(format!(
+                "{} is missing but the checkpoint commits probability metadata",
+                path.display()
+            )));
+        }
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{}: {error}",
+                path.display()
+            )));
+        }
+    };
+    if length % observe::PROBABILITY_METADATA_SIZE as u64 != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "probability sidecar {} has a torn metadata row ({length} bytes)",
+            path.display()
+        )));
+    }
+    if length < expected {
+        return Err(SourceUnavailable::new(format!(
+            "probability sidecar {} is shorter ({length} bytes) than the committed prefix ({expected} bytes)",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn preflight_stories_prefix(
+    path: &Path,
+    stories: u64,
+) -> Result<(Vec<u8>, Vec<StoryEntry>), SourceUnavailable> {
+    let bytes = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => fs::read(path)
+            .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))?,
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is not a regular story mapping",
+                path.display()
+            )));
+        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             if stories == 0 {
-                return Ok(());
+                return Ok((Vec::new(), Vec::new()));
             }
             return Err(SourceUnavailable::new(format!(
                 "{} is missing but the checkpoint commits {stories} stories; delete the observation directory and rerun",
@@ -406,6 +538,50 @@ fn reconcile_stories(path: &Path, stories: u64) -> Result<(), SourceUnavailable>
             )));
         }
     };
+    let mut entries = Vec::new();
+    for (line_index, line) in bytes.split(|&byte| byte == b'\n').enumerate() {
+        if entries.len() as u64 == stories {
+            break;
+        }
+        if line.is_empty() {
+            return Err(SourceUnavailable::new(format!(
+                "{} line {} is empty inside the committed story prefix",
+                path.display(),
+                line_index + 1
+            )));
+        }
+        let entry: StoryEntry = serde_json::from_slice(line).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{} line {}: invalid story entry: {error}",
+                path.display(),
+                line_index + 1
+            ))
+        })?;
+        if entry.story as usize != entries.len() {
+            return Err(SourceUnavailable::new(format!(
+                "{} line {}: story ordinals are not dense (got {}, expected {})",
+                path.display(),
+                line_index + 1,
+                entry.story,
+                entries.len()
+            )));
+        }
+        entries.push(entry);
+    }
+    if (entries.len() as u64) < stories {
+        return Err(SourceUnavailable::new(format!(
+            "{} has {} story lines but the checkpoint commits {stories}; delete the observation directory and rerun",
+            path.display(),
+            entries.len()
+        )));
+    }
+    Ok((bytes, entries))
+}
+
+/// Trim `stories.jsonl` back to the committed story count (crash window:
+/// a story line appended just before the checkpoint rename failed).
+fn reconcile_stories(path: &Path, stories: u64) -> Result<(), SourceUnavailable> {
+    let (bytes, _) = preflight_stories_prefix(path, stories)?;
     let mut lines: Vec<&[u8]> = bytes.split(|&byte| byte == b'\n').collect();
     if lines.last() == Some(&b"".as_slice()) {
         lines.pop();
@@ -425,13 +601,45 @@ fn reconcile_stories(path: &Path, stories: u64) -> Result<(), SourceUnavailable>
         trimmed.extend_from_slice(line);
         trimmed.push(b'\n');
     }
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, &trimmed)
-        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", tmp.display())))?;
-    fs::rename(&tmp, path).map_err(|error| {
-        SourceUnavailable::new(format!("{}: story mapping rename: {error}", path.display()))
-    })?;
-    Ok(())
+    for _ in 0..64 {
+        let sequence = STORIES_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = path.with_file_name(format!("stories.tmp-{}-{sequence}", std::process::id()));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{}: {error}",
+                    tmp.display()
+                )));
+            }
+        };
+        let write_result = file.write_all(&trimmed).and_then(|()| file.sync_all());
+        drop(file);
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&tmp);
+            return Err(SourceUnavailable::new(format!(
+                "{}: {error}",
+                tmp.display()
+            )));
+        }
+        if let Err(error) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(SourceUnavailable::new(format!(
+                "{}: story mapping rename: {error}",
+                path.display()
+            )));
+        }
+        return Ok(());
+    }
+    Err(SourceUnavailable::new(format!(
+        "could not reserve a unique story-mapping temporary beside {}",
+        path.display()
+    )))
 }
 
 /// Append one story mapping line to `stories.jsonl`.
@@ -776,65 +984,105 @@ enum Prepared {
     },
 }
 
-/// Open an observation directory: validate/resume the checkpoint, reconcile any
-/// interrupted on-disk shard/story tails, and count the article stream. Shared
-/// by the serial and batched drivers — everything up to the per-article loop is
-/// identical regardless of how records are produced.
-fn prepare_text_observation(
+/// Read-only compatibility check for every identity the text driver may
+/// persist. It deliberately runs before the first setter, checkpoint-tail
+/// reconciliation, or completed-corpus finalization so every refusal leaves
+/// the observation directory byte-identical.
+#[allow(clippy::too_many_arguments)]
+fn preflight_text_observation_identities(
+    out_dir: &Path,
+    writer: &ObservationShardWriter,
+    input_cid: &str,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<(), SourceUnavailable> {
+    let manifest = writer.manifest();
+    let payload_present = observe::observation_payload_present(out_dir, manifest, "text-identity")?;
+    match manifest.partition_rule.as_deref() {
+        Some(PARTITION_RULE) => {}
+        Some(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to a different partition rule; incompatible observation resume refused before mutation",
+                out_dir.display()
+            )));
+        }
+        None if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has observation payload but no partition rule; refusing to relabel legacy bytes before mutation",
+                out_dir.display()
+            )));
+        }
+        None => {}
+    }
+    match manifest.input_cid.as_deref() {
+        Some(recorded) if recorded == input_cid => {}
+        Some(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to a different input CID; incompatible observation resume refused before mutation",
+                out_dir.display()
+            )));
+        }
+        None if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has observation payload but no input CID; refusing to relabel orphan/legacy bytes as {input_cid} before mutation",
+                out_dir.display()
+            )));
+        }
+        None => {}
+    }
+    writer.preflight_geometry(geometry)?;
+    writer.preflight_tokenizer_adapter(tokenizer_adapter)?;
+    writer.preflight_attention_operator(attention_operator)
+}
+
+struct TextObservationPreflight {
+    input_cid: String,
+    checkpoint: Checkpoint,
+    repair_state_mirror: bool,
+    articles_total: u64,
+    stories_path: PathBuf,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect_text_observation(
     out_dir: &Path,
     articles_path: &Path,
     shard_bits: u8,
     resume: bool,
+    writer: &ObservationShardWriter,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
-) -> Result<Prepared, SourceUnavailable> {
+) -> Result<TextObservationPreflight, SourceUnavailable> {
     let kappa = input_kappa(articles_path)?;
-    let mut writer = ObservationShardWriter::open(out_dir, shard_bits)?;
-    // The tokenizer identity is the first manifest operation after opening
-    // the directory. In particular it precedes partition/input metadata,
-    // crash-tail reconciliation, count restoration, and finalization. A
-    // mismatched registered adapter — including an adapterless legacy corpus
-    // that already has payload — therefore fails before any output byte can be
-    // trimmed, relabeled, or otherwise mutated.
-    match (
-        writer.manifest().tokenizer_adapter.as_ref(),
-        tokenizer_adapter,
-    ) {
-        (Some(recorded), None) => {
-            return Err(SourceUnavailable::new(format!(
-                "{} is pinned to tokenizer adapter {}/{} (CID {}, digest {}); requested the adapterless legacy tokenizer; incompatible resume refused before mutation",
-                out_dir.display(),
-                recorded.family,
-                recorded.version,
-                recorded.tokenizer_cid,
-                recorded.adapter_digest,
-            )));
-        }
-        (_, Some(adapter)) => writer.set_tokenizer_adapter(adapter)?,
-        (None, None) => {}
-    }
+    let input_cid = format!("blake3:{}", blake3::Hash::from(kappa).to_hex());
     let shard_count = writer.manifest().shard_count();
     let stories_path = out_dir.join(STORIES_FILE);
-    let has_prior_state = out_dir.join(COMMITTED_FILE).exists()
-        || out_dir.join(observe::STATE_FILE).exists()
+    let story_temp_present = fs::read_dir(out_dir)?.any(|entry| {
+        entry.ok().is_some_and(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name == "stories.tmp" || name.starts_with("stories.tmp-"))
+        })
+    });
+    let stream_evidence = out_dir.join(observe::STATE_FILE).exists()
         || stories_path.exists()
+        || story_temp_present
+        || out_dir.join(".committed.bin.tmp").exists()
         || !writer.manifest().completed.is_empty()
-        || (0..shard_count).any(|shard| {
-            out_dir
-                .join(observe::shard_file_name(shard_bits, shard))
-                .exists()
-        });
+        || observe::observation_shard_payload_present(out_dir)?;
+    let has_prior_state = out_dir.join(COMMITTED_FILE).exists() || stream_evidence;
     if !resume && has_prior_state {
         return Err(SourceUnavailable::new(format!(
             "{} already contains an observation corpus; pass resume to continue it",
             out_dir.display()
         )));
     }
-    writer.set_partition_rule(PARTITION_RULE)?;
-    // The PROV link from produced artifacts back to the sealed corpus
-    // (issue #72): the input κ is the corpus CID of the D3 manifest.
-    writer.set_input_cid(&format!("blake3:{}", blake3::Hash::from(kappa).to_hex()))?;
-
-    let checkpoint = match read_checkpoint(out_dir, shard_count)? {
+    let persisted_checkpoint = read_checkpoint(out_dir, shard_count)?;
+    let has_persisted_checkpoint = persisted_checkpoint.is_some();
+    let checkpoint = match persisted_checkpoint {
         Some(checkpoint) => {
             if checkpoint.input_kappa != kappa {
                 return Err(SourceUnavailable::new(format!(
@@ -844,14 +1092,218 @@ fn prepare_text_observation(
             }
             checkpoint
         }
+        None if stream_evidence => {
+            return Err(SourceUnavailable::new(format!(
+                "{} contains text observation stream evidence but no authoritative {COMMITTED_FILE}; refusing a false fresh resume before mutation",
+                out_dir.display()
+            )));
+        }
         None => Checkpoint::fresh(shard_count, kappa),
     };
+    let repair_state_mirror =
+        out_dir.join(COMMITTED_FILE).exists() && state_mirror_needs_repair(out_dir, &checkpoint)?;
     if !checkpoint.done && !writer.manifest().completed.is_empty() {
         return Err(SourceUnavailable::new(format!(
             "{} has finalized shards but an unfinished checkpoint; delete the observation directory and rerun",
             out_dir.display()
         )));
     }
+    preflight_text_observation_identities(
+        out_dir,
+        writer,
+        &input_cid,
+        geometry,
+        attention_operator,
+        tokenizer_adapter,
+    )?;
+    let (_, story_entries) = preflight_stories_prefix(&stories_path, checkpoint.stories)?;
+    let articles_total = {
+        let file = fs::File::open(articles_path).map_err(|error| {
+            SourceUnavailable::new(format!("{}: {error}", articles_path.display()))
+        })?;
+        let mut lines = BufReader::new(file).lines();
+        let mut total = 0u64;
+        for line in &mut lines {
+            let line = line.map_err(|error| {
+                SourceUnavailable::new(format!("{}: {error}", articles_path.display()))
+            })?;
+            let article: Article = serde_json::from_str(&line).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "{} line {}: invalid article: {error}",
+                    articles_path.display(),
+                    total + 1
+                ))
+            })?;
+            if total < checkpoint.stories {
+                let recorded = &story_entries[total as usize];
+                let expected_partition = partition_of(&article.id);
+                if recorded.id != article.id
+                    || recorded.url != article.url
+                    || recorded.title != article.title
+                    || recorded.partition != expected_partition
+                {
+                    return Err(SourceUnavailable::new(format!(
+                        "{} story {} does not match the checkpoint-pinned input article metadata/partition; refusing corrupted story pairing before mutation",
+                        stories_path.display(),
+                        total
+                    )));
+                }
+            }
+            total += 1;
+        }
+        total
+    };
+    if checkpoint.stories > articles_total {
+        return Err(SourceUnavailable::new(format!(
+            "committed checkpoint covers {} stories but the input contains only {articles_total}",
+            checkpoint.stories
+        )));
+    }
+    if has_persisted_checkpoint && checkpoint.done != (checkpoint.stories == articles_total) {
+        return Err(SourceUnavailable::new(format!(
+            "committed checkpoint done={} disagrees with story progress {}/{}",
+            checkpoint.done, checkpoint.stories, articles_total
+        )));
+    }
+
+    // Validate every committed prefix before any identity setter, tokenizer
+    // export, state-mirror repair, or tail truncation. A later bad shard must
+    // never be discovered only after an earlier shard has already changed.
+    for shard in 0..shard_count {
+        let committed = checkpoint.shards[shard as usize].bytes;
+        preflight_shard_prefix(out_dir, shard_bits, shard, committed)?;
+        preflight_probability_prefix(out_dir, shard_bits, shard, committed)?;
+    }
+    Ok(TextObservationPreflight {
+        input_cid,
+        checkpoint,
+        repair_state_mirror,
+        articles_total,
+        stories_path,
+    })
+}
+
+/// Joint read-only text-observation preflight under an exclusive session.
+/// This covers partition rule, input CID, checkpoint/completion consistency,
+/// geometry, tokenizer, and attention before a command exports tokenizer
+/// bytes or invokes reconciliation.
+#[allow(clippy::too_many_arguments)]
+pub fn preflight_text_observation_in_session(
+    session: &observe::ObservationSession,
+    articles_path: &Path,
+    resume: bool,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<(), SourceUnavailable> {
+    let writer = session.writer()?;
+    inspect_text_observation(
+        session.dir(),
+        articles_path,
+        session.shard_bits(),
+        resume,
+        &writer,
+        geometry,
+        attention_operator,
+        tokenizer_adapter,
+    )?;
+    Ok(())
+}
+
+/// Repeat the joint text preflight, then publish every text identity before
+/// tokenizer export. No setter runs until the whole bundle agrees.
+#[allow(clippy::too_many_arguments)]
+pub fn pin_text_observation_identities_in_session(
+    session: &observe::ObservationSession,
+    articles_path: &Path,
+    resume: bool,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<(), SourceUnavailable> {
+    let mut writer = session.writer()?;
+    let inspected = inspect_text_observation(
+        session.dir(),
+        articles_path,
+        session.shard_bits(),
+        resume,
+        &writer,
+        geometry,
+        attention_operator,
+        tokenizer_adapter,
+    )?;
+    if let Some(adapter) = tokenizer_adapter {
+        writer.set_tokenizer_adapter(adapter)?;
+    }
+    writer.set_partition_rule(PARTITION_RULE)?;
+    writer.set_input_cid(&inspected.input_cid)?;
+    if let Some(geometry) = geometry {
+        writer.set_geometry(geometry)?;
+    }
+    if let Some(operator) = attention_operator {
+        writer.set_attention_operator(operator)?;
+    }
+    if inspected.repair_state_mirror {
+        repair_state_mirror(session.dir(), &inspected.checkpoint)?;
+    }
+    Ok(())
+}
+
+/// Open an observation directory: validate/resume the checkpoint, reconcile any
+/// interrupted on-disk shard/story tails, and count the article stream. Shared
+/// by the serial and batched drivers — everything up to the per-article loop is
+/// identical regardless of how records are produced.
+#[allow(clippy::too_many_arguments)]
+fn prepare_text_observation(
+    session: Option<&observe::ObservationSession>,
+    out_dir: &Path,
+    articles_path: &Path,
+    shard_bits: u8,
+    resume: bool,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<Prepared, SourceUnavailable> {
+    let mut writer = match session {
+        Some(session) => session.writer()?,
+        None => ObservationShardWriter::open(out_dir, shard_bits)?,
+    };
+    let shard_count = writer.manifest().shard_count();
+    let inspected = inspect_text_observation(
+        out_dir,
+        articles_path,
+        shard_bits,
+        resume,
+        &writer,
+        geometry,
+        attention_operator,
+        tokenizer_adapter,
+    )?;
+    let input_cid = inspected.input_cid;
+    let checkpoint = inspected.checkpoint;
+    let repair_checkpoint_mirror = inspected.repair_state_mirror;
+    let articles_total = inspected.articles_total;
+    let stories_path = inspected.stories_path;
+
+    // The tokenizer pin remains the first mutation of a compatible run, as in
+    // the post-#719 contract. Every other identity has already passed above.
+    if let Some(adapter) = tokenizer_adapter {
+        writer.set_tokenizer_adapter(adapter)?;
+    }
+    writer.set_partition_rule(PARTITION_RULE)?;
+    // The PROV link from produced artifacts back to the sealed corpus
+    // (issue #72): the input κ is the corpus CID of the D3 manifest.
+    writer.set_input_cid(&input_cid)?;
+    if let Some(geometry) = geometry {
+        writer.set_geometry(geometry)?;
+    }
+    if let Some(operator) = attention_operator {
+        writer.set_attention_operator(operator)?;
+    }
+    if repair_checkpoint_mirror {
+        repair_state_mirror(out_dir, &checkpoint)?;
+    }
+
     // Reconcile on-disk bytes to the committed checkpoint before writing:
     // interrupted articles leave content-stable tails that are trimmed, so
     // the restarted article's records are appended exactly once.
@@ -879,23 +1331,6 @@ fn prepare_text_observation(
         .map(|shard| shard.partitions)
         .collect();
     writer.restore_partition_counts(&counts)?;
-
-    // The article stream is processed in jsonl order; count it up front
-    // for progress and the report.
-    let articles_total = {
-        let file = fs::File::open(articles_path).map_err(|error| {
-            SourceUnavailable::new(format!("{}: {error}", articles_path.display()))
-        })?;
-        let mut lines = BufReader::new(file).lines();
-        let mut total = 0u64;
-        for line in &mut lines {
-            line.map_err(|error| {
-                SourceUnavailable::new(format!("{}: {error}", articles_path.display()))
-            })?;
-            total += 1;
-        }
-        total
-    };
 
     if checkpoint.done {
         // A crash between the done checkpoint and finalization can leave
@@ -940,16 +1375,97 @@ pub fn observe_text_corpus(
     shard_bits: u8,
     resume: bool,
 ) -> Result<ObservationReport, SourceUnavailable> {
+    observe_text_corpus_inner(
+        None,
+        oracles,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        out_dir,
+        shard_bits,
+        resume,
+    )
+}
+
+/// [`observe_text_corpus`] while retaining a caller-owned exclusive
+/// observation session across earlier identity pinning and tokenizer export.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus_in_session(
+    session: &observe::ObservationSession,
+    oracles: &mut [Box<dyn TeacherOracle + Send>],
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
+    observe_text_corpus_inner(
+        Some(session),
+        oracles,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        session.dir(),
+        session.shard_bits(),
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn observe_text_corpus_inner(
+    session: Option<&observe::ObservationSession>,
+    oracles: &mut [Box<dyn TeacherOracle + Send>],
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
     assert!(
         !oracles.is_empty(),
         "observe_text_corpus needs at least one oracle"
     );
+    let geometry = oracles[0].geometry_projection();
+    if let Some(geometry) = geometry.as_ref() {
+        observe::validate_registered_geometry_projection(geometry)?;
+    }
+    let attention_operator = oracles[0].attention_operator_spec();
+    if let Some(operator) = attention_operator.as_ref() {
+        observe::validate_registered_source_attention_operator(operator)?;
+    }
+    for oracle in &oracles[1..] {
+        let candidate_geometry = oracle.geometry_projection();
+        if let Some(candidate) = candidate_geometry.as_ref() {
+            observe::validate_registered_geometry_projection(candidate)?;
+        }
+        if candidate_geometry != geometry {
+            return Err(SourceUnavailable::new(
+                "serial observation workers declare different source geometries; refusing mixed projection eras before mutation",
+            ));
+        }
+        let candidate = oracle.attention_operator_spec();
+        if let Some(operator) = candidate.as_ref() {
+            observe::validate_registered_source_attention_operator(operator)?;
+        }
+        if candidate != attention_operator {
+            return Err(SourceUnavailable::new(
+                "serial observation workers declare different attention operators; refusing mixed arithmetic eras before mutation",
+            ));
+        }
+    }
     let adapter = tokenizer.adapter();
     let (mut writer, mut checkpoint, articles_total, stories_path) = match prepare_text_observation(
+        session,
         out_dir,
         articles_path,
         shard_bits,
         resume,
+        geometry.as_ref(),
+        attention_operator.as_ref(),
         adapter.as_ref(),
     )? {
         Prepared::Done(report) => return Ok(report),
@@ -960,23 +1476,6 @@ pub fn observe_text_corpus(
             stories_path,
         } => (writer, checkpoint, articles_total, stories_path),
     };
-
-    // #600: record the typed geometry-projection record the teacher
-    // oracle declares (the source→compiled reduction its embedding
-    // surface applies), when it declares one. Idempotent and atomic;
-    // legacy manifests without the field remain byte-identical.
-    if let Some(geometry) = oracles[0].geometry_projection() {
-        writer.set_geometry(&geometry)?;
-    }
-
-    // #602: record the typed attention-operator identity the teacher
-    // oracle's source executor computes (the boolean `r4_attention`
-    // switch resolved to its registered operator id), when the oracle
-    // declares one. Idempotent and atomic; legacy manifests without the
-    // field remain byte-identical.
-    if let Some(operator) = oracles[0].attention_operator_spec() {
-        writer.set_attention_operator(&operator)?;
-    }
 
     let workers = oracles.len();
     let seq_len = oracles[0].seq_len();
@@ -1189,13 +1688,78 @@ pub fn observe_text_corpus_batched<T: BatchedTeacher>(
     shard_bits: u8,
     resume: bool,
 ) -> Result<ObservationReport, SourceUnavailable> {
+    observe_text_corpus_batched_inner(
+        None,
+        oracle,
+        batch,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        out_dir,
+        shard_bits,
+        resume,
+    )
+}
+
+/// [`observe_text_corpus_batched`] under a caller-owned exclusive observation
+/// session.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus_batched_in_session<T: BatchedTeacher>(
+    session: &observe::ObservationSession,
+    oracle: &T,
+    batch: usize,
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
+    observe_text_corpus_batched_inner(
+        Some(session),
+        oracle,
+        batch,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        session.dir(),
+        session.shard_bits(),
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn observe_text_corpus_batched_inner<T: BatchedTeacher>(
+    session: Option<&observe::ObservationSession>,
+    oracle: &T,
+    batch: usize,
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+) -> Result<ObservationReport, SourceUnavailable> {
     assert!(batch >= 1, "observe_text_corpus_batched needs batch >= 1");
+    let geometry = oracle.geometry_projection();
+    if let Some(geometry) = geometry.as_ref() {
+        observe::validate_registered_geometry_projection(geometry)?;
+    }
+    let attention_operator = oracle.attention_operator_spec();
+    if let Some(operator) = attention_operator.as_ref() {
+        observe::validate_registered_source_attention_operator(operator)?;
+    }
     let adapter = tokenizer.adapter();
     let (mut writer, mut checkpoint, articles_total, stories_path) = match prepare_text_observation(
+        session,
         out_dir,
         articles_path,
         shard_bits,
         resume,
+        geometry.as_ref(),
+        attention_operator.as_ref(),
         adapter.as_ref(),
     )? {
         Prepared::Done(report) => return Ok(report),
@@ -1529,6 +2093,68 @@ mod tests {
         }
     }
 
+    struct DeclaredFakeOracle {
+        operator: Option<AttentionOperatorSpec>,
+        geometry: Option<GeometryProjection>,
+    }
+
+    impl RepresentationSource for DeclaredFakeOracle {
+        fn vocab_size(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn source_dimension(&self) -> usize {
+            4
+        }
+        fn tokenizer_address(&self) -> &str {
+            "fake-tokenizer"
+        }
+        fn read_embedding_rows(
+            &self,
+            _range: std::ops::Range<usize>,
+            output: &mut [f32],
+        ) -> Option<()> {
+            output.fill(0.0);
+            Some(())
+        }
+    }
+
+    impl BehaviorSource for DeclaredFakeOracle {
+        fn reset(&mut self) {}
+        fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]) {
+            for (index, logit) in logits.iter_mut().enumerate() {
+                let value = (token as u64 * 31 + pos as u64 * 7 + index as u64 * 13) % 29;
+                *logit = value as f32 * 0.25 - 3.0;
+            }
+        }
+    }
+
+    impl TeacherOracle for DeclaredFakeOracle {
+        fn vocab(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn dim(&self) -> usize {
+            4
+        }
+        fn seq_len(&self) -> usize {
+            FAKE_SEQ_LEN
+        }
+        fn kappa(&self) -> String {
+            "blake3:declared-fake".to_owned()
+        }
+        fn source_bytes(&self) -> usize {
+            0
+        }
+        fn embedding(&self, _token: usize, out: &mut [f32]) {
+            out.fill(0.0);
+        }
+        fn attention_operator_spec(&self) -> Option<AttentionOperatorSpec> {
+            self.operator.clone()
+        }
+        fn geometry_projection(&self) -> Option<GeometryProjection> {
+            self.geometry.clone()
+        }
+    }
+
     /// Independent replication of the driver loop over the first `up_to`
     /// articles, built ONLY from the shared encoder helpers: the expected
     /// per-shard record runs plus the rng state after them. This is the
@@ -1719,7 +2345,297 @@ mod tests {
         let mut torn = committed.clone();
         torn[0] = torn[0].wrapping_add(1);
         assert!(Checkpoint::decode(&torn, SHARD_COUNT).is_err());
+        let mut invalid_done = committed;
+        invalid_done[24] = 2;
+        assert!(Checkpoint::decode(&invalid_done, SHARD_COUNT).is_err());
+
+        // Each shard's partition counters must describe exactly its committed
+        // record prefix; matching only the global n would permit a corrupted
+        // partition split to be restored into the writer.
+        let mut invalid_partitions = checkpoint.encode();
+        let shard_zero_construction = HEADER_SIZE + INPUT_KAPPA_SIZE + 8;
+        invalid_partitions[shard_zero_construction] =
+            invalid_partitions[shard_zero_construction].wrapping_add(1);
+        assert!(Checkpoint::decode(&invalid_partitions, SHARD_COUNT).is_err());
+
+        let huge_records = u64::MAX / RECORD_SIZE as u64;
+        let overflow = Checkpoint {
+            n: 0,
+            stories: 0,
+            rng: RNG_SEED,
+            done: false,
+            input_kappa: kappa,
+            shards: vec![
+                ShardCheckpoint {
+                    bytes: huge_records * RECORD_SIZE as u64,
+                    partitions: PartitionCounts {
+                        construction: huge_records,
+                        held_out: 0,
+                    },
+                };
+                1 << 8
+            ],
+        };
+        let error = Checkpoint::decode(&overflow.encode(), 1 << 8)
+            .expect_err("overflowing shard totals must return an error");
+        assert!(error.reason.contains("overflows"), "{error}");
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn text_preflight_rejects_semantic_and_prefix_corruption_before_mutation() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let articles = test_articles();
+        let article_refs: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let input = unique_path("checkpoint-preflight-articles.jsonl");
+        write_articles(&input, &article_refs);
+        let dir = unique_path("checkpoint-preflight");
+        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![Box::new(FakeOracle)];
+        observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("complete reference corpus");
+
+        let committed_path = dir.join(COMMITTED_FILE);
+        let original_checkpoint = Checkpoint::decode(
+            &fs::read(&committed_path).expect("checkpoint bytes"),
+            SHARD_COUNT,
+        )
+        .expect("checkpoint");
+
+        let stories_path = dir.join(STORIES_FILE);
+        let original_stories = fs::read(&stories_path).expect("story bytes");
+        let first_newline = original_stories
+            .iter()
+            .position(|&byte| byte == b'\n')
+            .expect("first story newline");
+        let mut wrong_story: StoryEntry =
+            serde_json::from_slice(&original_stories[..first_newline]).expect("parse first story");
+        wrong_story.id = "wrong-committed-id".to_owned();
+        let mut mismatched_stories = serde_json::to_vec(&wrong_story).expect("encode wrong story");
+        mismatched_stories.push(b'\n');
+        mismatched_stories.extend_from_slice(&original_stories[first_newline + 1..]);
+        fs::write(&stories_path, mismatched_stories).expect("write mismatched story pairing");
+        let before = directory_fingerprint(&dir);
+        let error = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("committed story metadata must match the pinned input");
+        assert!(error.reason.contains("corrupted story pairing"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+        fs::write(&stories_path, &original_stories).expect("restore story bytes");
+
+        let mut blank_prefixed_stories = vec![b'\n'];
+        blank_prefixed_stories.extend_from_slice(&original_stories);
+        fs::write(&stories_path, blank_prefixed_stories)
+            .expect("insert empty committed story line");
+        let before = directory_fingerprint(&dir);
+        let error = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("an empty line cannot shift the committed story prefix");
+        assert!(
+            error
+                .reason
+                .contains("empty inside the committed story prefix"),
+            "{error}"
+        );
+        assert_eq!(directory_fingerprint(&dir), before);
+        fs::write(&stories_path, &original_stories).expect("restore story bytes");
+
+        let mut malformed_stories = original_stories.clone();
+        malformed_stories.extend_from_slice(b"{partial-uncommitted-json");
+        fs::write(&stories_path, malformed_stories).expect("append malformed story tail");
+        let recovered = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect("malformed uncommitted story tail is safely truncated");
+        assert!(recovered.done);
+        assert_eq!(
+            fs::read(&stories_path).expect("recovered stories"),
+            original_stories,
+            "recovery changed the committed story prefix"
+        );
+
+        // A persisted done checkpoint must cover exactly the input's dense
+        // story prefix. Refusal happens before the state mirror is repaired,
+        // any identity is republished, or completed shards are finalized.
+        let mut short_done = original_checkpoint.clone();
+        short_done.stories -= 1;
+        write_checkpoint(&dir, &short_done).expect("write semantic adversary");
+        let before = directory_fingerprint(&dir);
+        let error = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("done checkpoint with a short story prefix must fail");
+        assert!(
+            error.reason.contains("disagrees with story progress"),
+            "{error}"
+        );
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        // Restore the canonical checkpoint, then make an early shard longer
+        // than its committed prefix and a later shard shorter. Inspection must
+        // discover every bad prefix read-only: it may not truncate the early
+        // tail before discovering the later data loss.
+        write_checkpoint(&dir, &original_checkpoint).expect("restore checkpoint");
+        let nonempty: Vec<u32> = original_checkpoint
+            .shards
+            .iter()
+            .enumerate()
+            .filter_map(|(shard, checkpoint)| (checkpoint.bytes > 0).then_some(shard as u32))
+            .collect();
+        assert!(nonempty.len() >= 2, "fixture needs two non-empty shards");
+        let early = nonempty[0];
+        let late = *nonempty.last().expect("late shard");
+        let mut manifest = ObservationManifest::load(&dir)
+            .expect("load manifest before modelling an incomplete resume")
+            .expect("completed corpus has a manifest");
+        manifest
+            .completed
+            .retain(|&shard, _| shard != early && shard != late);
+        manifest.total_records = manifest.completed.values().map(|entry| entry.records).sum();
+        fs::write(
+            dir.join(crate::observation::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("encode incomplete manifest"),
+        )
+        .expect("mark the adversarial shards incomplete");
+        let early_path = dir.join(shard_file_name(SHARD_BITS, early));
+        let mut early_bytes = fs::read(&early_path).expect("early shard");
+        early_bytes.extend_from_slice(&[0u8; RECORD_SIZE]);
+        fs::write(&early_path, early_bytes).expect("append uncommitted early tail");
+        let late_path = dir.join(shard_file_name(SHARD_BITS, late));
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&late_path)
+            .expect("open late shard")
+            .set_len(original_checkpoint.shards[late as usize].bytes - RECORD_SIZE as u64)
+            .expect("shorten late shard");
+        let before = directory_fingerprint(&dir);
+        let error = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("short committed shard must fail before tail repair");
+        assert!(error.reason.contains("is shorter"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn planted_story_temp_symlink_is_refused_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("story-temp-articles.jsonl");
+        write_articles(&input, &[("1", "ab")]);
+        let dir = unique_path("story-temp-symlink");
+        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![Box::new(FakeOracle)];
+        observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("complete corpus");
+        append_story(
+            &dir.join(STORIES_FILE),
+            &StoryEntry {
+                story: 1,
+                id: "uncommitted-tail".to_owned(),
+                url: "https://example.test/tail".to_owned(),
+                title: "Tail".to_owned(),
+                partition: partition_of("uncommitted-tail"),
+            },
+        )
+        .expect("append uncommitted story tail");
+
+        let target = unique_path("story-temp-target");
+        fs::write(&target, b"external sentinel").expect("write external target");
+        let temp = dir.join("stories.tmp");
+        symlink(&target, &temp).expect("plant fixed story temp symlink");
+        let before = directory_fingerprint(&dir);
+        let target_before = fs::read(&target).expect("target bytes");
+        let link_before = fs::read_link(&temp).expect("link target");
+
+        let error = observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("story temporary symlink must fail before reconciliation");
+        assert!(error.reason.contains("not a regular file"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+        assert_eq!(
+            fs::read(&target).expect("target after refusal"),
+            target_before
+        );
+        assert_eq!(
+            fs::read_link(&temp).expect("link after refusal"),
+            link_before
+        );
+
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_file(input);
+        let _ = fs::remove_file(target);
     }
 
     #[test]
@@ -1826,6 +2742,36 @@ mod tests {
             .collect();
         assert_eq!(held_out_merged.len() as u64, held_out);
 
+        // committed.bin is authoritative across its write-before-state crash
+        // window: a missing or corrupt 25-byte mirror is repaired before the
+        // completed resume returns, without rewriting rows.
+        let expected_state = fs::read(dir_a.join(observe::STATE_FILE)).expect("state mirror");
+        for corrupt in [false, true] {
+            let state_path = dir_a.join(observe::STATE_FILE);
+            if corrupt {
+                fs::write(&state_path, b"corrupt").expect("corrupt state mirror");
+            } else {
+                fs::remove_file(&state_path).expect("remove state mirror");
+            }
+            let repaired = observe_text_corpus(
+                &mut pool,
+                60,
+                &tokenizer,
+                Some(&lengths),
+                &input,
+                &dir_a,
+                SHARD_BITS,
+                true,
+            )
+            .expect("repair completed state mirror");
+            assert!(repaired.done);
+            assert_eq!(repaired.written, 0);
+            assert_eq!(
+                fs::read(&state_path).expect("repaired state mirror"),
+                expected_state
+            );
+        }
+
         // Rerun: fully resumed, no byte changes anywhere.
         let fingerprint = directory_fingerprint(&dir_a);
         let rerun = observe_text_corpus(
@@ -1901,7 +2847,7 @@ mod tests {
     }
 
     #[test]
-    fn crash_trims_converge_to_single_pass_kappa() {
+    fn missing_checkpoint_refuses_and_committed_crash_trims_converge() {
         let articles = test_articles();
         let articles_ref: Vec<(&str, &str)> = articles
             .iter()
@@ -1916,10 +2862,24 @@ mod tests {
             expected_shards(&articles_ref, &tokenizer, Some(&lengths), articles.len());
         let (article0_shards, rng_after_0) =
             expected_shards(&articles_ref, &tokenizer, Some(&lengths), 1);
+        let reference = unique_path("crash-reference");
+        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![Box::new(FakeOracle)];
+        observe_text_corpus(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &reference,
+            SHARD_BITS,
+            false,
+        )
+        .expect("reference pass");
 
         // Craft A: a crash before the first checkpoint — shard files hold
         // a partial article-0 tail and one story line, no committed.bin.
-        // Open must trim everything and recompute from scratch.
+        // There is no authoritative per-shard boundary, so resume must refuse
+        // byte-identically rather than truncate everything to a guessed zero.
         let dir_a = unique_path("crash-pre");
         fs::create_dir_all(&dir_a).expect("mkdir a");
         let index_path = dir_a.join(STORIES_FILE);
@@ -1940,8 +2900,8 @@ mod tests {
             },
         )
         .expect("craft story line");
-        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![Box::new(FakeOracle)];
-        let report_a = observe_text_corpus(
+        let before_a = directory_fingerprint(&dir_a);
+        let error = observe_text_corpus(
             &mut pool,
             60,
             &tokenizer,
@@ -1951,9 +2911,12 @@ mod tests {
             SHARD_BITS,
             true,
         )
-        .expect("pre-checkpoint crash recovery");
-        assert!(report_a.done);
-        assert_eq!(merge_shards(&dir_a).expect("merge a"), expected);
+        .expect_err("missing authoritative checkpoint must be refused");
+        assert!(
+            error.reason.contains("no authoritative committed.bin"),
+            "{error}"
+        );
+        assert_eq!(directory_fingerprint(&dir_a), before_a);
 
         // Craft B: a crash after the article-0 checkpoint — committed.bin
         // pins article 0 but shard files and stories.jsonl already hold
@@ -1967,6 +2930,12 @@ mod tests {
             let mut writer =
                 ObservationShardWriter::open(&dir_b, SHARD_BITS).expect("open craft writer");
             writer.set_partition_rule(PARTITION_RULE).expect("rule");
+            writer
+                .set_input_cid(&format!(
+                    "blake3:{}",
+                    blake3::Hash::from(input_kappa(&input).expect("input kappa")).to_hex()
+                ))
+                .expect("input cid");
         }
         for shard in 0..SHARD_COUNT {
             let mut bytes = article0_shards[shard as usize].concat();
@@ -1978,7 +2947,7 @@ mod tests {
             fs::write(dir_b.join(shard_file_name(SHARD_BITS, shard)), bytes)
                 .expect("craft shard bytes");
             fs::copy(
-                dir_a.join(format!("{}.prob", shard_file_name(SHARD_BITS, shard))),
+                reference.join(format!("{}.prob", shard_file_name(SHARD_BITS, shard))),
                 dir_b.join(format!("{}.prob", shard_file_name(SHARD_BITS, shard))),
             )
             .expect("craft probability sidecar");
@@ -2037,7 +3006,7 @@ mod tests {
             .expect("story mapping");
         assert_eq!(index.len(), articles.len());
 
-        for dir in [&dir_a, &dir_b] {
+        for dir in [&dir_a, &dir_b, &reference] {
             let _ = fs::remove_dir_all(dir);
         }
         let _ = fs::remove_file(&input);
@@ -2224,6 +3193,8 @@ mod tests {
     /// against the serial driver's.
     struct FakeBatchedOracle {
         cfg: uor_r4_model_source::Config,
+        attention_operator: Option<AttentionOperatorSpec>,
+        geometry: Option<GeometryProjection>,
     }
 
     impl BatchedTeacher for FakeBatchedOracle {
@@ -2242,6 +3213,12 @@ mod tests {
         }
         fn vocab(&self) -> usize {
             FAKE_VOCAB
+        }
+        fn attention_operator_spec(&self) -> Option<AttentionOperatorSpec> {
+            self.attention_operator.clone()
+        }
+        fn geometry_projection(&self) -> Option<GeometryProjection> {
+            self.geometry.clone()
         }
         fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]) {
             for (b, st) in states.iter_mut().enumerate() {
@@ -2305,6 +3282,8 @@ mod tests {
         let dir_b = unique_path("batched");
         let fake = FakeBatchedOracle {
             cfg: fake_batched_config(),
+            attention_operator: None,
+            geometry: None,
         };
         let batched = observe_text_corpus_batched(
             &fake,
@@ -2373,6 +3352,8 @@ mod tests {
         let batched_dir = unique_path("registered-batched");
         let fake = FakeBatchedOracle {
             cfg: fake_batched_config(),
+            attention_operator: None,
+            geometry: None,
         };
         let batched = observe_text_corpus_batched(
             &fake,
@@ -2486,5 +3467,346 @@ mod tests {
 
         let _ = fs::remove_dir_all(dir);
         let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn serial_and_batched_paths_bind_their_actual_registered_operator() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("operator-binding-articles.jsonl");
+        write_articles(&input, &[("1", "ab")]);
+
+        let standard = AttentionOperatorSpec::standard();
+        let geometry = GeometryProjection::bucket_average(4, 2);
+        let serial_dir = unique_path("operator-binding-serial");
+        let mut serial_pool: Vec<Box<dyn TeacherOracle + Send>> =
+            vec![Box::new(DeclaredFakeOracle {
+                operator: Some(standard.clone()),
+                geometry: Some(geometry.clone()),
+            })];
+        observe_text_corpus(
+            &mut serial_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &serial_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("serial path binds declared operator");
+        let serial_manifest = ObservationManifest::load(&serial_dir)
+            .expect("read serial manifest")
+            .expect("serial manifest exists");
+        assert_eq!(serial_manifest.attention_operator.as_ref(), Some(&standard));
+        assert_eq!(serial_manifest.geometry.as_ref(), Some(&geometry));
+        let serial_before = directory_fingerprint(&serial_dir);
+        let mut pass_through_pool: Vec<Box<dyn TeacherOracle + Send>> =
+            vec![Box::new(DeclaredFakeOracle {
+                operator: Some(standard.clone()),
+                geometry: None,
+            })];
+        let error = observe_text_corpus(
+            &mut pass_through_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &serial_dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("pass-through serial worker cannot resume projected bytes");
+        assert!(error.reason.contains("geometry"), "{error}");
+        assert_eq!(directory_fingerprint(&serial_dir), serial_before);
+
+        let experimental = AttentionOperatorSpec::experimental_r4();
+        let batched_dir = unique_path("operator-binding-batched");
+        let batched = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(experimental.clone()),
+            geometry: Some(geometry.clone()),
+        };
+        observe_text_corpus_batched(
+            &batched,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &batched_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("batched path binds declared operator");
+        let batched_manifest = ObservationManifest::load(&batched_dir)
+            .expect("read batched manifest")
+            .expect("batched manifest exists");
+        assert_eq!(
+            batched_manifest.attention_operator.as_ref(),
+            Some(&experimental)
+        );
+        assert_eq!(batched_manifest.geometry.as_ref(), Some(&geometry));
+
+        let mixed_dir = unique_path("operator-binding-mixed-workers");
+        let mut mixed_pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
+            Box::new(DeclaredFakeOracle {
+                operator: Some(standard),
+                geometry: None,
+            }),
+            Box::new(DeclaredFakeOracle {
+                operator: Some(experimental),
+                geometry: None,
+            }),
+        ];
+        observe_text_corpus(
+            &mut mixed_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &mixed_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect_err("mixed serial worker operators must fail before output");
+        assert!(!mixed_dir.exists());
+
+        let mixed_geometry_dir = unique_path("operator-binding-mixed-geometries");
+        let mut mixed_geometry_pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
+            Box::new(DeclaredFakeOracle {
+                operator: Some(AttentionOperatorSpec::standard()),
+                geometry: Some(geometry),
+            }),
+            Box::new(DeclaredFakeOracle {
+                operator: Some(AttentionOperatorSpec::standard()),
+                geometry: None,
+            }),
+        ];
+        let error = observe_text_corpus(
+            &mut mixed_geometry_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &mixed_geometry_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect_err("mixed serial worker geometries must fail before output");
+        assert!(
+            error.reason.contains("different source geometries"),
+            "{error}"
+        );
+        assert!(!mixed_geometry_dir.exists());
+
+        let _ = fs::remove_dir_all(serial_dir);
+        let _ = fs::remove_dir_all(batched_dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn completed_text_resume_refuses_changed_or_missing_operator_atomically() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("operator-resume-articles.jsonl");
+        write_articles(&input, &[("1", "ab")]);
+        let dir = unique_path("operator-resume");
+
+        let standard = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::standard()),
+            geometry: None,
+        };
+        observe_text_corpus_batched(
+            &standard,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("create standard corpus");
+        let before = directory_fingerprint(&dir);
+
+        let projected = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::standard()),
+            geometry: Some(GeometryProjection::bucket_average(4, 2)),
+        };
+        let error = observe_text_corpus_batched(
+            &projected,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("projected batched worker cannot relabel pass-through bytes");
+        assert!(error.reason.contains("geometry"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        let experimental = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::experimental_r4()),
+            geometry: None,
+        };
+        let error = observe_text_corpus_batched(
+            &experimental,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("different operator cannot resume completed corpus");
+        assert!(error.reason.contains("incompatible observation resume"));
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        let undeclared = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: None,
+            geometry: None,
+        };
+        let error = observe_text_corpus_batched(
+            &undeclared,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("operatorless producer cannot resume explicit corpus");
+        assert!(error.reason.contains("declares none"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn operatorless_legacy_refusal_cannot_backfill_other_manifest_fields() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("operatorless-legacy-articles.jsonl");
+        write_articles(&input, &[("1", "ab")]);
+        let dir = unique_path("operatorless-legacy");
+
+        let legacy = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: None,
+            geometry: None,
+        };
+        observe_text_corpus_batched(
+            &legacy,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("create operatorless legacy corpus");
+        let mut manifest = ObservationManifest::load(&dir)
+            .expect("read manifest")
+            .expect("manifest exists");
+        manifest.partition_rule = None;
+        manifest.input_cid = None;
+        manifest.attention_operator = None;
+        fs::write(
+            dir.join(observe::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize legacy manifest"),
+        )
+        .expect("write legacy manifest fixture");
+        let before = directory_fingerprint(&dir);
+
+        let current = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::standard()),
+            geometry: None,
+        };
+        let error = observe_text_corpus_batched(
+            &current,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("legacy rows cannot be relabelled");
+        assert!(error.reason.contains("no partition rule"), "{error}");
+        assert_eq!(
+            directory_fingerprint(&dir),
+            before,
+            "refusal backfilled partition/input/operator provenance"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn checkpoint_input_mismatch_precedes_every_manifest_mutation() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input_a = unique_path("checkpoint-input-a.jsonl");
+        let input_b = unique_path("checkpoint-input-b.jsonl");
+        write_articles(&input_a, &[("1", "ab")]);
+        write_articles(&input_b, &[("1", "bc")]);
+        let dir = unique_path("checkpoint-input-mismatch");
+        let standard = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::standard()),
+            geometry: None,
+        };
+        observe_text_corpus_batched(
+            &standard,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input_a,
+            &dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("create first-input corpus");
+        let before = directory_fingerprint(&dir);
+
+        let error = observe_text_corpus_batched(
+            &standard,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input_b,
+            &dir,
+            SHARD_BITS,
+            true,
+        )
+        .expect_err("different input checkpoint must be refused");
+        assert!(error.reason.contains("checkpoint's input"), "{error}");
+        assert_eq!(directory_fingerprint(&dir), before);
+
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_file(input_a);
+        let _ = fs::remove_file(input_b);
     }
 }

--- a/crates/uor-r4-graph-compiler/src/trace_profile.rs
+++ b/crates/uor-r4-graph-compiler/src/trace_profile.rs
@@ -92,6 +92,7 @@ pub const SUPPORT_ABSENT_MARKER: u32 = u32::MAX;
 /// streams are captured, and whether the final-hidden (#95) lane rides
 /// along.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LayerLane {
     /// Declared post-layer capture indices, ascending and deduplicated.
     #[serde(default)]
@@ -108,6 +109,7 @@ pub struct LayerLane {
 /// The current-position q/k/v lane declaration (rotated query plus the
 /// key/value cache rows the #602 operators consumed), `full/1` only.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QkvLane {
     /// Declared capture indices, ascending and deduplicated.
     #[serde(default)]
@@ -117,6 +119,7 @@ pub struct QkvLane {
 /// The attention-support lane declaration: per-head top-S attention
 /// weights for declared layer indices, within the declared cap.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttentionSupportLane {
     /// Declared capture indices, ascending and deduplicated.
     #[serde(default)]
@@ -135,6 +138,7 @@ pub struct AttentionSupportLane {
 /// non-minimal profile is active; a minimal pass carries NO record, so
 /// legacy manifest bytes are unchanged.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TraceProfile {
     /// Registry id (`minimal`, `layer`, `attention-support`, `full`).
     #[serde(default)]

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -584,16 +584,15 @@ fn tokenizer_adapter_persists_in_the_manifest() {
         serde_json::from_str(&legacy_json).expect("legacy manifest deserializes");
     assert_eq!(legacy.tokenizer_adapter, None);
 
-    // Other identity metadata and empty payload files do not constitute a
-    // tokenizer era. This is the call order used by the text-observation
-    // preparation path before its first record.
+    // All identities are pinned before even an empty shard entry appears:
+    // recognized payload presence fixes the legacy tokenizer era.
     writer
         .set_partition_rule("fixture-partition-rule")
         .expect("persist other identity metadata");
-    std::fs::write(dir.join(shard_file_name(2, 0)), []).expect("empty shard placeholder");
     writer
         .set_tokenizer_adapter(&record)
         .expect("set and store");
+    std::fs::write(dir.join(shard_file_name(2, 0)), []).expect("empty shard placeholder");
     // Idempotent: re-setting the recorded value does not rewrite.
     writer
         .set_tokenizer_adapter(&record)
@@ -1621,6 +1620,9 @@ fn trace_sidecar_resumes_from_partial_writes() {
     // Single pass: the reference bytes.
     let dir_single = unique_path("trace-resume-single");
     let mut writer = ObservationShardWriter::open(&dir_single, SHARD_BITS).expect("open single");
+    writer
+        .set_trace_profile(&TraceProfile::layer(&[0]))
+        .expect("pin reference trace profile");
     write_all(&mut writer, 0..records.len());
     writer.finalize_all().expect("finalize single");
     let reference_trace = merge_trace_rows(&dir_single).expect("merge single");
@@ -1633,6 +1635,9 @@ fn trace_sidecar_resumes_from_partial_writes() {
     {
         let mut writer =
             ObservationShardWriter::open(&dir_resumed, SHARD_BITS).expect("open partial");
+        writer
+            .set_trace_profile(&TraceProfile::layer(&[0]))
+            .expect("pin resumed trace profile");
         write_all(&mut writer, 0..records.len() / 2);
         writer.flush().expect("flush partial");
     }

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -74,7 +74,8 @@
 //! declarations, so a behavioral change must bump the version (a new
 //! registry entry) instead of silently drifting.
 //!
-//! **Boundary note.** The two SOURCE specs describe HOST-SIDE
+//! **Boundary note.** The three SOURCE specs (the two Llama switch
+//! branches plus GPT-2's learned-absolute operator) describe HOST-SIDE
 //! source-teacher computation (f32 dot products, exp, division). They
 //! are provenance records, distinct from — and outside — the deployed
 //! inference operation contract
@@ -88,7 +89,7 @@
 //! registered TARGET operator: `R4RouteAttentionV1`, whose
 //! `permitted_operation_class` is the deployed integer class (XOR /
 //! masked popcount via table / saturating integer add / compare / table
-//! read — no float, no multiply, no divide), unlike the two source
+//! read — no float, no multiply, no divide), unlike the source
 //! records above. It reuses NO Q/K/V weights: its route codes, mask,
 //! and ScoreQ contributions are declared tables over the 288-bit
 //! signature substrate. Source-teacher and target routing semantics
@@ -110,6 +111,7 @@ use serde::{Deserialize, Serialize};
 /// documented on [`AttentionOperatorParams::standard`] and
 /// [`AttentionOperatorParams::experimental_r4`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttentionOperatorParams {
     /// How a query head selects its key/value head (grouped query).
     #[serde(default)]
@@ -241,6 +243,7 @@ impl AttentionOperatorParams {
 /// teacher paths the default-off switch always computed
 /// `standard-source-attention/1`).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttentionOperatorSpec {
     /// Registry id of the operator (e.g. `"standard-source-attention"`).
     #[serde(default)]
@@ -980,6 +983,14 @@ mod tests {
         assert_eq!(partial.id, "standard-source-attention");
         assert_eq!(partial.version, 0);
         assert_eq!(partial.params, AttentionOperatorParams::default());
+
+        for json in [
+            r#"{"id":"standard-source-attention","unregistered_claim":true}"#,
+            r#"{"params":{"unregistered_claim":"exact"}}"#,
+        ] {
+            serde_json::from_str::<AttentionOperatorSpec>(json)
+                .expect_err("unknown provenance claims must fail closed");
+        }
     }
 
     #[test]

--- a/crates/uor-r4-model-source/src/geometry.rs
+++ b/crates/uor-r4-model-source/src/geometry.rs
@@ -46,6 +46,7 @@ pub const COMPILED_WIDTH: u32 = 288;
 /// the canonical digest serialization byte-for-byte), documented on
 /// [`GeometryProjectionParams::bucket_average`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GeometryProjectionParams {
     /// How source columns are grouped into buckets.
     #[serde(default)]
@@ -88,6 +89,7 @@ impl GeometryProjectionParams {
 /// report and the observation manifest wherever the projection is known,
 /// so a geometry change is visible in provenance instead of silent.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GeometryProjection {
     /// Registry id of the projection algorithm (e.g. `"bucket-average"`).
     #[serde(default)]

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -1325,6 +1325,12 @@ impl crate::BatchedTeacher for HuggingFaceGpt2Oracle {
     fn vocab(&self) -> usize {
         self.model.cfg.vocab
     }
+    fn geometry_projection(&self) -> Option<crate::geometry::GeometryProjection> {
+        <Self as crate::TeacherOracle>::geometry_projection(self)
+    }
+    fn attention_operator_spec(&self) -> Option<crate::attention::AttentionOperatorSpec> {
+        <Self as crate::TeacherOracle>::attention_operator_spec(self)
+    }
     fn forward_batch_into(&self, states: &mut [Gpt2State], tokens: &[usize], positions: &[usize]) {
         self.model.forward_batch(states, tokens, positions);
     }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -1174,6 +1174,17 @@ impl TeacherOracle for LlamaOracle {
             &self.model.w[self.model.emb + token * d..self.model.emb + (token + 1) * d],
         );
     }
+    fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
+        // #704: this legacy checkpoint adapter executes the same current
+        // Llama attention implementation and public switch as the Safetensors
+        // adapter. Bind the branch actually selected by its mutable config.
+        // `None` is reserved for already-produced, pre-provenance corpora; a
+        // new observation must not be mislabeled as implicit standard/1 by
+        // omission when the current registry alias advances.
+        Some(attention::operator_for_r4_switch(
+            self.model.cfg.r4_attention,
+        ))
+    }
     fn hidden_state(&self) -> Option<&[f32]> {
         Some(&self.state.x)
     }
@@ -1687,11 +1698,15 @@ impl std::fmt::Display for SourceIngestKind {
             Self::UnknownAttentionOperator { id, version } => write!(
                 f,
                 "attention operator {id}/{version} is not in the versioned operator \
-                 registry (known: {}/{} and {}/{})",
+                 registry (registered entries include {}/{}, {}/{}, {}/{}, and {}/{})",
                 attention::AttentionOperatorSpec::STANDARD_ID,
                 attention::AttentionOperatorSpec::STANDARD_VERSION,
                 attention::AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
                 attention::AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+                attention::AttentionOperatorSpec::R4_ROUTE_ID,
+                attention::AttentionOperatorSpec::R4_ROUTE_VERSION,
             ),
         }
     }
@@ -2217,6 +2232,19 @@ pub trait BatchedTeacher {
     fn seq_len(&self) -> usize;
     /// Vocabulary size (logits length).
     fn vocab(&self) -> usize;
+    /// The source-to-compiled geometry identity applied by this batched
+    /// teacher, when one exists. The default keeps external/mock teachers
+    /// compatible while allowing the observation boundary to bind shipped
+    /// producers before writing rows.
+    fn geometry_projection(&self) -> Option<geometry::GeometryProjection> {
+        None
+    }
+    /// The registered source-attention identity executed by this batched
+    /// teacher. A producer that returns `None` may create only an unbound
+    /// legacy corpus and cannot resume one with an explicit recorded era.
+    fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
+        None
+    }
     /// Advance `states.len()` sequences one position each: sequence `b` steps
     /// `tokens[b]` at `positions[b]`, leaving its logits reachable through
     /// [`BatchedTeacher::logits_mut`].
@@ -2239,6 +2267,12 @@ impl BatchedTeacher for HuggingFaceLlamaOracle {
     }
     fn vocab(&self) -> usize {
         self.model.cfg.vocab
+    }
+    fn geometry_projection(&self) -> Option<geometry::GeometryProjection> {
+        <Self as TeacherOracle>::geometry_projection(self)
+    }
+    fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
+        <Self as TeacherOracle>::attention_operator_spec(self)
     }
     fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]) {
         self.model
@@ -2803,6 +2837,28 @@ mod tests {
         };
         model.rebuild_rope_cache();
         model
+    }
+
+    #[test]
+    fn legacy_llama_oracle_declares_the_selected_attention_branch() {
+        let model = tiny_llama();
+        let state = State::new(&model.cfg);
+        let mut oracle = LlamaOracle {
+            model,
+            state,
+            kappa: "blake3:synthetic".to_owned(),
+            source_bytes: 0,
+        };
+
+        assert_eq!(
+            oracle.attention_operator_spec(),
+            Some(attention::AttentionOperatorSpec::standard())
+        );
+        oracle.model.cfg.r4_attention = true;
+        assert_eq!(
+            oracle.attention_operator_spec(),
+            Some(attention::AttentionOperatorSpec::experimental_r4())
+        );
     }
 
     /// #603: the traced forward IS the exact executor — a

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -170,5 +170,5 @@ Written under `.uor-models/` (or `UOR_MODEL_STORE`):
 | `last_model.txt` / `last_model_name.txt` | Orchestrator's last model selection |
 | `last_engine.txt` | Persisted engine preference; **silently pins the cascade** for requests that omit `engine` |
 | `sources/<name>/` | Downloaded Hugging Face teacher sources |
-| `compiled/<name>/` | Compiled bundles: `score.r4g1`, `tless_artifacts.bin`, `tless_store.bin`, deployed `tokenizer.bin`, full source binding `tokenizer_adapter.json` (used to fail-close corpus resume/evaluation), `corpus.meta`, and `corpus.records` |
+| `compiled/<name>/` | Compiled bundles: `score.r4g1`, `tless_artifacts.bin`, `tless_store.bin`, deployed `tokenizer.bin`, full source binding `tokenizer_adapter.json`, source-attention binding `attention_operator.json` (both used to fail-close corpus resume/evaluation), `corpus.meta`, and `corpus.records` |
 | `corpora/` | Observation corpora |

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -92,7 +92,10 @@ without a manifest compile exactly as before, with the field absent.
 `models/smollm2-135m-instruct.json`) are weight-only identities: they cover
 the `model.safetensors` bytes and nothing else. They are NOT relabeled and do
 not become snapshot identities; the snapshot-wide identity is only the
-`source_manifest.json` root κ described above.
+`source_manifest.json` root κ described above. Neither identity includes the
+executor's arithmetic: changing a reduction leaves the source bytes and both
+source κs unchanged. The versioned `attention_operator` record, rather than a
+source κ re-pin, carries that arithmetic-era distinction.
 
 #### Sharded snapshots (#598)
 
@@ -183,6 +186,10 @@ everywhere). Hugging Face compilation defaults to
 attention cost and KV memory proportional to the eight-token deployed runtime
 window; increase `--target` or `--sequence-length` explicitly for quality
 experiments. Repeat the same command to resume an incomplete corpus.
+Stage A writes a registry-validated `attention_operator.json` before corpus
+rows. A resume must reproduce that exact operator; an existing payload with a
+missing or different binding is refused before mutation rather than being
+silently relabelled or mixed across arithmetic eras.
 
 On macOS, offline Hugging Face teacher execution uses Apple Accelerate's
 SIMD-optimized CPU BLAS. Linux and Windows use explicit NEON on AArch64 or
@@ -199,6 +206,7 @@ tless_artifacts.bin       # TLA teacher projection and class tables (TLA7 by def
 tless_store.bin           # TLS1 graded continuation evidence
 tokenizer.bin             # deployed token table (tagged decode-only for SentencePiece)
 tokenizer_adapter.json    # full source adapter binding for corpus resume/evaluation
+attention_operator.json   # registered source-attention binding for corpus resume/cover
 corpus.meta               # observation-corpus metadata
 corpus.records            # deterministic observation records
 hamming_calibration.json
@@ -542,24 +550,27 @@ tests (e.g. `forward_batch_matches_serial_forward`) guarding the
 executor path and unit tests pinning divisible and non-divisible head
 widths.
 
-The record threads into provenance the same way the #597 manifest κ,
-the #600 geometry record, and the #601 tokenizer record do: the observe
-drivers record it in the observation manifest automatically whenever
-the oracle declares one (`attention_operator`, an optional
-serde-defaulted field; `TeacherOracle::attention_operator_spec()`
-defaults to `None`, and the legacy checkpoint oracle declares none, so
-legacy manifest bytes are unchanged); the cover stages
-(`transformerless cover`, `graph-compile`) accept
-`--attention-operator <json>` and bind it as the optional
-`attention_operator` field of the cover/compile report; the typed
-compile API derives it from its `r4_attention` option; and the HTTP
-server's compile job binds the standard record (its teacher stage never
-enables the experimental switch). An absent record marks the implicit
-legacy era: documents produced before #602 are not rewritten, and — the
-switch having been default-off everywhere — a reader may *interpret* an
-absent record on teacher-produced inputs as `standard-source-attention/1`
-unless the producing invocation is known to have passed
-`--r4-attention`. **Honesty item:** the score/certify report structs in
+The record threads into provenance alongside the #597 manifest κ, the #600
+geometry record, and the #601 tokenizer record. Observe drivers record the
+oracle's exact declaration in the observation manifest (`attention_operator`,
+an optional serde-defaulted field), and all shipped Llama/GPT-2 source oracles
+declare their registered operator. Direct source compilation publishes the
+same record atomically as `attention_operator.json` before corpus bytes; resume
+requires exact equality and refuses a missing, malformed, unregistered, or
+different binding before mutation. The cover stages (`transformerless cover`,
+`graph-compile`) accept `--attention-operator <json>` and bind it as the
+optional `attention_operator` field of the cover/compile report. The typed API
+and HTTP server forward the registry-validated stage-A/recorded binding rather
+than reconstructing it from the `r4_attention` policy bit, which preserves
+GPT-2's learned-absolute identity. `compile-recorded` likewise propagates an
+explicit observation-manifest record.
+
+An absent record remains the implicit legacy era: documents produced before
+#602 are not rewritten, and a genuinely operator-less caller-supplied corpus
+may be interpreted as `standard-source-attention/1`. That compatibility does
+not authorize adding current source-teacher rows to unbound bytes; source
+compile/resume requires the explicit sidecar. **Honesty item:** the
+score/certify report structs in
 `uor-r4-graph-certify` carry no attention-operator field — that stage
 reads corpus, cover, and artifact bytes with no teacher oracle in reach
 (the #597 source κ and #600 geometry records are likewise absent there),
@@ -627,8 +638,8 @@ fixed-width era-stable byte format and cannot carry optional per-layer
 f32 lanes without a byte-format change, so richer lanes live in a
 per-shard side-car file (`shard-NN.bin.trace`, one fixed-width row per
 record), following the probability sidecar's existing pattern: the same
-deterministic content-addressed partitioning, crash-safe
-append/reconcile/resume, per-shard κ registration in the manifest
+deterministic content-addressed partitioning, torn shard/sidecar alignment
+repair, per-shard κ registration in the manifest
 (`ShardEntry::trace_kappa`), and canonical ascending-shard merge
 (`merge_trace_rows`). The primary shard bytes are identical for every
 profile. Lane order within a row is fixed (residuals ascending declared
@@ -642,6 +653,14 @@ an oracle without the bounded capture surface refuses richer profiles
 attention-support slot (fewer prefix positions than the cap) carries
 the explicit `SUPPORT_ABSENT_MARKER` (`0xFFFFFFFF` in both fields),
 never a zero-valued entry.
+
+**Raw-resume limitation.** The autoregressive `observe` checkpoint still
+records only global stream state, not committed byte lengths for every shard.
+It can reject malformed checkpoints and repair a torn shard/sidecar pair, but
+an abrupt failure after an aligned mid-story append can leave a tail that a
+retry cannot distinguish from committed rows; exactly-once raw resume requires
+a separate per-shard checkpoint-format follow-up. The text observation driver
+already carries per-shard committed lengths and truncates to them on resume.
 
 **Bundle identity.** The manifest's identity seam is ONE stable bundle:
 `ObservationManifest::identity_bundle_digest()` computes a canonical

--- a/docs/scaling_law.md
+++ b/docs/scaling_law.md
@@ -172,10 +172,13 @@ promise.
 - Saturation-sweep harness: **shipped and verified end-to-end** —
   `scripts/scale_sweep.sh` over `scripts/mc1_subsample_corpus.py`. The first run
   surfaced a latent bug: `compile-recorded --out $D` re-emits
-  `corpus.meta`/`corpus.records` into `$D`, clobbering the sub-sampled inputs
-  when they share those names. Fixed by writing the sub-sample under
-  `sub.meta`/`sub.records` (the #516 pipeline had dodged it only because
-  `obs_bundle_to_corpus.py` uses `.bin` names).
+  `corpus.meta`/`corpus.records` into `$D`, clobbering same-directory inputs.
+  The harness now writes each sub-sample as a canonical pair under
+  `$D/input/`, uses `copy-recorded-attention` to preserve its
+  registry-validated source-attention binding, and uses the copied output pair
+  for cover/score. Keeping input and output roots distinct also prevents an
+  unrelated same-directory filename pair from inheriting another corpus's
+  provenance.
 - β calibration: **coverage knee now measured; resolution exponent still open.**
   #531 observed two teachers (360M, 135M) past the knee — 1,995,026 records each
   on 17k Simple-Wiki via batched inference (#616) — and its dual sweep (recorded

--- a/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
+++ b/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
@@ -70,11 +70,12 @@ Compilation and training are explicitly unrestricted by this contract.
 
 Note (non-normative cross-reference, #602): the source attention operator
 specifications in `uor-r4-model-source::attention`
-(`standard-source-attention/1`, `experimental-r4-source-attention/1`) are
-host-side provenance records of teacher execution — an activity this
-section already excludes. They are distinct from this deployed contract,
-describe floating-point source computation the deployed hot path never
-performs, and change none of the operation lists or obligations above.
+(`standard-source-attention/1`, `experimental-r4-source-attention/1`, and
+GPT-2's `learned-absolute-source-attention/1`) are host-side provenance
+records of teacher execution — an activity this section already excludes.
+They are distinct from this deployed contract, describe floating-point source
+computation the deployed hot path never performs, and change none of the
+operation lists or obligations above.
 
 Note (non-normative cross-reference, #604): `r4-route-attention/1`
 (`R4RouteAttentionV1`, documented in `docs/MODEL_LIFECYCLE.md`) is a

--- a/docs/transformerless/OBSERVATION_FIRST.md
+++ b/docs/transformerless/OBSERVATION_FIRST.md
@@ -8,21 +8,26 @@ There are two separate offline workflows:
 1. Capture observations, if new teacher data is required. `observe` and the
    legacy `compile --source` path may load a CPU teacher; that is capture-only
    work and may use matrix operations internally.
-2. Compile recorded observations. `compile-recorded` consumes only
-   `corpus.meta` and `corpus.records` plus an explicit vocabulary size. It does
+2. Compile recorded observations. The command's data inputs are
+   `corpus.meta` and `corpus.records` plus an explicit vocabulary size; it also
+   validates their sibling attention-provenance record when present. It does
    not construct a teacher, load model weights, call the model-source forward
    path, or use GPU backends. The representation is a deterministic signed
    hash projection of the recorded top-k next-token distributions. Calibration
    and store construction use ordered worker reductions, so output bytes do
    not depend on worker count.
 
-`compile-recorded` does not yet accept an observation manifest or runtime
-tokenizer as input, so it cannot propagate a registered tokenizer identity or
-emit `tokenizer.bin`. It must not be treated as a self-contained text-serving
-bundle or used to infer/relabel the recorded token-id space. Carrying that
-provenance through the observation-first boundary requires a separate explicit
-input contract; issue #718 only wires source-tokenizer consumers that can
-resolve the original definition.
+`compile-recorded` resolves source-attention provenance from the recorded
+corpus directory: an explicit `attention_operator.json` and a sibling
+observation `manifest.json` are registry-validated, must agree when both are
+present, and are propagated into the compiled output. Genuine historical
+absence retains the implicit `standard-source-attention/1` interpretation.
+The command still does not accept a runtime tokenizer as input, propagate a
+registered tokenizer identity, or emit `tokenizer.bin`. It must therefore not
+be treated as a self-contained text-serving bundle or used to infer/relabel the
+recorded token-id space. Carrying tokenizer provenance through this boundary
+requires a separate explicit input contract; issue #718 only wires
+source-tokenizer consumers that can resolve the original definition.
 
 The root command is:
 

--- a/scripts/scale_sweep.sh
+++ b/scripts/scale_sweep.sh
@@ -33,25 +33,38 @@ fi
 mkdir -p "$WORK"
 printf '%-12s %-10s %-12s %-12s\n' records held_out top1_rule12 exct_miss_%
 
-# NOTE: `compile-recorded --out "$D"` re-emits `corpus.meta`/`corpus.records`
-# into "$D", so the sub-sampled corpus is written under DISTINCT names
-# (`sub.meta`/`sub.records`) that compile cannot clobber; cover and score read
-# those, never compile's emitted `corpus.*`.
+# Each sub-sample is a canonical corpus pair in its own input directory.
+# `compile-recorded` may then emit its canonical output pair in "$D" without
+# clobbering the input, while attention provenance remains directory-scoped and
+# cannot be inherited by an unrelated same-directory filename pair.
 for N in "${SIZES[@]}"; do
     D="$WORK/n-$N"
-    mkdir -p "$D"
+    INPUT="$D/input"
+    mkdir -p "$INPUT"
     python3 scripts/mc1_subsample_corpus.py \
         --src-meta "$SRC_META" --src-recs "$SRC_RECS" \
-        --out-meta "$D/sub.meta" --out-recs "$D/sub.records" \
+        --out-meta "$INPUT/corpus.meta" --out-recs "$INPUT/corpus.records" \
         --records "$N" >/dev/null
+
+    # Preserve the source corpus's exact attention era without copying a
+    # manifest whose record counts describe the unsampled corpus. The Rust
+    # boundary validates the complete source manifest, canonical corpus pair,
+    # registry record, and no-clobber destination before publishing anything.
+    "$R4" transformerless copy-recorded-attention \
+        --corpus-meta "$SRC_META" --corpus-recs "$SRC_RECS" \
+        --out "$INPUT/attention_operator.json" >/dev/null
+
     "$R4" transformerless compile-recorded \
-        --corpus-meta "$D/sub.meta" --corpus-recs "$D/sub.records" \
+        --corpus-meta "$INPUT/corpus.meta" --corpus-recs "$INPUT/corpus.records" \
         --vocab-size "$VOCAB" --out "$D" >/dev/null 2>&1
+    ATTENTION_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$D/attention_operator.json")"
     "$R4" transformerless cover \
-        --corpus-meta "$D/sub.meta" --corpus-recs "$D/sub.records" \
-        --artifacts "$D/tless_artifacts.bin" --out "$D/graph-cover" >/dev/null 2>&1
+        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
+        --artifacts "$D/tless_artifacts.bin" \
+        --attention-operator "$ATTENTION_OPERATOR" \
+        --out "$D/graph-cover" >/dev/null 2>&1
     "$R4" transformerless score \
-        --corpus-meta "$D/sub.meta" --corpus-recs "$D/sub.records" \
+        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
         --artifacts "$D/tless_artifacts.bin" --cover "$D/graph-cover/cover.r4g1" \
         --quality-profile relative_tla --out "$D/graph" >/dev/null 2>&1
     python3 - "$D/graph/score_report.json" "$N" <<'PY'

--- a/src/server.rs
+++ b/src/server.rs
@@ -1884,6 +1884,7 @@ fn validate_source_bundle_inventory(output: &Path) -> Result<(), String> {
         "tless_store.bin",
         "tokenizer.bin",
         "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
         "corpus.meta",
         "corpus.records",
     ] {
@@ -2011,6 +2012,36 @@ fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
     }
 }
 
+/// Append the exact registered source-attention identity recorded with one
+/// corpus. A genuinely operator-less caller corpus retains the historical
+/// implicit standard/1 interpretation; source-driven compiles must carry the
+/// explicit sidecar written by stage A.
+fn append_recorded_attention_operator(
+    cover_args: &mut Vec<String>,
+    corpus_meta: &Path,
+    corpus_recs: &Path,
+    require_explicit: bool,
+) -> Result<(), String> {
+    let operator = uor_r4_graph_cli::recorded_corpus_attention_operator(corpus_meta, corpus_recs)
+        .map_err(|error| error.to_string())?;
+    match operator {
+        Some(operator) => {
+            let json = serde_json::to_string(&operator).map_err(|error| error.to_string())?;
+            cover_args.extend(["--attention-operator".to_owned(), json]);
+            Ok(())
+        }
+        None if require_explicit => {
+            let root = corpus_meta.parent().unwrap_or_else(|| Path::new("."));
+            Err(format!(
+                "compiled source corpus is missing its attention-operator binding: {}",
+                root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE)
+                    .display()
+            ))
+        }
+        None => Ok(()),
+    }
+}
+
 fn compile_r4g1_bundle(
     cli: &ServerConfig,
     r4g1: &Arc<Mutex<Option<R4g1State>>>,
@@ -2030,6 +2061,7 @@ fn compile_r4g1_bundle(
     let source_root = downloaded_source
         .map(|source| compile_bundle_from_source(source, status, tokenizer_selection))
         .transpose()?;
+    let compiled_from_source = source_root.is_some();
     if downloaded_source.is_none() && tokenizer_selection.is_some() {
         return Err(
             "an explicit tokenizer selection requires a downloaded source directory".to_owned(),
@@ -2137,15 +2169,15 @@ fn compile_r4g1_bundle(
     if let Some(geometry) = downloaded_source.and_then(geometry_projection_of) {
         cover_args.extend(["--geometry-projection".to_owned(), geometry]);
     }
-    // #602: the server compile job never passes `--r4-attention` to the
-    // teacher stage above, so the teacher ran exactly the registered
-    // `standard-source-attention/1` operator; bind its typed record into
-    // the cover report.
-    if let Ok(operator) =
-        serde_json::to_string(&uor_r4_model_source::attention::AttentionOperatorSpec::standard())
-    {
-        cover_args.extend(["--attention-operator".to_owned(), operator]);
-    }
+    // #602/#704: bind the identity stage A or the observation manifest
+    // actually recorded. Reconstructing it as standard from the absent
+    // experimental switch would mislabel GPT-2's learned-absolute operator.
+    append_recorded_attention_operator(
+        &mut cover_args,
+        &corpus_meta,
+        &corpus_recs,
+        compiled_from_source,
+    )?;
     uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");
@@ -5410,6 +5442,107 @@ fn print_witness_line(a: &CliAnswer) {
 
 #[cfg(test)]
 mod tests {
+    fn attention_provenance_test_dir(label: &str) -> std::path::PathBuf {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "uor-r4-server-attention-{label}-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("create provenance test directory");
+        path
+    }
+
+    fn attention_corpus_markers(
+        root: &std::path::Path,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        std::fs::write(&meta, []).expect("create corpus metadata marker");
+        std::fs::write(&records, []).expect("create corpus records marker");
+        (meta, records)
+    }
+
+    #[test]
+    fn server_cover_uses_registry_validated_observation_manifest_operator() {
+        let root = attention_provenance_test_dir("learned-manifest");
+        let (meta, records) = attention_corpus_markers(&root);
+        let operator = uor_r4_model_source::attention::AttentionOperatorSpec::
+            learned_absolute_source_attention();
+        let mut manifest = uor_r4_graph_compiler::observation::ObservationManifest::new(1);
+        manifest.attention_operator = Some(operator.clone());
+        std::fs::write(
+            root.join(uor_r4_graph_compiler::observation::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let mut args = Vec::new();
+        super::append_recorded_attention_operator(&mut args, &meta, &records, false)
+            .expect("manifest operator is accepted");
+        assert_eq!(
+            args.first().map(String::as_str),
+            Some("--attention-operator")
+        );
+        let forwarded: uor_r4_model_source::attention::AttentionOperatorSpec =
+            serde_json::from_str(&args[1]).expect("forwarded record");
+        assert_eq!(forwarded, operator);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn server_cover_preserves_genuine_legacy_absence_but_requires_source_binding() {
+        let root = attention_provenance_test_dir("legacy-absence");
+        let (meta, records) = attention_corpus_markers(&root);
+
+        let mut args = Vec::new();
+        super::append_recorded_attention_operator(&mut args, &meta, &records, false)
+            .expect("caller-supplied legacy absence remains implicit");
+        assert!(args.is_empty());
+
+        let error =
+            super::append_recorded_attention_operator(&mut Vec::new(), &meta, &records, true)
+                .expect_err("source-driven compiles require an explicit binding");
+        assert!(error.contains("missing its attention-operator binding"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn server_cover_refuses_malformed_and_non_file_binding_entries() {
+        let root = attention_provenance_test_dir("invalid-binding");
+        let (meta, records) = attention_corpus_markers(&root);
+        let binding = root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE);
+        std::fs::write(&binding, b"{not json").expect("write malformed binding");
+        let error =
+            super::append_recorded_attention_operator(&mut Vec::new(), &meta, &records, false)
+                .expect_err("malformed binding must fail closed");
+        assert!(error.contains("attention_operator.json"));
+
+        std::fs::remove_file(&binding).expect("remove malformed binding");
+        std::fs::create_dir(&binding).expect("create non-file binding entry");
+        let error =
+            super::append_recorded_attention_operator(&mut Vec::new(), &meta, &records, false)
+                .expect_err("non-file binding must fail closed");
+        assert!(error.contains("attention_operator.json"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn server_cover_refuses_corpus_files_from_different_roots() {
+        let meta_root = attention_provenance_test_dir("meta-root");
+        let records_root = attention_provenance_test_dir("records-root");
+        let (meta, _) = attention_corpus_markers(&meta_root);
+        let (_, records) = attention_corpus_markers(&records_root);
+
+        let error =
+            super::append_recorded_attention_operator(&mut Vec::new(), &meta, &records, false)
+                .expect_err("unpaired roots must fail before cover");
+        assert!(error.contains("parent"));
+        let _ = std::fs::remove_dir_all(meta_root);
+        let _ = std::fs::remove_dir_all(records_root);
+    }
+
     #[test]
     fn http_tokenizer_selection_is_an_atomic_version_generic_pair() {
         let absent = super::HuggingFaceDownloadPayload::default();
@@ -5525,7 +5658,7 @@ mod tests {
     }
 
     #[test]
-    fn source_bundle_inventory_requires_a_regular_adapter_sidecar() {
+    fn source_bundle_inventory_requires_regular_tokenizer_and_attention_sidecars() {
         let root = std::env::temp_dir().join(format!(
             "uor-r4-source-bundle-inventory-{}",
             std::process::id()
@@ -5552,6 +5685,17 @@ mod tests {
         assert!(error.contains("not a regular file"), "{error}");
         std::fs::remove_dir(&sidecar).expect("remove invalid sidecar");
         std::fs::write(&sidecar, b"{}").expect("regular sidecar");
+
+        let error = super::validate_source_bundle_inventory(&root)
+            .expect_err("attention sidecar is required");
+        assert!(error.contains("attention_operator.json"), "{error}");
+        let attention = root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE);
+        std::fs::create_dir(&attention).expect("invalid attention sidecar directory");
+        let error = super::validate_source_bundle_inventory(&root)
+            .expect_err("present-invalid attention sidecar fails closed");
+        assert!(error.contains("not a regular file"), "{error}");
+        std::fs::remove_dir(&attention).expect("remove invalid attention sidecar");
+        std::fs::write(&attention, b"{}").expect("regular attention sidecar");
         super::validate_source_bundle_inventory(&root).expect("complete regular inventory");
         let _ = std::fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Summary

- bind every shipped source teacher and observation path to its exact registered attention-operator record
- publish `attention_operator.json` atomically for source compiles and propagate the recorded identity through API, server, cover, evaluation, and `compile-recorded`
- serialize observation sessions across identity validation, tokenizer export, reconciliation, row writes, and finalization; reject mismatched, malformed, unknown, symlinked, or stale provenance before mutation
- validate authoritative raw/text/compiler checkpoints, completed shard bytes and kappas, corpus/hidden tails, and canonical corpus pairing before resume
- replace the scale sweep's hand-written manifest parsing with the registry-validated `copy-recorded-attention` command
- document that source/snapshot κ remains a content identity; the versioned operator record carries the arithmetic era

## Scope and compatibility

This is the provenance-only A1 slice. It intentionally changes no teacher arithmetic and therefore does not move teacher outputs or require a κ re-pin.

Historical caller-supplied corpora with genuinely absent attention provenance retain the documented implicit `standard-source-attention/1` interpretation. Source-driven resume is stricter: existing payload without the explicit binding is refused rather than relabelled or mixed with a current teacher era.

The raw observation checkpoint still lacks per-shard committed lengths. This PR documents that aligned mid-story tails are not exactly-once recoverable; the checkpoint-format redesign remains a separate follow-up. Text observation already carries per-shard committed lengths.

The dense GPT-2 Conv1D/MLP/lm-head migration remains open. The broad exact-GEMM prototype measured about 220x slower, so the later arithmetic slice must retain the issue's acceptable-speed gate.

## Verification

- `cargo test --workspace --offline`
- `cargo test -p uor-r4-graph-compiler --offline` (131 unit; 26 induction + 1 ignored; 27 observe; 4 route-fit)
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all --check`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib --offline`
- `cargo deny check` (advisories, bans, licenses, and sources pass; only allowed duplicate warnings)
- `cargo run -q -p xtask -- check-model`
- `cargo run -q -p xtask -- audit-deferral`
- `cargo run -q -p xtask -- audit-limits`
- `python3 scripts/check_claim_wording.py`
- `bash -n scripts/scale_sweep.sh`
- non-vacuous Gate E: `/tmp/ref/out/model.bin` = 60,816,028 bytes; all 3 ignored release tests pass under `TLESS_CANONICAL_DETERMINISTIC=1`
- independent final review: CLEAN, no remaining P0-P2 findings

References #704
