### PR TITLE
serving: ship certified-native source attention v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,25 @@ operator that produced the rows; resume fails closed when an existing payload
 has a missing or different binding. `compile-recorded` propagates an explicit
 operator from an observation manifest, while a genuinely absent historical
 record retains the documented implicit `standard-source-attention/1` meaning.
+The current standard, experimental, and GPT-2 learned-absolute source records
+are version 2; their v1 records remain immutable accepted history. Version 2
+uses certified-native Q·K/value folds only when a mechanical rounding-cell
+witness proves the exact bit returned by pinned `uor-matmul`, with that exact
+kernel as the fallback. When the browser compile endpoint finds a populated v1
+bundle at the conventional model root, it preserves that root byte-for-byte and
+writes/resumes v2 at the deterministic `<name>-attention-v2` root instead.
+The managed server reserves that suffix: downloaded source basenames ending in
+it are rejected before output mutation. Compile, automatic restart discovery,
+reload, model listing, and status all inspect the conventional and suffixed
+roots as one logical pair. Reloading either `<name>` or the exact suffix alias
+selects the same physical bundle and maps its host encoder to
+`sources/<name>`; `/uor/v1/status` reports both the logical model name and
+the selected `physical_root`. A genuinely absent source keeps the #718
+decode-only behavior, while a present-invalid source or preferred bundle is
+terminal. Current-v2 serving additionally requires exact agreement among the
+root sidecar, canonical corpus/observation provenance, and
+`graph-cover/cover_report.json`; legacy v1 bundles remain compatible when the
+supporting records are genuinely absent.
 
 **Graph pipeline**
 
@@ -347,8 +366,8 @@ Anything else is served as a static file from the working directory; `/` serves
 |---|---|
 | `transformerless` | Allocation-free table-native codebook retrieval, sub-millisecond on CPU |
 | `r4g1` | The validated R4G1 graph scorer; needs a loaded `score.r4g1` |
-| `attention` | Standard scaled dot-product attention on the loaded teacher (up to 256 tokens) |
-| `r4-attention` | Experimental teacher attention variant (#602 operator `experimental-r4-source-attention/1`: a 4-wide-chunked dot product with the same softmax selector as `attention`; never measured against it — see `docs/deferral_record_2026_08_05.md`) |
+| `attention` | Llama uses current standard scaled-dot-product teacher attention (`standard-source-attention/2`, up to 256 tokens); GPT-2 uses `learned-absolute-source-attention/2` |
+| `r4-attention` | Llama uses the current experimental variant (`experimental-r4-source-attention/2`): a certified-exact dot over the leading 4-wide domain with the same softmax selector as `attention`; GPT-2 still uses `learned-absolute-source-attention/2` because the legacy switch does not alter its operator. The Llama variant has never been measured against standard attention — see `docs/deferral_record_2026_08_05.md` |
 | `geometric` | Route purely geometrically and decode from manifold resonance |
 
 Omitting `engine` runs the **full cascade, r4g1-first** — it does *not* mean
@@ -380,7 +399,8 @@ owning modules is in [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
 `UOR_R4_HOST`, `UOR_R4_PORT`.
 
 **Determinism and teacher math** — `TLESS_CANONICAL_DETERMINISTIC` (required for
-the cross-platform Gate E claim), `TLESS_EXACT_SCALAR`, `R4_TLESS_TLA6`,
+the cross-platform Gate E claim), `TLESS_EXACT_SCALAR` (deprecated no-op kept
+for script compatibility), `R4_TLESS_TLA6`,
 `R4_TLESS_TLA7`, `TLESS_REPIN_WRITE` (maintainer-only).
 
 **Measurement** — `R4_GATE_C_SAMPLE` (deterministic stride subsample; the sample

--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -833,12 +833,12 @@ mod tests {
         assert_eq!(with.len(), without.len() + 2);
     }
 
-    /// #602/#704 plumbing seam: stage B forwards the registry-validated
-    /// stage-A binding independently of the request switch. In particular,
-    /// an auto-detected GPT-2 teacher remains learned-absolute rather than
-    /// being relabelled standard because `r4_attention` is false.
+    /// #602/#704 plumbing seam: stage B forwards each registry-validated
+    /// stage-A record independently of the request switch. Explicit immutable
+    /// v1 records must remain their exact identities after the current aliases
+    /// advance, and every current v2 family must traverse the same seam.
     #[test]
-    fn attention_operator_is_threaded_into_cover_stage_flags() {
+    fn all_source_attention_records_are_threaded_into_cover_stage_flags() {
         use uor_r4_model_source::attention::AttentionOperatorSpec;
         let flag_value = |flags: &[String]| -> AttentionOperatorSpec {
             let index = flags
@@ -849,12 +849,12 @@ mod tests {
         };
 
         for (mut request, operator) in [
-            (request(None), AttentionOperatorSpec::standard()),
-            (request(None), AttentionOperatorSpec::experimental_r4()),
-            (
-                request(None),
-                AttentionOperatorSpec::learned_absolute_source_attention(),
-            ),
+            (request(None), AttentionOperatorSpec::standard_v1()),
+            (request(None), AttentionOperatorSpec::standard_v2()),
+            (request(None), AttentionOperatorSpec::experimental_r4_v1()),
+            (request(None), AttentionOperatorSpec::experimental_r4_v2()),
+            (request(None), AttentionOperatorSpec::learned_absolute_v1()),
+            (request(None), AttentionOperatorSpec::learned_absolute_v2()),
         ] {
             // Deliberately contradict the supplied record where possible:
             // the stage-A binding, not this policy bit, is authoritative.

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -23,7 +23,118 @@
 use std::collections::{BTreeMap, HashMap};
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::{AtomicU64, Ordering};
 use uor_r4_model_source::{RepresentationSource, TeacherOracle};
+
+#[cfg(not(target_arch = "wasm32"))]
+static SOURCE_CORPUS_CHECKPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Return whether `name` is one of the core compiler's reserved atomic
+/// checkpoint temporaries for `meta_file_name`.
+///
+/// Callers may reclaim such a file only while holding exclusive ownership of
+/// the corpus output. A process can die after `create_new` or a partial write,
+/// so byte completeness is deliberately not part of the name predicate.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn is_source_corpus_checkpoint_temporary_name(name: &str, meta_file_name: &str) -> bool {
+    let prefix = format!(".{meta_file_name}.checkpoint.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn source_corpus_checkpoint_bytes(n: u64, stories: u64, rng: u64, done: u8) -> [u8; 25] {
+    let mut bytes = [0u8; 25];
+    bytes[0..8].copy_from_slice(&n.to_le_bytes());
+    bytes[8..16].copy_from_slice(&stories.to_le_bytes());
+    bytes[16..24].copy_from_slice(&rng.to_le_bytes());
+    bytes[24] = done;
+    bytes
+}
+
+/// Atomically replace the fixed-width source corpus checkpoint.
+///
+/// The temporary is created beside the destination, synced, renamed, and the
+/// parent directory is synced. The records and hidden streams must be synced
+/// by the caller before invoking this helper so metadata can never durably
+/// name rows whose bytes were not durably committed first.
+#[cfg(not(target_arch = "wasm32"))]
+fn publish_source_corpus_checkpoint(mp: &str, bytes: &[u8; 25]) -> std::io::Result<()> {
+    let destination = std::path::Path::new(mp);
+    let parent = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "corpus checkpoint path is not UTF-8: {}",
+                    destination.display()
+                ),
+            )
+        })?;
+
+    match std::fs::symlink_metadata(destination) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "corpus checkpoint {} is not a regular non-symlink file",
+                    destination.display()
+                ),
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    let (temporary, mut file) = loop {
+        let sequence = SOURCE_CORPUS_CHECKPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(
+            ".{file_name}.checkpoint.{}.{}.tmp",
+            std::process::id(),
+            sequence
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => break (candidate, file),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    };
+
+    if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    drop(file);
+    if let Err(error) = std::fs::rename(&temporary, destination) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    std::fs::File::open(parent)?.sync_all()
+}
 
 #[inline]
 fn canonical_math_enabled() -> bool {
@@ -887,6 +998,13 @@ pub fn generate_to_with_token_byte_lengths(
     rp: &str,
     token_byte_lengths: Option<&[u32]>,
 ) {
+    let mut hidden_path = String::from(rp);
+    if hidden_path.ends_with("_recs.bin") {
+        hidden_path = hidden_path.replace("_recs.bin", "_hidden.bin");
+    } else {
+        hidden_path.push_str(".hidden");
+    }
+
     let (mut n, mut stories, mut rng, mut done) = match std::fs::read(mp) {
         Ok(b) if b.len() == 25 => (
             u64::from_le_bytes(b[0..8].try_into().unwrap()),
@@ -894,7 +1012,40 @@ pub fn generate_to_with_token_byte_lengths(
             u64::from_le_bytes(b[16..24].try_into().unwrap()),
             b[24],
         ),
-        _ => (0, 0, 0x5EED, 0),
+        Ok(b) => {
+            eprintln!(
+                "corpus metadata cannot be resumed: {mp} is {} bytes, expected exactly 25",
+                b.len()
+            );
+            return;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            for path in [rp, hidden_path.as_str()] {
+                match std::fs::symlink_metadata(path) {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Ok(_) => {
+                        eprintln!(
+                            "corpus metadata cannot be initialized: {path} exists without the authoritative zero checkpoint {mp}"
+                        );
+                        return;
+                    }
+                    Err(error) => {
+                        eprintln!("corpus stream {path} cannot be inspected: {error}");
+                        return;
+                    }
+                }
+            }
+            let checkpoint = source_corpus_checkpoint_bytes(0, 0, 0x5EED, 0);
+            if let Err(error) = publish_source_corpus_checkpoint(mp, &checkpoint) {
+                eprintln!("cannot publish initial corpus checkpoint {mp}: {error}");
+                return;
+            }
+            (0, 0, 0x5EED, 0)
+        }
+        Err(error) => {
+            eprintln!("corpus metadata cannot be read: {mp}: {error}");
+            return;
+        }
     };
     if (n as usize) < target {
         done = 0;
@@ -961,12 +1112,6 @@ pub fn generate_to_with_token_byte_lengths(
         .open(rp)
         .unwrap();
 
-    let mut hidden_path = String::from(rp);
-    if hidden_path.ends_with("_recs.bin") {
-        hidden_path = hidden_path.replace("_recs.bin", "_hidden.bin");
-    } else {
-        hidden_path.push_str(".hidden");
-    }
     let mut hidden_file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -1019,12 +1164,16 @@ pub fn generate_to_with_token_byte_lengths(
             token = next;
         }
         stories += 1;
-        let mut b = [0u8; 25];
-        b[0..8].copy_from_slice(&n.to_le_bytes());
-        b[8..16].copy_from_slice(&stories.to_le_bytes());
-        b[16..24].copy_from_slice(&rng.to_le_bytes());
-        b[24] = done;
-        std::fs::write(mp, b).unwrap();
+        // Commit ordering is records -> hidden rows -> metadata. A host crash
+        // can therefore leave only an uncommitted stream tail, which resume
+        // safely truncates to the last authoritative story checkpoint.
+        recs.flush().and_then(|()| recs.sync_all()).unwrap();
+        hidden_file
+            .flush()
+            .and_then(|()| hidden_file.sync_all())
+            .unwrap();
+        let checkpoint = source_corpus_checkpoint_bytes(n, stories, rng, done);
+        publish_source_corpus_checkpoint(mp, &checkpoint).unwrap();
     }
     println!(
         "corpus: {} / {} tokens, {} stories, done={}",
@@ -2119,7 +2268,20 @@ pub fn induce_hierarchical_codes(
 
 #[cfg(test)]
 mod capacity_override_tests {
-    use super::{capacity_override_f64, capacity_override_usize};
+    use super::{
+        capacity_override_f64, capacity_override_usize, is_source_corpus_checkpoint_temporary_name,
+        publish_source_corpus_checkpoint, source_corpus_checkpoint_bytes,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn checkpoint_test_path(label: &str) -> std::path::PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "uor-r4-core-checkpoint-{label}-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
 
     #[test]
     fn unset_returns_pinned_default() {
@@ -2151,5 +2313,42 @@ mod capacity_override_tests {
     fn zero_fails_loudly() {
         std::env::set_var("R4_TEST_CAP_ZERO", "0");
         let _ = capacity_override_usize("R4_TEST_CAP_ZERO", 50_000);
+    }
+
+    #[test]
+    fn source_corpus_checkpoint_publish_is_atomic_and_name_is_strict() {
+        let root = checkpoint_test_path("atomic");
+        std::fs::create_dir_all(&root).expect("checkpoint test directory");
+        let meta = root.join("corpus.meta");
+        let first = source_corpus_checkpoint_bytes(0, 0, 0x5EED, 0);
+        let second = source_corpus_checkpoint_bytes(17, 2, 99, 1);
+        publish_source_corpus_checkpoint(meta.to_str().expect("UTF-8 path"), &first)
+            .expect("initial atomic checkpoint");
+        publish_source_corpus_checkpoint(meta.to_str().expect("UTF-8 path"), &second)
+            .expect("atomic checkpoint replacement");
+        assert_eq!(std::fs::read(&meta).expect("stable checkpoint"), second);
+        assert!(std::fs::read_dir(&root)
+            .expect("checkpoint directory")
+            .all(|entry| !entry
+                .expect("checkpoint entry")
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")));
+        assert!(is_source_corpus_checkpoint_temporary_name(
+            ".corpus.meta.checkpoint.12.34.tmp",
+            "corpus.meta"
+        ));
+        for invalid in [
+            ".corpus.meta.checkpoint..34.tmp",
+            ".corpus.meta.checkpoint.12.x.tmp",
+            ".corpus.meta.checkpoint.12.34.56.tmp",
+            ".other.meta.checkpoint.12.34.tmp",
+        ] {
+            assert!(!is_source_corpus_checkpoint_temporary_name(
+                invalid,
+                "corpus.meta"
+            ));
+        }
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -25,6 +25,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::SourceUnavailable;
 use uor_r4_model_source::{RepresentationSource, TeacherOracle};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -72,7 +74,7 @@ fn source_corpus_checkpoint_bytes(n: u64, stories: u64, rng: u64, done: u8) -> [
 /// by the caller before invoking this helper so metadata can never durably
 /// name rows whose bytes were not durably committed first.
 #[cfg(not(target_arch = "wasm32"))]
-fn publish_source_corpus_checkpoint(mp: &str, bytes: &[u8; 25]) -> std::io::Result<()> {
+fn publish_source_corpus_checkpoint(mp: &str, bytes: &[u8; 25]) -> Result<(), SourceUnavailable> {
     let destination = std::path::Path::new(mp);
     let parent = destination
         .parent()
@@ -82,28 +84,22 @@ fn publish_source_corpus_checkpoint(mp: &str, bytes: &[u8; 25]) -> std::io::Resu
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "corpus checkpoint path is not UTF-8: {}",
-                    destination.display()
-                ),
-            )
+            SourceUnavailable::new(format!(
+                "corpus checkpoint path is not UTF-8: {}",
+                destination.display()
+            ))
         })?;
 
     match std::fs::symlink_metadata(destination) {
         Ok(metadata) if metadata.file_type().is_file() => {}
         Ok(_) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "corpus checkpoint {} is not a regular non-symlink file",
-                    destination.display()
-                ),
-            ));
+            return Err(SourceUnavailable::new(format!(
+                "corpus checkpoint {} is not a regular non-symlink file",
+                destination.display()
+            )));
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error),
+        Err(error) => return Err(SourceUnavailable::new(error)),
     }
 
     let (temporary, mut file) = loop {
@@ -120,20 +116,22 @@ fn publish_source_corpus_checkpoint(mp: &str, bytes: &[u8; 25]) -> std::io::Resu
         {
             Ok(file) => break (candidate, file),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
+            Err(error) => return Err(SourceUnavailable::new(error)),
         }
     };
 
     if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
         let _ = std::fs::remove_file(&temporary);
-        return Err(error);
+        return Err(SourceUnavailable::new(error));
     }
     drop(file);
     if let Err(error) = std::fs::rename(&temporary, destination) {
         let _ = std::fs::remove_file(&temporary);
-        return Err(error);
+        return Err(SourceUnavailable::new(error));
     }
-    std::fs::File::open(parent)?.sync_all()
+    std::fs::File::open(parent)?
+        .sync_all()
+        .map_err(SourceUnavailable::new)
 }
 
 #[inline]

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -38,7 +38,7 @@ pub mod cover_sweep;
 pub mod recommend_scale;
 mod runtime_corpus;
 mod scenarios;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -235,11 +235,161 @@ const COMPILE_OUTPUT_MUTABLE_FILES: [&str; 9] = [
 
 const SOURCE_CORPUS_META_BYTES: usize = 25;
 const SOURCE_CORPUS_RECORD_BYTES: u64 = 48;
+const SOURCE_CORPUS_META_FILE: &str = "corpus.meta";
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct SourceCompileResumePlan {
     records_committed_bytes: Option<u64>,
     hidden_committed_bytes: Option<u64>,
+}
+
+fn looks_like_source_corpus_checkpoint_temporary(name: &str) -> bool {
+    name.starts_with(&format!(".{SOURCE_CORPUS_META_FILE}.checkpoint.")) && name.ends_with(".tmp")
+}
+
+/// Validate, without mutating, the exact checkpoint-temporary namespace.
+/// A strict numeric name can contain zero, partial, or complete bytes because
+/// every one is an honest process-death point after `create_new`. Only the
+/// caller holding exclusive compile-session ownership may reclaim it later.
+fn validate_source_corpus_checkpoint_temporaries(output: &Path) -> Result<(), SourceUnavailable> {
+    let entries = match std::fs::read_dir(output) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "source compile output {} cannot be enumerated for checkpoint recovery: {error}",
+                output.display()
+            )));
+        }
+    };
+    for entry in entries {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if compiler::is_source_corpus_checkpoint_temporary_name(&name, SOURCE_CORPUS_META_FILE) {
+            let metadata =
+                std::fs::symlink_metadata(entry.path()).map_err(SourceUnavailable::new)?;
+            if !metadata.file_type().is_file() {
+                return Err(SourceUnavailable::new(format!(
+                    "recognized source corpus checkpoint temporary {} is not a regular non-symlink file",
+                    entry.path().display()
+                )));
+            }
+        } else if looks_like_source_corpus_checkpoint_temporary(&name) {
+            return Err(SourceUnavailable::new(format!(
+                "source compile output {} contains unrecognized checkpoint temporary {name}",
+                output.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn recover_source_corpus_checkpoint_temporaries(output: &Path) -> Result<(), SourceUnavailable> {
+    validate_source_corpus_checkpoint_temporaries(output)?;
+    let entries = match std::fs::read_dir(output) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    };
+    let mut reclaimed = false;
+    for entry in entries {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if compiler::is_source_corpus_checkpoint_temporary_name(&name, SOURCE_CORPUS_META_FILE) {
+            std::fs::remove_file(entry.path()).map_err(SourceUnavailable::new)?;
+            reclaimed = true;
+        }
+    }
+    if reclaimed {
+        sync_compile_output_directory(output)
+    } else {
+        Ok(())
+    }
+}
+
+fn initial_source_corpus_checkpoint() -> [u8; SOURCE_CORPUS_META_BYTES] {
+    let mut bytes = [0u8; SOURCE_CORPUS_META_BYTES];
+    bytes[16..24].copy_from_slice(&0x5EEDu64.to_le_bytes());
+    bytes
+}
+
+fn sync_compile_output_directory(output: &Path) -> Result<(), SourceUnavailable> {
+    std::fs::File::open(output)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "compile output directory {} cannot be durably synchronized: {error}",
+                output.display()
+            ))
+        })
+}
+
+struct SourceCorpusSession {
+    file: std::fs::File,
+}
+
+impl Drop for SourceCorpusSession {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn source_corpus_session(output: &Path) -> Result<SourceCorpusSession, SourceUnavailable> {
+    let parent = output.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(SourceUnavailable::new)?;
+    let output_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| SourceUnavailable::new("compile output name is not UTF-8"))?;
+    let path = parent.join(format!(".{output_name}.source-corpus-session.lock"));
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus session {} is not a regular non-symlink file",
+                path.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(SourceUnavailable::new)?;
+    let path_metadata = std::fs::symlink_metadata(&path).map_err(SourceUnavailable::new)?;
+    let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    if !path_metadata.file_type().is_file() || !file_metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "source corpus session {} changed type while opened",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino()
+        {
+            return Err(SourceUnavailable::new(format!(
+                "source corpus session {} changed identity while opened",
+                path.display()
+            )));
+        }
+    }
+    file.try_lock().map_err(|error| {
+        SourceUnavailable::new(format!(
+            "source corpus output {} is BUSY under another compiler session: {error}",
+            output.display()
+        ))
+    })?;
+    Ok(SourceCorpusSession { file })
 }
 
 /// Inspect every mutable compile-output leaf without following it. Binding
@@ -412,6 +562,7 @@ fn preflight_source_compile_resume(
     // This also rejects a symlink output root and every nonregular mutable
     // leaf, independently of whether both identity sidecars already match.
     let _ = compile_output_payload_inventory(output)?;
+    validate_source_corpus_checkpoint_temporaries(output)?;
     let meta_path = output.join("corpus.meta");
     let records_path = output.join("corpus.records");
     let hidden_path = output.join("corpus.records.hidden");
@@ -426,6 +577,19 @@ fn preflight_source_compile_resume(
             return Err(SourceUnavailable::new(format!(
                 "{} exists without corpus.meta/corpus.records; refusing an orphan hidden resume stream before mutation",
                 hidden_path.display()
+            )));
+        }
+        (true, false) if !hidden_present => {
+            let bytes = std::fs::read(&meta_path).map_err(SourceUnavailable::new)?;
+            if bytes == initial_source_corpus_checkpoint() {
+                // The core compiler durably publishes the authoritative zero
+                // checkpoint before it creates either stream. A process death
+                // in that narrow window is therefore a valid fresh prefix.
+                return Ok(SourceCompileResumePlan::default());
+            }
+            return Err(SourceUnavailable::new(format!(
+                "{} exists without corpus.records and is not the authoritative zero checkpoint; one-sided source corpus resume refused before mutation",
+                meta_path.display()
             )));
         }
         (true, false) | (false, true) => {
@@ -718,7 +882,7 @@ fn pin_compile_tokenizer_adapter(
             std::fs::remove_file(&temporary).map_err(|error| {
                 SourceUnavailable::new(format!("{}: {error}", temporary.display()))
             })?;
-            Ok(())
+            sync_compile_output_directory(output)
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let _ = std::fs::remove_file(&temporary);
@@ -728,7 +892,8 @@ fn pin_compile_tokenizer_adapter(
                     sidecar.display()
                 ))
             })?;
-            require_matching_compile_tokenizer_adapter(output, requested, &recorded)
+            require_matching_compile_tokenizer_adapter(output, requested, &recorded)?;
+            sync_compile_output_directory(output)
         }
         Err(error) => {
             let _ = std::fs::remove_file(&temporary);
@@ -813,6 +978,108 @@ fn validate_attention_operator(
     Ok(registered)
 }
 
+/// Parse a JSON document solely to reject duplicate object keys at every
+/// nesting level. `serde_json::Value` is last-key-wins, which is unsuitable
+/// for provenance records where duplicated fields could spell two arithmetic
+/// eras in one sidecar.
+struct DuplicateRejectingJson;
+
+impl<'de> Deserialize<'de> for DuplicateRejectingJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = DuplicateRejectingJson;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("JSON without duplicate object keys")
+            }
+
+            fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                DuplicateRejectingJson::deserialize(deserializer)
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                while sequence.next_element::<DuplicateRejectingJson>()?.is_some() {}
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut keys = std::collections::BTreeSet::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if !keys.insert(key.clone()) {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate JSON field {key:?}"
+                        )));
+                    }
+                    map.next_value::<DuplicateRejectingJson>()?;
+                }
+                Ok(DuplicateRejectingJson)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+fn reject_duplicate_attention_operator_json(
+    bytes: &[u8],
+    path: &Path,
+) -> Result<(), SourceUnavailable> {
+    serde_json::from_slice::<DuplicateRejectingJson>(bytes)
+        .map(|_| ())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{}: malformed attention-operator binding: {error}",
+                path.display()
+            ))
+        })
+}
+
 fn validate_attention_operator_json(
     value: &serde_json::Value,
     context: &str,
@@ -846,6 +1113,7 @@ fn read_optional_compiled_attention_operator(
             path.display()
         ))
     })?;
+    reject_duplicate_attention_operator_json(&bytes, &path)?;
     let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
         SourceUnavailable::new(format!(
             "{}: malformed attention-operator binding: {error}",
@@ -979,7 +1247,7 @@ fn publish_attention_operator_binding(
             std::fs::remove_file(&temporary).map_err(|error| {
                 SourceUnavailable::new(format!("{}: {error}", temporary.display()))
             })?;
-            Ok(())
+            sync_compile_output_directory(output)
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let _ = std::fs::remove_file(&temporary);
@@ -989,7 +1257,8 @@ fn publish_attention_operator_binding(
                     path.display()
                 ))
             })?;
-            require_matching_compiled_attention_operator(output, &requested, &recorded)
+            require_matching_compiled_attention_operator(output, &requested, &recorded)?;
+            sync_compile_output_directory(output)
         }
         Err(error) => {
             let _ = std::fs::remove_file(&temporary);
@@ -3749,6 +4018,30 @@ fn deepest_argmax(store: &runtime::Store, code: &[u8; compiler::STAGES]) -> Opti
     None
 }
 
+/// Require the evaluation oracle to compute the exact immutable attention
+/// record pinned by the compiled bundle. Sharing a family id is insufficient:
+/// v1 and v2 name different teacher arithmetic and cannot replay each other's
+/// corpus rows.
+fn require_matching_evaluation_attention_operator(
+    compiled: &Path,
+    recorded: &AttentionOperatorSpec,
+    actual: &AttentionOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    if actual == recorded {
+        return Ok(());
+    }
+    Err(SourceUnavailable::new(format!(
+        "{} is pinned to attention operator {}/{} (digest {}), but the loaded evaluation teacher computes {}/{} (digest {}); evaluation refused before replay",
+        compiled.display(),
+        recorded.id,
+        recorded.version,
+        recorded.declared_digest(),
+        actual.id,
+        actual.version,
+        actual.declared_digest(),
+    )))
+}
+
 fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     let options = parse_evaluate_report_options(args)?;
     // Evaluation decodes/classifies in the same registered id space selected
@@ -3825,18 +4118,11 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         &actual_attention_operator,
         "evaluation teacher attention operator",
     )?;
-    if actual_attention_operator != recorded_attention_operator {
-        return Err(SourceUnavailable::new(format!(
-            "{} is pinned to attention operator {}/{} (digest {}), but the loaded evaluation teacher computes {}/{} (digest {}); evaluation refused before replay",
-            options.compiled.display(),
-            recorded_attention_operator.id,
-            recorded_attention_operator.version,
-            recorded_attention_operator.declared_digest(),
-            actual_attention_operator.id,
-            actual_attention_operator.version,
-            actual_attention_operator.declared_digest(),
-        )));
-    }
+    require_matching_evaluation_attention_operator(
+        &options.compiled,
+        &recorded_attention_operator,
+        &actual_attention_operator,
+    )?;
     let mut teacher_logits = vec![0f32; oracle.vocab()];
     let artifacts_bytes = std::fs::read(&artifacts_path)?;
 
@@ -4284,6 +4570,7 @@ where
         .output
         .clone()
         .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
+    let _corpus_session = source_corpus_session(&output)?;
     eprintln!("compiler output: {}", output.display());
     let meta = output.join("corpus.meta");
     let records = output.join("corpus.records");
@@ -4320,6 +4607,11 @@ where
         })
         .transpose()?;
     let resume = preflight_source_compile_resume(&output, hidden_row_bytes, options.target)?;
+    // All read-only identity and resume checks have now accepted the bundle.
+    // Under the server's cross-process output session, reclaim only the
+    // core compiler's exact reserved checkpoint temporaries; arbitrary names
+    // and nonregular entries were rejected above without mutation.
+    recover_source_corpus_checkpoint_temporaries(&output)?;
     // A story checkpoint commits records and hidden rows together. Normalize
     // both interrupted tails before the core generator reopens either stream.
     reconcile_source_compile_resume(&output, &resume)?;
@@ -4609,6 +4901,21 @@ pub fn copy_recorded_attention(args: &[String]) -> Result<(), SourceUnavailable>
     }
 }
 
+/// Resolve explicit recorded provenance or the immutable standard/1 meaning
+/// of genuine pre-provenance absence for `compile-recorded`.
+fn recorded_compile_attention_operator(
+    corpus_meta: &Path,
+    corpus_recs: &Path,
+) -> Result<AttentionOperatorSpec, SourceUnavailable> {
+    match recorded_corpus_attention_operator(corpus_meta, corpus_recs)? {
+        Some(recorded) => Ok(recorded),
+        None => uor_r4_model_source::attention::operator_spec(
+            AttentionOperatorSpec::STANDARD_ID,
+            LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
+        ),
+    }
+}
+
 /// Compile a completed recorded corpus without loading or executing a
 /// transformer. This is the observation-first production path; teacher
 /// capture remains available through `observe`/`compile` as an explicitly
@@ -4617,13 +4924,7 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
     let options = parse_recorded_compile_options(args)?;
     preflight_recorded_compile_output(&options.output)?;
     let attention_operator =
-        match recorded_corpus_attention_operator(&options.corpus_meta, &options.corpus_recs)? {
-            Some(recorded) => recorded,
-            None => uor_r4_model_source::attention::operator_spec(
-                AttentionOperatorSpec::STANDARD_ID,
-                LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
-            )?,
-        };
+        recorded_compile_attention_operator(&options.corpus_meta, &options.corpus_recs)?;
     preflight_compiled_attention_operator(&options.output, &attention_operator)?;
     let meta = options
         .corpus_meta
@@ -5211,9 +5512,12 @@ mod tests {
     #[test]
     fn cover_options_carry_the_attention_operator() {
         for record in [
-            uor_r4_model_source::attention::AttentionOperatorSpec::standard(),
-            uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4(),
-            uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_source_attention(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::standard_v1(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4_v1(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::experimental_r4_v2(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v1(),
+            uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v2(),
         ] {
             let json = serde_json::to_string(&record).expect("record serializes");
             let args = ["--attention-operator".to_owned(), json];
@@ -5625,7 +5929,7 @@ mod tests {
     #[test]
     fn compile_attention_operator_sidecar_is_exact_atomic_and_idempotent() {
         let output = unique_cli_test_path("compile-attention-fresh");
-        let operator = AttentionOperatorSpec::learned_absolute_source_attention();
+        let operator = AttentionOperatorSpec::learned_absolute_v1();
         bind_compiled_attention_operator(&output, &operator).expect("fresh operator pin");
         let sidecar = output.join(ATTENTION_OPERATOR_BINDING_FILE);
         let bytes_before = std::fs::read(&sidecar).expect("sidecar bytes");
@@ -5641,6 +5945,134 @@ mod tests {
         );
         assert!(attention_operator_temp_entries(&output).is_empty());
         let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_reader_accepts_every_immutable_and_current_source_record() {
+        for operator in [
+            AttentionOperatorSpec::standard_v1(),
+            AttentionOperatorSpec::standard_v2(),
+            AttentionOperatorSpec::experimental_r4_v1(),
+            AttentionOperatorSpec::experimental_r4_v2(),
+            AttentionOperatorSpec::learned_absolute_v1(),
+            AttentionOperatorSpec::learned_absolute_v2(),
+        ] {
+            let output = unique_cli_test_path(&format!(
+                "compile-attention-reader-{}-v{}",
+                operator.id, operator.version
+            ));
+            bind_compiled_attention_operator(&output, &operator).expect("publish full record");
+            assert_eq!(
+                compiled_attention_operator(&output).expect("read registered source record"),
+                operator
+            );
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn compile_attention_operator_refuses_same_family_v1_to_v2_resume() {
+        let output = unique_cli_test_path("compile-attention-standard-v1-to-v2");
+        let v1 = AttentionOperatorSpec::standard_v1();
+        bind_compiled_attention_operator(&output, &v1).expect("pin immutable v1 record");
+        std::fs::write(output.join("corpus.records"), b"immutable v1 rows")
+            .expect("write v1 payload");
+        let before = directory_bytes(&output);
+
+        let error =
+            bind_compiled_attention_operator(&output, &AttentionOperatorSpec::standard_v2())
+                .expect_err("v2 cannot resume a v1 compile directory");
+        assert!(
+            error.reason.contains("pinned to attention operator"),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&output), before);
+        assert_eq!(
+            compiled_attention_operator(&output).expect("v1 binding remains"),
+            v1
+        );
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn compile_attention_operator_rejects_duplicate_v1_and_v2_eras_before_resume_mutation() {
+        for (operator, shadow_version) in [
+            (AttentionOperatorSpec::standard_v1(), 2),
+            (AttentionOperatorSpec::standard_v2(), 1),
+        ] {
+            let output = unique_cli_test_path(&format!(
+                "compile-attention-duplicate-v{}",
+                operator.version
+            ));
+            std::fs::create_dir_all(&output).expect("output directory");
+            std::fs::write(output.join("corpus.records"), b"immutable teacher rows")
+                .expect("write existing payload");
+            let canonical = serde_json::to_string_pretty(&operator).expect("operator JSON");
+            let recorded_version = format!("\"version\": {}", operator.version);
+            assert_eq!(
+                canonical.matches(&recorded_version).count(),
+                1,
+                "fixture has exactly one canonical version field"
+            );
+            let duplicate = canonical.replacen(
+                &recorded_version,
+                &format!(
+                    "\"version\": {shadow_version},\n  \"version\": {}",
+                    operator.version
+                ),
+                1,
+            );
+            std::fs::write(output.join(ATTENTION_OPERATOR_BINDING_FILE), duplicate)
+                .expect("write ambiguous sidecar");
+            let before = directory_bytes(&output);
+
+            let resume_error = preflight_compiled_attention_operator(&output, &operator)
+                .expect_err("last-key-wins must not authorize a compile resume");
+            assert!(
+                resume_error
+                    .reason
+                    .contains("duplicate JSON field \"version\""),
+                "{resume_error}"
+            );
+            assert_eq!(directory_bytes(&output), before);
+
+            let evaluation_error = compiled_attention_operator(&output)
+                .expect_err("evaluation provenance must reject the same ambiguity");
+            assert!(
+                evaluation_error
+                    .reason
+                    .contains("duplicate JSON field \"version\""),
+                "{evaluation_error}"
+            );
+            assert_eq!(directory_bytes(&output), before);
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn evaluation_attention_operator_accepts_exact_records_and_refuses_cross_era_replay() {
+        let compiled = Path::new("compiled-fixture");
+        for operator in [
+            AttentionOperatorSpec::standard_v1(),
+            AttentionOperatorSpec::standard_v2(),
+            AttentionOperatorSpec::experimental_r4_v1(),
+            AttentionOperatorSpec::experimental_r4_v2(),
+            AttentionOperatorSpec::learned_absolute_v1(),
+            AttentionOperatorSpec::learned_absolute_v2(),
+        ] {
+            require_matching_evaluation_attention_operator(compiled, &operator, &operator)
+                .expect("exact immutable record is replayable");
+        }
+
+        let error = require_matching_evaluation_attention_operator(
+            compiled,
+            &AttentionOperatorSpec::standard_v1(),
+            &AttentionOperatorSpec::standard_v2(),
+        )
+        .expect_err("same-family cross-era replay must fail closed");
+        assert!(error.reason.contains("evaluation refused before replay"));
+        assert!(error.reason.contains("standard-source-attention/1"));
+        assert!(error.reason.contains("standard-source-attention/2"));
     }
 
     #[test]
@@ -6222,6 +6654,60 @@ mod tests {
     }
 
     #[test]
+    fn source_compile_meta_only_zero_checkpoint_resumes_before_stream_creation() {
+        let output = unique_cli_test_path("source-resume-meta-only-zero");
+        std::fs::create_dir_all(&output).expect("compile output");
+        std::fs::write(
+            output.join(SOURCE_CORPUS_META_FILE),
+            initial_source_corpus_checkpoint(),
+        )
+        .expect("durable zero checkpoint fixture");
+
+        let plan = preflight_source_compile_resume(&output, Some(16), 10)
+            .expect("zero checkpoint precedes stream creation");
+        assert_eq!(plan, SourceCompileResumePlan::default());
+        assert!(!output.join("corpus.records").exists());
+        assert!(!output.join("corpus.records.hidden").exists());
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn source_compile_checkpoint_temp_crash_matrix_recovers_only_reserved_regular_files() {
+        for (case, bytes) in [
+            ("empty", Vec::new()),
+            ("partial", vec![0xA5; 9]),
+            ("complete", initial_source_corpus_checkpoint().to_vec()),
+        ] {
+            let output = unique_cli_test_path(&format!("source-checkpoint-temp-{case}"));
+            std::fs::create_dir_all(&output).expect("compile output");
+            let temporary = output.join(format!(
+                ".{SOURCE_CORPUS_META_FILE}.checkpoint.{}.1.tmp",
+                std::process::id()
+            ));
+            std::fs::write(&temporary, bytes).expect("checkpoint crash residue");
+            validate_source_corpus_checkpoint_temporaries(&output)
+                .expect("reserved regular crash residue");
+            recover_source_corpus_checkpoint_temporaries(&output)
+                .expect("exclusive-owner recovery");
+            assert!(!temporary.exists());
+            let _ = std::fs::remove_dir_all(output);
+        }
+
+        let malformed = unique_cli_test_path("source-checkpoint-temp-malformed");
+        std::fs::create_dir_all(&malformed).expect("compile output");
+        let unknown = malformed.join(format!(
+            ".{SOURCE_CORPUS_META_FILE}.checkpoint.not-numeric.1.tmp"
+        ));
+        std::fs::write(&unknown, b"sentinel").expect("unknown temporary");
+        let before = directory_bytes(&malformed);
+        let error = validate_source_corpus_checkpoint_temporaries(&malformed)
+            .expect_err("unknown checkpoint temporary is terminal");
+        assert!(error.reason.contains("unrecognized checkpoint temporary"));
+        assert_eq!(directory_bytes(&malformed), before);
+        let _ = std::fs::remove_dir_all(malformed);
+    }
+
+    #[test]
     fn source_compile_resume_keeps_legacy_missing_hidden_optional_but_refuses_short_present_hidden()
     {
         let historical = unique_cli_test_path("source-resume-no-hidden");
@@ -6505,7 +6991,7 @@ mod tests {
                 &session,
                 None,
                 None,
-                Some(&AttentionOperatorSpec::standard()),
+                Some(&AttentionOperatorSpec::standard_v1()),
             )
             .map_err(|error| error.reason)?;
             let mut writer = session.writer().map_err(|error| error.reason)?;
@@ -6539,7 +7025,7 @@ mod tests {
                 &session,
                 Some(&loser_adapter),
                 None,
-                Some(&AttentionOperatorSpec::experimental_r4()),
+                Some(&AttentionOperatorSpec::standard_v2()),
             );
             drop(session);
             match result {
@@ -6567,7 +7053,7 @@ mod tests {
         assert_eq!(manifest.tokenizer_adapter, None);
         assert_eq!(
             manifest.attention_operator,
-            Some(AttentionOperatorSpec::standard())
+            Some(AttentionOperatorSpec::standard_v1())
         );
         assert!(!output.join("tokenizer.bin").exists());
         assert_eq!(
@@ -6695,6 +7181,27 @@ mod tests {
     }
 
     #[test]
+    fn compile_recorded_genuine_absence_resolves_to_immutable_standard_v1() {
+        let root = unique_cli_test_path("compile-recorded-legacy-standard-v1");
+        let (meta, records) = corpus_markers(&root);
+        assert_eq!(
+            recorded_compile_attention_operator(&meta, &records)
+                .expect("genuine recorded-corpus absence has a pinned legacy meaning"),
+            AttentionOperatorSpec::standard_v1()
+        );
+        assert_eq!(
+            LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
+            AttentionOperatorSpec::STANDARD_V1_VERSION
+        );
+        assert_ne!(
+            AttentionOperatorSpec::standard_v1(),
+            AttentionOperatorSpec::standard(),
+            "the current alias must not leak into compile-recorded legacy absence"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn recorded_corpus_attention_operator_reads_both_sources_and_rejects_conflicts() {
         let sidecar_root = unique_cli_test_path("recorded-attention-sidecar");
         let sidecar_operator = AttentionOperatorSpec::learned_absolute_source_attention();
@@ -6718,14 +7225,14 @@ mod tests {
         );
 
         let conflict_root = unique_cli_test_path("recorded-attention-conflict");
-        bind_compiled_attention_operator(&conflict_root, &AttentionOperatorSpec::standard())
+        bind_compiled_attention_operator(&conflict_root, &AttentionOperatorSpec::standard_v1())
             .expect("sidecar binding");
         let mut manifest = observe::ObservationManifest::new(1);
-        manifest.attention_operator = Some(AttentionOperatorSpec::experimental_r4());
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard_v2());
         write_observation_manifest(&conflict_root, &manifest);
         let (meta, records) = corpus_markers(&conflict_root);
         let error = recorded_corpus_attention_operator(&meta, &records)
-            .expect_err("two provenance sources must agree exactly");
+            .expect_err("same-family v1/v2 provenance sources must agree exactly");
         assert!(
             error
                 .reason

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2565,13 +2565,13 @@ pub struct CoverReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub geometry: Option<uor_r4_model_source::geometry::GeometryProjection>,
     /// #602 typed record of the source attention operator the teacher
-    /// computed while producing the compiled inputs
-    /// (`standard-source-attention/1`, or
-    /// `experimental-r4-source-attention/1` when the `r4_attention`
-    /// switch was on), when the invoking pipeline knows it
-    /// (`--attention-operator`). Optional so every legacy report and
-    /// its bytes stay unchanged when unset; callers set the public
-    /// field after [`build_report`].
+    /// computed while producing the compiled inputs. Current source families
+    /// declare their `/2` records; immutable `/1` records remain valid, and
+    /// absence retains the implicit historical standard/1 meaning. The
+    /// invoking pipeline supplies the full record with
+    /// `--attention-operator`. Optional so every legacy report and its bytes
+    /// stay unchanged when unset; callers set the public field after
+    /// [`build_report`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
     pub config: CoverReportConfig,

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -917,14 +917,14 @@ pub struct ObservationManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokenizer_adapter: Option<TokenizerAdapter>,
     /// #602 typed record of the source attention operator the teacher
-    /// oracle computed while producing these observations
-    /// (`standard-source-attention/1`, or
-    /// `experimental-r4-source-attention/1` when the `r4_attention`
-    /// switch was on), when the producing pipeline's oracle declares
-    /// one. `None` marks the legacy interpretation documented in
-    /// `docs/MODEL_LIFECYCLE.md`. Optional with a serde default so
-    /// every legacy manifest stays readable and legacy manifest bytes
-    /// are unchanged when unset.
+    /// oracle computed while producing these observations. Current Llama
+    /// sources declare `standard-source-attention/2` or
+    /// `experimental-r4-source-attention/2`; GPT-2 declares
+    /// `learned-absolute-source-attention/2`. Immutable v1 records remain
+    /// accepted. `None` marks the implicit historical standard/1
+    /// interpretation documented in `docs/MODEL_LIFECYCLE.md`. Optional with
+    /// a serde default so every legacy manifest stays readable and legacy
+    /// manifest bytes are unchanged when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_operator: Option<AttentionOperatorSpec>,
     /// #603 typed record of the teacher-trace profile the producing pass
@@ -4815,9 +4815,12 @@ mod attention_operator_resume_tests {
         }
 
         for operator in [
-            AttentionOperatorSpec::standard(),
-            AttentionOperatorSpec::experimental_r4(),
-            AttentionOperatorSpec::learned_absolute_source_attention(),
+            AttentionOperatorSpec::standard_v1(),
+            AttentionOperatorSpec::standard_v2(),
+            AttentionOperatorSpec::experimental_r4_v1(),
+            AttentionOperatorSpec::experimental_r4_v2(),
+            AttentionOperatorSpec::learned_absolute_v1(),
+            AttentionOperatorSpec::learned_absolute_v2(),
         ] {
             let dir = TestDir::new(&operator.id);
             let mut writer = ObservationShardWriter::open(dir.path(), 1).expect("open writer");
@@ -4851,6 +4854,26 @@ mod attention_operator_resume_tests {
             Some(&standard)
         );
         assert_eq!(dir.bytes(), pinned, "mismatch changed directory bytes");
+
+        let same_family = TestDir::new("standard-v1-to-v2");
+        let v1 = AttentionOperatorSpec::standard_v1();
+        let v2 = AttentionOperatorSpec::standard_v2();
+        let mut writer =
+            ObservationShardWriter::open(same_family.path(), 1).expect("open same-family writer");
+        writer
+            .set_attention_operator(&v1)
+            .expect("pin immutable v1 record");
+        let pinned = same_family.bytes();
+        let error = writer
+            .set_attention_operator(&v2)
+            .expect_err("v2 cannot resume a v1 observation directory");
+        assert!(error.reason.contains("incompatible observation resume"));
+        assert_eq!(writer.manifest().attention_operator.as_ref(), Some(&v1));
+        assert_eq!(
+            same_family.bytes(),
+            pinned,
+            "v1-to-v2 refusal changed observation bytes"
+        );
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -3569,11 +3569,11 @@ mod tests {
         let mixed_dir = unique_path("operator-binding-mixed-workers");
         let mut mixed_pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
             Box::new(DeclaredFakeOracle {
-                operator: Some(standard),
+                operator: Some(AttentionOperatorSpec::standard_v1()),
                 geometry: None,
             }),
             Box::new(DeclaredFakeOracle {
-                operator: Some(experimental),
+                operator: Some(AttentionOperatorSpec::standard_v2()),
                 geometry: None,
             }),
         ];
@@ -3587,7 +3587,7 @@ mod tests {
             SHARD_BITS,
             false,
         )
-        .expect_err("mixed serial worker operators must fail before output");
+        .expect_err("same-family v1/v2 serial workers must fail before output");
         assert!(!mixed_dir.exists());
 
         let mixed_geometry_dir = unique_path("operator-binding-mixed-geometries");
@@ -3633,7 +3633,7 @@ mod tests {
 
         let standard = FakeBatchedOracle {
             cfg: fake_batched_config(),
-            attention_operator: Some(AttentionOperatorSpec::standard()),
+            attention_operator: Some(AttentionOperatorSpec::standard_v1()),
             geometry: None,
         };
         observe_text_corpus_batched(
@@ -3652,7 +3652,7 @@ mod tests {
 
         let projected = FakeBatchedOracle {
             cfg: fake_batched_config(),
-            attention_operator: Some(AttentionOperatorSpec::standard()),
+            attention_operator: Some(AttentionOperatorSpec::standard_v1()),
             geometry: Some(GeometryProjection::bucket_average(4, 2)),
         };
         let error = observe_text_corpus_batched(
@@ -3670,13 +3670,13 @@ mod tests {
         assert!(error.reason.contains("geometry"), "{error}");
         assert_eq!(directory_fingerprint(&dir), before);
 
-        let experimental = FakeBatchedOracle {
+        let current_v2 = FakeBatchedOracle {
             cfg: fake_batched_config(),
-            attention_operator: Some(AttentionOperatorSpec::experimental_r4()),
+            attention_operator: Some(AttentionOperatorSpec::standard_v2()),
             geometry: None,
         };
         let error = observe_text_corpus_batched(
-            &experimental,
+            &current_v2,
             2,
             60,
             &tokenizer,
@@ -3686,7 +3686,7 @@ mod tests {
             SHARD_BITS,
             true,
         )
-        .expect_err("different operator cannot resume completed corpus");
+        .expect_err("same-family v2 cannot resume a completed v1 corpus");
         assert!(error.reason.contains("incompatible observation resume"));
         assert_eq!(directory_fingerprint(&dir), before);
 

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -14,15 +14,16 @@
 //!   selector_normalization, value_aggregation, output_projection,
 //!   runtime_state, tie_breaking, permitted_operation_class, params}`
 //!   carried by the observation manifest and the cover/compile report.
-//! - [`standard_head_attention_weights`] and
-//!   [`head_attention_value_aggregate`] are the free, deterministic
-//!   reference implementations of `standard-source-attention/1` — the
-//!   exact arithmetic (iteration order, sequential f32 folds, one divide
-//!   per score) the teacher has always used, factored out unchanged.
-//! - [`experimental_r4_head_attention_weights`] is the factored
-//!   experimental branch, recorded under the honest id
-//!   `experimental-r4-source-attention/1` with its ACTUAL computation
-//!   (see below) — not the historical description.
+//! - [`standard_head_attention_weights`],
+//!   [`experimental_r4_head_attention_weights`], and
+//!   [`head_attention_value_aggregate`] implement the current version-2
+//!   source operators. Every raw Q·K and weighted-value dot returns the
+//!   correctly-rounded binary32 exact-real result: a native f64 sum is used
+//!   only when an outward interval lies strictly inside one binary32 RNE
+//!   cell; all other lanes use the pinned exact `uor-matmul` owner.
+//! - Version-1 entries remain immutable registry metadata for historical
+//!   artifacts. They name the former sequential/chunked f32 folds and remain
+//!   readable, but current source executors never silently resume as v1.
 //! - [`operator_spec`] is the versioned registry mapping `(id, version)`
 //!   to a spec; an unknown pair is refused by name on the sanctioned
 //!   [`SourceUnavailable`](crate::SourceUnavailable) surface rather than
@@ -37,9 +38,9 @@
 //! `h / kv_mul` where `kv_mul = n_heads / n_kv_heads`); RoPE rotation of
 //! q and k applied before any score (interleaved-pair or split-half
 //! layout is a source-config property, not an operator property); a
-//! growing KV cache attending the full prefix `0..=pos`; value
-//! aggregation as a position-ascending weighted sum `out[i] +=
-//! att[t] * v_t[i]`; and a dense per-layer f32 `wo` output projection.
+//! growing KV cache attending the full prefix `0..=pos`; correctly-rounded
+//! exact-real value dots over the full prefix; and a dense per-layer f32
+//! `wo` output projection.
 //! Both branches normalize scores with the SAME selector,
 //! `softmax_with_mode`: subtract the maximum score (first maximum on
 //! ties — value-identical, since only the maximum's value enters), then
@@ -49,21 +50,18 @@
 //!
 //! They differ ONLY in the compatibility relation:
 //!
-//! - **standard**: `score(t) = (Σ_{i<H} q[i]·k_t[i]) / sqrt(H)` for head
-//!   width `H`, accumulated as a single sequential f32 left fold over
-//!   every head dimension.
+//! - **standard**: `score(t) = RN32(Σ_{i<H} q[i]·k_t[i]) / sqrt(H)` for
+//!   head width `H`. The exact dot rounds once to binary32, then Llama's
+//!   historical per-score divide and per-weight softmax-sum divide remain.
 //! - **experimental**: `score(t) = (Σ_{c<⌊H/4⌋} Σ_{j<4}
-//!   q[4c+j]·k_t[4c+j]) / sqrt(H)` — the dot product computed in 4-wide
-//!   chunks (each chunk a left-to-right 4-term fold, chunk subtotals
-//!   then summed), which is still a dot product followed by the same
-//!   softmax. **Remainder policy**: the trailing `H mod 4` q/k
+//!   q[4c+j]·k_t[4c+j]) / sqrt(H)` — one correctly-rounded exact-real dot
+//!   over the historical floor-multiple-of-four domain, followed by the same
+//!   divide and softmax. **Remainder policy**: the trailing `H mod 4` q/k
 //!   dimensions are never read by the score (dropped), while the scale
 //!   divides by `sqrt(H)` over the FULL head width and value aggregation
 //!   still uses every head dimension. For `H < 4` no chunk exists, every
 //!   score is 0, and the softmax yields uniform weights over the prefix.
-//!   For `H` divisible by 4 the same terms are scored but the chunked
-//!   accumulation order can differ from the standard single fold in the
-//!   last bits.
+//!   For `H` divisible by 4 both operators score the same exact-real dot.
 //!
 //! **Implementation digest.** As with the #600 geometry record and the
 //! #601 tokenizer-adapter record, `implementation_digest` is the blake3
@@ -76,7 +74,8 @@
 //!
 //! **Boundary note.** The three SOURCE specs (the two Llama switch
 //! branches plus GPT-2's learned-absolute operator) describe HOST-SIDE
-//! source-teacher computation (f32 dot products, exp, division). They
+//! source-teacher computation (f32/f64 certified arithmetic, pinned exact
+//! fallback, exp, and division). They
 //! are provenance records, distinct from — and outside — the deployed
 //! inference operation contract
 //! (`docs/transformerless/INFERENCE_OPERATION_CONTRACT.md`), which
@@ -103,6 +102,12 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Stable arithmetic-era token shared by the three current source-attention
+/// records. It names the correctly-rounded f32 result contract and its two
+/// execution owners without freezing the particular conservative error-bound
+/// formula used to prove a native lane.
+pub const CERTIFIED_NATIVE_ARITHMETIC_ID: &str = "correctly-rounded-binary32-exact-real-dot-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback";
+
 /// Declared parameters of an attention operator — head selection, score
 /// scale, score-width policy (which head dimensions the compatibility
 /// relation reads), remainder policy for non-divisible head widths, and
@@ -125,13 +130,18 @@ pub struct AttentionOperatorParams {
     /// What happens to head dimensions outside the scored width.
     #[serde(default)]
     pub remainder_policy: String,
-    /// The f32 accumulation order of one score.
+    /// The arithmetic and rounding discipline of one score accumulation.
     #[serde(default)]
     pub score_accumulation: String,
 }
 
 impl AttentionOperatorParams {
-    /// The declared parameters of `standard-source-attention/1`:
+    /// The declared parameters of current `standard-source-attention/2`.
+    pub fn standard() -> Self {
+        Self::standard_v2()
+    }
+
+    /// Immutable parameters of historical `standard-source-attention/1`:
     ///
     /// - `head_selection = "grouped-query-kv-head-h-div-kv-mul"` — head
     ///   `h` reads kv head `h / kv_mul`, `kv_mul = n_heads / n_kv_heads`.
@@ -143,7 +153,7 @@ impl AttentionOperatorParams {
     ///   is no unscored remainder at any head width.
     /// - `score_accumulation = "sequential-f32-left-fold"` — one running
     ///   f32 sum over `i = 0..H` in order.
-    pub fn standard() -> Self {
+    pub fn standard_v1() -> Self {
         Self {
             head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
             score_scale: "divide-by-sqrt-full-head-size".to_owned(),
@@ -153,7 +163,25 @@ impl AttentionOperatorParams {
         }
     }
 
-    /// The declared parameters of `experimental-r4-source-attention/1`
+    /// Immutable parameters of current `standard-source-attention/2`.
+    pub fn standard_v2() -> Self {
+        Self {
+            head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
+            score_scale: "divide-by-sqrt-full-head-size".to_owned(),
+            score_width_policy: "full-head-width".to_owned(),
+            remainder_policy: "none-every-head-dimension-scored".to_owned(),
+            score_accumulation: CERTIFIED_NATIVE_ARITHMETIC_ID.to_owned(),
+        }
+    }
+
+    /// The declared parameters of current
+    /// `experimental-r4-source-attention/2`.
+    pub fn experimental_r4() -> Self {
+        Self::experimental_r4_v2()
+    }
+
+    /// Immutable parameters of historical
+    /// `experimental-r4-source-attention/1`
     /// — the ACTUAL computation of the `r4_attention` branch:
     ///
     /// - `head_selection = "grouped-query-kv-head-h-div-kv-mul"` — same
@@ -170,13 +198,25 @@ impl AttentionOperatorParams {
     /// - `score_accumulation = "per-4-chunk-left-fold-then-chunk-sum"` —
     ///   each chunk is a left-to-right 4-term f32 fold; chunk subtotals
     ///   are then summed in chunk order.
-    pub fn experimental_r4() -> Self {
+    pub fn experimental_r4_v1() -> Self {
         Self {
             head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
             score_scale: "divide-by-sqrt-full-head-size".to_owned(),
             score_width_policy: "chunks-of-4-floor-head-size-div-4".to_owned(),
             remainder_policy: "truncate-trailing-head-size-mod-4-dims-from-score".to_owned(),
             score_accumulation: "per-4-chunk-left-fold-then-chunk-sum".to_owned(),
+        }
+    }
+
+    /// Immutable parameters of current
+    /// `experimental-r4-source-attention/2`.
+    pub fn experimental_r4_v2() -> Self {
+        Self {
+            head_selection: "grouped-query-kv-head-h-div-kv-mul".to_owned(),
+            score_scale: "divide-by-sqrt-full-head-size".to_owned(),
+            score_width_policy: "chunks-of-4-floor-head-size-div-4".to_owned(),
+            remainder_policy: "truncate-trailing-head-size-mod-4-dims-from-score".to_owned(),
+            score_accumulation: CERTIFIED_NATIVE_ARITHMETIC_ID.to_owned(),
         }
     }
 
@@ -206,7 +246,14 @@ impl AttentionOperatorParams {
         }
     }
 
-    /// The declared parameters of `learned-absolute-source-attention/1`
+    /// The declared parameters of current
+    /// `learned-absolute-source-attention/2`.
+    pub fn learned_absolute() -> Self {
+        Self::learned_absolute_v2()
+    }
+
+    /// Immutable parameters of historical
+    /// `learned-absolute-source-attention/1`
     /// (#668) — the ACTUAL computation of the GPT-2 executor
     /// (`crate::gpt2::Gpt2Model::layer_forward`):
     ///
@@ -223,13 +270,25 @@ impl AttentionOperatorParams {
     ///   is no unscored remainder at any head width.
     /// - `score_accumulation = "sequential-f32-left-fold"` — one running
     ///   f32 sum over `i = 0..head_size` in order.
-    pub fn learned_absolute() -> Self {
+    pub fn learned_absolute_v1() -> Self {
         Self {
             head_selection: "multi-head-identity-kv-head-equals-query-head".to_owned(),
             score_scale: "multiply-by-reciprocal-sqrt-full-head-size".to_owned(),
             score_width_policy: "full-head-width".to_owned(),
             remainder_policy: "none-every-head-dimension-scored".to_owned(),
             score_accumulation: "sequential-f32-left-fold".to_owned(),
+        }
+    }
+
+    /// Immutable parameters of current
+    /// `learned-absolute-source-attention/2`.
+    pub fn learned_absolute_v2() -> Self {
+        Self {
+            head_selection: "multi-head-identity-kv-head-equals-query-head".to_owned(),
+            score_scale: "multiply-by-reciprocal-sqrt-full-head-size".to_owned(),
+            score_width_policy: "full-head-width".to_owned(),
+            remainder_policy: "none-every-head-dimension-scored".to_owned(),
+            score_accumulation: CERTIFIED_NATIVE_ARITHMETIC_ID.to_owned(),
         }
     }
 }
@@ -295,18 +354,26 @@ pub struct AttentionOperatorSpec {
 impl AttentionOperatorSpec {
     /// Registry id of the standard scaled-dot-product source operator.
     pub const STANDARD_ID: &'static str = "standard-source-attention";
-    /// Registry version of the standard operator currently implemented
+    /// Immutable historical version using sequential f32 Q·K/value folds.
+    pub const STANDARD_V1_VERSION: u32 = 1;
+    /// Current certified-native Q·K/value registry version implemented
     /// by [`standard_head_attention_weights`] +
     /// [`head_attention_value_aggregate`].
-    pub const STANDARD_VERSION: u32 = 1;
+    pub const STANDARD_V2_VERSION: u32 = 2;
+    /// Current standard registry version.
+    pub const STANDARD_VERSION: u32 = Self::STANDARD_V2_VERSION;
     /// Registry id of the experimental `r4_attention`-gated operator,
     /// named for what it computes (a chunked dot product with the same
     /// softmax selector), not for the historical description.
     pub const EXPERIMENTAL_R4_ID: &'static str = "experimental-r4-source-attention";
-    /// Registry version of the experimental operator currently
+    /// Immutable historical version using chunked f32 Q·K/value folds.
+    pub const EXPERIMENTAL_R4_V1_VERSION: u32 = 1;
+    /// Current certified-native Q·K/value registry version
     /// implemented by [`experimental_r4_head_attention_weights`] +
     /// [`head_attention_value_aggregate`].
-    pub const EXPERIMENTAL_R4_VERSION: u32 = 1;
+    pub const EXPERIMENTAL_R4_V2_VERSION: u32 = 2;
+    /// Current experimental registry version.
+    pub const EXPERIMENTAL_R4_VERSION: u32 = Self::EXPERIMENTAL_R4_V2_VERSION;
     /// Registry id of the `R4RouteAttentionV1` TARGET operator (#604) —
     /// the same id string as
     /// `uor-r4-graph-format::route_attention::ROUTE_ATTENTION_OPERATOR_ID`;
@@ -324,16 +391,24 @@ impl AttentionOperatorSpec {
     /// positional action, the field that distinguishes it from
     /// `standard-source-attention`.
     pub const LEARNED_ABSOLUTE_ID: &'static str = "learned-absolute-source-attention";
-    /// Registry version of the learned-absolute operator currently
+    /// Immutable historical version using sequential f32 Q·K/value folds.
+    pub const LEARNED_ABSOLUTE_V1_VERSION: u32 = 1;
+    /// Current certified-native Q·K/value registry version
     /// computed by the GPT-2 executor (`crate::gpt2::Gpt2Model`).
-    pub const LEARNED_ABSOLUTE_VERSION: u32 = 1;
+    pub const LEARNED_ABSOLUTE_V2_VERSION: u32 = 2;
+    /// Current learned-absolute registry version.
+    pub const LEARNED_ABSOLUTE_VERSION: u32 = Self::LEARNED_ABSOLUTE_V2_VERSION;
 
-    /// The `standard-source-attention/1` record — the operator the
-    /// default-off `r4_attention` switch has always computed.
+    /// The current `standard-source-attention/2` record.
     pub fn standard() -> Self {
+        Self::standard_v2()
+    }
+
+    /// Immutable historical `standard-source-attention/1` registry entry.
+    pub fn standard_v1() -> Self {
         let mut record = Self {
             id: Self::STANDARD_ID.to_owned(),
-            version: Self::STANDARD_VERSION,
+            version: Self::STANDARD_V1_VERSION,
             projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
             positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
             compatibility_relation: "scaled-dot-product".to_owned(),
@@ -343,22 +418,54 @@ impl AttentionOperatorSpec {
             runtime_state: "growing-kv-cache-full-prefix".to_owned(),
             tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
             permitted_operation_class: "host-source-f32".to_owned(),
-            params: AttentionOperatorParams::standard(),
+            params: AttentionOperatorParams::standard_v1(),
             implementation_digest: String::new(),
         };
         record.implementation_digest = record.declared_digest();
         record
     }
 
-    /// The `experimental-r4-source-attention/1` record — the ACTUAL
+    /// Immutable current `standard-source-attention/2` registry entry.
+    pub fn standard_v2() -> Self {
+        let mut record = Self {
+            id: Self::STANDARD_ID.to_owned(),
+            version: Self::STANDARD_V2_VERSION,
+            projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
+            positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
+            compatibility_relation:
+                "correctly-rounded-binary32-exact-real-full-width-dot".to_owned(),
+            selector_normalization:
+                "divide-by-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-per-weight-divide"
+                    .to_owned(),
+            value_aggregation:
+                "correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback"
+                    .to_owned(),
+            output_projection: "per-layer-dense-f32-wo".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class:
+                "host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback".to_owned(),
+            params: AttentionOperatorParams::standard_v2(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// The current `experimental-r4-source-attention/2` record.
+    pub fn experimental_r4() -> Self {
+        Self::experimental_r4_v2()
+    }
+
+    /// Immutable historical `experimental-r4-source-attention/1` record — the ACTUAL
     /// computation of the `r4_attention = true` branch: a 4-wide-chunked
     /// dot product (truncating the trailing `head_size mod 4`
     /// dimensions from the score) followed by the SAME max-subtracted
     /// softmax the standard operator uses.
-    pub fn experimental_r4() -> Self {
+    pub fn experimental_r4_v1() -> Self {
         let mut record = Self {
             id: Self::EXPERIMENTAL_R4_ID.to_owned(),
-            version: Self::EXPERIMENTAL_R4_VERSION,
+            version: Self::EXPERIMENTAL_R4_V1_VERSION,
             projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
             positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
             compatibility_relation: "chunked-4-wide-dot-product".to_owned(),
@@ -368,7 +475,36 @@ impl AttentionOperatorSpec {
             runtime_state: "growing-kv-cache-full-prefix".to_owned(),
             tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
             permitted_operation_class: "host-source-f32".to_owned(),
-            params: AttentionOperatorParams::experimental_r4(),
+            params: AttentionOperatorParams::experimental_r4_v1(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Immutable current `experimental-r4-source-attention/2` entry. Its
+    /// historical truncated score domain and full-head-size divide remain.
+    pub fn experimental_r4_v2() -> Self {
+        let mut record = Self {
+            id: Self::EXPERIMENTAL_R4_ID.to_owned(),
+            version: Self::EXPERIMENTAL_R4_V2_VERSION,
+            projections: "per-layer-dense-f32-wq-wk-wv".to_owned(),
+            positional_action: "rope-rotation-of-q-and-k-before-scoring".to_owned(),
+            compatibility_relation:
+                "correctly-rounded-binary32-exact-real-floor-multiple-of-4-width-dot"
+                    .to_owned(),
+            selector_normalization:
+                "divide-by-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-per-weight-divide"
+                    .to_owned(),
+            value_aggregation:
+                "correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback"
+                    .to_owned(),
+            output_projection: "per-layer-dense-f32-wo".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class:
+                "host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback".to_owned(),
+            params: AttentionOperatorParams::experimental_r4_v2(),
             implementation_digest: String::new(),
         };
         record.implementation_digest = record.declared_digest();
@@ -419,7 +555,12 @@ impl AttentionOperatorSpec {
         record
     }
 
-    /// The `learned-absolute-source-attention/1` record (#668) — the
+    /// The current `learned-absolute-source-attention/2` record (#668).
+    pub fn learned_absolute_source_attention() -> Self {
+        Self::learned_absolute_v2()
+    }
+
+    /// Immutable historical `learned-absolute-source-attention/1` record — the
     /// GPT-2-family source operator computed by the executor in
     /// [`crate::gpt2`] (`Gpt2Model::layer_forward`), the way
     /// `r4-route-attention/1`'s record names an operator whose
@@ -446,10 +587,10 @@ impl AttentionOperatorSpec {
     ///   bias.
     /// - head selection is plain multi-head (kv heads == query heads);
     ///   no grouped-query arithmetic exists.
-    pub fn learned_absolute_source_attention() -> Self {
+    pub fn learned_absolute_v1() -> Self {
         let mut record = Self {
             id: Self::LEARNED_ABSOLUTE_ID.to_owned(),
-            version: Self::LEARNED_ABSOLUTE_VERSION,
+            version: Self::LEARNED_ABSOLUTE_V1_VERSION,
             projections: "fused-c-attn-conv1d-qkv-with-bias".to_owned(),
             positional_action: "none-learned-absolute-positions-added-to-input-embeddings"
                 .to_owned(),
@@ -460,7 +601,38 @@ impl AttentionOperatorSpec {
             runtime_state: "growing-kv-cache-full-prefix".to_owned(),
             tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
             permitted_operation_class: "host-source-f32".to_owned(),
-            params: AttentionOperatorParams::learned_absolute(),
+            params: AttentionOperatorParams::learned_absolute_v1(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Immutable current `learned-absolute-source-attention/2` entry. GPT-2's
+    /// projections stay conventional; Q·K/value use certified-native cells
+    /// with the pinned exact fallback, and normalization retains reciprocal
+    /// multiplication rather than Llama's divisions.
+    pub fn learned_absolute_v2() -> Self {
+        let mut record = Self {
+            id: Self::LEARNED_ABSOLUTE_ID.to_owned(),
+            version: Self::LEARNED_ABSOLUTE_V2_VERSION,
+            projections: "fused-c-attn-conv1d-qkv-with-bias".to_owned(),
+            positional_action: "none-learned-absolute-positions-added-to-input-embeddings"
+                .to_owned(),
+            compatibility_relation:
+                "correctly-rounded-binary32-exact-real-full-width-dot".to_owned(),
+            selector_normalization:
+                "multiply-by-reciprocal-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-reciprocal-multiply"
+                    .to_owned(),
+            value_aggregation:
+                "correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback"
+                    .to_owned(),
+            output_projection: "dense-c-proj-conv1d-with-bias".to_owned(),
+            runtime_state: "growing-kv-cache-full-prefix".to_owned(),
+            tie_breaking: "first-maximum-softmax-stabilizer-value-identical".to_owned(),
+            permitted_operation_class:
+                "host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback".to_owned(),
+            params: AttentionOperatorParams::learned_absolute_v2(),
             implementation_digest: String::new(),
         };
         record.implementation_digest = record.declared_digest();
@@ -521,9 +693,10 @@ impl AttentionOperatorSpec {
 }
 
 /// The typed record the boolean `Config::r4_attention` switch selects:
-/// `false` has always computed `standard-source-attention/1`, `true` the
-/// `experimental-r4-source-attention/1` branch. This is the one boundary
-/// mapping from the legacy switch to the versioned operator identity.
+/// `false` selects current `standard-source-attention/2`, `true` current
+/// `experimental-r4-source-attention/2`. This is the one boundary mapping
+/// from the legacy switch to the versioned operator identity; explicit v1
+/// registry entries remain readable but are never selected as current.
 pub fn operator_for_r4_switch(r4_attention: bool) -> AttentionOperatorSpec {
     if r4_attention {
         AttentionOperatorSpec::experimental_r4()
@@ -547,19 +720,30 @@ pub fn operator_spec(
     version: u32,
 ) -> Result<AttentionOperatorSpec, crate::SourceUnavailable> {
     match (id, version) {
-        (AttentionOperatorSpec::STANDARD_ID, AttentionOperatorSpec::STANDARD_VERSION) => {
+        (AttentionOperatorSpec::STANDARD_ID, AttentionOperatorSpec::STANDARD_V1_VERSION) => {
+            Ok(AttentionOperatorSpec::standard_v1())
+        }
+        (AttentionOperatorSpec::STANDARD_ID, AttentionOperatorSpec::STANDARD_V2_VERSION) => {
             Ok(AttentionOperatorSpec::standard())
         }
         (
             AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
-            AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+            AttentionOperatorSpec::EXPERIMENTAL_R4_V1_VERSION,
+        ) => Ok(AttentionOperatorSpec::experimental_r4_v1()),
+        (
+            AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+            AttentionOperatorSpec::EXPERIMENTAL_R4_V2_VERSION,
         ) => Ok(AttentionOperatorSpec::experimental_r4()),
         (AttentionOperatorSpec::R4_ROUTE_ID, AttentionOperatorSpec::R4_ROUTE_VERSION) => {
             Ok(AttentionOperatorSpec::r4_route_attention_v1())
         }
         (
             AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
-            AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_V1_VERSION,
+        ) => Ok(AttentionOperatorSpec::learned_absolute_v1()),
+        (
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+            AttentionOperatorSpec::LEARNED_ABSOLUTE_V2_VERSION,
         ) => Ok(AttentionOperatorSpec::learned_absolute_source_attention()),
         _ => Err(crate::SourceIngestKind::UnknownAttentionOperator {
             id: id.to_owned(),
@@ -569,18 +753,451 @@ pub fn operator_spec(
     }
 }
 
-/// The `standard-source-attention/1` weight computation, factored
-/// verbatim out of `Llama::layer_forward`/`Llama::forward_batch` (#602):
+/// Arithmetic owner for source-attention execution and its controls.
+///
+/// Current production entry points select [`Self::CertifiedNative`]. The
+/// historical conventional fold and always-exact owner remain explicit for
+/// differential tests and matched measurement in one binary.
+#[doc(hidden)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum AttentionArithmetic {
+    #[default]
+    Conventional,
+    Exact,
+    CertifiedNative,
+}
+
+/// Per-dot verdict census for the #704 attention controls.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AttentionDotCensus {
+    pub(crate) lanes: usize,
+    pub(crate) conventional: usize,
+    pub(crate) exact_control: usize,
+    pub(crate) certified: usize,
+    pub(crate) fallback_nonfinite: usize,
+    pub(crate) fallback_zero: usize,
+    pub(crate) fallback_overflow: usize,
+    pub(crate) fallback_cell: usize,
+}
+
+impl AttentionDotCensus {
+    pub(crate) const fn fallbacks(self) -> usize {
+        self.fallback_nonfinite + self.fallback_zero + self.fallback_overflow + self.fallback_cell
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.lanes += other.lanes;
+        self.conventional += other.conventional;
+        self.exact_control += other.exact_control;
+        self.certified += other.certified;
+        self.fallback_nonfinite += other.fallback_nonfinite;
+        self.fallback_zero += other.fallback_zero;
+        self.fallback_overflow += other.fallback_overflow;
+        self.fallback_cell += other.fallback_cell;
+    }
+}
+
+/// Q·K and weighted-value verdicts accumulated across an attention run.
+#[doc(hidden)]
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AttentionArithmeticCensus {
+    pub(crate) qk: AttentionDotCensus,
+    pub(crate) value: AttentionDotCensus,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AttentionArithmeticCensus {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.qk.merge(other.qk);
+        self.value.merge(other.value);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CertificationRejection {
+    Nonfinite,
+    Zero,
+    Overflow,
+    Cell,
+}
+
+impl AttentionDotCensus {
+    fn zero_dot(lanes: usize, arithmetic: AttentionArithmetic) -> Self {
+        match arithmetic {
+            AttentionArithmetic::Conventional => Self {
+                lanes,
+                conventional: lanes,
+                ..Self::default()
+            },
+            AttentionArithmetic::Exact => Self {
+                lanes,
+                exact_control: lanes,
+                ..Self::default()
+            },
+            AttentionArithmetic::CertifiedNative => Self {
+                lanes,
+                fallback_zero: lanes,
+                ..Self::default()
+            },
+        }
+    }
+
+    fn reject(&mut self, reason: CertificationRejection) {
+        match reason {
+            CertificationRejection::Nonfinite => self.fallback_nonfinite += 1,
+            CertificationRejection::Zero => self.fallback_zero += 1,
+            CertificationRejection::Overflow => self.fallback_overflow += 1,
+            CertificationRejection::Cell => self.fallback_cell += 1,
+        }
+    }
+}
+
+#[inline]
+fn next_up_f64(value: f64) -> f64 {
+    if value.is_nan() || value == f64::INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f64::from_bits(1);
+    }
+    let bits = value.to_bits();
+    f64::from_bits(if value > 0.0 { bits + 1 } else { bits - 1 })
+}
+
+#[inline]
+fn next_down_f64(value: f64) -> f64 {
+    if value.is_nan() || value == f64::NEG_INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f64::from_bits((1u64 << 63) | 1);
+    }
+    let bits = value.to_bits();
+    f64::from_bits(if value > 0.0 { bits - 1 } else { bits + 1 })
+}
+
+#[inline]
+fn next_up_f32(value: f32) -> f32 {
+    if value.is_nan() || value == f32::INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits(1);
+    }
+    let bits = value.to_bits();
+    f32::from_bits(if value > 0.0 { bits + 1 } else { bits - 1 })
+}
+
+#[inline]
+fn next_down_f32(value: f32) -> f32 {
+    if value.is_nan() || value == f32::NEG_INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits((1u32 << 31) | 1);
+    }
+    let bits = value.to_bits();
+    f32::from_bits(if value > 0.0 { bits - 1 } else { bits + 1 })
+}
+
+/// Certify the correctly-rounded binary32 value of one exact real dot.
+///
+/// Every finite binary32 product is exact in binary64: it has at most 48
+/// significand bits and its exponent remains within the binary64 range. Only
+/// the sequential binary64 additions round. For `u = 2^-53`, their error is
+/// bounded by `gamma_k * sum(abs(products))`, here conservatively replaced by
+/// `gamma_k * k * max(abs(product))`. Every bound and interval operation is
+/// rounded outward. A native candidate is returned only when the resulting
+/// interval is strictly inside the exact midpoints to its adjacent binary32
+/// values; strictness rejects ties without needing a parity case. Nonfinite,
+/// zero, overflow-adjacent, and uncertain cells use the pinned exact owner.
+/// Exact products and partial sums lie on the `2^-298` grid, so nonzero
+/// accumulation cannot underflow binary64; with `k <= 2^53`, even
+/// `k * f32::MAX^2` remains far below binary64 overflow.
+#[inline]
+fn certify_dot(
+    approximate: f64,
+    max_product_abs: f64,
+    k: usize,
+) -> Result<f32, CertificationRejection> {
+    if !approximate.is_finite() || !max_product_abs.is_finite() {
+        return Err(CertificationRejection::Nonfinite);
+    }
+    let candidate = approximate as f32;
+    if candidate == 0.0 {
+        return Err(CertificationRejection::Zero);
+    }
+    if !candidate.is_finite() || candidate.abs() == f32::MAX {
+        return Err(CertificationRejection::Overflow);
+    }
+    if (k as u128) > (1u128 << f64::MANTISSA_DIGITS) {
+        return Err(CertificationRejection::Cell);
+    }
+
+    const UNIT_ROUNDOFF: f64 = 1.0 / ((1u64 << 53) as f64);
+    let mu = next_up_f64((k as f64) * UNIT_ROUNDOFF);
+    if mu >= 1.0 {
+        return Err(CertificationRejection::Cell);
+    }
+    let denominator = next_down_f64(1.0 - mu);
+    let gamma = next_up_f64(mu / denominator);
+    let sum_abs = next_up_f64((k as f64) * max_product_abs);
+    let error = next_up_f64(gamma * sum_abs);
+    if !error.is_finite() {
+        return Err(CertificationRejection::Cell);
+    }
+    let lower = next_down_f64(approximate - error);
+    let upper = next_up_f64(approximate + error);
+
+    let previous = next_down_f32(candidate);
+    let next = next_up_f32(candidate);
+    if !previous.is_finite() || !next.is_finite() {
+        return Err(CertificationRejection::Overflow);
+    }
+    let cell_lower = (f64::from(previous) + f64::from(candidate)) * 0.5;
+    let cell_upper = (f64::from(candidate) + f64::from(next)) * 0.5;
+    if lower > cell_lower && upper < cell_upper {
+        Ok(candidate)
+    } else {
+        Err(CertificationRejection::Cell)
+    }
+}
+
+fn exact_strided_matrix_vector(
+    out: &mut [f32],
+    matrix: &[f32],
+    columns: usize,
+    row_stride: usize,
+    column_stride: usize,
+    vector: &[f32],
+) {
+    if columns == 0 || out.is_empty() {
+        out.fill(0.0);
+        return;
+    }
+    let matrix = uor_matmul::MatView::new(
+        matrix,
+        out.len(),
+        columns,
+        uor_matmul::Strides {
+            rs: isize::try_from(row_stride).expect("attention row stride fits isize"),
+            cs: isize::try_from(column_stride).expect("attention column stride fits isize"),
+        },
+    )
+    .expect("attention cache view is within its validated model state");
+    let vector = uor_matmul::MatView::row_major(vector, columns, 1)
+        .expect("attention vector shape is exact");
+    let rows = out.len();
+    let output =
+        uor_matmul::MatViewMut::row_major(out, rows, 1).expect("attention output shape is exact");
+    let mut product = uor_matmul::Triple::new(matrix, vector, output)
+        .expect("attention matrix-vector product is conformant");
+    uor_matmul::driver::gemm_float(
+        &mut product,
+        &uor_matmul::Linear::OVERWRITE,
+        uor_matmul::GemmOptions::default(),
+    );
+}
+
+fn exact_strided_dot(
+    matrix: &[f32],
+    row: usize,
+    columns: usize,
+    row_stride: usize,
+    column_stride: usize,
+    vector: &[f32],
+) -> f32 {
+    if columns == 0 {
+        return 0.0;
+    }
+    let offset = row
+        .checked_mul(row_stride)
+        .expect("attention row offset is addressable");
+    let mut value = [0.0f32];
+    exact_strided_matrix_vector(
+        &mut value,
+        &matrix[offset..],
+        columns,
+        row_stride,
+        column_stride,
+        vector,
+    );
+    value[0]
+}
+
+fn controlled_strided_matrix_vector(
+    out: &mut [f32],
+    matrix: &[f32],
+    columns: usize,
+    row_stride: usize,
+    column_stride: usize,
+    vector: &[f32],
+    arithmetic: AttentionArithmetic,
+) -> AttentionDotCensus {
+    assert!(
+        isize::try_from(row_stride).is_ok() && isize::try_from(column_stride).is_ok(),
+        "attention strides must fit the exact owner's isize layout"
+    );
+    let mut census = AttentionDotCensus {
+        lanes: out.len(),
+        ..AttentionDotCensus::default()
+    };
+    match arithmetic {
+        AttentionArithmetic::Conventional => {
+            unreachable!("the caller owns its historical conventional fold")
+        }
+        AttentionArithmetic::Exact => {
+            exact_strided_matrix_vector(out, matrix, columns, row_stride, column_stride, vector);
+            census.exact_control = out.len();
+        }
+        AttentionArithmetic::CertifiedNative => {
+            for (row, output) in out.iter_mut().enumerate() {
+                let mut sum = 0.0f64;
+                let mut max_product_abs = 0.0f64;
+                let mut finite = true;
+                for column in 0..columns {
+                    let left = matrix[row * row_stride + column * column_stride];
+                    let right = vector[column];
+                    if !left.is_finite() || !right.is_finite() {
+                        finite = false;
+                        break;
+                    }
+                    let product = f64::from(left) * f64::from(right);
+                    sum += product;
+                    max_product_abs = max_product_abs.max(product.abs());
+                }
+                let verdict = if finite {
+                    certify_dot(sum, max_product_abs, columns)
+                } else {
+                    Err(CertificationRejection::Nonfinite)
+                };
+                match verdict {
+                    Ok(value) => {
+                        *output = value;
+                        census.certified += 1;
+                    }
+                    Err(reason) => {
+                        census.reject(reason);
+                        *output = exact_strided_dot(
+                            matrix,
+                            row,
+                            columns,
+                            row_stride,
+                            column_stride,
+                            vector,
+                        );
+                    }
+                }
+            }
+            debug_assert_eq!(census.certified + census.fallbacks(), census.lanes);
+        }
+    }
+    census
+}
+
+#[inline]
+fn strided_span_fits(
+    storage_len: usize,
+    offset: usize,
+    rows: usize,
+    columns: usize,
+    row_stride: usize,
+    column_stride: usize,
+) -> bool {
+    if rows == 0 {
+        return offset <= storage_len;
+    }
+    if columns == 0 {
+        return (rows - 1)
+            .checked_mul(row_stride)
+            .and_then(|last_row| offset.checked_add(last_row))
+            .is_some_and(|last_origin| last_origin <= storage_len);
+    }
+    (rows - 1)
+        .checked_mul(row_stride)
+        .and_then(|last_row| {
+            (columns - 1)
+                .checked_mul(column_stride)
+                .and_then(|last_column| last_row.checked_add(last_column))
+        })
+        .and_then(|last_index| offset.checked_add(last_index))
+        .and_then(|last_index| last_index.checked_add(1))
+        .is_some_and(|end| end <= storage_len)
+}
+
+/// Raw Q·K control used by the GPT-2 proof seam before its distinct scalar
+/// reciprocal-scale and reciprocal-sum normalization stages.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn head_dot_products_with_arithmetic(
+    out: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    scored_width: usize,
+    arithmetic: AttentionArithmetic,
+) -> AttentionDotCensus {
+    assert!(q.len() >= scored_width, "Q is shorter than scored width");
+    assert!(
+        isize::try_from(key_stride).is_ok(),
+        "key stride must fit the exact owner's isize layout"
+    );
+    assert!(
+        strided_span_fits(
+            keys.len(),
+            key_offset,
+            out.len(),
+            scored_width,
+            key_stride,
+            1,
+        ),
+        "key-cache layout does not contain every requested QK row"
+    );
+    match arithmetic {
+        AttentionArithmetic::Conventional => {
+            for (position, output) in out.iter_mut().enumerate() {
+                let key = &keys[position * key_stride + key_offset..][..scored_width];
+                let mut dot = 0.0f32;
+                for i in 0..scored_width {
+                    dot += q[i] * key[i];
+                }
+                *output = dot;
+            }
+            AttentionDotCensus {
+                lanes: out.len(),
+                conventional: out.len(),
+                ..AttentionDotCensus::default()
+            }
+        }
+        AttentionArithmetic::Exact | AttentionArithmetic::CertifiedNative => {
+            controlled_strided_matrix_vector(
+                out,
+                &keys[key_offset..],
+                scored_width,
+                key_stride,
+                1,
+                &q[..scored_width],
+                arithmetic,
+            )
+        }
+    }
+}
+
+/// Current `standard-source-attention/2` weight computation shared by
+/// `Llama::layer_forward` and `Llama::forward_batch`:
 /// fill `att` (one slot per cached position `t = 0..att.len()`) with the
 /// softmax-normalized scaled dot products of `q` against the cached keys.
 /// `keys` is the layer's key-cache region; position `t`'s key head starts
 /// at `t * key_stride + key_offset` (grouped query: `key_offset =
-/// (h / kv_mul) * head_size`). Iteration order and arithmetic — one
-/// sequential f32 left fold per score over the FULL head width, one
-/// divide by `sqrt(head_size)`, then the shared max-subtracted softmax —
-/// are bit-identical to the pre-#602 in-line loop. Deterministic and
-/// free of hidden state; `canonical` selects the D2 libm math path
-/// exactly as the executor does.
+/// (h / kv_mul) * head_size`). The full-width exact-real dot rounds once to
+/// f32 through the certified-native/exact-fallback owner, followed by Llama's
+/// historical divide by `sqrt(head_size)` and shared max-subtracted softmax.
+/// `canonical` selects the D2 libm math path exactly as the executor does.
 pub fn standard_head_attention_weights(
     att: &mut [f32],
     q: &[f32],
@@ -589,29 +1206,65 @@ pub fn standard_head_attention_weights(
     key_stride: usize,
     canonical: bool,
 ) {
-    let head_size = q.len();
-    for (t, attention) in att.iter_mut().enumerate() {
-        let k = &keys[t * key_stride + key_offset..][..head_size];
-        let mut score = 0.0f32;
-        for i in 0..head_size {
-            score += q[i] * k[i];
-        }
-        score /= crate::sqrtf(head_size as f32, canonical);
-        *attention = score;
-    }
-    crate::softmax_with_mode(att, canonical);
+    let _ = standard_head_attention_weights_with_arithmetic(
+        att,
+        q,
+        keys,
+        key_offset,
+        key_stride,
+        canonical,
+        AttentionArithmetic::CertifiedNative,
+    );
 }
 
-/// The `experimental-r4-source-attention/1` weight computation, factored
-/// verbatim out of the `r4_attention` branch (#602): the dot product is
-/// computed in 4-wide chunks over dimensions `0..4*(head_size/4)` — the
+/// Explicit standard-attention Q·K owner for differential evidence.
+/// Llama's historical per-score division and softmax order are shared by all
+/// three variants and occur only after the raw dot has rounded to `f32`.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn standard_head_attention_weights_with_arithmetic(
+    att: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    canonical: bool,
+    arithmetic: AttentionArithmetic,
+) -> AttentionDotCensus {
+    let head_size = q.len();
+    if att.is_empty() {
+        return AttentionDotCensus::zero_dot(0, arithmetic);
+    }
+    if head_size == 0 {
+        let census = AttentionDotCensus::zero_dot(att.len(), arithmetic);
+        // The exact dot over an empty dimension is zero. Scaling by sqrt(0)
+        // is undefined, so take the well-defined selector limit: equal zero
+        // scores normalized by the existing softmax owner.
+        att.fill(0.0);
+        crate::softmax_with_mode(att, canonical);
+        return census;
+    }
+    let mut census = head_dot_products_with_arithmetic(
+        att, q, keys, key_offset, key_stride, head_size, arithmetic,
+    );
+    let divisor = crate::sqrtf(head_size as f32, canonical);
+    for score in att.iter_mut() {
+        *score /= divisor;
+    }
+    crate::softmax_with_mode(att, canonical);
+    debug_assert_eq!(census.lanes, att.len());
+    census.lanes = att.len();
+    census
+}
+
+/// Current `experimental-r4-source-attention/2` weight computation: one
+/// correctly-rounded exact-real dot over dimensions
+/// `0..4*(head_size/4)` — the
 /// trailing `head_size mod 4` q/k dimensions are never read — divided by
 /// `sqrt(head_size)` over the FULL head width, then normalized by the
 /// SAME max-subtracted softmax as the standard operator. For
-/// `head_size < 4` every score is 0 and the weights are uniform.
-/// Iteration order and arithmetic are bit-identical to the pre-#602
-/// in-line loop. Still gated by `Config::r4_attention` at both call
-/// sites; factoring changes no selection.
+/// `head_size < 4` every score is 0 and the weights are uniform. The operator
+/// remains gated by `Config::r4_attention` at serial and batched call sites.
 pub fn experimental_r4_head_attention_weights(
     att: &mut [f32],
     q: &[f32],
@@ -620,33 +1273,122 @@ pub fn experimental_r4_head_attention_weights(
     key_stride: usize,
     canonical: bool,
 ) {
-    let head_size = q.len();
-    for (t, attention) in att.iter_mut().enumerate() {
-        let k = &keys[t * key_stride + key_offset..][..head_size];
-        let mut head_score = 0.0f32;
-        let chunks = head_size / 4;
-        for chunk_idx in 0..chunks {
-            let q_chunk = &q[chunk_idx * 4..(chunk_idx + 1) * 4];
-            let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
-            head_score += q_chunk[0] * k_chunk[0]
-                + q_chunk[1] * k_chunk[1]
-                + q_chunk[2] * k_chunk[2]
-                + q_chunk[3] * k_chunk[3];
-        }
-        head_score /= crate::sqrtf(head_size as f32, canonical);
-        *attention = head_score;
-    }
-    crate::softmax_with_mode(att, canonical);
+    let _ = experimental_r4_head_attention_weights_with_arithmetic(
+        att,
+        q,
+        keys,
+        key_offset,
+        key_stride,
+        canonical,
+        AttentionArithmetic::CertifiedNative,
+    );
 }
 
-/// The value aggregation both operators share, factored verbatim out of
-/// the executor (#602): zero `out` (one head width), then accumulate the
-/// position-ascending weighted sum `out[i] += att[t] * v_t[i]` over the
+/// Explicit experimental-attention Q·K owner for differential evidence.
+/// The historical truncated score domain and full-head-size divide are
+/// preserved in all modes.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn experimental_r4_head_attention_weights_with_arithmetic(
+    att: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    canonical: bool,
+    arithmetic: AttentionArithmetic,
+) -> AttentionDotCensus {
+    let head_size = q.len();
+    if att.is_empty() {
+        return AttentionDotCensus::zero_dot(0, arithmetic);
+    }
+    if head_size == 0 {
+        let census = AttentionDotCensus::zero_dot(att.len(), arithmetic);
+        // This is the H < 4 truncated-domain rule at H = 0: every raw score
+        // is the exact empty dot, hence the selector is uniform.
+        att.fill(0.0);
+        crate::softmax_with_mode(att, canonical);
+        return census;
+    }
+    let scored_width = 4 * (head_size / 4);
+    if scored_width == 0 && arithmetic != AttentionArithmetic::Conventional {
+        let census = AttentionDotCensus::zero_dot(att.len(), arithmetic);
+        // Version 2's truncated score domain reads no q/key dimensions when
+        // H < 4. Normalize the exact zero scores without imposing a cache
+        // layout for bytes this operator cannot observe.
+        att.fill(0.0);
+        crate::softmax_with_mode(att, canonical);
+        return census;
+    }
+    assert!(
+        isize::try_from(key_stride).is_ok(),
+        "key stride must fit the exact owner's isize layout"
+    );
+    let required_width = if arithmetic == AttentionArithmetic::Conventional {
+        head_size
+    } else {
+        scored_width
+    };
+    assert!(
+        strided_span_fits(
+            keys.len(),
+            key_offset,
+            att.len(),
+            required_width,
+            key_stride,
+            1,
+        ),
+        "key-cache layout does not contain every requested experimental QK row"
+    );
+    let census = match arithmetic {
+        AttentionArithmetic::Conventional => {
+            for (t, attention) in att.iter_mut().enumerate() {
+                let k = &keys[t * key_stride + key_offset..][..head_size];
+                let mut head_score = 0.0f32;
+                let chunks = head_size / 4;
+                for chunk_idx in 0..chunks {
+                    let q_chunk = &q[chunk_idx * 4..(chunk_idx + 1) * 4];
+                    let k_chunk = &k[chunk_idx * 4..(chunk_idx + 1) * 4];
+                    head_score += q_chunk[0] * k_chunk[0]
+                        + q_chunk[1] * k_chunk[1]
+                        + q_chunk[2] * k_chunk[2]
+                        + q_chunk[3] * k_chunk[3];
+                }
+                *attention = head_score;
+            }
+            AttentionDotCensus {
+                lanes: att.len(),
+                conventional: att.len(),
+                ..AttentionDotCensus::default()
+            }
+        }
+        AttentionArithmetic::Exact | AttentionArithmetic::CertifiedNative => {
+            controlled_strided_matrix_vector(
+                att,
+                &keys[key_offset..],
+                scored_width,
+                key_stride,
+                1,
+                &q[..scored_width],
+                arithmetic,
+            )
+        }
+    };
+    let divisor = crate::sqrtf(head_size as f32, canonical);
+    for score in att.iter_mut() {
+        *score /= divisor;
+    }
+    crate::softmax_with_mode(att, canonical);
+    census
+}
+
+/// Current version-2 value aggregation shared by all source operators: zero
+/// `out` (one head width), then compute the correctly-rounded exact-real
+/// position-weighted dot for each output lane over the
 /// cached values. `values` is the layer's value-cache region; position
 /// `t`'s value head starts at `t * value_stride + value_offset`. Every
-/// head dimension participates regardless of the scoring operator's
-/// width policy. Arithmetic order is bit-identical to the pre-#602
-/// in-line loop.
+/// head dimension participates regardless of the scoring operator's width
+/// policy; uncertified native lanes use the pinned exact fallback.
 pub fn head_attention_value_aggregate(
     out: &mut [f32],
     att: &[f32],
@@ -654,12 +1396,90 @@ pub fn head_attention_value_aggregate(
     value_offset: usize,
     value_stride: usize,
 ) {
+    let _ = head_attention_value_aggregate_with_arithmetic(
+        out,
+        att,
+        values,
+        value_offset,
+        value_stride,
+        AttentionArithmetic::CertifiedNative,
+    );
+}
+
+/// Explicit weighted-value owner for differential evidence.
+#[doc(hidden)]
+pub(crate) fn head_attention_value_aggregate_with_arithmetic(
+    out: &mut [f32],
+    att: &[f32],
+    values: &[f32],
+    value_offset: usize,
+    value_stride: usize,
+    arithmetic: AttentionArithmetic,
+) -> AttentionDotCensus {
     let head_size = out.len();
-    out.iter_mut().for_each(|v| *v = 0.0);
-    for (t, &attention) in att.iter().enumerate() {
-        let v = &values[t * value_stride + value_offset..][..head_size];
-        for i in 0..head_size {
-            out[i] += attention * v[i];
+    if out.is_empty() {
+        return AttentionDotCensus::zero_dot(0, arithmetic);
+    }
+    if att.is_empty() {
+        out.fill(0.0);
+        return match arithmetic {
+            AttentionArithmetic::Conventional => AttentionDotCensus {
+                lanes: head_size,
+                conventional: head_size,
+                ..AttentionDotCensus::default()
+            },
+            AttentionArithmetic::Exact => AttentionDotCensus {
+                lanes: head_size,
+                exact_control: head_size,
+                ..AttentionDotCensus::default()
+            },
+            AttentionArithmetic::CertifiedNative => AttentionDotCensus {
+                lanes: head_size,
+                fallback_zero: head_size,
+                ..AttentionDotCensus::default()
+            },
+        };
+    }
+    assert!(
+        isize::try_from(value_stride).is_ok(),
+        "value stride must fit the exact owner's isize layout"
+    );
+    assert!(
+        strided_span_fits(
+            values.len(),
+            value_offset,
+            head_size,
+            att.len(),
+            1,
+            value_stride,
+        ),
+        "value-cache layout does not contain every requested weighted-value lane"
+    );
+    match arithmetic {
+        AttentionArithmetic::Conventional => {
+            out.iter_mut().for_each(|value| *value = 0.0);
+            for (t, &attention) in att.iter().enumerate() {
+                let value = &values[t * value_stride + value_offset..][..head_size];
+                for i in 0..head_size {
+                    out[i] += attention * value[i];
+                }
+            }
+            AttentionDotCensus {
+                lanes: head_size,
+                conventional: head_size,
+                ..AttentionDotCensus::default()
+            }
+        }
+        AttentionArithmetic::Exact | AttentionArithmetic::CertifiedNative => {
+            controlled_strided_matrix_vector(
+                out,
+                &values[value_offset..],
+                att.len(),
+                1,
+                value_stride,
+                att,
+                arithmetic,
+            )
         }
     }
 }
@@ -667,6 +1487,77 @@ pub fn head_attention_value_aggregate(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    struct CountingAllocator;
+
+    thread_local! {
+        static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+        static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    fn record_allocation(pointer: *mut u8) {
+        if !pointer.is_null() {
+            let _ = COUNT_ALLOCATIONS.try_with(|gate| {
+                if gate.get() {
+                    let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+                }
+            });
+        }
+    }
+
+    // SAFETY: every request is forwarded unchanged to `System`; the
+    // thread-local cells are observational and never participate in allocation.
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            // SAFETY: the backing allocator receives the original request.
+            let pointer = unsafe { System.alloc(layout) };
+            record_allocation(pointer);
+            pointer
+        }
+
+        unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+            // SAFETY: the allocation came from `System` with this layout.
+            unsafe { System.dealloc(pointer, layout) }
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            // SAFETY: the backing allocator receives the original request.
+            let pointer = unsafe { System.alloc_zeroed(layout) };
+            record_allocation(pointer);
+            pointer
+        }
+
+        unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+            // SAFETY: the backing allocator receives the original request.
+            let resized = unsafe { System.realloc(pointer, layout, size) };
+            record_allocation(resized);
+            resized
+        }
+    }
+
+    #[global_allocator]
+    static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    struct AllocationMeasurement;
+
+    impl Drop for AllocationMeasurement {
+        fn drop(&mut self) {
+            COUNT_ALLOCATIONS.with(|gate| gate.set(false));
+        }
+    }
+
+    fn counted_allocations<T>(operation: impl FnOnce() -> T) -> (T, usize) {
+        ALLOCATIONS.with(|count| count.set(0));
+        COUNT_ALLOCATIONS.with(|gate| {
+            assert!(!gate.replace(true), "nested allocation measurement");
+        });
+        let measurement = AllocationMeasurement;
+        let result = operation();
+        drop(measurement);
+        (result, ALLOCATIONS.with(Cell::get))
+    }
 
     fn ramp(len: usize, seed: usize) -> Vec<f32> {
         (0..len)
@@ -687,6 +1578,521 @@ mod tests {
     /// `kv_heads` heads of width `head_size` each.
     fn cache(positions: usize, kv_heads: usize, head_size: usize, seed: usize) -> Vec<f32> {
         ramp(positions * kv_heads * head_size, seed)
+    }
+
+    fn assert_pinned_record(record: &AttentionOperatorSpec, pinned: &str) {
+        assert_eq!(record.canonical_bytes(), pinned.as_bytes());
+        let expected = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
+        assert_eq!(record.implementation_digest, expected);
+        assert_eq!(record.declared_digest(), expected);
+    }
+
+    fn assert_pinned_digest(record: &AttentionOperatorSpec, expected: &str) {
+        assert_eq!(record.implementation_digest, expected);
+        assert_eq!(record.declared_digest(), expected);
+    }
+
+    #[test]
+    fn raw_control_layout_rejection_is_failure_atomic() {
+        let poison = f32::from_bits(0x7fc0_704a);
+
+        let mut zero_width = [poison; 2];
+        let zero_width_before = zero_width.map(f32::to_bits);
+        let zero_width_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            head_dot_products_with_arithmetic(
+                &mut zero_width,
+                &[],
+                &[],
+                0,
+                1,
+                0,
+                AttentionArithmetic::Conventional,
+            )
+        }));
+        assert!(zero_width_error.is_err());
+        assert_eq!(zero_width.map(f32::to_bits), zero_width_before);
+
+        let mut qk = [poison; 2];
+        let qk_before = qk.map(f32::to_bits);
+        let qk_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            head_dot_products_with_arithmetic(
+                &mut qk,
+                &[1.0, 2.0, 3.0, 4.0],
+                &[1.0, 2.0, 3.0, 4.0],
+                0,
+                4,
+                4,
+                AttentionArithmetic::CertifiedNative,
+            )
+        }));
+        assert!(qk_error.is_err());
+        assert_eq!(qk.map(f32::to_bits), qk_before);
+
+        let mut experimental = [poison; 2];
+        let experimental_before = experimental.map(f32::to_bits);
+        let experimental_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            experimental_r4_head_attention_weights_with_arithmetic(
+                &mut experimental,
+                &[1.0, 2.0, 3.0, 4.0],
+                &[1.0, 2.0, 3.0, 4.0],
+                0,
+                4,
+                false,
+                AttentionArithmetic::Conventional,
+            )
+        }));
+        assert!(experimental_error.is_err());
+        assert_eq!(experimental.map(f32::to_bits), experimental_before);
+
+        let mut value = [poison; 2];
+        let value_before = value.map(f32::to_bits);
+        let value_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            head_attention_value_aggregate_with_arithmetic(
+                &mut value,
+                &[0.25, 0.75],
+                &[1.0, 2.0],
+                0,
+                2,
+                AttentionArithmetic::CertifiedNative,
+            )
+        }));
+        assert!(value_error.is_err());
+        assert_eq!(value.map(f32::to_bits), value_before);
+
+        let oversized_stride = (isize::MAX as usize) + 1;
+        let mut oversized_row = [poison; 1];
+        let oversized_row_before = oversized_row.map(f32::to_bits);
+        let oversized_row_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            head_dot_products_with_arithmetic(
+                &mut oversized_row,
+                &[1.0],
+                &[1.0],
+                0,
+                oversized_stride,
+                1,
+                AttentionArithmetic::CertifiedNative,
+            )
+        }));
+        assert!(oversized_row_error.is_err());
+        assert_eq!(oversized_row.map(f32::to_bits), oversized_row_before);
+
+        let mut oversized_column = [poison; 2];
+        let oversized_column_before = oversized_column.map(f32::to_bits);
+        let oversized_column_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            head_attention_value_aggregate_with_arithmetic(
+                &mut oversized_column,
+                &[1.0],
+                &[1.0, f32::NAN],
+                0,
+                oversized_stride,
+                AttentionArithmetic::CertifiedNative,
+            )
+        }));
+        assert!(oversized_column_error.is_err());
+        assert_eq!(oversized_column.map(f32::to_bits), oversized_column_before);
+    }
+
+    #[test]
+    fn certified_and_forced_fallback_raw_controls_allocate_nothing() {
+        let safe_query = [1.0f32, -2.0, 0.25, 4.0];
+        let safe_keys = [0.5f32, 0.75, -2.0, 0.25, -0.25, 0.5, 4.0, -0.5];
+        let mut safe_output = [0.0f32; 2];
+        let (safe, allocations) = counted_allocations(|| {
+            head_dot_products_with_arithmetic(
+                &mut safe_output,
+                &safe_query,
+                &safe_keys,
+                0,
+                4,
+                4,
+                AttentionArithmetic::CertifiedNative,
+            )
+        });
+        assert_eq!(allocations, 0, "certified QK allocated");
+        assert!(safe.certified > 0);
+
+        let tie_term = f32::from_bits(115 << 23);
+        let mut fallback_output = [0.0f32; 1];
+        let (fallback, allocations) = counted_allocations(|| {
+            head_dot_products_with_arithmetic(
+                &mut fallback_output,
+                &[1.0, tie_term],
+                &[1.0, tie_term],
+                0,
+                2,
+                2,
+                AttentionArithmetic::CertifiedNative,
+            )
+        });
+        assert_eq!(allocations, 0, "exact QK fallback allocated");
+        assert_eq!(fallback.fallback_cell, 1);
+
+        let mut value_output = [0.0f32; 1];
+        let (value, allocations) = counted_allocations(|| {
+            head_attention_value_aggregate_with_arithmetic(
+                &mut value_output,
+                &[1.0, tie_term],
+                &[1.0, tie_term],
+                0,
+                1,
+                AttentionArithmetic::CertifiedNative,
+            )
+        });
+        assert_eq!(allocations, 0, "exact value fallback allocated");
+        assert_eq!(value.fallback_cell, 1);
+    }
+
+    #[test]
+    fn current_llama_wrappers_materially_dispatch_certified_native() {
+        let query = [1.0e20f32, 1.0, -1.0e20];
+        let keys = [1.0f32, 1.0, 1.0, 1.0, 0.0, 1.0];
+        let mut shipped = [0.0; 2];
+        let mut certified = [0.0; 2];
+        let mut historical = [0.0; 2];
+        standard_head_attention_weights(&mut shipped, &query, &keys, 0, 3, false);
+        standard_head_attention_weights_with_arithmetic(
+            &mut certified,
+            &query,
+            &keys,
+            0,
+            3,
+            false,
+            AttentionArithmetic::CertifiedNative,
+        );
+        standard_head_attention_weights_with_arithmetic(
+            &mut historical,
+            &query,
+            &keys,
+            0,
+            3,
+            false,
+            AttentionArithmetic::Conventional,
+        );
+        assert_exact_bits(&shipped, &certified, "standard wrapper");
+        assert_ne!(shipped.map(f32::to_bits), historical.map(f32::to_bits));
+
+        let query = [1.0e20f32, 1.0, -1.0e20, 0.0];
+        let keys = [1.0f32, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0];
+        let mut shipped = [0.0; 2];
+        let mut certified = [0.0; 2];
+        let mut historical = [0.0; 2];
+        experimental_r4_head_attention_weights(&mut shipped, &query, &keys, 0, 4, false);
+        experimental_r4_head_attention_weights_with_arithmetic(
+            &mut certified,
+            &query,
+            &keys,
+            0,
+            4,
+            false,
+            AttentionArithmetic::CertifiedNative,
+        );
+        experimental_r4_head_attention_weights_with_arithmetic(
+            &mut historical,
+            &query,
+            &keys,
+            0,
+            4,
+            false,
+            AttentionArithmetic::Conventional,
+        );
+        assert_exact_bits(&shipped, &certified, "experimental wrapper");
+        assert_ne!(shipped.map(f32::to_bits), historical.map(f32::to_bits));
+
+        let attention = [1.0e20f32, 1.0, -1.0e20];
+        let values = [1.0f32, 1.0, 1.0];
+        let mut shipped = [0.0; 1];
+        let mut certified = [0.0; 1];
+        let mut historical = [0.0; 1];
+        head_attention_value_aggregate(&mut shipped, &attention, &values, 0, 1);
+        head_attention_value_aggregate_with_arithmetic(
+            &mut certified,
+            &attention,
+            &values,
+            0,
+            1,
+            AttentionArithmetic::CertifiedNative,
+        );
+        head_attention_value_aggregate_with_arithmetic(
+            &mut historical,
+            &attention,
+            &values,
+            0,
+            1,
+            AttentionArithmetic::Conventional,
+        );
+        assert_exact_bits(&shipped, &certified, "value wrapper");
+        assert_ne!(shipped.map(f32::to_bits), historical.map(f32::to_bits));
+    }
+
+    fn assert_exact_bits(got: &[f32], expected: &[f32], context: &str) {
+        assert_eq!(got.len(), expected.len(), "{context}: length");
+        for (lane, (&got, &expected)) in got.iter().zip(expected).enumerate() {
+            assert_eq!(
+                got.to_bits(),
+                expected.to_bits(),
+                "{context}: lane {lane}: got={got:?} expected={expected:?}"
+            );
+        }
+    }
+
+    fn independent_exact_dot(left: &[f32], right: &[f32]) -> f32 {
+        assert_eq!(left.len(), right.len());
+        if left.is_empty() {
+            return 0.0;
+        }
+        let mut output = [f32::from_bits(0x7fc0_704a)];
+        let mut packed_left = vec![uor_matmul::PackedCode::default(); left.len()];
+        let mut packed_right = vec![uor_matmul::PackedCode::default(); right.len()];
+        uor_matmul::slice::gemm_float(
+            1,
+            left.len(),
+            1,
+            left,
+            right,
+            &mut output,
+            &mut packed_left,
+            &mut packed_right,
+        )
+        .expect("independently gathered operands form one exact dot");
+        output[0]
+    }
+
+    fn verify_qk_exact(
+        context: &str,
+        rows: usize,
+        width: usize,
+        query: &[f32],
+        keys: &[f32],
+        key_offset: usize,
+        key_stride: usize,
+    ) -> AttentionDotCensus {
+        let independent: Vec<f32> = (0..rows)
+            .map(|row| {
+                let key: Vec<f32> = (0..width)
+                    .map(|column| keys[row * key_stride + key_offset + column])
+                    .collect();
+                independent_exact_dot(&query[..width], &key)
+            })
+            .collect();
+        let mut exact = vec![f32::NAN; rows];
+        let exact_census = head_dot_products_with_arithmetic(
+            &mut exact,
+            query,
+            keys,
+            key_offset,
+            key_stride,
+            width,
+            AttentionArithmetic::Exact,
+        );
+        assert_eq!(exact_census.exact_control, rows);
+        assert_exact_bits(&exact, &independent, context);
+
+        let mut candidate = vec![f32::NAN; rows];
+        let census = head_dot_products_with_arithmetic(
+            &mut candidate,
+            query,
+            keys,
+            key_offset,
+            key_stride,
+            width,
+            AttentionArithmetic::CertifiedNative,
+        );
+        assert_exact_bits(&candidate, &exact, context);
+        assert_eq!(census.certified + census.fallbacks(), rows);
+        census
+    }
+
+    fn verify_value_exact(
+        context: &str,
+        head_size: usize,
+        attention: &[f32],
+        values: &[f32],
+        value_offset: usize,
+        value_stride: usize,
+    ) -> AttentionDotCensus {
+        let independent: Vec<f32> = (0..head_size)
+            .map(|lane| {
+                let value_lane: Vec<f32> = (0..attention.len())
+                    .map(|position| values[position * value_stride + value_offset + lane])
+                    .collect();
+                independent_exact_dot(attention, &value_lane)
+            })
+            .collect();
+        let mut exact = vec![f32::NAN; head_size];
+        let exact_census = head_attention_value_aggregate_with_arithmetic(
+            &mut exact,
+            attention,
+            values,
+            value_offset,
+            value_stride,
+            AttentionArithmetic::Exact,
+        );
+        assert_eq!(exact_census.exact_control, head_size);
+        assert_exact_bits(&exact, &independent, context);
+
+        let mut candidate = vec![f32::NAN; head_size];
+        let census = head_attention_value_aggregate_with_arithmetic(
+            &mut candidate,
+            attention,
+            values,
+            value_offset,
+            value_stride,
+            AttentionArithmetic::CertifiedNative,
+        );
+        assert_exact_bits(&candidate, &exact, context);
+        assert_eq!(census.certified + census.fallbacks(), head_size);
+        census
+    }
+
+    fn splitmix(seed: &mut u64) -> u64 {
+        *seed = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = *seed;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn moderate_finite(seed: &mut u64) -> f32 {
+        let bits = splitmix(seed);
+        let sign = ((bits >> 63) as u32) << 31;
+        let exponent = 104 + ((bits >> 32) as u32 % 48);
+        let fraction = bits as u32 & 0x007f_ffff;
+        f32::from_bits(sign | (exponent << 23) | fraction)
+    }
+
+    #[test]
+    fn certified_controls_match_independently_gathered_exact_dots() {
+        let tie_term = f32::from_bits(115 << 23);
+        let mut qk = AttentionDotCensus::default();
+        let mut value = AttentionDotCensus::default();
+
+        for part in [
+            verify_qk_exact(
+                "ordinary strided QK",
+                2,
+                4,
+                &[1.0, -2.0, 0.25, 4.0],
+                &[
+                    99.0, 0.5, 0.75, -2.0, 0.25, 77.0, 98.0, -0.25, 0.5, 4.0, -0.5, 76.0,
+                ],
+                1,
+                6,
+            ),
+            verify_qk_exact(
+                "positive RNE tie",
+                1,
+                2,
+                &[1.0, tie_term],
+                &[1.0, tie_term],
+                0,
+                2,
+            ),
+            verify_qk_exact(
+                "exact cancellation to zero",
+                1,
+                2,
+                &[1.0, 1.0],
+                &[1.0, -1.0],
+                0,
+                2,
+            ),
+            verify_qk_exact(
+                "large cancellation residue",
+                1,
+                3,
+                &[1.0e20, 1.0, -1.0e20],
+                &[1.0, 1.0, 1.0],
+                0,
+                3,
+            ),
+            verify_qk_exact("overflow", 1, 1, &[f32::MAX], &[f32::MAX], 0, 1),
+            verify_qk_exact("nonfinite", 1, 1, &[f32::INFINITY], &[1.0], 0, 1),
+        ] {
+            qk.merge(part);
+        }
+        for part in [
+            verify_value_exact(
+                "ordinary strided values",
+                2,
+                &[0.25, -0.5, 0.75],
+                &[99.0, 1.0, 2.0, 98.0, -2.0, 4.0, 97.0, 0.25, -1.0],
+                1,
+                3,
+            ),
+            verify_value_exact("value RNE tie", 1, &[1.0, tie_term], &[1.0, tie_term], 0, 1),
+            verify_value_exact(
+                "value cancellation",
+                1,
+                &[1.0e20, 1.0, -1.0e20],
+                &[1.0, 1.0, 1.0],
+                0,
+                1,
+            ),
+            verify_value_exact("value zero", 1, &[1.0, -1.0], &[1.0, 1.0], 0, 1),
+            verify_value_exact("value overflow", 1, &[f32::MAX], &[f32::MAX], 0, 1),
+            verify_value_exact("value nonfinite", 1, &[f32::NAN], &[1.0], 0, 1),
+        ] {
+            value.merge(part);
+        }
+
+        let mut seed = 0x704a_77e5_d1a5_beef;
+        for case in 0..256usize {
+            let rows = 1 + splitmix(&mut seed) as usize % 12;
+            let width = 1 + splitmix(&mut seed) as usize % 64;
+            let key_offset = splitmix(&mut seed) as usize % 3;
+            let key_stride = key_offset + width + splitmix(&mut seed) as usize % 4;
+            let query: Vec<f32> = (0..width).map(|_| moderate_finite(&mut seed)).collect();
+            let mut keys = vec![0.0; rows * key_stride];
+            for row in 0..rows {
+                for column in 0..width {
+                    keys[row * key_stride + key_offset + column] = moderate_finite(&mut seed);
+                }
+            }
+            if case % 61 == 0 {
+                keys[key_offset] = f32::NEG_INFINITY;
+            }
+            qk.merge(verify_qk_exact(
+                &format!("random QK {case}"),
+                rows,
+                width,
+                &query,
+                &keys,
+                key_offset,
+                key_stride,
+            ));
+
+            let head_size = 1 + splitmix(&mut seed) as usize % 32;
+            let value_offset = splitmix(&mut seed) as usize % 3;
+            let value_stride = value_offset + head_size + splitmix(&mut seed) as usize % 4;
+            let attention: Vec<f32> = (0..rows).map(|_| moderate_finite(&mut seed)).collect();
+            let mut values = vec![0.0; rows * value_stride];
+            for position in 0..rows {
+                for lane in 0..head_size {
+                    values[position * value_stride + value_offset + lane] =
+                        moderate_finite(&mut seed);
+                }
+            }
+            if case % 67 == 0 {
+                values[value_offset] = f32::INFINITY;
+            }
+            value.merge(verify_value_exact(
+                &format!("random value {case}"),
+                head_size,
+                &attention,
+                &values,
+                value_offset,
+                value_stride,
+            ));
+        }
+
+        for (kind, census) in [("QK", qk), ("value", value)] {
+            assert!(census.certified > 0, "{kind}: no certified lane");
+            assert!(census.fallback_nonfinite > 0, "{kind}: nonfinite arm");
+            assert!(census.fallback_zero > 0, "{kind}: zero arm");
+            assert!(census.fallback_overflow > 0, "{kind}: overflow arm");
+            assert!(census.fallback_cell > 0, "{kind}: cell arm");
+        }
+        eprintln!("CERTIFIED_ATTENTION_PARITY qk={qk:?} value={value:?}");
     }
 
     #[test]
@@ -870,12 +2276,154 @@ mod tests {
         let value_offset = head_size;
         let mut out = vec![7.0f32; head_size]; // pre-dirtied: must be zeroed
         head_attention_value_aggregate(&mut out, &att, &values, value_offset, value_stride);
-        for i in 0..head_size {
-            let mut expected = 0.0f32;
-            for (t, &weight) in att.iter().enumerate() {
-                expected += weight * values[t * value_stride + value_offset + i];
+        let mut expected = vec![f32::NAN; head_size];
+        let census = head_attention_value_aggregate_with_arithmetic(
+            &mut expected,
+            &att,
+            &values,
+            value_offset,
+            value_stride,
+            AttentionArithmetic::Exact,
+        );
+        assert_eq!(census.exact_control, head_size);
+        assert_eq!(
+            out.iter().map(|value| value.to_bits()).collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn empty_attention_is_the_zero_weighted_sum_for_every_arithmetic_owner() {
+        let mut public = [7.0f32, 7.0];
+        head_attention_value_aggregate(&mut public, &[], &[], 0, 1);
+        assert_eq!(public.map(f32::to_bits), [0.0f32.to_bits(); 2]);
+
+        for arithmetic in [
+            AttentionArithmetic::Conventional,
+            AttentionArithmetic::Exact,
+            AttentionArithmetic::CertifiedNative,
+        ] {
+            let mut output = [7.0f32, 7.0];
+            let census = head_attention_value_aggregate_with_arithmetic(
+                &mut output,
+                &[],
+                &[],
+                usize::MAX,
+                usize::MAX,
+                arithmetic,
+            );
+            assert_eq!(output.map(f32::to_bits), [0.0f32.to_bits(); 2]);
+            assert_eq!(census.lanes, 2);
+            match arithmetic {
+                AttentionArithmetic::Conventional => {
+                    assert_eq!(census.conventional, 2);
+                    assert_eq!(census.exact_control, 0);
+                    assert_eq!(census.fallbacks(), 0);
+                }
+                AttentionArithmetic::Exact => {
+                    assert_eq!(census.conventional, 0);
+                    assert_eq!(census.exact_control, 2);
+                    assert_eq!(census.fallbacks(), 0);
+                }
+                AttentionArithmetic::CertifiedNative => {
+                    assert_eq!(census.conventional, 0);
+                    assert_eq!(census.exact_control, 0);
+                    assert_eq!(census.certified, 0);
+                    assert_eq!(census.fallback_zero, 2);
+                    assert_eq!(census.fallbacks(), 2);
+                }
             }
-            assert_eq!(out[i].to_bits(), expected.to_bits(), "dimension {i}");
+        }
+    }
+
+    #[test]
+    fn zero_extent_public_attention_weights_are_total_and_uniform() {
+        for weights in [
+            standard_head_attention_weights as fn(&mut [f32], &[f32], &[f32], usize, usize, bool),
+            experimental_r4_head_attention_weights,
+        ] {
+            let mut empty = [];
+            weights(&mut empty, &[], &[], usize::MAX, usize::MAX, false);
+            weights(
+                &mut empty,
+                &[1.0, 2.0, 3.0, 4.0],
+                &[],
+                usize::MAX,
+                usize::MAX,
+                false,
+            );
+
+            let mut singleton = [123.0f32];
+            weights(&mut singleton, &[], &[], usize::MAX, usize::MAX, false);
+            assert_eq!(singleton.map(f32::to_bits), [1.0f32.to_bits()]);
+
+            let mut weights3 = [123.0f32; 3];
+            weights(&mut weights3, &[], &[], usize::MAX, usize::MAX, true);
+            assert!(weights3.iter().all(|weight| weight.is_finite()));
+            assert_eq!(weights3[0].to_bits(), weights3[1].to_bits());
+            assert_eq!(weights3[1].to_bits(), weights3[2].to_bits());
+        }
+
+        for head_size in 1..4 {
+            let mut below_chunk = [123.0f32; 3];
+            experimental_r4_head_attention_weights(
+                &mut below_chunk,
+                &vec![1.0; head_size],
+                &[],
+                usize::MAX,
+                usize::MAX,
+                false,
+            );
+            assert!(below_chunk.iter().all(|weight| weight.is_finite()));
+            assert_eq!(below_chunk[0].to_bits(), below_chunk[1].to_bits());
+            assert_eq!(below_chunk[1].to_bits(), below_chunk[2].to_bits());
+
+            let mut exact = [123.0f32; 2];
+            let census = experimental_r4_head_attention_weights_with_arithmetic(
+                &mut exact,
+                &vec![1.0; head_size],
+                &[],
+                usize::MAX,
+                usize::MAX,
+                true,
+                AttentionArithmetic::Exact,
+            );
+            assert_eq!(exact[0].to_bits(), exact[1].to_bits());
+            assert_eq!(census.exact_control, exact.len());
+        }
+
+        let mut no_value_lanes = [];
+        head_attention_value_aggregate(&mut no_value_lanes, &[1.0], &[], usize::MAX, usize::MAX);
+
+        for arithmetic in [
+            AttentionArithmetic::Conventional,
+            AttentionArithmetic::Exact,
+            AttentionArithmetic::CertifiedNative,
+        ] {
+            let mut output = [123.0f32; 2];
+            let census = standard_head_attention_weights_with_arithmetic(
+                &mut output,
+                &[],
+                &[],
+                usize::MAX,
+                usize::MAX,
+                false,
+                arithmetic,
+            );
+            assert_eq!(output[0].to_bits(), output[1].to_bits());
+            assert_eq!(census.lanes, output.len());
+            match arithmetic {
+                AttentionArithmetic::Conventional => {
+                    assert_eq!(census.conventional, output.len())
+                }
+                AttentionArithmetic::Exact => assert_eq!(census.exact_control, output.len()),
+                AttentionArithmetic::CertifiedNative => {
+                    assert_eq!(census.fallback_zero, output.len())
+                }
+            }
         }
     }
 
@@ -900,11 +2448,11 @@ mod tests {
     }
 
     #[test]
-    fn canonical_serialization_is_byte_stable() {
+    fn legacy_standard_and_experimental_v1_canonical_bytes_remain_immutable() {
         // The canonical forms are pinned byte-for-byte: any drift in
         // field order, separators, or parameter tokens fails here — the
         // digest identity must not move silently.
-        let standard = AttentionOperatorSpec::standard();
+        let standard = AttentionOperatorSpec::standard_v1();
         let pinned_standard = "uor-r4-attention-operator/1\n\
              id=standard-source-attention\n\
              version=1\n\
@@ -923,14 +2471,13 @@ mod tests {
              param.remainder_policy=none-every-head-dimension-scored\n\
              param.score_accumulation=sequential-f32-left-fold\n";
         assert_eq!(standard.canonical_bytes(), pinned_standard.as_bytes());
-        let expected = format!(
-            "blake3:{}",
-            blake3::hash(pinned_standard.as_bytes()).to_hex()
+        assert_pinned_record(&standard, pinned_standard);
+        assert_pinned_digest(
+            &standard,
+            "blake3:d9520065caf35261af680b3b35c9893351166a739f04739df5216882ab5f3437",
         );
-        assert_eq!(standard.implementation_digest, expected);
-        assert_eq!(standard.declared_digest(), expected);
 
-        let experimental = AttentionOperatorSpec::experimental_r4();
+        let experimental = AttentionOperatorSpec::experimental_r4_v1();
         let pinned_experimental = "uor-r4-attention-operator/1\n\
              id=experimental-r4-source-attention\n\
              version=1\n\
@@ -948,29 +2495,174 @@ mod tests {
              param.score_width_policy=chunks-of-4-floor-head-size-div-4\n\
              param.remainder_policy=truncate-trailing-head-size-mod-4-dims-from-score\n\
              param.score_accumulation=per-4-chunk-left-fold-then-chunk-sum\n";
-        assert_eq!(
-            experimental.canonical_bytes(),
-            pinned_experimental.as_bytes()
-        );
-        assert_eq!(
-            experimental.declared_digest(),
-            experimental.implementation_digest
+        assert_pinned_record(&experimental, pinned_experimental);
+        assert_pinned_digest(
+            &experimental,
+            "blake3:aedf1e7732b4a8396f8e3439a7d375fea269c5cb632ca014ff1fdd8c592a3bab",
         );
         assert_ne!(
             standard.implementation_digest, experimental.implementation_digest,
             "the two operators are distinct identities"
         );
         // Rebuilding reproduces the records bit-for-bit.
-        assert_eq!(standard, AttentionOperatorSpec::standard());
-        assert_eq!(experimental, AttentionOperatorSpec::experimental_r4());
+        assert_eq!(standard, AttentionOperatorSpec::standard_v1());
+        assert_eq!(experimental, AttentionOperatorSpec::experimental_r4_v1());
+    }
+
+    #[test]
+    fn current_source_v2_canonical_bytes_and_digests_are_pinned() {
+        let standard = AttentionOperatorSpec::standard_v2();
+        let pinned_standard = "uor-r4-attention-operator/1\n\
+             id=standard-source-attention\n\
+             version=2\n\
+             projections=per-layer-dense-f32-wq-wk-wv\n\
+             positional_action=rope-rotation-of-q-and-k-before-scoring\n\
+             compatibility_relation=correctly-rounded-binary32-exact-real-full-width-dot\n\
+             selector_normalization=divide-by-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-per-weight-divide\n\
+             value_aggregation=correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n\
+             output_projection=per-layer-dense-f32-wo\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback\n\
+             param.head_selection=grouped-query-kv-head-h-div-kv-mul\n\
+             param.score_scale=divide-by-sqrt-full-head-size\n\
+             param.score_width_policy=full-head-width\n\
+             param.remainder_policy=none-every-head-dimension-scored\n\
+             param.score_accumulation=correctly-rounded-binary32-exact-real-dot-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n";
+        assert_eq!(pinned_standard.len(), 1_075);
+        assert_pinned_record(&standard, pinned_standard);
+        assert_pinned_digest(
+            &standard,
+            "blake3:fa4c8f233e217d3903678b7690de5cdfb27d83a4b68c52436cfabbc6ca6cfc59",
+        );
+
+        let experimental = AttentionOperatorSpec::experimental_r4_v2();
+        let pinned_experimental = "uor-r4-attention-operator/1\n\
+             id=experimental-r4-source-attention\n\
+             version=2\n\
+             projections=per-layer-dense-f32-wq-wk-wv\n\
+             positional_action=rope-rotation-of-q-and-k-before-scoring\n\
+             compatibility_relation=correctly-rounded-binary32-exact-real-floor-multiple-of-4-width-dot\n\
+             selector_normalization=divide-by-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-per-weight-divide\n\
+             value_aggregation=correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n\
+             output_projection=per-layer-dense-f32-wo\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback\n\
+             param.head_selection=grouped-query-kv-head-h-div-kv-mul\n\
+             param.score_scale=divide-by-sqrt-full-head-size\n\
+             param.score_width_policy=chunks-of-4-floor-head-size-div-4\n\
+             param.remainder_policy=truncate-trailing-head-size-mod-4-dims-from-score\n\
+             param.score_accumulation=correctly-rounded-binary32-exact-real-dot-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n";
+        assert_eq!(pinned_experimental.len(), 1_132);
+        assert_pinned_record(&experimental, pinned_experimental);
+        assert_pinned_digest(
+            &experimental,
+            "blake3:a71d3a9fbfd951528652b837a23d5bfd7742ba79d5082337c19db3a17776e654",
+        );
+
+        let learned = AttentionOperatorSpec::learned_absolute_v2();
+        let pinned_learned = "uor-r4-attention-operator/1\n\
+             id=learned-absolute-source-attention\n\
+             version=2\n\
+             projections=fused-c-attn-conv1d-qkv-with-bias\n\
+             positional_action=none-learned-absolute-positions-added-to-input-embeddings\n\
+             compatibility_relation=correctly-rounded-binary32-exact-real-full-width-dot\n\
+             selector_normalization=multiply-by-reciprocal-sqrt-full-head-size-then-softmax-max-subtracted-exp-sum-reciprocal-multiply\n\
+             value_aggregation=correctly-rounded-binary32-exact-real-position-weighted-sum-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n\
+             output_projection=dense-c-proj-conv1d-with-bias\n\
+             runtime_state=growing-kv-cache-full-prefix\n\
+             tie_breaking=first-maximum-softmax-stabilizer-value-identical\n\
+             permitted_operation_class=host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback\n\
+             param.head_selection=multi-head-identity-kv-head-equals-query-head\n\
+             param.score_scale=multiply-by-reciprocal-sqrt-full-head-size\n\
+             param.score_width_policy=full-head-width\n\
+             param.remainder_policy=none-every-head-dimension-scored\n\
+             param.score_accumulation=correctly-rounded-binary32-exact-real-dot-certified-native-f64-outward-cell-or-pinned-uor-matmul-exact-fallback\n";
+        assert_eq!(pinned_learned.len(), 1_152);
+        assert_pinned_record(&learned, pinned_learned);
+        assert_pinned_digest(
+            &learned,
+            "blake3:ba36fd1fef53a2e3744e1fee60e72677870d1cd2f2b484db755c0a5a74727231",
+        );
+
+        assert_eq!(AttentionOperatorSpec::standard(), standard);
+        assert_eq!(AttentionOperatorSpec::experimental_r4(), experimental);
+        assert_eq!(
+            AttentionOperatorSpec::learned_absolute_source_attention(),
+            learned
+        );
+        assert_eq!(
+            AttentionOperatorParams::standard(),
+            AttentionOperatorParams::standard_v2()
+        );
+        assert_eq!(
+            AttentionOperatorParams::experimental_r4(),
+            AttentionOperatorParams::experimental_r4_v2()
+        );
+        assert_eq!(
+            AttentionOperatorParams::learned_absolute(),
+            AttentionOperatorParams::learned_absolute_v2()
+        );
+        for record in [&standard, &experimental, &learned] {
+            assert_eq!(
+                record.params.score_accumulation,
+                CERTIFIED_NATIVE_ARITHMETIC_ID
+            );
+        }
+    }
+
+    #[test]
+    fn source_v2_keeps_model_family_semantics_but_mismatches_v1() {
+        for (v1, v2) in [
+            (
+                AttentionOperatorSpec::standard_v1(),
+                AttentionOperatorSpec::standard_v2(),
+            ),
+            (
+                AttentionOperatorSpec::experimental_r4_v1(),
+                AttentionOperatorSpec::experimental_r4_v2(),
+            ),
+            (
+                AttentionOperatorSpec::learned_absolute_v1(),
+                AttentionOperatorSpec::learned_absolute_v2(),
+            ),
+        ] {
+            assert_eq!(v2.id, v1.id);
+            assert_eq!(v2.projections, v1.projections);
+            assert_eq!(v2.positional_action, v1.positional_action);
+            assert_eq!(v2.output_projection, v1.output_projection);
+            assert_eq!(v2.runtime_state, v1.runtime_state);
+            assert_eq!(v2.tie_breaking, v1.tie_breaking);
+            assert_eq!(v2.params.head_selection, v1.params.head_selection);
+            assert_eq!(v2.params.score_scale, v1.params.score_scale);
+            assert_eq!(v2.params.score_width_policy, v1.params.score_width_policy);
+            assert_eq!(v2.params.remainder_policy, v1.params.remainder_policy);
+            assert_ne!(v2.version, v1.version);
+            assert_ne!(v2.implementation_digest, v1.implementation_digest);
+            assert_ne!(v2, v1, "same-id source eras must fail equality checks");
+        }
+        assert!(AttentionOperatorSpec::standard_v2()
+            .selector_normalization
+            .contains("per-weight-divide"));
+        assert!(AttentionOperatorSpec::experimental_r4_v2()
+            .params
+            .remainder_policy
+            .contains("truncate-trailing"));
+        assert!(AttentionOperatorSpec::learned_absolute_v2()
+            .selector_normalization
+            .contains("reciprocal-multiply"));
     }
 
     #[test]
     fn record_round_trips_through_serde_json() {
         for record in [
+            AttentionOperatorSpec::standard_v1(),
             AttentionOperatorSpec::standard(),
+            AttentionOperatorSpec::experimental_r4_v1(),
             AttentionOperatorSpec::experimental_r4(),
             AttentionOperatorSpec::r4_route_attention_v1(),
+            AttentionOperatorSpec::learned_absolute_v1(),
             AttentionOperatorSpec::learned_absolute_source_attention(),
         ] {
             let json = serde_json::to_string(&record).expect("serializes");
@@ -1014,33 +2706,48 @@ mod tests {
 
     #[test]
     fn registry_resolves_all_registered_operators() {
-        let standard = operator_spec(
-            AttentionOperatorSpec::STANDARD_ID,
-            AttentionOperatorSpec::STANDARD_VERSION,
-        )
-        .expect("registered standard operator");
-        assert_eq!(standard, AttentionOperatorSpec::standard());
-        let experimental = operator_spec(
-            AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
-            AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
-        )
-        .expect("registered experimental operator");
-        assert_eq!(experimental, AttentionOperatorSpec::experimental_r4());
-        let target = operator_spec(
-            AttentionOperatorSpec::R4_ROUTE_ID,
-            AttentionOperatorSpec::R4_ROUTE_VERSION,
-        )
-        .expect("registered target route operator");
-        assert_eq!(target, AttentionOperatorSpec::r4_route_attention_v1());
-        let learned = operator_spec(
-            AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
-            AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
-        )
-        .expect("registered learned-absolute operator");
-        assert_eq!(
-            learned,
-            AttentionOperatorSpec::learned_absolute_source_attention()
-        );
+        for (id, version, expected) in [
+            (
+                AttentionOperatorSpec::STANDARD_ID,
+                AttentionOperatorSpec::STANDARD_V1_VERSION,
+                AttentionOperatorSpec::standard_v1(),
+            ),
+            (
+                AttentionOperatorSpec::STANDARD_ID,
+                AttentionOperatorSpec::STANDARD_V2_VERSION,
+                AttentionOperatorSpec::standard_v2(),
+            ),
+            (
+                AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+                AttentionOperatorSpec::EXPERIMENTAL_R4_V1_VERSION,
+                AttentionOperatorSpec::experimental_r4_v1(),
+            ),
+            (
+                AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+                AttentionOperatorSpec::EXPERIMENTAL_R4_V2_VERSION,
+                AttentionOperatorSpec::experimental_r4_v2(),
+            ),
+            (
+                AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                AttentionOperatorSpec::LEARNED_ABSOLUTE_V1_VERSION,
+                AttentionOperatorSpec::learned_absolute_v1(),
+            ),
+            (
+                AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                AttentionOperatorSpec::LEARNED_ABSOLUTE_V2_VERSION,
+                AttentionOperatorSpec::learned_absolute_v2(),
+            ),
+            (
+                AttentionOperatorSpec::R4_ROUTE_ID,
+                AttentionOperatorSpec::R4_ROUTE_VERSION,
+                AttentionOperatorSpec::r4_route_attention_v1(),
+            ),
+        ] {
+            assert_eq!(
+                operator_spec(id, version).expect("registered entry"),
+                expected
+            );
+        }
     }
 
     #[test]
@@ -1067,9 +2774,11 @@ mod tests {
              param.remainder_policy=unmasked-bits-never-scored\n\
              param.score_accumulation=per-byte-popcount-table-add-left-fold\n";
         assert_eq!(target.canonical_bytes(), pinned.as_bytes());
-        let expected = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
-        assert_eq!(target.implementation_digest, expected);
-        assert_eq!(target.declared_digest(), expected);
+        assert_eq!(target.canonical_bytes().len(), 860);
+        assert_pinned_digest(
+            &target,
+            "blake3:33e5e5c58d4a33caea0409f1263df4213419e52bb5999144570dd959e5ee151d",
+        );
         // Distinct identity from both source operators.
         assert_ne!(
             target.implementation_digest,
@@ -1086,19 +2795,23 @@ mod tests {
             "deployed-integer-xor-popcount-add-compare-table-read"
         );
         assert_eq!(
-            AttentionOperatorSpec::standard().permitted_operation_class,
+            AttentionOperatorSpec::standard_v1().permitted_operation_class,
             "host-source-f32"
+        );
+        assert_eq!(
+            AttentionOperatorSpec::standard().permitted_operation_class,
+            "host-source-f32-f64-certified-plus-pinned-uor-matmul-exact-fallback"
         );
         // Rebuilding reproduces the record bit-for-bit.
         assert_eq!(target, AttentionOperatorSpec::r4_route_attention_v1());
     }
 
     #[test]
-    fn learned_absolute_canonical_serialization_is_byte_stable() {
+    fn legacy_learned_absolute_v1_canonical_bytes_remain_immutable() {
         // #668: the GPT-2-family operator's declared identity, pinned
         // byte-for-byte. Any drift in a field token is a version bump,
         // never a silent edit.
-        let learned = AttentionOperatorSpec::learned_absolute_source_attention();
+        let learned = AttentionOperatorSpec::learned_absolute_v1();
         let pinned = "uor-r4-attention-operator/1\n\
              id=learned-absolute-source-attention\n\
              version=1\n\
@@ -1117,14 +2830,16 @@ mod tests {
              param.remainder_policy=none-every-head-dimension-scored\n\
              param.score_accumulation=sequential-f32-left-fold\n";
         assert_eq!(learned.canonical_bytes(), pinned.as_bytes());
-        let expected = format!("blake3:{}", blake3::hash(pinned.as_bytes()).to_hex());
-        assert_eq!(learned.implementation_digest, expected);
-        assert_eq!(learned.declared_digest(), expected);
+        assert_pinned_record(&learned, pinned);
+        assert_pinned_digest(
+            &learned,
+            "blake3:00088e46d2b68616f8e58c33ce6b621925f82be5b22607f080e5f142e753796f",
+        );
 
         // It shares the standard operator's compatibility relation and
         // softmax selector, but is a DISTINCT identity: the positional
         // action and projections differ, so the declared digest differs.
-        let standard = AttentionOperatorSpec::standard();
+        let standard = AttentionOperatorSpec::standard_v1();
         assert_eq!(
             learned.compatibility_relation,
             standard.compatibility_relation
@@ -1143,21 +2858,19 @@ mod tests {
         );
         assert_ne!(
             learned.implementation_digest,
-            AttentionOperatorSpec::experimental_r4().implementation_digest
+            AttentionOperatorSpec::experimental_r4_v1().implementation_digest
         );
         // Rebuilding reproduces the record bit-for-bit.
-        assert_eq!(
-            learned,
-            AttentionOperatorSpec::learned_absolute_source_attention()
-        );
+        assert_eq!(learned, AttentionOperatorSpec::learned_absolute_v1());
     }
 
     #[test]
     fn registry_refuses_unknown_id_and_version_by_name() {
         for (id, version) in [
-            ("standard-source-attention", 2u32),
-            ("experimental-r4-source-attention", 9),
-            ("learned-absolute-source-attention", 2),
+            ("standard-source-attention", 3u32),
+            ("experimental-r4-source-attention", 3),
+            ("learned-absolute-source-attention", 3),
+            ("r4-route-attention", 2),
             ("mystery-attention", 1),
         ] {
             let error =

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -825,6 +825,12 @@ enum CertificationRejection {
     Cell,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CertificationVerdict {
+    Certified(f32),
+    Rejected(CertificationRejection),
+}
+
 impl AttentionDotCensus {
     fn zero_dot(lanes: usize, arithmetic: AttentionArithmetic) -> Self {
         match arithmetic {
@@ -919,36 +925,32 @@ fn next_down_f32(value: f32) -> f32 {
 /// accumulation cannot underflow binary64; with `k <= 2^53`, even
 /// `k * f32::MAX^2` remains far below binary64 overflow.
 #[inline]
-fn certify_dot(
-    approximate: f64,
-    max_product_abs: f64,
-    k: usize,
-) -> Result<f32, CertificationRejection> {
+fn certify_dot(approximate: f64, max_product_abs: f64, k: usize) -> CertificationVerdict {
     if !approximate.is_finite() || !max_product_abs.is_finite() {
-        return Err(CertificationRejection::Nonfinite);
+        return CertificationVerdict::Rejected(CertificationRejection::Nonfinite);
     }
     let candidate = approximate as f32;
     if candidate == 0.0 {
-        return Err(CertificationRejection::Zero);
+        return CertificationVerdict::Rejected(CertificationRejection::Zero);
     }
     if !candidate.is_finite() || candidate.abs() == f32::MAX {
-        return Err(CertificationRejection::Overflow);
+        return CertificationVerdict::Rejected(CertificationRejection::Overflow);
     }
     if (k as u128) > (1u128 << f64::MANTISSA_DIGITS) {
-        return Err(CertificationRejection::Cell);
+        return CertificationVerdict::Rejected(CertificationRejection::Cell);
     }
 
     const UNIT_ROUNDOFF: f64 = 1.0 / ((1u64 << 53) as f64);
     let mu = next_up_f64((k as f64) * UNIT_ROUNDOFF);
     if mu >= 1.0 {
-        return Err(CertificationRejection::Cell);
+        return CertificationVerdict::Rejected(CertificationRejection::Cell);
     }
     let denominator = next_down_f64(1.0 - mu);
     let gamma = next_up_f64(mu / denominator);
     let sum_abs = next_up_f64((k as f64) * max_product_abs);
     let error = next_up_f64(gamma * sum_abs);
     if !error.is_finite() {
-        return Err(CertificationRejection::Cell);
+        return CertificationVerdict::Rejected(CertificationRejection::Cell);
     }
     let lower = next_down_f64(approximate - error);
     let upper = next_up_f64(approximate + error);
@@ -956,14 +958,14 @@ fn certify_dot(
     let previous = next_down_f32(candidate);
     let next = next_up_f32(candidate);
     if !previous.is_finite() || !next.is_finite() {
-        return Err(CertificationRejection::Overflow);
+        return CertificationVerdict::Rejected(CertificationRejection::Overflow);
     }
     let cell_lower = (f64::from(previous) + f64::from(candidate)) * 0.5;
     let cell_upper = (f64::from(candidate) + f64::from(next)) * 0.5;
     if lower > cell_lower && upper < cell_upper {
-        Ok(candidate)
+        CertificationVerdict::Certified(candidate)
     } else {
-        Err(CertificationRejection::Cell)
+        CertificationVerdict::Rejected(CertificationRejection::Cell)
     }
 }
 
@@ -1073,14 +1075,14 @@ fn controlled_strided_matrix_vector(
                 let verdict = if finite {
                     certify_dot(sum, max_product_abs, columns)
                 } else {
-                    Err(CertificationRejection::Nonfinite)
+                    CertificationVerdict::Rejected(CertificationRejection::Nonfinite)
                 };
                 match verdict {
-                    Ok(value) => {
+                    CertificationVerdict::Certified(value) => {
                         *output = value;
                         census.certified += 1;
                     }
-                    Err(reason) => {
+                    CertificationVerdict::Rejected(reason) => {
                         census.reject(reason);
                         *output = exact_strided_dot(
                             matrix,

--- a/crates/uor-r4-model-source/src/conformance.rs
+++ b/crates/uor-r4-model-source/src/conformance.rs
@@ -627,10 +627,12 @@ pub struct TopKEntry {
     pub probability: f32,
 }
 
-/// Per-check absolute tolerances. Defaults (see [`Default`]) cover the
-/// deterministic-per-machine variance between the fast SIMD matmul backends
-/// the teacher may select on different hosts; on one host a replay is
-/// bit-identical and every delta is zero.
+/// Per-check absolute tolerances. Defaults (see [`Default`]) retain legacy
+/// fixture compatibility and cover the remaining noncanonical libm/reduction
+/// family. They are not Llama weight-projection tolerances: those projections
+/// use the pinned portable exact `uor-matmul` owner, while Gate E separately
+/// owns the canonical cross-platform byte-reproduction claim. GPT-2 has its
+/// own declared dense and current-attention arithmetic records.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FixtureTolerances {

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -265,6 +265,18 @@ impl Gpt2 {
             source_bytes: snapshot.source_bytes(),
         })
     }
+
+    /// Loaded model digest exposed only for hard-binding the #704 canary.
+    #[doc(hidden)]
+    pub fn attention_control_source_kappa(&self) -> &str {
+        &self.kappa
+    }
+
+    /// Loaded model byte count exposed only for hard-binding the #704 canary.
+    #[doc(hidden)]
+    pub fn attention_control_source_bytes(&self) -> usize {
+        self.source_bytes
+    }
 }
 
 /// GPT-2's `gelu_new` (the tanh approximation the checkpoint was trained
@@ -339,8 +351,55 @@ fn conv1d_batched(
     }
 }
 
+/// Preserve GPT-2's scalar post-dot order: multiply every raw Q·K result by
+/// one precomputed reciprocal square-root, then use one reciprocal of the
+/// softmax sum and multiply every normalized weight by it.
+fn scale_and_normalize_attention_scores(scores: &mut [f32], scale: f32) {
+    let mut max = f32::NEG_INFINITY;
+    for score in scores.iter_mut() {
+        *score *= scale;
+        if *score > max {
+            max = *score;
+        }
+    }
+    let mut sum = 0.0f32;
+    for score in scores.iter_mut() {
+        *score = (*score - max).exp();
+        sum += *score;
+    }
+    let inverse = 1.0 / sum;
+    for score in scores.iter_mut() {
+        *score *= inverse;
+    }
+}
+
+/// GPT-2 Q·K control preserving its reciprocal-multiply normalization order.
+#[doc(hidden)]
+pub(crate) fn attention_weights_with_arithmetic(
+    scores: &mut [f32],
+    q: &[f32],
+    keys: &[f32],
+    key_offset: usize,
+    key_stride: usize,
+    arithmetic: crate::attention::AttentionArithmetic,
+) -> crate::attention::AttentionDotCensus {
+    let census = crate::attention::head_dot_products_with_arithmetic(
+        scores,
+        q,
+        keys,
+        key_offset,
+        key_stride,
+        q.len(),
+        arithmetic,
+    );
+    let scale = 1.0 / (q.len() as f32).sqrt();
+    scale_and_normalize_attention_scores(scores, scale);
+    census
+}
+
 /// Recurrent decode state: per-layer key/value caches, the working
 /// residual, the final hidden state, and the last step's logits.
+#[derive(Clone, Debug, PartialEq)]
 pub struct Gpt2State {
     k_cache: Vec<f32>,
     v_cache: Vec<f32>,
@@ -349,6 +408,227 @@ pub struct Gpt2State {
     /// Final hidden state (post `ln_f`) of the last step (`n_embd`).
     pub hidden: Vec<f32>,
     x: Vec<f32>,
+}
+
+/// Arithmetic arm selected by the checked, evidence-only GPT-2 attention
+/// canary façade. Raw strided attention controls remain crate-private.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Gpt2AttentionCanaryMode {
+    Conventional,
+    Exact,
+    CertifiedNative,
+}
+
+/// Certified-lane and exact-fallback counts returned by the checked canary
+/// façade. Unlike the crate-private proof census, this report exposes no raw
+/// layout control.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Gpt2AttentionCanaryDotCensus {
+    lanes: usize,
+    certified: usize,
+    fallback_nonfinite: usize,
+    fallback_zero: usize,
+    fallback_overflow: usize,
+    fallback_cell: usize,
+}
+
+impl Gpt2AttentionCanaryDotCensus {
+    pub const fn lanes(self) -> usize {
+        self.lanes
+    }
+
+    pub const fn certified(self) -> usize {
+        self.certified
+    }
+
+    pub const fn fallback_nonfinite(self) -> usize {
+        self.fallback_nonfinite
+    }
+
+    pub const fn fallback_zero(self) -> usize {
+        self.fallback_zero
+    }
+
+    pub const fn fallback_overflow(self) -> usize {
+        self.fallback_overflow
+    }
+
+    pub const fn fallback_cell(self) -> usize {
+        self.fallback_cell
+    }
+
+    pub fn fallbacks(self) -> Result<usize, Gpt2AttentionCanaryError> {
+        checked_canary_count(
+            "fallback census",
+            self.fallback_nonfinite,
+            self.fallback_zero,
+        )
+        .and_then(|total| checked_canary_count("fallback census", total, self.fallback_overflow))
+        .and_then(|total| checked_canary_count("fallback census", total, self.fallback_cell))
+    }
+
+    fn checked_merge(
+        self,
+        other: Self,
+        component: &'static str,
+    ) -> Result<Self, Gpt2AttentionCanaryError> {
+        Ok(Self {
+            lanes: checked_canary_count(component, self.lanes, other.lanes)?,
+            certified: checked_canary_count(component, self.certified, other.certified)?,
+            fallback_nonfinite: checked_canary_count(
+                component,
+                self.fallback_nonfinite,
+                other.fallback_nonfinite,
+            )?,
+            fallback_zero: checked_canary_count(
+                component,
+                self.fallback_zero,
+                other.fallback_zero,
+            )?,
+            fallback_overflow: checked_canary_count(
+                component,
+                self.fallback_overflow,
+                other.fallback_overflow,
+            )?,
+            fallback_cell: checked_canary_count(
+                component,
+                self.fallback_cell,
+                other.fallback_cell,
+            )?,
+        })
+    }
+}
+
+impl From<crate::attention::AttentionDotCensus> for Gpt2AttentionCanaryDotCensus {
+    fn from(value: crate::attention::AttentionDotCensus) -> Self {
+        Self {
+            lanes: value.lanes,
+            certified: value.certified,
+            fallback_nonfinite: value.fallback_nonfinite,
+            fallback_zero: value.fallback_zero,
+            fallback_overflow: value.fallback_overflow,
+            fallback_cell: value.fallback_cell,
+        }
+    }
+}
+
+/// Aggregate QK and weighted-value census for a checked GPT-2 canary story.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Gpt2AttentionCanaryCensus {
+    qk: Gpt2AttentionCanaryDotCensus,
+    value: Gpt2AttentionCanaryDotCensus,
+}
+
+impl Gpt2AttentionCanaryCensus {
+    pub const fn qk(self) -> Gpt2AttentionCanaryDotCensus {
+        self.qk
+    }
+
+    pub const fn value(self) -> Gpt2AttentionCanaryDotCensus {
+        self.value
+    }
+
+    pub fn merge(&mut self, other: Self) -> Result<(), Gpt2AttentionCanaryError> {
+        let qk = self.qk.checked_merge(other.qk, "QK census")?;
+        let value = self.value.checked_merge(other.value, "value census")?;
+        self.qk = qk;
+        self.value = value;
+        Ok(())
+    }
+}
+
+impl From<crate::attention::AttentionArithmeticCensus> for Gpt2AttentionCanaryCensus {
+    fn from(value: crate::attention::AttentionArithmeticCensus) -> Self {
+        Self {
+            qk: value.qk.into(),
+            value: value.value.into(),
+        }
+    }
+}
+
+/// Failure from the checked, evidence-only GPT-2 attention canary façade.
+/// Every error is reported before either recurrent state or workspace bytes
+/// are mutated.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Gpt2AttentionCanaryError {
+    IndexOutOfRange {
+        component: &'static str,
+        index: usize,
+        bound: usize,
+    },
+    InvalidGeometry {
+        component: &'static str,
+    },
+    GeometryOverflow {
+        component: &'static str,
+    },
+    CounterOverflow {
+        component: &'static str,
+    },
+    LengthMismatch {
+        component: &'static str,
+        layer: Option<usize>,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl std::fmt::Display for Gpt2AttentionCanaryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IndexOutOfRange {
+                component,
+                index,
+                bound,
+            } => write!(formatter, "{component} index {index} is outside 0..{bound}"),
+            Self::InvalidGeometry { component } => {
+                write!(formatter, "invalid GPT-2 canary geometry: {component}")
+            }
+            Self::GeometryOverflow { component } => {
+                write!(
+                    formatter,
+                    "GPT-2 canary geometry overflows usize: {component}"
+                )
+            }
+            Self::CounterOverflow { component } => {
+                write!(formatter, "GPT-2 attention canary {component} overflow")
+            }
+            Self::LengthMismatch {
+                component,
+                layer,
+                expected,
+                actual,
+            } => {
+                if let Some(layer) = layer {
+                    write!(
+                        formatter,
+                        "GPT-2 canary layer {layer} {component} length {actual}, expected {expected}"
+                    )
+                } else {
+                    write!(
+                        formatter,
+                        "GPT-2 canary {component} length {actual}, expected {expected}"
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for Gpt2AttentionCanaryError {}
+
+fn checked_canary_count(
+    component: &'static str,
+    left: usize,
+    right: usize,
+) -> Result<usize, Gpt2AttentionCanaryError> {
+    left.checked_add(right)
+        .ok_or(Gpt2AttentionCanaryError::CounterOverflow { component })
 }
 
 impl Gpt2State {
@@ -373,7 +653,218 @@ impl Gpt2State {
     }
 }
 
+/// Opaque caller-owned scratch for the checked #704 attention canary façade.
+/// Construction is outside the hot path; every checked step validates and
+/// reuses these buffers without allocation.
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gpt2AttentionCanaryWorkspace {
+    normed: Vec<f32>,
+    qkv: Vec<f32>,
+    attn: Vec<f32>,
+    proj: Vec<f32>,
+    inner: Vec<f32>,
+    mlp_out: Vec<f32>,
+    scores: Vec<f32>,
+}
+
+impl Gpt2AttentionCanaryWorkspace {
+    fn new(config: &Gpt2Config) -> Self {
+        Self {
+            normed: vec![0.0; config.n_embd],
+            qkv: vec![0.0; 3 * config.n_embd],
+            attn: vec![0.0; config.n_embd],
+            proj: vec![0.0; config.n_embd],
+            inner: vec![0.0; config.n_inner],
+            mlp_out: vec![0.0; config.n_embd],
+            scores: vec![0.0; config.seq_len],
+        }
+    }
+}
+
+fn canary_product(
+    component: &'static str,
+    factors: &[usize],
+) -> Result<usize, Gpt2AttentionCanaryError> {
+    factors.iter().try_fold(1usize, |product, &factor| {
+        product
+            .checked_mul(factor)
+            .ok_or(Gpt2AttentionCanaryError::GeometryOverflow { component })
+    })
+}
+
+fn require_canary_length(
+    component: &'static str,
+    layer: Option<usize>,
+    actual: usize,
+    expected: usize,
+) -> Result<(), Gpt2AttentionCanaryError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(Gpt2AttentionCanaryError::LengthMismatch {
+            component,
+            layer,
+            expected,
+            actual,
+        })
+    }
+}
+
 impl Gpt2 {
+    fn validate_attention_canary_model(&self) -> Result<(), Gpt2AttentionCanaryError> {
+        let config = &self.cfg;
+        if config.n_embd == 0 {
+            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "n_embd must be nonzero",
+            });
+        }
+        if config.n_layer == 0 {
+            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "n_layer must be nonzero",
+            });
+        }
+        if config.vocab == 0 {
+            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "vocab must be nonzero",
+            });
+        }
+        if config.n_head == 0 || !config.n_embd.is_multiple_of(config.n_head) {
+            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "n_head must be nonzero and divide n_embd",
+            });
+        }
+        if config.seq_len == 0 || config.seq_len > config.n_positions {
+            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "seq_len must be in 1..=n_positions",
+            });
+        }
+
+        let d = config.n_embd;
+        let three_d = canary_product("3 * n_embd", &[3, d])?;
+        let token_table = canary_product("vocab * n_embd", &[config.vocab, d])?;
+        let position_table = canary_product("n_positions * n_embd", &[config.n_positions, d])?;
+        let square = canary_product("n_embd * n_embd", &[d, d])?;
+        let attention_projection = canary_product("n_embd * 3 * n_embd", &[d, three_d])?;
+        let feed_forward = canary_product("n_embd * n_inner", &[d, config.n_inner])?;
+        canary_product(
+            "n_layer * seq_len * n_embd",
+            &[config.n_layer, config.seq_len, d],
+        )?;
+
+        require_canary_length("model.wte", None, self.wte.len(), token_table)?;
+        require_canary_length("model.wpe", None, self.wpe.len(), position_table)?;
+        require_canary_length("model.layers", None, self.layers.len(), config.n_layer)?;
+        require_canary_length("model.ln_f_w", None, self.ln_f_w.len(), d)?;
+        require_canary_length("model.ln_f_b", None, self.ln_f_b.len(), d)?;
+        for layer_index in 0..self.layers.len() {
+            let layer = Some(layer_index);
+            require_canary_length("ln1_w", layer, self.layers[layer_index].ln1_w.len(), d)?;
+            require_canary_length("ln1_b", layer, self.layers[layer_index].ln1_b.len(), d)?;
+            require_canary_length(
+                "c_attn_w",
+                layer,
+                self.layers[layer_index].c_attn_w.len(),
+                attention_projection,
+            )?;
+            require_canary_length(
+                "c_attn_b",
+                layer,
+                self.layers[layer_index].c_attn_b.len(),
+                three_d,
+            )?;
+            require_canary_length(
+                "c_proj_w",
+                layer,
+                self.layers[layer_index].c_proj_w.len(),
+                square,
+            )?;
+            require_canary_length(
+                "c_proj_b",
+                layer,
+                self.layers[layer_index].c_proj_b.len(),
+                d,
+            )?;
+            require_canary_length("ln2_w", layer, self.layers[layer_index].ln2_w.len(), d)?;
+            require_canary_length("ln2_b", layer, self.layers[layer_index].ln2_b.len(), d)?;
+            require_canary_length(
+                "fc_w",
+                layer,
+                self.layers[layer_index].fc_w.len(),
+                feed_forward,
+            )?;
+            require_canary_length(
+                "fc_b",
+                layer,
+                self.layers[layer_index].fc_b.len(),
+                config.n_inner,
+            )?;
+            require_canary_length(
+                "mlp_w",
+                layer,
+                self.layers[layer_index].mlp_w.len(),
+                feed_forward,
+            )?;
+            require_canary_length("mlp_b", layer, self.layers[layer_index].mlp_b.len(), d)?;
+        }
+        Ok(())
+    }
+
+    fn validate_attention_canary_inputs(
+        &self,
+        state: &Gpt2State,
+        workspace: &Gpt2AttentionCanaryWorkspace,
+        token: usize,
+        pos: usize,
+    ) -> Result<(), Gpt2AttentionCanaryError> {
+        self.validate_attention_canary_model()?;
+        let config = &self.cfg;
+        if token >= config.vocab {
+            return Err(Gpt2AttentionCanaryError::IndexOutOfRange {
+                component: "token",
+                index: token,
+                bound: config.vocab,
+            });
+        }
+        if pos >= config.seq_len {
+            return Err(Gpt2AttentionCanaryError::IndexOutOfRange {
+                component: "position",
+                index: pos,
+                bound: config.seq_len,
+            });
+        }
+
+        let d = config.n_embd;
+        let three_d = canary_product("3 * n_embd", &[3, d])?;
+        let cache = canary_product(
+            "n_layer * seq_len * n_embd",
+            &[config.n_layer, config.seq_len, d],
+        )?;
+        require_canary_length("state.k_cache", None, state.k_cache.len(), cache)?;
+        require_canary_length("state.v_cache", None, state.v_cache.len(), cache)?;
+        require_canary_length("state.logits", None, state.logits.len(), config.vocab)?;
+        require_canary_length("state.hidden", None, state.hidden.len(), d)?;
+        require_canary_length("state.x", None, state.x.len(), d)?;
+        require_canary_length("workspace.normed", None, workspace.normed.len(), d)?;
+        require_canary_length("workspace.qkv", None, workspace.qkv.len(), three_d)?;
+        require_canary_length("workspace.attn", None, workspace.attn.len(), d)?;
+        require_canary_length("workspace.proj", None, workspace.proj.len(), d)?;
+        require_canary_length(
+            "workspace.inner",
+            None,
+            workspace.inner.len(),
+            config.n_inner,
+        )?;
+        require_canary_length("workspace.mlp_out", None, workspace.mlp_out.len(), d)?;
+        require_canary_length(
+            "workspace.scores",
+            None,
+            workspace.scores.len(),
+            config.seq_len,
+        )?;
+        Ok(())
+    }
+
     /// One teacher-forced forward step at `pos` (0-based), leaving logits
     /// and the final hidden state in `st`. `capture` receives the
     /// post-block residual stream for each declared layer index, in
@@ -418,6 +909,96 @@ impl Gpt2 {
             }
         }
         self.finish_forward(st);
+    }
+
+    fn forward_with_attention_arithmetic_unchecked(
+        &self,
+        st: &mut Gpt2State,
+        workspace: &mut Gpt2AttentionCanaryWorkspace,
+        token: usize,
+        pos: usize,
+        arithmetic: crate::attention::AttentionArithmetic,
+    ) -> crate::attention::AttentionArithmeticCensus {
+        let d = self.cfg.n_embd;
+        for i in 0..d {
+            st.x[i] = self.wte[token * d + i] + self.wpe[pos * d + i];
+        }
+        let mut census = crate::attention::AttentionArithmeticCensus::default();
+        for layer in 0..self.cfg.n_layer {
+            let block = self.block_forward_with_attention_arithmetic(
+                st,
+                layer,
+                pos,
+                &mut workspace.normed,
+                &mut workspace.qkv,
+                &mut workspace.attn,
+                &mut workspace.proj,
+                &mut workspace.inner,
+                &mut workspace.mlp_out,
+                &mut workspace.scores[..=pos],
+                arithmetic,
+            );
+            census.merge(block);
+        }
+        self.finish_forward_without_allocation(st);
+        census
+    }
+
+    /// Allocate opaque scratch for the checked attention canary façade.
+    #[doc(hidden)]
+    pub fn attention_canary_workspace(
+        &self,
+    ) -> Result<Gpt2AttentionCanaryWorkspace, Gpt2AttentionCanaryError> {
+        self.validate_attention_canary_model()?;
+        Ok(Gpt2AttentionCanaryWorkspace::new(&self.cfg))
+    }
+
+    /// Execute one matched attention-canary step after validating every model,
+    /// state, workspace, token, position, and derived slice extent. Validation
+    /// completes before any mutable byte is touched, so every `Err` is failure
+    /// atomic. Production [`Self::forward`] remains the normal executor.
+    #[doc(hidden)]
+    pub fn forward_attention_canary(
+        &self,
+        st: &mut Gpt2State,
+        workspace: &mut Gpt2AttentionCanaryWorkspace,
+        token: usize,
+        pos: usize,
+        mode: Gpt2AttentionCanaryMode,
+    ) -> Result<Gpt2AttentionCanaryCensus, Gpt2AttentionCanaryError> {
+        self.validate_attention_canary_inputs(st, workspace, token, pos)?;
+        let arithmetic = match mode {
+            Gpt2AttentionCanaryMode::Conventional => {
+                crate::attention::AttentionArithmetic::Conventional
+            }
+            Gpt2AttentionCanaryMode::Exact => crate::attention::AttentionArithmetic::Exact,
+            Gpt2AttentionCanaryMode::CertifiedNative => {
+                crate::attention::AttentionArithmetic::CertifiedNative
+            }
+        };
+        Ok(self
+            .forward_with_attention_arithmetic_unchecked(st, workspace, token, pos, arithmetic)
+            .into())
+    }
+
+    fn finish_forward_without_allocation(&self, st: &mut Gpt2State) {
+        let d = self.cfg.n_embd;
+        layer_norm(
+            &st.x,
+            &self.ln_f_w,
+            &self.ln_f_b,
+            self.cfg.layer_norm_eps,
+            &mut st.hidden,
+        );
+        let hidden = &st.hidden;
+        for (vocabulary_index, output) in st.logits.iter_mut().enumerate() {
+            let row = &self.wte[vocabulary_index * d..(vocabulary_index + 1) * d];
+            let mut accumulator = 0.0f32;
+            for i in 0..d {
+                accumulator += hidden[i] * row[i];
+            }
+            *output = accumulator;
+        }
     }
 
     /// Final `ln_f` LayerNorm into `st.hidden` and the tied lm-head into
@@ -493,6 +1074,64 @@ impl Gpt2 {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn block_forward_with_attention_arithmetic(
+        &self,
+        st: &mut Gpt2State,
+        layer_index: usize,
+        pos: usize,
+        normed: &mut [f32],
+        qkv: &mut [f32],
+        attn: &mut [f32],
+        proj: &mut [f32],
+        inner: &mut [f32],
+        mlp_out: &mut [f32],
+        scores: &mut [f32],
+        arithmetic: crate::attention::AttentionArithmetic,
+    ) -> crate::attention::AttentionArithmeticCensus {
+        let d = self.cfg.n_embd;
+        let layer = &self.layers[layer_index];
+
+        layer_norm(
+            &st.x,
+            &layer.ln1_w,
+            &layer.ln1_b,
+            self.cfg.layer_norm_eps,
+            normed,
+        );
+        conv1d(normed, &layer.c_attn_w, &layer.c_attn_b, 3 * d, qkv);
+        let census = self.block_attention_with_arithmetic(
+            st,
+            layer_index,
+            pos,
+            qkv,
+            attn,
+            scores,
+            arithmetic,
+        );
+        conv1d(attn, &layer.c_proj_w, &layer.c_proj_b, d, proj);
+        for (value, &projection) in st.x.iter_mut().zip(&proj[..d]) {
+            *value += projection;
+        }
+
+        layer_norm(
+            &st.x,
+            &layer.ln2_w,
+            &layer.ln2_b,
+            self.cfg.layer_norm_eps,
+            normed,
+        );
+        conv1d(normed, &layer.fc_w, &layer.fc_b, self.cfg.n_inner, inner);
+        for value in inner.iter_mut() {
+            *value = gelu_new(*value);
+        }
+        conv1d(inner, &layer.mlp_w, &layer.mlp_b, d, mlp_out);
+        for (value, &mlp) in st.x.iter_mut().zip(&mlp_out[..d]) {
+            *value += mlp;
+        }
+        census
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn block_forward(
         &self,
         st: &mut Gpt2State,
@@ -543,6 +1182,54 @@ impl Gpt2 {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn block_attention_with_arithmetic(
+        &self,
+        st: &mut Gpt2State,
+        layer: usize,
+        pos: usize,
+        qkv: &[f32],
+        attn: &mut [f32],
+        scores: &mut [f32],
+        arithmetic: crate::attention::AttentionArithmetic,
+    ) -> crate::attention::AttentionArithmeticCensus {
+        let d = self.cfg.n_embd;
+        let head_size = self.cfg.head_size();
+        let sequence_length = self.cfg.seq_len;
+        let base = (layer * sequence_length + pos) * d;
+        st.k_cache[base..base + d].copy_from_slice(&qkv[d..2 * d]);
+        st.v_cache[base..base + d].copy_from_slice(&qkv[2 * d..3 * d]);
+
+        debug_assert_eq!(scores.len(), pos + 1);
+        let mut census = crate::attention::AttentionArithmeticCensus::default();
+        let key_cache = &st.k_cache[layer * sequence_length * d..(layer + 1) * sequence_length * d];
+        let value_cache =
+            &st.v_cache[layer * sequence_length * d..(layer + 1) * sequence_length * d];
+        for head in 0..self.cfg.n_head {
+            let query = &qkv[head * head_size..(head + 1) * head_size];
+            census.qk.merge(attention_weights_with_arithmetic(
+                scores,
+                query,
+                key_cache,
+                head * head_size,
+                d,
+                arithmetic,
+            ));
+            let output = &mut attn[head * head_size..(head + 1) * head_size];
+            census.value.merge(
+                crate::attention::head_attention_value_aggregate_with_arithmetic(
+                    output,
+                    scores,
+                    value_cache,
+                    head * head_size,
+                    d,
+                    arithmetic,
+                ),
+            );
+        }
+        census
+    }
+
     /// The per-sequence attention sub-block shared by [`Gpt2::block_forward`]
     /// (serial) and [`Gpt2::forward_batch`] (batched): cache this position's
     /// k/v from the fused `qkv` projection, then for each head compute the
@@ -564,7 +1251,6 @@ impl Gpt2 {
     ) {
         let d = self.cfg.n_embd;
         let hs = self.cfg.head_size();
-        let scale = 1.0 / (hs as f32).sqrt();
         let seq = self.cfg.seq_len;
         // store this position's k, v (thirds 1 and 2 of the fused qkv).
         let base = (l * seq + pos) * d;
@@ -581,36 +1267,18 @@ impl Gpt2 {
             }
         }
         let mut scores = vec![0.0f32; pos + 1];
+        let key_cache = &st.k_cache[l * seq * d..(l + 1) * seq * d];
+        let value_cache = &st.v_cache[l * seq * d..(l + 1) * seq * d];
         for h in 0..self.cfg.n_head {
             let qh = &qkv[h * hs..(h + 1) * hs];
-            // scaled dot-product scores against every key up to pos.
-            let mut max = f32::NEG_INFINITY;
-            for (t, score) in scores.iter_mut().enumerate() {
-                let koff = (l * seq + t) * d + h * hs;
-                let kh = &st.k_cache[koff..koff + hs];
-                let mut dot = 0.0f32;
-                for i in 0..hs {
-                    dot += qh[i] * kh[i];
-                }
-                *score = dot * scale;
-                if *score > max {
-                    max = *score;
-                }
-            }
-            // softmax over positions 0..=pos.
-            let mut sum = 0.0f32;
-            for score in scores.iter_mut() {
-                *score = (*score - max).exp();
-                sum += *score;
-            }
-            let inv = 1.0 / sum;
-            // Normalize the softmax weights in place. `score * inv` is the
-            // exact per-position weight the value aggregation used before,
-            // so the executor arithmetic stays bit-identical — and `scores`
-            // now holds the per-head weights the #603 attention tap emits.
-            for score in scores.iter_mut() {
-                *score *= inv;
-            }
+            let _ = attention_weights_with_arithmetic(
+                &mut scores,
+                qh,
+                key_cache,
+                h * hs,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
             // #603 per-head attention-weight tap over positions 0..=pos.
             if let Some(request) = request {
                 if request.attention_layers.contains(&l) {
@@ -619,16 +1287,15 @@ impl Gpt2 {
                     }
                 }
             }
-            // weighted sum of values into this head's attention output.
             let ao = &mut attn[h * hs..(h + 1) * hs];
-            ao.fill(0.0);
-            for (t, &weight) in scores.iter().enumerate() {
-                let voff = (l * seq + t) * d + h * hs;
-                let vh = &st.v_cache[voff..voff + hs];
-                for i in 0..hs {
-                    ao[i] += weight * vh[i];
-                }
-            }
+            let _ = crate::attention::head_attention_value_aggregate_with_arithmetic(
+                ao,
+                &scores,
+                value_cache,
+                h * hs,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
         }
     }
 
@@ -785,6 +1452,270 @@ mod tests {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-tiny")
     }
 
+    fn assert_canary_unchanged(
+        state: &Gpt2State,
+        state_before: &Gpt2State,
+        workspace: &Gpt2AttentionCanaryWorkspace,
+        workspace_before: &Gpt2AttentionCanaryWorkspace,
+    ) {
+        assert_eq!(state, state_before, "invalid canary call mutated state");
+        assert_eq!(
+            workspace, workspace_before,
+            "invalid canary call mutated workspace"
+        );
+    }
+
+    #[test]
+    fn attention_control_preserves_gpt2_reciprocal_normalization_order() {
+        let raw = [
+            f32::from_bits(0xc2b3_f6f4),
+            f32::from_bits(0xc2bc_870f),
+            f32::from_bits(0xc213_2cb3),
+            f32::from_bits(0x416b_d2a8),
+            f32::from_bits(0xc15f_22ae),
+        ];
+        let query = [1.0f32, 0.0];
+        let keys: Vec<f32> = raw.iter().flat_map(|&score| [score, 0.0]).collect();
+        let mut exact = [0.0f32; 5];
+        attention_weights_with_arithmetic(
+            &mut exact,
+            &query,
+            &keys,
+            0,
+            2,
+            crate::attention::AttentionArithmetic::Exact,
+        );
+        let mut certified = [0.0f32; 5];
+        attention_weights_with_arithmetic(
+            &mut certified,
+            &query,
+            &keys,
+            0,
+            2,
+            crate::attention::AttentionArithmetic::CertifiedNative,
+        );
+
+        let reciprocal = 1.0 / 2.0f32.sqrt();
+        let mut expected = raw;
+        let mut max = f32::NEG_INFINITY;
+        for score in &mut expected {
+            *score *= reciprocal;
+            if *score > max {
+                max = *score;
+            }
+        }
+        let mut sum = 0.0f32;
+        for score in &mut expected {
+            *score = (*score - max).exp();
+            sum += *score;
+        }
+        let inverse = 1.0 / sum;
+        for score in &mut expected {
+            *score *= inverse;
+        }
+        assert_eq!(exact.map(f32::to_bits), expected.map(f32::to_bits));
+        assert_eq!(certified.map(f32::to_bits), exact.map(f32::to_bits));
+    }
+
+    #[test]
+    fn checked_attention_canary_rejects_every_invalid_input_before_mutation() {
+        let mut model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+
+        let mut state = Gpt2State::new(&model.cfg);
+        let mut workspace = model
+            .attention_canary_workspace()
+            .expect("valid model admits canary scratch");
+        let state_before = state.clone();
+        let workspace_before = workspace.clone();
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                model.cfg.vocab,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("out-of-range token must fail");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::IndexOutOfRange {
+                component: "token",
+                ..
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                model.cfg.seq_len,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("out-of-range position must fail");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::IndexOutOfRange {
+                component: "position",
+                ..
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        state.logits.pop();
+        let state_before = state.clone();
+        let workspace_before = workspace.clone();
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("invalid state geometry must fail");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::LengthMismatch {
+                component: "state.logits",
+                ..
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        state = Gpt2State::new(&model.cfg);
+        workspace.scores.pop();
+        let state_before = state.clone();
+        let workspace_before = workspace.clone();
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("invalid workspace geometry must fail");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::LengthMismatch {
+                component: "workspace.scores",
+                ..
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        workspace = Gpt2AttentionCanaryWorkspace::new(&model.cfg);
+        let state_before = state.clone();
+        let workspace_before = workspace.clone();
+        let original_head_count = model.cfg.n_head;
+        model.cfg.n_head = 0;
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("invalid model geometry must fail");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::InvalidGeometry { .. }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        model.cfg.n_head = original_head_count;
+        let original_layer_count = model.cfg.n_layer;
+        model.cfg.n_layer = 0;
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("zero-layer canary must be non-vacuously rejected");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "n_layer must be nonzero"
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+
+        model.cfg.n_layer = original_layer_count;
+        model.cfg.vocab = 0;
+        let error = model
+            .forward_attention_canary(
+                &mut state,
+                &mut workspace,
+                0,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect_err("zero-vocabulary canary must be non-vacuously rejected");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::InvalidGeometry {
+                component: "vocab must be nonzero"
+            }
+        ));
+        assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
+    }
+
+    #[test]
+    fn public_canary_census_overflow_fails_closed_and_atomically() {
+        let overflowing_fallbacks = Gpt2AttentionCanaryDotCensus {
+            fallback_nonfinite: usize::MAX,
+            fallback_zero: 1,
+            ..Gpt2AttentionCanaryDotCensus::default()
+        };
+        assert!(matches!(
+            overflowing_fallbacks.fallbacks(),
+            Err(Gpt2AttentionCanaryError::CounterOverflow {
+                component: "fallback census"
+            })
+        ));
+
+        let mut census = Gpt2AttentionCanaryCensus {
+            qk: Gpt2AttentionCanaryDotCensus {
+                lanes: 7,
+                certified: 7,
+                ..Gpt2AttentionCanaryDotCensus::default()
+            },
+            value: Gpt2AttentionCanaryDotCensus {
+                lanes: usize::MAX,
+                certified: 11,
+                ..Gpt2AttentionCanaryDotCensus::default()
+            },
+        };
+        let before = census;
+        let other = Gpt2AttentionCanaryCensus {
+            qk: Gpt2AttentionCanaryDotCensus {
+                lanes: 1,
+                certified: 1,
+                ..Gpt2AttentionCanaryDotCensus::default()
+            },
+            value: Gpt2AttentionCanaryDotCensus {
+                lanes: 1,
+                ..Gpt2AttentionCanaryDotCensus::default()
+            },
+        };
+        let error = census
+            .merge(other)
+            .expect_err("value overflow must reject the whole merge");
+        assert!(matches!(
+            error,
+            Gpt2AttentionCanaryError::CounterOverflow {
+                component: "value census"
+            }
+        ));
+        assert_eq!(census, before, "failed merge mutated the public census");
+    }
+
     fn f32_vec(value: &serde_json::Value) -> Vec<f32> {
         value
             .as_array()
@@ -873,7 +1804,7 @@ mod tests {
     /// #668: the GPT-2 oracle reports the truthful learned-absolute
     /// operator record, and it resolves through the versioned registry.
     /// Its positional action is NOT RoPE, so it is a distinct identity
-    /// from `standard-source-attention/1` — reusing that record would be
+    /// from current `standard-source-attention/2` — reusing that record would be
     /// a false operator identity.
     #[test]
     fn gpt2_oracle_reports_learned_absolute_operator() {
@@ -1269,7 +2200,7 @@ impl crate::TeacherOracle for HuggingFaceGpt2Oracle {
         // (this module) is its implementation — a scaled dot product with the
         // standard max-subtracted softmax, but learned absolute positions (no
         // RoPE on q/k) and GPT-2's fused-`c_attn`/`c_proj` Conv1D projections.
-        // Reusing `standard-source-attention/1` would misdeclare the positional
+        // Reusing `standard-source-attention/2` would misdeclare the positional
         // action, so this is its own registered `(id, version)`.
         Some(crate::attention::AttentionOperatorSpec::learned_absolute_source_attention())
     }

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -459,44 +459,28 @@ impl Gpt2AttentionCanaryDotCensus {
         self.fallback_cell
     }
 
-    pub fn fallbacks(self) -> Result<usize, Gpt2AttentionCanaryError> {
-        checked_canary_count(
-            "fallback census",
-            self.fallback_nonfinite,
-            self.fallback_zero,
-        )
-        .and_then(|total| checked_canary_count("fallback census", total, self.fallback_overflow))
-        .and_then(|total| checked_canary_count("fallback census", total, self.fallback_cell))
+    /// Total fallback count, or `None` when the private counters do not form a
+    /// `usize` product.
+    pub fn fallbacks(self) -> Option<usize> {
+        checked_canary_count(self.fallback_nonfinite, self.fallback_zero)
+            .and_then(|total| checked_canary_count(total, self.fallback_overflow))
+            .and_then(|total| checked_canary_count(total, self.fallback_cell))
     }
 
-    fn checked_merge(
-        self,
-        other: Self,
-        component: &'static str,
-    ) -> Result<Self, Gpt2AttentionCanaryError> {
-        Ok(Self {
-            lanes: checked_canary_count(component, self.lanes, other.lanes)?,
-            certified: checked_canary_count(component, self.certified, other.certified)?,
+    fn checked_merge(self, other: Self) -> Option<Self> {
+        Some(Self {
+            lanes: checked_canary_count(self.lanes, other.lanes)?,
+            certified: checked_canary_count(self.certified, other.certified)?,
             fallback_nonfinite: checked_canary_count(
-                component,
                 self.fallback_nonfinite,
                 other.fallback_nonfinite,
             )?,
-            fallback_zero: checked_canary_count(
-                component,
-                self.fallback_zero,
-                other.fallback_zero,
-            )?,
+            fallback_zero: checked_canary_count(self.fallback_zero, other.fallback_zero)?,
             fallback_overflow: checked_canary_count(
-                component,
                 self.fallback_overflow,
                 other.fallback_overflow,
             )?,
-            fallback_cell: checked_canary_count(
-                component,
-                self.fallback_cell,
-                other.fallback_cell,
-            )?,
+            fallback_cell: checked_canary_count(self.fallback_cell, other.fallback_cell)?,
         })
     }
 }
@@ -531,12 +515,14 @@ impl Gpt2AttentionCanaryCensus {
         self.value
     }
 
-    pub fn merge(&mut self, other: Self) -> Result<(), Gpt2AttentionCanaryError> {
-        let qk = self.qk.checked_merge(other.qk, "QK census")?;
-        let value = self.value.checked_merge(other.value, "value census")?;
+    /// Merge a story census atomically. `None` means the combined counters do
+    /// not form a `usize` product and leaves `self` byte-identical.
+    pub fn merge(&mut self, other: Self) -> Option<()> {
+        let qk = self.qk.checked_merge(other.qk)?;
+        let value = self.value.checked_merge(other.value)?;
         self.qk = qk;
         self.value = value;
-        Ok(())
+        Some(())
     }
 }
 
@@ -549,86 +535,8 @@ impl From<crate::attention::AttentionArithmeticCensus> for Gpt2AttentionCanaryCe
     }
 }
 
-/// Failure from the checked, evidence-only GPT-2 attention canary façade.
-/// Every error is reported before either recurrent state or workspace bytes
-/// are mutated.
-#[doc(hidden)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Gpt2AttentionCanaryError {
-    IndexOutOfRange {
-        component: &'static str,
-        index: usize,
-        bound: usize,
-    },
-    InvalidGeometry {
-        component: &'static str,
-    },
-    GeometryOverflow {
-        component: &'static str,
-    },
-    CounterOverflow {
-        component: &'static str,
-    },
-    LengthMismatch {
-        component: &'static str,
-        layer: Option<usize>,
-        expected: usize,
-        actual: usize,
-    },
-}
-
-impl std::fmt::Display for Gpt2AttentionCanaryError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::IndexOutOfRange {
-                component,
-                index,
-                bound,
-            } => write!(formatter, "{component} index {index} is outside 0..{bound}"),
-            Self::InvalidGeometry { component } => {
-                write!(formatter, "invalid GPT-2 canary geometry: {component}")
-            }
-            Self::GeometryOverflow { component } => {
-                write!(
-                    formatter,
-                    "GPT-2 canary geometry overflows usize: {component}"
-                )
-            }
-            Self::CounterOverflow { component } => {
-                write!(formatter, "GPT-2 attention canary {component} overflow")
-            }
-            Self::LengthMismatch {
-                component,
-                layer,
-                expected,
-                actual,
-            } => {
-                if let Some(layer) = layer {
-                    write!(
-                        formatter,
-                        "GPT-2 canary layer {layer} {component} length {actual}, expected {expected}"
-                    )
-                } else {
-                    write!(
-                        formatter,
-                        "GPT-2 canary {component} length {actual}, expected {expected}"
-                    )
-                }
-            }
-        }
-    }
-}
-
-impl std::error::Error for Gpt2AttentionCanaryError {}
-
-fn checked_canary_count(
-    component: &'static str,
-    left: usize,
-    right: usize,
-) -> Result<usize, Gpt2AttentionCanaryError> {
+fn checked_canary_count(left: usize, right: usize) -> Option<usize> {
     left.checked_add(right)
-        .ok_or(Gpt2AttentionCanaryError::CounterOverflow { component })
 }
 
 impl Gpt2State {
@@ -682,15 +590,15 @@ impl Gpt2AttentionCanaryWorkspace {
     }
 }
 
-fn canary_product(
-    component: &'static str,
-    factors: &[usize],
-) -> Result<usize, Gpt2AttentionCanaryError> {
-    factors.iter().try_fold(1usize, |product, &factor| {
-        product
-            .checked_mul(factor)
-            .ok_or(Gpt2AttentionCanaryError::GeometryOverflow { component })
-    })
+fn canary_product(component: &'static str, factors: &[usize]) -> Result<usize, SourceUnavailable> {
+    factors
+        .iter()
+        .try_fold(1usize, |product, &factor| product.checked_mul(factor))
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "GPT-2 attention canary geometry overflows usize: {component}"
+            ))
+        })
 }
 
 fn require_canary_length(
@@ -698,46 +606,44 @@ fn require_canary_length(
     layer: Option<usize>,
     actual: usize,
     expected: usize,
-) -> Result<(), Gpt2AttentionCanaryError> {
+) -> Result<(), SourceUnavailable> {
     if actual == expected {
         Ok(())
     } else {
-        Err(Gpt2AttentionCanaryError::LengthMismatch {
-            component,
-            layer,
-            expected,
-            actual,
-        })
+        let layer = layer.map_or_else(String::new, |layer| format!(" layer {layer}"));
+        Err(SourceUnavailable::new(format!(
+            "GPT-2 attention canary{layer} {component} length {actual}, expected {expected}"
+        )))
     }
 }
 
 impl Gpt2 {
-    fn validate_attention_canary_model(&self) -> Result<(), Gpt2AttentionCanaryError> {
+    fn validate_attention_canary_model(&self) -> Result<(), SourceUnavailable> {
         let config = &self.cfg;
         if config.n_embd == 0 {
-            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "n_embd must be nonzero",
-            });
+            return Err(SourceUnavailable::new(
+                "invalid GPT-2 attention canary geometry: n_embd must be nonzero",
+            ));
         }
         if config.n_layer == 0 {
-            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "n_layer must be nonzero",
-            });
+            return Err(SourceUnavailable::new(
+                "invalid GPT-2 attention canary geometry: n_layer must be nonzero",
+            ));
         }
         if config.vocab == 0 {
-            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "vocab must be nonzero",
-            });
+            return Err(SourceUnavailable::new(
+                "invalid GPT-2 attention canary geometry: vocab must be nonzero",
+            ));
         }
         if config.n_head == 0 || !config.n_embd.is_multiple_of(config.n_head) {
-            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "n_head must be nonzero and divide n_embd",
-            });
+            return Err(SourceUnavailable::new(
+                "invalid GPT-2 attention canary geometry: n_head must be nonzero and divide n_embd",
+            ));
         }
         if config.seq_len == 0 || config.seq_len > config.n_positions {
-            return Err(Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "seq_len must be in 1..=n_positions",
-            });
+            return Err(SourceUnavailable::new(
+                "invalid GPT-2 attention canary geometry: seq_len must be in 1..=n_positions",
+            ));
         }
 
         let d = config.n_embd;
@@ -816,53 +722,40 @@ impl Gpt2 {
         workspace: &Gpt2AttentionCanaryWorkspace,
         token: usize,
         pos: usize,
-    ) -> Result<(), Gpt2AttentionCanaryError> {
-        self.validate_attention_canary_model()?;
+    ) -> Option<()> {
+        self.validate_attention_canary_model().ok()?;
         let config = &self.cfg;
         if token >= config.vocab {
-            return Err(Gpt2AttentionCanaryError::IndexOutOfRange {
-                component: "token",
-                index: token,
-                bound: config.vocab,
-            });
+            return None;
         }
         if pos >= config.seq_len {
-            return Err(Gpt2AttentionCanaryError::IndexOutOfRange {
-                component: "position",
-                index: pos,
-                bound: config.seq_len,
-            });
+            return None;
         }
 
         let d = config.n_embd;
-        let three_d = canary_product("3 * n_embd", &[3, d])?;
+        let three_d = canary_product("3 * n_embd", &[3, d]).ok()?;
         let cache = canary_product(
             "n_layer * seq_len * n_embd",
             &[config.n_layer, config.seq_len, d],
-        )?;
-        require_canary_length("state.k_cache", None, state.k_cache.len(), cache)?;
-        require_canary_length("state.v_cache", None, state.v_cache.len(), cache)?;
-        require_canary_length("state.logits", None, state.logits.len(), config.vocab)?;
-        require_canary_length("state.hidden", None, state.hidden.len(), d)?;
-        require_canary_length("state.x", None, state.x.len(), d)?;
-        require_canary_length("workspace.normed", None, workspace.normed.len(), d)?;
-        require_canary_length("workspace.qkv", None, workspace.qkv.len(), three_d)?;
-        require_canary_length("workspace.attn", None, workspace.attn.len(), d)?;
-        require_canary_length("workspace.proj", None, workspace.proj.len(), d)?;
-        require_canary_length(
-            "workspace.inner",
-            None,
-            workspace.inner.len(),
-            config.n_inner,
-        )?;
-        require_canary_length("workspace.mlp_out", None, workspace.mlp_out.len(), d)?;
-        require_canary_length(
-            "workspace.scores",
-            None,
-            workspace.scores.len(),
-            config.seq_len,
-        )?;
-        Ok(())
+        )
+        .ok()?;
+        [
+            (state.k_cache.len(), cache),
+            (state.v_cache.len(), cache),
+            (state.logits.len(), config.vocab),
+            (state.hidden.len(), d),
+            (state.x.len(), d),
+            (workspace.normed.len(), d),
+            (workspace.qkv.len(), three_d),
+            (workspace.attn.len(), d),
+            (workspace.proj.len(), d),
+            (workspace.inner.len(), config.n_inner),
+            (workspace.mlp_out.len(), d),
+            (workspace.scores.len(), config.seq_len),
+        ]
+        .into_iter()
+        .all(|(actual, expected)| actual == expected)
+        .then_some(())
     }
 
     /// One teacher-forced forward step at `pos` (0-based), leaving logits
@@ -948,14 +841,14 @@ impl Gpt2 {
     #[doc(hidden)]
     pub fn attention_canary_workspace(
         &self,
-    ) -> Result<Gpt2AttentionCanaryWorkspace, Gpt2AttentionCanaryError> {
+    ) -> Result<Gpt2AttentionCanaryWorkspace, SourceUnavailable> {
         self.validate_attention_canary_model()?;
         Ok(Gpt2AttentionCanaryWorkspace::new(&self.cfg))
     }
 
     /// Execute one matched attention-canary step after validating every model,
     /// state, workspace, token, position, and derived slice extent. Validation
-    /// completes before any mutable byte is touched, so every `Err` is failure
+    /// completes before any mutable byte is touched, so `None` is failure
     /// atomic. Production [`Self::forward`] remains the normal executor.
     #[doc(hidden)]
     pub fn forward_attention_canary(
@@ -965,7 +858,7 @@ impl Gpt2 {
         token: usize,
         pos: usize,
         mode: Gpt2AttentionCanaryMode,
-    ) -> Result<Gpt2AttentionCanaryCensus, Gpt2AttentionCanaryError> {
+    ) -> Option<Gpt2AttentionCanaryCensus> {
         self.validate_attention_canary_inputs(st, workspace, token, pos)?;
         let arithmetic = match mode {
             Gpt2AttentionCanaryMode::Conventional => {
@@ -976,9 +869,10 @@ impl Gpt2 {
                 crate::attention::AttentionArithmetic::CertifiedNative
             }
         };
-        Ok(self
-            .forward_with_attention_arithmetic_unchecked(st, workspace, token, pos, arithmetic)
-            .into())
+        Some(
+            self.forward_with_attention_arithmetic_unchecked(st, workspace, token, pos, arithmetic)
+                .into(),
+        )
     }
 
     fn finish_forward_without_allocation(&self, st: &mut Gpt2State) {
@@ -1527,83 +1421,54 @@ mod tests {
             .expect("valid model admits canary scratch");
         let state_before = state.clone();
         let workspace_before = workspace.clone();
-        let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                model.cfg.vocab,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("out-of-range token must fail");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::IndexOutOfRange {
-                component: "token",
-                ..
-            }
-        ));
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            model.cfg.vocab,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(result, None, "out-of-range token must have no product");
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
-        let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                model.cfg.seq_len,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("out-of-range position must fail");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::IndexOutOfRange {
-                component: "position",
-                ..
-            }
-        ));
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            model.cfg.seq_len,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(result, None, "out-of-range position must have no product");
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
         state.logits.pop();
         let state_before = state.clone();
         let workspace_before = workspace.clone();
-        let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("invalid state geometry must fail");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::LengthMismatch {
-                component: "state.logits",
-                ..
-            }
-        ));
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(result, None, "invalid state must have no canary product");
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
         state = Gpt2State::new(&model.cfg);
         workspace.scores.pop();
         let state_before = state.clone();
         let workspace_before = workspace.clone();
-        let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("invalid workspace geometry must fail");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::LengthMismatch {
-                component: "workspace.scores",
-                ..
-            }
-        ));
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(
+            result, None,
+            "invalid workspace must have no canary product"
+        );
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
         workspace = Gpt2AttentionCanaryWorkspace::new(&model.cfg);
@@ -1612,57 +1477,65 @@ mod tests {
         let original_head_count = model.cfg.n_head;
         model.cfg.n_head = 0;
         let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("invalid model geometry must fail");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::InvalidGeometry { .. }
-        ));
+            .attention_canary_workspace()
+            .expect_err("invalid model geometry must refuse workspace construction");
+        assert_eq!(
+            error.reason,
+            "invalid GPT-2 attention canary geometry: n_head must be nonzero and divide n_embd"
+        );
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(result, None, "invalid model must have no canary product");
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
         model.cfg.n_head = original_head_count;
         let original_layer_count = model.cfg.n_layer;
         model.cfg.n_layer = 0;
         let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("zero-layer canary must be non-vacuously rejected");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "n_layer must be nonzero"
-            }
-        ));
+            .attention_canary_workspace()
+            .expect_err("zero-layer model must refuse workspace construction");
+        assert_eq!(
+            error.reason,
+            "invalid GPT-2 attention canary geometry: n_layer must be nonzero"
+        );
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(
+            result, None,
+            "zero-layer canary must be non-vacuously absent"
+        );
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
 
         model.cfg.n_layer = original_layer_count;
         model.cfg.vocab = 0;
         let error = model
-            .forward_attention_canary(
-                &mut state,
-                &mut workspace,
-                0,
-                0,
-                Gpt2AttentionCanaryMode::CertifiedNative,
-            )
-            .expect_err("zero-vocabulary canary must be non-vacuously rejected");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::InvalidGeometry {
-                component: "vocab must be nonzero"
-            }
-        ));
+            .attention_canary_workspace()
+            .expect_err("zero-vocabulary model must refuse workspace construction");
+        assert_eq!(
+            error.reason,
+            "invalid GPT-2 attention canary geometry: vocab must be nonzero"
+        );
+        let result = model.forward_attention_canary(
+            &mut state,
+            &mut workspace,
+            0,
+            0,
+            Gpt2AttentionCanaryMode::CertifiedNative,
+        );
+        assert_eq!(
+            result, None,
+            "zero-vocabulary canary must be non-vacuously absent"
+        );
         assert_canary_unchanged(&state, &state_before, &workspace, &workspace_before);
     }
 
@@ -1673,12 +1546,7 @@ mod tests {
             fallback_zero: 1,
             ..Gpt2AttentionCanaryDotCensus::default()
         };
-        assert!(matches!(
-            overflowing_fallbacks.fallbacks(),
-            Err(Gpt2AttentionCanaryError::CounterOverflow {
-                component: "fallback census"
-            })
-        ));
+        assert_eq!(overflowing_fallbacks.fallbacks(), None);
 
         let mut census = Gpt2AttentionCanaryCensus {
             qk: Gpt2AttentionCanaryDotCensus {
@@ -1704,15 +1572,7 @@ mod tests {
                 ..Gpt2AttentionCanaryDotCensus::default()
             },
         };
-        let error = census
-            .merge(other)
-            .expect_err("value overflow must reject the whole merge");
-        assert!(matches!(
-            error,
-            Gpt2AttentionCanaryError::CounterOverflow {
-                component: "value census"
-            }
-        ));
+        assert_eq!(census.merge(other), None);
         assert_eq!(census, before, "failed merge mutated the public census");
     }
 

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -2,9 +2,11 @@
 //! Arithmetic order mirrors the C exactly: sequential adds in matmul rows,
 //! rmsnorm/softmax/RoPE/SwiGLU op-for-op, libm via glibc on gnu targets.
 //! The Safetensors adapter also loads pinned Hugging Face SmolLM2 weights
-//! into this same source-only teacher surface. The pinned legacy teacher keeps
-//! the original reduction order; native Hugging Face compilation may use an
-//! optimized CPU matrix-vector backend.
+//! into this same source-only teacher surface. Llama/shared projections use the
+//! pinned portable exact `uor-matmul` owner. GPT-2 keeps its declared
+//! conventional dense sites and uses certified-native/exact-fallback current
+//! attention; canonical mode separately selects the remaining libm and
+//! ordered-reduction family.
 
 pub mod attention;
 pub mod conformance;
@@ -232,8 +234,9 @@ fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize
 }
 
 /// The teacher's matrix-operation backend, for the "teacher model ready"
-/// diagnostic. Since #655-B2 every teacher weight matmul is the pinned,
-/// portable `uor-matmul` exact GEMM — no per-machine SIMD/Accelerate path.
+/// diagnostic. Since #655-B2 every Llama/shared weight projection is the
+/// pinned portable `uor-matmul` exact GEMM — no per-machine SIMD/Accelerate
+/// path. GPT-2 owns its separate declared dense implementation.
 fn fast_matmul_backend() -> &'static str {
     "uor-matmul exact GEMM"
 }
@@ -576,12 +579,12 @@ impl Llama {
 
             // multihead attention (serial over heads; per-head work is
             // independent of order). The per-head weight computation and
-            // value aggregation are the free #602 reference functions in
-            // [`attention`], factored out of this loop unchanged; the
+            // value aggregation are the current #602/#704 functions in
+            // [`attention`]; the
             // `r4_attention` switch selects between exactly the two
-            // registered operators (`standard-source-attention/1` and
-            // `experimental-r4-source-attention/1`, a chunked dot
-            // product with the same softmax selector).
+            // registered operators (`standard-source-attention/2` and
+            // `experimental-r4-source-attention/2`, whose exact-real dot
+            // uses the historical floor-multiple-of-four domain).
             for h in 0..c.n_heads {
                 let q = &st.q[h * head_size..(h + 1) * head_size];
                 let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
@@ -689,10 +692,10 @@ impl Llama {
     /// instead of once per sequence, so B sequences cost one weight sweep — the
     /// amortization that lifts the teacher off the per-token memory-bandwidth
     /// wall. Every per-sequence op (rmsnorm, RoPE, attention, SwiGLU, residual)
-    /// mirrors [`Llama::forward`] exactly, and off macOS `matmul_batched` reuses
-    /// the same `dot_fast`, so this is bit-identical to calling `forward` on
-    /// each sequence with `fast_matmul = true`. `fast_matmul` is accepted for
-    /// signature parity; the batched path always takes the amortized kernel.
+    /// mirrors [`Llama::forward`] exactly. `matmul_batched` and the serial path
+    /// share the pinned exact `uor-matmul` owner, so their projection bits agree
+    /// on every target. `fast_matmul` is a compatibility parameter and does not
+    /// select another arithmetic owner.
     pub fn forward_batch(
         &self,
         states: &mut [State],
@@ -990,8 +993,8 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
     /// source executor computes during [`BehaviorSource::step`], when the
     /// oracle declares one. The boolean `r4_attention` switch maps to
     /// exactly the two registered operators
-    /// (`standard-source-attention/1` when off,
-    /// `experimental-r4-source-attention/1` when on — see
+    /// (`standard-source-attention/2` when off,
+    /// `experimental-r4-source-attention/2` when on — see
     /// [`attention::operator_for_r4_switch`]). `None` means the oracle
     /// predates the record (the legacy interpretation documented in
     /// `docs/MODEL_LIFECYCLE.md`); the default keeps every existing
@@ -1208,8 +1211,8 @@ impl TeacherOracle for LlamaOracle {
         request: &TraceCaptureRequest<'_>,
         sinks: &mut TraceCaptureSinks<'_, '_>,
     ) -> bool {
-        // Same matmul selection as `step` (the legacy exact scalar path),
-        // so a traced step and a plain step produce identical bits.
+        // Same pinned exact matmul owner as `step`, so a traced step and a
+        // plain step produce identical bits.
         self.model
             .forward_capturing_trace(&mut self.state, token, pos, false, request, sinks);
         logits.copy_from_slice(&self.state.logits);
@@ -1698,13 +1701,20 @@ impl std::fmt::Display for SourceIngestKind {
             Self::UnknownAttentionOperator { id, version } => write!(
                 f,
                 "attention operator {id}/{version} is not in the versioned operator \
-                 registry (registered entries include {}/{}, {}/{}, {}/{}, and {}/{})",
+                 registry (registered entries include {}/{}, {}/{}, {}/{}, {}/{}, \
+                 {}/{}, {}/{}, and {}/{})",
                 attention::AttentionOperatorSpec::STANDARD_ID,
-                attention::AttentionOperatorSpec::STANDARD_VERSION,
+                attention::AttentionOperatorSpec::STANDARD_V1_VERSION,
+                attention::AttentionOperatorSpec::STANDARD_ID,
+                attention::AttentionOperatorSpec::STANDARD_V2_VERSION,
                 attention::AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
-                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_V1_VERSION,
+                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_ID,
+                attention::AttentionOperatorSpec::EXPERIMENTAL_R4_V2_VERSION,
                 attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
-                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_V1_VERSION,
+                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_V2_VERSION,
                 attention::AttentionOperatorSpec::R4_ROUTE_ID,
                 attention::AttentionOperatorSpec::R4_ROUTE_VERSION,
             ),
@@ -2309,17 +2319,17 @@ impl HuggingFaceLlamaOracle {
     }
 
     /// Enable or disable the experimental attention variant
-    /// (`experimental-r4-source-attention/1`, #602): a 4-wide-chunked
-    /// dot product — truncating the trailing `head_size mod 4`
-    /// dimensions from the score — followed by the same softmax the
-    /// standard operator applies. Despite the flag's historical name it
-    /// is neither quaternionic nor softmax-bypassing (#515 audit).
+    /// (`experimental-r4-source-attention/2`, #602/#704): a correctly-rounded
+    /// exact-real dot over the floor-multiple-of-four head prefix — truncating
+    /// the trailing `head_size mod 4` dimensions — followed by the same
+    /// softmax the standard operator applies. Despite the flag's historical
+    /// name it is neither quaternionic nor softmax-bypassing (#515 audit).
     pub fn set_r4_attention(&mut self, enable: bool) {
         self.model.cfg.r4_attention = enable;
     }
 
     /// Check if the experimental attention variant
-    /// (`experimental-r4-source-attention/1`) is enabled.
+    /// (`experimental-r4-source-attention/2`) is enabled.
     pub fn r4_attention(&self) -> bool {
         self.model.cfg.r4_attention
     }
@@ -2477,11 +2487,9 @@ impl HuggingFaceLlamaOracle {
         let state = State::new(&model.cfg);
         let fast_matmul = !canonical_math && std::env::var("TLESS_EXACT_SCALAR").is_err();
         let backend = if canonical_math {
-            "canonical libm scalar (D2)"
-        } else if fast_matmul {
-            fast_matmul_backend()
+            "uor-matmul exact GEMM + canonical libm scalar (D2)"
         } else {
-            "exact scalar (deterministic)"
+            fast_matmul_backend()
         };
         eprintln!("teacher model ready (κ {kappa}, matmul={backend})");
         Ok(Self {
@@ -2728,7 +2736,7 @@ mod tests {
     }
 
     #[test]
-    fn fast_matmul_tracks_exact_cpu_result() {
+    fn matmul_flag_is_a_bit_exact_compatibility_noop() {
         const ROWS: usize = 67;
         const COLUMNS: usize = 73;
         let input: Vec<f32> = (0..COLUMNS)
@@ -2741,14 +2749,15 @@ mod tests {
         let mut fast = [0.0f32; ROWS];
         matmul(&mut exact, &input, &weights, COLUMNS, false);
         matmul(&mut fast, &input, &weights, COLUMNS, true);
-        for (expected, actual) in exact.into_iter().zip(fast) {
-            let tolerance = 1e-5f32.max(expected.abs() * 1e-5);
-            assert!((expected - actual).abs() <= tolerance);
-        }
+        assert_eq!(
+            exact.map(f32::to_bits),
+            fast.map(f32::to_bits),
+            "the compatibility flag must not select another matmul owner"
+        );
     }
 
     #[test]
-    fn matmul_batched_matches_serial_fast() {
+    fn matmul_batched_matches_serial_exact_bits() {
         const N: usize = 73;
         const ROWS: usize = 40;
         const BATCH: usize = 6;
@@ -2766,19 +2775,13 @@ mod tests {
             for row in 0..ROWS {
                 let want = serial[row];
                 let got = batched[bi * ROWS + row];
-                // Off macOS the batched kernel reuses the exact same dot_fast as
-                // the serial fast path, so it is bit-identical. On macOS it is
-                // Accelerate sgemm vs sgemv — deterministic, within tolerance.
-                #[cfg(not(target_os = "macos"))]
-                assert_eq!(got, want, "batched != serial at b{bi} row{row}");
-                #[cfg(target_os = "macos")]
-                {
-                    let tolerance = 1e-4f32.max(want.abs() * 1e-4);
-                    assert!(
-                        (got - want).abs() <= tolerance,
-                        "batched vs serial b{bi} row{row}"
-                    );
-                }
+                // Both shapes use the pinned exact owner and must agree in
+                // symbol bits on every target.
+                assert_eq!(
+                    got.to_bits(),
+                    want.to_bits(),
+                    "batched != serial at b{bi} row{row}"
+                );
             }
         }
     }

--- a/crates/uor-r4-model-source/src/teacher.rs
+++ b/crates/uor-r4-model-source/src/teacher.rs
@@ -120,8 +120,8 @@ impl Teacher {
     }
 
     /// Toggle the experimental #602 R4 route-attention operator. Llama maps
-    /// this to its two registered operators (`standard-source-attention/1`
-    /// off, `experimental-r4-source-attention/1` on). GPT-2 has no such
+    /// this to its two current registered operators (`standard-source-attention/2`
+    /// off, `experimental-r4-source-attention/2` on). GPT-2 has no such
     /// switch — its learned-absolute operator is a separate registry entry
     /// (#657 item 3) — so the toggle is a documented no-op there rather than
     /// silently reinterpreting a Llama switch it does not execute.

--- a/crates/uor-r4-model-source/tests/certified_native_attention.rs
+++ b/crates/uor-r4-model-source/tests/certified_native_attention.rs
@@ -1,0 +1,611 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use uor_r4_model_source::attention::{AttentionOperatorSpec, CERTIFIED_NATIVE_ARITHMETIC_ID};
+use uor_r4_model_source::gpt2::{
+    Gpt2, Gpt2AttentionCanaryCensus, Gpt2AttentionCanaryMode, Gpt2AttentionCanaryWorkspace,
+    Gpt2State,
+};
+
+struct CountingAllocator;
+
+thread_local! {
+    static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record_allocation(pointer: *mut u8) {
+    if !pointer.is_null() {
+        let _ = COUNT_ALLOCATIONS.try_with(|gate| {
+            if gate.get() {
+                let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+            }
+        });
+    }
+}
+
+// SAFETY: every request is forwarded unchanged to `System`; the thread-local
+// cells are observational and do not participate in allocation.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let pointer = unsafe { System.alloc(layout) };
+        record_allocation(pointer);
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the allocation came from `System` with this layout.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(pointer);
+        pointer
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let resized = unsafe { System.realloc(pointer, layout, size) };
+        record_allocation(resized);
+        resized
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+struct AllocationMeasurement;
+
+impl Drop for AllocationMeasurement {
+    fn drop(&mut self) {
+        COUNT_ALLOCATIONS.with(|gate| gate.set(false));
+    }
+}
+
+fn counted_allocations<T>(operation: impl FnOnce() -> T) -> (T, usize) {
+    ALLOCATIONS.with(|count| count.set(0));
+    COUNT_ALLOCATIONS.with(|gate| {
+        assert!(!gate.replace(true), "nested allocation measurement");
+    });
+    let measurement = AllocationMeasurement;
+    let result = operation();
+    drop(measurement);
+    (result, ALLOCATIONS.with(Cell::get))
+}
+
+fn assert_bits(got: &[f32], expected: &[f32], context: &str) {
+    assert_eq!(got.len(), expected.len(), "{context}: length");
+    for (lane, (&got, &expected)) in got.iter().zip(expected).enumerate() {
+        assert_eq!(
+            got.to_bits(),
+            expected.to_bits(),
+            "{context}: lane {lane}: got={got:?} expected={expected:?}"
+        );
+    }
+}
+
+const GPT2_SOURCE_ENV: &str = "UOR_GPT2_SOURCE";
+const GPT2_REPOSITORY: &str = "openai-community/gpt2";
+const GPT2_REVISION: &str = "607a30d783dfa663caf39e06633721c8d4cfcd7e";
+const GPT2_MODEL_KAPPA: &str =
+    "blake3:3bca1b7f6c327daecafc16e52d1319375299354e35413fb4e18d24e59b77ce06";
+const GPT2_CONFIG_KAPPA: &str =
+    "blake3:23e4471d412e06128072b559c031207de920b8a56d7108879d4b487c079a310c";
+const GPT2_MODEL_BYTES: usize = 548_105_171;
+const GPT2_CONFIG_BYTES: usize = 665;
+const GPT2_STEPS: usize = 32;
+const GPT2_PAIRS: usize = 5;
+const MAXIMUM_RATIO: f64 = 1.10;
+const UOR_MATMUL_REV: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+const STANDARD_V2_DIGEST: &str =
+    "blake3:fa4c8f233e217d3903678b7690de5cdfb27d83a4b68c52436cfabbc6ca6cfc59";
+const EXPERIMENTAL_V2_DIGEST: &str =
+    "blake3:a71d3a9fbfd951528652b837a23d5bfd7742ba79d5082337c19db3a17776e654";
+const LEARNED_ABSOLUTE_V2_DIGEST: &str =
+    "blake3:ba36fd1fef53a2e3744e1fee60e72677870d1cd2f2b484db755c0a5a74727231";
+const PINNED_RUSTC_RELEASE: &str = "1.97.1";
+const PINNED_RUSTC_HOST: &str = "aarch64-apple-darwin";
+
+fn real_gpt2_source() -> PathBuf {
+    std::env::var_os(GPT2_SOURCE_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join(".uor-models/sources/gpt2-124m")
+        })
+}
+
+#[derive(Deserialize)]
+struct SourceManifest {
+    schema: String,
+    repository: String,
+    revision: String,
+    files: Vec<SourceManifestFile>,
+}
+
+#[derive(Deserialize)]
+struct SourceManifestFile {
+    path: String,
+    bytes: usize,
+    kappa: String,
+}
+
+fn assert_manifest_file(
+    manifest: &SourceManifest,
+    path: &str,
+    expected_bytes: usize,
+    expected_kappa: &str,
+) {
+    let file = manifest
+        .files
+        .iter()
+        .find(|file| file.path == path)
+        .unwrap_or_else(|| panic!("source manifest is missing {path}"));
+    assert_eq!(file.bytes, expected_bytes, "{path} manifest bytes");
+    assert_eq!(file.kappa, expected_kappa, "{path} manifest kappa");
+}
+
+fn bind_production_attention_identity() -> String {
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let model_source_manifest =
+        std::fs::read_to_string(workspace.join("crates/uor-r4-model-source/Cargo.toml"))
+            .expect("read model-source Cargo.toml");
+    assert!(
+        model_source_manifest.contains(&format!("rev = \"{UOR_MATMUL_REV}\"")),
+        "model-source Cargo.toml does not pin the declared uor-matmul rev"
+    );
+    let lockfile = std::fs::read_to_string(workspace.join("Cargo.lock")).expect("read Cargo.lock");
+    assert!(
+        lockfile.contains(&format!("?rev={UOR_MATMUL_REV}#{UOR_MATMUL_REV}")),
+        "Cargo.lock does not resolve the declared uor-matmul rev"
+    );
+
+    let records = [
+        (AttentionOperatorSpec::standard_v2(), STANDARD_V2_DIGEST),
+        (
+            AttentionOperatorSpec::experimental_r4_v2(),
+            EXPERIMENTAL_V2_DIGEST,
+        ),
+        (
+            AttentionOperatorSpec::learned_absolute_v2(),
+            LEARNED_ABSOLUTE_V2_DIGEST,
+        ),
+    ];
+    for (record, expected_digest) in &records {
+        assert_eq!(record.version, 2);
+        assert_eq!(
+            record.params.score_accumulation,
+            CERTIFIED_NATIVE_ARITHMETIC_ID
+        );
+        assert_eq!(record.implementation_digest, *expected_digest);
+        assert_eq!(record.declared_digest(), *expected_digest);
+    }
+    assert_eq!(AttentionOperatorSpec::standard(), records[0].0);
+    assert_eq!(AttentionOperatorSpec::experimental_r4(), records[1].0);
+    assert_eq!(
+        AttentionOperatorSpec::learned_absolute_source_attention(),
+        records[2].0
+    );
+    eprintln!(
+        "CERTIFIED_ATTENTION_PRODUCTION arithmetic_id={CERTIFIED_NATIVE_ARITHMETIC_ID} standard_v2_digest={STANDARD_V2_DIGEST} experimental_v2_digest={EXPERIMENTAL_V2_DIGEST} learned_absolute_v2_digest={LEARNED_ABSOLUTE_V2_DIGEST} uor_matmul_rev={UOR_MATMUL_REV}"
+    );
+    LEARNED_ABSOLUTE_V2_DIGEST.to_owned()
+}
+
+#[test]
+fn production_attention_identity_is_hard_bound() {
+    let _ = bind_production_attention_identity();
+}
+
+#[test]
+fn checked_canary_facade_matches_production_and_exact_without_allocating() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-tiny");
+    let model = Gpt2::load(&fixture, None).expect("load tiny GPT-2 fixture");
+    let mut workspace = model
+        .attention_canary_workspace()
+        .expect("valid tiny model admits canary workspace");
+    let mut production = Gpt2State::new(&model.cfg);
+    let mut certified = Gpt2State::new(&model.cfg);
+    let mut exact = Gpt2State::new(&model.cfg);
+    let mut conventional = Gpt2State::new(&model.cfg);
+    let mut census = Gpt2AttentionCanaryCensus::default();
+
+    for (position, token) in [1usize, 3, 2].into_iter().enumerate() {
+        model.forward(&mut production, token, position, &[], &mut |_, _| {});
+        census
+            .merge(
+                model
+                    .forward_attention_canary(
+                        &mut certified,
+                        &mut workspace,
+                        token,
+                        position,
+                        Gpt2AttentionCanaryMode::CertifiedNative,
+                    )
+                    .expect("checked certified step"),
+            )
+            .expect("tiny certified census fits usize");
+        model
+            .forward_attention_canary(
+                &mut exact,
+                &mut workspace,
+                token,
+                position,
+                Gpt2AttentionCanaryMode::Exact,
+            )
+            .expect("checked exact step");
+        model
+            .forward_attention_canary(
+                &mut conventional,
+                &mut workspace,
+                token,
+                position,
+                Gpt2AttentionCanaryMode::Conventional,
+            )
+            .expect("checked conventional step");
+        assert_bits(
+            &certified.logits,
+            &production.logits,
+            "certified/production",
+        );
+        assert_bits(&certified.logits, &exact.logits, "certified/exact");
+    }
+    assert!(census.qk().lanes() > 0);
+    assert!(census.value().lanes() > 0);
+    assert!(census.qk().certified() > 0);
+    assert!(census.value().certified() > 0);
+    assert!(production
+        .logits
+        .iter()
+        .zip(&conventional.logits)
+        .any(|(current, historical)| current.to_bits() != historical.to_bits()));
+
+    let mut allocation_state = Gpt2State::new(&model.cfg);
+    let (_, allocations) = counted_allocations(|| {
+        model
+            .forward_attention_canary(
+                &mut allocation_state,
+                &mut workspace,
+                1,
+                0,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            )
+            .expect("checked allocation census step")
+    });
+    assert_eq!(allocations, 0, "checked canary hot step allocated");
+}
+
+fn bind_real_snapshot(path: &Path, model: &Gpt2) {
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let canonical = path.canonicalize().expect("canonicalize GPT-2 source");
+    assert_eq!(model.attention_control_source_kappa(), GPT2_MODEL_KAPPA);
+    assert_eq!(model.attention_control_source_bytes(), GPT2_MODEL_BYTES);
+
+    let config = std::fs::read(path.join("config.json")).expect("read GPT-2 config");
+    assert_eq!(config.len(), GPT2_CONFIG_BYTES);
+    let config_kappa = format!("blake3:{}", blake3::hash(&config).to_hex());
+    assert_eq!(config_kappa, GPT2_CONFIG_KAPPA);
+
+    let manifest: SourceManifest = serde_json::from_slice(
+        &std::fs::read(path.join("source_manifest.json")).expect("read source manifest"),
+    )
+    .expect("parse source manifest");
+    assert_eq!(manifest.schema, "uor-r4-source-manifest/1");
+    assert_eq!(manifest.repository, GPT2_REPOSITORY);
+    assert_eq!(manifest.revision, GPT2_REVISION);
+    assert_manifest_file(
+        &manifest,
+        "model.safetensors",
+        GPT2_MODEL_BYTES,
+        GPT2_MODEL_KAPPA,
+    );
+    assert_manifest_file(
+        &manifest,
+        "config.json",
+        GPT2_CONFIG_BYTES,
+        GPT2_CONFIG_KAPPA,
+    );
+
+    let toolchain = std::fs::read_to_string(workspace.join("rust-toolchain.toml"))
+        .expect("read pinned rust toolchain");
+    assert!(toolchain
+        .lines()
+        .any(|line| line.trim() == format!("channel = \"{PINNED_RUSTC_RELEASE}\"")));
+    let forbidden_build_overrides: Vec<(String, String)> = std::env::vars()
+        .filter(|(key, value)| {
+            !value.is_empty()
+                && (key.contains("RUSTFLAGS") || key.starts_with("CARGO_PROFILE_RELEASE_"))
+        })
+        .collect();
+    assert!(
+        forbidden_build_overrides.is_empty(),
+        "release canary forbids external build overrides: {forbidden_build_overrides:?}"
+    );
+    let rustc = Command::new("rustc")
+        .current_dir(&workspace)
+        .args(["--version", "--verbose"])
+        .output()
+        .expect("query rustc identity");
+    assert!(rustc.status.success());
+    let rustc_identity = String::from_utf8(rustc.stdout).expect("rustc identity is UTF-8");
+    let rustc_release = rustc_identity
+        .lines()
+        .find_map(|line| line.strip_prefix("release: "))
+        .expect("rustc -vV reports release");
+    let rustc_host = rustc_identity
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .expect("rustc -vV reports host");
+    assert_eq!(rustc_release, PINNED_RUSTC_RELEASE);
+    assert_eq!(rustc_host, PINNED_RUSTC_HOST);
+    eprintln!(
+        "CERTIFIED_ATTENTION_IDENTITY repository={GPT2_REPOSITORY} revision={GPT2_REVISION} model_kappa={GPT2_MODEL_KAPPA} model_bytes={GPT2_MODEL_BYTES} config_kappa={GPT2_CONFIG_KAPPA} config_bytes={GPT2_CONFIG_BYTES} source_path={} arch={} os={} rustc_release={PINNED_RUSTC_RELEASE} rustc_host={PINNED_RUSTC_HOST} build_overrides=none steps={GPT2_STEPS} pairs={GPT2_PAIRS} threshold={MAXIMUM_RATIO:.2}",
+        canonical.display(),
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+    );
+    for line in rustc_identity.lines() {
+        eprintln!("CERTIFIED_ATTENTION_RUSTC {line}");
+    }
+}
+
+fn deterministic_tokens(vocab: usize) -> [usize; GPT2_STEPS] {
+    assert!(vocab > 1);
+    std::array::from_fn(|position| 1 + position.wrapping_mul(7_919).wrapping_add(17) % (vocab - 1))
+}
+
+fn run_control_story(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    workspace: &mut Gpt2AttentionCanaryWorkspace,
+    tokens: &[usize; GPT2_STEPS],
+    mode: Gpt2AttentionCanaryMode,
+) -> Gpt2AttentionCanaryCensus {
+    let mut census = Gpt2AttentionCanaryCensus::default();
+    for (position, &token) in tokens.iter().enumerate() {
+        census
+            .merge(
+                model
+                    .forward_attention_canary(state, workspace, token, position, mode)
+                    .expect("hard-bound canary inputs are valid"),
+            )
+            .expect("32-token canary census fits usize");
+    }
+    census
+}
+
+fn timed_control_story(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    workspace: &mut Gpt2AttentionCanaryWorkspace,
+    tokens: &[usize; GPT2_STEPS],
+    mode: Gpt2AttentionCanaryMode,
+) -> (Duration, Gpt2AttentionCanaryCensus) {
+    state.reset();
+    let ((elapsed, census), allocations) = counted_allocations(|| {
+        let started = Instant::now();
+        let census = run_control_story(model, state, workspace, tokens, mode);
+        (started.elapsed(), census)
+    });
+    assert_eq!(allocations, 0, "the timed checked canary story allocated");
+    std::hint::black_box(&state.logits);
+    (elapsed, census)
+}
+
+fn assert_nonvacuous_candidate_census(context: &str, census: Gpt2AttentionCanaryCensus) {
+    for (kind, dots) in [("QK", census.qk()), ("value", census.value())] {
+        assert!(dots.lanes() > 0, "{context} {kind}: no lanes executed");
+        assert!(
+            dots.certified() > 0,
+            "{context} {kind}: all-fallback candidate is ineligible"
+        );
+        let fallbacks = dots.fallbacks().expect("fallback census fits usize");
+        assert_eq!(
+            dots.certified()
+                .checked_add(fallbacks)
+                .expect("candidate verdict partition fits usize"),
+            dots.lanes(),
+            "{context} {kind}: every lane must have one verdict"
+        );
+    }
+}
+
+fn median_five(mut values: [f64; GPT2_PAIRS]) -> f64 {
+    values.sort_by(f64::total_cmp);
+    values[GPT2_PAIRS / 2]
+}
+
+/// Hard gate only: one real GPT-2 32-token story, five alternating pairs.
+/// Exact is the checked preflight oracle; only conventional and certified are
+/// timed. The `<=1.10x` threshold is the posted #704 Choice-A consumer
+/// contract; this local certified-native path does not claim compliance with
+/// upstream #38's distinct arithmetic policy.
+#[test]
+#[ignore = "release-only, hard-bound real GPT-2 certified-attention canary"]
+#[allow(clippy::assertions_on_constants)]
+fn real_gpt2_certified_attention_32_token_gate() {
+    assert!(!cfg!(debug_assertions), "run the canary with --release");
+    let learned_absolute_v2_digest = bind_production_attention_identity();
+    let source = real_gpt2_source();
+    let model = Gpt2::load(&source, Some(GPT2_STEPS)).expect("load hard-bound real GPT-2");
+    bind_real_snapshot(&source, &model);
+    assert_eq!(model.cfg.n_embd, 768);
+    assert_eq!(model.cfg.n_head, 12);
+    assert_eq!(model.cfg.n_layer, 12);
+    assert_eq!(model.cfg.head_size(), 64);
+    let tokens = deterministic_tokens(model.cfg.vocab);
+    let mut workspace = model
+        .attention_canary_workspace()
+        .expect("hard-bound model admits checked canary workspace");
+
+    let mut production_state = Gpt2State::new(&model.cfg);
+    let mut production_control_state = Gpt2State::new(&model.cfg);
+    let mut production_control_census = Gpt2AttentionCanaryCensus::default();
+    for (position, &token) in tokens.iter().enumerate() {
+        model.forward(&mut production_state, token, position, &[], &mut |_, _| {});
+        production_control_census
+            .merge(
+                model
+                    .forward_attention_canary(
+                        &mut production_control_state,
+                        &mut workspace,
+                        token,
+                        position,
+                        Gpt2AttentionCanaryMode::CertifiedNative,
+                    )
+                    .expect("production-control canary inputs"),
+            )
+            .expect("production-control census fits usize");
+        assert_bits(
+            &production_control_state.logits,
+            &production_state.logits,
+            &format!("real production/default v2 position {position}"),
+        );
+    }
+    assert_nonvacuous_candidate_census("production-control", production_control_census);
+
+    let mut conventional_state = Gpt2State::new(&model.cfg);
+    let mut exact_state = Gpt2State::new(&model.cfg);
+    let mut candidate_state = Gpt2State::new(&model.cfg);
+    let mut preflight = Gpt2AttentionCanaryCensus::default();
+    for (position, &token) in tokens.iter().enumerate() {
+        model
+            .forward_attention_canary(
+                &mut exact_state,
+                &mut workspace,
+                token,
+                position,
+                Gpt2AttentionCanaryMode::Exact,
+            )
+            .expect("exact preflight inputs");
+        preflight
+            .merge(
+                model
+                    .forward_attention_canary(
+                        &mut candidate_state,
+                        &mut workspace,
+                        token,
+                        position,
+                        Gpt2AttentionCanaryMode::CertifiedNative,
+                    )
+                    .expect("candidate preflight inputs"),
+            )
+            .expect("preflight census fits usize");
+        assert_bits(
+            &candidate_state.logits,
+            &exact_state.logits,
+            &format!("real candidate/exact position {position}"),
+        );
+    }
+    assert_nonvacuous_candidate_census("preflight", preflight);
+    let exact_final = exact_state.logits.clone();
+
+    let _ = timed_control_story(
+        &model,
+        &mut conventional_state,
+        &mut workspace,
+        &tokens,
+        Gpt2AttentionCanaryMode::Conventional,
+    );
+    let _ = timed_control_story(
+        &model,
+        &mut candidate_state,
+        &mut workspace,
+        &tokens,
+        Gpt2AttentionCanaryMode::CertifiedNative,
+    );
+
+    let mut conventional_seconds = [0.0f64; GPT2_PAIRS];
+    let mut candidate_seconds = [0.0f64; GPT2_PAIRS];
+    let mut timed_census = Gpt2AttentionCanaryCensus::default();
+    for pair in 0..GPT2_PAIRS {
+        let candidate_first = pair % 2 == 0;
+        let (candidate_elapsed, conventional_elapsed) = if candidate_first {
+            let (candidate, census) = timed_control_story(
+                &model,
+                &mut candidate_state,
+                &mut workspace,
+                &tokens,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            );
+            timed_census
+                .merge(census)
+                .expect("timed candidate census fits usize");
+            assert_bits(
+                &candidate_state.logits,
+                &exact_final,
+                &format!("timed candidate pair {pair}"),
+            );
+            let (conventional, _) = timed_control_story(
+                &model,
+                &mut conventional_state,
+                &mut workspace,
+                &tokens,
+                Gpt2AttentionCanaryMode::Conventional,
+            );
+            (candidate, conventional)
+        } else {
+            let (conventional, _) = timed_control_story(
+                &model,
+                &mut conventional_state,
+                &mut workspace,
+                &tokens,
+                Gpt2AttentionCanaryMode::Conventional,
+            );
+            let (candidate, census) = timed_control_story(
+                &model,
+                &mut candidate_state,
+                &mut workspace,
+                &tokens,
+                Gpt2AttentionCanaryMode::CertifiedNative,
+            );
+            timed_census
+                .merge(census)
+                .expect("timed candidate census fits usize");
+            assert_bits(
+                &candidate_state.logits,
+                &exact_final,
+                &format!("timed candidate pair {pair}"),
+            );
+            (candidate, conventional)
+        };
+        candidate_seconds[pair] = candidate_elapsed.as_secs_f64();
+        conventional_seconds[pair] = conventional_elapsed.as_secs_f64();
+        eprintln!(
+            "CERTIFIED_ATTENTION_SAMPLE pair={pair} first={} candidate_ns={} conventional_ns={} ratio={:.9}",
+            if candidate_first {
+                "candidate"
+            } else {
+                "conventional"
+            },
+            candidate_elapsed.as_nanos(),
+            conventional_elapsed.as_nanos(),
+            candidate_seconds[pair] / conventional_seconds[pair],
+        );
+    }
+    assert_nonvacuous_candidate_census("timed", timed_census);
+
+    let ratios = std::array::from_fn(|pair| candidate_seconds[pair] / conventional_seconds[pair]);
+    let median_ratio = median_five(ratios);
+    let candidate_median = median_five(candidate_seconds);
+    let conventional_median = median_five(conventional_seconds);
+    let qk_rate = timed_census.qk().certified() as f64 / timed_census.qk().lanes() as f64;
+    let value_rate = timed_census.value().certified() as f64 / timed_census.value().lanes() as f64;
+    eprintln!(
+        "CERTIFIED_ATTENTION_RESULT arithmetic_id={CERTIFIED_NATIVE_ARITHMETIC_ID} learned_absolute_v2_digest={learned_absolute_v2_digest} uor_matmul_rev={UOR_MATMUL_REV} steps={GPT2_STEPS} pairs={GPT2_PAIRS} candidate_median_ns={:.0} conventional_median_ns={:.0} paired_median_ratio={median_ratio:.9} raw_ratios={ratios:?} qk_certification_rate={qk_rate:.9} value_certification_rate={value_rate:.9} timed_census={timed_census:?} preflight_census={preflight:?} production_control_census={production_control_census:?} threshold={MAXIMUM_RATIO:.2} threshold_rule=less-than-or-equal",
+        candidate_median * 1e9,
+        conventional_median * 1e9,
+    );
+    assert!(
+        median_ratio <= MAXIMUM_RATIO,
+        "certified attention misses the local gate: {median_ratio:.6}x > {MAXIMUM_RATIO:.2}x"
+    );
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -66,7 +66,7 @@ These are κ-relevant: changing them can change artifact bytes.
 | Variable | Meaning | Default |
 |---|---|---|
 | `TLESS_CANONICAL_DETERMINISTIC` | Any value ≠ `0` selects portable libm math and scalar reductions. **Required for the cross-platform Gate E claim.** | off |
-| `TLESS_EXACT_SCALAR` | Any value disables the SIMD/Accelerate fast matmul | unset (fast path on) |
+| `TLESS_EXACT_SCALAR` | Deprecated compatibility input. Llama/shared projections already use pinned exact `uor-matmul`, so this variable no longer changes their arithmetic; it does not select a GPT-2 Conv1D/lm-head route. | unset |
 | `TLESS_TEACHER_VFORCE_EXP` | macOS only; `0` disables Accelerate `vvexpf` | on (macOS); off under canonical mode |
 | `R4_TLESS_TLA6` | `0` opts a compile out of TLA6 emission | on |
 | `R4_TLESS_TLA7` | `0` opts a compile out of TLA7 (residual) emission → TLA6 | on |
@@ -171,4 +171,24 @@ Written under `.uor-models/` (or `UOR_MODEL_STORE`):
 | `last_engine.txt` | Persisted engine preference; **silently pins the cascade** for requests that omit `engine` |
 | `sources/<name>/` | Downloaded Hugging Face teacher sources |
 | `compiled/<name>/` | Compiled bundles: `score.r4g1`, `tless_artifacts.bin`, `tless_store.bin`, deployed `tokenizer.bin`, full source binding `tokenizer_adapter.json`, source-attention binding `attention_operator.json` (both used to fail-close corpus resume/evaluation), `corpus.meta`, and `corpus.records` |
+| `compiled/<name>-attention-v2/` | Browser-compile output when `compiled/<name>/` is already populated by the implicit or explicit source-attention v1 era. The server preserves the v1 root byte-for-byte and deterministically writes/resumes v2 here; restart discovery prefers this exact current-v2 sibling and maps the exact suffix back to `sources/<name>/`. Malformed, nonregular, conflicting, or unbound-populated v2 provenance is a hard error. Explicit CLI `--output` paths are never auto-rerouted. |
 | `corpora/` | Observation corpora |
+
+### Managed attention-era resolver (2026-08-15)
+
+`-attention-v2` is reserved for the server's physical era root; a downloaded
+source basename ending in that token is refused before compilation mutates an
+output. The base and exact-suffix reload names are aliases for one logical
+model. Both attach to `sources/<logical-name>/`, and status reports the
+selected physical root separately. A missing source is allowed for the #718
+decode-only path; a source entry that exists but is not a usable directory is
+an error.
+
+Every managed operation inspects both physical roots before choosing either
+one. A malformed/nonregular binding, an unbound populated suffix, a future
+version, conflicting operator families, or two current roots is terminal.
+Current-v2 startup/reload also requires the canonical corpus pair and
+`graph-cover/cover_report.json` to carry the same registry-exact operator as
+the root sidecar. Historical v1 remains readable when those newer supporting
+records are genuinely absent. These checks reconcile the available metadata;
+they do not add the graph-byte provenance section tracked separately by #637.

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -176,11 +176,11 @@ cargo run --release -- compile \
 `--revision` must be a full 40-character commit hash. `--seconds` limits the
 teacher-generation work performed by one invocation, while `--target` is the
 teacher-token goal. `--r4-attention` selects the experimental teacher
-attention variant during generation — the #602 operator
-`experimental-r4-source-attention/1`, a 4-wide-chunked dot product with the
-same softmax selector as the standard operator (see "Attention operator
-identity (#602)" below; omitting this flag runs the standard
-`standard-source-attention/1` scaled dot-product operator, the default
+attention variant during generation — the current #704 operator
+`experimental-r4-source-attention/2`, a certified-exact dot product over the
+leading `4·⌊H/4⌋` dimensions with the same softmax selector as the standard
+operator (see "Attention operator identity (#602, #704)" below; omitting this
+flag runs the current `standard-source-attention/2` operator, the default
 everywhere). Hugging Face compilation defaults to
 20,000 tokens and 128-token teacher stories. The bounded story length keeps
 attention cost and KV memory proportional to the eight-token deployed runtime
@@ -191,13 +191,50 @@ rows. A resume must reproduce that exact operator; an existing payload with a
 missing or different binding is refused before mutation rather than being
 silently relabelled or mixed across arithmetic eras.
 
-On macOS, offline Hugging Face teacher execution uses Apple Accelerate's
-SIMD-optimized CPU BLAS. Linux and Windows use explicit NEON on AArch64 or
-runtime-detected AVX2/FMA on x86-64, with a dependency-free scalar fallback.
-These compiler accelerators do not add a runtime dependency or change the
-allocation-free table-native inference path. Set `TLESS_TEACHER_EXACT=1` to
-force the slower, reduction-order-preserving scalar path for diagnostic
-comparisons. The pinned legacy proof workflow always uses that exact path.
+The browser compile endpoint additionally protects the conventional
+`.uor-models/compiled/<name>` root across the v1→v2 transition. If that root is
+populated and carries an explicit source-attention v1 binding (or has legacy
+payload with no binding), the endpoint leaves it byte-for-byte untouched and
+uses `.uor-models/compiled/<name>-attention-v2`. A matching v2 root resumes;
+malformed, nonregular, or conflicting provenance is a hard error rather than a
+reason to route around the evidence. On restart, discovery prefers the exact
+current-v2 sibling for the same base model and maps only that exact suffix back
+to `.uor-models/sources/<name>`. Explicit CLI `--output` paths retain the
+stricter existing behavior: an incompatible era is refused and the caller
+chooses a fresh directory.
+
+**Managed resolver hardening addendum (2026-08-15).** The server owns the exact
+`-attention-v2` suffix and rejects a downloaded source basename ending in it
+before creating or resuming output. Compile selection now inspects both roots
+even when the conventional root is already current, so a duplicate current
+root or malformed suffix cannot be hidden. Automatic restart, reload, model
+listing, and status use the same paired-root resolver. It returns the logical
+source name, selected physical root, graph, teacher artifact, and exact
+operator as one value. Base reload and the exact suffix alias therefore choose
+the same bundle and attach `.uor-models/sources/<logical-name>`; status exposes
+the physical root separately.
+
+A populated preferred root is authoritative: a graph/tokenizer load error does
+not fall through to a historical sibling. A genuinely absent source still
+permits #718 token-window/decode-only loading, while a present-invalid source
+is terminal. Before current-v2 install, the server exact-compares the root
+sidecar with the canonical corpus/observation record and requires the same
+operator in `graph-cover/cover_report.json`, then re-reads the resolved
+binding. Historical v1 bundles retain compatibility when those supporting
+records are genuinely absent. This is a consistency check over recorded
+metadata, not a claim that the score graph bytes themselves carry the operator;
+that R4G1 PROV binding remains tracked by #637.
+
+Offline Llama/shared teacher projections use the pinned portable exact
+`uor-matmul` owner on every host; there is no alternate Accelerate, NEON,
+AVX2/FMA, or scalar projection route for those sites. GPT-2 Conv1D/MLP and its
+tied `lm_head` remain explicitly conventional, while current-v2 QK/value
+attention uses the certified-native/exact-fallback owner described below.
+`TLESS_EXACT_SCALAR` remains accepted only so older scripts do not fail and no
+longer changes Llama projection arithmetic. `TLESS_CANONICAL_DETERMINISTIC=1`
+still selects the portable libm/reduction family for the other κ-sensitive
+teacher and compiler operations. None of these offline choices changes the
+allocation-free table-native inference path.
 
 When compilation completes, the output directory contains:
 
@@ -464,7 +501,7 @@ singleton-decode digest, rejects the reference out-of-range id through
 and runtime results. Absence is printed as `UNAVAILABLE`, following the
 repository's three-state fixture convention.
 
-#### Attention operator identity (#602)
+#### Attention operator identity (#602, #704)
 
 The attention operator the source teacher computes is a typed, versioned
 identity, not a boolean. `uor-r4-model-source::attention` defines
@@ -480,10 +517,10 @@ change must arrive as a new registry version). A versioned registry maps
 pair fails closed with the focused
 `SourceIngestKind::UnknownAttentionOperator` rather than being guessed.
 
-**Truthful operator inventory.** Two source operators map to the
+**Immutable v1 inventory (#602/#668).** Two source operators mapped to the
 teacher's `r4_attention` switch — they are exactly the two branches it
-selects between (`attention::operator_for_r4_switch` is the one boundary
-mapping from the legacy boolean to the versioned identity); a third
+selected between (`attention::operator_for_r4_switch` remains the one boundary
+mapping from the legacy boolean to the current versioned identity); a third
 source operator (`learned-absolute-source-attention/1`, #668) is
 registered for the GPT-2 family and selected by architecture rather than
 the switch:
@@ -540,15 +577,47 @@ the switch:
   compiled GPT-2 bundle carries a truthful operator row (feeding the #606
   certificate) instead of a misdeclared RoPE one.
 
-The reference implementations are free deterministic functions factored
-verbatim out of the executor (`standard_head_attention_weights`,
-`experimental_r4_head_attention_weights`,
-`head_attention_value_aggregate`) — iteration order and arithmetic
-unchanged, the same discipline as #600's `bucket_average_project` and
-#599's `layer_forward` factoring, with the existing bit-exactness parity
-tests (e.g. `forward_batch_matches_serial_forward`) guarding the
-executor path and unit tests pinning divisible and non-divisible head
-widths.
+At the #602 landing, the v1 reference implementations were free deterministic
+functions factored verbatim out of the executor
+(`standard_head_attention_weights`,
+`experimental_r4_head_attention_weights`, and
+`head_attention_value_aggregate`). The v1 records and their conventional
+control arms preserve that historical arithmetic; the current public seams
+advance as recorded in the dated addendum below.
+
+**#704 A2 current-era addendum (2026-08-15).** The three v1 records above stay
+immutable and accepted; they remain the truthful identity of existing corpus
+bytes. Each source family now also has a current v2 record, and the legacy
+unversioned constructors are current aliases for v2. `attention::operator_spec`
+resolves all six source records exactly.
+
+- `standard-source-attention/2` (switch off, the default) retains Llama's
+  projections, grouped-query head mapping, RoPE, per-score division by
+  `sqrt(H)`, max-subtracted softmax, and output projection. Full-width Q·K and
+  weighted-value folds use the certified-exact path: a hardware-native f64
+  fold is accepted only when an outward-error/rounding-cell witness proves the
+  exact f32 bit returned by pinned `uor-matmul`; uncertain lanes use that exact
+  kernel as fallback.
+- `experimental-r4-source-attention/2` (switch on) retains the scored domain
+  `0..4·⌊H/4⌋`, including the v1 remainder policy: trailing q/k dimensions do
+  not enter scores, scale still uses full `H`, and value aggregation still
+  covers the full head. Its Q·K/value folds use the same certified-exact path.
+  `H < 4` still produces zero scores and uniform softmax. The selector remains
+  the standard max-subtracted, divide-normalized softmax. The branch remains
+  selectable, default-off, and unmeasured.
+- `learned-absolute-source-attention/2` (GPT-2 architecture, never selected by
+  the switch) retains learned absolute positions and the historical GPT-2
+  reciprocal-multiply ordering: scores multiply the precomputed
+  `1/sqrt(head_size)`, and softmax computes one reciprocal before multiplying
+  each weight. Only Q·K and weighted-value folds are certified-exact. Dense
+  GPT-2 `c_attn`, `c_proj`, MLP projections, and `lm_head` remain conventional;
+  v2 makes no claim that they moved.
+
+The current shared seams preserve caller-owned output/scratch storage and keep
+the certified and exact-fallback arms allocation-free after setup. Tests pin
+the full/scored domains, GPT-2's reciprocal order, Llama's per-score division,
+the experimental tail policy, exact-bit parity, forced certificate rejection,
+and the registry's immutable v1/v2 bytes.
 
 The record threads into provenance alongside the #597 manifest κ, the #600
 geometry record, and the #601 tokenizer record. Observe drivers record the
@@ -563,7 +632,10 @@ optional `attention_operator` field of the cover/compile report. The typed API
 and HTTP server forward the registry-validated stage-A/recorded binding rather
 than reconstructing it from the `r4_attention` policy bit, which preserves
 GPT-2's learned-absolute identity. `compile-recorded` likewise propagates an
-explicit observation-manifest record.
+explicit observation-manifest record. New source compiles and observations
+declare the exact current-v2 record selected by architecture/switch; readers
+continue to accept exact immutable v1 records, but every resume, cover, and
+evaluation seam compares the whole record and refuses cross-era replay.
 
 An absent record remains the implicit legacy era: documents produced before
 #602 are not rewritten, and a genuinely operator-less caller-supplied corpus

--- a/docs/d2_canonical_compile.md
+++ b/docs/d2_canonical_compile.md
@@ -12,16 +12,18 @@ cargo run --release --bin r4 -- compile \
 The mode is selected by `TLESS_CANONICAL_DETERMINISTIC=1` and currently does
 the following:
 
-- disables Accelerate/NEON/AVX2 teacher matmul in favor of the ordered scalar
-  path;
+- keeps Llama/shared teacher projections on the always-enabled pinned exact
+  `uor-matmul` owner; GPT-2's deliberately conventional dense sites are
+  outside this legacy D2 switch;
 - routes teacher `sqrt`, `exp`, `pow`, `sin`, and `cos` through the portable
   pure-Rust `libm` implementation;
 - routes transformerless compiler softmax, power-of-two packing, projection
   normalization, and graph-cover normalization/entropy through the same
   portable math family.
 
-`--exact-scalar` remains the faster local-iteration switch. It selects scalar
-matmul only and does not claim cross-platform byte reproducibility.
+`--exact-scalar` is a deprecated compatibility input. It no longer changes
+Llama/shared projection arithmetic and does not select a GPT-2 Conv1D or
+`lm_head` implementation.
 
 The mode is compiler-side only; the deployed runtime contract is unchanged.
 CI now runs a macOS/Linux differential compile of the pinned
@@ -35,5 +37,6 @@ The 500k/TLA7 fixture was re-run under `TLESS_CANONICAL_DETERMINISTIC=1` on
 2026-08-02. It produced the existing 1,346,836-byte container and every
 recorded κ unchanged, so the re-pin is an explicit canonical-mode adoption
 with no artifact-byte delta. Gate E now invokes that mode and is required on
-Linux as well as macOS; accelerated legacy teacher builds remain a separate,
-non-canonical local-iteration path.
+Linux as well as macOS; canonical mode continues to own the remaining libm and
+scalar-reduction choices rather than selecting a different weight-matmul
+backend.

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -11,6 +11,10 @@ Each site is classified as one of:
   zero-multiply/divide/float contract.
 - **uor-matmul-owned** — the operation is performed by the pinned
   `uor-matmul` exact/coded surface (`b13c98449948174f590e337c4dc25dfc394a07d0`).
+- **certified-exact** — the host may use a hardware-native f64 fold only when
+  a mechanical outward-error/rounding-cell witness proves that its binary32
+  result is the same bit as the pinned `uor-matmul` exact owner; an ambiguous,
+  exceptional, zero, or overflow-adjacent lane falls back to that exact owner.
 - **conventional-to-migrate** — a project-owned conventional BLAS / hand-rolled
   matrix implementation that must be replaced by `uor-matmul` (or eliminated)
   under #655-B. No such site may remain reachable in the production chain once B
@@ -49,9 +53,10 @@ conventional arithmetic is a migration target for #655-B.
 The shared Llama teacher **weight matmuls** now call the pinned `uor-matmul`
 exact GEMM (`uor_matmul::slice::gemm_float`). The Accelerate `cblas_sgemv` /
 `cblas_sgemm` FFI and all hand-rolled SIMD dot helpers are removed. GPT-2's
-tied lm-head reuses `matmul_batched`, so it is migrated too. The result is
-correctly-rounded exact and byte-identical across targets (no per-machine
-Accelerate variance) — a determinism improvement for teacher-side κ.
+tied lm-head is a distinct hand-rolled fold and remains conventional below.
+The migrated Llama result is correctly-rounded exact and byte-identical across
+targets (no per-machine Accelerate variance) — a determinism improvement for
+teacher-side κ.
 
 | Site | Operation | Backend | Classification |
 |---|---|---|---|
@@ -62,19 +67,34 @@ No `cblas_*` symbol remains anywhere in the production chain; the CI guard now
 enforces zero library-BLAS use (only the two dependency-audit files, which list
 BLAS crate names as denylist data, are exempt).
 
+### certified-exact (migrated by #704 A2)
+
+Current-v2 source attention uses caller-owned output/scratch storage. For each
+Q·K row or weighted-value column it forms exact binary32 products in binary64,
+computes an outward roundoff enclosure, and accepts the native result only when
+the full enclosure lies strictly inside one binary32 rounding cell. The pinned
+`uor-matmul` exact GEMM is the control and fallback, so every accepted or
+fallback lane returns the same correctly-rounded f32 bit. This is host-side
+teacher arithmetic; it does not enter the deployed kernel.
+
+| Site | Operation | Backend | Classification |
+|---|---|---|---|
+| `uor-r4-model-source/src/attention.rs` source-attention helpers | per-head Q·K and weighted-value column folds for standard, experimental, and GPT-2 learned-absolute v2 | certified-native f64 fold + mechanical cell witness; pinned `uor-matmul` exact fallback | certified-exact |
+
 ### conventional-to-migrate (remaining — #655-B3)
 
-GPT-2 keeps its own hand-rolled f32 arithmetic, a separate follow-up:
+GPT-2 keeps conventional dense Conv1D arithmetic, a separate fixed-weight
+follow-up. Its current-v2 attention Q·K/value folds are certified-exact above:
 
 | Site | Operation | Backend today | Classification |
 |---|---|---|---|
-| `uor-r4-model-source/src/gpt2.rs` `conv1d` / `conv1d_batched` | Conv1D `x@W` | hand-rolled f32 | conventional-to-migrate |
-| `uor-r4-model-source/src/{lib.rs,gpt2.rs}` attention scoring | per-head `Q·K` / `·V` accumulation | hand-rolled f32 | conventional-to-migrate |
+| `uor-r4-model-source/src/gpt2.rs` `conv1d` / `conv1d_batched` | fixed-weight Conv1D `x@W` for `c_attn`, `c_proj`, and MLP projections | hand-rolled f32 | conventional-to-migrate |
+| `uor-r4-model-source/src/gpt2.rs` `finish_forward` / `forward_batch` | tied `lm_head` projection | hand-rolled f32 | conventional-to-migrate |
 
 These are not library-BLAS (no `cblas_*`), so the mechanical guard does not flag
 them; they are tracked here for #655-B3.
 
-## Teacher-arithmetic era (#655-B2)
+## Teacher-arithmetic eras (#655-B2, #704 A2)
 
 Switching the teacher weight matmuls from Accelerate/hand-rolled f32 to the exact
 `uor-matmul` GEMM changes teacher output bytes, so compiled artifacts produced
@@ -84,6 +104,13 @@ the "teacher model ready" diagnostic (`matmul=uor-matmul exact GEMM`). No test
 pins a pre-B2 teacher-derived κ as a constant (verified across the full suite),
 so no fixture re-pin is required; post-B2 CIDs are a new teacher-arithmetic era
 and are never retroactively assigned to pre-B2 artifacts.
+
+#704 A2 appends a second explicit era for source attention. The current
+`standard-source-attention/2`, `experimental-r4-source-attention/2`, and
+`learned-absolute-source-attention/2` records use the certified-exact Q·K and
+weighted-value folds described above. The immutable `/1` records continue to
+identify the prior sequential/chunked f32 bytes; existing v1 bundles are never
+relabelled or resumed as v2.
 
 ## Out of census scope
 
@@ -105,10 +132,13 @@ the crate-dependency audits confirm it pulls in no BLAS/GPU crate.
 - #655-A: census + guard landed (#699). No behavior/CID change.
 - #655-B1: `uor-matmul` promoted to production dep + exact-matmul parity harness
   (#701). No behavior/CID change.
-- #655-B2 (this): Llama teacher weight matmuls (`matmul`, `matmul_batched`;
-  GPT-2 lm-head reuse included) migrated to `uor_matmul::slice::gemm_float`;
-  `cblas_*` FFI + SIMD dot helpers removed; census guard tightened to zero
-  library-BLAS. Teacher-arithmetic era change (see above); no fixture re-pin
-  required.
-- #655-B3: migrate GPT-2 `conv1d` / `conv1d_batched` and the attention-scoring
-  accumulations (`Q·K` / `·V`) — the remaining hand-rolled f32 matrix ops.
+- #655-B2: Llama teacher weight matmuls (`matmul`, `matmul_batched`) migrated
+  to `uor_matmul::slice::gemm_float`; `cblas_*` FFI + SIMD dot helpers removed;
+  census guard tightened to zero library-BLAS. GPT-2's separate tied `lm_head`
+  fold did not migrate and remains in the conventional table above.
+  Teacher-arithmetic era change (see above); no fixture re-pin required.
+- #704 A2 (2026-08-15): source-attention Q·K and weighted-value folds migrated to the
+  certified-exact path for all current `/2` families; `/1` provenance remains
+  immutable.
+- #655-B3 remaining: migrate GPT-2 fixed-weight `conv1d` / `conv1d_batched`
+  and tied `lm_head` folds.

--- a/docs/r4_graph_compiler_implementation_plan.md
+++ b/docs/r4_graph_compiler_implementation_plan.md
@@ -72,6 +72,13 @@ platform BLAS) — slower, but byte-reproducible across platforms; (b) per-platf
 Recommendation: (a) for all certificate-bearing artifacts, with (b) tolerated for local iteration.
 Recorded in the R4G1 RFC in Phase 0; implemented as a compiler mode in Phase 2.
 
+Implementation update (2026-08-15): #655-B2 removed the historical
+Accelerate/NEON/AVX2 split from Llama/shared teacher projections, which now use
+the pinned portable exact `uor-matmul` owner. GPT-2 Conv1D/MLP and tied
+`lm_head` remain conventional; current-v2 QK/value attention has its own
+certified-native/exact-fallback owner. Canonical mode continues to govern the
+remaining libm and ordered-reduction choices.
+
 ### D3 — Evaluation distribution and corpora
 
 Question: which distribution do all certificates certify on? The current baseline is
@@ -234,9 +241,10 @@ only; it must never become a dependency of format/runtime/proof-model. Per-stage
    κ. CI asserts this on a pinned mini-corpus (T=1 vs T=4 → identical artifact bytes).
 2. No naive parallel FP reductions: FP addition is non-associative, so all reductions are ordered
    (shard-ID order) with f64 or fixed-point accumulators.
-3. Certificate-bearing compiles use scalar kernels only (no Accelerate/NEON matmul): platform SIMD
-   reorders FP sums internally and breaks cross-platform byte equality (D2). Platform-accelerated
-   mode is for local iteration, validated by behavioral equivalence (PDF §15).
+3. Llama/shared weight projections use pinned exact `uor-matmul`. Certificate-bearing compiles
+   additionally select the canonical libm and ordered-reduction family; GPT-2's conventional
+   dense sites and certified-exact current attention are recorded separately rather than being
+   relabeled by this historical D2 switch.
 4. Seeds pinned; any shuffling derives from a seeded PRNG over sample IDs, never iteration order.
 
 **Memory budget.** See [compiler_memory_budget.md](file:///Users/casey.allard/uor-r4/docs/compiler_memory_budget.md) (Issue #169) for the normative concurrency-aware memory budget and backpressure model. A `--memory-budget` flag derives shard sizes from
@@ -514,7 +522,8 @@ Objective: machine-checked evidence for the proof obligations (PDF §25, §27).
 Objective: AVX2/AVX-512/NEON kernels behind validated runtime dispatch (PDF §17, A5).
 
 - Precedent exists: `assign_plain` bulk-popcount fast path witnessed equal to kernel path
-  (PROOF.md P1); teacher matmul already has NEON/AVX2 backends (`teacher.rs:159-356`).
+  (PROOF.md P1). Historical teacher NEON/AVX2 backends were retired when #655-B2 made pinned exact
+  `uor-matmul` the sole teacher projection owner; they are not a current acceleration precedent.
 - Each specialized kernel: property-based equivalence over finite primitive domains + differential
   tests over runtime fixtures; optional disable flag; scalar safe Rust remains normative semantics.
 - Unsafe confined to adapter modules with SAFETY comments + Miri.

--- a/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
+++ b/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
@@ -68,14 +68,20 @@ This contract does **not** restrict:
 
 Compilation and training are explicitly unrestricted by this contract.
 
-Note (non-normative cross-reference, #602): the source attention operator
-specifications in `uor-r4-model-source::attention`
-(`standard-source-attention/1`, `experimental-r4-source-attention/1`, and
-GPT-2's `learned-absolute-source-attention/1`) are host-side provenance
-records of teacher execution — an activity this section already excludes.
-They are distinct from this deployed contract, describe floating-point source
-computation the deployed hot path never performs, and change none of the
-operation lists or obligations above.
+Note (non-normative cross-reference, #602 and #704): the source attention
+operator specifications in `uor-r4-model-source::attention` are host-side
+provenance records of teacher execution — an activity this section already
+excludes.
+The registry contains immutable historical and current records for all three
+source families: `standard-source-attention/{1,2}`,
+`experimental-r4-source-attention/{1,2}`, and GPT-2's
+`learned-absolute-source-attention/{1,2}`. Version 2 changes only source-teacher
+Q·K and weighted-value folds: native results are used only when a mechanical
+witness proves the exact pinned-`uor-matmul` f32 bit, with that exact kernel as
+the fallback. GPT-2's dense `c_attn`, `c_proj`, MLP, and `lm_head` remain
+conventional. These records are distinct from this deployed contract, describe
+floating-point source computation the deployed hot path never performs, and
+change none of the operation lists or obligations above.
 
 Note (non-normative cross-reference, #604): `r4-route-attention/1`
 (`R4RouteAttentionV1`, documented in `docs/MODEL_LIFECYCLE.md`) is a

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -953,35 +953,11 @@ fn trigger_in_client_compilation<W: Write>(
         )?;
     }
 
-    // Stage 2: Compile observation corpus
-    let accel_options = [
-        (
-            "1) Fast Hardware Acceleration",
-            "Use Apple Accelerate BLAS SIMD/AMX (~25x Speedup) [Default]",
-        ),
-        (
-            "2) Strict Exact Scalar CPU",
-            "Exact bitwise scalar math (Slower, exact proof baseline)",
-        ),
-    ];
-
-    let use_exact_scalar = matches!(
-        select_menu_interactive(
-            "Select Teacher Matrix Acceleration Mode for Compilation:",
-            &accel_options,
-            output,
-        ),
-        Ok(Some(1))
-    );
-
+    // Stage 2: Compile observation corpus. Projection ownership is fixed by
+    // the loaded architecture; the legacy --exact-scalar switch is a no-op.
     writeln!(
         output,
-        "[*] [Stage 2/4] Compiling zero-multiply observation corpus (accel: {})...",
-        if use_exact_scalar {
-            "exact scalar"
-        } else {
-            "Apple Accelerate BLAS SIMD/AMX"
-        }
+        "[*] [Stage 2/4] Compiling zero-multiply observation corpus (exact uor-matmul projections; certified-exact current attention)..."
     )?;
     output.flush()?;
     std::fs::create_dir_all(&compiled_dir).ok();
@@ -994,7 +970,7 @@ fn trigger_in_client_compilation<W: Write>(
         _ => ("176800", "300"),
     };
 
-    let mut compile_cmd_args = vec![
+    let compile_cmd_args = vec![
         "compile".to_string(),
         "--source".to_string(),
         source_dir.clone(),
@@ -1007,10 +983,6 @@ fn trigger_in_client_compilation<W: Write>(
         "--sequence-length".to_string(),
         "128".to_string(),
     ];
-    if use_exact_scalar {
-        compile_cmd_args.push("--exact-scalar".to_string());
-    }
-
     let status = std::process::Command::new(&r4_exe)
         .args(&compile_cmd_args)
         .status()?;
@@ -1553,7 +1525,10 @@ pub fn remote_interactive_chat(
                             let engine_options = [
                                 ("r4g1", "Sub-ms Zero-Multiply Residual Graph Engine"),
                                 ("attention", "Full Attention Teacher Oracle Fallback"),
-                                ("r4-attention", "Manifold-Constrained Geometric Attention"),
+                                (
+                                    "r4-attention",
+                                    "Llama Certified Leading-4 Attention (GPT-2 Learned-Absolute)",
+                                ),
                                 ("geometric", "f64 Geometric Router Engine"),
                                 ("transformerless-legacy", "Legacy Table Store Kernel"),
                             ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,12 +230,15 @@ struct CompileArgs {
     /// Teacher context allocation and story length.
     #[arg(long, default_value_t = 128)]
     sequence_length: usize,
-    /// Enable the experimental teacher attention variant (#602 operator
-    /// `experimental-r4-source-attention/1`: a 4-wide-chunked dot product with
-    /// the same softmax selector as the standard operator) during compilation.
+    /// Enable the current experimental Llama teacher attention variant (#704
+    /// operator `experimental-r4-source-attention/2`: certified-exact Q·K over
+    /// the leading 4-wide domain and certified-exact value aggregation, with
+    /// the standard max-subtracted softmax) during compilation. GPT-2 ignores
+    /// this legacy switch and uses its architecture-owned
+    /// `learned-absolute-source-attention/2` record.
     #[arg(long, default_value_t = false)]
     r4_attention: bool,
-    /// Force exact scalar CPU math instead of Apple Accelerate / SIMD hardware matrix acceleration.
+    /// Deprecated compatibility flag; no longer selects a different Llama matmul owner.
     #[arg(long, default_value_t = false)]
     exact_scalar: bool,
     /// Use the portable libm teacher path and scalar reductions for certificate-bearing builds.
@@ -883,15 +886,23 @@ fn audit_command(log_file: &PathBuf) -> Result<(), RunError> {
     let records: serde_json::Value = serde_json::from_str(&content)
         .map_err(|e| RunError::Command(format!("Failed to parse audit log: {}", e)))?;
 
-    println!("\n\x1b[1;36m┌─────────────────────────────────────────────────────────────────────────────┐\x1b[0m");
-    println!("\x1b[1;36m│  R⁴ UOR Auditability & Tracing Log Inspector                                │\x1b[0m");
-    println!("\x1b[1;36m├─────────────────────────────────────────────────────────────────────────────┤\x1b[0m");
+    println!(
+        "\n\x1b[1;36m┌─────────────────────────────────────────────────────────────────────────────┐\x1b[0m"
+    );
+    println!(
+        "\x1b[1;36m│  R⁴ UOR Auditability & Tracing Log Inspector                                │\x1b[0m"
+    );
+    println!(
+        "\x1b[1;36m├─────────────────────────────────────────────────────────────────────────────┤\x1b[0m"
+    );
     println!("  Audit Log Path: \x1b[1m{}\x1b[0m", log_file.display());
 
     if let Some(arr) = records.as_array() {
         println!("  Total Audited Turns: \x1b[32m{}\x1b[0m", arr.len());
         for (idx, item) in arr.iter().enumerate() {
-            println!("\x1b[1;36m├─────────────────────────────────────────────────────────────────────────────┤\x1b[0m");
+            println!(
+                "\x1b[1;36m├─────────────────────────────────────────────────────────────────────────────┤\x1b[0m"
+            );
             let q = item.get(0).and_then(|v| v.as_str()).unwrap_or("");
             let a = item.get(1).and_then(|v| v.as_str()).unwrap_or("");
             let audit = item.get(2);
@@ -921,11 +932,16 @@ fn audit_command(log_file: &PathBuf) -> Result<(), RunError> {
                     "\x1b[33m[! DRIFT]\x1b[0m"
                 };
 
-                println!("          UOR Address: \x1b[36m{}\x1b[0m | κ: {:.4} {} | mode: \x1b[32m{}\x1b[0m | latency: {:.2}ms", uor_addr, kappa, pass_str, mode, lat);
+                println!(
+                    "          UOR Address: \x1b[36m{}\x1b[0m | κ: {:.4} {} | mode: \x1b[32m{}\x1b[0m | latency: {:.2}ms",
+                    uor_addr, kappa, pass_str, mode, lat
+                );
             }
         }
     }
-    println!("\x1b[1;36m└─────────────────────────────────────────────────────────────────────────────┘\x1b[0m\n");
+    println!(
+        "\x1b[1;36m└─────────────────────────────────────────────────────────────────────────────┘\x1b[0m\n"
+    );
     Ok(())
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1090,8 +1090,12 @@ fn verify_opened_snapshot_child(
     } else {
         0
     };
+    // `libc::dev_t` is already `u64` on Linux but is narrower on Darwin;
+    // normalize the platform ABI before comparing it with `MetadataExt::dev`.
+    #[allow(clippy::unnecessary_cast)]
+    let status_device = status.st_dev as u64;
     if kind != expected_kind
-        || status.st_dev as u64 != opened_metadata.dev()
+        || status_device != opened_metadata.dev()
         || status.st_ino != opened_metadata.ino()
     {
         return Err(ModelError::Io(std::io::Error::new(

--- a/src/model.rs
+++ b/src/model.rs
@@ -746,6 +746,24 @@ pub struct SourceSnapshotInfo {
     pub source_execution_mode: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceTreeScope {
+    ManifestAdmitted,
+    ManifestlessAll,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum VerifiedSourceTreeEntry {
+    Directory {
+        path: String,
+    },
+    File {
+        path: String,
+        bytes: u64,
+        kappa: String,
+    },
+}
+
 /// Whether a file name is admitted into the snapshot manifest. Mirrors
 /// exactly what [`download_source`] admits: `*.safetensors` (including
 /// sharded weights), `*.json` (config, tokenizer, chat template,
@@ -771,8 +789,15 @@ pub fn build_source_manifest(
     snapshot_dir: &Path,
     info: &SourceSnapshotInfo,
 ) -> Result<SourceManifest, ModelError> {
-    let mut files = Vec::new();
-    collect_admitted_files(snapshot_dir, snapshot_dir, &mut files)?;
+    let mut files = verified_source_tree(snapshot_dir, SourceTreeScope::ManifestAdmitted)?
+        .into_iter()
+        .filter_map(|entry| match entry {
+            VerifiedSourceTreeEntry::File { path, bytes, kappa } => {
+                Some(SourceManifestFile { path, bytes, kappa })
+            }
+            VerifiedSourceTreeEntry::Directory { .. } => None,
+        })
+        .collect::<Vec<_>>();
     files.sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
     Ok(SourceManifest {
         schema: SOURCE_MANIFEST_SCHEMA.to_owned(),
@@ -785,71 +810,425 @@ pub fn build_source_manifest(
     })
 }
 
-fn collect_admitted_files(
-    root: &Path,
-    directory: &Path,
-    files: &mut Vec<SourceManifestFile>,
+pub(crate) fn verified_source_tree(
+    snapshot_dir: &Path,
+    scope: SourceTreeScope,
+) -> Result<Vec<VerifiedSourceTreeEntry>, ModelError> {
+    verified_source_tree_with_hook(snapshot_dir, scope, |_| {})
+}
+
+#[cfg(unix)]
+pub(crate) fn verified_source_tree_with_hook<F>(
+    snapshot_dir: &Path,
+    scope: SourceTreeScope,
+    mut before_open: F,
+) -> Result<Vec<VerifiedSourceTreeEntry>, ModelError>
+where
+    F: FnMut(&Path),
+{
+    let root = open_snapshot_directory_nofollow(snapshot_dir)?;
+    let root_metadata = root.metadata()?;
+    let mut entries = Vec::new();
+    walk_source_tree_directory(
+        snapshot_dir,
+        &root,
+        "",
+        scope,
+        &mut before_open,
+        &mut entries,
+    )?;
+    verify_opened_snapshot_entry(snapshot_dir, &root_metadata)?;
+    entries.sort_by(|left, right| {
+        verified_source_tree_entry_path(left)
+            .as_bytes()
+            .cmp(verified_source_tree_entry_path(right).as_bytes())
+    });
+    Ok(entries)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn verified_source_tree_with_hook<F>(
+    snapshot_dir: &Path,
+    _scope: SourceTreeScope,
+    _before_open: F,
+) -> Result<Vec<VerifiedSourceTreeEntry>, ModelError>
+where
+    F: FnMut(&Path),
+{
+    Err(ModelError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!(
+            "handle-bound source snapshot traversal is unavailable on this platform: {}",
+            snapshot_dir.display()
+        ),
+    )))
+}
+
+fn verified_source_tree_entry_path(entry: &VerifiedSourceTreeEntry) -> &str {
+    match entry {
+        VerifiedSourceTreeEntry::Directory { path }
+        | VerifiedSourceTreeEntry::File { path, .. } => path,
+    }
+}
+
+#[cfg(unix)]
+fn open_snapshot_directory_nofollow(path: &Path) -> Result<std::fs::File, ModelError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let directory = options.open(path)?;
+    if !directory.metadata()?.file_type().is_dir() {
+        return Err(ModelError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "source snapshot {} is not a regular non-symlink directory",
+                path.display()
+            ),
+        )));
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn same_snapshot_inode(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(unix)]
+fn same_snapshot_metadata_version(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    same_snapshot_inode(left, right)
+        && left.mode() == right.mode()
+        && left.len() == right.len()
+        && left.mtime() == right.mtime()
+        && left.mtime_nsec() == right.mtime_nsec()
+        && left.ctime() == right.ctime()
+        && left.ctime_nsec() == right.ctime_nsec()
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+unsafe fn source_tree_errno_pointer() -> *mut libc::c_int {
+    // SAFETY: caller uses the target libc's thread-local errno accessor.
+    unsafe { libc::__errno_location() }
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn source_tree_errno_pointer() -> *mut libc::c_int {
+    // SAFETY: caller uses the target libc's thread-local errno accessor.
+    unsafe { libc::__error() }
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android", target_vendor = "apple"))
+))]
+fn read_opened_directory_names(_directory: &std::fs::File) -> Result<Vec<String>, ModelError> {
+    Err(ModelError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "handle-bound directory enumeration is not implemented for this Unix target",
+    )))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+fn read_opened_directory_names(directory: &std::fs::File) -> Result<Vec<String>, ModelError> {
+    use std::os::fd::AsRawFd;
+
+    // SAFETY: `fcntl` duplicates the live directory descriptor. Ownership of
+    // the duplicate is transferred to `fdopendir` below.
+    let duplicate = unsafe { libc::fcntl(directory.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicate < 0 {
+        return Err(ModelError::Io(std::io::Error::last_os_error()));
+    }
+    // SAFETY: `duplicate` is a fresh owned directory descriptor.
+    let stream = unsafe { libc::fdopendir(duplicate) };
+    if stream.is_null() {
+        // SAFETY: fdopendir did not take ownership on failure.
+        unsafe { libc::close(duplicate) };
+        return Err(ModelError::Io(std::io::Error::last_os_error()));
+    }
+    struct DirectoryStream(*mut libc::DIR);
+    impl Drop for DirectoryStream {
+        fn drop(&mut self) {
+            // SAFETY: this guard uniquely owns the DIR pointer.
+            unsafe { libc::closedir(self.0) };
+        }
+    }
+    let stream = DirectoryStream(stream);
+    let mut names = Vec::new();
+    loop {
+        // SAFETY: the target accessor returns this thread's errno cell.
+        unsafe { *source_tree_errno_pointer() = 0 };
+        // SAFETY: `stream` stays live and uniquely owned during enumeration.
+        let entry = unsafe { libc::readdir(stream.0) };
+        if entry.is_null() {
+            // SAFETY: the target accessor returns this thread's errno cell.
+            let errno = unsafe { *source_tree_errno_pointer() };
+            if errno != 0 {
+                return Err(ModelError::Io(std::io::Error::from_raw_os_error(errno)));
+            }
+            break;
+        }
+        // SAFETY: POSIX dirent d_name is NUL-terminated for a successful
+        // readdir result and remains valid until the next readdir call.
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) }
+            .to_str()
+            .map_err(|_| ModelError::NonPortableSnapshotPath(PathBuf::from("<non-utf8>")))?;
+        if name != "." && name != ".." {
+            names.push(name.to_owned());
+        }
+    }
+    names.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    Ok(names)
+}
+
+#[cfg(unix)]
+fn verify_opened_snapshot_entry(
+    path: &Path,
+    opened_metadata: &std::fs::Metadata,
 ) -> Result<(), ModelError> {
-    for entry in std::fs::read_dir(directory)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else {
-            return Err(ModelError::NonPortableSnapshotPath(path));
-        };
-        if name.starts_with('.') {
-            continue;
-        }
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            collect_admitted_files(root, &path, files)?;
-        } else if file_type.is_file() && admitted_source_file(name) {
-            let relative = relative_manifest_path(root, &path)?;
-            let (bytes, kappa) = file_length_and_kappa(&path)?;
-            files.push(SourceManifestFile {
-                path: relative,
-                bytes,
-                kappa,
-            });
-        }
+    let current = std::fs::symlink_metadata(path)?;
+    if current.file_type().is_symlink()
+        || !same_snapshot_metadata_version(&current, opened_metadata)
+        || current.file_type().is_dir() != opened_metadata.file_type().is_dir()
+        || current.file_type().is_file() != opened_metadata.file_type().is_file()
+    {
+        return Err(ModelError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "source snapshot entry {} changed identity or type during handle-bound traversal",
+                path.display()
+            ),
+        )));
     }
     Ok(())
 }
 
-fn relative_manifest_path(root: &Path, path: &Path) -> Result<String, ModelError> {
-    let relative = path
-        .strip_prefix(root)
-        .map_err(|_| ModelError::NonPortableSnapshotPath(path.to_path_buf()))?;
-    let mut portable = String::new();
-    for component in relative.components() {
-        let Some(part) = component.as_os_str().to_str() else {
-            return Err(ModelError::NonPortableSnapshotPath(path.to_path_buf()));
-        };
-        if !portable.is_empty() {
-            portable.push('/');
-        }
-        portable.push_str(part);
+#[cfg(unix)]
+fn open_snapshot_child_nofollow(
+    parent: &std::fs::File,
+    name: &str,
+    display_path: &Path,
+) -> Result<std::fs::File, ModelError> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = std::ffi::CString::new(name)
+        .map_err(|_| ModelError::NonPortableSnapshotPath(display_path.to_path_buf()))?;
+    // SAFETY: `parent` and `name` remain live for the call, the C string is
+    // NUL-terminated, and a successful descriptor is transferred exactly
+    // once into `File` below.
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if descriptor < 0 {
+        let error = std::io::Error::last_os_error();
+        return Err(ModelError::Io(std::io::Error::new(
+            error.kind(),
+            format!(
+                "source snapshot entry {} cannot be opened without following links: {}",
+                display_path.display(),
+                error
+            ),
+        )));
     }
-    Ok(portable)
+    // SAFETY: `openat` returned a new owned descriptor and no other owner is
+    // constructed for it.
+    Ok(unsafe { std::fs::File::from_raw_fd(descriptor) })
 }
 
-/// Streamed raw blake3 of one file's bytes plus its length, as
-/// `blake3:<hex>` (per-file digests stay raw, unlike the manifest root κ).
-fn file_length_and_kappa(path: &Path) -> Result<(u64, String), ModelError> {
-    use std::io::Read as _;
-    let mut file = std::fs::File::open(path)?;
-    let mut hasher = blake3::Hasher::new();
-    let mut buffer = [0u8; 65_536];
-    let mut length = 0u64;
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        length += read as u64;
-        hasher.update(&buffer[..read]);
+#[cfg(unix)]
+fn verify_opened_snapshot_child(
+    parent: &std::fs::File,
+    name: &str,
+    display_path: &Path,
+    opened_metadata: &std::fs::Metadata,
+) -> Result<(), ModelError> {
+    use std::mem::MaybeUninit;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::MetadataExt;
+
+    let name = std::ffi::CString::new(name)
+        .map_err(|_| ModelError::NonPortableSnapshotPath(display_path.to_path_buf()))?;
+    let mut status = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: parent/name are live, status points to writable storage, and
+    // AT_SYMLINK_NOFOLLOW makes the final component itself authoritative.
+    let result = unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            status.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        let error = std::io::Error::last_os_error();
+        return Err(ModelError::Io(std::io::Error::new(
+            error.kind(),
+            format!(
+                "source snapshot entry {} cannot be rebound after open: {}",
+                display_path.display(),
+                error
+            ),
+        )));
     }
-    Ok((length, format!("blake3:{}", hasher.finalize().to_hex())))
+    // SAFETY: fstatat initialized status on success.
+    let status = unsafe { status.assume_init() };
+    let kind = status.st_mode & libc::S_IFMT;
+    let expected_kind = if opened_metadata.file_type().is_dir() {
+        libc::S_IFDIR
+    } else if opened_metadata.file_type().is_file() {
+        libc::S_IFREG
+    } else {
+        0
+    };
+    if kind != expected_kind
+        || status.st_dev as u64 != opened_metadata.dev()
+        || status.st_ino != opened_metadata.ino()
+    {
+        return Err(ModelError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "source snapshot entry {} changed identity or type during handle-bound traversal",
+                display_path.display()
+            ),
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn walk_source_tree_directory<F>(
+    snapshot_root: &Path,
+    directory: &std::fs::File,
+    relative_directory: &str,
+    scope: SourceTreeScope,
+    before_open: &mut F,
+    output: &mut Vec<VerifiedSourceTreeEntry>,
+) -> Result<(), ModelError>
+where
+    F: FnMut(&Path),
+{
+    use std::io::Read as _;
+
+    let names = read_opened_directory_names(directory)?;
+
+    for name in names {
+        if scope == SourceTreeScope::ManifestAdmitted && name.starts_with('.') {
+            continue;
+        }
+        let relative = if relative_directory.is_empty() {
+            name.clone()
+        } else {
+            format!("{relative_directory}/{name}")
+        };
+        let display_path = snapshot_root.join(&relative);
+        before_open(&display_path);
+        let mut child = open_snapshot_child_nofollow(directory, &name, &display_path)?;
+        let opened_metadata = child.metadata()?;
+        verify_opened_snapshot_child(directory, &name, &display_path, &opened_metadata)?;
+
+        if opened_metadata.file_type().is_dir() {
+            if scope == SourceTreeScope::ManifestlessAll && name == ".cache" {
+                continue;
+            }
+            if scope == SourceTreeScope::ManifestlessAll {
+                output.push(VerifiedSourceTreeEntry::Directory {
+                    path: relative.clone(),
+                });
+            }
+            walk_source_tree_directory(
+                snapshot_root,
+                &child,
+                &relative,
+                scope,
+                before_open,
+                output,
+            )?;
+            let final_metadata = child.metadata()?;
+            if !same_snapshot_metadata_version(&opened_metadata, &final_metadata) {
+                return Err(ModelError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "source snapshot directory {} changed while being traversed",
+                        display_path.display()
+                    ),
+                )));
+            }
+            verify_opened_snapshot_child(directory, &name, &display_path, &final_metadata)?;
+            continue;
+        }
+        if !opened_metadata.file_type().is_file() {
+            return Err(ModelError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "source snapshot entry {} is not a regular non-symlink file or directory",
+                    display_path.display()
+                ),
+            )));
+        }
+        if scope == SourceTreeScope::ManifestlessAll && name == ".cache" {
+            return Err(ModelError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "source snapshot entry {} uses reserved .cache transport name but is not a directory",
+                    display_path.display()
+                ),
+            )));
+        }
+        if scope == SourceTreeScope::ManifestAdmitted && !admitted_source_file(&name) {
+            verify_opened_snapshot_child(directory, &name, &display_path, &opened_metadata)?;
+            continue;
+        }
+
+        let mut hasher = blake3::Hasher::new();
+        let mut buffer = [0u8; 65_536];
+        let mut length = 0u64;
+        loop {
+            let read = child.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            length = length.checked_add(read as u64).ok_or_else(|| {
+                ModelError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "source snapshot entry {} is too large",
+                        display_path.display()
+                    ),
+                ))
+            })?;
+            hasher.update(&buffer[..read]);
+        }
+        let final_metadata = child.metadata()?;
+        if !same_snapshot_metadata_version(&opened_metadata, &final_metadata)
+            || !final_metadata.file_type().is_file()
+            || final_metadata.len() != length
+        {
+            return Err(ModelError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "source snapshot entry {} changed while being digested",
+                    display_path.display()
+                ),
+            )));
+        }
+        verify_opened_snapshot_child(directory, &name, &display_path, &final_metadata)?;
+        output.push(VerifiedSourceTreeEntry::File {
+            path: relative,
+            bytes: length,
+            kappa: format!("blake3:{}", hasher.finalize().to_hex()),
+        });
+    }
+    Ok(())
 }
 
 /// Canonical manifest bytes: stable field order (struct declaration
@@ -1162,6 +1541,82 @@ mod tests {
             source_manifest_kappa(&second).unwrap()
         );
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handle_bound_snapshot_walk_refuses_file_symlink_and_fifo_swaps() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+
+        fn fifo(path: &Path) {
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+            // SAFETY: the C string is live for the call and mkfifo does not
+            // retain its pointer.
+            assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        }
+
+        for (scope, scope_name) in [
+            (SourceTreeScope::ManifestAdmitted, "manifest"),
+            (SourceTreeScope::ManifestlessAll, "manifestless"),
+        ] {
+            for kind in ["symlink", "fifo"] {
+                let dir = snapshot_dir(&format!("handle-file-{scope_name}-{kind}"));
+                let target = dir.join("config.json");
+                let original = dir.join("config.original");
+                let mut swapped = false;
+                let result = verified_source_tree_with_hook(&dir, scope, |path| {
+                    if !swapped && path == target {
+                        std::fs::rename(&target, &original).unwrap();
+                        match kind {
+                            "symlink" => symlink(&original, &target).unwrap(),
+                            "fifo" => fifo(&target),
+                            _ => unreachable!(),
+                        }
+                        swapped = true;
+                    }
+                });
+                let error = result.expect_err("a post-enumeration file swap is terminal");
+                assert!(error.to_string().contains("config.json"), "{error}");
+                assert_eq!(
+                    std::fs::read(&original).expect("original file remains bound"),
+                    b"{\"hidden_size\":576}"
+                );
+                let _ = std::fs::remove_dir_all(dir);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handle_bound_snapshot_walk_refuses_directory_symlink_escape_and_cycle() {
+        use std::os::unix::fs::symlink;
+
+        for kind in ["outside", "cycle"] {
+            let dir = snapshot_dir(&format!("handle-directory-{kind}"));
+            let child = dir.join("nested");
+            let original = dir.join("nested-original");
+            let outside = snapshot_dir(&format!("handle-directory-{kind}-outside"));
+            std::fs::write(outside.join("escaped.json"), b"outside").unwrap();
+            let mut swapped = false;
+            let result =
+                verified_source_tree_with_hook(&dir, SourceTreeScope::ManifestlessAll, |path| {
+                    if !swapped && path == child {
+                        std::fs::rename(&child, &original).unwrap();
+                        match kind {
+                            "outside" => symlink(&outside, &child).unwrap(),
+                            "cycle" => symlink(&dir, &child).unwrap(),
+                            _ => unreachable!(),
+                        }
+                        swapped = true;
+                    }
+                });
+            let error = result.expect_err("a directory link swap cannot escape or cycle");
+            assert!(error.to_string().contains("nested"), "{error}");
+            assert!(outside.join("escaped.json").is_file());
+            let _ = std::fs::remove_dir_all(dir);
+            let _ = std::fs::remove_dir_all(outside);
+        }
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,14 +10,20 @@ use std::fs;
 use std::io::{prelude::*, BufReader};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
 use std::time::{Duration, Instant};
 use uor_foundation::pipeline::PrismModel;
 
 use uor_r4_core::transformerless::hf_bpe::{
-    resolve_source_tokenizer, TokenizerAdapterKey, TokenizerKind,
+    adapter_constructor, resolve_source_tokenizer, TokenizerAdapter, TokenizerAdapterKey,
+    TokenizerKind,
 };
+use uor_r4_core::transformerless::scenarios::RuntimeTokenizerIdentity;
 use uor_r4_graph_certify::ScoreStatus;
+use uor_r4_model_source::attention::AttentionOperatorSpec;
 use uor_r4_model_source::{BehaviorSource, TeacherOracle};
 use uor_r4_router::fallback::{
     run_cascade, CascadeOutcome, EngineStatus, TierFn, TierOutcome, TierResult,
@@ -61,6 +67,20 @@ pub struct ServerConfig {
 pub use uor_r4_api::{InferenceRequest, InferenceResponse, InferenceWitness};
 
 type ChatPayload = InferenceRequest;
+
+fn startup_source_candidates(last_model_name: &str) -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(4);
+    let last_model_name = last_model_name.trim();
+    if !last_model_name.is_empty() {
+        candidates.push(PathBuf::from(".uor-models/sources").join(last_model_name));
+    }
+    candidates.extend([
+        PathBuf::from(".uor-models/sources/smollm2-135m-instruct"),
+        PathBuf::from(".uor-models/sources/smollm2-360m-instruct"),
+        PathBuf::from(".uor-models/sources/smollm2-1-7b-instruct"),
+    ]);
+    candidates
+}
 
 #[derive(Debug, Deserialize)]
 pub struct ChatMessage {
@@ -217,6 +237,7 @@ struct ResetPayload {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 struct HuggingFaceDownloadPayload {
     model: Option<String>,
     /// Optional explicit source-tokenizer selection. The two fields are one
@@ -236,6 +257,24 @@ impl HuggingFaceDownloadPayload {
             (None, Some(_)) => Err("tokenizer_version requires tokenizer_family".to_owned()),
         }
     }
+
+    fn validate_download_controls(&self) -> Result<(), String> {
+        if self.tokenizer_family.is_some() || self.tokenizer_version.is_some() {
+            return Err(
+                "tokenizer_family/tokenizer_version apply only to compile and reload; the download endpoint accepts only model"
+                    .to_owned(),
+            );
+        }
+        Ok(())
+    }
+}
+
+fn parse_huggingface_control_payload(body: &[u8]) -> Result<HuggingFaceDownloadPayload, String> {
+    if body.is_empty() {
+        Ok(HuggingFaceDownloadPayload::default())
+    } else {
+        serde_json::from_slice(body).map_err(|error| format!("Invalid JSON: {error}"))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -253,6 +292,107 @@ struct HuggingFaceDownloadStatus {
     ready: bool,
     message: String,
     source: Option<String>,
+    /// Exact immutable identity whose verified snapshot was published at
+    /// `source`. Keeping the descriptor beside the path prevents an implicit
+    /// compile from trusting a substituted legacy-named directory merely
+    /// because download status still says it is ready.
+    completed_source: Option<SourceDownload>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompletedDownloadSource {
+    path: PathBuf,
+    identity: SourceDownload,
+}
+
+struct CompileSourceSelection {
+    path: Option<String>,
+    expected: Option<SourceDownload>,
+    require_manifest: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SourceCacheOperationKind {
+    Download,
+    Compile,
+    Reload,
+}
+
+impl SourceCacheOperationKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Download => "download",
+            Self::Compile => "compile",
+            Self::Reload => "reload",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActiveSourceCacheOperation {
+    id: u64,
+    kind: SourceCacheOperationKind,
+    subject: String,
+}
+
+#[derive(Debug, Default)]
+struct SourceCacheOperationState {
+    next_id: u64,
+    active: Option<ActiveSourceCacheOperation>,
+}
+
+type SharedSourceCacheOperations = Arc<Mutex<SourceCacheOperationState>>;
+
+/// One process-wide mutation/read reservation for the immutable source cache.
+///
+/// Downloads publish source directories, while compilation and reload hold
+/// borrowed teacher/tokenizer files open. Serializing these three operations
+/// prevents an HTTP download from replacing bytes after provenance validation
+/// but before the final serving tuple is installed. The server rejects a
+/// conflicting request immediately instead of making an unbounded HTTP wait.
+struct SourceCacheReservation {
+    state: SharedSourceCacheOperations,
+    id: u64,
+    armed: bool,
+}
+
+impl Drop for SourceCacheReservation {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut state = self.state.lock().unwrap();
+        if state.active.as_ref().map(|active| active.id) == Some(self.id) {
+            state.active = None;
+        }
+    }
+}
+
+fn try_reserve_source_cache_operation(
+    state: &SharedSourceCacheOperations,
+    kind: SourceCacheOperationKind,
+    subject: impl Into<String>,
+) -> Result<SourceCacheReservation, String> {
+    let subject = subject.into();
+    let mut current = state.lock().unwrap();
+    if let Some(active) = current.active.as_ref() {
+        return Err(format!(
+            "source cache is reserved by an active {} for {}; refusing {} for {}",
+            active.kind.label(),
+            active.subject,
+            kind.label(),
+            subject
+        ));
+    }
+    current.next_id = current.next_id.wrapping_add(1).max(1);
+    let id = current.next_id;
+    current.active = Some(ActiveSourceCacheOperation { id, kind, subject });
+    drop(current);
+    Ok(SourceCacheReservation {
+        state: Arc::clone(state),
+        id,
+        armed: true,
+    })
 }
 
 impl HuggingFaceDownloadStatus {
@@ -279,15 +419,73 @@ struct PinnedSourceManifest {
 }
 
 impl R4g1CompileStatus {
-    fn json(&self) -> serde_json::Value {
+    fn json(&self, serving: &ServingModelState) -> serde_json::Value {
+        let graph_loaded = serving.r4g1.is_some();
+        let text_ready = graph_text_ready(serving);
         serde_json::json!({
             "running": self.running,
-            "ready": self.ready,
+            "ready": text_ready,
+            "graph_loaded": graph_loaded,
+            "decode_only": graph_loaded && !text_ready,
             "progress": self.progress,
             "message": self.message,
             "report": self.report,
+            "model_name": active_canonical_model_name(serving),
+            "physical_root": status_physical_root(serving.active_bundle.as_ref()),
+            "terminal_error": serving.terminal_load_error.as_deref(),
+            "last_operation_error": serving.last_operation_error.as_deref(),
         })
     }
+}
+
+/// Owns the single long-running R4G1 replacement slot while a reload is
+/// prepared off-lock. Compilation uses the same `running` reservation, so the
+/// two writers cannot mutate the same bundle concurrently. Dropping a failed
+/// reload releases the reservation without changing the installed tuple.
+struct ReloadReservation {
+    status: Arc<Mutex<R4g1CompileStatus>>,
+    armed: bool,
+}
+
+impl ReloadReservation {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ReloadReservation {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut status = self.status.lock().unwrap();
+        status.running = false;
+        status.message = "R4G1 reload failed; active serving tuple preserved".to_owned();
+    }
+}
+
+fn reserve_r4g1_reload(
+    serving: &SharedServingModel,
+    status: &Arc<Mutex<R4g1CompileStatus>>,
+) -> Result<(u64, ReloadReservation), bool> {
+    let installed = serving.lock().unwrap();
+    let mut current = status.lock().unwrap();
+    if current.running {
+        return Err(current.ready);
+    }
+    current.running = true;
+    current.ready = graph_text_ready(&installed);
+    current.message = "Preparing an atomic R4G1 reload...".to_owned();
+    let epoch = installed.epoch;
+    drop(current);
+    drop(installed);
+    Ok((
+        epoch,
+        ReloadReservation {
+            status: Arc::clone(status),
+            armed: true,
+        },
+    ))
 }
 
 fn get_window_theme(win_idx: usize) -> &'static str {
@@ -314,7 +512,6 @@ fn get_window_theme(win_idx: usize) -> &'static str {
 
 /// Run the HTTP server with configuration supplied by the caller.
 pub fn run_server(cli: Arc<ServerConfig>) {
-    clear_r4g1_terminal_load_error();
     tracing::info!(
         host = %cli.host,
         port = cli.port,
@@ -328,45 +525,102 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     let start_time = Instant::now();
     let router = Arc::new(Mutex::new(UorR4Router::new(0.85)));
     let tless: Arc<Mutex<Option<tless_uor::TlessState>>> = Arc::new(Mutex::new(None));
-    let oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>> = Arc::new(Mutex::new(None));
+    let serving: SharedServingModel = Arc::new(Mutex::new(ServingModelState::default()));
 
     let last_model = std::fs::read_to_string(".uor-models/last_model_name.txt").unwrap_or_default();
     let last_model_name = last_model.trim();
 
-    let candidates = [
-        format!(".uor-models/sources/{}", last_model_name),
-        ".uor-models/sources/smollm2-135m-instruct".to_string(),
-        ".uor-models/sources/smollm2-360m-instruct".to_string(),
-        ".uor-models/sources/smollm2-1-7b-instruct".to_string(),
-    ];
-    let source_dir = candidates
-        .iter()
-        .filter(|p| !p.ends_with("/.uor-models/sources/"))
-        .find(|p| std::path::Path::new(p).join("model.safetensors").exists());
-    if let Some(path) = source_dir {
+    let candidates = startup_source_candidates(last_model_name);
+    let mut source_dir = None;
+    let mut startup_source_snapshot = None;
+    for candidate in &candidates {
+        match optional_source_directory(candidate) {
+            Ok(Some(path)) => {
+                let logical_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("uor-r4");
+                let snapshot = match verify_managed_source_snapshot(&path, logical_name) {
+                    Ok(snapshot) => snapshot,
+                    Err(error) => {
+                        println!("[-] Refusing present-invalid teacher source: {error}");
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
+                    }
+                };
+                source_dir = Some(path);
+                startup_source_snapshot = Some(snapshot);
+                break;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                println!("[-] Refusing present-invalid teacher source: {error}");
+                set_r4g1_terminal_load_error(&serving, error);
+                break;
+            }
+        }
+    }
+    if let Some(path) = source_dir.as_deref() {
         println!(
-            "[*] Loading full Llama teacher oracle from {} for attention-based generation...",
-            path
+            "[*] Loading full source teacher from {} for attention-based generation...",
+            path.display()
         );
-        match load_serving_source_tokenizer(std::path::Path::new(path), None)
-            .and_then(|_| uor_r4_model_source::Teacher::load(path))
-        {
-            Ok(o) => {
-                println!(
-                    "[+] Successfully loaded full Llama teacher model ({})!",
-                    path
+        let logical_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("uor-r4");
+        match prepare_optional_teacher_source_for_identity(Some(path), None, logical_name, None) {
+            Ok(Some(prepared)) => {
+                let final_snapshot =
+                    verify_managed_source_snapshot(path, logical_name).and_then(|after| {
+                        let before = startup_source_snapshot.as_ref().ok_or_else(|| {
+                            format!(
+                                "startup source {} has no initial verified snapshot",
+                                path.display()
+                            )
+                        })?;
+                        require_unchanged_managed_source_snapshot(
+                            path,
+                            "standalone teacher startup",
+                            before,
+                            &after,
+                        )?;
+                        Ok(after)
+                    });
+                match final_snapshot {
+                    Ok(_) => {
+                        println!(
+                            "[+] Successfully loaded full source teacher ({})!",
+                            path.display()
+                        );
+                        let mut installed = serving.lock().unwrap();
+                        installed.epoch = installed.epoch.wrapping_add(1);
+                        installed.oracle = Some(prepared.teacher);
+                        installed.source_tokenizer = Some(prepared.tokenizer);
+                        installed.teacher_default_r4_attention = false;
+                        installed.active_teacher_source = Some(prepared.source);
+                    }
+                    Err(error) => {
+                        println!("[-] Refusing changed teacher source: {error}");
+                        set_r4g1_terminal_load_error(&serving, error);
+                    }
+                }
+            }
+            Ok(None) => {
+                let error = format!(
+                    "present teacher source {} produced no loadable teacher",
+                    path.display()
                 );
-                *oracle.lock().unwrap() = Some(o);
+                println!("[-] {error}");
+                set_r4g1_terminal_load_error(&serving, error);
             }
             Err(e) => {
-                println!("[-] Failed to load full Llama teacher model: {:?}", e);
-                *SERVING_SOURCE_TOKENIZER.lock().unwrap() = None;
-                *oracle.lock().unwrap() = None;
+                println!("[-] Failed to load full teacher model: {e}");
+                set_r4g1_terminal_load_error(&serving, e);
             }
         }
     }
 
-    let r4g1: Arc<Mutex<Option<R4g1State>>> = Arc::new(Mutex::new(None));
     let r4g1_compile = Arc::new(Mutex::new(R4g1CompileStatus {
         running: false,
         ready: false,
@@ -376,39 +630,225 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     }));
     let hf_download = Arc::new(Mutex::new(HuggingFaceDownloadStatus {
         running: false,
-        ready: Path::new(".uor-models/sources/smollm2-135m-instruct").is_dir(),
+        ready: false,
         message: "Hugging Face source download idle".to_owned(),
         source: None,
+        completed_source: None,
     }));
-    let mut r4g1_candidates = r4g1::discover_path(
+    let source_cache_operations: SharedSourceCacheOperations =
+        Arc::new(Mutex::new(SourceCacheOperationState::default()));
+    let configured_graph = r4g1::discover_path(
         cli.r4g1_artifact.as_deref(),
         Path::new(&cli.tless_artifacts),
-    )
-    .map(|graph| vec![(graph, PathBuf::from(&cli.tless_artifacts))])
-    .unwrap_or_default();
-    if cli.r4g1_artifact.is_none() {
-        r4g1_candidates.extend(discover_compiled_r4g1_candidates());
+    );
+    let configured_graph_subject = configured_graph
+        .as_deref()
+        .map(graph_output_session_subject);
+    let mut startup_session_subjects = configured_graph_subject.into_iter().collect::<Vec<_>>();
+    startup_session_subjects.push(PathBuf::from(".uor-models/sources"));
+    startup_session_subjects.push(graph_output_session_subject(Path::new(
+        &cli.tless_artifacts,
+    )));
+    let startup_sessions = if cli.r4g1_artifact.is_none() {
+        try_lock_managed_inventory_write_sessions(
+            Path::new(".uor-models/compiled"),
+            startup_session_subjects,
+        )
+    } else {
+        try_lock_source_compile_sessions(
+            startup_session_subjects,
+            SourceCompileSessionMode::ExclusiveWriter,
+        )
+    };
+    let (startup_read_sessions, r4g1_discovery_allowed) = match startup_sessions {
+        Ok(sessions) => {
+            let recovery = if cli.r4g1_artifact.is_none() {
+                recover_managed_compiled_bundle_completion_temporaries(Path::new(
+                    ".uor-models/compiled",
+                ))
+            } else {
+                configured_graph
+                    .as_deref()
+                    .and_then(Path::parent)
+                    .and_then(Path::parent)
+                    .map(recover_compiled_bundle_completion_temporaries)
+                    .transpose()
+                    .map(|_| ())
+            };
+            match recovery {
+                Ok(()) => (Some(sessions), true),
+                Err(error) => {
+                    println!(
+                        "[-] Refusing R4G1 startup completion recovery before discovery: {error}"
+                    );
+                    set_r4g1_terminal_load_error(&serving, error);
+                    (Some(sessions), false)
+                }
+            }
+        }
+        Err(error) if source_compile_session_is_busy(&error) => {
+            // Another process is atomically refreshing this physical bundle.
+            // This is transient BUSY state, not invalid on-disk provenance;
+            // do not poison the independently loaded teacher or the next
+            // restart with a terminal marker derived from a partial read.
+            println!("[-] Deferring R4G1 startup while bundle publication is busy: {error}");
+            (None, false)
+        }
+        Err(error) => {
+            println!("[-] Refusing R4G1 startup session: {error}");
+            set_r4g1_terminal_load_error(&serving, error);
+            (None, false)
+        }
+    };
+    let mut r4g1_candidates = if r4g1_discovery_allowed {
+        configured_graph
+            .map(|graph| {
+                vec![(
+                    graph,
+                    PathBuf::from(&cli.tless_artifacts),
+                    None::<ResolvedCompiledBundle>,
+                )]
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    if cli.r4g1_artifact.is_none() && r4g1_discovery_allowed {
+        let mut discovery_valid = true;
+        let mut configured_external = false;
+        let mut configured_managed_logical = None;
+        match current_source_attention_era_version().and_then(|version| {
+            resolve_managed_teacher_bundle_in(
+                Path::new(&cli.tless_artifacts),
+                Path::new(".uor-models"),
+                version,
+            )
+        }) {
+            Ok(ConfiguredManagedBundle::Selected(candidate)) => {
+                let candidate = *candidate;
+                configured_managed_logical = Some(candidate.logical_name.clone());
+                r4g1_candidates = vec![(
+                    candidate.graph.clone(),
+                    candidate.teacher.clone(),
+                    Some(candidate),
+                )];
+            }
+            Ok(external @ ConfiguredManagedBundle::External) => {
+                configured_external = true;
+                discovery_valid = external.permits_inventory_discovery();
+            }
+            Ok(ConfiguredManagedBundle::Absent) => {
+                // A configured managed path selects one logical model even
+                // when that model is absent. Do not silently boot an
+                // unrelated bundle discovered elsewhere in the inventory.
+                r4g1_candidates.clear();
+                discovery_valid = ConfiguredManagedBundle::Absent.permits_inventory_discovery();
+            }
+            Ok(ConfiguredManagedBundle::Incomplete(error)) => {
+                println!("[-] Refusing incomplete configured managed R4G1 bundle: {error}");
+                set_r4g1_terminal_load_error(&serving, error);
+                r4g1_candidates.clear();
+                discovery_valid = false;
+            }
+            Err(error) => {
+                println!("[-] Refusing configured managed R4G1 bundle: {error}");
+                set_r4g1_terminal_load_error(&serving, error);
+                r4g1_candidates.clear();
+                discovery_valid = false;
+            }
+        }
+        if discovery_valid {
+            match discover_compiled_r4g1_candidates() {
+                Ok(candidates) => {
+                    for candidate in candidates {
+                        if configured_managed_logical.as_deref()
+                            == Some(candidate.logical_name.as_str())
+                        {
+                            continue;
+                        }
+                        r4g1_candidates.push((
+                            candidate.graph.clone(),
+                            candidate.teacher.clone(),
+                            Some(candidate),
+                        ));
+                    }
+                }
+                Err(error) => {
+                    println!("[-] Refusing compiled R4G1 discovery: {error}");
+                    if configured_external {
+                        println!(
+                            "[-] Ignoring unrelated managed inventory while honoring configured external R4G1 candidate"
+                        );
+                    } else {
+                        set_r4g1_terminal_load_error(&serving, error);
+                        r4g1_candidates.clear();
+                    }
+                }
+            }
+        }
     }
     let mut loaded_r4g1 = false;
-    for (graph_path, teacher_path) in r4g1_candidates {
-        let inputs_present = match (
-            regular_file_presence(&graph_path),
-            regular_file_presence(&teacher_path),
-        ) {
-            (Ok(graph), Ok(teacher)) => graph && teacher,
-            (Err(error), _) | (_, Err(error)) => {
+    for (graph_path, teacher_path, resolved) in r4g1_candidates {
+        if let Err(error) = validate_legacy_graph_generation_for_serving(&graph_path) {
+            println!(
+                "[-] Refusing incomplete or changed legacy R4G1 generation {}: {error}",
+                graph_path.display()
+            );
+            set_r4g1_terminal_load_error(&serving, error);
+            break;
+        }
+        let inputs_present = match required_r4g1_inputs_present(&graph_path, &teacher_path) {
+            Ok(present) => present,
+            Err(error) => {
                 println!("[-] Refusing present-invalid R4G1 bundle: {error}");
-                set_r4g1_terminal_load_error(error);
+                set_r4g1_terminal_load_error(&serving, error);
                 break;
             }
         };
         if !inputs_present {
             continue;
         }
-        let selected_source = source_dir
-            .map(Path::new)
-            .filter(|source| source.file_name() == teacher_path.parent().and_then(Path::file_name));
-        let inferred_source = if selected_source.is_none() {
+        if let Some(bundle) = resolved.as_ref() {
+            let current_version = match current_source_attention_era_version() {
+                Ok(version) => version,
+                Err(error) => {
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                }
+            };
+            if let Err(error) =
+                ensure_compiled_bundle_completion_for_serving(bundle, current_version)
+            {
+                println!(
+                    "[-] Refusing R4G1 graph {} because its bundle completion is invalid: {error}",
+                    graph_path.display()
+                );
+                set_r4g1_terminal_load_error(&serving, error);
+                break;
+            }
+        }
+        let resolved_source = match resolved.as_ref() {
+            Some(bundle) => match source_for_resolved_bundle_in(bundle, Path::new(".uor-models")) {
+                Ok(source) => source,
+                Err(error) => {
+                    println!(
+                        "[-] Refusing R4G1 graph {} because its logical source is invalid: {error}",
+                        graph_path.display()
+                    );
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                }
+            },
+            None => None,
+        };
+        let selected_source = if resolved.is_none() {
+            source_dir.as_deref().filter(|source| {
+                source.file_name() == teacher_path.parent().and_then(Path::file_name)
+            })
+        } else {
+            None
+        };
+        let inferred_source = if resolved.is_none() && selected_source.is_none() {
             match source_for_compiled_teacher(&teacher_path) {
                 Ok(source) => source,
                 Err(error) => {
@@ -416,7 +856,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                         "[-] Refusing R4G1 graph {} because its inferred source is invalid: {error}",
                         graph_path.display()
                     );
-                    set_r4g1_terminal_load_error(error);
+                    set_r4g1_terminal_load_error(&serving, error);
                     break;
                 }
             }
@@ -424,16 +864,174 @@ pub fn run_server(cli: Arc<ServerConfig>) {
             None
         };
         let source = selected_source.or(inferred_source.as_deref());
+        let source = resolved_source.as_deref().or(source);
+        let logical_name = resolved
+            .as_ref()
+            .map(|candidate| candidate.logical_name.as_str())
+            .or_else(|| {
+                source
+                    .and_then(Path::file_name)
+                    .and_then(|name| name.to_str())
+            })
+            .unwrap_or("uor-r4");
+        let verified_source_snapshot = match source {
+            Some(source) => match verify_managed_source_snapshot(source, logical_name) {
+                Ok(snapshot) => Some(snapshot),
+                Err(error) => {
+                    println!(
+                        "[-] Refusing R4G1 graph {} because its source snapshot is invalid: {error}",
+                        graph_path.display()
+                    );
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                }
+            },
+            None => None,
+        };
+        if let (Some(bundle), Some(_)) = (resolved.as_ref(), source) {
+            let current_version = match current_source_attention_era_version() {
+                Ok(version) => version,
+                Err(error) => {
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                }
+            };
+            if let Err(error) = validate_resolved_source_snapshot_binding(
+                bundle,
+                verified_source_snapshot.as_ref(),
+                current_version,
+            ) {
+                println!(
+                    "[-] Refusing R4G1 graph {} because source/corpus provenance conflicts: {error}",
+                    graph_path.display()
+                );
+                set_r4g1_terminal_load_error(&serving, error);
+                break;
+            }
+        }
         match R4g1State::load_with_source(&graph_path, &teacher_path, source) {
             Ok(state) => {
+                let mut prepared_teacher = match prepare_optional_teacher_source_for_identity(
+                    source,
+                    None,
+                    logical_name,
+                    state.tokenizer_adapter_identity(),
+                ) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        println!(
+                            "[-] Refusing R4G1 graph {} because its teacher source is invalid: {error}",
+                            graph_path.display()
+                        );
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
+                    }
+                };
+                let (teacher_default_r4_attention, teacher_mismatch) =
+                    match reconcile_prepared_teacher_with_bundle(
+                        &mut prepared_teacher,
+                        resolved.as_ref(),
+                    ) {
+                        Ok(decision) => decision,
+                        Err(error) => {
+                            println!(
+                                "[-] Refusing R4G1 graph {} because its teacher operator is invalid: {error}",
+                                graph_path.display()
+                            );
+                            set_r4g1_terminal_load_error(&serving, error);
+                            break;
+                        }
+                    };
+                if let Some(message) = teacher_mismatch.as_deref() {
+                    println!("[-] {message}");
+                }
+                let refreshed = match resolved.as_ref() {
+                    Some(candidate) => match current_source_attention_era_version()
+                        .and_then(|version| refresh_resolved_compiled_bundle(candidate, version))
+                    {
+                        Ok(refreshed) => Some(refreshed),
+                        Err(error) => {
+                            println!(
+                                "[-] Refusing R4G1 graph {} after provenance re-check: {error}",
+                                graph_path.display()
+                            );
+                            set_r4g1_terminal_load_error(&serving, error);
+                            break;
+                        }
+                    },
+                    None => None,
+                };
                 println!(
                     "[+] Loaded validated R4G1 graph runtime from {}",
                     graph_path.display()
                 );
-                *r4g1.lock().unwrap() = Some(state);
-                clear_r4g1_terminal_load_error();
+                let (teacher, tokenizer, teacher_source) = match prepared_teacher {
+                    Some(prepared) => (
+                        Some(prepared.teacher),
+                        Some(prepared.tokenizer),
+                        Some(prepared.source),
+                    ),
+                    None => (None, None, None),
+                };
+                if let (Some(source), Some(before)) = (source, verified_source_snapshot.as_ref()) {
+                    let after = match verify_managed_source_snapshot(source, logical_name) {
+                        Ok(after) => after,
+                        Err(error) => {
+                            println!(
+                                "[-] Refusing R4G1 graph {} after final source re-check: {error}",
+                                graph_path.display()
+                            );
+                            set_r4g1_terminal_load_error(&serving, error);
+                            break;
+                        }
+                    };
+                    if let Err(error) = require_unchanged_managed_source_snapshot(
+                        source,
+                        "R4G1 startup",
+                        before,
+                        &after,
+                    ) {
+                        println!(
+                            "[-] Refusing R4G1 graph {} after final source re-check: {error}",
+                            graph_path.display()
+                        );
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
+                    }
+                    if let Some(bundle) = refreshed.as_ref() {
+                        let current_version = match current_source_attention_era_version() {
+                            Ok(version) => version,
+                            Err(error) => {
+                                set_r4g1_terminal_load_error(&serving, error);
+                                break;
+                            }
+                        };
+                        if let Err(error) = validate_resolved_source_snapshot_binding(
+                            bundle,
+                            Some(&after),
+                            current_version,
+                        ) {
+                            println!(
+                                "[-] Refusing R4G1 graph {} after final source/corpus re-check: {error}",
+                                graph_path.display()
+                            );
+                            set_r4g1_terminal_load_error(&serving, error);
+                            break;
+                        }
+                    }
+                }
+                let mut installed = serving.lock().unwrap();
                 let mut compile_status = r4g1_compile.lock().unwrap();
-                compile_status.ready = true;
+                installed.epoch = installed.epoch.wrapping_add(1);
+                installed.r4g1 = Some(state);
+                installed.oracle = teacher;
+                installed.source_tokenizer = tokenizer;
+                installed.teacher_default_r4_attention = teacher_default_r4_attention;
+                installed.active_teacher_source = teacher_source;
+                installed.active_bundle = refreshed;
+                installed.terminal_load_error = None;
+                installed.last_operation_error = None;
+                compile_status.ready = graph_text_ready(&installed);
                 compile_status.progress = 100;
                 compile_status.message = "R4G1 graph runtime ready".to_owned();
                 loaded_r4g1 = true;
@@ -444,15 +1042,22 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                     "[-] Failed to load R4G1 graph runtime from {}: {error}",
                     graph_path.display()
                 );
-                if error.contains("tokenizer") {
-                    set_r4g1_terminal_load_error(error);
-                    break;
-                }
+                // This candidate was selected only after paired-root and
+                // provenance validation. A present preferred bundle that
+                // fails graph/tokenizer validation is terminal; falling
+                // through would silently downgrade its arithmetic era.
+                set_r4g1_terminal_load_error(&serving, error);
+                break;
             }
         }
     }
+    // All on-disk graph/cover/source bindings have been consumed and the
+    // serving tuple was installed atomically. Runtime requests use only the
+    // in-memory snapshot, so the shared filesystem sessions need not remain
+    // held for the lifetime of the server.
+    drop(startup_read_sessions);
     if !loaded_r4g1 {
-        if let Some(error) = r4g1_terminal_load_error() {
+        if let Some(error) = r4g1_terminal_load_error(&serving) {
             tracing::error!(%error, "R4G1 graph was rejected; default serving will fail closed");
         } else {
             tracing::info!("no validated R4G1 graph found; compile it from the dashboard");
@@ -539,14 +1144,22 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     for stream in listener.incoming().flatten() {
         let r_clone = Arc::clone(&router);
         let t_clone = Arc::clone(&tless);
-        let g_clone = Arc::clone(&r4g1);
+        let s_clone = Arc::clone(&serving);
         let gc_clone = Arc::clone(&r4g1_compile);
         let hf_clone = Arc::clone(&hf_download);
-        let o_clone = Arc::clone(&oracle);
+        let source_cache_clone = Arc::clone(&source_cache_operations);
         let c_clone = Arc::clone(&cli);
         std::thread::spawn(move || {
             handle_connection(
-                stream, r_clone, t_clone, g_clone, gc_clone, hf_clone, o_clone, c_clone, start_time,
+                stream,
+                r_clone,
+                t_clone,
+                s_clone,
+                gc_clone,
+                hf_clone,
+                source_cache_clone,
+                c_clone,
+                start_time,
             );
         });
     }
@@ -643,26 +1256,1055 @@ fn with_tless_server_state<R>(
     Some(r)
 }
 
-/// Find compiled dashboard bundles when the server was restarted without an
-/// explicit `--r4g1-artifact`. The compile endpoint loads its result into the
-/// live process, but a restart must pair each graph with the teacher artifact
-/// that produced it instead of looking beside the unrelated legacy defaults.
-fn discover_compiled_r4g1_candidates() -> Vec<(PathBuf, PathBuf)> {
-    let root = Path::new(".uor-models/compiled");
-    let mut bundles: Vec<PathBuf> = fs::read_dir(root)
-        .into_iter()
-        .flat_map(|entries| entries.flatten().map(|entry| entry.path()))
-        .filter(|path| path.is_dir())
-        .collect();
-    bundles.sort();
-    bundles
-        .into_iter()
-        .filter_map(|bundle| {
-            let graph = bundle.join("graph/score.r4g1");
-            let teacher = bundle.join("tless_artifacts.bin");
-            (graph.is_file() && teacher.is_file()).then_some((graph, teacher))
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CompiledRootState {
+    Absent,
+    Empty,
+    /// A source compile published its immutable source-snapshot binding, but
+    /// stage A did not yet publish any corpus payload or attention binding.
+    /// This is a resumable preflight state, not an implicit historical bundle.
+    PreAttentionIdentity,
+    ImplicitV1(Box<AttentionOperatorSpec>),
+    BoundHistorical(Box<AttentionOperatorSpec>),
+    BoundCurrent(Box<AttentionOperatorSpec>),
+}
+
+impl CompiledRootState {
+    fn operator(&self) -> Option<&AttentionOperatorSpec> {
+        match self {
+            Self::ImplicitV1(operator)
+            | Self::BoundHistorical(operator)
+            | Self::BoundCurrent(operator) => Some(operator),
+            Self::Absent | Self::Empty | Self::PreAttentionIdentity => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompiledModelPair {
+    logical_name: String,
+    conventional_root: PathBuf,
+    conventional: CompiledRootState,
+    current_root: PathBuf,
+    current: CompiledRootState,
+}
+
+/// One logical source resolved to the exact physical bundle selected for
+/// serving. Keeping all of these fields together prevents reload/status from
+/// reconstructing a source name from the resolver-owned era suffix.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedCompiledBundle {
+    logical_name: String,
+    physical_root: PathBuf,
+    graph: PathBuf,
+    teacher: PathBuf,
+    attention_operator: AttentionOperatorSpec,
+    /// Exact source snapshot root recorded by the selected cover report.
+    /// `None` is the historical pre-#597 state, not an inferred identity.
+    source_manifest_kappa: Option<String>,
+}
+
+/// The complete serving identity committed by startup, reload, or background
+/// compilation. One mutex protects the graph, teacher, tokenizer, logical /
+/// physical provenance, and failure/readiness state, so generation can never
+/// observe fields from two different installations.
+#[derive(Default)]
+struct ServingModelState {
+    epoch: u64,
+    r4g1: Option<R4g1State>,
+    oracle: Option<uor_r4_model_source::Teacher>,
+    source_tokenizer: Option<TokenizerKind>,
+    /// Teacher mode used by the unpinned fallback. Explicit `attention` and
+    /// `r4-attention` requests continue to select their named modes.
+    teacher_default_r4_attention: bool,
+    active_bundle: Option<ResolvedCompiledBundle>,
+    active_teacher_source: Option<PathBuf>,
+    terminal_load_error: Option<String>,
+    last_operation_error: Option<String>,
+}
+
+type SharedServingModel = Arc<Mutex<ServingModelState>>;
+
+struct PreparedTeacherSource {
+    teacher: uor_r4_model_source::Teacher,
+    tokenizer: TokenizerKind,
+    source: PathBuf,
+}
+
+fn source_attention_operator(operator: &AttentionOperatorSpec) -> bool {
+    matches!(
+        operator.id.as_str(),
+        AttentionOperatorSpec::STANDARD_ID
+            | AttentionOperatorSpec::EXPERIMENTAL_R4_ID
+            | AttentionOperatorSpec::LEARNED_ABSOLUTE_ID
+    )
+}
+
+fn attention_era_suffix(current_version: u32) -> String {
+    format!("-attention-v{current_version}")
+}
+
+fn validate_logical_model_name(name: &str, current_version: u32) -> Result<(), String> {
+    let suffix = attention_era_suffix(current_version);
+    let path = Path::new(name);
+    let one_normal_component = path.components().count() == 1
+        && path.file_name().and_then(|part| part.to_str()) == Some(name)
+        && name != "."
+        && name != "..";
+    if name.is_empty() || !one_normal_component {
+        return Err(format!(
+            "model name {name:?} is not one logical source basename"
+        ));
+    }
+    if name.ends_with(&suffix) {
+        return Err(format!(
+            "model name {name:?} uses the resolver-owned suffix {suffix}; source basenames ending in that suffix are reserved"
+        ));
+    }
+    Ok(())
+}
+
+fn logical_model_name_for_request(requested: &str, current_version: u32) -> Result<String, String> {
+    let suffix = attention_era_suffix(current_version);
+    let logical = requested
+        .strip_suffix(&suffix)
+        .filter(|base| !base.is_empty())
+        .unwrap_or(requested);
+    validate_logical_model_name(logical, current_version)?;
+    Ok(logical.to_owned())
+}
+
+fn inspect_compiled_root(
+    root: &Path,
+    current_version: u32,
+    resolver_owned_current_root: bool,
+) -> Result<CompiledRootState, String> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CompiledRootState::Absent)
+        }
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", root.display())),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "compiled model root {} is not a regular non-symlink directory",
+            root.display()
+        ));
+    }
+    let mut entries = fs::read_dir(root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?;
+    let populated = entries
+        .next()
+        .transpose()
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?
+        .is_some();
+    if !populated {
+        let initialization = source_compile_initialization_path(root)?;
+        match fs::symlink_metadata(&initialization) {
+            Ok(_) => {
+                return Err(format!(
+                    "compiled model root {} is empty beside an ambiguous legacy initialization claim {}; refusing adoption",
+                    root.display(),
+                    initialization.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "{} cannot be inspected: {error}",
+                    initialization.display()
+                ));
+            }
+        }
+        return Ok(CompiledRootState::Empty);
+    }
+
+    let binding = source_compile_attention_binding(root)?;
+    let (operator, explicit_binding) = match binding {
+        Some(operator) => (operator, true),
+        None if source_compile_pre_attention_prefix(root)? => {
+            return Ok(CompiledRootState::PreAttentionIdentity);
+        }
+        None if resolver_owned_current_root => {
+            return Err(format!(
+                "deterministic current-era bundle {} contains payload without {}; refusing to infer or relabel its arithmetic era",
+                root.display(),
+                uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+            ))
+        }
+        None => (AttentionOperatorSpec::standard_v1(), false),
+    };
+    if !source_attention_operator(&operator) {
+        return Err(format!(
+            "compiled model root {} is pinned to non-source attention operator {}/{}",
+            root.display(),
+            operator.id,
+            operator.version
+        ));
+    }
+    if operator.version > current_version {
+        return Err(format!(
+            "compiled model root {} is pinned to unsupported future attention operator {}/{}; current source era is {current_version}",
+            root.display(),
+            operator.id,
+            operator.version
+        ));
+    }
+    if resolver_owned_current_root && operator.version != current_version {
+        return Err(format!(
+            "deterministic current-era bundle {} is pinned to attention operator {}/{}; expected a source operator at version {current_version}",
+            root.display(),
+            operator.id,
+            operator.version
+        ));
+    }
+    let operator = Box::new(operator);
+    Ok(if !explicit_binding {
+        CompiledRootState::ImplicitV1(operator)
+    } else if operator.version == current_version {
+        CompiledRootState::BoundCurrent(operator)
+    } else {
+        CompiledRootState::BoundHistorical(operator)
+    })
+}
+
+/// Inspect both physical roots before making any selection. This is the one
+/// era boundary used by compile, startup, reload, and model/status reporting.
+fn inspect_compiled_model_pair(
+    compiled_root: &Path,
+    logical_name: &str,
+    current_version: u32,
+) -> Result<CompiledModelPair, String> {
+    validate_logical_model_name(logical_name, current_version)?;
+    let conventional_root = compiled_root.join(logical_name);
+    let current_root = compiled_root.join(format!(
+        "{logical_name}{}",
+        attention_era_suffix(current_version)
+    ));
+    let conventional = inspect_compiled_root(&conventional_root, current_version, false)?;
+    let current = inspect_compiled_root(&current_root, current_version, true)?;
+
+    if matches!(conventional, CompiledRootState::PreAttentionIdentity)
+        && current.operator().is_some()
+    {
+        return Err(format!(
+            "conventional root {} contains an unfinished pre-attention identity while current root {} is already bound; refusing to hide or overwrite either initialization",
+            conventional_root.display(),
+            current_root.display()
+        ));
+    }
+
+    if let (Some(historical), Some(current_operator)) =
+        (conventional.operator(), current.operator())
+    {
+        if historical.id != current_operator.id {
+            return Err(format!(
+                "compiled roots {} and {} conflict across source-attention families ({}/{} versus {}/{})",
+                conventional_root.display(),
+                current_root.display(),
+                historical.id,
+                historical.version,
+                current_operator.id,
+                current_operator.version
+            ));
+        }
+        if historical.version == current_version {
+            return Err(format!(
+                "duplicate current source-attention bundles exist for logical model {logical_name}: {} and {}",
+                conventional_root.display(),
+                current_root.display()
+            ));
+        }
+    }
+
+    Ok(CompiledModelPair {
+        logical_name: logical_name.to_owned(),
+        conventional_root,
+        conventional,
+        current_root,
+        current,
+    })
+}
+
+fn selected_compiled_root(pair: &CompiledModelPair) -> Option<(&Path, &AttentionOperatorSpec)> {
+    if let Some(operator) = pair.current.operator() {
+        Some((&pair.current_root, operator))
+    } else {
+        pair.conventional
+            .operator()
+            .map(|operator| (pair.conventional_root.as_path(), operator))
+    }
+}
+
+struct CoverProvenanceProjection {
+    attention_present: bool,
+    operator: Option<AttentionOperatorSpec>,
+    source_manifest_kappa_present: bool,
+    source_manifest_kappa: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for CoverProvenanceProjection {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ProjectionVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ProjectionVisitor {
+            type Value = CoverProvenanceProjection;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a cover report object")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut attention_present = false;
+                let mut operator = None;
+                let mut source_manifest_kappa_present = false;
+                let mut source_manifest_kappa = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "attention_operator" => {
+                            if attention_present {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "attention_operator",
+                                ));
+                            }
+                            attention_present = true;
+                            operator = map.next_value()?;
+                        }
+                        "source_manifest_kappa" => {
+                            if source_manifest_kappa_present {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "source_manifest_kappa",
+                                ));
+                            }
+                            source_manifest_kappa_present = true;
+                            source_manifest_kappa = map.next_value()?;
+                        }
+                        _ => {
+                            map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(CoverProvenanceProjection {
+                    attention_present,
+                    operator,
+                    source_manifest_kappa_present,
+                    source_manifest_kappa,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(ProjectionVisitor)
+    }
+}
+
+fn canonical_source_manifest_kappa(kappa: &str) -> bool {
+    kappa.strip_prefix("blake3:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn parse_cover_provenance(
+    report_path: &Path,
+) -> Result<(bool, Option<AttentionOperatorSpec>, Option<String>), String> {
+    let Some(bytes) = read_regular_file_nofollow(report_path, "cover report")? else {
+        return Ok((false, None, None));
+    };
+    let projection: CoverProvenanceProjection = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed JSON: {error}", report_path.display()))?;
+    if let Some(kappa) = projection.source_manifest_kappa.as_deref() {
+        if !canonical_source_manifest_kappa(kappa) {
+            return Err(format!(
+                "{} records a non-canonical source_manifest_kappa {kappa:?}",
+                report_path.display()
+            ));
+        }
+    }
+    if projection.attention_present {
+        if let Some(recorded) = projection.operator.as_ref() {
+            let registered =
+                uor_r4_model_source::attention::operator_spec(&recorded.id, recorded.version)
+                    .map_err(|error| format!("{}: {error}", report_path.display()))?;
+            if &registered != recorded || !source_attention_operator(recorded) {
+                return Err(format!(
+                    "{} does not contain a registry-exact source attention operator {}/{}",
+                    report_path.display(),
+                    recorded.id,
+                    recorded.version
+                ));
+            }
+        }
+    }
+    // A JSON `null` is compatible with the historical unrecorded state; the
+    // presence bit exists only so duplicate top-level controls are rejected.
+    let _ = projection.source_manifest_kappa_present;
+    Ok((true, projection.operator, projection.source_manifest_kappa))
+}
+
+/// Reconcile every attention identity the server bundle records. Current-v2
+/// serving requires both the canonical corpus pair and its cover report; old
+/// v1 bundles remain readable when those supporting records are genuinely
+/// absent. R4G1 graph-byte provenance itself remains the separate #637 PROV
+/// contract, so this check deliberately makes no stronger claim.
+fn validate_serving_attention_provenance(
+    bundle: &Path,
+    expected: &AttentionOperatorSpec,
+    current_version: u32,
+) -> Result<Option<String>, String> {
+    // New server-published generations carry a digest-complete transaction
+    // record. Its presence is authoritative; no caller may silently fall
+    // back to piecemeal graph/report reads if any member drifted.
+    let _ = validate_compiled_bundle_completion(bundle)?;
+    let meta = bundle.join("corpus.meta");
+    let records = bundle.join("corpus.records");
+    let meta_present = regular_file_presence(&meta)?;
+    let records_present = regular_file_presence(&records)?;
+    let recorded_corpus = match (meta_present, records_present) {
+        (true, true) => uor_r4_graph_cli::recorded_corpus_attention_operator(&meta, &records)
+            .map_err(|error| error.to_string())?,
+        (false, false) if expected.version < current_version => None,
+        (false, false) => {
+            return Err(format!(
+                "current source-attention bundle {} is missing its canonical corpus.meta/corpus.records provenance pair",
+                bundle.display()
+            ))
+        }
+        _ => {
+            return Err(format!(
+                "compiled bundle {} has only one of corpus.meta/corpus.records; recorded provenance is incomplete",
+                bundle.display()
+            ))
+        }
+    };
+    if meta_present {
+        let recorded = recorded_corpus.unwrap_or_else(AttentionOperatorSpec::standard_v1);
+        if &recorded != expected {
+            return Err(format!(
+                "compiled bundle {} records attention operator {}/{} in its corpus provenance but its selected root is {}/{}",
+                bundle.display(),
+                recorded.id,
+                recorded.version,
+                expected.id,
+                expected.version
+            ));
+        }
+    }
+
+    let report_path = bundle.join("graph-cover/cover_report.json");
+    let (report_present, report_operator, source_manifest_kappa) =
+        parse_cover_provenance(&report_path)?;
+    if expected.version == current_version && !report_present {
+        return Err(format!(
+            "current source-attention bundle {} is missing required cover provenance {}",
+            bundle.display(),
+            report_path.display()
+        ));
+    }
+    if report_present {
+        let recorded = report_operator.unwrap_or_else(AttentionOperatorSpec::standard_v1);
+        if &recorded != expected {
+            return Err(format!(
+                "{} records attention operator {}/{} but bundle {} is selected as {}/{}",
+                report_path.display(),
+                recorded.id,
+                recorded.version,
+                bundle.display(),
+                expected.id,
+                expected.version
+            ));
+        }
+    }
+    Ok(source_manifest_kappa)
+}
+
+fn source_manifest_kappa(manifest: &crate::model::SourceManifest) -> Result<String, String> {
+    crate::model::source_manifest_kappa(manifest)
+        .map_err(|error| format!("source manifest cannot be addressed: {error}"))
+}
+
+fn validate_resolved_source_snapshot_binding(
+    bundle: &ResolvedCompiledBundle,
+    snapshot: Option<&VerifiedManagedSourceSnapshot>,
+    current_version: u32,
+) -> Result<(), String> {
+    match (snapshot, bundle.source_manifest_kappa.as_deref()) {
+        (Some(snapshot), Some(recorded)) => {
+            let actual = &snapshot.content_kappa;
+            if recorded != actual {
+                return Err(format!(
+                    "compiled bundle {} records source snapshot kappa {recorded}, but source {} verifies as {actual}; refusing mixed source/corpus identities",
+                    bundle.physical_root.display(),
+                    bundle.logical_name
+                ));
+            }
+        }
+        (Some(_), None) if bundle.attention_operator.version == current_version => {
+            return Err(format!(
+                "current source-attention bundle {} has a verified source snapshot but its cover report records no source_manifest_kappa",
+                bundle.physical_root.display()
+            ));
+        }
+        (None, Some(recorded)) => {
+            return Err(format!(
+                "compiled bundle {} records source snapshot kappa {recorded}, but no verified source snapshot is available",
+                bundle.physical_root.display()
+            ));
+        }
+        (Some(_), None) | (None, None) => {}
+    }
+    Ok(())
+}
+
+fn resolve_loadable_compiled_bundle(
+    pair: &CompiledModelPair,
+    current_version: u32,
+) -> Result<Option<ResolvedCompiledBundle>, String> {
+    if matches!(
+        pair.current,
+        CompiledRootState::Empty | CompiledRootState::PreAttentionIdentity
+    ) {
+        return Err(format!(
+            "preferred current source-attention root {} is present but incomplete; refusing historical fallback",
+            pair.current_root.display()
+        ));
+    }
+    let Some((physical_root, operator)) = selected_compiled_root(pair) else {
+        return Ok(None);
+    };
+    let primary_graph = physical_root.join("graph/score.r4g1");
+    let fallback_graph = physical_root.join("compiled.r4g1");
+    let graph = select_regular_fallback_path(&primary_graph, &fallback_graph)?;
+    let teacher = physical_root.join("tless_artifacts.bin");
+    let teacher_present = regular_file_presence(&teacher)?;
+    let Some(graph) = graph else {
+        if teacher_present {
+            return Err(format!(
+                "selected compiled bundle {} has a teacher artifact but no R4G1 graph",
+                physical_root.display()
+            ));
+        }
+        return Ok(None);
+    };
+    if !teacher_present {
+        return Err(format!(
+            "selected compiled bundle {} has graph {} but no teacher artifact {}",
+            physical_root.display(),
+            graph.display(),
+            teacher.display()
+        ));
+    }
+    let source_manifest_kappa =
+        validate_serving_attention_provenance(physical_root, operator, current_version)?;
+    Ok(Some(ResolvedCompiledBundle {
+        logical_name: pair.logical_name.clone(),
+        physical_root: physical_root.to_path_buf(),
+        graph,
+        teacher,
+        attention_operator: operator.clone(),
+        source_manifest_kappa,
+    }))
+}
+
+fn resolve_requested_compiled_bundle_in(
+    models_root: &Path,
+    requested: &str,
+    current_version: u32,
+) -> Result<Option<ResolvedCompiledBundle>, String> {
+    reject_requested_suffix_source_collision(requested, models_root, current_version)?;
+    let logical_name = logical_model_name_for_request(requested, current_version)?;
+    let pair = inspect_compiled_model_pair(
+        &models_root.join("compiled"),
+        &logical_name,
+        current_version,
+    )?;
+    let resolved = resolve_loadable_compiled_bundle(&pair, current_version)?;
+    if let Some(bundle) = resolved.as_ref() {
+        reject_reserved_suffix_source_collision(bundle, models_root, current_version)?;
+    }
+    Ok(resolved)
+}
+
+fn reject_requested_suffix_source_collision(
+    requested: &str,
+    models_root: &Path,
+    current_version: u32,
+) -> Result<(), String> {
+    let suffix = attention_era_suffix(current_version);
+    if requested.strip_suffix(&suffix).is_none() {
+        return Ok(());
+    }
+    let ambiguous = models_root.join("sources").join(requested);
+    match fs::symlink_metadata(&ambiguous) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Ok(_) => Err(format!(
+            "requested model {requested:?} is ambiguous because the pre-existing source basename {} collides with the resolver-owned suffix; request the logical base explicitly after resolving the collision",
+            ambiguous.display()
+        )),
+        Err(error) => Err(format!("{} cannot be inspected: {error}", ambiguous.display())),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ConfiguredManagedBundle {
+    External,
+    Absent,
+    Incomplete(String),
+    Selected(Box<ResolvedCompiledBundle>),
+}
+
+impl ConfiguredManagedBundle {
+    fn permits_inventory_discovery(&self) -> bool {
+        matches!(self, Self::External | Self::Selected(_))
+    }
+}
+
+fn normalized_absolute_path(path: &Path) -> Result<PathBuf, String> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("current directory is unavailable: {error}"))?
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+/// Re-enter the managed resolver when `--tless-artifacts` names the canonical
+/// teacher file inside `models_root/compiled/<physical-root>`. Existing paths
+/// are classified by their canonical target so a symlink alias cannot bypass
+/// the paired-era resolver. Lexical normalization is used only when the target
+/// is genuinely absent and therefore cannot be canonicalized.
+fn resolve_managed_teacher_bundle_in(
+    teacher_path: &Path,
+    models_root: &Path,
+    current_version: u32,
+) -> Result<ConfiguredManagedBundle, String> {
+    if teacher_path.file_name() != Some(std::ffi::OsStr::new("tless_artifacts.bin")) {
+        return Ok(ConfiguredManagedBundle::External);
+    }
+    let Some(physical_root) = teacher_path.parent() else {
+        return Ok(ConfiguredManagedBundle::External);
+    };
+    let compiled_root = models_root.join("compiled");
+    let normalized_compiled_root = normalized_absolute_path(&compiled_root)?;
+    let lexical_managed =
+        normalized_absolute_path(physical_root.parent().unwrap_or_else(|| Path::new(".")))?
+            == normalized_compiled_root;
+
+    let physical_metadata = match fs::symlink_metadata(physical_root) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(format!(
+                "{} cannot be inspected while classifying the managed namespace: {error}",
+                physical_root.display()
+            ));
+        }
+    };
+    let mut classified_root = physical_root.to_path_buf();
+    if physical_metadata.is_some() {
+        let compiled_metadata = match fs::symlink_metadata(&compiled_root) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(format!(
+                    "{} cannot be inspected while classifying {}: {error}",
+                    compiled_root.display(),
+                    teacher_path.display()
+                ));
+            }
+        };
+        if compiled_metadata.is_none() {
+            if lexical_managed {
+                return Err(format!(
+                    "configured managed path {} exists while its compiled namespace {} is absent",
+                    teacher_path.display(),
+                    compiled_root.display()
+                ));
+            }
+            return Ok(ConfiguredManagedBundle::External);
+        }
+        let canonical_compiled = fs::canonicalize(&compiled_root).map_err(|error| {
+            format!(
+                "{} cannot be canonicalized while classifying {}: {error}",
+                compiled_root.display(),
+                teacher_path.display()
+            )
+        })?;
+        let canonical_physical = fs::canonicalize(physical_root).map_err(|error| {
+            format!(
+                "{} cannot be canonicalized while classifying the managed namespace: {error}",
+                physical_root.display()
+            )
+        })?;
+        if canonical_physical.parent() == Some(canonical_compiled.as_path()) {
+            classified_root = canonical_physical;
+        } else {
+            let canonical_teacher = match fs::symlink_metadata(teacher_path) {
+                Ok(_) => Some(fs::canonicalize(teacher_path).map_err(|error| {
+                    format!(
+                        "{} cannot be canonicalized while classifying the managed namespace: {error}",
+                        teacher_path.display()
+                    )
+                })?),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => {
+                    return Err(format!(
+                        "{} cannot be inspected while classifying the managed namespace: {error}",
+                        teacher_path.display()
+                    ));
+                }
+            };
+            let canonical_teacher_root = canonical_teacher
+                .as_deref()
+                .and_then(Path::parent)
+                .filter(|root| root.parent() == Some(canonical_compiled.as_path()));
+            if let Some(root) = canonical_teacher_root {
+                classified_root = root.to_path_buf();
+            } else if lexical_managed {
+                return Err(format!(
+                    "configured managed path {} resolves outside {}; refusing namespace escape",
+                    teacher_path.display(),
+                    compiled_root.display()
+                ));
+            } else {
+                return Ok(ConfiguredManagedBundle::External);
+            }
+        }
+    } else if !lexical_managed {
+        return Ok(ConfiguredManagedBundle::External);
+    }
+
+    let physical_name = classified_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "managed compiled bundle name is not UTF-8: {}",
+                physical_root.display()
+            )
+        })?;
+    let logical_name = logical_model_name_for_request(physical_name, current_version)?;
+    let pair = inspect_compiled_model_pair(&compiled_root, &logical_name, current_version)?;
+    if matches!(
+        pair.current,
+        CompiledRootState::Empty | CompiledRootState::PreAttentionIdentity
+    ) {
+        return Ok(ConfiguredManagedBundle::Incomplete(format!(
+            "preferred current bundle {} exists but is incomplete; refusing historical adjacent-path fallback",
+            pair.current_root.display()
+        )));
+    }
+    match resolve_loadable_compiled_bundle(&pair, current_version)? {
+        Some(bundle) => Ok(ConfiguredManagedBundle::Selected(Box::new(bundle))),
+        None
+            if matches!(pair.conventional, CompiledRootState::Absent)
+                && matches!(pair.current, CompiledRootState::Absent) =>
+        {
+            Ok(ConfiguredManagedBundle::Absent)
+        }
+        None => Ok(ConfiguredManagedBundle::Incomplete(format!(
+            "configured managed model {logical_name} has a present selected root without a complete graph/teacher bundle"
+        ))),
+    }
+}
+
+fn source_for_resolved_bundle_in(
+    bundle: &ResolvedCompiledBundle,
+    models_root: &Path,
+) -> Result<Option<PathBuf>, String> {
+    reject_reserved_suffix_source_collision(
+        bundle,
+        models_root,
+        current_source_attention_era_version()?,
+    )?;
+    optional_source_directory(&models_root.join("sources").join(&bundle.logical_name))
+}
+
+fn reject_reserved_suffix_source_collision(
+    bundle: &ResolvedCompiledBundle,
+    models_root: &Path,
+    current_version: u32,
+) -> Result<(), String> {
+    let expected_physical = format!(
+        "{}{}",
+        bundle.logical_name,
+        attention_era_suffix(current_version)
+    );
+    if bundle
+        .physical_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        != Some(expected_physical.as_str())
+    {
+        return Ok(());
+    }
+    let ambiguous = models_root.join("sources").join(&expected_physical);
+    match fs::symlink_metadata(&ambiguous) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Ok(_) => Err(format!(
+            "managed bundle {} is ambiguous because the pre-existing source basename {} collides with the resolver-owned suffix; refusing to map it to sources/{}",
+            bundle.physical_root.display(),
+            ambiguous.display(),
+            bundle.logical_name
+        )),
+        Err(error) => Err(format!("{} cannot be inspected: {error}", ambiguous.display())),
+    }
+}
+
+fn status_physical_root(bundle: Option<&ResolvedCompiledBundle>) -> Option<String> {
+    bundle.map(|bundle| bundle.physical_root.display().to_string())
+}
+
+#[cfg(test)]
+fn teacher_ready_for_source(
+    oracle_loaded: bool,
+    active_teacher_source: Option<&Path>,
+    resolved_source: Option<&Path>,
+) -> bool {
+    oracle_loaded && resolved_source.is_some() && active_teacher_source == resolved_source
+}
+
+fn graph_text_ready(state: &ServingModelState) -> bool {
+    state
+        .r4g1
+        .as_ref()
+        .is_some_and(|graph| !graph.host_encoder_unavailable())
+}
+
+fn teacher_text_ready(state: &ServingModelState) -> bool {
+    state.oracle.is_some()
+        && state.source_tokenizer.is_some()
+        && state.active_teacher_source.is_some()
+}
+
+fn installed_logical_model_name(state: &ServingModelState) -> String {
+    state
+        .active_bundle
+        .as_ref()
+        .map(|bundle| bundle.logical_name.clone())
+        .or_else(|| {
+            state
+                .active_teacher_source
+                .as_deref()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                .map(str::to_owned)
         })
-        .collect()
+        .unwrap_or_else(|| "uor-r4".to_owned())
+}
+
+fn active_canonical_model_name(state: &ServingModelState) -> Option<String> {
+    if !graph_text_ready(state) && !teacher_text_ready(state) {
+        return None;
+    }
+    Some(installed_logical_model_name(state))
+}
+
+/// Resolve the OpenAI request model before any routing or generation side
+/// effects. `uor-r4` is the one intentional compatibility alias; responses
+/// always report the canonical active identity rather than echoing the alias.
+fn resolve_active_request_model(
+    state: &ServingModelState,
+    requested: Option<&str>,
+) -> Result<String, String> {
+    let active = active_canonical_model_name(state);
+    resolve_request_model_name(active.as_deref(), requested)
+}
+
+fn resolve_request_model_name(
+    active: Option<&str>,
+    requested: Option<&str>,
+) -> Result<String, String> {
+    let active = active.ok_or_else(|| "no text-ready serving model is active".to_owned())?;
+    match requested.map(str::trim).filter(|name| !name.is_empty()) {
+        None | Some("uor-r4") => Ok(active.to_owned()),
+        Some(name) if name == active => Ok(active.to_owned()),
+        Some(name) => Err(format!(
+            "The model '{name}' is not active; the active model is '{active}'."
+        )),
+    }
+}
+
+fn active_models(state: &ServingModelState) -> Vec<(String, u64)> {
+    let Some(name) = active_canonical_model_name(state) else {
+        return Vec::new();
+    };
+    let created = state
+        .active_bundle
+        .as_ref()
+        .and_then(|bundle| fs::metadata(&bundle.teacher).ok())
+        .and_then(|meta| meta.modified().ok())
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|delta| delta.as_secs())
+        .unwrap_or(0);
+    vec![(name, created)]
+}
+
+fn resolve_reload_bundle_in(
+    models_root: &Path,
+    requested: &str,
+    current_version: u32,
+) -> Result<Option<(ResolvedCompiledBundle, Option<PathBuf>)>, String> {
+    let Some(bundle) =
+        resolve_requested_compiled_bundle_in(models_root, requested, current_version)?
+    else {
+        return Ok(None);
+    };
+    let source = source_for_resolved_bundle_in(&bundle, models_root)?;
+    Ok(Some((bundle, source)))
+}
+
+fn refresh_resolved_compiled_bundle(
+    resolved: &ResolvedCompiledBundle,
+    current_version: u32,
+) -> Result<ResolvedCompiledBundle, String> {
+    let compiled_root = resolved.physical_root.parent().ok_or_else(|| {
+        format!(
+            "{} has no compiled-model parent",
+            resolved.physical_root.display()
+        )
+    })?;
+    let pair = inspect_compiled_model_pair(compiled_root, &resolved.logical_name, current_version)?;
+    let refreshed = resolve_loadable_compiled_bundle(&pair, current_version)?.ok_or_else(|| {
+        format!(
+            "resolved compiled bundle {} disappeared before installation",
+            resolved.physical_root.display()
+        )
+    })?;
+    if &refreshed != resolved {
+        return Err(format!(
+            "compiled model {} changed between resolution and installation",
+            resolved.logical_name
+        ));
+    }
+    Ok(refreshed)
+}
+
+/// Find compiled dashboard bundles when the server was restarted without an
+/// explicit `--r4g1-artifact`. Every immediate entry is part of a logical
+/// pair: non-directories/symlinks and invalid siblings are terminal, while a
+/// valid current-era root wins over its historical sibling deterministically.
+fn discover_compiled_r4g1_candidates() -> Result<Vec<ResolvedCompiledBundle>, String> {
+    discover_compiled_r4g1_candidates_in(
+        Path::new(".uor-models/compiled"),
+        current_source_attention_era_version()?,
+    )
+}
+
+#[allow(dead_code)] // retained for protocol tests and future non-mutating inventory clients
+fn try_lock_managed_inventory_read_sessions(
+    compiled_root: &Path,
+    additional_subjects: impl IntoIterator<Item = PathBuf>,
+) -> Result<SourceCompileSessionLocks, String> {
+    // The inventory root is the namespace lock for entry creation/removal.
+    // Source-driven writers acquire it exclusively before publishing either
+    // era sibling, so a reader cannot enumerate a moving logical inventory.
+    let mut subjects = vec![compiled_root.to_path_buf()];
+    subjects.extend(additional_subjects);
+    // The namespace lock is sufficient for inventory stability because every
+    // server writer, including the configured legacy lane, takes the same
+    // exclusive subject before touching a managed graph/cover output. The
+    // additional subjects cover configured sinks outside that namespace.
+    try_lock_source_compile_sessions(subjects, SourceCompileSessionMode::SharedReader)
+}
+
+fn try_lock_managed_inventory_write_sessions(
+    compiled_root: &Path,
+    additional_subjects: impl IntoIterator<Item = PathBuf>,
+) -> Result<SourceCompileSessionLocks, String> {
+    let mut subjects = vec![compiled_root.to_path_buf()];
+    subjects.extend(additional_subjects);
+    try_lock_source_compile_sessions(subjects, SourceCompileSessionMode::ExclusiveWriter)
+}
+
+fn discover_compiled_r4g1_candidates_in(
+    root: &Path,
+    current_version: u32,
+) -> Result<Vec<ResolvedCompiledBundle>, String> {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(format!(
+                "compiled model root {} cannot be inspected: {error}",
+                root.display()
+            ));
+        }
+    };
+    let suffix = attention_era_suffix(current_version);
+    let mut logical_names = std::collections::BTreeSet::<String>::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "compiled model root {} cannot be enumerated: {error}",
+                root.display()
+            )
+        })?;
+        let bundle = entry.path();
+        let metadata = fs::symlink_metadata(&bundle)
+            .map_err(|error| format!("{} cannot be inspected: {error}", bundle.display()))?;
+        if entry.file_name() == std::ffi::OsStr::new(SOURCE_COMPILE_STAGING_DIR) {
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "source compile staging namespace {} is not a regular non-symlink directory",
+                    bundle.display()
+                ));
+            }
+            continue;
+        }
+        if !metadata.file_type().is_dir() {
+            return Err(format!(
+                "compiled model candidate {} is not a regular non-symlink directory",
+                bundle.display()
+            ));
+        }
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| format!("compiled bundle name is not UTF-8: {}", bundle.display()))?;
+        let logical_name = name
+            .strip_suffix(&suffix)
+            .filter(|base| !base.is_empty())
+            .unwrap_or(&name)
+            .to_owned();
+        validate_logical_model_name(&logical_name, current_version)?;
+        logical_names.insert(logical_name);
+    }
+
+    let mut selected = Vec::new();
+    for logical_name in logical_names {
+        let pair = inspect_compiled_model_pair(root, &logical_name, current_version)?;
+        if let Some(candidate) = resolve_loadable_compiled_bundle(&pair, current_version)? {
+            reject_reserved_suffix_source_collision(
+                &candidate,
+                root.parent().unwrap_or_else(|| Path::new(".")),
+                current_version,
+            )?;
+            selected.push(candidate);
+        }
+    }
+    Ok(selected)
 }
 
 /// Inspect an optional file without collapsing a present-invalid filesystem
@@ -685,6 +2327,25 @@ fn regular_file_presence(path: &Path) -> Result<bool, String> {
         return Err(format!("{} is not a regular file", path.display()));
     }
     Ok(true)
+}
+
+fn required_r4g1_inputs_present(graph: &Path, teacher: &Path) -> Result<bool, String> {
+    let graph_present = regular_file_presence(graph)?;
+    let teacher_present = regular_file_presence(teacher)?;
+    match (graph_present, teacher_present) {
+        (true, true) => Ok(true),
+        (false, false) => Ok(false),
+        (true, false) => Err(format!(
+            "R4G1 graph {} is present but its teacher artifact {} is absent",
+            graph.display(),
+            teacher.display()
+        )),
+        (false, true) => Err(format!(
+            "R4G1 teacher artifact {} is present but its graph {} is absent",
+            teacher.display(),
+            graph.display()
+        )),
+    }
 }
 
 fn append_tokenizer_arg(
@@ -738,10 +2399,12 @@ fn optional_source_directory(path: &Path) -> Result<Option<PathBuf>, String> {
     Ok(Some(path.to_path_buf()))
 }
 
-/// Conventional source snapshot corresponding to
-/// `.uor-models/compiled/<name>/tless_artifacts.bin`. Genuine absence is
-/// optional; a present non-directory, dangling symlink, or unreadable entry is
-/// a hard error so it cannot be mistaken for "no host adapter available."
+/// Source snapshot corresponding to a compiled teacher. Conventional
+/// `.uor-models/compiled/<name>` maps directly; the server-owned exact
+/// `<name>-attention-v2` suffix maps back to `<name>` only when the bundle
+/// carries a registry-exact current-v2 binding. Genuine source absence is
+/// optional; invalid provenance or a present non-directory, dangling symlink,
+/// or unreadable source entry is a hard error.
 fn source_for_compiled_teacher(teacher_path: &Path) -> Result<Option<PathBuf>, String> {
     source_for_compiled_teacher_in(teacher_path, Path::new(".uor-models"))
 }
@@ -750,10 +2413,39 @@ fn source_for_compiled_teacher_in(
     teacher_path: &Path,
     models_root: &Path,
 ) -> Result<Option<PathBuf>, String> {
-    let Some(name) = teacher_path.parent().and_then(Path::file_name) else {
+    let Some(bundle) = teacher_path.parent() else {
         return Ok(None);
     };
-    let source = models_root.join("sources").join(name);
+    let Some(name) = bundle.file_name() else {
+        return Ok(None);
+    };
+    let managed_compiled_root = models_root.join("compiled");
+    if bundle.parent() != Some(managed_compiled_root.as_path()) {
+        // Explicit CLI paths are outside the managed resolver namespace.
+        // Preserve their historical literal parent-name mapping, including
+        // names that happen to resemble the server-owned era suffix.
+        return optional_source_directory(&models_root.join("sources").join(name));
+    }
+    let Some(name) = name.to_str() else {
+        return Ok(None);
+    };
+    let current_version = current_source_attention_era_version()?;
+    let logical_name = logical_model_name_for_request(name, current_version)?;
+    let compiled_root = bundle.parent().ok_or_else(|| {
+        format!(
+            "compiled teacher bundle {} has no compiled-model root",
+            bundle.display()
+        )
+    })?;
+    let pair = inspect_compiled_model_pair(compiled_root, &logical_name, current_version)?;
+    if bundle != pair.conventional_root && bundle != pair.current_root {
+        return Err(format!(
+            "compiled teacher {} is outside the resolved roots for logical model {}",
+            teacher_path.display(),
+            logical_name
+        ));
+    }
+    let source = models_root.join("sources").join(logical_name);
     optional_source_directory(&source)
 }
 
@@ -834,7 +2526,7 @@ struct R4g1Text {
 /// decoding intentionally use the same tokenizer as the compiled teacher
 /// artifact; R4G1 stores token ids, not user-facing text.
 fn generate_r4g1_text(
-    slot: &Arc<Mutex<Option<R4g1State>>>,
+    state: Option<&R4g1State>,
     prompt: &str,
     max_tokens: usize,
 ) -> Result<Option<R4g1Text>, String> {
@@ -844,8 +2536,7 @@ fn generate_r4g1_text(
     let mut generated = [0u32; MAX_SERVER_TOKENS];
     let mut bytes = [0u8; MAX_SERVER_TEXT_BYTES];
     let (byte_count, status, widened, abstained, usage) = {
-        let guard = slot.lock().unwrap();
-        let Some(state) = guard.as_ref() else {
+        let Some(state) = state else {
             return Ok(None);
         };
         let seed_len = match state.encode_into(prompt, &mut seed) {
@@ -913,35 +2604,34 @@ fn generate_r4g1_text(
     }))
 }
 
-/// Exact registered tokenizer paired with the loaded teacher oracle. A parse
-/// or selection failure clears the slot: teacher-backed serving never falls
-/// through to a tokenizer from another id space.
-static SERVING_SOURCE_TOKENIZER: std::sync::Mutex<Option<TokenizerKind>> =
-    std::sync::Mutex::new(None);
-
-/// Focused startup/reload failure for a graph that was present but could not
-/// be bound safely. Keeping it separate from `Option<R4g1State>` preserves the
-/// distinction between genuine absence (the historical cascade may continue)
-/// and a rejected tokenizer binding (the default cascade must stop).
-static R4G1_TERMINAL_LOAD_ERROR: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
-
-fn clear_r4g1_terminal_load_error() {
-    *R4G1_TERMINAL_LOAD_ERROR.lock().unwrap() = None;
+fn set_r4g1_terminal_load_error(serving: &SharedServingModel, error: impl Into<String>) {
+    let mut installed = serving.lock().unwrap();
+    let error = error.into();
+    installed.terminal_load_error = Some(error.clone());
+    installed.last_operation_error = Some(error);
 }
 
-fn set_r4g1_terminal_load_error(error: impl Into<String>) {
-    *R4G1_TERMINAL_LOAD_ERROR.lock().unwrap() = Some(error.into());
+fn r4g1_terminal_load_error(serving: &SharedServingModel) -> Option<String> {
+    serving.lock().unwrap().terminal_load_error.clone()
 }
 
-fn r4g1_terminal_load_error() -> Option<String> {
-    R4G1_TERMINAL_LOAD_ERROR.lock().unwrap().clone()
+fn record_replacement_failure(serving: &SharedServingModel, error: impl Into<String>) {
+    let mut installed = serving.lock().unwrap();
+    let error = error.into();
+    installed.last_operation_error = Some(error.clone());
+    if installed.r4g1.is_none()
+        && installed.oracle.is_none()
+        && installed.active_bundle.is_none()
+        && installed.active_teacher_source.is_none()
+    {
+        installed.terminal_load_error = Some(error);
+    }
 }
 
-fn load_serving_source_tokenizer(
+fn resolve_serving_source_tokenizer(
     dir: &std::path::Path,
     selection: Option<&TokenizerAdapterKey>,
-) -> Result<(), uor_r4_model_source::SourceUnavailable> {
-    *SERVING_SOURCE_TOKENIZER.lock().unwrap() = None;
+) -> Result<TokenizerKind, uor_r4_model_source::SourceUnavailable> {
     let tokenizer = resolve_source_tokenizer(dir, selection)?;
     let adapter = tokenizer.adapter().ok_or_else(|| {
         uor_r4_model_source::SourceUnavailable::new(format!(
@@ -957,19 +2647,151 @@ fn load_serving_source_tokenizer(
         adapter.tokenizer_cid,
         adapter.adapter_digest,
     );
-    *SERVING_SOURCE_TOKENIZER.lock().unwrap() = Some(tokenizer);
-    Ok(())
+    Ok(tokenizer)
+}
+
+fn tokenizer_identity_matches(
+    adapter: &TokenizerAdapter,
+    expected: &RuntimeTokenizerIdentity,
+) -> bool {
+    adapter.family == expected.family
+        && adapter.version == expected.version
+        && adapter.tokenizer_cid == expected.tokenizer_cid
+        && adapter.adapter_digest == expected.adapter_digest
+}
+
+fn prepare_optional_teacher_source_for_identity(
+    source: Option<&Path>,
+    selection: Option<&TokenizerAdapterKey>,
+    logical_name: &str,
+    expected: Option<&RuntimeTokenizerIdentity>,
+) -> Result<Option<PreparedTeacherSource>, String> {
+    let Some(source) = source else {
+        if selection.is_some() {
+            return Err(format!(
+                "model {logical_name} cannot apply an explicit tokenizer selection without its source directory"
+            ));
+        }
+        return Ok(None);
+    };
+    validate_managed_source_for_serving(source, logical_name)?;
+    if selection.is_some() && expected.is_none() {
+        return Err(format!(
+            "model {logical_name} uses an untagged bundle tokenizer, so an explicit source-tokenizer selection cannot be proven equal"
+        ));
+    }
+    let tokenizer = resolve_serving_source_tokenizer(source, selection)
+        .map_err(|error| format!("teacher tokenizer for {logical_name} is unusable: {error}"))?;
+    let adapter = tokenizer.adapter().ok_or_else(|| {
+        format!("teacher tokenizer for {logical_name} has no registered adapter identity")
+    })?;
+    if let Some(expected) = expected {
+        if !tokenizer_identity_matches(&adapter, expected) {
+            return Err(format!(
+                "teacher tokenizer for {logical_name} is {}/{} (CID {}, digest {}), but the compiled bundle requires {}/{} (CID {}, digest {})",
+                adapter.family,
+                adapter.version,
+                adapter.tokenizer_cid,
+                adapter.adapter_digest,
+                expected.family,
+                expected.version,
+                expected.tokenizer_cid,
+                expected.adapter_digest,
+            ));
+        }
+    }
+    // `Teacher::load` is the source crate's single-file/indexed-shard
+    // ingestion boundary. Calling it directly distinguishes a genuine absent
+    // source (handled above) from missing, malformed, ambiguous, or incomplete
+    // weights, including `model.safetensors.index.json` layouts.
+    let teacher = uor_r4_model_source::Teacher::load(source)
+        .map_err(|error| format!("teacher source for {logical_name} is unusable: {error}"))?;
+    Ok(Some(PreparedTeacherSource {
+        teacher,
+        tokenizer,
+        source: source.to_path_buf(),
+    }))
+}
+
+/// Select the exact executable teacher mode recorded by a managed graph. A
+/// historical operator has no current Teacher implementation, so its graph
+/// keeps its independently bound host encoder but is not silently backstopped
+/// by v2 Teacher arithmetic.
+fn teacher_mode_for_bundle_records(
+    default: &AttentionOperatorSpec,
+    experimental: Option<&AttentionOperatorSpec>,
+    bundle: &AttentionOperatorSpec,
+) -> Option<bool> {
+    if default == bundle {
+        Some(false)
+    } else if experimental == Some(bundle) {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+fn reconcile_prepared_teacher_with_bundle(
+    prepared: &mut Option<PreparedTeacherSource>,
+    bundle: Option<&ResolvedCompiledBundle>,
+) -> Result<(bool, Option<String>), String> {
+    let (Some(prepared_teacher), Some(bundle)) = (prepared.as_mut(), bundle) else {
+        return Ok((false, None));
+    };
+    let default = prepared_teacher
+        .teacher
+        .attention_operator_spec()
+        .ok_or_else(|| {
+            format!(
+                "teacher source {} declares no attention operator",
+                prepared_teacher.source.display()
+            )
+        })?;
+    prepared_teacher.teacher.set_r4_attention(true);
+    let experimental = prepared_teacher.teacher.attention_operator_spec();
+    prepared_teacher.teacher.set_r4_attention(false);
+    if let Some(mode) =
+        teacher_mode_for_bundle_records(&default, experimental.as_ref(), &bundle.attention_operator)
+    {
+        return Ok((mode, None));
+    }
+
+    let available = experimental
+        .map(|operator| {
+            format!(
+                "{}/{} or {}/{}",
+                default.id, default.version, operator.id, operator.version
+            )
+        })
+        .unwrap_or_else(|| format!("{}/{}", default.id, default.version));
+    let message = format!(
+        "teacher source {} provides {available}, but compiled bundle {} records {}/{}; keeping the valid graph and omitting its incompatible teacher fallback",
+        prepared_teacher.source.display(),
+        bundle.physical_root.display(),
+        bundle.attention_operator.id,
+        bundle.attention_operator.version
+    );
+    *prepared = None;
+    Ok((false, Some(message)))
+}
+
+fn teacher_r4_attention_for_request(pinned: Option<&str>, default_r4_attention: bool) -> bool {
+    match pinned {
+        Some(TIER_ATTENTION) => false,
+        Some(TIER_R4_ATTENTION) => true,
+        _ => default_r4_attention,
+    }
 }
 
 fn generate_attention_text(
     oracle: &mut uor_r4_model_source::Teacher,
+    tokenizer: Option<&TokenizerKind>,
     prompt: &str,
     max_tokens: usize,
 ) -> Option<(String, ServingUsage)> {
     // 1. Construct token seed for prompt
     let formatted_prompt = format!("User: {}\nAssistant:", prompt.trim());
-    let source_tokenizer = SERVING_SOURCE_TOKENIZER.lock().unwrap();
-    let tokenizer = source_tokenizer.as_ref()?;
+    let tokenizer = tokenizer?;
     let seed = tokenizer.encode(&formatted_prompt);
 
     let seed_len = seed.len();
@@ -1408,14 +3230,14 @@ fn resolve_pinned_tier(requested: Option<&str>) -> Option<&'static str> {
 /// Unusable text is `Pathological` with the reason; an unavailable runtime
 /// or scoring error is `Failed`.
 fn r4g1_tier(
-    slot: &Arc<Mutex<Option<R4g1State>>>,
+    state: Option<&R4g1State>,
     prompt: &str,
     max_tokens: usize,
     signal: &mut R4g1Signal,
     load_error: Option<&str>,
     usage: &Cell<Option<ServingUsage>>,
 ) -> TierResult {
-    match generate_r4g1_text(slot, prompt, max_tokens.max(32)) {
+    match generate_r4g1_text(state, prompt, max_tokens.max(32)) {
         Ok(Some(gen)) if gen.abstained => {
             signal.status = gen.status.map(r4g1::PolicyStatus::from).map(|s| s.label());
             signal.widened = gen.widened;
@@ -1478,6 +3300,7 @@ fn transformerless_tier(
 /// cascade tier.
 fn attention_tier(
     oracle: &mut Option<uor_r4_model_source::Teacher>,
+    tokenizer: Option<&TokenizerKind>,
     prompt: &str,
     max_tokens: usize,
     r4_attention: bool,
@@ -1487,7 +3310,7 @@ fn attention_tier(
         return TierResult::failed("teacher oracle is not loaded");
     };
     o.set_r4_attention(r4_attention);
-    let generated = generate_attention_text(o, prompt, max_tokens);
+    let generated = generate_attention_text(o, tokenizer, prompt, max_tokens);
     o.set_r4_attention(false);
     match generated {
         Some((text, counts)) if is_usable_generated_text(&text) => {
@@ -1551,9 +3374,8 @@ fn tokenizer_unavailable_is_terminal(
 #[allow(clippy::too_many_arguments)]
 fn run_serving_cascade(
     router: &mut UorR4Router,
-    r4g1: &Arc<Mutex<Option<R4g1State>>>,
+    serving: &mut ServingModelState,
     tless: &Arc<Mutex<Option<tless_uor::TlessState>>>,
-    oracle: &mut Option<uor_r4_model_source::Teacher>,
     prompt: &str,
     identity: &str,
     max_tokens: usize,
@@ -1562,15 +3384,21 @@ fn run_serving_cascade(
     session_signature: Option<&[u8]>,
     pinned: Option<&'static str>,
 ) -> ServingCascade {
+    let ServingModelState {
+        r4g1,
+        oracle,
+        source_tokenizer,
+        teacher_default_r4_attention,
+        terminal_load_error,
+        ..
+    } = serving;
+    let r4g1 = r4g1.as_ref();
+    let source_tokenizer = source_tokenizer.as_ref();
     let mut signal = R4g1Signal::default();
     let mut geometric: Option<uor_r4_router::GeometricResponse> = None;
     let usage = Cell::new(None);
-    let load_error = r4g1_terminal_load_error();
-    let host_encoder_unavailable = r4g1
-        .lock()
-        .unwrap()
-        .as_ref()
-        .is_some_and(R4g1State::host_encoder_unavailable);
+    let load_error = terminal_load_error.clone();
+    let host_encoder_unavailable = r4g1.is_some_and(R4g1State::host_encoder_unavailable);
     // A tagged graph without its exact host encoder must terminate as
     // tokenizer-unavailable. Continuing to the transformerless tier would
     // invoke the historical greedy encoder in another id space, precisely the
@@ -1610,21 +3438,48 @@ fn run_serving_cascade(
             tiers.push((
                 TIER_TEACHER_ORACLE,
                 Box::new(move || {
-                    attention_tier(oracle, prompt, max_tokens.max(128), false, usage_ref)
+                    attention_tier(
+                        oracle,
+                        source_tokenizer,
+                        prompt,
+                        max_tokens.max(128),
+                        teacher_r4_attention_for_request(None, *teacher_default_r4_attention),
+                        usage_ref,
+                    )
                 }),
             ));
         } else if pinned == Some(TIER_ATTENTION) {
             tiers.push((
                 TIER_ATTENTION,
                 Box::new(move || {
-                    attention_tier(oracle, prompt, max_tokens.max(256), false, usage_ref)
+                    attention_tier(
+                        oracle,
+                        source_tokenizer,
+                        prompt,
+                        max_tokens.max(256),
+                        teacher_r4_attention_for_request(
+                            Some(TIER_ATTENTION),
+                            *teacher_default_r4_attention,
+                        ),
+                        usage_ref,
+                    )
                 }),
             ));
         } else if pinned == Some(TIER_R4_ATTENTION) {
             tiers.push((
                 TIER_R4_ATTENTION,
                 Box::new(move || {
-                    attention_tier(oracle, prompt, max_tokens.max(256), true, usage_ref)
+                    attention_tier(
+                        oracle,
+                        source_tokenizer,
+                        prompt,
+                        max_tokens.max(256),
+                        teacher_r4_attention_for_request(
+                            Some(TIER_R4_ATTENTION),
+                            *teacher_default_r4_attention,
+                        ),
+                        usage_ref,
+                    )
                 }),
             ));
         }
@@ -1878,6 +3733,22 @@ fn r4g1_compile_paths(cli: &ServerConfig) -> Result<(PathBuf, PathBuf, PathBuf, 
     ))
 }
 
+fn require_unchanged_legacy_compile_paths(
+    selected: &(PathBuf, PathBuf, PathBuf, PathBuf),
+    refreshed: &(PathBuf, PathBuf, PathBuf, PathBuf),
+) -> Result<(), String> {
+    if selected == refreshed {
+        return Ok(());
+    }
+    Err(format!(
+        "legacy R4G1 compile path selection changed while acquiring its cross-process output sessions ({} / {} -> {} / {}); refusing stale or ambiguous mutation",
+        selected.0.display(),
+        selected.3.display(),
+        refreshed.0.display(),
+        refreshed.3.display()
+    ))
+}
+
 fn validate_source_bundle_inventory(output: &Path) -> Result<(), String> {
     for file in [
         "tless_artifacts.bin",
@@ -1907,11 +3778,4364 @@ fn validate_source_bundle_inventory(output: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Parse a JSON document solely to reject duplicate object keys at every
+/// nesting level. `serde_json::Value` is last-key-wins, which is unsuitable
+/// for provenance records where duplicated fields could spell two eras in one
+/// sidecar.
+struct DuplicateRejectingJson;
+
+impl<'de> serde::Deserialize<'de> for DuplicateRejectingJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = DuplicateRejectingJson;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("JSON without duplicate object keys")
+            }
+
+            fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                DuplicateRejectingJson::deserialize(deserializer)
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                while sequence.next_element::<DuplicateRejectingJson>()?.is_some() {}
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut keys = std::collections::BTreeSet::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if !keys.insert(key.clone()) {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate JSON field {key:?}"
+                        )));
+                    }
+                    map.next_value::<DuplicateRejectingJson>()?;
+                }
+                Ok(DuplicateRejectingJson)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+fn reject_duplicate_json_fields(
+    bytes: &[u8],
+    path: &Path,
+    description: &str,
+) -> Result<(), String> {
+    serde_json::from_slice::<DuplicateRejectingJson>(bytes)
+        .map(|_| ())
+        .map_err(|error| format!("{}: malformed {description}: {error}", path.display(),))
+}
+
+/// Read an output directory's exact source-attention binding. Genuine
+/// absence stays `None`; every present-invalid entry is terminal so the
+/// server never routes around malformed provenance into a fresh directory.
+fn source_compile_attention_binding(
+    output: &Path,
+) -> Result<Option<uor_r4_model_source::attention::AttentionOperatorSpec>, String> {
+    let path = output.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE);
+    let Some(file) = open_regular_file_nofollow(&path, "attention-operator binding")? else {
+        return Ok(None);
+    };
+    let value = validate_pre_attention_identity_handle(
+        file,
+        &path,
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+    )?;
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))
+}
+
+const SOURCE_MANIFEST_KAPPA_BINDING_FILE: &str = "source_manifest_kappa.json";
+const SOURCE_MANIFEST_KAPPA_BINDING_SCHEMA: &str = "uor-r4-source-manifest-kappa-binding/1";
+const SOURCE_COMPILE_PREFLIGHT_FILE: &str = "source_compile_preflight.json";
+const SOURCE_COMPILE_PREFLIGHT_SCHEMA: &str = "uor-r4-source-compile-preflight/1";
+const SOURCE_COMPILE_STAGING_DIR: &str = ".uor-r4-source-compile-staging";
+const SOURCE_COMPILE_SESSION_LOCK_SUFFIX: &str = ".compile-session.lock";
+const COMPILED_BUNDLE_STAGE_TAG: &str = "bundle-stage";
+const COMPILED_BUNDLE_STAGE_MARKER_FILE: &str = ".compiled_bundle_stage.json";
+const COMPILED_BUNDLE_STAGE_SCHEMA: &str = "uor-r4-compiled-bundle-stage/1";
+const COMPILED_BUNDLE_COMPLETION_FILE: &str = "compiled_bundle_completion.json";
+const COMPILED_BUNDLE_COMPLETION_SCHEMA: &str = "uor-r4-compiled-bundle-completion/1";
+const LEGACY_GRAPH_GENERATION_SCHEMA: &str = "uor-r4-legacy-graph-generation/1";
+const LEGACY_GRAPH_ATTEMPT_SCHEMA: &str = "uor-r4-legacy-graph-attempt/1";
+static NEXT_SOURCE_KAPPA_BINDING_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct SourceManifestKappaBinding {
+    schema: String,
+    source_manifest_kappa: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct SourceCompilePreflight {
+    schema: String,
+    source_manifest_kappa: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledBundleCompletion {
+    schema: String,
+    files: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledBundleStageMarker {
+    schema: String,
+    final_output: String,
+    stage_path: String,
+    source_snapshot_kappa: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyGraphGenerationIdentity {
+    cover_output: String,
+    graph_output: String,
+    input_files: std::collections::BTreeMap<String, String>,
+    cover_controls_kappa: String,
+    score_controls_kappa: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyGraphGenerationAttempt {
+    schema: String,
+    identity: LegacyGraphGenerationIdentity,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyGraphGenerationCompletion {
+    schema: String,
+    identity: LegacyGraphGenerationIdentity,
+    output_files: std::collections::BTreeMap<String, String>,
+}
+
+fn open_regular_file_nofollow(path: &Path, label: &str) -> Result<Option<fs::File>, String> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // Do not follow a link swapped in after a directory scan. NONBLOCK
+        // also ensures a raced FIFO/device cannot hang the server before its
+        // opened-handle metadata is rejected below.
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "{} cannot be opened as a regular non-symlink {label}: {error}",
+                path.display()
+            ));
+        }
+    };
+    let file_metadata = file.metadata().map_err(|error| {
+        format!(
+            "{} opened {label} handle cannot be inspected: {error}",
+            path.display()
+        )
+    })?;
+    let path_metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    if !file_metadata.file_type().is_file()
+        || !path_metadata.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&path_metadata, &file_metadata)
+    {
+        return Err(format!(
+            "{} is not a regular file; a stable non-symlink {label} is required",
+            path.display()
+        ));
+    }
+    Ok(Some(file))
+}
+
+fn read_opened_regular_file_nofollow(
+    mut file: fs::File,
+    path: &Path,
+    label: &str,
+) -> Result<Vec<u8>, String> {
+    let opened_metadata = file.metadata().map_err(|error| {
+        format!(
+            "{} opened {label} handle cannot be inspected: {error}",
+            path.display()
+        )
+    })?;
+    if !opened_metadata.file_type().is_file() {
+        return Err(format!(
+            "{} opened {label} handle is not a regular file",
+            path.display()
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| format!("{} cannot be read: {error}", path.display()))?;
+    let final_file_metadata = file.metadata().map_err(|error| {
+        format!(
+            "{} opened {label} handle cannot be reinspected: {error}",
+            path.display()
+        )
+    })?;
+    let final_path_metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    if !final_file_metadata.file_type().is_file()
+        || !final_path_metadata.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&opened_metadata, &final_file_metadata)
+        || !source_compile_lock_metadata_matches(&final_path_metadata, &final_file_metadata)
+        || final_file_metadata.len() != bytes.len() as u64
+    {
+        return Err(format!(
+            "{} changed identity, type, or length while its {label} bytes were read",
+            path.display()
+        ));
+    }
+    Ok(bytes)
+}
+
+fn read_regular_file_nofollow(path: &Path, label: &str) -> Result<Option<Vec<u8>>, String> {
+    open_regular_file_nofollow(path, label)?
+        .map(|file| read_opened_regular_file_nofollow(file, path, label))
+        .transpose()
+}
+
+fn read_required_regular_file_nofollow(path: &Path, label: &str) -> Result<Vec<u8>, String> {
+    read_regular_file_nofollow(path, label)?.ok_or_else(|| {
+        format!(
+            "{} disappeared before its {label} bytes could be read",
+            path.display()
+        )
+    })
+}
+
+fn source_compile_preflight_bytes(kappa: Option<&str>) -> Result<Vec<u8>, String> {
+    if kappa.is_some_and(|kappa| !canonical_source_manifest_kappa(kappa)) {
+        return Err(format!(
+            "source manifest kappa {kappa:?} is not canonical",
+            kappa = kappa.unwrap_or_default()
+        ));
+    }
+    let record = SourceCompilePreflight {
+        schema: SOURCE_COMPILE_PREFLIGHT_SCHEMA.to_owned(),
+        source_manifest_kappa: kappa.map(str::to_owned),
+    };
+    let mut bytes = serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn read_source_compile_preflight_path(path: &Path) -> Result<SourceCompilePreflight, String> {
+    let bytes = read_required_regular_file_nofollow(path, "source compile preflight")?;
+    reject_duplicate_json_fields(&bytes, path, "source compile preflight")?;
+    let record: SourceCompilePreflight = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if record.schema != SOURCE_COMPILE_PREFLIGHT_SCHEMA {
+        return Err(format!(
+            "{} records unsupported schema {:?}",
+            path.display(),
+            record.schema
+        ));
+    }
+    let canonical = source_compile_preflight_bytes(record.source_manifest_kappa.as_deref())?;
+    if bytes != canonical {
+        return Err(format!(
+            "{} is not the canonical source compile preflight",
+            path.display()
+        ));
+    }
+    Ok(record)
+}
+
+fn source_compile_initialization_path(output: &Path) -> Result<PathBuf, String> {
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no parent for atomic initialization",
+            output.display()
+        )
+    })?;
+    let name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "source compile output name is not UTF-8: {}",
+                output.display()
+            )
+        })?;
+    Ok(parent.join(format!(".{name}.{SOURCE_COMPILE_PREFLIGHT_FILE}.init")))
+}
+
+fn read_optional_source_compile_preflight(
+    output: &Path,
+) -> Result<Option<SourceCompilePreflight>, String> {
+    let path = output.join(SOURCE_COMPILE_PREFLIGHT_FILE);
+    match open_regular_file_nofollow(&path, "source compile preflight")? {
+        Some(file) => {
+            let bytes = read_opened_regular_file_nofollow(file, &path, "source compile preflight")?;
+            reject_duplicate_json_fields(&bytes, &path, "source compile preflight")?;
+            let record: SourceCompilePreflight = serde_json::from_slice(&bytes)
+                .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+            if record.schema != SOURCE_COMPILE_PREFLIGHT_SCHEMA {
+                return Err(format!(
+                    "{} records unsupported schema {:?}",
+                    path.display(),
+                    record.schema
+                ));
+            }
+            let canonical =
+                source_compile_preflight_bytes(record.source_manifest_kappa.as_deref())?;
+            if bytes != canonical {
+                return Err(format!(
+                    "{} is not the canonical source compile preflight",
+                    path.display()
+                ));
+            }
+            Ok(Some(record))
+        }
+        None => Ok(None),
+    }
+}
+
+fn source_manifest_kappa_binding_bytes(kappa: &str) -> Result<Vec<u8>, String> {
+    if !canonical_source_manifest_kappa(kappa) {
+        return Err(format!("source manifest kappa {kappa:?} is not canonical"));
+    }
+    let binding = SourceManifestKappaBinding {
+        schema: SOURCE_MANIFEST_KAPPA_BINDING_SCHEMA.to_owned(),
+        source_manifest_kappa: kappa.to_owned(),
+    };
+    let mut bytes = serde_json::to_vec_pretty(&binding).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn read_optional_source_manifest_kappa_binding(output: &Path) -> Result<Option<String>, String> {
+    let path = output.join(SOURCE_MANIFEST_KAPPA_BINDING_FILE);
+    let Some(bytes) = read_regular_file_nofollow(&path, "source-manifest kappa binding")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, &path, "source-manifest kappa binding")?;
+    let binding: SourceManifestKappaBinding = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if binding.schema != SOURCE_MANIFEST_KAPPA_BINDING_SCHEMA {
+        return Err(format!(
+            "{} records unsupported schema {:?}",
+            path.display(),
+            binding.schema
+        ));
+    }
+    let canonical = source_manifest_kappa_binding_bytes(&binding.source_manifest_kappa)?;
+    if bytes != canonical {
+        return Err(format!(
+            "{} is not the canonical source-manifest kappa binding",
+            path.display()
+        ));
+    }
+    Ok(Some(binding.source_manifest_kappa))
+}
+
+fn source_compile_output_has_payload(output: &Path) -> Result<bool, String> {
+    let metadata = match fs::symlink_metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", output.display())),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile output {} is not a regular non-symlink directory",
+            output.display()
+        ));
+    }
+    validate_source_compile_identity_temporaries(output)?;
+    let entries = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source compile output {} contains a non-UTF-8 entry",
+                output.display()
+            )
+        })?;
+        if name == SOURCE_MANIFEST_KAPPA_BINDING_FILE || name == SOURCE_COMPILE_PREFLIGHT_FILE {
+            continue;
+        }
+        if name == "tokenizer_adapter.json"
+            || name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+        {
+            validate_pre_attention_identity_file(&entry.path(), name)?;
+            continue;
+        }
+        if let Some(kind) = atomic_identity_temporary_kind(name) {
+            validate_pre_attention_identity_file(&entry.path(), kind)?;
+            continue;
+        }
+        if looks_like_atomic_identity_temporary(name) {
+            return Err(format!(
+                "source compile output {} contains unrecognized or non-owned identity temporary {name}",
+                output.display()
+            ));
+        }
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn looks_like_atomic_identity_temporary(name: &str) -> bool {
+    [
+        SOURCE_COMPILE_PREFLIGHT_FILE,
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+    ]
+    .iter()
+    .any(|sidecar| name.starts_with(&format!(".{sidecar}.")) && name.ends_with(".tmp"))
+}
+
+fn atomic_identity_temporary_kind(name: &str) -> Option<&'static str> {
+    for sidecar in [
+        SOURCE_COMPILE_PREFLIGHT_FILE,
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+    ] {
+        let prefix = format!(".{sidecar}.");
+        let Some(sequence) = name
+            .strip_prefix(&prefix)
+            .and_then(|rest| rest.strip_suffix(".tmp"))
+        else {
+            continue;
+        };
+        let mut parts = sequence.split('.');
+        if parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            && parts.next().is_some_and(|part| {
+                !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
+            })
+            && parts.next().is_none()
+        {
+            return Some(sidecar);
+        }
+    }
+    None
+}
+
+fn validate_source_compile_identity_temporaries(output: &Path) -> Result<(), String> {
+    let mut identities = std::collections::BTreeMap::<&'static str, serde_json::Value>::new();
+    for kind in [
+        SOURCE_COMPILE_PREFLIGHT_FILE,
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+    ] {
+        let path = output.join(kind);
+        if let Some(file) = open_regular_file_nofollow(&path, "pre-attention identity record")? {
+            let value = validate_pre_attention_identity_handle(file, &path, kind)?;
+            identities.insert(kind, value);
+        }
+    }
+    let entries = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source compile output {} contains a non-UTF-8 entry",
+                output.display()
+            )
+        })?;
+        if let Some(kind) = atomic_identity_temporary_kind(name) {
+            let value = validate_pre_attention_identity_file(&entry.path(), kind)?;
+            if let Some(existing) = identities.get(kind) {
+                if existing != &value {
+                    return Err(format!(
+                        "source compile output {} has conflicting stable/temporary {kind} identities",
+                        output.display()
+                    ));
+                }
+            } else {
+                identities.insert(kind, value);
+            }
+        } else if looks_like_atomic_identity_temporary(name) {
+            return Err(format!(
+                "source compile output {} contains unrecognized or non-owned identity temporary {name}",
+                output.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reclaim only graph/server publisher temporaries whose exact reserved name
+/// is known. The caller must hold the physical output's exclusive OS session
+/// lock, so no live cooperating publisher can own these files. Stable
+/// sidecars are never removed; symlinks, special entries, and merely
+/// similar/unknown names remain terminal.
+fn recover_source_compile_identity_temporaries(output: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", output.display())),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile output {} is not a regular non-symlink directory",
+            output.display()
+        ));
+    }
+    let entries = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source compile output {} contains a non-UTF-8 entry",
+                output.display()
+            )
+        })?;
+        if atomic_identity_temporary_kind(name).is_some() {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)
+                .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized source identity temporary {} is not a regular non-symlink file; refusing recovery",
+                    path.display()
+                ));
+            }
+            fs::remove_file(&path).map_err(|error| {
+                format!(
+                    "recognized source identity temporary {} cannot be reclaimed under exclusive session ownership: {error}",
+                    path.display()
+                )
+            })?;
+        } else if uor_r4_core::transformerless::compiler::is_source_corpus_checkpoint_temporary_name(
+            name,
+            "corpus.meta",
+        ) {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)
+                .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized source corpus checkpoint temporary {} is not a regular non-symlink file; refusing recovery",
+                    path.display()
+                ));
+            }
+            fs::remove_file(&path).map_err(|error| {
+                format!(
+                    "recognized source corpus checkpoint temporary {} cannot be reclaimed under exclusive session ownership: {error}",
+                    path.display()
+                )
+            })?;
+        } else if name.starts_with(".corpus.meta.checkpoint.") && name.ends_with(".tmp") {
+            return Err(format!(
+                "source compile output {} contains unrecognized or non-owned checkpoint temporary {name}",
+                output.display()
+            ));
+        } else if looks_like_atomic_identity_temporary(name) {
+            return Err(format!(
+                "source compile output {} contains unrecognized or non-owned identity temporary {name}",
+                output.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return the identity carried by canonical preflight temporaries. The outer
+/// option distinguishes no temporary from a manifestless `null` binding.
+fn source_compile_preflight_temporary_binding(
+    output: &Path,
+) -> Result<Option<Option<String>>, String> {
+    let entries = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+    let mut binding: Option<Option<String>> = None;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if atomic_identity_temporary_kind(name) != Some(SOURCE_COMPILE_PREFLIGHT_FILE) {
+            continue;
+        }
+        let value =
+            validate_pre_attention_identity_file(&entry.path(), SOURCE_COMPILE_PREFLIGHT_FILE)?;
+        let record: SourceCompilePreflight = serde_json::from_value(value)
+            .map_err(|error| format!("{} is malformed: {error}", entry.path().display()))?;
+        if let Some(existing) = binding.as_ref() {
+            if existing != &record.source_manifest_kappa {
+                return Err(format!(
+                    "source compile output {} has conflicting canonical preflight temporaries",
+                    output.display()
+                ));
+            }
+        } else {
+            binding = Some(record.source_manifest_kappa);
+        }
+    }
+    Ok(binding)
+}
+
+fn validate_pre_attention_identity_file(
+    path: &Path,
+    kind: &str,
+) -> Result<serde_json::Value, String> {
+    let file =
+        open_regular_file_nofollow(path, "pre-attention identity record")?.ok_or_else(|| {
+            format!(
+                "pre-attention identity entry {} disappeared before validation",
+                path.display()
+            )
+        })?;
+    validate_pre_attention_identity_handle(file, path, kind)
+}
+
+fn validate_pre_attention_identity_handle(
+    file: fs::File,
+    path: &Path,
+    kind: &str,
+) -> Result<serde_json::Value, String> {
+    let description = if kind == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE {
+        "attention-operator binding"
+    } else {
+        "pre-attention identity record"
+    };
+    let bytes = read_opened_regular_file_nofollow(file, path, description)?;
+    reject_duplicate_json_fields(&bytes, path, description)?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    match kind {
+        SOURCE_COMPILE_PREFLIGHT_FILE => {
+            let record: SourceCompilePreflight = serde_json::from_value(value.clone())
+                .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+            if record.schema != SOURCE_COMPILE_PREFLIGHT_SCHEMA {
+                return Err(format!(
+                    "{} records unsupported schema {:?}",
+                    path.display(),
+                    record.schema
+                ));
+            }
+            let expected = source_compile_preflight_bytes(record.source_manifest_kappa.as_deref())?;
+            if bytes != expected {
+                return Err(format!(
+                    "{} is not a canonical source compile preflight temporary",
+                    path.display()
+                ));
+            }
+        }
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE => {
+            let binding: SourceManifestKappaBinding = serde_json::from_value(value.clone())
+                .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+            if binding.schema != SOURCE_MANIFEST_KAPPA_BINDING_SCHEMA {
+                return Err(format!(
+                    "{} records unsupported schema {:?}",
+                    path.display(),
+                    binding.schema
+                ));
+            }
+            let expected = source_manifest_kappa_binding_bytes(&binding.source_manifest_kappa)?;
+            if bytes != expected {
+                return Err(format!(
+                    "{} is not a canonical source-manifest kappa binding temporary",
+                    path.display()
+                ));
+            }
+        }
+        "tokenizer_adapter.json" => {
+            let adapter: TokenizerAdapter =
+                serde_json::from_value(value.clone()).map_err(|error| {
+                    format!(
+                        "{} is not a tokenizer adapter record: {error}",
+                        path.display()
+                    )
+                })?;
+            adapter_constructor(&adapter.family, adapter.version).map_err(|error| {
+                format!(
+                    "{} names an unsupported tokenizer adapter: {error}",
+                    path.display()
+                )
+            })?;
+            if !canonical_source_manifest_kappa(&adapter.tokenizer_cid) {
+                return Err(format!(
+                    "{} records a noncanonical tokenizer CID {}",
+                    path.display(),
+                    adapter.tokenizer_cid
+                ));
+            }
+            let declared = adapter.declared_digest();
+            if adapter.adapter_digest != declared {
+                return Err(format!(
+                    "{} declares tokenizer adapter digest {}, expected {declared}",
+                    path.display(),
+                    adapter.adapter_digest
+                ));
+            }
+            if value
+                != serde_json::to_value(&adapter)
+                    .map_err(|error| format!("{}: {error}", path.display()))?
+            {
+                return Err(format!(
+                    "{} is not the full canonical tokenizer adapter record",
+                    path.display()
+                ));
+            }
+        }
+        kind if kind == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE => {
+            let operator: AttentionOperatorSpec =
+                serde_json::from_value(value.clone()).map_err(|error| {
+                    format!(
+                        "{} is not an attention operator record: {error}",
+                        path.display()
+                    )
+                })?;
+            let registered =
+                uor_r4_model_source::attention::operator_spec(&operator.id, operator.version)
+                    .map_err(|error| format!("{}: {error}", path.display()))?;
+            if operator != registered
+                || value
+                    != serde_json::to_value(&registered)
+                        .map_err(|error| format!("{}: {error}", path.display()))?
+            {
+                return Err(format!(
+                    "{} is not the full registered attention operator record",
+                    path.display()
+                ));
+            }
+        }
+        _ => {
+            return Err(format!(
+                "{} is not a recognized pre-attention identity entry",
+                path.display()
+            ));
+        }
+    }
+    Ok(value)
+}
+
+/// Recognize only the immutable identity prefix that source compilation can
+/// publish before its attention sidecar. This makes a process-death retry
+/// resumable without treating arbitrary payload as an implicit v1 bundle.
+fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
+    let preflight = read_optional_source_compile_preflight(output)?;
+    reject_legacy_source_compile_initialization(output)?;
+    let kappa = read_optional_source_manifest_kappa_binding(output)?;
+    let recorded_kappa = preflight
+        .as_ref()
+        .and_then(|record| record.source_manifest_kappa.as_deref());
+    if let Some(kappa) = kappa.as_deref() {
+        if preflight.is_some() && recorded_kappa != Some(kappa) {
+            return Err(format!(
+                "source compile root {} has conflicting preflight ({recorded_kappa:?}) and source-manifest kappa ({kappa}) identities",
+                output.display()
+            ));
+        }
+    }
+    let mut saw_identity = preflight.is_some() || kappa.is_some();
+    let mut unexpected = Vec::new();
+    let entries = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source compile root {} contains a non-UTF-8 pre-attention entry",
+                output.display()
+            )
+        })?;
+        if name == SOURCE_MANIFEST_KAPPA_BINDING_FILE || name == SOURCE_COMPILE_PREFLIGHT_FILE {
+            saw_identity = true;
+            continue;
+        }
+        if name == "tokenizer_adapter.json" {
+            validate_pre_attention_identity_file(&entry.path(), name)?;
+            saw_identity = true;
+            continue;
+        }
+        if let Some(kind) = atomic_identity_temporary_kind(name) {
+            validate_pre_attention_identity_file(&entry.path(), kind)?;
+            saw_identity = true;
+            continue;
+        }
+        if looks_like_atomic_identity_temporary(name) {
+            return Err(format!(
+                "source compile root {} contains unrecognized or non-owned identity temporary {name}",
+                output.display()
+            ));
+        }
+        unexpected.push(name.to_owned());
+    }
+    if saw_identity && !unexpected.is_empty() {
+        return Err(format!(
+            "source compile root {} contains {} beside {} but has no {}; refusing to infer a historical era from an interrupted current-era compile",
+            output.display(),
+            unexpected.join(", "),
+            SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+            uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+        ));
+    }
+    Ok(saw_identity)
+}
+
+fn publish_bytes_no_clobber(path: &Path, expected: &[u8], label: &str) -> Result<(), String> {
+    if let Some(existing) = read_regular_file_nofollow(path, label)? {
+        return if existing == expected {
+            sync_parent_directory(path, label)
+        } else {
+            Err(format!(
+                "{} already records a different {label}",
+                path.display()
+            ))
+        };
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let parent_metadata = fs::symlink_metadata(parent)
+        .map_err(|error| format!("{} cannot be inspected: {error}", parent.display()))?;
+    if !parent_metadata.file_type().is_dir() {
+        return Err(format!(
+            "{} is not a regular non-symlink directory",
+            parent.display()
+        ));
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("{} has no UTF-8 file name", path.display()))?;
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let temporary = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), id));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("{}: {error}", temporary.display())),
+        };
+        if let Err(error) = file.write_all(expected).and_then(|()| file.sync_all()) {
+            let _ = fs::remove_file(&temporary);
+            return Err(format!("{}: {error}", temporary.display()));
+        }
+        drop(file);
+        match fs::hard_link(&temporary, path) {
+            Ok(()) => {
+                fs::remove_file(&temporary)
+                    .map_err(|error| format!("{}: {error}", temporary.display()))?;
+                return sync_parent_directory(path, label);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let _ = fs::remove_file(&temporary);
+                let existing = read_regular_file_nofollow(path, label)?.ok_or_else(|| {
+                    format!(
+                        "{} concurrently appeared and disappeared while publishing {label}",
+                        path.display()
+                    )
+                })?;
+                return if existing == expected {
+                    sync_parent_directory(path, label)
+                } else {
+                    Err(format!(
+                        "{} concurrently recorded a different {label}",
+                        path.display()
+                    ))
+                };
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&temporary);
+                return Err(format!(
+                    "{label} publish {} -> {}: {error}",
+                    temporary.display(),
+                    path.display()
+                ));
+            }
+        }
+    }
+    Err(format!(
+        "could not reserve a unique {label} temporary in {}",
+        parent.display()
+    ))
+}
+
+fn sync_parent_directory(path: &Path, label: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            format!(
+                "{label} parent directory {} cannot be durably synchronized: {error}",
+                parent.display()
+            )
+        })
+}
+
+#[cfg(unix)]
+fn exclusive_rename_path_bytes(path: &Path) -> Result<std::ffi::CString, String> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        format!(
+            "source compile publication path contains an interior NUL: {}",
+            path.display()
+        )
+    })
+}
+
+/// Rename one fully populated staging directory into an absent final name
+/// without ever replacing an entry published by another actor.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_directory_no_replace(from: &Path, to: &Path) -> Result<(), std::io::Error> {
+    let from = exclusive_rename_path_bytes(from)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let to = exclusive_rename_path_bytes(to)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    // SAFETY: both C strings are live for the call, contain no interior NUL,
+    // and `renameat2` borrows rather than retains their pointers.
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn rename_directory_no_replace(from: &Path, to: &Path) -> Result<(), std::io::Error> {
+    let from = exclusive_rename_path_bytes(from)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let to = exclusive_rename_path_bytes(to)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    // SAFETY: both C strings are live for the call, contain no interior NUL,
+    // and `renameatx_np` borrows rather than retains their pointers.
+    let result = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_vendor = "apple")))]
+fn rename_directory_no_replace(_from: &Path, _to: &Path) -> Result<(), std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "this platform has no atomic no-replace directory rename primitive",
+    ))
+}
+
+/// Atomically exchange two existing directory names on the same filesystem.
+/// The fully validated replacement becomes visible in one namespace step;
+/// the old last-good directory moves to `from` for post-publication cleanup.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn exchange_directories(from: &Path, to: &Path) -> Result<(), std::io::Error> {
+    let from = exclusive_rename_path_bytes(from)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let to = exclusive_rename_path_bytes(to)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    // SAFETY: both C strings remain live for the call and renameat2 borrows
+    // their pointers. RENAME_EXCHANGE is a single filesystem transaction.
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_EXCHANGE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn exchange_directories(from: &Path, to: &Path) -> Result<(), std::io::Error> {
+    let from = exclusive_rename_path_bytes(from)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let to = exclusive_rename_path_bytes(to)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    // SAFETY: both C strings remain live for the call and renameatx_np
+    // borrows their pointers. RENAME_SWAP is an atomic name exchange.
+    let result = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_SWAP,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_vendor = "apple")))]
+fn exchange_directories(_from: &Path, _to: &Path) -> Result<(), std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "this platform has no atomic directory-exchange primitive",
+    ))
+}
+
+fn source_compile_staging_root(parent: &Path) -> PathBuf {
+    parent.join(SOURCE_COMPILE_STAGING_DIR)
+}
+
+fn source_compile_session_lock_path(output: &Path) -> Result<PathBuf, String> {
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no parent for session coordination",
+            output.display()
+        )
+    })?;
+    let output_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "source compile output name is not UTF-8: {}",
+                output.display()
+            )
+        })?;
+    Ok(source_compile_staging_root(parent)
+        .join(format!("{output_name}{SOURCE_COMPILE_SESSION_LOCK_SUFFIX}")))
+}
+
+/// Cross-process ownership for one physical source-compile output.
+///
+/// The coordination inode lives in the reserved staging namespace rather
+/// than in the mutable bundle inventory. It is deliberately persistent: two
+/// cooperating processes must always open and lock the same inode, including
+/// after a completed compile. Dropping the guard releases the OS lock but does
+/// not unlink the coordination file.
+struct SourceCompileSessionLock {
+    file: fs::File,
+}
+
+struct SourceCompileSessionLocks {
+    _locks: Vec<SourceCompileSessionLock>,
+}
+
+#[allow(dead_code)] // SharedReader remains part of the tested cross-process protocol
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SourceCompileSessionMode {
+    SharedReader,
+    ExclusiveWriter,
+}
+
+impl SourceCompileSessionMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::SharedReader => "reader",
+            Self::ExclusiveWriter => "writer",
+        }
+    }
+}
+
+fn source_compile_session_is_busy(error: &str) -> bool {
+    error.contains(" is BUSY under an active cross-process compile session; refusing ")
+}
+
+fn graph_output_session_subject(graph_path: &Path) -> PathBuf {
+    graph_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
+}
+
+impl Drop for SourceCompileSessionLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+#[cfg(unix)]
+fn source_compile_lock_metadata_matches(
+    path_metadata: &fs::Metadata,
+    file_metadata: &fs::Metadata,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    path_metadata.dev() == file_metadata.dev() && path_metadata.ino() == file_metadata.ino()
+}
+
+#[cfg(not(unix))]
+fn source_compile_lock_metadata_matches(
+    _path_metadata: &fs::Metadata,
+    _file_metadata: &fs::Metadata,
+) -> bool {
+    // `OpenOptions` plus the before/after regular-file checks below reject
+    // pre-existing links and type changes. Unix additionally compares the
+    // opened inode because its portable metadata extension exposes identity.
+    true
+}
+
+fn canonical_compile_session_subject(subject: &Path) -> Result<PathBuf, String> {
+    let normalized = normalized_absolute_path(subject)?;
+    let mut existing = normalized.as_path();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(existing) {
+            Ok(_) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let name = existing.file_name().ok_or_else(|| {
+                    format!(
+                        "compile session subject {} has no existing ancestor",
+                        normalized.display()
+                    )
+                })?;
+                missing.push(name.to_os_string());
+                existing = existing.parent().ok_or_else(|| {
+                    format!(
+                        "compile session subject {} has no existing ancestor",
+                        normalized.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "compile session subject {} cannot be inspected: {error}",
+                    existing.display()
+                ));
+            }
+        }
+    }
+    let mut canonical = fs::canonicalize(existing).map_err(|error| {
+        format!(
+            "compile session subject ancestor {} cannot be canonicalized: {error}",
+            existing.display()
+        )
+    })?;
+    for component in missing.into_iter().rev() {
+        canonical.push(component);
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+fn try_lock_source_compile_session_mode(
+    subject: &Path,
+    mode: SourceCompileSessionMode,
+) -> Result<SourceCompileSessionLock, String> {
+    let output = canonical_compile_session_subject(subject)?;
+    try_lock_canonical_source_compile_session_mode(&output, mode)
+}
+
+/// Lock one already-canonical subject. Multi-subject callers canonicalize
+/// exactly once before sorting, then use this inner primitive so an alias
+/// swap cannot change the subject or acquisition order between those steps.
+fn try_lock_canonical_source_compile_session_mode(
+    output: &Path,
+    mode: SourceCompileSessionMode,
+) -> Result<SourceCompileSessionLock, String> {
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no parent for session coordination",
+            output.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("{} cannot be created: {error}", parent.display()))?;
+    let parent_metadata = fs::symlink_metadata(parent)
+        .map_err(|error| format!("{} cannot be inspected: {error}", parent.display()))?;
+    if !parent_metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile parent {} is not a regular non-symlink directory",
+            parent.display()
+        ));
+    }
+    let staging = ensure_source_compile_staging_root(parent)?;
+    let lock_path = source_compile_session_lock_path(output)?;
+    debug_assert_eq!(lock_path.parent(), Some(staging.as_path()));
+
+    match fs::symlink_metadata(&lock_path) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(format!(
+                "source compile session coordination {} is not a regular non-symlink file",
+                lock_path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "source compile session coordination {} cannot be inspected: {error}",
+                lock_path.display()
+            ));
+        }
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // O_NOFOLLOW closes the link-swap seam between the metadata check and
+        // open. O_NONBLOCK ensures a raced FIFO/device cannot block this
+        // request before the opened-handle type check rejects it.
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(&lock_path).map_err(|error| {
+        format!(
+            "source compile session coordination {} cannot be opened: {error}",
+            lock_path.display()
+        )
+    })?;
+    let path_metadata = fs::symlink_metadata(&lock_path).map_err(|error| {
+        format!(
+            "source compile session coordination {} cannot be reinspected: {error}",
+            lock_path.display()
+        )
+    })?;
+    let file_metadata = file.metadata().map_err(|error| {
+        format!(
+            "source compile session coordination {} handle cannot be inspected: {error}",
+            lock_path.display()
+        )
+    })?;
+    if !path_metadata.file_type().is_file()
+        || !file_metadata.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&path_metadata, &file_metadata)
+    {
+        return Err(format!(
+            "source compile session coordination {} changed identity or is not a regular non-symlink file",
+            lock_path.display()
+        ));
+    }
+
+    let lock = match mode {
+        SourceCompileSessionMode::SharedReader => file.try_lock_shared(),
+        SourceCompileSessionMode::ExclusiveWriter => file.try_lock(),
+    };
+    match lock {
+        Ok(()) => Ok(SourceCompileSessionLock { file }),
+        Err(fs::TryLockError::WouldBlock) => Err(format!(
+            "source compile output {} is BUSY under an active cross-process compile session; refusing {} access",
+            output.display(), mode.label()
+        )),
+        Err(fs::TryLockError::Error(error)) => Err(format!(
+            "source compile session coordination {} cannot be locked: {error}",
+            lock_path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+fn try_lock_source_compile_session(output: &Path) -> Result<SourceCompileSessionLock, String> {
+    try_lock_source_compile_session_mode(output, SourceCompileSessionMode::ExclusiveWriter)
+}
+
+fn try_lock_source_compile_sessions(
+    subjects: impl IntoIterator<Item = PathBuf>,
+    mode: SourceCompileSessionMode,
+) -> Result<SourceCompileSessionLocks, String> {
+    let mut subjects = subjects
+        .into_iter()
+        .map(|subject| canonical_compile_session_subject(&subject))
+        .collect::<Result<Vec<_>, _>>()?;
+    subjects.sort_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+    subjects.dedup();
+    let mut locks = Vec::with_capacity(subjects.len());
+    for subject in subjects {
+        locks.push(try_lock_canonical_source_compile_session_mode(
+            &subject, mode,
+        )?);
+    }
+    Ok(SourceCompileSessionLocks { _locks: locks })
+}
+
+fn ensure_source_compile_staging_root(parent: &Path) -> Result<PathBuf, String> {
+    let staging = source_compile_staging_root(parent);
+    match fs::create_dir(&staging) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(format!("{} cannot be created: {error}", staging.display())),
+    }
+    let metadata = fs::symlink_metadata(&staging)
+        .map_err(|error| format!("{} cannot be inspected: {error}", staging.display()))?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile staging namespace {} is not a regular non-symlink directory",
+            staging.display()
+        ));
+    }
+    Ok(staging)
+}
+
+fn compiled_bundle_stage_name(output_name: &str, pid: u32, id: u64) -> String {
+    format!(".{output_name}.{COMPILED_BUNDLE_STAGE_TAG}.{pid}.{id}")
+}
+
+fn is_compiled_bundle_stage_name(name: &str, output_name: &str) -> bool {
+    let prefix = format!(".{output_name}.{COMPILED_BUNDLE_STAGE_TAG}.");
+    let Some(sequence) = name.strip_prefix(&prefix) else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn looks_like_compiled_bundle_stage(name: &str, output_name: &str) -> bool {
+    name.starts_with(&format!(".{output_name}.{COMPILED_BUNDLE_STAGE_TAG}."))
+}
+
+fn compiled_bundle_stage_marker_bytes(
+    final_output: &Path,
+    stage_path: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<Vec<u8>, String> {
+    if !canonical_source_manifest_kappa(source_snapshot_kappa) {
+        return Err(format!(
+            "source snapshot kappa {source_snapshot_kappa:?} is not canonical"
+        ));
+    }
+    let final_output = canonical_compile_session_subject(final_output)?;
+    let final_output = final_output.to_str().ok_or_else(|| {
+        format!(
+            "compiled-bundle destination is not UTF-8: {}",
+            final_output.display()
+        )
+    })?;
+    let stage_path = canonical_compile_session_subject(stage_path)?;
+    let stage_path = stage_path.to_str().ok_or_else(|| {
+        format!(
+            "compiled-bundle stage is not UTF-8: {}",
+            stage_path.display()
+        )
+    })?;
+    let mut bytes = serde_json::to_vec_pretty(&CompiledBundleStageMarker {
+        schema: COMPILED_BUNDLE_STAGE_SCHEMA.to_owned(),
+        final_output: final_output.to_owned(),
+        stage_path: stage_path.to_owned(),
+        source_snapshot_kappa: source_snapshot_kappa.to_owned(),
+    })
+    .map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn read_compiled_bundle_stage_marker(stage: &Path) -> Result<Option<Vec<u8>>, String> {
+    let path = stage.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
+    let Some(bytes) = read_regular_file_nofollow(&path, "compiled-bundle stage marker")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, &path, "compiled-bundle stage marker")?;
+    let record: CompiledBundleStageMarker = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    let mut canonical = serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
+    canonical.push(b'\n');
+    if record.schema != COMPILED_BUNDLE_STAGE_SCHEMA || bytes != canonical {
+        return Err(format!(
+            "{} is not a canonical supported compiled-bundle stage marker",
+            path.display()
+        ));
+    }
+    Ok(Some(bytes))
+}
+
+fn validate_compiled_bundle_stage_marker_location(root: &Path, bytes: &[u8]) -> Result<(), String> {
+    let record: CompiledBundleStageMarker =
+        serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+    if !canonical_source_manifest_kappa(&record.source_snapshot_kappa) {
+        return Err(format!(
+            "compiled-bundle marker in {} records noncanonical source snapshot κ {:?}",
+            root.display(),
+            record.source_snapshot_kappa
+        ));
+    }
+    let final_output = canonical_compile_session_subject(Path::new(&record.final_output))?;
+    let stage_path = canonical_compile_session_subject(Path::new(&record.stage_path))?;
+    if final_output.to_str() != Some(record.final_output.as_str())
+        || stage_path.to_str() != Some(record.stage_path.as_str())
+    {
+        return Err(format!(
+            "compiled-bundle marker in {} contains a noncanonical path",
+            root.display()
+        ));
+    }
+    let output_name = final_output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("compiled output is not UTF-8: {}", final_output.display()))?;
+    let stage_name = stage_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("compiled stage is not UTF-8: {}", stage_path.display()))?;
+    let final_parent = final_output
+        .parent()
+        .ok_or_else(|| format!("compiled output {} has no parent", final_output.display()))?;
+    let expected_stage_parent =
+        canonical_compile_session_subject(&source_compile_staging_root(final_parent))?;
+    if stage_path.parent() != Some(expected_stage_parent.as_path())
+        || !is_compiled_bundle_stage_name(stage_name, output_name)
+    {
+        return Err(format!(
+            "compiled-bundle marker in {} records an invalid stage path {}",
+            root.display(),
+            stage_path.display()
+        ));
+    }
+    let actual = canonical_compile_session_subject(root)?;
+    if actual != final_output && actual != stage_path {
+        return Err(format!(
+            "compiled-bundle marker in {} belongs to neither its public nor staging namespace",
+            root.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_compiled_bundle_stage_marker(stage: &Path, expected: &[u8]) -> Result<bool, String> {
+    Ok(read_compiled_bundle_stage_marker(stage)?.is_some_and(|bytes| bytes == expected))
+}
+
+fn cleanup_published_compiled_bundle_stage_marker(
+    final_output: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    let Some(bytes) = read_compiled_bundle_stage_marker(final_output)? else {
+        return Ok(());
+    };
+    validate_compiled_bundle_stage_marker_location(final_output, &bytes)?;
+    let record: CompiledBundleStageMarker =
+        serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+    if record.source_snapshot_kappa != source_snapshot_kappa {
+        return Err(format!(
+            "published compiled-bundle marker in {} binds source snapshot {}, not {}",
+            final_output.display(),
+            record.source_snapshot_kappa,
+            source_snapshot_kappa
+        ));
+    }
+    validate_compiled_bundle_completion(final_output)?.ok_or_else(|| {
+        format!(
+            "published compiled-bundle marker in {} has no exact completion record",
+            final_output.display()
+        )
+    })?;
+    let path = final_output.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
+    fs::remove_file(&path).map_err(|error| {
+        format!(
+            "published compiled-bundle marker {} cannot be reclaimed: {error}",
+            path.display()
+        )
+    })?;
+    fs::File::open(final_output)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", final_output.display()))
+}
+
+fn is_atomic_publisher_temporary(name: &str, stable_name: &str) -> bool {
+    let prefix = format!(".{stable_name}.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn looks_like_atomic_publisher_temporary(name: &str, stable_name: &str) -> bool {
+    name.starts_with(&format!(".{stable_name}.")) && name.ends_with(".tmp")
+}
+
+fn compiled_bundle_stage_temporaries(stage: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut temporaries = Vec::new();
+    for entry in fs::read_dir(stage)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} contains a non-UTF-8 entry",
+                stage.display()
+            )
+        })?;
+        let exact = [
+            COMPILED_BUNDLE_STAGE_MARKER_FILE,
+            COMPILED_BUNDLE_COMPLETION_FILE,
+        ]
+        .into_iter()
+        .any(|stable| is_atomic_publisher_temporary(name, stable));
+        let looks_reserved = [
+            COMPILED_BUNDLE_STAGE_MARKER_FILE,
+            COMPILED_BUNDLE_COMPLETION_FILE,
+        ]
+        .into_iter()
+        .any(|stable| looks_like_atomic_publisher_temporary(name, stable));
+        if exact {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized compiled-bundle publisher temporary {} is not a regular non-symlink file",
+                    entry.path().display()
+                ));
+            }
+            temporaries.push(entry.path());
+        } else if looks_reserved {
+            return Err(format!(
+                "compiled-bundle stage {} contains unrecognized publisher temporary {name}",
+                stage.display()
+            ));
+        }
+    }
+    Ok(temporaries)
+}
+
+fn reset_resumable_compiled_bundle_stage(
+    stage: &Path,
+    temporaries: Vec<PathBuf>,
+) -> Result<(), String> {
+    let completion = stage.join(COMPILED_BUNDLE_COMPLETION_FILE);
+    let mut remove_completion = false;
+    match fs::symlink_metadata(&completion) {
+        Ok(metadata) if metadata.file_type().is_file() => remove_completion = true,
+        Ok(_) => {
+            return Err(format!(
+                "resumable compiled-bundle completion {} is not a regular non-symlink file",
+                completion.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "{} cannot be inspected: {error}",
+                completion.display()
+            ));
+        }
+    }
+    let mut derived = Vec::new();
+    for name in ["graph-cover", "graph"] {
+        let path = stage.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_dir() => derived.push(path),
+            Ok(_) => {
+                return Err(format!(
+                    "resumable compiled-bundle output {} is not a regular non-symlink directory",
+                    path.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!("{} cannot be inspected: {error}", path.display()));
+            }
+        }
+    }
+    if remove_completion {
+        fs::remove_file(&completion)
+            .map_err(|error| format!("{} cannot be reclaimed: {error}", completion.display()))?;
+    }
+    for temporary in temporaries {
+        fs::remove_file(&temporary).map_err(|error| {
+            format!(
+                "recognized compiled-bundle publisher temporary {} cannot be reclaimed: {error}",
+                temporary.display()
+            )
+        })?;
+    }
+    for path in derived {
+        fs::remove_dir_all(&path).map_err(|error| {
+            format!(
+                "derived compiled-bundle stage output {} cannot be reclaimed: {error}",
+                path.display()
+            )
+        })?;
+    }
+    fs::File::open(stage)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", stage.display()))
+}
+
+fn recover_compiled_bundle_stages(
+    output: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<Option<(PathBuf, Vec<u8>)>, String> {
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no staging parent",
+            output.display()
+        )
+    })?;
+    let output_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("source compile output is not UTF-8: {}", output.display()))?;
+    let staging = ensure_source_compile_staging_root(parent)?;
+    let mut resumable = None;
+    let mut stale = Vec::new();
+    for entry in fs::read_dir(&staging)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", staging.display()))?
+    {
+        let entry = entry
+            .map_err(|error| format!("{} cannot be enumerated: {error}", staging.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source compile staging namespace {} contains a non-UTF-8 entry",
+                staging.display()
+            )
+        })?;
+        if is_compiled_bundle_stage_name(name, output_name) {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "recognized compiled-bundle stage {} is not a regular non-symlink directory",
+                    entry.path().display()
+                ));
+            }
+            let temporaries = compiled_bundle_stage_temporaries(&entry.path())?;
+            let expected_marker =
+                compiled_bundle_stage_marker_bytes(output, &entry.path(), source_snapshot_kappa)?;
+            let recorded_marker = read_compiled_bundle_stage_marker(&entry.path())?;
+            if recorded_marker.as_deref() == Some(expected_marker.as_slice()) {
+                if resumable.is_some() {
+                    return Err(format!(
+                        "source compile output {} has multiple resumable bundle stages; refusing ambiguous adoption",
+                        output.display()
+                    ));
+                }
+                resumable = Some((entry.path(), expected_marker, temporaries));
+            } else if recorded_marker.is_some()
+                && validate_compiled_bundle_completion(&entry.path())?.is_none()
+            {
+                return Err(format!(
+                    "{} does not bind this exact compiled output, stage path, and source snapshot",
+                    entry
+                        .path()
+                        .join(COMPILED_BUNDLE_STAGE_MARKER_FILE)
+                        .display()
+                ));
+            } else {
+                // A markerless exact stage is either a crash before any
+                // resumable work began or the old final directory left after
+                // a committed exchange. Neither may be adopted as compiler
+                // input, and exclusive session ownership makes reclamation
+                // race-free with every cooperating publisher.
+                stale.push(entry.path());
+            }
+        } else if looks_like_compiled_bundle_stage(name, output_name) {
+            return Err(format!(
+                "source compile staging namespace {} contains unrecognized bundle stage {name}",
+                staging.display()
+            ));
+        }
+    }
+    // Classification is complete before the first mutation. A later malformed
+    // or duplicate candidate can therefore never leave earlier stage entries
+    // partially reclaimed.
+    for stage in stale {
+        fs::remove_dir_all(&stage).map_err(|error| {
+            format!(
+                "stale compiled-bundle stage {} cannot be reclaimed under exclusive session ownership: {error}",
+                stage.display()
+            )
+        })?;
+    }
+    if let Some((stage, expected_marker, temporaries)) = resumable.as_ref() {
+        reset_resumable_compiled_bundle_stage(stage, temporaries.clone())?;
+        if !validate_compiled_bundle_stage_marker(stage, expected_marker)? {
+            return Err(format!(
+                "resumable compiled-bundle stage {} lost its owner marker during recovery",
+                stage.display()
+            ));
+        }
+    }
+    fs::File::open(&staging)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", staging.display()))?;
+    Ok(resumable.map(|(path, marker, _)| (path, marker)))
+}
+
+fn copy_regular_file_nofollow(source: &Path, destination: &Path) -> Result<(), String> {
+    let mut source_file = open_regular_file_nofollow(source, "compiled-bundle source file")?
+        .ok_or_else(|| format!("compiled-bundle source file {} is absent", source.display()))?;
+    let opened_metadata = source_file
+        .metadata()
+        .map_err(|error| format!("{} cannot be inspected: {error}", source.display()))?;
+    let mut destination_file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+        .map_err(|error| format!("{} cannot be created: {error}", destination.display()))?;
+    let copied = std::io::copy(&mut source_file, &mut destination_file)
+        .map_err(|error| format!("{} cannot be copied: {error}", source.display()))?;
+    destination_file
+        .sync_all()
+        .map_err(|error| format!("{} cannot be synced: {error}", destination.display()))?;
+    let final_source_metadata = source_file
+        .metadata()
+        .map_err(|error| format!("{} cannot be reinspected: {error}", source.display()))?;
+    let final_path_metadata = fs::symlink_metadata(source)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", source.display()))?;
+    if !final_source_metadata.file_type().is_file()
+        || !final_path_metadata.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&opened_metadata, &final_source_metadata)
+        || !source_compile_lock_metadata_matches(&final_path_metadata, &final_source_metadata)
+        || copied != final_source_metadata.len()
+    {
+        return Err(format!(
+            "compiled-bundle source file {} changed identity, type, or length while copied",
+            source.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_legacy_coordination_directory_for_prefix_copy(path: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "legacy coordination entry {} is not a regular non-symlink directory",
+            path.display()
+        ));
+    }
+    for entry in fs::read_dir(path)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", path.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", path.display()))?;
+        let name = entry.file_name();
+        let name = name
+            .to_str()
+            .ok_or_else(|| format!("{} contains a non-UTF-8 coordination entry", path.display()))?;
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|error| format!("{} cannot be inspected: {error}", entry.path().display()))?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "legacy coordination entry {} is not a regular non-symlink file",
+                entry.path().display()
+            ));
+        }
+        let legacy_completion = name.starts_with(".legacy-graph-")
+            && name.ends_with(".completion.json")
+            && name
+                .strip_prefix(".legacy-graph-")
+                .and_then(|rest| rest.strip_suffix(".completion.json"))
+                .is_some_and(|hash| {
+                    hash.len() == 64
+                        && hash
+                            .bytes()
+                            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+                });
+        if !name.ends_with(SOURCE_COMPILE_SESSION_LOCK_SUFFIX) && !legacy_completion {
+            return Err(format!(
+                "legacy coordination directory {} contains unfinished or unrecognized entry {name}; refusing source-refresh copy",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn copy_compiled_bundle_prefix(source: &Path, destination: &Path) -> Result<(), String> {
+    for entry in fs::read_dir(source)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", source.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", source.display()))?;
+        let name = entry.file_name();
+        if name == std::ffi::OsStr::new("graph")
+            || name == std::ffi::OsStr::new("graph-cover")
+            || name == std::ffi::OsStr::new(COMPILED_BUNDLE_COMPLETION_FILE)
+            || name == std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE)
+        {
+            continue;
+        }
+        if name == std::ffi::OsStr::new(SOURCE_COMPILE_STAGING_DIR) {
+            validate_legacy_coordination_directory_for_prefix_copy(&entry.path())?;
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|error| format!("{} cannot be inspected: {error}", entry.path().display()))?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "compiled-bundle prefix {} contains nonregular entry {}; refusing staging copy",
+                source.display(),
+                entry.path().display()
+            ));
+        }
+        copy_regular_file_nofollow(&entry.path(), &destination.join(name))?;
+    }
+    fs::File::open(destination)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", destination.display()))
+}
+
+fn validate_copied_compiled_bundle_prefix(
+    destination: &Path,
+    completion: &CompiledBundleCompletion,
+) -> Result<(), String> {
+    let expected = completion
+        .files
+        .iter()
+        .filter(|(relative, _)| {
+            !relative.starts_with("graph/") && !relative.starts_with("graph-cover/")
+        })
+        .map(|(relative, kappa)| (relative.clone(), kappa.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let actual = compiled_bundle_file_kappas(destination)?;
+    if actual != expected {
+        return Err(format!(
+            "compiled-bundle prefix copied into {} does not exactly match the authoritative completed generation",
+            destination.display()
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CompiledBundleStage {
+    path: PathBuf,
+    final_output: PathBuf,
+    marker_bytes: Vec<u8>,
+}
+
+impl CompiledBundleStage {
+    fn allocate(final_output: &Path, source_snapshot_kappa: &str) -> Result<Self, String> {
+        // A stable completion is authoritative. Validate every recorded
+        // corpus/artifact member before copying a single byte into a resumable
+        // refresh stage, and retain the exact record for a post-copy recheck.
+        // This prevents a structurally parseable tamper from being copied and
+        // freshly re-certified as a new generation.
+        recover_compiled_bundle_completion_temporaries(final_output)?;
+        let authoritative_completion = validate_compiled_bundle_completion(final_output)?;
+        cleanup_published_compiled_bundle_stage_marker(final_output, source_snapshot_kappa)?;
+        if let Some((path, marker_bytes)) =
+            recover_compiled_bundle_stages(final_output, source_snapshot_kappa)?
+        {
+            return Ok(Self {
+                path,
+                final_output: final_output.to_path_buf(),
+                marker_bytes,
+            });
+        }
+        let parent = final_output.parent().ok_or_else(|| {
+            format!(
+                "source compile output {} has no staging parent",
+                final_output.display()
+            )
+        })?;
+        let output_name = final_output
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                format!(
+                    "source compile output is not UTF-8: {}",
+                    final_output.display()
+                )
+            })?;
+        let staging = ensure_source_compile_staging_root(parent)?;
+        for _ in 0..128 {
+            let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+            let path = staging.join(compiled_bundle_stage_name(
+                output_name,
+                std::process::id(),
+                id,
+            ));
+            match fs::create_dir(&path) {
+                Ok(()) => {
+                    let marker_bytes = match compiled_bundle_stage_marker_bytes(
+                        final_output,
+                        &path,
+                        source_snapshot_kappa,
+                    ) {
+                        Ok(bytes) => bytes,
+                        Err(error) => {
+                            let _ = fs::remove_dir_all(&path);
+                            let _ =
+                                fs::File::open(&staging).and_then(|directory| directory.sync_all());
+                            return Err(error);
+                        }
+                    };
+                    if let Err(error) = copy_compiled_bundle_prefix(final_output, &path) {
+                        let _ = fs::remove_dir_all(&path);
+                        return Err(error);
+                    }
+                    if let Some(before) = authoritative_completion.as_ref() {
+                        let after = match validate_compiled_bundle_completion(final_output) {
+                            Ok(Some(after)) => after,
+                            Ok(None) => {
+                                let _ = fs::remove_dir_all(&path);
+                                return Err(format!(
+                                    "authoritative compiled bundle {} lost its completion record while a refresh stage was copied",
+                                    final_output.display()
+                                ));
+                            }
+                            Err(error) => {
+                                let _ = fs::remove_dir_all(&path);
+                                return Err(error);
+                            }
+                        };
+                        if &after != before {
+                            let _ = fs::remove_dir_all(&path);
+                            return Err(format!(
+                                "authoritative compiled bundle {} changed completion identity while a refresh stage was copied",
+                                final_output.display()
+                            ));
+                        }
+                        if let Err(error) = validate_copied_compiled_bundle_prefix(&path, before) {
+                            let _ = fs::remove_dir_all(&path);
+                            return Err(error);
+                        }
+                    }
+                    if let Err(error) = publish_bytes_no_clobber(
+                        &path.join(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                        &marker_bytes,
+                        "compiled-bundle stage marker",
+                    ) {
+                        let _ = fs::remove_dir_all(&path);
+                        return Err(error);
+                    }
+                    if let Err(error) =
+                        fs::File::open(&staging).and_then(|directory| directory.sync_all())
+                    {
+                        let _ = fs::remove_dir_all(&path);
+                        let _ = fs::File::open(&staging).and_then(|directory| directory.sync_all());
+                        return Err(format!("{} cannot be synced: {error}", staging.display()));
+                    }
+                    return Ok(Self {
+                        path,
+                        final_output: final_output.to_path_buf(),
+                        marker_bytes,
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(format!(
+                        "compiled-bundle stage {} cannot be created: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Err(format!(
+            "could not allocate a compiled-bundle stage for {}",
+            final_output.display()
+        ))
+    }
+
+    fn sync_publication_parents(&self, label: &str) -> Result<(), String> {
+        // The working generation lives in the hidden staging namespace while
+        // the public generation lives directly below the compiled root. A
+        // rename/exchange mutates both directories, so durability requires
+        // syncing both even if the first synchronization already failed.
+        let final_parent = sync_parent_directory(&self.final_output, label);
+        let stage_parent = sync_parent_directory(&self.path, label);
+        match (final_parent, stage_parent) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(final_error), Ok(())) => Err(final_error),
+            (Ok(()), Err(stage_error)) => Err(stage_error),
+            (Err(final_error), Err(stage_error)) => Err(format!("{final_error}; {stage_error}")),
+        }
+    }
+
+    fn publish(&mut self) -> Result<(), String> {
+        validate_compiled_bundle_completion(&self.path)?.ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} has no durable completion record",
+                self.path.display()
+            )
+        })?;
+        if !validate_compiled_bundle_stage_marker(&self.path, &self.marker_bytes)? {
+            return Err(format!(
+                "compiled-bundle stage {} has no exact owner marker",
+                self.path.display()
+            ));
+        }
+        match fs::symlink_metadata(&self.final_output) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                if let Err(error) = exchange_directories(&self.path, &self.final_output) {
+                    return Err(format!(
+                        "validated compiled-bundle stage {} cannot atomically replace {}: {error}",
+                        self.path.display(),
+                        self.final_output.display(),
+                    ));
+                }
+                if let Err(error) = self.sync_publication_parents("compiled-bundle publication") {
+                    let rollback = exchange_directories(&self.path, &self.final_output)
+                        .map_err(|rollback_error| rollback_error.to_string())
+                        .and_then(|()| {
+                            self.sync_publication_parents("compiled-bundle swap rollback")
+                        });
+                    return Err(format!(
+                        "{error}; atomic compiled-bundle swap rollback: {}",
+                        rollback
+                            .map(|()| "restored last-good".to_owned())
+                            .unwrap_or_else(|rollback_error| rollback_error)
+                    ));
+                }
+                let published_marker = self.final_output.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
+                if validate_compiled_bundle_stage_marker(&self.final_output, &self.marker_bytes)
+                    == Ok(true)
+                    && fs::remove_file(&published_marker).is_ok()
+                {
+                    let _ = fs::File::open(&self.final_output)
+                        .and_then(|directory| directory.sync_all());
+                }
+                // Publication is complete and durable at this point. Cleanup
+                // is best-effort; an exact stale stage is safely reclaimed by
+                // the next exclusive owner rather than turning a committed
+                // disk replacement into a false client-visible failure.
+                let _ = fs::remove_dir_all(&self.path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if let Err(error) = rename_directory_no_replace(&self.path, &self.final_output) {
+                    return Err(format!(
+                        "validated compiled-bundle stage {} cannot be atomically published at {}: {error}",
+                        self.path.display(),
+                        self.final_output.display(),
+                    ));
+                }
+                if let Err(error) = self.sync_publication_parents("compiled-bundle publication") {
+                    let rollback = rename_directory_no_replace(&self.final_output, &self.path)
+                        .map_err(|rollback_error| rollback_error.to_string())
+                        .and_then(|()| {
+                            self.sync_publication_parents("compiled-bundle publish rollback")
+                        });
+                    return Err(format!(
+                        "{error}; fresh compiled-bundle publication rollback: {}",
+                        rollback
+                            .map(|()| "removed incomplete final namespace".to_owned())
+                            .unwrap_or_else(|rollback_error| rollback_error)
+                    ));
+                }
+                let published_marker = self.final_output.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
+                if validate_compiled_bundle_stage_marker(&self.final_output, &self.marker_bytes)
+                    == Ok(true)
+                    && fs::remove_file(&published_marker).is_ok()
+                {
+                    let _ = fs::File::open(&self.final_output)
+                        .and_then(|directory| directory.sync_all());
+                }
+            }
+            Ok(_) => {
+                return Err(format!(
+                    "compiled-bundle destination {} is not a regular non-symlink directory",
+                    self.final_output.display()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "compiled-bundle destination {} cannot be inspected: {error}",
+                    self.final_output.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn collect_compiled_bundle_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut Vec<(String, PathBuf)>,
+    ignored: &std::collections::BTreeSet<PathBuf>,
+) -> Result<(), String> {
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("{} cannot be enumerated: {error}", directory.display()))?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        if ignored.contains(&path) {
+            continue;
+        }
+        let relative = path.strip_prefix(root).map_err(|_| {
+            format!(
+                "compiled-bundle entry {} escaped root {}",
+                path.display(),
+                root.display()
+            )
+        })?;
+        let relative_utf8 = relative.to_str().ok_or_else(|| {
+            format!(
+                "compiled-bundle entry {} has a non-UTF-8 relative path",
+                path.display()
+            )
+        })?;
+        if relative_utf8 == COMPILED_BUNDLE_COMPLETION_FILE {
+            continue;
+        }
+        if relative_utf8 == COMPILED_BUNDLE_STAGE_MARKER_FILE {
+            let bytes = read_required_regular_file_nofollow(&path, "compiled-bundle stage marker")?;
+            reject_duplicate_json_fields(&bytes, &path, "compiled-bundle stage marker")?;
+            let record: CompiledBundleStageMarker = serde_json::from_slice(&bytes)
+                .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+            let mut canonical =
+                serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
+            canonical.push(b'\n');
+            if record.schema != COMPILED_BUNDLE_STAGE_SCHEMA || bytes != canonical {
+                return Err(format!(
+                    "{} is not a canonical supported compiled-bundle stage marker",
+                    path.display()
+                ));
+            }
+            validate_compiled_bundle_stage_marker_location(root, &bytes)?;
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+        if metadata.file_type().is_file() {
+            files.push((relative_utf8.to_owned(), path));
+        } else if metadata.file_type().is_dir() && matches!(relative_utf8, "graph" | "graph-cover")
+        {
+            collect_compiled_bundle_files(root, &path, files, ignored)?;
+        } else {
+            return Err(format!(
+                "compiled bundle {} contains unsupported nonregular entry {}",
+                root.display(),
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn compiled_bundle_file_kappas(
+    root: &Path,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    compiled_bundle_file_kappas_ignoring(root, &std::collections::BTreeSet::new())
+}
+
+fn compiled_bundle_file_kappas_ignoring(
+    root: &Path,
+    ignored: &std::collections::BTreeSet<PathBuf>,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let mut files = Vec::new();
+    collect_compiled_bundle_files(root, root, &mut files, ignored)?;
+    let mut kappas = std::collections::BTreeMap::new();
+    for (relative, path) in files {
+        let bytes = read_required_regular_file_nofollow(&path, "compiled-bundle member")?;
+        kappas.insert(
+            relative,
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+        );
+    }
+    Ok(kappas)
+}
+
+fn sync_regular_file_nofollow(path: &Path, label: &str) -> Result<(), String> {
+    let file = open_regular_file_nofollow(path, label)?
+        .ok_or_else(|| format!("{} disappeared before synchronization", path.display()))?;
+    let opened = file
+        .metadata()
+        .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+    file.sync_all()
+        .map_err(|error| format!("{} cannot be synced: {error}", path.display()))?;
+    let final_handle = file
+        .metadata()
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    let final_path = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    if !final_handle.file_type().is_file()
+        || !final_path.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&opened, &final_handle)
+        || !source_compile_lock_metadata_matches(&final_path, &final_handle)
+    {
+        return Err(format!(
+            "{} changed identity or type while its {label} bytes were synchronized",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn sync_compiled_bundle_members(root: &Path) -> Result<(), String> {
+    let mut files = Vec::new();
+    collect_compiled_bundle_files(root, root, &mut files, &std::collections::BTreeSet::new())?;
+    for (_, path) in files {
+        sync_regular_file_nofollow(&path, "compiled-bundle member")?;
+    }
+    for directory in [
+        root.join("graph-cover"),
+        root.join("graph"),
+        root.to_path_buf(),
+    ] {
+        fs::File::open(&directory)
+            .and_then(|handle| handle.sync_all())
+            .map_err(|error| format!("{} cannot be synced: {error}", directory.display()))?;
+    }
+    Ok(())
+}
+
+fn compiled_bundle_completion_bytes(
+    files: std::collections::BTreeMap<String, String>,
+) -> Result<Vec<u8>, String> {
+    let mut bytes = serde_json::to_vec_pretty(&CompiledBundleCompletion {
+        schema: COMPILED_BUNDLE_COMPLETION_SCHEMA.to_owned(),
+        files,
+    })
+    .map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn publish_compiled_bundle_completion(root: &Path) -> Result<(), String> {
+    for required in [
+        "corpus.meta",
+        "corpus.records",
+        "tless_artifacts.bin",
+        "tokenizer.bin",
+        "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        SOURCE_COMPILE_PREFLIGHT_FILE,
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        "graph-cover/cover.r4g1",
+        "graph-cover/cover_report.json",
+        "graph/score.r4g1",
+        "graph/score_report.json",
+    ] {
+        if !regular_file_presence(&root.join(required))? {
+            return Err(format!(
+                "compiled-bundle stage {} is incomplete; missing required {required}",
+                root.display()
+            ));
+        }
+    }
+    // The completion record is the commit point. Every member and directory
+    // entry it names must reach stable storage before that record can become
+    // visible, otherwise a host crash could persist a truthful completion
+    // record ahead of its graph/corpus bytes.
+    sync_compiled_bundle_members(root)?;
+    let files = compiled_bundle_file_kappas(root)?;
+    let bytes = compiled_bundle_completion_bytes(files)?;
+    publish_bytes_no_clobber(
+        &root.join(COMPILED_BUNDLE_COMPLETION_FILE),
+        &bytes,
+        "compiled-bundle completion",
+    )
+}
+
+fn validate_staged_graph_outputs(root: &Path) -> Result<(), String> {
+    for relative in ["graph-cover/cover.r4g1", "graph/score.r4g1"] {
+        let path = root.join(relative);
+        let bytes = read_required_regular_file_nofollow(&path, "staged R4G1 artifact")?;
+        let view = uor_r4_graph_format::GraphView::parse(&bytes)
+            .map_err(|error| format!("{} is not a valid R4G1 artifact: {error}", path.display()))?;
+        view.verify_cids().map_err(|error| {
+            format!(
+                "{} failed R4G1 integrity verification: {error}",
+                path.display()
+            )
+        })?;
+        if view.head().is_none() {
+            return Err(format!("{} has no R4G1 HEAD section", path.display()));
+        }
+    }
+    for relative in ["graph-cover/cover_report.json", "graph/score_report.json"] {
+        let path = root.join(relative);
+        let bytes = read_required_regular_file_nofollow(&path, "staged graph report")?;
+        reject_duplicate_json_fields(&bytes, &path, "staged graph report")?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+        if !value.is_object() {
+            return Err(format!("{} must contain a JSON object", path.display()));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum GraphOutputKind {
+    Cover,
+    Score,
+}
+
+impl GraphOutputKind {
+    fn files(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Cover => ("cover.r4g1", "cover_report.json"),
+            Self::Score => ("score.r4g1", "score_report.json"),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Cover => "cover",
+            Self::Score => "score",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LegacyGraphRecordPaths {
+    attempt: PathBuf,
+    completion: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LegacyGraphGenerationAction {
+    Reuse,
+    BuildBoth,
+    ResumeScore,
+}
+
+fn canonical_path_text(path: &Path, label: &str) -> Result<String, String> {
+    canonical_compile_session_subject(path)?
+        .to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| format!("{label} is not UTF-8: {}", path.display()))
+}
+
+fn bytes_kappa(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn regular_file_kappa(path: &Path, label: &str) -> Result<String, String> {
+    read_required_regular_file_nofollow(path, label).map(|bytes| bytes_kappa(&bytes))
+}
+
+fn legacy_graph_controls_kappa(args: &[String]) -> Result<String, String> {
+    serde_json::to_vec(args)
+        .map(|bytes| bytes_kappa(&bytes))
+        .map_err(|error| error.to_string())
+}
+
+struct LegacyGraphGenerationInputs<'a> {
+    artifacts: &'a Path,
+    corpus_meta: &'a Path,
+    corpus_recs: &'a Path,
+    tokenizer: &'a Path,
+    cover_output: &'a Path,
+    graph_output: &'a Path,
+    cover_args: &'a [String],
+    score_args: &'a [String],
+}
+
+fn capture_legacy_graph_generation_identity(
+    inputs: LegacyGraphGenerationInputs<'_>,
+) -> Result<LegacyGraphGenerationIdentity, String> {
+    let LegacyGraphGenerationInputs {
+        artifacts,
+        corpus_meta,
+        corpus_recs,
+        tokenizer,
+        cover_output,
+        graph_output,
+        cover_args,
+        score_args,
+    } = inputs;
+    let mut inputs = std::collections::BTreeMap::new();
+    for (path, label) in [
+        (artifacts, "legacy transformerless artifact"),
+        (corpus_meta, "legacy corpus metadata"),
+        (corpus_recs, "legacy corpus records"),
+    ] {
+        inputs.insert(
+            canonical_path_text(path, label)?,
+            regular_file_kappa(path, label)?,
+        );
+    }
+    for (path, label) in [
+        (tokenizer.to_path_buf(), "legacy tokenizer"),
+        (
+            corpus_meta
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            "legacy attention-operator binding",
+        ),
+        (
+            corpus_meta
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join("manifest.json"),
+            "legacy observation manifest",
+        ),
+    ] {
+        if let Some(bytes) = read_regular_file_nofollow(&path, label)? {
+            inputs.insert(canonical_path_text(&path, label)?, bytes_kappa(&bytes));
+        }
+    }
+    Ok(LegacyGraphGenerationIdentity {
+        cover_output: canonical_path_text(cover_output, "legacy cover output")?,
+        graph_output: canonical_path_text(graph_output, "legacy score output")?,
+        input_files: inputs,
+        cover_controls_kappa: legacy_graph_controls_kappa(cover_args)?,
+        score_controls_kappa: legacy_graph_controls_kappa(score_args)?,
+    })
+}
+
+fn legacy_graph_record_paths(
+    identity: &LegacyGraphGenerationIdentity,
+) -> Result<LegacyGraphRecordPaths, String> {
+    legacy_graph_record_paths_for_outputs(
+        Path::new(&identity.cover_output),
+        Path::new(&identity.graph_output),
+        true,
+    )
+}
+
+fn legacy_graph_record_paths_for_outputs(
+    cover: &Path,
+    graph: &Path,
+    create_coordination: bool,
+) -> Result<LegacyGraphRecordPaths, String> {
+    let cover_output = canonical_path_text(cover, "legacy cover output")?;
+    let graph_output = canonical_path_text(graph, "legacy score output")?;
+    let cover = Path::new(&cover_output);
+    let parent = cover.parent().ok_or_else(|| {
+        format!(
+            "legacy cover output {} has no coordination parent",
+            cover.display()
+        )
+    })?;
+    // Keep transaction records outside the bundle inventory itself. A source
+    // refresh copies every non-derived root entry and must never encounter a
+    // legacy coordination directory as executable model payload.
+    let coordination_parent = parent
+        .parent()
+        .filter(|ancestor| ancestor.parent().is_some())
+        .unwrap_or(parent);
+    let coordination = source_compile_staging_root(coordination_parent);
+    if create_coordination {
+        ensure_source_compile_staging_root(coordination_parent)?;
+    }
+    let key_material = format!("{cover_output}\0{graph_output}");
+    let key = blake3::hash(key_material.as_bytes()).to_hex();
+    Ok(LegacyGraphRecordPaths {
+        attempt: coordination.join(format!(".legacy-graph-{key}.attempt.json")),
+        completion: coordination.join(format!(".legacy-graph-{key}.completion.json")),
+    })
+}
+
+fn legacy_graph_attempt_bytes(identity: &LegacyGraphGenerationIdentity) -> Result<Vec<u8>, String> {
+    let mut bytes = serde_json::to_vec_pretty(&LegacyGraphGenerationAttempt {
+        schema: LEGACY_GRAPH_ATTEMPT_SCHEMA.to_owned(),
+        identity: identity.clone(),
+    })
+    .map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn legacy_graph_completion_bytes(
+    record: &LegacyGraphGenerationCompletion,
+) -> Result<Vec<u8>, String> {
+    let mut bytes = serde_json::to_vec_pretty(record).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn read_optional_legacy_graph_attempt(
+    path: &Path,
+) -> Result<Option<LegacyGraphGenerationAttempt>, String> {
+    let Some(bytes) = read_regular_file_nofollow(path, "legacy graph attempt")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, path, "legacy graph attempt")?;
+    let record: LegacyGraphGenerationAttempt = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if record.schema != LEGACY_GRAPH_ATTEMPT_SCHEMA
+        || bytes != legacy_graph_attempt_bytes(&record.identity)?
+    {
+        return Err(format!(
+            "{} is not a canonical supported legacy graph attempt",
+            path.display()
+        ));
+    }
+    Ok(Some(record))
+}
+
+fn read_optional_legacy_graph_completion(
+    path: &Path,
+) -> Result<Option<LegacyGraphGenerationCompletion>, String> {
+    let Some(bytes) = read_regular_file_nofollow(path, "legacy graph completion")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, path, "legacy graph completion")?;
+    let record: LegacyGraphGenerationCompletion = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if record.schema != LEGACY_GRAPH_GENERATION_SCHEMA
+        || bytes != legacy_graph_completion_bytes(&record)?
+    {
+        return Err(format!(
+            "{} is not a canonical supported legacy graph completion",
+            path.display()
+        ));
+    }
+    Ok(Some(record))
+}
+
+fn is_atomic_replace_temporary(name: &str, stable_name: &str) -> bool {
+    let prefix = format!(".{stable_name}.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".replace.tmp"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn recover_atomic_replace_temporaries(path: &Path, label: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let stable_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("{} has no UTF-8 file name", path.display()))?;
+    let prefix = format!(".{stable_name}.");
+    let mut recoverable = Vec::new();
+    for entry in fs::read_dir(parent)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "{} contains a non-UTF-8 coordination entry",
+                parent.display()
+            )
+        })?;
+        if is_atomic_replace_temporary(name, stable_name) {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized {label} replacement temporary {} is not a regular non-symlink file",
+                    entry.path().display()
+                ));
+            }
+            recoverable.push(entry.path());
+        } else if name.starts_with(&prefix) && name.ends_with(".replace.tmp") {
+            return Err(format!(
+                "{} contains unrecognized {label} replacement temporary {name}",
+                parent.display()
+            ));
+        }
+    }
+    let recovered = !recoverable.is_empty();
+    for temporary in recoverable {
+        fs::remove_file(&temporary).map_err(|error| {
+            format!(
+                "recognized {label} replacement temporary {} cannot be reclaimed: {error}",
+                temporary.display()
+            )
+        })?;
+    }
+    if recovered {
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("{} cannot be synced: {error}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn rollback_atomic_byte_replacement(
+    path: &Path,
+    previous: Option<&[u8]>,
+    label: &str,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    match previous {
+        Some(previous) => {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| format!("{} has no UTF-8 file name", path.display()))?;
+            for _ in 0..128 {
+                let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+                let temporary =
+                    parent.join(format!(".{name}.{}.{}.replace.tmp", std::process::id(), id));
+                let mut file = match fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&temporary)
+                {
+                    Ok(file) => file,
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(format!("{}: {error}", temporary.display())),
+                };
+                file.write_all(previous)
+                    .and_then(|()| file.sync_all())
+                    .map_err(|error| format!("{}: {error}", temporary.display()))?;
+                drop(file);
+                fs::rename(&temporary, path).map_err(|error| {
+                    format!(
+                        "{label} rollback {} -> {} failed: {error}",
+                        temporary.display(),
+                        path.display()
+                    )
+                })?;
+                return fs::File::open(parent)
+                    .and_then(|directory| directory.sync_all())
+                    .map_err(|error| format!("{} cannot be synced: {error}", parent.display()));
+            }
+            Err(format!(
+                "could not reserve a {label} rollback temporary in {}",
+                parent.display()
+            ))
+        }
+        None => {
+            fs::remove_file(path)
+                .map_err(|error| format!("{} cannot be rolled back: {error}", path.display()))?;
+            fs::File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|error| format!("{} cannot be synced: {error}", parent.display()))
+        }
+    }
+}
+
+fn replace_bytes_atomically(path: &Path, expected: &[u8], label: &str) -> Result<(), String> {
+    recover_atomic_replace_temporaries(path, label)?;
+    let previous = read_regular_file_nofollow(path, label)?;
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            return Err(format!(
+                "{} is not a regular non-symlink {label}",
+                path.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", path.display())),
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("{} has no UTF-8 file name", path.display()))?;
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let temporary = parent.join(format!(".{name}.{}.{}.replace.tmp", std::process::id(), id));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("{}: {error}", temporary.display())),
+        };
+        if let Err(error) = file.write_all(expected).and_then(|()| file.sync_all()) {
+            let _ = fs::remove_file(&temporary);
+            return Err(format!("{}: {error}", temporary.display()));
+        }
+        drop(file);
+        if let Err(error) = fs::rename(&temporary, path) {
+            let _ = fs::remove_file(&temporary);
+            return Err(format!(
+                "atomic {label} replacement {} -> {} failed: {error}",
+                temporary.display(),
+                path.display()
+            ));
+        }
+        return match sync_parent_directory(path, label) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                let rollback = rollback_atomic_byte_replacement(path, previous.as_deref(), label)
+                    .map(|()| "restored previous record".to_owned())
+                    .unwrap_or_else(|rollback_error| rollback_error);
+                Err(format!("{error}; {label} rollback: {rollback}"))
+            }
+        };
+    }
+    Err(format!(
+        "could not reserve a unique {label} replacement temporary in {}",
+        parent.display()
+    ))
+}
+
+fn graph_output_file_kappas(
+    output: &Path,
+    kind: GraphOutputKind,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    if !validate_graph_output_directory(output, kind)? {
+        return Err(format!(
+            "{} output {} is absent",
+            kind.label(),
+            output.display()
+        ));
+    }
+    let mut files = std::collections::BTreeMap::new();
+    for name in [kind.files().0, kind.files().1] {
+        let path = output.join(name);
+        files.insert(
+            canonical_path_text(&path, "legacy graph output member")?,
+            regular_file_kappa(&path, "legacy graph output member")?,
+        );
+    }
+    Ok(files)
+}
+
+fn legacy_graph_output_file_kappas(
+    cover_output: &Path,
+    graph_output: &Path,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let mut files = graph_output_file_kappas(cover_output, GraphOutputKind::Cover)?;
+    files.extend(graph_output_file_kappas(
+        graph_output,
+        GraphOutputKind::Score,
+    )?);
+    Ok(files)
+}
+
+fn legacy_graph_generation_action(
+    identity: &LegacyGraphGenerationIdentity,
+) -> Result<(LegacyGraphGenerationAction, LegacyGraphRecordPaths, Vec<u8>), String> {
+    let paths = legacy_graph_record_paths(identity)?;
+    recover_atomic_replace_temporaries(&paths.completion, "legacy graph completion")?;
+    let attempt_bytes = legacy_graph_attempt_bytes(identity)?;
+    let attempt = read_optional_legacy_graph_attempt(&paths.attempt)?;
+    let exact_attempt = match attempt.as_ref() {
+        Some(attempt) if attempt.identity == *identity => true,
+        Some(_) => {
+            return Err(format!(
+                "legacy graph outputs {} and {} retain a different unfinished generation attempt; refusing to overwrite its crash state",
+                identity.cover_output, identity.graph_output
+            ));
+        }
+        None => false,
+    };
+    let cover_output = Path::new(&identity.cover_output);
+    let graph_output = Path::new(&identity.graph_output);
+    let cover_complete = validate_graph_output_directory(cover_output, GraphOutputKind::Cover)?;
+    let graph_complete = validate_graph_output_directory(graph_output, GraphOutputKind::Score)?;
+    let completion = read_optional_legacy_graph_completion(&paths.completion)?;
+    if let Some(completion) = completion.as_ref() {
+        let outputs = if cover_complete && graph_complete {
+            Some(legacy_graph_output_file_kappas(cover_output, graph_output)?)
+        } else {
+            None
+        };
+        if completion.identity == *identity {
+            if outputs.as_ref() != Some(&completion.output_files) {
+                return Err(
+                    "legacy graph outputs changed after their exact input-bound completion was published; refusing refresh recertification"
+                        .to_owned(),
+                );
+            }
+            return Ok((LegacyGraphGenerationAction::Reuse, paths, attempt_bytes));
+        }
+        if !exact_attempt && outputs.as_ref() != Some(&completion.output_files) {
+            return Err(
+                "legacy graph outputs do not match their last durable generation and no exact current attempt authorizes crash recovery"
+                    .to_owned(),
+            );
+        }
+    }
+    let action = match (cover_complete, graph_complete, exact_attempt) {
+        (true, false, true) => LegacyGraphGenerationAction::ResumeScore,
+        (false, true, true) => {
+            return Err(
+                "legacy score output exists without its cover during an unfinished generation; refusing an impossible publication order"
+                    .to_owned(),
+            );
+        }
+        (true, false, false) | (false, true, false) => {
+            return Err(format!(
+                "legacy R4G1 outputs are one-sided (cover complete={cover_complete}, score complete={graph_complete}) without an exact server attempt record; refusing arbitrary partial state"
+            ));
+        }
+        _ => LegacyGraphGenerationAction::BuildBoth,
+    };
+    Ok((action, paths, attempt_bytes))
+}
+
+fn validate_legacy_graph_generation_for_serving(graph_path: &Path) -> Result<(), String> {
+    let Some(graph_output) = graph_path.parent() else {
+        return Ok(());
+    };
+    if graph_output.file_name() != Some(std::ffi::OsStr::new("graph")) {
+        return Ok(());
+    }
+    let Some(root) = graph_output.parent() else {
+        return Ok(());
+    };
+    let cover_output = root.join("graph-cover");
+    let paths = legacy_graph_record_paths_for_outputs(&cover_output, graph_output, false)?;
+    let coordination = paths
+        .completion
+        .parent()
+        .ok_or_else(|| format!("{} has no coordination parent", paths.completion.display()))?;
+    match fs::symlink_metadata(coordination) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => {
+            return Err(format!(
+                "legacy graph coordination root for {} is not a regular non-symlink directory",
+                graph_path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("{}: {error}", graph_path.display())),
+    }
+    recover_atomic_replace_temporaries(&paths.completion, "legacy graph completion")?;
+    let attempt = read_optional_legacy_graph_attempt(&paths.attempt)?;
+    let Some(completion) = read_optional_legacy_graph_completion(&paths.completion)? else {
+        if let Some(attempt) = attempt {
+            return Err(format!(
+                "legacy graph generation for {} is incomplete under attempt schema {}; retry Compile / Refresh before serving",
+                graph_path.display(),
+                attempt.schema
+            ));
+        }
+        // Pre-transaction historical bundles retain their read compatibility.
+        return Ok(());
+    };
+    let expected_cover = canonical_path_text(&cover_output, "legacy cover output")?;
+    let expected_graph = canonical_path_text(graph_output, "legacy score output")?;
+    if completion.identity.cover_output != expected_cover
+        || completion.identity.graph_output != expected_graph
+    {
+        return Err(format!(
+            "legacy graph completion beside {} binds different physical outputs",
+            graph_path.display()
+        ));
+    }
+    let actual_outputs = legacy_graph_output_file_kappas(&cover_output, graph_output)?;
+    if actual_outputs != completion.output_files {
+        return Err(format!(
+            "legacy graph output generation {} changed after its durable completion",
+            graph_path.display()
+        ));
+    }
+    for (path, expected) in &completion.identity.input_files {
+        let path = Path::new(path);
+        let actual = regular_file_kappa(path, "legacy graph bound input")?;
+        if &actual != expected {
+            return Err(format!(
+                "legacy graph input {} changed after {} was completed",
+                path.display(),
+                graph_path.display()
+            ));
+        }
+    }
+    if let Some(attempt) = attempt {
+        if attempt.identity != completion.identity {
+            return Err(format!(
+                "legacy graph generation for {} has a completion and a conflicting unfinished attempt",
+                graph_path.display()
+            ));
+        }
+        let bytes = legacy_graph_attempt_bytes(&attempt.identity)?;
+        remove_exact_legacy_attempt(&paths.attempt, &bytes)?;
+    }
+    Ok(())
+}
+
+fn validate_graph_output_directory(output: &Path, kind: GraphOutputKind) -> Result<bool, String> {
+    let metadata = match fs::symlink_metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", output.display())),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "{} output {} is not a regular non-symlink directory",
+            kind.label(),
+            output.display()
+        ));
+    }
+    let (artifact_name, report_name) = kind.files();
+    let mut inventory = fs::read_dir(output)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?
+        .map(|entry| {
+            let entry = entry
+                .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+            let name = entry
+                .file_name()
+                .to_str()
+                .map(str::to_owned)
+                .ok_or_else(|| format!("{} contains a non-UTF-8 output entry", output.display()))?;
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "{} output entry {} is not a regular non-symlink file",
+                    kind.label(),
+                    entry.path().display()
+                ));
+            }
+            Ok(name)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    inventory.sort();
+    let mut expected = vec![artifact_name.to_owned(), report_name.to_owned()];
+    expected.sort();
+    if inventory != expected {
+        return Err(format!(
+            "{} output {} must contain exactly {artifact_name} and {report_name}; found {:?}",
+            kind.label(),
+            output.display(),
+            inventory
+        ));
+    }
+    let artifact_path = output.join(artifact_name);
+    let report_path = output.join(report_name);
+    let artifact = read_regular_file_nofollow(&artifact_path, "R4G1 output artifact")?;
+    let report = read_regular_file_nofollow(&report_path, "R4G1 output report")?;
+    let (Some(artifact), Some(report)) = (artifact, report) else {
+        return Err(format!(
+            "{} output {} exists without its complete {artifact_name}/{report_name} pair; refusing to adopt or mutate partial publication",
+            kind.label(),
+            output.display()
+        ));
+    };
+    let view = uor_r4_graph_format::GraphView::parse(&artifact).map_err(|error| {
+        format!(
+            "{} output artifact {} is invalid: {error}",
+            kind.label(),
+            artifact_path.display()
+        )
+    })?;
+    view.verify_cids().map_err(|error| {
+        format!(
+            "{} output artifact {} failed integrity verification: {error}",
+            kind.label(),
+            artifact_path.display()
+        )
+    })?;
+    if view.head().is_none() {
+        return Err(format!(
+            "{} output artifact {} has no R4G1 HEAD section",
+            kind.label(),
+            artifact_path.display()
+        ));
+    }
+    reject_duplicate_json_fields(&report, &report_path, "R4G1 output report")?;
+    let value: serde_json::Value = serde_json::from_slice(&report)
+        .map_err(|error| format!("{} is malformed: {error}", report_path.display()))?;
+    if !value.is_object() {
+        return Err(format!(
+            "{} must contain a JSON object",
+            report_path.display()
+        ));
+    }
+    Ok(true)
+}
+
+fn sync_graph_output_directory(output: &Path, kind: GraphOutputKind) -> Result<(), String> {
+    if !validate_graph_output_directory(output, kind)? {
+        return Err(format!(
+            "{} staging directory {} remained absent before synchronization",
+            kind.label(),
+            output.display()
+        ));
+    }
+    let (artifact, report) = kind.files();
+    sync_regular_file_nofollow(&output.join(artifact), "R4G1 output artifact")?;
+    sync_regular_file_nofollow(&output.join(report), "R4G1 output report")?;
+    fs::File::open(output)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", output.display()))
+}
+
+struct GraphOutputStage {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum GraphStageInstall {
+    Fresh,
+    Exchanged,
+}
+
+impl GraphOutputStage {
+    fn allocate(final_output: &Path, kind: GraphOutputKind) -> Result<Self, String> {
+        let parent = final_output
+            .parent()
+            .ok_or_else(|| format!("graph output {} has no parent", final_output.display()))?;
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("{} cannot be created: {error}", parent.display()))?;
+        let name = final_output
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("graph output is not UTF-8: {}", final_output.display()))?;
+        let prefix = format!(".{name}.{}-staging-", kind.label());
+        for entry in fs::read_dir(parent)
+            .map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?
+        {
+            let entry = entry
+                .map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?;
+            let entry_name = entry.file_name();
+            let Some(entry_name) = entry_name.to_str() else {
+                continue;
+            };
+            if !entry_name.starts_with(&prefix) {
+                continue;
+            }
+            let sequence = &entry_name[prefix.len()..];
+            let mut parts = sequence.split('-');
+            let exact = parts.next().is_some_and(|part| {
+                !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
+            }) && parts.next().is_some_and(|part| {
+                !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
+            }) && parts.next().is_none();
+            if !exact {
+                return Err(format!(
+                    "graph output parent {} contains unrecognized staging entry {entry_name}",
+                    parent.display()
+                ));
+            }
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "recognized graph staging entry {} is not a regular non-symlink directory",
+                    entry.path().display()
+                ));
+            }
+            fs::remove_dir_all(entry.path()).map_err(|error| {
+                format!(
+                    "stale graph staging entry {} cannot be reclaimed under exclusive output ownership: {error}",
+                    entry.path().display()
+                )
+            })?;
+        }
+        for _ in 0..128 {
+            let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+            let path = parent.join(format!("{prefix}{}-{id}", std::process::id()));
+            match fs::create_dir(&path) {
+                Ok(()) => {
+                    return Ok(Self { path, armed: true });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(format!("{} cannot be created: {error}", path.display()));
+                }
+            }
+        }
+        Err(format!(
+            "could not allocate a {} staging directory beside {}",
+            kind.label(),
+            final_output.display()
+        ))
+    }
+
+    #[cfg(test)]
+    fn publish(mut self, final_output: &Path, kind: GraphOutputKind) -> Result<(), String> {
+        sync_graph_output_directory(&self.path, kind)?;
+        rename_directory_no_replace(&self.path, final_output).map_err(|error| {
+            format!(
+                "validated {} staging directory {} cannot be exclusively published at {}: {error}",
+                kind.label(),
+                self.path.display(),
+                final_output.display()
+            )
+        })?;
+        if let Err(error) = sync_parent_directory(final_output, "R4G1 graph output publication") {
+            let rollback = rename_directory_no_replace(final_output, &self.path).and_then(|()| {
+                fs::File::open(final_output.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+            });
+            return Err(format!(
+                "{error}; R4G1 graph output publication rollback: {}",
+                rollback
+                    .map(|()| "removed incomplete final namespace".to_owned())
+                    .unwrap_or_else(|rollback_error| rollback_error.to_string())
+            ));
+        }
+        self.armed = false;
+        Ok(())
+    }
+
+    fn install_for_generation(
+        &mut self,
+        final_output: &Path,
+        kind: GraphOutputKind,
+    ) -> Result<GraphStageInstall, String> {
+        sync_graph_output_directory(&self.path, kind)?;
+        let install = match fs::symlink_metadata(final_output) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                validate_graph_output_directory(final_output, kind)?;
+                exchange_directories(&self.path, final_output).map_err(|error| {
+                    format!(
+                        "validated {} stage {} cannot replace {}: {error}",
+                        kind.label(),
+                        self.path.display(),
+                        final_output.display()
+                    )
+                })?;
+                GraphStageInstall::Exchanged
+            }
+            Ok(_) => {
+                return Err(format!(
+                    "{} output {} is not a regular non-symlink directory",
+                    kind.label(),
+                    final_output.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                rename_directory_no_replace(&self.path, final_output).map_err(|error| {
+                    format!(
+                        "validated {} stage {} cannot be exclusively published at {}: {error}",
+                        kind.label(),
+                        self.path.display(),
+                        final_output.display()
+                    )
+                })?;
+                GraphStageInstall::Fresh
+            }
+            Err(error) => {
+                return Err(format!(
+                    "{} output {} cannot be inspected: {error}",
+                    kind.label(),
+                    final_output.display()
+                ));
+            }
+        };
+        if let Err(error) =
+            sync_parent_directory(final_output, "legacy graph generation installation")
+        {
+            let rollback = self
+                .rollback_generation_install(final_output, install)
+                .map(|()| "restored pre-install generation".to_owned())
+                .unwrap_or_else(|rollback_error| rollback_error);
+            return Err(format!("{error}; installation rollback: {rollback}"));
+        }
+        Ok(install)
+    }
+
+    fn rollback_generation_install(
+        &mut self,
+        final_output: &Path,
+        install: GraphStageInstall,
+    ) -> Result<(), String> {
+        match install {
+            GraphStageInstall::Fresh => rename_directory_no_replace(final_output, &self.path)
+                .map_err(|error| error.to_string())?,
+            GraphStageInstall::Exchanged => {
+                exchange_directories(&self.path, final_output).map_err(|error| error.to_string())?
+            }
+        }
+        sync_parent_directory(final_output, "legacy graph generation rollback")
+    }
+
+    fn finish_generation_install(&mut self, final_output: &Path) -> Result<(), String> {
+        match fs::symlink_metadata(&self.path) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                fs::remove_dir_all(&self.path).map_err(|error| {
+                    format!(
+                        "replaced graph generation {} cannot be reclaimed: {error}",
+                        self.path.display()
+                    )
+                })?;
+                sync_parent_directory(final_output, "legacy graph generation cleanup")?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(_) => {
+                return Err(format!(
+                    "graph generation cleanup path {} is not a directory",
+                    self.path.display()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "graph generation cleanup path {} cannot be inspected: {error}",
+                    self.path.display()
+                ));
+            }
+        }
+        self.armed = false;
+        Ok(())
+    }
+}
+
+impl Drop for GraphOutputStage {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+fn replace_out_argument(args: &[String], output: &Path) -> Result<Vec<String>, String> {
+    let mut staged = args.to_vec();
+    let index = staged
+        .iter()
+        .position(|argument| argument == "--out")
+        .ok_or_else(|| "graph writer arguments contain no --out control".to_owned())?;
+    let value = staged
+        .get_mut(index + 1)
+        .ok_or_else(|| "graph writer --out control has no value".to_owned())?;
+    *value = output.display().to_string();
+    Ok(staged)
+}
+
+fn replace_argument_value(args: &mut [String], name: &str, value: &Path) -> Result<(), String> {
+    let index = args
+        .iter()
+        .position(|argument| argument == name)
+        .ok_or_else(|| format!("graph writer arguments contain no {name} control"))?;
+    let target = args
+        .get_mut(index + 1)
+        .ok_or_else(|| format!("graph writer {name} control has no value"))?;
+    *target = value.display().to_string();
+    Ok(())
+}
+
+fn build_graph_writer_stage<F>(
+    final_output: &Path,
+    kind: GraphOutputKind,
+    args: &[String],
+    writer: F,
+) -> Result<GraphOutputStage, String>
+where
+    F: FnOnce(&[String]) -> Result<(), String>,
+{
+    let stage = GraphOutputStage::allocate(final_output, kind)?;
+    let staged_args = replace_out_argument(args, &stage.path)?;
+    writer(&staged_args)?;
+    sync_graph_output_directory(&stage.path, kind)?;
+    Ok(stage)
+}
+
+fn staged_legacy_graph_output_kappas(
+    cover_stage: &Path,
+    score_stage: &Path,
+    cover_output: &Path,
+    score_output: &Path,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let mut files = std::collections::BTreeMap::new();
+    for (stage, output, kind) in [
+        (cover_stage, cover_output, GraphOutputKind::Cover),
+        (score_stage, score_output, GraphOutputKind::Score),
+    ] {
+        if !validate_graph_output_directory(stage, kind)? {
+            return Err(format!(
+                "{} legacy generation stage {} is absent",
+                kind.label(),
+                stage.display()
+            ));
+        }
+        for name in [kind.files().0, kind.files().1] {
+            files.insert(
+                canonical_path_text(&output.join(name), "legacy graph output member")?,
+                regular_file_kappa(&stage.join(name), "staged legacy graph output member")?,
+            );
+        }
+    }
+    Ok(files)
+}
+
+fn remove_exact_legacy_attempt(path: &Path, expected: &[u8]) -> Result<(), String> {
+    let Some(bytes) = read_regular_file_nofollow(path, "legacy graph attempt")? else {
+        return Ok(());
+    };
+    if bytes != expected {
+        return Err(format!(
+            "legacy graph attempt {} changed before completion cleanup",
+            path.display()
+        ));
+    }
+    fs::remove_file(path)
+        .map_err(|error| format!("{} cannot be reclaimed: {error}", path.display()))?;
+    sync_parent_directory(path, "legacy graph attempt cleanup")
+}
+
+fn ensure_legacy_graph_attempt(path: &Path, expected: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let stable_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("{} has no UTF-8 file name", path.display()))?;
+    let stable = read_regular_file_nofollow(path, "legacy graph attempt")?;
+    if stable.as_deref().is_some_and(|bytes| bytes != expected) {
+        return Err(format!(
+            "{} records a different unfinished legacy graph attempt",
+            path.display()
+        ));
+    }
+    let mut recoverable = Vec::new();
+    for entry in fs::read_dir(parent)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "{} contains a non-UTF-8 coordination entry",
+                parent.display()
+            )
+        })?;
+        if is_atomic_publisher_temporary(name, stable_name) {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized legacy attempt temporary {} is not a regular non-symlink file",
+                    entry.path().display()
+                ));
+            }
+            let bytes = read_required_regular_file_nofollow(
+                &entry.path(),
+                "legacy graph attempt temporary",
+            )?;
+            let admissible = if stable.is_some() {
+                bytes == expected
+            } else {
+                expected.starts_with(&bytes)
+            };
+            if !admissible {
+                return Err(format!(
+                    "legacy graph attempt temporary {} is not an exact publisher crash prefix",
+                    entry.path().display()
+                ));
+            }
+            recoverable.push(entry.path());
+        } else if looks_like_atomic_publisher_temporary(name, stable_name) {
+            return Err(format!(
+                "{} contains unrecognized legacy attempt temporary {name}",
+                parent.display()
+            ));
+        }
+    }
+    for temporary in recoverable {
+        fs::remove_file(&temporary).map_err(|error| {
+            format!(
+                "recognized legacy attempt temporary {} cannot be reclaimed: {error}",
+                temporary.display()
+            )
+        })?;
+    }
+    publish_bytes_no_clobber(path, expected, "legacy graph attempt")
+}
+
+fn publish_legacy_graph_generation_pair(
+    mut cover_stage: GraphOutputStage,
+    mut score_stage: GraphOutputStage,
+    cover_output: &Path,
+    score_output: &Path,
+    paths: &LegacyGraphRecordPaths,
+    attempt_bytes: &[u8],
+    completion: &LegacyGraphGenerationCompletion,
+) -> Result<(), String> {
+    let completion_bytes = legacy_graph_completion_bytes(completion)?;
+    let cover_install = cover_stage.install_for_generation(cover_output, GraphOutputKind::Cover)?;
+    let score_install =
+        match score_stage.install_for_generation(score_output, GraphOutputKind::Score) {
+            Ok(install) => install,
+            Err(error) => {
+                let rollback = cover_stage
+                    .rollback_generation_install(cover_output, cover_install)
+                    .map(|()| "restored cover generation".to_owned())
+                    .unwrap_or_else(|rollback_error| rollback_error);
+                return Err(format!("{error}; cover rollback: {rollback}"));
+            }
+        };
+    let installed = legacy_graph_output_file_kappas(cover_output, score_output);
+    let commit = installed.and_then(|installed| {
+        if installed != completion.output_files {
+            return Err(
+                "installed legacy graph generation differs from its staged digest set".to_owned(),
+            );
+        }
+        replace_bytes_atomically(
+            &paths.completion,
+            &completion_bytes,
+            "legacy graph completion",
+        )
+    });
+    if let Err(error) = commit {
+        let score_rollback = score_stage
+            .rollback_generation_install(score_output, score_install)
+            .map(|()| "restored score generation".to_owned())
+            .unwrap_or_else(|rollback_error| rollback_error);
+        let cover_rollback = cover_stage
+            .rollback_generation_install(cover_output, cover_install)
+            .map(|()| "restored cover generation".to_owned())
+            .unwrap_or_else(|rollback_error| rollback_error);
+        return Err(format!(
+            "{error}; score rollback: {score_rollback}; cover rollback: {cover_rollback}"
+        ));
+    }
+    // The completion is now the durable commit point. Reclaiming old
+    // directories and the exact attempt is cleanup; failures are reported so
+    // the next exclusive owner can finish without ever rewriting final bytes.
+    cover_stage.finish_generation_install(cover_output)?;
+    score_stage.finish_generation_install(score_output)?;
+    remove_exact_legacy_attempt(&paths.attempt, attempt_bytes)
+}
+
+fn publish_legacy_graph_score_resume(
+    mut score_stage: GraphOutputStage,
+    cover_output: &Path,
+    score_output: &Path,
+    paths: &LegacyGraphRecordPaths,
+    attempt_bytes: &[u8],
+    identity: &LegacyGraphGenerationIdentity,
+) -> Result<(), String> {
+    let score_install = score_stage.install_for_generation(score_output, GraphOutputKind::Score)?;
+    let output_files = match legacy_graph_output_file_kappas(cover_output, score_output) {
+        Ok(files) => files,
+        Err(error) => {
+            let rollback = score_stage
+                .rollback_generation_install(score_output, score_install)
+                .map(|()| "removed resumed score generation".to_owned())
+                .unwrap_or_else(|rollback_error| rollback_error);
+            return Err(format!("{error}; score rollback: {rollback}"));
+        }
+    };
+    let completion = LegacyGraphGenerationCompletion {
+        schema: LEGACY_GRAPH_GENERATION_SCHEMA.to_owned(),
+        identity: identity.clone(),
+        output_files,
+    };
+    let bytes = legacy_graph_completion_bytes(&completion)?;
+    if let Err(error) =
+        replace_bytes_atomically(&paths.completion, &bytes, "legacy graph completion")
+    {
+        let rollback = score_stage
+            .rollback_generation_install(score_output, score_install)
+            .map(|()| "removed resumed score generation".to_owned())
+            .unwrap_or_else(|rollback_error| rollback_error);
+        return Err(format!("{error}; score rollback: {rollback}"));
+    }
+    score_stage.finish_generation_install(score_output)?;
+    remove_exact_legacy_attempt(&paths.attempt, attempt_bytes)
+}
+
+#[cfg(test)]
+fn run_graph_writer_staged<F>(
+    final_output: &Path,
+    kind: GraphOutputKind,
+    args: &[String],
+    writer: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&[String]) -> Result<(), String>,
+{
+    if validate_graph_output_directory(final_output, kind)? {
+        return Ok(());
+    }
+    let stage = GraphOutputStage::allocate(final_output, kind)?;
+    let staged_args = replace_out_argument(args, &stage.path)?;
+    writer(&staged_args)?;
+    stage.publish(final_output, kind)
+}
+
+fn compiled_bundle_completion_temporaries(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", root.display())),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "compiled bundle {} is not a regular non-symlink directory",
+            root.display()
+        ));
+    }
+    let mut temporaries = Vec::new();
+    for entry in fs::read_dir(root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "compiled bundle {} contains a non-UTF-8 entry",
+                root.display()
+            )
+        })?;
+        if is_atomic_publisher_temporary(name, COMPILED_BUNDLE_COMPLETION_FILE) {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "recognized compiled-bundle completion temporary {} is not a regular non-symlink file",
+                    entry.path().display()
+                ));
+            }
+            let bytes = read_required_regular_file_nofollow(
+                &entry.path(),
+                "compiled-bundle completion temporary",
+            )?;
+            temporaries.push((entry.path(), bytes));
+        } else if looks_like_atomic_publisher_temporary(name, COMPILED_BUNDLE_COMPLETION_FILE) {
+            return Err(format!(
+                "compiled bundle {} contains unrecognized completion publisher temporary {name}",
+                root.display()
+            ));
+        }
+    }
+    temporaries.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(temporaries)
+}
+
+fn validate_compiled_bundle_completion_bytes(
+    root: &Path,
+    path: &Path,
+    bytes: &[u8],
+    ignored: &std::collections::BTreeSet<PathBuf>,
+) -> Result<CompiledBundleCompletion, String> {
+    reject_duplicate_json_fields(bytes, path, "compiled-bundle completion")?;
+    let record: CompiledBundleCompletion = serde_json::from_slice(bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if record.schema != COMPILED_BUNDLE_COMPLETION_SCHEMA {
+        return Err(format!(
+            "{} records unsupported schema {:?}",
+            path.display(),
+            record.schema
+        ));
+    }
+    let canonical = compiled_bundle_completion_bytes(record.files.clone())?;
+    if bytes != canonical {
+        return Err(format!(
+            "{} is not a canonical compiled-bundle completion record",
+            path.display()
+        ));
+    }
+    let actual = compiled_bundle_file_kappas_ignoring(root, ignored)?;
+    if actual != record.files {
+        return Err(format!(
+            "compiled bundle {} changed after its durable completion record was published",
+            root.display()
+        ));
+    }
+    Ok(record)
+}
+
+/// Reconcile the only crash residue which can coexist with a committed
+/// completion: the publisher's exact hard-linked temporary. Callers hold the
+/// bundle's cross-process session, so no cooperating publisher can still own
+/// the temporary. Classification and full member validation precede the first
+/// removal; malformed, conflicting, symlinked, or special entries remain
+/// terminal and untouched.
+fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), String> {
+    let temporaries = compiled_bundle_completion_temporaries(root)?;
+    if temporaries.is_empty() {
+        return Ok(());
+    }
+    let stable = root.join(COMPILED_BUNDLE_COMPLETION_FILE);
+    let stable_bytes = read_regular_file_nofollow(&stable, "compiled-bundle completion")?;
+    let candidate = stable_bytes
+        .as_deref()
+        .unwrap_or_else(|| temporaries[0].1.as_slice());
+    if temporaries
+        .iter()
+        .any(|(_, temporary)| temporary.as_slice() != candidate)
+    {
+        return Err(format!(
+            "compiled bundle {} has conflicting stable/temporary completion records",
+            root.display()
+        ));
+    }
+    let ignored = temporaries
+        .iter()
+        .map(|(path, _)| path.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    validate_compiled_bundle_completion_bytes(root, &stable, candidate, &ignored)?;
+
+    if stable_bytes.is_none() {
+        match fs::hard_link(&temporaries[0].0, &stable) {
+            Ok(()) => sync_parent_directory(&stable, "compiled-bundle completion recovery")?,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let raced = read_required_regular_file_nofollow(
+                    &stable,
+                    "concurrently recovered compiled-bundle completion",
+                )?;
+                if raced != candidate {
+                    return Err(format!(
+                        "{} concurrently recorded a different compiled-bundle completion",
+                        stable.display()
+                    ));
+                }
+            }
+            Err(error) => {
+                return Err(format!(
+                    "compiled-bundle completion recovery {} -> {} failed: {error}",
+                    temporaries[0].0.display(),
+                    stable.display()
+                ));
+            }
+        }
+    }
+    for (temporary, expected) in temporaries {
+        let current = read_required_regular_file_nofollow(
+            &temporary,
+            "compiled-bundle completion temporary before recovery",
+        )?;
+        if current != expected {
+            return Err(format!(
+                "compiled-bundle completion temporary {} changed before recovery",
+                temporary.display()
+            ));
+        }
+        fs::remove_file(&temporary).map_err(|error| {
+            format!(
+                "recognized compiled-bundle completion temporary {} cannot be reclaimed: {error}",
+                temporary.display()
+            )
+        })?;
+    }
+    sync_parent_directory(&stable, "compiled-bundle completion recovery")?;
+    validate_compiled_bundle_completion(root)?.ok_or_else(|| {
+        format!(
+            "compiled bundle {} lost its recovered completion record",
+            root.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn validate_compiled_bundle_completion(
+    root: &Path,
+) -> Result<Option<CompiledBundleCompletion>, String> {
+    let path = root.join(COMPILED_BUNDLE_COMPLETION_FILE);
+    let Some(bytes) = read_regular_file_nofollow(&path, "compiled-bundle completion")? else {
+        return Ok(None);
+    };
+    validate_compiled_bundle_completion_bytes(
+        root,
+        &path,
+        &bytes,
+        &std::collections::BTreeSet::new(),
+    )
+    .map(Some)
+}
+
+fn ensure_compiled_bundle_completion_for_serving(
+    bundle: &ResolvedCompiledBundle,
+    current_version: u32,
+) -> Result<(), String> {
+    recover_compiled_bundle_completion_temporaries(&bundle.physical_root)?;
+    if validate_compiled_bundle_completion(&bundle.physical_root)?.is_some() {
+        return Ok(());
+    }
+    if bundle.attention_operator.version < current_version {
+        // Historical completed v1 roots predate this server transaction
+        // record. Their existing provenance compatibility remains unchanged.
+        return Ok(());
+    }
+    validate_staged_graph_outputs(&bundle.physical_root)?;
+    publish_compiled_bundle_completion(&bundle.physical_root)?;
+    validate_compiled_bundle_completion(&bundle.physical_root)?
+        .ok_or_else(|| {
+            format!(
+                "current compiled bundle {} lost its bootstrapped completion record",
+                bundle.physical_root.display()
+            )
+        })
+        .map(|_| ())
+}
+
+fn recover_managed_compiled_bundle_completion_temporaries(
+    compiled_root: &Path,
+) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(compiled_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "{} cannot be inspected before completion recovery: {error}",
+                compiled_root.display()
+            ));
+        }
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "compiled model inventory {} is not a regular non-symlink directory",
+            compiled_root.display()
+        ));
+    }
+    for entry in fs::read_dir(compiled_root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", compiled_root.display()))?
+    {
+        let entry = entry.map_err(|error| {
+            format!("{} cannot be enumerated: {error}", compiled_root.display())
+        })?;
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|error| format!("{} cannot be inspected: {error}", entry.path().display()))?;
+        if metadata.file_type().is_dir() {
+            recover_compiled_bundle_completion_temporaries(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn create_source_compile_preflight_stage(
+    output: &Path,
+    expected: &[u8],
+) -> Result<PathBuf, String> {
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no parent for atomic staging",
+            output.display()
+        )
+    })?;
+    let output_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "source compile output name is not UTF-8: {}",
+                output.display()
+            )
+        })?;
+    let staging_root = ensure_source_compile_staging_root(parent)?;
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let stage = staging_root.join(format!(
+            ".{output_name}.{}.{}.stage",
+            std::process::id(),
+            id
+        ));
+        match fs::create_dir(&stage) {
+            Ok(()) => {
+                if let Err(error) = publish_bytes_no_clobber(
+                    &stage.join(SOURCE_COMPILE_PREFLIGHT_FILE),
+                    expected,
+                    "source compile preflight",
+                ) {
+                    let _ = fs::remove_dir(&stage);
+                    return Err(error);
+                }
+                let directory = fs::File::open(&stage)
+                    .map_err(|error| format!("{} cannot be opened: {error}", stage.display()))?;
+                directory
+                    .sync_all()
+                    .map_err(|error| format!("{} cannot be synced: {error}", stage.display()))?;
+                return Ok(stage);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("{} cannot be created: {error}", stage.display())),
+        }
+    }
+    Err(format!(
+        "could not reserve a unique source compile stage in {}",
+        staging_root.display()
+    ))
+}
+
+fn remove_owned_source_compile_stage(stage: &Path, expected: &[u8]) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(stage)
+        .map_err(|error| format!("{} cannot be inspected: {error}", stage.display()))?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "owned source compile stage {} changed type before cleanup",
+            stage.display()
+        ));
+    }
+    let marker = stage.join(SOURCE_COMPILE_PREFLIGHT_FILE);
+    let recorded = read_source_compile_preflight_path(&marker)?;
+    if source_compile_preflight_bytes(recorded.source_manifest_kappa.as_deref())? != expected {
+        return Err(format!(
+            "owned source compile stage {} changed identity before cleanup",
+            stage.display()
+        ));
+    }
+    let entries = fs::read_dir(stage)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?;
+    if entries.len() != 1 || entries[0].file_name() != SOURCE_COMPILE_PREFLIGHT_FILE {
+        return Err(format!(
+            "owned source compile stage {} acquired unexpected entries; refusing cleanup",
+            stage.display()
+        ));
+    }
+    fs::remove_file(&marker).map_err(|error| format!("{}: {error}", marker.display()))?;
+    fs::remove_dir(stage).map_err(|error| format!("{}: {error}", stage.display()))
+}
+
+fn reject_legacy_source_compile_initialization(output: &Path) -> Result<(), String> {
+    let initialization = source_compile_initialization_path(output)?;
+    match fs::symlink_metadata(&initialization) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Ok(_) => Err(format!(
+            "stranded legacy source compile initialization {} is ambiguous and cannot authorize adoption; refusing mutation",
+            initialization.display()
+        )),
+        Err(error) => Err(format!("{} cannot be inspected: {error}", initialization.display())),
+    }
+}
+
+/// Publish a marker-bearing compile directory in one atomic, exclusive
+/// namespace operation. Process death can leave only a hidden staging
+/// directory; the resolver-visible final root is either absent or already
+/// carries its canonical preflight marker.
+fn publish_source_compile_preflight(output: &Path, kappa: Option<&str>) -> Result<(), String> {
+    let expected = source_compile_preflight_bytes(kappa)?;
+    let parent = output.parent().ok_or_else(|| {
+        format!(
+            "source compile output {} has no parent for atomic publication",
+            output.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("{} cannot be created: {error}", parent.display()))?;
+    let parent_metadata = fs::symlink_metadata(parent)
+        .map_err(|error| format!("{} cannot be inspected: {error}", parent.display()))?;
+    if !parent_metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile parent {} is not a regular non-symlink directory",
+            parent.display()
+        ));
+    }
+    reject_legacy_source_compile_initialization(output)?;
+
+    match fs::symlink_metadata(output) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "source compile output {} is not a regular non-symlink directory",
+                    output.display()
+                ));
+            }
+            validate_source_compile_identity_temporaries(output)?;
+            if let Some(recorded) = read_optional_source_compile_preflight(output)? {
+                if recorded.source_manifest_kappa.as_deref() == kappa {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "source compile output {} is preflight-bound to {:?}, not {:?}",
+                    output.display(),
+                    recorded.source_manifest_kappa,
+                    kappa
+                ));
+            }
+            if !source_compile_pre_attention_prefix(output)? {
+                return Err(format!(
+                    "source compile output {} exists without a stable source compile preflight; refusing to adopt or mutate it",
+                    output.display()
+                ));
+            }
+            let temporary = source_compile_preflight_temporary_binding(output)?;
+            let bound = read_optional_source_manifest_kappa_binding(output)?;
+            let recovered = match (temporary, bound) {
+                (Some(temporary), Some(bound)) if temporary.as_deref() == Some(&bound) => {
+                    Some(temporary)
+                }
+                (Some(temporary), None) => Some(temporary),
+                (None, Some(bound)) => Some(Some(bound)),
+                (Some(temporary), Some(bound)) => {
+                    return Err(format!(
+                        "source compile output {} has conflicting temporary preflight {:?} and source binding {bound}",
+                        output.display(),
+                        temporary
+                    ));
+                }
+                (None, None) => None,
+            };
+            let Some(recovered) = recovered else {
+                return Err(format!(
+                    "source compile output {} has identity sidecars but no recoverable source snapshot binding",
+                    output.display()
+                ));
+            };
+            if recovered.as_deref() != kappa {
+                return Err(format!(
+                    "source compile output {} has recoverable binding {:?}, not requested {:?}",
+                    output.display(),
+                    recovered,
+                    kappa
+                ));
+            }
+            publish_bytes_no_clobber(
+                &output.join(SOURCE_COMPILE_PREFLIGHT_FILE),
+                &expected,
+                "source compile preflight",
+            )?;
+            return Ok(());
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", output.display())),
+    }
+
+    let stage = create_source_compile_preflight_stage(output, &expected)?;
+    match rename_directory_no_replace(&stage, output) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            let cleanup_error = remove_owned_source_compile_stage(&stage, &expected).err();
+            let raced = match fs::symlink_metadata(output) {
+                Ok(metadata) if metadata.file_type().is_dir() => {
+                    match read_optional_source_compile_preflight(output) {
+                        Ok(Some(recorded))
+                            if recorded.source_manifest_kappa.as_deref() == kappa =>
+                        {
+                            None
+                        }
+                        Ok(Some(recorded)) => Some(format!(
+                            "raced output records {:?}, not {:?}",
+                            recorded.source_manifest_kappa, kappa
+                        )),
+                        Ok(None) => {
+                            Some("raced output has no stable source compile preflight".to_owned())
+                        }
+                        Err(error) => Some(error),
+                    }
+                }
+                Ok(_) => Some("raced output is not a regular non-symlink directory".to_owned()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(format!(
+                    "final output is still absent after exclusive rename failure: {rename_error}"
+                )),
+                Err(error) => Some(format!("raced output cannot be inspected: {error}")),
+            };
+            if raced.is_none() && cleanup_error.is_none() {
+                return Ok(());
+            }
+            Err(format!(
+                "atomic source compile publication {} -> {} failed: {}; cleanup: {}",
+                stage.display(),
+                output.display(),
+                raced.unwrap_or_else(|| rename_error.to_string()),
+                cleanup_error.unwrap_or_else(|| "owned stage removed".to_owned())
+            ))
+        }
+    }
+}
+
+fn publish_source_manifest_kappa_binding(output: &Path, kappa: &str) -> Result<(), String> {
+    let expected = source_manifest_kappa_binding_bytes(kappa)?;
+    let metadata = fs::symlink_metadata(output).map_err(|error| {
+        format!(
+            "{} has no marker-bearing source compile preflight directory: {error}",
+            output.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source compile output {} is not a regular non-symlink directory",
+            output.display()
+        ));
+    }
+    let path = output.join(SOURCE_MANIFEST_KAPPA_BINDING_FILE);
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let temporary = output.join(format!(
+            ".{SOURCE_MANIFEST_KAPPA_BINDING_FILE}.{}.{}.tmp",
+            std::process::id(),
+            id
+        ));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("{}: {error}", temporary.display())),
+        };
+        if let Err(error) = file.write_all(&expected).and_then(|()| file.sync_all()) {
+            let _ = fs::remove_file(&temporary);
+            return Err(format!("{}: {error}", temporary.display()));
+        }
+        drop(file);
+        match fs::hard_link(&temporary, &path) {
+            Ok(()) => {
+                fs::remove_file(&temporary)
+                    .map_err(|error| format!("{}: {error}", temporary.display()))?;
+                return Ok(());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let _ = fs::remove_file(&temporary);
+                let recorded = read_optional_source_manifest_kappa_binding(output)?
+                    .ok_or_else(|| format!("{} appeared and then disappeared", path.display()))?;
+                if recorded == kappa {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "source compile output {} is already bound to source manifest kappa {recorded}, not {kappa}",
+                    output.display()
+                ));
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&temporary);
+                return Err(format!(
+                    "source-manifest kappa binding publish {} -> {}: {error}",
+                    temporary.display(),
+                    path.display()
+                ));
+            }
+        }
+    }
+    Err(format!(
+        "could not reserve a unique source-manifest kappa binding temporary in {}",
+        output.display()
+    ))
+}
+
+fn preflight_and_bind_source_snapshot_kappa(
+    output: &Path,
+    requested: Option<&str>,
+) -> Result<(), String> {
+    if requested.is_some_and(|kappa| !canonical_source_manifest_kappa(kappa)) {
+        return Err(format!(
+            "source snapshot kappa {requested:?} is not canonical"
+        ));
+    }
+    let requested = requested.map(str::to_owned);
+    let recorded = read_optional_source_manifest_kappa_binding(output)?;
+    match (requested.as_deref(), recorded.as_deref()) {
+        (None, None) => {}
+        (None, Some(recorded)) => {
+            return Err(format!(
+                "legacy manifestless source cannot resume source compile output {} bound to source manifest kappa {recorded}",
+                output.display()
+            ));
+        }
+        (Some(requested), Some(recorded)) if requested == recorded => {}
+        (Some(requested), Some(recorded)) => {
+            return Err(format!(
+                "source compile output {} is bound to source manifest kappa {recorded}, not current source {requested}; refusing cross-snapshot resume",
+                output.display()
+            ));
+        }
+        (Some(_), None) => {}
+    }
+
+    let mut cover_bootstrap = false;
+    if recorded.is_none() {
+        if let Some(requested) = requested.as_deref() {
+            if source_compile_output_has_payload(output)? {
+                let report = output.join("graph-cover/cover_report.json");
+                let (present, _, cover_kappa) = parse_cover_provenance(&report)?;
+                if !present || cover_kappa.as_deref() != Some(requested) {
+                    return Err(format!(
+                        "populated source compile output {} has no immutable source-manifest kappa binding or exact cover provenance for {requested}; refusing to resume or relabel it",
+                        output.display()
+                    ));
+                }
+                cover_bootstrap = true;
+            }
+        }
+    }
+    if cover_bootstrap {
+        reject_legacy_source_compile_initialization(output)?;
+        let expected = source_compile_preflight_bytes(requested.as_deref())?;
+        publish_bytes_no_clobber(
+            &output.join(SOURCE_COMPILE_PREFLIGHT_FILE),
+            &expected,
+            "source compile preflight",
+        )?;
+    } else {
+        publish_source_compile_preflight(output, requested.as_deref())?;
+    }
+    if let Some(requested) = requested.as_deref() {
+        publish_source_manifest_kappa_binding(output, requested)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn preflight_and_bind_source_manifest_kappa(
+    output: &Path,
+    manifest: Option<&crate::model::SourceManifest>,
+) -> Result<(), String> {
+    let requested = manifest.map(source_manifest_kappa).transpose()?;
+    preflight_and_bind_source_snapshot_kappa(output, requested.as_deref())
+}
+
+/// All current source families advance in one arithmetic era. Keep the check
+/// executable so a future independently-versioned family cannot silently use
+/// the server's shared era suffix.
+fn current_source_attention_era_version() -> Result<u32, String> {
+    use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+    let versions = [
+        AttentionOperatorSpec::STANDARD_VERSION,
+        AttentionOperatorSpec::EXPERIMENTAL_R4_VERSION,
+        AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION,
+    ];
+    versions
+        .iter()
+        .all(|version| *version == versions[0])
+        .then_some(versions[0])
+        .ok_or_else(|| {
+            format!(
+                "source attention families no longer share one current era: standard={}, experimental={}, learned-absolute={}",
+                versions[0], versions[1], versions[2]
+            )
+        })
+}
+
+/// Select the browser compile output without mutating either arithmetic era.
+/// A fresh or already-current conventional root remains usable. An explicit
+/// historical binding, or an unbound populated legacy root, redirects to the
+/// deterministic `<name>-attention-vN` root. The era root itself must be
+/// uncreated or carry a registry-exact current-version binding. A present
+/// empty era root is terminal, matching load-time precedence: otherwise a
+/// compile could write the conventional sibling and immediately become
+/// unloadable behind the empty preferred root.
+#[cfg(test)]
+fn source_compile_output_for_attention_era(
+    compiled_root: &Path,
+    name: &str,
+    current_version: u32,
+) -> Result<PathBuf, String> {
+    // The paired inspection validates both siblings before selection. A
+    // current conventional root therefore cannot hide a duplicate, malformed,
+    // or unbound resolver-owned suffix root.
+    let pair = inspect_compiled_model_pair(compiled_root, name, current_version)?;
+    select_source_compile_output_from_pair(pair)
+}
+
+fn select_source_compile_output_from_pair(pair: CompiledModelPair) -> Result<PathBuf, String> {
+    match (&pair.conventional, &pair.current) {
+        (_, CompiledRootState::Empty) => Err(format!(
+            "preferred current bundle {} exists but is empty; refusing compile mutation until the stale empty root is removed",
+            pair.current_root.display()
+        )),
+        (
+            CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_),
+            CompiledRootState::PreAttentionIdentity,
+        ) => Ok(pair.current_root),
+        (_, CompiledRootState::PreAttentionIdentity) => Err(format!(
+            "preferred current bundle {} contains only a pre-attention identity prefix without a matching historical conventional bundle; refusing ambiguous compile mutation",
+            pair.current_root.display()
+        )),
+        (_, CompiledRootState::BoundCurrent(_)) => Ok(pair.current_root),
+        (CompiledRootState::BoundCurrent(_), CompiledRootState::Absent) => {
+            Ok(pair.conventional_root)
+        }
+        (
+            CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_),
+            CompiledRootState::Absent,
+        ) => Ok(pair.current_root),
+        (
+            CompiledRootState::Absent
+                | CompiledRootState::Empty
+                | CompiledRootState::PreAttentionIdentity,
+            CompiledRootState::Absent,
+        ) => Ok(pair.conventional_root),
+        (_, CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_)) => {
+            Err(format!(
+                "resolver-owned current root {} was not classified as current",
+                pair.current_root.display()
+            ))
+        }
+    }
+}
+
+fn source_compile_output_for_operator_era(
+    compiled_root: &Path,
+    name: &str,
+    current_version: u32,
+    source_operator: &AttentionOperatorSpec,
+) -> Result<PathBuf, String> {
+    let registered =
+        uor_r4_model_source::attention::operator_spec(&source_operator.id, source_operator.version)
+            .map_err(|error| format!("source teacher attention operator is invalid: {error}"))?;
+    if &registered != source_operator
+        || !source_attention_operator(source_operator)
+        || source_operator.version != current_version
+    {
+        return Err(format!(
+            "source teacher declares unsupported compile attention operator {}/{} for current era {current_version}",
+            source_operator.id, source_operator.version
+        ));
+    }
+    let pair = inspect_compiled_model_pair(compiled_root, name, current_version)?;
+    for recorded in [pair.conventional.operator(), pair.current.operator()]
+        .into_iter()
+        .flatten()
+    {
+        if recorded.id != source_operator.id {
+            return Err(format!(
+                "compiled model {} already records source-attention family {}/{} but the selected source teacher declares {}/{}; refusing to create or mutate a conflicting current-era sibling",
+                pair.logical_name,
+                recorded.id,
+                recorded.version,
+                source_operator.id,
+                source_operator.version
+            ));
+        }
+    }
+    select_source_compile_output_from_pair(pair)
+}
+
+struct CompiledSourceBundle {
+    final_output: PathBuf,
+    working_output: PathBuf,
+    stage: CompiledBundleStage,
+    /// Held until the caller finishes cover/score validation and atomically
+    /// installs the replacement serving state. This is intentionally not
+    /// released when Stage A returns: every compiler write derived from the
+    /// selected source root belongs to the same cross-process transaction.
+    _sessions: SourceCompileSessionLocks,
+}
+
+impl CompiledSourceBundle {
+    fn publish(&mut self) -> Result<(), String> {
+        publish_compiled_bundle_completion(&self.working_output)?;
+        validate_compiled_bundle_completion(&self.working_output)?.ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} lost its completion record before publication",
+                self.working_output.display()
+            )
+        })?;
+        self.stage.publish()
+    }
+}
+
+#[cfg(test)]
+fn immutable_graph_artifact_present(graph_path: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(graph_path) {
+        // Any present entry belongs to the last published attempt. A valid
+        // graph is immutable/idempotent; an invalid or nonregular entry must
+        // fail later validation unchanged. Neither case authorizes truncating
+        // last-good bytes in place.
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!(
+            "existing graph artifact {} cannot be inspected before immutable reuse: {error}",
+            graph_path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+fn run_graph_writer_if_incomplete<F>(reuse_existing_graph: bool, writer: F) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    if reuse_existing_graph {
+        Ok(())
+    } else {
+        writer()
+    }
+}
+
 fn compile_bundle_from_source(
     source: &Path,
     status: &Arc<Mutex<R4g1CompileStatus>>,
     tokenizer_selection: Option<&TokenizerAdapterKey>,
-) -> Result<PathBuf, String> {
+    source_snapshot_kappa: &str,
+    requested_graph_path: Option<&Path>,
+) -> Result<CompiledSourceBundle, String> {
     let name = source
         .file_name()
         .and_then(|name| name.to_str())
@@ -1921,7 +8145,10 @@ fn compile_bundle_from_source(
                 source.display()
             )
         })?;
-    let output = PathBuf::from(".uor-models/compiled").join(name);
+    // This is a server-owned namespace, not a model-family convention.
+    // Reject a colliding source basename before selecting or creating any
+    // output directory.
+    validate_logical_model_name(name, current_source_attention_era_version()?)?;
     // Resolve once before the resumable stage mutates its output and pass the
     // selected family/version as an atomic pair. Sources with multiple
     // definitions are intentionally refused until the caller names one.
@@ -1930,11 +8157,82 @@ fn compile_bundle_from_source(
     let adapter = tokenizer
         .adapter()
         .ok_or_else(|| "source resolved to an adapterless tokenizer".to_owned())?;
+    let teacher = uor_r4_model_source::Teacher::load(source)
+        .map_err(|error| format!("source teacher cannot be loaded before compile: {error}"))?;
+    let source_operator = teacher
+        .attention_operator_spec()
+        .ok_or_else(|| "source teacher declares no attention operator".to_owned())?;
+    let compiled_root = Path::new(".uor-models/compiled");
+    let current_version = current_source_attention_era_version()?;
+    let conventional = compiled_root.join(name);
+    let current = compiled_root.join(format!("{name}{}", attention_era_suffix(current_version)));
+    let mut session_subjects = vec![
+        compiled_root.to_path_buf(),
+        conventional.clone(),
+        current.clone(),
+        source
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf(),
+        source.to_path_buf(),
+    ];
+    if let Some(graph_path) = requested_graph_path {
+        let graph_output = graph_path.parent().ok_or_else(|| {
+            format!(
+                "configured graph artifact {} has no output directory",
+                graph_path.display()
+            )
+        })?;
+        session_subjects.push(graph_output.to_path_buf());
+    }
+    let sessions = try_lock_source_compile_sessions(
+        session_subjects,
+        SourceCompileSessionMode::ExclusiveWriter,
+    )?;
+    recover_source_compile_identity_temporaries(&conventional)?;
+    recover_source_compile_identity_temporaries(&current)?;
+    let output = source_compile_output_for_operator_era(
+        compiled_root,
+        name,
+        current_version,
+        &source_operator,
+    )?;
+    // The process-local source-cache reservation is acquired by the HTTP
+    // handler first. Both era siblings and any external score sink are now
+    // exclusively owned before selection, preflight publication, or adoption.
+    // The returned guards remain live through final serving installation.
+    let refreshed_output = source_compile_output_for_operator_era(
+        compiled_root,
+        name,
+        current_version,
+        &source_operator,
+    )?;
+    if refreshed_output != output {
+        return Err(format!(
+            "source compile output selection changed from {} to {} while acquiring its cross-process session; refusing stale mutation",
+            output.display(),
+            refreshed_output.display()
+        ));
+    }
+    let canonical_graph_path = output.join("graph/score.r4g1");
+    if let Some(requested) = requested_graph_path {
+        if normalized_absolute_path(requested)? != normalized_absolute_path(&canonical_graph_path)?
+        {
+            return Err(format!(
+                "source-driven browser compilation requires its graph sink at {}; configured external sink {} cannot participate in the atomic compiled-bundle transaction",
+                canonical_graph_path.display(),
+                requested.display()
+            ));
+        }
+    }
+    preflight_and_bind_source_snapshot_kappa(&output, Some(source_snapshot_kappa))?;
+    let stage = CompiledBundleStage::allocate(&output, source_snapshot_kappa)?;
+    let working_output = stage.path.clone();
     let args = vec![
         "--source".to_owned(),
         source.display().to_string(),
         "--output".to_owned(),
-        output.display().to_string(),
+        working_output.display().to_string(),
         "--seconds".to_owned(),
         R4G1_CORPUS_SECONDS.to_owned(),
         "--target".to_owned(),
@@ -1949,7 +8247,7 @@ fn compile_bundle_from_source(
     // The teacher compile can take most of the wall-clock time. Run it in a
     // child worker so the server can report corpus progress while the native
     // compiler is generating/resuming records.
-    let meta_path = output.join("corpus.meta");
+    let meta_path = working_output.join("corpus.meta");
     let status_for_compiler = Arc::clone(status);
     let compiler = std::thread::spawn(move || {
         set_r4g1_compile_progress(
@@ -1984,9 +8282,9 @@ fn compile_bundle_from_source(
             )
         })?
         .map_err(|error| error.to_string())?;
-    validate_source_bundle_inventory(&output)?;
-    let meta = output.join("corpus.meta");
-    let records = output.join("corpus.records");
+    validate_source_bundle_inventory(&working_output)?;
+    let meta = working_output.join("corpus.meta");
+    let records = working_output.join("corpus.records");
     let meta_str = meta
         .to_str()
         .ok_or_else(|| format!("corpus metadata path is not UTF-8: {}", meta.display()))?;
@@ -1996,10 +8294,15 @@ fn compile_bundle_from_source(
     if uor_r4_core::transformerless::compiler::load_corpus_from(meta_str, records_str).is_none() {
         return Err(format!(
             "teacher corpus is incomplete at {}; click Compile / Refresh again to resume generation toward {} samples",
-            output.display(), R4G1_CORPUS_TARGET
+            working_output.display(), R4G1_CORPUS_TARGET
         ));
     }
-    Ok(output)
+    Ok(CompiledSourceBundle {
+        final_output: output,
+        working_output,
+        stage,
+        _sessions: sessions,
+    })
 }
 
 fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
@@ -2044,11 +8347,24 @@ fn append_recorded_attention_operator(
 
 fn compile_r4g1_bundle(
     cli: &ServerConfig,
-    r4g1: &Arc<Mutex<Option<R4g1State>>>,
+    serving: &SharedServingModel,
     status: &Arc<Mutex<R4g1CompileStatus>>,
     downloaded_source: Option<&Path>,
+    expected_source: Option<&SourceDownload>,
     tokenizer_selection: Option<&TokenizerAdapterKey>,
+    require_source_manifest: bool,
 ) -> Result<serde_json::Value, String> {
+    let base_epoch = serving.lock().unwrap().epoch;
+    let source_snapshot_before = downloaded_source
+        .map(|source| {
+            let manifest = validate_compile_source_snapshot_for_identity(
+                source,
+                require_source_manifest,
+                expected_source,
+            )?;
+            verified_managed_source_snapshot_from_manifest(source, manifest)
+        })
+        .transpose()?;
     set_r4g1_compile_progress(
         status,
         5,
@@ -2058,9 +8374,31 @@ fn compile_r4g1_bundle(
     // when an older corpus bundle already exists, resume the teacher compile
     // first so the requested target (currently 200k tokens) is actually
     // reached instead of silently rebuilding the old ~20k corpus.
-    let source_root = downloaded_source
-        .map(|source| compile_bundle_from_source(source, status, tokenizer_selection))
+    let mut compiled_source = downloaded_source
+        .map(|source| {
+            compile_bundle_from_source(
+                source,
+                status,
+                tokenizer_selection,
+                source_snapshot_before
+                    .as_ref()
+                    .map(|snapshot| snapshot.content_kappa.as_str())
+                    .ok_or_else(|| {
+                        format!(
+                            "compiled source {} has no verified snapshot identity",
+                            source.display()
+                        )
+                    })?,
+                cli.r4g1_artifact.as_deref().map(Path::new),
+            )
+        })
         .transpose()?;
+    let source_root = compiled_source
+        .as_ref()
+        .map(|compiled| compiled.working_output.clone());
+    let managed_source_root = compiled_source
+        .as_ref()
+        .map(|compiled| compiled.final_output.clone());
     let compiled_from_source = source_root.is_some();
     if downloaded_source.is_none() && tokenizer_selection.is_some() {
         return Err(
@@ -2068,18 +8406,18 @@ fn compile_r4g1_bundle(
         );
     }
     set_r4g1_compile_progress(status, 20, "Building the R4G1 cover...");
-    let (artifacts, corpus_meta, corpus_recs, cover_output, graph_output, graph_path) =
+    let (mut artifacts, corpus_meta, corpus_recs, cover_output, mut graph_output, mut graph_path) =
         match source_root {
             Some(root) => {
                 let artifacts = root.join("tless_artifacts.bin");
                 let corpus_meta = root.join("corpus.meta");
                 let corpus_recs = root.join("corpus.records");
                 let cover_output = root.join("graph-cover");
-                let graph_path = cli
-                    .r4g1_artifact
-                    .as_ref()
-                    .map(PathBuf::from)
-                    .unwrap_or_else(|| root.join("graph").join("score.r4g1"));
+                // `compile_bundle_from_source` already proved that any
+                // explicit configured sink denotes the final canonical graph.
+                // All writers and pre-publication loads must nevertheless use
+                // the hidden working generation, never that live final path.
+                let graph_path = root.join("graph").join("score.r4g1");
                 let graph_output = graph_path
                     .parent()
                     .unwrap_or_else(|| Path::new("."))
@@ -2113,6 +8451,29 @@ fn compile_r4g1_bundle(
                 Err(error) => return Err(error),
             },
         };
+    let legacy_sessions = if compiled_from_source {
+        None
+    } else {
+        Some(try_lock_source_compile_sessions(
+            [
+                PathBuf::from(".uor-models/compiled"),
+                cover_output.clone(),
+                graph_output.clone(),
+            ],
+            SourceCompileSessionMode::ExclusiveWriter,
+        )?)
+    };
+    let _legacy_sessions = legacy_sessions;
+    if !compiled_from_source {
+        let selected = (
+            corpus_meta.clone(),
+            corpus_recs.clone(),
+            cover_output.clone(),
+            graph_output.clone(),
+        );
+        let refreshed = r4g1_compile_paths(cli)?;
+        require_unchanged_legacy_compile_paths(&selected, &refreshed)?;
+    }
     for path in [&artifacts, &corpus_meta, &corpus_recs] {
         if !path.is_file() {
             return Err(format!(
@@ -2155,12 +8516,15 @@ fn compile_r4g1_bundle(
         &tokenizer_path,
         downloaded_source.is_some(),
     )?;
-    // #597: when compiling from a downloaded snapshot that carries a
-    // source-snapshot manifest, bind its root κ into the cover report.
-    // Opportunistic by design: a legacy snapshot without a manifest (or an
-    // unreadable one) compiles exactly as before, with no κ recorded.
-    if let Some(kappa) = downloaded_source.and_then(source_manifest_kappa_of) {
-        cover_args.extend(["--source-manifest-kappa".to_owned(), kappa]);
+    // #597/#704: server-selected source snapshots were strictly validated
+    // above. A manifest-backed source uses its canonical manifest κ; a
+    // genuine legacy manifestless source uses the deterministic verified tree
+    // κ, so a resumed corpus cannot be relabeled after source-byte drift.
+    if let Some(snapshot) = source_snapshot_before.as_ref() {
+        cover_args.extend([
+            "--source-manifest-kappa".to_owned(),
+            snapshot.content_kappa.clone(),
+        ]);
     }
     // #600: bind the typed geometry-projection record the teacher adapter
     // applies (bucket-average/1, hidden_size→288) into the cover report,
@@ -2178,7 +8542,9 @@ fn compile_r4g1_bundle(
         &corpus_recs,
         compiled_from_source,
     )?;
-    uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
+    if compiled_from_source {
+        uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
+    }
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");
     let cover_artifact = cover_output.join("cover.r4g1");
@@ -2209,19 +8575,328 @@ fn compile_r4g1_bundle(
         &tokenizer_path,
         downloaded_source.is_some(),
     )?;
-    uor_r4_graph_cli::score_command(&score_args).map_err(|error| error.to_string())?;
+    if compiled_from_source {
+        uor_r4_graph_cli::score_command(&score_args).map_err(|error| error.to_string())?;
+    } else {
+        let identity = capture_legacy_graph_generation_identity(LegacyGraphGenerationInputs {
+            artifacts: &artifacts,
+            corpus_meta: &corpus_meta,
+            corpus_recs: &corpus_recs,
+            tokenizer: &tokenizer_path,
+            cover_output: &cover_output,
+            graph_output: &graph_output,
+            cover_args: &cover_args,
+            score_args: &score_args,
+        })?;
+        let (action, record_paths, attempt_bytes) = legacy_graph_generation_action(&identity)?;
+        match action {
+            LegacyGraphGenerationAction::Reuse => {
+                remove_exact_legacy_attempt(&record_paths.attempt, &attempt_bytes)?;
+            }
+            LegacyGraphGenerationAction::ResumeScore => {
+                ensure_legacy_graph_attempt(&record_paths.attempt, &attempt_bytes)?;
+                let score_stage = build_graph_writer_stage(
+                    &graph_output,
+                    GraphOutputKind::Score,
+                    &score_args,
+                    |args| uor_r4_graph_cli::score_command(args).map_err(|error| error.to_string()),
+                )?;
+                R4g1State::load_with_source(&score_stage.path.join("score.r4g1"), &artifacts, None)
+                    .map_err(|error| {
+                        format!("staged resumed legacy graph failed validation: {error}")
+                    })?;
+                let after =
+                    capture_legacy_graph_generation_identity(LegacyGraphGenerationInputs {
+                        artifacts: &artifacts,
+                        corpus_meta: &corpus_meta,
+                        corpus_recs: &corpus_recs,
+                        tokenizer: &tokenizer_path,
+                        cover_output: &cover_output,
+                        graph_output: &graph_output,
+                        cover_args: &cover_args,
+                        score_args: &score_args,
+                    })?;
+                if after != identity {
+                    return Err(
+                        "legacy graph compiler inputs changed while the score resume was staged; refusing publication"
+                            .to_owned(),
+                    );
+                }
+                publish_legacy_graph_score_resume(
+                    score_stage,
+                    &cover_output,
+                    &graph_output,
+                    &record_paths,
+                    &attempt_bytes,
+                    &identity,
+                )?;
+            }
+            LegacyGraphGenerationAction::BuildBoth => {
+                ensure_legacy_graph_attempt(&record_paths.attempt, &attempt_bytes)?;
+                let cover_stage = build_graph_writer_stage(
+                    &cover_output,
+                    GraphOutputKind::Cover,
+                    &cover_args,
+                    |args| uor_r4_graph_cli::cover_command(args).map_err(|error| error.to_string()),
+                )?;
+                let mut staged_score_args = score_args.clone();
+                replace_argument_value(
+                    &mut staged_score_args,
+                    "--cover",
+                    &cover_stage.path.join("cover.r4g1"),
+                )?;
+                let score_stage = build_graph_writer_stage(
+                    &graph_output,
+                    GraphOutputKind::Score,
+                    &staged_score_args,
+                    |args| uor_r4_graph_cli::score_command(args).map_err(|error| error.to_string()),
+                )?;
+                R4g1State::load_with_source(&score_stage.path.join("score.r4g1"), &artifacts, None)
+                    .map_err(|error| {
+                        format!("staged replacement legacy graph failed validation: {error}")
+                    })?;
+                let after =
+                    capture_legacy_graph_generation_identity(LegacyGraphGenerationInputs {
+                        artifacts: &artifacts,
+                        corpus_meta: &corpus_meta,
+                        corpus_recs: &corpus_recs,
+                        tokenizer: &tokenizer_path,
+                        cover_output: &cover_output,
+                        graph_output: &graph_output,
+                        cover_args: &cover_args,
+                        score_args: &score_args,
+                    })?;
+                if after != identity {
+                    return Err(
+                        "legacy graph compiler inputs changed while replacement outputs were staged; refusing publication"
+                            .to_owned(),
+                    );
+                }
+                let output_files = staged_legacy_graph_output_kappas(
+                    &cover_stage.path,
+                    &score_stage.path,
+                    &cover_output,
+                    &graph_output,
+                )?;
+                let completion = LegacyGraphGenerationCompletion {
+                    schema: LEGACY_GRAPH_GENERATION_SCHEMA.to_owned(),
+                    identity,
+                    output_files,
+                };
+                publish_legacy_graph_generation_pair(
+                    cover_stage,
+                    score_stage,
+                    &cover_output,
+                    &graph_output,
+                    &record_paths,
+                    &attempt_bytes,
+                    &completion,
+                )?;
+            }
+        }
+    }
+
+    let source_snapshot_after_cover = match (downloaded_source, source_snapshot_before.as_ref()) {
+        (Some(source), Some(before)) => {
+            let manifest = validate_compile_source_snapshot_for_identity(
+                source,
+                require_source_manifest,
+                expected_source,
+            )?;
+            let after = verified_managed_source_snapshot_from_manifest(source, manifest)?;
+            require_unchanged_managed_source_snapshot(source, "R4G1 compilation", before, &after)?;
+            Some(after)
+        }
+        _ => None,
+    };
+
+    if let Some(compiled) = compiled_source.as_mut() {
+        validate_staged_graph_outputs(&compiled.working_output)?;
+        // Exercise the exact runtime/quality-policy loader against the staged
+        // graph+report+artifact+tokenizer set before a single final namespace
+        // byte changes. Malformed or below-floor reports cannot be hidden by
+        // an otherwise parseable score.r4g1.
+        R4g1State::load_with_source(&graph_path, &artifacts, downloaded_source)
+            .map_err(|error| format!("staged compiled graph failed validation: {error}"))?;
+        if let (Some(source), Some(before)) =
+            (downloaded_source, source_snapshot_after_cover.as_ref())
+        {
+            let manifest = validate_compile_source_snapshot_for_identity(
+                source,
+                require_source_manifest,
+                expected_source,
+            )?;
+            let after = verified_managed_source_snapshot_from_manifest(source, manifest)?;
+            require_unchanged_managed_source_snapshot(
+                source,
+                "staged R4G1 runtime validation",
+                before,
+                &after,
+            )?;
+            let recorded = read_optional_source_manifest_kappa_binding(&compiled.working_output)?
+                .ok_or_else(|| {
+                format!(
+                    "staged compiled bundle {} lost its source snapshot binding before publication",
+                    compiled.working_output.display()
+                )
+            })?;
+            let (_, _, cover_kappa) = parse_cover_provenance(
+                &compiled
+                    .working_output
+                    .join("graph-cover/cover_report.json"),
+            )?;
+            if recorded != after.content_kappa
+                || cover_kappa.as_deref() != Some(after.content_kappa.as_str())
+            {
+                return Err(format!(
+                    "staged compiled bundle {} does not bind verified source snapshot {} consistently across Stage A and cover provenance",
+                    compiled.working_output.display(),
+                    after.content_kappa
+                ));
+            }
+        }
+        compiled.publish()?;
+        let final_root = compiled.final_output.clone();
+        artifacts = final_root.join("tless_artifacts.bin");
+        graph_output = final_root.join("graph");
+        graph_path = graph_output.join("score.r4g1");
+    }
 
     set_r4g1_compile_progress(status, 90, "Validating and loading the compiled graph...");
+    let current_version = current_source_attention_era_version()?;
+    let resolved = match (managed_source_root.as_ref(), downloaded_source) {
+        (Some(root), Some(source)) if graph_path.starts_with(root) => {
+            let logical_name = source
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    format!(
+                        "source path is not a valid model directory: {}",
+                        source.display()
+                    )
+                })?;
+            let compiled_root = root.parent().ok_or_else(|| {
+                format!(
+                    "compiled output {} has no compiled-model parent",
+                    root.display()
+                )
+            })?;
+            let pair = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
+            let resolved =
+                resolve_loadable_compiled_bundle(&pair, current_version)?.ok_or_else(|| {
+                    format!(
+                        "compiled output {} did not resolve to a loadable graph bundle",
+                        root.display()
+                    )
+                })?;
+            if resolved.physical_root != *root
+                || resolved.graph != graph_path
+                || resolved.teacher != artifacts
+            {
+                return Err(format!(
+                    "compiled output {} resolved to a different physical bundle {}",
+                    root.display(),
+                    resolved.physical_root.display()
+                ));
+            }
+            validate_resolved_source_snapshot_binding(
+                &resolved,
+                source_snapshot_after_cover.as_ref(),
+                current_version,
+            )?;
+            Some(resolved)
+        }
+        _ => None,
+    };
     let inferred_source = if downloaded_source.is_none() {
         source_for_compiled_teacher(&artifacts)?
     } else {
         None
     };
     let source_for_host = downloaded_source.or(inferred_source.as_deref());
+    let logical_name = resolved
+        .as_ref()
+        .map(|resolved| resolved.logical_name.as_str())
+        .or_else(|| {
+            source_for_host
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+        })
+        .unwrap_or("uor-r4");
+    let source_snapshot_before_prepare = match source_for_host {
+        Some(source) if downloaded_source == Some(source) => Some(
+            source_snapshot_after_cover.clone().ok_or_else(|| {
+                format!(
+                    "compiled source {} lost its verified source snapshot before serving preparation",
+                    source.display()
+                )
+            })?,
+        ),
+        Some(source) => Some(verify_managed_source_snapshot(source, logical_name)?),
+        None => None,
+    };
     let state = R4g1State::load_with_source(&graph_path, &artifacts, source_for_host)
         .map_err(|error| format!("compiled graph was written but failed validation: {error}"))?;
-    *r4g1.lock().unwrap() = Some(state);
-    clear_r4g1_terminal_load_error();
+    let mut replacement_teacher = prepare_optional_teacher_source_for_identity(
+        source_for_host,
+        tokenizer_selection,
+        logical_name,
+        state.tokenizer_adapter_identity(),
+    )?;
+    let (teacher_default_r4_attention, _teacher_mismatch) =
+        reconcile_prepared_teacher_with_bundle(&mut replacement_teacher, resolved.as_ref())?;
+    let refreshed = resolved
+        .as_ref()
+        .map(|resolved| refresh_resolved_compiled_bundle(resolved, current_version))
+        .transpose()?;
+    if let (Some(source), Some(before)) = (source_for_host, source_snapshot_before_prepare.as_ref())
+    {
+        let after = if downloaded_source == Some(source) {
+            let manifest = validate_compile_source_snapshot_for_identity(
+                source,
+                require_source_manifest,
+                expected_source,
+            )?;
+            verified_managed_source_snapshot_from_manifest(source, manifest)?
+        } else {
+            verify_managed_source_snapshot(source, logical_name)?
+        };
+        require_unchanged_managed_source_snapshot(
+            source,
+            "R4G1 compilation installation",
+            before,
+            &after,
+        )?;
+        if let Some(bundle) = refreshed.as_ref() {
+            validate_resolved_source_snapshot_binding(bundle, Some(&after), current_version)?;
+        }
+    }
+    let (teacher, tokenizer, teacher_source) = match replacement_teacher {
+        Some(prepared) => (
+            Some(prepared.teacher),
+            Some(prepared.tokenizer),
+            Some(prepared.source),
+        ),
+        None => (None, None, None),
+    };
+    let mut installed = serving.lock().unwrap();
+    if installed.epoch != base_epoch {
+        return Err(
+            "active serving model changed while background compilation was preparing; refusing stale installation"
+                .to_owned(),
+        );
+    }
+    let mut compile_status = status.lock().unwrap();
+    installed.epoch = installed.epoch.wrapping_add(1);
+    installed.r4g1 = Some(state);
+    installed.oracle = teacher;
+    installed.source_tokenizer = tokenizer;
+    installed.teacher_default_r4_attention = teacher_default_r4_attention;
+    installed.active_teacher_source = teacher_source;
+    installed.active_bundle = refreshed;
+    installed.terminal_load_error = None;
+    installed.last_operation_error = None;
+    compile_status.ready = graph_text_ready(&installed);
 
     let report_path = graph_output.join("score_report.json");
     let report = fs::read_to_string(&report_path)
@@ -2235,19 +8910,23 @@ fn compile_r4g1_bundle(
 
 fn spawn_r4g1_compile(
     cli: Arc<ServerConfig>,
-    r4g1: Arc<Mutex<Option<R4g1State>>>,
+    serving: SharedServingModel,
     status: Arc<Mutex<R4g1CompileStatus>>,
-    downloaded_source: Option<String>,
+    source: CompileSourceSelection,
     tokenizer_selection: Option<TokenizerAdapterKey>,
+    reservation: SourceCacheReservation,
 ) {
     std::thread::spawn(move || {
+        let _reservation = reservation;
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             compile_r4g1_bundle(
                 &cli,
-                &r4g1,
+                &serving,
                 &status,
-                downloaded_source.as_deref().map(Path::new),
+                source.path.as_deref().map(Path::new),
+                source.expected.as_ref(),
                 tokenizer_selection.as_ref(),
+                source.require_manifest,
             )
         }))
         .map_err(|payload| {
@@ -2258,11 +8937,12 @@ fn spawn_r4g1_compile(
         })
         .and_then(|result| result);
 
+        let mut installed = serving.lock().unwrap();
         let mut current = status.lock().unwrap();
         current.running = false;
         match result {
             Ok(details) => {
-                current.ready = true;
+                current.ready = graph_text_ready(&installed);
                 current.progress = 100;
                 current.report = details
                     .get("report")
@@ -2277,9 +8957,10 @@ fn spawn_r4g1_compile(
                 );
             }
             Err(error) => {
-                current.ready = r4g1.lock().unwrap().is_some();
+                current.ready = graph_text_ready(&installed);
                 current.progress = 0;
                 current.message = format!("R4G1 compilation failed: {error}");
+                installed.last_operation_error = Some(error);
             }
         }
     });
@@ -2294,30 +8975,81 @@ fn set_r4g1_compile_progress(status: &Arc<Mutex<R4g1CompileStatus>>, progress: u
     }
 }
 
-fn pinned_huggingface_source() -> Result<SourceDownload, String> {
-    let manifest_path = Path::new("models/smollm2-135m-instruct.json");
-    let manifest = fs::read_to_string(manifest_path).map_err(|error| {
+fn source_descriptor_for_logical_name_in(
+    descriptors_root: &Path,
+    logical_name: &str,
+) -> Result<Option<SourceDownload>, String> {
+    let one_component = Path::new(logical_name).components().count() == 1
+        && Path::new(logical_name)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(logical_name);
+    if logical_name.is_empty() || !one_component {
+        return Err(format!(
+            "managed source logical name {logical_name:?} is not one portable basename"
+        ));
+    }
+    let manifest_path = descriptors_root.join(format!("{logical_name}.json"));
+    let Some(bytes) = read_regular_file_nofollow(&manifest_path, "model descriptor")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, &manifest_path, "model descriptor")?;
+    let manifest: PinnedSourceManifest = serde_json::from_slice(&bytes).map_err(|error| {
         format!(
-            "pinned Hugging Face manifest is unavailable at {}: {error}",
+            "invalid model descriptor {}: {error}",
             manifest_path.display()
         )
     })?;
-    let manifest: PinnedSourceManifest = serde_json::from_str(&manifest)
-        .map_err(|error| format!("invalid pinned Hugging Face manifest: {error}"))?;
-    let name = manifest
-        .source_directory
-        .as_deref()
-        .map(Path::new)
-        .and_then(Path::file_name)
-        .and_then(|name| name.to_str())
-        .unwrap_or("smollm2-135m-instruct")
-        .to_owned();
-    Ok(SourceDownload {
+    // Reuse the public HTTP grammar and full-revision validation rather than
+    // admitting a descriptor the downloader itself would later reject.
+    source_from_model_spec(&format!("{}@{}", manifest.repository, manifest.revision)).map_err(
+        |error| {
+            format!(
+                "invalid model descriptor {}: {error}",
+                manifest_path.display()
+            )
+        },
+    )?;
+    if let Some(source_directory) = manifest.source_directory.as_deref() {
+        let recorded_name = Path::new(source_directory)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                format!(
+                    "model descriptor {} has a non-UTF-8 source_directory basename",
+                    manifest_path.display()
+                )
+            })?;
+        if recorded_name != logical_name {
+            return Err(format!(
+                "model descriptor {} maps logical model {logical_name:?} to mismatched source basename {recorded_name:?}",
+                manifest_path.display()
+            ));
+        }
+    }
+    Ok(Some(SourceDownload {
         repository: manifest.repository,
         revision: manifest.revision,
-        name,
+        name: logical_name.to_owned(),
         output: manifest.source_directory.map(PathBuf::from),
         license: manifest.license,
+    }))
+}
+
+fn optional_pinned_huggingface_source_in(
+    descriptors_root: &Path,
+) -> Result<Option<SourceDownload>, String> {
+    source_descriptor_for_logical_name_in(descriptors_root, "smollm2-135m-instruct")
+}
+
+fn optional_pinned_huggingface_source() -> Result<Option<SourceDownload>, String> {
+    optional_pinned_huggingface_source_in(Path::new("models"))
+}
+
+fn pinned_huggingface_source() -> Result<SourceDownload, String> {
+    optional_pinned_huggingface_source()?.ok_or_else(|| {
+        "pinned Hugging Face manifest is unavailable at models/smollm2-135m-instruct.json"
+            .to_owned()
     })
 }
 
@@ -2326,21 +9058,39 @@ fn source_from_model_spec(model: &str) -> Result<SourceDownload, String> {
         .trim()
         .split_once('@')
         .ok_or_else(|| "custom model must use owner/repository@<40-character-commit>".to_owned())?;
-    if repository.is_empty()
+    let valid_repository_part = |part: &str| {
+        !part.is_empty()
+            && part.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+            })
+    };
+    let (owner, repository_name) = repository
+        .split_once('/')
+        .filter(|(owner, name)| {
+            valid_repository_part(owner) && valid_repository_part(name) && !name.contains('/')
+        })
+        .ok_or_else(|| "custom model repository must use owner/repository".to_owned())?;
+    if owner.is_empty()
         || revision.len() != 40
         || !revision.bytes().all(|byte| byte.is_ascii_hexdigit())
     {
         return Err("custom model must use owner/repository@<40-character-commit>".to_owned());
     }
-    let name = repository
-        .rsplit('/')
-        .next()
-        .filter(|name| !name.is_empty())
-        .ok_or_else(|| "custom model repository must use owner/repository".to_owned())?;
+    // The historical `<basename>-<first12>` key collided for forks sharing a
+    // repository basename and for distinct revisions with the same prefix.
+    // Domain-separate and hash the complete immutable identity; the resulting
+    // source basename also becomes the compiled logical root, so Stage-A
+    // corpus resume cannot cross identities merely because shapes agree.
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4-source-cache-v2\0");
+    hasher.update(repository.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(revision.as_bytes());
+    let identity_digest = hasher.finalize();
     Ok(SourceDownload {
         repository: repository.to_owned(),
         revision: revision.to_owned(),
-        name: format!("{}-{}", name, &revision[..12]),
+        name: format!("{}-{}", repository_name, identity_digest.to_hex()),
         output: None,
         // A custom owner/repository@revision spec carries no license
         // metadata; the snapshot's license file is still digested.
@@ -2355,13 +9105,22 @@ fn huggingface_source(model: Option<&str>) -> Result<SourceDownload, String> {
     }
 }
 
-/// Root κ of the #597 source-snapshot manifest inside a downloaded
-/// snapshot directory, when one is present and verifiable. Total: any
-/// miss (legacy snapshot, malformed manifest, addressing failure)
-/// resolves to `None` so pre-#597 snapshots keep compiling unchanged.
-fn source_manifest_kappa_of(source: &Path) -> Option<String> {
-    let manifest = crate::model::read_source_manifest(source).ok()?;
-    crate::model::source_manifest_kappa(&manifest).ok()
+fn explicitly_requested_huggingface_source(
+    model: Option<&str>,
+) -> Result<Option<SourceDownload>, String> {
+    model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(source_from_model_spec)
+        .transpose()
+}
+
+fn collision_resistant_source_cache_name(name: &str) -> bool {
+    name.rsplit_once('-').is_some_and(|(base, digest)| {
+        !base.is_empty()
+            && digest.len() == 64
+            && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
 }
 
 /// JSON serialization of the #600 geometry-projection record the teacher
@@ -2385,24 +9144,1122 @@ fn geometry_projection_of(source: &Path) -> Option<String> {
     serde_json::to_string(&record).ok()
 }
 
-fn downloaded_source_path(source: &SourceDownload) -> PathBuf {
-    source.output.clone().unwrap_or_else(|| {
-        PathBuf::from(".uor-models")
-            .join("sources")
-            .join(&source.name)
+fn downloaded_source_path_in(source: &SourceDownload, models_root: &Path) -> PathBuf {
+    source
+        .output
+        .clone()
+        .unwrap_or_else(|| models_root.join("sources").join(&source.name))
+}
+
+fn reject_source_snapshot_special_entries(root: &Path, _directory: &Path) -> Result<(), String> {
+    // Use the same openat/O_NOFOLLOW handle-bound traversal as byte
+    // addressing. A preliminary DirEntry-type walk followed by path-based
+    // `read_dir` could otherwise follow a raced directory symlink (or cycle),
+    // and a path-based file open could block on a raced FIFO. `.cache`
+    // transport directories remain excluded by the shared walker; a `.cache`
+    // file and every other symlink/special entry are terminal.
+    crate::model::verified_source_tree(root, crate::model::SourceTreeScope::ManifestlessAll)
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "source snapshot {} has an invalid filesystem inventory: {error}",
+                root.display()
+            )
+        })
+}
+
+fn validate_manifest_weight_files(
+    source_dir: &Path,
+    manifest: &crate::model::SourceManifest,
+) -> Result<(), String> {
+    let recorded_paths = manifest
+        .files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let index_path = source_dir.join(uor_r4_model_source::SAFETENSORS_INDEX_FILE_NAME);
+    match read_regular_file_nofollow(&index_path, "Safetensors shard index")? {
+        Some(bytes) => {
+            reject_duplicate_json_fields(&bytes, &index_path, "Safetensors shard index")?;
+            let index: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+                format!(
+                    "{} is not a valid shard index: {error}",
+                    index_path.display()
+                )
+            })?;
+            let weight_map = index
+                .get("weight_map")
+                .and_then(serde_json::Value::as_object)
+                .ok_or_else(|| {
+                    format!("{} has no object-valued weight_map", index_path.display())
+                })?;
+            if weight_map.is_empty() {
+                return Err(format!("{} has an empty weight_map", index_path.display()));
+            }
+            for (tensor, value) in weight_map {
+                let shard = value.as_str().ok_or_else(|| {
+                    format!(
+                        "{} weight_map entry {tensor:?} is not a shard-name string",
+                        index_path.display()
+                    )
+                })?;
+                if shard.is_empty()
+                    || shard.starts_with('.')
+                    || shard.contains(['/', '\\'])
+                    || shard.contains("..")
+                    || !recorded_paths.contains(shard)
+                {
+                    return Err(format!(
+                        "{} references shard {shard:?} outside the exact source manifest inventory",
+                        index_path.display()
+                    ));
+                }
+            }
+        }
+        None => {
+            if !recorded_paths.contains(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME) {
+                return Err(format!(
+                    "source snapshot {} records neither {} nor an indexed manifest-bound shard set",
+                    source_dir.display(),
+                    uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Verify the exact manifest identity and every admitted teacher/tokenizer
+/// byte before a source directory may be downloaded-over, compiled, or
+/// reloaded. This is stricter than the generic optional-source resolver:
+/// managed cache snapshots may not be symlink aliases, and manifests must use
+/// their canonical bytes with no ignored/duplicate controls.
+fn validate_source_snapshot_integrity(
+    source_dir: &Path,
+    expected: Option<&SourceDownload>,
+) -> Result<crate::model::SourceManifest, String> {
+    let metadata = fs::symlink_metadata(source_dir).map_err(|error| {
+        format!(
+            "source snapshot {} cannot be inspected: {error}",
+            source_dir.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source snapshot {} is not a regular non-symlink directory",
+            source_dir.display()
+        ));
+    }
+    reject_source_snapshot_special_entries(source_dir, source_dir)?;
+
+    let manifest_path = source_dir.join(crate::model::SOURCE_MANIFEST_FILE_NAME);
+    let manifest_bytes = read_regular_file_nofollow(&manifest_path, "source manifest")?
+        .ok_or_else(|| {
+            format!(
+                "source snapshot {} has no regular {}",
+                source_dir.display(),
+                crate::model::SOURCE_MANIFEST_FILE_NAME
+            )
+        })?;
+    reject_duplicate_json_fields(&manifest_bytes, &manifest_path, "source manifest")?;
+    let manifest = crate::model::parse_source_manifest(&manifest_bytes).map_err(|error| {
+        format!(
+            "source snapshot {} has an invalid {}: {error}",
+            source_dir.display(),
+            crate::model::SOURCE_MANIFEST_FILE_NAME
+        )
+    })?;
+    let canonical = crate::model::canonical_source_manifest_bytes(&manifest)
+        .map_err(|error| format!("{} is not canonical: {error}", manifest_path.display()))?;
+    if canonical != manifest_bytes {
+        return Err(format!(
+            "{} is not the exact canonical source manifest; refusing ignored or ambiguous fields",
+            manifest_path.display()
+        ));
+    }
+    if manifest.source_execution_mode != crate::model::SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT
+    {
+        return Err(format!(
+            "{} records unsupported source execution mode {:?}",
+            manifest_path.display(),
+            manifest.source_execution_mode
+        ));
+    }
+    if manifest.revision.len() != 40
+        || !manifest
+            .revision
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(format!(
+            "{} does not record a full 40-character source revision",
+            manifest_path.display()
+        ));
+    }
+    if let Some(expected) = expected {
+        if manifest.repository != expected.repository || manifest.revision != expected.revision {
+            return Err(format!(
+                "requested model {}@{} resolves to {}, but its {} records {}@{}; refusing to compile or overwrite a different cached teacher",
+                expected.repository,
+                expected.revision,
+                source_dir.display(),
+                crate::model::SOURCE_MANIFEST_FILE_NAME,
+                manifest.repository,
+                manifest.revision,
+            ));
+        }
+        if manifest.license != expected.license {
+            return Err(format!(
+                "requested model {}@{} resolves to {}, but its {} records license {:?} instead of expected {:?}; refusing to reuse or compile a falsely licensed source snapshot",
+                expected.repository,
+                expected.revision,
+                source_dir.display(),
+                crate::model::SOURCE_MANIFEST_FILE_NAME,
+                manifest.license,
+                expected.license,
+            ));
+        }
+    }
+    let physical_name = source_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "source snapshot basename is not UTF-8: {}",
+                source_dir.display()
+            )
+        })?;
+    if collision_resistant_source_cache_name(physical_name) {
+        let recorded_spec = format!("{}@{}", manifest.repository, manifest.revision);
+        let recorded_source = source_from_model_spec(&recorded_spec).map_err(|error| {
+            format!(
+                "{} records a non-portable v2 cache identity {recorded_spec}: {error}",
+                manifest_path.display()
+            )
+        })?;
+        if recorded_source.name != physical_name {
+            return Err(format!(
+                "source snapshot {} has collision-resistant basename {physical_name:?}, but its {} identity {}@{} derives {:?}; refusing renamed or substituted teacher bytes",
+                source_dir.display(),
+                crate::model::SOURCE_MANIFEST_FILE_NAME,
+                manifest.repository,
+                manifest.revision,
+                recorded_source.name,
+            ));
+        }
+    }
+
+    let mut rebuilt = crate::model::build_source_manifest(
+        source_dir,
+        &crate::model::SourceSnapshotInfo {
+            repository: manifest.repository.clone(),
+            revision: manifest.revision.clone(),
+            license: manifest.license.clone(),
+            source_execution_mode: manifest.source_execution_mode.clone(),
+        },
+    )
+    .map_err(|error| {
+        format!(
+            "source snapshot {} cannot be re-addressed: {error}",
+            source_dir.display()
+        )
+    })?;
+    // Preserve the recorded producer version while comparing the immutable
+    // identity and file inventory; otherwise an older but exact snapshot
+    // would appear modified merely because this server binary is newer.
+    rebuilt.compiler_version = manifest.compiler_version.clone();
+    if rebuilt != manifest {
+        return Err(format!(
+            "source snapshot {} no longer matches its recorded file inventory; refusing partial or modified teacher bytes",
+            source_dir.display()
+        ));
+    }
+    validate_manifest_weight_files(source_dir, &manifest)?;
+    Ok(manifest)
+}
+
+fn validate_requested_source_manifest(
+    source_dir: &Path,
+    requested: &SourceDownload,
+) -> Result<(), String> {
+    validate_source_snapshot_integrity(source_dir, Some(requested)).map(|_| ())
+}
+
+fn validate_legacy_compatible_source_manifest(
+    source_dir: &Path,
+    expected_when_present: &SourceDownload,
+) -> Result<Option<crate::model::SourceManifest>, String> {
+    let manifest_path = source_dir.join(crate::model::SOURCE_MANIFEST_FILE_NAME);
+    match fs::symlink_metadata(&manifest_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            validate_manifestless_source_structure(source_dir)?;
+            Ok(None)
+        }
+        Ok(_) => {
+            validate_source_snapshot_integrity(source_dir, Some(expected_when_present)).map(Some)
+        }
+        Err(error) => Err(format!(
+            "{} cannot be inspected: {error}",
+            manifest_path.display()
+        )),
+    }
+}
+
+fn validate_manifestless_source_structure(source_dir: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source_dir).map_err(|error| {
+        format!(
+            "legacy source snapshot {} cannot be inspected: {error}",
+            source_dir.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "legacy source snapshot {} is not a regular non-symlink directory",
+            source_dir.display()
+        ));
+    }
+    reject_source_snapshot_special_entries(source_dir, source_dir)
+}
+
+fn validate_compile_source_snapshot(
+    source_dir: &Path,
+    require_manifest: bool,
+) -> Result<Option<crate::model::SourceManifest>, String> {
+    let manifest_path = source_dir.join(crate::model::SOURCE_MANIFEST_FILE_NAME);
+    match fs::symlink_metadata(&manifest_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && !require_manifest => {
+            validate_manifestless_source_structure(source_dir)?;
+            Ok(None)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Err(format!(
+            "source snapshot {} is missing its required {}",
+            source_dir.display(),
+            crate::model::SOURCE_MANIFEST_FILE_NAME
+        )),
+        Ok(_) => validate_source_snapshot_integrity(source_dir, None).map(Some),
+        Err(error) => Err(format!(
+            "{} cannot be inspected: {error}",
+            manifest_path.display()
+        )),
+    }
+}
+
+fn validate_compile_source_snapshot_for_identity(
+    source_dir: &Path,
+    require_manifest: bool,
+    expected: Option<&SourceDownload>,
+) -> Result<Option<crate::model::SourceManifest>, String> {
+    match (expected, require_manifest) {
+        (Some(expected), true) => {
+            validate_source_snapshot_integrity(source_dir, Some(expected)).map(Some)
+        }
+        (Some(expected), false) => validate_legacy_compatible_source_manifest(source_dir, expected),
+        (None, _) => validate_compile_source_snapshot(source_dir, require_manifest),
+    }
+}
+
+fn validate_managed_source_for_serving_in(
+    source_dir: &Path,
+    logical_name: &str,
+    descriptors_root: &Path,
+) -> Result<Option<crate::model::SourceManifest>, String> {
+    let metadata = fs::symlink_metadata(source_dir).map_err(|error| {
+        format!(
+            "managed source {} cannot be inspected before serving: {error}",
+            source_dir.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "managed source {} is not a regular non-symlink directory",
+            source_dir.display()
+        ));
+    }
+    // Even a genuine pre-manifest source may not hide executable model files
+    // behind visible symlinks or special entries. Legacy compatibility is
+    // absence of a provenance record, not permission to retarget bytes.
+    reject_source_snapshot_special_entries(source_dir, source_dir)?;
+    let physical_name = source_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("managed source name is not UTF-8: {}", source_dir.display()))?;
+    let require_manifest = collision_resistant_source_cache_name(logical_name)
+        || collision_resistant_source_cache_name(physical_name);
+    if collision_resistant_source_cache_name(logical_name) && physical_name != logical_name {
+        return Err(format!(
+            "managed source {} does not match collision-resistant logical model {logical_name:?}",
+            source_dir.display()
+        ));
+    }
+    if let Some(descriptor) = source_descriptor_for_logical_name_in(descriptors_root, logical_name)?
+    {
+        return validate_legacy_compatible_source_manifest(source_dir, &descriptor);
+    }
+    validate_compile_source_snapshot(source_dir, require_manifest)
+}
+
+fn validate_managed_source_for_serving(
+    source_dir: &Path,
+    logical_name: &str,
+) -> Result<Option<crate::model::SourceManifest>, String> {
+    validate_managed_source_for_serving_in(source_dir, logical_name, Path::new("models"))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct VerifiedManagedSourceSnapshot {
+    manifest: Option<crate::model::SourceManifest>,
+    content_kappa: String,
+}
+
+fn validate_manifestless_index_shards(source_dir: &Path) -> Result<(), String> {
+    let index_path = source_dir.join(uor_r4_model_source::SAFETENSORS_INDEX_FILE_NAME);
+    let Some(bytes) = read_regular_file_nofollow(&index_path, "manifestless shard index")? else {
+        return Ok(());
+    };
+    reject_duplicate_json_fields(&bytes, &index_path, "manifestless Safetensors shard index")?;
+    let index: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        format!(
+            "{} is not a valid shard index: {error}",
+            index_path.display()
+        )
+    })?;
+    let weight_map = index
+        .get("weight_map")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| format!("{} has no object-valued weight_map", index_path.display()))?;
+    if weight_map.is_empty() {
+        return Err(format!("{} has an empty weight_map", index_path.display()));
+    }
+    for (tensor, value) in weight_map {
+        let shard = value.as_str().ok_or_else(|| {
+            format!(
+                "{} weight_map entry {tensor:?} is not a shard-name string",
+                index_path.display()
+            )
+        })?;
+        if shard.is_empty()
+            || shard.starts_with('.')
+            || shard.contains(['/', '\\'])
+            || shard.contains("..")
+        {
+            return Err(format!(
+                "{} references hidden or nonportable executable shard {shard:?}; manifestless source κ requires a visible bare shard name",
+                index_path.display()
+            ));
+        }
+        let shard_path = source_dir.join(shard);
+        let shard_metadata = fs::symlink_metadata(&shard_path).map_err(|error| {
+            format!(
+                "{} references unavailable shard {}: {error}",
+                index_path.display(),
+                shard_path.display()
+            )
+        })?;
+        if !shard_metadata.file_type().is_file() {
+            return Err(format!(
+                "{} references shard {} that is not a regular non-symlink file",
+                index_path.display(),
+                shard_path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verified_managed_source_snapshot_from_manifest(
+    source_dir: &Path,
+    manifest: Option<crate::model::SourceManifest>,
+) -> Result<VerifiedManagedSourceSnapshot, String> {
+    verified_managed_source_snapshot_from_manifest_with_tree(source_dir, manifest, |source_dir| {
+        crate::model::verified_source_tree(
+            source_dir,
+            crate::model::SourceTreeScope::ManifestlessAll,
+        )
+        .map_err(|error| error.to_string())
     })
+}
+
+fn verified_managed_source_snapshot_from_manifest_with_tree<F>(
+    source_dir: &Path,
+    manifest: Option<crate::model::SourceManifest>,
+    manifestless_tree: F,
+) -> Result<VerifiedManagedSourceSnapshot, String>
+where
+    F: FnOnce(&Path) -> Result<Vec<crate::model::VerifiedSourceTreeEntry>, String>,
+{
+    let content_kappa = match manifest.as_ref() {
+        Some(manifest) => source_manifest_kappa(manifest)?,
+        None => {
+            validate_manifestless_index_shards(source_dir)?;
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(b"uor-r4-manifestless-source-tree-v2\0");
+            let entries = manifestless_tree(source_dir)?;
+            for entry in entries {
+                match entry {
+                    crate::model::VerifiedSourceTreeEntry::Directory { path } => {
+                        hasher.update(b"D");
+                        hasher.update(&(path.len() as u64).to_le_bytes());
+                        hasher.update(path.as_bytes());
+                    }
+                    crate::model::VerifiedSourceTreeEntry::File { path, bytes, kappa } => {
+                        hasher.update(b"F");
+                        hasher.update(&(path.len() as u64).to_le_bytes());
+                        hasher.update(path.as_bytes());
+                        hasher.update(&bytes.to_le_bytes());
+                        hasher.update(&(kappa.len() as u64).to_le_bytes());
+                        hasher.update(kappa.as_bytes());
+                    }
+                }
+            }
+            format!("blake3:{}", hasher.finalize().to_hex())
+        }
+    };
+    Ok(VerifiedManagedSourceSnapshot {
+        manifest,
+        content_kappa,
+    })
+}
+
+fn verify_managed_source_snapshot_in(
+    source_dir: &Path,
+    logical_name: &str,
+    descriptors_root: &Path,
+) -> Result<VerifiedManagedSourceSnapshot, String> {
+    let manifest =
+        validate_managed_source_for_serving_in(source_dir, logical_name, descriptors_root)?;
+    verified_managed_source_snapshot_from_manifest(source_dir, manifest)
+}
+
+fn verify_managed_source_snapshot(
+    source_dir: &Path,
+    logical_name: &str,
+) -> Result<VerifiedManagedSourceSnapshot, String> {
+    verify_managed_source_snapshot_in(source_dir, logical_name, Path::new("models"))
+}
+
+fn require_unchanged_managed_source_snapshot(
+    source_dir: &Path,
+    operation: &str,
+    before: &VerifiedManagedSourceSnapshot,
+    after: &VerifiedManagedSourceSnapshot,
+) -> Result<(), String> {
+    if before == after {
+        return Ok(());
+    }
+    Err(format!(
+        "source snapshot {} changed while {operation} was preparing ({} -> {}); refusing mixed-identity installation",
+        source_dir.display(),
+        before.content_kappa,
+        after.content_kappa
+    ))
+}
+
+fn select_compile_source_path_in(
+    models_root: &Path,
+    requested: Option<&SourceDownload>,
+    cached: Option<&CompletedDownloadSource>,
+    fallback: Option<&SourceDownload>,
+) -> Result<Option<PathBuf>, String> {
+    if let Some(requested) = requested {
+        let path = downloaded_source_path_in(requested, models_root);
+        let Some(path) = optional_source_directory(&path)? else {
+            return Err(format!(
+                "requested model {}@{} is not downloaded at {}; download it before compiling",
+                requested.repository,
+                requested.revision,
+                path.display()
+            ));
+        };
+        validate_requested_source_manifest(&path, requested)?;
+        return Ok(Some(path));
+    }
+    if let Some(cached) = cached {
+        let Some(path) = optional_source_directory(&cached.path)? else {
+            return Err(format!(
+                "completed Hugging Face source {} was recorded ready but is now absent; refusing to downgrade this compile to configured legacy inputs",
+                cached.path.display()
+            ));
+        };
+        validate_source_snapshot_integrity(&path, Some(&cached.identity))?;
+        return Ok(Some(path));
+    }
+    let Some(fallback) = fallback else {
+        return Ok(None);
+    };
+    let fallback_path = downloaded_source_path_in(fallback, models_root);
+    let Some(path) = optional_source_directory(&fallback_path)? else {
+        return Ok(None);
+    };
+    // A genuine pre-#597 pinned snapshot remains a read-only compatibility
+    // input. If it has a manifest, every field and byte must be exact;
+    // malformed/present-invalid manifests never downgrade to legacy absence.
+    validate_legacy_compatible_source_manifest(&path, fallback)?;
+    Ok(Some(path))
+}
+
+fn completed_download_source(
+    status: &HuggingFaceDownloadStatus,
+) -> Result<Option<CompletedDownloadSource>, String> {
+    if status.running {
+        return Err("a Hugging Face source download is still running".to_owned());
+    }
+    if !status.ready {
+        return Ok(None);
+    }
+    let source = status.source.as_deref().ok_or_else(|| {
+        "Hugging Face download status is ready but records no completed source".to_owned()
+    })?;
+    if source.trim().is_empty() {
+        return Err("Hugging Face download status records an empty source path".to_owned());
+    }
+    let identity = status.completed_source.clone().ok_or_else(|| {
+        "Hugging Face download status is ready but records no completed source identity".to_owned()
+    })?;
+    let path = PathBuf::from(source);
+    let expected_path = downloaded_source_path_in(&identity, Path::new(".uor-models"));
+    if path != expected_path {
+        return Err(format!(
+            "Hugging Face download status path {} conflicts with completed identity {}@{} at {}",
+            path.display(),
+            identity.repository,
+            identity.revision,
+            expected_path.display()
+        ));
+    }
+    Ok(Some(CompletedDownloadSource { path, identity }))
+}
+
+fn reserve_compile_source_selection(
+    operations: &SharedSourceCacheOperations,
+    status: &Arc<Mutex<HuggingFaceDownloadStatus>>,
+    subject: impl Into<String>,
+) -> Result<(SourceCacheReservation, Option<CompletedDownloadSource>), String> {
+    // Reservation must precede the completed-download snapshot. Otherwise a
+    // download can publish Bob and update status after compilation snapshots
+    // Alice (or the pinned fallback) but before compilation acquires the
+    // operation slot.
+    let reservation =
+        try_reserve_source_cache_operation(operations, SourceCacheOperationKind::Compile, subject)?;
+    let source = completed_download_source(&status.lock().unwrap())?;
+    Ok((reservation, source))
+}
+
+static NEXT_SOURCE_STAGING_ID: AtomicU64 = AtomicU64::new(0);
+const DOWNLOAD_STAGE_MARKER_FILE: &str = ".download_stage.json";
+const DOWNLOAD_STAGE_MARKER_SCHEMA: &str = "uor-r4-download-stage/1";
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct DownloadStageMarker {
+    schema: String,
+    destination: String,
+    stage_path: String,
+    repository: String,
+    revision: String,
+    license: Option<String>,
+}
+
+fn remove_source_staging_path(path: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", path.display())),
+    };
+    if metadata.file_type().is_dir() {
+        fs::remove_dir_all(path)
+            .map_err(|error| format!("{} cannot be removed: {error}", path.display()))
+    } else {
+        fs::remove_file(path)
+            .map_err(|error| format!("{} cannot be removed: {error}", path.display()))
+    }
+}
+
+struct SourceStagingDirectory {
+    path: PathBuf,
+    armed: bool,
+}
+
+fn is_download_stage_name(name: &str, final_name: &str) -> bool {
+    let prefix = format!(".{final_name}.download-staging-");
+    let Some(sequence) = name.strip_prefix(&prefix) else {
+        return false;
+    };
+    let mut parts = sequence.split('-');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn download_stage_marker_bytes(
+    final_path: &Path,
+    stage_path: &Path,
+    source: &SourceDownload,
+) -> Result<Vec<u8>, String> {
+    let destination = canonical_compile_session_subject(final_path)?;
+    let stage_path = canonical_compile_session_subject(stage_path)?;
+    let destination = destination
+        .to_str()
+        .ok_or_else(|| format!("source destination is not UTF-8: {}", destination.display()))?;
+    let stage_path = stage_path
+        .to_str()
+        .ok_or_else(|| format!("download stage is not UTF-8: {}", stage_path.display()))?;
+    let mut bytes = serde_json::to_vec_pretty(&DownloadStageMarker {
+        schema: DOWNLOAD_STAGE_MARKER_SCHEMA.to_owned(),
+        destination: destination.to_owned(),
+        stage_path: stage_path.to_owned(),
+        repository: source.repository.clone(),
+        revision: source.revision.clone(),
+        license: source.license.clone(),
+    })
+    .map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn read_download_stage_marker(stage: &Path) -> Result<Option<Vec<u8>>, String> {
+    let path = stage.join(DOWNLOAD_STAGE_MARKER_FILE);
+    let Some(bytes) = read_regular_file_nofollow(&path, "download-stage marker")? else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, &path, "download-stage marker")?;
+    let record: DownloadStageMarker = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    let mut canonical = serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
+    canonical.push(b'\n');
+    if record.schema != DOWNLOAD_STAGE_MARKER_SCHEMA || bytes != canonical {
+        return Err(format!(
+            "{} is not a canonical supported download-stage marker",
+            path.display()
+        ));
+    }
+    Ok(Some(bytes))
+}
+
+fn recover_download_stages(final_path: &Path, source: &SourceDownload) -> Result<(), String> {
+    let parent = final_path.parent().ok_or_else(|| {
+        format!(
+            "source destination {} has no parent directory",
+            final_path.display()
+        )
+    })?;
+    let final_name = final_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("source destination is not UTF-8: {}", final_path.display()))?;
+    let entries = match fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "{} cannot be enumerated: {error}",
+                parent.display()
+            ))
+        }
+    };
+    let prefix = format!(".{final_name}.download-staging-");
+    let mut stale = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", parent.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source cache {} contains a non-UTF-8 staging entry",
+                parent.display()
+            )
+        })?;
+        if is_download_stage_name(name, final_name) {
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                format!("{} cannot be inspected: {error}", entry.path().display())
+            })?;
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "recognized download stage {} is not a regular non-symlink directory",
+                    entry.path().display()
+                ));
+            }
+            let expected = download_stage_marker_bytes(final_path, &entry.path(), source)?;
+            let recorded = read_download_stage_marker(&entry.path())?;
+            let mut marker_temporaries = Vec::new();
+            let mut other_entries = Vec::new();
+            for child in fs::read_dir(entry.path()).map_err(|error| {
+                format!("{} cannot be enumerated: {error}", entry.path().display())
+            })? {
+                let child = child.map_err(|error| {
+                    format!("{} cannot be enumerated: {error}", entry.path().display())
+                })?;
+                let child_name = child.file_name();
+                let child_name = child_name.to_str().ok_or_else(|| {
+                    format!(
+                        "download stage {} contains a non-UTF-8 entry",
+                        entry.path().display()
+                    )
+                })?;
+                if is_atomic_publisher_temporary(child_name, DOWNLOAD_STAGE_MARKER_FILE) {
+                    let child_metadata = fs::symlink_metadata(child.path()).map_err(|error| {
+                        format!("{} cannot be inspected: {error}", child.path().display())
+                    })?;
+                    if !child_metadata.file_type().is_file() {
+                        return Err(format!(
+                            "recognized download-stage marker temporary {} is not a regular non-symlink file",
+                            child.path().display()
+                        ));
+                    }
+                    marker_temporaries.push(child.path());
+                } else if looks_like_atomic_publisher_temporary(
+                    child_name,
+                    DOWNLOAD_STAGE_MARKER_FILE,
+                ) {
+                    return Err(format!(
+                        "download stage {} contains unrecognized marker temporary {child_name}",
+                        entry.path().display()
+                    ));
+                } else if child_name != DOWNLOAD_STAGE_MARKER_FILE {
+                    other_entries.push(child.path());
+                }
+            }
+            match recorded {
+                Some(recorded) if recorded == expected => stale.push(entry.path()),
+                Some(_) => {
+                    return Err(format!(
+                        "download stage {} does not bind this exact destination and source identity",
+                        entry.path().display()
+                    ));
+                }
+                None if other_entries.is_empty() => {
+                    // `create_dir` precedes the durable marker publication.
+                    // An empty stage (or one containing only an exact torn
+                    // marker temporary) is the sole markerless crash prefix.
+                    stale.push(entry.path());
+                }
+                None => {
+                    return Err(format!(
+                        "markerless download stage {} contains source payload; refusing unowned reclamation",
+                        entry.path().display()
+                    ));
+                }
+            }
+            let _ = marker_temporaries;
+        } else if name.starts_with(&prefix) {
+            return Err(format!(
+                "source cache {} contains unrecognized download stage {name}",
+                parent.display()
+            ));
+        }
+    }
+    for stage in stale {
+        fs::remove_dir_all(&stage).map_err(|error| {
+            format!(
+                "stale source download stage {} cannot be reclaimed under exclusive destination ownership: {error}",
+                stage.display()
+            )
+        })?;
+    }
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", parent.display()))?;
+    Ok(())
+}
+
+impl SourceStagingDirectory {
+    fn allocate(final_path: &Path, source: &SourceDownload) -> Result<Self, String> {
+        let parent = final_path.parent().ok_or_else(|| {
+            format!(
+                "source destination {} has no parent directory",
+                final_path.display()
+            )
+        })?;
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("{} cannot be created: {error}", parent.display()))?;
+        let final_name = final_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("source destination is not UTF-8: {}", final_path.display()))?;
+        recover_download_stages(final_path, source)?;
+        for _ in 0..128 {
+            let id = NEXT_SOURCE_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+            let candidate = parent.join(format!(
+                ".{final_name}.download-staging-{}-{id}",
+                std::process::id()
+            ));
+            match fs::create_dir(&candidate) {
+                Ok(()) => {
+                    let marker = match download_stage_marker_bytes(final_path, &candidate, source) {
+                        Ok(marker) => marker,
+                        Err(error) => {
+                            let _ = fs::remove_dir_all(&candidate);
+                            return Err(error);
+                        }
+                    };
+                    if let Err(error) = publish_bytes_no_clobber(
+                        &candidate.join(DOWNLOAD_STAGE_MARKER_FILE),
+                        &marker,
+                        "download-stage marker",
+                    ) {
+                        let _ = fs::remove_dir_all(&candidate);
+                        return Err(error);
+                    }
+                    if let Err(error) =
+                        fs::File::open(parent).and_then(|directory| directory.sync_all())
+                    {
+                        let _ = fs::remove_dir_all(&candidate);
+                        return Err(format!("{} cannot be synced: {error}", parent.display()));
+                    }
+                    return Ok(Self {
+                        path: candidate,
+                        armed: true,
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(format!(
+                        "source staging directory {} cannot be created: {error}",
+                        candidate.display()
+                    ))
+                }
+            }
+        }
+        Err(format!(
+            "could not allocate a unique source staging directory beside {}",
+            final_path.display()
+        ))
+    }
+
+    fn discard(&mut self) -> Result<(), String> {
+        remove_source_staging_path(&self.path)?;
+        self.armed = false;
+        Ok(())
+    }
+
+    fn disarm_after_publish(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SourceStagingDirectory {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = remove_source_staging_path(&self.path);
+        }
+    }
+}
+
+fn validate_published_download_stage_marker(
+    destination: &Path,
+    source: &SourceDownload,
+) -> Result<(), String> {
+    let Some(bytes) = read_download_stage_marker(destination)? else {
+        return Ok(());
+    };
+    let record: DownloadStageMarker =
+        serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+    let stage = PathBuf::from(&record.stage_path);
+    let expected = download_stage_marker_bytes(destination, &stage, source)?;
+    let destination_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("source destination is not UTF-8: {}", destination.display()))?;
+    let stage_name = stage
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("download stage is not UTF-8: {}", stage.display()))?;
+    let destination_parent = canonical_compile_session_subject(
+        destination
+            .parent()
+            .ok_or_else(|| format!("{} has no parent", destination.display()))?,
+    )?;
+    if bytes != expected
+        || stage.parent() != Some(destination_parent.as_path())
+        || !is_download_stage_name(stage_name, destination_name)
+    {
+        return Err(format!(
+            "published download-stage marker {} does not bind this exact destination and source identity",
+            destination.join(DOWNLOAD_STAGE_MARKER_FILE).display()
+        ));
+    }
+    Ok(())
+}
+
+fn sync_source_snapshot_for_publication(
+    source_dir: &Path,
+    manifest: &crate::model::SourceManifest,
+) -> Result<(), String> {
+    let mut directories = std::collections::BTreeSet::new();
+    directories.insert(source_dir.to_path_buf());
+    for relative in manifest
+        .files
+        .iter()
+        .map(|file| file.path.as_str())
+        .chain(std::iter::once(crate::model::SOURCE_MANIFEST_FILE_NAME))
+    {
+        let path = source_dir.join(relative);
+        sync_regular_file_nofollow(&path, "downloaded source member")?;
+        let mut parent = path.parent();
+        while let Some(directory) = parent {
+            if !directory.starts_with(source_dir) {
+                break;
+            }
+            directories.insert(directory.to_path_buf());
+            if directory == source_dir {
+                break;
+            }
+            parent = directory.parent();
+        }
+    }
+    let mut directories = directories.into_iter().collect::<Vec<_>>();
+    directories.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    for directory in directories {
+        fs::File::open(&directory)
+            .and_then(|handle| handle.sync_all())
+            .map_err(|error| format!("{} cannot be synced: {error}", directory.display()))?;
+    }
+    Ok(())
+}
+
+fn download_source_atomically_in<F>(
+    source: &SourceDownload,
+    models_root: &Path,
+    downloader: F,
+) -> Result<PathBuf, String>
+where
+    F: FnOnce(&SourceDownload) -> Result<PathBuf, String>,
+{
+    let destination = downloaded_source_path_in(source, models_root);
+    let _download_sessions = try_lock_source_compile_sessions(
+        [models_root.join("sources"), destination.clone()],
+        SourceCompileSessionMode::ExclusiveWriter,
+    )?;
+    match fs::symlink_metadata(&destination) {
+        Ok(_) => {
+            validate_published_download_stage_marker(&destination, source)?;
+            validate_source_snapshot_integrity(&destination, Some(source))?;
+            return Ok(destination);
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "source destination {} cannot be inspected: {error}",
+                destination.display()
+            ))
+        }
+    }
+
+    let mut staging = SourceStagingDirectory::allocate(&destination, source)?;
+    let mut staged_source = source.clone();
+    staged_source.output = Some(staging.path.clone());
+    let reported = downloader(&staged_source)?;
+    if reported != staging.path {
+        return Err(format!(
+            "source downloader reported {}, expected its reserved staging directory {}",
+            reported.display(),
+            staging.path.display()
+        ));
+    }
+    let manifest = validate_source_snapshot_integrity(&staging.path, Some(source))?;
+    sync_source_snapshot_for_publication(&staging.path, &manifest)?;
+
+    match rename_directory_no_replace(&staging.path, &destination) {
+        Ok(()) => {
+            if let Err(error) = sync_parent_directory(&destination, "downloaded source publication")
+            {
+                let rollback = rename_directory_no_replace(&destination, &staging.path)
+                    .map_err(|rollback_error| rollback_error.to_string())
+                    .and_then(|()| {
+                        sync_parent_directory(&destination, "downloaded source rollback")
+                    });
+                return Err(format!(
+                    "{error}; downloaded source publication rollback: {}",
+                    rollback
+                        .map(|()| "removed incomplete destination namespace".to_owned())
+                        .unwrap_or_else(|rollback_error| rollback_error)
+                ));
+            }
+            staging.disarm_after_publish();
+            let published_marker = destination.join(DOWNLOAD_STAGE_MARKER_FILE);
+            if validate_published_download_stage_marker(&destination, source).is_ok()
+                && fs::remove_file(&published_marker).is_ok()
+            {
+                let _ = fs::File::open(&destination).and_then(|directory| directory.sync_all());
+            }
+            Ok(destination)
+        }
+        Err(rename_error) => {
+            // Another process may have won the destination after our initial
+            // absence check. Never replace even an empty directory. Reuse a
+            // raced winner only after its complete manifest and admitted-byte
+            // inventory prove the exact requested identity.
+            match fs::symlink_metadata(&destination) {
+                Ok(_) => {
+                    validate_published_download_stage_marker(&destination, source)?;
+                    validate_source_snapshot_integrity(&destination, Some(source)).map_err(
+                        |validation_error| {
+                            format!(
+                                "validated source staging directory {} lost exclusive publication at {} ({rename_error}); raced destination is not the exact immutable source: {validation_error}",
+                                staging.path.display(),
+                                destination.display()
+                            )
+                        },
+                    )?;
+                    staging.discard()?;
+                    Ok(destination)
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Err(format!(
+                    "validated source staging directory {} could not be exclusively published at {} and no raced destination exists: {rename_error}",
+                    staging.path.display(),
+                    destination.display()
+                )),
+                Err(error) => Err(format!(
+                    "source destination {} cannot be inspected after exclusive publication failure ({rename_error}): {error}",
+                    destination.display()
+                )),
+            }
+        }
+    }
+}
+
+type HuggingFaceDownloadResult = Result<(SourceDownload, PathBuf), String>;
+
+fn apply_huggingface_download_result(
+    current: &mut HuggingFaceDownloadStatus,
+    result: HuggingFaceDownloadResult,
+) {
+    current.running = false;
+    match result {
+        Ok((source, destination)) => {
+            current.ready = true;
+            current.source = Some(destination.display().to_string());
+            current.completed_source = Some(source.clone());
+            current.message = format!(
+                "Downloaded Hugging Face source {} ({})",
+                source.repository, source.name
+            );
+        }
+        Err(error) => {
+            // A failed staged attempt did not mutate the previously published
+            // directory. Preserve the last completed ready/source tuple.
+            current.message = format!("Hugging Face download failed: {error}");
+        }
+    }
 }
 
 fn spawn_huggingface_download(
     status: Arc<Mutex<HuggingFaceDownloadStatus>>,
     source: SourceDownload,
+    reservation: SourceCacheReservation,
 ) {
     std::thread::spawn(move || {
+        let _reservation = reservation;
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let name = source.name.clone();
-            let repository = source.repository.clone();
-            let destination = download_source(&source).map_err(|error| error.to_string())?;
-            Ok::<_, String>((repository, name, destination))
+            let destination = download_source_atomically_in(
+                &source,
+                Path::new(".uor-models"),
+                |staged_source| download_source(staged_source).map_err(|error| error.to_string()),
+            )?;
+            Ok::<_, String>((source, destination))
         }))
         .map_err(|payload| {
             format!(
@@ -2412,18 +10269,7 @@ fn spawn_huggingface_download(
         })
         .and_then(|result| result);
 
-        let mut current = status.lock().unwrap();
-        current.running = false;
-        match result {
-            Ok((repository, name, destination)) => {
-                current.ready = true;
-                current.source = Some(destination.display().to_string());
-                current.message = format!("Downloaded Hugging Face source {repository} ({name})");
-            }
-            Err(error) => {
-                current.message = format!("Hugging Face download failed: {error}");
-            }
-        }
+        apply_huggingface_download_result(&mut status.lock().unwrap(), result);
     });
 }
 
@@ -2460,17 +10306,30 @@ enum GenerationOutcome {
 #[allow(clippy::too_many_arguments)]
 fn generate_serving_completion(
     router: &Arc<Mutex<UorR4Router>>,
-    r4g1: &Arc<Mutex<Option<R4g1State>>>,
+    serving: &SharedServingModel,
     tless: &Arc<Mutex<Option<tless_uor::TlessState>>>,
-    oracle: &Arc<Mutex<Option<uor_r4_model_source::Teacher>>>,
     cli: &Arc<ServerConfig>,
     start_time: Instant,
+    expected_model: &str,
     prompt_text: &str,
     engine: Option<&str>,
     max_tokens: usize,
     temperature_override: Option<f64>,
 ) -> GenerationOutcome {
     let identity = "tenant-alpha".to_string();
+
+    let mut serving_guard = serving.lock().unwrap();
+    if active_canonical_model_name(&serving_guard).as_deref() != Some(expected_model) {
+        return GenerationOutcome::Declined {
+            status: 409,
+            body: openai_error_body(
+                "server_error",
+                "active model changed before generation began; retry the request",
+                Some("model"),
+                Some("model_changed"),
+            ),
+        };
+    }
 
     let mut router_guard = router.lock().unwrap();
 
@@ -2536,22 +10395,21 @@ fn generate_serving_completion(
     // Issue #248: the single serving cascade, honoring an engine pin from the
     // request or the persisted `/engine` selection.
     let pinned = resolve_pinned_tier(engine);
-    let cascade = {
-        let mut oracle_guard = oracle.lock().unwrap();
-        run_serving_cascade(
-            &mut router_guard,
-            r4g1,
-            tless,
-            &mut oracle_guard,
-            prompt_text,
-            &identity,
-            max_tokens,
-            temperature,
-            gamma,
-            Some(&session_signature),
-            pinned,
-        )
-    };
+    // One serving-state guard spans the complete request. Reload and
+    // background compilation prepare off-lock and wait to swap until routing
+    // and generation finish against one internally consistent tuple.
+    let cascade = run_serving_cascade(
+        &mut router_guard,
+        &mut serving_guard,
+        tless,
+        prompt_text,
+        &identity,
+        max_tokens,
+        temperature,
+        gamma,
+        Some(&session_signature),
+        pinned,
+    );
     let generation_mode = derive_generation_mode(&cascade, pinned);
     let Some(final_response_text) = cascade.outcome.text.clone() else {
         // Declined by all: an honest terminal instead of serving the sparse-
@@ -2658,10 +10516,10 @@ fn handle_connection(
     mut stream: TcpStream,
     router: Arc<Mutex<UorR4Router>>,
     tless: Arc<Mutex<Option<tless_uor::TlessState>>>,
-    r4g1: Arc<Mutex<Option<R4g1State>>>,
+    serving: SharedServingModel,
     r4g1_compile: Arc<Mutex<R4g1CompileStatus>>,
     hf_download: Arc<Mutex<HuggingFaceDownloadStatus>>,
-    oracle: Arc<Mutex<Option<uor_r4_model_source::Teacher>>>,
+    source_cache_operations: SharedSourceCacheOperations,
     cli: Arc<ServerConfig>,
     start_time: Instant,
 ) {
@@ -2727,9 +10585,9 @@ fn handle_connection(
 
     // Vendor API endpoints
     if clean_path == "/v1/models" && method == "GET" {
-        // #654 phase B: advertise only loadable compiled bundles, each with
-        // every field the pinned Model schema requires.
-        let models = loadable_models_in(Path::new(COMPILED_MODELS_DIR));
+        // Advertise only the text-ready model this process can actually run.
+        // Disk inventory is not request-time model selection.
+        let models = active_models(&serving.lock().unwrap());
         send_json_response(stream, 200, &models_list_body(&models).to_string());
         return;
     }
@@ -2738,7 +10596,7 @@ fn handle_connection(
     // absent from the loadable set is a 404 with the standard error envelope.
     if method == "GET" {
         if let Some(model_id) = clean_path.strip_prefix("/v1/models/") {
-            let models = loadable_models_in(Path::new(COMPILED_MODELS_DIR));
+            let models = active_models(&serving.lock().unwrap());
             match models.iter().find(|(id, _)| id == model_id) {
                 Some((id, created)) => {
                     send_json_response(stream, 200, &openai_model_object(id, *created).to_string())
@@ -2760,52 +10618,31 @@ fn handle_connection(
         // #654 phase G: canonical /uor/v1/status; /v1/status stays a deprecated
         // alias (Deprecation header) so /v1 is OpenAI-only without losing this.
         let dep = deprecation_headers(clean_path);
-        let r4g1_loaded = r4g1.lock().unwrap().is_some();
-        let oracle_loaded = oracle.lock().unwrap().is_some();
-
-        let model_candidates = [
-            "smollm2-135m-instruct",
-            "smollm2-360m-instruct",
-            "smollm2-1-7b-instruct",
-        ];
-
-        let active_model = model_candidates
-            .iter()
-            .find(|m| {
-                std::path::Path::new(&format!(".uor-models/compiled/{}/tless_artifacts.bin", m))
-                    .is_file()
-            })
-            .unwrap_or(&"smollm2-135m-instruct");
-
-        let source_downloaded =
-            std::path::Path::new(&format!(".uor-models/sources/{}", active_model)).is_dir();
-        let bundle_compiled = std::path::Path::new(&format!(
-            ".uor-models/compiled/{}/tless_artifacts.bin",
-            active_model
-        ))
-        .is_file();
-        let graph_compiled = std::path::Path::new(&format!(
-            ".uor-models/compiled/{}/graph/score.r4g1",
-            active_model
-        ))
-        .is_file()
-            || std::path::Path::new(&format!(
-                ".uor-models/compiled/{}/compiled.r4g1",
-                active_model
-            ))
-            .is_file();
-        let engine_active = r4g1_loaded || oracle_loaded;
+        let installed = serving.lock().unwrap();
+        let graph_loaded = installed.r4g1.is_some();
+        let graph_ready = graph_text_ready(&installed);
+        let decode_only = graph_loaded && !graph_ready;
+        let teacher_ready = teacher_text_ready(&installed);
+        let engine_active = graph_ready || teacher_ready;
+        let logical_name = installed_logical_model_name(&installed);
+        let bundle_compiled = installed.active_bundle.is_some();
 
         let body = serde_json::json!({
-            "model_name": active_model,
-            "r4g1_ready": r4g1_loaded,
-            "teacher_ready": oracle_loaded,
+            "model_name": logical_name,
+            "physical_root": status_physical_root(installed.active_bundle.as_ref()),
+            "attention_operator": installed.active_bundle.as_ref().map(|bundle| &bundle.attention_operator),
+            "r4g1_loaded": graph_loaded,
+            "r4g1_ready": graph_ready,
+            "decode_only": decode_only,
+            "teacher_ready": teacher_ready,
             "engine_active": engine_active,
+            "terminal_error": installed.terminal_load_error.as_deref(),
+            "last_operation_error": installed.last_operation_error.as_deref(),
             "stages": {
-                "stage_1_download": source_downloaded,
+                "stage_1_download": installed.active_teacher_source.is_some(),
                 "stage_2_compile": bundle_compiled,
-                "stage_3_graph_score": graph_compiled,
-                "stage_4_r4g1_active": r4g1_loaded
+                "stage_3_graph_score": graph_loaded,
+                "stage_4_r4g1_active": graph_ready
             }
         });
         send_json_response_ext(stream, 200, &body.to_string(), &dep);
@@ -2815,21 +10652,16 @@ fn handle_connection(
     if extended_route_canonical(clean_path) == Some("/uor/v1/reload") && method == "POST" {
         // #654 phase G: canonical /uor/v1/reload; /v1/reload deprecated alias.
         let dep = deprecation_headers(clean_path);
-        let payload: HuggingFaceDownloadPayload = if body.is_empty() {
-            HuggingFaceDownloadPayload::default()
-        } else {
-            match serde_json::from_slice(&body) {
-                Ok(payload) => payload,
-                Err(error) => {
-                    send_json_response_ext(
-                        stream,
-                        400,
-                        &serde_json::json!({ "error": format!("Invalid JSON: {error}") })
-                            .to_string(),
-                        &dep,
-                    );
-                    return;
-                }
+        let payload = match parse_huggingface_control_payload(&body) {
+            Ok(payload) => payload,
+            Err(error) => {
+                send_json_response_ext(
+                    stream,
+                    400,
+                    &serde_json::json!({ "error": error }).to_string(),
+                    &dep,
+                );
+                return;
             }
         };
         let tokenizer_selection = match payload.tokenizer_selection() {
@@ -2844,32 +10676,56 @@ fn handle_connection(
                 return;
             }
         };
-        let target_model = payload.model.as_deref().unwrap_or("smollm2-135m-instruct");
-
-        let teacher_path = PathBuf::from(format!(
-            ".uor-models/compiled/{}/tless_artifacts.bin",
-            target_model
-        ));
-        let graph_path = PathBuf::from(format!(
-            ".uor-models/compiled/{}/graph/score.r4g1",
-            target_model
-        ));
-        let fallback_path = PathBuf::from(format!(
-            ".uor-models/compiled/{}/compiled.r4g1",
-            target_model
-        ));
-
-        // A reload changes the selected model atomically: discard the old
-        // graph/oracle/tokenizer tuple before inspecting the replacement.
-        *r4g1.lock().unwrap() = None;
-        *oracle.lock().unwrap() = None;
-        *SERVING_SOURCE_TOKENIZER.lock().unwrap() = None;
-        clear_r4g1_terminal_load_error();
-
-        let path_to_load = match select_regular_fallback_path(&graph_path, &fallback_path) {
-            Ok(path) => path,
+        let target_model = payload
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .unwrap_or("smollm2-135m-instruct");
+        let _source_cache_reservation = match try_reserve_source_cache_operation(
+            &source_cache_operations,
+            SourceCacheOperationKind::Reload,
+            target_model,
+        ) {
+            Ok(reservation) => reservation,
             Err(error) => {
-                set_r4g1_terminal_load_error(error.clone());
+                send_json_response_ext(
+                    stream,
+                    409,
+                    &serde_json::json!({
+                        "status": "error",
+                        "running": true,
+                        "message": error,
+                    })
+                    .to_string(),
+                    &dep,
+                );
+                return;
+            }
+        };
+        let (base_epoch, mut reload_reservation) =
+            match reserve_r4g1_reload(&serving, &r4g1_compile) {
+                Ok(reservation) => reservation,
+                Err(ready) => {
+                    send_json_response_ext(
+                        stream,
+                        409,
+                        &serde_json::json!({
+                            "status": "error",
+                            "running": true,
+                            "ready": ready,
+                            "message": "another R4G1 compile or reload is already running"
+                        })
+                        .to_string(),
+                        &dep,
+                    );
+                    return;
+                }
+            };
+        let current_version = match current_source_attention_era_version() {
+            Ok(version) => version,
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
                 send_json_response_ext(
                     stream,
                     500,
@@ -2879,11 +10735,58 @@ fn handle_connection(
                 return;
             }
         };
-        let oracle_source_path = PathBuf::from(format!(".uor-models/sources/{}", target_model));
-        let source_for_reload = match optional_source_directory(&oracle_source_path) {
-            Ok(source) => source,
+        let reload_logical = match logical_model_name_for_request(target_model, current_version) {
+            Ok(logical) => logical,
             Err(error) => {
-                set_r4g1_terminal_load_error(error.clone());
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    400,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+        };
+        let compiled_root = Path::new(".uor-models/compiled");
+        let suffix = attention_era_suffix(current_version);
+        let reload_read_sessions = match try_lock_managed_inventory_write_sessions(
+            compiled_root,
+            [
+                compiled_root.join(&reload_logical),
+                compiled_root.join(format!("{reload_logical}{suffix}")),
+                PathBuf::from(".uor-models/sources"),
+            ],
+        ) {
+            Ok(sessions) => sessions,
+            Err(error) if source_compile_session_is_busy(&error) => {
+                // BUSY is transient cross-process publication, not a defect
+                // in the active serving tuple or the on-disk candidate. Keep
+                // both the prior tuple and its terminal/readiness markers.
+                reload_reservation.disarm();
+                let installed = serving.lock().unwrap();
+                let mut status = r4g1_compile.lock().unwrap();
+                status.running = false;
+                status.ready = graph_text_ready(&installed);
+                status.message =
+                    "R4G1 reload deferred while another process publishes the bundle".to_owned();
+                drop(status);
+                drop(installed);
+                send_json_response_ext(
+                    stream,
+                    409,
+                    &serde_json::json!({
+                        "status": "error",
+                        "running": true,
+                        "message": error,
+                    })
+                    .to_string(),
+                    &dep,
+                );
+                return;
+            }
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
                 send_json_response_ext(
                     stream,
                     500,
@@ -2893,12 +10796,146 @@ fn handle_connection(
                 return;
             }
         };
+        if let Err(error) = recover_managed_compiled_bundle_completion_temporaries(compiled_root) {
+            record_replacement_failure(&serving, error.clone());
+            send_json_response_ext(
+                stream,
+                500,
+                &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                &dep,
+            );
+            return;
+        }
+        let (resolved, source_for_reload) = match resolve_reload_bundle_in(
+            Path::new(".uor-models"),
+            target_model,
+            current_version,
+        ) {
+            Ok(Some(resolved)) => resolved,
+            Ok(None) => {
+                record_replacement_failure(
+                    &serving,
+                    format!("no compiled R4G1 graph artifact found for model '{target_model}'"),
+                );
+                let resp = serde_json::json!({
+                    "status": "error",
+                    "message": format!("No compiled R4G1 graph artifact found for model '{}'. Please compile it first.", target_model)
+                });
+                send_json_response_ext(stream, 404, &resp.to_string(), &dep);
+                return;
+            }
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+        };
+        if let Err(error) = validate_legacy_graph_generation_for_serving(&resolved.graph) {
+            record_replacement_failure(&serving, error.clone());
+            send_json_response_ext(
+                stream,
+                500,
+                &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                &dep,
+            );
+            return;
+        }
+        if let Err(error) =
+            ensure_compiled_bundle_completion_for_serving(&resolved, current_version)
+        {
+            record_replacement_failure(&serving, error.clone());
+            send_json_response_ext(
+                stream,
+                500,
+                &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                &dep,
+            );
+            return;
+        }
+        let reload_source_snapshot_before = match source_for_reload
+            .as_deref()
+            .map(|source| verify_managed_source_snapshot(source, &resolved.logical_name))
+            .transpose()
+        {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+        };
+        if source_for_reload.is_some() {
+            if let Err(error) = validate_resolved_source_snapshot_binding(
+                &resolved,
+                reload_source_snapshot_before.as_ref(),
+                current_version,
+            ) {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+        }
 
-        let teacher_model_present = match source_for_reload.as_deref() {
-            Some(source) => match regular_file_presence(&source.join("model.safetensors")) {
-                Ok(present) => present,
+        let replacement_state = match r4g1::R4g1State::load_with_source(
+            &resolved.graph,
+            &resolved.teacher,
+            source_for_reload.as_deref(),
+        ) {
+            Ok(state) => state,
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
+                let resp = serde_json::json!({
+                    "status": "error",
+                    "message": format!("Failed to load R4G1 graph artifact: {error}")
+                });
+                send_json_response_ext(stream, 500, &resp.to_string(), &dep);
+                return;
+            }
+        };
+
+        // Prepare the optional teacher/tokenizer pair without mutating the
+        // active slots. A genuinely absent source is the #718 decode-only
+        // case; a present source was already required to be a directory and
+        // the R4G1 loader has enforced any tagged host-encoder identity.
+        let mut replacement_teacher = match prepare_optional_teacher_source_for_identity(
+            source_for_reload.as_deref(),
+            tokenizer_selection.as_ref(),
+            &resolved.logical_name,
+            replacement_state.tokenizer_adapter_identity(),
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+        };
+        let (teacher_default_r4_attention, _teacher_mismatch) =
+            match reconcile_prepared_teacher_with_bundle(&mut replacement_teacher, Some(&resolved))
+            {
+                Ok(decision) => decision,
                 Err(error) => {
-                    set_r4g1_terminal_load_error(error.clone());
+                    record_replacement_failure(&serving, error.clone());
                     send_json_response_ext(
                         stream,
                         500,
@@ -2907,66 +10944,116 @@ fn handle_connection(
                     );
                     return;
                 }
-            },
-            None => false,
+            };
+        let refreshed = match refresh_resolved_compiled_bundle(&resolved, current_version) {
+            Ok(refreshed) => refreshed,
+            Err(error) => {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
         };
-        if let (true, Some(source)) = (teacher_model_present, source_for_reload.as_deref()) {
-            match load_serving_source_tokenizer(source, tokenizer_selection.as_ref())
-                .and_then(|_| uor_r4_model_source::Teacher::load(source))
+        if let (Some(source), Some(before)) = (
+            source_for_reload.as_deref(),
+            reload_source_snapshot_before.as_ref(),
+        ) {
+            let after = match verify_managed_source_snapshot(source, &resolved.logical_name) {
+                Ok(after) => after,
+                Err(error) => {
+                    record_replacement_failure(&serving, error.clone());
+                    send_json_response_ext(
+                        stream,
+                        500,
+                        &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                        &dep,
+                    );
+                    return;
+                }
+            };
+            if let Err(error) =
+                require_unchanged_managed_source_snapshot(source, "R4G1 reload", before, &after)
             {
-                Ok(o) => {
-                    println!(
-                        "[+] Successfully reloaded teacher oracle model for '{}'",
-                        target_model
-                    );
-                    *oracle.lock().unwrap() = Some(o);
-                }
-                Err(e) => {
-                    println!(
-                        "[-] Note: Teacher oracle reload skipped for '{}': {:?}",
-                        target_model, e
-                    );
-                    *SERVING_SOURCE_TOKENIZER.lock().unwrap() = None;
-                    *oracle.lock().unwrap() = None;
-                }
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
+            }
+            if let Err(error) =
+                validate_resolved_source_snapshot_binding(&refreshed, Some(&after), current_version)
+            {
+                record_replacement_failure(&serving, error.clone());
+                send_json_response_ext(
+                    stream,
+                    500,
+                    &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                    &dep,
+                );
+                return;
             }
         }
 
-        if let Some(path_to_load) = path_to_load {
-            match r4g1::R4g1State::load_with_source(
-                &path_to_load,
-                &teacher_path,
-                source_for_reload.as_deref(),
-            ) {
-                Ok(state) => {
-                    *r4g1.lock().unwrap() = Some(state);
-                    clear_r4g1_terminal_load_error();
-                    let resp = serde_json::json!({
-                        "status": "success",
-                        "model": target_model,
-                        "message": format!("Successfully reloaded R4G1 runtime for model '{}'", target_model)
-                    });
-                    send_json_response_ext(stream, 200, &resp.to_string(), &dep);
-                    return;
-                }
-                Err(e) => {
-                    set_r4g1_terminal_load_error(e.clone());
-                    let resp = serde_json::json!({
-                        "status": "error",
-                        "message": format!("Failed to load R4G1 graph artifact: {}", e)
-                    });
-                    send_json_response_ext(stream, 500, &resp.to_string(), &dep);
-                    return;
-                }
-            }
-        } else {
-            let resp = serde_json::json!({
-                "status": "error",
-                "message": format!("No compiled R4G1 graph artifact found for model '{}'. Please compile it first.", target_model)
-            });
-            send_json_response_ext(stream, 404, &resp.to_string(), &dep);
+        // Install the graph/oracle/tokenizer identity tuple only after the
+        // selected sidecar, corpus, and cover records were re-read exactly.
+        let (replacement_oracle, replacement_tokenizer, replacement_teacher_source) =
+            match replacement_teacher {
+                Some(prepared) => (
+                    Some(prepared.teacher),
+                    Some(prepared.tokenizer),
+                    Some(prepared.source),
+                ),
+                None => (None, None, None),
+            };
+        let mut installed = serving.lock().unwrap();
+        if installed.epoch != base_epoch {
+            let error =
+                "active serving model changed while reload was preparing; refusing stale installation"
+                    .to_owned();
+            installed.last_operation_error = Some(error.clone());
+            drop(installed);
+            send_json_response_ext(
+                stream,
+                409,
+                &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                &dep,
+            );
             return;
         }
+        let mut compile_status = r4g1_compile.lock().unwrap();
+        installed.epoch = installed.epoch.wrapping_add(1);
+        installed.r4g1 = Some(replacement_state);
+        installed.oracle = replacement_oracle;
+        installed.source_tokenizer = replacement_tokenizer;
+        installed.teacher_default_r4_attention = teacher_default_r4_attention;
+        installed.active_teacher_source = replacement_teacher_source;
+        installed.active_bundle = Some(refreshed.clone());
+        installed.terminal_load_error = None;
+        installed.last_operation_error = None;
+        compile_status.ready = graph_text_ready(&installed);
+        compile_status.running = false;
+        compile_status.progress = 100;
+        compile_status.message = format!(
+            "R4G1 graph runtime ready after reload of {}",
+            refreshed.logical_name
+        );
+        reload_reservation.disarm();
+        drop(reload_read_sessions);
+        let resp = serde_json::json!({
+            "status": "success",
+            "model": refreshed.logical_name,
+            "physical_root": refreshed.physical_root.display().to_string(),
+            "message": format!("Successfully reloaded R4G1 runtime for model '{}'", refreshed.logical_name)
+        });
+        send_json_response_ext(stream, 200, &resp.to_string(), &dep);
+        return;
     }
 
     if extended_route_canonical(clean_path) == Some("/uor/v1/corpus") && method == "POST" {
@@ -3068,6 +11155,33 @@ fn handle_connection(
             }
         };
 
+        let model_name =
+            match resolve_active_request_model(&serving.lock().unwrap(), req.model.as_deref()) {
+                Ok(model) => model,
+                Err(error) if error.starts_with("no text-ready") => {
+                    send_openai_error(
+                        stream,
+                        503,
+                        "server_error",
+                        &error,
+                        Some("model"),
+                        Some("model_not_ready"),
+                    );
+                    return;
+                }
+                Err(error) => {
+                    send_openai_error(
+                        stream,
+                        404,
+                        "invalid_request_error",
+                        &error,
+                        Some("model"),
+                        Some("model_not_found"),
+                    );
+                    return;
+                }
+            };
+
         // #654 phase C: flatten the supported roles (system/developer/user/
         // assistant); an unsupported role fails closed with the envelope
         // rather than being silently accepted.
@@ -3093,11 +11207,11 @@ fn handle_connection(
         // /v1/responses) so both wire surfaces run the identical cascade.
         let gen = match generate_serving_completion(
             &router,
-            &r4g1,
+            &serving,
             &tless,
-            &oracle,
             &cli,
             start_time,
+            &model_name,
             &prompt_text,
             req.engine.as_deref(),
             max_tokens,
@@ -3112,7 +11226,6 @@ fn handle_connection(
 
         // Values shared by the single-JSON and the streaming surfaces.
         let response_id = format!("chatcmpl-uor-r4-{}", gen.created_ts);
-        let model_name = req.model.clone().unwrap_or_else(|| "uor-r4".to_string());
         let system_fingerprint = format!("uor-r4-{}", gen.generation_mode);
         // #654 phase C: `length` when the served completion reached the
         // effective token budget, otherwise `stop`.
@@ -3192,6 +11305,33 @@ fn handle_connection(
             }
         };
 
+        let model_name =
+            match resolve_active_request_model(&serving.lock().unwrap(), req.model.as_deref()) {
+                Ok(model) => model,
+                Err(error) if error.starts_with("no text-ready") => {
+                    send_openai_error(
+                        stream,
+                        503,
+                        "server_error",
+                        &error,
+                        Some("model"),
+                        Some("model_not_ready"),
+                    );
+                    return;
+                }
+                Err(error) => {
+                    send_openai_error(
+                        stream,
+                        404,
+                        "invalid_request_error",
+                        &error,
+                        Some("model"),
+                        Some("model_not_found"),
+                    );
+                    return;
+                }
+            };
+
         let prompt_text = match flatten_responses_input(&req.input, req.instructions.as_deref()) {
             Ok(text) => text,
             Err(message) => {
@@ -3210,11 +11350,11 @@ fn handle_connection(
         let max_tokens = req.max_output_tokens.unwrap_or(256);
         let gen = match generate_serving_completion(
             &router,
-            &r4g1,
+            &serving,
             &tless,
-            &oracle,
             &cli,
             start_time,
+            &model_name,
             &prompt_text,
             req.engine.as_deref(),
             max_tokens,
@@ -3226,9 +11366,6 @@ fn handle_connection(
             }
             GenerationOutcome::Generated(gen) => *gen,
         };
-
-        let model_name = req.model.clone().unwrap_or_else(|| "uor-r4".to_string());
-
         // Streaming for /v1/responses: like chat streaming, the cascade produces
         // the whole completion up front, so this re-frames the finished text as
         // the Responses typed-event sequence (created → … → response.completed;
@@ -3276,6 +11413,7 @@ fn handle_connection(
         // "auto"/empty and the legacy `ollama` alias run the full cascade.
         let pinned = resolve_pinned_tier(payload.engine.as_deref());
 
+        let mut installed = serving.lock().unwrap();
         let mut router_guard = router.lock().unwrap();
 
         // 1. Dry run routing to get baseline parameters via UOR pipeline
@@ -3355,22 +11493,18 @@ fn handle_connection(
         // RECORDED in the per-tier trail while later tiers still attempt
         // (PR #223 semantics, centralized in `SERVING_ABSTAIN_POLICY`).
         let t_gen = Instant::now();
-        let mut cascade = {
-            let mut oracle_guard = oracle.lock().unwrap();
-            run_serving_cascade(
-                &mut router_guard,
-                &r4g1,
-                &tless,
-                &mut oracle_guard,
-                &payload.text,
-                &identity,
-                max_tokens,
-                temperature,
-                gamma,
-                Some(&session_signature),
-                pinned,
-            )
-        };
+        let mut cascade = run_serving_cascade(
+            &mut router_guard,
+            &mut installed,
+            &tless,
+            &payload.text,
+            &identity,
+            max_tokens,
+            temperature,
+            gamma,
+            Some(&session_signature),
+            pinned,
+        );
 
         // Legacy response fields, derived from the trail so consumers keep
         // the names and values they rely on.
@@ -3919,8 +12053,9 @@ fn handle_connection(
     }
 
     if clean_path == "/api/r4g1/status" && method == "GET" {
+        let installed = serving.lock().unwrap();
         let status = r4g1_compile.lock().unwrap().clone();
-        send_json_response(stream, 200, &status.json().to_string());
+        send_json_response(stream, 200, &status.json(&installed).to_string());
         return;
     }
 
@@ -3961,10 +12096,10 @@ fn handle_connection(
         if window_tokens.len() > 8 {
             window_tokens = window_tokens.split_off(window_tokens.len() - 8);
         }
-        let guard = r4g1.lock().unwrap();
-        let Some(state) = guard.as_ref() else {
-            let load_error = r4g1_terminal_load_error();
-            let (status, body) = r4g1_unavailable_response_with_reason(load_error.as_deref());
+        let installed = serving.lock().unwrap();
+        let Some(state) = installed.r4g1.as_ref() else {
+            let load_error = installed.terminal_load_error.as_deref();
+            let (status, body) = r4g1_unavailable_response_with_reason(load_error);
             send_json_response(stream, status, &body.to_string());
             return;
         };
@@ -4022,10 +12157,10 @@ fn handle_connection(
             .or_else(|| payload.get("witness"))
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
-        let guard = r4g1.lock().unwrap();
-        let Some(state) = guard.as_ref() else {
-            let load_error = r4g1_terminal_load_error();
-            let (status, body) = r4g1_unavailable_response_with_reason(load_error.as_deref());
+        let installed = serving.lock().unwrap();
+        let Some(state) = installed.r4g1.as_ref() else {
+            let load_error = installed.terminal_load_error.as_deref();
+            let (status, body) = r4g1_unavailable_response_with_reason(load_error);
             send_json_response(stream, status, &body.to_string());
             return;
         };
@@ -4176,8 +12311,8 @@ fn handle_connection(
                 );
                 return;
             };
-            let guard = r4g1.lock().unwrap();
-            let Some(state) = guard.as_ref() else {
+            let installed = serving.lock().unwrap();
+            let Some(state) = installed.r4g1.as_ref() else {
                 send_json_response(
                     stream,
                     503,
@@ -4253,22 +12388,18 @@ fn handle_connection(
     }
 
     if clean_path == "/api/huggingface/download" && method == "POST" {
-        let payload: HuggingFaceDownloadPayload = if body.is_empty() {
-            HuggingFaceDownloadPayload::default()
-        } else {
-            match serde_json::from_slice(&body) {
-                Ok(payload) => payload,
-                Err(error) => {
-                    send_json_response(
-                        stream,
-                        400,
-                        &format!("{{\"error\":\"Invalid JSON: {error}\"}}"),
-                    );
-                    return;
-                }
+        let payload = match parse_huggingface_control_payload(&body) {
+            Ok(payload) => payload,
+            Err(error) => {
+                send_json_response(
+                    stream,
+                    400,
+                    &serde_json::json!({ "error": error }).to_string(),
+                );
+                return;
             }
         };
-        if let Err(error) = payload.tokenizer_selection() {
+        if let Err(error) = payload.validate_download_controls() {
             send_json_response(
                 stream,
                 400,
@@ -4283,6 +12414,26 @@ fn handle_connection(
                     stream,
                     400,
                     &serde_json::json!({ "error": error }).to_string(),
+                );
+                return;
+            }
+        };
+        let destination = downloaded_source_path_in(&source, Path::new(".uor-models"));
+        let source_cache_reservation = match try_reserve_source_cache_operation(
+            &source_cache_operations,
+            SourceCacheOperationKind::Download,
+            destination.display().to_string(),
+        ) {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                send_json_response(
+                    stream,
+                    409,
+                    &serde_json::json!({
+                        "running": true,
+                        "error": error,
+                    })
+                    .to_string(),
                 );
                 return;
             }
@@ -4302,14 +12453,13 @@ fn handle_connection(
             return;
         }
         status.running = true;
-        status.ready = false;
         let revision_preview: String = source.revision.chars().take(12).collect();
         status.message = format!(
             "Downloading {}@{}; this may take a few minutes...",
             source.repository, revision_preview
         );
         drop(status);
-        spawn_huggingface_download(Arc::clone(&hf_download), source);
+        spawn_huggingface_download(Arc::clone(&hf_download), source, source_cache_reservation);
         send_json_response(
             stream,
             202,
@@ -4323,19 +12473,15 @@ fn handle_connection(
     }
 
     if clean_path == "/api/r4g1/compile" && method == "POST" {
-        let payload: HuggingFaceDownloadPayload = if body.is_empty() {
-            HuggingFaceDownloadPayload::default()
-        } else {
-            match serde_json::from_slice(&body) {
-                Ok(payload) => payload,
-                Err(error) => {
-                    send_json_response(
-                        stream,
-                        400,
-                        &format!("{{\"error\":\"Invalid JSON: {error}\"}}"),
-                    );
-                    return;
-                }
+        let payload = match parse_huggingface_control_payload(&body) {
+            Ok(payload) => payload,
+            Err(error) => {
+                send_json_response(
+                    stream,
+                    400,
+                    &serde_json::json!({ "error": error }).to_string(),
+                );
+                return;
             }
         };
         let tokenizer_selection = match payload.tokenizer_selection() {
@@ -4349,6 +12495,78 @@ fn handle_connection(
                 return;
             }
         };
+        let requested_source =
+            match explicitly_requested_huggingface_source(payload.model.as_deref()) {
+                Ok(source) => source,
+                Err(error) => {
+                    send_json_response(
+                        stream,
+                        400,
+                        &serde_json::json!({ "error": error }).to_string(),
+                    );
+                    return;
+                }
+            };
+        let compile_subject = requested_source
+            .as_ref()
+            .map(|source| {
+                downloaded_source_path_in(source, Path::new(".uor-models"))
+                    .display()
+                    .to_string()
+            })
+            .unwrap_or_else(|| "completed download status or pinned fallback".to_owned());
+        let (source_cache_reservation, cached_source) = match reserve_compile_source_selection(
+            &source_cache_operations,
+            &hf_download,
+            compile_subject,
+        ) {
+            Ok(selection) => selection,
+            Err(error) => {
+                send_json_response(
+                    stream,
+                    409,
+                    &serde_json::json!({ "error": error }).to_string(),
+                );
+                return;
+            }
+        };
+        let fallback_source = if requested_source.is_none() && cached_source.is_none() {
+            match optional_pinned_huggingface_source() {
+                Ok(source) => source,
+                Err(error) => {
+                    send_json_response(
+                        stream,
+                        409,
+                        &serde_json::json!({ "error": error }).to_string(),
+                    );
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+        let require_source_manifest = requested_source.is_some() || cached_source.is_some();
+        let expected_source = requested_source
+            .clone()
+            .or_else(|| cached_source.as_ref().map(|source| source.identity.clone()))
+            .or_else(|| fallback_source.clone());
+        let downloaded_source = match select_compile_source_path_in(
+            Path::new(".uor-models"),
+            requested_source.as_ref(),
+            cached_source.as_ref(),
+            fallback_source.as_ref(),
+        ) {
+            Ok(source) => source.map(|path| path.display().to_string()),
+            Err(error) => {
+                send_json_response(
+                    stream,
+                    409,
+                    &serde_json::json!({ "error": error }).to_string(),
+                );
+                return;
+            }
+        };
+        let installed = serving.lock().unwrap();
         let mut status = r4g1_compile.lock().unwrap();
         if status.running {
             send_json_response(
@@ -4364,24 +12582,24 @@ fn handle_connection(
             return;
         }
         status.running = true;
-        status.ready = r4g1.lock().unwrap().is_some();
+        status.ready = graph_text_ready(&installed);
         status.progress = 1;
         status.message = "Compiling R4G1 cover and scored graph...".to_owned();
         status.report = None;
         drop(status);
-
-        let downloaded_source = hf_download.lock().unwrap().source.clone().or_else(|| {
-            let source = huggingface_source(payload.model.as_deref()).ok()?;
-            let path = downloaded_source_path(&source);
-            path.is_dir().then(|| path.display().to_string())
-        });
+        drop(installed);
 
         spawn_r4g1_compile(
             Arc::clone(&cli),
-            Arc::clone(&r4g1),
+            Arc::clone(&serving),
             Arc::clone(&r4g1_compile),
-            downloaded_source,
+            CompileSourceSelection {
+                path: downloaded_source,
+                expected: expected_source,
+                require_manifest: require_source_manifest,
+            },
             tokenizer_selection,
+            source_cache_reservation,
         );
         send_json_response(
             stream,
@@ -4401,7 +12619,7 @@ fn handle_connection(
         let ready = Path::new(&cli.tless_artifacts).is_file()
             && Path::new(&cli.tless_store).is_file()
             && Path::new(&cli.tless_tokenizer).is_file();
-        let r4g1_ready = r4g1.lock().unwrap().is_some();
+        let r4g1_ready = graph_text_ready(&serving.lock().unwrap());
         let body = serde_json::json!({
             "models": if ready { vec![serde_json::json!({
                 "name": "uor-transformerless",
@@ -4419,6 +12637,9 @@ fn handle_connection(
     }
 
     if clean_path == "/api/sysinfo" && method == "GET" {
+        // Snapshot the serving state before locking the router. Generation
+        // acquires these locks in that order and sysinfo must not invert it.
+        let r4g1_ready = graph_text_ready(&serving.lock().unwrap());
         let mut router_guard = router.lock().unwrap();
         let sentences_indexed = router_guard.get_total_indexed_sentences();
         let active_streams = router_guard.get_active_streams_native();
@@ -4512,8 +12733,6 @@ fn handle_connection(
         });
 
         let max_tokens = router_guard.get_suggested_token_limit("Welcome", identity);
-        let r4g1_ready = r4g1.lock().unwrap().is_some();
-
         let info = serde_json::json!({
             "uptime_seconds": start_time.elapsed().as_secs_f64().round(),
             "sentences_indexed": sentences_indexed,
@@ -4615,9 +12834,6 @@ fn handle_connection(
     let _ = stream.write_all(&contents);
 }
 
-/// The directory holding compiled model bundles.
-const COMPILED_MODELS_DIR: &str = ".uor-models/compiled";
-
 /// The standard OpenAI error object envelope (#654 phase B):
 /// `{ "error": { "message", "type", "param", "code" } }`, with `param`/`code`
 /// serialized as JSON `null` when absent. Official SDKs parse errors from this
@@ -4665,33 +12881,25 @@ fn openai_model_object(id: &str, created: u64) -> serde_json::Value {
     })
 }
 
-/// The models loadable from `compiled_dir`: each immediate subdirectory that
-/// contains a compiled `tless_artifacts.bin` bundle, reported as
-/// `(id = directory name, created = the bundle's mtime in unix seconds)` and
-/// sorted by id for a deterministic listing. Advertising only compiled bundles
-/// keeps `/v1/models` truthful — an id absent here is not loadable.
-fn loadable_models_in(compiled_dir: &Path) -> Vec<(String, u64)> {
+/// The resolver-validated logical models loadable from the compiled root,
+/// reported with the selected physical teacher artifact's mtime. Invalid
+/// siblings are an inventory error, and a v2 physical suffix is never exposed
+/// as a second OpenAI model id.
+#[cfg(test)]
+fn loadable_models_in(compiled_dir: &Path) -> Result<Vec<(String, u64)>, String> {
     let mut models = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(compiled_dir) {
-        for entry in entries.flatten() {
-            let artifact = entry.path().join("tless_artifacts.bin");
-            if !artifact.is_file() {
-                continue;
-            }
-            let Some(id) = entry.file_name().to_str().map(str::to_owned) else {
-                continue;
-            };
-            let created = std::fs::metadata(&artifact)
-                .ok()
-                .and_then(|meta| meta.modified().ok())
-                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|delta| delta.as_secs())
-                .unwrap_or(0);
-            models.push((id, created));
-        }
+    let current_version = current_source_attention_era_version()?;
+    for resolved in discover_compiled_r4g1_candidates_in(compiled_dir, current_version)? {
+        let created = std::fs::metadata(&resolved.teacher)
+            .ok()
+            .and_then(|meta| meta.modified().ok())
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|delta| delta.as_secs())
+            .unwrap_or(0);
+        models.push((resolved.logical_name, created));
     }
     models.sort_by(|a, b| a.0.cmp(&b.0));
-    models
+    Ok(models)
 }
 
 /// The `GET /v1/models` list body over the loadable models.
@@ -5464,30 +13672,3426 @@ mod tests {
         (meta, records)
     }
 
-    #[test]
-    fn server_cover_uses_registry_validated_observation_manifest_operator() {
-        let root = attention_provenance_test_dir("learned-manifest");
-        let (meta, records) = attention_corpus_markers(&root);
-        let operator = uor_r4_model_source::attention::AttentionOperatorSpec::
-            learned_absolute_source_attention();
-        let mut manifest = uor_r4_graph_compiler::observation::ObservationManifest::new(1);
-        manifest.attention_operator = Some(operator.clone());
-        std::fs::write(
-            root.join(uor_r4_graph_compiler::observation::MANIFEST_FILE),
-            serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
-        )
-        .expect("write manifest");
+    fn write_test_source_manifest(
+        source_dir: &std::path::Path,
+        source: &crate::model::SourceDownload,
+    ) -> Vec<u8> {
+        std::fs::create_dir_all(source_dir).expect("create source snapshot");
+        let weights = source_dir.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME);
+        if !weights.exists() {
+            std::fs::write(&weights, b"test-safetensors-bytes").expect("write test source weights");
+        }
+        write_test_source_manifest_without_default_weights(source_dir, source)
+    }
 
-        let mut args = Vec::new();
-        super::append_recorded_attention_operator(&mut args, &meta, &records, false)
-            .expect("manifest operator is accepted");
+    fn write_test_source_manifest_without_default_weights(
+        source_dir: &std::path::Path,
+        source: &crate::model::SourceDownload,
+    ) -> Vec<u8> {
+        std::fs::create_dir_all(source_dir).expect("create source snapshot");
+        let manifest = crate::model::build_source_manifest(
+            source_dir,
+            &crate::model::SourceSnapshotInfo {
+                repository: source.repository.clone(),
+                revision: source.revision.clone(),
+                license: source.license.clone(),
+                source_execution_mode: crate::model::SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT
+                    .to_owned(),
+            },
+        )
+        .expect("build source manifest");
+        crate::model::write_source_manifest(source_dir, &manifest).expect("write source manifest");
+        std::fs::read(source_dir.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+            .expect("read source manifest bytes")
+    }
+
+    fn completed_source(
+        path: &std::path::Path,
+        identity: &crate::model::SourceDownload,
+    ) -> super::CompletedDownloadSource {
+        let mut identity = identity.clone();
+        identity.output = Some(path.to_path_buf());
+        super::CompletedDownloadSource {
+            path: path.to_path_buf(),
+            identity,
+        }
+    }
+
+    #[test]
+    fn empty_last_model_never_selects_the_sources_inventory_root() {
+        let candidates = super::startup_source_candidates("  \n");
         assert_eq!(
-            args.first().map(String::as_str),
-            Some("--attention-operator")
+            candidates.first().map(std::path::PathBuf::as_path),
+            Some(std::path::Path::new(
+                ".uor-models/sources/smollm2-135m-instruct"
+            ))
         );
-        let forwarded: uor_r4_model_source::attention::AttentionOperatorSpec =
-            serde_json::from_str(&args[1]).expect("forwarded record");
-        assert_eq!(forwarded, operator);
+        assert!(candidates
+            .iter()
+            .all(|candidate| candidate != std::path::Path::new(".uor-models/sources")));
+
+        let named = super::startup_source_candidates("teacher-beta");
+        assert_eq!(
+            named.first().map(std::path::PathBuf::as_path),
+            Some(std::path::Path::new(".uor-models/sources/teacher-beta"))
+        );
+    }
+
+    fn write_attention_binding(
+        root: &std::path::Path,
+        operator: &uor_r4_model_source::attention::AttentionOperatorSpec,
+    ) -> Vec<u8> {
+        std::fs::create_dir_all(root).expect("create bound compile root");
+        let mut bytes = serde_json::to_vec_pretty(operator).expect("serialize full operator");
+        bytes.push(b'\n');
+        std::fs::write(
+            root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            &bytes,
+        )
+        .expect("write attention binding");
+        bytes
+    }
+
+    fn write_tokenizer_adapter_binding(root: &std::path::Path, marker: &str) -> Vec<u8> {
+        let tokenizer_json = format!(
+            r#"{{
+                "fixture_marker":"{marker}",
+                "pre_tokenizer":{{"type":"ByteLevel","add_prefix_space":false}},
+                "model":{{"type":"BPE","vocab":{{"a":0}},"merges":[]}}
+            }}"#
+        );
+        let adapter =
+            uor_r4_core::transformerless::hf_bpe::HfBpeTokenizer::from_tokenizer_json_bytes(
+                tokenizer_json.as_bytes(),
+            )
+            .expect("tokenizer adapter fixture")
+            .adapter();
+        let mut bytes = serde_json::to_vec_pretty(&adapter).expect("serialize tokenizer adapter");
+        bytes.push(b'\n');
+        std::fs::write(root.join("tokenizer_adapter.json"), &bytes)
+            .expect("write tokenizer adapter binding");
+        bytes
+    }
+
+    fn graph_state_with_exact_host_encoder(root: &std::path::Path) -> super::R4g1State {
+        use std::collections::BTreeMap;
+        use uor_r4_core::transformerless::{compiler, runtime, scenarios};
+        use uor_r4_graph_certify::score::{
+            emit_scored_r4g1_with_tokenizer_cid, EmissionTables, QuantizationErrorStats,
+            ScoredGraphSections, Smoothing,
+        };
+        use uor_r4_graph_certify::score_runtime::RegionParams;
+        use uor_r4_graph_format::ScoreQ;
+
+        let source = root.join("source");
+        let bundle = root.join("bundle");
+        std::fs::create_dir_all(&source).expect("create tokenizer source");
+        std::fs::create_dir_all(bundle.join("graph")).expect("create graph bundle");
+        let tokenizer_json = br#"{
+            "pre_tokenizer":{"type":"ByteLevel","add_prefix_space":false},
+            "model":{"type":"BPE","vocab":{" ":0,"a":1,"b":2},"merges":[]}
+        }"#;
+        std::fs::write(source.join("tokenizer.json"), tokenizer_json)
+            .expect("write source tokenizer");
+        let tokenizer = uor_r4_core::transformerless::hf_bpe::resolve_source_tokenizer(
+            &source,
+            Some(&uor_r4_core::transformerless::hf_bpe::TokenizerAdapterKey::hf_byte_bpe_v1()),
+        )
+        .expect("resolve source tokenizer");
+        let runtime_table = tokenizer
+            .runtime_decode_table()
+            .expect("registered tokenizer has a runtime table");
+        let tokenizer_path = bundle.join("tokenizer.bin");
+        scenarios::export_runtime_tokenizer_table(&runtime_table, &tokenizer_path)
+            .expect("export tagged tokenizer");
+        let tokenizer_bytes = std::fs::read(&tokenizer_path).expect("read tagged tokenizer");
+        let runtime_tokenizer =
+            scenarios::Tokenizer::from_bytes(&tokenizer_bytes).expect("parse exported tokenizer");
+        let mut runtime_encoded = [0u32; 32];
+        assert_eq!(
+            runtime_tokenizer.encode_into("a", &mut runtime_encoded),
+            Some(2),
+            "the exported bundle tokenizer must encode the regression prompt"
+        );
+
+        let artifact_bytes =
+            include_bytes!("../crates/uor-r4-core/tests/fixtures/tless_artifacts.bin").to_vec();
+        let artifacts = compiler::parse_artifacts(&artifact_bytes).expect("parse teacher fixture");
+        let regions = [RegionParams {
+            node: 1,
+            depth: 1,
+            radius: 0,
+            sig: [0; compiler::SIG_BYTES],
+            parent: None,
+        }];
+        let mut root_prior = BTreeMap::new();
+        root_prior.insert(0, ScoreQ::from_raw(-1));
+        let emissions = EmissionTables {
+            root_prior,
+            root_floor: ScoreQ::from_raw(-2),
+            root_total: 1,
+            region_lists: vec![Vec::new()],
+            smoothing: Smoothing::AddOne,
+            root_prior_quantization: QuantizationErrorStats::default(),
+            emission_quantization: QuantizationErrorStats::default(),
+            selection_stats: Default::default(),
+        };
+        let store: runtime::Store = (0..=compiler::STAGES).map(|_| BTreeMap::new()).collect();
+        let store_bytes = runtime::store_bytes(&store);
+        let sections = ScoredGraphSections {
+            regions: &regions,
+            structural: &[],
+            transitions: &[],
+            transition_quantization: QuantizationErrorStats::default(),
+            emissions: &emissions,
+            context_rows: &[],
+            exct_tls1: &store_bytes,
+            exct_top_x: 1,
+            fwd_rows: &[],
+        };
+        let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
+            .expect("fixture vocabulary fits u32");
+        let (graph, _) = emit_scored_r4g1_with_tokenizer_cid(
+            &artifact_bytes,
+            (b"fixture-meta", b"fixture-records"),
+            vocab,
+            &sections,
+            *blake3::hash(&tokenizer_bytes).as_bytes(),
+        );
+        let graph_path = bundle.join("graph/score.r4g1");
+        let teacher_path = bundle.join("tless_artifacts.bin");
+        std::fs::write(&graph_path, graph).expect("write graph fixture");
+        std::fs::write(&teacher_path, artifact_bytes).expect("write teacher fixture");
+        super::R4g1State::load_with_source(&graph_path, &teacher_path, Some(&source))
+            .expect("load graph with exact host encoder")
+    }
+
+    #[test]
+    fn server_cover_forwards_full_learned_v1_and_v2_observation_records() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        for operator in [
+            AttentionOperatorSpec::learned_absolute_v1(),
+            AttentionOperatorSpec::learned_absolute_v2(),
+        ] {
+            let root =
+                attention_provenance_test_dir(&format!("learned-manifest-v{}", operator.version));
+            let (meta, records) = attention_corpus_markers(&root);
+            let mut manifest = uor_r4_graph_compiler::observation::ObservationManifest::new(1);
+            manifest.attention_operator = Some(operator.clone());
+            std::fs::write(
+                root.join(uor_r4_graph_compiler::observation::MANIFEST_FILE),
+                serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+            )
+            .expect("write manifest");
+
+            let mut args = Vec::new();
+            super::append_recorded_attention_operator(&mut args, &meta, &records, false)
+                .expect("manifest operator is accepted");
+            assert_eq!(
+                args.first().map(String::as_str),
+                Some("--attention-operator")
+            );
+            let forwarded: AttentionOperatorSpec =
+                serde_json::from_str(&args[1]).expect("forwarded record");
+            assert_eq!(forwarded, operator);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn source_compile_routes_immutable_v1_bundles_to_a_fresh_v2_era() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        assert_eq!(
+            super::current_source_attention_era_version().expect("one current source era"),
+            2
+        );
+        for (label, v1, v2) in [
+            (
+                "standard",
+                AttentionOperatorSpec::standard_v1(),
+                AttentionOperatorSpec::standard_v2(),
+            ),
+            (
+                "experimental",
+                AttentionOperatorSpec::experimental_r4_v1(),
+                AttentionOperatorSpec::experimental_r4_v2(),
+            ),
+            (
+                "learned",
+                AttentionOperatorSpec::learned_absolute_v1(),
+                AttentionOperatorSpec::learned_absolute_v2(),
+            ),
+        ] {
+            let root = attention_provenance_test_dir(&format!("era-{label}"));
+            let compiled = root.join("compiled");
+            let conventional = compiled.join("teacher");
+            let binding_before = write_attention_binding(&conventional, &v1);
+            let payload = conventional.join("corpus.records");
+            std::fs::write(&payload, b"immutable v1 payload").expect("write v1 payload");
+
+            let era = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+                .expect("v1 selects a separate v2 era");
+            assert_eq!(era, compiled.join("teacher-attention-v2"));
+            assert!(!era.exists(), "selection is read-only");
+            assert_eq!(
+                std::fs::read(conventional.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                    .expect("v1 binding remains"),
+                binding_before
+            );
+            assert_eq!(
+                std::fs::read(&payload).expect("v1 payload remains"),
+                b"immutable v1 payload"
+            );
+
+            let v2_binding = write_attention_binding(&era, &v2);
+            std::fs::write(era.join("corpus.records"), b"resumable v2 payload")
+                .expect("write v2 payload");
+            assert_eq!(
+                super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+                    .expect("matching v2 era resumes"),
+                era
+            );
+            assert_eq!(
+                std::fs::read(era.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                    .expect("v2 binding remains"),
+                v2_binding
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn source_compile_refuses_cross_family_successor_before_creating_current_root() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("era-family-preflight");
+        let compiled = root.join("compiled");
+        let historical = compiled.join("teacher");
+        let historical_binding =
+            write_attention_binding(&historical, &AttentionOperatorSpec::experimental_r4_v1());
+        let payload = historical.join("corpus.records");
+        std::fs::write(&payload, b"immutable experimental-v1 corpus")
+            .expect("write historical corpus");
+        let current = compiled.join("teacher-attention-v2");
+
+        let error = super::source_compile_output_for_operator_era(
+            &compiled,
+            "teacher",
+            2,
+            &AttentionOperatorSpec::standard_v2(),
+        )
+        .expect_err("a standard source cannot populate an experimental successor");
+        assert!(
+            error.contains("experimental-r4-source-attention/1"),
+            "{error}"
+        );
+        assert!(error.contains("standard-source-attention/2"), "{error}");
+        assert!(
+            !current.exists(),
+            "family rejection precedes suffix creation"
+        );
+        assert_eq!(
+            std::fs::read(historical.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                .expect("historical binding after refusal"),
+            historical_binding
+        );
+        assert_eq!(
+            std::fs::read(&payload).expect("historical payload after refusal"),
+            b"immutable experimental-v1 corpus"
+        );
+
+        assert_eq!(
+            super::source_compile_output_for_operator_era(
+                &compiled,
+                "teacher",
+                2,
+                &AttentionOperatorSpec::experimental_r4_v2(),
+            )
+            .expect("the exact family successor remains selectable"),
+            current
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_uses_fresh_or_current_conventional_root() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("era-conventional");
+        let compiled = root.join("compiled");
+        assert_eq!(
+            super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+                .expect("fresh conventional root"),
+            compiled.join("teacher")
+        );
+        write_attention_binding(
+            &compiled.join("teacher"),
+            &AttentionOperatorSpec::standard_v2(),
+        );
+        assert_eq!(
+            super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+                .expect("current conventional root resumes"),
+            compiled.join("teacher")
+        );
+        assert!(!compiled.join("teacher-attention-v2").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_era_selection_fails_closed_on_invalid_provenance() {
+        let root = attention_provenance_test_dir("era-invalid");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        std::fs::create_dir_all(&conventional).expect("create conventional root");
+        let binding = conventional.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE);
+        std::fs::write(&binding, b"{not json").expect("write malformed binding");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("malformed provenance is terminal");
+        assert!(
+            error.contains("malformed attention-operator binding"),
+            "{error}"
+        );
+        assert!(!compiled.join("teacher-attention-v2").exists());
+
+        std::fs::remove_file(&binding).expect("remove malformed binding");
+        std::fs::create_dir(&binding).expect("create nonregular binding");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("nonregular provenance is terminal");
+        assert!(error.contains("not a regular file"), "{error}");
+        assert!(!compiled.join("teacher-attention-v2").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_inspects_current_suffix_before_resuming_conventional_v2() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("era-inspect-both");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        write_attention_binding(&conventional, &AttentionOperatorSpec::standard_v2());
+        std::fs::write(
+            conventional.join("corpus.records"),
+            b"current conventional payload",
+        )
+        .expect("write conventional payload");
+
+        std::fs::create_dir_all(&current).expect("create current suffix");
+        std::fs::write(
+            current.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            b"{malformed",
+        )
+        .expect("write malformed suffix binding");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("malformed suffix cannot be hidden by conventional v2");
+        assert!(
+            error.contains("malformed attention-operator binding"),
+            "{error}"
+        );
+
+        std::fs::remove_dir_all(&current).expect("remove malformed suffix");
+        write_attention_binding(&current, &AttentionOperatorSpec::standard_v2());
+        std::fs::write(current.join("corpus.records"), b"duplicate current payload")
+            .expect("write suffix payload");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("two current roots are ambiguous");
+        assert!(error.contains("duplicate current"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_rejects_empty_preferred_current_before_any_mutation() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("era-empty-preferred-current");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        std::fs::create_dir_all(&current).expect("create empty preferred current root");
+
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("an empty preferred root must block fresh conventional output");
+        assert!(error.contains("exists but is empty"), "{error}");
+        assert!(
+            !conventional.exists(),
+            "selection cannot create its fallback"
+        );
+        assert_eq!(
+            std::fs::read_dir(&current)
+                .expect("read empty root")
+                .count(),
+            0,
+            "the preferred root remains untouched"
+        );
+
+        let binding = write_attention_binding(&conventional, &AttentionOperatorSpec::standard_v2());
+        let payload = conventional.join("corpus.records");
+        std::fs::write(&payload, b"current conventional payload")
+            .expect("write conventional payload");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("empty preferred root must also block conventional-v2 resume");
+        assert!(error.contains("exists but is empty"), "{error}");
+        assert_eq!(
+            std::fs::read(conventional.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                .expect("read unchanged binding"),
+            binding
+        );
+        assert_eq!(
+            std::fs::read(&payload).expect("read unchanged payload"),
+            b"current conventional payload"
+        );
+        assert_eq!(
+            std::fs::read_dir(&current)
+                .expect("read empty root")
+                .count(),
+            0
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_retries_only_validated_pre_attention_crash_prefixes() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("pre-attention-crash-prefix");
+        let compiled = root.join("compiled");
+        let kappa = format!("blake3:{}", "7".repeat(64));
+
+        let standard = compiled.join("standard");
+        super::publish_source_compile_preflight(&standard, Some(&kappa))
+            .expect("publish standard preflight");
+        super::publish_source_manifest_kappa_binding(&standard, &kappa)
+            .expect("publish standard kappa");
+        assert_eq!(
+            super::source_compile_output_for_operator_era(
+                &compiled,
+                "standard",
+                2,
+                &AttentionOperatorSpec::standard_v2(),
+            )
+            .expect("kappa-only conventional prefix resumes"),
+            standard
+        );
+
+        let learned = compiled.join("learned");
+        super::publish_source_compile_preflight(&learned, Some(&kappa))
+            .expect("publish learned preflight");
+        super::publish_source_manifest_kappa_binding(&learned, &kappa)
+            .expect("publish learned kappa");
+        let tokenizer_before = write_tokenizer_adapter_binding(&learned, "learned-crash");
+        let mut temporary_operator =
+            serde_json::to_vec_pretty(&AttentionOperatorSpec::learned_absolute_v2())
+                .expect("serialize temporary operator");
+        temporary_operator.push(b'\n');
+        let temporary = learned.join(".attention_operator.json.42.7.tmp");
+        std::fs::write(&temporary, &temporary_operator).expect("write valid crash temporary");
+        assert_eq!(
+            super::source_compile_output_for_operator_era(
+                &compiled,
+                "learned",
+                2,
+                &AttentionOperatorSpec::learned_absolute_v2(),
+            )
+            .expect("tokenizer-published learned prefix resumes"),
+            learned
+        );
+        assert_eq!(
+            std::fs::read(learned.join("tokenizer_adapter.json"))
+                .expect("read unchanged tokenizer binding"),
+            tokenizer_before
+        );
+        assert_eq!(
+            std::fs::read(&temporary).expect("read unchanged identity temporary"),
+            temporary_operator
+        );
+
+        let historical = compiled.join("experimental");
+        write_attention_binding(&historical, &AttentionOperatorSpec::experimental_r4_v1());
+        std::fs::write(historical.join("corpus.records"), b"immutable v1")
+            .expect("write historical payload");
+        let successor = compiled.join("experimental-attention-v2");
+        super::publish_source_compile_preflight(&successor, Some(&kappa))
+            .expect("publish redirected preflight");
+        super::publish_source_manifest_kappa_binding(&successor, &kappa)
+            .expect("publish redirected kappa");
+        write_tokenizer_adapter_binding(&successor, "experimental-crash");
+        assert_eq!(
+            super::source_compile_output_for_operator_era(
+                &compiled,
+                "experimental",
+                2,
+                &AttentionOperatorSpec::experimental_r4_v2(),
+            )
+            .expect("historical family successor resumes its partial suffix"),
+            successor
+        );
+        let pair = super::inspect_compiled_model_pair(&compiled, "experimental", 2)
+            .expect("inspect partial successor");
+        let error = super::resolve_loadable_compiled_bundle(&pair, 2)
+            .expect_err("a pre-attention successor is never loadable");
+        assert!(error.contains("present but incomplete"), "{error}");
+
+        let invalid = compiled.join("invalid");
+        super::publish_source_compile_preflight(&invalid, Some(&kappa))
+            .expect("publish invalid fixture preflight");
+        std::fs::write(invalid.join("corpus.meta"), b"unexpected mutable payload")
+            .expect("write interrupted payload");
+        let payload_before = std::fs::read(invalid.join("corpus.meta")).expect("payload before");
+        let error = super::source_compile_output_for_operator_era(
+            &compiled,
+            "invalid",
+            2,
+            &AttentionOperatorSpec::standard_v2(),
+        )
+        .expect_err("unbound mutable payload is not a recoverable identity prefix");
+        assert!(error.contains("interrupted current-era compile"), "{error}");
+        assert_eq!(
+            std::fs::read(invalid.join("corpus.meta")).expect("payload after"),
+            payload_before
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_initialization_never_strands_an_unmarked_empty_root() {
+        let root = attention_provenance_test_dir("preflight-atomic-root");
+        let compiled = root.join("compiled");
+        std::fs::create_dir_all(&compiled).expect("create compiled parent");
+        let output = compiled.join("teacher");
+        let kappa = format!("blake3:{}", "8".repeat(64));
+        super::publish_source_compile_preflight(&output, Some(&kappa))
+            .expect("fresh publication atomically installs a marker-bearing root");
+        assert!(output.is_dir());
+        assert!(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE).is_file());
+        super::publish_source_compile_preflight(&output, Some(&kappa))
+            .expect("same-identity publisher is idempotent");
+        let marker_before = std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+            .expect("marker before conflict");
+        let other = format!("blake3:{}", "9".repeat(64));
+        let error = super::publish_source_compile_preflight(&output, Some(&other))
+            .expect_err("another identity cannot relabel the published root");
+        assert!(error.contains("preflight-bound"), "{error}");
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("marker after conflict"),
+            marker_before
+        );
+
+        let manifestless = compiled.join("legacy-source");
+        super::publish_source_compile_preflight(&manifestless, None)
+            .expect("manifestless compile also gets a marker-bearing root");
+        let record = super::read_optional_source_compile_preflight(&manifestless)
+            .expect("read manifestless preflight")
+            .expect("manifestless preflight present");
+        assert_eq!(record.source_manifest_kappa, None);
+
+        for (name, payload) in [
+            ("empty-race", None),
+            ("payload-race", Some(b"external".as_slice())),
+        ] {
+            let raced = compiled.join(name);
+            std::fs::create_dir(&raced).expect("external race creates final root");
+            if let Some(payload) = payload {
+                std::fs::write(raced.join("corpus.records"), payload)
+                    .expect("external race writes payload");
+            }
+            let error = super::publish_source_compile_preflight(&raced, Some(&kappa))
+                .expect_err("an external final root is never adopted");
+            assert!(
+                error.contains("without a stable") || error.contains("refusing to infer"),
+                "{error}"
+            );
+            assert!(!raced.join(super::SOURCE_COMPILE_PREFLIGHT_FILE).exists());
+            if let Some(payload) = payload {
+                assert_eq!(
+                    std::fs::read(raced.join("corpus.records")).expect("payload after refusal"),
+                    payload
+                );
+            }
+        }
+
+        let arbitrary_current = compiled.join("other-attention-v2");
+        std::fs::create_dir(&arbitrary_current).expect("create arbitrary empty preferred root");
+        let error = super::source_compile_output_for_attention_era(&compiled, "other", 2)
+            .expect_err("unmarked empty preferred root remains terminal");
+        assert!(error.contains("exists but is empty"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_staging_is_exclusive_crash_safe_and_owner_scoped() {
+        let root = attention_provenance_test_dir("preflight-staging-state-machine");
+        let compiled = root.join("compiled");
+        std::fs::create_dir_all(&compiled).expect("create compiled parent");
+        let kappa = format!("blake3:{}", "a".repeat(64));
+        let expected =
+            super::source_compile_preflight_bytes(Some(&kappa)).expect("canonical preflight bytes");
+
+        // A crash before or after the hidden stage marker never exposes a
+        // resolver-visible final root. The staging namespace itself is the
+        // only top-level entry and is deliberately omitted from discovery.
+        let staging =
+            super::ensure_source_compile_staging_root(&compiled).expect("create staging namespace");
+        let empty_crash = staging.join(".teacher.1.1.stage");
+        std::fs::create_dir(&empty_crash).expect("simulate crash before stage marker");
+        assert!(super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect("hidden crash stage is not a model")
+            .is_empty());
+        let marker_crash =
+            super::create_source_compile_preflight_stage(&compiled.join("teacher"), &expected)
+                .expect("simulate crash after stage marker");
+        assert!(!compiled.join("teacher").exists());
+
+        // Two complete publishers own disjoint stages. Atomic no-replace
+        // publication selects exactly one; the loser may remove only its own
+        // still-exact stage.
+        let first =
+            super::create_source_compile_preflight_stage(&compiled.join("winner"), &expected)
+                .expect("first publisher stage");
+        let second =
+            super::create_source_compile_preflight_stage(&compiled.join("winner"), &expected)
+                .expect("second publisher stage");
+        assert_ne!(first, second);
+        let winner = compiled.join("winner");
+        super::rename_directory_no_replace(&first, &winner).expect("first publisher wins");
+        super::rename_directory_no_replace(&second, &winner)
+            .expect_err("second publisher cannot replace the winner");
+        super::remove_owned_source_compile_stage(&second, &expected)
+            .expect("loser removes only its own exact stage");
+        assert_eq!(
+            std::fs::read(winner.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("winning marker"),
+            expected
+        );
+
+        // An external empty or populated final root wins the namespace race;
+        // the staged publisher refuses replacement and its payload is intact.
+        for (name, payload) in [
+            ("external-empty", None),
+            ("external-payload", Some(b"foreign".as_slice())),
+        ] {
+            let output = compiled.join(name);
+            let stage = super::create_source_compile_preflight_stage(&output, &expected)
+                .expect("prepare raced publisher stage");
+            std::fs::create_dir(&output).expect("external actor creates final root");
+            if let Some(payload) = payload {
+                std::fs::write(output.join("corpus.records"), payload)
+                    .expect("external actor writes payload");
+            }
+            super::rename_directory_no_replace(&stage, &output)
+                .expect_err("exclusive rename never replaces external state");
+            super::remove_owned_source_compile_stage(&stage, &expected)
+                .expect("failed publisher cleans only its own stage");
+            assert!(!output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE).exists());
+            if let Some(payload) = payload {
+                assert_eq!(
+                    std::fs::read(output.join("corpus.records")).expect("foreign payload"),
+                    payload
+                );
+            }
+        }
+
+        // Cleanup is ownership-sensitive: once another actor adds an entry,
+        // the server leaves the stage untouched rather than recursively
+        // deleting bytes it no longer exclusively owns.
+        let tampered =
+            super::create_source_compile_preflight_stage(&compiled.join("tampered"), &expected)
+                .expect("create cleanup fixture");
+        std::fs::write(tampered.join("foreign"), b"do not delete").expect("tamper owned stage");
+        let error = super::remove_owned_source_compile_stage(&tampered, &expected)
+            .expect_err("tampered stage is not removed");
+        assert!(error.contains("unexpected entries"), "{error}");
+        assert_eq!(
+            std::fs::read(tampered.join("foreign")).expect("foreign stage byte"),
+            b"do not delete"
+        );
+
+        super::remove_owned_source_compile_stage(&marker_crash, &expected)
+            .expect("test owns marker-crash stage");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_session_lock_rejects_fresh_and_existing_cross_process_losers() {
+        let root = attention_provenance_test_dir("source-compile-session-lock");
+        let output = root.join("compiled/teacher");
+        let kappa = format!("blake3:{}", "c".repeat(64));
+
+        // Two independently opened file descriptions model two server
+        // processes. The first session owns the physical root before its
+        // preflight exists; the loser receives BUSY and cannot publish it.
+        let first = super::try_lock_source_compile_session(&output)
+            .expect("first compiler owns fresh output");
+        let lock_path =
+            super::source_compile_session_lock_path(&output).expect("coordination path");
+        let metadata = std::fs::symlink_metadata(&lock_path).expect("coordination inode");
+        assert!(metadata.file_type().is_file());
+        let expected_lock_parent =
+            super::source_compile_staging_root(output.parent().expect("output parent"));
+        assert_eq!(lock_path.parent(), Some(expected_lock_parent.as_path()));
+        let error = super::try_lock_source_compile_session(&output)
+            .err()
+            .expect("fresh-root loser is nonblocking");
+        assert!(error.contains("BUSY"), "{error}");
+        assert!(!output.exists(), "loser cannot publish the fresh root");
+
+        // The winner publishes identity and a payload while retaining the
+        // session. Seeing the same κ is not ownership: a second process still
+        // cannot adopt or write the existing root.
+        super::publish_source_compile_preflight(&output, Some(&kappa))
+            .expect("winner publishes preflight");
+        super::publish_source_manifest_kappa_binding(&output, &kappa)
+            .expect("winner binds source snapshot");
+        let payload = output.join("corpus.records");
+        std::fs::write(&payload, b"winner-owned corpus").expect("winner payload");
+        let marker_before =
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE)).expect("marker");
+        let payload_before = std::fs::read(&payload).expect("payload");
+        let error = super::try_lock_source_compile_session(&output)
+            .err()
+            .expect("same-kappa existing-root loser is nonblocking");
+        assert!(error.contains("BUSY"), "{error}");
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("marker after loser"),
+            marker_before
+        );
+        assert_eq!(
+            std::fs::read(&payload).expect("payload after loser"),
+            payload_before
+        );
+
+        // Only release transfers ownership. A later retry takes the same
+        // persistent coordination inode and may idempotently resume the exact
+        // completed identity without changing winner bytes.
+        drop(first);
+        let retry = super::try_lock_source_compile_session(&output)
+            .expect("retry owns session after release");
+        super::publish_source_compile_preflight(&output, Some(&kappa))
+            .expect("retry resumes exact preflight");
+        super::publish_source_manifest_kappa_binding(&output, &kappa)
+            .expect("retry resumes exact source binding");
+        assert_eq!(
+            std::fs::read(&payload).expect("payload after retry"),
+            payload_before
+        );
+        drop(retry);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_session_sets_coordinate_writers_readers_and_partial_failure() {
+        let root = attention_provenance_test_dir("source-compile-session-sets");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("alpha");
+        let current = compiled.join("alpha-attention-v2");
+        let external_graph = root.join("external/graph");
+        let subjects = vec![
+            compiled.clone(),
+            conventional.clone(),
+            current.clone(),
+            external_graph.clone(),
+        ];
+
+        let writer = super::try_lock_source_compile_sessions(
+            subjects.clone(),
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("one process owns every mutable sink");
+        let error = super::try_lock_source_compile_sessions(
+            [compiled.clone()],
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .err()
+        .expect("managed startup reader is nonblocking while writer owns namespace");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        let error = super::try_lock_source_compile_sessions(
+            [external_graph.clone()],
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .err()
+        .expect("external graph reader is nonblocking while writer owns sink");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(writer);
+
+        let first_reader = super::try_lock_source_compile_sessions(
+            subjects.clone(),
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .expect("first reader owns one stable snapshot");
+        let second_reader = super::try_lock_source_compile_sessions(
+            subjects.clone(),
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .expect("readers may share the stable snapshot");
+        let error = super::try_lock_source_compile_sessions(
+            subjects.clone(),
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("writer cannot truncate while either reader is preparing");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(first_reader);
+        let error = super::try_lock_source_compile_sessions(
+            subjects.clone(),
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("second reader still blocks the writer");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(second_reader);
+        let retry = super::try_lock_source_compile_sessions(
+            subjects,
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("ownership transfers only after every reader drops");
+        drop(retry);
+
+        // Acquisition is canonical, sorted, and failure-atomic. `00-free`
+        // sorts before the independently held `99-busy`; when the set loses
+        // at the latter, its earlier lock is released immediately.
+        let free = root.join("00-free");
+        let busy = root.join("99-busy");
+        let busy_owner = super::try_lock_source_compile_sessions(
+            [busy.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("hold later-sorted subject");
+        let error = super::try_lock_source_compile_sessions(
+            [busy.clone(), free.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("multi-lock loser refuses without waiting");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        let free_owner = super::try_lock_source_compile_sessions(
+            [free],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("failed set released its earlier partial acquisition");
+        drop(free_owner);
+        drop(busy_owner);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_and_shared_external_compile_sinks_have_exact_winner_loser_ownership() {
+        let root = attention_provenance_test_dir("legacy-external-session-sinks");
+        let compiled = root.join("compiled");
+        let legacy_cover = root.join("legacy/graph-cover");
+        let legacy_graph = root.join("legacy/graph");
+        std::fs::create_dir_all(&legacy_cover).expect("legacy cover output");
+        std::fs::create_dir_all(&legacy_graph).expect("legacy graph output");
+        let cover_sentinel = legacy_cover.join("cover.r4g1");
+        let graph_sentinel = legacy_graph.join("score.r4g1");
+        std::fs::write(&cover_sentinel, b"winner cover").expect("cover sentinel");
+        std::fs::write(&graph_sentinel, b"winner graph").expect("graph sentinel");
+        let legacy_subjects = vec![compiled.clone(), legacy_cover.clone(), legacy_graph.clone()];
+        let legacy_winner = super::try_lock_source_compile_sessions(
+            legacy_subjects.clone(),
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("first configured-legacy compiler owns all outputs");
+        let error = super::try_lock_source_compile_sessions(
+            legacy_subjects.clone(),
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("second no-source compiler refuses before truncation");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert_eq!(
+            std::fs::read(&cover_sentinel).expect("cover after loser"),
+            b"winner cover"
+        );
+        assert_eq!(
+            std::fs::read(&graph_sentinel).expect("graph after loser"),
+            b"winner graph"
+        );
+        drop(legacy_winner);
+        let retry = super::try_lock_source_compile_sessions(
+            legacy_subjects,
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("legacy retry owns outputs after winner release");
+        drop(retry);
+
+        // Distinct source identities can still alias one configured external
+        // score sink. Even without relying on the managed namespace subject,
+        // the exact external output key elects only one writer and a losing
+        // partial acquisition is rolled back.
+        let source_a = root.join("source-a");
+        let source_b = root.join("source-b");
+        let shared_external = root.join("shared-external-graph");
+        let source_a_winner = super::try_lock_source_compile_sessions(
+            [source_a.clone(), shared_external.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("source A owns shared external sink");
+        let error = super::try_lock_source_compile_sessions(
+            [source_b.clone(), shared_external.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("source B cannot alias source A's sink");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        let source_b_independent = super::try_lock_source_compile_sessions(
+            [source_b],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("losing multi-sink attempt released source B's own subject");
+        drop(source_b_independent);
+        drop(source_a_winner);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_compile_selection_refresh_refuses_post_selection_inventory_change() {
+        let root = attention_provenance_test_dir("legacy-selection-refresh");
+        let first = root.join("compiled/alpha");
+        let second = root.join("compiled/beta");
+        let selected = (
+            first.join("corpus.meta"),
+            first.join("corpus.records"),
+            first.join("graph-cover"),
+            first.join("graph"),
+        );
+        let refreshed = (
+            second.join("corpus.meta"),
+            second.join("corpus.records"),
+            second.join("graph-cover"),
+            second.join("graph"),
+        );
+        std::fs::create_dir_all(selected.3.clone()).expect("selected graph output");
+        let sentinel = selected.3.join("sentinel");
+        std::fs::write(&sentinel, b"unchanged").expect("selected sentinel");
+        let error = super::require_unchanged_legacy_compile_paths(&selected, &refreshed)
+            .expect_err("a publisher changed discovery before lock acquisition");
+        assert!(error.contains("changed while acquiring"), "{error}");
+        assert_eq!(
+            std::fs::read(&sentinel).expect("sentinel after refusal"),
+            b"unchanged"
+        );
+        super::require_unchanged_legacy_compile_paths(&selected, &selected)
+            .expect("exact post-lock refresh is stable");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_compile_session_sets_canonicalize_aliases_once() {
+        use std::os::unix::fs::symlink;
+
+        let root = attention_provenance_test_dir("source-compile-session-alias");
+        let real = root.join("real-sink");
+        let alias = root.join("alias-sink");
+        std::fs::create_dir_all(&real).expect("real external sink parent");
+        symlink(&real, &alias).expect("external sink alias");
+        let real_graph = real.join("graph");
+        let alias_graph = alias.join("graph");
+
+        let writer = super::try_lock_source_compile_sessions(
+            [real_graph.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("real spelling owns absent graph child");
+        let error = super::try_lock_source_compile_sessions(
+            [alias_graph.clone()],
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .err()
+        .expect("alias reader resolves to the same canonical subject");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(writer);
+        let reader = super::try_lock_source_compile_sessions(
+            [alias_graph],
+            super::SourceCompileSessionMode::SharedReader,
+        )
+        .expect("alias succeeds after owner release");
+        let error = super::try_lock_source_compile_sessions(
+            [real_graph],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("canonical reader blocks the real-spelling writer");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(reader);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn busy_bundle_readers_preserve_serving_markers_until_install_finishes() {
+        let root = attention_provenance_test_dir("source-compile-reader-state");
+        let compiled = root.join("compiled");
+        let output = compiled.join("teacher");
+        let writer = super::try_lock_source_compile_sessions(
+            [compiled.clone(), output.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("publisher owns managed bundle");
+
+        let mut serving = super::ServingModelState {
+            epoch: 41,
+            terminal_load_error: Some("prior terminal marker".to_owned()),
+            last_operation_error: Some("prior operation marker".to_owned()),
+            ..Default::default()
+        };
+        let error = super::try_lock_managed_inventory_read_sessions(&compiled, [output.clone()])
+            .err()
+            .expect("startup/reload reader returns BUSY before disk inspection");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert_eq!(serving.epoch, 41);
+        assert_eq!(
+            serving.terminal_load_error.as_deref(),
+            Some("prior terminal marker")
+        );
+        assert_eq!(
+            serving.last_operation_error.as_deref(),
+            Some("prior operation marker")
+        );
+        drop(writer);
+
+        let reader = super::try_lock_managed_inventory_read_sessions(&compiled, [output.clone()])
+            .expect("reader captures stable publication snapshot");
+        let error = super::try_lock_source_compile_sessions(
+            [compiled.clone(), output.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("writer remains blocked immediately before simulated install");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        serving.epoch += 1;
+        serving.last_operation_error = None;
+        let error = super::try_lock_source_compile_sessions(
+            [compiled.clone(), output.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .err()
+        .expect("atomic in-memory install does not prematurely release reader");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        drop(reader);
+        let retry = super::try_lock_source_compile_sessions(
+            [compiled, output],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("next publisher starts only after install releases reader");
+        drop(retry);
+        assert_eq!(serving.epoch, 42);
+        assert_eq!(
+            serving.terminal_load_error.as_deref(),
+            Some("prior terminal marker")
+        );
+        assert_eq!(serving.last_operation_error, None);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn exclusive_session_recovers_only_reserved_regular_torn_identity_temps() {
+        let root = attention_provenance_test_dir("source-compile-torn-temps");
+        let output = root.join("compiled/teacher");
+        let kappa = format!("blake3:{}", "d".repeat(64));
+        let session = super::try_lock_source_compile_session(&output)
+            .expect("test owns output recovery session");
+        super::preflight_and_bind_source_snapshot_kappa(&output, Some(&kappa))
+            .expect("publish stable P and K records");
+        let preflight_before =
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE)).expect("stable P");
+        let kappa_before = std::fs::read(output.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+            .expect("stable K");
+
+        for (index, sidecar) in [
+            super::SOURCE_COMPILE_PREFLIGHT_FILE,
+            super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+            "tokenizer_adapter.json",
+            uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let empty = output.join(format!(".{sidecar}.700.{index}.tmp"));
+            let truncated = output.join(format!(".{sidecar}.701.{index}.tmp"));
+            std::fs::write(&empty, b"").expect("zero-byte torn create");
+            std::fs::write(&truncated, b"{\"prefix\":").expect("mid-write crash prefix");
+        }
+        super::recover_source_compile_identity_temporaries(&output)
+            .expect("exclusive owner reclaims strict reserved temp names");
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("stable P after recovery"),
+            preflight_before
+        );
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+                .expect("stable K after recovery"),
+            kappa_before
+        );
+        assert!(std::fs::read_dir(&output)
+            .expect("enumerate recovered root")
+            .all(|entry| !entry
+                .expect("entry")
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")));
+
+        let unknown = output.join(".tokenizer_adapter.json.owner.tmp");
+        std::fs::write(&unknown, b"").expect("unknown temp spelling");
+        let error = super::recover_source_compile_identity_temporaries(&output)
+            .expect_err("unknown lookalike is never reclaimed");
+        assert!(error.contains("unrecognized or non-owned"), "{error}");
+        assert!(unknown.is_file());
+        drop(session);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exclusive_session_never_recovers_symlink_or_fifo_identity_temps() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+
+        fn fifo(path: &std::path::Path) {
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+                .expect("fixture path has no NUL");
+            // SAFETY: the C string is live and mkfifo does not retain it.
+            assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        }
+
+        for kind in ["symlink", "fifo"] {
+            let root = attention_provenance_test_dir(&format!("torn-temp-{kind}"));
+            let output = root.join("compiled/teacher");
+            std::fs::create_dir_all(&output).expect("output root");
+            let session = super::try_lock_source_compile_session(&output)
+                .expect("test owns recovery session");
+            let temporary = output.join(".source_compile_preflight.json.800.1.tmp");
+            match kind {
+                "symlink" => symlink(root.join("missing"), &temporary).expect("dangling temp"),
+                "fifo" => fifo(&temporary),
+                _ => unreachable!(),
+            }
+            let error = super::recover_source_compile_identity_temporaries(&output)
+                .expect_err("special entry is terminal and nonblocking");
+            assert!(error.contains("not a regular non-symlink file"), "{error}");
+            assert!(std::fs::symlink_metadata(&temporary).is_ok());
+            drop(session);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn existing_graph_publication_is_immutable_under_refresh_failure() {
+        let root = attention_provenance_test_dir("immutable-graph-refresh");
+        let graph = root.join("bundle/graph/score.r4g1");
+        let cover = root.join("bundle/graph-cover/cover.r4g1");
+        let score_report = root.join("bundle/graph/score_report.json");
+        std::fs::create_dir_all(graph.parent().expect("graph parent")).expect("graph parent");
+        std::fs::create_dir_all(cover.parent().expect("cover parent")).expect("cover parent");
+        std::fs::write(&graph, b"last-good graph").expect("graph bytes");
+        std::fs::write(&cover, b"last-good cover").expect("cover bytes");
+        std::fs::write(&score_report, b"last-good report").expect("report bytes");
+        let before = [
+            std::fs::read(&graph).expect("graph before"),
+            std::fs::read(&cover).expect("cover before"),
+            std::fs::read(&score_report).expect("report before"),
+        ];
+
+        let reuse = super::immutable_graph_artifact_present(&graph)
+            .expect("existing graph selects immutable idempotent branch");
+        let mut writer_calls = 0usize;
+        super::run_graph_writer_if_incomplete(reuse, || {
+            writer_calls += 1;
+            std::fs::write(&cover, b"truncated").expect("simulated cover writer");
+            std::fs::write(&graph, b"truncated").expect("simulated score writer");
+            Err("injected writer failure".to_owned())
+        })
+        .expect("immutable branch suppresses the failing writer");
+        assert_eq!(
+            writer_calls, 0,
+            "stable outputs are never reopened by refresh"
+        );
+        assert_eq!(std::fs::read(&graph).expect("graph after"), before[0]);
+        assert_eq!(std::fs::read(&cover).expect("cover after"), before[1]);
+        assert_eq!(
+            std::fs::read(&score_report).expect("report after"),
+            before[2]
+        );
+
+        std::fs::remove_file(&graph).expect("model incomplete graph-absent case");
+        assert!(!super::immutable_graph_artifact_present(&graph)
+            .expect("only graph absence authorizes incomplete build"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn write_completion_fixture(root: &std::path::Path, tag: &[u8]) {
+        std::fs::create_dir_all(root.join("graph-cover")).expect("cover directory");
+        std::fs::create_dir_all(root.join("graph")).expect("graph directory");
+        for file in [
+            "corpus.meta",
+            "corpus.records",
+            "tless_artifacts.bin",
+            "tokenizer.bin",
+            "tokenizer_adapter.json",
+            uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+            super::SOURCE_COMPILE_PREFLIGHT_FILE,
+            super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        ] {
+            std::fs::write(root.join(file), tag).expect("bundle fixture member");
+        }
+        for file in [
+            "graph-cover/cover.r4g1",
+            "graph-cover/cover_report.json",
+            "graph/score.r4g1",
+            "graph/score_report.json",
+        ] {
+            std::fs::write(root.join(file), tag).expect("graph fixture member");
+        }
+    }
+
+    #[test]
+    fn completed_bundle_stage_atomically_replaces_last_good_and_failure_preserves_it() {
+        let root = attention_provenance_test_dir("completed-bundle-stage");
+        let output = root.join("compiled/model");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        write_completion_fixture(&output, b"old");
+        super::publish_compiled_bundle_completion(&output).expect("bootstrap old completion");
+        let old_graph = std::fs::read(output.join("graph/score.r4g1")).expect("old graph");
+        let old_corpus = std::fs::read(output.join("corpus.records")).expect("old corpus");
+
+        let failed_path = {
+            let failed =
+                super::CompiledBundleStage::allocate(&output, &source_kappa).expect("failed stage");
+            std::fs::create_dir_all(failed.path.join("graph")).expect("partial graph directory");
+            std::fs::write(failed.path.join("graph/score.r4g1"), b"partial")
+                .expect("partial score residue");
+            std::fs::write(failed.path.join("corpus.records"), b"advanced")
+                .expect("resumable corpus progress");
+            let error = super::publish_compiled_bundle_completion(&failed.path)
+                .expect_err("missing report/cover cannot complete");
+            assert!(error.contains("incomplete"), "{error}");
+            failed.path.clone()
+        };
+        assert!(failed_path.exists(), "incomplete stage remains resumable");
+        assert_eq!(
+            std::fs::read(output.join("graph/score.r4g1")).expect("old graph preserved"),
+            old_graph
+        );
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("old corpus preserved"),
+            old_corpus
+        );
+
+        let mut replacement = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect("replacement stage");
+        assert_eq!(replacement.path, failed_path, "retry adopts exact stage");
+        assert_eq!(
+            std::fs::read(replacement.path.join("corpus.records")).expect("resumed corpus"),
+            b"advanced"
+        );
+        assert!(
+            !replacement.path.join("graph").exists(),
+            "derived partial graph is rebuilt, not adopted"
+        );
+        write_completion_fixture(&replacement.path, b"new");
+        super::publish_compiled_bundle_completion(&replacement.path)
+            .expect("durable replacement completion");
+        replacement.publish().expect("atomic directory exchange");
+        assert_eq!(
+            std::fs::read(output.join("graph/score.r4g1")).expect("new graph"),
+            b"new"
+        );
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("advanced corpus"),
+            b"new"
+        );
+        super::validate_compiled_bundle_completion(&output)
+            .expect("new completion validates")
+            .expect("completion present");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_bundle_stage_refuses_cross_snapshot_adoption_without_mutation() {
+        let root = attention_provenance_test_dir("compiled-stage-snapshot-conflict");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"old");
+        let first_kappa = format!("blake3:{}", "1".repeat(64));
+        let second_kappa = format!("blake3:{}", "2".repeat(64));
+        let stage = super::CompiledBundleStage::allocate(&output, &first_kappa)
+            .expect("first snapshot stage");
+        std::fs::create_dir_all(stage.path.join("graph")).expect("partial graph directory");
+        std::fs::write(
+            stage.path.join("graph/score.r4g1"),
+            b"first-snapshot-partial",
+        )
+        .expect("partial graph");
+        let stage_path = stage.path.clone();
+        drop(stage);
+
+        let error = super::CompiledBundleStage::allocate(&output, &second_kappa)
+            .expect_err("different snapshot cannot adopt stage");
+        assert!(error.contains("does not bind this exact"), "{error}");
+        assert_eq!(
+            std::fs::read(stage_path.join("graph/score.r4g1"))
+                .expect("conflicting stage is untouched"),
+            b"first-snapshot-partial"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_bundle_stage_recovers_only_exact_regular_publisher_temporaries() {
+        let root = attention_provenance_test_dir("compiled-stage-publisher-temporaries");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"old");
+        let source_kappa = format!("blake3:{}", "3".repeat(64));
+        let stage =
+            super::CompiledBundleStage::allocate(&output, &source_kappa).expect("resumable stage");
+        let stage_path = stage.path.clone();
+        drop(stage);
+        let marker_temp = stage_path.join(format!(
+            ".{}.71.1.tmp",
+            super::COMPILED_BUNDLE_STAGE_MARKER_FILE
+        ));
+        let completion_temp = stage_path.join(format!(
+            ".{}.71.2.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&marker_temp, b"").expect("pre-write marker crash");
+        std::fs::write(&completion_temp, b"{\n").expect("mid-write completion crash");
+
+        let recovered = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect("exact regular residue recovers");
+        assert_eq!(recovered.path, stage_path);
+        assert!(!marker_temp.exists());
+        assert!(!completion_temp.exists());
+        drop(recovered);
+
+        let unknown = stage_path.join(format!(
+            ".{}.owner.9.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&unknown, b"unknown").expect("unknown lookalike");
+        let error = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect_err("unknown publisher residue is terminal");
+        assert!(
+            error.contains("unrecognized publisher temporary"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(&unknown).expect("unknown residue remains untouched"),
+            b"unknown"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compiled_bundle_stage_refuses_special_publisher_temporary_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let root = attention_provenance_test_dir("compiled-stage-special-temporary");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"old");
+        let source_kappa = format!("blake3:{}", "4".repeat(64));
+        let stage =
+            super::CompiledBundleStage::allocate(&output, &source_kappa).expect("resumable stage");
+        let stage_path = stage.path.clone();
+        drop(stage);
+        let temporary = stage_path.join(format!(
+            ".{}.72.1.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        symlink(root.join("missing"), &temporary).expect("dangling publisher temporary");
+        let error = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect_err("special publisher residue is terminal");
+        assert!(error.contains("not a regular non-symlink file"), "{error}");
+        assert!(std::fs::symlink_metadata(&temporary).is_ok());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn post_exchange_stage_marker_crash_state_keeps_new_generation_loadable() {
+        let root = attention_provenance_test_dir("compiled-stage-post-exchange-marker");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"old");
+        super::publish_compiled_bundle_completion(&output).expect("old completion");
+        let source_kappa = format!("blake3:{}", "5".repeat(64));
+        let stage = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect("replacement stage");
+        write_completion_fixture(&stage.path, b"new");
+        super::publish_compiled_bundle_completion(&stage.path).expect("new completion");
+
+        super::exchange_directories(&stage.path, &output).expect("simulate committed exchange");
+        stage
+            .sync_publication_parents("simulated post-exchange crash")
+            .expect("both parents durable");
+        assert!(
+            output
+                .join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE)
+                .is_file(),
+            "crash point retains marker in the published generation"
+        );
+        super::validate_compiled_bundle_completion(&output)
+            .expect("published completion validates")
+            .expect("published completion present");
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("new corpus"),
+            b"new"
+        );
+
+        let retry = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect("next owner reclaims exchanged old generation");
+        assert_ne!(retry.path, stage.path);
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("published corpus unchanged"),
+            b"new"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn public_completion_hard_link_residue_recovers_before_validation() {
+        let root = attention_provenance_test_dir("public-completion-hard-link-residue");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"stable");
+        super::publish_compiled_bundle_completion(&output).expect("publish stable completion");
+        let stable = output.join(super::COMPILED_BUNDLE_COMPLETION_FILE);
+        let temporary = output.join(format!(
+            ".{}.91.7.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::hard_link(&stable, &temporary)
+            .expect("simulate crash after stable hard link before temp unlink");
+
+        let strict_error = super::validate_compiled_bundle_completion(&output)
+            .expect_err("raw member hashing sees the unrecovered residue");
+        assert!(strict_error.contains("changed after"), "{strict_error}");
+        super::recover_managed_compiled_bundle_completion_temporaries(&root.join("compiled"))
+            .expect("startup/reload inventory owner reclaims exact linked residue");
+        assert!(!temporary.exists());
+        super::validate_compiled_bundle_completion(&output)
+            .expect("completion validates after recovery")
+            .expect("completion remains present");
+
+        let tampered = output.join(format!(
+            ".{}.92.8.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&tampered, b"not the committed completion")
+            .expect("write conflicting exact-name residue");
+        let error = super::recover_compiled_bundle_completion_temporaries(&output)
+            .expect_err("conflicting regular residue is terminal");
+        assert!(error.contains("conflicting"), "{error}");
+        assert_eq!(
+            std::fs::read(&tampered).expect("tampered residue remains"),
+            b"not the committed completion"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            std::fs::remove_file(&tampered).expect("remove regular conflict fixture");
+            symlink(&stable, &tampered).expect("exact-byte symlink residue");
+            let error = super::recover_compiled_bundle_completion_temporaries(&output)
+                .expect_err("symlink residue is terminal without following");
+            assert!(error.contains("not a regular non-symlink"), "{error}");
+            assert!(std::fs::symlink_metadata(&tampered).is_ok());
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_refresh_refuses_tampered_authoritative_completion_before_copy() {
+        let root = attention_provenance_test_dir("authoritative-completion-before-copy");
+        let output = root.join("compiled/model");
+        let source_kappa = format!("blake3:{}", "6".repeat(64));
+        write_completion_fixture(&output, b"M1");
+        super::publish_compiled_bundle_completion(&output).expect("publish M1 completion");
+        let completion_before = std::fs::read(output.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("completion before tamper");
+        std::fs::write(output.join("corpus.records"), b"M2 structurally valid rows")
+            .expect("tamper authoritative corpus bytes");
+        let corpus_after_tamper =
+            std::fs::read(output.join("corpus.records")).expect("tampered corpus");
+
+        let error = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect_err("refresh cannot copy and recertify a tampered completion");
+        assert!(error.contains("changed after"), "{error}");
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("corpus after refusal"),
+            corpus_after_tamper
+        );
+        assert_eq!(
+            std::fs::read(output.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                .expect("completion after refusal"),
+            completion_before
+        );
+        let staging = super::source_compile_staging_root(output.parent().expect("output parent"));
+        assert!(
+            !staging.exists(),
+            "authoritative validation precedes refresh-stage allocation"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn minimal_r4g1_bytes() -> Vec<u8> {
+        let mut head = [0u8; uor_r4_graph_format::HEAD_PAYLOAD_LEN];
+        head[184..186].copy_from_slice(&8u16.to_le_bytes());
+        head[204] = 1;
+        head[212..214].copy_from_slice(&64u16.to_le_bytes());
+        let mut builder = uor_r4_graph_format::ArtifactBuilder::new(6);
+        builder.add_section(uor_r4_graph_format::SectionId::HEAD, 0, &head);
+        builder.build().expect("minimal R4G1 fixture")
+    }
+
+    fn write_valid_graph_output(output: &std::path::Path, kind: super::GraphOutputKind, tag: &str) {
+        std::fs::create_dir_all(output).expect("graph output directory");
+        let (artifact, report) = kind.files();
+        std::fs::write(output.join(artifact), minimal_r4g1_bytes()).expect("graph artifact");
+        std::fs::write(
+            output.join(report),
+            serde_json::to_vec(&serde_json::json!({ "tag": tag })).expect("graph report"),
+        )
+        .expect("graph report bytes");
+    }
+
+    fn legacy_test_identity(
+        cover: &std::path::Path,
+        graph: &std::path::Path,
+        input_tag: &str,
+    ) -> super::LegacyGraphGenerationIdentity {
+        super::LegacyGraphGenerationIdentity {
+            cover_output: super::canonical_path_text(cover, "test cover").expect("cover path"),
+            graph_output: super::canonical_path_text(graph, "test graph").expect("graph path"),
+            input_files: std::collections::BTreeMap::new(),
+            cover_controls_kappa: super::bytes_kappa(input_tag.as_bytes()),
+            score_controls_kappa: format!("blake3:{}", "b".repeat(64)),
+        }
+    }
+
+    #[test]
+    fn legacy_owned_cover_only_crash_resumes_score_but_arbitrary_pair_is_terminal() {
+        let root = attention_provenance_test_dir("legacy-owned-one-sided-resume");
+        let cover = root.join("bundle/graph-cover");
+        let graph = root.join("bundle/graph");
+        write_valid_graph_output(&cover, super::GraphOutputKind::Cover, "owned cover");
+        let identity = legacy_test_identity(&cover, &graph, "input-v1");
+
+        let error = super::legacy_graph_generation_action(&identity)
+            .expect_err("unmarked one-sided state is arbitrary and terminal");
+        assert!(error.contains("without an exact server attempt"), "{error}");
+        let paths = super::legacy_graph_record_paths(&identity).expect("record paths");
+        let attempt = super::legacy_graph_attempt_bytes(&identity).expect("attempt bytes");
+        super::ensure_legacy_graph_attempt(&paths.attempt, &attempt)
+            .expect("durable attempt predates cover publication");
+        let serving_error =
+            super::validate_legacy_graph_generation_for_serving(&graph.join("score.r4g1"))
+                .expect_err("startup/reload cannot observe the one-sided attempt");
+        assert!(serving_error.contains("incomplete"), "{serving_error}");
+        assert_eq!(
+            super::legacy_graph_generation_action(&identity)
+                .expect("owned one-sided state classifies")
+                .0,
+            super::LegacyGraphGenerationAction::ResumeScore
+        );
+
+        let args = vec!["--out".to_owned(), graph.display().to_string()];
+        let score_stage = super::build_graph_writer_stage(
+            &graph,
+            super::GraphOutputKind::Score,
+            &args,
+            |staged| {
+                write_valid_graph_output(
+                    std::path::Path::new(&staged[1]),
+                    super::GraphOutputKind::Score,
+                    "resumed score",
+                );
+                Ok(())
+            },
+        )
+        .expect("stage resumed score");
+        super::publish_legacy_graph_score_resume(
+            score_stage,
+            &cover,
+            &graph,
+            &paths,
+            &attempt,
+            &identity,
+        )
+        .expect("publish score and exact completion");
+        assert!(!paths.attempt.exists());
+        assert_eq!(
+            super::legacy_graph_generation_action(&identity)
+                .expect("completed generation reuses")
+                .0,
+            super::LegacyGraphGenerationAction::Reuse
+        );
+        super::ensure_legacy_graph_attempt(&paths.attempt, &attempt)
+            .expect("simulate crash after completion commit before attempt cleanup");
+        super::validate_legacy_graph_generation_for_serving(&graph.join("score.r4g1"))
+            .expect("completed pair reclaims its redundant exact attempt");
+        assert!(!paths.attempt.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_generation_identity_refreshes_changed_inputs_and_rolls_back_failure() {
+        let root = attention_provenance_test_dir("legacy-input-bound-generation");
+        let bundle = root.join("bundle");
+        let cover = bundle.join("graph-cover");
+        let graph = bundle.join("graph");
+        let artifacts = bundle.join("tless_artifacts.bin");
+        let corpus_meta = bundle.join("corpus.meta");
+        let corpus_records = bundle.join("corpus.records");
+        let tokenizer = bundle.join("tokenizer.bin");
+        std::fs::create_dir_all(&bundle).expect("legacy input bundle");
+        std::fs::write(&artifacts, b"stable transformerless artifact").expect("artifact");
+        std::fs::write(&corpus_meta, b"structurally valid metadata").expect("metadata");
+        std::fs::write(&corpus_records, b"structurally valid corpus generation one")
+            .expect("generation-one records");
+        std::fs::write(&tokenizer, b"stable tokenizer").expect("tokenizer");
+        let cover_args = vec![
+            "--corpus-meta".to_owned(),
+            corpus_meta.display().to_string(),
+            "--out".to_owned(),
+            cover.display().to_string(),
+        ];
+        let score_args = vec![
+            "--corpus-recs".to_owned(),
+            corpus_records.display().to_string(),
+            "--out".to_owned(),
+            graph.display().to_string(),
+        ];
+        write_valid_graph_output(&cover, super::GraphOutputKind::Cover, "old cover");
+        write_valid_graph_output(&graph, super::GraphOutputKind::Score, "old score");
+        let old_identity =
+            super::capture_legacy_graph_generation_identity(super::LegacyGraphGenerationInputs {
+                artifacts: &artifacts,
+                corpus_meta: &corpus_meta,
+                corpus_recs: &corpus_records,
+                tokenizer: &tokenizer,
+                cover_output: &cover,
+                graph_output: &graph,
+                cover_args: &cover_args,
+                score_args: &score_args,
+            })
+            .expect("capture generation-one inputs");
+        let paths = super::legacy_graph_record_paths(&old_identity).expect("record paths");
+        let old_completion = super::LegacyGraphGenerationCompletion {
+            schema: super::LEGACY_GRAPH_GENERATION_SCHEMA.to_owned(),
+            identity: old_identity.clone(),
+            output_files: super::legacy_graph_output_file_kappas(&cover, &graph)
+                .expect("old output digests"),
+        };
+        super::replace_bytes_atomically(
+            &paths.completion,
+            &super::legacy_graph_completion_bytes(&old_completion).expect("old completion bytes"),
+            "test legacy completion",
+        )
+        .expect("publish old completion");
+        assert_eq!(
+            super::legacy_graph_generation_action(&old_identity)
+                .expect("unchanged inputs reuse")
+                .0,
+            super::LegacyGraphGenerationAction::Reuse
+        );
+
+        std::fs::write(&corpus_records, b"structurally valid corpus generation two")
+            .expect("replace corpus pair with generation two");
+        let new_identity =
+            super::capture_legacy_graph_generation_identity(super::LegacyGraphGenerationInputs {
+                artifacts: &artifacts,
+                corpus_meta: &corpus_meta,
+                corpus_recs: &corpus_records,
+                tokenizer: &tokenizer,
+                cover_output: &cover,
+                graph_output: &graph,
+                cover_args: &cover_args,
+                score_args: &score_args,
+            })
+            .expect("capture generation-two inputs");
+        assert_ne!(old_identity, new_identity);
+        let (action, new_paths, attempt) = super::legacy_graph_generation_action(&new_identity)
+            .expect("changed input schedules replacement");
+        assert_eq!(action, super::LegacyGraphGenerationAction::BuildBoth);
+        super::ensure_legacy_graph_attempt(&new_paths.attempt, &attempt)
+            .expect("publish replacement attempt");
+        let cover_before = std::fs::read(cover.join("cover_report.json")).expect("old cover");
+        let score_before = std::fs::read(graph.join("score_report.json")).expect("old score");
+
+        let build = |output: &std::path::Path, kind: super::GraphOutputKind, tag: &'static str| {
+            let args = vec!["--out".to_owned(), output.display().to_string()];
+            super::build_graph_writer_stage(output, kind, &args, |staged| {
+                write_valid_graph_output(std::path::Path::new(&staged[1]), kind, tag);
+                Ok(())
+            })
+            .expect("build replacement stage")
+        };
+        let cover_stage = build(&cover, super::GraphOutputKind::Cover, "new cover");
+        let score_stage = build(&graph, super::GraphOutputKind::Score, "new score");
+        let mut wrong_outputs = super::staged_legacy_graph_output_kappas(
+            &cover_stage.path,
+            &score_stage.path,
+            &cover,
+            &graph,
+        )
+        .expect("new output digests");
+        *wrong_outputs.values_mut().next().expect("one digest") =
+            format!("blake3:{}", "0".repeat(64));
+        let wrong_completion = super::LegacyGraphGenerationCompletion {
+            schema: super::LEGACY_GRAPH_GENERATION_SCHEMA.to_owned(),
+            identity: new_identity.clone(),
+            output_files: wrong_outputs,
+        };
+        let error = super::publish_legacy_graph_generation_pair(
+            cover_stage,
+            score_stage,
+            &cover,
+            &graph,
+            &new_paths,
+            &attempt,
+            &wrong_completion,
+        )
+        .expect_err("pre-commit mismatch rolls both outputs back");
+        assert!(error.contains("differs from its staged digest"), "{error}");
+        assert_eq!(
+            std::fs::read(cover.join("cover_report.json")).expect("cover after rollback"),
+            cover_before
+        );
+        assert_eq!(
+            std::fs::read(graph.join("score_report.json")).expect("score after rollback"),
+            score_before
+        );
+
+        let cover_stage = build(&cover, super::GraphOutputKind::Cover, "new cover");
+        let score_stage = build(&graph, super::GraphOutputKind::Score, "new score");
+        let completion = super::LegacyGraphGenerationCompletion {
+            schema: super::LEGACY_GRAPH_GENERATION_SCHEMA.to_owned(),
+            identity: new_identity.clone(),
+            output_files: super::staged_legacy_graph_output_kappas(
+                &cover_stage.path,
+                &score_stage.path,
+                &cover,
+                &graph,
+            )
+            .expect("exact replacement digests"),
+        };
+        super::publish_legacy_graph_generation_pair(
+            cover_stage,
+            score_stage,
+            &cover,
+            &graph,
+            &new_paths,
+            &attempt,
+            &completion,
+        )
+        .expect("atomic replacement commits");
+        assert_ne!(
+            std::fs::read(cover.join("cover_report.json")).expect("new cover"),
+            cover_before
+        );
+        assert_ne!(
+            std::fs::read(graph.join("score_report.json")).expect("new score"),
+            score_before
+        );
+        assert_eq!(
+            super::legacy_graph_generation_action(&new_identity)
+                .expect("new identity now reuses")
+                .0,
+            super::LegacyGraphGenerationAction::Reuse
+        );
+        super::validate_legacy_graph_generation_for_serving(&graph.join("score.r4g1"))
+            .expect("replacement completion binds current inputs");
+        std::fs::write(&corpus_records, b"third uncompiled corpus generation")
+            .expect("mutate bound input after completion");
+        let error = super::validate_legacy_graph_generation_for_serving(&graph.join("score.r4g1"))
+            .expect_err("startup/reload rejects stale graph after input drift");
+        assert!(error.contains("input"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn fresh_graph_output_uses_staging_and_retry_never_observes_partial_final() {
+        let root = attention_provenance_test_dir("fresh-graph-staging");
+        let final_output = root.join("graph");
+        let args = vec!["--out".to_owned(), final_output.display().to_string()];
+        let error = super::run_graph_writer_staged(
+            &final_output,
+            super::GraphOutputKind::Score,
+            &args,
+            |staged| {
+                let output = std::path::Path::new(&staged[1]);
+                std::fs::write(output.join("score.r4g1"), minimal_r4g1_bytes())
+                    .expect("partial staged graph");
+                Err("injected short-write failure".to_owned())
+            },
+        )
+        .expect_err("failed stage is not published");
+        assert!(error.contains("injected"), "{error}");
+        assert!(!final_output.exists());
+
+        super::run_graph_writer_staged(
+            &final_output,
+            super::GraphOutputKind::Score,
+            &args,
+            |staged| {
+                let output = std::path::Path::new(&staged[1]);
+                std::fs::write(output.join("score.r4g1"), minimal_r4g1_bytes())
+                    .expect("staged score");
+                std::fs::write(output.join("score_report.json"), b"{}").expect("staged report");
+                Ok(())
+            },
+        )
+        .expect("retry atomically publishes the complete pair");
+        assert!(final_output.join("score.r4g1").is_file());
+        assert!(final_output.join("score_report.json").is_file());
+
+        let mut called = false;
+        super::run_graph_writer_staged(&final_output, super::GraphOutputKind::Score, &args, |_| {
+            called = true;
+            Err("must not rewrite complete generation".to_owned())
+        })
+        .expect("complete generation is immutable");
+        assert!(!called);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_compile_publishers_reject_symlink_directory_and_fifo_controls() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+
+        fn fifo(path: &std::path::Path) {
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+                .expect("fixture path has no NUL");
+            // SAFETY: the C string is live for the call and `mkfifo` does not
+            // retain its pointer.
+            let result = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+            assert_eq!(result, 0, "mkfifo: {}", std::io::Error::last_os_error());
+        }
+
+        let root = attention_provenance_test_dir("preflight-special-entries");
+        let compiled = root.join("compiled");
+        std::fs::create_dir_all(&compiled).expect("create compiled parent");
+        let kappa = format!("blake3:{}", "b".repeat(64));
+        let expected =
+            super::source_compile_preflight_bytes(Some(&kappa)).expect("canonical preflight");
+        let exact_target = root.join("exact.json");
+        std::fs::write(&exact_target, &expected).expect("write exact target");
+
+        // The generic no-clobber primitive checks entry type before reading,
+        // so even a FIFO cannot block and an exact-byte symlink is not an
+        // idempotent marker.
+        for kind in ["exact-symlink", "dangling-symlink", "directory", "fifo"] {
+            let path = root.join(kind);
+            match kind {
+                "exact-symlink" => symlink(&exact_target, &path).expect("exact symlink"),
+                "dangling-symlink" => {
+                    symlink(root.join("absent"), &path).expect("dangling symlink")
+                }
+                "directory" => std::fs::create_dir(&path).expect("marker directory"),
+                "fifo" => fifo(&path),
+                _ => unreachable!(),
+            }
+            let error = super::publish_bytes_no_clobber(&path, &expected, "test marker")
+                .expect_err("non-regular marker is terminal before read");
+            assert!(error.contains("non-symlink"), "{error}");
+        }
+
+        // Deterministically exercise the former lstat->read race. Hold an
+        // already-open regular handle, swap its path to a symlink or FIFO,
+        // then finish the production handle-based read. The post-read inode
+        // check refuses both swaps and the publisher's fresh open is
+        // non-following/nonblocking as well.
+        for kind in ["swap-symlink", "swap-fifo"] {
+            let path = root.join(kind);
+            let original = root.join(format!("{kind}.original"));
+            std::fs::write(&path, &expected).expect("write pre-swap regular marker");
+            let opened = super::open_regular_file_nofollow(&path, "test marker")
+                .expect("open regular marker")
+                .expect("marker exists");
+            std::fs::rename(&path, &original).expect("move opened inode away");
+            match kind {
+                "swap-symlink" => symlink(&original, &path).expect("swap exact symlink"),
+                "swap-fifo" => fifo(&path),
+                _ => unreachable!(),
+            }
+            let error = super::read_opened_regular_file_nofollow(opened, &path, "test marker")
+                .expect_err("path swap after open must be detected");
+            assert!(error.contains("changed identity"), "{error}");
+            let error = super::publish_bytes_no_clobber(&path, &expected, "test marker")
+                .expect_err("swapped special entry is never read or accepted");
+            assert!(error.contains("non-symlink"), "{error}");
+            assert_eq!(
+                std::fs::read(&original).expect("opened original bytes remain"),
+                expected
+            );
+        }
+
+        // Both the retired parent-init namespace and the stable in-root
+        // marker are strict controls. Presence never authorizes adoption and
+        // no staging/output bytes are created on refusal.
+        for kind in [
+            "regular",
+            "exact-symlink",
+            "dangling-symlink",
+            "directory",
+            "fifo",
+        ] {
+            let output = compiled.join(format!("init-{kind}"));
+            let init = super::source_compile_initialization_path(&output)
+                .expect("legacy initialization path");
+            match kind {
+                "regular" => std::fs::write(&init, &expected).expect("regular init"),
+                "exact-symlink" => symlink(&exact_target, &init).expect("exact init symlink"),
+                "dangling-symlink" => {
+                    symlink(root.join("missing-init"), &init).expect("dangling init symlink")
+                }
+                "directory" => std::fs::create_dir(&init).expect("init directory"),
+                "fifo" => fifo(&init),
+                _ => unreachable!(),
+            }
+            let error = super::publish_source_compile_preflight(&output, Some(&kappa))
+                .expect_err("legacy initialization cannot authorize publication");
+            assert!(error.contains("ambiguous"), "{error}");
+            assert!(!output.exists());
+        }
+
+        for kind in ["exact-symlink", "dangling-symlink", "directory", "fifo"] {
+            let output = compiled.join(format!("stable-{kind}"));
+            std::fs::create_dir(&output).expect("output root");
+            let marker = output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE);
+            match kind {
+                "exact-symlink" => symlink(&exact_target, &marker).expect("exact stable symlink"),
+                "dangling-symlink" => {
+                    symlink(root.join("missing-stable"), &marker).expect("dangling stable symlink")
+                }
+                "directory" => std::fs::create_dir(&marker).expect("stable directory"),
+                "fifo" => fifo(&marker),
+                _ => unreachable!(),
+            }
+            let error = super::publish_source_compile_preflight(&output, Some(&kappa))
+                .expect_err("invalid stable marker is terminal before read");
+            assert!(error.contains("non-symlink"), "{error}");
+            assert_eq!(
+                std::fs::read_dir(&output)
+                    .expect("enumerate refused output")
+                    .count(),
+                1
+            );
+        }
+
+        let symlink_root = compiled.join("root-symlink");
+        let target_root = root.join("target-root");
+        std::fs::create_dir(&target_root).expect("target root");
+        std::fs::write(
+            target_root.join(super::SOURCE_COMPILE_PREFLIGHT_FILE),
+            &expected,
+        )
+        .expect("target marker");
+        symlink(&target_root, &symlink_root).expect("root symlink");
+        let error = super::publish_source_compile_preflight(&symlink_root, Some(&kappa))
+            .expect_err("root symlink cannot expose target marker");
+        assert!(error.contains("non-symlink directory"), "{error}");
+
+        let staging = super::source_compile_staging_root(&compiled);
+        symlink(&target_root, &staging).expect("staging namespace symlink");
+        let output = compiled.join("staging-symlink");
+        let error = super::publish_source_compile_preflight(&output, Some(&kappa))
+            .expect_err("staging namespace symlink is terminal");
+        assert!(error.contains("staging namespace"), "{error}");
+        assert!(!output.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn identity_temporary_crash_windows_resume_only_canonical_exact_records() {
+        let root = attention_provenance_test_dir("preflight-temporary-crashes");
+        let compiled = root.join("compiled");
+        std::fs::create_dir_all(&compiled).expect("create compiled parent");
+        let kappa = format!("blake3:{}", "c".repeat(64));
+        let preflight =
+            super::source_compile_preflight_bytes(Some(&kappa)).expect("preflight bytes");
+        let binding =
+            super::source_manifest_kappa_binding_bytes(&kappa).expect("source binding bytes");
+
+        // Stable-preflight temp exists before its hard link.
+        let pre_before = compiled.join("pre-before-link");
+        std::fs::create_dir(&pre_before).expect("preflight temp root");
+        let pre_temp = pre_before.join(format!(
+            ".{}.100.1.tmp",
+            super::SOURCE_COMPILE_PREFLIGHT_FILE
+        ));
+        std::fs::write(&pre_temp, &preflight).expect("preflight temporary");
+        super::publish_source_compile_preflight(&pre_before, Some(&kappa))
+            .expect("canonical preflight temp resumes publication");
+        assert!(pre_before
+            .join(super::SOURCE_COMPILE_PREFLIGHT_FILE)
+            .is_file());
+        assert!(!super::source_compile_output_has_payload(&pre_before)
+            .expect("preflight temporary is identity, not corpus payload"));
+
+        // Stable link exists but process died before removing its temp.
+        let pre_after = compiled.join("pre-after-link");
+        super::publish_source_compile_preflight(&pre_after, Some(&kappa))
+            .expect("publish stable preflight");
+        std::fs::write(
+            pre_after.join(format!(
+                ".{}.100.2.tmp",
+                super::SOURCE_COMPILE_PREFLIGHT_FILE
+            )),
+            &preflight,
+        )
+        .expect("linked preflight temporary");
+        super::publish_source_compile_preflight(&pre_after, Some(&kappa))
+            .expect("linked preflight plus exact temp resumes");
+        assert!(!super::source_compile_output_has_payload(&pre_after)
+            .expect("linked preflight temp is ignored"));
+
+        // Source-κ temp exists before and after its hard link.
+        let k_before = compiled.join("k-before-link");
+        super::publish_source_compile_preflight(&k_before, Some(&kappa))
+            .expect("publish K-before root");
+        std::fs::write(
+            k_before.join(format!(
+                ".{}.101.1.tmp",
+                super::SOURCE_MANIFEST_KAPPA_BINDING_FILE
+            )),
+            &binding,
+        )
+        .expect("source K temporary before link");
+        super::preflight_and_bind_source_snapshot_kappa(&k_before, Some(&kappa))
+            .expect("K temporary before link is recoverable");
+        assert!(k_before
+            .join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE)
+            .is_file());
+        assert!(!super::source_compile_output_has_payload(&k_before)
+            .expect("K temp before link is ignored"));
+
+        let k_after = compiled.join("k-after-link");
+        super::preflight_and_bind_source_snapshot_kappa(&k_after, Some(&kappa))
+            .expect("publish K-after root");
+        std::fs::write(
+            k_after.join(format!(
+                ".{}.101.2.tmp",
+                super::SOURCE_MANIFEST_KAPPA_BINDING_FILE
+            )),
+            &binding,
+        )
+        .expect("source K temporary after link");
+        super::preflight_and_bind_source_snapshot_kappa(&k_after, Some(&kappa))
+            .expect("linked K plus exact temp resumes");
+        assert!(!super::source_compile_output_has_payload(&k_after)
+            .expect("K temp after link is ignored"));
+
+        // Tokenizer and attention publisher residues are identity-only when
+        // regular and registry-exact; a tampered or symlinked owned-shape temp
+        // is terminal rather than ignored.
+        let identity = compiled.join("identity-temps");
+        super::preflight_and_bind_source_snapshot_kappa(&identity, Some(&kappa))
+            .expect("identity temp root");
+        let scratch = root.join("identity-scratch");
+        std::fs::create_dir(&scratch).expect("identity scratch");
+        let tokenizer = write_tokenizer_adapter_binding(&scratch, "crash-temp");
+        let attention = write_attention_binding(
+            &scratch,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+        );
+        std::fs::write(
+            identity.join(".tokenizer_adapter.json.102.1.tmp"),
+            tokenizer,
+        )
+        .expect("tokenizer temp");
+        std::fs::write(
+            identity.join(format!(
+                ".{}.102.2.tmp",
+                uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+            )),
+            attention,
+        )
+        .expect("attention temp");
+        assert!(!super::source_compile_output_has_payload(&identity)
+            .expect("exact tokenizer/attention temps are identity-only"));
+
+        let tampered = identity.join(format!(
+            ".{}.103.1.tmp",
+            super::SOURCE_MANIFEST_KAPPA_BINDING_FILE
+        ));
+        std::fs::write(&tampered, b"{malformed").expect("tampered temp");
+        let error = super::source_compile_output_has_payload(&identity)
+            .expect_err("tampered owned-shape temporary is terminal");
+        assert!(error.contains("malformed"), "{error}");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            std::fs::remove_file(&tampered).expect("remove tampered temp");
+            symlink(
+                identity.join(super::SOURCE_COMPILE_PREFLIGHT_FILE),
+                &tampered,
+            )
+            .expect("symlink temp to an existing identity file");
+            let error = super::source_compile_output_has_payload(&identity)
+                .expect_err("symlinked owned-shape temporary is terminal");
+            assert!(error.contains("non-symlink"), "{error}");
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn manifestless_current_compile_resume_is_bound_to_verified_tree_kappa() {
+        let root = attention_provenance_test_dir("manifestless-tree-kappa-resume");
+        let source = root.join("source");
+        let output = root.join("compiled/teacher");
+        std::fs::create_dir_all(&source).expect("create manifestless source");
+        std::fs::write(source.join("config.json"), b"manifestless source M1")
+            .expect("write M1 source");
+        let m1 = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect("verify M1 tree");
+        super::preflight_and_bind_source_snapshot_kappa(&output, Some(&m1.content_kappa))
+            .expect("bind current-era Stage A to M1 tree");
+        std::fs::write(output.join("corpus.records"), b"M1 immutable corpus prefix")
+            .expect("simulate Stage-A crash after M1 rows");
+        let marker_before = std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+            .expect("M1 marker before replacement");
+        let binding_before = std::fs::read(output.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+            .expect("M1 binding before replacement");
+        let corpus_before = std::fs::read(output.join("corpus.records")).expect("M1 corpus");
+
+        std::fs::write(source.join("config.json"), b"manifestless source M2")
+            .expect("replace source with M2");
+        let m2 = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect("verify M2 tree");
+        assert_ne!(m1.content_kappa, m2.content_kappa);
+        let error =
+            super::preflight_and_bind_source_snapshot_kappa(&output, Some(&m2.content_kappa))
+                .expect_err("M2 cannot resume or relabel M1 corpus rows");
+        assert!(error.contains(&m1.content_kappa), "{error}");
+        assert!(error.contains(&m2.content_kappa), "{error}");
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("marker after refusal"),
+            marker_before
+        );
+        assert_eq!(
+            std::fs::read(output.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+                .expect("binding after refusal"),
+            binding_before
+        );
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("corpus after refusal"),
+            corpus_before
+        );
+
+        let resolved = super::ResolvedCompiledBundle {
+            logical_name: "teacher".to_owned(),
+            physical_root: output.clone(),
+            graph: output.join("graph/score.r4g1"),
+            teacher: output.join("tless_artifacts.bin"),
+            attention_operator: uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(
+            ),
+            source_manifest_kappa: Some(m1.content_kappa.clone()),
+        };
+        let error = super::validate_resolved_source_snapshot_binding(&resolved, Some(&m2), 2)
+            .expect_err("serving cannot attach M2 teacher bytes to M1 graph provenance");
+        assert!(error.contains(&m1.content_kappa), "{error}");
+        assert!(error.contains(&m2.content_kappa), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn manifestless_tree_kappa_rejects_hidden_shards_and_binds_visible_weights() {
+        let root = attention_provenance_test_dir("manifestless-hidden-shards");
+        let source = root.join("source");
+        std::fs::create_dir_all(&source).expect("create source");
+        let index = source.join(uor_r4_model_source::SAFETENSORS_INDEX_FILE_NAME);
+
+        std::fs::write(
+            source.join(".secret.safetensors"),
+            b"hidden executable weights",
+        )
+        .expect("write hidden shard");
+        std::fs::write(
+            &index,
+            br#"{"weight_map":{"model.weight":".secret.safetensors"}}"#,
+        )
+        .expect("write hidden-shard index");
+        let error = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect_err("hidden executable shard cannot escape the tree κ");
+        assert!(error.contains("hidden or nonportable"), "{error}");
+
+        std::fs::remove_file(source.join(".secret.safetensors")).expect("remove hidden shard");
+        std::fs::remove_file(&index).expect("remove hidden index");
+        std::fs::write(
+            source.join(".cache"),
+            b"file masquerading as transport metadata",
+        )
+        .expect("write .cache file");
+        let error = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect_err("a .cache file is not excluded transport metadata");
+        assert!(error.contains("not a directory"), "{error}");
+
+        std::fs::remove_file(source.join(".cache")).expect("remove .cache file");
+        std::fs::create_dir(source.join(".cache")).expect("create transport cache directory");
+        std::fs::write(source.join(".cache/transport"), b"revision one")
+            .expect("write transport metadata");
+        std::fs::write(source.join("visible.safetensors"), b"visible weights M1")
+            .expect("write visible shard");
+        std::fs::write(
+            &index,
+            br#"{"weight_map":{"model.weight":"visible.safetensors"}}"#,
+        )
+        .expect("write visible index");
+        let m1 = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect("visible indexed source verifies");
+        std::fs::write(source.join(".cache/transport"), b"revision two")
+            .expect("refresh transport metadata");
+        let cache_refreshed = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect("transport cache refresh remains out of κ scope");
+        assert_eq!(m1.content_kappa, cache_refreshed.content_kappa);
+
+        std::fs::write(source.join("visible.safetensors"), b"visible weights M2")
+            .expect("mutate executable shard");
+        let m2 = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect("mutated visible indexed source verifies as a new snapshot");
+        assert_ne!(
+            m1.content_kappa, m2.content_kappa,
+            "every executable visible shard byte participates in the tree κ"
+        );
+
+        std::fs::write(&index, br#"{"weight_map":{"model.weight":".cache"}}"#)
+            .expect("point index at cache directory");
+        let error = super::verified_managed_source_snapshot_from_manifest(&source, None)
+            .expect_err("transport directory cannot be an executable shard");
+        assert!(error.contains("hidden or nonportable"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn manifestless_startup_compile_and_reload_refuse_handle_swap_without_mutation() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+
+        fn fifo(path: &std::path::Path) {
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+                .expect("fixture path has no NUL");
+            // SAFETY: the C string is live and mkfifo does not retain it.
+            assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        }
+
+        for operation in ["startup", "compile", "reload"] {
+            for kind in ["file-symlink", "file-fifo", "dir-outside", "dir-cycle"] {
+                let root =
+                    attention_provenance_test_dir(&format!("manifestless-{operation}-{kind}"));
+                let source = root.join("source");
+                let nested = source.join("nested");
+                let outside = root.join("outside");
+                std::fs::create_dir_all(&nested).expect("source tree");
+                std::fs::create_dir_all(&outside).expect("outside tree");
+                std::fs::write(source.join("config.json"), b"bound config").expect("source file");
+                std::fs::write(nested.join("tokenizer.json"), b"bound nested")
+                    .expect("nested source file");
+                std::fs::write(outside.join("escaped.json"), b"outside").expect("outside file");
+                let compiled_sentinel = root.join("compiled-sentinel");
+                std::fs::write(&compiled_sentinel, b"last-good output").expect("compiled sentinel");
+                let serving = super::ServingModelState {
+                    epoch: 17,
+                    terminal_load_error: Some("prior terminal".to_owned()),
+                    last_operation_error: Some("prior operation".to_owned()),
+                    ..Default::default()
+                };
+
+                let file = source.join("config.json");
+                let file_original = source.join("config.original");
+                let directory_original = source.join("nested-original");
+                let mut swapped = false;
+                let result = super::verified_managed_source_snapshot_from_manifest_with_tree(
+                    &source,
+                    None,
+                    |source_root| {
+                        crate::model::verified_source_tree_with_hook(
+                            source_root,
+                            crate::model::SourceTreeScope::ManifestlessAll,
+                            |path| {
+                                if swapped {
+                                    return;
+                                }
+                                match kind {
+                                    "file-symlink" if path == file => {
+                                        std::fs::rename(&file, &file_original)
+                                            .expect("move regular file");
+                                        symlink(&file_original, &file).expect("swap symlink");
+                                        swapped = true;
+                                    }
+                                    "file-fifo" if path == file => {
+                                        std::fs::rename(&file, &file_original)
+                                            .expect("move regular file");
+                                        fifo(&file);
+                                        swapped = true;
+                                    }
+                                    "dir-outside" if path == nested => {
+                                        std::fs::rename(&nested, &directory_original)
+                                            .expect("move child directory");
+                                        symlink(&outside, &nested).expect("outside link");
+                                        swapped = true;
+                                    }
+                                    "dir-cycle" if path == nested => {
+                                        std::fs::rename(&nested, &directory_original)
+                                            .expect("move child directory");
+                                        symlink(&source, &nested).expect("cycle link");
+                                        swapped = true;
+                                    }
+                                    _ => {}
+                                }
+                            },
+                        )
+                        .map_err(|error| error.to_string())
+                    },
+                );
+                let error = result.expect_err("handle swap must fail before operation install");
+                assert!(
+                    error.contains("cannot be opened") || error.contains("changed identity"),
+                    "{operation}/{kind}: {error}"
+                );
+                assert_eq!(
+                    std::fs::read(&compiled_sentinel).expect("output after refusal"),
+                    b"last-good output"
+                );
+                assert_eq!(serving.epoch, 17);
+                assert_eq!(
+                    serving.terminal_load_error.as_deref(),
+                    Some("prior terminal")
+                );
+                assert_eq!(
+                    serving.last_operation_error.as_deref(),
+                    Some("prior operation")
+                );
+                assert_eq!(
+                    std::fs::read(outside.join("escaped.json")).expect("outside byte"),
+                    b"outside"
+                );
+                let _ = std::fs::remove_dir_all(root);
+            }
+        }
+    }
+
+    #[test]
+    fn source_compile_rejects_resolver_suffix_basename_before_mutation() {
+        let root = attention_provenance_test_dir("reserved-source-name");
+        let compiled = root.join("compiled");
+        let error = super::source_compile_output_for_attention_era(
+            &compiled,
+            "vendor-model-attention-v2",
+            2,
+        )
+        .expect_err("resolver-owned suffix is not an arbitrary source basename");
+        assert!(error.contains("resolver-owned suffix"), "{error}");
+        assert!(!compiled.exists(), "name rejection is read-only");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_compile_routes_unbound_legacy_payload_but_not_an_unbound_v2_root() {
+        let root = attention_provenance_test_dir("era-unbound");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        std::fs::create_dir_all(&conventional).expect("create legacy root");
+        std::fs::write(conventional.join("corpus.meta"), b"implicit v1")
+            .expect("write legacy payload");
+        let era = compiled.join("teacher-attention-v2");
+        assert_eq!(
+            super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+                .expect("implicit v1 selects v2 root"),
+            era
+        );
+
+        std::fs::create_dir_all(&era).expect("create v2 root");
+        std::fs::write(era.join("corpus.records"), b"unbound bytes")
+            .expect("write unbound v2 payload");
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("unbound deterministic era cannot be relabelled");
+        assert!(error.contains("contains payload without"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn write_loadable_graph_bundle(
+        bundle: &std::path::Path,
+        operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+    ) {
+        write_loadable_graph_bundle_with_kappa(bundle, operator, None);
+    }
+
+    fn write_loadable_graph_bundle_with_kappa(
+        bundle: &std::path::Path,
+        operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+        source_manifest_kappa: Option<&str>,
+    ) {
+        std::fs::create_dir_all(bundle.join("graph")).expect("create graph bundle");
+        std::fs::write(bundle.join("graph/score.r4g1"), b"graph").expect("write graph");
+        std::fs::write(bundle.join("tless_artifacts.bin"), b"teacher").expect("write teacher");
+        if let Some(operator) = operator {
+            write_attention_binding(bundle, operator);
+            std::fs::write(bundle.join("corpus.meta"), []).expect("write corpus metadata marker");
+            std::fs::write(bundle.join("corpus.records"), []).expect("write corpus records marker");
+            std::fs::create_dir_all(bundle.join("graph-cover"))
+                .expect("create cover-report directory");
+            let mut report = serde_json::json!({
+                "attention_operator": operator,
+            });
+            if let Some(kappa) = source_manifest_kappa {
+                report["source_manifest_kappa"] = serde_json::Value::String(kappa.to_owned());
+            }
+            std::fs::write(
+                bundle.join("graph-cover/cover_report.json"),
+                serde_json::to_vec_pretty(&report).expect("serialize cover provenance"),
+            )
+            .expect("write cover provenance");
+        }
+    }
+
+    #[test]
+    fn restart_discovery_prefers_current_v2_and_maps_suffix_to_base_source() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("restart-prefer-v2");
+        let compiled = root.join("compiled");
+        let sources = root.join("sources");
+        std::fs::create_dir_all(sources.join("teacher")).expect("create real source");
+        let historical = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&historical, Some(&AttentionOperatorSpec::standard_v1()));
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        let discovered = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect("both exact eras are discoverable");
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].logical_name, "teacher");
+        assert_eq!(discovered[0].physical_root, current);
+        assert_eq!(discovered[0].graph, current.join("graph/score.r4g1"));
+        assert_eq!(discovered[0].teacher, current.join("tless_artifacts.bin"));
+        let configured_historical = super::resolve_managed_teacher_bundle_in(
+            &historical.join("tless_artifacts.bin"),
+            &root,
+            2,
+        )
+        .expect("configured managed teacher re-enters paired resolver");
+        let super::ConfiguredManagedBundle::Selected(configured_historical) = configured_historical
+        else {
+            panic!("paired resolver must select a loadable bundle");
+        };
+        assert_eq!(
+            *configured_historical, discovered[0],
+            "a configured historical physical path cannot bypass its preferred current sibling"
+        );
+        assert_eq!(
+            super::resolve_managed_teacher_bundle_in(
+                &root.join("external/teacher/tless_artifacts.bin"),
+                &root,
+                2,
+            )
+            .expect("external explicit path remains outside managed resolution"),
+            super::ConfiguredManagedBundle::External
+        );
+        assert_eq!(
+            super::source_for_compiled_teacher_in(&discovered[0].teacher, &root)
+                .expect("exact v2 suffix maps to source"),
+            Some(sources.join("teacher"))
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn managed_resolver_classifies_external_absent_and_symlink_aliases_without_bypass() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("managed-path-classification");
+        let external = root.join("external");
+        std::fs::create_dir_all(&external).expect("create external bundle");
+        std::fs::write(external.join("tless_artifacts.bin"), b"external teacher")
+            .expect("write external teacher");
+        assert_eq!(
+            super::resolve_managed_teacher_bundle_in(
+                &external.join("tless_artifacts.bin"),
+                &root.join("fresh-models-root"),
+                2,
+            )
+            .expect("an absent managed namespace cannot invalidate an external artifact"),
+            super::ConfiguredManagedBundle::External
+        );
+
+        let models = root.join("models");
+        let historical = models.join("compiled/teacher");
+        let current = models.join("compiled/teacher-attention-v2");
+        write_loadable_graph_bundle(&historical, Some(&AttentionOperatorSpec::standard_v1()));
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            let alias_parent = root.join("aliases");
+            std::fs::create_dir_all(&alias_parent).expect("create alias parent");
+            symlink(&historical, alias_parent.join("historical-alias"))
+                .expect("alias historical physical root");
+            let resolved = super::resolve_managed_teacher_bundle_in(
+                &alias_parent.join("historical-alias/tless_artifacts.bin"),
+                &models,
+                2,
+            )
+            .expect("canonical namespace classification");
+            let super::ConfiguredManagedBundle::Selected(resolved) = resolved else {
+                panic!("managed symlink alias must re-enter the paired resolver");
+            };
+            assert_eq!(resolved.physical_root, current);
+            assert_eq!(resolved.logical_name, "teacher");
+        }
+
+        let absent = super::resolve_managed_teacher_bundle_in(
+            &models.join("compiled/missing/tless_artifacts.bin"),
+            &models,
+            2,
+        )
+        .expect("genuine configured absence is classified");
+        assert_eq!(absent, super::ConfiguredManagedBundle::Absent);
+        assert!(
+            !absent.permits_inventory_discovery(),
+            "configured managed absence cannot fall through to an unrelated inventory model"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolver_owned_suffix_rejects_preupgrade_source_basename_collision() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("reserved-source-collision");
+        let current = root.join("compiled/teacher-attention-v2");
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+        std::fs::create_dir_all(root.join("sources/teacher-attention-v2"))
+            .expect("create genuine pre-upgrade suffixed source");
+
+        let error = super::discover_compiled_r4g1_candidates_in(&root.join("compiled"), 2)
+            .expect_err("ambiguous source basename cannot be stripped by discovery");
+        assert!(error.contains("pre-existing source basename"), "{error}");
+        let error = super::resolve_reload_bundle_in(&root, "teacher", 2)
+            .expect_err("reload cannot map the collision to sources/teacher");
+        assert!(error.contains("pre-existing source basename"), "{error}");
+
+        std::fs::remove_dir_all(&current).expect("remove resolver-owned current root");
+        write_loadable_graph_bundle(
+            &root.join("compiled/teacher"),
+            Some(&AttentionOperatorSpec::standard_v1()),
+        );
+        assert!(super::resolve_reload_bundle_in(&root, "teacher", 2)
+            .expect("explicit logical base remains unambiguous")
+            .is_some());
+        let error = super::resolve_reload_bundle_in(&root, "teacher-attention-v2", 2)
+            .expect_err("exact suffix alias cannot consume a genuine source basename");
+        assert!(
+            error.contains("request the logical base explicitly"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn preferred_current_load_failure_never_exposes_historical_fallback_candidate() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("restart-current-load-failure");
+        let compiled = root.join("compiled");
+        let historical = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&historical, Some(&AttentionOperatorSpec::standard_v1()));
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        let discovered = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect("resolver chooses one authoritative candidate");
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].physical_root, current);
+        let load =
+            super::R4g1State::load_with_source(&discovered[0].graph, &discovered[0].teacher, None);
+        assert!(load.is_err(), "fixture graph is deliberately invalid");
+        assert!(
+            discovered
+                .iter()
+                .all(|candidate| candidate.physical_root != historical),
+            "the startup loop cannot fall through to historical after preferred v2 load failure"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn restart_discovery_does_not_hide_invalid_sibling_provenance() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("restart-invalid-sibling");
+        let compiled = root.join("compiled");
+        let historical = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&historical, None);
+        std::fs::write(
+            historical.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            b"{malformed",
+        )
+        .expect("write malformed historical binding");
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("valid v2 must not route around malformed v1 evidence");
+        assert!(
+            error.contains("malformed attention-operator binding"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn restart_discovery_requires_binding_on_populated_exact_v2_suffix() {
+        let root = attention_provenance_test_dir("restart-unbound-v2");
+        let compiled = root.join("compiled");
+        write_loadable_graph_bundle(&compiled.join("teacher-attention-v2"), None);
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("unbound deterministic v2 bundle is not a legacy candidate");
+        assert!(error.contains("contains payload without"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn restart_discovery_rejects_non_directory_and_symlink_candidates() {
+        let root = attention_provenance_test_dir("restart-non-directory");
+        let compiled = root.join("compiled");
+        std::fs::create_dir_all(&compiled).expect("create compiled root");
+        std::fs::write(compiled.join("teacher"), b"not a bundle directory")
+            .expect("write non-directory candidate");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("present non-directory is not absence");
+        assert!(error.contains("non-symlink directory"), "{error}");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            std::fs::remove_file(compiled.join("teacher")).expect("remove file candidate");
+            let target = root.join("target");
+            std::fs::create_dir(&target).expect("create symlink target");
+            symlink(&target, compiled.join("teacher")).expect("create candidate symlink");
+            let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+                .expect_err("directory symlink is not a managed bundle root");
+            assert!(error.contains("non-symlink directory"), "{error}");
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn startup_candidate_distinguishes_absence_from_incomplete_present_state() {
+        let root = attention_provenance_test_dir("startup-incomplete");
+        let graph = root.join("score.r4g1");
+        let teacher = root.join("tless_artifacts.bin");
+        assert!(!super::required_r4g1_inputs_present(&graph, &teacher)
+            .expect("joint absence is optional"));
+
+        std::fs::write(&graph, b"present graph").expect("write graph");
+        let error = super::required_r4g1_inputs_present(&graph, &teacher)
+            .expect_err("present graph with absent teacher is terminal");
+        assert!(error.contains("teacher artifact"), "{error}");
+
+        std::fs::remove_file(&graph).expect("remove graph");
+        std::fs::write(&teacher, b"present teacher").expect("write teacher");
+        let error = super::required_r4g1_inputs_present(&graph, &teacher)
+            .expect_err("present teacher with absent graph is terminal");
+        assert!(error.contains("graph"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn current_restart_requires_exact_corpus_and_cover_provenance() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("restart-current-provenance");
+        let compiled = root.join("compiled");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        std::fs::remove_file(current.join("graph-cover/cover_report.json"))
+            .expect("remove current cover report");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("current bundle requires its cover identity");
+        assert!(
+            error.contains("missing required cover provenance"),
+            "{error}"
+        );
+
+        std::fs::write(
+            current.join("graph-cover/cover_report.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "attention_operator": AttentionOperatorSpec::standard_v1(),
+            }))
+            .expect("serialize stale cover"),
+        )
+        .expect("write stale cover report");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("a copied v2 sidecar cannot relabel a v1 cover");
+        assert!(error.contains("records attention operator"), "{error}");
+        assert!(error.contains("/1"), "{error}");
+
+        let v1 = serde_json::to_string(&AttentionOperatorSpec::standard_v1())
+            .expect("serialize historical operator");
+        let v2 = serde_json::to_string(&AttentionOperatorSpec::standard_v2())
+            .expect("serialize current operator");
+        std::fs::write(
+            current.join("graph-cover/cover_report.json"),
+            format!("{{\"attention_operator\":{v1},\"attention_operator\":{v2}}}"),
+        )
+        .expect("write duplicate cover provenance");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("duplicate cover identities cannot be last-key-wins");
+        assert!(error.contains("duplicate field"), "{error}");
+
+        let mut manifest = uor_r4_graph_compiler::observation::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::standard_v1());
+        std::fs::write(
+            current.join(uor_r4_graph_compiler::observation::MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest).expect("serialize stale manifest"),
+        )
+        .expect("write stale observation manifest");
+        std::fs::write(
+            current.join("graph-cover/cover_report.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "attention_operator": AttentionOperatorSpec::standard_v2(),
+            }))
+            .expect("serialize current cover"),
+        )
+        .expect("restore current cover");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("sidecar and observation provenance must reconcile");
+        assert!(error.contains("different attention operators"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn current_serving_requires_cover_kappa_to_match_verified_source_bytes() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("serving-source-kappa-binding");
+        let identity = crate::model::SourceDownload {
+            repository: "owner/model".to_owned(),
+            revision: "6".repeat(40),
+            name: "teacher".to_owned(),
+            output: None,
+            license: Some("Apache-2.0".to_owned()),
+        };
+        let source = root.join("sources/teacher");
+        std::fs::create_dir_all(&source).expect("create source");
+        std::fs::write(source.join("config.json"), b"source snapshot M1").expect("write M1 config");
+        write_test_source_manifest(&source, &identity);
+        let manifest_m1 = crate::model::read_source_manifest(&source).expect("read M1 manifest");
+        let kappa_m1 = crate::model::source_manifest_kappa(&manifest_m1).expect("address M1");
+
+        let current = root.join("compiled/teacher-attention-v2");
+        write_loadable_graph_bundle_with_kappa(
+            &current,
+            Some(&AttentionOperatorSpec::standard_v2()),
+            Some(&kappa_m1),
+        );
+        let cover_before = std::fs::read(current.join("graph-cover/cover_report.json"))
+            .expect("cover bytes before substitution");
+        let graph_before = std::fs::read(current.join("graph/score.r4g1"))
+            .expect("graph bytes before substitution");
+        let resolved = super::resolve_requested_compiled_bundle_in(&root, "teacher", 2)
+            .expect("resolve current bundle")
+            .expect("current bundle is loadable");
+        let verified_m1 =
+            super::verify_managed_source_snapshot_in(&source, "teacher", &root.join("descriptors"))
+                .expect("M1 source verifies");
+        super::validate_resolved_source_snapshot_binding(&resolved, Some(&verified_m1), 2)
+            .expect("M1 cover/source pair matches");
+
+        std::fs::write(source.join("config.json"), b"source snapshot M2")
+            .expect("replace admitted bytes with M2");
+        write_test_source_manifest(&source, &identity);
+        let verified_m2 =
+            super::verify_managed_source_snapshot_in(&source, "teacher", &root.join("descriptors"))
+                .expect("M2 is internally self-consistent");
+        let kappa_m2 = verified_m2.content_kappa.clone();
+        assert_ne!(kappa_m1, kappa_m2, "fixture changes the source root");
+        let error =
+            super::validate_resolved_source_snapshot_binding(&resolved, Some(&verified_m2), 2)
+                .expect_err("old graph/corpus M1 may not install with teacher/tokenizer M2");
+        assert!(error.contains(&kappa_m1), "{error}");
+        assert!(error.contains(&kappa_m2), "{error}");
+        assert_eq!(
+            std::fs::read(current.join("graph-cover/cover_report.json"))
+                .expect("cover after refusal"),
+            cover_before
+        );
+        assert_eq!(
+            std::fs::read(current.join("graph/score.r4g1")).expect("graph after refusal"),
+            graph_before
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn final_source_snapshot_gate_rejects_manifest_and_legacy_drift_for_every_installer() {
+        use std::sync::{Arc, Barrier};
+
+        for (index, operation, manifest_backed) in [
+            (0, "standalone teacher startup", true),
+            (1, "R4G1 startup", false),
+            (2, "R4G1 compilation installation", true),
+            (3, "R4G1 reload", false),
+        ] {
+            let root = attention_provenance_test_dir(&format!("snapshot-tail-{index}"));
+            let source = root.join("sources/teacher");
+            std::fs::create_dir_all(&source).expect("create source");
+            std::fs::write(source.join("config.json"), b"snapshot M1").expect("write M1 config");
+            std::fs::write(source.join("model.safetensors"), b"weights").expect("write weights");
+            let identity = crate::model::SourceDownload {
+                repository: "owner/model".to_owned(),
+                revision: format!("{index:x}").repeat(40),
+                name: "teacher".to_owned(),
+                output: None,
+                license: Some("Apache-2.0".to_owned()),
+            };
+            if manifest_backed {
+                write_test_source_manifest_without_default_weights(&source, &identity);
+            }
+            let before = super::verify_managed_source_snapshot_in(
+                &source,
+                "teacher",
+                &root.join("descriptors"),
+            )
+            .expect("verify M1");
+
+            let barrier = Arc::new(Barrier::new(2));
+            let worker_barrier = Arc::clone(&barrier);
+            let worker_source = source.clone();
+            let worker_identity = identity.clone();
+            let worker = std::thread::spawn(move || {
+                worker_barrier.wait();
+                std::fs::write(worker_source.join("config.json"), b"snapshot M2")
+                    .expect("publish M2 config");
+                if manifest_backed {
+                    write_test_source_manifest_without_default_weights(
+                        &worker_source,
+                        &worker_identity,
+                    );
+                }
+                worker_barrier.wait();
+            });
+            barrier.wait();
+            barrier.wait();
+            worker.join().expect("snapshot publisher");
+
+            let after = super::verify_managed_source_snapshot_in(
+                &source,
+                "teacher",
+                &root.join("descriptors"),
+            )
+            .expect("M2 remains internally valid");
+            assert_ne!(before.content_kappa, after.content_kappa);
+            let error = super::require_unchanged_managed_source_snapshot(
+                &source, operation, &before, &after,
+            )
+            .expect_err("M1-to-M2 replacement cannot cross an install boundary");
+            assert!(error.contains(operation), "{error}");
+
+            let mut installed = super::ServingModelState {
+                epoch: 17,
+                terminal_load_error: Some("prior terminal".to_owned()),
+                ..super::ServingModelState::default()
+            };
+            if super::require_unchanged_managed_source_snapshot(&source, operation, &before, &after)
+                .is_ok()
+            {
+                installed.epoch = installed.epoch.wrapping_add(1);
+                installed.terminal_load_error = None;
+            }
+            assert_eq!(installed.epoch, 17, "{operation} must not install");
+            assert_eq!(
+                installed.terminal_load_error.as_deref(),
+                Some("prior terminal"),
+                "{operation} preserves prior state"
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn crashed_download_stage_is_reclaimed_once_under_destination_session() {
+        let models_root = attention_provenance_test_dir("download-stage-recovery");
+        let source = super::source_from_model_spec(&format!("owner/model@{}", "a".repeat(40)))
+            .expect("source identity");
+        let destination = super::downloaded_source_path_in(&source, &models_root);
+        let parent = destination.parent().expect("source parent");
+        std::fs::create_dir_all(parent).expect("source parent");
+        let final_name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("UTF-8 cache name");
+        let stale = parent.join(format!(".{final_name}.download-staging-999-1"));
+        std::fs::create_dir(&stale).expect("stale download stage");
+        let marker = super::download_stage_marker_bytes(&destination, &stale, &source)
+            .expect("stale stage owner marker");
+        super::publish_bytes_no_clobber(
+            &stale.join(super::DOWNLOAD_STAGE_MARKER_FILE),
+            &marker,
+            "test download-stage marker",
+        )
+        .expect("publish stale owner marker");
+        std::fs::write(stale.join("model.safetensors"), vec![0xA5; 4096])
+            .expect("model-sized stale sentinel");
+
+        let published = super::download_source_atomically_in(&source, &models_root, |staged| {
+            assert!(
+                !stale.exists(),
+                "exclusive owner reclaimed prior crash residue"
+            );
+            write_test_source_manifest(
+                staged.output.as_deref().expect("reserved stage output"),
+                &source,
+            );
+            Ok(staged.output.clone().expect("reported stage"))
+        })
+        .expect("retry publishes exactly one complete source");
+        assert_eq!(published, destination);
+        assert!(!stale.exists());
+        assert!(std::fs::read_dir(parent)
+            .expect("source cache entries")
+            .all(|entry| !entry
+                .expect("source cache entry")
+                .file_name()
+                .to_string_lossy()
+                .contains("download-staging")));
+        let _ = std::fs::remove_dir_all(models_root);
+    }
+
+    #[test]
+    fn markerless_payload_download_stage_is_never_reclaimed_or_overwritten() {
+        let models_root = attention_provenance_test_dir("download-stage-markerless-payload");
+        let source = super::source_from_model_spec(&format!("owner/model@{}", "9".repeat(40)))
+            .expect("source identity");
+        let destination = super::downloaded_source_path_in(&source, &models_root);
+        let parent = destination.parent().expect("source parent");
+        std::fs::create_dir_all(parent).expect("source parent");
+        let final_name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("UTF-8 cache name");
+        let unowned = parent.join(format!(".{final_name}.download-staging-998-1"));
+        std::fs::create_dir(&unowned).expect("unowned stage");
+        std::fs::write(unowned.join("model.safetensors"), b"external payload")
+            .expect("unowned payload");
+
+        let error = super::download_source_atomically_in(&source, &models_root, |_| {
+            panic!("transport must not start after unowned residue")
+        })
+        .expect_err("markerless payload is terminal");
+        assert!(error.contains("markerless download stage"), "{error}");
+        assert_eq!(
+            std::fs::read(unowned.join("model.safetensors")).expect("payload preserved"),
+            b"external payload"
+        );
+        assert!(!destination.exists());
+        let _ = std::fs::remove_dir_all(models_root);
+    }
+
+    #[test]
+    fn source_cache_session_refuses_download_while_compile_reader_owns_exact_path() {
+        let models_root = attention_provenance_test_dir("download-compile-os-session");
+        let source = super::source_from_model_spec(&format!("owner/model@{}", "b".repeat(40)))
+            .expect("source identity");
+        let destination = super::downloaded_source_path_in(&source, &models_root);
+        let owner = super::try_lock_source_compile_sessions(
+            [models_root.join("sources"), destination.clone()],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("compile-side source snapshot owner");
+        let invoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let invoked_by_download = std::sync::Arc::clone(&invoked);
+        let error = super::download_source_atomically_in(&source, &models_root, move |_| {
+            invoked_by_download.store(true, std::sync::atomic::Ordering::SeqCst);
+            unreachable!("transport must not begin while exact source path is busy")
+        })
+        .expect_err("download refuses instead of waiting or mutating");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert!(!invoked.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!destination.exists());
+        drop(owner);
+        let _ = std::fs::remove_dir_all(models_root);
+    }
+
+    #[test]
+    fn graph_teacher_operator_reconciliation_preserves_exact_modes_only() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let standard = AttentionOperatorSpec::standard_v2();
+        let experimental = AttentionOperatorSpec::experimental_r4_v2();
+        let learned = AttentionOperatorSpec::learned_absolute_v2();
+        assert_eq!(
+            super::teacher_mode_for_bundle_records(&standard, Some(&experimental), &standard),
+            Some(false)
+        );
+        assert_eq!(
+            super::teacher_mode_for_bundle_records(&standard, Some(&experimental), &experimental),
+            Some(true),
+            "current experimental bundles select the executable r4 mode"
+        );
+        assert_eq!(
+            super::teacher_mode_for_bundle_records(&learned, Some(&learned), &learned),
+            Some(false),
+            "GPT-2's learned-absolute operator remains its default mode"
+        );
+        for historical in [
+            AttentionOperatorSpec::standard_v1(),
+            AttentionOperatorSpec::experimental_r4_v1(),
+            AttentionOperatorSpec::learned_absolute_v1(),
+        ] {
+            assert_eq!(
+                super::teacher_mode_for_bundle_records(&standard, Some(&experimental), &historical),
+                None,
+                "historical graph arithmetic has no current Teacher fallback"
+            );
+        }
+        assert!(super::teacher_r4_attention_for_request(None, true));
+        assert!(!super::teacher_r4_attention_for_request(
+            Some(super::TIER_ATTENTION),
+            true
+        ));
+        assert!(super::teacher_r4_attention_for_request(
+            Some(super::TIER_R4_ATTENTION),
+            false
+        ));
+    }
+
+    #[test]
+    fn historical_graph_keeps_its_exact_host_encoder_without_teacher_fallback() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("historical-host-encoder");
+        let graph = graph_state_with_exact_host_encoder(&root);
+        assert!(
+            !graph.host_encoder_unavailable(),
+            "the source-bound tokenizer is independent of Teacher attention arithmetic"
+        );
+        let mut encoded = [0u32; 32];
+        assert!(
+            graph.encode_into("a", &mut encoded).is_some(),
+            "the historical graph retains a usable text encoder"
+        );
+        let serving = super::ServingModelState {
+            r4g1: Some(graph),
+            oracle: None,
+            source_tokenizer: None,
+            active_bundle: Some(super::ResolvedCompiledBundle {
+                logical_name: "teacher".to_owned(),
+                physical_root: root.join("compiled/teacher"),
+                graph: root.join("compiled/teacher/graph/score.r4g1"),
+                teacher: root.join("compiled/teacher/tless_artifacts.bin"),
+                attention_operator: AttentionOperatorSpec::standard_v1(),
+                source_manifest_kappa: None,
+            }),
+            ..super::ServingModelState::default()
+        };
+        assert!(super::graph_text_ready(&serving));
+        assert!(!super::teacher_text_ready(&serving));
+        assert_eq!(
+            super::active_canonical_model_name(&serving).as_deref(),
+            Some("teacher"),
+            "a host-encoded historical graph remains advertised"
+        );
+        assert_eq!(
+            super::resolve_active_request_model(&serving, Some("uor-r4"))
+                .expect("legacy alias resolves to the graph"),
+            "teacher"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cover_source_kappa_is_duplicate_strict_and_stage_a_resume_is_snapshot_bound() {
+        let root = attention_provenance_test_dir("stage-a-source-kappa-binding");
+        let identity = crate::model::SourceDownload {
+            repository: "owner/model".to_owned(),
+            revision: "7".repeat(40),
+            name: "teacher".to_owned(),
+            output: None,
+            license: Some("Apache-2.0".to_owned()),
+        };
+        let source_m1 = root.join("source-m1");
+        let source_m2 = root.join("source-m2");
+        std::fs::create_dir_all(&source_m1).expect("create M1 source");
+        std::fs::create_dir_all(&source_m2).expect("create M2 source");
+        std::fs::write(source_m1.join("config.json"), b"M1 bytes").expect("write M1");
+        std::fs::write(source_m2.join("config.json"), b"M2 bytes").expect("write M2");
+        write_test_source_manifest(&source_m1, &identity);
+        write_test_source_manifest(&source_m2, &identity);
+        let manifest_m1 = crate::model::read_source_manifest(&source_m1).expect("read M1");
+        let manifest_m2 = crate::model::read_source_manifest(&source_m2).expect("read M2");
+        let kappa_m1 = crate::model::source_manifest_kappa(&manifest_m1).expect("address M1");
+        let kappa_m2 = crate::model::source_manifest_kappa(&manifest_m2).expect("address M2");
+        assert_ne!(kappa_m1, kappa_m2);
+
+        let output = root.join("compiled/teacher");
+        std::fs::create_dir_all(output.join("graph-cover")).expect("create populated output");
+        let corpus = output.join("corpus.records");
+        std::fs::write(&corpus, b"M1 corpus bytes").expect("write M1 corpus sentinel");
+        let report = output.join("graph-cover/cover_report.json");
+        std::fs::write(
+            &report,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "source_manifest_kappa": &kappa_m1,
+            }))
+            .expect("serialize M1 cover"),
+        )
+        .expect("write M1 cover");
+        let report_before = std::fs::read(&report).expect("cover before mismatch");
+
+        let error = super::preflight_and_bind_source_manifest_kappa(&output, Some(&manifest_m2))
+            .expect_err("M2 cannot resume populated M1 Stage-A output");
+        assert!(
+            error.contains("no immutable source-manifest kappa binding"),
+            "{error}"
+        );
+        assert!(!output
+            .join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE)
+            .exists());
+        assert_eq!(
+            std::fs::read(&corpus).expect("corpus after refusal"),
+            b"M1 corpus bytes"
+        );
+        assert_eq!(
+            std::fs::read(&report).expect("cover after refusal"),
+            report_before
+        );
+
+        super::preflight_and_bind_source_manifest_kappa(&output, Some(&manifest_m1))
+            .expect("exact cover κ bootstraps the immutable Stage-A binding");
+        assert_eq!(
+            super::read_optional_source_manifest_kappa_binding(&output)
+                .expect("read Stage-A binding")
+                .as_deref(),
+            Some(kappa_m1.as_str())
+        );
+        super::preflight_and_bind_source_manifest_kappa(&output, Some(&manifest_m1))
+            .expect("exact resume is idempotent");
+
+        let duplicate_report = root.join("duplicate-cover.json");
+        std::fs::write(
+            &duplicate_report,
+            format!(
+                "{{\"source_manifest_kappa\":\"{kappa_m1}\",\"source_manifest_kappa\":\"{kappa_m2}\"}}"
+            ),
+        )
+        .expect("write duplicate source κ");
+        let error = super::parse_cover_provenance(&duplicate_report)
+            .expect_err("duplicate cover source κ cannot be last-key-wins");
+        assert!(error.contains("duplicate field"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn restart_sidecar_rejects_duplicate_operator_fields_before_registry_validation() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("restart-duplicate-sidecar-field");
+        let compiled = root.join("compiled");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        let canonical = serde_json::to_string(&AttentionOperatorSpec::standard_v2())
+            .expect("serialize current operator");
+        let duplicate = canonical.replacen("\"version\":2", "\"version\":1,\"version\":2", 1);
+        assert_ne!(duplicate, canonical, "fixture injects a duplicate version");
+        std::fs::write(
+            current.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            duplicate,
+        )
+        .expect("write duplicate sidecar");
+        let error = super::discover_compiled_r4g1_candidates_in(&compiled, 2)
+            .expect_err("duplicate sidecar keys cannot collapse to current-v2");
+        assert!(
+            error.contains("duplicate JSON field \"version\""),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn reload_base_and_exact_suffix_resolve_same_physical_bundle_and_base_source() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("reload-logical-physical");
+        let compiled = root.join("compiled");
+        let source = root.join("sources/teacher");
+        std::fs::create_dir_all(&source).expect("create logical source");
+        let current = compiled.join("teacher-attention-v2");
+        write_loadable_graph_bundle(&current, Some(&AttentionOperatorSpec::standard_v2()));
+
+        let (base, base_source) = super::resolve_reload_bundle_in(&root, "teacher", 2)
+            .expect("base request resolves")
+            .expect("base is loadable");
+        let (alias, alias_source) =
+            super::resolve_reload_bundle_in(&root, "teacher-attention-v2", 2)
+                .expect("exact suffix alias resolves")
+                .expect("suffix alias is loadable");
+        assert_eq!(base, alias);
+        assert_eq!(base.logical_name, "teacher");
+        assert_eq!(base.physical_root, current);
+        assert_eq!(
+            super::status_physical_root(Some(&base)),
+            Some(current.display().to_string()),
+            "status reports the selected physical v2 root, not compiled/<logical>"
+        );
+        assert_eq!(base_source, Some(source.clone()));
+        assert_eq!(alias_source, Some(source.clone()));
+        assert!(super::teacher_ready_for_source(
+            true,
+            Some(source.as_path()),
+            base_source.as_deref(),
+        ));
+        assert!(
+            !super::teacher_ready_for_source(true, Some(current.as_path()), base_source.as_deref(),),
+            "a teacher loaded from the physical suffix root is not ready for the logical source"
+        );
+        let advertised = super::loadable_models_in(&compiled).expect("valid v2 inventory");
+        assert_eq!(
+            advertised
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["teacher"],
+            "model listing exposes the logical id once, never the physical suffix"
+        );
+
+        std::fs::remove_dir_all(root.join("sources/teacher")).expect("remove optional source");
+        let (decode_only, source) = super::resolve_reload_bundle_in(&root, "teacher", 2)
+            .expect("genuine source absence is valid")
+            .expect("graph remains decode-loadable");
+        assert_eq!(decode_only.physical_root, current);
+        assert_eq!(source, None);
+        assert!(
+            !super::teacher_ready_for_source(true, None, source.as_deref()),
+            "decode-only source absence must not report a teacher-ready state"
+        );
+
+        std::fs::create_dir_all(root.join("sources")).expect("restore sources root");
+        std::fs::write(root.join("sources/teacher"), b"invalid source entry")
+            .expect("write invalid logical source");
+        let error = super::resolve_reload_bundle_in(&root, "teacher-attention-v2", 2)
+            .expect_err("present-invalid base source is terminal for suffix reload");
+        assert!(error.contains("not a source directory"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn failed_replacement_preserves_active_tuple_and_prior_terminal_marker() {
+        use std::sync::{Arc, Mutex};
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let active = super::ResolvedCompiledBundle {
+            logical_name: "alpha".to_owned(),
+            physical_root: "/compiled/alpha-attention-v2".into(),
+            graph: "/compiled/alpha-attention-v2/graph/score.r4g1".into(),
+            teacher: "/compiled/alpha-attention-v2/tless_artifacts.bin".into(),
+            attention_operator: AttentionOperatorSpec::standard_v2(),
+            source_manifest_kappa: None,
+        };
+        let serving = Arc::new(Mutex::new(super::ServingModelState {
+            active_bundle: Some(active.clone()),
+            terminal_load_error: Some("startup marker".to_owned()),
+            ..super::ServingModelState::default()
+        }));
+        super::record_replacement_failure(&serving, "bad reload");
+        let installed = serving.lock().unwrap();
+        assert_eq!(installed.active_bundle.as_ref(), Some(&active));
+        assert_eq!(
+            installed.terminal_load_error.as_deref(),
+            Some("startup marker")
+        );
+        assert_eq!(
+            installed.last_operation_error.as_deref(),
+            Some("bad reload")
+        );
+        drop(installed);
+
+        let empty = Arc::new(Mutex::new(super::ServingModelState::default()));
+        super::record_replacement_failure(&empty, "no initial tuple");
+        let empty = empty.lock().unwrap();
+        assert_eq!(
+            empty.terminal_load_error.as_deref(),
+            Some("no initial tuple")
+        );
+        assert_eq!(
+            empty.last_operation_error.as_deref(),
+            Some("no initial tuple")
+        );
+    }
+
+    #[test]
+    fn reload_and_compile_share_one_replacement_reservation() {
+        use std::sync::{Arc, Mutex};
+
+        let serving = Arc::new(Mutex::new(super::ServingModelState::default()));
+        let status = Arc::new(Mutex::new(super::R4g1CompileStatus {
+            running: false,
+            ready: false,
+            progress: 0,
+            message: "idle".to_owned(),
+            report: None,
+        }));
+        let (_epoch, reservation) =
+            super::reserve_r4g1_reload(&serving, &status).expect("first writer reserves");
+        assert!(status.lock().unwrap().running);
+        assert!(
+            super::reserve_r4g1_reload(&serving, &status).is_err(),
+            "a concurrent reload or compile cannot enter the preparation window"
+        );
+        drop(reservation);
+        let status = status.lock().unwrap();
+        assert!(!status.running);
+        assert!(status.message.contains("active serving tuple preserved"));
+    }
+
+    #[test]
+    fn status_identity_uses_the_actual_nondefault_teacher_source_without_a_graph() {
+        let state = super::ServingModelState {
+            active_teacher_source: Some("/sources/teacher-beta".into()),
+            ..super::ServingModelState::default()
+        };
+        assert_eq!(super::installed_logical_model_name(&state), "teacher-beta");
+        assert_eq!(
+            super::active_canonical_model_name(&state),
+            None,
+            "a source path alone is not a text-ready engine"
+        );
+    }
+
+    #[test]
+    fn legacy_v1_only_reload_and_startup_remain_compatible() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("legacy-v1-reload");
+        let historical = root.join("compiled/teacher");
+        write_loadable_graph_bundle(&historical, Some(&AttentionOperatorSpec::standard_v1()));
+
+        let discovered = super::discover_compiled_r4g1_candidates_in(&root.join("compiled"), 2)
+            .expect("historical-only startup remains supported");
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].physical_root, historical);
+        let (reloaded, source) = super::resolve_reload_bundle_in(&root, "teacher", 2)
+            .expect("historical-only reload remains supported")
+            .expect("historical graph is loadable");
+        assert_eq!(
+            reloaded.attention_operator,
+            AttentionOperatorSpec::standard_v1()
+        );
+        assert_eq!(source, None);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -5575,6 +17179,1053 @@ mod tests {
     }
 
     #[test]
+    fn public_source_control_payload_rejects_unknown_fields_before_operations() {
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        for body in [
+            br#"{"modle":"owner/model@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#.as_slice(),
+            br#"{"tokenzier_family":"hf-bpe","tokenizer_version":1}"#.as_slice(),
+        ] {
+            let error = super::parse_huggingface_control_payload(body)
+                .expect_err("unknown public source controls must fail closed");
+            assert!(error.contains("unknown field"), "{error}");
+            assert!(
+                operations.lock().expect("operation state").active.is_none(),
+                "the shared parser used by download, compile, and reload runs before reservation or status mutation"
+            );
+        }
+
+        let empty = super::parse_huggingface_control_payload(br#"{"model":"  "}"#)
+            .expect("empty dashboard model control is syntactically valid");
+        assert_eq!(
+            super::explicitly_requested_huggingface_source(empty.model.as_deref())
+                .expect("empty request normalizes to fallback"),
+            None,
+            "an empty dashboard field must not turn the pinned legacy fallback into an explicit custom request"
+        );
+
+        let download_with_compile_controls = super::parse_huggingface_control_payload(
+            br#"{"model":"owner/model@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","tokenizer_family":"hf-bpe","tokenizer_version":1}"#,
+        )
+        .expect("known compile controls parse before endpoint validation");
+        let error = download_with_compile_controls
+            .validate_download_controls()
+            .expect_err("download may not acknowledge and ignore compile-only controls");
+        assert!(error.contains("only to compile and reload"), "{error}");
+        assert!(
+            operations.lock().expect("operation state").active.is_none(),
+            "download control rejection precedes cache reservation and transport"
+        );
+    }
+
+    #[test]
+    fn custom_model_parser_enforces_portable_owner_repository_grammar() {
+        let revision = "a".repeat(40);
+        for invalid in [
+            format!("model@{revision}"),
+            format!("owner/nested/model@{revision}"),
+            format!("own er/model@{revision}"),
+            format!("owner/mo?del@{revision}"),
+        ] {
+            let error = super::source_from_model_spec(&invalid)
+                .expect_err("invalid repositories must fail synchronously at the HTTP edge");
+            assert!(error.contains("owner/repository"), "{invalid}: {error}");
+        }
+    }
+
+    #[test]
+    fn full_source_identity_keys_keep_forks_and_revisions_disjoint() {
+        let root = attention_provenance_test_dir("collision-free-source-identity");
+        let shared_revision = "a".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{shared_revision}"))
+            .expect("alice source");
+        let bob = super::source_from_model_spec(&format!("bob/model@{shared_revision}"))
+            .expect("bob source");
+        let other_revision = format!("{}{}", "a".repeat(12), "b".repeat(28));
+        let alice_other = super::source_from_model_spec(&format!("alice/model@{other_revision}"))
+            .expect("second alice revision");
+
+        assert_ne!(alice.name, bob.name, "repository owner is identity-bearing");
+        assert_ne!(
+            alice.name, alice_other.name,
+            "the full revision, not its first 12 characters, is identity-bearing"
+        );
+        let alice_path = super::downloaded_source_path_in(&alice, &root);
+        let bob_path = super::downloaded_source_path_in(&bob, &root);
+        assert_ne!(alice_path, bob_path);
+        assert_ne!(
+            root.join("compiled").join(&alice.name),
+            root.join("compiled").join(&bob.name),
+            "the source basename feeds a disjoint compiled logical root"
+        );
+        assert_eq!(alice.name.split('-').next(), Some("model"));
+        assert_eq!(alice.name.len(), "model-".len() + 64);
+        assert!(super::collision_resistant_source_cache_name(&alice.name));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn intact_v2_snapshot_cannot_be_renamed_under_another_logical_identity() {
+        let root = attention_provenance_test_dir("renamed-v2-source-snapshot");
+        let revision = "b".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{revision}"))
+            .expect("alice source");
+        let bob =
+            super::source_from_model_spec(&format!("bob/model@{revision}")).expect("bob source");
+        let alice_path = super::downloaded_source_path_in(&alice, &root);
+        std::fs::create_dir_all(&alice_path).expect("create substituted Alice cache path");
+        std::fs::write(alice_path.join("config.json"), b"intact Bob config")
+            .expect("write Bob config under Alice name");
+        let bob_manifest = write_test_source_manifest(&alice_path, &bob);
+        let bob_config = std::fs::read(alice_path.join("config.json")).expect("Bob config bytes");
+        let compiled_sentinel = root.join("compiled/alice-existing.bin");
+        std::fs::create_dir_all(compiled_sentinel.parent().expect("compiled parent"))
+            .expect("create compiled inventory");
+        std::fs::write(&compiled_sentinel, b"existing Alice compile")
+            .expect("write compiled sentinel");
+
+        let error = super::validate_source_snapshot_integrity(&alice_path, None)
+            .expect_err("self-consistent Bob bytes cannot claim Alice's v2 cache basename");
+        assert!(
+            error.contains("renamed or substituted teacher bytes"),
+            "{error}"
+        );
+        assert!(error.contains(&alice.name), "{error}");
+        assert!(error.contains(&bob.name), "{error}");
+        let cached_alice = completed_source(&alice_path, &alice);
+        let error = super::select_compile_source_path_in(&root, None, Some(&cached_alice), None)
+            .expect_err("implicit cached compile must enforce path-to-manifest identity");
+        assert!(error.contains("requested model alice/model"), "{error}");
+        assert!(error.contains("records bob/model"), "{error}");
+        let error = super::validate_compile_source_snapshot(&alice_path, true)
+            .expect_err("reload/compile strict validation shares the same identity boundary");
+        assert!(
+            error.contains("renamed or substituted teacher bytes"),
+            "{error}"
+        );
+        let error = super::validate_managed_source_for_serving(&alice_path, &alice.name)
+            .expect_err("restart serving uses the same v2 path/manifest binding");
+        assert!(
+            error.contains("renamed or substituted teacher bytes"),
+            "{error}"
+        );
+
+        assert_eq!(
+            std::fs::read(alice_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                .expect("manifest after refusal"),
+            bob_manifest,
+            "identity rejection is read-only"
+        );
+        assert_eq!(
+            std::fs::read(alice_path.join("config.json")).expect("config after refusal"),
+            bob_config,
+            "substituted source bytes are not rewritten"
+        );
+        assert_eq!(
+            std::fs::read(&compiled_sentinel).expect("compiled sentinel after refusal"),
+            b"existing Alice compile",
+            "refusal occurs before compile output mutation"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_compile_model_never_reuses_a_different_cached_download() {
+        let root = attention_provenance_test_dir("compile-source-selection");
+        let source = |repository: &str, name: &str| crate::model::SourceDownload {
+            repository: repository.to_owned(),
+            revision: "1".repeat(40),
+            name: name.to_owned(),
+            output: None,
+            license: None,
+        };
+        let alpha = source("owner/alpha", "alpha");
+        let beta = source("owner/beta", "beta");
+        let alpha_path = super::downloaded_source_path_in(&alpha, &root);
+        let beta_path = super::downloaded_source_path_in(&beta, &root);
+        write_test_source_manifest(&alpha_path, &alpha);
+        write_test_source_manifest(&beta_path, &beta);
+
+        let cached_alpha = completed_source(&alpha_path, &alpha);
+        assert_eq!(
+            super::select_compile_source_path_in(&root, Some(&beta), Some(&cached_alpha), None,)
+                .expect("explicit downloaded beta wins"),
+            Some(beta_path.clone())
+        );
+        std::fs::remove_dir_all(&beta_path).expect("remove beta download");
+        let error =
+            super::select_compile_source_path_in(&root, Some(&beta), Some(&cached_alpha), None)
+                .expect_err("cached alpha cannot satisfy explicit beta");
+        assert!(error.contains("owner/beta"), "{error}");
+        assert!(error.contains("download it before compiling"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_compile_model_requires_exact_manifest_when_cache_names_collide() {
+        let root = attention_provenance_test_dir("compile-source-identity-collision");
+        let revision = "a".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{revision}"))
+            .expect("alice source descriptor");
+        let mut bob = super::source_from_model_spec(&format!("bob/model@{revision}"))
+            .expect("bob source descriptor");
+        // Reproduce a historical/custom-output collision explicitly. New
+        // descriptors above are disjoint, but existing directories must still
+        // be rejected read-only when their manifest records another owner.
+        bob.name = alice.name.clone();
+        let alice_path = super::downloaded_source_path_in(&alice, &root);
+        let bob_path = super::downloaded_source_path_in(&bob, &root);
+        assert_eq!(
+            alice_path, bob_path,
+            "same basename and revision prefix reproduce the historical cache collision"
+        );
+
+        std::fs::create_dir_all(&alice_path).expect("create colliding cache directory");
+        let sentinel = alice_path.join("config.json");
+        std::fs::write(&sentinel, br#"{"model_type":"llama"}"#)
+            .expect("write cached alice payload");
+        let manifest_before = write_test_source_manifest(&alice_path, &alice);
+        let payload_before = std::fs::read(&sentinel).expect("read alice payload before");
+        let compiled_sentinel = root.join("compiled/keep.bin");
+        std::fs::create_dir_all(compiled_sentinel.parent().expect("compiled parent"))
+            .expect("create compiled root");
+        std::fs::write(&compiled_sentinel, b"pre-existing compiled bytes")
+            .expect("write compiled sentinel");
+
+        let error = super::select_compile_source_path_in(&root, Some(&bob), None, None)
+            .expect_err("bob cannot consume alice's colliding cache directory");
+        assert!(
+            error.contains(&format!("requested model bob/model@{revision}")),
+            "{error}"
+        );
+        assert!(
+            error.contains(&format!("records alice/model@{revision}")),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(alice_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                .expect("read manifest after refusal"),
+            manifest_before,
+            "identity refusal is read-only"
+        );
+        assert_eq!(
+            std::fs::read(&sentinel).expect("read payload after refusal"),
+            payload_before,
+            "cached teacher bytes remain untouched"
+        );
+        assert_eq!(
+            std::fs::read(&compiled_sentinel).expect("read compiled sentinel after refusal"),
+            b"pre-existing compiled bytes",
+            "identity mismatch is rejected before any compile output mutation"
+        );
+        assert_eq!(
+            super::select_compile_source_path_in(&root, Some(&alice), None, None)
+                .expect("the exact manifest owner is accepted"),
+            Some(alice_path)
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn pinned_legacy_fallback_is_read_only_but_completed_cache_requires_a_manifest() {
+        let root = attention_provenance_test_dir("legacy-source-manifest-compatibility");
+        let fallback = crate::model::SourceDownload {
+            repository: "owner/legacy".to_owned(),
+            revision: "c".repeat(40),
+            name: "legacy".to_owned(),
+            output: None,
+            license: None,
+        };
+        let path = super::downloaded_source_path_in(&fallback, &root);
+        std::fs::create_dir_all(&path).expect("create legacy snapshot");
+        std::fs::write(
+            path.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME),
+            b"legacy unmanifested weights",
+        )
+        .expect("write legacy weights");
+
+        assert_eq!(
+            super::select_compile_source_path_in(&root, None, None, Some(&fallback))
+                .expect("genuine pinned pre-manifest input remains readable"),
+            Some(path.clone())
+        );
+        let cached = completed_source(&path, &fallback);
+        let error = super::select_compile_source_path_in(&root, None, Some(&cached), None)
+            .expect_err("a completed HTTP download must never be inferred from legacy bytes");
+        assert!(error.contains("source_manifest.json"), "{error}");
+
+        std::fs::create_dir(path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+            .expect("create present-invalid manifest entry");
+        let error = super::select_compile_source_path_in(&root, None, None, Some(&fallback))
+            .expect_err("present-invalid fallback manifest may not downgrade to absence");
+        assert!(error.contains("source_manifest.json"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn present_source_manifest_license_must_match_pinned_descriptor_exactly() {
+        let root = attention_provenance_test_dir("source-manifest-license-binding");
+        let expected = crate::model::SourceDownload {
+            repository: "owner/pinned-model".to_owned(),
+            revision: "4".repeat(40),
+            name: "pinned-model".to_owned(),
+            output: None,
+            license: Some("Apache-2.0".to_owned()),
+        };
+        let source_path = super::downloaded_source_path_in(&expected, &root);
+        std::fs::create_dir_all(&source_path).expect("create pinned source");
+        std::fs::write(source_path.join("config.json"), b"pinned config")
+            .expect("write pinned config");
+        let output_sentinel = root.join("compiled/existing-output.bin");
+        std::fs::create_dir_all(output_sentinel.parent().expect("compiled parent"))
+            .expect("create compiled output root");
+        std::fs::write(&output_sentinel, b"existing compiled output")
+            .expect("write output sentinel");
+        let status = super::HuggingFaceDownloadStatus {
+            running: false,
+            ready: true,
+            message: "pinned source complete".to_owned(),
+            source: Some(source_path.display().to_string()),
+            completed_source: Some(expected.clone()),
+        };
+        let source_path_text = source_path.display().to_string();
+
+        for wrong_license in [None, Some("MIT".to_owned())] {
+            let mut wrong = expected.clone();
+            wrong.license = wrong_license;
+            let manifest_before = write_test_source_manifest(&source_path, &wrong);
+            let config_before =
+                std::fs::read(source_path.join("config.json")).expect("config before refusal");
+            let error = super::validate_legacy_compatible_source_manifest(&source_path, &expected)
+                .expect_err("null or wrong SPDX cannot satisfy the pinned descriptor");
+            assert!(error.contains("records license"), "{error}");
+            assert!(error.contains("Apache-2.0"), "{error}");
+
+            let invoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let invoked_by_downloader = std::sync::Arc::clone(&invoked);
+            let error = super::download_source_atomically_in(&expected, &root, move |_| {
+                invoked_by_downloader.store(true, std::sync::atomic::Ordering::SeqCst);
+                unreachable!("license mismatch must reject before transport or overwrite")
+            })
+            .expect_err("existing falsely licensed cache cannot be reused or overwritten");
+            assert!(error.contains("records license"), "{error}");
+            assert!(!invoked.load(std::sync::atomic::Ordering::SeqCst));
+            assert_eq!(
+                std::fs::read(source_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                    .expect("manifest after refusal"),
+                manifest_before
+            );
+            assert_eq!(
+                std::fs::read(source_path.join("config.json")).expect("config after refusal"),
+                config_before
+            );
+            assert!(status.ready);
+            assert_eq!(status.source.as_deref(), Some(source_path_text.as_str()));
+            assert_eq!(
+                std::fs::read(&output_sentinel).expect("output after refusal"),
+                b"existing compiled output"
+            );
+        }
+
+        std::fs::remove_file(source_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+            .expect("remove manifest for genuine pre-597 compatibility check");
+        assert_eq!(
+            super::validate_legacy_compatible_source_manifest(&source_path, &expected)
+                .expect("genuine manifest absence remains a legacy input"),
+            None
+        );
+
+        write_test_source_manifest(&source_path, &expected);
+        assert!(
+            super::validate_legacy_compatible_source_manifest(&source_path, &expected)
+                .expect("exact pinned license is accepted")
+                .is_some()
+        );
+        let reused = super::download_source_atomically_in(&expected, &root, |_| {
+            panic!("an exact immutable cache should be reused without transport")
+        })
+        .expect("exact licensed cache is reusable");
+        assert_eq!(reused, source_path);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn completed_legacy_named_source_retains_exact_download_identity() {
+        let root = attention_provenance_test_dir("completed-source-exact-identity");
+        let expected = crate::model::SourceDownload {
+            repository: "owner/pinned-model".to_owned(),
+            revision: "8".repeat(40),
+            name: "pinned-model".to_owned(),
+            output: None,
+            license: Some("Apache-2.0".to_owned()),
+        };
+        let substituted = crate::model::SourceDownload {
+            repository: "attacker/other-model".to_owned(),
+            revision: "9".repeat(40),
+            name: "pinned-model".to_owned(),
+            output: None,
+            license: Some("Apache-2.0".to_owned()),
+        };
+        let source_path = super::downloaded_source_path_in(&expected, &root);
+        std::fs::create_dir_all(&source_path).expect("create legacy-named cache path");
+        std::fs::write(source_path.join("config.json"), b"substituted source")
+            .expect("write substituted bytes");
+        let manifest_before = write_test_source_manifest(&source_path, &substituted);
+        let output_sentinel = root.join("compiled/existing-output.bin");
+        std::fs::create_dir_all(output_sentinel.parent().expect("compiled parent"))
+            .expect("create compiled root");
+        std::fs::write(&output_sentinel, b"existing output").expect("write output sentinel");
+
+        let cached = completed_source(&source_path, &expected);
+        let error = super::select_compile_source_path_in(&root, None, Some(&cached), None)
+            .expect_err(
+                "implicit compile must validate the completed descriptor, not only its path",
+            );
+        assert!(error.contains("owner/pinned-model"), "{error}");
+        assert!(error.contains("attacker/other-model"), "{error}");
+        assert_eq!(
+            std::fs::read(source_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                .expect("manifest after refusal"),
+            manifest_before
+        );
+        assert_eq!(
+            std::fs::read(&output_sentinel).expect("output after refusal"),
+            b"existing output"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_named_managed_source_uses_descriptor_identity_and_invalid_default_is_terminal() {
+        let root = attention_provenance_test_dir("descriptor-bound-legacy-source");
+        let descriptors = root.join("models");
+        let source = root.join("sources/pinned-teacher");
+        std::fs::create_dir_all(&descriptors).expect("create descriptor root");
+        std::fs::create_dir_all(&source).expect("create source root");
+        let expected = crate::model::SourceDownload {
+            repository: "owner/pinned-teacher".to_owned(),
+            revision: "a".repeat(40),
+            name: "pinned-teacher".to_owned(),
+            output: Some(source.clone()),
+            license: Some("Apache-2.0".to_owned()),
+        };
+        std::fs::write(
+            descriptors.join("pinned-teacher.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "repository": &expected.repository,
+                "revision": &expected.revision,
+                "license": &expected.license,
+                "source_directory": source.display().to_string(),
+            }))
+            .expect("serialize descriptor"),
+        )
+        .expect("write descriptor");
+        let mut substituted = expected.clone();
+        substituted.repository = "other/pinned-teacher".to_owned();
+        let manifest_before = write_test_source_manifest(&source, &substituted);
+        let sentinel = root.join("compiled/sentinel.bin");
+        std::fs::create_dir_all(sentinel.parent().expect("compiled parent"))
+            .expect("create compiled root");
+        std::fs::write(&sentinel, b"unchanged").expect("write sentinel");
+
+        let error =
+            super::validate_managed_source_for_serving_in(&source, "pinned-teacher", &descriptors)
+                .expect_err("a present manifest must exactly match the known descriptor");
+        assert!(error.contains("owner/pinned-teacher"), "{error}");
+        assert!(error.contains("other/pinned-teacher"), "{error}");
+        assert_eq!(
+            std::fs::read(source.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                .expect("manifest after refusal"),
+            manifest_before
+        );
+        assert_eq!(std::fs::read(&sentinel).expect("sentinel"), b"unchanged");
+
+        write_test_source_manifest(&source, &expected);
+        assert!(super::validate_managed_source_for_serving_in(
+            &source,
+            "pinned-teacher",
+            &descriptors,
+        )
+        .expect("exact descriptor-bound source")
+        .is_some());
+        std::fs::remove_file(source.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+            .expect("remove manifest for legacy compatibility");
+        assert_eq!(
+            super::validate_managed_source_for_serving_in(&source, "pinned-teacher", &descriptors,)
+                .expect("genuine pre-manifest source remains compatible"),
+            None
+        );
+
+        let pinned_descriptor = descriptors.join("smollm2-135m-instruct.json");
+        std::fs::write(&pinned_descriptor, b"{present-invalid")
+            .expect("write malformed pinned descriptor");
+        let descriptor_before = std::fs::read(&pinned_descriptor).expect("descriptor bytes");
+        let error = super::optional_pinned_huggingface_source_in(&descriptors)
+            .expect_err("present-invalid default descriptor cannot collapse to no fallback");
+        assert!(error.contains("malformed model descriptor"), "{error}");
+        assert_eq!(
+            std::fs::read(&pinned_descriptor).expect("descriptor after refusal"),
+            descriptor_before
+        );
+        assert_eq!(std::fs::read(&sentinel).expect("sentinel"), b"unchanged");
+        std::fs::remove_file(&pinned_descriptor).expect("remove malformed descriptor");
+        assert_eq!(
+            super::optional_pinned_huggingface_source_in(&descriptors)
+                .expect("genuine descriptor absence is optional"),
+            None
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn assert_source_cache_reservation_conflict(
+        active: super::SourceCacheOperationKind,
+        attempted: super::SourceCacheOperationKind,
+    ) {
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        let reservation = super::try_reserve_source_cache_operation(
+            &operations,
+            active,
+            format!("{}-source", active.label()),
+        )
+        .unwrap_or_else(|error| panic!("reserve active operation: {error}"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let worker_operations = std::sync::Arc::clone(&operations);
+        let worker_barrier = std::sync::Arc::clone(&barrier);
+        let worker = std::thread::spawn(move || {
+            worker_barrier.wait();
+            match super::try_reserve_source_cache_operation(
+                &worker_operations,
+                attempted,
+                format!("{}-source", attempted.label()),
+            ) {
+                Ok(_) => panic!("conflicting operation unexpectedly acquired the cache"),
+                Err(error) => error,
+            }
+        });
+        barrier.wait();
+        let error = worker.join().expect("reservation worker");
+        assert!(error.contains(active.label()), "{error}");
+        assert!(error.contains(attempted.label()), "{error}");
+        drop(reservation);
+        assert!(operations.lock().expect("operation state").active.is_none());
+    }
+
+    #[test]
+    fn source_cache_reservation_closes_download_compile_and_reload_races() {
+        use super::SourceCacheOperationKind::{Compile, Download, Reload};
+
+        assert_source_cache_reservation_conflict(Compile, Download);
+        assert_source_cache_reservation_conflict(Download, Compile);
+        assert_source_cache_reservation_conflict(Reload, Download);
+        assert_source_cache_reservation_conflict(Download, Reload);
+    }
+
+    #[test]
+    fn compile_snapshots_completed_download_only_after_reservation_handoff() {
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        let alice = crate::model::SourceDownload {
+            repository: "alice/model".to_owned(),
+            revision: "a".repeat(40),
+            name: "alice".to_owned(),
+            output: Some("/sources/alice".into()),
+            license: None,
+        };
+        let bob = crate::model::SourceDownload {
+            repository: "bob/model".to_owned(),
+            revision: "b".repeat(40),
+            name: "bob".to_owned(),
+            output: Some("/sources/bob".into()),
+            license: None,
+        };
+        let status = std::sync::Arc::new(std::sync::Mutex::new(super::HuggingFaceDownloadStatus {
+            running: false,
+            ready: true,
+            message: "Alice complete".to_owned(),
+            source: Some("/sources/alice".to_owned()),
+            completed_source: Some(alice),
+        }));
+        let download = super::try_reserve_source_cache_operation(
+            &operations,
+            super::SourceCacheOperationKind::Download,
+            "/sources/bob",
+        )
+        .unwrap_or_else(|error| panic!("reserve Bob download: {error}"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let worker_operations = std::sync::Arc::clone(&operations);
+        let worker_status = std::sync::Arc::clone(&status);
+        let worker_barrier = std::sync::Arc::clone(&barrier);
+        let worker = std::thread::spawn(move || {
+            worker_barrier.wait();
+            match super::reserve_compile_source_selection(
+                &worker_operations,
+                &worker_status,
+                "implicit source",
+            ) {
+                Ok(_) => panic!("compile may not snapshot Alice through Bob's reservation"),
+                Err(error) => error,
+            }
+        });
+        barrier.wait();
+        let error = worker.join().expect("compile attempt");
+        assert!(error.contains("active download"), "{error}");
+
+        // Bob's completed tuple becomes visible before the download releases
+        // the cache. The next compile first acquires the handed-off slot and
+        // only then samples status, so it cannot retain stale Alice/fallback.
+        {
+            let mut current = status.lock().expect("download status");
+            current.running = false;
+            current.ready = true;
+            current.source = Some("/sources/bob".to_owned());
+            current.completed_source = Some(bob.clone());
+            current.message = "Bob complete".to_owned();
+        }
+        drop(download);
+        let (compile, selected) =
+            super::reserve_compile_source_selection(&operations, &status, "implicit source")
+                .expect("compile acquires completed handoff");
+        assert_eq!(
+            selected,
+            Some(super::CompletedDownloadSource {
+                path: std::path::PathBuf::from("/sources/bob"),
+                identity: bob,
+            })
+        );
+        drop(compile);
+    }
+
+    #[test]
+    fn failed_staged_download_preserves_prior_source_and_ready_status() {
+        let root = attention_provenance_test_dir("failed-staged-download");
+        let revision = "d".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{revision}"))
+            .expect("alice source");
+        let bob =
+            super::source_from_model_spec(&format!("bob/model@{revision}")).expect("bob source");
+        let alice_path = super::downloaded_source_path_in(&alice, &root);
+        std::fs::create_dir_all(&alice_path).expect("create old published source");
+        std::fs::write(alice_path.join("config.json"), b"old published config")
+            .expect("write old config");
+        let old_manifest = write_test_source_manifest(&alice_path, &alice);
+        let old_config = std::fs::read(alice_path.join("config.json")).expect("old config bytes");
+        let bob_path = super::downloaded_source_path_in(&bob, &root);
+
+        let error = super::download_source_atomically_in(&bob, &root, |staged| {
+            let stage = staged.output.as_ref().expect("staging output");
+            std::fs::write(stage.join("config.json"), b"partial replacement config")
+                .expect("write partial stage");
+            write_test_source_manifest(stage, staged);
+            Err("synthetic transport failure".to_owned())
+        })
+        .expect_err("failed downloader must not publish its staging directory");
+        assert!(error.contains("synthetic transport failure"), "{error}");
+        assert!(!bob_path.exists(), "failed identity was never published");
+        assert_eq!(
+            std::fs::read(alice_path.join("config.json")).expect("config after failure"),
+            old_config
+        );
+        assert_eq!(
+            std::fs::read(alice_path.join(crate::model::SOURCE_MANIFEST_FILE_NAME))
+                .expect("manifest after failure"),
+            old_manifest
+        );
+        assert!(
+            std::fs::read_dir(root.join("sources"))
+                .expect("source inventory")
+                .filter_map(Result::ok)
+                .all(|entry| !entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains("download-staging")),
+            "failure cleanup leaves no partially selectable staging directory"
+        );
+
+        let mut status = super::HuggingFaceDownloadStatus {
+            running: true,
+            ready: true,
+            message: "redownload started".to_owned(),
+            source: Some(alice_path.display().to_string()),
+            completed_source: Some({
+                let mut completed = alice.clone();
+                completed.output = Some(alice_path.clone());
+                completed
+            }),
+        };
+        super::apply_huggingface_download_result(
+            &mut status,
+            Err("synthetic transport failure".to_owned()),
+        );
+        assert!(!status.running);
+        assert!(status.ready);
+        let alice_path_text = alice_path.display().to_string();
+        assert_eq!(status.source.as_deref(), Some(alice_path_text.as_str()));
+        assert!(status.message.contains("synthetic transport failure"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn staged_download_never_replaces_a_raced_empty_or_populated_destination() {
+        let root = attention_provenance_test_dir("download-exclusive-publish-race");
+        for (kind, payload) in [
+            ("empty", None),
+            ("payload", Some(b"external winner".as_slice())),
+        ] {
+            let models_root = root.join(kind);
+            let source = super::source_from_model_spec(&format!(
+                "owner/{kind}-model@{}",
+                if kind == "empty" {
+                    "1".repeat(40)
+                } else {
+                    "2".repeat(40)
+                }
+            ))
+            .expect("source identity");
+            let destination = super::downloaded_source_path_in(&source, &models_root);
+            let raced_destination = destination.clone();
+            let error =
+                super::download_source_atomically_in(&source, &models_root, move |staged| {
+                    let stage = staged.output.as_ref().expect("reserved staging path");
+                    std::fs::write(stage.join("config.json"), b"validated staged config")
+                        .expect("write staged config");
+                    write_test_source_manifest(stage, staged);
+
+                    // This is the exact post-absence/pre-publish barrier: an
+                    // external actor wins the final name after transport began.
+                    std::fs::create_dir_all(&raced_destination)
+                        .expect("external actor wins destination");
+                    if let Some(payload) = payload {
+                        std::fs::write(raced_destination.join("external.bin"), payload)
+                            .expect("external payload");
+                    }
+                    Ok(stage.clone())
+                })
+                .expect_err("exclusive publish may not replace a raced destination");
+            assert!(error.contains("lost exclusive publication"), "{error}");
+            assert!(destination.is_dir());
+            assert!(
+                !destination.join("config.json").exists(),
+                "validated staging bytes cannot replace the external winner"
+            );
+            assert!(
+                !destination
+                    .join(crate::model::SOURCE_MANIFEST_FILE_NAME)
+                    .exists(),
+                "external winner is not relabeled with the staged manifest"
+            );
+            if let Some(payload) = payload {
+                assert_eq!(
+                    std::fs::read(destination.join("external.bin"))
+                        .expect("external payload after refusal"),
+                    payload
+                );
+            } else {
+                assert_eq!(
+                    std::fs::read_dir(&destination)
+                        .expect("empty raced destination")
+                        .count(),
+                    0,
+                    "an empty external winner remains byte-for-byte empty"
+                );
+            }
+            let sources = models_root.join("sources");
+            assert!(
+                std::fs::read_dir(&sources)
+                    .expect("source inventory")
+                    .filter_map(Result::ok)
+                    .all(|entry| !entry
+                        .file_name()
+                        .to_string_lossy()
+                        .contains("download-staging")),
+                "failed exclusive publication cleans only its owned stage"
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn atomic_publication_keeps_sequential_forks_disjoint_and_refuses_legacy_collision() {
+        let root = attention_provenance_test_dir("sequential-source-publication");
+        let revision = "e".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{revision}"))
+            .expect("alice source");
+        let bob =
+            super::source_from_model_spec(&format!("bob/model@{revision}")).expect("bob source");
+        let publish = |source: &crate::model::SourceDownload| {
+            super::download_source_atomically_in(source, &root, |staged| {
+                let stage = staged.output.as_ref().expect("staging output");
+                std::fs::write(stage.join("config.json"), staged.repository.as_bytes())
+                    .expect("write staged config");
+                write_test_source_manifest(stage, staged);
+                Ok(stage.clone())
+            })
+        };
+        let alice_path = publish(&alice).expect("publish alice");
+        let bob_path = publish(&bob).expect("publish bob");
+        assert_ne!(alice_path, bob_path);
+        super::validate_source_snapshot_integrity(&alice_path, Some(&alice))
+            .expect("alice remains exact");
+        super::validate_source_snapshot_integrity(&bob_path, Some(&bob))
+            .expect("bob remains exact");
+
+        let mut colliding_bob = bob.clone();
+        colliding_bob.output = Some(alice_path.clone());
+        let invoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let invoked_by_downloader = std::sync::Arc::clone(&invoked);
+        let error = super::download_source_atomically_in(&colliding_bob, &root, move |_| {
+            invoked_by_downloader.store(true, std::sync::atomic::Ordering::SeqCst);
+            unreachable!("identity mismatch must be rejected before transport")
+        })
+        .expect_err("a colliding custom output cannot relabel Alice as Bob");
+        assert!(error.contains("records alice/model"), "{error}");
+        assert!(!invoked.load(std::sync::atomic::Ordering::SeqCst));
+        super::validate_source_snapshot_integrity(&alice_path, Some(&alice))
+            .expect("Alice bytes remain unchanged after refusal");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn stale_or_incomplete_download_status_is_not_an_implicit_compile_source() {
+        let stale = super::HuggingFaceDownloadStatus {
+            running: false,
+            ready: false,
+            message: "failed replacement".to_owned(),
+            source: Some("/stale/partial/source".to_owned()),
+            completed_source: None,
+        };
+        assert_eq!(
+            super::completed_download_source(&stale).expect("not ready is an ordinary miss"),
+            None
+        );
+
+        let mut running = stale.clone();
+        running.running = true;
+        assert!(super::completed_download_source(&running).is_err());
+
+        let mut inconsistent = stale;
+        inconsistent.ready = true;
+        inconsistent.source = None;
+        assert!(super::completed_download_source(&inconsistent).is_err());
+    }
+
+    #[test]
+    fn missing_completed_source_never_downgrades_compile_to_legacy_inputs() {
+        let root = attention_provenance_test_dir("missing-completed-source");
+        let revision = "3".repeat(40);
+        let source = super::source_from_model_spec(&format!("owner/model@{revision}"))
+            .expect("custom source");
+        let source_path = super::downloaded_source_path_in(&source, &root);
+        std::fs::create_dir_all(&source_path).expect("create completed source");
+        write_test_source_manifest(&source_path, &source);
+        let moved_source = root.join("externally-moved-source");
+        std::fs::rename(&source_path, &moved_source).expect("move completed source externally");
+
+        let legacy_root = root.join("configured-legacy-inputs");
+        std::fs::create_dir_all(&legacy_root).expect("create legacy inputs");
+        for name in ["tless_artifacts.bin", "corpus.meta", "corpus.records"] {
+            std::fs::write(legacy_root.join(name), b"pre-existing legacy bytes")
+                .expect("write legacy input");
+        }
+        let output_sentinel = root.join("compiled/existing-output.bin");
+        std::fs::create_dir_all(output_sentinel.parent().expect("output parent"))
+            .expect("create output root");
+        std::fs::write(&output_sentinel, b"pre-existing compiled output")
+            .expect("write output sentinel");
+
+        let download_status =
+            std::sync::Arc::new(std::sync::Mutex::new(super::HuggingFaceDownloadStatus {
+                running: false,
+                ready: true,
+                message: "custom source complete".to_owned(),
+                source: Some(source_path.display().to_string()),
+                completed_source: Some({
+                    let mut completed = source.clone();
+                    completed.output = Some(source_path.clone());
+                    completed
+                }),
+            }));
+        let compile_status = super::R4g1CompileStatus {
+            running: false,
+            ready: true,
+            progress: 77,
+            message: "prior compile state".to_owned(),
+            report: Some(serde_json::json!({ "prior": true })),
+        };
+        let compile_status_before = compile_status.clone();
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        let (_reservation, cached) = super::reserve_compile_source_selection(
+            &operations,
+            &download_status,
+            "implicit completed source",
+        )
+        .expect("reserve before status snapshot");
+        let cached = cached.expect("ready status remains authoritative");
+        let error = super::select_compile_source_path_in(&root, None, Some(&cached), None)
+            .expect_err("absent completed source must stop before legacy compile selection");
+        assert!(
+            error.contains("recorded ready but is now absent"),
+            "{error}"
+        );
+        assert!(error.contains("refusing to downgrade"), "{error}");
+
+        let current_download = download_status.lock().expect("download status");
+        assert!(current_download.ready);
+        let source_path_text = source_path.display().to_string();
+        assert_eq!(
+            current_download.source.as_deref(),
+            Some(source_path_text.as_str())
+        );
+        assert_eq!(compile_status.running, compile_status_before.running);
+        assert_eq!(compile_status.ready, compile_status_before.ready);
+        assert_eq!(compile_status.progress, compile_status_before.progress);
+        assert_eq!(compile_status.message, compile_status_before.message);
+        assert_eq!(compile_status.report, compile_status_before.report);
+        assert_eq!(
+            std::fs::read(&output_sentinel).expect("output sentinel after refusal"),
+            b"pre-existing compiled output"
+        );
+        for name in ["tless_artifacts.bin", "corpus.meta", "corpus.records"] {
+            assert_eq!(
+                std::fs::read(legacy_root.join(name)).expect("legacy input after refusal"),
+                b"pre-existing legacy bytes"
+            );
+        }
+        assert!(moved_source.is_dir(), "moved source remains untouched");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_manifest_must_bind_every_index_referenced_shard() {
+        let root = attention_provenance_test_dir("hidden-indexed-shard");
+        let source = crate::model::SourceDownload {
+            repository: "owner/model".to_owned(),
+            revision: "f".repeat(40),
+            name: "hidden-shard".to_owned(),
+            output: None,
+            license: None,
+        };
+        let source_dir = root.join("sources/hidden-shard");
+        std::fs::create_dir_all(&source_dir).expect("create hidden-shard source");
+        std::fs::write(
+            source_dir.join(".secret.safetensors"),
+            b"unbound hidden weights",
+        )
+        .expect("write hidden shard");
+        std::fs::write(
+            source_dir.join(uor_r4_model_source::SAFETENSORS_INDEX_FILE_NAME),
+            br#"{"weight_map":{"model.weight":".secret.safetensors"}}"#,
+        )
+        .expect("write shard index");
+        write_test_source_manifest(&source_dir, &source);
+        // Remove the helper's single-file weight so the index is the only
+        // executable source layout, then rebuild the exact manifest.
+        std::fs::remove_file(source_dir.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME))
+            .expect("remove helper single-file weights");
+        write_test_source_manifest_without_default_weights(&source_dir, &source);
+
+        let error = super::validate_source_snapshot_integrity(&source_dir, Some(&source))
+            .expect_err("hidden index shard is executable but absent from the manifest");
+        assert!(
+            error.contains("outside the exact source manifest inventory"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_manifest_rejects_visible_symlinked_teacher_inputs() {
+        use std::os::unix::fs::symlink;
+
+        let root = attention_provenance_test_dir("symlinked-source-input");
+        let source = crate::model::SourceDownload {
+            repository: "owner/model".to_owned(),
+            revision: "1".repeat(40),
+            name: "symlinked-source".to_owned(),
+            output: None,
+            license: None,
+        };
+        let source_dir = root.join("sources/symlinked-source");
+        std::fs::create_dir_all(&source_dir).expect("create source");
+        let outside = root.join("outside.safetensors");
+        std::fs::write(&outside, b"outside weights").expect("write outside weights");
+        std::fs::write(
+            source_dir.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME),
+            b"original bound weights",
+        )
+        .expect("write original source weights");
+        write_test_source_manifest_without_default_weights(&source_dir, &source);
+        std::fs::remove_file(source_dir.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME))
+            .expect("remove original bound weights");
+        symlink(
+            &outside,
+            source_dir.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME),
+        )
+        .expect("create weight symlink");
+        let error = super::validate_source_snapshot_integrity(&source_dir, Some(&source))
+            .expect_err("teacher source symlink may not disappear from manifest admission");
+        assert!(error.contains("without following links"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_startup_rejects_byte_drift_and_source_root_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = attention_provenance_test_dir("managed-startup-source-validation");
+        let revision = "2".repeat(40);
+        let alice = super::source_from_model_spec(&format!("alice/model@{revision}"))
+            .expect("alice source");
+        let bob =
+            super::source_from_model_spec(&format!("bob/model@{revision}")).expect("bob source");
+        let alice_path = super::downloaded_source_path_in(&alice, &root);
+        std::fs::create_dir_all(&alice_path).expect("create Alice source");
+        std::fs::write(alice_path.join("config.json"), b"recorded config")
+            .expect("write Alice config");
+        write_test_source_manifest(&alice_path, &alice);
+        std::fs::write(alice_path.join("config.json"), b"drifted config")
+            .expect("mutate admitted bytes after manifest");
+        let error = super::validate_managed_source_for_serving(&alice_path, &alice.name)
+            .expect_err("restart may not load bytes that drifted from the manifest");
+        assert!(error.contains("file inventory"), "{error}");
+
+        std::fs::remove_dir_all(&alice_path).expect("remove drifted Alice source");
+        let bob_path = super::downloaded_source_path_in(&bob, &root);
+        std::fs::create_dir_all(&bob_path).expect("create Bob source");
+        write_test_source_manifest(&bob_path, &bob);
+        symlink(&bob_path, &alice_path).expect("alias Alice cache name to Bob source");
+        let error = super::validate_managed_source_for_serving(&alice_path, &alice.name)
+            .expect_err("managed startup source roots may not be symlink aliases");
+        assert!(error.contains("non-symlink directory"), "{error}");
+
+        let legacy = root.join("sources/legacy-with-symlinked-weights");
+        std::fs::create_dir_all(&legacy).expect("create pre-manifest legacy source");
+        let outside = root.join("legacy-outside.safetensors");
+        std::fs::write(&outside, b"retargetable legacy weights")
+            .expect("write legacy outside weights");
+        symlink(
+            &outside,
+            legacy.join(uor_r4_model_source::SAFETENSORS_SINGLE_FILE_NAME),
+        )
+        .expect("create visible legacy weight symlink");
+        let error =
+            super::validate_managed_source_for_serving(&legacy, "legacy-with-symlinked-weights")
+                .expect_err("manifest absence does not permit executable source symlinks");
+        assert!(error.contains("without following links"), "{error}");
+        let error = super::validate_compile_source_snapshot(&legacy, false)
+            .expect_err("legacy compile/reload shares the structural source boundary");
+        assert!(error.contains("without following links"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn inferred_source_distinguishes_absence_from_present_invalid_entries() {
         let root = std::env::temp_dir().join(format!(
             "uor-r4-serving-inferred-source-{}",
@@ -5598,6 +18249,16 @@ mod tests {
         assert_eq!(
             super::source_for_compiled_teacher_in(&teacher, &root).expect("directory is present"),
             Some(source.clone())
+        );
+
+        let explicit_source = root.join("sources/external-attention-v2");
+        std::fs::create_dir(&explicit_source).expect("explicit source directory");
+        let explicit_teacher = root.join("elsewhere/external-attention-v2/tless_artifacts.bin");
+        assert_eq!(
+            super::source_for_compiled_teacher_in(&explicit_teacher, &root)
+                .expect("explicit CLI paths retain literal source mapping"),
+            Some(explicit_source),
+            "the managed suffix is reserved only inside models_root/compiled"
         );
 
         std::fs::remove_dir(&source).expect("remove source directory");
@@ -5744,7 +18405,7 @@ mod tests {
     }
 
     #[test]
-    fn serving_source_tokenizer_is_registered_and_parse_failures_clear_it() {
+    fn serving_source_tokenizer_resolution_is_failure_atomic() {
         let dir =
             std::env::temp_dir().join(format!("uor-r4-serving-tokenizer-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -5759,14 +18420,9 @@ mod tests {
         )
         .expect("tokenizer definition");
         let selection = uor_r4_core::transformerless::hf_bpe::TokenizerAdapterKey::hf_byte_bpe_v1();
-        super::load_serving_source_tokenizer(&dir, Some(&selection))
+        let tokenizer = super::resolve_serving_source_tokenizer(&dir, Some(&selection))
             .expect("registered source loads");
-        let adapter = super::SERVING_SOURCE_TOKENIZER
-            .lock()
-            .unwrap()
-            .as_ref()
-            .and_then(|tokenizer| tokenizer.adapter())
-            .expect("registered identity");
+        let adapter = tokenizer.adapter().expect("registered identity");
         assert_eq!(adapter.family, "hf-byte-bpe");
         assert_eq!(adapter.version, 1);
 
@@ -5775,23 +18431,93 @@ mod tests {
             b"present to make selection ambiguous",
         )
         .expect("second tokenizer definition");
-        let error = super::load_serving_source_tokenizer(&dir, None)
-            .expect_err("ambiguous source selection fails closed");
+        let error = match super::resolve_serving_source_tokenizer(&dir, None) {
+            Err(error) => error,
+            Ok(_) => panic!("ambiguous source selection must fail closed"),
+        };
         assert!(
             error
                 .reason
                 .contains("both tokenizer.json and spiece.model"),
             "{error}"
         );
-        assert!(super::SERVING_SOURCE_TOKENIZER.lock().unwrap().is_none());
+        assert_eq!(
+            adapter.family, "hf-byte-bpe",
+            "a failed replacement cannot mutate the already prepared tokenizer value"
+        );
         std::fs::remove_file(dir.join("spiece.model")).expect("remove second definition");
 
         std::fs::write(&tokenizer_path, br#"{"model":{"type":"Unigram"}}"#)
             .expect("replace with unsupported wrapper");
-        let error = super::load_serving_source_tokenizer(&dir, Some(&selection))
-            .expect_err("unsupported selected definition fails closed");
+        let error = match super::resolve_serving_source_tokenizer(&dir, Some(&selection)) {
+            Err(error) => error,
+            Ok(_) => panic!("unsupported selected definition must fail closed"),
+        };
         assert!(error.reason.contains("hf-byte-bpe/1"), "{error}");
-        assert!(super::SERVING_SOURCE_TOKENIZER.lock().unwrap().is_none());
+        assert_eq!(adapter.version, 1);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn present_indexed_source_and_explicit_tokenizer_mismatch_are_terminal() {
+        use uor_r4_core::transformerless::hf_bpe::TokenizerAdapterKey;
+        use uor_r4_core::transformerless::scenarios::RuntimeTokenizerIdentity;
+
+        let dir = attention_provenance_test_dir("indexed-source-invalid");
+        std::fs::write(
+            dir.join("tokenizer.json"),
+            br#"{
+                "model":{"type":"BPE","vocab":{"a":0},"merges":[]},
+                "pre_tokenizer":{"type":"ByteLevel","add_prefix_space":false}
+            }"#,
+        )
+        .expect("tokenizer definition");
+        std::fs::write(dir.join("config.json"), br#"{"model_type":"llama"}"#)
+            .expect("minimal family marker");
+        std::fs::write(
+            dir.join("model.safetensors.index.json"),
+            br#"{"weight_map":{"x":"missing-shard.safetensors"}}"#,
+        )
+        .expect("indexed shard manifest");
+
+        assert_eq!(
+            super::optional_source_directory(&dir).expect("present directory is selected"),
+            Some(dir.clone()),
+            "startup selection does not require a monolithic model.safetensors"
+        );
+        let error = match super::prepare_optional_teacher_source_for_identity(
+            Some(&dir),
+            None,
+            "indexed-source",
+            None,
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a present malformed indexed source must not become decode-only"),
+        };
+        assert!(error.contains("teacher source"), "{error}");
+
+        let tokenizer = super::resolve_serving_source_tokenizer(
+            &dir,
+            Some(&TokenizerAdapterKey::hf_byte_bpe_v1()),
+        )
+        .expect("fixture tokenizer resolves");
+        let adapter = tokenizer.adapter().expect("registered adapter");
+        let mismatched = RuntimeTokenizerIdentity {
+            family: adapter.family.clone(),
+            version: adapter.version,
+            tokenizer_cid: "blake3:different-tokenizer".to_owned(),
+            adapter_digest: adapter.adapter_digest.clone(),
+        };
+        let error = match super::prepare_optional_teacher_source_for_identity(
+            Some(&dir),
+            Some(&TokenizerAdapterKey::hf_byte_bpe_v1()),
+            "indexed-source",
+            Some(&mismatched),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("explicit adapter selection cannot cross tokenizer identities"),
+        };
+        assert!(error.contains("compiled bundle requires"), "{error}");
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -6104,18 +18830,78 @@ mod tests {
     }
 
     #[test]
+    fn openai_model_alias_and_wire_surfaces_report_only_the_active_canonical_id() {
+        let canonical = super::resolve_request_model_name(Some("alpha"), Some("uor-r4"))
+            .expect("legacy alias intentionally maps to active");
+        assert_eq!(canonical, "alpha");
+        assert_eq!(
+            super::resolve_request_model_name(Some("alpha"), None).unwrap(),
+            "alpha"
+        );
+        assert_eq!(
+            super::resolve_request_model_name(Some("alpha"), Some("alpha")).unwrap(),
+            "alpha"
+        );
+        assert!(super::resolve_request_model_name(Some("alpha"), Some("beta")).is_err());
+        assert!(super::resolve_request_model_name(None, Some("uor-r4")).is_err());
+
+        let listed = super::models_list_body(&[(canonical.clone(), 7)]);
+        assert_eq!(listed["data"].as_array().unwrap().len(), 1);
+        assert_eq!(listed["data"][0]["id"], "alpha");
+
+        let chat_json = super::VendorChatCompletionsResponse {
+            id: "chatcmpl-alpha-1".to_owned(),
+            object: "chat.completion".to_owned(),
+            created: 1,
+            model: canonical.clone(),
+            choices: Vec::new(),
+            usage: super::VendorUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+            system_fingerprint: None,
+            uor_audit: None,
+            cascade_trail: serde_json::json!([]),
+        };
+        assert_eq!(serde_json::to_value(chat_json).unwrap()["model"], "alpha");
+
+        let chat_frames = super::build_chat_stream_frames(
+            "chatcmpl-alpha-1",
+            1,
+            &canonical,
+            "uor-r4-r4g1",
+            "ok",
+            "stop",
+            None,
+            None,
+            serde_json::json!([]),
+        );
+        for chunk in parse_stream_chunks(&chat_frames) {
+            assert_eq!(chunk["model"], "alpha");
+        }
+
+        let response = super::build_responses_body(dummy_generation("ok", 1, 1), &canonical, 64);
+        assert_eq!(response["model"], "alpha");
+        let response_frames =
+            super::build_responses_stream_frames("resp-alpha-1", 1, &canonical, "ok", response);
+        let events = parse_responses_events(&response_frames);
+        assert_eq!(events[0].1["response"]["model"], "alpha");
+        assert_eq!(events.last().unwrap().1["response"]["model"], "alpha");
+    }
+
+    #[test]
     fn loadable_models_lists_only_compiled_bundles_sorted() {
         let dir = std::env::temp_dir().join(format!("uor-r4-models-654b-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         for name in ["beta-model", "alpha-model"] {
             let bundle = dir.join(name);
-            std::fs::create_dir_all(&bundle).unwrap();
-            std::fs::write(bundle.join("tless_artifacts.bin"), b"artifact").unwrap();
+            write_loadable_graph_bundle(&bundle, None);
         }
         // A directory without a compiled artifact is NOT loadable.
         std::fs::create_dir_all(dir.join("no-bundle")).unwrap();
 
-        let models = super::loadable_models_in(&dir);
+        let models = super::loadable_models_in(&dir).expect("valid model inventory");
         let ids: Vec<&str> = models.iter().map(|(id, _)| id.as_str()).collect();
         assert_eq!(
             ids,
@@ -6140,7 +18926,9 @@ mod tests {
     fn loadable_models_is_empty_without_a_compiled_dir() {
         let dir = std::env::temp_dir().join(format!("uor-r4-nomodels-654b-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
-        assert!(super::loadable_models_in(&dir).is_empty());
+        assert!(super::loadable_models_in(&dir)
+            .expect("genuinely absent inventory")
+            .is_empty());
     }
 
     #[test]

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -194,15 +194,37 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
             if sanctioned.iter().any(|s| tail.contains(s)) {
                 continue;
             }
-            // serde's `Serialize`/`Deserialize` contract is not the model's
-            // error surface: a `Serializer::serialize_*`-shaped helper returns
-            // `Result<S::Ok, S::Error>` and a `Deserialize::deserialize`-shaped
-            // helper returns `Result<T, D::Error>`, where the error is the
-            // *data format's* (the caller's serde impl), not a limitation this
-            // model reports. These associated-type signatures are fixed by the
-            // trait and cannot name a sanctioned type, so they are carved out
-            // exactly like a sanctioned return.
-            if tail.contains("S::Ok") || tail.contains("S::Error") || tail.contains("D::Error") {
+            // serde's `Serialize`/`Deserialize`/`Visitor` contracts are not the
+            // model's error surface. Their signatures return the caller's data
+            // format error (`S::Error`, `D::Error`, `A::Error`, or the generic
+            // `E` on a `visit_*` scalar callback), not a limitation this model
+            // reports. These signatures are fixed by the trait and cannot name
+            // a sanctioned type, so they are carved out exactly like a
+            // sanctioned return. Keep the generic carve-out syntactically tied
+            // to a Visitor callback and its fixed `Self::Value` result so an
+            // ordinary helper named `visit_*` cannot hide an unrelated error.
+            let serde_visitor_scalar = [
+                "fn visit_bool<",
+                "fn visit_i64<",
+                "fn visit_u64<",
+                "fn visit_f64<",
+                "fn visit_str<",
+                "fn visit_string<",
+                "fn visit_none<",
+                "fn visit_unit<",
+            ]
+            .iter()
+            .any(|signature| line.trim_start().starts_with(signature))
+                && tail.contains("Result<Self::Value, E>");
+            let serde_visitor_access = (line.trim_start().starts_with("fn visit_seq")
+                || line.trim_start().starts_with("fn visit_map"))
+                && tail.contains("Result<Self::Value, A::Error>");
+            if tail.contains("S::Ok")
+                || tail.contains("S::Error")
+                || tail.contains("D::Error")
+                || serde_visitor_scalar
+                || serde_visitor_access
+            {
                 continue;
             }
             // The uor_foundation SDK's enforcement and pipeline traits fix their


### PR DESCRIPTION
## Summary

- advance immutable source-attention aliases to v2 while preserving every v1 canonical record
- route Llama and GPT-2 QK/value reductions through certified-native f64 cell proofs with pinned exact `uor-matmul` fallback
- bind observation, compilation, and serving provenance to exact operator/source identities while preserving historical-era bundles
- make source download, compile, refresh, and Stage-A checkpoints crash-atomic and cross-process serialized
- keep GPT-2 Conv1D, MLP, and tied `lm_head` conventional

## Decision evidence

The committed-SHA real GPT-2 canary passed on the pinned 124M snapshot:

- candidate median: 1,273,138,500 ns
- conventional median: 1,259,395,084 ns
- paired median ratio: **1.010964087** (acceptance limit: 1.10)
- QK certification rate: 0.999973695
- value certification rate: 1.0
- exact recurrent output parity and zero-allocation guards passed
- pinned `uor-matmul` revision: `b13c98449948174f590e337c4dc25dfc394a07d0`

## Validation

- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all -- --check`
- graph-format `no_std` and `alloc` checks
- wasm32 root-library check
- claim-wording and diff checks
- release ignored real-GPT2 canary on the committed SHA
- independent model-source and whole-diff P0-P2 audits: CLEAN

References #704

#704 remains open because GPT-2 Conv1D, MLP, and tied `lm_head` migration is not part of this PR.