### PR TITLE
observation: add transactional raw checkpoints

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -1372,6 +1372,7 @@ fn observation_payload_exists(
 
     for name in [
         observe::STATE_FILE,
+        observe::RAW_COMMITTED_FILE,
         "merged.bin",
         "committed.bin",
         ".committed.bin.tmp",
@@ -6616,7 +6617,11 @@ mod tests {
 
     #[test]
     fn observation_preflight_treats_zero_byte_payload_entries_as_era_evidence() {
-        for (case, payload_name) in [("state", observe::STATE_FILE), ("shard", "shard-99.bin")] {
+        for (case, payload_name) in [
+            ("state", observe::STATE_FILE),
+            ("raw-committed", observe::RAW_COMMITTED_FILE),
+            ("shard", "shard-99.bin"),
+        ] {
             let output = unique_cli_test_path(&format!("observe-zero-byte-{case}"));
             write_observation_manifest(&output, &observe::ObservationManifest::new(1));
             std::fs::write(output.join(payload_name), []).expect("zero-byte payload entry");

--- a/crates/uor-r4-graph-compiler/README.md
+++ b/crates/uor-r4-graph-compiler/README.md
@@ -8,7 +8,7 @@ This crate implements the offline compilation stages that cross-compile pinned H
 
 ## Key Components
 
-- **Observation Pipeline** (`observation.rs`, `observation_shards.rs`): Content-addressed observation extraction with deterministic shard spill/resume (ChatML prompt formatting lives in `uor-r4-graph-cli::scenarios`).
+- **Observation Pipeline** (`observation.rs`, `observation_shards.rs`): Content-addressed observation extraction with deterministic shard spill and transactional raw resume (ChatML prompt formatting lives in `uor-r4-graph-cli::scenarios`). At every whole-story boundary the versioned `raw-committed.bin` checkpoint atomically binds the global teacher state, manifest identity/layout, and the committed base-record length of every shard. Resume first validates every shard and companion without mutation, then trims tentative aligned tails and repairs the 25-byte `state.bin` compatibility mirror. Unfinished legacy raw directories without this authoritative boundary fail closed; fully finalized, κ-validated legacy bundles remain readable without rewriting historical bytes.
 - **Cover Induction** (`induction.rs`): Spherical K-means clustering over teacher representation spaces with calibrated overlapping region radii.
 - **Score & Residual Accumulation** (`residual.rs`, `pack.rs`): Pre-quantized fixed-point `ScoreQ` residual computation across resolution depths and R4G1 packing.
 

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -16,15 +16,17 @@
 //!   shard-id order**, so shard completion order never changes the merged
 //!   observation bytes.
 //!
-//! Resume extends the corpus' append-only resumability (`compiler.rs`):
-//! `state.bin` checkpoints the deterministic teacher stream at whole-story
-//! boundaries (same 25-byte layout as the corpus meta), and
-//! `manifest.json` records which shards are complete with their content κ.
-//! A rerun skips completed shards and continues incomplete shards after
-//! validating record/sidecar alignment. The raw 25-byte checkpoint does not
-//! carry per-shard committed lengths, so an aligned mid-story tail cannot be
-//! distinguished from committed rows and raw resume is not an exactly-once
-//! recovery claim. The text driver has a separate per-shard checkpoint.
+//! Resume is transactional at whole-story boundaries. `raw-committed.bin` is
+//! the authoritative, versioned snapshot: it binds the observation identity
+//! and row layout to the deterministic teacher state plus one committed record
+//! count per shard. Every affected base/probability/trace stream is flushed and
+//! synchronized before that snapshot is atomically replaced. `state.bin`
+//! remains the historical 25-byte compatibility mirror and is published only
+//! after the authoritative snapshot. On resume, every stream is inspected
+//! before any is truncated, so complete aligned bytes beyond the committed
+//! vector are tentative and are regenerated exactly once. Fully finalized,
+//! kappa-validated legacy raw bundles remain readable; an unfinished legacy
+//! raw directory has no provable transaction boundary and fails closed.
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::trace_profile::SUPPORT_ABSENT_MARKER;
@@ -139,8 +141,9 @@ pub const MANIFEST_FILE: &str = "manifest.json";
 const OBSERVATION_SESSION_LOCK_PREFIX: &str = ".uor-r4-observation-session-";
 
 #[cfg(not(target_arch = "wasm32"))]
-const OBSERVATION_PAYLOAD_FILES: [&str; 7] = [
+const OBSERVATION_PAYLOAD_FILES: [&str; 8] = [
     STATE_FILE,
+    RAW_COMMITTED_FILE,
     "merged.bin",
     "committed.bin",
     ".committed.bin.tmp",
@@ -152,11 +155,297 @@ const OBSERVATION_PAYLOAD_FILES: [&str; 7] = [
 #[cfg(not(target_arch = "wasm32"))]
 static MANIFEST_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+#[cfg(not(target_arch = "wasm32"))]
+static RAW_CHECKPOINT_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// Generator checkpoint file name within an observation directory.
 pub const STATE_FILE: &str = "state.bin";
 
+/// Authoritative raw-observation transaction snapshot. This is deliberately
+/// distinct from the text driver's `committed.bin`; neither format is accepted
+/// by the other driver.
+pub const RAW_COMMITTED_FILE: &str = "raw-committed.bin";
+
+#[cfg(not(target_arch = "wasm32"))]
+const RAW_COMMITTED_MAGIC: [u8; 8] = *b"R4RAWCOM";
+#[cfg(not(target_arch = "wasm32"))]
+const RAW_COMMITTED_SCHEMA: u16 = 1;
+#[cfg(not(target_arch = "wasm32"))]
+const RAW_COMMITTED_HEADER_BYTES: usize = 88;
+
 #[cfg(not(target_arch = "wasm32"))]
 type ObservationState = (u64, u64, u64, u8);
+
+/// Canonical raw-observation transaction snapshot.
+///
+/// The encoded representation is exactly `88 + 8 * shard_count` bytes. It is
+/// timestamp-free and stores record counts rather than redundant companion
+/// lengths; probability and trace lengths are derived with checked arithmetic
+/// from the pinned row widths.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawCommittedCheckpoint {
+    shard_bits: u8,
+    trace_row_bytes: Option<u64>,
+    n: u64,
+    stories: u64,
+    rng: u64,
+    done: bool,
+    identity_digest: [u8; 32],
+    committed_records: Vec<u64>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RawCommittedCheckpoint {
+    /// Construct and validate a checkpoint against the manifest identity and
+    /// layout that it commits.
+    pub fn new(
+        manifest: &ObservationManifest,
+        n: u64,
+        stories: u64,
+        rng: u64,
+        done: bool,
+        committed_records: Vec<u64>,
+    ) -> Result<Self, SourceUnavailable> {
+        manifest.validate_loaded_semantics()?;
+        let checkpoint = Self {
+            shard_bits: manifest.shard_bits,
+            trace_row_bytes: manifest.trace_row_bytes,
+            n,
+            stories,
+            rng,
+            done,
+            identity_digest: *blake3::hash(&manifest.identity_bundle_bytes()).as_bytes(),
+            committed_records,
+        };
+        checkpoint.validate_intrinsic()?;
+        checkpoint.validate_manifest(manifest)?;
+        Ok(checkpoint)
+    }
+
+    /// Decode the exact canonical binary representation. Compatibility with a
+    /// particular manifest is checked separately by the locked resume path.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SourceUnavailable> {
+        if bytes.len() < RAW_COMMITTED_HEADER_BYTES {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint has {} bytes, shorter than the {RAW_COMMITTED_HEADER_BYTES}-byte header",
+                bytes.len()
+            )));
+        }
+        if bytes[0..8] != RAW_COMMITTED_MAGIC {
+            return Err(invalid_data(
+                "raw observation checkpoint has invalid magic; refusing mixed or corrupt checkpoint format"
+                    .to_owned(),
+            ));
+        }
+        let schema = u16::from_le_bytes(bytes[8..10].try_into().expect("2-byte slice"));
+        if schema != RAW_COMMITTED_SCHEMA {
+            return Err(invalid_data(format!(
+                "unsupported raw observation checkpoint schema {schema}; expected {RAW_COMMITTED_SCHEMA}"
+            )));
+        }
+        let shard_bits = bytes[10];
+        let done = match bytes[11] {
+            0 => false,
+            1 => true,
+            value => {
+                return Err(invalid_data(format!(
+                    "raw observation checkpoint has invalid done byte {value}; expected 0 or 1"
+                )));
+            }
+        };
+        let record_size = u32::from_le_bytes(bytes[12..16].try_into().expect("4-byte slice"));
+        if record_size != RECORD_SIZE as u32 {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint records {record_size}-byte base rows, expected {RECORD_SIZE}"
+            )));
+        }
+        let probability_size = u32::from_le_bytes(bytes[16..20].try_into().expect("4-byte slice"));
+        if probability_size != PROBABILITY_METADATA_SIZE as u32 {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint records {probability_size}-byte probability rows, expected {PROBABILITY_METADATA_SIZE}"
+            )));
+        }
+        let trace_width = u64::from_le_bytes(bytes[20..28].try_into().expect("8-byte slice"));
+        let trace_row_bytes = (trace_width != 0).then_some(trace_width);
+        let n = u64::from_le_bytes(bytes[28..36].try_into().expect("8-byte slice"));
+        let stories = u64::from_le_bytes(bytes[36..44].try_into().expect("8-byte slice"));
+        let rng = u64::from_le_bytes(bytes[44..52].try_into().expect("8-byte slice"));
+        let identity_digest = bytes[52..84].try_into().expect("32-byte slice");
+        let encoded_shards = u32::from_le_bytes(bytes[84..88].try_into().expect("4-byte slice"));
+        let expected_shards = 1u32.checked_shl(u32::from(shard_bits)).ok_or_else(|| {
+            invalid_data(format!(
+                "raw observation checkpoint shard_bits {shard_bits} cannot define a bounded fan-out"
+            ))
+        })?;
+        if shard_bits > MAX_SHARD_BITS || encoded_shards != expected_shards {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint fan-out {encoded_shards} does not match shard_bits {shard_bits} (maximum {MAX_SHARD_BITS})"
+            )));
+        }
+        let vector_bytes = usize::try_from(encoded_shards)
+            .ok()
+            .and_then(|count| count.checked_mul(8))
+            .and_then(|length| RAW_COMMITTED_HEADER_BYTES.checked_add(length))
+            .ok_or_else(|| invalid_data("raw checkpoint length overflows usize".to_owned()))?;
+        if bytes.len() != vector_bytes {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint has {} bytes, expected exactly {vector_bytes} for {encoded_shards} shards",
+                bytes.len()
+            )));
+        }
+        let mut committed_records = Vec::with_capacity(encoded_shards as usize);
+        for row in bytes[RAW_COMMITTED_HEADER_BYTES..].chunks_exact(8) {
+            committed_records.push(u64::from_le_bytes(row.try_into().expect("8-byte slice")));
+        }
+        let checkpoint = Self {
+            shard_bits,
+            trace_row_bytes,
+            n,
+            stories,
+            rng,
+            done,
+            identity_digest,
+            committed_records,
+        };
+        checkpoint.validate_intrinsic()?;
+        Ok(checkpoint)
+    }
+
+    /// Encode the canonical binary representation.
+    pub fn encode(&self) -> Result<Vec<u8>, SourceUnavailable> {
+        self.validate_intrinsic()?;
+        let capacity = RAW_COMMITTED_HEADER_BYTES
+            .checked_add(self.committed_records.len().checked_mul(8).ok_or_else(|| {
+                invalid_data("raw checkpoint vector length overflows usize".to_owned())
+            })?)
+            .ok_or_else(|| invalid_data("raw checkpoint length overflows usize".to_owned()))?;
+        let mut bytes = Vec::with_capacity(capacity);
+        bytes.extend_from_slice(&RAW_COMMITTED_MAGIC);
+        bytes.extend_from_slice(&RAW_COMMITTED_SCHEMA.to_le_bytes());
+        bytes.push(self.shard_bits);
+        bytes.push(u8::from(self.done));
+        bytes.extend_from_slice(&(RECORD_SIZE as u32).to_le_bytes());
+        bytes.extend_from_slice(&(PROBABILITY_METADATA_SIZE as u32).to_le_bytes());
+        bytes.extend_from_slice(&self.trace_row_bytes.unwrap_or(0).to_le_bytes());
+        bytes.extend_from_slice(&self.n.to_le_bytes());
+        bytes.extend_from_slice(&self.stories.to_le_bytes());
+        bytes.extend_from_slice(&self.rng.to_le_bytes());
+        bytes.extend_from_slice(&self.identity_digest);
+        bytes.extend_from_slice(&(self.committed_records.len() as u32).to_le_bytes());
+        for records in &self.committed_records {
+            bytes.extend_from_slice(&records.to_le_bytes());
+        }
+        debug_assert_eq!(bytes.len(), capacity);
+        Ok(bytes)
+    }
+
+    /// Global teacher state selected by this transaction.
+    pub fn state(&self) -> (u64, u64, u64, bool) {
+        (self.n, self.stories, self.rng, self.done)
+    }
+
+    /// Per-shard committed record counts in canonical shard order.
+    pub fn committed_records(&self) -> &[u64] {
+        &self.committed_records
+    }
+
+    /// Pinned shard fan-out exponent.
+    pub fn shard_bits(&self) -> u8 {
+        self.shard_bits
+    }
+
+    /// Pinned trace row width, absent for a minimal raw pass.
+    pub fn trace_row_bytes(&self) -> Option<u64> {
+        self.trace_row_bytes
+    }
+
+    fn validate_intrinsic(&self) -> Result<(), SourceUnavailable> {
+        if self.shard_bits > MAX_SHARD_BITS {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint shard_bits {} exceeds maximum {MAX_SHARD_BITS}",
+                self.shard_bits
+            )));
+        }
+        let shard_count = 1usize << self.shard_bits;
+        if self.committed_records.len() != shard_count {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint has {} shard counters, expected {shard_count}",
+                self.committed_records.len()
+            )));
+        }
+        if self.trace_row_bytes == Some(0) {
+            return Err(invalid_data(
+                "raw observation checkpoint records a zero-byte trace row".to_owned(),
+            ));
+        }
+        if self.stories > u32::MAX as u64 {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint records {} stories, outside the u32 story wire domain",
+                self.stories
+            )));
+        }
+        let total = self.committed_records.iter().try_fold(0u64, |sum, count| {
+            count.checked_mul(RECORD_SIZE as u64).ok_or_else(|| {
+                invalid_data("raw checkpoint base byte length overflows u64".to_owned())
+            })?;
+            count
+                .checked_mul(PROBABILITY_METADATA_SIZE as u64)
+                .ok_or_else(|| {
+                    invalid_data("raw checkpoint probability byte length overflows u64".to_owned())
+                })?;
+            if let Some(row_bytes) = self.trace_row_bytes {
+                count.checked_mul(row_bytes).ok_or_else(|| {
+                    invalid_data("raw checkpoint trace byte length overflows u64".to_owned())
+                })?;
+            }
+            sum.checked_add(*count).ok_or_else(|| {
+                invalid_data("raw observation checkpoint record total overflows u64".to_owned())
+            })
+        })?;
+        if total != self.n {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint n={} does not match per-shard record total {total}",
+                self.n
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_manifest(&self, manifest: &ObservationManifest) -> Result<(), SourceUnavailable> {
+        if self.shard_bits != manifest.shard_bits
+            || self.committed_records.len() != manifest.shard_count() as usize
+        {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint fan-out does not match manifest shard_bits {}",
+                manifest.shard_bits
+            )));
+        }
+        if self.trace_row_bytes != manifest.trace_row_bytes {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint trace row width {:?} does not match manifest {:?}",
+                self.trace_row_bytes, manifest.trace_row_bytes
+            )));
+        }
+        let expected_identity = *blake3::hash(&manifest.identity_bundle_bytes()).as_bytes();
+        if self.identity_digest != expected_identity {
+            return Err(invalid_data(format!(
+                "raw observation checkpoint identity does not match manifest bundle {}",
+                manifest.identity_bundle_digest()
+            )));
+        }
+        for (&shard, entry) in &manifest.completed {
+            if self.committed_records[shard as usize] != entry.records {
+                return Err(invalid_data(format!(
+                    "raw observation checkpoint commits {} records for finalized shard {shard}, but the manifest commits {}",
+                    self.committed_records[shard as usize], entry.records
+                )));
+            }
+        }
+        Ok(())
+    }
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 fn read_observation_state(dir: &Path) -> Result<Option<ObservationState>, SourceUnavailable> {
@@ -200,6 +489,126 @@ fn read_observation_state(dir: &Path) -> Result<Option<ObservationState>, Source
         u64::from_le_bytes(bytes[16..24].try_into().expect("8-byte slice")),
         done,
     )))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn encode_observation_state(state: ObservationState) -> [u8; 25] {
+    let (n, stories, rng, done) = state;
+    let mut bytes = [0u8; 25];
+    bytes[0..8].copy_from_slice(&n.to_le_bytes());
+    bytes[8..16].copy_from_slice(&stories.to_le_bytes());
+    bytes[16..24].copy_from_slice(&rng.to_le_bytes());
+    bytes[24] = done;
+    bytes
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn sync_directory(dir: &Path) -> Result<(), SourceUnavailable> {
+    fs::File::open(dir)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn atomic_publish_observation_file(
+    dir: &Path,
+    destination_name: &str,
+    temporary_stem: &str,
+    bytes: &[u8],
+) -> Result<(), SourceUnavailable> {
+    let destination = dir.join(destination_name);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            return Err(invalid_input(format!(
+                "observation transaction file {} is not a regular file; refusing atomic replacement",
+                destination.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    for _ in 0..64 {
+        let sequence =
+            RAW_CHECKPOINT_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temporary = dir.join(format!(
+            ".{temporary_stem}.tmp-{}-{sequence}",
+            std::process::id()
+        ));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        };
+        let write_result = file.write_all(bytes).and_then(|()| file.sync_all());
+        drop(file);
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&temporary);
+            return Err(error.into());
+        }
+        if let Err(error) = fs::rename(&temporary, &destination) {
+            let _ = fs::remove_file(&temporary);
+            return Err(error.into());
+        }
+        sync_directory(dir)?;
+        return Ok(());
+    }
+    Err(invalid_input(format!(
+        "could not reserve a unique {destination_name} temporary in {}",
+        dir.display()
+    )))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn publish_raw_checkpoint(
+    dir: &Path,
+    checkpoint: &RawCommittedCheckpoint,
+) -> Result<(), SourceUnavailable> {
+    atomic_publish_observation_file(
+        dir,
+        RAW_COMMITTED_FILE,
+        RAW_COMMITTED_FILE,
+        &checkpoint.encode()?,
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn publish_state_mirror(
+    dir: &Path,
+    checkpoint: &RawCommittedCheckpoint,
+) -> Result<(), SourceUnavailable> {
+    let (n, stories, rng, done) = checkpoint.state();
+    atomic_publish_observation_file(
+        dir,
+        STATE_FILE,
+        STATE_FILE,
+        &encode_observation_state((n, stories, rng, u8::from(done))),
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn read_raw_checkpoint(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<Option<RawCommittedCheckpoint>, SourceUnavailable> {
+    let path = dir.join(RAW_COMMITTED_FILE);
+    match fs::symlink_metadata(&path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            return Err(invalid_input(format!(
+                "raw observation checkpoint {} is not a regular file",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+    }
+    let checkpoint = RawCommittedCheckpoint::decode(&fs::read(path)?)?;
+    checkpoint.validate_manifest(manifest)?;
+    Ok(Some(checkpoint))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -751,7 +1160,10 @@ impl ObservationManifest {
                     validate_completed_payloads(dir, &manifest)?;
                     if manifest.trace_profile.is_some()
                         && manifest.trace_row_bytes.is_none()
-                        && (regular_file_present(&dir.join(STATE_FILE), "trace-layout")?
+                        && (regular_file_present(
+                            &dir.join(RAW_COMMITTED_FILE),
+                            "trace-layout",
+                        )? || regular_file_present(&dir.join(STATE_FILE), "trace-layout")?
                             || observation_shard_payload_present(dir)?)
                     {
                         return Err(invalid_data(format!(
@@ -779,9 +1191,9 @@ impl ObservationManifest {
     }
 
     /// Persist the manifest atomically (write-then-rename). Shard files are
-    /// flushed before completed entries are published. A lost manifest update
-    /// leaves that shard incomplete; resume validates and appends its existing
-    /// aligned bytes. See the raw checkpoint limitation in the module docs.
+    /// flushed before completed entries are published. A lost finalization
+    /// update leaves that shard incomplete; raw resume restores the
+    /// authoritative committed prefix before retrying finalization.
     #[cfg(not(target_arch = "wasm32"))]
     fn store(&self, dir: &Path) -> Result<(), SourceUnavailable> {
         let bytes = serde_json::to_vec_pretty(self)
@@ -828,6 +1240,7 @@ impl ObservationManifest {
                 let _ = fs::remove_file(&tmp);
                 return Err(error.into());
             }
+            sync_directory(dir)?;
             return Ok(());
         }
         Err(invalid_input(format!(
@@ -997,6 +1410,7 @@ fn validate_completed_payloads(
 fn is_observation_payload_name(name: &str) -> bool {
     OBSERVATION_PAYLOAD_FILES.contains(&name)
         || is_manifest_temp_name(name)
+        || is_raw_transaction_temp_name(name)
         || name.starts_with("stories.tmp-")
         || is_shard_payload_name(name)
 }
@@ -1004,6 +1418,11 @@ fn is_observation_payload_name(name: &str) -> bool {
 #[cfg(not(target_arch = "wasm32"))]
 fn is_manifest_temp_name(name: &str) -> bool {
     name == ".manifest.json.tmp" || name.starts_with(".manifest.json.tmp-")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_raw_transaction_temp_name(name: &str) -> bool {
+    name.starts_with(".raw-committed.bin.tmp-") || name.starts_with(".state.bin.tmp-")
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1245,151 +1664,353 @@ pub(crate) fn observation_shard_payload_present(dir: &Path) -> Result<bool, Sour
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn raw_shard_record_total(
-    dir: &Path,
-    manifest: &ObservationManifest,
-) -> Result<(bool, u64), SourceUnavailable> {
-    let mut present = false;
-    let mut records = 0u64;
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else {
-            continue;
-        };
-        if !is_base_shard_payload_name(name) {
-            continue;
-        }
-        present = true;
-        let shard = name
-            .strip_prefix("shard-")
-            .and_then(|rest| rest.strip_suffix(".bin"))
-            .and_then(|index| index.parse::<u32>().ok())
-            .ok_or_else(|| invalid_data(format!("invalid observation shard name {name}")))?;
-        if shard >= manifest.shard_count() {
-            return Err(invalid_data(format!(
-                "observation shard {name} is outside the manifest's {}-shard fan-out",
-                manifest.shard_count()
-            )));
-        }
-        let metadata = fs::symlink_metadata(entry.path())?;
-        if !metadata.file_type().is_file() {
-            return Err(invalid_input(format!(
-                "observation shard {} is not a regular file",
-                entry.path().display()
-            )));
-        }
-        let length = metadata.len();
-        if length % RECORD_SIZE as u64 != 0 {
-            return Err(invalid_data(format!(
-                "observation shard {} has a torn record ({length} bytes)",
-                entry.path().display()
-            )));
-        }
-        records = records
-            .checked_add(length / RECORD_SIZE as u64)
-            .ok_or_else(|| {
-                invalid_data("observation shard record total overflows u64".to_owned())
-            })?;
-    }
-    Ok((present, records))
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RawResumeStatus {
+    /// No raw or text transaction evidence exists yet.
+    Fresh,
+    /// A versioned raw checkpoint authoritatively selects these bytes/state.
+    Authoritative(RawCommittedCheckpoint),
+    /// A pre-checkpoint raw bundle whose complete manifest and kappas prove its
+    /// final boundaries. It is accepted read-only and is never migrated.
+    FinalizedLegacy {
+        records: u64,
+        stories: u64,
+        rng: u64,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn raw_recoverable_record_total(
-    dir: &Path,
-    manifest: &ObservationManifest,
-) -> Result<u64, SourceUnavailable> {
-    let regular_length = |path: &Path| -> Result<Option<u64>, SourceUnavailable> {
-        match fs::symlink_metadata(path) {
-            Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.len())),
-            Ok(_) => Err(invalid_input(format!(
-                "raw observation payload {} is not a regular file",
+#[derive(Debug)]
+struct RawPayloadRecovery {
+    path: PathBuf,
+    current_bytes: u64,
+    committed_bytes: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+struct RawRecoveryPlan {
+    checkpoint: RawCommittedCheckpoint,
+    payloads: Vec<RawPayloadRecovery>,
+    repair_state_mirror: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum RawResumePlan {
+    Fresh,
+    Authoritative(RawRecoveryPlan),
+    FinalizedLegacy(ObservationState),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_recovery_payload(
+    path: PathBuf,
+    row_bytes: u64,
+    committed_rows: u64,
+    label: &str,
+) -> Result<Option<RawPayloadRecovery>, SourceUnavailable> {
+    let committed_bytes = committed_rows.checked_mul(row_bytes).ok_or_else(|| {
+        invalid_data(format!(
+            "raw checkpoint {label} committed byte length overflows u64"
+        ))
+    })?;
+    let current_bytes = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => metadata.len(),
+        Ok(_) => {
+            return Err(invalid_input(format!(
+                "raw observation {label} {} is not a regular file",
                 path.display()
-            ))),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
-        }
-    };
-    let mut recoverable = 0u64;
-    for shard in 0..manifest.shard_count() {
-        let base_path = dir.join(shard_file_name(manifest.shard_bits, shard));
-        let probability_path = dir.join(format!(
-            "{}.prob",
-            shard_file_name(manifest.shard_bits, shard)
-        ));
-        let trace_path = dir.join(trace_sidecar_name(manifest.shard_bits, shard));
-        let base_length = regular_length(&base_path)?;
-        let probability_length = regular_length(&probability_path)?;
-        let trace_length = regular_length(&trace_path)?;
-        let Some(base_length) = base_length else {
-            if probability_length.is_some() || trace_length.is_some() {
-                return Err(invalid_data(format!(
-                    "raw observation shard {shard} has a sidecar but no base record file"
-                )));
-            }
-            continue;
-        };
-        if base_length % RECORD_SIZE as u64 != 0 {
-            return Err(invalid_data(format!(
-                "raw observation shard {} has a torn record",
-                base_path.display()
             )));
         }
-        let base_records = base_length / RECORD_SIZE as u64;
-        let probability_records = match probability_length {
-            Some(length) if length % PROBABILITY_METADATA_SIZE as u64 == 0 => {
-                length / PROBABILITY_METADATA_SIZE as u64
-            }
-            Some(_) => {
+        Err(error) if error.kind() == io::ErrorKind::NotFound && committed_bytes == 0 => {
+            return Ok(None);
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(invalid_data(format!(
+                "raw observation {label} {} is missing but the checkpoint commits {committed_bytes} bytes",
+                path.display()
+            )));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if current_bytes % row_bytes != 0 {
+        return Err(invalid_data(format!(
+            "raw observation {label} {} has a torn row ({current_bytes} bytes at width {row_bytes})",
+            path.display()
+        )));
+    }
+    if current_bytes < committed_bytes {
+        return Err(invalid_data(format!(
+            "raw observation {label} {} has {current_bytes} bytes, shorter than the committed {committed_bytes}-byte prefix",
+            path.display()
+        )));
+    }
+    Ok(Some(RawPayloadRecovery {
+        path,
+        current_bytes,
+        committed_bytes,
+    }))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn current_raw_record_counts(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<Vec<u64>, SourceUnavailable> {
+    let row_count = |path: &Path, row_bytes: u64, label: &str| match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            let length = metadata.len();
+            if length % row_bytes != 0 {
                 return Err(invalid_data(format!(
-                    "raw probability sidecar {} has a torn metadata row",
-                    probability_path.display()
+                    "raw observation {label} {} has a torn row ({length} bytes at width {row_bytes})",
+                    path.display()
                 )));
             }
-            None if base_records == 0 => 0,
-            None => {
-                return Err(invalid_data(format!(
-                    "raw observation shard {} has records but no probability sidecar",
-                    base_path.display()
-                )));
-            }
-        };
-        let mut shard_recoverable = base_records.min(probability_records);
-        match (manifest.trace_profile.as_ref(), trace_length) {
-            (None, Some(_)) => {
-                return Err(invalid_data(format!(
-                    "raw observation shard {shard} has a trace sidecar but no trace profile"
-                )));
-            }
-            (None, None) => {}
-            (Some(_), Some(length)) => {
-                let row_bytes = manifest.trace_row_bytes.ok_or_else(|| {
-                    invalid_data("traced raw observation has no pinned trace row width".to_owned())
-                })?;
-                if length % row_bytes != 0 {
+            Ok(Some(length / row_bytes))
+        }
+        Ok(_) => Err(invalid_input(format!(
+            "raw observation {label} {} is not a regular file",
+            path.display()
+        ))),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    };
+    let mut counts = Vec::with_capacity(manifest.shard_count() as usize);
+    for shard in 0..manifest.shard_count() {
+        let base_name = shard_file_name(manifest.shard_bits, shard);
+        let base = row_count(&dir.join(&base_name), RECORD_SIZE as u64, "base shard")?.unwrap_or(0);
+        let probability = row_count(
+            &dir.join(format!("{base_name}.prob")),
+            PROBABILITY_METADATA_SIZE as u64,
+            "probability sidecar",
+        )?
+        .unwrap_or(0);
+        if probability != base {
+            return Err(invalid_data(format!(
+                "raw observation shard {shard} has {base} base rows but {probability} probability rows"
+            )));
+        }
+        let trace_path = dir.join(trace_sidecar_name(manifest.shard_bits, shard));
+        match manifest.trace_row_bytes {
+            Some(row_bytes) => {
+                let trace = row_count(&trace_path, row_bytes, "trace sidecar")?.unwrap_or(0);
+                if trace != base {
                     return Err(invalid_data(format!(
-                        "raw trace sidecar {} has a torn row",
-                        trace_path.display()
+                        "raw observation shard {shard} has {base} base rows but {trace} trace rows"
                     )));
                 }
-                shard_recoverable = shard_recoverable.min(length / row_bytes);
             }
-            (Some(_), None) if base_records == 0 => {
-                shard_recoverable = 0;
-            }
-            (Some(_), None) => {
+            None if regular_file_present(&trace_path, "raw-checkpoint")? => {
                 return Err(invalid_data(format!(
-                    "raw observation shard {} has records but no trace sidecar",
-                    base_path.display()
+                    "raw observation shard {shard} has a trace sidecar under the minimal layout"
                 )));
             }
+            None => {}
         }
-        recoverable = recoverable.checked_add(shard_recoverable).ok_or_else(|| {
-            invalid_data("recoverable raw observation record total overflows u64".to_owned())
-        })?;
+        counts.push(base);
     }
-    Ok(recoverable)
+    Ok(counts)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn state_mirror_needs_repair(
+    dir: &Path,
+    checkpoint: &RawCommittedCheckpoint,
+) -> Result<bool, SourceUnavailable> {
+    let path = dir.join(STATE_FILE);
+    let expected = {
+        let (n, stories, rng, done) = checkpoint.state();
+        encode_observation_state((n, stories, rng, u8::from(done)))
+    };
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(fs::read(path)? != expected),
+        Ok(_) => Err(invalid_input(format!(
+            "observation state mirror {} is not a regular file",
+            path.display()
+        ))),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_raw_resume(
+    dir: &Path,
+    manifest: &ObservationManifest,
+) -> Result<RawResumePlan, SourceUnavailable> {
+    let text_story_evidence = fs::read_dir(dir)?.try_fold(false, |found, entry| {
+        let entry = entry?;
+        let is_story = entry.file_name().to_str().is_some_and(|name| {
+            name == "stories.jsonl" || name == "stories.tmp" || name.starts_with("stories.tmp-")
+        });
+        Ok::<_, io::Error>(found || is_story)
+    })?;
+    if manifest.partition_rule.is_some()
+        || manifest.input_cid.is_some()
+        || text_story_evidence
+        || regular_file_present(&dir.join("committed.bin"), "raw-checkpoint")?
+        || regular_file_present(&dir.join(".committed.bin.tmp"), "raw-checkpoint")?
+    {
+        return Err(invalid_data(format!(
+            "{} contains the text observation committed.bin format; refusing a mixed raw observation resume",
+            dir.display()
+        )));
+    }
+    let Some(checkpoint) = read_raw_checkpoint(dir, manifest)? else {
+        let state = read_observation_state(dir)?;
+        let shard_payload = observation_shard_payload_present(dir)?;
+        let merged = regular_file_present(&dir.join("merged.bin"), "raw-checkpoint")?;
+        let stream_evidence = state.is_some()
+            || shard_payload
+            || merged
+            || manifest.total_records != 0
+            || !manifest.completed.is_empty();
+        if !stream_evidence {
+            return Ok(RawResumePlan::Fresh);
+        }
+        let fully_finalized = manifest.completed.len() == manifest.shard_count() as usize;
+        if fully_finalized
+            && let Some((n, stories, rng, 1)) = state
+            && n == manifest.total_records
+        {
+            return Ok(RawResumePlan::FinalizedLegacy((n, stories, rng, 1)));
+        }
+        return Err(invalid_data(format!(
+            "{} is an unfinished legacy raw observation directory with no authoritative {RAW_COMMITTED_FILE}; its aligned bytes cannot prove a whole-story boundary, so restart in a fresh output directory",
+            dir.display()
+        )));
+    };
+    if !checkpoint.done && !manifest.completed.is_empty() {
+        return Err(invalid_data(format!(
+            "{} has finalized raw shards but its authoritative checkpoint is unfinished; refusing an inconsistent resume",
+            dir.display()
+        )));
+    }
+
+    let mut payloads = Vec::new();
+    for (shard, &records) in checkpoint.committed_records().iter().enumerate() {
+        let shard = shard as u32;
+        let base_name = shard_file_name(manifest.shard_bits, shard);
+        if let Some(plan) = preflight_recovery_payload(
+            dir.join(&base_name),
+            RECORD_SIZE as u64,
+            records,
+            "base shard",
+        )? {
+            payloads.push(plan);
+        }
+        if let Some(plan) = preflight_recovery_payload(
+            dir.join(format!("{base_name}.prob")),
+            PROBABILITY_METADATA_SIZE as u64,
+            records,
+            "probability sidecar",
+        )? {
+            payloads.push(plan);
+        }
+        let trace_path = dir.join(trace_sidecar_name(manifest.shard_bits, shard));
+        match checkpoint.trace_row_bytes() {
+            Some(row_bytes) => {
+                if let Some(plan) =
+                    preflight_recovery_payload(trace_path, row_bytes, records, "trace sidecar")?
+                {
+                    payloads.push(plan);
+                }
+            }
+            None if regular_file_present(&trace_path, "raw-checkpoint")? => {
+                return Err(invalid_data(format!(
+                    "raw observation shard {shard} has a trace sidecar, but the checkpoint pins the minimal trace layout"
+                )));
+            }
+            None => {}
+        }
+    }
+    Ok(RawResumePlan::Authoritative(RawRecoveryPlan {
+        repair_state_mirror: state_mirror_needs_repair(dir, &checkpoint)?,
+        checkpoint,
+        payloads,
+    }))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn status_from_plan(plan: &RawResumePlan) -> RawResumeStatus {
+    match plan {
+        RawResumePlan::Fresh => RawResumeStatus::Fresh,
+        RawResumePlan::Authoritative(plan) => {
+            RawResumeStatus::Authoritative(plan.checkpoint.clone())
+        }
+        RawResumePlan::FinalizedLegacy((records, stories, rng, _)) => {
+            RawResumeStatus::FinalizedLegacy {
+                records: *records,
+                stories: *stories,
+                rng: *rng,
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn apply_raw_recovery(dir: &Path, plan: &RawRecoveryPlan) -> Result<(), SourceUnavailable> {
+    // Phase two still opens and revalidates every file before changing the
+    // first one. This keeps a late permission/race failure from partially
+    // applying the plan assembled by the read-only phase.
+    let mut files = Vec::with_capacity(plan.payloads.len());
+    for payload in &plan.payloads {
+        let truncate = payload.current_bytes != payload.committed_bytes;
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(truncate)
+            .open(&payload.path)?;
+        if file.metadata()?.len() != payload.current_bytes {
+            return Err(invalid_data(format!(
+                "raw observation payload {} changed after preflight; refusing recovery",
+                payload.path.display()
+            )));
+        }
+        files.push((file, payload.committed_bytes, truncate));
+    }
+    for (file, committed_bytes, truncate) in files {
+        if truncate {
+            file.set_len(committed_bytes)?;
+            file.sync_all()?;
+        }
+    }
+    if plan
+        .payloads
+        .iter()
+        .any(|payload| payload.current_bytes != payload.committed_bytes)
+    {
+        sync_directory(dir)?;
+    }
+    if plan.repair_state_mirror {
+        publish_state_mirror(dir, &plan.checkpoint)?;
+    }
+    Ok(())
+}
+
+/// Inspect raw recovery under an already-held observation session without
+/// mutating payload, provenance, checkpoint, or mirror bytes.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn preflight_raw_observation_in_session(
+    session: &ObservationSession,
+) -> Result<RawResumeStatus, SourceUnavailable> {
+    let writer = session.writer()?;
+    let plan = preflight_raw_resume(session.dir(), writer.manifest())?;
+    Ok(status_from_plan(&plan))
+}
+
+/// Apply an authoritative raw recovery under an already-held session. Fresh
+/// outputs are left untouched (the observe driver publishes their identity-
+/// bound zero checkpoint), and finalized legacy bundles remain read-only.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn recover_raw_observation_in_session(
+    session: &ObservationSession,
+) -> Result<RawResumeStatus, SourceUnavailable> {
+    let writer = session.writer()?;
+    let plan = preflight_raw_resume(session.dir(), writer.manifest())?;
+    if let RawResumePlan::Authoritative(recovery) = &plan {
+        apply_raw_recovery(session.dir(), recovery)?;
+    }
+    Ok(status_from_plan(&plan))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1397,27 +2018,14 @@ fn preflight_observation_state(
     dir: &Path,
     manifest: &ObservationManifest,
 ) -> Result<Option<ObservationState>, SourceUnavailable> {
-    let state = read_observation_state(dir)?;
-    let (base_shard_present, _) = raw_shard_record_total(dir, manifest)?;
-    let shard_payload_present = base_shard_present || observation_shard_payload_present(dir)?;
-    let merged_present = regular_file_present(&dir.join("merged.bin"), "checkpoint")?;
-    let manifest_stream_evidence = manifest.total_records != 0 || !manifest.completed.is_empty();
-    if state.is_none() && (shard_payload_present || merged_present || manifest_stream_evidence) {
-        return Err(invalid_data(format!(
-            "{} contains raw observation stream evidence but no {STATE_FILE}; refusing to restart from a false fresh state",
-            dir.display()
-        )));
-    }
-    if let Some((n, _, _, _)) = state {
-        let recoverable_records = raw_recoverable_record_total(dir, manifest)?;
-        if recoverable_records < n {
-            return Err(invalid_data(format!(
-                "{} checkpoint records {n} generated rows, but its aligned base/sidecar prefixes retain only {recoverable_records}; refusing lossy resume before mutation",
-                dir.display()
-            )));
+    match preflight_raw_resume(dir, manifest)? {
+        RawResumePlan::Fresh => Ok(None),
+        RawResumePlan::Authoritative(plan) => {
+            let (n, stories, rng, done) = plan.checkpoint.state();
+            Ok(Some((n, stories, rng, u8::from(done))))
         }
+        RawResumePlan::FinalizedLegacy(state) => Ok(Some(state)),
     }
-    Ok(state)
 }
 
 /// Exclusive coordination guard for one observation output directory.
@@ -1677,9 +2285,8 @@ struct ShardHandle {
 /// manifest. Records may arrive interleaved across shards (routed by
 /// [`shard_of`]); each incomplete shard is appended to after its aligned
 /// record/sidecar prefix is validated. Completed shards are never rewritten:
-/// writes routed to them are skipped. Semantic exactly-once recovery is the
-/// caller checkpoint's responsibility; the raw checkpoint limitation is
-/// documented at module scope.
+/// writes routed to them are skipped. The raw driver commits this writer's
+/// synchronized per-shard lengths at whole-story boundaries.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct ObservationShardWriter {
     dir: PathBuf,
@@ -2037,7 +2644,8 @@ impl ObservationShardWriter {
                 self.dir.display()
             ))),
             (None, Some(_))
-                if regular_file_present(&self.dir.join(STATE_FILE), "trace-layout")?
+                if regular_file_present(&self.dir.join(RAW_COMMITTED_FILE), "trace-layout")?
+                    || regular_file_present(&self.dir.join(STATE_FILE), "trace-layout")?
                     || observation_shard_payload_present(&self.dir)? =>
             {
                 Err(invalid_input(format!(
@@ -2047,6 +2655,23 @@ impl ObservationShardWriter {
             }
             (None, Some(_)) | (None, None) => Ok(()),
         }
+    }
+
+    fn set_trace_row_bytes(&mut self, row_bytes: u64) -> Result<(), SourceUnavailable> {
+        if row_bytes == 0 {
+            return Err(invalid_input(
+                "trace row width must be greater than zero".to_owned(),
+            ));
+        }
+        self.preflight_trace_row_bytes(Some(row_bytes))?;
+        if self.manifest.trace_row_bytes == Some(row_bytes) {
+            return Ok(());
+        }
+        let mut candidate = self.manifest.clone();
+        candidate.trace_row_bytes = Some(row_bytes);
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
+        Ok(())
     }
 
     /// Record a non-minimal #603 trace-profile identity after compatibility
@@ -2240,8 +2865,7 @@ impl ObservationShardWriter {
                 )));
             }
             None => {
-                self.manifest.trace_row_bytes = Some(trace_row.len() as u64);
-                self.manifest.store(&self.dir)?;
+                self.set_trace_row_bytes(trace_row.len() as u64)?;
             }
             Some(_) => {}
         }
@@ -2309,6 +2933,26 @@ impl ObservationShardWriter {
             }
         }
         Ok(())
+    }
+
+    /// Durably synchronize every open raw stream, then return its strict
+    /// aligned record-count vector. This is the payload half of a whole-story
+    /// transaction and must complete before `raw-committed.bin` is replaced.
+    fn synchronize_raw_transaction(&mut self) -> Result<Vec<u64>, SourceUnavailable> {
+        self.flush()?;
+        for handle in self.handles.iter().flatten() {
+            handle.file.get_ref().sync_all()?;
+            if let Some(probability) = handle.probability.as_ref() {
+                probability.get_ref().sync_all()?;
+            }
+            if let Some(trace) = handle.trace.as_ref() {
+                trace.get_ref().sync_all()?;
+            }
+        }
+        // Persist any stream directory entries created since the previous
+        // transaction before publishing a checkpoint that refers to them.
+        sync_directory(&self.dir)?;
+        current_raw_record_counts(&self.dir, &self.manifest)
     }
 
     /// Finalize one shard: flush, κ-pin its file, and record it in the
@@ -3196,10 +3840,10 @@ impl TraceCapture {
 /// to `shard_of(sample_id(context_window), shard_bits)`, where the context
 /// window is the existing 8-token window of fed tokens. Resume continues the
 /// stream from a strictly decoded `state.bin`, skips completed shards, and
-/// appends to alignment-validated incomplete shards. Because raw `state.bin`
-/// has no per-shard committed lengths, aligned mid-story tails are not
-/// exactly-once recoverable; use the text driver where transactional
-/// per-shard recovery is required.
+/// appends to checkpoint-trimmed incomplete shards. `raw-committed.bin` is the
+/// authoritative whole-story boundary; the legacy `state.bin` is repaired as
+/// its compatibility mirror. Aligned bytes past the committed vector are
+/// tentative and are regenerated exactly once.
 ///
 /// This is the minimal trace profile: byte-for-byte today's records,
 /// sidecars, and manifest (no `trace_profile` field is recorded). Richer
@@ -3344,9 +3988,9 @@ fn observe_sharded_inner(
     };
     writer.preflight_geometry(geometry.as_ref())?;
     writer.preflight_attention_operator(attention_operator.as_ref())?;
-    let restored_state = preflight_observation_state(out, writer.manifest())?;
+    let preflight_state = preflight_observation_state(out, writer.manifest())?;
     let requested_target = u64::try_from(target).unwrap_or(u64::MAX);
-    if restored_state.is_some_and(|(n, _, _, _)| n < requested_target)
+    if preflight_state.is_some_and(|(n, _, _, _)| n < requested_target)
         && !writer.manifest().completed.is_empty()
     {
         return Err(invalid_input(format!(
@@ -3395,6 +4039,35 @@ fn observe_sharded_inner(
     if let Some(profile) = trace_profile_to_set.as_ref() {
         writer.set_trace_profile(profile)?;
     }
+    if let Some(trace) = trace.as_ref() {
+        writer.set_trace_row_bytes(trace.row_bytes as u64)?;
+    }
+    // Re-read the complete checkpoint/payload snapshot after every identity
+    // and layout setter has landed. Fresh runs publish the authoritative empty
+    // prefix before reconciliation or the first append. Existing runs apply
+    // the all-shard plan only after its read-only phase succeeded in full.
+    let resume = preflight_raw_resume(out, writer.manifest())?;
+    let restored_state = match &resume {
+        RawResumePlan::Fresh => {
+            let checkpoint = RawCommittedCheckpoint::new(
+                writer.manifest(),
+                0,
+                0,
+                0x5EED,
+                false,
+                vec![0; writer.manifest().shard_count() as usize],
+            )?;
+            publish_raw_checkpoint(out, &checkpoint)?;
+            publish_state_mirror(out, &checkpoint)?;
+            Some((0, 0, 0x5EED, 0))
+        }
+        RawResumePlan::Authoritative(plan) => {
+            apply_raw_recovery(out, plan)?;
+            let (n, stories, rng, done) = plan.checkpoint.state();
+            Some((n, stories, rng, u8::from(done)))
+        }
+        RawResumePlan::FinalizedLegacy(state) => Some(*state),
+    };
     let trace_row_bytes = writer.manifest().trace_row_bytes;
     for shard in 0..writer.manifest().shard_count() {
         match (trace.as_ref(), trace_row_bytes) {
@@ -3404,7 +4077,6 @@ fn observe_sharded_inner(
             _ => reconcile_probability_pair(out, shard_bits, shard)?,
         }
     }
-    let state_path = out.join(STATE_FILE);
     let (mut n, mut stories, mut rng, mut done) = restored_state.unwrap_or((0, 0, 0x5EED, 0));
     if (n as usize) < target {
         done = 0;
@@ -3498,16 +4170,19 @@ fn observe_sharded_inner(
             token = next;
         }
         stories += 1;
-        // Whole-story checkpoint: flush shard bytes first so they cover
-        // exactly the completed stories, then pin the stream position
-        // (identical 25-byte layout to the corpus meta).
-        writer.flush()?;
-        let mut state = [0u8; 25];
-        state[0..8].copy_from_slice(&n.to_le_bytes());
-        state[8..16].copy_from_slice(&stories.to_le_bytes());
-        state[16..24].copy_from_slice(&rng.to_le_bytes());
-        state[24] = done;
-        fs::write(&state_path, state)?;
+        // Whole-story transaction: payload synchronization, authoritative
+        // per-shard checkpoint replacement, then the legacy state mirror.
+        let committed_records = writer.synchronize_raw_transaction()?;
+        let checkpoint = RawCommittedCheckpoint::new(
+            writer.manifest(),
+            n,
+            stories,
+            rng,
+            done == 1,
+            committed_records,
+        )?;
+        publish_raw_checkpoint(out, &checkpoint)?;
+        publish_state_mirror(out, &checkpoint)?;
     }
     if done == 1 {
         writer.finalize_all()?;
@@ -4615,7 +5290,9 @@ mod attention_operator_resume_tests {
             };
             let error = observe_sharded(&mut oracle, 60, 1, 1, dir.path(), None)
                 .expect_err("stream evidence without state must fail");
-            assert!(error.reason.contains("no state.bin"), "{error}");
+            assert!(error.reason.contains("unfinished legacy"), "{error}");
+            assert!(error.reason.contains(RAW_COMMITTED_FILE), "{error}");
+            assert!(error.reason.contains("fresh output directory"), "{error}");
             assert_eq!(dir.bytes(), before);
         }
 
@@ -4637,7 +5314,9 @@ mod attention_operator_resume_tests {
         };
         let error = observe_sharded(&mut oracle, 60, 1, 1, missing_rows.path(), None)
             .expect_err("checkpoint rows missing from base shards must fail");
-        assert!(error.reason.contains("retain only 0"), "{error}");
+        assert!(error.reason.contains("unfinished legacy"), "{error}");
+        assert!(error.reason.contains(RAW_COMMITTED_FILE), "{error}");
+        assert!(error.reason.contains("fresh output directory"), "{error}");
         assert_eq!(missing_rows.bytes(), before);
 
         for alias_name in ["shard-1.bin", "shard-000.bin"] {
@@ -4696,11 +5375,10 @@ mod attention_operator_resume_tests {
         };
         observe_sharded(&mut oracle, 60, 1, 1, completed.path(), None)
             .expect("complete raw corpus");
-        fs::remove_file(completed.path().join(STATE_FILE)).expect("remove checkpoint");
         let before = completed.bytes();
-        let error = observe_sharded(&mut oracle, 60, 1, 1, completed.path(), None)
-            .expect_err("completed manifest without state must fail");
-        assert!(error.reason.contains("no state.bin"), "{error}");
+        fs::remove_file(completed.path().join(STATE_FILE)).expect("remove checkpoint");
+        observe_sharded(&mut oracle, 60, 1, 1, completed.path(), None)
+            .expect("authoritative checkpoint repairs a missing state mirror");
         assert_eq!(completed.bytes(), before);
     }
 

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -1055,6 +1055,24 @@ fn inspect_text_observation(
     attention_operator: Option<&AttentionOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<TextObservationPreflight, SourceUnavailable> {
+    let raw_checkpoint = out_dir.join(observe::RAW_COMMITTED_FILE);
+    match fs::symlink_metadata(&raw_checkpoint) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            return Err(SourceUnavailable::new(format!(
+                "{} contains the raw observation {} format; refusing a mixed text observation resume",
+                out_dir.display(),
+                observe::RAW_COMMITTED_FILE
+            )));
+        }
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "raw observation checkpoint {} is not a regular file; refusing text observation preflight",
+                raw_checkpoint.display()
+            )));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
     let kappa = input_kappa(articles_path)?;
     let input_cid = format!("blake3:{}", blake3::Hash::from(kappa).to_hex());
     let shard_count = writer.manifest().shard_count();

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -6,11 +6,13 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uor_r4_graph_compiler::observation::{
-    MANIFEST_FILE, ObservationManifest, ObservationShardWriter, ProbabilityMetadata, RECORD_SIZE,
+    MANIFEST_FILE, ObservationManifest, ObservationSession, ObservationShardWriter,
+    ProbabilityMetadata, RAW_COMMITTED_FILE, RECORD_SIZE, RawCommittedCheckpoint, RawResumeStatus,
     STATE_FILE, merge_probability_metadata, merge_shards, merge_trace_rows, message_bits_per_token,
-    observe_sharded, observe_sharded_traced, sample_id, shard_file_name, shard_of,
-    trace_sidecar_name,
+    observe_sharded, observe_sharded_traced, preflight_raw_observation_in_session,
+    recover_raw_observation_in_session, sample_id, shard_file_name, shard_of, trace_sidecar_name,
 };
+use uor_r4_graph_compiler::observation_text::preflight_text_observation_in_session;
 use uor_r4_graph_compiler::trace_profile::{SUPPORT_ABSENT_MARKER, TraceProfile};
 use uor_r4_model_source::geometry::GeometryProjection;
 use uor_r4_model_source::{
@@ -55,6 +57,423 @@ fn fixture_byte_bpe_adapter(
     )
     .expect("fixture tokenizer parses")
     .adapter()
+}
+
+// -------------------------------------- raw transaction checkpoint (#725) --
+
+#[test]
+fn raw_committed_checkpoint_is_canonical_and_strictly_decoded() {
+    let manifest = ObservationManifest::new(1);
+    let checkpoint =
+        RawCommittedCheckpoint::new(&manifest, 3, 2, 0x0123_4567_89AB_CDEF, false, vec![2, 1])
+            .expect("valid checkpoint");
+    let encoded = checkpoint.encode().expect("canonical encoding");
+
+    assert_eq!(&encoded[0..8], b"R4RAWCOM");
+    assert_eq!(u16::from_le_bytes(encoded[8..10].try_into().unwrap()), 1);
+    assert_eq!(encoded[10], 1, "shard_bits");
+    assert_eq!(encoded[11], 0, "done");
+    assert_eq!(
+        u32::from_le_bytes(encoded[12..16].try_into().unwrap()),
+        RECORD_SIZE as u32
+    );
+    assert_eq!(
+        u32::from_le_bytes(encoded[16..20].try_into().unwrap()),
+        16,
+        "probability row width"
+    );
+    assert_eq!(encoded.len(), 88 + 2 * 8);
+    assert_eq!(
+        RawCommittedCheckpoint::decode(&encoded).expect("round trip"),
+        checkpoint
+    );
+    assert_eq!(checkpoint.state(), (3, 2, 0x0123_4567_89AB_CDEF, false));
+    assert_eq!(checkpoint.committed_records(), &[2, 1]);
+    assert_eq!(checkpoint.shard_bits(), 1);
+    assert_eq!(checkpoint.trace_row_bytes(), None);
+    assert_eq!(
+        checkpoint.encode().unwrap(),
+        encoded,
+        "timestamp-free bytes"
+    );
+
+    let rejects = |label: &str, bytes: Vec<u8>| {
+        let error = match RawCommittedCheckpoint::decode(&bytes) {
+            Ok(_) => panic!("{label} must be rejected"),
+            Err(error) => error,
+        };
+        assert!(
+            error.reason.contains("raw observation checkpoint")
+                || error.reason.contains("raw checkpoint"),
+            "{label}: focused diagnostic: {error}"
+        );
+    };
+
+    rejects("truncated", encoded[..encoded.len() - 1].to_vec());
+    let mut extra = encoded.clone();
+    extra.push(0);
+    rejects("extra byte", extra);
+    let mut bad_magic = encoded.clone();
+    bad_magic[0] ^= 0xFF;
+    rejects("bad magic", bad_magic);
+    let mut unknown_version = encoded.clone();
+    unknown_version[8..10].copy_from_slice(&2u16.to_le_bytes());
+    rejects("unknown version", unknown_version);
+    let mut invalid_done = encoded.clone();
+    invalid_done[11] = 2;
+    rejects("invalid done", invalid_done);
+    let mut wrong_record_width = encoded.clone();
+    wrong_record_width[12..16].copy_from_slice(&87u32.to_le_bytes());
+    rejects("wrong record width", wrong_record_width);
+    let mut wrong_probability_width = encoded.clone();
+    wrong_probability_width[16..20].copy_from_slice(&15u32.to_le_bytes());
+    rejects("wrong probability width", wrong_probability_width);
+    let mut fanout_mismatch = encoded.clone();
+    fanout_mismatch[84..88].copy_from_slice(&1u32.to_le_bytes());
+    rejects("fan-out mismatch", fanout_mismatch);
+    let mut total_mismatch = encoded.clone();
+    total_mismatch[28..36].copy_from_slice(&4u64.to_le_bytes());
+    rejects("record total mismatch", total_mismatch);
+
+    assert!(
+        RawCommittedCheckpoint::new(
+            &ObservationManifest::new(0),
+            u64::MAX,
+            0,
+            0,
+            false,
+            vec![u64::MAX],
+        )
+        .is_err(),
+        "derived base/probability byte lengths must not overflow"
+    );
+    assert!(
+        RawCommittedCheckpoint::new(
+            &ObservationManifest::new(0),
+            0,
+            u64::from(u32::MAX) + 1,
+            0,
+            false,
+            vec![0],
+        )
+        .is_err(),
+        "story ids are a u32 wire field"
+    );
+
+    assert_eq!(RAW_COMMITTED_FILE, "raw-committed.bin");
+}
+
+fn raw_state_bytes(checkpoint: &RawCommittedCheckpoint) -> Vec<u8> {
+    let (records, stories, rng, done) = checkpoint.state();
+    let mut bytes = Vec::with_capacity(25);
+    bytes.extend_from_slice(&records.to_le_bytes());
+    bytes.extend_from_slice(&stories.to_le_bytes());
+    bytes.extend_from_slice(&rng.to_le_bytes());
+    bytes.push(u8::from(done));
+    bytes
+}
+
+fn fixture_probability(rank: u16) -> ProbabilityMetadata {
+    ProbabilityMetadata {
+        target_logprob_nats: -0.25 - f32::from(rank),
+        entropy_bits: 1.5 + f32::from(rank),
+        top8_mass: 0.75,
+        target_rank: rank,
+    }
+}
+
+#[test]
+fn raw_recovery_validates_every_shard_before_truncating_any_tail() {
+    let dir = unique_path("raw-two-phase-late-invalid");
+    let mut writer = ObservationShardWriter::open(&dir, 1).expect("writer");
+    writer
+        .write_record_with_probability(&[0x10; RECORD_SIZE], fixture_probability(0), 0)
+        .expect("committed shard 0 row");
+    writer
+        .write_record_with_probability(&[0x20; RECORD_SIZE], fixture_probability(1), 1)
+        .expect("committed shard 1 row");
+    writer.flush().expect("flush committed prefix");
+    let checkpoint =
+        RawCommittedCheckpoint::new(writer.manifest(), 2, 1, 0xCAFE, false, vec![1, 1])
+            .expect("checkpoint");
+
+    // Earlier shard has a complete tentative row that would be truncated.
+    writer
+        .write_record_with_probability(&[0x30; RECORD_SIZE], fixture_probability(2), 0)
+        .expect("tentative early row");
+    writer.flush().expect("flush tentative row");
+    drop(writer);
+    std::fs::write(
+        dir.join(RAW_COMMITTED_FILE),
+        checkpoint.encode().expect("encode checkpoint"),
+    )
+    .expect("write checkpoint");
+    std::fs::write(dir.join(STATE_FILE), raw_state_bytes(&checkpoint)).expect("write mirror");
+
+    // A later companion has lost committed data. Recovery must discover this
+    // in the read-only phase and leave the earlier tentative tail untouched.
+    let late_probability = dir.join(format!("{}.prob", shard_file_name(1, 1)));
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&late_probability)
+        .expect("open late companion")
+        .set_len(0)
+        .expect("shorten below checkpoint");
+    let before = directory_bytes(&dir);
+
+    let session = ObservationSession::acquire(&dir, 1).expect("session");
+    let error = recover_raw_observation_in_session(&session)
+        .expect_err("late short companion must fail the read-only phase");
+    assert!(
+        error.reason.contains("probability sidecar")
+            && error.reason.contains("shorter than the committed"),
+        "focused late-shard error: {error}"
+    );
+    drop(session);
+    assert_eq!(
+        directory_bytes(&dir),
+        before,
+        "a later invalid shard must precede every truncation and mirror change"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn raw_recovery_truncates_independent_tails_repairs_mirror_and_is_idempotent() {
+    let dir = unique_path("raw-recovery-idempotent");
+    let mut writer = ObservationShardWriter::open(&dir, 1).expect("writer");
+    writer
+        .write_record_with_probability(&[0x41; RECORD_SIZE], fixture_probability(0), 0)
+        .expect("committed shard 0 row");
+    writer
+        .write_record_with_probability(&[0x42; RECORD_SIZE], fixture_probability(1), 1)
+        .expect("committed shard 1 row");
+    writer.flush().expect("flush committed prefix");
+    let checkpoint =
+        RawCommittedCheckpoint::new(writer.manifest(), 2, 7, 0x1234, false, vec![1, 1])
+            .expect("checkpoint");
+    drop(writer);
+    std::fs::write(
+        dir.join(RAW_COMMITTED_FILE),
+        checkpoint.encode().expect("encode checkpoint"),
+    )
+    .expect("write checkpoint");
+
+    // Different streams retain different supported aligned crash tails.
+    let base0 = dir.join(shard_file_name(1, 0));
+    let mut base0_bytes = std::fs::read(&base0).expect("base 0 prefix");
+    base0_bytes.extend_from_slice(&[0xA0; RECORD_SIZE]);
+    std::fs::write(&base0, base0_bytes).expect("append base-only tail");
+    let probability1 = dir.join(format!("{}.prob", shard_file_name(1, 1)));
+    let mut probability1_bytes = std::fs::read(&probability1).expect("probability 1 prefix");
+    probability1_bytes.extend_from_slice(&fixture_probability(9).encode());
+    std::fs::write(&probability1, probability1_bytes).expect("append probability-only tail");
+    std::fs::write(dir.join(STATE_FILE), [0xFF; 9]).expect("write corrupt mirror");
+
+    let session = ObservationSession::acquire(&dir, 1).expect("session");
+    assert!(matches!(
+        preflight_raw_observation_in_session(&session).expect("read-only preflight"),
+        RawResumeStatus::Authoritative(ref observed) if observed == &checkpoint
+    ));
+    assert!(matches!(
+        recover_raw_observation_in_session(&session).expect("recover"),
+        RawResumeStatus::Authoritative(ref observed) if observed == &checkpoint
+    ));
+    drop(session);
+
+    assert_eq!(std::fs::metadata(&base0).unwrap().len(), RECORD_SIZE as u64);
+    assert_eq!(
+        std::fs::metadata(&probability1).unwrap().len(),
+        16,
+        "probability companion returns to one committed row"
+    );
+    assert_eq!(
+        std::fs::read(dir.join(STATE_FILE)).expect("repaired mirror"),
+        raw_state_bytes(&checkpoint)
+    );
+    let once = directory_bytes(&dir);
+    let session = ObservationSession::acquire(&dir, 1).expect("second session");
+    recover_raw_observation_in_session(&session).expect("idempotent second recovery");
+    drop(session);
+    assert_eq!(directory_bytes(&dir), once, "second recovery rewrote bytes");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn raw_checkpoint_binds_identity_fanout_and_trace_layout_before_mutation() {
+    let canonical_manifest = ObservationManifest::new(1);
+    let canonical =
+        RawCommittedCheckpoint::new(&canonical_manifest, 0, 0, 0x5EED, false, vec![0, 0])
+            .expect("canonical checkpoint")
+            .encode()
+            .expect("encode checkpoint");
+
+    let mut wrong_identity = canonical.clone();
+    wrong_identity[52] ^= 1;
+    let mut wrong_trace_width = canonical.clone();
+    wrong_trace_width[20..28].copy_from_slice(&8u64.to_le_bytes());
+    let wrong_fanout =
+        RawCommittedCheckpoint::new(&ObservationManifest::new(0), 0, 0, 0x5EED, false, vec![0])
+            .expect("other fan-out checkpoint")
+            .encode()
+            .expect("encode other fan-out");
+
+    for (label, checkpoint_bytes, expected) in [
+        ("identity", wrong_identity, "identity"),
+        ("trace-layout", wrong_trace_width, "trace row width"),
+        ("fan-out", wrong_fanout, "fan-out"),
+    ] {
+        let dir = unique_path(&format!("raw-bind-{label}"));
+        std::fs::create_dir_all(&dir).expect("create directory");
+        std::fs::write(dir.join(RAW_COMMITTED_FILE), checkpoint_bytes)
+            .expect("write adversarial checkpoint");
+        let before = directory_bytes(&dir);
+        let session = ObservationSession::acquire(&dir, 1).expect("session");
+        let error =
+            preflight_raw_observation_in_session(&session).expect_err("layout mismatch must fail");
+        assert!(error.reason.contains(expected), "{label}: {error}");
+        drop(session);
+        assert_eq!(directory_bytes(&dir), before, "{label} mutated bytes");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[test]
+fn raw_resume_refuses_mixed_text_checkpoint_formats_without_mutation() {
+    for text_checkpoint in ["committed.bin", ".committed.bin.tmp"] {
+        let dir = unique_path(&format!("raw-mixed-{text_checkpoint}"));
+        std::fs::create_dir_all(&dir).expect("create directory");
+        let checkpoint =
+            RawCommittedCheckpoint::new(&ObservationManifest::new(0), 0, 0, 0x5EED, false, vec![0])
+                .expect("raw checkpoint");
+        std::fs::write(dir.join(RAW_COMMITTED_FILE), checkpoint.encode().unwrap())
+            .expect("write raw checkpoint");
+        std::fs::write(dir.join(text_checkpoint), b"text-checkpoint-evidence")
+            .expect("write text checkpoint evidence");
+        let before = directory_bytes(&dir);
+
+        let session = ObservationSession::acquire(&dir, 0).expect("session");
+        let error = preflight_raw_observation_in_session(&session)
+            .expect_err("mixed driver formats must fail closed");
+        assert!(
+            error.reason.contains("text observation")
+                && error.reason.contains("mixed raw observation resume"),
+            "{text_checkpoint}: {error}"
+        );
+        drop(session);
+        assert_eq!(directory_bytes(&dir), before);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn text_preflight_reciprocally_refuses_raw_checkpoint_entries_before_mutation() {
+    use std::os::unix::fs::symlink;
+
+    let input = unique_path("mixed-text-articles.jsonl");
+    std::fs::write(
+        &input,
+        br#"{"id":"1","url":"https://example.invalid/1","title":"one","text":"ab"}
+"#,
+    )
+    .expect("write article fixture");
+
+    // A genuine regular raw checkpoint is valid directory content for the
+    // common session layer, but belongs to the other driver and must be
+    // rejected by text preflight before it publishes committed.bin/state.
+    let regular = unique_path("text-refuses-regular-raw-checkpoint");
+    let session = ObservationSession::acquire(&regular, 0).expect("session");
+    std::fs::write(regular.join(RAW_COMMITTED_FILE), b"raw checkpoint evidence")
+        .expect("write raw evidence");
+    let before = directory_bytes(&regular);
+    let error = preflight_text_observation_in_session(&session, &input, true, None, None, None)
+        .expect_err("text driver must refuse a genuine raw checkpoint");
+    assert!(
+        error.reason.contains("raw observation")
+            && error.reason.contains("mixed text observation resume"),
+        "focused reciprocal mixed-format error: {error}"
+    );
+    assert_eq!(directory_bytes(&regular), before);
+    drop(session);
+
+    // Create adversarial entries after session acquisition so the public text
+    // preflight itself exercises the common reload plus its explicit raw-entry
+    // validation. Dangling links are inspected, never followed or ignored.
+    let dangling = unique_path("text-refuses-dangling-raw-checkpoint");
+    let session = ObservationSession::acquire(&dangling, 0).expect("session");
+    let link_target = std::path::Path::new("missing-raw-checkpoint-target");
+    symlink(link_target, dangling.join(RAW_COMMITTED_FILE)).expect("dangling checkpoint link");
+    let error = preflight_text_observation_in_session(&session, &input, true, None, None, None)
+        .expect_err("dangling raw checkpoint must fail text preflight");
+    assert!(error.reason.contains("not a regular file"), "{error}");
+    assert_eq!(
+        std::fs::read_link(dangling.join(RAW_COMMITTED_FILE)).expect("link survives"),
+        link_target
+    );
+    assert!(!dangling.join(STATE_FILE).exists());
+    assert!(!dangling.join("committed.bin").exists());
+    drop(session);
+
+    let nonregular = unique_path("text-refuses-nonregular-raw-checkpoint");
+    let session = ObservationSession::acquire(&nonregular, 0).expect("session");
+    std::fs::create_dir(nonregular.join(RAW_COMMITTED_FILE))
+        .expect("raw checkpoint directory entry");
+    let error = preflight_text_observation_in_session(&session, &input, true, None, None, None)
+        .expect_err("nonregular raw checkpoint must fail text preflight");
+    assert!(error.reason.contains("not a regular file"), "{error}");
+    assert!(nonregular.join(RAW_COMMITTED_FILE).is_dir());
+    assert!(!nonregular.join(STATE_FILE).exists());
+    assert!(!nonregular.join("committed.bin").exists());
+    drop(session);
+
+    for dir in [&regular, &dangling, &nonregular] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+    let _ = std::fs::remove_file(&input);
+}
+
+#[cfg(unix)]
+#[test]
+fn raw_checkpoint_symlink_and_nonregular_entries_are_refused() {
+    use std::os::unix::fs::symlink;
+
+    let symlink_dir = unique_path("raw-checkpoint-symlink");
+    std::fs::create_dir_all(&symlink_dir).expect("create symlink fixture");
+    let victim = symlink_dir.with_extension("victim");
+    std::fs::write(&victim, b"external checkpoint target").expect("write victim");
+    symlink(&victim, symlink_dir.join(RAW_COMMITTED_FILE)).expect("checkpoint symlink");
+    let error = ObservationSession::acquire(&symlink_dir, 0)
+        .err()
+        .expect("checkpoint symlink must be refused during session preflight");
+    assert!(
+        error.reason.contains("not a regular file"),
+        "focused symlink refusal: {error}"
+    );
+    assert_eq!(
+        std::fs::read(&victim).expect("victim survives"),
+        b"external checkpoint target"
+    );
+    assert!(
+        std::fs::symlink_metadata(symlink_dir.join(RAW_COMMITTED_FILE))
+            .expect("link survives")
+            .file_type()
+            .is_symlink()
+    );
+
+    let directory_entry = unique_path("raw-checkpoint-directory-entry");
+    std::fs::create_dir_all(directory_entry.join(RAW_COMMITTED_FILE))
+        .expect("checkpoint directory entry");
+    let error = ObservationSession::acquire(&directory_entry, 0)
+        .err()
+        .expect("checkpoint directory must be refused");
+    assert!(error.reason.contains("not a regular file"), "{error}");
+
+    let _ = std::fs::remove_dir_all(&symlink_dir);
+    let _ = std::fs::remove_file(&victim);
+    let _ = std::fs::remove_dir_all(&directory_entry);
 }
 
 // ------------------------------------------------------------ sample id --
@@ -368,6 +787,159 @@ impl TeacherOracle for FakeOracle {
         for value in out.iter_mut() {
             *value = 0.0;
         }
+    }
+}
+
+#[test]
+fn fresh_raw_run_publishes_zero_checkpoint_before_any_append() {
+    let dir = unique_path("raw-zero-checkpoint");
+    std::fs::create_dir_all(&dir).expect("create output");
+    let stale = dir.join(".raw-committed.bin.tmp-stale");
+    std::fs::write(&stale, b"never authoritative").expect("stale temporary");
+
+    let session = ObservationSession::acquire(&dir, 1).expect("fresh session");
+    assert_eq!(
+        preflight_raw_observation_in_session(&session).expect("stale temp is ignored"),
+        RawResumeStatus::Fresh
+    );
+    drop(session);
+
+    let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+    let summary =
+        observe_sharded(&mut oracle, 0, 10, 1, &dir, None).expect("zero-budget initialization");
+    assert_eq!(summary.records, 0);
+    assert_eq!(summary.written, 0);
+    assert!(!summary.done);
+
+    let checkpoint = RawCommittedCheckpoint::decode(
+        &std::fs::read(dir.join(RAW_COMMITTED_FILE)).expect("authoritative checkpoint"),
+    )
+    .expect("decode zero checkpoint");
+    assert_eq!(checkpoint.state(), (0, 0, 0x5EED, false));
+    assert_eq!(checkpoint.committed_records(), &[0, 0]);
+    assert_eq!(
+        std::fs::read(dir.join(STATE_FILE)).expect("state mirror"),
+        raw_state_bytes(&checkpoint)
+    );
+    assert_eq!(
+        std::fs::read(&stale).expect("stale temp remains inert"),
+        b"never authoritative"
+    );
+    for shard in 0..2 {
+        assert!(
+            !dir.join(shard_file_name(1, shard)).exists(),
+            "zero checkpoint must precede the first shard append"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Small-fixture empirical record for #725. This intentionally has no timing
+/// threshold: filesystem synchronization latency is host-dependent. Run with
+/// `--ignored --nocapture` to report the canonical footprint plus median/mean
+/// end-to-end publication latency for the authoritative zero boundary and its
+/// `state.bin` mirror through the public observe entry point.
+#[test]
+#[ignore = "manual checkpoint publication overhead measurement"]
+fn raw_checkpoint_small_fixture_overhead_measurement() {
+    const ITERATIONS: usize = 31;
+    const SHARD_BITS: u8 = 2;
+    let dir = unique_path("raw-checkpoint-overhead");
+    let mut samples_ns = Vec::with_capacity(ITERATIONS);
+
+    // Warm the public path and establish the permanent out-of-directory lock
+    // inode before sampling. Removal is outside the measured interval and is
+    // safe because this is a private test directory with a zero checkpoint.
+    let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+    observe_sharded(&mut oracle, 0, 1, SHARD_BITS, &dir, None).expect("warm-up publish");
+    for _ in 0..ITERATIONS {
+        std::fs::remove_file(dir.join(RAW_COMMITTED_FILE)).expect("remove prior raw checkpoint");
+        std::fs::remove_file(dir.join(STATE_FILE)).expect("remove prior mirror");
+        let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+        let started = std::time::Instant::now();
+        observe_sharded(&mut oracle, 0, 1, SHARD_BITS, &dir, None)
+            .expect("publish zero transaction");
+        samples_ns.push(started.elapsed().as_nanos());
+    }
+
+    let checkpoint_bytes =
+        std::fs::read(dir.join(RAW_COMMITTED_FILE)).expect("published checkpoint bytes");
+    let checkpoint =
+        RawCommittedCheckpoint::decode(&checkpoint_bytes).expect("decode measured checkpoint");
+    assert_eq!(checkpoint.committed_records(), &[0, 0, 0, 0]);
+    assert_eq!(checkpoint_bytes.len(), 88 + 8 * (1 << SHARD_BITS));
+    assert_eq!(
+        std::fs::metadata(dir.join(STATE_FILE)).unwrap().len(),
+        25,
+        "compatibility mirror footprint"
+    );
+
+    samples_ns.sort_unstable();
+    let median_ns = samples_ns[ITERATIONS / 2];
+    let mean_ns = samples_ns.iter().sum::<u128>() / ITERATIONS as u128;
+    eprintln!(
+        "raw_checkpoint_overhead: iterations={ITERATIONS} shards={} canonical_bytes={} mirror_bytes=25 median_publish_ns={median_ns} mean_publish_ns={mean_ns}",
+        1usize << SHARD_BITS,
+        checkpoint_bytes.len(),
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_raw_checkpoint_accepts_only_fresh_or_finalized_legacy() {
+    // Unfinished legacy bytes have no provable whole-story boundary.
+    let incomplete = unique_path("raw-incomplete-legacy");
+    let mut writer = ObservationShardWriter::open(&incomplete, 1).expect("legacy writer");
+    writer
+        .write_record_with_probability(&[0x71; RECORD_SIZE], fixture_probability(1), 0)
+        .expect("legacy row");
+    writer.flush().expect("flush legacy row");
+    drop(writer);
+    let mut unfinished_state = Vec::with_capacity(25);
+    unfinished_state.extend_from_slice(&1u64.to_le_bytes());
+    unfinished_state.extend_from_slice(&1u64.to_le_bytes());
+    unfinished_state.extend_from_slice(&0xABCDu64.to_le_bytes());
+    unfinished_state.push(0);
+    std::fs::write(incomplete.join(STATE_FILE), unfinished_state).expect("legacy state");
+    let before = directory_bytes(&incomplete);
+    let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+    let error = observe_sharded(&mut oracle, 10, 2, 1, &incomplete, None)
+        .expect_err("unfinished legacy must fail closed");
+    assert!(
+        error.reason.contains("unfinished legacy")
+            && error.reason.contains("no authoritative raw-committed.bin")
+            && error.reason.contains("fresh output directory"),
+        "focused migration guidance: {error}"
+    );
+    assert_eq!(
+        directory_bytes(&incomplete),
+        before,
+        "legacy refusal must precede mutation"
+    );
+
+    // A fully finalized legacy bundle has manifest κs and a done state that
+    // prove every final boundary, so it remains readable without migration.
+    let complete = unique_path("raw-complete-legacy");
+    let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+    observe_sharded(&mut oracle, 10, 1, 1, &complete, None).expect("complete fixture");
+    std::fs::remove_file(complete.join(RAW_COMMITTED_FILE))
+        .expect("synthesize pre-checkpoint legacy bundle");
+    let complete_before = directory_bytes(&complete);
+    let mut oracle = FakeOracle { dim: 4, vocab: 8 };
+    let summary = observe_sharded(&mut oracle, 10, 1, 1, &complete, None)
+        .expect("finalized legacy remains replayable");
+    assert!(summary.done);
+    assert_eq!(summary.written, 0);
+    assert_eq!(
+        directory_bytes(&complete),
+        complete_before,
+        "finalized legacy bytes must not be rewritten or migrated"
+    );
+
+    for dir in [&incomplete, &complete] {
+        let _ = std::fs::remove_dir_all(dir);
     }
 }
 
@@ -1412,6 +1984,11 @@ impl TeacherOracle for FakeTraceOracle {
     fn seq_len(&self) -> usize {
         6
     }
+    fn eos_token(&self) -> usize {
+        // Keep the deterministic crash fixture at fixed six-row story
+        // boundaries; sampled vocabulary tokens can never equal this value.
+        usize::MAX
+    }
     fn kappa(&self) -> String {
         "blake3:fake-trace".to_string()
     }
@@ -1493,6 +2070,290 @@ fn traced_run_bytes(dir: &std::path::Path, shard_bits: u8) -> Vec<Vec<u8>> {
         });
     }
     files
+}
+
+fn clone_observation_files(from: &std::path::Path, to: &std::path::Path) {
+    std::fs::create_dir_all(to).expect("create cloned observation directory");
+    for (name, bytes) in directory_bytes(from) {
+        std::fs::write(to.join(name), bytes).expect("clone observation file");
+    }
+}
+
+fn append_reference_rows(
+    reference: &std::path::Path,
+    resumed: &std::path::Path,
+    name: &str,
+    row_bytes: usize,
+    committed_rows: usize,
+    appended_rows: usize,
+) {
+    let reference_bytes = std::fs::read(reference.join(name)).unwrap_or_default();
+    let mut resumed_bytes = std::fs::read(resumed.join(name)).unwrap_or_default();
+    let committed_bytes = committed_rows
+        .checked_mul(row_bytes)
+        .expect("fixture committed byte length");
+    assert_eq!(
+        resumed_bytes.len(),
+        committed_bytes,
+        "{name}: prefix fixture agrees with checkpoint"
+    );
+    assert!(
+        reference_bytes.len() >= committed_bytes + appended_rows * row_bytes,
+        "{name}: reference contains requested tentative rows"
+    );
+    assert_eq!(
+        resumed_bytes,
+        reference_bytes[..committed_bytes],
+        "{name}: committed prefix matches uninterrupted run"
+    );
+    resumed_bytes.extend_from_slice(
+        &reference_bytes[committed_bytes..committed_bytes + appended_rows * row_bytes],
+    );
+    if !resumed_bytes.is_empty() {
+        std::fs::write(resumed.join(name), resumed_bytes).expect("append tentative rows");
+    }
+}
+
+/// Convert a finalized story-boundary fixture into the exact on-disk state of
+/// a crash after heterogeneous aligned writes from later stories but before
+/// the next authoritative checkpoint replacement.
+fn craft_raw_crash_tails(
+    prefix: &std::path::Path,
+    reference: &std::path::Path,
+    resumed: &std::path::Path,
+) -> RawCommittedCheckpoint {
+    clone_observation_files(prefix, resumed);
+    let old_checkpoint = RawCommittedCheckpoint::decode(
+        &std::fs::read(prefix.join(RAW_COMMITTED_FILE)).expect("prefix checkpoint"),
+    )
+    .expect("decode prefix checkpoint");
+    let (records, stories, rng, _) = old_checkpoint.state();
+    assert_eq!(records, 12, "fixture checkpoint is exactly two stories");
+    assert_eq!(stories, 2, "fixed-width story fixture");
+
+    let mut manifest = ObservationManifest::load(resumed)
+        .expect("manifest io")
+        .expect("prefix manifest");
+    manifest.completed.clear();
+    manifest.total_records = 0;
+    std::fs::write(
+        resumed.join(MANIFEST_FILE),
+        serde_json::to_vec_pretty(&manifest).expect("serialize incomplete manifest"),
+    )
+    .expect("write incomplete manifest");
+    let checkpoint = RawCommittedCheckpoint::new(
+        &manifest,
+        records,
+        stories,
+        rng,
+        false,
+        old_checkpoint.committed_records().to_vec(),
+    )
+    .expect("unfinished authoritative checkpoint");
+    std::fs::write(
+        resumed.join(RAW_COMMITTED_FILE),
+        checkpoint.encode().expect("encode checkpoint"),
+    )
+    .expect("write checkpoint");
+    std::fs::write(resumed.join(STATE_FILE), [0xD5; 25]).expect("stale state mirror");
+
+    let reference_checkpoint = RawCommittedCheckpoint::decode(
+        &std::fs::read(reference.join(RAW_COMMITTED_FILE)).expect("reference checkpoint"),
+    )
+    .expect("decode reference checkpoint");
+    assert_eq!(reference_checkpoint.state().0, 24);
+    let mut touched_shards = 0usize;
+    let mut companion_skew = false;
+    let mut trace_skew = false;
+    for (shard, (&committed, &final_rows)) in checkpoint
+        .committed_records()
+        .iter()
+        .zip(reference_checkpoint.committed_records())
+        .enumerate()
+    {
+        let later_rows = usize::try_from(final_rows - committed).expect("fixture tail rows");
+        if later_rows == 0 {
+            continue;
+        }
+        touched_shards += 1;
+        let base_name = shard_file_name(checkpoint.shard_bits(), shard as u32);
+        append_reference_rows(
+            reference,
+            resumed,
+            &base_name,
+            RECORD_SIZE,
+            committed as usize,
+            later_rows,
+        );
+        let probability_rows = if shard.is_multiple_of(2) {
+            0
+        } else {
+            later_rows.min(1)
+        };
+        append_reference_rows(
+            reference,
+            resumed,
+            &format!("{base_name}.prob"),
+            16,
+            committed as usize,
+            probability_rows,
+        );
+        companion_skew |= probability_rows != later_rows;
+        if let Some(trace_row_bytes) = checkpoint.trace_row_bytes() {
+            let trace_rows = if shard.is_multiple_of(3) {
+                later_rows
+            } else {
+                later_rows.saturating_sub(1)
+            };
+            append_reference_rows(
+                reference,
+                resumed,
+                &trace_sidecar_name(checkpoint.shard_bits(), shard as u32),
+                trace_row_bytes as usize,
+                committed as usize,
+                trace_rows,
+            );
+            trace_skew |= trace_rows != later_rows || trace_rows != probability_rows;
+        }
+    }
+    assert!(
+        touched_shards >= 2,
+        "deterministic fixture must exercise tentative tails on several shards"
+    );
+    assert!(companion_skew, "base/probability crash windows differ");
+    if checkpoint.trace_row_bytes().is_some() {
+        assert!(trace_skew, "base/probability/trace tails differ");
+    }
+    checkpoint
+}
+
+fn assert_raw_reference_resume_convergence(traced: bool) {
+    const SHARD_BITS: u8 = 2;
+    const PREFIX_RECORDS: usize = 12;
+    const FINAL_RECORDS: usize = 24;
+    let profile = TraceProfile::full(&[0, 1], 3);
+    let reference = unique_path(if traced {
+        "raw-reference-traced"
+    } else {
+        "raw-reference-minimal"
+    });
+    let prefix = unique_path(if traced {
+        "raw-prefix-traced"
+    } else {
+        "raw-prefix-minimal"
+    });
+    let resumed = unique_path(if traced {
+        "raw-resumed-traced"
+    } else {
+        "raw-resumed-minimal"
+    });
+
+    let run = |dir: &std::path::Path, target: usize| {
+        let mut oracle = FakeTraceOracle::new();
+        if traced {
+            observe_sharded_traced(&mut oracle, 30, target, SHARD_BITS, dir, None, &profile)
+                .expect("traced observation")
+        } else {
+            observe_sharded(&mut oracle, 30, target, SHARD_BITS, dir, None)
+                .expect("minimal observation")
+        }
+    };
+    assert!(run(&reference, FINAL_RECORDS).done);
+    assert!(run(&prefix, PREFIX_RECORDS).done);
+    let checkpoint = craft_raw_crash_tails(&prefix, &reference, &resumed);
+    assert_eq!(checkpoint.state().0, PREFIX_RECORDS as u64);
+
+    let summary = run(&resumed, FINAL_RECORDS);
+    assert!(summary.done);
+    assert_eq!(summary.records, FINAL_RECORDS as u64);
+    assert_eq!(
+        directory_bytes(&resumed),
+        directory_bytes(&reference),
+        "resume must converge checkpoint, mirror, manifest, shards, companions, and kappas byte-for-byte"
+    );
+    assert_eq!(
+        merge_shards(&resumed).expect("resumed merged base"),
+        merge_shards(&reference).expect("reference merged base")
+    );
+    assert_eq!(
+        merge_probability_metadata(&resumed).expect("resumed merged probability"),
+        merge_probability_metadata(&reference).expect("reference merged probability")
+    );
+    if traced {
+        assert_eq!(
+            merge_trace_rows(&resumed).expect("resumed merged trace"),
+            merge_trace_rows(&reference).expect("reference merged trace")
+        );
+    }
+
+    for dir in [&reference, &prefix, &resumed] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+#[test]
+fn minimal_raw_failure_injection_converges_to_uninterrupted_bytes() {
+    assert_raw_reference_resume_convergence(false);
+}
+
+#[test]
+fn traced_raw_failure_injection_converges_to_uninterrupted_bytes() {
+    assert_raw_reference_resume_convergence(true);
+}
+
+#[test]
+fn final_checkpoint_resume_is_idempotent_across_finalization_and_merge() {
+    const SHARD_BITS: u8 = 2;
+    const TARGET: usize = 12;
+    let reference = unique_path("raw-finalization-reference");
+    let resumed = unique_path("raw-finalization-resumed");
+    let mut oracle = FakeTraceOracle::new();
+    observe_sharded(&mut oracle, 30, TARGET, SHARD_BITS, &reference, None).expect("reference run");
+    clone_observation_files(&reference, &resumed);
+
+    let checkpoint = RawCommittedCheckpoint::decode(
+        &std::fs::read(resumed.join(RAW_COMMITTED_FILE)).expect("final checkpoint"),
+    )
+    .expect("decode final checkpoint");
+    assert_eq!(
+        checkpoint.state(),
+        (TARGET as u64, 2, checkpoint.state().2, true)
+    );
+    let mut manifest = ObservationManifest::load(&resumed)
+        .expect("manifest io")
+        .expect("manifest");
+    manifest.completed.clear();
+    manifest.total_records = 0;
+    std::fs::write(
+        resumed.join(MANIFEST_FILE),
+        serde_json::to_vec_pretty(&manifest).expect("serialize incomplete manifest"),
+    )
+    .expect("simulate crash before finalization");
+    std::fs::remove_file(resumed.join(STATE_FILE)).expect("simulate missing mirror");
+    std::fs::write(resumed.join("merged.bin"), b"partial merged crash bytes")
+        .expect("simulate interrupted merge");
+
+    let mut oracle = FakeTraceOracle::new();
+    let summary = observe_sharded(&mut oracle, 30, TARGET, SHARD_BITS, &resumed, None)
+        .expect("resume final checkpoint");
+    assert!(summary.done);
+    assert_eq!(summary.written, 0);
+
+    // This is the graph-cli done-path operation: an interrupted `merged.bin`
+    // is derived afresh from the now κ-validated canonical shard order.
+    for dir in [&reference, &resumed] {
+        let merged = merge_shards(dir).expect("canonical merge");
+        std::fs::write(dir.join("merged.bin"), merged).expect("publish merged fixture");
+    }
+    assert_eq!(
+        directory_bytes(&resumed),
+        directory_bytes(&reference),
+        "checkpoint, finalization, mirror repair, and merge must converge"
+    );
+
+    for dir in [&reference, &resumed] {
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }
 
 /// #603 determinism: the same inputs and profile produce byte-identical

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -654,13 +654,58 @@ attention-support slot (fewer prefix positions than the cap) carries
 the explicit `SUPPORT_ABSENT_MARKER` (`0xFFFFFFFF` in both fields),
 never a zero-valued entry.
 
-**Raw-resume limitation.** The autoregressive `observe` checkpoint still
-records only global stream state, not committed byte lengths for every shard.
-It can reject malformed checkpoints and repair a torn shard/sidecar pair, but
-an abrupt failure after an aligned mid-story append can leave a tail that a
-retry cannot distinguish from committed rows; exactly-once raw resume requires
-a separate per-shard checkpoint-format follow-up. The text observation driver
-already carries per-shard committed lengths and truncates to them on resume.
+**Transactional raw resume.** The autoregressive `observe` driver publishes a
+versioned, self-identifying `raw-committed.bin` checkpoint at every whole-story
+boundary. It is authoritative over the 25-byte `state.bin` compatibility
+mirror and binds the global teacher state, shard fan-out, identity-bundle
+digest, probability-row width, trace-row presence/width, and committed base
+record length of every shard. Probability and trace lengths are derived from
+those base lengths with checked arithmetic. Before any identity publication,
+mirror repair, truncation, append, or finalization, resume validates the full
+checkpoint and every base/`.prob`/`.trace` prefix under the existing exclusive
+`ObservationSession`. Only after that read-only pass succeeds are aligned bytes
+beyond the committed vector truncated; the next whole story is then regenerated
+from the checkpoint-selected teacher state. The recovery step is idempotent
+when different shards or companions retain different amounts of tentative
+data.
+
+**Definition.** The canonical checkpoint footprint is exactly
+`88 + 8 × shard_count` bytes: 104 bytes for the two-shard test fixture and
+2,136 bytes at the supported 256-shard maximum. It is O(number of shards),
+timestamp-free, and independent of completion order.
+
+**Empirical Criterion.** On 2026-08-15, the ignored four-shard fixture
+`raw_checkpoint_small_fixture_overhead_measurement` ran 31 zero-boundary
+publications through the public observe entry point on the local Darwin arm64
+development host. The authoritative file was 120 bytes, its compatibility
+mirror was 25 bytes, median end-to-end publication latency was 16,612,542 ns,
+and mean latency was 16,473,677 ns. This is a diagnostic record, not a portable
+latency threshold; filesystem synchronization cost is host-dependent.
+
+**Guarantee.** Status: **Structural**. After the enumerated aligned-tail crash
+windows, raw resume converges byte-for-byte to the uninterrupted shard,
+probability, trace, manifest, checkpoint, mirror, merge, and κ bytes, without
+duplicating a story. Evidence:
+`minimal_raw_failure_injection_converges_to_uninterrupted_bytes`,
+`traced_raw_failure_injection_converges_to_uninterrupted_bytes`,
+`raw_recovery_validates_every_shard_before_truncating_any_tail`, and
+`final_checkpoint_resume_is_idempotent_across_finalization_and_merge` in
+`crates/uor-r4-graph-compiler/tests/observe.rs`.
+
+**Assumption.** The host filesystem honors synchronized file writes, atomic
+same-directory replacement, and directory synchronization as documented by
+its platform APIs.
+
+**Compatibility and failure model.** A fresh raw directory receives a
+zero-length authoritative checkpoint before its first shard append. Missing or
+corrupt `state.bin` is repaired from `raw-committed.bin`; it does not select the
+transaction. A missing raw checkpoint is accepted only for a genuinely fresh
+directory or a fully finalized legacy raw bundle whose manifest counts and
+content κs validate. An unfinished legacy raw directory fails closed because
+aligned historical bytes cannot prove their last committed story boundary, and
+mixed raw/text checkpoint formats are refused. Existing observation records,
+probability rows, trace rows, text `committed.bin`, `state.bin`, merged bytes,
+and public readers keep their historical layouts.
 
 **Bundle identity.** The manifest's identity seam is ONE stable bundle:
 `ObservationManifest::identity_bundle_digest()` computes a canonical


### PR DESCRIPTION
## Summary

- add the canonical `R4RAWCOM` schema-1 `raw-committed.bin` checkpoint, binding teacher state, observation identity/layout, and every shard’s committed record count
- synchronize shard, probability, and trace payloads before atomically publishing the authoritative checkpoint, then publish the existing 25-byte `state.bin` compatibility mirror
- recover through a two-phase all-entry preflight, truncating tentative aligned tails only after every shard and companion validates
- repair missing or corrupt state mirrors, resume interrupted finalization/merge idempotently, and fail closed for unfinished legacy or mixed raw/text directories
- retain fully finalized, kappa-validated legacy bundles without migration or historical byte changes
- document the structural guarantee, filesystem assumption, canonical footprint, and small-fixture overhead measurement

No teacher arithmetic, observation-row wire format, trace format, routing, deployed runtime, or kappa fixture changes are included.

## Verification

- `cargo test -p uor-r4-graph-compiler --offline`
  - 131 unit tests; 26 induction tests with 1 existing release-only ignore; 39 observation tests with 1 manual measurement ignore; 4 route-fit tests
- `cargo test -p uor-r4-graph-cli --lib --offline` — 78 passed
- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all --check`
- `cargo check -p uor-r4-graph-format --no-default-features --offline`
- `cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib --offline`
- `python3 scripts/check_claim_wording.py`
- `cargo test -p uor-r4-graph-compiler --offline --test observe raw_checkpoint_small_fixture_overhead_measurement -- --ignored --nocapture`
  - 4 shards; 120-byte authoritative checkpoint; 25-byte mirror
  - median 16,612,542 ns; mean 16,473,677 ns across 31 publications; diagnostic only, no threshold

Closes #725