### PR TITLE
Ship certified GPT-2 dense v2 with transactional corpus provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,6 +1964,7 @@ name = "uor-r4-graph-cli"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "libc",
  "serde",
  "serde_json",
  "uor-matmul-core",
@@ -1981,6 +1982,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "env_logger",
+ "libc",
  "libm",
  "log",
  "rayon",

--- a/README.md
+++ b/README.md
@@ -290,14 +290,22 @@ r4 transformerless observe-text \
   [--input PATH] \
   [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] \
   [--out obs-text]
-r4 transformerless cover        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out cover]
+r4 transformerless cover        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out cover] [--bundle-root ROOT]
 r4 transformerless cover-sweep  [...]
-r4 transformerless score        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out DIR]
+r4 transformerless score        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out DIR] [--bundle-root ROOT]
 r4 transformerless convert-r4g1 --artifacts TLA --store TLS1 --out R4G1
 r4 transformerless copy-recorded-attention --corpus-meta M --corpus-recs R --out attention_operator.json
 r4 transformerless compile-recorded --corpus-meta M --corpus-recs R --vocab-size N --out DIR
 r4 graph infill --artifact score.r4g1 --skeleton 12,_,_,_,99,_,_,_,7
 ```
+
+`--bundle-root ROOT` explicitly joins cover/score output publication to that
+managed bundle's producer transaction. Without it, `--out` is an exact
+standalone output root, including a direct child of the corpus root or paths
+whose basename is `graph` or `graph-cover`. Physically present completion,
+owner, or Stage-A-seal evidence is refused at transaction start; later parent
+state never changes an already selected standalone transaction into bundle
+participation.
 
 **Certification and comparison** (need the llama2.c checkpoint — see
 [Troubleshooting](#troubleshooting))

--- a/README.md
+++ b/README.md
@@ -295,9 +295,18 @@ r4 transformerless cover-sweep  [...]
 r4 transformerless score        [--corpus-meta M] [--corpus-recs R] [--artifacts A] [--tokenizer PATH] [--out DIR] [--bundle-root ROOT]
 r4 transformerless convert-r4g1 --artifacts TLA --store TLS1 --out R4G1
 r4 transformerless copy-recorded-attention --corpus-meta M --corpus-recs R --out attention_operator.json
+r4 transformerless subsample-recorded-corpus --src-meta M --src-recs R --out-meta M2 --out-recs R2 --records N
 r4 transformerless compile-recorded --corpus-meta M --corpus-recs R --vocab-size N --out DIR
 r4 graph infill --artifact score.r4g1 --skeleton 12,_,_,_,99,_,_,_,7
 ```
+
+`subsample-recorded-corpus` is the provenance-preserving derivation path for
+scaling controls: it retains complete deterministic story runs from the
+finalized source's fixed train/held partitions and publishes records, hidden
+rows, execution sidecars, and their binding as one transaction. The historical
+`copy-recorded-attention` command is limited to legacy attention-only corpora;
+it refuses a source with dense execution provenance instead of silently
+dropping or relabelling the dense sidecar.
 
 `--bundle-root ROOT` explicitly joins cover/score output publication to that
 managed bundle's producer transaction. Without it, `--out` is an exact

--- a/README.md
+++ b/README.md
@@ -250,31 +250,35 @@ r4 import --name N --source-model M --capability continuation|instruction-chat \
           --artifacts F --store F --tokenizer F [--evaluation-report F]
 ```
 
-Source compiles write `attention_operator.json` beside `corpus.meta` and
-`corpus.records`. The registry-validated sidecar binds the source-attention
-operator that produced the rows; resume fails closed when an existing payload
-has a missing or different binding. `compile-recorded` propagates an explicit
-operator from an observation manifest, while a genuinely absent historical
-record retains the documented implicit `standard-source-attention/1` meaning.
-The current standard, experimental, and GPT-2 learned-absolute source records
-are version 2; their v1 records remain immutable accepted history. Version 2
-uses certified-native Q·K/value folds only when a mechanical rounding-cell
-witness proves the exact bit returned by pinned `uor-matmul`, with that exact
-kernel as the fallback. When the browser compile endpoint finds a populated v1
-bundle at the conventional model root, it preserves that root byte-for-byte and
-writes/resumes v2 at the deterministic `<name>-attention-v2` root instead.
-The managed server reserves that suffix: downloaded source basenames ending in
-it are rejected before output mutation. Compile, automatic restart discovery,
-reload, model listing, and status all inspect the conventional and suffixed
-roots as one logical pair. Reloading either `<name>` or the exact suffix alias
-selects the same physical bundle and maps its host encoder to
-`sources/<name>`; `/uor/v1/status` reports both the logical model name and
-the selected `physical_root`. A genuinely absent source keeps the #718
-decode-only behavior, while a present-invalid source or preferred bundle is
-terminal. Current-v2 serving additionally requires exact agreement among the
-root sidecar, canonical corpus/observation provenance, and
-`graph-cover/cover_report.json`; legacy v1 bundles remain compatible when the
-supporting records are genuinely absent.
+Source compiles write `attention_operator.json` and, for GPT-2, the optional
+`dense_operator.json` beside `corpus.meta` and `corpus.records`. These
+registry-validated records bind the host-side arithmetic that produced the
+rows; resume fails closed on a missing, malformed, different, or impossible
+attention+dense pair. `compile-recorded`, cover, evaluation, certification,
+the typed API, and the server propagate and revalidate that pair. Genuine
+historical dense absence remains readable (and Llama declares no dense
+record); it is never synthesized or relabelled.
+
+The current standard, experimental, and GPT-2 learned-absolute attention
+records are version 2. GPT-2 pairs `learned-absolute-source-attention/2` with
+`gpt2-source-dense/2`; the immutable v1/v1 pair remains accepted history.
+Current attention and dense folds use certified-native arithmetic only when a
+mechanical rounding-cell witness proves the pinned `uor-matmul` result, with
+that owner as fallback. This is offline source-teacher execution provenance,
+not a deployed matrix operation.
+
+The managed server resolves three physical roots for one logical model, in
+preference order: `<name>-attention-v2-dense-v2`, `<name>-attention-v2`, then
+`<name>`. A current GPT-2 dense/2 bundle is valid only in the composite root;
+an attention-v2/no-dense bundle may occupy a fresh base or the attention-only
+root, and a historical v1/v1 bundle may remain at the base. Resolver-owned
+suffixes are reserved and stripped by longest match. Malformed preferred
+evidence is terminal, never a reason to fall back. Compile, restart discovery,
+reload, listing, `/uor/v1/status`, and `/api/r4g1/status` use the same resolver
+and expose the selected `physical_root` plus optional attention/dense records.
+Current-v2 serving requires exact agreement among root sidecars, canonical
+corpus/observation provenance, and `graph-cover/cover_report.json`; legacy
+absence remains compatible only where explicitly documented.
 
 **Graph pipeline**
 

--- a/crates/uor-r4-api/README.md
+++ b/crates/uor-r4-api/README.md
@@ -22,6 +22,10 @@ rather than driving its CLI.
   resumes from the work-directory checkpoint (detected structurally from
   the corpus metadata done byte — the same gate the corpus loader
   applies — never by parsing stage stdout).
+  `CompiledModel::source_execution_identity()` registry-validates the
+  attention/dense pair persisted in `compile_report.json`;
+  `attention_operator()` and `dense_operator()` are nonbreaking convenience
+  accessors. Dense absence remains `None` for Llama and historical reports.
 - **Typed engine** (`engine::R4Engine`): loads from byte slices only
   (`EngineParts`) — no filesystem access. The graph passes the format
   crate's two-stage structural validation and CID verification before
@@ -76,6 +80,11 @@ validated `TokenizerAdapter` record: family, version, CID of the exact raw
 definition, declared policy, and adapter digest. That raw-definition CID is
 distinct from `provenance.digests.tokenizer`, which addresses the emitted
 runtime `tokenizer.bin` bytes.
+
+Source arithmetic is execution provenance, not a compile knob. The API derives
+the teacher's registered `attention_operator` and optional `dense_operator`
+from the source adapter, forwards both through Stage A and cover, and does not
+add a `CompileOptions` selector that could mislabel model-produced rows.
 
 ## Downstream contract
 

--- a/crates/uor-r4-api/src/compile.rs
+++ b/crates/uor-r4-api/src/compile.rs
@@ -25,6 +25,7 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use serde::Deserialize;
 use uor_r4_core::transformerless::hf_bpe::{adapter_constructor, resolve_source_tokenizer};
 pub use uor_r4_core::transformerless::hf_bpe::{TokenizerAdapter, TokenizerAdapterKey};
 use uor_r4_graph_certify::score::{
@@ -38,6 +39,8 @@ use uor_r4_graph_format::{
     ContractVersion, FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR,
     INFERENCE_OPERATION_CONTRACT_VERSION,
 };
+use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
 use uor_r4_model_source::SourceUnavailable;
 
 /// Which compiler stage a progress event or failure belongs to.
@@ -222,6 +225,80 @@ pub struct CompiledModel {
     pub provenance: CompileProvenance,
 }
 
+/// Exact optional host-side source execution records persisted in the cover
+/// report. This is compile evidence, not a deployed-runtime operator choice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceExecutionIdentity {
+    pub attention_operator: Option<AttentionOperatorSpec>,
+    pub dense_operator: Option<DenseOperatorSpec>,
+}
+
+#[derive(Deserialize)]
+struct CompileReportExecutionProjection {
+    #[serde(default)]
+    attention_operator: Option<AttentionOperatorSpec>,
+    #[serde(default)]
+    dense_operator: Option<DenseOperatorSpec>,
+}
+
+impl CompiledModel {
+    /// Parse and registry-validate the source attention/dense pair from the
+    /// immutable `compile_report` bytes returned with this model.
+    pub fn source_execution_identity(&self) -> Result<SourceExecutionIdentity, SourceUnavailable> {
+        let projection: CompileReportExecutionProjection =
+            serde_json::from_slice(&self.compile_report).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "compile_report.json does not contain readable source execution provenance: {error}"
+                ))
+            })?;
+        if let Some(operator) = projection.attention_operator.as_ref() {
+            let registered =
+                uor_r4_model_source::attention::operator_spec(&operator.id, operator.version)?;
+            if registered != *operator {
+                return Err(SourceUnavailable::new(format!(
+                    "compile report attention operator {}/{} diverges from its immutable registry record",
+                    operator.id, operator.version
+                )));
+            }
+        }
+        if let Some(operator) = projection.dense_operator.as_ref() {
+            let registered =
+                uor_r4_model_source::dense::operator_spec(&operator.id, operator.version)?;
+            if registered != *operator {
+                return Err(SourceUnavailable::new(format!(
+                    "compile report dense operator {}/{} diverges from its immutable registry record",
+                    operator.id, operator.version
+                )));
+            }
+        }
+        uor_r4_model_source::dense::validate_source_execution_pair(
+            projection.attention_operator.as_ref(),
+            projection.dense_operator.as_ref(),
+        )
+        .map_err(|mut error| {
+            error.reason = format!(
+                "compile report source execution provenance: {}",
+                error.reason
+            );
+            error
+        })?;
+        Ok(SourceExecutionIdentity {
+            attention_operator: projection.attention_operator,
+            dense_operator: projection.dense_operator,
+        })
+    }
+
+    /// Exact optional source-attention record from `compile_report.json`.
+    pub fn attention_operator(&self) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+        Ok(self.source_execution_identity()?.attention_operator)
+    }
+
+    /// Exact optional host-side dense record from `compile_report.json`.
+    pub fn dense_operator(&self) -> Result<Option<DenseOperatorSpec>, SourceUnavailable> {
+        Ok(self.source_execution_identity()?.dense_operator)
+    }
+}
+
 /// The result of one [`compile`] call: either the scored graph is ready,
 /// or the teacher corpus is still incomplete and the same request should
 /// be re-run (the corpus checkpoint in the work directory resumes). The
@@ -294,6 +371,7 @@ pub fn compile(
     })?;
     let tokenizer_adapter = read_stage_a_tokenizer_adapter(work, &preflight_tokenizer_adapter)?;
     let attention_operator = uor_r4_graph_cli::compiled_attention_operator(work)?;
+    let dense_operator = uor_r4_graph_cli::compiled_dense_operator(work)?;
 
     if !corpus_complete(&meta)? {
         return Ok(CompileOutcome::Incomplete {
@@ -312,8 +390,13 @@ pub fn compile(
         percent: 0,
         label: "Inducing multiresolution cover...",
     });
-    uor_r4_graph_compiler::compile(&stage_b_flags(request, &cover_out, &attention_operator)?)
-        .map_err(|error| SourceUnavailable::new(format!("{} stage: {error}", Stage::GraphCover)))?;
+    uor_r4_graph_compiler::compile(&stage_b_flags(
+        request,
+        &cover_out,
+        &attention_operator,
+        dense_operator.as_ref(),
+    )?)
+    .map_err(|error| SourceUnavailable::new(format!("{} stage: {error}", Stage::GraphCover)))?;
     progress(ProgressEvent {
         stage: Stage::GraphCover,
         percent: 100,
@@ -584,6 +667,7 @@ fn stage_b_flags(
     request: &CompileRequest,
     cover_out: &Path,
     operator: &uor_r4_model_source::attention::AttentionOperatorSpec,
+    dense_operator: Option<&uor_r4_model_source::dense::DenseOperatorSpec>,
 ) -> Result<Vec<String>, SourceUnavailable> {
     let options = &request.options;
     let work = &request.work_dir;
@@ -620,6 +704,12 @@ fn stage_b_flags(
         SourceUnavailable::new(format!("attention-operator binding serialization: {error}"))
     })?;
     flags.extend(["--attention-operator".to_owned(), json]);
+    if let Some(operator) = dense_operator {
+        let json = serde_json::to_string(operator).map_err(|error| {
+            SourceUnavailable::new(format!("dense-operator binding serialization: {error}"))
+        })?;
+        flags.extend(["--dense-operator".to_owned(), json]);
+    }
     Ok(flags)
 }
 
@@ -671,6 +761,29 @@ mod tests {
         }
     }
 
+    fn compiled_model_with_report(report: serde_json::Value) -> CompiledModel {
+        CompiledModel {
+            graph: Vec::new(),
+            signature_artifact: Vec::new(),
+            tokenizer: None,
+            score_report: Vec::new(),
+            compile_report: serde_json::to_vec(&report).expect("compile report fixture"),
+            provenance: CompileProvenance {
+                options: CompileOptions::default(),
+                tokenizer_adapter: TokenizerAdapter::default(),
+                format_version: (FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR),
+                contract_version: INFERENCE_OPERATION_CONTRACT_VERSION,
+                digests: ComponentDigests {
+                    graph: "blake3:fixture".to_owned(),
+                    signature_artifact: "blake3:fixture".to_owned(),
+                    tokenizer: None,
+                    score_report: "blake3:fixture".to_owned(),
+                    compile_report: "blake3:fixture".to_owned(),
+                },
+            },
+        }
+    }
+
     #[test]
     fn tokenizer_adapter_is_threaded_as_an_atomic_stage_a_pair() {
         let mut request = request(None);
@@ -690,7 +803,7 @@ mod tests {
         let expected = request.work_dir.join("tokenizer.bin").display().to_string();
         let operator = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
         for flags in [
-            stage_b_flags(&request, Path::new("cover"), &operator).expect("cover flags"),
+            stage_b_flags(&request, Path::new("cover"), &operator, None).expect("cover flags"),
             stage_c_flags(&request, Path::new("cover"), Path::new("scored")),
         ] {
             assert!(
@@ -823,12 +936,18 @@ mod tests {
     fn source_manifest_kappa_is_threaded_into_cover_stage_flags() {
         let kappa = format!("blake3:{}", "7".repeat(64));
         let operator = uor_r4_model_source::attention::AttentionOperatorSpec::standard();
-        let with = stage_b_flags(&request(Some(kappa.clone())), Path::new("cover"), &operator)
-            .expect("flags");
+        let with = stage_b_flags(
+            &request(Some(kappa.clone())),
+            Path::new("cover"),
+            &operator,
+            None,
+        )
+        .expect("flags");
         assert!(with
             .windows(2)
             .any(|pair| pair == ["--source-manifest-kappa", kappa.as_str()]));
-        let without = stage_b_flags(&request(None), Path::new("cover"), &operator).expect("flags");
+        let without =
+            stage_b_flags(&request(None), Path::new("cover"), &operator, None).expect("flags");
         assert!(!without.iter().any(|flag| flag == "--source-manifest-kappa"));
         assert_eq!(with.len(), without.len() + 2);
     }
@@ -859,8 +978,85 @@ mod tests {
             // Deliberately contradict the supplied record where possible:
             // the stage-A binding, not this policy bit, is authoritative.
             request.options.r4_attention = operator == AttentionOperatorSpec::standard();
-            let flags = stage_b_flags(&request, Path::new("cover"), &operator).expect("flags");
+            let flags =
+                stage_b_flags(&request, Path::new("cover"), &operator, None).expect("flags");
             assert_eq!(flag_value(&flags), operator);
         }
+    }
+
+    #[test]
+    fn dense_operator_is_exactly_threaded_or_omitted_from_cover_flags() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        let with = stage_b_flags(&request(None), Path::new("cover"), &attention, Some(&dense))
+            .expect("dense flags");
+        let index = with
+            .iter()
+            .position(|flag| flag == "--dense-operator")
+            .expect("dense flag present");
+        let round_trip: DenseOperatorSpec =
+            serde_json::from_str(&with[index + 1]).expect("dense record round trip");
+        assert_eq!(round_trip, dense);
+
+        let without = stage_b_flags(&request(None), Path::new("cover"), &attention, None)
+            .expect("dense-absent flags");
+        assert!(!without.iter().any(|flag| flag == "--dense-operator"));
+    }
+
+    #[test]
+    fn compiled_model_exposes_registry_validated_source_execution_identity() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        let model = compiled_model_with_report(serde_json::json!({
+            "attention_operator": attention,
+            "dense_operator": dense,
+        }));
+        assert_eq!(
+            model.source_execution_identity().expect("valid identity"),
+            SourceExecutionIdentity {
+                attention_operator: Some(AttentionOperatorSpec::learned_absolute_v2()),
+                dense_operator: Some(DenseOperatorSpec::gpt2_v2()),
+            }
+        );
+        assert_eq!(
+            model.attention_operator().expect("attention accessor"),
+            Some(AttentionOperatorSpec::learned_absolute_v2())
+        );
+        assert_eq!(
+            model.dense_operator().expect("dense accessor"),
+            Some(DenseOperatorSpec::gpt2_v2())
+        );
+
+        let legacy = compiled_model_with_report(serde_json::json!({"schema": 1}));
+        assert_eq!(
+            legacy.source_execution_identity().expect("legacy absence"),
+            SourceExecutionIdentity {
+                attention_operator: None,
+                dense_operator: None,
+            }
+        );
+
+        let cross_era = compiled_model_with_report(serde_json::json!({
+            "attention_operator": AttentionOperatorSpec::learned_absolute_v1(),
+            "dense_operator": DenseOperatorSpec::gpt2_v2(),
+        }));
+        assert!(cross_era.source_execution_identity().is_err());
+
+        let mut drifted = DenseOperatorSpec::gpt2_v2();
+        drifted.implementation_digest = format!("blake3:{}", "0".repeat(64));
+        let drifted = compiled_model_with_report(serde_json::json!({
+            "attention_operator": AttentionOperatorSpec::learned_absolute_v2(),
+            "dense_operator": drifted,
+        }));
+        let error = drifted
+            .source_execution_identity()
+            .expect_err("full-record drift is terminal");
+        assert!(error.reason.contains("diverges"), "{error}");
     }
 }

--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -27,8 +27,8 @@ pub mod serving_eval;
 
 pub use compile::{
     compile, CompileOptions, CompileOutcome, CompileProvenance, CompileRequest, CompiledModel,
-    ComponentDigests, ProgressEvent, QualityProfile, ResumeHint, ScoringOptions, Stage,
-    TokenizerAdapter, TokenizerAdapterKey,
+    ComponentDigests, ProgressEvent, QualityProfile, ResumeHint, ScoringOptions,
+    SourceExecutionIdentity, Stage, TokenizerAdapter, TokenizerAdapterKey,
 };
 pub use engine::{
     validate_quality_report, AbiVersion, AbstainOutcome, EngineParts, GenerateStatus,

--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -551,6 +551,33 @@ pub fn corpus_paths() -> (&'static str, &'static str) {
     ("/tmp/c_meta.bin", "/tmp/c_recs.bin")
 }
 
+/// Derive the optional hidden-row stream beside a corpus record stream.
+///
+/// Only the record file name participates in the historical
+/// `_recs.bin` -> `_hidden.bin` convention. Replacing that substring in the
+/// complete path can silently redirect the hidden stream when a parent
+/// directory happens to contain `_recs.bin`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn corpus_hidden_path(records: &std::path::Path) -> std::path::PathBuf {
+    let Some(file_name) = records.file_name() else {
+        let mut path = records.as_os_str().to_os_string();
+        path.push(".hidden");
+        return std::path::PathBuf::from(path);
+    };
+    let hidden_name = match file_name
+        .to_str()
+        .and_then(|name| name.strip_suffix("_recs.bin"))
+    {
+        Some(stem) => std::ffi::OsString::from(format!("{stem}_hidden.bin")),
+        None => {
+            let mut name = file_name.to_os_string();
+            name.push(".hidden");
+            name
+        }
+    };
+    records.with_file_name(hidden_name)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_corpus() -> Option<Corpus> {
     // Keep the historical defaults for normal certification, but allow
@@ -568,13 +595,22 @@ pub fn load_corpus() -> Option<Corpus> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_corpus_from(mp: &str, rp: &str) -> Option<Corpus> {
     let meta = std::fs::read(mp).ok()?;
+    let records = std::fs::read(rp).ok()?;
+    let hidden = std::fs::read(corpus_hidden_path(std::path::Path::new(rp))).ok();
+    load_corpus_bytes(&meta, &records, hidden.as_deref())
+}
+
+/// Parse one exact captured corpus generation. Callers that already hold
+/// provenance-bound bytes use this seam so parsing cannot reopen a different
+/// path generation. `hidden` retains the same optional 288-wide f32 layout as
+/// [`load_corpus_from`].
+pub fn load_corpus_bytes(meta: &[u8], rb_full: &[u8], hidden: Option<&[u8]>) -> Option<Corpus> {
     if meta.len() != 25 || meta[24] != 1 {
         return None;
     }
     let n = u64::from_le_bytes(meta[0..8].try_into().unwrap()) as usize;
     let stories = u64::from_le_bytes(meta[8..16].try_into().unwrap());
-    let rb_full = std::fs::read(rp).ok()?;
-    let record_size = if rb_full.len() >= n * 88 && (n > 0 && rb_full.len() % 88 == 0) {
+    let record_size = if rb_full.len() >= n * 88 && (n > 0 && rb_full.len().is_multiple_of(88)) {
         88usize
     } else if rb_full.len() >= n * 48 {
         48usize
@@ -703,14 +739,7 @@ pub fn load_corpus_from(mp: &str, rp: &str) -> Option<Corpus> {
         hidden: None,
     };
 
-    let mut hidden_path = String::from(rp);
-    if hidden_path.ends_with("_recs.bin") {
-        hidden_path = hidden_path.replace("_recs.bin", "_hidden.bin");
-    } else {
-        hidden_path.push_str(".hidden");
-    }
-
-    if let Ok(hb) = std::fs::read(&hidden_path) {
+    if let Some(hb) = hidden {
         // Teacher hidden state is dimension 288 (D)
         if hb.len() == n * D * 4 {
             let mut hidden = Vec::with_capacity(n);
@@ -996,12 +1025,7 @@ pub fn generate_to_with_token_byte_lengths(
     rp: &str,
     token_byte_lengths: Option<&[u32]>,
 ) {
-    let mut hidden_path = String::from(rp);
-    if hidden_path.ends_with("_recs.bin") {
-        hidden_path = hidden_path.replace("_recs.bin", "_hidden.bin");
-    } else {
-        hidden_path.push_str(".hidden");
-    }
+    let hidden_path = corpus_hidden_path(std::path::Path::new(rp));
 
     let (mut n, mut stories, mut rng, mut done) = match std::fs::read(mp) {
         Ok(b) if b.len() == 25 => (
@@ -1018,17 +1042,21 @@ pub fn generate_to_with_token_byte_lengths(
             return;
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            for path in [rp, hidden_path.as_str()] {
+            for path in [std::path::Path::new(rp), hidden_path.as_path()] {
                 match std::fs::symlink_metadata(path) {
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                     Ok(_) => {
                         eprintln!(
-                            "corpus metadata cannot be initialized: {path} exists without the authoritative zero checkpoint {mp}"
+                            "corpus metadata cannot be initialized: {} exists without the authoritative zero checkpoint {mp}",
+                            path.display()
                         );
                         return;
                     }
                     Err(error) => {
-                        eprintln!("corpus stream {path} cannot be inspected: {error}");
+                        eprintln!(
+                            "corpus stream {} cannot be inspected: {error}",
+                            path.display()
+                        );
                         return;
                     }
                 }
@@ -2267,8 +2295,9 @@ pub fn induce_hierarchical_codes(
 #[cfg(test)]
 mod capacity_override_tests {
     use super::{
-        capacity_override_f64, capacity_override_usize, is_source_corpus_checkpoint_temporary_name,
-        publish_source_corpus_checkpoint, source_corpus_checkpoint_bytes,
+        capacity_override_f64, capacity_override_usize, corpus_hidden_path,
+        is_source_corpus_checkpoint_temporary_name, publish_source_corpus_checkpoint,
+        source_corpus_checkpoint_bytes,
     };
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -2348,5 +2377,19 @@ mod capacity_override_tests {
             ));
         }
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn hidden_stream_suffix_changes_only_the_record_file_name() {
+        let nested = std::path::Path::new("/tmp/parent_recs.bin/corpus.records");
+        assert_eq!(
+            corpus_hidden_path(nested),
+            std::path::PathBuf::from("/tmp/parent_recs.bin/corpus.records.hidden")
+        );
+        let legacy = std::path::Path::new("/tmp/parent_recs.bin/corpus_recs.bin");
+        assert_eq!(
+            corpus_hidden_path(legacy),
+            std::path::PathBuf::from("/tmp/parent_recs.bin/corpus_hidden.bin")
+        );
     }
 }

--- a/crates/uor-r4-graph-certify/src/octeract_trace_screen.rs
+++ b/crates/uor-r4-graph-certify/src/octeract_trace_screen.rs
@@ -26,6 +26,9 @@ use uor_r4_graph_format::route_attention::{
 };
 use uor_r4_graph_format::ScoreQ;
 use uor_r4_model_source::attention::{operator_spec, AttentionOperatorSpec};
+use uor_r4_model_source::dense::{
+    operator_spec as dense_operator_spec, validate_source_execution_pair,
+};
 use uor_r4_model_source::geometry::{projection_implementation, GeometryProjection};
 
 use crate::frame_consistency::{frame_control_default, FrameControl};
@@ -326,6 +329,10 @@ pub struct ScreenIdentities {
     pub target_operator_digest: Option<String>,
     /// Teacher/source attention-operator digest, supplied explicitly.
     pub source_attention_operator_digest: Option<String>,
+    /// Teacher/source dense-operator digest. `None` is typed historical/Llama
+    /// absence, not an inferred arithmetic record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_dense_operator_digest: Option<String>,
     /// Compiler identity.
     pub compiler: Option<String>,
     /// Closed evidence-registry id, absent only when no input was supplied.
@@ -1435,6 +1442,7 @@ enum InputCheck<'a> {
         input: OcteractTraceInput<'a>,
         lane_index: usize,
         source_operator_digest: Option<String>,
+        source_dense_operator_digest: Option<String>,
     },
     Unavailable(String),
 }
@@ -1809,6 +1817,40 @@ fn validate_input<'a>(input: OcteractTraceInput<'a>, kind: TraceKind) -> InputCh
             }
         }
     };
+    let source_dense_operator_digest = match input.observation_manifest {
+        None => None,
+        Some(observation) => {
+            let digest = match observation.dense_operator.as_ref() {
+                None => None,
+                Some(source_dense) => {
+                    let registered =
+                        match dense_operator_spec(&source_dense.id, source_dense.version) {
+                            Ok(record) => record,
+                            Err(_) => {
+                                return InputCheck::Unavailable(
+                                    "source dense operator is not a registered record".to_owned(),
+                                );
+                            }
+                        };
+                    if &registered != source_dense {
+                        return InputCheck::Unavailable(
+                            "source dense operator record is tampered".to_owned(),
+                        );
+                    }
+                    Some(source_dense.declared_digest())
+                }
+            };
+            if let Err(error) = validate_source_execution_pair(
+                observation.attention_operator.as_ref(),
+                observation.dense_operator.as_ref(),
+            ) {
+                return InputCheck::Unavailable(format!(
+                    "observation source execution identity is invalid: {error}"
+                ));
+            }
+            digest
+        }
+    };
 
     if kind == TraceKind::PinnedReal {
         let Some(observation) = input.observation_manifest else {
@@ -1917,12 +1959,14 @@ fn validate_input<'a>(input: OcteractTraceInput<'a>, kind: TraceKind) -> InputCh
         input,
         lane_index,
         source_operator_digest,
+        source_dense_operator_digest,
     }
 }
 
 fn report_identities(
     input: Option<OcteractTraceInput<'_>>,
     source_operator_digest: Option<String>,
+    source_dense_operator_digest: Option<String>,
 ) -> ScreenIdentities {
     let mut identities = ScreenIdentities {
         octeract_source_sha256: OCTERACT_CYPHER_SOURCE.sha256.to_owned(),
@@ -1963,6 +2007,7 @@ fn report_identities(
     identities.adapter = input.fit_manifest.adapter.clone();
     identities.target_operator_digest = input.fit_manifest.operator_identity.clone();
     identities.source_attention_operator_digest = source_operator_digest;
+    identities.source_dense_operator_digest = source_dense_operator_digest;
     identities.compiler = input.fit_manifest.compiler.clone();
     identities.trace_evidence_id = Some(input.evidence.id().to_owned());
     identities.trace_evidence_version = Some(input.evidence.version());
@@ -2054,27 +2099,37 @@ pub fn run_octeract_trace_screen(
         return unavailable_report(
             contract,
             kind,
-            report_identities(None, None),
+            report_identities(None, None, None),
             "required explicitly supplied pinned full/1 trace input is absent".to_owned(),
         );
     };
     let checked = validate_input(supplied, kind);
-    let (input, lane_index, source_operator_digest) = match checked {
+    let (input, lane_index, source_operator_digest, source_dense_operator_digest) = match checked {
         InputCheck::Ready {
             input,
             lane_index,
             source_operator_digest,
-        } => (input, lane_index, source_operator_digest),
+            source_dense_operator_digest,
+        } => (
+            input,
+            lane_index,
+            source_operator_digest,
+            source_dense_operator_digest,
+        ),
         InputCheck::Unavailable(reason) => {
             return unavailable_report(
                 contract,
                 kind,
-                report_identities(Some(supplied), None),
+                report_identities(Some(supplied), None, None),
                 reason,
             );
         }
     };
-    let identities = report_identities(Some(input), source_operator_digest);
+    let identities = report_identities(
+        Some(input),
+        source_operator_digest,
+        source_dense_operator_digest,
+    );
     let Some(head) = input.fitted.head(SCREEN_LAYER, SCREEN_HEAD) else {
         return unavailable_report(
             contract,

--- a/crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs
+++ b/crates/uor-r4-graph-certify/tests/octeract_trace_screen_661.rs
@@ -27,6 +27,7 @@ use uor_r4_graph_compiler::route_fit::{
 use uor_r4_graph_compiler::trace_profile::TraceProfile;
 use uor_r4_graph_format::route_attention::ROUTE_CODE_BYTES;
 use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
 use uor_r4_model_source::geometry::GeometryProjection;
 use uor_r4_model_source::TraceCaptureGeometry;
 
@@ -711,6 +712,7 @@ fn instrument_report_is_deterministic_comprehensive_and_nonpromoting() {
                 .as_str()
         )
     );
+    assert_eq!(first.identities.source_dense_operator_digest, None);
     assert_ne!(
         first.identities.target_operator_digest, first.identities.source_attention_operator_digest,
         "the target dormant operator must never be relabeled as the teacher source operator"
@@ -1009,6 +1011,81 @@ fn pinned_real_rejects_unknown_or_tampered_source_provenance_records() {
         "{}",
         report.disposition_reason
     );
+}
+
+#[test]
+fn source_dense_provenance_is_reported_and_impossible_pairs_are_unavailable() {
+    let mut fixture = fixture();
+    let mut observation = bound_observation(&mut fixture);
+    observation.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+    observation.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+    fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+    let report = run_octeract_trace_screen(
+        Some(screen_input(&fixture, Some(&observation))),
+        TraceKind::InstrumentConformance,
+    );
+    assert!(
+        report.controls.instrument_valid,
+        "{}",
+        report.disposition_reason
+    );
+    assert_eq!(
+        report.identities.source_dense_operator_digest.as_deref(),
+        Some(DenseOperatorSpec::gpt2_v2().declared_digest().as_str())
+    );
+
+    for (case, attention, dense) in [
+        (
+            "cross-era",
+            Some(AttentionOperatorSpec::learned_absolute_v1()),
+            DenseOperatorSpec::gpt2_v2(),
+        ),
+        ("dense-only", None, DenseOperatorSpec::gpt2_v2()),
+    ] {
+        let (mut fixture, mut observation) = real_shaped_fixture();
+        observation.attention_operator = attention;
+        observation.dense_operator = Some(dense);
+        fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+        let report = run_octeract_trace_screen(
+            Some(screen_input(&fixture, Some(&observation))),
+            TraceKind::PinnedReal,
+        );
+        assert_unavailable(&report);
+        assert!(
+            report
+                .disposition_reason
+                .contains("source execution identity is invalid"),
+            "{case}: {}",
+            report.disposition_reason
+        );
+        assert_eq!(report.identities.source_dense_operator_digest, None);
+    }
+
+    for case in ["unknown", "tampered"] {
+        let (mut fixture, mut observation) = real_shaped_fixture();
+        observation.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+        let mut dense = DenseOperatorSpec::gpt2_v2();
+        if case == "unknown" {
+            dense.id = "unregistered-dense".to_owned();
+            dense.version = 99;
+            dense.implementation_digest = dense.declared_digest();
+        } else {
+            dense.implementation_digest = format!("blake3:{}", "0".repeat(64));
+        }
+        observation.dense_operator = Some(dense);
+        fixture.corpus.identity_bundle_digest = observation.identity_bundle_digest();
+        let report = run_octeract_trace_screen(
+            Some(screen_input(&fixture, Some(&observation))),
+            TraceKind::PinnedReal,
+        );
+        assert_unavailable(&report);
+        assert!(
+            report.disposition_reason.contains("source dense operator"),
+            "{case}: {}",
+            report.disposition_reason
+        );
+        assert_eq!(report.identities.source_dense_operator_digest, None);
+    }
 }
 
 #[test]

--- a/crates/uor-r4-graph-cli/Cargo.toml
+++ b/crates/uor-r4-graph-cli/Cargo.toml
@@ -19,6 +19,9 @@ serde_json = { version = "1.0", features = ["float_roundtrip"] }
 blake3 = "1.5.0"
 uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format" }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 # #622/#626: dev-only ecosystem reference for tropical (max-plus) semantics.
 # The tropical_2hop_626 harness's fold must byte-agree with

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -32,15 +32,18 @@ use uor_r4_graph_certify as score_runtime;
 use uor_r4_graph_compiler::induction as cover;
 use uor_r4_graph_compiler::observation as observe;
 use uor_r4_graph_compiler::observation_text as observe_text;
+use uor_r4_graph_compiler::recorded_corpus::{
+    PLANNED_OUTPUT_RESERVED_PREFIX, PlannedOutputMember, RecordedCorpusRole,
+};
 use uor_r4_graph_compiler::reproducibility as repro;
 mod convert_r4g1;
 pub mod cover_sweep;
 pub mod recommend_scale;
 mod runtime_corpus;
 mod scenarios;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use uor_r4_core::transformerless::hf_bpe::{
@@ -51,7 +54,7 @@ use uor_r4_core::transformerless::scenarios as core_scenarios;
 use uor_r4_core::transformerless::scenarios::RuntimeTokenizerDecodeTable;
 use uor_r4_model_source::{
     BehaviorSource, LlamaOracle, SourceUnavailable, Teacher, TeacherOracle,
-    attention::AttentionOperatorSpec,
+    attention::AttentionOperatorSpec, dense::DenseOperatorSpec,
 };
 
 const DEFAULT_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
@@ -65,11 +68,16 @@ const TOKENIZER_ADAPTER_FILE: &str = "tokenizer_adapter.json";
 /// Compile-directory binding for the source attention operator that produced
 /// `corpus.meta` / `corpus.records`.
 pub const ATTENTION_OPERATOR_BINDING_FILE: &str = "attention_operator.json";
+/// Compile-directory binding for the host-side dense arithmetic that produced
+/// `corpus.meta` / `corpus.records`.
+pub const DENSE_OPERATOR_BINDING_FILE: &str = "dense_operator.json";
 // Pre-#602 corpora computed the immutable standard-source-attention/1
 // operator even after the registry's current source version advances.
 const LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION: u32 = 1;
 static TOKENIZER_ADAPTER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static ATTENTION_OPERATOR_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static DENSE_OPERATOR_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static PLANNED_OUTPUT_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn is_blake3_cid(value: &str) -> bool {
     value.len() == "blake3:".len() + 64
@@ -221,7 +229,7 @@ struct CompileOutputPayloadInventory {
 // Identity sidecars are validated separately by their strict readers and are
 // published atomically; every other output is inventoried here before either
 // identity can take an exact-resume fast path.
-const COMPILE_OUTPUT_MUTABLE_FILES: [&str; 9] = [
+const COMPILE_OUTPUT_MUTABLE_FILES: [&str; 10] = [
     "tokenizer.bin",
     "corpus.meta",
     "corpus.records",
@@ -231,6 +239,7 @@ const COMPILE_OUTPUT_MUTABLE_FILES: [&str; 9] = [
     "hamming_calibration.json",
     "hierarchical_codes.json",
     "space_manifest.json",
+    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
 ];
 
 const SOURCE_CORPUS_META_BYTES: usize = 25;
@@ -328,13 +337,233 @@ fn sync_compile_output_directory(output: &Path) -> Result<(), SourceUnavailable>
         })
 }
 
+fn write_regular_file_synced(
+    path: &Path,
+    bytes: &[u8],
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be opened without following links: {error}",
+            path.display()
+        ))
+    })?;
+    let path_metadata = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    if !path_metadata.file_type().is_file() || !file_metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino()
+        {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed identity while opened",
+                path.display()
+            )));
+        }
+    }
+    file.set_len(0)
+        .and_then(|()| file.write_all(bytes))
+        .and_then(|()| file.sync_all())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context} {} cannot be durably written: {error}",
+                path.display()
+            ))
+        })?;
+    let final_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    let final_file = file.metadata().map_err(SourceUnavailable::new)?;
+    if !final_path.file_type().is_file()
+        || !final_file.file_type().is_file()
+        || final_file.len() != bytes.len() as u64
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed type or length during its durable write",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if final_path.dev() != final_file.dev() || final_path.ino() != final_file.ino() {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed identity during its durable write",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn planned_output_member(
+    path: &Path,
+    context: &str,
+) -> Result<PlannedOutputMember, SourceUnavailable> {
+    let stable_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| SourceUnavailable::new(format!("{context} stable filename is not UTF-8")))?;
+    PlannedOutputMember::ALL
+        .into_iter()
+        .find(|member| member.stable_name() == stable_name)
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "{context} stable filename {stable_name:?} is not a registered planned-output member"
+            ))
+        })
+}
+
+fn preflight_guarded_planned_file(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: &[u8],
+    context: &str,
+) -> Result<bool, SourceUnavailable> {
+    let _ = planned_output_member(path, context)?;
+    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+    require_existing_file_matches_if_present(path, Some(expected), context)
+}
+
+fn preflight_guarded_planned_absence(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let member = planned_output_member(path, context)?;
+    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+    if guard.has_planned_output_residue(member)? {
+        return Err(SourceUnavailable::new(format!(
+            "{context} has staged bytes but the planned generation declares this member absent"
+        )));
+    }
+    let _ = require_existing_file_matches_if_present(path, None, context)?;
+    Ok(())
+}
+
+fn preflight_guarded_planned_scope(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    allowed: &[PlannedOutputMember],
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    guard
+        .preflight_planned_output_scope(allowed)
+        .map_err(|mut error| {
+            error.reason = format!("{context}: {}", error.reason);
+            error
+        })
+}
+
+/// Publish one deterministic member without ever exposing a zero/partial
+/// authoritative pathname. Honest process death can leave only a recognized
+/// non-authoritative `.writing` inode, which an exact guarded retry reclaims.
+fn publish_guarded_planned_file(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: &[u8],
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let member = planned_output_member(path, context)?;
+    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+    if require_existing_file_matches_if_present(path, Some(expected), context)? {
+        guard.reclaim_planned_output_residues(member)?;
+        return sync_compile_output_directory(guard.root());
+    }
+    guard.reclaim_planned_output_residues(member)?;
+
+    let stable_name = member.stable_name();
+    let staging = loop {
+        let sequence = PLANNED_OUTPUT_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = guard.root().join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{stable_name}--{}.{}.writing",
+            std::process::id(),
+            sequence
+        ));
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        }
+        match options.open(&candidate) {
+            Ok(mut file) => {
+                file.write_all(expected)
+                    .and_then(|()| file.sync_all())
+                    .map_err(|error| {
+                        SourceUnavailable::new(format!(
+                            "{context} staging {} cannot be durably written: {error}",
+                            candidate.display()
+                        ))
+                    })?;
+                break candidate;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        }
+    };
+    guard.verify_owned_root()?;
+    match std::fs::hard_link(&staging, path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let published =
+                read_optional_regular_file_nofollow(path, context)?.ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "{context} stable path {} appeared and disappeared",
+                        path.display()
+                    ))
+                })?;
+            if published != expected {
+                return Err(SourceUnavailable::new(format!(
+                    "{context} stable path {} appeared with conflicting bytes",
+                    path.display()
+                )));
+            }
+        }
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+    std::fs::remove_file(&staging).map_err(SourceUnavailable::new)?;
+    sync_compile_output_directory(guard.root())?;
+    let published = read_optional_regular_file_nofollow(path, context)?.ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{context} stable path {} disappeared after publication",
+            path.display()
+        ))
+    })?;
+    if published != expected {
+        return Err(SourceUnavailable::new(format!(
+            "{context} stable path {} does not contain the exact planned bytes",
+            path.display()
+        )));
+    }
+    guard.verify_owned_root()
+}
+
 struct SourceCorpusSession {
     file: std::fs::File,
+    recorded_corpus: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard>,
 }
 
 impl Drop for SourceCorpusSession {
     fn drop(&mut self) {
-        let _ = self.file.unlock();
+        self.release_in_order(|| {});
     }
 }
 
@@ -389,7 +618,83 @@ fn source_corpus_session(output: &Path) -> Result<SourceCorpusSession, SourceUna
             output.display()
         ))
     })?;
-    Ok(SourceCorpusSession { file })
+    Ok(SourceCorpusSession {
+        file,
+        recorded_corpus: None,
+    })
+}
+
+impl SourceCorpusSession {
+    fn release_in_order<F>(&mut self, after_common_release: F)
+    where
+        F: FnOnce(),
+    {
+        // Reverse the canonical acquisition order: common corpus guard first,
+        // source-specific outer session second. Releasing the outer lock while
+        // the common guard is still live would let another source writer enter
+        // and then fail BUSY on the inner guard.
+        drop(self.recorded_corpus.take());
+        after_common_release();
+        let _ = self.file.unlock();
+    }
+
+    /// Acquire the common recorded-corpus guard after all read-only semantic
+    /// preflights, then create/bind a fresh root before the first member
+    /// mutation. The source-specific session is always acquired first.
+    fn acquire_recorded_corpus(
+        &mut self,
+        output: &Path,
+    ) -> Result<
+        &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+        SourceUnavailable,
+    > {
+        if self.recorded_corpus.is_none() {
+            let mut guard =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    output,
+                )?;
+            guard.ensure_root()?;
+            guard.preflight_planned_output_scope(&[])?;
+            let _ = guard.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+            self.recorded_corpus = Some(guard);
+        }
+        self.recorded_corpus.as_ref().ok_or_else(|| {
+            SourceUnavailable::new("recorded-corpus producer guard was not retained")
+        })
+    }
+
+    fn recorded_corpus_guard(
+        &self,
+    ) -> Result<
+        &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+        SourceUnavailable,
+    > {
+        self.recorded_corpus.as_ref().ok_or_else(|| {
+            SourceUnavailable::new("recorded-corpus producer guard was not acquired")
+        })
+    }
+
+    /// Begin the source mutation only after the caller has repeated every
+    /// requested identity/resume preflight under the retained common guard.
+    fn begin_recorded_corpus_mutation(&self, output: &Path) -> Result<(), SourceUnavailable> {
+        let guard = self.recorded_corpus_guard()?;
+        guard.preflight_planned_output_scope(&[])?;
+        let publication =
+            uor_r4_graph_compiler::recorded_corpus::preflight_source_update_publication(
+                guard,
+                &output.join("corpus.meta"),
+                &output.join("corpus.records"),
+            )?;
+        guard.begin_compile_attempt()?;
+        if publication.recoverable_binding {
+            uor_r4_graph_compiler::recorded_corpus::publish_binding(
+                guard,
+                &output.join("corpus.meta"),
+                &output.join("corpus.records"),
+            )?;
+        }
+        Ok(())
+    }
 }
 
 /// Inspect every mutable compile-output leaf without following it. Binding
@@ -949,6 +1254,272 @@ fn strict_regular_file_if_present(path: &Path, context: &str) -> Result<bool, So
     }
 }
 
+#[cfg(unix)]
+fn opened_file_identity_matches(
+    path_metadata: &std::fs::Metadata,
+    file_metadata: &std::fs::Metadata,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    path_metadata.dev() == file_metadata.dev() && path_metadata.ino() == file_metadata.ino()
+}
+
+#[cfg(unix)]
+fn opened_file_generation_matches(
+    initial: &std::fs::Metadata,
+    final_metadata: &std::fs::Metadata,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    opened_file_identity_matches(initial, final_metadata)
+        && initial.len() == final_metadata.len()
+        && initial.mtime() == final_metadata.mtime()
+        && initial.mtime_nsec() == final_metadata.mtime_nsec()
+        && initial.ctime() == final_metadata.ctime()
+        && initial.ctime_nsec() == final_metadata.ctime_nsec()
+}
+
+#[cfg(not(unix))]
+fn opened_file_generation_matches(
+    initial: &std::fs::Metadata,
+    final_metadata: &std::fs::Metadata,
+) -> bool {
+    opened_file_identity_matches(initial, final_metadata)
+        && initial.len() == final_metadata.len()
+        && initial.modified().ok() == final_metadata.modified().ok()
+}
+
+#[cfg(not(unix))]
+fn opened_file_identity_matches(
+    _path_metadata: &std::fs::Metadata,
+    _file_metadata: &std::fs::Metadata,
+) -> bool {
+    // The opened handle and both path checks still reject pre-existing links
+    // and type changes. Unix additionally exposes a stable inode identity.
+    true
+}
+
+/// Read one optional provenance sidecar through a single opened handle. The
+/// path is never reopened for bytes: Unix refuses links at `open(2)`, while
+/// every platform checks that the path still names the opened regular file
+/// before and after the read.
+fn read_optional_regular_file_nofollow_with<F>(
+    path: &Path,
+    context: &str,
+    after_open: F,
+) -> Result<Option<Vec<u8>>, SourceUnavailable>
+where
+    F: FnOnce(),
+{
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // `O_NOFOLLOW` closes the lstat/open link-swap seam. `O_NONBLOCK`
+        // prevents a raced FIFO or device from hanging before the opened
+        // handle's type is rejected below.
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} is not a regular file or cannot be opened without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let opened_metadata = file.metadata().map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} opened handle cannot be inspected: {error}",
+            path.display()
+        ))
+    })?;
+    if !opened_metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} opened handle is not a regular file",
+            path.display()
+        )));
+    }
+
+    let path_metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be reinspected after open: {error}",
+            path.display()
+        ))
+    })?;
+    if !path_metadata.file_type().is_file()
+        || !opened_file_identity_matches(&path_metadata, &opened_metadata)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed identity or is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be read: {error}",
+            path.display()
+        ))
+    })?;
+    if opened_metadata.len() != bytes.len() as u64 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed length while its bytes were read",
+            path.display()
+        )));
+    }
+
+    // Tests use this seam to model an adversarial path or same-inode rewrite
+    // at the only meaningful boundary: after one exact handle read but before
+    // the generation is accepted. Production supplies an empty closure.
+    after_open();
+
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} opened handle cannot be rewound: {error}",
+            path.display()
+        ))
+    })?;
+    let mut verification_offset = 0usize;
+    let mut verification_buffer = [0u8; 8192];
+    loop {
+        let count = file.read(&mut verification_buffer).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context} {} cannot be verified through its opened handle: {error}",
+                path.display()
+            ))
+        })?;
+        if count == 0 {
+            break;
+        }
+        let end = verification_offset.checked_add(count).ok_or_else(|| {
+            SourceUnavailable::new(format!("{context} verification byte count overflow"))
+        })?;
+        if bytes.get(verification_offset..end) != Some(&verification_buffer[..count]) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed content while its opened handle was verified",
+                path.display()
+            )));
+        }
+        verification_offset = end;
+    }
+    let final_file_metadata = file.metadata().map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} opened handle cannot be reinspected: {error}",
+            path.display()
+        ))
+    })?;
+    let final_path_metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be reinspected after read: {error}",
+            path.display()
+        ))
+    })?;
+    if !final_file_metadata.file_type().is_file()
+        || !final_path_metadata.file_type().is_file()
+        || !opened_file_generation_matches(&opened_metadata, &final_file_metadata)
+        || !opened_file_identity_matches(&final_path_metadata, &final_file_metadata)
+        || verification_offset != bytes.len()
+        || final_file_metadata.len() != bytes.len() as u64
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed identity, type, length, content, or generation while its bytes were read",
+            path.display()
+        )));
+    }
+    Ok(Some(bytes))
+}
+
+fn read_optional_regular_file_nofollow(
+    path: &Path,
+    context: &str,
+) -> Result<Option<Vec<u8>>, SourceUnavailable> {
+    read_optional_regular_file_nofollow_with(path, context, || {})
+}
+
+fn verify_optional_regular_file_nofollow(
+    path: &Path,
+    context: &str,
+    expected: Option<&[u8]>,
+) -> Result<(), SourceUnavailable> {
+    let Some(expected) = expected else {
+        return match std::fs::symlink_metadata(path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(SourceUnavailable::new(format!(
+                "{context} {} cannot be reinspected: {error}",
+                path.display()
+            ))),
+            Ok(_) => Err(SourceUnavailable::new(format!(
+                "{context} {} appeared after typed absence was captured",
+                path.display()
+            ))),
+        };
+    };
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be reopened without following links: {error}",
+            path.display()
+        ))
+    })?;
+    let initial_file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    let initial_path_metadata = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial_file_metadata.file_type().is_file()
+        || !initial_path_metadata.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path_metadata, &initial_file_metadata)
+        || initial_file_metadata.len() != expected.len() as u64
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} no longer names the captured regular-file generation",
+            path.display()
+        )));
+    }
+    let mut offset = 0usize;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let count = file.read(&mut buffer).map_err(SourceUnavailable::new)?;
+        if count == 0 {
+            break;
+        }
+        let end = offset
+            .checked_add(count)
+            .ok_or_else(|| SourceUnavailable::new(format!("{context} byte count overflow")))?;
+        if expected.get(offset..end) != Some(&buffer[..count]) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed bytes after capture",
+                path.display()
+            )));
+        }
+        offset = end;
+    }
+    let final_file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    let final_path_metadata = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if offset != expected.len()
+        || !final_file_metadata.file_type().is_file()
+        || !final_path_metadata.file_type().is_file()
+        || !opened_file_generation_matches(&initial_file_metadata, &final_file_metadata)
+        || !opened_file_identity_matches(&final_path_metadata, &final_file_metadata)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed identity, bytes, or generation after capture",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
 fn validate_attention_operator(
     recorded: &AttentionOperatorSpec,
     context: &str,
@@ -978,93 +1549,7 @@ fn validate_attention_operator(
     Ok(registered)
 }
 
-/// Parse a JSON document solely to reject duplicate object keys at every
-/// nesting level. `serde_json::Value` is last-key-wins, which is unsuitable
-/// for provenance records where duplicated fields could spell two arithmetic
-/// eras in one sidecar.
-struct DuplicateRejectingJson;
-
-impl<'de> Deserialize<'de> for DuplicateRejectingJson {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct Visitor;
-
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = DuplicateRejectingJson;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("JSON without duplicate object keys")
-            }
-
-            fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_none<E>(self) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_unit<E>(self) -> Result<Self::Value, E> {
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                DuplicateRejectingJson::deserialize(deserializer)
-            }
-
-            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                while sequence.next_element::<DuplicateRejectingJson>()?.is_some() {}
-                Ok(DuplicateRejectingJson)
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                let mut keys = std::collections::BTreeSet::new();
-                while let Some(key) = map.next_key::<String>()? {
-                    if !keys.insert(key.clone()) {
-                        return Err(serde::de::Error::custom(format!(
-                            "duplicate JSON field {key:?}"
-                        )));
-                    }
-                    map.next_value::<DuplicateRejectingJson>()?;
-                }
-                Ok(DuplicateRejectingJson)
-            }
-        }
-
-        deserializer.deserialize_any(Visitor)
-    }
-}
+type DuplicateRejectingJson = uor_r4_graph_compiler::recorded_corpus::DuplicateRejectingJson;
 
 fn reject_duplicate_attention_operator_json(
     bytes: &[u8],
@@ -1100,27 +1585,36 @@ fn validate_attention_operator_json(
     Ok(registered)
 }
 
-fn read_optional_compiled_attention_operator(
-    output: &Path,
-) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
-    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
-    if !strict_regular_file_if_present(&path, "attention-operator binding")? {
-        return Ok(None);
-    }
-    let bytes = std::fs::read(&path).map_err(|error| {
-        SourceUnavailable::new(format!(
-            "{}: unreadable attention-operator binding: {error}",
-            path.display()
-        ))
-    })?;
-    reject_duplicate_attention_operator_json(&bytes, &path)?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+fn parse_compiled_attention_operator_bytes(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<AttentionOperatorSpec, SourceUnavailable> {
+    reject_duplicate_attention_operator_json(bytes, path)?;
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
         SourceUnavailable::new(format!(
             "{}: malformed attention-operator binding: {error}",
             path.display()
         ))
     })?;
-    validate_attention_operator_json(&value, &path.display().to_string()).map(Some)
+    validate_attention_operator_json(&value, &path.display().to_string())
+}
+
+fn read_optional_compiled_attention_operator_with_bytes(
+    output: &Path,
+) -> Result<Option<(AttentionOperatorSpec, Vec<u8>)>, SourceUnavailable> {
+    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let Some(bytes) = read_optional_regular_file_nofollow(&path, "attention-operator binding")?
+    else {
+        return Ok(None);
+    };
+    let operator = parse_compiled_attention_operator_bytes(&path, &bytes)?;
+    Ok(Some((operator, bytes)))
+}
+
+fn read_optional_compiled_attention_operator(
+    output: &Path,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    Ok(read_optional_compiled_attention_operator_with_bytes(output)?.map(|(operator, _)| operator))
 }
 
 /// Read and registry-validate a compile directory's attention-operator
@@ -1283,17 +1777,300 @@ fn bind_compiled_attention_operator(
     publish_attention_operator_binding(output, &requested)
 }
 
+fn validate_dense_operator(
+    recorded: &DenseOperatorSpec,
+    context: &str,
+) -> Result<DenseOperatorSpec, SourceUnavailable> {
+    let registered = uor_r4_model_source::dense::operator_spec(&recorded.id, recorded.version)
+        .map_err(|mut error| {
+            error.reason = format!("{context}: {}", error.reason);
+            error
+        })?;
+    if recorded != &registered {
+        return Err(SourceUnavailable::new(format!(
+            "{context} does not match registered dense operator {}/{}",
+            recorded.id, recorded.version
+        )));
+    }
+    Ok(registered)
+}
+
+fn validate_source_execution_pair(
+    attention: &AttentionOperatorSpec,
+    dense: Option<&DenseOperatorSpec>,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(attention), dense).map_err(
+        |mut error| {
+            error.reason = format!("{context}: {}", error.reason);
+            error
+        },
+    )
+}
+
+fn reject_duplicate_dense_operator_json(
+    bytes: &[u8],
+    path: &Path,
+) -> Result<(), SourceUnavailable> {
+    serde_json::from_slice::<DuplicateRejectingJson>(bytes)
+        .map(|_| ())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{}: malformed dense-operator binding: {error}",
+                path.display()
+            ))
+        })
+}
+
+fn validate_dense_operator_json(
+    value: &serde_json::Value,
+    context: &str,
+) -> Result<DenseOperatorSpec, SourceUnavailable> {
+    let recorded: DenseOperatorSpec = serde_json::from_value(value.clone()).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context}: malformed dense-operator record: {error}"
+        ))
+    })?;
+    let registered = validate_dense_operator(&recorded, context)?;
+    let registered_json = serde_json::to_value(&registered).map_err(SourceUnavailable::new)?;
+    if value != &registered_json {
+        return Err(SourceUnavailable::new(format!(
+            "{context} is not the full registered dense-operator record; missing, unknown, or noncanonical fields are refused"
+        )));
+    }
+    Ok(registered)
+}
+
+fn parse_compiled_dense_operator_bytes(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<DenseOperatorSpec, SourceUnavailable> {
+    reject_duplicate_dense_operator_json(bytes, path)?;
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: malformed dense-operator binding: {error}",
+            path.display()
+        ))
+    })?;
+    validate_dense_operator_json(&value, &path.display().to_string())
+}
+
+fn read_optional_compiled_dense_operator_with_bytes(
+    output: &Path,
+) -> Result<Option<(DenseOperatorSpec, Vec<u8>)>, SourceUnavailable> {
+    let path = output.join(DENSE_OPERATOR_BINDING_FILE);
+    let Some(bytes) = read_optional_regular_file_nofollow(&path, "dense-operator binding")? else {
+        return Ok(None);
+    };
+    let operator = parse_compiled_dense_operator_bytes(&path, &bytes)?;
+    Ok(Some((operator, bytes)))
+}
+
+fn read_optional_compiled_dense_operator(
+    output: &Path,
+) -> Result<Option<DenseOperatorSpec>, SourceUnavailable> {
+    Ok(read_optional_compiled_dense_operator_with_bytes(output)?.map(|(operator, _)| operator))
+}
+
+/// Read a compile directory's optional dense-execution binding. Absence is a
+/// real compatibility state for Llama and historical corpora and is never
+/// synthesized as GPT-2 v1.
+pub fn compiled_dense_operator(
+    output: &Path,
+) -> Result<Option<DenseOperatorSpec>, SourceUnavailable> {
+    read_optional_compiled_dense_operator(output)
+}
+
+/// Jointly preflight optional dense provenance. `true` means no publication
+/// is needed (the exact record exists, or both requested and recorded are
+/// absent).
+fn preflight_compiled_dense_operator(
+    output: &Path,
+    requested: Option<&DenseOperatorSpec>,
+) -> Result<bool, SourceUnavailable> {
+    let requested = requested
+        .map(|record| validate_dense_operator(record, "proposed teacher dense-operator binding"))
+        .transpose()?;
+    let inventory = compile_output_payload_inventory(output)?;
+    let recorded = read_optional_compiled_dense_operator(output)?;
+    match (recorded.as_ref(), requested.as_ref()) {
+        (Some(recorded), Some(requested)) if recorded == requested => Ok(true),
+        (Some(recorded), Some(requested)) => Err(SourceUnavailable::new(format!(
+            "{} is pinned to dense operator {}/{} (digest {}); requested {}/{} (digest {}); use a fresh output directory for the new teacher-execution era",
+            output.display(),
+            recorded.id,
+            recorded.version,
+            recorded.declared_digest(),
+            requested.id,
+            requested.version,
+            requested.declared_digest(),
+        ))),
+        (Some(recorded), None) => Err(SourceUnavailable::new(format!(
+            "{} is pinned to dense operator {}/{} (digest {}); the requested producer declares none; incompatible compile resume refused before mutation",
+            output.display(),
+            recorded.id,
+            recorded.version,
+            recorded.declared_digest(),
+        ))),
+        (None, Some(requested)) if inventory.first_present.is_some() => {
+            let name = inventory.first_present.unwrap_or("compiler");
+            Err(SourceUnavailable::new(format!(
+                "{} contains {name} payload without {DENSE_OPERATOR_BINDING_FILE}; it belongs to a legacy dense-execution era and cannot resume under {}/{}; use a fresh output directory",
+                output.display(),
+                requested.id,
+                requested.version,
+            )))
+        }
+        (None, Some(_)) => Ok(false),
+        (None, None) => Ok(true),
+    }
+}
+
+fn require_matching_compiled_dense_operator(
+    output: &Path,
+    requested: &DenseOperatorSpec,
+    recorded: &DenseOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    if recorded == requested {
+        return Ok(());
+    }
+    Err(SourceUnavailable::new(format!(
+        "{} is pinned to dense operator {}/{} (digest {}); requested {}/{} (digest {}); incompatible compile resume refused before mutation",
+        output.display(),
+        recorded.id,
+        recorded.version,
+        recorded.declared_digest(),
+        requested.id,
+        requested.version,
+        requested.declared_digest(),
+    )))
+}
+
+fn publish_dense_operator_binding(
+    output: &Path,
+    requested: &DenseOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    let requested = validate_dense_operator(requested, "proposed teacher dense-operator binding")?;
+    if let Some(recorded) = read_optional_compiled_dense_operator(output)? {
+        return require_matching_compiled_dense_operator(output, &requested, &recorded);
+    }
+
+    std::fs::create_dir_all(output).map_err(SourceUnavailable::new)?;
+    let path = output.join(DENSE_OPERATOR_BINDING_FILE);
+    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
+    bytes.push(b'\n');
+    let temporary = loop {
+        let sequence = DENSE_OPERATOR_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = output.join(format!(
+            ".{DENSE_OPERATOR_BINDING_FILE}.{}.{}.tmp",
+            std::process::id(),
+            sequence
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(&bytes).and_then(|()| file.sync_all()) {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(SourceUnavailable::new(format!(
+                        "{}: {error}",
+                        candidate.display()
+                    )));
+                }
+                drop(file);
+                break candidate;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{}: {error}",
+                    candidate.display()
+                )));
+            }
+        }
+    };
+
+    match std::fs::hard_link(&temporary, &path) {
+        Ok(()) => {
+            std::fs::remove_file(&temporary).map_err(|error| {
+                SourceUnavailable::new(format!("{}: {error}", temporary.display()))
+            })?;
+            sync_compile_output_directory(output)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = std::fs::remove_file(&temporary);
+            let recorded = read_optional_compiled_dense_operator(output)?.ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "{} appeared during dense-operator publication but is now absent",
+                    path.display()
+                ))
+            })?;
+            require_matching_compiled_dense_operator(output, &requested, &recorded)?;
+            sync_compile_output_directory(output)
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&temporary);
+            Err(SourceUnavailable::new(format!(
+                "dense-operator sidecar publish {} -> {}: {error}",
+                temporary.display(),
+                path.display()
+            )))
+        }
+    }
+}
+
+fn bind_compiled_dense_operator(
+    output: &Path,
+    requested: Option<&DenseOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    if preflight_compiled_dense_operator(output, requested)? {
+        return Ok(());
+    }
+    let requested = requested.ok_or_else(|| {
+        SourceUnavailable::new("dense-operator publication requested without a record")
+    })?;
+    publish_dense_operator_binding(output, requested)
+}
+
+fn pin_compile_identities_with_dense(
+    output: &Path,
+    tokenizer: &TokenizerAdapter,
+    attention_operator: &AttentionOperatorSpec,
+    dense_operator: Option<&DenseOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    validate_source_execution_pair(
+        attention_operator,
+        dense_operator,
+        "teacher-declared source execution",
+    )?;
+    // Every check is deliberately read-only. Do not let a successful prefix
+    // of a mismatched identity bundle mutate a resumable output.
+    preflight_compile_tokenizer_adapter(output, tokenizer)?;
+    preflight_compiled_attention_operator(output, attention_operator)?;
+    preflight_compiled_dense_operator(output, dense_operator)?;
+    pin_compile_tokenizer_adapter(output, tokenizer)?;
+    if dense_operator.is_some() {
+        // Dense-first makes every crash prefix fail closed. Publishing
+        // attention first would leave a valid-looking learned-v2/absent-dense
+        // compatibility record until the final generation binding appeared.
+        bind_compiled_dense_operator(output, dense_operator)?;
+    }
+    bind_compiled_attention_operator(output, attention_operator)?;
+    if dense_operator.is_none() {
+        bind_compiled_dense_operator(output, dense_operator)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
 fn pin_compile_identities(
     output: &Path,
     tokenizer: &TokenizerAdapter,
     attention_operator: &AttentionOperatorSpec,
 ) -> Result<(), SourceUnavailable> {
-    // Both checks are deliberately read-only. Do not let the successful half
-    // of a mismatched identity pair mutate a resumable output.
-    preflight_compile_tokenizer_adapter(output, tokenizer)?;
-    preflight_compiled_attention_operator(output, attention_operator)?;
-    pin_compile_tokenizer_adapter(output, tokenizer)?;
-    bind_compiled_attention_operator(output, attention_operator)
+    pin_compile_identities_with_dense(output, tokenizer, attention_operator, None)
 }
 
 /// Recorded compilation has no tokenizer authority: its input is already a
@@ -1301,10 +2078,15 @@ fn pin_compile_identities(
 /// compiler's adapter claim or its runtime table would produce a bundle that
 /// looks bound to a token space the recorded path never verified.
 fn preflight_recorded_compile_output(output: &Path) -> Result<(), SourceUnavailable> {
-    const FORBIDDEN_RECORDED_OUTPUT_LEAVES: [&str; 3] = [
+    const FORBIDDEN_RECORDED_OUTPUT_LEAVES: [&str; 8] = [
         "tokenizer.bin",
-        "corpus.records.hidden",
         "space_manifest.json",
+        "compile_report.json",
+        "source_compile_preflight.json",
+        "source_manifest_kappa.json",
+        "compiled_bundle_completion.json",
+        ".compiled_bundle_stage.json",
+        "tokenizer_adapter.json",
     ];
     let _ = compile_output_payload_inventory(output)?;
     if read_compile_tokenizer_adapter(output)?.is_some() {
@@ -1313,11 +2095,24 @@ fn preflight_recorded_compile_output(output: &Path) -> Result<(), SourceUnavaila
             output.display()
         )));
     }
-    for name in FORBIDDEN_RECORDED_OUTPUT_LEAVES {
-        let path = output.join(name);
-        if strict_regular_file_if_present(&path, "recorded compile unsupported leaf")? {
+    let entries = match std::fs::read_dir(output) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    };
+    for entry in entries {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(entry_name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let forbidden = FORBIDDEN_RECORDED_OUTPUT_LEAVES.iter().any(|stable| {
+            entry_name == *stable
+                || entry_name.starts_with(&format!(".{stable}."))
+                || entry_name.starts_with(&format!("{stable}."))
+        });
+        if forbidden {
             return Err(SourceUnavailable::new(format!(
-                "recorded compile output {} contains {name}, which compile-recorded cannot verify or reproduce; use a fresh recorded-only output directory",
+                "recorded compile output {} contains {entry_name}, which compile-recorded cannot verify or reproduce; use a fresh recorded-only output directory",
                 output.display()
             )));
         }
@@ -1351,6 +2146,87 @@ struct CopyRecordedAttentionOptions {
     corpus_meta: PathBuf,
     corpus_recs: PathBuf,
     output: PathBuf,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SubsampleRecordedCorpusOptions {
+    source_meta: PathBuf,
+    source_records: PathBuf,
+    output_meta: PathBuf,
+    output_records: PathBuf,
+    records: usize,
+}
+
+fn parse_subsample_recorded_corpus_options(
+    args: &[String],
+) -> Result<SubsampleRecordedCorpusOptions, SourceUnavailable> {
+    let mut source_meta = None;
+    let mut source_records = None;
+    let mut output_meta = None;
+    let mut output_records = None;
+    let mut records = None;
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| SourceUnavailable::new(format!("missing value for {flag}")))?;
+        match flag.as_str() {
+            "--src-meta" => source_meta = Some(PathBuf::from(value)),
+            "--src-recs" => source_records = Some(PathBuf::from(value)),
+            "--out-meta" => output_meta = Some(PathBuf::from(value)),
+            "--out-recs" => output_records = Some(PathBuf::from(value)),
+            "--records" => {
+                let parsed = value.parse::<usize>().map_err(|_| {
+                    SourceUnavailable::new(format!("invalid --records value: {value}"))
+                })?;
+                if parsed == 0 {
+                    return Err(SourceUnavailable::new(
+                        "--records must be greater than zero",
+                    ));
+                }
+                records = Some(parsed);
+            }
+            _ => {
+                return Err(SourceUnavailable::new(format!(
+                    "unknown subsample-recorded-corpus option: {flag}"
+                )));
+            }
+        }
+        index += 2;
+    }
+    let output_meta =
+        output_meta.ok_or_else(|| SourceUnavailable::new("--out-meta is required"))?;
+    let output_records =
+        output_records.ok_or_else(|| SourceUnavailable::new("--out-recs is required"))?;
+    if output_meta.file_name() != Some(std::ffi::OsStr::new("corpus.meta"))
+        || output_records.file_name() != Some(std::ffi::OsStr::new("corpus.records"))
+    {
+        return Err(SourceUnavailable::new(
+            "subsample output must use the exact canonical corpus.meta/corpus.records filenames",
+        ));
+    }
+    let meta_parent = output_meta
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let records_parent = output_records
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if meta_parent != records_parent {
+        return Err(SourceUnavailable::new(
+            "--out-meta and --out-recs must have one exact lexical parent directory",
+        ));
+    }
+    Ok(SubsampleRecordedCorpusOptions {
+        source_meta: source_meta.ok_or_else(|| SourceUnavailable::new("--src-meta is required"))?,
+        source_records: source_records
+            .ok_or_else(|| SourceUnavailable::new("--src-recs is required"))?,
+        output_meta,
+        output_records,
+        records: records.ok_or_else(|| SourceUnavailable::new("--records is required"))?,
+    })
 }
 
 fn parse_copy_recorded_attention_options(
@@ -1572,20 +2448,12 @@ fn parse_observe_options(args: &[String]) -> Result<ObserveOptions, SourceUnavai
     Ok(options)
 }
 
-fn read_optional_observation_manifest(
+fn parse_observation_manifest_bytes(
     output: &Path,
-) -> Result<Option<observe::ObservationManifest>, SourceUnavailable> {
-    let path = output.join(observe::MANIFEST_FILE);
-    if !strict_regular_file_if_present(&path, "observation manifest")? {
-        return Ok(None);
-    }
-    let bytes = std::fs::read(&path).map_err(|error| {
-        SourceUnavailable::new(format!(
-            "{}: unreadable observation manifest: {error}",
-            path.display()
-        ))
-    })?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+    path: &Path,
+    bytes: &[u8],
+) -> Result<observe::ObservationManifest, SourceUnavailable> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
         SourceUnavailable::new(format!(
             "{}: malformed observation manifest: {error}",
             path.display()
@@ -1593,6 +2461,9 @@ fn read_optional_observation_manifest(
     })?;
     if let Some(operator) = value.get("attention_operator") {
         validate_attention_operator_json(operator, &path.display().to_string())?;
+    }
+    if let Some(operator) = value.get("dense_operator") {
+        validate_dense_operator_json(operator, &path.display().to_string())?;
     }
     let parsed: observe::ObservationManifest = serde_json::from_value(value).map_err(|error| {
         SourceUnavailable::new(format!(
@@ -1616,7 +2487,23 @@ fn read_optional_observation_manifest(
             path.display()
         )));
     }
-    Ok(Some(validated))
+    Ok(validated)
+}
+
+fn read_optional_observation_manifest(
+    output: &Path,
+) -> Result<Option<observe::ObservationManifest>, SourceUnavailable> {
+    let path = output.join(observe::MANIFEST_FILE);
+    if !strict_regular_file_if_present(&path, "observation manifest")? {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{}: unreadable observation manifest: {error}",
+            path.display()
+        ))
+    })?;
+    parse_observation_manifest_bytes(output, &path, &bytes).map(Some)
 }
 
 fn observation_payload_exists(
@@ -1696,11 +2583,12 @@ fn observation_payload_exists(
 /// Validate the tokenizer and operator halves of an observation identity
 /// without opening a writer. Any conflict therefore leaves both manifest
 /// fields and `tokenizer.bin` unchanged.
-fn preflight_observation_identities(
+fn preflight_observation_identities_with_dense(
     output: &Path,
     shard_bits: u8,
     tokenizer: Option<&TokenizerAdapter>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
 ) -> Result<(), SourceUnavailable> {
     if let Some(tokenizer) = tokenizer {
         validate_tokenizer_adapter_record(tokenizer)?;
@@ -1710,6 +2598,21 @@ fn preflight_observation_identities(
             validate_attention_operator(operator, "teacher-declared attention operator")
         })
         .transpose()?;
+    let requested_dense = dense_operator
+        .map(|operator| validate_dense_operator(operator, "teacher-declared dense operator"))
+        .transpose()?;
+    match (requested_operator.as_ref(), requested_dense.as_ref()) {
+        (Some(attention), dense) => {
+            validate_source_execution_pair(attention, dense, "teacher-declared source execution")?
+        }
+        (None, Some(dense)) => {
+            return Err(SourceUnavailable::new(format!(
+                "teacher-declared source execution supplies dense operator {}/{} without an attention operator",
+                dense.id, dense.version
+            )));
+        }
+        (None, None) => {}
+    }
     let manifest = read_optional_observation_manifest(output)?;
     if let Some(manifest) = &manifest {
         if manifest.shard_bits != shard_bits {
@@ -1732,6 +2635,31 @@ fn preflight_observation_identities(
                 recorded,
                 &output.join(observe::MANIFEST_FILE).display().to_string(),
             )?;
+        }
+        if let Some(recorded) = &manifest.dense_operator {
+            validate_dense_operator(
+                recorded,
+                &output.join(observe::MANIFEST_FILE).display().to_string(),
+            )?;
+        }
+        match (
+            manifest.attention_operator.as_ref(),
+            manifest.dense_operator.as_ref(),
+        ) {
+            (Some(attention), dense) => validate_source_execution_pair(
+                attention,
+                dense,
+                &output.join(observe::MANIFEST_FILE).display().to_string(),
+            )?,
+            (None, Some(dense)) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{} records dense operator {}/{} without an attention operator",
+                    output.join(observe::MANIFEST_FILE).display(),
+                    dense.id,
+                    dense.version
+                )));
+            }
+            (None, None) => {}
         }
     }
     // Inventory every payload entry even when the two recorded identities
@@ -1811,48 +2739,169 @@ fn preflight_observation_identities(
         }
         (None, _) => {}
     }
+
+    match (
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.dense_operator.as_ref()),
+        requested_dense.as_ref(),
+    ) {
+        (Some(recorded), Some(requested)) if recorded == requested => {}
+        (Some(recorded), Some(requested)) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to dense operator {}/{} (digest {}); requested {}/{} (digest {}); incompatible observation resume refused before mutation",
+                output.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        (Some(recorded), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to dense operator {}/{} but the requested oracle declares no operator; use a fresh output directory for the legacy arithmetic era",
+                output.display(),
+                recorded.id,
+                recorded.version,
+            )));
+        }
+        (None, Some(requested)) if payload_exists => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has no recorded dense operator but already contains observation payload; refusing to relabel legacy rows as {}/{} before mutation",
+                output.display(),
+                requested.id,
+                requested.version,
+            )));
+        }
+        (None, _) => {}
+    }
     Ok(())
 }
 
-fn pin_raw_observation_identities_before_output(
+#[cfg(test)]
+fn preflight_observation_identities(
+    output: &Path,
+    shard_bits: u8,
+    tokenizer: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    preflight_observation_identities_with_dense(
+        output,
+        shard_bits,
+        tokenizer,
+        attention_operator,
+        None,
+    )
+}
+
+fn pin_raw_observation_identities_before_output_with_dense(
     session: &observe::ObservationSession,
     tokenizer: Option<&TokenizerAdapter>,
     geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
 ) -> Result<(), SourceUnavailable> {
-    preflight_observation_identities(
+    preflight_observation_identities_with_dense(
         session.dir(),
         session.shard_bits(),
         tokenizer,
         attention_operator,
+        dense_operator,
     )?;
     let operator = attention_operator
         .map(|operator| {
             validate_attention_operator(operator, "teacher-declared attention operator")
         })
         .transpose()?;
+    let dense = dense_operator
+        .map(|operator| validate_dense_operator(operator, "teacher-declared dense operator"))
+        .transpose()?;
     // The lower boundary joins geometry with tokenizer/operator on the same
     // locked snapshot. Run its full read-only pass before publishing any
     // identity, then repeat and pin the whole bundle while this session stays
     // live through tokenizer export, reconciliation, and row writes.
-    observe::preflight_observation_identities_in_session(
+    observe::preflight_observation_identities_in_session_with_dense(
         session,
         None,
         geometry,
         tokenizer,
         operator.as_ref(),
+        dense.as_ref(),
         None,
     )?;
-    observe::pin_observation_identities_in_session(
+    observe::pin_observation_identities_in_session_with_dense(
         session,
         None,
         geometry,
         tokenizer,
         operator.as_ref(),
+        dense.as_ref(),
         None,
     )
 }
 
+#[cfg(test)]
+fn pin_raw_observation_identities_before_output(
+    session: &observe::ObservationSession,
+    tokenizer: Option<&TokenizerAdapter>,
+    geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    pin_raw_observation_identities_before_output_with_dense(
+        session,
+        tokenizer,
+        geometry,
+        attention_operator,
+        None,
+    )
+}
+
+fn pin_text_observation_identities_before_output_with_dense(
+    session: &observe::ObservationSession,
+    input: &Path,
+    tokenizer: Option<&TokenizerAdapter>,
+    geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    preflight_observation_identities_with_dense(
+        session.dir(),
+        session.shard_bits(),
+        tokenizer,
+        attention_operator,
+        dense_operator,
+    )?;
+    let operator = attention_operator
+        .map(|operator| {
+            validate_attention_operator(operator, "teacher-declared attention operator")
+        })
+        .transpose()?;
+    let dense = dense_operator
+        .map(|operator| validate_dense_operator(operator, "teacher-declared dense operator"))
+        .transpose()?;
+    observe_text::preflight_text_observation_in_session_with_dense(
+        session,
+        input,
+        true,
+        geometry,
+        operator.as_ref(),
+        dense.as_ref(),
+        tokenizer,
+    )?;
+    observe_text::pin_text_observation_identities_in_session_with_dense(
+        session,
+        input,
+        true,
+        geometry,
+        operator.as_ref(),
+        dense.as_ref(),
+        tokenizer,
+    )
+}
+
+#[cfg(test)]
 fn pin_text_observation_identities_before_output(
     session: &observe::ObservationSession,
     input: &Path,
@@ -1860,32 +2909,13 @@ fn pin_text_observation_identities_before_output(
     geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
 ) -> Result<(), SourceUnavailable> {
-    preflight_observation_identities(
-        session.dir(),
-        session.shard_bits(),
+    pin_text_observation_identities_before_output_with_dense(
+        session,
+        input,
         tokenizer,
+        geometry,
         attention_operator,
-    )?;
-    let operator = attention_operator
-        .map(|operator| {
-            validate_attention_operator(operator, "teacher-declared attention operator")
-        })
-        .transpose()?;
-    observe_text::preflight_text_observation_in_session(
-        session,
-        input,
-        true,
-        geometry,
-        operator.as_ref(),
-        tokenizer,
-    )?;
-    observe_text::pin_text_observation_identities_in_session(
-        session,
-        input,
-        true,
-        geometry,
-        operator.as_ref(),
-        tokenizer,
+        None,
     )
 }
 
@@ -1929,11 +2959,13 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
     let session = observe::ObservationSession::acquire(&options.output, options.shards)?;
     let geometry = oracle.geometry_projection();
     let attention_operator = oracle.attention_operator_spec();
-    pin_raw_observation_identities_before_output(
+    let dense_operator = oracle.dense_operator_spec();
+    pin_raw_observation_identities_before_output_with_dense(
         &session,
         adapter.as_ref(),
         geometry.as_ref(),
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
     )?;
     let token_byte_lengths = if let Some(runtime_table) = runtime_table.as_ref() {
         eprintln!("exporting tokenizer...");
@@ -1960,7 +2992,19 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
         // as the from-text driver, issue #75).
         let merged = observe::merge_shards(session.dir()).map_err(SourceUnavailable::new)?;
         let merged_path = session.dir().join("merged.bin");
-        std::fs::write(&merged_path, &merged)?;
+        write_regular_file_synced(&merged_path, &merged, "merged raw observation corpus")?;
+        let state_path = session.dir().join(observe::STATE_FILE);
+        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            session.recorded_corpus_guard(),
+            &state_path,
+            &merged_path,
+        )?;
+        let captured = uor_r4_graph_compiler::recorded_corpus::capture(&state_path, &merged_path)?;
+        if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
+            return Err(SourceUnavailable::new(
+                "raw observation binding changed during exact post-publication capture",
+            ));
+        }
         println!(
             "observe complete: {} records at {}",
             summary.records,
@@ -2210,6 +3254,7 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
     }
     let geometry = pool[0].geometry_projection();
     let attention_operator = pool[0].attention_operator_spec();
+    let dense_operator = pool[0].dense_operator_spec();
     for (worker, oracle) in pool.iter().enumerate().skip(1) {
         if oracle.geometry_projection() != geometry {
             return Err(SourceUnavailable::new(format!(
@@ -2221,17 +3266,23 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
                 "observe-text worker {worker} loaded a different attention operator before output; refusing a mixed teacher pool"
             )));
         }
+        if oracle.dense_operator_spec() != dense_operator {
+            return Err(SourceUnavailable::new(format!(
+                "observe-text worker {worker} loaded a different dense operator before output; refusing a mixed teacher pool"
+            )));
+        }
     }
     // All potentially fallible teacher/tokenizer loading is complete before
     // the locked output session publishes identities or tokenizer bytes.
     let session = observe::ObservationSession::acquire(&options.output, options.shards)?;
     let adapter = tokenizer.adapter();
-    pin_text_observation_identities_before_output(
+    pin_text_observation_identities_before_output_with_dense(
         &session,
         &options.input,
         adapter.as_ref(),
         geometry.as_ref(),
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
     )?;
     if let Some(runtime_table) = runtime_table.as_ref() {
         token_byte_lengths = export_observation_tokenizer_in_session(&session, runtime_table)?;
@@ -2249,7 +3300,7 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         true,
     )
     .map_err(SourceUnavailable::new)?;
-    let result = finish_observe_text_report(&report, session.dir());
+    let result = finish_observe_text_report(&report, &session);
     drop(session);
     result
 }
@@ -2275,12 +3326,14 @@ fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), Sour
     let adapter = tokenizer.adapter();
     let geometry = teacher.geometry_projection();
     let attention_operator = teacher.attention_operator_spec();
-    pin_text_observation_identities_before_output(
+    let dense_operator = teacher.dense_operator_spec();
+    pin_text_observation_identities_before_output_with_dense(
         &session,
         &options.input,
         adapter.as_ref(),
         geometry.as_ref(),
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
     )?;
     let token_byte_lengths = export_observation_tokenizer_in_session(&session, &runtime_table)?;
     eprintln!("observing with batch {}", options.batch);
@@ -2307,7 +3360,7 @@ fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), Sour
         ),
     }
     .map_err(SourceUnavailable::new)?;
-    let result = finish_observe_text_report(&report, session.dir());
+    let result = finish_observe_text_report(&report, &session);
     drop(session);
     result
 }
@@ -2316,8 +3369,9 @@ fn observe_text_batched_command(options: &ObserveTextOptions) -> Result<(), Sour
 /// merged record stream. Shared by the serial/pool and batched entry points.
 fn finish_observe_text_report(
     report: &observe_text::ObservationReport,
-    output: &std::path::Path,
+    session: &observe::ObservationSession,
 ) -> Result<(), SourceUnavailable> {
+    let output = session.dir();
     println!(
         "observe-text: {} records across {}/{} shards ({} written this run)",
         report.records, report.shards_completed, report.shard_count, report.written
@@ -2347,7 +3401,19 @@ fn finish_observe_text_report(
         // --corpus-recs with state.bin as --corpus-meta (issue #72).
         let merged = observe::merge_shards(output).map_err(SourceUnavailable::new)?;
         let merged_path = output.join("merged.bin");
-        std::fs::write(&merged_path, &merged)?;
+        write_regular_file_synced(&merged_path, &merged, "merged text observation corpus")?;
+        let state_path = output.join(observe::STATE_FILE);
+        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            session.recorded_corpus_guard(),
+            &state_path,
+            &merged_path,
+        )?;
+        let captured = uor_r4_graph_compiler::recorded_corpus::capture(&state_path, &merged_path)?;
+        if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
+            return Err(SourceUnavailable::new(
+                "text observation binding changed during exact post-publication capture",
+            ));
+        }
         println!(
             "observe-text complete: merged κ {} at {}",
             report
@@ -2398,6 +3464,9 @@ struct CoverOptions {
     /// record itself; the pipeline that held the oracle (or its
     /// `r4_attention` switch) passes it.
     attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
+    /// Typed host-side dense-execution record. Absence is retained for
+    /// historical corpora and Llama; present records are registry exact.
+    dense_operator: Option<DenseOperatorSpec>,
 }
 
 fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailable> {
@@ -2418,6 +3487,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         source_manifest_kappa: None,
         geometry: None,
         attention_operator: None,
+        dense_operator: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -2504,6 +3574,9 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                 })?);
             }
             "--attention-operator" => {
+                serde_json::from_str::<DuplicateRejectingJson>(value).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid --attention-operator value: {error}"))
+                })?;
                 let recorded: serde_json::Value = serde_json::from_str(value).map_err(|error| {
                     SourceUnavailable::new(format!("invalid --attention-operator value: {error}"))
                 })?;
@@ -2511,6 +3584,16 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                     &recorded,
                     "--attention-operator",
                 )?);
+            }
+            "--dense-operator" => {
+                serde_json::from_str::<DuplicateRejectingJson>(value).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid --dense-operator value: {error}"))
+                })?;
+                let recorded: serde_json::Value = serde_json::from_str(value).map_err(|error| {
+                    SourceUnavailable::new(format!("invalid --dense-operator value: {error}"))
+                })?;
+                options.dense_operator =
+                    Some(validate_dense_operator_json(&recorded, "--dense-operator")?);
             }
             _ => {
                 return Err(SourceUnavailable::new(format!(
@@ -2520,7 +3603,53 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         }
         index += 2;
     }
+    match (
+        options.attention_operator.as_ref(),
+        options.dense_operator.as_ref(),
+    ) {
+        (Some(attention), dense) => {
+            validate_source_execution_pair(attention, dense, "cover provenance")?;
+        }
+        (None, Some(dense)) => {
+            return Err(SourceUnavailable::new(format!(
+                "cover provenance supplies dense operator {}/{} without an attention operator",
+                dense.id, dense.version
+            )));
+        }
+        (None, None) => {}
+    }
     Ok(options)
+}
+
+fn require_cover_recorded_execution_identity(
+    options: &CoverOptions,
+    recorded: &RecordedCorpusExecutionIdentity,
+) -> Result<(), SourceUnavailable> {
+    let attention_label = |record: Option<&AttentionOperatorSpec>| {
+        record
+            .map(|record| format!("{}/{}", record.id, record.version))
+            .unwrap_or_else(|| "absent".to_owned())
+    };
+    let dense_label = |record: Option<&DenseOperatorSpec>| {
+        record
+            .map(|record| format!("{}/{}", record.id, record.version))
+            .unwrap_or_else(|| "absent".to_owned())
+    };
+    if options.attention_operator.as_ref() != recorded.attention_operator.as_ref() {
+        return Err(SourceUnavailable::new(format!(
+            "cover --attention-operator {} does not match recorded corpus attention provenance {}; refusing before output mutation",
+            attention_label(options.attention_operator.as_ref()),
+            attention_label(recorded.attention_operator.as_ref())
+        )));
+    }
+    if options.dense_operator.as_ref() != recorded.dense_operator.as_ref() {
+        return Err(SourceUnavailable::new(format!(
+            "cover --dense-operator {} does not match recorded corpus dense provenance {}; refusing before output mutation",
+            dense_label(options.dense_operator.as_ref()),
+            dense_label(recorded.dense_operator.as_ref())
+        )));
+    }
+    Ok(())
 }
 
 /// Multiresolution cover induction (plan §5 Phase 2, issue #60): induce
@@ -2567,12 +3696,8 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
         options.corpus_recs.clone()
     };
 
-    let corpus_meta = corpus_meta_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus metadata path is not UTF-8"))?;
-    let corpus_recs = corpus_recs_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
+    let recorded_corpus = recorded_corpus_snapshot(&corpus_meta_path, &corpus_recs_path)?;
+    require_cover_recorded_execution_identity(&options, &recorded_corpus.execution)?;
     // #450: resolve and announce the inputs *before* the long work, so the
     // run says which teacher container it actually read. `--artifacts`
     // defaults to a shared mutable path that helper scripts overwrite.
@@ -2587,25 +3712,16 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     })?;
     let artifact_kappa = repro::container_kappa(&artifact_container);
     repro::announce_teacher_container(&options.artifacts, &artifact_kappa);
-    let meta_bytes = std::fs::read(&options.corpus_meta).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", options.corpus_meta.display()))
-    })?;
-    let recs_bytes = std::fs::read(&options.corpus_recs).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", options.corpus_recs.display()))
-    })?;
+    let meta_bytes = recorded_corpus.meta_bytes;
+    let recs_bytes = recorded_corpus.records_bytes;
     let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
-    repro::announce_corpus(&options.corpus_meta, &options.corpus_recs, &corpus_kappa);
-    if options.corpus_meta != corpus_meta_path || options.corpus_recs != corpus_recs_path {
-        // The κ above addresses the requested paths; the corpus itself is
-        // loaded from the fallback-resolved ones. Say so rather than let a
-        // reader assume the printed κ covers the loaded records.
-        eprintln!(
-            "corpus streams (loaded, after fallback resolution): {} + {}",
-            corpus_meta_path.display(),
-            corpus_recs_path.display()
-        );
-    }
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
+    repro::announce_corpus(&corpus_meta_path, &corpus_recs_path, &corpus_kappa);
+    let corpus = compiler::load_corpus_bytes(
+        &meta_bytes,
+        &recs_bytes,
+        recorded_corpus.hidden_bytes.as_deref(),
+    )
+    .ok_or_else(|| {
         SourceUnavailable::new(format!(
             "corpus is incomplete at {}/{}; run compile until it is complete",
             corpus_meta_path.display(),
@@ -2699,6 +3815,9 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     // #602: bind the teacher's attention-operator record when the caller
     // passed it (`--attention-operator`).
     report.attention_operator = options.attention_operator.clone();
+    // Bind optional host-side dense arithmetic without changing the graph
+    // runtime or artifact format.
+    report.dense_operator = options.dense_operator.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("cover.r4g1");
@@ -3657,6 +4776,12 @@ struct EvaluationSource {
     /// #268 candidate 3: whether a BOS token was prepended at every
     /// held-out story boundary during teacher-forcing (schema 3).
     bos_prefix: bool,
+    /// Exact source-attention arithmetic replayed by the evaluation oracle
+    /// (schema 4).
+    attention_operator: AttentionOperatorSpec,
+    /// Exact optional host-side dense arithmetic replayed by the evaluation
+    /// oracle. `None` is durable typed absence for Llama/historical bundles.
+    dense_operator: Option<DenseOperatorSpec>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -3667,6 +4792,11 @@ struct EvaluationArtifacts {
     tokenizer_cid: String,
     corpus_meta_cid: String,
     corpus_records_cid: String,
+    attention_operator_cid: String,
+    dense_operator_cid: Option<String>,
+    /// Exact content address of the canonical generation commit. Historical
+    /// markerless/Llama bundles retain typed absence.
+    recorded_corpus_binding_cid: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -4042,6 +5172,41 @@ fn require_matching_evaluation_attention_operator(
     )))
 }
 
+fn require_matching_evaluation_dense_operator(
+    compiled: &Path,
+    recorded: Option<&DenseOperatorSpec>,
+    actual: Option<&DenseOperatorSpec>,
+) -> Result<(), SourceUnavailable> {
+    match (recorded, actual) {
+        (Some(recorded), Some(actual)) if recorded == actual => Ok(()),
+        (None, None) => Ok(()),
+        (Some(recorded), Some(actual)) => Err(SourceUnavailable::new(format!(
+            "{} is pinned to dense operator {}/{} (digest {}), but the loaded evaluation teacher computes {}/{} (digest {}); evaluation refused before replay",
+            compiled.display(),
+            recorded.id,
+            recorded.version,
+            recorded.declared_digest(),
+            actual.id,
+            actual.version,
+            actual.declared_digest(),
+        ))),
+        (Some(recorded), None) => Err(SourceUnavailable::new(format!(
+            "{} is pinned to dense operator {}/{} (digest {}), but the loaded evaluation teacher declares none; evaluation refused before replay",
+            compiled.display(),
+            recorded.id,
+            recorded.version,
+            recorded.declared_digest(),
+        ))),
+        (None, Some(actual)) => Err(SourceUnavailable::new(format!(
+            "{} records the legacy dense-operator-absent era, but the loaded evaluation teacher computes {}/{} (digest {}); evaluation refused before replay",
+            compiled.display(),
+            actual.id,
+            actual.version,
+            actual.declared_digest(),
+        ))),
+    }
+}
+
 fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     let options = parse_evaluate_report_options(args)?;
     // Evaluation decodes/classifies in the same registered id space selected
@@ -4062,7 +5227,6 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         &tokenizer_adapter,
         &recorded_adapter,
     )?;
-    let recorded_attention_operator = compiled_attention_operator(&options.compiled)?;
     let report_path = options
         .report
         .clone()
@@ -4074,6 +5238,40 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     let scored_graph_path = options.compiled.join("graph").join("score.r4g1");
     let corpus_meta_path = options.compiled.join("corpus.meta");
     let corpus_records_path = options.compiled.join("corpus.records");
+    let recorded_corpus = recorded_corpus_snapshot(&corpus_meta_path, &corpus_records_path)?;
+    let recorded_attention_operator = recorded_corpus
+        .execution
+        .attention_operator
+        .clone()
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "{}: missing teacher attention-operator binding",
+                options
+                    .compiled
+                    .join(ATTENTION_OPERATOR_BINDING_FILE)
+                    .display()
+            ))
+        })?;
+    let attention_bytes = recorded_corpus
+        .attention_operator_bytes
+        .as_deref()
+        .ok_or_else(|| {
+            SourceUnavailable::new(
+                "compiled evaluation attention identity has no exact captured sidecar bytes",
+            )
+        })?;
+    let recorded_dense_operator = recorded_corpus.execution.dense_operator.clone();
+    if recorded_dense_operator.is_some() != recorded_corpus.dense_operator_bytes.is_some() {
+        return Err(SourceUnavailable::new(
+            "compiled evaluation dense identity and exact captured sidecar-byte presence disagree",
+        ));
+    }
+    let attention_operator_cid = format!("blake3:{}", blake3::hash(attention_bytes).to_hex());
+    let dense_operator_cid = recorded_corpus
+        .dense_operator_bytes
+        .as_deref()
+        .map(|bytes| format!("blake3:{}", blake3::hash(bytes).to_hex()));
+    let recorded_corpus_binding_cid = recorded_corpus.binding_cid.clone();
     let scored_graph_bytes =
         read_required_regular_file(&scored_graph_path, "final scored R4G1 graph")?;
     let tokenizer_bytes = read_required_regular_file(&tokenizer_path, "tokenizer.bin")?;
@@ -4082,16 +5280,20 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     let artifacts_cid = file_cid(&artifacts_path)?;
     let store_cid = file_cid(&store_path)?;
     let tokenizer_cid = format!("blake3:{}", blake3::hash(&tokenizer_bytes).to_hex());
-    let corpus_meta_cid = file_cid(&corpus_meta_path)?;
-    let corpus_records_cid = file_cid(&corpus_records_path)?;
-
-    let corpus_meta = corpus_meta_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus metadata path is not UTF-8"))?;
-    let corpus_records = corpus_records_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_records).ok_or_else(|| {
+    let corpus_meta_cid = format!(
+        "blake3:{}",
+        blake3::hash(&recorded_corpus.meta_bytes).to_hex()
+    );
+    let corpus_records_cid = format!(
+        "blake3:{}",
+        blake3::hash(&recorded_corpus.records_bytes).to_hex()
+    );
+    let corpus = compiler::load_corpus_bytes(
+        &recorded_corpus.meta_bytes,
+        &recorded_corpus.records_bytes,
+        recorded_corpus.hidden_bytes.as_deref(),
+    )
+    .ok_or_else(|| {
         SourceUnavailable::new(format!(
             "corpus is incomplete at {}; rerun compile until it is complete",
             options.compiled.display()
@@ -4118,10 +5320,24 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         &actual_attention_operator,
         "evaluation teacher attention operator",
     )?;
+    let actual_dense_operator = oracle
+        .dense_operator_spec()
+        .map(|operator| validate_dense_operator(&operator, "evaluation teacher dense operator"))
+        .transpose()?;
+    validate_source_execution_pair(
+        &actual_attention_operator,
+        actual_dense_operator.as_ref(),
+        "evaluation teacher source execution",
+    )?;
     require_matching_evaluation_attention_operator(
         &options.compiled,
         &recorded_attention_operator,
         &actual_attention_operator,
+    )?;
+    require_matching_evaluation_dense_operator(
+        &options.compiled,
+        recorded_dense_operator.as_ref(),
+        actual_dense_operator.as_ref(),
     )?;
     let mut teacher_logits = vec![0f32; oracle.vocab()];
     let artifacts_bytes = std::fs::read(&artifacts_path)?;
@@ -4377,7 +5593,7 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         ),
     };
     let report = EvaluationReport {
-        schema: 3,
+        schema: 5,
         distribution: EvaluationDistribution {
             name: distribution_name,
             split: "compiler::train_cut 80/20 by story id".to_owned(),
@@ -4388,6 +5604,8 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
             cid: source_cid,
             sequence_length: options.sequence_length,
             bos_prefix: options.bos,
+            attention_operator: recorded_attention_operator,
+            dense_operator: recorded_dense_operator,
         },
         artifacts: EvaluationArtifacts {
             directory: options.compiled.display().to_string(),
@@ -4396,6 +5614,9 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
             tokenizer_cid,
             corpus_meta_cid,
             corpus_records_cid,
+            attention_operator_cid,
+            dense_operator_cid,
+            recorded_corpus_binding_cid,
         },
         metrics: EvaluationMetrics {
             top1_accuracy_pct,
@@ -4570,7 +5791,7 @@ where
         .output
         .clone()
         .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
-    let _corpus_session = source_corpus_session(&output)?;
+    let mut corpus_session = source_corpus_session(&output)?;
     eprintln!("compiler output: {}", output.display());
     let meta = output.join("corpus.meta");
     let records = output.join("corpus.records");
@@ -4590,11 +5811,18 @@ where
     let attention_operator = oracle.attention_operator_spec().ok_or_else(|| {
         SourceUnavailable::new("Hugging Face teacher declares no attention operator")
     })?;
+    let dense_operator = oracle.dense_operator_spec();
+    validate_source_execution_pair(
+        &attention_operator,
+        dense_operator.as_ref(),
+        "Hugging Face teacher source execution",
+    )?;
     // Keep every identity and corpus-resume check read-only until the whole
     // bundle has been accepted. In particular, malformed regular metadata
     // must not be mistaken for a fresh corpus after either sidecar is pinned.
     preflight_compile_tokenizer_adapter(&output, &tokenizer_adapter)?;
     preflight_compiled_attention_operator(&output, &attention_operator)?;
+    preflight_compiled_dense_operator(&output, dense_operator.as_ref())?;
     let hidden_row_bytes = oracle
         .hidden_state()
         .map(|hidden| {
@@ -4606,7 +5834,17 @@ where
                 })
         })
         .transpose()?;
+    let _ = preflight_source_compile_resume(&output, hidden_row_bytes, options.target)?;
+    // Canonical order: source-specific outer session, then the one common
+    // recorded-corpus producer guard. Repeat every semantic/resume preflight
+    // after the common guard creates or binds the root and before the first
+    // recover/pin/generate mutation.
+    corpus_session.acquire_recorded_corpus(&output)?;
+    preflight_compile_tokenizer_adapter(&output, &tokenizer_adapter)?;
+    preflight_compiled_attention_operator(&output, &attention_operator)?;
+    preflight_compiled_dense_operator(&output, dense_operator.as_ref())?;
     let resume = preflight_source_compile_resume(&output, hidden_row_bytes, options.target)?;
+    corpus_session.begin_recorded_corpus_mutation(&output)?;
     // All read-only identity and resume checks have now accepted the bundle.
     // Under the server's cross-process output session, reclaim only the
     // core compiler's exact reserved checkpoint temporaries; arbitrary names
@@ -4615,7 +5853,12 @@ where
     // A story checkpoint commits records and hidden rows together. Normalize
     // both interrupted tails before the core generator reopens either stream.
     reconcile_source_compile_resume(&output, &resume)?;
-    pin_compile_identities(&output, &tokenizer_adapter, &attention_operator)?;
+    pin_compile_identities_with_dense(
+        &output,
+        &tokenizer_adapter,
+        &attention_operator,
+        dense_operator.as_ref(),
+    )?;
     progress(5, "Exporting tokenizer...");
     eprintln!("exporting tokenizer...");
     let tokenizer_export = core_scenarios::export_runtime_tokenizer_table(
@@ -4632,13 +5875,36 @@ where
         records,
         tokenizer_export.source_byte_lengths.as_deref(),
     );
-    let Some(corpus) = compiler::load_corpus_from(meta, records) else {
+    if compiler::load_corpus_from(meta, records).is_none() {
         println!(
             "corpus is not complete; rerun the same command to resume {}",
             output.display()
         );
         return Ok(());
-    };
+    }
+    let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+        corpus_session.recorded_corpus_guard()?,
+        Path::new(meta),
+        Path::new(records),
+    )?;
+    let captured =
+        uor_r4_graph_compiler::recorded_corpus::capture(Path::new(meta), Path::new(records))?;
+    if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
+        return Err(SourceUnavailable::new(
+            "published recorded-corpus binding CID changed during exact recapture",
+        ));
+    }
+    corpus_session
+        .recorded_corpus_guard()?
+        .finish_compile_attempt()?;
+    let corpus = compiler::load_corpus_bytes(
+        &captured.meta_bytes,
+        &captured.records_bytes,
+        captured.hidden_bytes.as_deref(),
+    )
+    .ok_or_else(|| {
+        SourceUnavailable::new("published recorded corpus failed exact-byte recapture and parsing")
+    })?;
     progress(55, "Compiling table-native artifact...");
     eprintln!("teacher corpus complete; compiling table-native artifact...");
     let artifacts = compiler::compile(&oracle, &corpus);
@@ -4729,6 +5995,83 @@ where
     Ok(())
 }
 
+/// Registry-exact host execution identity attached to a recorded corpus.
+/// Both fields preserve genuine historical absence; callers that need the
+/// pre-#602 standard/1 interpretation apply it only after this joint snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedCorpusExecutionIdentity {
+    pub attention_operator: Option<AttentionOperatorSpec>,
+    pub dense_operator: Option<DenseOperatorSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordedCorpusSnapshot {
+    execution: RecordedCorpusExecutionIdentity,
+    attention_operator_bytes: Option<Vec<u8>>,
+    dense_operator_bytes: Option<Vec<u8>>,
+    meta_bytes: Vec<u8>,
+    records_bytes: Vec<u8>,
+    hidden_bytes: Option<Vec<u8>>,
+    binding_cid: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordedCorpusStreamFingerprint {
+    meta_bytes: Vec<u8>,
+    records_length: u64,
+    records_digest: String,
+    hidden: Option<(u64, String)>,
+}
+
+fn recorded_corpus_stream_fingerprint(
+    snapshot: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusStreamSnapshot,
+) -> RecordedCorpusStreamFingerprint {
+    RecordedCorpusStreamFingerprint {
+        meta_bytes: snapshot.meta_bytes.clone(),
+        records_length: snapshot.records.len(),
+        records_digest: snapshot.records.declared_digest().to_owned(),
+        hidden: snapshot
+            .hidden
+            .as_ref()
+            .map(|hidden| (hidden.len(), hidden.declared_digest().to_owned())),
+    }
+}
+
+fn recorded_execution_from_stream(
+    snapshot: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusStreamSnapshot,
+) -> RecordedCorpusExecutionIdentity {
+    RecordedCorpusExecutionIdentity {
+        attention_operator: snapshot.execution.attention_operator.clone(),
+        dense_operator: snapshot.execution.dense_operator.clone(),
+    }
+}
+
+#[cfg(test)]
+fn recorded_hidden_path(corpus_records: &Path) -> Result<PathBuf, SourceUnavailable> {
+    let records = corpus_records
+        .to_str()
+        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
+    Ok(if records.ends_with("_recs.bin") {
+        PathBuf::from(records.replace("_recs.bin", "_hidden.bin"))
+    } else {
+        PathBuf::from(format!("{records}.hidden"))
+    })
+}
+
+#[cfg(test)]
+fn recorded_provenance_snapshot(root: &Path) -> Result<[Option<Vec<u8>>; 3], SourceUnavailable> {
+    let paths = [
+        root.join(observe::MANIFEST_FILE),
+        root.join(ATTENTION_OPERATOR_BINDING_FILE),
+        root.join(DENSE_OPERATOR_BINDING_FILE),
+    ];
+    let mut snapshot: [Option<Vec<u8>>; 3] = [None, None, None];
+    for (slot, path) in paths.iter().enumerate() {
+        snapshot[slot] = read_optional_regular_file_nofollow(path, "recorded provenance")?;
+    }
+    Ok(snapshot)
+}
+
 /// Resolve the arithmetic era accompanying a canonically paired recorded
 /// corpus. Observation directories carry it in `manifest.json`; compile
 /// directories carry the extracted sidecar. `None` means both records are
@@ -4738,10 +6081,17 @@ where
 /// (`corpus.meta` / `corpus.records`) or observation (`state.bin` /
 /// `merged.bin`) pair. Arbitrarily named files remain compatible only when
 /// both provenance entries are genuinely absent.
-pub fn recorded_corpus_attention_operator(
+#[cfg(test)]
+fn recorded_corpus_execution_identity_and_capture_with_recheck_hooks<T, F, G>(
     corpus_meta: &Path,
     corpus_records: &Path,
-) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    after_snapshot: F,
+    before_recheck: G,
+) -> Result<(RecordedCorpusExecutionIdentity, T), SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce() -> Result<T, SourceUnavailable>,
+{
     fn canonical_parent(path: &Path, label: &str) -> Result<PathBuf, SourceUnavailable> {
         let metadata = std::fs::symlink_metadata(path).map_err(|error| {
             SourceUnavailable::new(format!(
@@ -4802,18 +6152,48 @@ pub fn recorded_corpus_attention_operator(
         )));
     }
     let root = meta_root;
-    let sidecar = read_optional_compiled_attention_operator(&root)?;
+    let before = recorded_provenance_snapshot(&root)?;
+    after_snapshot();
+    let captured = before_recheck()?;
+    let after = recorded_provenance_snapshot(&root)?;
+    if before != after {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus provenance in {} changed or disappeared while its attention/dense identity was resolved; retry from a stable snapshot",
+            root.display()
+        )));
+    }
+    let attention_path = root.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let sidecar = before[1]
+        .as_deref()
+        .map(|bytes| parse_compiled_attention_operator_bytes(&attention_path, bytes))
+        .transpose()?;
+    let dense_path = root.join(DENSE_OPERATOR_BINDING_FILE);
+    let dense_sidecar = before[2]
+        .as_deref()
+        .map(|bytes| parse_compiled_dense_operator_bytes(&dense_path, bytes))
+        .transpose()?;
     let manifest_path = root.join(observe::MANIFEST_FILE);
-    let manifest = read_optional_observation_manifest(&root)?;
+    let manifest = before[0]
+        .as_deref()
+        .map(|bytes| parse_observation_manifest_bytes(&root, &manifest_path, bytes))
+        .transpose()?;
     let manifest_present = manifest.is_some();
     let manifest_operator = manifest
-        .and_then(|manifest| manifest.attention_operator)
+        .as_ref()
+        .and_then(|manifest| manifest.attention_operator.clone())
         .map(|recorded| {
             validate_attention_operator(&recorded, &manifest_path.display().to_string())
         })
         .transpose()?;
+    let manifest_dense = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.dense_operator.clone())
+        .map(|recorded| validate_dense_operator(&recorded, &manifest_path.display().to_string()))
+        .transpose()?;
 
-    if (sidecar.is_some() || manifest_present) && !is_canonical_pair(corpus_meta, corpus_records) {
+    if (sidecar.is_some() || dense_sidecar.is_some() || manifest_present)
+        && !is_canonical_pair(corpus_meta, corpus_records)
+    {
         return Err(SourceUnavailable::new(format!(
             "recorded-corpus provenance in {} applies only to the canonical corpus.meta/corpus.records or state.bin/merged.bin pair; refusing to attach it to {}/{}",
             root.display(),
@@ -4835,9 +6215,9 @@ pub fn recorded_corpus_attention_operator(
         )));
     }
 
-    match (sidecar, manifest_operator) {
+    let attention = match (sidecar, manifest_operator) {
         (Some(sidecar), Some(manifest)) if sidecar != manifest => {
-            Err(SourceUnavailable::new(format!(
+            return Err(SourceUnavailable::new(format!(
                 "{} and {} declare different attention operators ({}/{} digest {} versus {}/{} digest {})",
                 root.join(ATTENTION_OPERATOR_BINDING_FILE).display(),
                 manifest_path.display(),
@@ -4847,62 +6227,744 @@ pub fn recorded_corpus_attention_operator(
                 manifest.id,
                 manifest.version,
                 manifest.declared_digest(),
-            )))
+            )));
         }
-        (Some(sidecar), _) => Ok(Some(sidecar)),
-        (None, Some(manifest)) => Ok(Some(manifest)),
-        (None, None) => Ok(None),
+        (Some(sidecar), _) => Some(sidecar),
+        (None, Some(manifest)) => Some(manifest),
+        (None, None) => None,
+    };
+    if let Some(sidecar) = dense_sidecar.as_ref()
+        && manifest_present
+        && manifest_dense.is_none()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{} declares dense operator {}/{} but present {} records the legacy dense-operator-absent era; refusing conflicting recorded-corpus provenance",
+            root.join(DENSE_OPERATOR_BINDING_FILE).display(),
+            sidecar.id,
+            sidecar.version,
+            manifest_path.display(),
+        )));
     }
+    let dense = match (dense_sidecar, manifest_dense) {
+        (Some(sidecar), Some(manifest)) if sidecar != manifest => {
+            return Err(SourceUnavailable::new(format!(
+                "{} and {} declare different dense operators ({}/{} digest {} versus {}/{} digest {})",
+                root.join(DENSE_OPERATOR_BINDING_FILE).display(),
+                manifest_path.display(),
+                sidecar.id,
+                sidecar.version,
+                sidecar.declared_digest(),
+                manifest.id,
+                manifest.version,
+                manifest.declared_digest(),
+            )));
+        }
+        (Some(sidecar), _) => Some(sidecar),
+        (None, Some(manifest)) => Some(manifest),
+        (None, None) => None,
+    };
+    match (attention.as_ref(), dense.as_ref()) {
+        (Some(attention), dense) => {
+            validate_source_execution_pair(attention, dense, "recorded corpus provenance")?;
+        }
+        (None, Some(dense)) => {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus declares dense operator {}/{} without an attention operator",
+                dense.id, dense.version
+            )));
+        }
+        (None, None) => {}
+    }
+    Ok((
+        RecordedCorpusExecutionIdentity {
+            attention_operator: attention,
+            dense_operator: dense,
+        },
+        captured,
+    ))
 }
 
-/// Copy only the registry-exact source-attention provenance of a recorded
-/// corpus. This tooling seam deliberately delegates all source pairing and
-/// manifest validation to [`recorded_corpus_attention_operator`] instead of
-/// reinterpreting observation JSON in a shell/Python helper.
+#[cfg(test)]
+fn recorded_corpus_execution_identity_with_recheck_hooks<F, G>(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    after_snapshot: F,
+    before_recheck: G,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    recorded_corpus_execution_identity_and_capture_with_recheck_hooks(
+        corpus_meta,
+        corpus_records,
+        after_snapshot,
+        || {
+            before_recheck();
+            Ok(())
+        },
+    )
+    .map(|(execution, ())| execution)
+}
+
+/// Resolve attention and dense provenance from one stable filesystem
+/// snapshot, refusing any change or disappearance observed during the read.
+pub fn recorded_corpus_execution_identity(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let captured =
+        uor_r4_graph_compiler::recorded_corpus::execution_identity(corpus_meta, corpus_records)?;
+    Ok(RecordedCorpusExecutionIdentity {
+        attention_operator: captured.attention_operator,
+        dense_operator: captured.dense_operator,
+    })
+}
+
+#[cfg(test)]
+fn recorded_corpus_snapshot_with_hooks<F, G>(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    after_provenance_capture: F,
+    after_corpus_capture: G,
+) -> Result<RecordedCorpusSnapshot, SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    let (execution, (meta_bytes, records_bytes, hidden_bytes)) =
+        recorded_corpus_execution_identity_and_capture_with_recheck_hooks(
+            corpus_meta,
+            corpus_records,
+            after_provenance_capture,
+            || {
+                let meta_bytes =
+                    read_optional_regular_file_nofollow(corpus_meta, "recorded corpus metadata")?
+                        .ok_or_else(|| {
+                        SourceUnavailable::new(format!(
+                            "recorded corpus metadata {} disappeared during capture",
+                            corpus_meta.display()
+                        ))
+                    })?;
+                let records_bytes =
+                    read_optional_regular_file_nofollow(corpus_records, "recorded corpus records")?
+                        .ok_or_else(|| {
+                            SourceUnavailable::new(format!(
+                                "recorded corpus records {} disappeared during capture",
+                                corpus_records.display()
+                            ))
+                        })?;
+                let hidden_path = recorded_hidden_path(corpus_records)?;
+                let hidden_bytes = read_optional_regular_file_nofollow(
+                    &hidden_path,
+                    "recorded corpus hidden stream",
+                )?;
+
+                after_corpus_capture();
+
+                verify_optional_regular_file_nofollow(
+                    corpus_meta,
+                    "recorded corpus metadata",
+                    Some(meta_bytes.as_slice()),
+                )?;
+                verify_optional_regular_file_nofollow(
+                    corpus_records,
+                    "recorded corpus records",
+                    Some(records_bytes.as_slice()),
+                )?;
+                verify_optional_regular_file_nofollow(
+                    &hidden_path,
+                    "recorded corpus hidden stream",
+                    hidden_bytes.as_deref(),
+                )?;
+                Ok((meta_bytes, records_bytes, hidden_bytes))
+            },
+        )?;
+    Ok(RecordedCorpusSnapshot {
+        execution,
+        attention_operator_bytes: None,
+        dense_operator_bytes: None,
+        meta_bytes,
+        records_bytes,
+        hidden_bytes,
+        binding_cid: None,
+    })
+}
+
+#[cfg(test)]
+fn recorded_corpus_snapshot_with_hook<F>(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    after_capture: F,
+) -> Result<RecordedCorpusSnapshot, SourceUnavailable>
+where
+    F: FnOnce(),
+{
+    recorded_corpus_snapshot_with_hooks(corpus_meta, corpus_records, || {}, after_capture)
+}
+
+fn recorded_corpus_snapshot(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusSnapshot, SourceUnavailable> {
+    let captured = uor_r4_graph_compiler::recorded_corpus::capture(corpus_meta, corpus_records)?;
+    Ok(RecordedCorpusSnapshot {
+        execution: RecordedCorpusExecutionIdentity {
+            attention_operator: captured.execution.attention_operator,
+            dense_operator: captured.execution.dense_operator,
+        },
+        attention_operator_bytes: captured.attention_operator_bytes,
+        dense_operator_bytes: captured.dense_operator_bytes,
+        meta_bytes: captured.meta_bytes,
+        records_bytes: captured.records_bytes,
+        hidden_bytes: captured.hidden_bytes,
+        binding_cid: captured.binding_cid,
+    })
+}
+
+pub fn recorded_corpus_attention_operator(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    Ok(recorded_corpus_execution_identity(corpus_meta, corpus_records)?.attention_operator)
+}
+
+/// Resolve the optional dense-execution record accompanying a recorded
+/// corpus. Unlike the pre-#602 attention interpretation, genuine absence is
+/// never synthesized: it is the exact historical/Llama compatibility state.
+pub fn recorded_corpus_dense_operator(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<Option<DenseOperatorSpec>, SourceUnavailable> {
+    Ok(recorded_corpus_execution_identity(corpus_meta, corpus_records)?.dense_operator)
+}
+
+/// Copy the complete registry-exact source-execution pair of a recorded
+/// corpus. The historical command name and `--out attention_operator.json`
+/// spelling remain stable; a present dense record is published to the sibling
+/// `dense_operator.json`. Every source and destination check precedes either
+/// publication so a conflict cannot partially relabel the derived corpus.
 pub fn copy_recorded_attention(args: &[String]) -> Result<(), SourceUnavailable> {
+    copy_recorded_attention_with_after_dense(args, || Ok(()))
+}
+
+fn copy_recorded_attention_with_after_dense<F>(
+    args: &[String],
+    _after_dense: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnOnce() -> Result<(), SourceUnavailable>,
+{
     let options = parse_copy_recorded_attention_options(args)?;
-    let resolved = recorded_corpus_attention_operator(&options.corpus_meta, &options.corpus_recs)?;
-    match resolved {
-        Some(operator) => {
-            let parent = options
-                .output
+    // Resolve the source pair before touching the destination. The lower
+    // bounded reader hashes large members without retaining them and holds a
+    // source guard for markerless compatibility generations.
+    let resolved = recorded_corpus_execution_identity(&options.corpus_meta, &options.corpus_recs)?;
+    let parent = options
+        .output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    match std::fs::symlink_metadata(parent) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "source-execution destination parent {} is not a real directory",
+                parent.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SourceUnavailable::new(format!(
+                "source-execution destination parent {} is absent; create its complete canonical corpus pair before copying provenance",
+                parent.display()
+            )));
+        }
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "source-execution destination parent {} cannot be inspected: {error}",
+                parent.display()
+            )));
+        }
+    }
+
+    let destination_root = std::fs::canonicalize(parent).map_err(SourceUnavailable::new)?;
+    let mut producer =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+            &destination_root,
+        )?;
+    producer.ensure_root()?;
+    let source_root = std::fs::canonicalize(
+        options
+            .corpus_meta
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new(".")),
+    )
+    .map_err(SourceUnavailable::new)?;
+    if producer.protects_directory(&source_root)? {
+        return Err(SourceUnavailable::new(
+            "copy-recorded-attention source and destination resolve to the same canonical corpus root; in-place provenance copy is refused before mutation",
+        ));
+    }
+
+    preflight_guarded_planned_scope(&producer, &[], "provenance-copy destination")?;
+    let recoverable_binding =
+        producer.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+    if recoverable_binding {
+        return Err(SourceUnavailable::new(
+            "copy-recorded-attention owns no corpus generation and cannot recover a canonical binding temporary",
+        ));
+    }
+    let destination_meta = destination_root.join("corpus.meta");
+    let destination_records = destination_root.join("corpus.records");
+    let destination = uor_r4_graph_compiler::recorded_corpus::open_stream(
+        &destination_meta,
+        &destination_records,
+    )?;
+    let destination_execution = recorded_execution_from_stream(&destination);
+    let destination_fingerprint = recorded_corpus_stream_fingerprint(&destination);
+    if destination.binding_cid.is_some() {
+        if destination_execution == resolved {
+            destination.verify_generation()?;
+            return Ok(());
+        }
+        return Err(SourceUnavailable::new(
+            "destination corpus is already binding-committed under a different source-execution identity; refusing relabel before mutation",
+        ));
+    }
+    if resolved.dense_operator.is_some() {
+        return Err(SourceUnavailable::new(
+            "copy-recorded-attention cannot authorize a new dense-present derivation; use subsample-recorded-corpus so derived bytes and provenance commit in one guarded transaction",
+        ));
+    }
+    if destination_execution == resolved {
+        destination.verify_generation()?;
+        return Ok(());
+    }
+    let destination_unbound = destination_execution.attention_operator.is_none()
+        && destination_execution.dense_operator.is_none();
+    if !destination_unbound {
+        return Err(SourceUnavailable::new(
+            "destination markerless corpus already carries a different execution identity; refusing relabel before mutation",
+        ));
+    }
+    let Some(attention) = resolved.attention_operator.as_ref() else {
+        destination.verify_generation()?;
+        return Ok(());
+    };
+    destination.verify_generation()?;
+    publish_attention_operator_binding(&destination_root, attention)?;
+    let published = uor_r4_graph_compiler::recorded_corpus::open_stream(
+        &destination_meta,
+        &destination_records,
+    )?;
+    let published_execution = recorded_execution_from_stream(&published);
+    if published_execution.attention_operator.as_ref() != Some(attention)
+        || published_execution.dense_operator.is_some()
+        || published.binding_cid.is_some()
+        || recorded_corpus_stream_fingerprint(&published) != destination_fingerprint
+    {
+        return Err(SourceUnavailable::new(
+            "markerless attention provenance copy changed during exact recapture",
+        ));
+    }
+    published.verify_generation()?;
+    Ok(())
+}
+
+fn exact_finalized_record_width(records: usize, byte_len: usize) -> Option<usize> {
+    [88usize, 48, 32, 12].into_iter().find(|width| {
+        records
+            .checked_mul(*width)
+            .is_some_and(|expected| expected == byte_len)
+    })
+}
+
+/// Derive one smaller, story-run-aligned corpus from a single exact source
+/// snapshot. Unlike the historical Python+copy sequence, corpus bytes and the
+/// complete source-execution pair commit under one destination guard and one
+/// canonical generation binding.
+pub fn subsample_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable> {
+    subsample_recorded_corpus_with_before_binding(args, || Ok(()))
+}
+
+fn subsample_recorded_corpus_with_before_binding<F>(
+    args: &[String],
+    before_binding: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnOnce() -> Result<(), SourceUnavailable>,
+{
+    let options = parse_subsample_recorded_corpus_options(args)?;
+    let mut source = recorded_corpus_snapshot(&options.source_meta, &options.source_records)?;
+    if source.binding_cid.is_none() {
+        // Compatibility for archived legacy/attention-only scale inputs: one
+        // cooperative source guard makes the lower repeated-read snapshot
+        // stable against every in-repo producer. Dense input never reaches
+        // this lane because lower capture requires its canonical binding.
+        let source_root = std::fs::canonicalize(
+            options
+                .source_meta
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
-                .unwrap_or_else(|| Path::new("."));
-            match std::fs::symlink_metadata(parent) {
-                Ok(metadata) if metadata.file_type().is_dir() => {}
-                Ok(_) => {
-                    return Err(SourceUnavailable::new(format!(
-                        "attention-operator destination parent {} is not a real directory",
-                        parent.display()
-                    )));
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(SourceUnavailable::new(format!(
-                        "attention-operator destination parent {} cannot be inspected: {error}",
-                        parent.display()
-                    )));
-                }
-            }
-            publish_attention_operator_binding(parent, &operator)
-        }
-        None => match std::fs::symlink_metadata(&options.output) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(SourceUnavailable::new(format!(
-                "legacy recorded corpus destination {} cannot be inspected: {error}",
-                options.output.display()
-            ))),
-            Ok(_) => Err(SourceUnavailable::new(format!(
-                "recorded corpus has no attention-operator provenance, but destination {} is present; refusing to preserve or relabel a stale binding",
-                options.output.display()
-            ))),
-        },
+                .unwrap_or_else(|| Path::new(".")),
+        )
+        .map_err(SourceUnavailable::new)?;
+        let source_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &source_root,
+            )?;
+        source = recorded_corpus_snapshot(&options.source_meta, &options.source_records)?;
+        drop(source_guard);
     }
+    if source.meta_bytes.len() != SOURCE_CORPUS_META_BYTES || source.meta_bytes[24] != 1 {
+        return Err(SourceUnavailable::new(
+            "subsample source is not one exact finalized 25-byte corpus generation",
+        ));
+    }
+    let source_records_u64 = u64::from_le_bytes(
+        source.meta_bytes[0..8]
+            .try_into()
+            .map_err(|_| SourceUnavailable::new("invalid source corpus record count"))?,
+    );
+    let source_records = usize::try_from(source_records_u64).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "source corpus record count {source_records_u64} cannot be represented on this host"
+        ))
+    })?;
+    if options.records >= source_records {
+        return Err(SourceUnavailable::new(format!(
+            "source has {source_records} finalized records; --records {} must be strictly smaller",
+            options.records
+        )));
+    }
+    let record_width = exact_finalized_record_width(source_records, source.records_bytes.len())
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "source record stream length {} is not exactly n times one registered width (88, 48, 32, or 12) for n={source_records}",
+                source.records_bytes.len()
+            ))
+        })?;
+    let parsed = compiler::load_corpus_bytes(&source.meta_bytes, &source.records_bytes, None)
+        .ok_or_else(|| SourceUnavailable::new("subsample source corpus bytes are malformed"))?;
+    let source_stories_u64 = u64::from_le_bytes(
+        source.meta_bytes[8..16]
+            .try_into()
+            .map_err(|_| SourceUnavailable::new("invalid source corpus story count"))?,
+    );
+    let source_stories = u32::try_from(source_stories_u64).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "source corpus story count {source_stories_u64} exceeds the u32 story-id range"
+        ))
+    })?;
+    let source_train_cut = ((f64::from(source_stories) * 0.8) as u32).max(1);
+    let mut runs = Vec::new();
+    let mut start = 0usize;
+    while start < source_records {
+        let story = parsed.story[start];
+        if story >= source_stories {
+            return Err(SourceUnavailable::new(format!(
+                "source record {start} declares story {story}, outside the metadata story range 0..{source_stories}"
+            )));
+        }
+        let mut end = start + 1;
+        while end < source_records && parsed.story[end] == story {
+            end += 1;
+        }
+        runs.push((start, end, story, story < source_train_cut));
+        start = end;
+    }
+
+    // Preserve the source compiler's fixed story partition. Quotas are
+    // deterministic 80/20 record budgets; only complete story runs that fit
+    // their side's budget are retained, in original source order.
+    let train_quota = options
+        .records
+        .checked_mul(4)
+        .ok_or_else(|| SourceUnavailable::new("subsample train quota overflows"))?
+        / 5;
+    let held_out_quota = options.records - train_quota;
+    if train_quota == 0 || held_out_quota == 0 {
+        return Err(SourceUnavailable::new(
+            "subsample target is too small to retain records from both fixed source partitions",
+        ));
+    }
+    let mut train_remaining = train_quota;
+    let mut held_out_remaining = held_out_quota;
+    let mut selected = Vec::new();
+    let mut train_records = 0usize;
+    let mut held_out_records = 0usize;
+    let mut last_selected_story = None;
+    for &(run_start, run_end, story, train) in &runs {
+        let rows = run_end - run_start;
+        let remaining = if train {
+            &mut train_remaining
+        } else {
+            &mut held_out_remaining
+        };
+        // Filtering cannot make two source-separated runs of the same story
+        // adjacent: v1/v2 rows reconstruct input/span boundaries solely from
+        // adjacent story equality and would otherwise stitch them together.
+        if rows <= *remaining && last_selected_story != Some(story) {
+            *remaining -= rows;
+            if train {
+                train_records += rows;
+            } else {
+                held_out_records += rows;
+            }
+            selected.push((run_start, run_end));
+            last_selected_story = Some(story);
+        }
+    }
+    if train_records == 0 || held_out_records == 0 {
+        return Err(SourceUnavailable::new(format!(
+            "no complete story-run selection fits both fixed source partitions within train/held-out quotas {train_quota}/{held_out_quota}"
+        )));
+    }
+    let retained_records = train_records
+        .checked_add(held_out_records)
+        .ok_or_else(|| SourceUnavailable::new("subsample retained count overflows"))?;
+    let output_capacity = retained_records
+        .checked_mul(record_width)
+        .ok_or_else(|| SourceUnavailable::new("subsample record byte length overflows"))?;
+    let mut output_records_bytes = Vec::with_capacity(output_capacity);
+    for &(run_start, run_end) in &selected {
+        let byte_start = run_start
+            .checked_mul(record_width)
+            .ok_or_else(|| SourceUnavailable::new("subsample record start overflows"))?;
+        let byte_end = run_end
+            .checked_mul(record_width)
+            .ok_or_else(|| SourceUnavailable::new("subsample record end overflows"))?;
+        output_records_bytes.extend_from_slice(&source.records_bytes[byte_start..byte_end]);
+    }
+    let mut output_meta_bytes = Vec::with_capacity(SOURCE_CORPUS_META_BYTES);
+    output_meta_bytes.extend_from_slice(
+        &u64::try_from(retained_records)
+            .map_err(|_| SourceUnavailable::new("subsample count exceeds u64"))?
+            .to_le_bytes(),
+    );
+    output_meta_bytes.extend_from_slice(&source_stories_u64.to_le_bytes());
+    output_meta_bytes.extend_from_slice(&source.meta_bytes[16..24]);
+    output_meta_bytes.push(1);
+
+    let output_hidden_bytes = source
+        .hidden_bytes
+        .as_deref()
+        .map(|hidden| {
+            if source_records == 0 || hidden.len() % source_records != 0 {
+                return Err(SourceUnavailable::new(format!(
+                    "source hidden stream is {} bytes, which is not an exact nonzero row width for {source_records} finalized rows",
+                    hidden.len()
+                )));
+            }
+            let row_bytes = hidden.len() / source_records;
+            if row_bytes == 0 || row_bytes % std::mem::size_of::<f32>() != 0 {
+                return Err(SourceUnavailable::new(
+                    "source hidden stream row width is zero or is not an exact f32 byte multiple",
+                ));
+            }
+            let output_capacity = retained_records
+                .checked_mul(row_bytes)
+                .ok_or_else(|| SourceUnavailable::new("subsample hidden length overflows"))?;
+            let mut output = Vec::with_capacity(output_capacity);
+            for &(run_start, run_end) in &selected {
+                let byte_start = run_start
+                    .checked_mul(row_bytes)
+                    .ok_or_else(|| SourceUnavailable::new("subsample hidden start overflows"))?;
+                let byte_end = run_end
+                    .checked_mul(row_bytes)
+                    .ok_or_else(|| SourceUnavailable::new("subsample hidden end overflows"))?;
+                output.extend_from_slice(&hidden[byte_start..byte_end]);
+            }
+            Ok(output)
+        })
+        .transpose()?;
+
+    let output_root = options
+        .output_meta
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let output_parent = output_root
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(output_parent).map_err(SourceUnavailable::new)?;
+    let mut producer =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+            output_root,
+        )?;
+    let source_root = std::fs::canonicalize(
+        options
+            .source_meta
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new(".")),
+    )
+    .map_err(SourceUnavailable::new)?;
+    if producer.protects_directory(&source_root)? {
+        return Err(SourceUnavailable::new(
+            "subsample source and destination resolve to the same canonical corpus root; in-place derivation is refused before mutation",
+        ));
+    }
+    producer.ensure_root()?;
+    let output_root = producer.root().to_path_buf();
+    let output_meta = output_root.join("corpus.meta");
+    let output_records = output_root.join("corpus.records");
+    let output_hidden = output_root.join("corpus.records.hidden");
+    if strict_regular_file_if_present(
+        &output_root.join(observe::MANIFEST_FILE),
+        "subsample destination observation manifest",
+    )? {
+        return Err(SourceUnavailable::new(
+            "subsample destination contains an observation manifest; use a fresh compile-style corpus root",
+        ));
+    }
+    let subsample_members = [
+        PlannedOutputMember::Records,
+        PlannedOutputMember::Hidden,
+        PlannedOutputMember::Metadata,
+    ];
+    preflight_guarded_planned_scope(&producer, &subsample_members, "subsample destination")?;
+    producer.preflight_planned_output_stable_scope(&subsample_members)?;
+    producer.preflight_deterministic_compile_inventory(&subsample_members)?;
+    let recoverable_temporary =
+        producer.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+
+    let attention_ready = match source.execution.attention_operator.as_ref() {
+        Some(attention) => preflight_compiled_attention_operator(&output_root, attention)?,
+        None => {
+            if read_optional_compiled_attention_operator(&output_root)?.is_some() {
+                return Err(SourceUnavailable::new(
+                    "subsample source declares no attention identity but destination has one",
+                ));
+            }
+            true
+        }
+    };
+    let dense_ready =
+        preflight_compiled_dense_operator(&output_root, source.execution.dense_operator.as_ref())?;
+    let records_ready = preflight_guarded_planned_file(
+        &producer,
+        &output_records,
+        &output_records_bytes,
+        "subsample destination records",
+    )?;
+    let hidden_ready = match output_hidden_bytes.as_deref() {
+        Some(hidden) => preflight_guarded_planned_file(
+            &producer,
+            &output_hidden,
+            hidden,
+            "subsample destination hidden stream",
+        )?,
+        None => {
+            preflight_guarded_planned_absence(
+                &producer,
+                &output_hidden,
+                "subsample destination hidden stream",
+            )?;
+            true
+        }
+    };
+    let meta_ready = preflight_guarded_planned_file(
+        &producer,
+        &output_meta,
+        &output_meta_bytes,
+        "subsample destination metadata",
+    )?;
+
+    let stable_binding = strict_regular_file_if_present(
+        &output_root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        "subsample destination generation binding",
+    )?;
+    if stable_binding || recoverable_temporary {
+        if !attention_ready || !dense_ready || !records_ready || !hidden_ready || !meta_ready {
+            return Err(SourceUnavailable::new(
+                "subsample destination has binding commit evidence without the exact complete planned generation; refusing recovery before mutation",
+            ));
+        }
+        uor_r4_graph_compiler::recorded_corpus::preflight_binding_evidence_matches_current(
+            &producer,
+            &output_meta,
+            &output_records,
+        )?;
+    }
+    producer.begin_compile_attempt()?;
+    if stable_binding || recoverable_temporary {
+        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            &producer,
+            &output_meta,
+            &output_records,
+        )?;
+        let published = recorded_corpus_snapshot(&output_meta, &output_records)?;
+        if published.execution != source.execution
+            || published.meta_bytes != output_meta_bytes
+            || published.records_bytes != output_records_bytes
+            || published.hidden_bytes != output_hidden_bytes
+            || published.binding_cid.as_deref() != Some(binding_cid.as_str())
+        {
+            return Err(SourceUnavailable::new(
+                "subsample binding recovery does not match the exact planned generation",
+            ));
+        }
+        producer.finish_compile_attempt()?;
+        return Ok(());
+    }
+
+    if let Some(dense) = source.execution.dense_operator.as_ref() {
+        publish_dense_operator_binding(&output_root, dense)?;
+    }
+    if let Some(attention) = source.execution.attention_operator.as_ref() {
+        publish_attention_operator_binding(&output_root, attention)?;
+    }
+    publish_guarded_planned_file(
+        &producer,
+        &output_records,
+        &output_records_bytes,
+        "subsample destination records",
+    )?;
+    if let Some(hidden) = output_hidden_bytes.as_deref() {
+        publish_guarded_planned_file(
+            &producer,
+            &output_hidden,
+            hidden,
+            "subsample destination hidden stream",
+        )?;
+    }
+    publish_guarded_planned_file(
+        &producer,
+        &output_meta,
+        &output_meta_bytes,
+        "subsample destination metadata",
+    )?;
+    before_binding()?;
+    let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+        &producer,
+        &output_meta,
+        &output_records,
+    )?;
+    let published = recorded_corpus_snapshot(&output_meta, &output_records)?;
+    if published.execution != source.execution
+        || published.meta_bytes != output_meta_bytes
+        || published.records_bytes != output_records_bytes
+        || published.hidden_bytes != output_hidden_bytes
+        || published.binding_cid.as_deref() != Some(binding_cid.as_str())
+    {
+        return Err(SourceUnavailable::new(
+            "subsample publication changed during exact post-binding recapture",
+        ));
+    }
+    producer.finish_compile_attempt()?;
+    println!(
+        "subsample recorded corpus: {retained_records} records ({train_records} train, {held_out_records} held out; target {}) of {source_records}; {}-byte rows; binding {binding_cid}",
+        options.records, record_width
+    );
+    Ok(())
 }
 
 /// Resolve explicit recorded provenance or the immutable standard/1 meaning
 /// of genuine pre-provenance absence for `compile-recorded`.
+#[cfg(test)]
 fn recorded_compile_attention_operator(
     corpus_meta: &Path,
     corpus_recs: &Path,
@@ -4920,21 +6982,105 @@ fn recorded_compile_attention_operator(
 /// transformer. This is the observation-first production path; teacher
 /// capture remains available through `observe`/`compile` as an explicitly
 /// separate offline step.
+struct PreparedRecordedCompile {
+    corpus: RecordedCorpusSnapshot,
+    attention_operator: AttentionOperatorSpec,
+    dense_operator: Option<DenseOperatorSpec>,
+}
+
+fn write_captured_recorded_corpus(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    output: &Path,
+    corpus: &RecordedCorpusSnapshot,
+) -> Result<(), SourceUnavailable> {
+    publish_guarded_planned_file(
+        guard,
+        &output.join("corpus.records"),
+        &corpus.records_bytes,
+        "recorded compile corpus records",
+    )?;
+    if let Some(hidden) = corpus.hidden_bytes.as_deref() {
+        publish_guarded_planned_file(
+            guard,
+            &output.join("corpus.records.hidden"),
+            hidden,
+            "recorded compile corpus hidden stream",
+        )?;
+    }
+    // Metadata is the core corpus checkpoint and therefore commits last among
+    // corpus members. A crash before this write cannot advertise new counts
+    // for records or hidden rows that were not durably synchronized.
+    publish_guarded_planned_file(
+        guard,
+        &output.join("corpus.meta"),
+        &corpus.meta_bytes,
+        "recorded compile corpus metadata",
+    )?;
+    Ok(())
+}
+
+fn require_existing_file_matches_if_present(
+    path: &Path,
+    expected: Option<&[u8]>,
+    context: &str,
+) -> Result<bool, SourceUnavailable> {
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(SourceUnavailable::new(format!(
+            "{context} {} cannot be inspected: {error}",
+            path.display()
+        ))),
+        Ok(_) => {
+            verify_optional_regular_file_nofollow(path, context, expected).map_err(
+                |mut error| {
+                    error.reason = format!(
+                        "{}; deterministic planned member mismatch is terminal before mutation",
+                        error.reason
+                    );
+                    error
+                },
+            )?;
+            Ok(true)
+        }
+    }
+}
+
+fn preflight_recorded_compile_execution_identity(
+    options: &RecordedCompileOptions,
+) -> Result<PreparedRecordedCompile, SourceUnavailable> {
+    preflight_recorded_compile_output(&options.output)?;
+    let corpus = recorded_corpus_snapshot(&options.corpus_meta, &options.corpus_recs)?;
+    let attention_operator = match corpus.execution.attention_operator.as_ref() {
+        Some(recorded) => recorded.clone(),
+        None => uor_r4_model_source::attention::operator_spec(
+            AttentionOperatorSpec::STANDARD_ID,
+            LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
+        )?,
+    };
+    let dense_operator = corpus.execution.dense_operator.clone();
+    validate_source_execution_pair(
+        &attention_operator,
+        dense_operator.as_ref(),
+        "recorded compile provenance",
+    )?;
+    preflight_compiled_attention_operator(&options.output, &attention_operator)?;
+    preflight_compiled_dense_operator(&options.output, dense_operator.as_ref())?;
+    Ok(PreparedRecordedCompile {
+        corpus,
+        attention_operator,
+        dense_operator,
+    })
+}
+
 pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable> {
     let options = parse_recorded_compile_options(args)?;
-    preflight_recorded_compile_output(&options.output)?;
-    let attention_operator =
-        recorded_compile_attention_operator(&options.corpus_meta, &options.corpus_recs)?;
-    preflight_compiled_attention_operator(&options.output, &attention_operator)?;
-    let meta = options
-        .corpus_meta
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus metadata path is not UTF-8"))?;
-    let records = options
-        .corpus_recs
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
-    let corpus = compiler::load_corpus_from(meta, records).ok_or_else(|| {
+    let prepared = preflight_recorded_compile_execution_identity(&options)?;
+    let corpus = compiler::load_corpus_bytes(
+        &prepared.corpus.meta_bytes,
+        &prepared.corpus.records_bytes,
+        prepared.corpus.hidden_bytes.as_deref(),
+    )
+    .ok_or_else(|| {
         SourceUnavailable::new(format!(
             "recorded corpus is incomplete or invalid at {}/{}",
             options.corpus_meta.display(),
@@ -4955,28 +7101,241 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         .map(|count| count.get().min(8))
         .unwrap_or(1);
     let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads);
-
-    bind_compiled_attention_operator(&options.output, &attention_operator)?;
-    std::fs::write(
-        options.output.join("tless_artifacts.bin"),
-        compiler::artifact_bytes(&artifacts),
-    )?;
-    std::fs::write(
-        options.output.join("tless_store.bin"),
-        runtime::store_bytes(&store),
-    )?;
-    std::fs::write(
-        options.output.join("hamming_calibration.json"),
-        serde_json::to_string_pretty(&calibration).map_err(SourceUnavailable::from)?,
-    )?;
-    std::fs::write(
-        options.output.join("hierarchical_codes.json"),
-        serde_json::to_string_pretty(&hierarchical).map_err(SourceUnavailable::from)?,
-    )?;
-    std::fs::copy(&options.corpus_meta, options.output.join("corpus.meta"))?;
-    std::fs::copy(&options.corpus_recs, options.output.join("corpus.records"))?;
-
     let artifact_bytes = compiler::artifact_bytes(&artifacts);
+    let store_bytes = runtime::store_bytes(&store);
+    let calibration_bytes = serde_json::to_vec_pretty(&calibration)?;
+    let hierarchical_bytes = serde_json::to_vec_pretty(&hierarchical)?;
+
+    let preflight_planned_files = || -> Result<(), SourceUnavailable> {
+        require_existing_file_matches_if_present(
+            &options.output.join("tless_artifacts.bin"),
+            Some(&artifact_bytes),
+            "recorded compile artifact",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("tless_store.bin"),
+            Some(&store_bytes),
+            "recorded compile store",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("hamming_calibration.json"),
+            Some(&calibration_bytes),
+            "recorded compile calibration",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("hierarchical_codes.json"),
+            Some(&hierarchical_bytes),
+            "recorded compile hierarchical codes",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("corpus.meta"),
+            Some(&prepared.corpus.meta_bytes),
+            "recorded compile corpus metadata",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("corpus.records"),
+            Some(&prepared.corpus.records_bytes),
+            "recorded compile corpus records",
+        )?;
+        require_existing_file_matches_if_present(
+            &options.output.join("corpus.records.hidden"),
+            prepared.corpus.hidden_bytes.as_deref(),
+            "recorded compile corpus hidden stream",
+        )?;
+        Ok(())
+    };
+
+    preflight_planned_files()?;
+    let output_parent = options
+        .output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(output_parent).map_err(SourceUnavailable::new)?;
+    let mut producer =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+            &options.output,
+        )?;
+    let source_root = std::fs::canonicalize(
+        options
+            .corpus_meta
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new(".")),
+    )
+    .map_err(SourceUnavailable::new)?;
+    if producer.protects_directory(&source_root)? {
+        return Err(SourceUnavailable::new(
+            "compile-recorded source and destination resolve to the same canonical corpus root; in-place derivation is refused before mutation",
+        ));
+    }
+    producer.ensure_root()?;
+    preflight_guarded_planned_scope(
+        &producer,
+        &PlannedOutputMember::ALL,
+        "recorded compile destination",
+    )?;
+    let recoverable_temporary =
+        producer.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+    preflight_recorded_compile_output(&options.output)?;
+    let attention_ready =
+        preflight_compiled_attention_operator(&options.output, &prepared.attention_operator)?;
+    let dense_ready =
+        preflight_compiled_dense_operator(&options.output, prepared.dense_operator.as_ref())?;
+    preflight_planned_files()?;
+    let artifact_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("tless_artifacts.bin"),
+        &artifact_bytes,
+        "recorded compile artifact",
+    )?;
+    let store_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("tless_store.bin"),
+        &store_bytes,
+        "recorded compile store",
+    )?;
+    let calibration_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("hamming_calibration.json"),
+        &calibration_bytes,
+        "recorded compile calibration",
+    )?;
+    let hierarchical_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("hierarchical_codes.json"),
+        &hierarchical_bytes,
+        "recorded compile hierarchical codes",
+    )?;
+    let records_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("corpus.records"),
+        &prepared.corpus.records_bytes,
+        "recorded compile corpus records",
+    )?;
+    let hidden_ready = match prepared.corpus.hidden_bytes.as_deref() {
+        Some(hidden) => preflight_guarded_planned_file(
+            &producer,
+            &options.output.join("corpus.records.hidden"),
+            hidden,
+            "recorded compile corpus hidden stream",
+        )?,
+        None => {
+            preflight_guarded_planned_absence(
+                &producer,
+                &options.output.join("corpus.records.hidden"),
+                "recorded compile corpus hidden stream",
+            )?;
+            true
+        }
+    };
+    let meta_ready = preflight_guarded_planned_file(
+        &producer,
+        &options.output.join("corpus.meta"),
+        &prepared.corpus.meta_bytes,
+        "recorded compile corpus metadata",
+    )?;
+    let stable_binding = strict_regular_file_if_present(
+        &options
+            .output
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        "recorded compile generation binding",
+    )?;
+    let planned_ready = artifact_ready
+        && store_ready
+        && calibration_ready
+        && hierarchical_ready
+        && records_ready
+        && hidden_ready
+        && meta_ready;
+    if stable_binding || recoverable_temporary {
+        if !planned_ready || !attention_ready || !dense_ready {
+            return Err(SourceUnavailable::new(
+                "recorded compile output contains binding commit evidence but not the exact complete intended generation; refusing member mutation before recovery",
+            ));
+        }
+        uor_r4_graph_compiler::recorded_corpus::preflight_binding_evidence_matches_current(
+            &producer,
+            &options.output.join("corpus.meta"),
+            &options.output.join("corpus.records"),
+        )?;
+    }
+    if stable_binding && !recoverable_temporary && planned_ready && attention_ready && dense_ready {
+        if producer.compile_attempt_active()? {
+            producer.finish_compile_attempt()?;
+        }
+        println!(
+            "recorded compile complete: {} ({} corpus records, artifact κ blake3:{})",
+            options.output.display(),
+            corpus.n,
+            blake3::hash(&artifact_bytes).to_hex()
+        );
+        return Ok(());
+    }
+    producer.preflight_deterministic_compile_inventory(&PlannedOutputMember::ALL)?;
+    producer.begin_compile_attempt()?;
+    if recoverable_temporary {
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            &producer,
+            &options.output.join("corpus.meta"),
+            &options.output.join("corpus.records"),
+        )?;
+    }
+
+    // Dense-first ensures every crash prefix of a current GPT-2 generation is
+    // invalid rather than a false, valid-looking attention-only generation.
+    bind_compiled_dense_operator(&options.output, prepared.dense_operator.as_ref())?;
+    bind_compiled_attention_operator(&options.output, &prepared.attention_operator)?;
+    publish_guarded_planned_file(
+        &producer,
+        &options.output.join("tless_artifacts.bin"),
+        &artifact_bytes,
+        "recorded compile artifact",
+    )?;
+    publish_guarded_planned_file(
+        &producer,
+        &options.output.join("tless_store.bin"),
+        &store_bytes,
+        "recorded compile store",
+    )?;
+    publish_guarded_planned_file(
+        &producer,
+        &options.output.join("hamming_calibration.json"),
+        &calibration_bytes,
+        "recorded compile calibration",
+    )?;
+    publish_guarded_planned_file(
+        &producer,
+        &options.output.join("hierarchical_codes.json"),
+        &hierarchical_bytes,
+        "recorded compile hierarchical codes",
+    )?;
+    write_captured_recorded_corpus(&producer, &options.output, &prepared.corpus)?;
+    let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+        &producer,
+        &options.output.join("corpus.meta"),
+        &options.output.join("corpus.records"),
+    )?;
+    let published = recorded_corpus_snapshot(
+        &options.output.join("corpus.meta"),
+        &options.output.join("corpus.records"),
+    )?;
+    let destination_execution = RecordedCorpusExecutionIdentity {
+        attention_operator: Some(prepared.attention_operator.clone()),
+        dense_operator: prepared.dense_operator.clone(),
+    };
+    if published.binding_cid.as_deref() != Some(binding_cid.as_str())
+        || published.execution != destination_execution
+        || published.meta_bytes != prepared.corpus.meta_bytes
+        || published.records_bytes != prepared.corpus.records_bytes
+        || published.hidden_bytes != prepared.corpus.hidden_bytes
+    {
+        return Err(SourceUnavailable::new(
+            "recorded compile publication changed during exact post-binding recapture",
+        ));
+    }
+    producer.finish_compile_attempt()?;
+
     println!(
         "recorded compile complete: {} ({} corpus records, artifact κ blake3:{})",
         options.output.display(),
@@ -5144,6 +7503,7 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
         }
         Some("compile-recorded") => compile_recorded_corpus(&args[1..])?,
         Some("copy-recorded-attention") => copy_recorded_attention(&args[1..])?,
+        Some("subsample-recorded-corpus") => subsample_recorded_corpus(&args[1..])?,
         Some("store") => {
             let c = compiler::load_corpus()
                 .expect("corpus incomplete: run `transformerless gen` first");
@@ -5188,7 +7548,8 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
                 "R4 transformerless — compile a mul-free table artifact\n\
                  commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
                  recorded compile (no transformer): compile-recorded --corpus-meta <META> --corpus-recs <RECS> --vocab-size <N> --out <DIR>\n\
-                 recorded provenance copy: copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
+                 recorded execution copy (including dense sibling): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
+                 guarded recorded-corpus derivation: subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N]\n\
@@ -5279,6 +7640,31 @@ mod tests {
         std::env::temp_dir().join(format!("uor-r4-cli-{name}-{nonce}"))
     }
 
+    #[test]
+    fn source_corpus_session_releases_common_guard_before_outer_lock() {
+        let base = unique_cli_test_path("source-session-drop-order");
+        let root = base.join("compiled");
+        std::fs::create_dir_all(&root).expect("root");
+        let mut session = source_corpus_session(&root).expect("outer session");
+        session
+            .acquire_recorded_corpus(&root)
+            .expect("common guard");
+
+        session.release_in_order(|| {
+            let error = source_corpus_session(&root)
+                .err()
+                .expect("outer lock remains BUSY until common guard is released");
+            assert!(error.to_string().contains("BUSY"), "{error}");
+        });
+
+        let mut successor = source_corpus_session(&root).expect("outer lock released last");
+        successor
+            .acquire_recorded_corpus(&root)
+            .expect("common guard can be reacquired after full release");
+        drop(successor);
+        std::fs::remove_dir_all(&base).expect("cleanup root");
+    }
+
     fn fixture_adapter(marker: &str) -> TokenizerAdapter {
         let tokenizer_json = format!(
             r#"{{
@@ -5359,6 +7745,23 @@ mod tests {
         entries
     }
 
+    fn dense_operator_temp_entries(path: &Path) -> Vec<String> {
+        let prefix = format!(".{DENSE_OPERATOR_BINDING_FILE}.");
+        let mut entries: Vec<String> = std::fs::read_dir(path)
+            .expect("read test directory")
+            .map(|entry| {
+                entry
+                    .expect("directory entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(&prefix) && name.ends_with(".tmp"))
+            .collect();
+        entries.sort();
+        entries
+    }
+
     fn write_observation_manifest(path: &Path, manifest: &observe::ObservationManifest) {
         std::fs::create_dir_all(path).expect("observation directory");
         std::fs::write(
@@ -5404,6 +7807,27 @@ mod tests {
             (position, position + 1),
             (position, position + 1),
         )
+    }
+
+    fn complete_test_corpus(path: &Path) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(path).expect("corpus directory");
+        let meta = path.join("corpus.meta");
+        let records = path.join("corpus.records");
+        std::fs::write(&records, source_v3_record(0, 0)).expect("complete corpus records");
+        std::fs::write(&meta, source_resume_meta(1, 1)).expect("complete corpus metadata");
+        (meta, records)
+    }
+
+    fn publish_test_corpus_binding(path: &Path, meta: &Path, records: &Path) -> String {
+        let mut guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(path)
+                .expect("test producer guard");
+        guard.ensure_root().expect("test corpus root");
+        guard.begin_compile_attempt().expect("test compile attempt");
+        let cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(&guard, meta, records)
+            .expect("test corpus binding");
+        guard.finish_compile_attempt().expect("finish test attempt");
+        cid
     }
 
     fn source_v2_record(story: u32) -> [u8; 32] {
@@ -5565,6 +7989,159 @@ mod tests {
         ])
         .expect_err("unknown provenance fields are refused");
         assert!(error.reason.contains("unregistered_claim"));
+
+        let duplicate = serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v2())
+            .expect("attention JSON")
+            .replacen("\"version\":2", "\"version\":1,\"version\":2", 1);
+        let error = parse_cover_options(&["--attention-operator".to_owned(), duplicate])
+            .expect_err("duplicate attention era is ambiguous");
+        assert!(error.reason.contains("duplicate JSON field \"version\""));
+    }
+
+    #[test]
+    fn cover_options_carry_only_registered_joint_dense_execution_eras() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        for (attention, dense) in [
+            (
+                AttentionOperatorSpec::learned_absolute_v1(),
+                DenseOperatorSpec::gpt2_v1(),
+            ),
+            (
+                AttentionOperatorSpec::learned_absolute_v2(),
+                DenseOperatorSpec::gpt2_v2(),
+            ),
+        ] {
+            let args = [
+                "--attention-operator".to_owned(),
+                serde_json::to_string(&attention).expect("attention JSON"),
+                "--dense-operator".to_owned(),
+                serde_json::to_string(&dense).expect("dense JSON"),
+            ];
+            let options = parse_cover_options(&args).expect("registered source-execution era");
+            assert_eq!(options.attention_operator.as_ref(), Some(&attention));
+            assert_eq!(options.dense_operator.as_ref(), Some(&dense));
+        }
+        let defaults = parse_cover_options(&[]).expect("legacy/Llama defaults");
+        assert_eq!(defaults.dense_operator, None);
+
+        let dense_json =
+            serde_json::to_string(&DenseOperatorSpec::gpt2_v2()).expect("current dense JSON");
+        let error = parse_cover_options(&["--dense-operator".to_owned(), dense_json.clone()])
+            .expect_err("dense without attention is terminal");
+        assert!(error.reason.contains("without an attention"), "{error}");
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v1())
+                .expect("v1 attention JSON"),
+            "--dense-operator".to_owned(),
+            dense_json,
+        ])
+        .expect_err("cross-era cover provenance is terminal");
+        assert!(error.reason.contains("source execution pair"), "{error}");
+
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v2())
+                .expect("attention JSON"),
+            "--dense-operator".to_owned(),
+            "{not json".to_owned(),
+        ])
+        .expect_err("malformed dense record is terminal");
+        assert!(error.reason.contains("--dense-operator"), "{error}");
+
+        let mut drifted = DenseOperatorSpec::gpt2_v2();
+        drifted.conv1d_bias.push_str("-tampered");
+        drifted.implementation_digest = drifted.declared_digest();
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v2())
+                .expect("attention JSON"),
+            "--dense-operator".to_owned(),
+            serde_json::to_string(&drifted).expect("drifted dense JSON"),
+        ])
+        .expect_err("registry-divergent dense record is terminal");
+        assert!(
+            error.reason.contains("does not match registered"),
+            "{error}"
+        );
+
+        let duplicate_dense = serde_json::to_string(&DenseOperatorSpec::gpt2_v2())
+            .expect("dense JSON")
+            .replacen("\"version\":2", "\"version\":1,\"version\":2", 1);
+        let error = parse_cover_options(&[
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v2())
+                .expect("attention JSON"),
+            "--dense-operator".to_owned(),
+            duplicate_dense,
+        ])
+        .expect_err("duplicate dense era is ambiguous");
+        assert!(error.reason.contains("duplicate JSON field \"version\""));
+    }
+
+    #[test]
+    fn cover_reconciles_the_exact_recorded_pair_before_any_output_mutation() {
+        let corpus_root = unique_cli_test_path("cover-recorded-execution");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&corpus_root, &attention).expect("attention sidecar");
+        bind_compiled_dense_operator(&corpus_root, Some(&dense)).expect("dense sidecar");
+        let (meta, records) = corpus_markers(&corpus_root);
+        let artifacts = corpus_root.join("missing-artifacts.bin");
+        let output = unique_cli_test_path("cover-recorded-execution-output");
+        std::fs::create_dir_all(&output).expect("cover output");
+        std::fs::write(output.join("sentinel"), b"output-before").expect("output sentinel");
+        let output_before = directory_bytes(&output);
+
+        let base_args = || {
+            vec![
+                "--corpus-meta".to_owned(),
+                meta.display().to_string(),
+                "--corpus-recs".to_owned(),
+                records.display().to_string(),
+                "--artifacts".to_owned(),
+                artifacts.display().to_string(),
+                "--out".to_owned(),
+                output.display().to_string(),
+            ]
+        };
+        let missing_pair = base_args();
+        let mut missing_dense = base_args();
+        missing_dense.extend([
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&attention).expect("attention JSON"),
+        ]);
+        let mut wrong_pair = base_args();
+        wrong_pair.extend([
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&AttentionOperatorSpec::learned_absolute_v1())
+                .expect("v1 attention JSON"),
+            "--dense-operator".to_owned(),
+            serde_json::to_string(&DenseOperatorSpec::gpt2_v1()).expect("v1 dense JSON"),
+        ]);
+        for args in [missing_pair, missing_dense, wrong_pair] {
+            let error = cover_command(&args).expect_err("recorded pair mismatch is terminal");
+            assert!(
+                error.reason.contains("does not match recorded corpus"),
+                "{error}"
+            );
+            assert_eq!(directory_bytes(&output), output_before);
+        }
+
+        let mut matching = base_args();
+        matching.extend([
+            "--attention-operator".to_owned(),
+            serde_json::to_string(&attention).expect("attention JSON"),
+            "--dense-operator".to_owned(),
+            serde_json::to_string(&dense).expect("dense JSON"),
+        ]);
+        let error = cover_command(&matching).expect_err("missing artifact follows pair preflight");
+        assert!(error.reason.contains("missing-artifacts.bin"), "{error}");
+        assert_eq!(directory_bytes(&output), output_before);
+
+        let _ = std::fs::remove_dir_all(corpus_root);
+        let _ = std::fs::remove_dir_all(output);
     }
 
     #[test]
@@ -5597,7 +8174,7 @@ mod tests {
         let directory = unique_cli_test_path("stage-tokenizer-directory");
         std::fs::create_dir_all(&directory).expect("create directory");
         let error = explicit_tokenizer_cid(Some(&directory)).expect_err("directory refused");
-        assert!(error.reason.contains("not a regular file"));
+        assert!(error.reason.contains("not a regular file"), "{error}");
 
         let _ = std::fs::remove_file(tokenizer);
         let _ = std::fs::remove_dir_all(directory);
@@ -5948,6 +8525,238 @@ mod tests {
     }
 
     #[test]
+    fn compile_dense_operator_sidecar_is_optional_registry_exact_and_atomic() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let absent = unique_cli_test_path("compile-dense-absent");
+        assert_eq!(
+            compiled_dense_operator(&absent).expect("optional absence"),
+            None
+        );
+
+        for operator in [DenseOperatorSpec::gpt2_v1(), DenseOperatorSpec::gpt2_v2()] {
+            let output =
+                unique_cli_test_path(&format!("compile-dense-reader-v{}", operator.version));
+            bind_compiled_dense_operator(&output, Some(&operator)).expect("publish dense record");
+            let sidecar = output.join(DENSE_OPERATOR_BINDING_FILE);
+            let before = std::fs::read(&sidecar).expect("dense sidecar bytes");
+            assert_eq!(before.last(), Some(&b'\n'));
+            assert_eq!(
+                compiled_dense_operator(&output).expect("registry-validated dense read"),
+                Some(operator.clone())
+            );
+            bind_compiled_dense_operator(&output, Some(&operator)).expect("idempotent dense pin");
+            assert_eq!(
+                std::fs::read(&sidecar).expect("dense sidecar reread"),
+                before
+            );
+            assert!(dense_operator_temp_entries(&output).is_empty());
+            let _ = std::fs::remove_dir_all(output);
+        }
+
+        let parked = unique_cli_test_path("compile-dense-parked-temp");
+        std::fs::create_dir_all(&parked).expect("parked temp output");
+        let temporary = parked.join(format!(".{DENSE_OPERATOR_BINDING_FILE}.123.1.tmp"));
+        std::fs::write(&temporary, b"incomplete abandoned writer")
+            .expect("park abandoned temporary");
+        bind_compiled_dense_operator(&parked, Some(&DenseOperatorSpec::gpt2_v2()))
+            .expect("unique atomic publication does not adopt an abandoned temp");
+        assert_eq!(
+            compiled_dense_operator(&parked).expect("stable record wins"),
+            Some(DenseOperatorSpec::gpt2_v2())
+        );
+        assert_eq!(
+            std::fs::read(&temporary).expect("abandoned temp is not reclaimed here"),
+            b"incomplete abandoned writer"
+        );
+        let _ = std::fs::remove_dir_all(parked);
+    }
+
+    #[test]
+    fn compile_dense_operator_reader_rejects_invalid_evidence_without_mutation() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let malformed = unique_cli_test_path("compile-dense-malformed");
+        std::fs::create_dir_all(&malformed).expect("malformed output");
+        std::fs::write(malformed.join(DENSE_OPERATOR_BINDING_FILE), b"{not json")
+            .expect("malformed dense binding");
+        let before = directory_bytes(&malformed);
+        let error = compiled_dense_operator(&malformed).expect_err("malformed is terminal");
+        assert!(error.reason.contains("malformed dense-operator binding"));
+        assert_eq!(directory_bytes(&malformed), before);
+
+        let duplicate = unique_cli_test_path("compile-dense-duplicate");
+        std::fs::create_dir_all(&duplicate).expect("duplicate output");
+        let canonical =
+            serde_json::to_string_pretty(&DenseOperatorSpec::gpt2_v2()).expect("dense JSON");
+        let duplicate_json =
+            canonical.replacen("\"version\": 2", "\"version\": 1,\n  \"version\": 2", 1);
+        std::fs::write(duplicate.join(DENSE_OPERATOR_BINDING_FILE), duplicate_json)
+            .expect("duplicate dense binding");
+        let before = directory_bytes(&duplicate);
+        let error = compiled_dense_operator(&duplicate).expect_err("duplicate key is terminal");
+        assert!(
+            error.reason.contains("duplicate JSON field \"version\""),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&duplicate), before);
+
+        let unknown = unique_cli_test_path("compile-dense-unknown");
+        std::fs::create_dir_all(&unknown).expect("unknown output");
+        let mut unknown_record = DenseOperatorSpec::gpt2_v2();
+        unknown_record.version = u32::MAX;
+        unknown_record.implementation_digest = unknown_record.declared_digest();
+        std::fs::write(
+            unknown.join(DENSE_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&unknown_record).expect("unknown dense JSON"),
+        )
+        .expect("unknown dense binding");
+        let error = compiled_dense_operator(&unknown).expect_err("unknown version is terminal");
+        assert!(matches!(
+            error.kind,
+            uor_r4_model_source::SourceIngestKind::UnknownDenseOperator { version, .. }
+                if version == u32::MAX
+        ));
+
+        let drift = unique_cli_test_path("compile-dense-drift");
+        std::fs::create_dir_all(&drift).expect("drift output");
+        let mut drifted = DenseOperatorSpec::gpt2_v2();
+        drifted.conv1d_bias.push_str("-tampered");
+        drifted.implementation_digest = drifted.declared_digest();
+        std::fs::write(
+            drift.join(DENSE_OPERATOR_BINDING_FILE),
+            serde_json::to_vec_pretty(&drifted).expect("drifted dense JSON"),
+        )
+        .expect("drifted dense binding");
+        let error = compiled_dense_operator(&drift).expect_err("record drift is terminal");
+        assert!(
+            error.reason.contains("does not match registered"),
+            "{error}"
+        );
+
+        let nonregular = unique_cli_test_path("compile-dense-directory");
+        std::fs::create_dir_all(nonregular.join(DENSE_OPERATOR_BINDING_FILE))
+            .expect("directory dense binding");
+        let error = compiled_dense_operator(&nonregular).expect_err("nonregular is terminal");
+        assert!(error.reason.contains("not a regular file"), "{error}");
+
+        for output in [malformed, duplicate, unknown, drift, nonregular] {
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compiled_execution_sidecar_reader_rejects_post_open_link_swap() {
+        use std::os::unix::fs::symlink;
+
+        for name in [ATTENTION_OPERATOR_BINDING_FILE, DENSE_OPERATOR_BINDING_FILE] {
+            let output = unique_cli_test_path(&format!("compiled-sidecar-swap-{name}"));
+            std::fs::create_dir_all(&output).expect("sidecar output");
+            let path = output.join(name);
+            std::fs::write(&path, b"opened provenance bytes").expect("initial regular sidecar");
+            let target = output.with_extension(format!("{name}.external"));
+            let target_bytes = b"external target must never be read or changed";
+            std::fs::write(&target, target_bytes).expect("external target");
+
+            let error = read_optional_regular_file_nofollow_with(
+                &path,
+                "execution-operator binding",
+                || {
+                    std::fs::remove_file(&path).expect("replace opened sidecar");
+                    symlink(&target, &path).expect("swap path to link after open");
+                },
+            )
+            .expect_err("path/handle identity mismatch is terminal");
+            assert!(error.reason.contains("changed identity"), "{error}");
+            assert_eq!(
+                std::fs::read(&target).expect("external target survives"),
+                target_bytes
+            );
+            assert_eq!(
+                std::fs::read_link(&path).expect("swapped link survives"),
+                target
+            );
+
+            std::fs::remove_file(&path).expect("remove swapped link");
+            std::fs::remove_file(&target).expect("remove external target");
+            let _ = std::fs::remove_dir_all(output);
+        }
+
+        let rewrites = [
+            (
+                ATTENTION_OPERATOR_BINDING_FILE,
+                serde_json::to_vec_pretty(&AttentionOperatorSpec::learned_absolute_v1())
+                    .expect("attention v1 JSON"),
+                serde_json::to_vec_pretty(&AttentionOperatorSpec::learned_absolute_v2())
+                    .expect("attention v2 JSON"),
+            ),
+            (
+                DENSE_OPERATOR_BINDING_FILE,
+                serde_json::to_vec_pretty(&DenseOperatorSpec::gpt2_v1()).expect("dense v1 JSON"),
+                serde_json::to_vec_pretty(&DenseOperatorSpec::gpt2_v2()).expect("dense v2 JSON"),
+            ),
+        ];
+        for (name, initial, replacement) in rewrites {
+            let output = unique_cli_test_path(&format!("compiled-sidecar-rewrite-{name}"));
+            std::fs::create_dir_all(&output).expect("sidecar output");
+            let path = output.join(name);
+            std::fs::write(&path, &initial).expect("initial canonical sidecar");
+
+            let error = read_optional_regular_file_nofollow_with(
+                &path,
+                "execution-operator binding",
+                || std::fs::write(&path, &replacement).expect("in-place canonical rewrite"),
+            )
+            .expect_err("same-inode rewrite is a changed generation");
+            assert!(error.reason.contains("changed"), "{error}");
+            assert_eq!(
+                std::fs::read(&path).expect("replacement survives refusal"),
+                replacement
+            );
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[test]
+    fn compile_dense_operator_refuses_payload_relabel_and_cross_era_joint_pin() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let legacy = unique_cli_test_path("compile-dense-legacy-payload");
+        std::fs::create_dir_all(&legacy).expect("legacy output");
+        std::fs::write(legacy.join("corpus.records"), b"legacy dense rows")
+            .expect("legacy payload");
+        let before = directory_bytes(&legacy);
+        let error = bind_compiled_dense_operator(&legacy, Some(&DenseOperatorSpec::gpt2_v2()))
+            .expect_err("legacy payload cannot be relabelled");
+        assert!(
+            error.reason.contains("legacy dense-execution era"),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&legacy), before);
+
+        let cross_era = unique_cli_test_path("compile-dense-cross-era");
+        std::fs::create_dir_all(&cross_era).expect("cross-era output");
+        std::fs::write(cross_era.join("sentinel"), b"before").expect("sentinel");
+        let before = directory_bytes(&cross_era);
+        let error = pin_compile_identities_with_dense(
+            &cross_era,
+            &fixture_adapter("cross-era"),
+            &AttentionOperatorSpec::learned_absolute_v1(),
+            Some(&DenseOperatorSpec::gpt2_v2()),
+        )
+        .expect_err("cross-era joint identity must fail before publication");
+        assert!(error.reason.contains("source execution pair"), "{error}");
+        assert_eq!(directory_bytes(&cross_era), before);
+        assert!(!cross_era.join(TOKENIZER_ADAPTER_FILE).exists());
+        assert!(!cross_era.join(ATTENTION_OPERATOR_BINDING_FILE).exists());
+        assert!(!cross_era.join(DENSE_OPERATOR_BINDING_FILE).exists());
+
+        let _ = std::fs::remove_dir_all(legacy);
+        let _ = std::fs::remove_dir_all(cross_era);
+    }
+
+    #[test]
     fn compile_attention_operator_reader_accepts_every_immutable_and_current_source_record() {
         for operator in [
             AttentionOperatorSpec::standard_v1(),
@@ -6073,6 +8882,76 @@ mod tests {
         assert!(error.reason.contains("evaluation refused before replay"));
         assert!(error.reason.contains("standard-source-attention/1"));
         assert!(error.reason.contains("standard-source-attention/2"));
+    }
+
+    #[test]
+    fn evaluation_dense_operator_requires_exact_value_and_exact_absence() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let compiled = Path::new("compiled-fixture");
+        let v1 = DenseOperatorSpec::gpt2_v1();
+        let v2 = DenseOperatorSpec::gpt2_v2();
+        require_matching_evaluation_dense_operator(compiled, Some(&v1), Some(&v1))
+            .expect("exact historical dense replay");
+        require_matching_evaluation_dense_operator(compiled, Some(&v2), Some(&v2))
+            .expect("exact current dense replay");
+        require_matching_evaluation_dense_operator(compiled, None, None)
+            .expect("typed dense absence replay");
+
+        for (recorded, actual) in [(Some(&v1), Some(&v2)), (Some(&v2), None), (None, Some(&v2))] {
+            let error = require_matching_evaluation_dense_operator(compiled, recorded, actual)
+                .expect_err("dense era mismatch must fail before replay");
+            assert!(
+                error.reason.contains("evaluation refused before replay"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn evaluation_snapshot_cids_are_from_one_binding_checked_generation() {
+        let compiled = unique_cli_test_path("evaluation-captured-execution");
+        let attention_v2 = AttentionOperatorSpec::learned_absolute_v2();
+        let dense_v2 = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&compiled, &attention_v2).expect("v2 attention");
+        bind_compiled_dense_operator(&compiled, Some(&dense_v2)).expect("v2 dense");
+        let (meta, records) = complete_test_corpus(&compiled);
+        let binding_cid = publish_test_corpus_binding(&compiled, &meta, &records);
+        let attention_path = compiled.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let dense_path = compiled.join(DENSE_OPERATOR_BINDING_FILE);
+        let attention_v2_bytes = std::fs::read(&attention_path).expect("captured attention bytes");
+        let dense_v2_bytes = std::fs::read(&dense_path).expect("captured dense bytes");
+        let captured = recorded_corpus_snapshot(&meta, &records).expect("exact snapshot");
+        assert_eq!(captured.execution.attention_operator, Some(attention_v2));
+        assert_eq!(captured.execution.dense_operator, Some(dense_v2));
+        assert_eq!(
+            format!(
+                "blake3:{}",
+                blake3::hash(
+                    captured
+                        .attention_operator_bytes
+                        .as_deref()
+                        .expect("attention bytes")
+                )
+                .to_hex()
+            ),
+            format!("blake3:{}", blake3::hash(&attention_v2_bytes).to_hex())
+        );
+        assert_eq!(
+            format!(
+                "blake3:{}",
+                blake3::hash(
+                    captured
+                        .dense_operator_bytes
+                        .as_deref()
+                        .expect("dense bytes")
+                )
+                .to_hex()
+            ),
+            format!("blake3:{}", blake3::hash(&dense_v2_bytes).to_hex())
+        );
+        assert_eq!(captured.binding_cid, Some(binding_cid));
+        let _ = std::fs::remove_dir_all(compiled);
     }
 
     #[test]
@@ -6759,7 +9638,7 @@ mod tests {
 
     #[test]
     fn recorded_compile_refuses_unsupported_source_bundle_leaves_before_mutation() {
-        for case in ["adapter", "table", "hidden", "space-manifest"] {
+        for case in ["adapter", "table", "space-manifest"] {
             let output = unique_cli_test_path(&format!("recorded-output-stale-{case}"));
             if case == "adapter" {
                 pin_compile_tokenizer_adapter(&output, &fixture_adapter("stale-recorded"))
@@ -6773,13 +9652,6 @@ mod tests {
                     b"stale tokenizer table sentinel",
                 )
                 .expect("stale tokenizer table");
-            }
-            if case == "hidden" {
-                std::fs::write(
-                    output.join("corpus.records.hidden"),
-                    b"stale teacher hidden-row sentinel",
-                )
-                .expect("stale hidden stream");
             }
             if case == "space-manifest" {
                 std::fs::write(
@@ -7202,6 +10074,123 @@ mod tests {
     }
 
     #[test]
+    fn compile_recorded_preflight_propagates_the_joint_dense_execution_identity() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let source = unique_cli_test_path("compile-recorded-dense-source");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&source, &attention).expect("source attention binding");
+        bind_compiled_dense_operator(&source, Some(&dense)).expect("source dense binding");
+        let (meta, records) = corpus_markers(&source);
+
+        let output = unique_cli_test_path("compile-recorded-dense-output");
+        let args = vec![
+            "--corpus-meta".to_owned(),
+            meta.display().to_string(),
+            "--corpus-recs".to_owned(),
+            records.display().to_string(),
+            "--vocab-size".to_owned(),
+            "16".to_owned(),
+            "--out".to_owned(),
+            output.display().to_string(),
+        ];
+        let options = parse_recorded_compile_options(&args).expect("recorded compile options");
+        let prepared = preflight_recorded_compile_execution_identity(&options)
+            .expect("preflight current GPT-2 recorded corpus");
+        assert_eq!(prepared.attention_operator, attention);
+        assert_eq!(prepared.dense_operator, Some(dense));
+        assert_eq!(prepared.corpus.meta_bytes, b"meta marker");
+        assert_eq!(prepared.corpus.records_bytes, b"records marker");
+        assert!(
+            !output.exists(),
+            "all recorded execution checks precede output publication"
+        );
+
+        let _ = std::fs::remove_dir_all(source);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recorded_corpus_capture_refuses_post_resolution_swap_and_copy_never_reopens_source() {
+        use std::os::unix::fs::symlink;
+
+        let source = unique_cli_test_path("recorded-corpus-captured-source");
+        let (meta, records) = corpus_markers(&source);
+        let hidden = source.join("corpus.records.hidden");
+        std::fs::write(&hidden, b"captured hidden bytes").expect("hidden bytes");
+        let external = unique_cli_test_path("recorded-corpus-external-records");
+        std::fs::write(&external, b"external replacement bytes").expect("external records");
+        let output = unique_cli_test_path("recorded-corpus-swap-output");
+        std::fs::create_dir_all(&output).expect("output");
+        std::fs::write(output.join("sentinel"), b"before").expect("sentinel");
+        let output_before = directory_bytes(&output);
+
+        let error = recorded_corpus_snapshot_with_hook(&meta, &records, || {
+            std::fs::remove_file(&records).expect("remove captured records path");
+            symlink(&external, &records).expect("post-resolution records symlink")
+        })
+        .expect_err("post-resolution path generation swap is terminal");
+        assert!(
+            error.reason.contains("without following links")
+                || error.reason.contains("captured regular-file generation"),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&output), output_before);
+        std::fs::remove_file(&records).expect("remove swapped link");
+        std::fs::write(&records, b"records marker").expect("restore records");
+
+        let captured = recorded_corpus_snapshot(&meta, &records).expect("stable exact capture");
+        assert_eq!(captured.meta_bytes, b"meta marker");
+        assert_eq!(captured.records_bytes, b"records marker");
+        assert_eq!(
+            captured.hidden_bytes.as_deref(),
+            Some(b"captured hidden bytes".as_slice())
+        );
+        std::fs::remove_file(&meta).expect("remove captured metadata source");
+        std::fs::remove_file(&records).expect("remove captured records source");
+        symlink(&external, &meta).expect("swap metadata after complete capture");
+        symlink(&external, &records).expect("swap records after complete capture");
+
+        let mut output_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("output guard");
+        output_guard.ensure_root().expect("output root");
+        write_captured_recorded_corpus(&output_guard, &output, &captured)
+            .expect("copy uses owned captured bytes only");
+        assert_eq!(
+            std::fs::read(output.join("corpus.meta")).expect("output meta"),
+            b"meta marker"
+        );
+        assert_eq!(
+            std::fs::read(output.join("corpus.records")).expect("output records"),
+            b"records marker"
+        );
+        assert_eq!(
+            std::fs::read(&external).expect("external survives"),
+            b"external replacement bytes"
+        );
+
+        let _ = std::fs::remove_dir_all(source);
+        let _ = std::fs::remove_dir_all(output);
+        let _ = std::fs::remove_file(external);
+    }
+
+    #[test]
+    fn captured_corpus_byte_parser_matches_the_path_wrapper_contract() {
+        let meta = source_resume_meta(1, 1);
+        let record = source_v3_record(7, 0);
+        let corpus =
+            compiler::load_corpus_bytes(&meta, &record, None).expect("captured v3 corpus parses");
+        assert_eq!(corpus.n, 1);
+        assert_eq!(corpus.stories, 1);
+        assert_eq!(corpus.story, vec![7]);
+        assert_eq!(corpus.next, vec![7]);
+    }
+
+    #[test]
     fn recorded_corpus_attention_operator_reads_both_sources_and_rejects_conflicts() {
         let sidecar_root = unique_cli_test_path("recorded-attention-sidecar");
         let sidecar_operator = AttentionOperatorSpec::learned_absolute_source_attention();
@@ -7267,6 +10256,150 @@ mod tests {
         let _ = std::fs::remove_dir_all(conflict_root);
         let _ = std::fs::remove_dir_all(operatorless_manifest_root);
         let _ = std::fs::remove_dir_all(legacy_root);
+    }
+
+    #[test]
+    fn recorded_corpus_execution_identity_resolves_dense_and_rejects_impossible_pairs() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let sidecar_root = unique_cli_test_path("recorded-execution-sidecars");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&sidecar_root, &attention).expect("attention sidecar");
+        bind_compiled_dense_operator(&sidecar_root, Some(&dense)).expect("dense sidecar");
+        let (meta, records) = corpus_markers(&sidecar_root);
+        assert_eq!(
+            recorded_corpus_execution_identity(&meta, &records).expect("joint sidecar identity"),
+            RecordedCorpusExecutionIdentity {
+                attention_operator: Some(attention.clone()),
+                dense_operator: Some(dense.clone()),
+            }
+        );
+
+        let manifest_root = unique_cli_test_path("recorded-execution-manifest");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(attention.clone());
+        manifest.dense_operator = Some(dense.clone());
+        write_observation_manifest(&manifest_root, &manifest);
+        let (state, merged) = observation_corpus_markers(&manifest_root);
+        assert_eq!(
+            recorded_corpus_execution_identity(&state, &merged).expect("joint manifest identity"),
+            RecordedCorpusExecutionIdentity {
+                attention_operator: Some(attention),
+                dense_operator: Some(dense),
+            }
+        );
+
+        let cross_era = unique_cli_test_path("recorded-execution-cross-era");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v1());
+        manifest.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+        write_observation_manifest(&cross_era, &manifest);
+        let (state, merged) = observation_corpus_markers(&cross_era);
+        let before = directory_bytes(&cross_era);
+        let error = recorded_corpus_execution_identity(&state, &merged)
+            .expect_err("cross-era pair is terminal");
+        assert!(
+            error.reason.contains("does not match") || error.reason.contains("not registered"),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&cross_era), before);
+
+        let dense_only = unique_cli_test_path("recorded-execution-dense-only");
+        bind_compiled_dense_operator(&dense_only, Some(&DenseOperatorSpec::gpt2_v2()))
+            .expect("dense-only sidecar fixture");
+        let (meta, records) = corpus_markers(&dense_only);
+        let before = directory_bytes(&dense_only);
+        let error = recorded_corpus_execution_identity(&meta, &records)
+            .expect_err("dense without attention is terminal");
+        assert!(error.reason.contains("without an attention"), "{error}");
+        assert_eq!(directory_bytes(&dense_only), before);
+
+        for root in [sidecar_root, manifest_root, cross_era, dense_only] {
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn recorded_corpus_joint_snapshot_rejects_manifest_disappearance_before_output_mutation() {
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let root = unique_cli_test_path("recorded-execution-toctou");
+        let mut manifest = observe::ObservationManifest::new(1);
+        manifest.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+        manifest.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+        write_observation_manifest(&root, &manifest);
+        let (state, merged) = observation_corpus_markers(&root);
+        let output = unique_cli_test_path("recorded-execution-toctou-output");
+        std::fs::create_dir_all(&output).expect("output directory");
+        std::fs::write(output.join("sentinel"), b"last-good output").expect("sentinel");
+        let output_before = directory_bytes(&output);
+        let manifest_path = root.join(observe::MANIFEST_FILE);
+
+        let error = recorded_corpus_execution_identity_with_recheck_hooks(
+            &state,
+            &merged,
+            || {},
+            || std::fs::remove_file(&manifest_path).expect("simulate manifest disappearance"),
+        )
+        .expect_err("one execution identity cannot span filesystem generations");
+        assert!(error.reason.contains("changed or disappeared"), "{error}");
+        assert_eq!(directory_bytes(&output), output_before);
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn recorded_corpus_joint_snapshot_returns_only_captured_bytes_across_aba_swap() {
+        let root = unique_cli_test_path("recorded-execution-aba");
+        let v1_attention = AttentionOperatorSpec::learned_absolute_v1();
+        let v1_dense = DenseOperatorSpec::gpt2_v1();
+        bind_compiled_attention_operator(&root, &v1_attention).expect("v1 attention");
+        bind_compiled_dense_operator(&root, Some(&v1_dense)).expect("v1 dense");
+        let (meta, records) = corpus_markers(&root);
+        let attention_path = root.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let dense_path = root.join(DENSE_OPERATOR_BINDING_FILE);
+        let attention_v1_bytes = std::fs::read(&attention_path).expect("v1 attention bytes");
+        let dense_v1_bytes = std::fs::read(&dense_path).expect("v1 dense bytes");
+        let mut attention_v2_bytes =
+            serde_json::to_vec_pretty(&AttentionOperatorSpec::learned_absolute_v2())
+                .expect("v2 attention JSON");
+        attention_v2_bytes.push(b'\n');
+        let mut dense_v2_bytes =
+            serde_json::to_vec_pretty(&DenseOperatorSpec::gpt2_v2()).expect("v2 dense JSON");
+        dense_v2_bytes.push(b'\n');
+
+        let resolved = recorded_corpus_execution_identity_with_recheck_hooks(
+            &meta,
+            &records,
+            || {
+                std::fs::write(&attention_path, &attention_v2_bytes)
+                    .expect("transient v2 attention");
+                std::fs::write(&dense_path, &dense_v2_bytes).expect("transient v2 dense");
+            },
+            || {
+                std::fs::write(&attention_path, &attention_v1_bytes).expect("restore v1 attention");
+                std::fs::write(&dense_path, &dense_v1_bytes).expect("restore v1 dense");
+            },
+        )
+        .expect("the exact captured A generation remains authoritative");
+        assert_eq!(
+            resolved,
+            RecordedCorpusExecutionIdentity {
+                attention_operator: Some(v1_attention),
+                dense_operator: Some(v1_dense),
+            }
+        );
+        assert_eq!(
+            std::fs::read(attention_path).expect("restored attention"),
+            attention_v1_bytes
+        );
+        assert_eq!(
+            std::fs::read(dense_path).expect("restored dense"),
+            dense_v1_bytes
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -7409,30 +10542,35 @@ mod tests {
         symlink(&target, root.join(observe::MANIFEST_FILE)).expect("manifest symlink");
         let error = recorded_corpus_attention_operator(&meta, &records)
             .expect_err("a present manifest symlink is not legacy absence");
-        assert!(error.reason.contains("not a regular file"));
+        assert!(error.reason.contains("not a regular"), "{error}");
         let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
-    fn copy_recorded_attention_uses_registry_resolver_and_preserves_true_legacy_absence() {
+    fn copy_recorded_attention_preserves_markerless_legacy_compatibility() {
         let source = unique_cli_test_path("copy-recorded-attention-source");
-        let operator = AttentionOperatorSpec::learned_absolute_source_attention();
+        let operator = AttentionOperatorSpec::standard_v1();
         bind_compiled_attention_operator(&source, &operator).expect("source binding");
-        let (meta, records) = corpus_markers(&source);
-        let destination = unique_cli_test_path("copy-recorded-attention-destination")
-            .join(ATTENTION_OPERATOR_BINDING_FILE);
+        let (meta, records) = complete_test_corpus(&source);
+        let destination_root = unique_cli_test_path("copy-recorded-attention-destination");
+        let (destination_meta, destination_records) = complete_test_corpus(&destination_root);
+        let destination = destination_root.join(ATTENTION_OPERATOR_BINDING_FILE);
         copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
-            .expect("copy exact source provenance");
+            .expect("copy historical attention provenance");
         assert_eq!(
-            compiled_attention_operator(destination.parent().expect("destination parent"))
-                .expect("copied binding"),
+            compiled_attention_operator(&destination_root).expect("copied binding"),
             operator
         );
+        assert_eq!(compiled_dense_operator(&destination_root).unwrap(), None);
+        let captured = recorded_corpus_snapshot(&destination_meta, &destination_records)
+            .expect("markerless compatibility destination");
+        assert!(captured.binding_cid.is_none());
 
         let legacy = unique_cli_test_path("copy-recorded-attention-legacy");
-        let (legacy_meta, legacy_records) = corpus_markers(&legacy);
-        let absent_destination = unique_cli_test_path("copy-recorded-attention-legacy-destination")
-            .join(ATTENTION_OPERATOR_BINDING_FILE);
+        let (legacy_meta, legacy_records) = complete_test_corpus(&legacy);
+        let absent_root = unique_cli_test_path("copy-recorded-attention-legacy-destination");
+        complete_test_corpus(&absent_root);
+        let absent_destination = absent_root.join(ATTENTION_OPERATOR_BINDING_FILE);
         copy_recorded_attention(&copy_recorded_attention_args(
             &legacy_meta,
             &legacy_records,
@@ -7441,33 +10579,69 @@ mod tests {
         .expect("true legacy absence is a no-op");
         assert!(!absent_destination.exists());
 
-        let stale_parent = unique_cli_test_path("copy-recorded-attention-stale-legacy");
-        std::fs::create_dir_all(&stale_parent).expect("stale destination parent");
-        let stale_destination = stale_parent.join(ATTENTION_OPERATOR_BINDING_FILE);
-        std::fs::write(&stale_destination, b"stale binding").expect("stale destination");
-        let stale_before = std::fs::read(&stale_destination).expect("stale bytes");
-        let error = copy_recorded_attention(&copy_recorded_attention_args(
-            &legacy_meta,
-            &legacy_records,
-            &stale_destination,
-        ))
-        .expect_err("legacy absence cannot retain a stale destination");
-        assert!(
-            error
-                .reason
-                .contains("has no attention-operator provenance")
+        for root in [source, destination_root, legacy, absent_root] {
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn copy_recorded_attention_dense_is_bound_verification_only() {
+        let source = unique_cli_test_path("copy-recorded-dense-first-source");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&source, &attention).expect("source attention");
+        bind_compiled_dense_operator(&source, Some(&dense)).expect("source dense");
+        let (meta, records) = complete_test_corpus(&source);
+        publish_test_corpus_binding(&source, &meta, &records);
+        let destination_root = unique_cli_test_path("copy-recorded-dense-first-destination");
+        complete_test_corpus(&destination_root);
+        let destination = destination_root.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let args = copy_recorded_attention_args(&meta, &records, &destination);
+        let before = directory_bytes(&destination_root);
+        let error = copy_recorded_attention(&args)
+            .expect_err("unbound destination cannot acquire dense provenance");
+        assert!(error.reason.contains("cannot authorize"), "{error}");
+        assert_eq!(directory_bytes(&destination_root), before);
+
+        std::fs::remove_dir_all(&destination_root).expect("replace unbound fixture");
+        bind_compiled_dense_operator(&destination_root, Some(&dense)).expect("bound dense");
+        bind_compiled_attention_operator(&destination_root, &attention).expect("bound attention");
+        let (destination_meta, destination_records) = complete_test_corpus(&destination_root);
+        publish_test_corpus_binding(&destination_root, &destination_meta, &destination_records);
+        let bound_before = directory_bytes(&destination_root);
+        copy_recorded_attention(&args).expect("exact bound destination verifies as a no-op");
+        assert_eq!(directory_bytes(&destination_root), bound_before);
+
+        let attention_only_source = unique_cli_test_path("copy-recorded-attention-only-source");
+        let attention_only = AttentionOperatorSpec::standard_v1();
+        bind_compiled_attention_operator(&attention_only_source, &attention_only)
+            .expect("attention-only source");
+        let (meta, records) = complete_test_corpus(&attention_only_source);
+        let attention_only_root = unique_cli_test_path("copy-recorded-attention-only-destination");
+        complete_test_corpus(&attention_only_root);
+        let attention_only_destination = attention_only_root.join(ATTENTION_OPERATOR_BINDING_FILE);
+        copy_recorded_attention_with_after_dense(
+            &copy_recorded_attention_args(&meta, &records, &attention_only_destination),
+            || Err(SourceUnavailable::new("dense hook must not run")),
+        )
+        .expect("attention-only publication order is unchanged");
+        assert_eq!(
+            compiled_attention_operator(&attention_only_root).expect("attention-only destination"),
+            attention_only
         );
         assert_eq!(
-            std::fs::read(&stale_destination).expect("stale bytes"),
-            stale_before
+            compiled_dense_operator(&attention_only_root).expect("typed dense absence"),
+            None
         );
 
-        let _ = std::fs::remove_dir_all(source);
-        if let Some(parent) = destination.parent() {
-            let _ = std::fs::remove_dir_all(parent);
+        for root in [
+            source,
+            destination_root,
+            attention_only_source,
+            attention_only_root,
+        ] {
+            let _ = std::fs::remove_dir_all(root);
         }
-        let _ = std::fs::remove_dir_all(legacy);
-        let _ = std::fs::remove_dir_all(stale_parent);
     }
 
     #[test]
@@ -7544,10 +10718,10 @@ mod tests {
         let source = unique_cli_test_path("copy-recorded-attention-symlink-source");
         bind_compiled_attention_operator(&source, &AttentionOperatorSpec::standard())
             .expect("source binding");
-        let (meta, records) = corpus_markers(&source);
+        let (meta, records) = complete_test_corpus(&source);
         let destination_parent =
             unique_cli_test_path("copy-recorded-attention-symlink-destination");
-        std::fs::create_dir_all(&destination_parent).expect("destination parent");
+        complete_test_corpus(&destination_parent);
         let destination = destination_parent.join(ATTENTION_OPERATOR_BINDING_FILE);
         let sentinel = unique_cli_test_path("copy-recorded-attention-symlink-sentinel");
         let sentinel_bytes = b"external sentinel must remain unchanged";
@@ -7557,7 +10731,11 @@ mod tests {
         let error =
             copy_recorded_attention(&copy_recorded_attention_args(&meta, &records, &destination))
                 .expect_err("destination symlink must be refused");
-        assert!(error.reason.contains("not a regular file"));
+        assert!(
+            error.reason.contains("not a regular")
+                || error.reason.contains("without following links"),
+            "{error}"
+        );
         assert_eq!(std::fs::read(&sentinel).expect("sentinel"), sentinel_bytes);
         assert!(
             std::fs::symlink_metadata(&destination)
@@ -7630,6 +10808,8 @@ mod tests {
                 cid: "blake3:1111".to_owned(),
                 sequence_length: 256,
                 bos_prefix: false,
+                attention_operator: AttentionOperatorSpec::standard_v1(),
+                dense_operator: None,
             },
             artifacts: EvaluationArtifacts {
                 directory: ".uor-models/compiled/smollm2-135m-instruct".to_owned(),
@@ -7638,6 +10818,9 @@ mod tests {
                 tokenizer_cid: "blake3:4444".to_owned(),
                 corpus_meta_cid: "blake3:5555".to_owned(),
                 corpus_records_cid: "blake3:6666".to_owned(),
+                attention_operator_cid: "blake3:7777".to_owned(),
+                dense_operator_cid: None,
+                recorded_corpus_binding_cid: None,
             },
             metrics: EvaluationMetrics {
                 top1_accuracy_pct: 35.5,
@@ -7671,6 +10854,38 @@ mod tests {
         assert_eq!(envelope.report.metrics.top1_accuracy_pct, 35.5);
         assert_eq!(envelope.report.source.sequence_length, 256);
         assert!(envelope.report_cid_of_report_bytes.starts_with("blake3:"));
+        let legacy_json: serde_json::Value =
+            serde_json::from_slice(&json).expect("legacy-compatible report JSON");
+        assert_eq!(
+            legacy_json["source"]["dense_operator"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            legacy_json["artifacts"]["dense_operator_cid"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            legacy_json["artifacts"]["recorded_corpus_binding_cid"],
+            serde_json::Value::Null
+        );
+
+        let mut gpt2 = report;
+        gpt2.schema = 5;
+        gpt2.source.attention_operator = AttentionOperatorSpec::learned_absolute_v2();
+        gpt2.source.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+        gpt2.artifacts.dense_operator_cid = Some("blake3:8888".to_owned());
+        gpt2.artifacts.recorded_corpus_binding_cid = Some("blake3:9999".to_owned());
+        let gpt2_json = serde_json::to_value(&gpt2).expect("GPT-2 evaluation report JSON");
+        assert_eq!(gpt2_json["schema"], 5);
+        assert_eq!(
+            gpt2_json["source"]["dense_operator"]["implementation_digest"],
+            DenseOperatorSpec::gpt2_v2().implementation_digest
+        );
+        assert_eq!(gpt2_json["artifacts"]["dense_operator_cid"], "blake3:8888");
+        assert_eq!(
+            gpt2_json["artifacts"]["recorded_corpus_binding_cid"],
+            "blake3:9999"
+        );
     }
 
     #[test]

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -418,7 +418,7 @@ fn planned_output_member(
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| SourceUnavailable::new(format!("{context} stable filename is not UTF-8")))?;
-    PlannedOutputMember::ALL
+    PlannedOutputMember::REGISTERED
         .into_iter()
         .find(|member| member.stable_name() == stable_name)
         .ok_or_else(|| {
@@ -434,9 +434,32 @@ fn preflight_guarded_planned_file(
     expected: &[u8],
     context: &str,
 ) -> Result<bool, SourceUnavailable> {
-    let _ = planned_output_member(path, context)?;
-    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
-    require_existing_file_matches_if_present(path, Some(expected), context)
+    preflight_guarded_planned_file_in_scope(
+        guard,
+        path,
+        expected,
+        context,
+        &PlannedOutputMember::ALL,
+    )
+}
+
+fn preflight_guarded_planned_file_in_scope(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: &[u8],
+    context: &str,
+    allowed: &[PlannedOutputMember],
+) -> Result<bool, SourceUnavailable> {
+    let member = planned_output_member(path, context)?;
+    guard.preflight_planned_output_scope(allowed)?;
+    let max_bytes = u64::try_from(expected.len())
+        .map_err(|_| SourceUnavailable::new(format!("{context} length exceeds u64")))?;
+    guard.verify_optional_owned_entry_bytes(
+        std::ffi::OsStr::new(member.stable_name()),
+        expected,
+        max_bytes,
+        context,
+    )
 }
 
 fn preflight_guarded_planned_absence(
@@ -477,86 +500,318 @@ fn publish_guarded_planned_file(
     expected: &[u8],
     context: &str,
 ) -> Result<(), SourceUnavailable> {
+    publish_guarded_planned_file_with_after_sync(
+        guard,
+        path,
+        expected,
+        context,
+        &PlannedOutputMember::ALL,
+        |_| Ok(()),
+    )
+}
+
+/// Testable crash boundary for deterministic planned members. Returning an
+/// error from `after_sync` models process death after the complete staging
+/// inode is durable but before its atomic no-clobber publication. The staging
+/// inode deliberately remains for the exact guarded retry to reclaim.
+fn publish_guarded_planned_file_with_after_sync<F>(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: &[u8],
+    context: &str,
+    allowed: &[PlannedOutputMember],
+    after_sync: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnOnce(&Path) -> Result<(), SourceUnavailable>,
+{
     let member = planned_output_member(path, context)?;
-    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
-    if require_existing_file_matches_if_present(path, Some(expected), context)? {
+    guard.preflight_planned_output_scope(allowed)?;
+    let max_bytes = u64::try_from(expected.len())
+        .map_err(|_| SourceUnavailable::new(format!("{context} length exceeds u64")))?;
+    let stable_name = std::ffi::OsStr::new(member.stable_name());
+    if guard.verify_optional_owned_entry_bytes(stable_name, expected, max_bytes, context)? {
         guard.reclaim_planned_output_residues(member)?;
-        return sync_compile_output_directory(guard.root());
+        guard.sync_owned_root()?;
+        return guard.verify_owned_root();
     }
     guard.reclaim_planned_output_residues(member)?;
 
-    let stable_name = member.stable_name();
-    let staging = loop {
-        let sequence = PLANNED_OUTPUT_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-        let candidate = guard.root().join(format!(
-            "{PLANNED_OUTPUT_RESERVED_PREFIX}{stable_name}--{}.{}.writing",
-            std::process::id(),
-            sequence
-        ));
-        let mut options = std::fs::OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-
-            options
-                .mode(0o600)
-                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-        }
-        match options.open(&candidate) {
-            Ok(mut file) => {
-                file.write_all(expected)
-                    .and_then(|()| file.sync_all())
-                    .map_err(|error| {
-                        SourceUnavailable::new(format!(
-                            "{context} staging {} cannot be durably written: {error}",
-                            candidate.display()
-                        ))
-                    })?;
-                break candidate;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(SourceUnavailable::new(error)),
-        }
-    };
+    let sequence = PLANNED_OUTPUT_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let staging_name = format!(
+        "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--{}.{}.writing",
+        member.stable_name(),
+        std::process::id(),
+        sequence
+    );
+    let staging_leaf = std::ffi::OsStr::new(&staging_name);
+    let staging = guard.root().join(staging_leaf);
+    let mut file = guard.create_new_owned_entry(staging_leaf)?;
+    file.write_all(expected)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context} staging {} cannot be durably written: {error}",
+                staging.display()
+            ))
+        })?;
+    drop(file);
     guard.verify_owned_root()?;
-    match std::fs::hard_link(&staging, path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let published =
-                read_optional_regular_file_nofollow(path, context)?.ok_or_else(|| {
-                    SourceUnavailable::new(format!(
-                        "{context} stable path {} appeared and disappeared",
-                        path.display()
-                    ))
-                })?;
-            if published != expected {
-                return Err(SourceUnavailable::new(format!(
-                    "{context} stable path {} appeared with conflicting bytes",
-                    path.display()
-                )));
-            }
-        }
-        Err(error) => return Err(SourceUnavailable::new(error)),
-    }
-    std::fs::remove_file(&staging).map_err(SourceUnavailable::new)?;
-    sync_compile_output_directory(guard.root())?;
-    let published = read_optional_regular_file_nofollow(path, context)?.ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "{context} stable path {} disappeared after publication",
-            path.display()
-        ))
-    })?;
-    if published != expected {
-        return Err(SourceUnavailable::new(format!(
-            "{context} stable path {} does not contain the exact planned bytes",
-            path.display()
-        )));
-    }
+    after_sync(&staging)?;
+    guard.link_owned_entry(staging_leaf, stable_name)?;
+    guard.unlink_owned_entry(staging_leaf)?;
+    guard.sync_owned_root()?;
+    guard.verify_owned_entry_bytes(stable_name, expected, max_bytes, context)?;
     guard.verify_owned_root()
 }
 
-struct SourceCorpusSession {
+fn stream_regular_file_summary_nofollow(
+    path: &Path,
+    context: &str,
+) -> Result<
+    Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary>,
+    SourceUnavailable,
+> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} cannot be streamed without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let initial_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let initial_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial_file.file_type().is_file()
+        || !initial_path.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path, &initial_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not one regular non-symlink inode",
+            path.display()
+        )));
+    }
+    let captured_length = initial_file.len();
+    let mut remaining = captured_length;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| SourceUnavailable::new(format!("{context} length overflows usize")))?;
+        let count = file
+            .read(&mut buffer[..limit])
+            .map_err(SourceUnavailable::new)?;
+        if count == 0 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} ended before its captured {captured_length}-byte length",
+                path.display()
+            )));
+        }
+        hasher.update(&buffer[..count]);
+        remaining -= count as u64;
+    }
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} grew beyond its captured {captured_length}-byte length",
+            path.display()
+        )));
+    }
+    let final_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let final_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !final_file.file_type().is_file()
+        || !final_path.file_type().is_file()
+        || !opened_file_generation_matches(&initial_file, &final_file)
+        || !opened_file_identity_matches(&final_path, &final_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed generation while it was streamed",
+            path.display()
+        )));
+    }
+    Ok(Some(
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary {
+            length: captured_length,
+            blake3: format!("blake3:{}", hasher.finalize().to_hex()),
+        },
+    ))
+}
+
+fn preflight_guarded_planned_stream(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: Option<&uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary>,
+    context: &str,
+) -> Result<bool, SourceUnavailable> {
+    preflight_guarded_planned_stream_in_scope(
+        guard,
+        path,
+        expected,
+        context,
+        &PlannedOutputMember::ALL,
+    )
+}
+
+fn preflight_guarded_planned_stream_in_scope(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    expected: Option<&uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary>,
+    context: &str,
+    allowed: &[PlannedOutputMember],
+) -> Result<bool, SourceUnavailable> {
+    let member = planned_output_member(path, context)?;
+    guard.preflight_planned_output_scope(allowed)?;
+    if let Some(expected) = expected {
+        return guard.verify_optional_owned_entry_summary(
+            std::ffi::OsStr::new(member.stable_name()),
+            expected,
+            context,
+        );
+    }
+    let actual = stream_regular_file_summary_nofollow(path, context)?;
+    if actual.is_some() {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is present but the planned generation declares typed absence",
+            path.display()
+        )));
+    }
+    if guard.has_planned_output_residue(member)? {
+        return Err(SourceUnavailable::new(format!(
+            "{context} has staged bytes but the planned generation declares this member absent"
+        )));
+    }
+    Ok(true)
+}
+
+/// Stream one deterministic large member through a guarded owner-only stage.
+/// The source is never accumulated in memory; the staged length/digest must
+/// equal the predeclared source summary before the stable hard-link appears.
+fn publish_guarded_planned_stream<R: Read + Seek>(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    source: &mut R,
+    expected: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    publish_guarded_planned_stream_with_before_link(guard, path, source, expected, context, |_| {
+        Ok(())
+    })
+}
+
+fn publish_guarded_planned_stream_with_before_link<R, F>(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    source: &mut R,
+    expected: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary,
+    context: &str,
+    before_link: F,
+) -> Result<(), SourceUnavailable>
+where
+    R: Read + Seek,
+    F: FnOnce(&Path) -> Result<(), SourceUnavailable>,
+{
+    let member = planned_output_member(path, context)?;
+    if preflight_guarded_planned_stream(guard, path, Some(expected), context)? {
+        guard.reclaim_planned_output_residues(member)?;
+        guard.sync_owned_root()?;
+        return guard.verify_owned_root();
+    }
+    guard.reclaim_planned_output_residues(member)?;
+
+    let stable_name = std::ffi::OsStr::new(member.stable_name());
+    let sequence = PLANNED_OUTPUT_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let staging_name = format!(
+        "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--{}.{}.writing",
+        member.stable_name(),
+        std::process::id(),
+        sequence
+    );
+    let staging_leaf = std::ffi::OsStr::new(&staging_name);
+    let staging = guard.root().join(staging_leaf);
+    let mut staging_file = guard.create_new_owned_entry(staging_leaf)?;
+    let staging_initial = staging_file.metadata().map_err(SourceUnavailable::new)?;
+
+    source
+        .seek(SeekFrom::Start(0))
+        .map_err(SourceUnavailable::new)?;
+    let mut length = 0u64;
+    let mut remaining = expected.length;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| SourceUnavailable::new(format!("{context} length overflows usize")))?;
+        let count = source
+            .read(&mut buffer[..limit])
+            .map_err(SourceUnavailable::new)?;
+        if count == 0 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} source ended before its declared {}-byte length",
+                expected.length
+            )));
+        }
+        staging_file
+            .write_all(&buffer[..count])
+            .map_err(SourceUnavailable::new)?;
+        length = length.checked_add(count as u64).ok_or_else(|| {
+            SourceUnavailable::new(format!("{context} staged length overflows u64"))
+        })?;
+        hasher.update(&buffer[..count]);
+        remaining -= count as u64;
+    }
+    let mut extra = [0u8; 1];
+    if source.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} source grew beyond its declared {}-byte length",
+            expected.length
+        )));
+    }
+    staging_file.sync_all().map_err(SourceUnavailable::new)?;
+    let staged = uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary {
+        length,
+        blake3: format!("blake3:{}", hasher.finalize().to_hex()),
+    };
+    if &staged != expected {
+        return Err(SourceUnavailable::new(format!(
+            "{context} source stream changed from its predeclared length or BLAKE3 while staged"
+        )));
+    }
+    let staging_final = staging_file.metadata().map_err(SourceUnavailable::new)?;
+    if !staging_final.file_type().is_file()
+        || staging_final.len() != expected.length
+        || !opened_file_identity_matches(&staging_initial, &staging_final)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} staging {} changed identity, length, or generation before publication",
+            staging.display()
+        )));
+    }
+    drop(staging_file);
+    guard.verify_owned_entry_summary(staging_leaf, expected, context)?;
+    guard.verify_owned_root()?;
+    before_link(&staging)?;
+    guard.link_owned_entry(staging_leaf, stable_name)?;
+    guard.unlink_owned_entry(staging_leaf)?;
+    guard.sync_owned_root()?;
+    guard.verify_owned_entry_summary(stable_name, expected, context)?;
+    guard.verify_owned_root()
+}
+
+/// Exclusive source-corpus transaction retained across one complete teacher
+/// compile. Managed server callers may acquire this before publishing their
+/// stage-local source identity and pass it into `compile_hugging_face_with_session`
+/// so P/K and corpus/artifact publication share one common producer interval.
+pub struct SourceCorpusSession {
     file: std::fs::File,
     recorded_corpus: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard>,
 }
@@ -624,6 +879,16 @@ fn source_corpus_session(output: &Path) -> Result<SourceCorpusSession, SourceUna
     })
 }
 
+/// Acquire the source-specific outer session followed by the common recorded-
+/// corpus producer guard for an already chosen output root.
+pub fn acquire_source_corpus_session(
+    output: &Path,
+) -> Result<SourceCorpusSession, SourceUnavailable> {
+    let mut session = source_corpus_session(output)?;
+    session.acquire_recorded_corpus(output)?;
+    Ok(session)
+}
+
 impl SourceCorpusSession {
     fn release_in_order<F>(&mut self, after_common_release: F)
     where
@@ -663,7 +928,7 @@ impl SourceCorpusSession {
         })
     }
 
-    fn recorded_corpus_guard(
+    pub fn recorded_corpus_guard(
         &self,
     ) -> Result<
         &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
@@ -1360,16 +1625,30 @@ where
         )));
     }
 
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).map_err(|error| {
+    let captured_len = usize::try_from(opened_metadata.len()).map_err(|_| {
         SourceUnavailable::new(format!(
-            "{context} {} cannot be read: {error}",
+            "{context} {} length cannot be represented on this host",
             path.display()
         ))
     })?;
-    if opened_metadata.len() != bytes.len() as u64 {
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(captured_len).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot reserve {captured_len} bytes: {error}",
+            path.display()
+        ))
+    })?;
+    bytes.resize(captured_len, 0);
+    file.read_exact(&mut bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot read its captured {captured_len}-byte generation: {error}",
+            path.display()
+        ))
+    })?;
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
         return Err(SourceUnavailable::new(format!(
-            "{context} {} changed length while its bytes were read",
+            "{context} {} grew beyond its captured length while its bytes were read",
             path.display()
         )));
     }
@@ -1687,6 +1966,16 @@ fn require_matching_compiled_attention_operator(
     )))
 }
 
+fn canonical_attention_operator_bytes(
+    requested: &AttentionOperatorSpec,
+) -> Result<Vec<u8>, SourceUnavailable> {
+    let requested =
+        validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
+    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
 fn publish_attention_operator_binding(
     output: &Path,
     requested: &AttentionOperatorSpec,
@@ -1699,8 +1988,7 @@ fn publish_attention_operator_binding(
 
     std::fs::create_dir_all(output).map_err(SourceUnavailable::new)?;
     let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
-    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
-    bytes.push(b'\n');
+    let bytes = canonical_attention_operator_bytes(&requested)?;
     let temporary = loop {
         let sequence = ATTENTION_OPERATOR_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let candidate = output.join(format!(
@@ -1946,6 +2234,15 @@ fn require_matching_compiled_dense_operator(
     )))
 }
 
+fn canonical_dense_operator_bytes(
+    requested: &DenseOperatorSpec,
+) -> Result<Vec<u8>, SourceUnavailable> {
+    let requested = validate_dense_operator(requested, "proposed teacher dense-operator binding")?;
+    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
 fn publish_dense_operator_binding(
     output: &Path,
     requested: &DenseOperatorSpec,
@@ -1957,8 +2254,7 @@ fn publish_dense_operator_binding(
 
     std::fs::create_dir_all(output).map_err(SourceUnavailable::new)?;
     let path = output.join(DENSE_OPERATOR_BINDING_FILE);
-    let mut bytes = serde_json::to_vec_pretty(&requested).map_err(SourceUnavailable::new)?;
-    bytes.push(b'\n');
+    let bytes = canonical_dense_operator_bytes(&requested)?;
     let temporary = loop {
         let sequence = DENSE_OPERATOR_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let candidate = output.join(format!(
@@ -2999,12 +3295,17 @@ pub fn observe_command(args: &[String]) -> Result<(), SourceUnavailable> {
             &state_path,
             &merged_path,
         )?;
-        let captured = uor_r4_graph_compiler::recorded_corpus::capture(&state_path, &merged_path)?;
+        let captured = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+            session.recorded_corpus_guard(),
+            &state_path,
+            &merged_path,
+        )?;
         if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
             return Err(SourceUnavailable::new(
-                "raw observation binding changed during exact post-publication capture",
+                "raw observation binding changed during bounded post-publication verification",
             ));
         }
+        captured.verify_generation()?;
         println!(
             "observe complete: {} records at {}",
             summary.records,
@@ -3408,12 +3709,17 @@ fn finish_observe_text_report(
             &state_path,
             &merged_path,
         )?;
-        let captured = uor_r4_graph_compiler::recorded_corpus::capture(&state_path, &merged_path)?;
+        let captured = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+            session.recorded_corpus_guard(),
+            &state_path,
+            &merged_path,
+        )?;
         if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
             return Err(SourceUnavailable::new(
-                "text observation binding changed during exact post-publication capture",
+                "text observation binding changed during bounded post-publication verification",
             ));
         }
+        captured.verify_generation()?;
         println!(
             "observe-text complete: merged κ {} at {}",
             report
@@ -3696,7 +4002,7 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
         options.corpus_recs.clone()
     };
 
-    let recorded_corpus = recorded_corpus_snapshot(&corpus_meta_path, &corpus_recs_path)?;
+    let recorded_corpus = recorded_compiler_corpus(&corpus_meta_path, &corpus_recs_path)?;
     require_cover_recorded_execution_identity(&options, &recorded_corpus.execution)?;
     // #450: resolve and announce the inputs *before* the long work, so the
     // run says which teacher container it actually read. `--artifacts`
@@ -3716,18 +4022,7 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     let recs_bytes = recorded_corpus.records_bytes;
     let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
     repro::announce_corpus(&corpus_meta_path, &corpus_recs_path, &corpus_kappa);
-    let corpus = compiler::load_corpus_bytes(
-        &meta_bytes,
-        &recs_bytes,
-        recorded_corpus.hidden_bytes.as_deref(),
-    )
-    .ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            corpus_meta_path.display(),
-            corpus_recs_path.display()
-        ))
-    })?;
+    let corpus = recorded_corpus.corpus;
 
     let config = cover::CoverConfig {
         depths: options.depths,
@@ -4146,12 +4441,6 @@ pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
         options.corpus_recs.clone()
     };
 
-    let corpus_meta = corpus_meta_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus metadata path is not UTF-8"))?;
-    let corpus_recs = corpus_recs_path
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
     // #450: resolve and announce the inputs *before* the long work, so the
     // run says which teacher container it actually read. `--artifacts`
     // defaults to a shared mutable path that helper scripts overwrite.
@@ -4166,21 +4455,12 @@ pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
     })?;
     let artifact_kappa = repro::container_kappa(&artifact_container);
     repro::announce_teacher_container(&options.artifacts, &artifact_kappa);
-    let meta_bytes = std::fs::read(&corpus_meta_path).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", corpus_meta_path.display()))
-    })?;
-    let recs_bytes = std::fs::read(&corpus_recs_path).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", corpus_recs_path.display()))
-    })?;
+    let recorded_corpus = recorded_compiler_corpus(&corpus_meta_path, &corpus_recs_path)?;
+    let meta_bytes = recorded_corpus.meta_bytes;
+    let recs_bytes = recorded_corpus.records_bytes;
     let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
     repro::announce_corpus(&corpus_meta_path, &corpus_recs_path, &corpus_kappa);
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            corpus_meta_path.display(),
-            corpus_recs_path.display()
-        ))
-    })?;
+    let corpus = recorded_corpus.corpus;
 
     let config = score::ScoreConfig {
         transition_out_degree: options.transition_out_degree,
@@ -5238,7 +5518,7 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
     let scored_graph_path = options.compiled.join("graph").join("score.r4g1");
     let corpus_meta_path = options.compiled.join("corpus.meta");
     let corpus_records_path = options.compiled.join("corpus.records");
-    let recorded_corpus = recorded_corpus_snapshot(&corpus_meta_path, &corpus_records_path)?;
+    let recorded_corpus = recorded_compiler_corpus(&corpus_meta_path, &corpus_records_path)?;
     let recorded_attention_operator = recorded_corpus
         .execution
         .attention_operator
@@ -5284,21 +5564,8 @@ fn evaluate_report(args: &[String]) -> Result<(), SourceUnavailable> {
         "blake3:{}",
         blake3::hash(&recorded_corpus.meta_bytes).to_hex()
     );
-    let corpus_records_cid = format!(
-        "blake3:{}",
-        blake3::hash(&recorded_corpus.records_bytes).to_hex()
-    );
-    let corpus = compiler::load_corpus_bytes(
-        &recorded_corpus.meta_bytes,
-        &recorded_corpus.records_bytes,
-        recorded_corpus.hidden_bytes.as_deref(),
-    )
-    .ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "corpus is incomplete at {}; rerun compile until it is complete",
-            options.compiled.display()
-        ))
-    })?;
+    let corpus_records_cid = recorded_corpus.records_cid.clone();
+    let corpus = recorded_corpus.corpus;
     let held_out_cut = compiler::train_cut(&corpus);
     // --bos occupies one oracle position per story, so a full
     // `sequence_length`-token story needs one extra cache slot. The
@@ -5750,10 +6017,31 @@ pub fn compile_hugging_face(args: &[String]) -> Result<(), SourceUnavailable> {
     compile_hugging_face_with_progress(args, |_, _| {})
 }
 
+/// Compile through a caller-retained source/common transaction. The session
+/// must protect the parsed `--output`; it is consumed so neither lock can be
+/// released before every compiler-side write has finished.
+pub fn compile_hugging_face_with_session(
+    args: &[String],
+    session: SourceCorpusSession,
+) -> Result<(), SourceUnavailable> {
+    compile_hugging_face_with_progress_and_session(args, Some(session), |_, _| {})
+}
+
 /// Compile a Hugging Face teacher bundle and report coarse compiler phases.
 /// The callback is compiler-side only and does not affect generated bytes.
 pub fn compile_hugging_face_with_progress<F>(
     args: &[String],
+    progress: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnMut(u8, &'static str),
+{
+    compile_hugging_face_with_progress_and_session(args, None, progress)
+}
+
+fn compile_hugging_face_with_progress_and_session<F>(
+    args: &[String],
+    provided_session: Option<SourceCorpusSession>,
     mut progress: F,
 ) -> Result<(), SourceUnavailable>
 where
@@ -5791,7 +6079,21 @@ where
         .output
         .clone()
         .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
-    let mut corpus_session = source_corpus_session(&output)?;
+    let mut corpus_session = if let Some(session) = provided_session {
+        if !session
+            .recorded_corpus_guard()?
+            .protects_directory(&output)?
+        {
+            return Err(SourceUnavailable::new(format!(
+                "provided source-corpus session for {} does not protect parsed compile output {}",
+                session.recorded_corpus_guard()?.root().display(),
+                output.display()
+            )));
+        }
+        session
+    } else {
+        source_corpus_session(&output)?
+    };
     eprintln!("compiler output: {}", output.display());
     let meta = output.join("corpus.meta");
     let records = output.join("corpus.records");
@@ -5875,7 +6177,12 @@ where
         records,
         tokenizer_export.source_byte_lengths.as_deref(),
     );
-    if compiler::load_corpus_from(meta, records).is_none() {
+    let finalized_meta =
+        read_optional_regular_file_nofollow(Path::new(meta), "source compile corpus metadata")?;
+    if !finalized_meta
+        .as_deref()
+        .is_some_and(|bytes| bytes.len() == SOURCE_CORPUS_META_BYTES && bytes[24] == 1)
+    {
         println!(
             "corpus is not complete; rerun the same command to resume {}",
             output.display()
@@ -5887,24 +6194,28 @@ where
         Path::new(meta),
         Path::new(records),
     )?;
-    let captured =
-        uor_r4_graph_compiler::recorded_corpus::capture(Path::new(meta), Path::new(records))?;
+    let mut captured = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+        corpus_session.recorded_corpus_guard()?,
+        Path::new(meta),
+        Path::new(records),
+    )?;
     if captured.binding_cid.as_deref() != Some(binding_cid.as_str()) {
         return Err(SourceUnavailable::new(
-            "published recorded-corpus binding CID changed during exact recapture",
+            "published recorded-corpus binding CID changed during bounded verification",
         ));
     }
+    let meta_bytes = captured.meta_bytes.clone();
+    let (records_bytes, hidden_bytes) = captured.materialize_compiler_corpus_bytes()?;
+    let corpus = compiler::load_corpus_bytes(&meta_bytes, &records_bytes, hidden_bytes.as_deref())
+        .ok_or_else(|| {
+            SourceUnavailable::new(
+                "published recorded corpus failed bounded exact-generation parsing",
+            )
+        })?;
+    drop(captured);
     corpus_session
         .recorded_corpus_guard()?
         .finish_compile_attempt()?;
-    let corpus = compiler::load_corpus_bytes(
-        &captured.meta_bytes,
-        &captured.records_bytes,
-        captured.hidden_bytes.as_deref(),
-    )
-    .ok_or_else(|| {
-        SourceUnavailable::new("published recorded corpus failed exact-byte recapture and parsing")
-    })?;
     progress(55, "Compiling table-native artifact...");
     eprintln!("teacher corpus complete; compiling table-native artifact...");
     let artifacts = compiler::compile(&oracle, &corpus);
@@ -6013,6 +6324,66 @@ struct RecordedCorpusSnapshot {
     records_bytes: Vec<u8>,
     hidden_bytes: Option<Vec<u8>>,
     binding_cid: Option<String>,
+}
+
+/// The exact recorded generation required by compiler/evaluation consumers.
+/// Record bytes are materialized because the existing compiler parses them;
+/// hidden rows are materialized only when they have the compiler's fixed `D`
+/// width. Wider source-model rows remain bound by their retained stream digest
+/// and never become a multi-gigabyte allocation that the compiler discards.
+struct RecordedCompilerCorpus {
+    execution: RecordedCorpusExecutionIdentity,
+    attention_operator_bytes: Option<Vec<u8>>,
+    dense_operator_bytes: Option<Vec<u8>>,
+    meta_bytes: Vec<u8>,
+    records_bytes: Vec<u8>,
+    records_cid: String,
+    corpus: compiler::Corpus,
+    binding_cid: Option<String>,
+}
+
+fn materialize_recorded_compiler_corpus(
+    mut stream: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusStreamSnapshot,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCompilerCorpus, SourceUnavailable> {
+    let execution = recorded_execution_from_stream(&stream);
+    let attention_operator_bytes = stream.attention_operator_bytes.clone();
+    let dense_operator_bytes = stream.dense_operator_bytes.clone();
+    let meta_bytes = stream.meta_bytes.clone();
+    let records_cid = stream.records.declared_digest().to_owned();
+    let binding_cid = stream.binding_cid.clone();
+    let (records_bytes, hidden_bytes) = stream.materialize_compiler_corpus_bytes()?;
+    let corpus = compiler::load_corpus_bytes(&meta_bytes, &records_bytes, hidden_bytes.as_deref())
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "corpus is incomplete at {}/{}; run compile until it is complete",
+                corpus_meta.display(),
+                corpus_records.display()
+            ))
+        })?;
+    Ok(RecordedCompilerCorpus {
+        execution,
+        attention_operator_bytes,
+        dense_operator_bytes,
+        meta_bytes,
+        records_bytes,
+        records_cid,
+        corpus,
+        binding_cid,
+    })
+}
+
+fn recorded_compiler_corpus(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCompilerCorpus, SourceUnavailable> {
+    let (stream, _source_guard) =
+        uor_r4_graph_compiler::recorded_corpus::open_stream_for_derivation(
+            corpus_meta,
+            corpus_records,
+        )?;
+    materialize_recorded_compiler_corpus(stream, corpus_meta, corpus_records)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6457,8 +6828,8 @@ where
 {
     let options = parse_copy_recorded_attention_options(args)?;
     // Resolve the source pair before touching the destination. The lower
-    // bounded reader hashes large members without retaining them and holds a
-    // source guard for markerless compatibility generations.
+    // bounded reader hashes large members without retaining them and takes a
+    // non-mutating shared coordination lock when one already exists.
     let resolved = recorded_corpus_execution_identity(&options.corpus_meta, &options.corpus_recs)?;
     let parent = options
         .output
@@ -6983,7 +7354,11 @@ fn recorded_compile_attention_operator(
 /// capture remains available through `observe`/`compile` as an explicitly
 /// separate offline step.
 struct PreparedRecordedCompile {
-    corpus: RecordedCorpusSnapshot,
+    source: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusStreamSnapshot,
+    source_guard: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard>,
+    meta_bytes: Vec<u8>,
+    records_bytes: Vec<u8>,
+    corpus: compiler::Corpus,
     attention_operator: AttentionOperatorSpec,
     dense_operator: Option<DenseOperatorSpec>,
 }
@@ -6991,19 +7366,21 @@ struct PreparedRecordedCompile {
 fn write_captured_recorded_corpus(
     guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
     output: &Path,
-    corpus: &RecordedCorpusSnapshot,
+    prepared: &mut PreparedRecordedCompile,
 ) -> Result<(), SourceUnavailable> {
     publish_guarded_planned_file(
         guard,
         &output.join("corpus.records"),
-        &corpus.records_bytes,
+        &prepared.records_bytes,
         "recorded compile corpus records",
     )?;
-    if let Some(hidden) = corpus.hidden_bytes.as_deref() {
-        publish_guarded_planned_file(
+    if let Some(hidden) = prepared.source.hidden.as_mut() {
+        let summary = hidden.summary();
+        publish_guarded_planned_stream(
             guard,
             &output.join("corpus.records.hidden"),
             hidden,
+            &summary,
             "recorded compile corpus hidden stream",
         )?;
     }
@@ -7013,7 +7390,7 @@ fn write_captured_recorded_corpus(
     publish_guarded_planned_file(
         guard,
         &output.join("corpus.meta"),
-        &corpus.meta_bytes,
+        &prepared.meta_bytes,
         "recorded compile corpus metadata",
     )?;
     Ok(())
@@ -7045,27 +7422,65 @@ fn require_existing_file_matches_if_present(
     }
 }
 
+fn require_existing_stream_matches_if_present(
+    path: &Path,
+    expected: Option<&uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary>,
+    context: &str,
+) -> Result<bool, SourceUnavailable> {
+    let actual = stream_regular_file_summary_nofollow(path, context)?;
+    match (actual.as_ref(), expected) {
+        (None, _) => Ok(false),
+        (Some(actual), Some(expected)) if actual == expected => Ok(true),
+        (Some(_), Some(_)) => Err(SourceUnavailable::new(format!(
+            "{context} {} has a different length or BLAKE3; deterministic planned member mismatch is terminal before mutation",
+            path.display()
+        ))),
+        (Some(_), None) => Err(SourceUnavailable::new(format!(
+            "{context} {} is present but the planned generation declares typed absence; deterministic planned member mismatch is terminal before mutation",
+            path.display()
+        ))),
+    }
+}
+
 fn preflight_recorded_compile_execution_identity(
     options: &RecordedCompileOptions,
 ) -> Result<PreparedRecordedCompile, SourceUnavailable> {
     preflight_recorded_compile_output(&options.output)?;
-    let corpus = recorded_corpus_snapshot(&options.corpus_meta, &options.corpus_recs)?;
-    let attention_operator = match corpus.execution.attention_operator.as_ref() {
+    let (mut source, source_guard) =
+        uor_r4_graph_compiler::recorded_corpus::open_stream_for_derivation(
+            &options.corpus_meta,
+            &options.corpus_recs,
+        )?;
+    let attention_operator = match source.execution.attention_operator.as_ref() {
         Some(recorded) => recorded.clone(),
         None => uor_r4_model_source::attention::operator_spec(
             AttentionOperatorSpec::STANDARD_ID,
             LEGACY_STANDARD_ATTENTION_OPERATOR_VERSION,
         )?,
     };
-    let dense_operator = corpus.execution.dense_operator.clone();
+    let dense_operator = source.execution.dense_operator.clone();
     validate_source_execution_pair(
         &attention_operator,
         dense_operator.as_ref(),
         "recorded compile provenance",
     )?;
+    let meta_bytes = source.meta_bytes.clone();
+    let (records_bytes, hidden_bytes) = source.materialize_compiler_corpus_bytes()?;
+    let corpus = compiler::load_corpus_bytes(&meta_bytes, &records_bytes, hidden_bytes.as_deref())
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus is incomplete or invalid at {}/{}",
+                options.corpus_meta.display(),
+                options.corpus_recs.display()
+            ))
+        })?;
     preflight_compiled_attention_operator(&options.output, &attention_operator)?;
     preflight_compiled_dense_operator(&options.output, dense_operator.as_ref())?;
     Ok(PreparedRecordedCompile {
+        source,
+        source_guard,
+        meta_bytes,
+        records_bytes,
         corpus,
         attention_operator,
         dense_operator,
@@ -7073,39 +7488,75 @@ fn preflight_recorded_compile_execution_identity(
 }
 
 pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable> {
-    let options = parse_recorded_compile_options(args)?;
-    let prepared = preflight_recorded_compile_execution_identity(&options)?;
-    let corpus = compiler::load_corpus_bytes(
-        &prepared.corpus.meta_bytes,
-        &prepared.corpus.records_bytes,
-        prepared.corpus.hidden_bytes.as_deref(),
+    compile_recorded_corpus_with(
+        args,
+        build_recorded_compile_products,
+        |_| Ok(()),
+        |_| Ok(()),
     )
-    .ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "recorded corpus is incomplete or invalid at {}/{}",
-            options.corpus_meta.display(),
-            options.corpus_recs.display()
-        ))
+}
+
+struct RecordedCompileProducts {
+    artifact_bytes: Vec<u8>,
+    store_bytes: Vec<u8>,
+    calibration_bytes: Vec<u8>,
+    hierarchical_bytes: Vec<u8>,
+}
+
+fn build_recorded_compile_products(
+    corpus: &compiler::Corpus,
+    vocab_size: usize,
+) -> Result<RecordedCompileProducts, SourceUnavailable> {
+    let artifacts = compiler::compile_recorded(corpus, vocab_size).ok_or_else(|| {
+        SourceUnavailable::new("recorded compile failed: empty corpus or invalid vocabulary")
     })?;
+    let calibration = compiler::calibrate_hamming_regions(&artifacts, corpus);
+    let hierarchical =
+        compiler::induce_hierarchical_codes(&artifacts.token_codes, vocab_size, corpus);
+    let threads = std::thread::available_parallelism()
+        .map(|count| count.get().min(8))
+        .unwrap_or(1);
+    let (store, _) = runtime::build_store_with_threads(&artifacts, corpus, threads);
+    Ok(RecordedCompileProducts {
+        artifact_bytes: compiler::artifact_bytes(&artifacts),
+        store_bytes: runtime::store_bytes(&store),
+        calibration_bytes: serde_json::to_vec_pretty(&calibration)?,
+        hierarchical_bytes: serde_json::to_vec_pretty(&hierarchical)?,
+    })
+}
+
+fn compile_recorded_corpus_with<B, D, A>(
+    args: &[String],
+    build_products: B,
+    after_dense_sync: D,
+    after_attention_sync: A,
+) -> Result<(), SourceUnavailable>
+where
+    B: FnOnce(&compiler::Corpus, usize) -> Result<RecordedCompileProducts, SourceUnavailable>,
+    D: FnOnce(&Path) -> Result<(), SourceUnavailable>,
+    A: FnOnce(&Path) -> Result<(), SourceUnavailable>,
+{
+    let options = parse_recorded_compile_options(args)?;
+    let mut prepared = preflight_recorded_compile_execution_identity(&options)?;
+    let corpus = &prepared.corpus;
+    let corpus_records = corpus.n;
     eprintln!(
         "recorded compile: {} records, {} stories, vocabulary {} (no teacher loaded)",
         corpus.n, corpus.stories, options.vocab_size
     );
-    let artifacts = compiler::compile_recorded(&corpus, options.vocab_size).ok_or_else(|| {
-        SourceUnavailable::new("recorded compile failed: empty corpus or invalid vocabulary")
-    })?;
-    let calibration = compiler::calibrate_hamming_regions(&artifacts, &corpus);
-    let hierarchical =
-        compiler::induce_hierarchical_codes(&artifacts.token_codes, options.vocab_size, &corpus);
-    let threads = std::thread::available_parallelism()
-        .map(|count| count.get().min(8))
-        .unwrap_or(1);
-    let (store, _) = runtime::build_store_with_threads(&artifacts, &corpus, threads);
-    let artifact_bytes = compiler::artifact_bytes(&artifacts);
-    let store_bytes = runtime::store_bytes(&store);
-    let calibration_bytes = serde_json::to_vec_pretty(&calibration)?;
-    let hierarchical_bytes = serde_json::to_vec_pretty(&hierarchical)?;
+    let RecordedCompileProducts {
+        artifact_bytes,
+        store_bytes,
+        calibration_bytes,
+        hierarchical_bytes,
+    } = build_products(corpus, options.vocab_size)?;
 
+    let source_records_summary = prepared.source.records.summary();
+    let source_hidden_summary = prepared
+        .source
+        .hidden
+        .as_ref()
+        .map(|hidden| hidden.summary());
     let preflight_planned_files = || -> Result<(), SourceUnavailable> {
         require_existing_file_matches_if_present(
             &options.output.join("tless_artifacts.bin"),
@@ -7129,23 +7580,28 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         )?;
         require_existing_file_matches_if_present(
             &options.output.join("corpus.meta"),
-            Some(&prepared.corpus.meta_bytes),
+            Some(&prepared.meta_bytes),
             "recorded compile corpus metadata",
         )?;
         require_existing_file_matches_if_present(
             &options.output.join("corpus.records"),
-            Some(&prepared.corpus.records_bytes),
+            Some(&prepared.records_bytes),
             "recorded compile corpus records",
         )?;
-        require_existing_file_matches_if_present(
+        require_existing_stream_matches_if_present(
             &options.output.join("corpus.records.hidden"),
-            prepared.corpus.hidden_bytes.as_deref(),
+            source_hidden_summary.as_ref(),
             "recorded compile corpus hidden stream",
         )?;
         Ok(())
     };
 
     preflight_planned_files()?;
+    // Markerless compatibility ownership cannot be nested with the
+    // destination producer guard. The retained no-follow source handles and
+    // their final generation check remain live after this lock is released.
+    prepared.source.verify_generation()?;
+    drop(prepared.source_guard.take());
     let output_parent = options
         .output
         .parent()
@@ -7172,7 +7628,7 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
     producer.ensure_root()?;
     preflight_guarded_planned_scope(
         &producer,
-        &PlannedOutputMember::ALL,
+        &PlannedOutputMember::REGISTERED,
         "recorded compile destination",
     )?;
     let recoverable_temporary =
@@ -7180,60 +7636,87 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
     preflight_recorded_compile_output(&options.output)?;
     let attention_ready =
         preflight_compiled_attention_operator(&options.output, &prepared.attention_operator)?;
+    let attention_bytes = canonical_attention_operator_bytes(&prepared.attention_operator)?;
+    let attention_bytes_ready = preflight_guarded_planned_file_in_scope(
+        &producer,
+        &options.output.join(ATTENTION_OPERATOR_BINDING_FILE),
+        &attention_bytes,
+        "recorded compile attention operator",
+        &PlannedOutputMember::REGISTERED,
+    )?;
     let dense_ready =
         preflight_compiled_dense_operator(&options.output, prepared.dense_operator.as_ref())?;
-    preflight_planned_files()?;
-    let artifact_ready = preflight_guarded_planned_file(
-        &producer,
-        &options.output.join("tless_artifacts.bin"),
-        &artifact_bytes,
-        "recorded compile artifact",
-    )?;
-    let store_ready = preflight_guarded_planned_file(
-        &producer,
-        &options.output.join("tless_store.bin"),
-        &store_bytes,
-        "recorded compile store",
-    )?;
-    let calibration_ready = preflight_guarded_planned_file(
-        &producer,
-        &options.output.join("hamming_calibration.json"),
-        &calibration_bytes,
-        "recorded compile calibration",
-    )?;
-    let hierarchical_ready = preflight_guarded_planned_file(
-        &producer,
-        &options.output.join("hierarchical_codes.json"),
-        &hierarchical_bytes,
-        "recorded compile hierarchical codes",
-    )?;
-    let records_ready = preflight_guarded_planned_file(
-        &producer,
-        &options.output.join("corpus.records"),
-        &prepared.corpus.records_bytes,
-        "recorded compile corpus records",
-    )?;
-    let hidden_ready = match prepared.corpus.hidden_bytes.as_deref() {
-        Some(hidden) => preflight_guarded_planned_file(
+    let dense_bytes = prepared
+        .dense_operator
+        .as_ref()
+        .map(canonical_dense_operator_bytes)
+        .transpose()?;
+    let dense_bytes_ready = match dense_bytes.as_deref() {
+        Some(bytes) => preflight_guarded_planned_file_in_scope(
             &producer,
-            &options.output.join("corpus.records.hidden"),
-            hidden,
-            "recorded compile corpus hidden stream",
+            &options.output.join(DENSE_OPERATOR_BINDING_FILE),
+            bytes,
+            "recorded compile dense operator",
+            &PlannedOutputMember::REGISTERED,
         )?,
         None => {
             preflight_guarded_planned_absence(
                 &producer,
-                &options.output.join("corpus.records.hidden"),
-                "recorded compile corpus hidden stream",
+                &options.output.join(DENSE_OPERATOR_BINDING_FILE),
+                "recorded compile dense operator",
             )?;
             true
         }
     };
-    let meta_ready = preflight_guarded_planned_file(
+    preflight_planned_files()?;
+    let artifact_ready = preflight_guarded_planned_file_in_scope(
+        &producer,
+        &options.output.join("tless_artifacts.bin"),
+        &artifact_bytes,
+        "recorded compile artifact",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let store_ready = preflight_guarded_planned_file_in_scope(
+        &producer,
+        &options.output.join("tless_store.bin"),
+        &store_bytes,
+        "recorded compile store",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let calibration_ready = preflight_guarded_planned_file_in_scope(
+        &producer,
+        &options.output.join("hamming_calibration.json"),
+        &calibration_bytes,
+        "recorded compile calibration",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let hierarchical_ready = preflight_guarded_planned_file_in_scope(
+        &producer,
+        &options.output.join("hierarchical_codes.json"),
+        &hierarchical_bytes,
+        "recorded compile hierarchical codes",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let records_ready = preflight_guarded_planned_stream_in_scope(
+        &producer,
+        &options.output.join("corpus.records"),
+        Some(&source_records_summary),
+        "recorded compile corpus records",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let hidden_ready = preflight_guarded_planned_stream_in_scope(
+        &producer,
+        &options.output.join("corpus.records.hidden"),
+        source_hidden_summary.as_ref(),
+        "recorded compile corpus hidden stream",
+        &PlannedOutputMember::REGISTERED,
+    )?;
+    let meta_ready = preflight_guarded_planned_file_in_scope(
         &producer,
         &options.output.join("corpus.meta"),
-        &prepared.corpus.meta_bytes,
+        &prepared.meta_bytes,
         "recorded compile corpus metadata",
+        &PlannedOutputMember::REGISTERED,
     )?;
     let stable_binding = strict_regular_file_if_present(
         &options
@@ -7241,7 +7724,9 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
             .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
         "recorded compile generation binding",
     )?;
-    let planned_ready = artifact_ready
+    let planned_ready = attention_bytes_ready
+        && dense_bytes_ready
+        && artifact_ready
         && store_ready
         && calibration_ready
         && hierarchical_ready
@@ -7261,18 +7746,20 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         )?;
     }
     if stable_binding && !recoverable_temporary && planned_ready && attention_ready && dense_ready {
+        producer
+            .preflight_ready_deterministic_compile_inventory(&PlannedOutputMember::REGISTERED)?;
         if producer.compile_attempt_active()? {
             producer.finish_compile_attempt()?;
         }
         println!(
             "recorded compile complete: {} ({} corpus records, artifact κ blake3:{})",
             options.output.display(),
-            corpus.n,
+            corpus_records,
             blake3::hash(&artifact_bytes).to_hex()
         );
         return Ok(());
     }
-    producer.preflight_deterministic_compile_inventory(&PlannedOutputMember::ALL)?;
+    producer.preflight_deterministic_compile_inventory(&PlannedOutputMember::REGISTERED)?;
     producer.begin_compile_attempt()?;
     if recoverable_temporary {
         uor_r4_graph_compiler::recorded_corpus::publish_binding(
@@ -7284,8 +7771,24 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
 
     // Dense-first ensures every crash prefix of a current GPT-2 generation is
     // invalid rather than a false, valid-looking attention-only generation.
-    bind_compiled_dense_operator(&options.output, prepared.dense_operator.as_ref())?;
-    bind_compiled_attention_operator(&options.output, &prepared.attention_operator)?;
+    if let Some(bytes) = dense_bytes.as_deref() {
+        publish_guarded_planned_file_with_after_sync(
+            &producer,
+            &options.output.join(DENSE_OPERATOR_BINDING_FILE),
+            bytes,
+            "recorded compile dense operator",
+            &PlannedOutputMember::REGISTERED,
+            after_dense_sync,
+        )?;
+    }
+    publish_guarded_planned_file_with_after_sync(
+        &producer,
+        &options.output.join(ATTENTION_OPERATOR_BINDING_FILE),
+        &attention_bytes,
+        "recorded compile attention operator",
+        &PlannedOutputMember::REGISTERED,
+        after_attention_sync,
+    )?;
     publish_guarded_planned_file(
         &producer,
         &options.output.join("tless_artifacts.bin"),
@@ -7310,13 +7813,18 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         &hierarchical_bytes,
         "recorded compile hierarchical codes",
     )?;
-    write_captured_recorded_corpus(&producer, &options.output, &prepared.corpus)?;
+    write_captured_recorded_corpus(&producer, &options.output, &mut prepared)?;
+    // All derived payload bytes are now durable but uncommitted. Refuse a
+    // changed source generation before the destination binding can make them
+    // authoritative as one corpus.
+    prepared.source.verify_generation()?;
     let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
         &producer,
         &options.output.join("corpus.meta"),
         &options.output.join("corpus.records"),
     )?;
-    let published = recorded_corpus_snapshot(
+    let published = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+        &producer,
         &options.output.join("corpus.meta"),
         &options.output.join("corpus.records"),
     )?;
@@ -7325,21 +7833,23 @@ pub fn compile_recorded_corpus(args: &[String]) -> Result<(), SourceUnavailable>
         dense_operator: prepared.dense_operator.clone(),
     };
     if published.binding_cid.as_deref() != Some(binding_cid.as_str())
-        || published.execution != destination_execution
-        || published.meta_bytes != prepared.corpus.meta_bytes
-        || published.records_bytes != prepared.corpus.records_bytes
-        || published.hidden_bytes != prepared.corpus.hidden_bytes
+        || recorded_execution_from_stream(&published) != destination_execution
+        || published.meta_bytes != prepared.meta_bytes
+        || published.records.summary() != source_records_summary
+        || published.hidden.as_ref().map(|hidden| hidden.summary()) != source_hidden_summary
     {
         return Err(SourceUnavailable::new(
             "recorded compile publication changed during exact post-binding recapture",
         ));
     }
+    published.verify_generation()?;
+    drop(published);
     producer.finish_compile_attempt()?;
 
     println!(
         "recorded compile complete: {} ({} corpus records, artifact κ blake3:{})",
         options.output.display(),
-        corpus.n,
+        corpus_records,
         blake3::hash(&artifact_bytes).to_hex()
     );
     Ok(())
@@ -7665,6 +8175,147 @@ mod tests {
         std::fs::remove_dir_all(&base).expect("cleanup root");
     }
 
+    #[test]
+    fn guarded_stream_publication_recovers_partial_stage_without_body_buffering() {
+        let root = unique_cli_test_path("planned-stream-recovery");
+        std::fs::create_dir_all(&root).expect("root");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(&root)
+                .expect("producer guard");
+        let residue = root.join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.1.writing",
+            PlannedOutputMember::Hidden.stable_name()
+        ));
+        std::fs::write(&residue, b"partial").expect("honest crash residue");
+        let bytes = b"complete hidden stream";
+        let expected = uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary {
+            length: bytes.len() as u64,
+            blake3: format!("blake3:{}", blake3::hash(bytes).to_hex()),
+        };
+        let mut source = std::io::Cursor::new(bytes.as_slice());
+        let stable = root.join(PlannedOutputMember::Hidden.stable_name());
+        publish_guarded_planned_stream(
+            &guard,
+            &stable,
+            &mut source,
+            &expected,
+            "test hidden stream",
+        )
+        .expect("exact retry publishes stream");
+        assert_eq!(std::fs::read(&stable).unwrap(), bytes);
+        assert!(!residue.exists());
+        assert_eq!(
+            stream_regular_file_summary_nofollow(&stable, "test hidden stream")
+                .expect("summary")
+                .expect("present"),
+            expected
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guarded_planned_byte_commit_cannot_be_redirected_after_last_root_check() {
+        let root = unique_cli_test_path("planned-byte-root-swap");
+        std::fs::create_dir_all(&root).expect("root");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(&root)
+                .expect("producer guard");
+        let guarded_root = guard.root().to_path_buf();
+        let displaced = guarded_root.with_file_name(format!(
+            "{}-guarded",
+            guarded_root
+                .file_name()
+                .expect("root leaf")
+                .to_string_lossy()
+        ));
+        let stable = guarded_root.join(PlannedOutputMember::Artifact.stable_name());
+        let expected = b"retained-root artifact";
+        let error = publish_guarded_planned_file_with_after_sync(
+            &guard,
+            &stable,
+            expected,
+            "planned byte root swap",
+            &PlannedOutputMember::ALL,
+            |_| {
+                std::fs::rename(&guarded_root, &displaced).expect("displace guarded root");
+                std::fs::create_dir(&guarded_root).expect("replacement root");
+                std::fs::write(guarded_root.join("replacement-sentinel"), b"replacement")
+                    .expect("replacement sentinel");
+                Ok(())
+            },
+        )
+        .expect_err("path replacement must be reported after retained-root commit");
+        assert!(error.reason.contains("changed"), "{error}");
+        assert_eq!(
+            std::fs::read(displaced.join(PlannedOutputMember::Artifact.stable_name()))
+                .expect("commit stayed on retained root"),
+            expected
+        );
+        assert!(!stable.exists(), "replacement root was not mutated");
+        assert_eq!(
+            std::fs::read(guarded_root.join("replacement-sentinel")).expect("sentinel"),
+            b"replacement"
+        );
+        drop(guard);
+        let _ = std::fs::remove_dir_all(guarded_root);
+        let _ = std::fs::remove_dir_all(displaced);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guarded_planned_stream_commit_cannot_be_redirected_after_last_root_check() {
+        let root = unique_cli_test_path("planned-stream-root-swap");
+        std::fs::create_dir_all(&root).expect("root");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(&root)
+                .expect("producer guard");
+        let guarded_root = guard.root().to_path_buf();
+        let displaced = guarded_root.with_file_name(format!(
+            "{}-guarded",
+            guarded_root
+                .file_name()
+                .expect("root leaf")
+                .to_string_lossy()
+        ));
+        let stable = guarded_root.join(PlannedOutputMember::Hidden.stable_name());
+        let expected_bytes = b"retained-root hidden stream";
+        let expected = uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary {
+            length: expected_bytes.len() as u64,
+            blake3: format!("blake3:{}", blake3::hash(expected_bytes).to_hex()),
+        };
+        let mut source = std::io::Cursor::new(expected_bytes.as_slice());
+        let error = publish_guarded_planned_stream_with_before_link(
+            &guard,
+            &stable,
+            &mut source,
+            &expected,
+            "planned stream root swap",
+            |_| {
+                std::fs::rename(&guarded_root, &displaced).expect("displace guarded root");
+                std::fs::create_dir(&guarded_root).expect("replacement root");
+                std::fs::write(guarded_root.join("replacement-sentinel"), b"replacement")
+                    .expect("replacement sentinel");
+                Ok(())
+            },
+        )
+        .expect_err("path replacement must be reported after retained-root commit");
+        assert!(error.reason.contains("changed"), "{error}");
+        assert_eq!(
+            std::fs::read(displaced.join(PlannedOutputMember::Hidden.stable_name()))
+                .expect("stream commit stayed on retained root"),
+            expected_bytes
+        );
+        assert!(!stable.exists(), "replacement root was not mutated");
+        assert_eq!(
+            std::fs::read(guarded_root.join("replacement-sentinel")).expect("sentinel"),
+            b"replacement"
+        );
+        drop(guard);
+        let _ = std::fs::remove_dir_all(guarded_root);
+        let _ = std::fs::remove_dir_all(displaced);
+    }
+
     fn fixture_adapter(marker: &str) -> TokenizerAdapter {
         let tokenizer_json = format!(
             r#"{{
@@ -7778,6 +8429,55 @@ mod tests {
         std::fs::write(&meta, b"meta marker").expect("metadata marker");
         std::fs::write(&records, b"records marker").expect("records marker");
         (meta, records)
+    }
+
+    fn finalized_corpus(path: &Path, next: u32) -> (PathBuf, PathBuf, Vec<u8>, Vec<u8>) {
+        std::fs::create_dir_all(path).expect("corpus directory");
+        let meta = path.join("corpus.meta");
+        let records = path.join("corpus.records");
+        let mut meta_bytes = vec![0u8; SOURCE_CORPUS_META_BYTES];
+        meta_bytes[0..8].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[16..24].copy_from_slice(&0x5EEDu64.to_le_bytes());
+        meta_bytes[24] = 1;
+        let mut record_bytes = vec![0u8; observe::RECORD_SIZE];
+        record_bytes[4..8].copy_from_slice(&next.to_le_bytes());
+        record_bytes[20..24].copy_from_slice(&next.to_le_bytes());
+        record_bytes[32..36].copy_from_slice(&100u32.to_le_bytes());
+        record_bytes[36..40].copy_from_slice(&1u32.to_le_bytes());
+        record_bytes[40..44].copy_from_slice(&u32::MAX.to_le_bytes());
+        record_bytes[44..48].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(&meta, &meta_bytes).expect("finalized metadata");
+        std::fs::write(&records, &record_bytes).expect("finalized records");
+        (meta, records, meta_bytes, record_bytes)
+    }
+
+    fn fixture_recorded_compile_products(
+        _corpus: &compiler::Corpus,
+        _vocab_size: usize,
+    ) -> Result<RecordedCompileProducts, SourceUnavailable> {
+        Ok(RecordedCompileProducts {
+            artifact_bytes: b"fixture recorded artifact".to_vec(),
+            store_bytes: b"fixture recorded store".to_vec(),
+            calibration_bytes: b"{\"fixture\":\"calibration\"}".to_vec(),
+            hierarchical_bytes: b"{\"fixture\":\"hierarchical\"}".to_vec(),
+        })
+    }
+
+    fn planned_output_residue_entries(path: &Path) -> Vec<String> {
+        let mut entries: Vec<_> = std::fs::read_dir(path)
+            .expect("read planned-output root")
+            .map(|entry| {
+                entry
+                    .expect("planned-output entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX))
+            .collect();
+        entries.sort();
+        entries
     }
 
     fn observation_corpus_markers(path: &Path) -> (PathBuf, PathBuf) {
@@ -10082,7 +10782,19 @@ mod tests {
         let dense = DenseOperatorSpec::gpt2_v2();
         bind_compiled_attention_operator(&source, &attention).expect("source attention binding");
         bind_compiled_dense_operator(&source, Some(&dense)).expect("source dense binding");
-        let (meta, records) = corpus_markers(&source);
+        let (meta, records, meta_bytes, record_bytes) = finalized_corpus(&source, 7);
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &source,
+            )
+            .expect("source guard");
+        guard.begin_compile_attempt().expect("source attempt");
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(&guard, &meta, &records)
+            .expect("source binding");
+        guard
+            .finish_compile_attempt()
+            .expect("finish source binding");
+        drop(guard);
 
         let output = unique_cli_test_path("compile-recorded-dense-output");
         let args = vec![
@@ -10100,8 +10812,9 @@ mod tests {
             .expect("preflight current GPT-2 recorded corpus");
         assert_eq!(prepared.attention_operator, attention);
         assert_eq!(prepared.dense_operator, Some(dense));
-        assert_eq!(prepared.corpus.meta_bytes, b"meta marker");
-        assert_eq!(prepared.corpus.records_bytes, b"records marker");
+        assert_eq!(prepared.meta_bytes, meta_bytes);
+        assert_eq!(prepared.records_bytes, record_bytes);
+        assert_eq!(prepared.corpus.n, 1);
         assert!(
             !output.exists(),
             "all recorded execution checks precede output publication"
@@ -10110,9 +10823,239 @@ mod tests {
         let _ = std::fs::remove_dir_all(source);
     }
 
+    #[test]
+    fn compile_recorded_command_recovers_each_sidecar_sync_crash_and_is_ready_idempotent() {
+        let source = unique_cli_test_path("compile-recorded-sidecar-crash-source");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_dense_operator(&source, Some(&dense)).expect("source dense binding");
+        bind_compiled_attention_operator(&source, &attention).expect("source attention binding");
+        let (meta, records, _, _) = finalized_corpus(&source, 11);
+        publish_test_corpus_binding(&source, &meta, &records);
+
+        for crash_member in [
+            PlannedOutputMember::DenseOperator,
+            PlannedOutputMember::AttentionOperator,
+        ] {
+            let output = unique_cli_test_path(match crash_member {
+                PlannedOutputMember::DenseOperator => "compile-recorded-dense-sync-crash",
+                PlannedOutputMember::AttentionOperator => "compile-recorded-attention-sync-crash",
+                _ => unreachable!("sidecar crash fixture"),
+            });
+            let args = vec![
+                "--corpus-meta".to_owned(),
+                meta.display().to_string(),
+                "--corpus-recs".to_owned(),
+                records.display().to_string(),
+                "--vocab-size".to_owned(),
+                "16".to_owned(),
+                "--out".to_owned(),
+                output.display().to_string(),
+            ];
+
+            let injected = match crash_member {
+                PlannedOutputMember::DenseOperator => compile_recorded_corpus_with(
+                    &args,
+                    fixture_recorded_compile_products,
+                    |_| Err(SourceUnavailable::new("injected dense sidecar sync crash")),
+                    |_| Ok(()),
+                ),
+                PlannedOutputMember::AttentionOperator => compile_recorded_corpus_with(
+                    &args,
+                    fixture_recorded_compile_products,
+                    |_| Ok(()),
+                    |_| {
+                        Err(SourceUnavailable::new(
+                            "injected attention sidecar sync crash",
+                        ))
+                    },
+                ),
+                _ => unreachable!("sidecar crash fixture"),
+            }
+            .expect_err("injected post-sync crash must interrupt publication");
+            assert!(injected.reason.contains("sidecar sync crash"), "{injected}");
+            let residues = planned_output_residue_entries(&output);
+            assert_eq!(residues.len(), 1, "one exact durable crash residue");
+            assert!(
+                residues[0].contains(crash_member.stable_name()),
+                "residue belongs to the interrupted sidecar: {residues:?}"
+            );
+            assert!(
+                !output.join(crash_member.stable_name()).exists(),
+                "post-sync crash precedes stable hard-link publication"
+            );
+
+            compile_recorded_corpus_with(
+                &args,
+                fixture_recorded_compile_products,
+                |_| Ok(()),
+                |_| Ok(()),
+            )
+            .expect("exact command retry recovers and commits");
+            assert!(planned_output_residue_entries(&output).is_empty());
+            assert!(attention_operator_temp_entries(&output).is_empty());
+            assert!(dense_operator_temp_entries(&output).is_empty());
+            assert_eq!(
+                compiled_dense_operator(&output).expect("published dense"),
+                Some(dense.clone())
+            );
+            assert_eq!(
+                compiled_attention_operator(&output).expect("published attention"),
+                attention
+            );
+            assert!(
+                output
+                    .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+                    .is_file(),
+                "the command reaches binding-last commit"
+            );
+
+            let ready = directory_bytes(&output);
+            compile_recorded_corpus_with(
+                &args,
+                fixture_recorded_compile_products,
+                |_| panic!("ready rerun must not republish dense"),
+                |_| panic!("ready rerun must not republish attention"),
+            )
+            .expect("ready command rerun is idempotent");
+            assert_eq!(directory_bytes(&output), ready);
+            let _ = std::fs::remove_dir_all(output);
+        }
+
+        let _ = std::fs::remove_dir_all(source);
+    }
+
+    #[test]
+    fn compile_recorded_preflight_and_publication_stream_opaque_hidden() {
+        let source = unique_cli_test_path("compile-recorded-stream-source");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        bind_compiled_attention_operator(&source, &attention).expect("source attention");
+        bind_compiled_dense_operator(&source, Some(&dense)).expect("source dense");
+        let (meta, records, _, _) = finalized_corpus(&source, 9);
+        let hidden = source.join("corpus.records.hidden");
+        let hidden_bytes = [
+            0.0f32.to_le_bytes(),
+            0.25f32.to_le_bytes(),
+            (-1.0f32).to_le_bytes(),
+        ]
+        .concat();
+        std::fs::write(&hidden, &hidden_bytes).expect("opaque hidden rows");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &source,
+            )
+            .expect("source guard");
+        guard.begin_compile_attempt().expect("source attempt");
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(&guard, &meta, &records)
+            .expect("source binding");
+        guard.finish_compile_attempt().expect("finish source");
+        drop(guard);
+
+        let output = unique_cli_test_path("compile-recorded-stream-output");
+        let args = vec![
+            "--corpus-meta".to_owned(),
+            meta.display().to_string(),
+            "--corpus-recs".to_owned(),
+            records.display().to_string(),
+            "--vocab-size".to_owned(),
+            "16".to_owned(),
+            "--out".to_owned(),
+            output.display().to_string(),
+        ];
+        let options = parse_recorded_compile_options(&args).expect("compile options");
+        let mut prepared = preflight_recorded_compile_execution_identity(&options)
+            .expect("bounded compile preflight");
+        assert!(
+            prepared.corpus.hidden.is_none(),
+            "non-D hidden rows are not materialized into compiler state"
+        );
+        let expected_hidden = prepared
+            .source
+            .hidden
+            .as_ref()
+            .expect("retained opaque hidden stream")
+            .summary();
+        prepared
+            .source
+            .verify_generation()
+            .expect("source generation");
+        drop(prepared.source_guard.take());
+
+        std::fs::create_dir_all(&output).expect("output root");
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("output guard");
+        producer
+            .preflight_deterministic_compile_inventory(&PlannedOutputMember::ALL)
+            .expect("fresh deterministic inventory");
+        producer.begin_compile_attempt().expect("output attempt");
+        bind_compiled_dense_operator(&output, prepared.dense_operator.as_ref())
+            .expect("output dense");
+        bind_compiled_attention_operator(&output, &prepared.attention_operator)
+            .expect("output attention");
+        write_captured_recorded_corpus(&producer, &output, &mut prepared)
+            .expect("stream recorded corpus");
+        prepared
+            .source
+            .verify_generation()
+            .expect("final source generation");
+        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            &producer,
+            &output.join("corpus.meta"),
+            &output.join("corpus.records"),
+        )
+        .expect("output binding");
+        producer.finish_compile_attempt().expect("finish output");
+        assert_eq!(
+            std::fs::read(output.join("corpus.records.hidden")).expect("copied hidden"),
+            hidden_bytes
+        );
+        assert!(
+            !output
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists()
+        );
+        let captured = uor_r4_graph_compiler::recorded_corpus::open_stream(
+            &output.join("corpus.meta"),
+            &output.join("corpus.records"),
+        )
+        .expect("bound recorded output");
+        assert_eq!(captured.execution.attention_operator, Some(attention));
+        assert_eq!(captured.execution.dense_operator, Some(dense));
+        assert_eq!(captured.binding_cid.as_deref(), Some(binding_cid.as_str()));
+        assert_eq!(
+            captured.hidden.as_ref().expect("hidden summary").summary(),
+            expected_hidden
+        );
+        captured.verify_generation().expect("stable output");
+
+        std::fs::create_dir(output.join("graph")).expect("downstream graph");
+        std::fs::create_dir(output.join("graph-cover")).expect("downstream cover");
+        std::fs::write(output.join("graph/sentinel"), b"graph").expect("graph sentinel");
+        std::fs::write(output.join("graph-cover/sentinel"), b"cover").expect("cover sentinel");
+        producer
+            .preflight_ready_deterministic_compile_inventory(&PlannedOutputMember::ALL)
+            .expect("ready exact inventory tolerates downstream graph outputs");
+        assert_eq!(
+            std::fs::read(output.join("graph/sentinel")).unwrap(),
+            b"graph"
+        );
+        assert_eq!(
+            std::fs::read(output.join("graph-cover/sentinel")).unwrap(),
+            b"cover"
+        );
+
+        drop(producer);
+        let _ = std::fs::remove_dir_all(source);
+        let _ = std::fs::remove_dir_all(output);
+    }
+
     #[cfg(unix)]
     #[test]
-    fn recorded_corpus_capture_refuses_post_resolution_swap_and_copy_never_reopens_source() {
+    fn recorded_corpus_capture_refuses_post_resolution_swap() {
         use std::os::unix::fs::symlink;
 
         let source = unique_cli_test_path("recorded-corpus-captured-source");
@@ -10121,11 +11064,6 @@ mod tests {
         std::fs::write(&hidden, b"captured hidden bytes").expect("hidden bytes");
         let external = unique_cli_test_path("recorded-corpus-external-records");
         std::fs::write(&external, b"external replacement bytes").expect("external records");
-        let output = unique_cli_test_path("recorded-corpus-swap-output");
-        std::fs::create_dir_all(&output).expect("output");
-        std::fs::write(output.join("sentinel"), b"before").expect("sentinel");
-        let output_before = directory_bytes(&output);
-
         let error = recorded_corpus_snapshot_with_hook(&meta, &records, || {
             std::fs::remove_file(&records).expect("remove captured records path");
             symlink(&external, &records).expect("post-resolution records symlink")
@@ -10136,7 +11074,6 @@ mod tests {
                 || error.reason.contains("captured regular-file generation"),
             "{error}"
         );
-        assert_eq!(directory_bytes(&output), output_before);
         std::fs::remove_file(&records).expect("remove swapped link");
         std::fs::write(&records, b"records marker").expect("restore records");
 
@@ -10152,29 +11089,12 @@ mod tests {
         symlink(&external, &meta).expect("swap metadata after complete capture");
         symlink(&external, &records).expect("swap records after complete capture");
 
-        let mut output_guard =
-            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
-                &output,
-            )
-            .expect("output guard");
-        output_guard.ensure_root().expect("output root");
-        write_captured_recorded_corpus(&output_guard, &output, &captured)
-            .expect("copy uses owned captured bytes only");
-        assert_eq!(
-            std::fs::read(output.join("corpus.meta")).expect("output meta"),
-            b"meta marker"
-        );
-        assert_eq!(
-            std::fs::read(output.join("corpus.records")).expect("output records"),
-            b"records marker"
-        );
         assert_eq!(
             std::fs::read(&external).expect("external survives"),
             b"external replacement bytes"
         );
 
         let _ = std::fs::remove_dir_all(source);
-        let _ = std::fs::remove_dir_all(output);
         let _ = std::fs::remove_file(external);
     }
 

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -33,7 +33,8 @@ use uor_r4_graph_compiler::induction as cover;
 use uor_r4_graph_compiler::observation as observe;
 use uor_r4_graph_compiler::observation_text as observe_text;
 use uor_r4_graph_compiler::recorded_corpus::{
-    PLANNED_OUTPUT_RESERVED_PREFIX, PlannedOutputMember, RecordedCorpusRole,
+    PLANNED_OUTPUT_RESERVED_PREFIX, PlannedOutputMember, RecordedCorpusProducerGuard,
+    RecordedCorpusReaderPins, RecordedCorpusRole,
 };
 use uor_r4_graph_compiler::reproducibility as repro;
 mod convert_r4g1;
@@ -816,6 +817,15 @@ pub struct SourceCorpusSession {
     recorded_corpus: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard>,
 }
 
+impl std::fmt::Debug for SourceCorpusSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SourceCorpusSession")
+            .field("recorded_corpus", &self.recorded_corpus.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
 impl Drop for SourceCorpusSession {
     fn drop(&mut self) {
         self.release_in_order(|| {});
@@ -1554,6 +1564,59 @@ fn opened_file_generation_matches(
         && initial.modified().ok() == final_metadata.modified().ok()
 }
 
+#[cfg(unix)]
+fn is_publisher_alias_cleanup_transition(
+    initial: &std::fs::Metadata,
+    final_metadata: &std::fs::Metadata,
+    final_path_metadata: &std::fs::Metadata,
+    captured_len: usize,
+    verification_offset: usize,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    initial.file_type().is_file()
+        && final_metadata.file_type().is_file()
+        && final_path_metadata.file_type().is_file()
+        && opened_file_identity_matches(initial, final_metadata)
+        && opened_file_identity_matches(final_path_metadata, final_metadata)
+        && initial.len() == captured_len as u64
+        && final_metadata.len() == captured_len as u64
+        && verification_offset == captured_len
+        && initial.mtime() == final_metadata.mtime()
+        && initial.mtime_nsec() == final_metadata.mtime_nsec()
+        && (initial.ctime() != final_metadata.ctime()
+            || initial.ctime_nsec() != final_metadata.ctime_nsec())
+        && initial.nlink() == 2
+        && final_metadata.nlink() == 1
+}
+
+#[cfg(not(unix))]
+fn is_publisher_alias_cleanup_transition(
+    _initial: &std::fs::Metadata,
+    _final_metadata: &std::fs::Metadata,
+    _final_path_metadata: &std::fs::Metadata,
+    _captured_len: usize,
+    _verification_offset: usize,
+) -> bool {
+    false
+}
+
+struct StrictRegularFileSnapshot {
+    bytes: Vec<u8>,
+    metadata: std::fs::Metadata,
+}
+
+struct PublisherAliasCleanup {
+    snapshot: StrictRegularFileSnapshot,
+    terminal_error: SourceUnavailable,
+}
+
+enum StrictOptionalRegularFileCapture {
+    Absent,
+    Stable(StrictRegularFileSnapshot),
+    PublisherAliasCleanup(PublisherAliasCleanup),
+}
+
 #[cfg(not(unix))]
 fn opened_file_identity_matches(
     _path_metadata: &std::fs::Metadata,
@@ -1568,11 +1631,11 @@ fn opened_file_identity_matches(
 /// path is never reopened for bytes: Unix refuses links at `open(2)`, while
 /// every platform checks that the path still names the opened regular file
 /// before and after the read.
-fn read_optional_regular_file_nofollow_with<F>(
+fn capture_optional_regular_file_nofollow_with<F>(
     path: &Path,
     context: &str,
     after_open: F,
-) -> Result<Option<Vec<u8>>, SourceUnavailable>
+) -> Result<StrictOptionalRegularFileCapture, SourceUnavailable>
 where
     F: FnOnce(),
 {
@@ -1589,7 +1652,9 @@ where
     }
     let mut file = match options.open(path) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(StrictOptionalRegularFileCapture::Absent);
+        }
         Err(error) => {
             return Err(SourceUnavailable::new(format!(
                 "{context} {} is not a regular file or cannot be opened without following links: {error}",
@@ -1699,6 +1764,12 @@ where
             path.display()
         ))
     })?;
+    let terminal_error = || {
+        SourceUnavailable::new(format!(
+            "{context} {} changed identity, type, length, content, or generation while its bytes were read",
+            path.display()
+        ))
+    };
     if !final_file_metadata.file_type().is_file()
         || !final_path_metadata.file_type().is_file()
         || !opened_file_generation_matches(&opened_metadata, &final_file_metadata)
@@ -1706,12 +1777,100 @@ where
         || verification_offset != bytes.len()
         || final_file_metadata.len() != bytes.len() as u64
     {
-        return Err(SourceUnavailable::new(format!(
-            "{context} {} changed identity, type, length, content, or generation while its bytes were read",
-            path.display()
-        )));
+        let error = terminal_error();
+        if is_publisher_alias_cleanup_transition(
+            &opened_metadata,
+            &final_file_metadata,
+            &final_path_metadata,
+            bytes.len(),
+            verification_offset,
+        ) {
+            return Ok(StrictOptionalRegularFileCapture::PublisherAliasCleanup(
+                PublisherAliasCleanup {
+                    snapshot: StrictRegularFileSnapshot {
+                        bytes,
+                        metadata: final_file_metadata,
+                    },
+                    terminal_error: error,
+                },
+            ));
+        }
+        return Err(error);
     }
-    Ok(Some(bytes))
+    Ok(StrictOptionalRegularFileCapture::Stable(
+        StrictRegularFileSnapshot {
+            bytes,
+            metadata: final_file_metadata,
+        },
+    ))
+}
+
+fn read_optional_regular_file_nofollow_with<F>(
+    path: &Path,
+    context: &str,
+    after_open: F,
+) -> Result<Option<Vec<u8>>, SourceUnavailable>
+where
+    F: FnOnce(),
+{
+    match capture_optional_regular_file_nofollow_with(path, context, after_open)? {
+        StrictOptionalRegularFileCapture::Absent => Ok(None),
+        StrictOptionalRegularFileCapture::Stable(snapshot) => Ok(Some(snapshot.bytes)),
+        StrictOptionalRegularFileCapture::PublisherAliasCleanup(cleanup) => {
+            Err(cleanup.terminal_error)
+        }
+    }
+}
+
+fn read_optional_regular_file_for_operator_publisher_with_hooks<F, B, G>(
+    path: &Path,
+    context: &str,
+    after_first_open: F,
+    before_retry: B,
+    after_retry_open: G,
+) -> Result<Option<Vec<u8>>, SourceUnavailable>
+where
+    F: FnOnce(),
+    B: FnOnce(),
+    G: FnOnce(),
+{
+    let first = capture_optional_regular_file_nofollow_with(path, context, after_first_open)?;
+    let StrictOptionalRegularFileCapture::PublisherAliasCleanup(first_cleanup) = first else {
+        return match first {
+            StrictOptionalRegularFileCapture::Absent => Ok(None),
+            StrictOptionalRegularFileCapture::Stable(snapshot) => Ok(Some(snapshot.bytes)),
+            StrictOptionalRegularFileCapture::PublisherAliasCleanup(_) => unreachable!(),
+        };
+    };
+
+    before_retry();
+    match capture_optional_regular_file_nofollow_with(path, context, after_retry_open)? {
+        StrictOptionalRegularFileCapture::Absent => Err(SourceUnavailable::new(format!(
+            "{context} {} disappeared during the one permitted publisher alias-cleanup retry",
+            path.display()
+        ))),
+        StrictOptionalRegularFileCapture::PublisherAliasCleanup(cleanup) => {
+            Err(cleanup.terminal_error)
+        }
+        StrictOptionalRegularFileCapture::Stable(retry) => {
+            if !opened_file_generation_matches(&first_cleanup.snapshot.metadata, &retry.metadata)
+                || first_cleanup.snapshot.bytes != retry.bytes
+            {
+                return Err(SourceUnavailable::new(format!(
+                    "{context} {} changed generation or content across the one permitted publisher alias-cleanup retry",
+                    path.display()
+                )));
+            }
+            Ok(Some(retry.bytes))
+        }
+    }
+}
+
+fn read_optional_regular_file_for_operator_publisher(
+    path: &Path,
+    context: &str,
+) -> Result<Option<Vec<u8>>, SourceUnavailable> {
+    read_optional_regular_file_for_operator_publisher_with_hooks(path, context, || {}, || {}, || {})
 }
 
 fn read_optional_regular_file_nofollow(
@@ -1896,6 +2055,44 @@ fn read_optional_compiled_attention_operator(
     Ok(read_optional_compiled_attention_operator_with_bytes(output)?.map(|(operator, _)| operator))
 }
 
+#[cfg(test)]
+fn read_optional_compiled_attention_operator_for_publisher_with_hooks<F, B, G>(
+    output: &Path,
+    after_first_open: F,
+    before_retry: B,
+    after_retry_open: G,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable>
+where
+    F: FnOnce(),
+    B: FnOnce(),
+    G: FnOnce(),
+{
+    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let Some(bytes) = read_optional_regular_file_for_operator_publisher_with_hooks(
+        &path,
+        "attention-operator binding",
+        after_first_open,
+        before_retry,
+        after_retry_open,
+    )?
+    else {
+        return Ok(None);
+    };
+    parse_compiled_attention_operator_bytes(&path, &bytes).map(Some)
+}
+
+fn read_optional_compiled_attention_operator_for_publisher(
+    output: &Path,
+) -> Result<Option<AttentionOperatorSpec>, SourceUnavailable> {
+    let path = output.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let Some(bytes) =
+        read_optional_regular_file_for_operator_publisher(&path, "attention-operator binding")?
+    else {
+        return Ok(None);
+    };
+    parse_compiled_attention_operator_bytes(&path, &bytes).map(Some)
+}
+
 /// Read and registry-validate a compile directory's attention-operator
 /// binding. A missing sidecar is an error on this source-driven/API seam; use
 /// [`recorded_corpus_attention_operator`] when legacy absence is meaningful.
@@ -1919,7 +2116,7 @@ fn preflight_compiled_attention_operator(
     let requested =
         validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
     let inventory = compile_output_payload_inventory(output)?;
-    let recorded = read_optional_compiled_attention_operator(output)?;
+    let recorded = read_optional_compiled_attention_operator_for_publisher(output)?;
     if let Some(recorded) = recorded {
         if recorded != requested {
             return Err(SourceUnavailable::new(format!(
@@ -1982,7 +2179,7 @@ fn publish_attention_operator_binding(
 ) -> Result<(), SourceUnavailable> {
     let requested =
         validate_attention_operator(requested, "proposed teacher attention-operator binding")?;
-    if let Some(recorded) = read_optional_compiled_attention_operator(output)? {
+    if let Some(recorded) = read_optional_compiled_attention_operator_for_publisher(output)? {
         return require_matching_compiled_attention_operator(output, &requested, &recorded);
     }
 
@@ -2033,12 +2230,13 @@ fn publish_attention_operator_binding(
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let _ = std::fs::remove_file(&temporary);
-            let recorded = read_optional_compiled_attention_operator(output)?.ok_or_else(|| {
-                SourceUnavailable::new(format!(
-                    "{} appeared during attention-operator publication but is now absent",
-                    path.display()
-                ))
-            })?;
+            let recorded = read_optional_compiled_attention_operator_for_publisher(output)?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "{} appeared during attention-operator publication but is now absent",
+                        path.display()
+                    ))
+                })?;
             require_matching_compiled_attention_operator(output, &requested, &recorded)?;
             sync_compile_output_directory(output)
         }
@@ -2160,6 +2358,44 @@ fn read_optional_compiled_dense_operator(
     Ok(read_optional_compiled_dense_operator_with_bytes(output)?.map(|(operator, _)| operator))
 }
 
+#[cfg(test)]
+fn read_optional_compiled_dense_operator_for_publisher_with_hooks<F, B, G>(
+    output: &Path,
+    after_first_open: F,
+    before_retry: B,
+    after_retry_open: G,
+) -> Result<Option<DenseOperatorSpec>, SourceUnavailable>
+where
+    F: FnOnce(),
+    B: FnOnce(),
+    G: FnOnce(),
+{
+    let path = output.join(DENSE_OPERATOR_BINDING_FILE);
+    let Some(bytes) = read_optional_regular_file_for_operator_publisher_with_hooks(
+        &path,
+        "dense-operator binding",
+        after_first_open,
+        before_retry,
+        after_retry_open,
+    )?
+    else {
+        return Ok(None);
+    };
+    parse_compiled_dense_operator_bytes(&path, &bytes).map(Some)
+}
+
+fn read_optional_compiled_dense_operator_for_publisher(
+    output: &Path,
+) -> Result<Option<DenseOperatorSpec>, SourceUnavailable> {
+    let path = output.join(DENSE_OPERATOR_BINDING_FILE);
+    let Some(bytes) =
+        read_optional_regular_file_for_operator_publisher(&path, "dense-operator binding")?
+    else {
+        return Ok(None);
+    };
+    parse_compiled_dense_operator_bytes(&path, &bytes).map(Some)
+}
+
 /// Read a compile directory's optional dense-execution binding. Absence is a
 /// real compatibility state for Llama and historical corpora and is never
 /// synthesized as GPT-2 v1.
@@ -2180,7 +2416,7 @@ fn preflight_compiled_dense_operator(
         .map(|record| validate_dense_operator(record, "proposed teacher dense-operator binding"))
         .transpose()?;
     let inventory = compile_output_payload_inventory(output)?;
-    let recorded = read_optional_compiled_dense_operator(output)?;
+    let recorded = read_optional_compiled_dense_operator_for_publisher(output)?;
     match (recorded.as_ref(), requested.as_ref()) {
         (Some(recorded), Some(requested)) if recorded == requested => Ok(true),
         (Some(recorded), Some(requested)) => Err(SourceUnavailable::new(format!(
@@ -2248,7 +2484,7 @@ fn publish_dense_operator_binding(
     requested: &DenseOperatorSpec,
 ) -> Result<(), SourceUnavailable> {
     let requested = validate_dense_operator(requested, "proposed teacher dense-operator binding")?;
-    if let Some(recorded) = read_optional_compiled_dense_operator(output)? {
+    if let Some(recorded) = read_optional_compiled_dense_operator_for_publisher(output)? {
         return require_matching_compiled_dense_operator(output, &requested, &recorded);
     }
 
@@ -2297,12 +2533,13 @@ fn publish_dense_operator_binding(
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let _ = std::fs::remove_file(&temporary);
-            let recorded = read_optional_compiled_dense_operator(output)?.ok_or_else(|| {
-                SourceUnavailable::new(format!(
-                    "{} appeared during dense-operator publication but is now absent",
-                    path.display()
-                ))
-            })?;
+            let recorded = read_optional_compiled_dense_operator_for_publisher(output)?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "{} appeared during dense-operator publication but is now absent",
+                        path.display()
+                    ))
+                })?;
             require_matching_compiled_dense_operator(output, &requested, &recorded)?;
             sync_compile_output_directory(output)
         }
@@ -2414,6 +2651,219 @@ fn preflight_recorded_compile_output(output: &Path) -> Result<(), SourceUnavaila
         }
     }
     Ok(())
+}
+
+/// Resolve a compile output through the deepest existing physical ancestor
+/// without creating any parent or output entry. A final symlink is never a
+/// compile root; intermediate aliases are collapsed once so all later owner
+/// checks, session acquisition, and writes use the same physical namespace.
+fn canonical_hf_compile_output_subject(output: &Path) -> Result<PathBuf, SourceUnavailable> {
+    match std::fs::symlink_metadata(output) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(SourceUnavailable::new(format!(
+                "compile output {} is a symlink; a physical non-symlink directory is required",
+                output.display()
+            )));
+        }
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            return std::fs::canonicalize(output).map_err(SourceUnavailable::new);
+        }
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "compile output {} is not a regular non-symlink directory",
+                output.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+
+    let mut cursor = output;
+    let mut missing = Vec::<std::ffi::OsString>::new();
+    loop {
+        match std::fs::symlink_metadata(cursor) {
+            Ok(_) => {
+                let physical = std::fs::canonicalize(cursor).map_err(SourceUnavailable::new)?;
+                let metadata =
+                    std::fs::symlink_metadata(&physical).map_err(SourceUnavailable::new)?;
+                if !metadata.file_type().is_dir() {
+                    return Err(SourceUnavailable::new(format!(
+                        "deepest existing compile-output ancestor {} does not resolve to a physical directory",
+                        cursor.display()
+                    )));
+                }
+                let mut resolved = physical;
+                for leaf in missing.iter().rev() {
+                    resolved.push(leaf);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let leaf = cursor.file_name().ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "compile output {} has no physical ancestor and final name",
+                        output.display()
+                    ))
+                })?;
+                if leaf == std::ffi::OsStr::new(".") || leaf == std::ffi::OsStr::new("..") {
+                    return Err(SourceUnavailable::new(format!(
+                        "compile output {} contains a reserved unresolved path component",
+                        output.display()
+                    )));
+                }
+                missing.push(leaf.to_os_string());
+                cursor = cursor
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+            }
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        }
+    }
+}
+
+fn has_server_private_stage_topology(root: &Path) -> bool {
+    if root.parent().and_then(Path::file_name)
+        != Some(std::ffi::OsStr::new(".uor-r4-source-compile-staging"))
+    {
+        return false;
+    }
+    let Some(name) = root.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some((logical, sequence)) = name.rsplit_once(".bundle-stage.") else {
+        return false;
+    };
+    if !logical.starts_with('.') || logical.len() == 1 {
+        return false;
+    }
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn compiled_bundle_owner_ancestor(output: &Path) -> Result<Option<PathBuf>, SourceUnavailable> {
+    let mut candidate = match std::fs::symlink_metadata(output) {
+        Ok(metadata) if metadata.file_type().is_dir() => Some(output),
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "compile output {} is not a regular non-symlink directory",
+                output.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => output.parent(),
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    };
+    while let Some(root) = candidate {
+        let metadata = match std::fs::symlink_metadata(root) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                candidate = root.parent();
+                continue;
+            }
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        };
+        if metadata.file_type().is_dir() {
+            // The private-stage topology itself reserves this root for the
+            // managed server. Select its common authority even in the narrow
+            // interval before the owner marker is published, so a direct
+            // child compile cannot race marker appearance and seed an
+            // independent child transaction inside the stage.
+            if has_server_private_stage_topology(root) {
+                return std::fs::canonicalize(root)
+                    .map(Some)
+                    .map_err(SourceUnavailable::new);
+            }
+            for leaf in [
+                "compiled_bundle_completion.json",
+                ".compiled_bundle_stage.json",
+                ".compiled_bundle_stage_a.json",
+            ] {
+                match std::fs::symlink_metadata(root.join(leaf)) {
+                    Ok(_) => {
+                        return std::fs::canonicalize(root)
+                            .map(Some)
+                            .map_err(SourceUnavailable::new);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(SourceUnavailable::new(error)),
+                }
+            }
+        }
+        candidate = root.parent();
+    }
+    Ok(None)
+}
+
+fn reject_foreign_compiled_bundle_stage_owner(output: &Path) -> Result<(), SourceUnavailable> {
+    let Some(owner_root) = compiled_bundle_owner_ancestor(output)? else {
+        return Ok(());
+    };
+    // The read-only ancestor classification precedes any child session/root
+    // creation. Reacquire that exact ancestor's common authority and recheck
+    // while held; never seed independent coordination inside a private stage.
+    let guard = RecordedCorpusProducerGuard::try_acquire(&owner_root)?;
+    guard.verify_owned_root()?;
+    let mut present = false;
+    for leaf in [
+        "compiled_bundle_completion.json",
+        ".compiled_bundle_stage.json",
+        ".compiled_bundle_stage_a.json",
+    ] {
+        match std::fs::symlink_metadata(owner_root.join(leaf)) {
+            Ok(_) => present = true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        }
+    }
+    guard.verify_owned_root()?;
+    let state = if present {
+        "is an owned or completed server compiled-bundle ancestor"
+    } else {
+        "changed owner state during guarded classification"
+    };
+    Err(SourceUnavailable::new(format!(
+        "compile output {} {state} at {}; direct source compilation cannot mutate it without the exact managed capability",
+        output.display(),
+        owner_root.display()
+    )))
+}
+
+fn require_exact_managed_compiled_bundle_stage_owner(
+    guard: &RecordedCorpusProducerGuard,
+    output: &Path,
+) -> Result<(), SourceUnavailable> {
+    if !guard.protects_directory(output)? {
+        return Err(SourceUnavailable::new(format!(
+            "managed source capability for {} does not protect exact output {}",
+            guard.root().display(),
+            output.display()
+        )));
+    }
+    guard.verify_owned_root()?;
+    let marker = output.join(".compiled_bundle_stage.json");
+    match std::fs::symlink_metadata(&marker) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "managed compiled-bundle owner marker {} is not a regular non-symlink file",
+                marker.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SourceUnavailable::new(format!(
+                "managed source capability cannot mutate {} without its exact server owner marker",
+                output.display()
+            )));
+        }
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+    guard.verify_owned_root()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -3753,6 +4203,10 @@ struct CoverOptions {
     entropy_gain_bits: f64,
     radius_quantile: u32,
     output: PathBuf,
+    /// Explicit stable mutation authority for a managed/canonical bundle.
+    /// Without this flag, `--out` is always an arbitrary standalone root,
+    /// even when its basename is `graph-cover`.
+    bundle_root: Option<PathBuf>,
     /// Root κ of the #597 source-snapshot manifest of the teacher source
     /// (`--source-manifest-kappa`), carried verbatim into the cover
     /// report. This crate never computes the κ (no uor-addr dependency).
@@ -3790,6 +4244,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         entropy_gain_bits: cover::DEFAULT_SPLIT_ENTROPY_GAIN_BITS,
         radius_quantile: cover::RADIUS_QUANTILE_NUMERATOR,
         output: PathBuf::from("cover"),
+        bundle_root: None,
         source_manifest_kappa: None,
         geometry: None,
         attention_operator: None,
@@ -3871,6 +4326,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
                 }
             }
             "--out" => options.output = PathBuf::from(value),
+            "--bundle-root" => options.bundle_root = Some(PathBuf::from(value)),
             "--source-manifest-kappa" => {
                 options.source_manifest_kappa = Some(value.clone());
             }
@@ -3964,12 +4420,29 @@ fn require_cover_recorded_execution_identity(
 /// against it and against the incumbent 4×256 class cover, and write the
 /// R4G1 artifact plus the JSON recall/stability report.
 pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
+    cover_command_with_authority(args, GraphCommandCallerAuthority::Public)
+}
+
+/// Run cover induction while a managed caller retains the one common
+/// recorded-corpus producer transaction for the bundle root. This is the
+/// server-only seam: acquiring again would self-contend, while falling back to
+/// pathname reads would leave completion publication outside the transaction.
+pub fn cover_command_under_producer_guard(
+    args: &[String],
+    guard: &RecordedCorpusProducerGuard,
+) -> Result<(), SourceUnavailable> {
+    cover_command_with_authority(args, GraphCommandCallerAuthority::Provided(guard))
+}
+
+fn cover_command_with_authority(
+    args: &[String],
+    caller_authority: GraphCommandCallerAuthority<'_>,
+) -> Result<(), SourceUnavailable> {
     #[cfg(debug_assertions)]
     eprintln!(
         "warning: debug builds make cover induction much slower; use `cargo run --release -- transformerless cover ...`"
     );
-    let options = parse_cover_options(args)?;
-    let tokenizer_cid = explicit_tokenizer_cid(options.tokenizer.as_deref())?.unwrap_or([0; 32]);
+    let mut options = parse_cover_options(args)?;
     let corpus_meta_path = if !options.corpus_meta.exists() {
         if let Some(parent) = options.corpus_meta.parent() {
             if parent.join("corpus.meta").exists() {
@@ -4002,7 +4475,30 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
         options.corpus_recs.clone()
     };
 
-    let recorded_corpus = recorded_compiler_corpus(&corpus_meta_path, &corpus_recs_path)?;
+    let transaction_authority = match caller_authority {
+        GraphCommandCallerAuthority::Public => match options.bundle_root.as_deref() {
+            Some(root) => GraphTransactionAuthority::DeclaredBundle(root),
+            None => GraphTransactionAuthority::StandaloneExact,
+        },
+        GraphCommandCallerAuthority::Provided(guard) => {
+            if let Some(root) = options.bundle_root.as_deref() {
+                return Err(SourceUnavailable::new(format!(
+                    "cover already has retained producer authority for {}; do not supply a second --bundle-root {} declaration",
+                    guard.root().display(),
+                    root.display()
+                )));
+            }
+            GraphTransactionAuthority::ProvidedBundle(guard)
+        }
+    };
+    let (recorded_corpus, mut transaction) = begin_graph_command_transaction(
+        transaction_authority,
+        &corpus_meta_path,
+        &corpus_recs_path,
+        &mut options.output,
+        "cover",
+    )?;
+    let tokenizer_cid = explicit_tokenizer_cid(options.tokenizer.as_deref())?.unwrap_or([0; 32]);
     require_cover_recorded_execution_identity(&options, &recorded_corpus.execution)?;
     // #450: resolve and announce the inputs *before* the long work, so the
     // run says which teacher container it actually read. `--artifacts`
@@ -4114,15 +4610,18 @@ pub fn cover_command(args: &[String]) -> Result<(), SourceUnavailable> {
     // runtime or artifact format.
     report.dense_operator = options.dense_operator.clone();
 
-    std::fs::create_dir_all(&options.output)?;
+    transaction.prepare_output_directory(&options.output)?;
     let artifact_path = options.output.join("cover.r4g1");
-    std::fs::write(&artifact_path, &artifact_bytes)
-        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", artifact_path.display())))?;
+    write_regular_file_synced(&artifact_path, &artifact_bytes, "cover R4G1 artifact")?;
     let report_json = serde_json::to_string_pretty(&report)?;
     let report_path = options.output.join("cover_report.json");
-    std::fs::write(&report_path, &report_json)
-        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", report_path.display())))?;
-
+    write_regular_file_synced(
+        &report_path,
+        report_json.as_bytes(),
+        "cover induction report",
+    )?;
+    sync_compile_output_directory(&options.output)?;
+    transaction.verify_after_output(&options.output)?;
     println!(
         "cover complete: {} regions ({} splits), {} edges ({} refinement + {} neighbor), depths 1..={}",
         induced.cover.regions.len(),
@@ -4184,6 +4683,10 @@ struct ScoreOptions {
     scoring_variant: score_runtime::ScoringVariant,
     quality_profile: String,
     output: PathBuf,
+    /// Explicit stable mutation authority for a managed/canonical bundle.
+    /// Without this flag, `--out` is always an arbitrary standalone root,
+    /// even when its basename is `graph`.
+    bundle_root: Option<PathBuf>,
 }
 
 fn parse_score_options(args: &[String]) -> Result<ScoreOptions, SourceUnavailable> {
@@ -4210,6 +4713,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, SourceUnavailabl
         scoring_variant: score_runtime::ScoringVariant::ChainTelescoped,
         quality_profile: "pinned".to_owned(),
         output: PathBuf::from("score"),
+        bundle_root: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -4366,6 +4870,7 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, SourceUnavailabl
                 options.quality_profile = value.clone();
             }
             "--out" => options.output = PathBuf::from(value),
+            "--bundle-root" => options.bundle_root = Some(PathBuf::from(value)),
             _ => {
                 return Err(SourceUnavailable::new(format!(
                     "unknown score option: {flag}"
@@ -4385,24 +4890,27 @@ fn parse_score_options(args: &[String]) -> Result<ScoreOptions, SourceUnavailabl
 /// side by side on the held-out partition — writing `score.r4g1` and
 /// `score_report.json`.
 pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
+    score_command_with_authority(args, GraphCommandCallerAuthority::Public)
+}
+
+/// Score a managed bundle while its server-owned common producer transaction
+/// remains live from Stage A through completion publication.
+pub fn score_command_under_producer_guard(
+    args: &[String],
+    guard: &RecordedCorpusProducerGuard,
+) -> Result<(), SourceUnavailable> {
+    score_command_with_authority(args, GraphCommandCallerAuthority::Provided(guard))
+}
+
+fn score_command_with_authority(
+    args: &[String],
+    caller_authority: GraphCommandCallerAuthority<'_>,
+) -> Result<(), SourceUnavailable> {
     #[cfg(debug_assertions)]
     eprintln!(
         "warning: debug builds make scoring much slower; use `cargo run --release -- transformerless score ...`"
     );
-    let options = parse_score_options(args)?;
-    // Resolve tokenizer/cover identity before corpus observation or output
-    // mutation. This both preserves a bound cover CID when no tokenizer flag is
-    // repeated and rejects an explicit cross-id-space swap up front.
-    let explicit_tokenizer_cid = explicit_tokenizer_cid(options.tokenizer.as_deref())?;
-    let cover_bytes = options
-        .cover
-        .as_ref()
-        .map(|path| {
-            std::fs::read(path)
-                .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))
-        })
-        .transpose()?;
-    let tokenizer_cid = scored_tokenizer_cid(cover_bytes.as_deref(), explicit_tokenizer_cid)?;
+    let mut options = parse_score_options(args)?;
     // #488: account for where a real corpus's hours go across the WHOLE score
     // pipeline, not just Gate C. Same instrument, same conventions as #471
     // (stderr only — a duration in `score_report.json` would break the
@@ -4441,9 +4949,35 @@ pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
         options.corpus_recs.clone()
     };
 
-    // #450: resolve and announce the inputs *before* the long work, so the
-    // run says which teacher container it actually read. `--artifacts`
-    // defaults to a shared mutable path that helper scripts overwrite.
+    let transaction_authority = match caller_authority {
+        GraphCommandCallerAuthority::Public => match options.bundle_root.as_deref() {
+            Some(root) => GraphTransactionAuthority::DeclaredBundle(root),
+            None => GraphTransactionAuthority::StandaloneExact,
+        },
+        GraphCommandCallerAuthority::Provided(guard) => {
+            if let Some(root) = options.bundle_root.as_deref() {
+                return Err(SourceUnavailable::new(format!(
+                    "score already has retained producer authority for {}; do not supply a second --bundle-root {} declaration",
+                    guard.root().display(),
+                    root.display()
+                )));
+            }
+            GraphTransactionAuthority::ProvidedBundle(guard)
+        }
+    };
+    let (recorded_corpus, mut transaction) = begin_graph_command_transaction(
+        transaction_authority,
+        &corpus_meta_path,
+        &corpus_recs_path,
+        &mut options.output,
+        "score",
+    )?;
+    // Same-root/server transactions are already protected here; standalone
+    // cross-root output ownership remains deferred. Capture every remaining
+    // input inside that ordering so a cooperating same-bundle writer cannot
+    // create a mixed source/graph generation. For cross-root output, these
+    // bytes are all materialized before prepare_output_directory acquires its
+    // sole output producer.
     let artifact_container = std::fs::read(&options.artifacts).map_err(|error| {
         SourceUnavailable::new(format!("{}: {error}", options.artifacts.display()))
     })?;
@@ -4455,7 +4989,16 @@ pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
     })?;
     let artifact_kappa = repro::container_kappa(&artifact_container);
     repro::announce_teacher_container(&options.artifacts, &artifact_kappa);
-    let recorded_corpus = recorded_compiler_corpus(&corpus_meta_path, &corpus_recs_path)?;
+    let explicit_tokenizer_cid = explicit_tokenizer_cid(options.tokenizer.as_deref())?;
+    let cover_bytes = options
+        .cover
+        .as_ref()
+        .map(|path| {
+            std::fs::read(path)
+                .map_err(|error| SourceUnavailable::new(format!("{}: {error}", path.display())))
+        })
+        .transpose()?;
+    let tokenizer_cid = scored_tokenizer_cid(cover_bytes.as_deref(), explicit_tokenizer_cid)?;
     let meta_bytes = recorded_corpus.meta_bytes;
     let recs_bytes = recorded_corpus.records_bytes;
     let corpus_kappa = repro::corpus_stream_kappa(&meta_bytes, &recs_bytes);
@@ -4686,14 +5229,14 @@ pub fn score_command(args: &[String]) -> Result<(), SourceUnavailable> {
             histogram.join(" ")
         );
     }
-    std::fs::create_dir_all(&options.output).map_err(SourceUnavailable::new)?;
+    transaction.prepare_output_directory(&options.output)?;
     let artifact_path = options.output.join("score.r4g1");
-    std::fs::write(&artifact_path, &artifact_bytes)
-        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", artifact_path.display())))?;
+    write_regular_file_synced(&artifact_path, &artifact_bytes, "scored R4G1 artifact")?;
     let report_json = serde_json::to_string_pretty(&report).map_err(SourceUnavailable::new)?;
     let report_path = options.output.join("score_report.json");
-    std::fs::write(&report_path, &report_json)
-        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", report_path.display())))?;
+    write_regular_file_synced(&report_path, report_json.as_bytes(), "graph score report")?;
+    sync_compile_output_directory(&options.output)?;
+    transaction.verify_after_output(&options.output)?;
     // #488: report build (from the gate-c mark) + both artifact writes. The
     // trailing stdout summary below is negligible and shows up as the total's
     // remainder — which is the check that no stage went unnamed.
@@ -6018,12 +6561,13 @@ pub fn compile_hugging_face(args: &[String]) -> Result<(), SourceUnavailable> {
 }
 
 /// Compile through a caller-retained source/common transaction. The session
-/// must protect the parsed `--output`; it is consumed so neither lock can be
-/// released before every compiler-side write has finished.
+/// must protect the parsed `--output`; the same opaque authority is returned
+/// so a managed caller can validate and seal the exact compiled generation
+/// before either lock is released.
 pub fn compile_hugging_face_with_session(
     args: &[String],
     session: SourceCorpusSession,
-) -> Result<(), SourceUnavailable> {
+) -> Result<SourceCorpusSession, SourceUnavailable> {
     compile_hugging_face_with_progress_and_session(args, Some(session), |_, _| {})
 }
 
@@ -6036,14 +6580,14 @@ pub fn compile_hugging_face_with_progress<F>(
 where
     F: FnMut(u8, &'static str),
 {
-    compile_hugging_face_with_progress_and_session(args, None, progress)
+    compile_hugging_face_with_progress_and_session(args, None, progress).map(drop)
 }
 
 fn compile_hugging_face_with_progress_and_session<F>(
     args: &[String],
     provided_session: Option<SourceCorpusSession>,
     mut progress: F,
-) -> Result<(), SourceUnavailable>
+) -> Result<SourceCorpusSession, SourceUnavailable>
 where
     F: FnMut(u8, &'static str),
 {
@@ -6058,6 +6602,15 @@ where
         .source
         .clone()
         .unwrap_or_else(|| PathBuf::from(".uor-models/sources").join(&slug));
+    let requested_output = options
+        .output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
+    let output = canonical_hf_compile_output_subject(&requested_output)?;
+    let server_owned_stage = provided_session.is_some();
+    if !server_owned_stage {
+        reject_foreign_compiled_bundle_stage_owner(&output)?;
+    }
     if let Some(repository) = options.model.as_deref() {
         download_hf_source(
             repository,
@@ -6075,21 +6628,11 @@ where
     let runtime_table = tokenizer.runtime_decode_table().ok_or_else(|| {
         SourceUnavailable::new("registered source tokenizer has no runtime decode table")
     })?;
-    let output = options
-        .output
-        .clone()
-        .unwrap_or_else(|| PathBuf::from(".uor-models/compiled").join(&slug));
     let mut corpus_session = if let Some(session) = provided_session {
-        if !session
-            .recorded_corpus_guard()?
-            .protects_directory(&output)?
-        {
-            return Err(SourceUnavailable::new(format!(
-                "provided source-corpus session for {} does not protect parsed compile output {}",
-                session.recorded_corpus_guard()?.root().display(),
-                output.display()
-            )));
-        }
+        require_exact_managed_compiled_bundle_stage_owner(
+            session.recorded_corpus_guard()?,
+            &output,
+        )?;
         session
     } else {
         source_corpus_session(&output)?
@@ -6142,6 +6685,11 @@ where
     // after the common guard creates or binds the root and before the first
     // recover/pin/generate mutation.
     corpus_session.acquire_recorded_corpus(&output)?;
+    if !server_owned_stage {
+        // Repeat under the common producer authority so a cooperating server
+        // cannot install an owner marker in the check-to-lock interval.
+        reject_foreign_compiled_bundle_stage_owner(&output)?;
+    }
     preflight_compile_tokenizer_adapter(&output, &tokenizer_adapter)?;
     preflight_compiled_attention_operator(&output, &attention_operator)?;
     preflight_compiled_dense_operator(&output, dense_operator.as_ref())?;
@@ -6187,7 +6735,7 @@ where
             "corpus is not complete; rerun the same command to resume {}",
             output.display()
         );
-        return Ok(());
+        return Ok(corpus_session);
     }
     let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
         corpus_session.recorded_corpus_guard()?,
@@ -6303,7 +6851,7 @@ where
     println!(
         "bundle ready for local `ask`; use `cargo run -- import --help` to attach a quality attestation and persist a named manifest (name: {slug})"
     );
-    Ok(())
+    Ok(corpus_session)
 }
 
 /// Registry-exact host execution identity attached to a recorded corpus.
@@ -6340,6 +6888,567 @@ struct RecordedCompilerCorpus {
     records_cid: String,
     corpus: compiler::Corpus,
     binding_cid: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum GraphCommandCallerAuthority<'a> {
+    /// Public CLI/API entry point. Parsed `--bundle-root` selects the declared
+    /// bundle mode; its absence selects exact standalone mode.
+    Public,
+    /// Managed server stage whose producer interval began after Stage A and
+    /// remains live through completion publication.
+    Provided(&'a RecordedCorpusProducerGuard),
+}
+
+#[derive(Clone, Copy)]
+enum GraphTransactionAuthority<'a> {
+    /// Exact canonical `--out`; physical owner evidence present at transaction
+    /// start is terminal, but no later ancestor state changes this mode.
+    StandaloneExact,
+    /// Public caller explicitly joins one canonical bundle-root transaction.
+    DeclaredBundle(&'a Path),
+    /// Managed caller already holds that bundle-root producer transaction.
+    ProvidedBundle(&'a RecordedCorpusProducerGuard),
+}
+
+enum GraphTransactionProducer<'a> {
+    Provided(&'a RecordedCorpusProducerGuard),
+    Owned(RecordedCorpusProducerGuard),
+    /// Cross-root lane. The source reader pin has already been released;
+    /// acquire the stable exact-output or declared-bundle root only
+    /// immediately before mutation.
+    Pending(Option<PathBuf>),
+}
+
+struct GraphCommandTransaction<'a> {
+    producer: GraphTransactionProducer<'a>,
+    root: PathBuf,
+    direct_entrypoint: bool,
+    label: &'static str,
+}
+
+impl GraphCommandTransaction<'_> {
+    fn guard(&self) -> Result<&RecordedCorpusProducerGuard, SourceUnavailable> {
+        match &self.producer {
+            GraphTransactionProducer::Provided(guard) => Ok(guard),
+            GraphTransactionProducer::Owned(guard) => Ok(guard),
+            GraphTransactionProducer::Pending(_) => Err(SourceUnavailable::new(format!(
+                "{} output producer authority has not been acquired",
+                self.label
+            ))),
+        }
+    }
+
+    fn acquire_pending_output(&mut self) -> Result<(), SourceUnavailable> {
+        let pending = match &mut self.producer {
+            GraphTransactionProducer::Pending(root) => root.take(),
+            GraphTransactionProducer::Provided(_) | GraphTransactionProducer::Owned(_) => None,
+        };
+        if let Some(root) = pending {
+            let guard = RecordedCorpusProducerGuard::try_acquire(&root)?;
+            if self.direct_entrypoint && guard.root_exists() {
+                reject_foreign_compiled_bundle_stage_owner_for_graph(&guard)?;
+            }
+            reject_completed_graph_transaction(&guard, self.label)?;
+            self.producer = GraphTransactionProducer::Owned(guard);
+        }
+        Ok(())
+    }
+
+    fn prepare_output_directory(&mut self, output: &Path) -> Result<(), SourceUnavailable> {
+        self.prepare_output_directory_with_after_guard(output, |_| Ok(()))
+    }
+
+    fn prepare_output_directory_with_after_guard<F>(
+        &mut self,
+        output: &Path,
+        after_guard: F,
+    ) -> Result<(), SourceUnavailable>
+    where
+        F: FnOnce(&RecordedCorpusProducerGuard) -> Result<(), SourceUnavailable>,
+    {
+        self.acquire_pending_output()?;
+        reject_completed_graph_transaction(self.guard()?, self.label)?;
+        after_guard(self.guard()?)?;
+
+        match &mut self.producer {
+            GraphTransactionProducer::Owned(guard) if !guard.root_exists() => {
+                guard.ensure_root()?;
+            }
+            GraphTransactionProducer::Provided(guard) if !guard.root_exists() => {
+                return Err(SourceUnavailable::new(format!(
+                    "provided {} producer root {} is absent",
+                    self.label,
+                    guard.root().display()
+                )));
+            }
+            GraphTransactionProducer::Pending(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "{} output producer authority remained pending",
+                    self.label
+                )));
+            }
+            GraphTransactionProducer::Provided(_) | GraphTransactionProducer::Owned(_) => {}
+        }
+        let guard = self.guard()?;
+        if !guard.protects_directory(&self.root)? {
+            return Err(SourceUnavailable::new(format!(
+                "{} producer guard for {} does not protect canonical transaction root {}",
+                self.label,
+                guard.root().display(),
+                self.root.display()
+            )));
+        }
+        if output != self.root {
+            if output.parent() != Some(self.root.as_path()) {
+                return Err(SourceUnavailable::new(format!(
+                    "{} output {} is not the transaction root or one direct owned child of {}",
+                    self.label,
+                    output.display(),
+                    self.root.display()
+                )));
+            }
+            match std::fs::symlink_metadata(output) {
+                Ok(metadata) if metadata.file_type().is_dir() => {}
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "{} output {} is not a regular non-symlink directory",
+                        self.label,
+                        output.display()
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    std::fs::create_dir(output).map_err(|error| {
+                        SourceUnavailable::new(format!(
+                            "{} output {} cannot be created under retained producer authority: {error}",
+                            self.label,
+                            output.display()
+                        ))
+                    })?;
+                }
+                Err(error) => return Err(SourceUnavailable::new(error)),
+            }
+        }
+        let canonical_output = std::fs::canonicalize(output).map_err(SourceUnavailable::new)?;
+        if canonical_output != output {
+            return Err(SourceUnavailable::new(format!(
+                "{} output {} changed canonical identity before mutation",
+                self.label,
+                output.display()
+            )));
+        }
+        reject_completed_graph_transaction(guard, self.label)
+    }
+
+    fn verify_after_output(&self, output: &Path) -> Result<(), SourceUnavailable> {
+        let guard = self.guard()?;
+        if !guard.protects_directory(&self.root)? {
+            return Err(SourceUnavailable::new(format!(
+                "{} producer guard stopped protecting transaction root {}",
+                self.label,
+                self.root.display()
+            )));
+        }
+        let metadata = std::fs::symlink_metadata(output).map_err(SourceUnavailable::new)?;
+        if !metadata.file_type().is_dir()
+            || std::fs::canonicalize(output).map_err(SourceUnavailable::new)? != output
+        {
+            return Err(SourceUnavailable::new(format!(
+                "{} output {} changed directory identity during publication",
+                self.label,
+                output.display()
+            )));
+        }
+        reject_completed_graph_transaction(guard, self.label)?;
+        guard.verify_owned_root()
+    }
+}
+
+fn canonical_existing_corpus_root(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<PathBuf, SourceUnavailable> {
+    let parent = |path: &Path, label: &str| -> Result<PathBuf, SourceUnavailable> {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::canonicalize(parent).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{label} parent {} cannot be canonicalized: {error}",
+                parent.display()
+            ))
+        })
+    };
+    let meta_root = parent(corpus_meta, "recorded corpus metadata")?;
+    let records_root = parent(corpus_records, "recorded corpus records")?;
+    if meta_root != records_root {
+        return Err(SourceUnavailable::new(format!(
+            "corpus.meta and corpus.records have different canonical parent roots ({} versus {}); no graph transaction can bind them",
+            meta_root.display(),
+            records_root.display()
+        )));
+    }
+    Ok(meta_root)
+}
+
+fn canonical_output_subject(output: &Path, label: &str) -> Result<PathBuf, SourceUnavailable> {
+    match std::fs::symlink_metadata(output) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            std::fs::canonicalize(output).map_err(SourceUnavailable::new)
+        }
+        Ok(_) => Err(SourceUnavailable::new(format!(
+            "{label} output {} is not a regular non-symlink directory",
+            output.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let leaf = output.file_name().ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "{label} output {} has no final directory name",
+                    output.display()
+                ))
+            })?;
+            if leaf == std::ffi::OsStr::new(".") || leaf == std::ffi::OsStr::new("..") {
+                return Err(SourceUnavailable::new(format!(
+                    "{label} output {} has a reserved final directory name",
+                    output.display()
+                )));
+            }
+            let parent = output
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            let parent = std::fs::canonicalize(parent).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "{label} output parent {} cannot be canonicalized before publication: {error}",
+                    parent.display()
+                ))
+            })?;
+            Ok(parent.join(leaf))
+        }
+        Err(error) => Err(SourceUnavailable::new(error)),
+    }
+}
+
+/// Read-only start-time classification for exact standalone output. This does
+/// not select or widen transaction authority: it only refuses an output that
+/// was already physically nested in a completed/owned bundle when the command
+/// began. Later ancestor changes do not alter standalone exact-root mode.
+fn existing_graph_owner_ancestor(output: &Path) -> Result<Option<PathBuf>, SourceUnavailable> {
+    let mut candidate = if output.exists() {
+        Some(output)
+    } else {
+        output.parent()
+    };
+    while let Some(root) = candidate {
+        let metadata = match std::fs::symlink_metadata(root) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                candidate = root.parent();
+                continue;
+            }
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        };
+        if metadata.file_type().is_dir() {
+            for leaf in [
+                "compiled_bundle_completion.json",
+                ".compiled_bundle_stage.json",
+                ".compiled_bundle_stage_a.json",
+            ] {
+                match std::fs::symlink_metadata(root.join(leaf)) {
+                    Ok(_) => {
+                        return std::fs::canonicalize(root)
+                            .map(Some)
+                            .map_err(SourceUnavailable::new);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(SourceUnavailable::new(error)),
+                }
+            }
+            let completion_prefix = ".compiled_bundle_completion.json.";
+            for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+                let entry = entry.map_err(SourceUnavailable::new)?;
+                let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                    continue;
+                };
+                if name.starts_with(completion_prefix) && name.ends_with(".tmp") {
+                    return std::fs::canonicalize(root)
+                        .map(Some)
+                        .map_err(SourceUnavailable::new);
+                }
+            }
+        }
+        candidate = root.parent();
+    }
+    Ok(None)
+}
+
+fn reject_existing_graph_owner_ancestor(
+    output: &Path,
+    label: &str,
+) -> Result<(), SourceUnavailable> {
+    let Some(root) = existing_graph_owner_ancestor(output)? else {
+        return Ok(());
+    };
+    let completion = root.join("compiled_bundle_completion.json");
+    match std::fs::symlink_metadata(&completion) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            return Err(SourceUnavailable::new(format!(
+                "{label} standalone output ancestor {} was already an immutable completed bundle at transaction start; pass --bundle-root to participate explicitly",
+                root.display()
+            )));
+        }
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{label} standalone output ancestor {} had a malformed nonregular completion record at transaction start; refusing graph mutation",
+                root.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+    let completion_prefix = ".compiled_bundle_completion.json.";
+    for entry in std::fs::read_dir(&root).map_err(SourceUnavailable::new)? {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if name.starts_with(completion_prefix) && name.ends_with(".tmp") {
+            return Err(SourceUnavailable::new(format!(
+                "{label} standalone output ancestor {} had unfinished completion publication evidence {name} at transaction start; refusing graph mutation",
+                root.display()
+            )));
+        }
+    }
+    Err(SourceUnavailable::new(format!(
+        "{label} standalone output ancestor {} was already an owned server compiled-bundle stage at transaction start; pass --bundle-root only for a public completed bundle",
+        root.display()
+    )))
+}
+
+fn declared_graph_transaction_root(
+    output: &Path,
+    declared: &Path,
+    label: &str,
+) -> Result<PathBuf, SourceUnavailable> {
+    let metadata = std::fs::symlink_metadata(declared).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "declared {label} --bundle-root {} cannot be inspected: {error}",
+            declared.display()
+        ))
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(SourceUnavailable::new(format!(
+            "declared {label} --bundle-root {} is not a regular non-symlink directory",
+            declared.display()
+        )));
+    }
+    let root = std::fs::canonicalize(declared).map_err(SourceUnavailable::new)?;
+    if output.parent() != Some(root.as_path()) {
+        return Err(SourceUnavailable::new(format!(
+            "{label} output {} is not one direct child of declared bundle root {}",
+            output.display(),
+            root.display()
+        )));
+    }
+    Ok(root)
+}
+
+fn reject_foreign_compiled_bundle_stage_owner_for_graph(
+    guard: &RecordedCorpusProducerGuard,
+) -> Result<(), SourceUnavailable> {
+    guard.verify_owned_root()?;
+    for leaf in [
+        ".compiled_bundle_stage.json",
+        ".compiled_bundle_stage_a.json",
+    ] {
+        match std::fs::symlink_metadata(guard.root().join(leaf)) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(SourceUnavailable::new(error)),
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "graph output ancestor {} is an owned server compiled-bundle stage; direct graph commands require the explicit server-retained producer seam",
+                    guard.root().display()
+                )));
+            }
+        }
+    }
+    guard.verify_owned_root()
+}
+
+fn reject_completed_graph_transaction(
+    guard: &RecordedCorpusProducerGuard,
+    label: &str,
+) -> Result<(), SourceUnavailable> {
+    if !guard.root_exists() {
+        return Ok(());
+    }
+    guard.verify_owned_root()?;
+    let completion = guard.root().join("compiled_bundle_completion.json");
+    match std::fs::symlink_metadata(&completion) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(SourceUnavailable::new(error)),
+        Ok(metadata) if metadata.file_type().is_file() => {
+            return Err(SourceUnavailable::new(format!(
+                "{label} output ancestor {} is an immutable completed bundle; refusing graph mutation",
+                guard.root().display()
+            )));
+        }
+        Ok(_) => {
+            return Err(SourceUnavailable::new(format!(
+                "{label} output ancestor {} has a malformed nonregular completion record; refusing graph mutation",
+                guard.root().display()
+            )));
+        }
+    }
+    let prefix = ".compiled_bundle_completion.json.";
+    for entry in std::fs::read_dir(guard.root()).map_err(SourceUnavailable::new)? {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if name.starts_with(prefix) && name.ends_with(".tmp") {
+            return Err(SourceUnavailable::new(format!(
+                "{label} output ancestor {} has unfinished completion publication residue {name}; refusing graph mutation",
+                guard.root().display()
+            )));
+        }
+    }
+    guard.verify_owned_root()
+}
+
+fn begin_graph_command_transaction<'a>(
+    authority: GraphTransactionAuthority<'a>,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    output: &mut PathBuf,
+    label: &'static str,
+) -> Result<(RecordedCompilerCorpus, GraphCommandTransaction<'a>), SourceUnavailable> {
+    let source_root = canonical_existing_corpus_root(corpus_meta, corpus_records)?;
+    let canonical_output = canonical_output_subject(output, label)?;
+    let transaction_root = match authority {
+        GraphTransactionAuthority::StandaloneExact => {
+            reject_existing_graph_owner_ancestor(&canonical_output, label)?;
+            canonical_output.clone()
+        }
+        GraphTransactionAuthority::DeclaredBundle(root) => {
+            declared_graph_transaction_root(&canonical_output, root, label)?
+        }
+        GraphTransactionAuthority::ProvidedBundle(guard) => guard.root().to_path_buf(),
+    };
+    if canonical_output != transaction_root
+        && canonical_output.parent() != Some(transaction_root.as_path())
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{label} output {} is neither the selected transaction root nor one direct physical child of {}",
+            canonical_output.display(),
+            transaction_root.display()
+        )));
+    }
+    *output = canonical_output;
+
+    match authority {
+        GraphTransactionAuthority::ProvidedBundle(guard) => {
+            if transaction_root != source_root || !guard.protects_directory(&source_root)? {
+                return Err(SourceUnavailable::new(format!(
+                    "provided {label} producer guard for {} does not own canonical corpus/output transaction root {}",
+                    guard.root().display(),
+                    source_root.display()
+                )));
+            }
+            reject_completed_graph_transaction(guard, label)?;
+            let stream = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+                guard,
+                corpus_meta,
+                corpus_records,
+            )?;
+            let recorded =
+                materialize_recorded_compiler_corpus(stream, corpus_meta, corpus_records)?;
+            guard.verify_owned_root()?;
+            Ok((
+                recorded,
+                GraphCommandTransaction {
+                    producer: GraphTransactionProducer::Provided(guard),
+                    root: transaction_root,
+                    direct_entrypoint: false,
+                    label,
+                },
+            ))
+        }
+        GraphTransactionAuthority::StandaloneExact
+        | GraphTransactionAuthority::DeclaredBundle(_)
+            if transaction_root == source_root =>
+        {
+            let guard = RecordedCorpusProducerGuard::try_acquire(&source_root)?;
+            reject_foreign_compiled_bundle_stage_owner_for_graph(&guard)?;
+            reject_completed_graph_transaction(&guard, label)?;
+            let stream = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+                &guard,
+                corpus_meta,
+                corpus_records,
+            )?;
+            let recorded =
+                materialize_recorded_compiler_corpus(stream, corpus_meta, corpus_records)?;
+            guard.verify_owned_root()?;
+            Ok((
+                recorded,
+                GraphCommandTransaction {
+                    producer: GraphTransactionProducer::Owned(guard),
+                    root: transaction_root,
+                    direct_entrypoint: true,
+                    label,
+                },
+            ))
+        }
+        GraphTransactionAuthority::StandaloneExact
+        | GraphTransactionAuthority::DeclaredBundle(_) => {
+            // Capture the complete source generation under one shared pin,
+            // perform its final verification, then release it before any
+            // output producer is acquired. This avoids unordered two-root
+            // locks for arbitrary standalone layouts.
+            let pins = RecordedCorpusReaderPins::try_acquire([&source_root])?;
+            let stream = uor_r4_graph_compiler::recorded_corpus::open_stream_under_reader_pins(
+                &pins,
+                corpus_meta,
+                corpus_records,
+            )?;
+            let recorded = if stream.binding_cid.is_some() {
+                let recorded =
+                    materialize_recorded_compiler_corpus(stream, corpus_meta, corpus_records)?;
+                pins.verify()?;
+                drop(pins);
+                recorded
+            } else {
+                // A shared pin excludes cooperating writers but is not the
+                // lower protocol's markerless cross-file ABA authority. Reopen
+                // that compatibility generation through its documented
+                // producer lane, retaining it through final materialization.
+                drop(stream);
+                drop(pins);
+                let (stream, source_guard) =
+                    uor_r4_graph_compiler::recorded_corpus::open_stream_for_derivation(
+                        corpus_meta,
+                        corpus_records,
+                    )?;
+                let recorded =
+                    materialize_recorded_compiler_corpus(stream, corpus_meta, corpus_records)?;
+                if let Some(guard) = source_guard.as_ref() {
+                    guard.verify_owned_root()?;
+                }
+                drop(source_guard);
+                recorded
+            };
+            Ok((
+                recorded,
+                GraphCommandTransaction {
+                    producer: GraphTransactionProducer::Pending(Some(transaction_root.clone())),
+                    root: transaction_root,
+                    direct_entrypoint: true,
+                    label,
+                },
+            ))
+        }
+    }
 }
 
 fn materialize_recorded_compiler_corpus(
@@ -6686,6 +7795,25 @@ pub fn recorded_corpus_execution_identity(
 ) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
     let captured =
         uor_r4_graph_compiler::recorded_corpus::execution_identity(corpus_meta, corpus_records)?;
+    Ok(RecordedCorpusExecutionIdentity {
+        attention_operator: captured.attention_operator,
+        dense_operator: captured.dense_operator,
+    })
+}
+
+/// Resolve the recorded execution identity while a managed caller already
+/// retains the exact common producer root. This is the non-self-contending
+/// companion used between Stage A and graph completion.
+pub fn recorded_corpus_execution_identity_under_producer_guard(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let captured = uor_r4_graph_compiler::recorded_corpus::execution_identity_under_producer_guard(
+        guard,
+        corpus_meta,
+        corpus_records,
+    )?;
     Ok(RecordedCorpusExecutionIdentity {
         attention_operator: captured.attention_operator,
         dense_operator: captured.dense_operator,
@@ -8061,6 +9189,9 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
                  recorded execution copy (including dense sibling): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
                  guarded recorded-corpus derivation: subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
+                 graph cover: cover --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
+                 graph score: score --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
+                   --bundle-root explicitly declares one managed/canonical bundle authority; without it, --out is an exact standalone root fixed at transaction start\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N]\n\
                  A-mode infill serving: graph infill --artifact <scored R4G1> --skeleton <token ids, _ for free> [--teacher <TLA container>]\n\
@@ -8150,6 +9281,29 @@ mod tests {
         std::env::temp_dir().join(format!("uor-r4-cli-{name}-{nonce}"))
     }
 
+    #[cfg(unix)]
+    fn hard_link_test_sidecar(
+        output: &Path,
+        stable_name: &str,
+        bytes: &[u8],
+        alias_tag: &str,
+    ) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(output).expect("sidecar output");
+        let stable = output.join(stable_name);
+        let alias = output.join(format!(".{stable_name}.{alias_tag}.tmp"));
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&alias)
+            .expect("create sidecar alias");
+        file.write_all(bytes).expect("write sidecar alias");
+        file.sync_all().expect("sync sidecar alias");
+        drop(file);
+        std::fs::hard_link(&alias, &stable).expect("publish sidecar hard link");
+        sync_compile_output_directory(output).expect("sync sidecar directory");
+        (stable, alias)
+    }
+
     #[test]
     fn source_corpus_session_releases_common_guard_before_outer_lock() {
         let base = unique_cli_test_path("source-session-drop-order");
@@ -8162,8 +9316,7 @@ mod tests {
 
         session.release_in_order(|| {
             let error = source_corpus_session(&root)
-                .err()
-                .expect("outer lock remains BUSY until common guard is released");
+                .expect_err("outer lock remains BUSY until common guard is released");
             assert!(error.to_string().contains("BUSY"), "{error}");
         });
 
@@ -8518,6 +9671,15 @@ mod tests {
         (meta, records)
     }
 
+    fn complete_test_observation_corpus(path: &Path) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(path).expect("observation directory");
+        let state = path.join(observe::STATE_FILE);
+        let merged = path.join("merged.bin");
+        std::fs::write(&merged, source_v3_record(0, 0)).expect("complete observation records");
+        std::fs::write(&state, source_resume_meta(1, 1)).expect("complete observation state");
+        (state, merged)
+    }
+
     fn publish_test_corpus_binding(path: &Path, meta: &Path, records: &Path) -> String {
         let mut guard =
             uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(path)
@@ -8528,6 +9690,615 @@ mod tests {
             .expect("test corpus binding");
         guard.finish_compile_attempt().expect("finish test attempt");
         cid
+    }
+
+    fn publish_test_observation_binding(path: &Path, state: &Path, merged: &Path) -> String {
+        let mut guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(path)
+                .expect("test observation producer guard");
+        guard.ensure_root().expect("test observation root");
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(&guard, state, merged)
+            .expect("test observation binding")
+    }
+
+    fn directory_entry_names(path: &Path) -> Vec<String> {
+        let mut names = std::fs::read_dir(path)
+            .expect("directory inventory")
+            .map(|entry| {
+                entry
+                    .expect("directory entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn direct_cover_and_score_refuse_completed_bundle_ancestor_without_member_mutation() {
+        let root = unique_cli_test_path("graph-completed-ancestor");
+        std::fs::create_dir_all(&root).expect("completed root");
+        std::fs::write(root.join("corpus.meta"), b"unread completion sentinel")
+            .expect("metadata sentinel");
+        std::fs::write(root.join("corpus.records"), b"unread completion sentinel")
+            .expect("records sentinel");
+        std::fs::write(root.join("compiled_bundle_completion.json"), b"{}\n")
+            .expect("completion sentinel");
+        let before = directory_entry_names(&root);
+        for (command, output_leaf) in [("cover", "graph-cover"), ("score", "graph")] {
+            let args = vec![
+                "--corpus-meta".to_owned(),
+                root.join("corpus.meta").display().to_string(),
+                "--corpus-recs".to_owned(),
+                root.join("corpus.records").display().to_string(),
+                "--bundle-root".to_owned(),
+                root.display().to_string(),
+                "--out".to_owned(),
+                root.join(output_leaf).display().to_string(),
+            ];
+            let error = match command {
+                "cover" => cover_command(&args),
+                "score" => score_command(&args),
+                _ => unreachable!(),
+            }
+            .expect_err("completed bundle is immutable");
+            assert!(
+                error.reason.contains("immutable completed bundle"),
+                "{command}: {error}"
+            );
+            assert_eq!(directory_entry_names(&root), before, "{command}");
+            assert!(!root.join(".uor-r4-recorded-corpus-locks").exists());
+            assert!(!root.join(output_leaf).exists());
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn declared_bundle_graph_holds_parent_guard_before_child_mutation() {
+        let root = unique_cli_test_path("graph-parent-completion-race");
+        let source = root.join("source");
+        let bundle = root.join("bundle");
+        std::fs::create_dir_all(&bundle).expect("markerless bundle parent");
+        let (meta, records, _, _) = finalized_corpus(&source, 7);
+        publish_test_corpus_binding(&source, &meta, &records);
+        let output = bundle.join("graph");
+        let mut canonical_output = output.clone();
+        let (_, mut transaction) = begin_graph_command_transaction(
+            GraphTransactionAuthority::DeclaredBundle(&bundle),
+            &meta,
+            &records,
+            &mut canonical_output,
+            "score",
+        )
+        .expect("source generation is captured before deferred output ownership");
+        assert!(!output.exists());
+
+        transaction
+            .prepare_output_directory_with_after_guard(&canonical_output, |authority| {
+                assert_eq!(
+                    authority.root(),
+                    std::fs::canonicalize(&bundle).expect("canonical declared bundle")
+                );
+                assert!(!output.exists(), "child mutation follows parent authority");
+                let busy = RecordedCorpusProducerGuard::try_acquire(&bundle)
+                    .expect_err("cooperating parent publisher is BUSY at the barrier");
+                assert!(busy.reason.contains("BUSY"), "{busy}");
+                Ok(())
+            })
+            .expect("declared bundle child publication");
+        assert_eq!(
+            directory_entry_names(&bundle),
+            vec!["graph"],
+            "the child appears only inside the retained parent transaction"
+        );
+        assert!(output.is_dir());
+        assert!(!bundle
+            .join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn standalone_graph_refuses_owner_evidence_present_at_transaction_start_without_mutation() {
+        let root = unique_cli_test_path("graph-standalone-existing-owner");
+        let source = root.join("source");
+        let (meta, records, _, _) = finalized_corpus(&source, 7);
+        publish_test_corpus_binding(&source, &meta, &records);
+        for leaf in [
+            "compiled_bundle_completion.json",
+            ".compiled_bundle_stage.json",
+            ".compiled_bundle_stage_a.json",
+            ".compiled_bundle_completion.json.17.19.tmp",
+            ".compiled_bundle_completion.json.reserved.tmp",
+        ] {
+            let bundle = root.join(leaf.replace('.', "-"));
+            std::fs::create_dir_all(&bundle).expect("owned ancestor");
+            std::fs::write(bundle.join(leaf), b"stable owner evidence\n").expect("owner evidence");
+            let before = directory_entry_names(&bundle);
+            let mut output = bundle.join("graph");
+            let error = match begin_graph_command_transaction(
+                GraphTransactionAuthority::StandaloneExact,
+                &meta,
+                &records,
+                &mut output,
+                "score",
+            ) {
+                Ok(_) => panic!("pre-existing owner ancestor must refuse standalone start"),
+                Err(error) => error,
+            };
+            assert!(
+                error.reason.contains("transaction start"),
+                "{leaf}: {error}"
+            );
+            assert_eq!(directory_entry_names(&bundle), before, "{leaf}");
+            assert!(!bundle.join("graph").exists(), "{leaf}");
+            assert!(!bundle
+                .join(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+                )
+                .exists());
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn standalone_graph_never_adopts_parent_completion_published_after_start() {
+        let root = unique_cli_test_path("graph-standalone-late-parent-owner");
+        let source = root.join("source");
+        let bundle = root.join("bundle");
+        std::fs::create_dir_all(&bundle).expect("standalone output parent");
+        let (meta, records, _, _) = finalized_corpus(&source, 7);
+        publish_test_corpus_binding(&source, &meta, &records);
+        let output = bundle.join("graph");
+        let mut canonical_output = output.clone();
+        let (_, mut transaction) = begin_graph_command_transaction(
+            GraphTransactionAuthority::StandaloneExact,
+            &meta,
+            &records,
+            &mut canonical_output,
+            "score",
+        )
+        .expect("standalone mode is fixed at transaction start");
+
+        let parent_writer = RecordedCorpusProducerGuard::try_acquire(&bundle)
+            .expect("independent parent publisher after standalone start");
+        let completion = bundle.join("compiled_bundle_completion.json");
+        std::fs::write(&completion, b"late parent completion\n").expect("late parent completion");
+        parent_writer
+            .verify_owned_root()
+            .expect("parent publisher authority");
+        drop(parent_writer);
+        let completion_before = std::fs::read(&completion).expect("completion before output");
+
+        transaction
+            .prepare_output_directory(&canonical_output)
+            .expect("late parent state never changes standalone exact-root mode");
+        assert_eq!(
+            transaction.guard().expect("standalone guard").root(),
+            std::fs::canonicalize(&output).expect("canonical standalone output")
+        );
+        assert_eq!(
+            std::fs::read(&completion).expect("completion after output"),
+            completion_before,
+            "the independent standalone transaction never edits parent evidence"
+        );
+        drop(transaction);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn declared_bundle_root_requires_physical_direct_child_without_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_cli_test_path("graph-declared-physical-containment");
+        let source = root.join("source");
+        let bundle = root.join("bundle");
+        let unrelated = root.join("unrelated");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&bundle).expect("declared bundle");
+        std::fs::create_dir_all(&unrelated).expect("unrelated root");
+        std::fs::create_dir_all(&outside).expect("outside root");
+        let (meta, records, _, _) = finalized_corpus(&source, 7);
+        publish_test_corpus_binding(&source, &meta, &records);
+
+        let before = [
+            directory_entry_names(&bundle),
+            directory_entry_names(&unrelated),
+            directory_entry_names(&outside),
+        ];
+        let mut unrelated_output = bundle.join("graph-unrelated");
+        let error = match begin_graph_command_transaction(
+            GraphTransactionAuthority::DeclaredBundle(&unrelated),
+            &meta,
+            &records,
+            &mut unrelated_output,
+            "score",
+        ) {
+            Ok(_) => panic!("unrelated declared root must refuse"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not one direct child"), "{error}");
+
+        symlink(&outside, bundle.join("escape")).expect("parent escape alias");
+        let mut escaped_output = bundle.join("escape/graph");
+        let error = match begin_graph_command_transaction(
+            GraphTransactionAuthority::DeclaredBundle(&bundle),
+            &meta,
+            &records,
+            &mut escaped_output,
+            "score",
+        ) {
+            Ok(_) => panic!("physical parent escape must refuse"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not one direct child"), "{error}");
+        assert!(!outside.join("graph").exists());
+
+        let target = outside.join("target");
+        std::fs::create_dir(&target).expect("final symlink target");
+        let final_alias = bundle.join("graph");
+        symlink(&target, &final_alias).expect("final output alias");
+        let mut final_output = final_alias.clone();
+        let error = match begin_graph_command_transaction(
+            GraphTransactionAuthority::DeclaredBundle(&bundle),
+            &meta,
+            &records,
+            &mut final_output,
+            "score",
+        ) {
+            Ok(_) => panic!("final output symlink must refuse"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("non-symlink directory"), "{error}");
+        assert!(
+            final_alias
+                .symlink_metadata()
+                .expect("final alias")
+                .file_type()
+                .is_symlink()
+        );
+
+        assert_eq!(directory_entry_names(&unrelated), before[1]);
+        assert!(
+            directory_entry_names(&bundle).contains(&"escape".to_owned()),
+            "only the test's preexisting aliases are present"
+        );
+        assert!(!bundle
+            .join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn graph_same_root_public_contender_is_busy_and_managed_seam_reuses_guard() {
+        let root = unique_cli_test_path("graph-managed-producer");
+        let (meta, records, _, _) = finalized_corpus(&root, 7);
+        publish_test_corpus_binding(&root, &meta, &records);
+        let guard = RecordedCorpusProducerGuard::try_acquire(&root).expect("managed producer");
+        let output = root.join("graph-cover");
+        let mut output_for_transaction = output.clone();
+        let (recorded, mut transaction) = begin_graph_command_transaction(
+            GraphTransactionAuthority::ProvidedBundle(&guard),
+            &meta,
+            &records,
+            &mut output_for_transaction,
+            "cover",
+        )
+        .expect("provided managed producer avoids self-contention");
+        assert_eq!(recorded.corpus.n, 1);
+        transaction
+            .prepare_output_directory(&output_for_transaction)
+            .expect("managed output directory");
+        let busy = RecordedCorpusProducerGuard::try_acquire(&root)
+            .expect_err("external graph contender is BUSY");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        transaction
+            .verify_after_output(&output_for_transaction)
+            .expect("managed authority remains valid");
+        let duplicate_authority_args = vec![
+            "--corpus-meta".to_owned(),
+            meta.display().to_string(),
+            "--corpus-recs".to_owned(),
+            records.display().to_string(),
+            "--bundle-root".to_owned(),
+            root.display().to_string(),
+            "--out".to_owned(),
+            output.display().to_string(),
+        ];
+        let before_duplicate = directory_entry_names(&root);
+        let error = cover_command_under_producer_guard(&duplicate_authority_args, &guard)
+            .expect_err("provided authority rejects a second root declaration");
+        assert!(error.reason.contains("second --bundle-root"), "{error}");
+        assert_eq!(directory_entry_names(&root), before_duplicate);
+        drop(transaction);
+        drop(guard);
+
+        let blocker = RecordedCorpusProducerGuard::try_acquire(&root).expect("public blocker");
+        let before = directory_entry_names(&root);
+        let args = vec![
+            "--corpus-meta".to_owned(),
+            meta.display().to_string(),
+            "--corpus-recs".to_owned(),
+            records.display().to_string(),
+            "--bundle-root".to_owned(),
+            root.display().to_string(),
+            "--out".to_owned(),
+            output.display().to_string(),
+        ];
+        let error = cover_command(&args).expect_err("public same-root contender is BUSY");
+        assert!(error.reason.contains("BUSY"), "{error}");
+        assert_eq!(directory_entry_names(&root), before);
+        drop(blocker);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn standalone_graph_outputs_guard_only_their_exact_roots_and_do_not_contend() {
+        let root = unique_cli_test_path("graph-standalone-output-roots");
+        let source = root.join("source");
+        let (meta, records, _, _) = finalized_corpus(&source, 7);
+        publish_test_corpus_binding(&source, &meta, &records);
+        let output_a = root.join("graph");
+        let output_b = root.join("graph-cover");
+
+        let mut canonical_a = output_a.clone();
+        let (_, mut transaction_a) = begin_graph_command_transaction(
+            GraphTransactionAuthority::StandaloneExact,
+            &meta,
+            &records,
+            &mut canonical_a,
+            "cover",
+        )
+        .expect("capture source before standalone output A");
+        let mut canonical_b = output_b.clone();
+        let (_, mut transaction_b) = begin_graph_command_transaction(
+            GraphTransactionAuthority::StandaloneExact,
+            &meta,
+            &records,
+            &mut canonical_b,
+            "score",
+        )
+        .expect("capture source before standalone output B");
+        assert!(!output_a.exists());
+        assert!(!output_b.exists());
+
+        transaction_a
+            .prepare_output_directory(&canonical_a)
+            .expect("acquire exact standalone output A");
+        transaction_b
+            .prepare_output_directory(&canonical_b)
+            .expect("unrelated standalone output B does not contend");
+        assert!(
+            transaction_a
+                .guard()
+                .expect("output A guard")
+                .protects_directory(&output_a)
+                .expect("output A identity")
+        );
+        assert_eq!(
+            transaction_a.guard().expect("output A guard").root(),
+            std::fs::canonicalize(&output_a).expect("canonical output A"),
+            "the conventional basename never widens arbitrary --out authority to its parent"
+        );
+        assert!(
+            transaction_b
+                .guard()
+                .expect("output B guard")
+                .protects_directory(&output_b)
+                .expect("output B identity")
+        );
+        assert_eq!(
+            transaction_b.guard().expect("output B guard").root(),
+            std::fs::canonicalize(&output_b).expect("canonical output B"),
+            "graph-cover is also an exact standalone output without provided bundle authority"
+        );
+        assert!(!output_a
+            .join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .exists());
+        assert!(!output_b
+            .join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .exists());
+        assert!(
+            root.join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .is_dir()
+        );
+
+        let busy = RecordedCorpusProducerGuard::try_acquire(&output_a)
+            .expect_err("only output A itself contends with output A");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        transaction_a
+            .verify_after_output(&canonical_a)
+            .expect("output A authority remains exact");
+        transaction_b
+            .verify_after_output(&canonical_b)
+            .expect("output B authority remains exact");
+        drop(transaction_b);
+        drop(transaction_a);
+
+        let source_bundle = root.join("unflagged-source-bundle");
+        let (same_meta, same_records, _, _) = finalized_corpus(&source_bundle, 11);
+        publish_test_corpus_binding(&source_bundle, &same_meta, &same_records);
+        let same_root_child = source_bundle.join("graph");
+        let mut canonical_child = same_root_child.clone();
+        let (_, mut child_transaction) = begin_graph_command_transaction(
+            GraphTransactionAuthority::StandaloneExact,
+            &same_meta,
+            &same_records,
+            &mut canonical_child,
+            "score",
+        )
+        .expect("unflagged source-child output is captured as standalone");
+        child_transaction
+            .prepare_output_directory(&canonical_child)
+            .expect("unflagged source-child exact authority");
+        assert_eq!(
+            child_transaction
+                .guard()
+                .expect("source-child guard")
+                .root(),
+            std::fs::canonicalize(&same_root_child).expect("canonical source-child output"),
+            "lexical output.parent == corpus root never implies public bundle mode"
+        );
+        let parent_guard = RecordedCorpusProducerGuard::try_acquire(&source_bundle)
+            .expect("standalone child guard does not contend with undeclared parent authority");
+        drop(parent_guard);
+        drop(child_transaction);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn public_hf_compile_refuses_server_owner_records_but_provided_session_passes_owner_gate() {
+        for owner_leaf in [
+            ".compiled_bundle_stage.json",
+            ".compiled_bundle_stage_a.json",
+        ] {
+            let root =
+                unique_cli_test_path(&format!("hf-owner-{}", owner_leaf.replace(['.', '_'], "-")));
+            std::fs::create_dir_all(&root).expect("owned server stage");
+            std::fs::write(
+                root.join(".compiled_bundle_stage.json"),
+                b"owner sentinel\n",
+            )
+            .expect("owner marker");
+            if owner_leaf == ".compiled_bundle_stage_a.json" {
+                std::fs::write(root.join(owner_leaf), b"seal sentinel\n").expect("owner seal");
+            }
+            let source = root.with_file_name(format!(
+                "{}-missing-source",
+                root.file_name().expect("root leaf").to_string_lossy()
+            ));
+            let args = vec![
+                "--source".to_owned(),
+                source.display().to_string(),
+                "--output".to_owned(),
+                root.display().to_string(),
+            ];
+            let before = directory_bytes(&root);
+            let error = compile_hugging_face(&args)
+                .expect_err("public compiler cannot adopt a private server stage");
+            assert!(error.reason.contains("compiled-bundle ancestor"), "{error}");
+            assert_eq!(directory_bytes(&root), before);
+
+            let child = root.join("child");
+            let child_args = vec![
+                "--source".to_owned(),
+                source.display().to_string(),
+                "--output".to_owned(),
+                child.display().to_string(),
+            ];
+            let error = compile_hugging_face(&child_args)
+                .expect_err("public compiler cannot seed a child inside a private stage");
+            assert!(error.reason.contains("compiled-bundle ancestor"), "{error}");
+            assert_eq!(directory_bytes(&root), before);
+            assert!(!child.exists());
+            assert!(!root
+                .join(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+                )
+                .exists());
+
+            let mut session = source_corpus_session(&root).expect("server outer session");
+            session
+                .acquire_recorded_corpus(&root)
+                .expect("server common producer");
+            let error = compile_hugging_face_with_session(&args, session)
+                .expect_err("missing source fails only after the provided-session owner gate");
+            assert!(!error.reason.contains("server owner marker"), "{error}");
+            assert_eq!(directory_bytes(&root), before);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn public_hf_child_compile_reserves_markerless_private_stage_topology() {
+        let root = unique_cli_test_path("hf-markerless-private-stage-topology");
+        let staging = root.join(".uor-r4-source-compile-staging");
+        let stage = staging.join(".teacher.bundle-stage.7.9");
+        let child = stage.join("child");
+        std::fs::create_dir_all(&stage).expect("markerless private-stage allocation boundary");
+        let source = root.join("missing-source");
+        let args = vec![
+            "--source".to_owned(),
+            source.display().to_string(),
+            "--output".to_owned(),
+            child.display().to_string(),
+        ];
+        let stage_before = directory_bytes(&stage);
+
+        let error = compile_hugging_face(&args)
+            .expect_err("private-stage topology is reserved before owner-marker publication");
+        assert!(error.reason.contains("managed capability"), "{error}");
+        assert_eq!(directory_bytes(&stage), stage_before);
+        assert!(!child.exists());
+        assert!(!stage
+            .join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            .exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_hf_compile_canonicalizes_alias_ancestors_before_any_creation() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_cli_test_path("hf-private-stage-alias");
+        let stage = root.join("private-stage");
+        let alias = root.join("stage-alias");
+        std::fs::create_dir_all(&stage).expect("private stage");
+        std::fs::write(
+            stage.join(".compiled_bundle_stage.json"),
+            b"owner sentinel\n",
+        )
+        .expect("private owner marker");
+        std::fs::write(stage.join("sentinel"), b"private bytes").expect("private stage sentinel");
+        symlink(&stage, &alias).expect("alias to private stage");
+        let source = root.join("missing-source");
+        let stage_before = directory_bytes(&stage);
+
+        let child_args = vec![
+            "--source".to_owned(),
+            source.display().to_string(),
+            "--output".to_owned(),
+            alias.join("child").display().to_string(),
+        ];
+        let error = compile_hugging_face(&child_args)
+            .expect_err("physical private-stage ancestor is detected through an alias");
+        assert!(error.reason.contains("compiled-bundle ancestor"), "{error}");
+        assert_eq!(directory_bytes(&stage), stage_before);
+        assert!(!stage.join("child").exists());
+        assert!(
+            std::fs::symlink_metadata(&alias)
+                .expect("alias remains")
+                .file_type()
+                .is_symlink()
+        );
+
+        let final_alias_args = vec![
+            "--source".to_owned(),
+            source.display().to_string(),
+            "--output".to_owned(),
+            alias.display().to_string(),
+        ];
+        let error = compile_hugging_face(&final_alias_args)
+            .expect_err("a final output symlink is rejected before owner/session creation");
+        assert!(error.reason.contains("is a symlink"), "{error}");
+        assert_eq!(directory_bytes(&stage), stage_before);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     fn source_v2_record(story: u32) -> [u8; 32] {
@@ -8787,7 +10558,8 @@ mod tests {
         let dense = DenseOperatorSpec::gpt2_v2();
         bind_compiled_attention_operator(&corpus_root, &attention).expect("attention sidecar");
         bind_compiled_dense_operator(&corpus_root, Some(&dense)).expect("dense sidecar");
-        let (meta, records) = corpus_markers(&corpus_root);
+        let (meta, records) = complete_test_corpus(&corpus_root);
+        publish_test_corpus_binding(&corpus_root, &meta, &records);
         let artifacts = corpus_root.join("missing-artifacts.bin");
         let output = unique_cli_test_path("cover-recorded-execution-output");
         std::fs::create_dir_all(&output).expect("cover output");
@@ -9416,6 +11188,154 @@ mod tests {
             );
             let _ = std::fs::remove_dir_all(output);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn operator_publisher_retry_is_narrow_exact_and_preserves_a_conflicting_winner() {
+        let operator = AttentionOperatorSpec::standard_v1();
+        let bytes = canonical_attention_operator_bytes(&operator).expect("attention bytes");
+
+        let generic = unique_cli_test_path("publisher-alias-generic-terminal");
+        let (generic_stable, generic_alias) =
+            hard_link_test_sidecar(&generic, ATTENTION_OPERATOR_BINDING_FILE, &bytes, "generic");
+        let error = read_optional_regular_file_nofollow_with(
+            &generic_stable,
+            "attention-operator binding",
+            || std::fs::remove_file(&generic_alias).expect("unlink publisher alias"),
+        )
+        .expect_err("the generic strict reader keeps ctime transitions terminal");
+        assert!(error.reason.contains("changed identity"), "{error}");
+        assert_eq!(std::fs::read(&generic_stable).unwrap(), bytes);
+
+        let exact = unique_cli_test_path("publisher-alias-attention-exact");
+        let (exact_stable, exact_alias) =
+            hard_link_test_sidecar(&exact, ATTENTION_OPERATOR_BINDING_FILE, &bytes, "exact");
+        let recorded = read_optional_compiled_attention_operator_for_publisher_with_hooks(
+            &exact,
+            || std::fs::remove_file(&exact_alias).expect("unlink exact publisher alias"),
+            || {},
+            || {},
+        )
+        .expect("one exact retry accepts the stable winner");
+        assert_eq!(recorded, Some(operator.clone()));
+        assert_eq!(std::fs::read(&exact_stable).unwrap(), bytes);
+
+        let conflicting = unique_cli_test_path("publisher-alias-attention-conflict");
+        let (conflicting_stable, conflicting_alias) = hard_link_test_sidecar(
+            &conflicting,
+            ATTENTION_OPERATOR_BINDING_FILE,
+            &bytes,
+            "conflict",
+        );
+        let recorded = read_optional_compiled_attention_operator_for_publisher_with_hooks(
+            &conflicting,
+            || {
+                std::fs::remove_file(&conflicting_alias)
+                    .expect("unlink conflicting publisher alias")
+            },
+            || {},
+            || {},
+        )
+        .expect("retry reads the complete conflicting winner")
+        .expect("conflicting winner is present");
+        let error = require_matching_compiled_attention_operator(
+            &conflicting,
+            &AttentionOperatorSpec::standard_v2(),
+            &recorded,
+        )
+        .expect_err("a complete conflicting winner remains terminal");
+        assert!(
+            error.reason.contains("pinned to attention operator"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(&conflicting_stable).unwrap(), bytes);
+
+        for output in [generic, exact, conflicting] {
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn operator_publisher_retry_rejects_second_cleanup_aba_path_and_content_changes() {
+        let original = b"publisher generation A";
+
+        let second = unique_cli_test_path("publisher-alias-second-cleanup");
+        let (second_stable, first_alias) =
+            hard_link_test_sidecar(&second, ATTENTION_OPERATOR_BINDING_FILE, original, "first");
+        let second_alias = second.join(format!(".{ATTENTION_OPERATOR_BINDING_FILE}.second.tmp"));
+        let error = read_optional_regular_file_for_operator_publisher_with_hooks(
+            &second_stable,
+            "attention-operator binding",
+            || std::fs::remove_file(&first_alias).expect("unlink first alias"),
+            || std::fs::hard_link(&second_stable, &second_alias).expect("plant second alias"),
+            || std::fs::remove_file(&second_alias).expect("unlink second alias"),
+        )
+        .expect_err("a second alias-cleanup transition is terminal");
+        assert!(error.reason.contains("changed identity"), "{error}");
+        assert_eq!(std::fs::read(&second_stable).unwrap(), original);
+
+        let aba = unique_cli_test_path("publisher-alias-aba");
+        let (aba_stable, aba_alias) =
+            hard_link_test_sidecar(&aba, ATTENTION_OPERATOR_BINDING_FILE, original, "first");
+        let replacement = aba.join("replacement");
+        std::fs::write(&replacement, original).expect("write ABA replacement");
+        let error = read_optional_regular_file_for_operator_publisher_with_hooks(
+            &aba_stable,
+            "attention-operator binding",
+            || std::fs::remove_file(&aba_alias).expect("unlink ABA alias"),
+            || {
+                std::fs::remove_file(&aba_stable).expect("remove first stable inode");
+                std::fs::rename(&replacement, &aba_stable).expect("replace stable path")
+            },
+            || {},
+        )
+        .expect_err("an exact-byte path ABA between attempts is terminal");
+        assert!(error.reason.contains("across the one permitted"), "{error}");
+        assert_eq!(std::fs::read(&aba_stable).unwrap(), original);
+
+        let content = unique_cli_test_path("publisher-alias-content");
+        let (content_stable, content_alias) =
+            hard_link_test_sidecar(&content, ATTENTION_OPERATOR_BINDING_FILE, original, "first");
+        let replacement = b"publisher generation B";
+        assert_eq!(replacement.len(), original.len());
+        let error = read_optional_regular_file_for_operator_publisher_with_hooks(
+            &content_stable,
+            "attention-operator binding",
+            || std::fs::remove_file(&content_alias).expect("unlink content alias"),
+            || std::fs::write(&content_stable, replacement).expect("rewrite between attempts"),
+            || {},
+        )
+        .expect_err("a same-inode content change between attempts is terminal");
+        assert!(error.reason.contains("across the one permitted"), "{error}");
+        assert_eq!(std::fs::read(&content_stable).unwrap(), replacement);
+
+        for output in [second, aba, content] {
+            let _ = std::fs::remove_dir_all(output);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dense_operator_publisher_retries_one_exact_alias_cleanup() {
+        let operator = DenseOperatorSpec::gpt2_v2();
+        let bytes = canonical_dense_operator_bytes(&operator).expect("dense bytes");
+        let output = unique_cli_test_path("publisher-alias-dense-exact");
+        let (stable, alias) =
+            hard_link_test_sidecar(&output, DENSE_OPERATOR_BINDING_FILE, &bytes, "exact");
+
+        let recorded = read_optional_compiled_dense_operator_for_publisher_with_hooks(
+            &output,
+            || std::fs::remove_file(&alias).expect("unlink dense publisher alias"),
+            || {},
+            || {},
+        )
+        .expect("one exact retry accepts the dense winner");
+        assert_eq!(recorded, Some(operator));
+        assert_eq!(std::fs::read(stable).unwrap(), bytes);
+
+        let _ = std::fs::remove_dir_all(output);
     }
 
     #[test]
@@ -11187,7 +13107,8 @@ mod tests {
         let dense = DenseOperatorSpec::gpt2_v2();
         bind_compiled_attention_operator(&sidecar_root, &attention).expect("attention sidecar");
         bind_compiled_dense_operator(&sidecar_root, Some(&dense)).expect("dense sidecar");
-        let (meta, records) = corpus_markers(&sidecar_root);
+        let (meta, records) = complete_test_corpus(&sidecar_root);
+        publish_test_corpus_binding(&sidecar_root, &meta, &records);
         assert_eq!(
             recorded_corpus_execution_identity(&meta, &records).expect("joint sidecar identity"),
             RecordedCorpusExecutionIdentity {
@@ -11201,7 +13122,8 @@ mod tests {
         manifest.attention_operator = Some(attention.clone());
         manifest.dense_operator = Some(dense.clone());
         write_observation_manifest(&manifest_root, &manifest);
-        let (state, merged) = observation_corpus_markers(&manifest_root);
+        let (state, merged) = complete_test_observation_corpus(&manifest_root);
+        publish_test_observation_binding(&manifest_root, &state, &merged);
         assert_eq!(
             recorded_corpus_execution_identity(&state, &merged).expect("joint manifest identity"),
             RecordedCorpusExecutionIdentity {

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -429,21 +429,6 @@ fn planned_output_member(
         })
 }
 
-fn preflight_guarded_planned_file(
-    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
-    path: &Path,
-    expected: &[u8],
-    context: &str,
-) -> Result<bool, SourceUnavailable> {
-    preflight_guarded_planned_file_in_scope(
-        guard,
-        path,
-        expected,
-        context,
-        &PlannedOutputMember::ALL,
-    )
-}
-
 fn preflight_guarded_planned_file_in_scope(
     guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
     path: &Path,
@@ -468,8 +453,17 @@ fn preflight_guarded_planned_absence(
     path: &Path,
     context: &str,
 ) -> Result<(), SourceUnavailable> {
+    preflight_guarded_planned_absence_in_scope(guard, path, context, &PlannedOutputMember::ALL)
+}
+
+fn preflight_guarded_planned_absence_in_scope(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    path: &Path,
+    context: &str,
+    allowed: &[PlannedOutputMember],
+) -> Result<(), SourceUnavailable> {
     let member = planned_output_member(path, context)?;
-    guard.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+    guard.preflight_planned_output_scope(allowed)?;
     if guard.has_planned_output_residue(member)? {
         return Err(SourceUnavailable::new(format!(
             "{context} has staged bytes but the planned generation declares this member absent"
@@ -2900,7 +2894,7 @@ struct SubsampleRecordedCorpusOptions {
     source_records: PathBuf,
     output_meta: PathBuf,
     output_records: PathBuf,
-    records: usize,
+    records: u64,
 }
 
 fn parse_subsample_recorded_corpus_options(
@@ -2923,7 +2917,7 @@ fn parse_subsample_recorded_corpus_options(
             "--out-meta" => output_meta = Some(PathBuf::from(value)),
             "--out-recs" => output_records = Some(PathBuf::from(value)),
             "--records" => {
-                let parsed = value.parse::<usize>().map_err(|_| {
+                let parsed = value.parse::<u64>().map_err(|_| {
                     SourceUnavailable::new(format!("invalid --records value: {value}"))
                 })?;
                 if parsed == 0 {
@@ -6864,6 +6858,7 @@ pub struct RecordedCorpusExecutionIdentity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(test)]
 struct RecordedCorpusSnapshot {
     execution: RecordedCorpusExecutionIdentity,
     attention_operator_bytes: Option<Vec<u8>>,
@@ -7902,6 +7897,7 @@ where
     recorded_corpus_snapshot_with_hooks(corpus_meta, corpus_records, || {}, after_capture)
 }
 
+#[cfg(test)]
 fn recorded_corpus_snapshot(
     corpus_meta: &Path,
     corpus_records: &Path,
@@ -8071,12 +8067,454 @@ where
     Ok(())
 }
 
-fn exact_finalized_record_width(records: usize, byte_len: usize) -> Option<usize> {
-    [88usize, 48, 32, 12].into_iter().find(|width| {
+fn exact_finalized_record_width(records: u64, byte_len: u64) -> Option<u64> {
+    if records == 0 {
+        return None;
+    }
+    [88u64, 48, 32, 12].into_iter().find(|width| {
         records
             .checked_mul(*width)
             .is_some_and(|expected| expected == byte_len)
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SelectedRowRange {
+    start: u64,
+    end: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SelectedByteRange {
+    start: u64,
+    end: u64,
+}
+
+impl SelectedByteRange {
+    fn len(self) -> u64 {
+        self.end - self.start
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RecordedCorpusSelection {
+    ranges: Vec<SelectedRowRange>,
+    retained_records: u64,
+    train_records: u64,
+    held_out_records: u64,
+}
+
+fn append_selected_row_range(ranges: &mut Vec<SelectedRowRange>, start: u64, end: u64) {
+    if let Some(previous) = ranges.last_mut()
+        && previous.end == start
+    {
+        previous.end = end;
+        return;
+    }
+    ranges.push(SelectedRowRange { start, end });
+}
+
+/// Scan the record body once, validate every story id, and greedily retain
+/// complete runs under quotas derived from the source compiler's fixed story
+/// partition. The plan is row-index-only: no record or output body is retained.
+fn select_recorded_corpus_ranges<R: Read + Seek>(
+    records: &mut R,
+    source_records: u64,
+    record_width: u64,
+    source_stories: u64,
+    target_records: u64,
+) -> Result<RecordedCorpusSelection, SourceUnavailable> {
+    if target_records > source_records {
+        return Err(SourceUnavailable::new(format!(
+            "source has {source_records} finalized records; --records {target_records} exceeds the source generation"
+        )));
+    }
+    if target_records == 0 || source_records == 0 {
+        return Err(SourceUnavailable::new(
+            "subsample source and target must each contain at least one finalized record",
+        ));
+    }
+    let width = usize::try_from(record_width).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "registered record width {record_width} cannot be represented on this host"
+        ))
+    })?;
+    if width > 88 || width < std::mem::size_of::<u32>() {
+        return Err(SourceUnavailable::new(format!(
+            "registered record width {record_width} is outside the supported scanner range"
+        )));
+    }
+
+    let full_source = target_records == source_records;
+    let (mut train_remaining, mut held_out_remaining) = if full_source {
+        (u64::MAX, u64::MAX)
+    } else {
+        let train = target_records
+            .checked_mul(4)
+            .ok_or_else(|| SourceUnavailable::new("subsample train quota overflows u64"))?
+            / 5;
+        let held_out = target_records - train;
+        if train == 0 || held_out == 0 {
+            return Err(SourceUnavailable::new(
+                "subsample target is too small to retain records from both fixed source partitions",
+            ));
+        }
+        (train, held_out)
+    };
+    // This expression is intentionally identical to compiler::train_cut.
+    let source_train_cut = ((source_stories as f64 * 0.8) as u32).max(1);
+    let mut selected = Vec::new();
+    let mut train_records = 0u64;
+    let mut held_out_records = 0u64;
+    let mut last_selected_story = None;
+
+    let mut consider_run =
+        |run_start: u64, run_end: u64, story: u32| -> Result<(), SourceUnavailable> {
+            let rows = run_end
+                .checked_sub(run_start)
+                .ok_or_else(|| SourceUnavailable::new("subsample story-run bounds are reversed"))?;
+            let train = story < source_train_cut;
+            let remaining = if train {
+                &mut train_remaining
+            } else {
+                &mut held_out_remaining
+            };
+            if full_source || (rows <= *remaining && last_selected_story != Some(story)) {
+                if !full_source {
+                    *remaining -= rows;
+                }
+                if train {
+                    train_records = train_records.checked_add(rows).ok_or_else(|| {
+                        SourceUnavailable::new("subsample retained train count overflows u64")
+                    })?;
+                } else {
+                    held_out_records = held_out_records.checked_add(rows).ok_or_else(|| {
+                        SourceUnavailable::new("subsample retained held-out count overflows u64")
+                    })?;
+                }
+                append_selected_row_range(&mut selected, run_start, run_end);
+                last_selected_story = Some(story);
+            }
+            Ok(())
+        };
+
+    records
+        .seek(SeekFrom::Start(0))
+        .map_err(SourceUnavailable::new)?;
+    let mut row = [0u8; 88];
+    let mut run_start = 0u64;
+    let mut current_story = None;
+    for index in 0..source_records {
+        records.read_exact(&mut row[..width]).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "subsample source records ended while reading row {index} at width {record_width}: {error}"
+            ))
+        })?;
+        let story = u32::from_le_bytes(
+            row[0..4]
+                .try_into()
+                .map_err(|_| SourceUnavailable::new("record story id is truncated"))?,
+        );
+        if u64::from(story) >= source_stories {
+            return Err(SourceUnavailable::new(format!(
+                "source record {index} declares story {story}, outside the metadata story range 0..{source_stories}"
+            )));
+        }
+        match current_story {
+            Some(previous) if previous != story => {
+                consider_run(run_start, index, previous)?;
+                run_start = index;
+                current_story = Some(story);
+            }
+            None => current_story = Some(story),
+            Some(_) => {}
+        }
+    }
+    if let Some(story) = current_story {
+        consider_run(run_start, source_records, story)?;
+    }
+    let mut extra = [0u8; 1];
+    if records.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(
+            "subsample source records extend beyond the exact finalized row layout",
+        ));
+    }
+
+    if train_records == 0 || held_out_records == 0 {
+        let train_quota = target_records * 4 / 5;
+        let held_out_quota = target_records - train_quota;
+        return Err(SourceUnavailable::new(format!(
+            "source selection does not represent both fixed source partitions within train/held-out quotas {train_quota}/{held_out_quota}"
+        )));
+    }
+    let retained_records = train_records
+        .checked_add(held_out_records)
+        .ok_or_else(|| SourceUnavailable::new("subsample retained count overflows u64"))?;
+    if retained_records > target_records {
+        return Err(SourceUnavailable::new(
+            "subsample greedy selection exceeded its declared target",
+        ));
+    }
+    Ok(RecordedCorpusSelection {
+        ranges: selected,
+        retained_records,
+        train_records,
+        held_out_records,
+    })
+}
+
+fn selected_byte_ranges(
+    rows: &[SelectedRowRange],
+    row_bytes: u64,
+) -> Result<Vec<SelectedByteRange>, SourceUnavailable> {
+    if row_bytes == 0 {
+        return Err(SourceUnavailable::new(
+            "selected byte ranges require a nonzero row width",
+        ));
+    }
+    let mut ranges: Vec<SelectedByteRange> = Vec::with_capacity(rows.len());
+    for row_range in rows {
+        let start = row_range
+            .start
+            .checked_mul(row_bytes)
+            .ok_or_else(|| SourceUnavailable::new("selected byte-range start overflows u64"))?;
+        let end = row_range
+            .end
+            .checked_mul(row_bytes)
+            .ok_or_else(|| SourceUnavailable::new("selected byte-range end overflows u64"))?;
+        if let Some(previous) = ranges.last_mut()
+            && previous.end == start
+        {
+            previous.end = end;
+        } else {
+            ranges.push(SelectedByteRange { start, end });
+        }
+    }
+    Ok(ranges)
+}
+
+/// Read/seek view that concatenates selected source ranges without allocating
+/// or spooling the selected body. Source offsets and logical length remain
+/// u64, so sparse multi-gigabyte inputs do not become host-sized allocations.
+trait SelectedRangeSource: Read + Seek {}
+
+impl<T: Read + Seek> SelectedRangeSource for T {}
+
+struct SelectedRangesReader<'a> {
+    source: &'a mut dyn SelectedRangeSource,
+    ranges: &'a [SelectedByteRange],
+    length: u64,
+    position: u64,
+    range_index: usize,
+    range_offset: u64,
+    source_position: Option<u64>,
+}
+
+impl<'a> SelectedRangesReader<'a> {
+    fn new<R: Read + Seek>(
+        source: &'a mut R,
+        ranges: &'a [SelectedByteRange],
+    ) -> Result<Self, SourceUnavailable> {
+        let mut length = 0u64;
+        let mut previous_end = None;
+        for range in ranges {
+            if range.start >= range.end {
+                return Err(SourceUnavailable::new(
+                    "selected source range is empty or reversed",
+                ));
+            }
+            if previous_end.is_some_and(|end| end >= range.start) {
+                return Err(SourceUnavailable::new(
+                    "selected source ranges overlap or were not coalesced",
+                ));
+            }
+            length = length
+                .checked_add(range.len())
+                .ok_or_else(|| SourceUnavailable::new("selected stream length overflows u64"))?;
+            previous_end = Some(range.end);
+        }
+        Ok(Self {
+            source,
+            ranges,
+            length,
+            position: 0,
+            range_index: 0,
+            range_offset: 0,
+            source_position: None,
+        })
+    }
+
+    fn len(&self) -> u64 {
+        self.length
+    }
+
+    fn reset_cursor(&mut self, target: u64) {
+        self.position = target;
+        self.source_position = None;
+        let mut remaining = target;
+        for (index, range) in self.ranges.iter().enumerate() {
+            if remaining < range.len() {
+                self.range_index = index;
+                self.range_offset = remaining;
+                return;
+            }
+            remaining -= range.len();
+        }
+        self.range_index = self.ranges.len();
+        self.range_offset = 0;
+    }
+}
+
+impl std::io::Read for SelectedRangesReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if buffer.is_empty() || self.position >= self.length {
+            return Ok(0);
+        }
+        let mut written = 0usize;
+        while written < buffer.len() && self.position < self.length {
+            let range = self.ranges.get(self.range_index).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "selected range cursor ended before the declared logical length",
+                )
+            })?;
+            let source_target = range.start.checked_add(self.range_offset).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "selected source cursor overflows u64",
+                )
+            })?;
+            if self.source_position != Some(source_target) {
+                self.source.seek(SeekFrom::Start(source_target))?;
+                self.source_position = Some(source_target);
+            }
+            let range_remaining = range.end - source_target;
+            let limit = usize::try_from(range_remaining.min((buffer.len() - written) as u64))
+                .map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "selected read length does not fit usize",
+                    )
+                })?;
+            let count = self.source.read(&mut buffer[written..written + limit])?;
+            if count == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "selected source range ended before its declared boundary",
+                ));
+            }
+            let count_u64 = count as u64;
+            written += count;
+            self.position = self.position.checked_add(count_u64).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "selected logical position overflows u64",
+                )
+            })?;
+            self.range_offset += count_u64;
+            self.source_position = source_target.checked_add(count_u64);
+            if self.range_offset == range.len() {
+                self.range_index += 1;
+                self.range_offset = 0;
+            }
+        }
+        Ok(written)
+    }
+}
+
+impl std::io::Seek for SelectedRangesReader<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        let target = match position {
+            SeekFrom::Start(target) => i128::from(target),
+            SeekFrom::End(offset) => i128::from(self.length) + i128::from(offset),
+            SeekFrom::Current(offset) => i128::from(self.position) + i128::from(offset),
+        };
+        let target = u64::try_from(target).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "selected logical seek is outside the u64 address space",
+            )
+        })?;
+        self.reset_cursor(target);
+        Ok(target)
+    }
+}
+
+fn summarize_selected_stream(
+    reader: &mut SelectedRangesReader<'_>,
+    context: &str,
+) -> Result<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary, SourceUnavailable>
+{
+    reader
+        .seek(SeekFrom::Start(0))
+        .map_err(SourceUnavailable::new)?;
+    let length = reader.len();
+    let mut remaining = length;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| SourceUnavailable::new(format!("{context} length overflows usize")))?;
+        let count = reader
+            .read(&mut buffer[..limit])
+            .map_err(SourceUnavailable::new)?;
+        if count == 0 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} ended before its declared {length}-byte length"
+            )));
+        }
+        hasher.update(&buffer[..count]);
+        remaining -= count as u64;
+    }
+    let mut extra = [0u8; 1];
+    if reader.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} grew beyond its declared {length}-byte length"
+        )));
+    }
+    Ok(
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary {
+            length,
+            blake3: format!("blake3:{}", hasher.finalize().to_hex()),
+        },
+    )
+}
+
+struct ExpectedSubsampleGeneration<'a> {
+    execution: &'a RecordedCorpusExecutionIdentity,
+    meta: &'a [u8],
+    records: &'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary,
+    hidden: Option<&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusMemberSummary>,
+}
+
+fn postcheck_subsample_generation(
+    guard: &RecordedCorpusProducerGuard,
+    output_meta: &Path,
+    output_records: &Path,
+    expected: &ExpectedSubsampleGeneration<'_>,
+    expected_binding_cid: Option<&str>,
+) -> Result<String, SourceUnavailable> {
+    let published = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+        guard,
+        output_meta,
+        output_records,
+    )?;
+    let binding_cid = published.binding_cid.clone().ok_or_else(|| {
+        SourceUnavailable::new("subsample postcheck found no canonical generation binding")
+    })?;
+    if expected_binding_cid.is_some_and(|expected| expected != binding_cid)
+        || recorded_execution_from_stream(&published) != *expected.execution
+        || published.meta_bytes != expected.meta
+        || &published.records.summary() != expected.records
+        || published.hidden.as_ref().map(|hidden| hidden.summary()) != expected.hidden.cloned()
+    {
+        return Err(SourceUnavailable::new(
+            "subsample publication changed during bounded post-binding recapture",
+        ));
+    }
+    published.verify_generation()?;
+    guard.verify_owned_root()?;
+    Ok(binding_cid)
 }
 
 /// Derive one smaller, story-run-aligned corpus from a single exact source
@@ -8095,222 +8533,118 @@ where
     F: FnOnce() -> Result<(), SourceUnavailable>,
 {
     let options = parse_subsample_recorded_corpus_options(args)?;
-    let mut source = recorded_corpus_snapshot(&options.source_meta, &options.source_records)?;
-    if source.binding_cid.is_none() {
-        // Compatibility for archived legacy/attention-only scale inputs: one
-        // cooperative source guard makes the lower repeated-read snapshot
-        // stable against every in-repo producer. Dense input never reaches
-        // this lane because lower capture requires its canonical binding.
-        let source_root = std::fs::canonicalize(
-            options
-                .source_meta
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty())
-                .unwrap_or_else(|| Path::new(".")),
-        )
-        .map_err(SourceUnavailable::new)?;
-        let source_guard =
-            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
-                &source_root,
-            )?;
-        source = recorded_corpus_snapshot(&options.source_meta, &options.source_records)?;
-        drop(source_guard);
-    }
+    let requested_output_root = options
+        .output_meta
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let source_root = options
+        .source_meta
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut authority =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusDerivationGuards::try_acquire(
+            source_root,
+            requested_output_root,
+        )?;
+    authority.verify()?;
+    let output_root = authority.destination_guard().root().to_path_buf();
+    let output_meta = output_root.join("corpus.meta");
+    let output_records = output_root.join("corpus.records");
+    let output_hidden = output_root.join("corpus.records.hidden");
+
+    let mut source = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+        authority.source_guard(),
+        &options.source_meta,
+        &options.source_records,
+    )?;
     if source.meta_bytes.len() != SOURCE_CORPUS_META_BYTES || source.meta_bytes[24] != 1 {
         return Err(SourceUnavailable::new(
             "subsample source is not one exact finalized 25-byte corpus generation",
         ));
     }
-    let source_records_u64 = u64::from_le_bytes(
+    let source_records = u64::from_le_bytes(
         source.meta_bytes[0..8]
             .try_into()
             .map_err(|_| SourceUnavailable::new("invalid source corpus record count"))?,
     );
-    let source_records = usize::try_from(source_records_u64).map_err(|_| {
-        SourceUnavailable::new(format!(
-            "source corpus record count {source_records_u64} cannot be represented on this host"
-        ))
-    })?;
-    if options.records >= source_records {
+    if options.records > source_records {
         return Err(SourceUnavailable::new(format!(
-            "source has {source_records} finalized records; --records {} must be strictly smaller",
+            "source has {source_records} finalized records; --records {} exceeds the source generation",
             options.records
         )));
     }
-    let record_width = exact_finalized_record_width(source_records, source.records_bytes.len())
-        .ok_or_else(|| {
-            SourceUnavailable::new(format!(
-                "source record stream length {} is not exactly n times one registered width (88, 48, 32, or 12) for n={source_records}",
-                source.records_bytes.len()
-            ))
-        })?;
-    let parsed = compiler::load_corpus_bytes(&source.meta_bytes, &source.records_bytes, None)
-        .ok_or_else(|| SourceUnavailable::new("subsample source corpus bytes are malformed"))?;
     let source_stories_u64 = u64::from_le_bytes(
         source.meta_bytes[8..16]
             .try_into()
             .map_err(|_| SourceUnavailable::new("invalid source corpus story count"))?,
     );
-    let source_stories = u32::try_from(source_stories_u64).map_err(|_| {
-        SourceUnavailable::new(format!(
-            "source corpus story count {source_stories_u64} exceeds the u32 story-id range"
-        ))
-    })?;
-    let source_train_cut = ((f64::from(source_stories) * 0.8) as u32).max(1);
-    let mut runs = Vec::new();
-    let mut start = 0usize;
-    while start < source_records {
-        let story = parsed.story[start];
-        if story >= source_stories {
-            return Err(SourceUnavailable::new(format!(
-                "source record {start} declares story {story}, outside the metadata story range 0..{source_stories}"
-            )));
-        }
-        let mut end = start + 1;
-        while end < source_records && parsed.story[end] == story {
-            end += 1;
-        }
-        runs.push((start, end, story, story < source_train_cut));
-        start = end;
-    }
-
-    // Preserve the source compiler's fixed story partition. Quotas are
-    // deterministic 80/20 record budgets; only complete story runs that fit
-    // their side's budget are retained, in original source order.
-    let train_quota = options
-        .records
-        .checked_mul(4)
-        .ok_or_else(|| SourceUnavailable::new("subsample train quota overflows"))?
-        / 5;
-    let held_out_quota = options.records - train_quota;
-    if train_quota == 0 || held_out_quota == 0 {
+    let record_width = exact_finalized_record_width(source_records, source.records.len())
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "source record stream length {} is not exactly n times one registered width (88, 48, 32, or 12) for n={source_records}",
+                source.records.len()
+            ))
+        })?;
+    let selection = select_recorded_corpus_ranges(
+        &mut source.records,
+        source_records,
+        record_width,
+        source_stories_u64,
+        options.records,
+    )?;
+    let record_ranges = selected_byte_ranges(&selection.ranges, record_width)?;
+    let records_summary = {
+        let mut reader = SelectedRangesReader::new(&mut source.records, &record_ranges)?;
+        summarize_selected_stream(&mut reader, "subsample selected record stream")?
+    };
+    let expected_records_length = selection
+        .retained_records
+        .checked_mul(record_width)
+        .ok_or_else(|| SourceUnavailable::new("subsample record byte length overflows u64"))?;
+    if records_summary.length != expected_records_length {
         return Err(SourceUnavailable::new(
-            "subsample target is too small to retain records from both fixed source partitions",
+            "subsample selected record summary has an inconsistent row length",
         ));
     }
-    let mut train_remaining = train_quota;
-    let mut held_out_remaining = held_out_quota;
-    let mut selected = Vec::new();
-    let mut train_records = 0usize;
-    let mut held_out_records = 0usize;
-    let mut last_selected_story = None;
-    for &(run_start, run_end, story, train) in &runs {
-        let rows = run_end - run_start;
-        let remaining = if train {
-            &mut train_remaining
-        } else {
-            &mut held_out_remaining
-        };
-        // Filtering cannot make two source-separated runs of the same story
-        // adjacent: v1/v2 rows reconstruct input/span boundaries solely from
-        // adjacent story equality and would otherwise stitch them together.
-        if rows <= *remaining && last_selected_story != Some(story) {
-            *remaining -= rows;
-            if train {
-                train_records += rows;
-            } else {
-                held_out_records += rows;
-            }
-            selected.push((run_start, run_end));
-            last_selected_story = Some(story);
-        }
-    }
-    if train_records == 0 || held_out_records == 0 {
-        return Err(SourceUnavailable::new(format!(
-            "no complete story-run selection fits both fixed source partitions within train/held-out quotas {train_quota}/{held_out_quota}"
-        )));
-    }
-    let retained_records = train_records
-        .checked_add(held_out_records)
-        .ok_or_else(|| SourceUnavailable::new("subsample retained count overflows"))?;
-    let output_capacity = retained_records
-        .checked_mul(record_width)
-        .ok_or_else(|| SourceUnavailable::new("subsample record byte length overflows"))?;
-    let mut output_records_bytes = Vec::with_capacity(output_capacity);
-    for &(run_start, run_end) in &selected {
-        let byte_start = run_start
-            .checked_mul(record_width)
-            .ok_or_else(|| SourceUnavailable::new("subsample record start overflows"))?;
-        let byte_end = run_end
-            .checked_mul(record_width)
-            .ok_or_else(|| SourceUnavailable::new("subsample record end overflows"))?;
-        output_records_bytes.extend_from_slice(&source.records_bytes[byte_start..byte_end]);
-    }
-    let mut output_meta_bytes = Vec::with_capacity(SOURCE_CORPUS_META_BYTES);
-    output_meta_bytes.extend_from_slice(
-        &u64::try_from(retained_records)
-            .map_err(|_| SourceUnavailable::new("subsample count exceeds u64"))?
-            .to_le_bytes(),
-    );
-    output_meta_bytes.extend_from_slice(&source_stories_u64.to_le_bytes());
-    output_meta_bytes.extend_from_slice(&source.meta_bytes[16..24]);
-    output_meta_bytes.push(1);
 
-    let output_hidden_bytes = source
-        .hidden_bytes
-        .as_deref()
-        .map(|hidden| {
-            if source_records == 0 || hidden.len() % source_records != 0 {
+    let (hidden_ranges, hidden_summary) = match source.hidden.as_mut() {
+        Some(hidden) => {
+            if hidden.len() % source_records != 0 {
                 return Err(SourceUnavailable::new(format!(
-                    "source hidden stream is {} bytes, which is not an exact nonzero row width for {source_records} finalized rows",
+                    "source hidden stream is {} bytes, which is not an exact row width for {source_records} finalized rows",
                     hidden.len()
                 )));
             }
             let row_bytes = hidden.len() / source_records;
-            if row_bytes == 0 || row_bytes % std::mem::size_of::<f32>() != 0 {
+            if row_bytes == 0 || row_bytes % std::mem::size_of::<f32>() as u64 != 0 {
                 return Err(SourceUnavailable::new(
                     "source hidden stream row width is zero or is not an exact f32 byte multiple",
                 ));
             }
-            let output_capacity = retained_records
+            let ranges = selected_byte_ranges(&selection.ranges, row_bytes)?;
+            let summary = {
+                let mut reader = SelectedRangesReader::new(hidden, &ranges)?;
+                summarize_selected_stream(&mut reader, "subsample selected hidden stream")?
+            };
+            let expected_length = selection
+                .retained_records
                 .checked_mul(row_bytes)
-                .ok_or_else(|| SourceUnavailable::new("subsample hidden length overflows"))?;
-            let mut output = Vec::with_capacity(output_capacity);
-            for &(run_start, run_end) in &selected {
-                let byte_start = run_start
-                    .checked_mul(row_bytes)
-                    .ok_or_else(|| SourceUnavailable::new("subsample hidden start overflows"))?;
-                let byte_end = run_end
-                    .checked_mul(row_bytes)
-                    .ok_or_else(|| SourceUnavailable::new("subsample hidden end overflows"))?;
-                output.extend_from_slice(&hidden[byte_start..byte_end]);
+                .ok_or_else(|| SourceUnavailable::new("subsample hidden length overflows u64"))?;
+            if summary.length != expected_length {
+                return Err(SourceUnavailable::new(
+                    "subsample selected hidden summary has an inconsistent row length",
+                ));
             }
-            Ok(output)
-        })
-        .transpose()?;
-
-    let output_root = options
-        .output_meta
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let output_parent = output_root
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(output_parent).map_err(SourceUnavailable::new)?;
-    let mut producer =
-        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
-            output_root,
-        )?;
-    let source_root = std::fs::canonicalize(
-        options
-            .source_meta
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new(".")),
-    )
-    .map_err(SourceUnavailable::new)?;
-    if producer.protects_directory(&source_root)? {
-        return Err(SourceUnavailable::new(
-            "subsample source and destination resolve to the same canonical corpus root; in-place derivation is refused before mutation",
-        ));
-    }
-    producer.ensure_root()?;
-    let output_root = producer.root().to_path_buf();
-    let output_meta = output_root.join("corpus.meta");
-    let output_records = output_root.join("corpus.records");
-    let output_hidden = output_root.join("corpus.records.hidden");
+            (Some(ranges), Some(summary))
+        }
+        None => (None, None),
+    };
+    source.verify_generation()?;
+    authority.verify()?;
+    authority.destination_guard_mut().ensure_root()?;
+    authority.verify()?;
     if strict_regular_file_if_present(
         &output_root.join(observe::MANIFEST_FILE),
         "subsample destination observation manifest",
@@ -8319,18 +8653,38 @@ where
             "subsample destination contains an observation manifest; use a fresh compile-style corpus root",
         ));
     }
+
+    let mut output_meta_bytes = source.meta_bytes.clone();
+    output_meta_bytes[0..8].copy_from_slice(&selection.retained_records.to_le_bytes());
+    let expected_execution = RecordedCorpusExecutionIdentity {
+        attention_operator: source.execution.attention_operator.clone(),
+        dense_operator: source.execution.dense_operator.clone(),
+    };
+    let attention_bytes = expected_execution
+        .attention_operator
+        .as_ref()
+        .map(canonical_attention_operator_bytes)
+        .transpose()?;
+    let dense_bytes = expected_execution
+        .dense_operator
+        .as_ref()
+        .map(canonical_dense_operator_bytes)
+        .transpose()?;
     let subsample_members = [
+        PlannedOutputMember::AttentionOperator,
+        PlannedOutputMember::DenseOperator,
         PlannedOutputMember::Records,
         PlannedOutputMember::Hidden,
         PlannedOutputMember::Metadata,
     ];
-    preflight_guarded_planned_scope(&producer, &subsample_members, "subsample destination")?;
+    let producer = authority.destination_guard();
+    preflight_guarded_planned_scope(producer, &subsample_members, "subsample destination")?;
     producer.preflight_planned_output_stable_scope(&subsample_members)?;
     producer.preflight_deterministic_compile_inventory(&subsample_members)?;
     let recoverable_temporary =
         producer.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
 
-    let attention_ready = match source.execution.attention_operator.as_ref() {
+    let attention_ready = match expected_execution.attention_operator.as_ref() {
         Some(attention) => preflight_compiled_attention_operator(&output_root, attention)?,
         None => {
             if read_optional_compiled_attention_operator(&output_root)?.is_some() {
@@ -8341,122 +8695,243 @@ where
             true
         }
     };
-    let dense_ready =
-        preflight_compiled_dense_operator(&output_root, source.execution.dense_operator.as_ref())?;
-    let records_ready = preflight_guarded_planned_file(
-        &producer,
-        &output_records,
-        &output_records_bytes,
-        "subsample destination records",
-    )?;
-    let hidden_ready = match output_hidden_bytes.as_deref() {
-        Some(hidden) => preflight_guarded_planned_file(
-            &producer,
-            &output_hidden,
-            hidden,
-            "subsample destination hidden stream",
+    let attention_bytes_ready = match attention_bytes.as_deref() {
+        Some(bytes) => preflight_guarded_planned_file_in_scope(
+            producer,
+            &output_root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            bytes,
+            "subsample destination attention operator",
+            &subsample_members,
         )?,
         None => {
-            preflight_guarded_planned_absence(
-                &producer,
-                &output_hidden,
-                "subsample destination hidden stream",
+            preflight_guarded_planned_absence_in_scope(
+                producer,
+                &output_root.join(ATTENTION_OPERATOR_BINDING_FILE),
+                "subsample destination attention operator",
+                &subsample_members,
             )?;
             true
         }
     };
-    let meta_ready = preflight_guarded_planned_file(
-        &producer,
+    let dense_ready = preflight_compiled_dense_operator(
+        &output_root,
+        expected_execution.dense_operator.as_ref(),
+    )?;
+    let dense_bytes_ready = match dense_bytes.as_deref() {
+        Some(bytes) => preflight_guarded_planned_file_in_scope(
+            producer,
+            &output_root.join(DENSE_OPERATOR_BINDING_FILE),
+            bytes,
+            "subsample destination dense operator",
+            &subsample_members,
+        )?,
+        None => {
+            preflight_guarded_planned_absence_in_scope(
+                producer,
+                &output_root.join(DENSE_OPERATOR_BINDING_FILE),
+                "subsample destination dense operator",
+                &subsample_members,
+            )?;
+            true
+        }
+    };
+    let records_ready = preflight_guarded_planned_stream_in_scope(
+        producer,
+        &output_records,
+        Some(&records_summary),
+        "subsample destination records",
+        &subsample_members,
+    )?;
+    let hidden_ready = match hidden_summary.as_ref() {
+        Some(hidden) => preflight_guarded_planned_stream_in_scope(
+            producer,
+            &output_hidden,
+            Some(hidden),
+            "subsample destination hidden stream",
+            &subsample_members,
+        )?,
+        None => {
+            preflight_guarded_planned_absence_in_scope(
+                producer,
+                &output_hidden,
+                "subsample destination hidden stream",
+                &subsample_members,
+            )?;
+            true
+        }
+    };
+    let meta_ready = preflight_guarded_planned_file_in_scope(
+        producer,
         &output_meta,
         &output_meta_bytes,
         "subsample destination metadata",
+        &subsample_members,
     )?;
 
     let stable_binding = strict_regular_file_if_present(
         &output_root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
         "subsample destination generation binding",
     )?;
+    let planned_ready =
+        attention_bytes_ready && dense_bytes_ready && records_ready && hidden_ready && meta_ready;
     if stable_binding || recoverable_temporary {
-        if !attention_ready || !dense_ready || !records_ready || !hidden_ready || !meta_ready {
+        if !attention_ready || !dense_ready || !planned_ready {
             return Err(SourceUnavailable::new(
                 "subsample destination has binding commit evidence without the exact complete planned generation; refusing recovery before mutation",
             ));
         }
         uor_r4_graph_compiler::recorded_corpus::preflight_binding_evidence_matches_current(
-            &producer,
+            producer,
             &output_meta,
             &output_records,
         )?;
     }
-    producer.begin_compile_attempt()?;
-    if stable_binding || recoverable_temporary {
-        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
-            &producer,
+    if stable_binding && !recoverable_temporary && attention_ready && dense_ready && planned_ready {
+        producer.preflight_ready_deterministic_compile_inventory(&subsample_members)?;
+        source.verify_generation()?;
+        authority.verify()?;
+        let expected = ExpectedSubsampleGeneration {
+            execution: &expected_execution,
+            meta: &output_meta_bytes,
+            records: &records_summary,
+            hidden: hidden_summary.as_ref(),
+        };
+        let binding_cid = postcheck_subsample_generation(
+            producer,
             &output_meta,
             &output_records,
+            &expected,
+            None,
         )?;
-        let published = recorded_corpus_snapshot(&output_meta, &output_records)?;
-        if published.execution != source.execution
-            || published.meta_bytes != output_meta_bytes
-            || published.records_bytes != output_records_bytes
-            || published.hidden_bytes != output_hidden_bytes
-            || published.binding_cid.as_deref() != Some(binding_cid.as_str())
-        {
-            return Err(SourceUnavailable::new(
-                "subsample binding recovery does not match the exact planned generation",
-            ));
+        if producer.compile_attempt_active()? {
+            producer.finish_compile_attempt()?;
         }
-        producer.finish_compile_attempt()?;
+        println!(
+            "subsample recorded corpus: {} records ({} train, {} held out; requested {}) of {source_records}; {record_width}-byte rows; binding {binding_cid}",
+            selection.retained_records,
+            selection.train_records,
+            selection.held_out_records,
+            options.records,
+        );
         return Ok(());
     }
 
-    if let Some(dense) = source.execution.dense_operator.as_ref() {
-        publish_dense_operator_binding(&output_root, dense)?;
+    producer.preflight_deterministic_compile_inventory(&subsample_members)?;
+    producer.begin_compile_attempt()?;
+    if stable_binding || recoverable_temporary {
+        source.verify_generation()?;
+        authority.verify()?;
+        let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            producer,
+            &output_meta,
+            &output_records,
+        )?;
+        let expected = ExpectedSubsampleGeneration {
+            execution: &expected_execution,
+            meta: &output_meta_bytes,
+            records: &records_summary,
+            hidden: hidden_summary.as_ref(),
+        };
+        let checked_binding_cid = postcheck_subsample_generation(
+            producer,
+            &output_meta,
+            &output_records,
+            &expected,
+            Some(&binding_cid),
+        )?;
+        debug_assert_eq!(checked_binding_cid, binding_cid);
+        producer.finish_compile_attempt()?;
+        println!(
+            "subsample recorded corpus: {} records ({} train, {} held out; requested {}) of {source_records}; {record_width}-byte rows; binding {binding_cid}",
+            selection.retained_records,
+            selection.train_records,
+            selection.held_out_records,
+            options.records,
+        );
+        return Ok(());
     }
-    if let Some(attention) = source.execution.attention_operator.as_ref() {
-        publish_attention_operator_binding(&output_root, attention)?;
+
+    // Dense-first makes every GPT-2 crash prefix invalid rather than a
+    // valid-looking attention-only generation.
+    if let Some(bytes) = dense_bytes.as_deref() {
+        publish_guarded_planned_file_with_after_sync(
+            producer,
+            &output_root.join(DENSE_OPERATOR_BINDING_FILE),
+            bytes,
+            "subsample destination dense operator",
+            &subsample_members,
+            |_| Ok(()),
+        )?;
     }
-    publish_guarded_planned_file(
-        &producer,
-        &output_records,
-        &output_records_bytes,
-        "subsample destination records",
-    )?;
-    if let Some(hidden) = output_hidden_bytes.as_deref() {
-        publish_guarded_planned_file(
-            &producer,
+    if let Some(bytes) = attention_bytes.as_deref() {
+        publish_guarded_planned_file_with_after_sync(
+            producer,
+            &output_root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            bytes,
+            "subsample destination attention operator",
+            &subsample_members,
+            |_| Ok(()),
+        )?;
+    }
+    {
+        let mut reader = SelectedRangesReader::new(&mut source.records, &record_ranges)?;
+        publish_guarded_planned_stream(
+            producer,
+            &output_records,
+            &mut reader,
+            &records_summary,
+            "subsample destination records",
+        )?;
+    }
+    if let (Some(hidden), Some(ranges), Some(summary)) = (
+        source.hidden.as_mut(),
+        hidden_ranges.as_deref(),
+        hidden_summary.as_ref(),
+    ) {
+        let mut reader = SelectedRangesReader::new(hidden, ranges)?;
+        publish_guarded_planned_stream(
+            producer,
             &output_hidden,
-            hidden,
+            &mut reader,
+            summary,
             "subsample destination hidden stream",
         )?;
     }
     publish_guarded_planned_file(
-        &producer,
+        producer,
         &output_meta,
         &output_meta_bytes,
         "subsample destination metadata",
     )?;
     before_binding()?;
+    source.verify_generation()?;
+    authority.verify()?;
     let binding_cid = uor_r4_graph_compiler::recorded_corpus::publish_binding(
-        &producer,
+        producer,
         &output_meta,
         &output_records,
     )?;
-    let published = recorded_corpus_snapshot(&output_meta, &output_records)?;
-    if published.execution != source.execution
-        || published.meta_bytes != output_meta_bytes
-        || published.records_bytes != output_records_bytes
-        || published.hidden_bytes != output_hidden_bytes
-        || published.binding_cid.as_deref() != Some(binding_cid.as_str())
-    {
-        return Err(SourceUnavailable::new(
-            "subsample publication changed during exact post-binding recapture",
-        ));
-    }
+    let expected = ExpectedSubsampleGeneration {
+        execution: &expected_execution,
+        meta: &output_meta_bytes,
+        records: &records_summary,
+        hidden: hidden_summary.as_ref(),
+    };
+    let checked_binding_cid = postcheck_subsample_generation(
+        producer,
+        &output_meta,
+        &output_records,
+        &expected,
+        Some(&binding_cid),
+    )?;
+    debug_assert_eq!(checked_binding_cid, binding_cid);
     producer.finish_compile_attempt()?;
     println!(
-        "subsample recorded corpus: {retained_records} records ({train_records} train, {held_out_records} held out; target {}) of {source_records}; {}-byte rows; binding {binding_cid}",
-        options.records, record_width
+        "subsample recorded corpus: {} records ({} train, {} held out; requested {}) of {source_records}; {record_width}-byte rows; binding {binding_cid}",
+        selection.retained_records,
+        selection.train_records,
+        selection.held_out_records,
+        options.records,
     );
     Ok(())
 }
@@ -9186,8 +9661,8 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
                 "R4 transformerless — compile a mul-free table artifact\n\
                  commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
                  recorded compile (no transformer): compile-recorded --corpus-meta <META> --corpus-recs <RECS> --vocab-size <N> --out <DIR>\n\
-                 recorded execution copy (including dense sibling): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
-                 guarded recorded-corpus derivation: subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
+                 markerless legacy attention copy (dense-present derivations are refused): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
+                 guarded streaming corpus derivation (N <= source; complete runs may undershoot): subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
                  graph cover: cover --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
                  graph score: score --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
@@ -10314,6 +10789,531 @@ mod tests {
             record[offset..offset + 4].copy_from_slice(&weight.to_le_bytes());
         }
         record
+    }
+
+    fn subsample_args(source: &Path, destination: &Path, records: u64) -> Vec<String> {
+        vec![
+            "--src-meta".to_owned(),
+            source.join("corpus.meta").to_string_lossy().into_owned(),
+            "--src-recs".to_owned(),
+            source.join("corpus.records").to_string_lossy().into_owned(),
+            "--out-meta".to_owned(),
+            destination
+                .join("corpus.meta")
+                .to_string_lossy()
+                .into_owned(),
+            "--out-recs".to_owned(),
+            destination
+                .join("corpus.records")
+                .to_string_lossy()
+                .into_owned(),
+            "--records".to_owned(),
+            records.to_string(),
+        ]
+    }
+
+    fn subsample_fixture_row(width: usize, story: u32, index: u32) -> Vec<u8> {
+        let next = 100 + index;
+        match width {
+            12 => {
+                let mut row = vec![0u8; 12];
+                row[0..4].copy_from_slice(&story.to_le_bytes());
+                row[4..6].copy_from_slice(&(next as u16).to_le_bytes());
+                row[6..8].copy_from_slice(&(next as u16).to_le_bytes());
+                row[8..12].copy_from_slice(&(-0.25f32).to_le_bytes());
+                row
+            }
+            32 => {
+                let mut row = vec![0u8; 32];
+                row[0..4].copy_from_slice(&story.to_le_bytes());
+                row[4..8].copy_from_slice(&next.to_le_bytes());
+                for (slot, token) in [next, next + 1, next + 2].into_iter().enumerate() {
+                    let offset = 8 + slot * 4;
+                    row[offset..offset + 4].copy_from_slice(&token.to_le_bytes());
+                }
+                for (slot, weight) in [70u32, 20, 10].into_iter().enumerate() {
+                    let offset = 20 + slot * 4;
+                    row[offset..offset + 4].copy_from_slice(&weight.to_le_bytes());
+                }
+                row
+            }
+            48 => compiler::encode_v3_record(
+                story,
+                next,
+                &[next, next + 1, next + 2],
+                &[70, 20, 10],
+                (1_000 + index, 1_001 + index),
+                (2_000 + index, 2_001 + index),
+            )
+            .to_vec(),
+            88 => {
+                let mut row = vec![0u8; 88];
+                row[0..4].copy_from_slice(&story.to_le_bytes());
+                row[4..8].copy_from_slice(&next.to_le_bytes());
+                for slot in 0..8usize {
+                    let token = next + slot as u32;
+                    let token_offset = 8 + slot * 4;
+                    let weight_offset = 40 + slot * 4;
+                    row[token_offset..token_offset + 4].copy_from_slice(&token.to_le_bytes());
+                    row[weight_offset..weight_offset + 4]
+                        .copy_from_slice(&(80u32.saturating_sub(slot as u32 * 10)).to_le_bytes());
+                }
+                row[72..76].copy_from_slice(&(1_000 + index).to_le_bytes());
+                row[76..80].copy_from_slice(&(1_001 + index).to_le_bytes());
+                row[80..84].copy_from_slice(&(2_000 + index).to_le_bytes());
+                row[84..88].copy_from_slice(&(2_001 + index).to_le_bytes());
+                row
+            }
+            _ => panic!("unsupported fixture width {width}"),
+        }
+    }
+
+    fn write_subsample_fixture(root: &Path, width: usize, hidden_row_bytes: usize) -> Vec<Vec<u8>> {
+        std::fs::create_dir_all(root).expect("fixture root");
+        bind_compiled_dense_operator(root, Some(&DenseOperatorSpec::gpt2_v2()))
+            .expect("fixture dense identity");
+        bind_compiled_attention_operator(root, &AttentionOperatorSpec::learned_absolute_v2())
+            .expect("fixture attention identity");
+        let stories = [
+            0u32, 0, 0, // selected train run
+            1, 1, 1, 1, 1, 1, // skipped: too large
+            0, 0, // skipped: would stitch the selected story-0 run
+            2, 2, // selected
+            3, 3, 3, 3, // skipped: too large for remaining quota
+            4, 4, 4, // selected
+            8, 8, // selected held-out run
+            9, 9, // skipped: held-out quota has one row left
+        ];
+        let rows = stories
+            .into_iter()
+            .enumerate()
+            .map(|(index, story)| subsample_fixture_row(width, story, index as u32))
+            .collect::<Vec<_>>();
+        let records = rows.iter().flatten().copied().collect::<Vec<_>>();
+        let mut meta = vec![0u8; SOURCE_CORPUS_META_BYTES];
+        meta[0..8].copy_from_slice(&(rows.len() as u64).to_le_bytes());
+        meta[8..16].copy_from_slice(&10u64.to_le_bytes());
+        meta[16..24].copy_from_slice(&0x0729_5EED_u64.to_le_bytes());
+        meta[24] = 1;
+        std::fs::write(root.join("corpus.records"), records).expect("fixture records");
+        std::fs::write(root.join("corpus.meta"), meta).expect("fixture metadata");
+        if hidden_row_bytes != 0 {
+            let hidden = (0..rows.len())
+                .flat_map(|index| {
+                    (0..hidden_row_bytes)
+                        .map(move |byte| (index as u8).wrapping_mul(17).wrapping_add(byte as u8))
+                })
+                .collect::<Vec<_>>();
+            std::fs::write(root.join("corpus.records.hidden"), hidden).expect("fixture hidden");
+        }
+        rows
+    }
+
+    #[test]
+    fn subsample_streams_all_registered_widths_with_fixed_partition_and_exact_raw_rows() {
+        let selected_indices = [0usize, 1, 2, 11, 12, 17, 18, 19, 20, 21];
+        let expected_story = [0u32, 0, 0, 2, 2, 4, 4, 4, 8, 8];
+        let base = unique_cli_test_path("subsample-all-widths");
+        std::fs::create_dir_all(&base).expect("base");
+
+        for width in [12usize, 32, 48, 88] {
+            let source = base.join(format!("source-{width}"));
+            let destination = base.join(format!("destination-{width}"));
+            let rows = write_subsample_fixture(&source, width, 12);
+            let attention = AttentionOperatorSpec::learned_absolute_v2();
+            let dense = DenseOperatorSpec::gpt2_v2();
+            publish_test_corpus_binding(
+                &source,
+                &source.join("corpus.meta"),
+                &source.join("corpus.records"),
+            );
+
+            subsample_recorded_corpus(&subsample_args(&source, &destination, 11))
+                .expect("streaming subsample");
+            let meta = std::fs::read(destination.join("corpus.meta")).expect("output meta");
+            let source_meta = std::fs::read(source.join("corpus.meta")).expect("source meta");
+            assert_eq!(u64::from_le_bytes(meta[0..8].try_into().unwrap()), 10);
+            assert_eq!(u64::from_le_bytes(meta[8..16].try_into().unwrap()), 10);
+            assert_eq!(&meta[16..25], &source_meta[16..25]);
+
+            let expected_records = selected_indices
+                .iter()
+                .flat_map(|&index| rows[index].iter().copied())
+                .collect::<Vec<_>>();
+            let output_records =
+                std::fs::read(destination.join("corpus.records")).expect("output records");
+            assert_eq!(output_records, expected_records, "raw width {width}");
+            let corpus = compiler::load_corpus_bytes(&meta, &output_records, None)
+                .expect("derived corpus parses");
+            assert_eq!(corpus.story, expected_story, "stories width {width}");
+            let expected_input = [1u32, 100, 101, 1, 111, 1, 117, 118, 1, 120];
+            assert_eq!(corpus.input, expected_input, "inputs width {width}");
+            if matches!(width, 48 | 88) {
+                assert_eq!(
+                    corpus.span_start,
+                    selected_indices
+                        .iter()
+                        .map(|index| 1_000 + *index as u32)
+                        .collect::<Vec<_>>()
+                );
+                assert_eq!(
+                    corpus.byte_end,
+                    selected_indices
+                        .iter()
+                        .map(|index| 2_001 + *index as u32)
+                        .collect::<Vec<_>>()
+                );
+            } else {
+                assert_eq!(corpus.span_start, [0u32, 1, 2, 0, 1, 0, 1, 2, 0, 1]);
+                assert_eq!(corpus.byte_start, [u32::MAX; 10]);
+            }
+            let source_hidden =
+                std::fs::read(source.join("corpus.records.hidden")).expect("source hidden");
+            let expected_hidden = selected_indices
+                .iter()
+                .flat_map(|index| source_hidden[index * 12..index * 12 + 12].iter().copied())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                std::fs::read(destination.join("corpus.records.hidden")).unwrap(),
+                expected_hidden
+            );
+            assert_eq!(
+                compiled_attention_operator(&destination).unwrap(),
+                attention
+            );
+            assert_eq!(compiled_dense_operator(&destination).unwrap(), Some(dense));
+            if width == 48 {
+                let binding = std::fs::read(
+                    destination
+                        .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+                )
+                .expect("canonical output binding");
+                assert_eq!(
+                    format!("blake3:{}", blake3::hash(&binding).to_hex()),
+                    "blake3:2c05c249b75bc7dbc52cd79412443b4fc49bd9b6f01f86d660b5e908f1998c26"
+                );
+            }
+
+            let ready = directory_bytes(&destination);
+            subsample_recorded_corpus(&subsample_args(&source, &destination, 11))
+                .expect("idempotent ready rerun");
+            assert_eq!(directory_bytes(&destination), ready);
+        }
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn selected_ranges_reader_uses_fixed_buffers_at_multi_gigabyte_offsets() {
+        #[derive(Default)]
+        struct SparseReader {
+            position: u64,
+            max_request: usize,
+        }
+        impl Read for SparseReader {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                self.max_request = self.max_request.max(buffer.len());
+                for (offset, byte) in buffer.iter_mut().enumerate() {
+                    *byte = self.position.wrapping_add(offset as u64) as u8;
+                }
+                self.position += buffer.len() as u64;
+                Ok(buffer.len())
+            }
+        }
+        impl Seek for SparseReader {
+            fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+                let next = match position {
+                    SeekFrom::Start(next) => next,
+                    SeekFrom::Current(offset) => {
+                        u64::try_from(i128::from(self.position) + i128::from(offset)).unwrap()
+                    }
+                    SeekFrom::End(_) => panic!("fixture has no finite physical end"),
+                };
+                self.position = next;
+                Ok(next)
+            }
+        }
+
+        let ranges = [
+            SelectedByteRange {
+                start: 5 * 1024 * 1024 * 1024,
+                end: 5 * 1024 * 1024 * 1024 + 70_000,
+            },
+            SelectedByteRange {
+                start: 9 * 1024 * 1024 * 1024,
+                end: 9 * 1024 * 1024 * 1024 + 123,
+            },
+        ];
+        let mut source = SparseReader::default();
+        let summary = {
+            let mut selected = SelectedRangesReader::new(&mut source, &ranges).expect("ranges");
+            summarize_selected_stream(&mut selected, "sparse selected stream").expect("summary")
+        };
+        assert_eq!(summary.length, 70_123);
+        assert!(summary.blake3.starts_with("blake3:"));
+        assert!(source.max_request <= 64 * 1024, "{}", source.max_request);
+    }
+
+    #[test]
+    fn selector_preserves_u64_story_count_train_cut_and_requires_both_partitions() {
+        let mut records = Vec::new();
+        records.extend_from_slice(&subsample_fixture_row(12, 0, 0));
+        records.extend_from_slice(&subsample_fixture_row(12, u32::MAX, 1));
+        let mut cursor = std::io::Cursor::new(records);
+        let selected =
+            select_recorded_corpus_ranges(&mut cursor, 2, 12, u64::from(u32::MAX) + 100, 2)
+                .expect("u64 story metadata uses compiler train-cut cast semantics");
+        assert_eq!(selected.train_records, 1);
+        assert_eq!(selected.held_out_records, 1);
+        assert_eq!(selected.ranges, [SelectedRowRange { start: 0, end: 2 }]);
+
+        let mut train_only = std::io::Cursor::new(
+            [
+                subsample_fixture_row(12, 0, 0),
+                subsample_fixture_row(12, 0, 1),
+            ]
+            .concat(),
+        );
+        let error = select_recorded_corpus_ranges(&mut train_only, 2, 12, 10, 2)
+            .expect_err("full-source lane still requires both fixed partitions");
+        assert!(
+            error.reason.contains("both fixed source partitions"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn subsample_full_lane_refuses_oversize_and_malformed_hidden_rows() {
+        let base = unique_cli_test_path("subsample-full-and-hidden");
+        std::fs::create_dir_all(&base).expect("base");
+        let source = base.join("source");
+        write_subsample_fixture(&source, 48, 12);
+        publish_test_corpus_binding(
+            &source,
+            &source.join("corpus.meta"),
+            &source.join("corpus.records"),
+        );
+
+        let full = base.join("full");
+        subsample_recorded_corpus(&subsample_args(&source, &full, 24))
+            .expect("N equal to source is an exact full lane");
+        for member in ["corpus.meta", "corpus.records", "corpus.records.hidden"] {
+            assert_eq!(
+                std::fs::read(full.join(member)).unwrap(),
+                std::fs::read(source.join(member)).unwrap(),
+                "full lane member {member}"
+            );
+        }
+
+        let oversize = base.join("oversize");
+        let error = subsample_recorded_corpus(&subsample_args(&source, &oversize, 25))
+            .expect_err("N above the finalized source is refused");
+        assert!(error.reason.contains("exceeds the source"), "{error}");
+        assert!(
+            !oversize.exists(),
+            "oversize refusal publishes no output root"
+        );
+
+        for (name, hidden_bytes, expected) in [
+            (
+                "not-divisible",
+                vec![0u8; 24 * 4 + 1],
+                "not an exact row width",
+            ),
+            (
+                "not-f32-aligned",
+                vec![0u8; 24 * 6],
+                "not an exact f32 byte multiple",
+            ),
+        ] {
+            let malformed = base.join(name);
+            write_subsample_fixture(&malformed, 48, 0);
+            std::fs::write(malformed.join("corpus.records.hidden"), hidden_bytes)
+                .expect("malformed hidden body");
+            publish_test_corpus_binding(
+                &malformed,
+                &malformed.join("corpus.meta"),
+                &malformed.join("corpus.records"),
+            );
+            let destination = base.join(format!("{name}-output"));
+            let error = subsample_recorded_corpus(&subsample_args(&malformed, &destination, 11))
+                .expect_err("malformed hidden layout is terminal");
+            assert!(error.reason.contains(expected), "{error}");
+            assert!(
+                !destination.exists(),
+                "hidden-layout refusal publishes no output root"
+            );
+        }
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn subsample_refuses_alias_missing_parent_and_busy_roots_without_payload_mutation() {
+        let base = unique_cli_test_path("subsample-root-authority");
+        std::fs::create_dir_all(&base).expect("base");
+        let source = base.join("source");
+        write_subsample_fixture(&source, 48, 12);
+        publish_test_corpus_binding(
+            &source,
+            &source.join("corpus.meta"),
+            &source.join("corpus.records"),
+        );
+        let source_before = directory_bytes(&source);
+
+        let in_place = subsample_recorded_corpus(&subsample_args(&source, &source, 11))
+            .expect_err("in-place derivation is refused");
+        assert!(
+            in_place.reason.contains("same canonical root"),
+            "{in_place}"
+        );
+        assert_eq!(directory_bytes(&source), source_before);
+
+        let missing_parent = base.join("missing-parent").join("destination");
+        let error = subsample_recorded_corpus(&subsample_args(&source, &missing_parent, 11))
+            .expect_err("destination immediate parent must already exist");
+        assert!(error.reason.contains("cannot be canonicalized"), "{error}");
+        assert!(!base.join("missing-parent").exists());
+        assert_eq!(directory_bytes(&source), source_before);
+
+        #[cfg(unix)]
+        {
+            let source_link = base.join("source-link");
+            std::os::unix::fs::symlink(&source, &source_link).expect("source symlink");
+            let destination = base.join("symlink-output");
+            let error = subsample_recorded_corpus(&subsample_args(&source_link, &destination, 11))
+                .expect_err("lexical source-root symlink is refused");
+            assert!(error.reason.contains("not a real non-symlink"), "{error}");
+            assert!(!destination.exists());
+            assert_eq!(directory_bytes(&source), source_before);
+        }
+
+        let source_blocker =
+            RecordedCorpusProducerGuard::try_acquire(&source).expect("source contention fixture");
+        let source_busy_output = base.join("source-busy-output");
+        let error = subsample_recorded_corpus(&subsample_args(&source, &source_busy_output, 11))
+            .expect_err("source BUSY is propagated");
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&error),
+            "{error}"
+        );
+        assert!(!source_busy_output.exists());
+        assert_eq!(directory_bytes(&source), source_before);
+        drop(source_blocker);
+
+        let destination = base.join("destination-busy");
+        std::fs::create_dir(&destination).expect("destination fixture");
+        let destination_blocker = RecordedCorpusProducerGuard::try_acquire(&destination)
+            .expect("destination contention fixture");
+        let error = subsample_recorded_corpus(&subsample_args(&source, &destination, 11))
+            .expect_err("destination BUSY is propagated");
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&error),
+            "{error}"
+        );
+        assert!(directory_bytes(&destination).is_empty());
+        assert_eq!(directory_bytes(&source), source_before);
+        drop(destination_blocker);
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn subsample_markerless_compatibility_crash_recovery_and_wrong_role_are_exact() {
+        let base = unique_cli_test_path("subsample-compat-recovery");
+        std::fs::create_dir_all(&base).expect("base");
+
+        let attention_only = base.join("attention-only");
+        write_subsample_fixture(&attention_only, 48, 12);
+        std::fs::remove_file(attention_only.join(DENSE_OPERATOR_BINDING_FILE))
+            .expect("make markerless attention-only source");
+        let attention_output = base.join("attention-output");
+        subsample_recorded_corpus(&subsample_args(&attention_only, &attention_output, 11))
+            .expect("markerless attention-only source remains compatible");
+        assert_eq!(
+            compiled_attention_operator(&attention_output).unwrap(),
+            AttentionOperatorSpec::learned_absolute_v2()
+        );
+        assert_eq!(compiled_dense_operator(&attention_output).unwrap(), None);
+
+        let markerless_dense = base.join("markerless-dense");
+        write_subsample_fixture(&markerless_dense, 48, 12);
+        std::fs::remove_file(markerless_dense.join(ATTENTION_OPERATOR_BINDING_FILE))
+            .expect("make invalid markerless dense source");
+        let dense_before = directory_bytes(&markerless_dense);
+        let dense_output = base.join("dense-output");
+        let error =
+            subsample_recorded_corpus(&subsample_args(&markerless_dense, &dense_output, 11))
+                .expect_err("markerless dense source is refused");
+        assert!(
+            error.reason.contains("dense")
+                && (error.reason.contains("binding") || error.reason.contains("attention")),
+            "{error}"
+        );
+        assert!(!dense_output.exists());
+        assert_eq!(directory_bytes(&markerless_dense), dense_before);
+
+        let source = base.join("bound-source");
+        write_subsample_fixture(&source, 48, 12);
+        publish_test_corpus_binding(
+            &source,
+            &source.join("corpus.meta"),
+            &source.join("corpus.records"),
+        );
+        let recovered = base.join("recovered");
+        let args = subsample_args(&source, &recovered, 11);
+        let error = subsample_recorded_corpus_with_before_binding(&args, || {
+            Err(SourceUnavailable::new("injected crash before binding"))
+        })
+        .expect_err("pre-binding crash boundary");
+        assert!(error.reason.contains("injected crash"), "{error}");
+        assert!(
+            !recovered
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+                .exists()
+        );
+        assert!(
+            recovered
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists()
+        );
+        let records_before = std::fs::read(recovered.join("corpus.records")).unwrap();
+        let hidden_before = std::fs::read(recovered.join("corpus.records.hidden")).unwrap();
+        let meta_before = std::fs::read(recovered.join("corpus.meta")).unwrap();
+        subsample_recorded_corpus(&args).expect("exact crash-prefix rerun commits binding");
+        assert_eq!(
+            std::fs::read(recovered.join("corpus.records")).unwrap(),
+            records_before
+        );
+        assert_eq!(
+            std::fs::read(recovered.join("corpus.records.hidden")).unwrap(),
+            hidden_before
+        );
+        assert_eq!(
+            std::fs::read(recovered.join("corpus.meta")).unwrap(),
+            meta_before
+        );
+        assert!(
+            recovered
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+                .exists()
+        );
+        assert!(
+            !recovered
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists()
+        );
+
+        let wrong_role = base.join("wrong-role");
+        let (state, merged) = complete_test_observation_corpus(&wrong_role);
+        publish_test_observation_binding(&wrong_role, &state, &merged);
+        std::fs::remove_file(state).expect("remove observation state body");
+        std::fs::remove_file(merged).expect("remove observation merged body");
+        let wrong_before = directory_bytes(&wrong_role);
+        let error = subsample_recorded_corpus(&subsample_args(&source, &wrong_role, 11))
+            .expect_err("observation-role binding cannot become a compile corpus");
+        assert!(error.reason.contains("cross-role"), "{error}");
+        assert_eq!(directory_bytes(&wrong_role), wrong_before);
+
+        let _ = std::fs::remove_dir_all(base);
     }
 
     fn copy_recorded_attention_args(meta: &Path, records: &Path, output: &Path) -> Vec<String> {

--- a/crates/uor-r4-graph-cli/tests/gpt2_compile_canary_670.rs
+++ b/crates/uor-r4-graph-cli/tests/gpt2_compile_canary_670.rs
@@ -34,8 +34,11 @@
 use std::path::{Path, PathBuf};
 
 use uor_r4_core::transformerless::compiler;
-use uor_r4_graph_cli::{compile_hugging_face_with_progress, cover_command};
+use uor_r4_graph_cli::{
+    compile_hugging_face_with_progress, compiled_dense_operator, cover_command,
+};
 use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
 use uor_r4_model_source::geometry::{self, GeometryProjection};
 
 /// GPT-2 (124M) source hidden width; the geometry projection the oracle
@@ -141,6 +144,7 @@ fn cover_args(
     kappa: &str,
     geometry_json: &str,
     operator_json: &str,
+    dense_operator_json: &str,
 ) -> Vec<String> {
     vec![
         "--artifacts".to_owned(),
@@ -163,6 +167,8 @@ fn cover_args(
         geometry_json.to_owned(),
         "--attention-operator".to_owned(),
         operator_json.to_owned(),
+        "--dense-operator".to_owned(),
+        dense_operator_json.to_owned(),
         "--regions-budget".to_owned(),
         "16".to_owned(),
         "--memory-budget".to_owned(),
@@ -200,8 +206,11 @@ fn gpt2_cover_certifies_source_parity_rows() {
     // The source rows the GPT-2 oracle declares (see `uor-r4-model-source`
     // gpt2.rs `attention_operator_spec` / `geometry_projection`).
     let operator = AttentionOperatorSpec::learned_absolute_source_attention();
+    let dense_operator = DenseOperatorSpec::gpt2_source_dense();
     let geometry_proj = GeometryProjection::bucket_average(GPT2_N_EMBD, geometry::COMPILED_WIDTH);
     let operator_json = serde_json::to_string(&operator).expect("operator serializes");
+    let dense_operator_json =
+        serde_json::to_string(&dense_operator).expect("dense operator serializes");
     let geometry_json = serde_json::to_string(&geometry_proj).expect("geometry serializes");
 
     let compiled = unique_out("cover-src");
@@ -217,6 +226,11 @@ fn gpt2_cover_certifies_source_parity_rows() {
         compiled.join("corpus.meta").is_file() && compiled.join("corpus.records").is_file(),
         "compile emits the teacher corpus streams for cover"
     );
+    assert_eq!(
+        compiled_dense_operator(&compiled).expect("compiled dense binding"),
+        Some(dense_operator.clone()),
+        "GPT-2 stage A pins the current certified dense execution record"
+    );
 
     cover_command(&cover_args(
         &compiled,
@@ -224,6 +238,7 @@ fn gpt2_cover_certifies_source_parity_rows() {
         &source_kappa,
         &geometry_json,
         &operator_json,
+        &dense_operator_json,
     ))
     .expect("cover induction over the GPT-2 teacher");
 
@@ -250,6 +265,12 @@ fn gpt2_cover_certifies_source_parity_rows() {
     assert_eq!(
         report_operator, operator,
         "the report's operator is the GPT-2 learned-absolute source attention"
+    );
+    let report_dense: DenseOperatorSpec = serde_json::from_value(report["dense_operator"].clone())
+        .expect("report carries a dense-operator row");
+    assert_eq!(
+        report_dense, dense_operator,
+        "the report's dense operator is the certified GPT-2 source implementation"
     );
     // #600: the geometry row round-trips to bucket-average(768 → compiled).
     let report_geometry: GeometryProjection =
@@ -279,6 +300,7 @@ fn gpt2_cover_certifies_source_parity_rows() {
         &source_kappa,
         &geometry_json,
         &operator_json,
+        &dense_operator_json,
     ))
     .expect("cover induction (second run)");
     let bytes_b = std::fs::read(cover_b.join("cover.r4g1")).expect("read second-run cover.r4g1");

--- a/crates/uor-r4-graph-cli/tests/scale_sweep_script_729.rs
+++ b/crates/uor-r4-graph-cli/tests/scale_sweep_script_729.rs
@@ -1,0 +1,359 @@
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new() -> Self {
+        let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "uor-r4-scale-sweep-729-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).expect("create unique scratch directory");
+        Self(path)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn write_meta(path: &Path, records: u64) {
+    let mut bytes = Vec::with_capacity(25);
+    bytes.extend_from_slice(&records.to_le_bytes());
+    bytes.extend_from_slice(&10_u64.to_le_bytes());
+    bytes.extend_from_slice(&7_u64.to_le_bytes());
+    bytes.push(1);
+    std::fs::write(path, bytes).expect("write finalized source metadata");
+}
+
+fn write_fake_r4(path: &Path) {
+    std::fs::write(
+        path,
+        r#"#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import shutil
+import struct
+import sys
+
+args = sys.argv[1:]
+with open(os.environ["FAKE_LOG"], "a", encoding="utf-8") as log:
+    log.write(" ".join(args) + "\n")
+
+def value(flag):
+    return args[args.index(flag) + 1]
+
+operation = args[1]
+if operation == "subsample-recorded-corpus":
+    source_meta = Path(value("--src-meta"))
+    source_n = struct.unpack_from("<Q", source_meta.read_bytes())[0]
+    requested = int(value("--records"))
+    actual = requested if requested == source_n else requested - 1
+    out_meta = Path(value("--out-meta"))
+    out_recs = Path(value("--out-recs"))
+    out_meta.parent.mkdir(parents=True, exist_ok=True)
+    out_meta.write_bytes(struct.pack("<QQQ", actual, 10, 7) + b"\x01")
+    out_recs.write_bytes(b"")
+elif operation == "compile-recorded":
+    output = Path(value("--out"))
+    output.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(value("--corpus-meta"), output / "corpus.meta")
+    shutil.copyfile(value("--corpus-recs"), output / "corpus.records")
+    (output / "tless_artifacts.bin").write_bytes(b"artifacts")
+    (output / "attention_operator.json").write_text('{"schema":2}')
+    if os.environ.get("FAKE_DENSE") == "1":
+        (output / "dense_operator.json").write_text('{"schema":2}')
+elif operation == "cover":
+    output = Path(value("--out"))
+    output.mkdir(parents=True, exist_ok=True)
+    actual = struct.unpack_from("<Q", Path(value("--corpus-meta")).read_bytes())[0]
+    train = actual * 4 // 5
+    held = actual - train
+    if os.environ.get("FAKE_BAD_COUNTS") == "1":
+        held += 1
+    report = {"inputs": {"train_observations": train, "held_out_observations": held}}
+    (output / "cover_report.json").write_text(json.dumps(report))
+    (output / "cover.r4g1").write_bytes(b"cover")
+elif operation == "score":
+    output = Path(value("--out"))
+    output.mkdir(parents=True, exist_ok=True)
+    cover_report = Path(value("--cover")).parent / "cover_report.json"
+    held = json.loads(cover_report.read_text())["inputs"]["held_out_observations"]
+    report = {
+        "gate_c": {
+            "held_out_population": held,
+            "rule12_precedence": {"top1_agreement": 0.25},
+        },
+        "distribution": {"held_out_positions": held, "exct_miss_rate": 0.5},
+    }
+    (output / "score_report.json").write_text(json.dumps(report))
+else:
+    raise SystemExit(f"unexpected operation: {operation}")
+"#,
+    )
+    .expect("write fake r4");
+    let mut permissions = std::fs::metadata(path)
+        .expect("fake r4 metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("make fake r4 executable");
+}
+
+struct SweepOptions<'a> {
+    targets: &'a [&'a str],
+    dense: bool,
+    bad_counts: bool,
+}
+
+fn run_sweep(
+    source_meta: &Path,
+    source_recs: &Path,
+    fake_r4: &Path,
+    work: &Path,
+    log: &Path,
+    options: SweepOptions<'_>,
+) -> Output {
+    let mut command = Command::new("bash");
+    command
+        .arg(workspace_root().join("scripts/scale_sweep.sh"))
+        .arg(source_meta)
+        .arg(source_recs)
+        .arg("49152")
+        .args(options.targets)
+        .env("R4", fake_r4)
+        .env("WORK", work)
+        .env("FAKE_LOG", log);
+    if options.dense {
+        command.env("FAKE_DENSE", "1");
+    }
+    if options.bad_counts {
+        command.env("FAKE_BAD_COUNTS", "1");
+    }
+    command.output().expect("run scale sweep")
+}
+
+fn fixture(scratch: &Scratch, records: u64) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let source_meta = scratch.0.join("source.meta");
+    let source_recs = scratch.0.join("source.records");
+    let fake_r4 = scratch.0.join("fake-r4");
+    let log = scratch.0.join("calls.log");
+    write_meta(&source_meta, records);
+    std::fs::write(&source_recs, b"").expect("write source records fixture");
+    write_fake_r4(&fake_r4);
+    (source_meta, source_recs, fake_r4, log)
+}
+
+#[test]
+fn fixed_partition_workflow_is_rerunnable_and_reports_requested_vs_actual() {
+    let scratch = Scratch::new();
+    let (meta, recs, fake_r4, log) = fixture(&scratch, 20);
+    let work = scratch.0.join("work");
+
+    let first = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &work,
+        &log,
+        SweepOptions {
+            targets: &["10", "20"],
+            dense: true,
+            bad_counts: false,
+        },
+    );
+    assert!(
+        first.status.success(),
+        "first sweep failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_stdout = String::from_utf8(first.stdout).expect("UTF-8 sweep output");
+    let rows: Vec<Vec<&str>> = first_stdout
+        .lines()
+        .filter(|line| line.starts_with(|character: char| character.is_ascii_digit()))
+        .map(|line| line.split_whitespace().collect())
+        .collect();
+    assert_eq!(rows[0][..4], ["10", "9", "7", "2"]);
+    assert_eq!(rows[1][..4], ["20", "20", "16", "4"]);
+
+    for target in ["10", "20"] {
+        let case = work.join(format!("n-{target}"));
+        for sibling in ["input", "compiled", "cover", "score"] {
+            assert!(case.join(sibling).is_dir(), "missing {target}/{sibling}");
+        }
+    }
+    let first_log = std::fs::read_to_string(&log).expect("read first invocation log");
+    assert!(first_log.contains("subsample-recorded-corpus"));
+    assert!(
+        first_log.contains("--records 20"),
+        "exact source was not sampled"
+    );
+    assert!(first_log.contains("--dense-operator"));
+    assert!(first_log.contains("n-10/compiled"));
+    assert!(first_log.contains("n-10/cover"));
+    assert!(first_log.contains("n-10/score"));
+
+    let second = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &work,
+        &log,
+        SweepOptions {
+            targets: &["10", "20"],
+            dense: true,
+            bad_counts: false,
+        },
+    );
+    assert!(second.status.success());
+    assert_eq!(first_stdout.as_bytes(), second.stdout);
+}
+
+#[test]
+fn all_targets_are_rejected_before_work_or_r4_mutation() {
+    let scratch = Scratch::new();
+    let (meta, recs, fake_r4, log) = fixture(&scratch, 20);
+    let work = scratch.0.join("must-not-exist");
+
+    let output = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &work,
+        &log,
+        SweepOptions {
+            targets: &["10", "21"],
+            dense: false,
+            bad_counts: false,
+        },
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exceeds finalized source size"));
+    assert!(!work.exists(), "preflight failure created WORK");
+    assert!(!log.exists(), "preflight failure invoked r4");
+}
+
+#[test]
+fn default_targets_are_bounded_candidates_plus_exact_source() {
+    let scratch = Scratch::new();
+    let (meta, recs, fake_r4, log) = fixture(&scratch, 900_001);
+    let output = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &scratch.0.join("work"),
+        &log,
+        SweepOptions {
+            targets: &[],
+            dense: false,
+            bad_counts: false,
+        },
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 sweep output");
+    let requested: Vec<&str> = stdout
+        .lines()
+        .filter(|line| line.starts_with(|character: char| character.is_ascii_digit()))
+        .map(|line| line.split_whitespace().next().expect("requested column"))
+        .collect();
+    assert_eq!(requested, ["50000", "200000", "800000", "900001"]);
+}
+
+#[test]
+fn attention_only_cover_omits_the_dense_argument() {
+    let scratch = Scratch::new();
+    let (meta, recs, fake_r4, log) = fixture(&scratch, 20);
+    let output = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &scratch.0.join("work"),
+        &log,
+        SweepOptions {
+            targets: &["20"],
+            dense: false,
+            bad_counts: false,
+        },
+    );
+    assert!(
+        output.status.success(),
+        "attention-only sweep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let calls = std::fs::read_to_string(log).expect("read attention-only invocation log");
+    let cover = calls
+        .lines()
+        .find(|line| line.starts_with("transformerless cover "))
+        .expect("cover invocation");
+    assert!(cover.contains("--attention-operator"));
+    assert!(!cover.contains("--dense-operator"));
+}
+
+#[test]
+fn inconsistent_cover_counts_are_terminal() {
+    let scratch = Scratch::new();
+    let (meta, recs, fake_r4, log) = fixture(&scratch, 20);
+    let output = run_sweep(
+        &meta,
+        &recs,
+        &fake_r4,
+        &scratch.0.join("work"),
+        &log,
+        SweepOptions {
+            targets: &["10"],
+            dense: false,
+            bad_counts: true,
+        },
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cover partition mismatch"));
+}
+
+#[test]
+fn retired_python_writer_never_touches_outputs() {
+    let scratch = Scratch::new();
+    let out_meta = scratch.0.join("sentinel.meta");
+    let out_recs = scratch.0.join("sentinel.records");
+    std::fs::write(&out_meta, b"meta sentinel").expect("write metadata sentinel");
+    std::fs::write(&out_recs, b"records sentinel").expect("write records sentinel");
+
+    let output = Command::new("python3")
+        .arg(workspace_root().join("scripts/mc1_subsample_corpus.py"))
+        .args([
+            "--src-meta",
+            "missing.meta",
+            "--src-recs",
+            "missing.records",
+        ])
+        .arg("--out-meta")
+        .arg(&out_meta)
+        .arg("--out-recs")
+        .arg(&out_recs)
+        .args(["--records", "10"])
+        .output()
+        .expect("run retired Python writer");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("is retired"));
+    assert_eq!(
+        std::fs::read(&out_meta).expect("read metadata sentinel"),
+        b"meta sentinel"
+    );
+    assert_eq!(
+        std::fs::read(&out_recs).expect("read records sentinel"),
+        b"records sentinel"
+    );
+}

--- a/crates/uor-r4-graph-compiler/Cargo.toml
+++ b/crates/uor-r4-graph-compiler/Cargo.toml
@@ -16,6 +16,9 @@ serde_json = "1.0"
 log = "0.4"
 env_logger = "0.11"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 # #515 preserve-and-gate: dormant compiler surfaces with NO default-build
 # reference (code or tests) are compile-toggled here, default OFF. Modules that

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2574,6 +2574,10 @@ pub struct CoverReport {
     /// [`build_report`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
+    /// Host-side dense execution provenance, when the source oracle declares
+    /// one. Optional so legacy and Llama report bytes remain unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dense_operator: Option<uor_r4_model_source::dense::DenseOperatorSpec>,
     pub config: CoverReportConfig,
     pub inputs: CoverReportInputs,
     pub objective: CoverReportObjective,
@@ -2796,6 +2800,7 @@ pub fn build_report(config: &CoverConfig, induced: &InducedCover, data: ReportDa
         // stages do not see the teacher.
         geometry: None,
         attention_operator: None,
+        dense_operator: None,
         config: CoverReportConfig {
             depths: config.depths,
             k0: config.k0,

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -193,18 +193,47 @@ fn explicit_tokenizer_cid(path: Option<&std::path::Path>) -> Result<[u8; 32], So
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn preflight_graph_compile_corpus(
-    options: &GraphCompileOptions,
-) -> Result<(recorded_corpus::RecordedCorpusSnapshot, compiler::Corpus), SourceUnavailable> {
-    preflight_graph_compile_corpus_with_hooks(options, || {}, || {})
+struct PreparedGraphCompileCorpus {
+    meta_bytes: Vec<u8>,
+    records_bytes: Vec<u8>,
+    corpus: compiler::Corpus,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn preflight_graph_compile_corpus(
+    options: &GraphCompileOptions,
+) -> Result<PreparedGraphCompileCorpus, SourceUnavailable> {
+    let (mut snapshot, _source_guard) =
+        recorded_corpus::open_stream_for_derivation(&options.corpus_meta, &options.corpus_recs)?;
+    recorded_corpus::require_execution_identity(
+        &snapshot.execution,
+        options.attention_operator.as_ref(),
+        options.dense_operator.as_ref(),
+        "graph-compile provenance",
+    )?;
+    let (records_bytes, hidden_bytes) = snapshot.materialize_compiler_corpus_bytes()?;
+    let meta_bytes = snapshot.meta_bytes.clone();
+    let corpus = compiler::load_corpus_bytes(&meta_bytes, &records_bytes, hidden_bytes.as_deref())
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "corpus is incomplete at {}/{}; run compile until it is complete",
+                options.corpus_meta.display(),
+                options.corpus_recs.display()
+            ))
+        })?;
+    Ok(PreparedGraphCompileCorpus {
+        meta_bytes,
+        records_bytes,
+        corpus,
+    })
+}
+
+#[cfg(all(not(target_arch = "wasm32"), test))]
 fn preflight_graph_compile_corpus_with_hooks<F, G>(
     options: &GraphCompileOptions,
     after_provenance_capture: F,
     after_corpus_capture: G,
-) -> Result<(recorded_corpus::RecordedCorpusSnapshot, compiler::Corpus), SourceUnavailable>
+) -> Result<PreparedGraphCompileCorpus, SourceUnavailable>
 where
     F: FnOnce(),
     G: FnOnce(),
@@ -233,7 +262,11 @@ where
             options.corpus_recs.display()
         ))
     })?;
-    Ok((snapshot, corpus))
+    Ok(PreparedGraphCompileCorpus {
+        meta_bytes: snapshot.meta_bytes,
+        records_bytes: snapshot.records_bytes,
+        corpus,
+    })
 }
 
 /// Run the full multiresolution graph compilation pipeline (Option 1).
@@ -253,7 +286,8 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     // Capture corpus bytes and their exact attention+dense execution identity
     // as one no-following transaction. This lower boundary rejects caller
     // relabeling and inter-phase generation swaps before output mutation.
-    let (recorded_corpus, corpus) = preflight_graph_compile_corpus(&options)?;
+    let recorded_corpus = preflight_graph_compile_corpus(&options)?;
+    let corpus = &recorded_corpus.corpus;
     let env_jobs = std::env::var("R4_COMPILER_THREADS").ok();
     let jobs_config = jobs_config::CompilerJobsConfig::resolve(options.jobs, env_jobs.as_deref())
         .ok_or_else(|| {
@@ -294,9 +328,9 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
         "graph-compiler: inducing (depths {}, k0 {}, regions budget {}, memory budget {} MiB)...",
         config.depths, config.k0, config.regions_budget, options.memory_budget_mb
     );
-    let (train_positions, held_out_positions) = induction::split_positions(&corpus);
-    let train = induction::build_observations(&artifacts, &corpus, &train_positions);
-    let held_out = induction::build_observations(&artifacts, &corpus, &held_out_positions);
+    let (train_positions, held_out_positions) = induction::split_positions(corpus);
+    let train = induction::build_observations(&artifacts, corpus, &train_positions);
+    let held_out = induction::build_observations(&artifacts, corpus, &held_out_positions);
     let induced = induction::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)
         .ok_or_else(|| {
             SourceUnavailable::new("cover induction needs at least one train observation")
@@ -1185,8 +1219,14 @@ mod tokenizer_observe_tests {
     fn graph_compile_preflight_rejects_dense_absence_and_wrong_era_before_mutation() {
         let root = unique_path("graph-compile-recorded-dense-v2");
         std::fs::create_dir_all(&root).expect("corpus root");
-        std::fs::write(root.join("corpus.meta"), b"captured metadata").expect("metadata");
-        std::fs::write(root.join("corpus.records"), b"captured records").expect("records");
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        let mut meta_bytes = [0u8; 25];
+        meta_bytes[0..8].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[24] = 1;
+        std::fs::write(&meta, meta_bytes).expect("metadata");
+        std::fs::write(&records, [0u8; 48]).expect("records");
         write_execution_sidecar(
             &root.join(recorded_corpus::ATTENTION_OPERATOR_BINDING_FILE),
             &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v2(),
@@ -1195,6 +1235,12 @@ mod tokenizer_observe_tests {
             &root.join(recorded_corpus::DENSE_OPERATOR_BINDING_FILE),
             &uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v2(),
         );
+        let guard =
+            recorded_corpus::RecordedCorpusProducerGuard::try_acquire(&root).expect("source guard");
+        guard.begin_compile_attempt().expect("source attempt");
+        recorded_corpus::publish_binding(&guard, &meta, &records).expect("source binding");
+        guard.finish_compile_attempt().expect("finish source");
+        drop(guard);
         let output = unique_path("graph-compile-recorded-dense-output");
         std::fs::create_dir_all(&output).expect("output root");
         std::fs::write(output.join("sentinel"), b"last-good output").expect("sentinel");

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -1324,7 +1324,12 @@ mod tokenizer_observe_tests {
         )
         .err()
         .expect("provenance A cannot label corpus B");
-        assert!(error.reason.contains("changed after capture"), "{error}");
+        assert!(
+            error
+                .reason
+                .contains("changed identity, type, or length after capture"),
+            "{error}"
+        );
         assert_eq!(directory_bytes(&output), output_before);
 
         let _ = std::fs::remove_dir_all(root);

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -21,6 +21,8 @@ pub mod perturbation;
 pub mod probability_calibration;
 pub mod quantum_cover;
 pub mod rate_distortion_compression;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod recorded_corpus;
 pub mod reference_compiler_ir;
 pub mod reproducibility;
 pub mod residual;
@@ -75,6 +77,9 @@ pub struct GraphCompileOptions {
     /// record itself; the pipeline that held the oracle (or its
     /// `r4_attention` switch) passes it.
     pub attention_operator: Option<uor_r4_model_source::attention::AttentionOperatorSpec>,
+    /// Typed host-side dense execution record (`--dense-operator`). This is
+    /// source provenance derived from the oracle, never a compiler knob.
+    pub dense_operator: Option<uor_r4_model_source::dense::DenseOperatorSpec>,
 }
 
 /// Parse graph-compile CLI arguments. `None` when the arguments do not name a
@@ -98,6 +103,7 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
         source_manifest_kappa: None,
         geometry: None,
         attention_operator: None,
+        dense_operator: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -149,10 +155,22 @@ pub fn parse_options(args: &[String]) -> Option<GraphCompileOptions> {
                 observation::validate_registered_source_attention_operator(&operator).ok()?;
                 options.attention_operator = Some(operator);
             }
+            "--dense-operator" => {
+                let operator: uor_r4_model_source::dense::DenseOperatorSpec =
+                    serde_json::from_str(value).ok()?;
+                observation::validate_registered_source_dense_operator(&operator).ok()?;
+                options.dense_operator = Some(operator);
+            }
             _ => return None,
         }
         index += 2;
     }
+    observation::validate_source_execution_identity(
+        options.attention_operator.as_ref(),
+        options.dense_operator.as_ref(),
+        "graph-compile provenance",
+    )
+    .ok()?;
     Some(options)
 }
 
@@ -174,6 +192,50 @@ fn explicit_tokenizer_cid(path: Option<&std::path::Path>) -> Result<[u8; 32], So
     Ok(*blake3::hash(&bytes).as_bytes())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_graph_compile_corpus(
+    options: &GraphCompileOptions,
+) -> Result<(recorded_corpus::RecordedCorpusSnapshot, compiler::Corpus), SourceUnavailable> {
+    preflight_graph_compile_corpus_with_hooks(options, || {}, || {})
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_graph_compile_corpus_with_hooks<F, G>(
+    options: &GraphCompileOptions,
+    after_provenance_capture: F,
+    after_corpus_capture: G,
+) -> Result<(recorded_corpus::RecordedCorpusSnapshot, compiler::Corpus), SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    let snapshot = recorded_corpus::capture_with_hooks(
+        &options.corpus_meta,
+        &options.corpus_recs,
+        after_provenance_capture,
+        after_corpus_capture,
+    )?;
+    recorded_corpus::require_execution_identity(
+        &snapshot.execution,
+        options.attention_operator.as_ref(),
+        options.dense_operator.as_ref(),
+        "graph-compile provenance",
+    )?;
+    let corpus = compiler::load_corpus_bytes(
+        &snapshot.meta_bytes,
+        &snapshot.records_bytes,
+        snapshot.hidden_bytes.as_deref(),
+    )
+    .ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "corpus is incomplete at {}/{}; run compile until it is complete",
+            options.corpus_meta.display(),
+            options.corpus_recs.display()
+        ))
+    })?;
+    Ok((snapshot, corpus))
+}
+
 /// Run the full multiresolution graph compilation pipeline (Option 1).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
@@ -188,6 +250,10 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     // mutation. A missing, dangling, directory, or other non-regular path is a
     // hard error; only flag absence selects the legacy zero-CID contract.
     let tokenizer_cid = explicit_tokenizer_cid(options.tokenizer.as_deref())?;
+    // Capture corpus bytes and their exact attention+dense execution identity
+    // as one no-following transaction. This lower boundary rejects caller
+    // relabeling and inter-phase generation swaps before output mutation.
+    let (recorded_corpus, corpus) = preflight_graph_compile_corpus(&options)?;
     let env_jobs = std::env::var("R4_COMPILER_THREADS").ok();
     let jobs_config = jobs_config::CompilerJobsConfig::resolve(options.jobs, env_jobs.as_deref())
         .ok_or_else(|| {
@@ -200,14 +266,6 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
         "graph-compiler: initialized dedicated thread pool ({} workers, source: {:?})",
         jobs_config.jobs, jobs_config.source
     );
-    let corpus_meta = options
-        .corpus_meta
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus metadata path is not UTF-8"))?;
-    let corpus_recs = options
-        .corpus_recs
-        .to_str()
-        .ok_or_else(|| SourceUnavailable::new("corpus records path is not UTF-8"))?;
     // #450: announce the resolved containers before the long work.
     let artifact_container = std::fs::read(&options.artifacts).map_err(|error| {
         SourceUnavailable::new(format!("{}: {error}", options.artifacts.display()))
@@ -220,21 +278,10 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     })?;
     let artifact_kappa = reproducibility::container_kappa(&artifact_container);
     reproducibility::announce_teacher_container(&options.artifacts, &artifact_kappa);
-    let meta_bytes = std::fs::read(&options.corpus_meta).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", options.corpus_meta.display()))
-    })?;
-    let recs_bytes = std::fs::read(&options.corpus_recs).map_err(|error| {
-        SourceUnavailable::new(format!("{}: {error}", options.corpus_recs.display()))
-    })?;
-    let corpus_kappa = reproducibility::corpus_stream_kappa(&meta_bytes, &recs_bytes);
+    let meta_bytes = &recorded_corpus.meta_bytes;
+    let recs_bytes = &recorded_corpus.records_bytes;
+    let corpus_kappa = reproducibility::corpus_stream_kappa(meta_bytes, recs_bytes);
     reproducibility::announce_corpus(&options.corpus_meta, &options.corpus_recs, &corpus_kappa);
-    let corpus = compiler::load_corpus_from(corpus_meta, corpus_recs).ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "corpus is incomplete at {}/{}; run compile until it is complete",
-            options.corpus_meta.display(),
-            options.corpus_recs.display()
-        ))
-    })?;
 
     let config = induction::CoverConfig {
         depths: options.depths,
@@ -268,7 +315,7 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
         .map_err(|_| SourceUnavailable::new("vocabulary exceeds u32 token ids"))?;
     let (artifact_bytes, info) = induction::emit_r4g1_with_tokenizer_cid(
         &artifact_container,
-        (&meta_bytes, &recs_bytes),
+        (meta_bytes, recs_bytes),
         vocab,
         &induced.cover,
         &edges,
@@ -302,6 +349,7 @@ pub fn compile(args: &[String]) -> Result<(), SourceUnavailable> {
     // #602: bind the teacher's attention-operator record when the caller
     // passed it (`--attention-operator`).
     report.attention_operator = options.attention_operator.clone();
+    report.dense_operator = options.dense_operator.clone();
 
     std::fs::create_dir_all(&options.output)?;
     let artifact_path = options.output.join("compiled.r4g1");
@@ -545,6 +593,7 @@ fn preflight_observation_metadata(
     source_manifest_kappa: Option<&str>,
     geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
     attention_operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+    dense_operator: Option<&uor_r4_model_source::dense::DenseOperatorSpec>,
     trace_profile: Option<&trace_profile::TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
     let existing = observation::ObservationManifest::load(output)?;
@@ -563,6 +612,7 @@ fn preflight_observation_metadata(
         source_manifest_kappa,
         geometry,
         attention_operator,
+        dense_operator,
         trace_profile,
     )
 }
@@ -576,6 +626,7 @@ fn preflight_observation_metadata_for_manifest(
     source_manifest_kappa: Option<&str>,
     geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
     attention_operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+    dense_operator: Option<&uor_r4_model_source::dense::DenseOperatorSpec>,
     trace_profile: Option<&trace_profile::TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
     let payload_present =
@@ -586,6 +637,22 @@ fn preflight_observation_metadata_for_manifest(
     if let Some(operator) = attention_operator {
         observation::validate_registered_source_attention_operator(operator)?;
     }
+    if let Some(operator) = recorded.dense_operator.as_ref() {
+        observation::validate_registered_source_dense_operator(operator)?;
+    }
+    if let Some(operator) = dense_operator {
+        observation::validate_registered_source_dense_operator(operator)?;
+    }
+    observation::validate_source_execution_identity(
+        recorded.attention_operator.as_ref(),
+        recorded.dense_operator.as_ref(),
+        "recorded observation provenance",
+    )?;
+    observation::validate_source_execution_identity(
+        attention_operator,
+        dense_operator,
+        "requested observation provenance",
+    )?;
     match (
         recorded.source_manifest_kappa.as_deref(),
         source_manifest_kappa,
@@ -682,6 +749,39 @@ fn preflight_observation_metadata_for_manifest(
         }
         _ => {}
     }
+    match (recorded.dense_operator.as_ref(), dense_operator) {
+        (Some(existing), Some(requested)) if existing != requested => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to dense operator {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version,
+                existing.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        (Some(existing), None) => {
+            return Err(SourceUnavailable::new(format!(
+                "{} is pinned to dense operator {}/{} digest {}; the requested producer declares none; incompatible observation resume refused before mutation",
+                output.display(),
+                existing.id,
+                existing.version,
+                existing.declared_digest(),
+            )));
+        }
+        (None, Some(requested)) if payload_present => {
+            return Err(SourceUnavailable::new(format!(
+                "{} has no recorded dense operator but already contains observation payload; refusing to relabel those bytes as {}/{} digest {} before mutation",
+                output.display(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            )));
+        }
+        _ => {}
+    }
     match (recorded.trace_profile.as_ref(), trace_profile) {
         (None, None) => {}
         (Some(recorded), Some(requested)) if recorded == requested => {}
@@ -726,6 +826,7 @@ fn preflight_observation_identities(
     source_manifest_kappa: Option<&str>,
     geometry: Option<&uor_r4_model_source::geometry::GeometryProjection>,
     attention_operator: Option<&uor_r4_model_source::attention::AttentionOperatorSpec>,
+    dense_operator: Option<&uor_r4_model_source::dense::DenseOperatorSpec>,
     trace_profile: Option<&trace_profile::TraceProfile>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<(), SourceUnavailable> {
@@ -735,6 +836,7 @@ fn preflight_observation_identities(
         source_manifest_kappa,
         geometry,
         attention_operator,
+        dense_operator,
         trace_profile,
     )?;
     preflight_observation_tokenizer(output, shard_bits, tokenizer_adapter)
@@ -817,16 +919,18 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
     // loads and preserves the stored fields).
     let geometry = oracle.geometry_projection();
     let attention_operator = oracle.attention_operator_spec();
+    let dense_operator = oracle.dense_operator_spec();
     let session = observation::ObservationSession::acquire(&options.output, options.shards)?;
     let tokenizer_adapter = registered_tokenizer
         .as_ref()
         .map(|resolved| &resolved.adapter);
-    observation::preflight_observation_identities_in_session(
+    observation::preflight_observation_identities_in_session_with_dense(
         &session,
         options.source_manifest_kappa.as_deref(),
         geometry.as_ref(),
         tokenizer_adapter,
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
         requested_trace_profile.as_ref(),
     )?;
     observation::preflight_observation_trace_layout_in_session(
@@ -834,12 +938,13 @@ pub fn observe(args: &[String]) -> Result<(), SourceUnavailable> {
         &*oracle,
         requested_trace_profile.as_ref(),
     )?;
-    observation::pin_observation_identities_in_session(
+    observation::pin_observation_identities_in_session_with_dense(
         &session,
         options.source_manifest_kappa.as_deref(),
         geometry.as_ref(),
         tokenizer_adapter,
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
         requested_trace_profile.as_ref(),
     )?;
 
@@ -1043,6 +1148,141 @@ mod tokenizer_observe_tests {
 
         let _ = std::fs::remove_file(tokenizer);
         let _ = std::fs::remove_dir_all(directory);
+    }
+
+    fn write_execution_sidecar<T: serde::Serialize>(path: &Path, record: &T) {
+        let mut bytes = serde_json::to_vec_pretty(record).expect("execution sidecar JSON");
+        bytes.push(b'\n');
+        std::fs::write(path, bytes).expect("write execution sidecar");
+    }
+
+    fn graph_compile_corpus_options(
+        root: &Path,
+        output: &Path,
+        attention: &uor_r4_model_source::attention::AttentionOperatorSpec,
+        dense: Option<&uor_r4_model_source::dense::DenseOperatorSpec>,
+    ) -> GraphCompileOptions {
+        let mut args = vec![
+            "--corpus-meta".to_owned(),
+            root.join("corpus.meta").display().to_string(),
+            "--corpus-recs".to_owned(),
+            root.join("corpus.records").display().to_string(),
+            "--out".to_owned(),
+            output.display().to_string(),
+            "--attention-operator".to_owned(),
+            serde_json::to_string(attention).expect("attention JSON"),
+        ];
+        if let Some(dense) = dense {
+            args.extend([
+                "--dense-operator".to_owned(),
+                serde_json::to_string(dense).expect("dense JSON"),
+            ]);
+        }
+        parse_options(&args).expect("valid graph-compile options")
+    }
+
+    #[test]
+    fn graph_compile_preflight_rejects_dense_absence_and_wrong_era_before_mutation() {
+        let root = unique_path("graph-compile-recorded-dense-v2");
+        std::fs::create_dir_all(&root).expect("corpus root");
+        std::fs::write(root.join("corpus.meta"), b"captured metadata").expect("metadata");
+        std::fs::write(root.join("corpus.records"), b"captured records").expect("records");
+        write_execution_sidecar(
+            &root.join(recorded_corpus::ATTENTION_OPERATOR_BINDING_FILE),
+            &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        write_execution_sidecar(
+            &root.join(recorded_corpus::DENSE_OPERATOR_BINDING_FILE),
+            &uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v2(),
+        );
+        let output = unique_path("graph-compile-recorded-dense-output");
+        std::fs::create_dir_all(&output).expect("output root");
+        std::fs::write(output.join("sentinel"), b"last-good output").expect("sentinel");
+        let output_before = directory_bytes(&output);
+
+        let absent_dense = graph_compile_corpus_options(
+            &root,
+            &output,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v2(),
+            None,
+        );
+        let error = preflight_graph_compile_corpus(&absent_dense)
+            .err()
+            .expect("omitted dense identity cannot relabel a dense/v2 corpus");
+        assert!(error.reason.contains("dense execution identity"), "{error}");
+        assert_eq!(directory_bytes(&output), output_before);
+
+        let wrong_era = graph_compile_corpus_options(
+            &root,
+            &output,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v1(),
+            Some(&uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v1()),
+        );
+        let error = preflight_graph_compile_corpus(&wrong_era)
+            .err()
+            .expect("v1 execution flags cannot relabel a v2 corpus");
+        assert!(
+            error.reason.contains("attention execution identity"),
+            "{error}"
+        );
+        assert_eq!(directory_bytes(&output), output_before);
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(output);
+    }
+
+    #[test]
+    fn graph_compile_preflight_rejects_inter_phase_generation_swap_before_mutation() {
+        let root = unique_path("graph-compile-inter-phase-swap");
+        std::fs::create_dir_all(&root).expect("corpus root");
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        let attention_path = root.join(recorded_corpus::ATTENTION_OPERATOR_BINDING_FILE);
+        let dense_path = root.join(recorded_corpus::DENSE_OPERATOR_BINDING_FILE);
+        std::fs::write(&meta, b"corpus A metadata").expect("metadata A");
+        std::fs::write(&records, b"corpus A records").expect("records A");
+        write_execution_sidecar(
+            &attention_path,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v1(),
+        );
+        write_execution_sidecar(
+            &dense_path,
+            &uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v1(),
+        );
+        let output = unique_path("graph-compile-inter-phase-output");
+        std::fs::create_dir_all(&output).expect("output root");
+        std::fs::write(output.join("sentinel"), b"last-good output").expect("sentinel");
+        let output_before = directory_bytes(&output);
+        let options = graph_compile_corpus_options(
+            &root,
+            &output,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v1(),
+            Some(&uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v1()),
+        );
+
+        let error = preflight_graph_compile_corpus_with_hooks(
+            &options,
+            || {
+                write_execution_sidecar(
+                    &attention_path,
+                    &uor_r4_model_source::attention::AttentionOperatorSpec::learned_absolute_v2(),
+                );
+                write_execution_sidecar(
+                    &dense_path,
+                    &uor_r4_model_source::dense::DenseOperatorSpec::gpt2_v2(),
+                );
+                std::fs::write(&meta, b"corpus B metadata").expect("metadata B");
+                std::fs::write(&records, b"corpus B records").expect("records B");
+            },
+            || {},
+        )
+        .err()
+        .expect("provenance A cannot label corpus B");
+        assert!(error.reason.contains("changed after capture"), "{error}");
+        assert_eq!(directory_bytes(&output), output_before);
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(output);
     }
 
     #[test]
@@ -1291,6 +1531,7 @@ mod tokenizer_observe_tests {
             None,
             None,
             None,
+            None,
             Some(&first.adapter),
         )
         .expect_err("registered request cannot relabel adapterless payload");
@@ -1311,6 +1552,7 @@ mod tokenizer_observe_tests {
             Some(&requested_source_kappa),
             Some(&geometry),
             Some(&attention),
+            None,
             None,
             None,
         )
@@ -1378,6 +1620,7 @@ mod tokenizer_observe_tests {
             None,
             Some(&requested_geometry),
             Some(&attention),
+            None,
             Some(&trace),
             Some(&resolved.adapter),
         )
@@ -1396,6 +1639,7 @@ mod tokenizer_observe_tests {
             None,
             Some(&recorded_geometry),
             None,
+            None,
             Some(&trace),
             Some(&resolved.adapter),
         )
@@ -1412,6 +1656,7 @@ mod tokenizer_observe_tests {
             None,
             Some(&recorded_geometry),
             Some(&attention),
+            None,
             None,
             Some(&resolved.adapter),
         )

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -53,6 +53,9 @@ use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::attention::AttentionOperatorSpec;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::attention::operator_spec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
+#[cfg(not(target_arch = "wasm32"))]
+use uor_r4_model_source::dense::operator_spec as dense_operator_spec;
 use uor_r4_model_source::geometry::GeometryProjection;
 #[cfg(not(target_arch = "wasm32"))]
 use uor_r4_model_source::geometry::projection_implementation;
@@ -138,7 +141,7 @@ pub const MANIFEST_FILE: &str = "manifest.json";
 /// writer lock. It is not observation payload and is never removed as a lease,
 /// so process death releases the lock without leaving a stale-lock state.
 #[cfg(not(target_arch = "wasm32"))]
-const OBSERVATION_SESSION_LOCK_PREFIX: &str = ".uor-r4-observation-session-";
+const OBSERVATION_SESSION_COORDINATION_DIR: &str = ".uor-r4-observation-sessions";
 
 #[cfg(not(target_arch = "wasm32"))]
 const OBSERVATION_PAYLOAD_FILES: [&str; 8] = [
@@ -647,6 +650,41 @@ pub(crate) fn validate_registered_source_attention_operator(
     Ok(())
 }
 
+/// Validate that a dense-execution provenance record is exactly one immutable
+/// entry from the model-source registry. Dense records describe host-side
+/// teacher execution; they are never deployed runtime operators.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn validate_registered_source_dense_operator(
+    operator: &DenseOperatorSpec,
+) -> Result<(), SourceUnavailable> {
+    let registered = dense_operator_spec(&operator.id, operator.version)?;
+    if registered != *operator {
+        return Err(invalid_input(format!(
+            "dense operator {}/{} diverges from its immutable registry record; refusing provenance before mutation",
+            operator.id, operator.version
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the composite host-execution identity, after each present record
+/// has independently matched its immutable registry entry. Dense provenance
+/// is GPT-2-specific: it is meaningless without learned-absolute attention,
+/// and an explicit dense era must agree with the corresponding attention era.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn validate_source_execution_identity(
+    attention: Option<&AttentionOperatorSpec>,
+    dense: Option<&DenseOperatorSpec>,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    uor_r4_model_source::dense::validate_source_execution_pair(attention, dense).map_err(
+        |mut error| {
+            error.reason = format!("{context}: {}", error.reason);
+            error
+        },
+    )
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn validate_registered_tokenizer_adapter(
     adapter: &TokenizerAdapter,
@@ -789,6 +827,29 @@ pub fn shard_file_name(shard_bits: u8, shard: u32) -> String {
     format!("shard-{shard:0width$}.bin")
 }
 
+/// Filename-only discriminator for payload/checkpoint evidence owned
+/// exclusively by an observation session. Compile-style corpus producers use
+/// this at their shared lower preflight so a torn or stripped observation
+/// root cannot be mistaken for a fresh compile destination.
+pub(crate) fn is_observation_exclusive_entry_name(name: &str) -> bool {
+    matches!(
+        name,
+        MANIFEST_FILE
+            | STATE_FILE
+            | RAW_COMMITTED_FILE
+            | "merged.bin"
+            | "committed.bin"
+            | ".committed.bin.tmp"
+            | "stories.jsonl"
+            | "stories.tmp"
+    ) || name.starts_with("shard-")
+        || name.starts_with("stories.tmp-")
+        || name.starts_with(".manifest.json.tmp")
+        || name.starts_with(".raw-committed.bin.tmp")
+        || name.starts_with(".state.bin.tmp")
+        || name.starts_with(".committed.bin.tmp")
+}
+
 /// R5: the host-ingestion boundary reports exactly one condition — a declared
 /// external source or sink could not be ingested or persisted. These helpers
 /// keep the observed malformation as the reason.
@@ -927,6 +988,12 @@ pub struct ObservationManifest {
     /// manifest bytes are unchanged when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention_operator: Option<AttentionOperatorSpec>,
+    /// Typed record of the host-side dense arithmetic the teacher executed.
+    /// GPT-2 current sources declare `gpt2-source-dense/2`; Llama and legacy
+    /// corpora declare none. Absence stays typed absence rather than being
+    /// guessed as a GPT-2 historical version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dense_operator: Option<DenseOperatorSpec>,
     /// #603 typed record of the teacher-trace profile the producing pass
     /// captured under (which lanes, which declared layer indices, which
     /// caps), when a non-minimal profile was active. `None` marks the
@@ -959,6 +1026,7 @@ impl ObservationManifest {
             geometry: None,
             tokenizer_adapter: None,
             attention_operator: None,
+            dense_operator: None,
             trace_profile: None,
             trace_row_bytes: None,
             completed: BTreeMap::new(),
@@ -967,10 +1035,12 @@ impl ObservationManifest {
     }
 
     /// Canonical serialization of the manifest's identity BUNDLE (#603):
-    /// the five identity fields (`input_cid`, `source_manifest_kappa`,
+    /// the seven identity fields (`input_cid`, `source_manifest_kappa`,
     /// `geometry` #600, `tokenizer_adapter` #601, `attention_operator`
-    /// #602) plus the #603 `trace_profile`, in that fixed order, one
-    /// line per component. Absence is part of the digest input as an
+    /// #602, optional `dense_operator` #704, and the #603 `trace_profile`),
+    /// in that fixed order, one line per component. The legacy `/1` stream
+    /// omits the later dense component entirely; `/2` is selected only when
+    /// dense provenance is present. Absence is part of the digest input as an
     /// EXPLICIT marker: an unset component serializes as
     /// `<name>=absent`, a set component as `<name>=present:<value>`
     /// (the raw string for the κ/CID fields, the declared-identity
@@ -985,7 +1055,14 @@ impl ObservationManifest {
                 Some(value) => text.push_str(&format!("{name}=present:{value}\n")),
             }
         }
-        let mut text = String::from("uor-r4-observation-identity-bundle/1\n");
+        // The legacy `/1` byte stream is immutable. Merely teaching this
+        // manifest about an optional dense identity must not change any old
+        // checkpoint digest. A present dense record alone selects `/2`.
+        let mut text = if self.dense_operator.is_some() {
+            String::from("uor-r4-observation-identity-bundle/2\n")
+        } else {
+            String::from("uor-r4-observation-identity-bundle/1\n")
+        };
         line(&mut text, "input_cid", self.input_cid.clone());
         line(
             &mut text,
@@ -1013,6 +1090,15 @@ impl ObservationManifest {
                 .as_ref()
                 .map(|record| record.declared_digest()),
         );
+        if self.dense_operator.is_some() {
+            line(
+                &mut text,
+                "dense_operator",
+                self.dense_operator
+                    .as_ref()
+                    .map(|record| record.declared_digest()),
+            );
+        }
         line(
             &mut text,
             "trace_profile",
@@ -1140,6 +1226,61 @@ impl ObservationManifest {
         Ok(())
     }
 
+    /// Parse and registry-validate one manifest generation already captured
+    /// by a caller-owned filesystem snapshot. Unlike [`Self::load`], this
+    /// never reopens `manifest.json`; recorded-corpus consumers can therefore
+    /// bind the returned execution identity to the exact captured manifest
+    /// bytes. It deliberately preserves [`Self::load`]'s validation of every
+    /// manifest-referenced shard payload and trace layout.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn parse_captured_execution_identity(
+        dir: &Path,
+        path: &Path,
+        bytes: &[u8],
+    ) -> Result<Self, SourceUnavailable> {
+        let manifest: Self = serde_json::from_slice(bytes).map_err(|error| {
+            invalid_data(format!(
+                "invalid observation manifest {}: {error}",
+                path.display()
+            ))
+        })?;
+        manifest.validate_loaded_semantics()?;
+        validate_canonical_shard_payload_names(dir, &manifest)?;
+        validate_completed_payloads(dir, &manifest)?;
+        if manifest.trace_profile.is_some()
+            && manifest.trace_row_bytes.is_none()
+            && (regular_file_present(&dir.join(RAW_COMMITTED_FILE), "trace-layout")?
+                || regular_file_present(&dir.join(STATE_FILE), "trace-layout")?
+                || observation_shard_payload_present(dir)?)
+        {
+            return Err(invalid_data(format!(
+                "observation manifest records a trace profile but no trace row width despite existing raw stream payload in {}",
+                dir.display()
+            )));
+        }
+        if let Some(geometry) = manifest.geometry.as_ref() {
+            validate_registered_geometry_projection(geometry)?;
+        }
+        if let Some(adapter) = manifest.tokenizer_adapter.as_ref() {
+            validate_registered_tokenizer_adapter(adapter)?;
+        }
+        if let Some(operator) = manifest.attention_operator.as_ref() {
+            validate_registered_source_attention_operator(operator)?;
+        }
+        if let Some(operator) = manifest.dense_operator.as_ref() {
+            validate_registered_source_dense_operator(operator)?;
+        }
+        validate_source_execution_identity(
+            manifest.attention_operator.as_ref(),
+            manifest.dense_operator.as_ref(),
+            &format!("observation manifest {}", path.display()),
+        )?;
+        if let Some(profile) = manifest.trace_profile.as_ref() {
+            validate_registered_trace_profile(profile)?;
+        }
+        Ok(manifest)
+    }
+
     /// Load the manifest of an observation directory, if present.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(dir: &Path) -> Result<Option<Self>, SourceUnavailable> {
@@ -1180,6 +1321,14 @@ impl ObservationManifest {
                     if let Some(operator) = manifest.attention_operator.as_ref() {
                         validate_registered_source_attention_operator(operator)?;
                     }
+                    if let Some(operator) = manifest.dense_operator.as_ref() {
+                        validate_registered_source_dense_operator(operator)?;
+                    }
+                    validate_source_execution_identity(
+                        manifest.attention_operator.as_ref(),
+                        manifest.dense_operator.as_ref(),
+                        &format!("observation manifest {}", path.display()),
+                    )?;
                     if let Some(profile) = manifest.trace_profile.as_ref() {
                         validate_registered_trace_profile(profile)?;
                     }
@@ -1505,26 +1654,65 @@ fn recover_manifest_temp_residue(dir: &Path) -> Result<(), SourceUnavailable> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn prepare_observation_root(dir: &Path) -> Result<(), SourceUnavailable> {
-    match fs::symlink_metadata(dir) {
-        Ok(metadata) if metadata.file_type().is_dir() => {}
-        Ok(_) => {
-            return Err(invalid_input(format!(
-                "observation output root {} is not a directory; symlink and non-directory roots are refused",
-                dir.display()
-            )));
-        }
-        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::create_dir_all(dir)?,
-        Err(error) => return Err(error.into()),
-    }
-    match fs::symlink_metadata(dir) {
+fn prepare_observation_parent(dir: &Path) -> Result<(), SourceUnavailable> {
+    let parent = dir
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    match fs::symlink_metadata(parent) {
         Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
         Ok(_) => Err(invalid_input(format!(
-            "observation output root {} ceased to be a directory",
-            dir.display()
+            "observation output parent {} is not a real directory",
+            parent.display()
         ))),
         Err(error) => Err(error.into()),
     }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), unix))]
+fn observation_metadata_identity_matches(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(all(not(target_arch = "wasm32"), not(unix)))]
+fn observation_metadata_identity_matches(_left: &fs::Metadata, _right: &fs::Metadata) -> bool {
+    true
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn open_observation_directory_nofollow(
+    path: &Path,
+    context: &str,
+) -> Result<fs::File, SourceUnavailable> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(
+            libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        );
+    }
+    let file = options.open(path).map_err(|error| {
+        invalid_input(format!(
+            "{context} {} cannot be opened without following links: {error}",
+            path.display()
+        ))
+    })?;
+    let path_metadata = fs::symlink_metadata(path)?;
+    let file_metadata = file.metadata()?;
+    if !path_metadata.file_type().is_dir()
+        || !file_metadata.file_type().is_dir()
+        || !observation_metadata_identity_matches(&path_metadata, &file_metadata)
+    {
+        return Err(invalid_input(format!(
+            "{context} {} is not one stable real directory",
+            path.display()
+        )));
+    }
+    Ok(file)
 }
 
 /// Acquire the process-crash-safe, full-session writer lock. The permanent
@@ -1533,63 +1721,115 @@ fn prepare_observation_root(dir: &Path) -> Result<(), SourceUnavailable> {
 /// after process death, so no stale-lock recovery protocol is needed.
 #[cfg(not(target_arch = "wasm32"))]
 fn acquire_observation_session_lock(dir: &Path) -> Result<fs::File, SourceUnavailable> {
-    // Keep coordination outside the observation directory so even the first
-    // refused resume leaves that directory byte-identical. Hash the canonical
-    // output path so aliases contend on one permanent sibling inode without
-    // exposing arbitrary path bytes in its file name.
-    let canonical = fs::canonicalize(dir)?;
-    let parent = canonical.parent().ok_or_else(|| {
+    // Keep coordination outside the observation directory so an absent root
+    // remains absent when another producer owns the common logical-path
+    // guard. The exact basename lives inside a protected sibling directory;
+    // filesystem collation therefore makes case/Unicode aliases contend on
+    // the same inode without needing a lossy path hash.
+    let root_name = dir.file_name().ok_or_else(|| {
         invalid_input(format!(
-            "observation output {} has no parent for its coordination lock",
-            canonical.display()
+            "observation output {} has no final component for its coordination lock",
+            dir.display()
         ))
     })?;
-    let digest = blake3::hash(canonical.to_string_lossy().as_bytes());
-    let path = parent.join(format!(
-        "{OBSERVATION_SESSION_LOCK_PREFIX}{}.lock",
-        digest.to_hex()
-    ));
-    let file = loop {
-        match fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .open(&path)
-        {
-            Ok(file) => break file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                match fs::symlink_metadata(&path) {
-                    Ok(metadata) if metadata.file_type().is_file() => {}
-                    Ok(_) => {
-                        return Err(invalid_input(format!(
-                            "observation session lock {} is not a regular file; symlinks and non-file entries are refused",
-                            path.display()
-                        )));
-                    }
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                    Err(error) => return Err(error.into()),
-                }
-                let file = fs::OpenOptions::new().read(true).write(true).open(&path)?;
-                if !file.metadata()?.file_type().is_file() {
-                    return Err(invalid_input(format!(
-                        "observation session lock {} is not a regular file",
-                        path.display()
-                    )));
-                }
-                break file;
-            }
-            Err(error) => return Err(error.into()),
-        }
-    };
-    file.lock()?;
-    match fs::symlink_metadata(&path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(file),
-        Ok(_) => Err(invalid_input(format!(
-            "observation session lock {} ceased to be a regular file while acquiring it",
-            path.display()
-        ))),
-        Err(error) => Err(error.into()),
+    if root_name == std::ffi::OsStr::new(".") || root_name == std::ffi::OsStr::new("..") {
+        return Err(invalid_input(
+            "observation output cannot be '.' or '..'".to_owned(),
+        ));
     }
+    let requested_parent = dir
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let canonical_parent = fs::canonicalize(requested_parent)?;
+    let parent_file = open_observation_directory_nofollow(
+        &canonical_parent,
+        "observation session canonical parent",
+    )?;
+    let coordination = canonical_parent.join(OBSERVATION_SESSION_COORDINATION_DIR);
+    match fs::create_dir(&coordination) {
+        Ok(()) => parent_file.sync_all()?,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+    let coordination_file = open_observation_directory_nofollow(
+        &coordination,
+        "observation session coordination directory",
+    )?;
+    let path = coordination.join(root_name);
+    let mut options = fs::OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(&path).map_err(|error| {
+        invalid_input(format!(
+            "observation session lock {} cannot be opened without following links: {error}",
+            path.display()
+        ))
+    })?;
+    let initial_path = fs::symlink_metadata(&path)?;
+    let initial_file = file.metadata()?;
+    if !initial_path.file_type().is_file()
+        || !initial_file.file_type().is_file()
+        || !observation_metadata_identity_matches(&initial_path, &initial_file)
+    {
+        return Err(invalid_input(format!(
+            "observation session lock {} is not one stable regular non-symlink inode",
+            path.display()
+        )));
+    }
+    file.lock()?;
+    let final_path = fs::symlink_metadata(&path)?;
+    let final_file = file.metadata()?;
+    if !final_path.file_type().is_file()
+        || !final_file.file_type().is_file()
+        || !observation_metadata_identity_matches(&initial_file, &final_file)
+        || !observation_metadata_identity_matches(&final_path, &final_file)
+    {
+        return Err(invalid_input(format!(
+            "observation session lock {} changed identity or type while acquired",
+            path.display()
+        )));
+    }
+    let final_parent = parent_file.metadata()?;
+    let path_parent = fs::symlink_metadata(&canonical_parent)?;
+    let final_coordination = coordination_file.metadata()?;
+    let path_coordination = fs::symlink_metadata(&coordination)?;
+    if !observation_metadata_identity_matches(&final_parent, &path_parent)
+        || !observation_metadata_identity_matches(&final_coordination, &path_coordination)
+    {
+        return Err(invalid_input(
+            "observation session coordination directories changed identity while acquired"
+                .to_owned(),
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn acquire_observation_session_guards_with_hook<F>(
+    dir: &Path,
+    after_outer_lock: F,
+) -> Result<
+    (
+        crate::recorded_corpus::RecordedCorpusProducerGuard,
+        fs::File,
+    ),
+    SourceUnavailable,
+>
+where
+    F: FnOnce(),
+{
+    let observation_lock = acquire_observation_session_lock(dir)?;
+    after_outer_lock();
+    let recorded_corpus_guard =
+        crate::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(dir)?;
+    Ok((recorded_corpus_guard, observation_lock))
 }
 
 /// Name of one shard's #603 trace sidecar: `<shard file>.trace`,
@@ -1993,7 +2233,7 @@ fn apply_raw_recovery(dir: &Path, plan: &RawRecoveryPlan) -> Result<(), SourceUn
 pub fn preflight_raw_observation_in_session(
     session: &ObservationSession,
 ) -> Result<RawResumeStatus, SourceUnavailable> {
-    let writer = session.writer()?;
+    let writer = session.writer_for_preflight()?;
     let plan = preflight_raw_resume(session.dir(), writer.manifest())?;
     Ok(status_from_plan(&plan))
 }
@@ -2005,8 +2245,10 @@ pub fn preflight_raw_observation_in_session(
 pub fn recover_raw_observation_in_session(
     session: &ObservationSession,
 ) -> Result<RawResumeStatus, SourceUnavailable> {
-    let writer = session.writer()?;
+    let writer = session.writer_for_preflight()?;
     let plan = preflight_raw_resume(session.dir(), writer.manifest())?;
+    drop(writer);
+    session.recover_recorded_corpus_binding_after_preflight()?;
     if let RawResumePlan::Authoritative(recovery) = &plan {
         apply_raw_recovery(session.dir(), recovery)?;
     }
@@ -2044,7 +2286,9 @@ pub struct ObservationSession {
 
 #[cfg(not(target_arch = "wasm32"))]
 struct ObservationSessionState {
+    _recorded_corpus_guard: crate::recorded_corpus::RecordedCorpusProducerGuard,
     _lock: fs::File,
+    binding_recovery_needed: std::sync::atomic::AtomicBool,
     writer_active: std::sync::atomic::AtomicBool,
 }
 
@@ -2072,23 +2316,62 @@ impl ObservationSession {
                 "shard_bits {shard_bits} exceeds the writer maximum {MAX_SHARD_BITS}"
             )));
         }
-        let dir = dir.as_ref().to_path_buf();
-        prepare_observation_root(&dir)?;
-        validate_observation_entry_types(&dir)?;
+        let requested_dir = dir.as_ref().to_path_buf();
+        prepare_observation_parent(&requested_dir)?;
         // Fail static semantic refusals before creating the permanent
         // coordination inode. This snapshot is only an optimization for
         // failure atomicity; `load_manifest` repeats it authoritatively after
         // the lock is acquired.
-        if let Some(manifest) = ObservationManifest::load(&dir)?
-            && manifest.shard_bits != shard_bits
-        {
-            return Err(invalid_input(format!(
-                "manifest shard_bits {} does not match requested {shard_bits}",
-                manifest.shard_bits
-            )));
+        match fs::symlink_metadata(&requested_dir) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                validate_observation_entry_types(&requested_dir)?;
+                if let Some(manifest) = ObservationManifest::load(&requested_dir)?
+                    && manifest.shard_bits != shard_bits
+                {
+                    return Err(invalid_input(format!(
+                        "manifest shard_bits {} does not match requested {shard_bits}",
+                        manifest.shard_bits
+                    )));
+                }
+            }
+            Ok(_) => {
+                return Err(invalid_input(format!(
+                    "observation output root {} is not a real directory",
+                    requested_dir.display()
+                )));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
         }
+        // Global acquisition order is writer-specific outer session before
+        // the common recorded-corpus guard. Every public raw/text/batched
+        // session therefore owns both for its complete mutable lifetime. A
+        // common-guard BUSY refusal drops the just-acquired outer file before
+        // returning, so no path can retain a prefix of the lock order.
+        let (mut recorded_corpus_guard, observation_lock) =
+            acquire_observation_session_guards_with_hook(&requested_dir, || {})?;
+        if recorded_corpus_guard.root_exists() {
+            recorded_corpus_guard.preflight_planned_output_scope(&[])?;
+            let _ = recorded_corpus_guard.preflight_publication_namespace_for(
+                crate::recorded_corpus::RecordedCorpusRole::Observation,
+            )?;
+        }
+        recorded_corpus_guard.ensure_root()?;
+        let dir = recorded_corpus_guard.root().to_path_buf();
+        validate_observation_entry_types(&dir)?;
+        // Namespace validation is read-only at generic acquisition. A
+        // command may not promote an exact `.tmp` until its requested
+        // tokenizer/geometry/attention/dense/text identities have all passed
+        // under this session; otherwise a mismatched invocation could mutate
+        // a directory it must reject byte-for-byte.
+        recorded_corpus_guard.preflight_planned_output_scope(&[])?;
+        let binding_recovery_needed = recorded_corpus_guard.preflight_publication_namespace_for(
+            crate::recorded_corpus::RecordedCorpusRole::Observation,
+        )?;
         let state = Arc::new(ObservationSessionState {
-            _lock: acquire_observation_session_lock(&dir)?,
+            _recorded_corpus_guard: recorded_corpus_guard,
+            _lock: observation_lock,
+            binding_recovery_needed: std::sync::atomic::AtomicBool::new(binding_recovery_needed),
             writer_active: std::sync::atomic::AtomicBool::new(false),
         });
         let session = Self {
@@ -2113,9 +2396,52 @@ impl ObservationSession {
         self.shard_bits
     }
 
+    /// Common recorded-corpus producer guard held for this session's full
+    /// provenance, shard, checkpoint, merge, and binding-publication lifetime.
+    pub fn recorded_corpus_guard(&self) -> &crate::recorded_corpus::RecordedCorpusProducerGuard {
+        &self.state._recorded_corpus_guard
+    }
+
+    /// Promote an exact crash temporary only after the caller's complete
+    /// command-specific identity preflight has succeeded under this session.
+    pub(crate) fn recover_recorded_corpus_binding_after_preflight(
+        &self,
+    ) -> Result<(), SourceUnavailable> {
+        if !self
+            .state
+            .binding_recovery_needed
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Ok(());
+        }
+        crate::recorded_corpus::publish_binding(
+            self.recorded_corpus_guard(),
+            &self.dir.join(STATE_FILE),
+            &self.dir.join("merged.bin"),
+        )?;
+        self.state
+            .binding_recovery_needed
+            .store(false, std::sync::atomic::Ordering::Release);
+        Ok(())
+    }
+
     /// Open a writer that shares this session's already-held exclusive lock.
     /// The manifest and payload entry types are reloaded under the lock.
     pub fn writer(&self) -> Result<ObservationShardWriter, SourceUnavailable> {
+        if self
+            .state
+            .binding_recovery_needed
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err(invalid_input(format!(
+                "observation session for {} has an unpublished canonical corpus binding temporary; complete command-specific identity preflight and recovery before mutation",
+                self.dir.display()
+            )));
+        }
+        self.writer_for_preflight()
+    }
+
+    pub(crate) fn writer_for_preflight(&self) -> Result<ObservationShardWriter, SourceUnavailable> {
         if self
             .state
             .writer_active
@@ -2178,18 +2504,57 @@ fn preflight_writer_identity_bundle(
     geometry: Option<&GeometryProjection>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
     trace_profile: Option<&TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
+    validate_source_execution_identity(
+        writer.manifest().attention_operator.as_ref(),
+        writer.manifest().dense_operator.as_ref(),
+        &format!("observation manifest {}", writer.dir.display()),
+    )?;
+    validate_source_execution_identity(
+        attention_operator,
+        dense_operator,
+        "requested observation source execution",
+    )?;
     writer.preflight_source_manifest_kappa(source_manifest_kappa)?;
     writer.preflight_geometry(geometry)?;
     writer.preflight_tokenizer_adapter(tokenizer_adapter)?;
     writer.preflight_attention_operator(attention_operator)?;
+    writer.preflight_dense_operator(dense_operator)?;
     writer.preflight_trace_profile(trace_profile)
 }
 
 /// Joint, read-only provenance preflight under a caller-held observation
 /// session. Commands call this before tokenizer export or any identity setter;
 /// the lower driver repeats the checks before reconciliation and row writes.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+pub fn preflight_observation_identities_in_session_with_dense(
+    session: &ObservationSession,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&GeometryProjection>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
+    trace_profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    let writer = session.writer_for_preflight()?;
+    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
+    preflight_writer_identity_bundle(
+        &writer,
+        source_manifest_kappa,
+        geometry,
+        tokenizer_adapter,
+        attention_operator,
+        dense_operator,
+        trace_profile,
+    )
+}
+
+/// Compatibility entry point for producers from the dense-operator-absent
+/// era. New source-aware callers should use
+/// [`preflight_observation_identities_in_session_with_dense`].
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
 pub fn preflight_observation_identities_in_session(
@@ -2200,14 +2565,13 @@ pub fn preflight_observation_identities_in_session(
     attention_operator: Option<&AttentionOperatorSpec>,
     trace_profile: Option<&TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
-    let writer = session.writer()?;
-    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
-    preflight_writer_identity_bundle(
-        &writer,
+    preflight_observation_identities_in_session_with_dense(
+        session,
         source_manifest_kappa,
         geometry,
         tokenizer_adapter,
         attention_operator,
+        None,
         trace_profile,
     )
 }
@@ -2229,13 +2593,54 @@ pub fn preflight_observation_trace_layout_in_session(
         Some(profile) if !profile.is_minimal() => Some(TraceCapture::new(profile, oracle)?),
         Some(_) | None => None,
     };
-    let writer = session.writer()?;
+    let writer = session.writer_for_preflight()?;
     writer.preflight_trace_row_bytes(trace.as_ref().map(|trace| trace.row_bytes as u64))
 }
 
 /// Jointly preflight, then publish all present identity records under one
 /// exclusive session. No setter runs until every requested/recorded identity
 /// has passed the read-only bundle check.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+pub fn pin_observation_identities_in_session_with_dense(
+    session: &ObservationSession,
+    source_manifest_kappa: Option<&str>,
+    geometry: Option<&GeometryProjection>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
+    trace_profile: Option<&TraceProfile>,
+) -> Result<(), SourceUnavailable> {
+    let mut writer = session.writer_for_preflight()?;
+    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
+    preflight_writer_identity_bundle(
+        &writer,
+        source_manifest_kappa,
+        geometry,
+        tokenizer_adapter,
+        attention_operator,
+        dense_operator,
+        trace_profile,
+    )?;
+    session.recover_recorded_corpus_binding_after_preflight()?;
+    if let Some(adapter) = tokenizer_adapter {
+        writer.set_tokenizer_adapter(adapter)?;
+    }
+    if let Some(kappa) = source_manifest_kappa {
+        writer.set_source_manifest_kappa(kappa)?;
+    }
+    if let Some(geometry) = geometry {
+        writer.set_geometry(geometry)?;
+    }
+    writer.set_source_execution_pair(attention_operator, dense_operator)?;
+    if let Some(profile) = trace_profile {
+        writer.set_trace_profile(profile)?;
+    }
+    Ok(())
+}
+
+/// Compatibility entry point preserving the pre-#704 positional API and
+/// exact dense-absent semantics.
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
 pub fn pin_observation_identities_in_session(
@@ -2246,32 +2651,15 @@ pub fn pin_observation_identities_in_session(
     attention_operator: Option<&AttentionOperatorSpec>,
     trace_profile: Option<&TraceProfile>,
 ) -> Result<(), SourceUnavailable> {
-    let mut writer = session.writer()?;
-    let _ = preflight_observation_state(session.dir(), writer.manifest())?;
-    preflight_writer_identity_bundle(
-        &writer,
+    pin_observation_identities_in_session_with_dense(
+        session,
         source_manifest_kappa,
         geometry,
         tokenizer_adapter,
         attention_operator,
+        None,
         trace_profile,
-    )?;
-    if let Some(adapter) = tokenizer_adapter {
-        writer.set_tokenizer_adapter(adapter)?;
-    }
-    if let Some(kappa) = source_manifest_kappa {
-        writer.set_source_manifest_kappa(kappa)?;
-    }
-    if let Some(geometry) = geometry {
-        writer.set_geometry(geometry)?;
-    }
-    if let Some(operator) = attention_operator {
-        writer.set_attention_operator(operator)?;
-    }
-    if let Some(profile) = trace_profile {
-        writer.set_trace_profile(profile)?;
-    }
-    Ok(())
+    )
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2305,7 +2693,9 @@ impl ObservationShardWriter {
     /// manifest pins the fan-out; requesting a different `shard_bits` for
     /// the same directory is an error.
     pub fn open(dir: impl AsRef<Path>, shard_bits: u8) -> Result<Self, SourceUnavailable> {
-        ObservationSession::acquire(dir, shard_bits)?.writer()
+        let session = ObservationSession::acquire(dir, shard_bits)?;
+        session.recover_recorded_corpus_binding_after_preflight()?;
+        session.writer()
     }
 
     pub fn manifest(&self) -> &ObservationManifest {
@@ -2586,6 +2976,112 @@ impl ObservationShardWriter {
         }
         let mut candidate = self.manifest.clone();
         candidate.attention_operator = Some(operator.clone());
+        validate_source_execution_identity(
+            candidate.attention_operator.as_ref(),
+            candidate.dense_operator.as_ref(),
+            "proposed observation manifest",
+        )?;
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
+        Ok(())
+    }
+
+    /// Read-only symmetric compatibility check for the host-side dense
+    /// execution era. An explicit producer may not relabel payload created
+    /// before dense provenance existed, and an operatorless producer may not
+    /// resume bytes already pinned to one.
+    pub fn preflight_dense_operator(
+        &self,
+        requested: Option<&DenseOperatorSpec>,
+    ) -> Result<(), SourceUnavailable> {
+        if let Some(recorded) = self.manifest.dense_operator.as_ref() {
+            validate_registered_source_dense_operator(recorded)?;
+        }
+        if let Some(requested) = requested {
+            validate_registered_source_dense_operator(requested)?;
+        }
+        let payload_present =
+            observation_payload_present(&self.dir, &self.manifest, "dense-operator")?;
+
+        match (self.manifest.dense_operator.as_ref(), requested) {
+            (Some(recorded), Some(requested)) if recorded == requested => Ok(()),
+            (Some(recorded), Some(requested)) => Err(invalid_input(format!(
+                "{} is pinned to dense operator {}/{} digest {}; requested {}/{} digest {}; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            ))),
+            (Some(recorded), None) => Err(invalid_input(format!(
+                "{} is pinned to dense operator {}/{} digest {}; the requested producer declares none; incompatible observation resume refused before mutation",
+                self.dir.display(),
+                recorded.id,
+                recorded.version,
+                recorded.declared_digest(),
+            ))),
+            (None, Some(requested)) if payload_present => Err(invalid_input(format!(
+                "{} has no recorded dense operator but already contains observation payload from a legacy execution era; refusing to relabel those bytes as {}/{} digest {} before mutation",
+                self.dir.display(),
+                requested.id,
+                requested.version,
+                requested.declared_digest(),
+            ))),
+            (None, Some(_)) | (None, None) => Ok(()),
+        }
+    }
+
+    /// Atomically record the exact dense execution owner declared by the
+    /// teacher oracle. Registry equality and payload compatibility are checked
+    /// again immediately before publication.
+    pub fn set_dense_operator(
+        &mut self,
+        operator: &DenseOperatorSpec,
+    ) -> Result<(), SourceUnavailable> {
+        self.preflight_dense_operator(Some(operator))?;
+        recover_manifest_temp_residue(&self.dir)?;
+        if self.manifest.dense_operator.as_ref() == Some(operator) {
+            return Ok(());
+        }
+        let mut candidate = self.manifest.clone();
+        candidate.dense_operator = Some(operator.clone());
+        validate_source_execution_identity(
+            candidate.attention_operator.as_ref(),
+            candidate.dense_operator.as_ref(),
+            "proposed observation manifest",
+        )?;
+        candidate.store(&self.dir)?;
+        self.manifest = candidate;
+        Ok(())
+    }
+
+    /// Atomically publish the complete source-execution pair in one manifest
+    /// replacement. Dense-aware producers use this instead of two setters so
+    /// no crash prefix can expose learned-attention/current-dense as a
+    /// plausible markerless attention-only generation.
+    pub fn set_source_execution_pair(
+        &mut self,
+        attention_operator: Option<&AttentionOperatorSpec>,
+        dense_operator: Option<&DenseOperatorSpec>,
+    ) -> Result<(), SourceUnavailable> {
+        validate_source_execution_identity(
+            attention_operator,
+            dense_operator,
+            "proposed observation manifest source execution",
+        )?;
+        self.preflight_attention_operator(attention_operator)?;
+        self.preflight_dense_operator(dense_operator)?;
+        if self.manifest.attention_operator.as_ref() == attention_operator
+            && self.manifest.dense_operator.as_ref() == dense_operator
+        {
+            return Ok(());
+        }
+        recover_manifest_temp_residue(&self.dir)?;
+        let mut candidate = self.manifest.clone();
+        candidate.attention_operator = attention_operator.cloned();
+        candidate.dense_operator = dense_operator.cloned();
         candidate.store(&self.dir)?;
         self.manifest = candidate;
         Ok(())
@@ -3982,12 +4478,22 @@ fn observe_sharded_inner(
     if let Some(operator) = attention_operator.as_ref() {
         validate_registered_source_attention_operator(operator)?;
     }
+    let dense_operator = oracle.dense_operator_spec();
+    if let Some(operator) = dense_operator.as_ref() {
+        validate_registered_source_dense_operator(operator)?;
+    }
+    validate_source_execution_identity(
+        attention_operator.as_ref(),
+        dense_operator.as_ref(),
+        "teacher-declared observation source execution",
+    )?;
     let mut writer = match session {
         Some(session) => session.writer()?,
         None => ObservationShardWriter::open(out, shard_bits)?,
     };
     writer.preflight_geometry(geometry.as_ref())?;
     writer.preflight_attention_operator(attention_operator.as_ref())?;
+    writer.preflight_dense_operator(dense_operator.as_ref())?;
     let preflight_state = preflight_observation_state(out, writer.manifest())?;
     let requested_target = u64::try_from(target).unwrap_or(u64::MAX);
     if preflight_state.is_some_and(|(n, _, _, _)| n < requested_target)
@@ -4035,6 +4541,9 @@ fn observe_sharded_inner(
     }
     if let Some(operator) = attention_operator.as_ref() {
         writer.set_attention_operator(operator)?;
+    }
+    if let Some(operator) = dense_operator.as_ref() {
+        writer.set_dense_operator(operator)?;
     }
     if let Some(profile) = trace_profile_to_set.as_ref() {
         writer.set_trace_profile(profile)?;
@@ -5110,6 +5619,38 @@ mod attention_operator_resume_tests {
             !dir.path().join("tokenizer.bin").exists(),
             "loser exported tokenizer bytes"
         );
+    }
+
+    #[test]
+    fn observation_outer_lock_precedes_common_guard_and_busy_unwinds_outer() {
+        let dir = TestDir::new("outer-before-common-order");
+        let thread_dir = dir.path().to_path_buf();
+        let (outer_held_tx, outer_held_rx) = mpsc::channel();
+        let release = std::sync::Arc::new(Barrier::new(2));
+        let thread_release = std::sync::Arc::clone(&release);
+        let worker = std::thread::spawn(move || {
+            acquire_observation_session_guards_with_hook(&thread_dir, || {
+                outer_held_tx.send(()).expect("announce outer lock");
+                thread_release.wait();
+            })
+        });
+
+        outer_held_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("worker acquired outer observation lock");
+        let common = crate::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(dir.path())
+            .expect("worker has not inverted order by acquiring common first");
+        release.wait();
+        let error = worker
+            .join()
+            .expect("worker joins")
+            .expect_err("common contender is BUSY");
+        assert!(error.reason.contains("BUSY"), "{error}");
+        drop(common);
+
+        let outer_retry = acquire_observation_session_lock(dir.path())
+            .expect("BUSY path unwound its outer observation lock");
+        drop(outer_retry);
     }
 
     struct DeclaredOperatorOracle {

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -5482,6 +5482,26 @@ mod attention_operator_resume_tests {
     }
 
     #[test]
+    fn observation_session_rejects_any_planned_output_residue_before_root_mutation() {
+        let dir = TestDir::new("observation-planned-output-preflight");
+        let residue = dir.path().join(format!(
+            "{}{}--77.3.writing",
+            crate::recorded_corpus::PLANNED_OUTPUT_RESERVED_PREFIX,
+            crate::recorded_corpus::PlannedOutputMember::Records.stable_name()
+        ));
+        fs::write(&residue, b"partial compile output").expect("planned-output residue");
+        let before = dir.bytes();
+
+        let error = match ObservationSession::acquire(dir.path(), 1) {
+            Ok(_) => panic!("observation sessions own an empty planned-output scope"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("foreign member"), "{error}");
+        assert_eq!(dir.bytes(), before, "preflight refusal mutated the root");
+        assert!(!dir.path().join(MANIFEST_FILE).exists());
+    }
+
+    #[test]
     fn one_session_never_issues_stale_or_concurrent_writers() {
         let dir = TestDir::new("single-writer-lease");
         let session = ObservationSession::acquire(dir.path(), 1).expect("acquire session");

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -55,6 +55,7 @@ use uor_r4_model_source::BatchedTeacher;
 use uor_r4_model_source::SourceUnavailable;
 use uor_r4_model_source::TeacherOracle;
 use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
 use uor_r4_model_source::geometry::GeometryProjection;
 use uor_r4_model_source::progress::Progress;
 
@@ -995,9 +996,20 @@ fn preflight_text_observation_identities(
     input_cid: &str,
     geometry: Option<&GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<(), SourceUnavailable> {
     let manifest = writer.manifest();
+    observe::validate_source_execution_identity(
+        manifest.attention_operator.as_ref(),
+        manifest.dense_operator.as_ref(),
+        "recorded text-observation execution provenance",
+    )?;
+    observe::validate_source_execution_identity(
+        attention_operator,
+        dense_operator,
+        "requested text-observation execution provenance",
+    )?;
     let payload_present = observe::observation_payload_present(out_dir, manifest, "text-identity")?;
     match manifest.partition_rule.as_deref() {
         Some(PARTITION_RULE) => {}
@@ -1033,7 +1045,8 @@ fn preflight_text_observation_identities(
     }
     writer.preflight_geometry(geometry)?;
     writer.preflight_tokenizer_adapter(tokenizer_adapter)?;
-    writer.preflight_attention_operator(attention_operator)
+    writer.preflight_attention_operator(attention_operator)?;
+    writer.preflight_dense_operator(dense_operator)
 }
 
 struct TextObservationPreflight {
@@ -1053,6 +1066,7 @@ fn inspect_text_observation(
     writer: &ObservationShardWriter,
     geometry: Option<&GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<TextObservationPreflight, SourceUnavailable> {
     let raw_checkpoint = out_dir.join(observe::RAW_COMMITTED_FILE);
@@ -1132,6 +1146,7 @@ fn inspect_text_observation(
         &input_cid,
         geometry,
         attention_operator,
+        dense_operator,
         tokenizer_adapter,
     )?;
     let (_, story_entries) = preflight_stories_prefix(&stories_path, checkpoint.stories)?;
@@ -1206,15 +1221,16 @@ fn inspect_text_observation(
 /// geometry, tokenizer, and attention before a command exports tokenizer
 /// bytes or invokes reconciliation.
 #[allow(clippy::too_many_arguments)]
-pub fn preflight_text_observation_in_session(
+pub fn preflight_text_observation_in_session_with_dense(
     session: &observe::ObservationSession,
     articles_path: &Path,
     resume: bool,
     geometry: Option<&GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<(), SourceUnavailable> {
-    let writer = session.writer()?;
+    let writer = session.writer_for_preflight()?;
     inspect_text_observation(
         session.dir(),
         articles_path,
@@ -1223,15 +1239,14 @@ pub fn preflight_text_observation_in_session(
         &writer,
         geometry,
         attention_operator,
+        dense_operator,
         tokenizer_adapter,
     )?;
     Ok(())
 }
 
-/// Repeat the joint text preflight, then publish every text identity before
-/// tokenizer export. No setter runs until the whole bundle agrees.
-#[allow(clippy::too_many_arguments)]
-pub fn pin_text_observation_identities_in_session(
+/// Compatibility entry point preserving the pre-#704 dense-absent API.
+pub fn preflight_text_observation_in_session(
     session: &observe::ObservationSession,
     articles_path: &Path,
     resume: bool,
@@ -1239,7 +1254,30 @@ pub fn pin_text_observation_identities_in_session(
     attention_operator: Option<&AttentionOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<(), SourceUnavailable> {
-    let mut writer = session.writer()?;
+    preflight_text_observation_in_session_with_dense(
+        session,
+        articles_path,
+        resume,
+        geometry,
+        attention_operator,
+        None,
+        tokenizer_adapter,
+    )
+}
+
+/// Repeat the joint text preflight, then publish every text identity before
+/// tokenizer export. No setter runs until the whole bundle agrees.
+#[allow(clippy::too_many_arguments)]
+pub fn pin_text_observation_identities_in_session_with_dense(
+    session: &observe::ObservationSession,
+    articles_path: &Path,
+    resume: bool,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<(), SourceUnavailable> {
+    let mut writer = session.writer_for_preflight()?;
     let inspected = inspect_text_observation(
         session.dir(),
         articles_path,
@@ -1248,8 +1286,10 @@ pub fn pin_text_observation_identities_in_session(
         &writer,
         geometry,
         attention_operator,
+        dense_operator,
         tokenizer_adapter,
     )?;
+    session.recover_recorded_corpus_binding_after_preflight()?;
     if let Some(adapter) = tokenizer_adapter {
         writer.set_tokenizer_adapter(adapter)?;
     }
@@ -1258,13 +1298,31 @@ pub fn pin_text_observation_identities_in_session(
     if let Some(geometry) = geometry {
         writer.set_geometry(geometry)?;
     }
-    if let Some(operator) = attention_operator {
-        writer.set_attention_operator(operator)?;
-    }
+    writer.set_source_execution_pair(attention_operator, dense_operator)?;
     if inspected.repair_state_mirror {
         repair_state_mirror(session.dir(), &inspected.checkpoint)?;
     }
     Ok(())
+}
+
+/// Compatibility entry point preserving the pre-#704 dense-absent API.
+pub fn pin_text_observation_identities_in_session(
+    session: &observe::ObservationSession,
+    articles_path: &Path,
+    resume: bool,
+    geometry: Option<&GeometryProjection>,
+    attention_operator: Option<&AttentionOperatorSpec>,
+    tokenizer_adapter: Option<&TokenizerAdapter>,
+) -> Result<(), SourceUnavailable> {
+    pin_text_observation_identities_in_session_with_dense(
+        session,
+        articles_path,
+        resume,
+        geometry,
+        attention_operator,
+        None,
+        tokenizer_adapter,
+    )
 }
 
 /// Open an observation directory: validate/resume the checkpoint, reconcile any
@@ -1280,6 +1338,7 @@ fn prepare_text_observation(
     resume: bool,
     geometry: Option<&GeometryProjection>,
     attention_operator: Option<&AttentionOperatorSpec>,
+    dense_operator: Option<&DenseOperatorSpec>,
     tokenizer_adapter: Option<&TokenizerAdapter>,
 ) -> Result<Prepared, SourceUnavailable> {
     let mut writer = match session {
@@ -1295,6 +1354,7 @@ fn prepare_text_observation(
         &writer,
         geometry,
         attention_operator,
+        dense_operator,
         tokenizer_adapter,
     )?;
     let input_cid = inspected.input_cid;
@@ -1317,6 +1377,9 @@ fn prepare_text_observation(
     }
     if let Some(operator) = attention_operator {
         writer.set_attention_operator(operator)?;
+    }
+    if let Some(operator) = dense_operator {
+        writer.set_dense_operator(operator)?;
     }
     if repair_checkpoint_mirror {
         repair_state_mirror(out_dir, &checkpoint)?;
@@ -1455,6 +1518,15 @@ fn observe_text_corpus_inner(
     if let Some(operator) = attention_operator.as_ref() {
         observe::validate_registered_source_attention_operator(operator)?;
     }
+    let dense_operator = oracles[0].dense_operator_spec();
+    if let Some(operator) = dense_operator.as_ref() {
+        observe::validate_registered_source_dense_operator(operator)?;
+    }
+    observe::validate_source_execution_identity(
+        attention_operator.as_ref(),
+        dense_operator.as_ref(),
+        "serial observation worker execution provenance",
+    )?;
     for oracle in &oracles[1..] {
         let candidate_geometry = oracle.geometry_projection();
         if let Some(candidate) = candidate_geometry.as_ref() {
@@ -1465,13 +1537,27 @@ fn observe_text_corpus_inner(
                 "serial observation workers declare different source geometries; refusing mixed projection eras before mutation",
             ));
         }
-        let candidate = oracle.attention_operator_spec();
-        if let Some(operator) = candidate.as_ref() {
+        let candidate_attention = oracle.attention_operator_spec();
+        if let Some(operator) = candidate_attention.as_ref() {
             observe::validate_registered_source_attention_operator(operator)?;
         }
-        if candidate != attention_operator {
+        let candidate_dense = oracle.dense_operator_spec();
+        if let Some(operator) = candidate_dense.as_ref() {
+            observe::validate_registered_source_dense_operator(operator)?;
+        }
+        observe::validate_source_execution_identity(
+            candidate_attention.as_ref(),
+            candidate_dense.as_ref(),
+            "serial observation worker execution provenance",
+        )?;
+        if candidate_attention != attention_operator {
             return Err(SourceUnavailable::new(
                 "serial observation workers declare different attention operators; refusing mixed arithmetic eras before mutation",
+            ));
+        }
+        if candidate_dense != dense_operator {
+            return Err(SourceUnavailable::new(
+                "serial observation workers declare different dense operators; refusing mixed execution eras before mutation",
             ));
         }
     }
@@ -1484,6 +1570,7 @@ fn observe_text_corpus_inner(
         resume,
         geometry.as_ref(),
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
         adapter.as_ref(),
     )? {
         Prepared::Done(report) => return Ok(report),
@@ -1769,6 +1856,15 @@ fn observe_text_corpus_batched_inner<T: BatchedTeacher>(
     if let Some(operator) = attention_operator.as_ref() {
         observe::validate_registered_source_attention_operator(operator)?;
     }
+    let dense_operator = oracle.dense_operator_spec();
+    if let Some(operator) = dense_operator.as_ref() {
+        observe::validate_registered_source_dense_operator(operator)?;
+    }
+    observe::validate_source_execution_identity(
+        attention_operator.as_ref(),
+        dense_operator.as_ref(),
+        "batched observation worker execution provenance",
+    )?;
     let adapter = tokenizer.adapter();
     let (mut writer, mut checkpoint, articles_total, stories_path) = match prepare_text_observation(
         session,
@@ -1778,6 +1874,7 @@ fn observe_text_corpus_batched_inner<T: BatchedTeacher>(
         resume,
         geometry.as_ref(),
         attention_operator.as_ref(),
+        dense_operator.as_ref(),
         adapter.as_ref(),
     )? {
         Prepared::Done(report) => return Ok(report),
@@ -2113,6 +2210,7 @@ mod tests {
 
     struct DeclaredFakeOracle {
         operator: Option<AttentionOperatorSpec>,
+        dense_operator: Option<DenseOperatorSpec>,
         geometry: Option<GeometryProjection>,
     }
 
@@ -2167,6 +2265,9 @@ mod tests {
         }
         fn attention_operator_spec(&self) -> Option<AttentionOperatorSpec> {
             self.operator.clone()
+        }
+        fn dense_operator_spec(&self) -> Option<DenseOperatorSpec> {
+            self.dense_operator.clone()
         }
         fn geometry_projection(&self) -> Option<GeometryProjection> {
             self.geometry.clone()
@@ -3212,6 +3313,7 @@ mod tests {
     struct FakeBatchedOracle {
         cfg: uor_r4_model_source::Config,
         attention_operator: Option<AttentionOperatorSpec>,
+        dense_operator: Option<DenseOperatorSpec>,
         geometry: Option<GeometryProjection>,
     }
 
@@ -3234,6 +3336,9 @@ mod tests {
         }
         fn attention_operator_spec(&self) -> Option<AttentionOperatorSpec> {
             self.attention_operator.clone()
+        }
+        fn dense_operator_spec(&self) -> Option<DenseOperatorSpec> {
+            self.dense_operator.clone()
         }
         fn geometry_projection(&self) -> Option<GeometryProjection> {
             self.geometry.clone()
@@ -3301,6 +3406,7 @@ mod tests {
         let fake = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: None,
+            dense_operator: None,
             geometry: None,
         };
         let batched = observe_text_corpus_batched(
@@ -3342,6 +3448,146 @@ mod tests {
     }
 
     #[test]
+    fn serial_and_batched_reject_cross_era_dense_before_any_output_mutation() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("cross-era-dense-articles.jsonl");
+        write_articles(&input, &[("cross-era", "ab")]);
+
+        let serial_dir = unique_path("cross-era-dense-serial");
+        fs::create_dir_all(&serial_dir).expect("create serial output");
+        fs::write(serial_dir.join("sentinel"), b"serial-before").expect("write serial sentinel");
+        let serial_before = directory_fingerprint(&serial_dir);
+        let mut serial_pool: Vec<Box<dyn TeacherOracle + Send>> =
+            vec![Box::new(DeclaredFakeOracle {
+                operator: Some(AttentionOperatorSpec::learned_absolute_v1()),
+                dense_operator: Some(DenseOperatorSpec::gpt2_v2()),
+                geometry: None,
+            })];
+        let error = observe_text_corpus(
+            &mut serial_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &serial_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect_err("serial cross-era source execution pair must fail");
+        assert!(error.reason.contains("source execution pair"), "{error}");
+        assert_eq!(
+            directory_fingerprint(&serial_dir),
+            serial_before,
+            "serial refusal mutated the output directory"
+        );
+
+        let batched_dir = unique_path("cross-era-dense-batched");
+        fs::create_dir_all(&batched_dir).expect("create batched output");
+        fs::write(batched_dir.join("sentinel"), b"batched-before").expect("write batched sentinel");
+        let batched_before = directory_fingerprint(&batched_dir);
+        let batched = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(AttentionOperatorSpec::learned_absolute_v1()),
+            dense_operator: Some(DenseOperatorSpec::gpt2_v2()),
+            geometry: None,
+        };
+        let error = observe_text_corpus_batched(
+            &batched,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &batched_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect_err("batched cross-era source execution pair must fail");
+        assert!(error.reason.contains("source execution pair"), "{error}");
+        assert_eq!(
+            directory_fingerprint(&batched_dir),
+            batched_before,
+            "batched refusal mutated the output directory"
+        );
+
+        let _ = fs::remove_dir_all(serial_dir);
+        let _ = fs::remove_dir_all(batched_dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn serial_and_batched_propagate_current_gpt2_execution_identity() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let input = unique_path("current-dense-articles.jsonl");
+        write_articles(&input, &[("current", "ab")]);
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+
+        let serial_dir = unique_path("current-dense-serial");
+        let mut serial_pool: Vec<Box<dyn TeacherOracle + Send>> =
+            vec![Box::new(DeclaredFakeOracle {
+                operator: Some(attention.clone()),
+                dense_operator: Some(dense.clone()),
+                geometry: None,
+            })];
+        let serial = observe_text_corpus(
+            &mut serial_pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &serial_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("serial current GPT-2 observation");
+
+        let batched_dir = unique_path("current-dense-batched");
+        let batched_oracle = FakeBatchedOracle {
+            cfg: fake_batched_config(),
+            attention_operator: Some(attention.clone()),
+            dense_operator: Some(dense.clone()),
+            geometry: None,
+        };
+        let batched = observe_text_corpus_batched(
+            &batched_oracle,
+            2,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &batched_dir,
+            SHARD_BITS,
+            false,
+        )
+        .expect("batched current GPT-2 observation");
+
+        assert!(serial.done && batched.done);
+        assert_eq!(
+            merge_shards(&serial_dir).expect("merge serial"),
+            merge_shards(&batched_dir).expect("merge batched")
+        );
+        for dir in [&serial_dir, &batched_dir] {
+            let manifest = ObservationManifest::load(dir)
+                .expect("read observation manifest")
+                .expect("observation manifest exists");
+            assert_eq!(manifest.attention_operator.as_ref(), Some(&attention));
+            assert_eq!(manifest.dense_operator.as_ref(), Some(&dense));
+            assert!(
+                manifest
+                    .identity_bundle_bytes()
+                    .starts_with(b"uor-r4-observation-identity-bundle/2\n")
+            );
+        }
+
+        let _ = fs::remove_dir_all(serial_dir);
+        let _ = fs::remove_dir_all(batched_dir);
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
     fn registered_adapter_is_identical_on_serial_and_batched_manifests() {
         let tokenizer = fixture_registered_tokenizer("serial-batched");
         let adapter = tokenizer.adapter().expect("registered adapter");
@@ -3371,6 +3617,7 @@ mod tests {
         let fake = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: None,
+            dense_operator: None,
             geometry: None,
         };
         let batched = observe_text_corpus_batched(
@@ -3500,6 +3747,7 @@ mod tests {
         let mut serial_pool: Vec<Box<dyn TeacherOracle + Send>> =
             vec![Box::new(DeclaredFakeOracle {
                 operator: Some(standard.clone()),
+                dense_operator: None,
                 geometry: Some(geometry.clone()),
             })];
         observe_text_corpus(
@@ -3522,6 +3770,7 @@ mod tests {
         let mut pass_through_pool: Vec<Box<dyn TeacherOracle + Send>> =
             vec![Box::new(DeclaredFakeOracle {
                 operator: Some(standard.clone()),
+                dense_operator: None,
                 geometry: None,
             })];
         let error = observe_text_corpus(
@@ -3543,6 +3792,7 @@ mod tests {
         let batched = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(experimental.clone()),
+            dense_operator: None,
             geometry: Some(geometry.clone()),
         };
         observe_text_corpus_batched(
@@ -3570,10 +3820,12 @@ mod tests {
         let mut mixed_pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
             Box::new(DeclaredFakeOracle {
                 operator: Some(AttentionOperatorSpec::standard_v1()),
+                dense_operator: None,
                 geometry: None,
             }),
             Box::new(DeclaredFakeOracle {
                 operator: Some(AttentionOperatorSpec::standard_v2()),
+                dense_operator: None,
                 geometry: None,
             }),
         ];
@@ -3594,10 +3846,12 @@ mod tests {
         let mut mixed_geometry_pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
             Box::new(DeclaredFakeOracle {
                 operator: Some(AttentionOperatorSpec::standard()),
+                dense_operator: None,
                 geometry: Some(geometry),
             }),
             Box::new(DeclaredFakeOracle {
                 operator: Some(AttentionOperatorSpec::standard()),
+                dense_operator: None,
                 geometry: None,
             }),
         ];
@@ -3634,6 +3888,7 @@ mod tests {
         let standard = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(AttentionOperatorSpec::standard_v1()),
+            dense_operator: None,
             geometry: None,
         };
         observe_text_corpus_batched(
@@ -3653,6 +3908,7 @@ mod tests {
         let projected = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(AttentionOperatorSpec::standard_v1()),
+            dense_operator: None,
             geometry: Some(GeometryProjection::bucket_average(4, 2)),
         };
         let error = observe_text_corpus_batched(
@@ -3673,6 +3929,7 @@ mod tests {
         let current_v2 = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(AttentionOperatorSpec::standard_v2()),
+            dense_operator: None,
             geometry: None,
         };
         let error = observe_text_corpus_batched(
@@ -3693,6 +3950,7 @@ mod tests {
         let undeclared = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: None,
+            dense_operator: None,
             geometry: None,
         };
         let error = observe_text_corpus_batched(
@@ -3725,6 +3983,7 @@ mod tests {
         let legacy = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: None,
+            dense_operator: None,
             geometry: None,
         };
         observe_text_corpus_batched(
@@ -3755,6 +4014,7 @@ mod tests {
         let current = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(AttentionOperatorSpec::standard()),
+            dense_operator: None,
             geometry: None,
         };
         let error = observe_text_corpus_batched(
@@ -3792,6 +4052,7 @@ mod tests {
         let standard = FakeBatchedOracle {
             cfg: fake_batched_config(),
             attention_operator: Some(AttentionOperatorSpec::standard()),
+            dense_operator: None,
             geometry: None,
         };
         observe_text_corpus_batched(

--- a/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
+++ b/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
@@ -2282,6 +2282,64 @@ impl RecordedCorpusProducerHandoff {
     }
 }
 
+/// Canonically sorted, non-promoting ownership of one source/destination
+/// derivation pair.
+///
+/// A derivation reads one complete source generation while publishing a
+/// different destination generation. Acquiring the two ordinary producer
+/// guards independently would make lock order caller-dependent, while exposing
+/// [`RecordedCorpusProducerHandoff`] directly would also expose an unrelated
+/// root-promotion capability. This narrow facade reuses the handoff's sorted,
+/// failure-atomic acquisition and deliberately provides only stable
+/// source/destination guard access.
+#[derive(Debug)]
+pub struct RecordedCorpusDerivationGuards {
+    handoff: RecordedCorpusProducerHandoff,
+}
+
+impl RecordedCorpusDerivationGuards {
+    /// Capture and exclusively acquire a distinct source and destination root.
+    ///
+    /// Both parents must already exist. Existing roots are pinned by directory
+    /// inode and an absent destination is pinned as typed absence until the
+    /// destination guard creates it. Canonical aliases, symlink roots, and an
+    /// in-place source/destination pair fail before corpus-member mutation.
+    pub fn try_acquire(
+        source_root: impl AsRef<Path>,
+        destination_root: impl AsRef<Path>,
+    ) -> Result<Self, SourceUnavailable> {
+        let expected = [
+            RecordedCorpusRootGeneration::capture(source_root)?,
+            RecordedCorpusRootGeneration::capture(destination_root)?,
+        ];
+        let handoff = RecordedCorpusProducerHandoff::try_acquire(&expected, 0, 1)?;
+        handoff.verify()?;
+        Ok(Self { handoff })
+    }
+
+    /// Exclusive guard for the immutable derivation source.
+    pub fn source_guard(&self) -> &RecordedCorpusProducerGuard {
+        self.handoff.final_guard()
+    }
+
+    /// Exclusive guard for the destination publication transaction.
+    pub fn destination_guard(&self) -> &RecordedCorpusProducerGuard {
+        self.handoff.stage_guard()
+    }
+
+    /// Mutable destination access required to create a previously absent
+    /// output root. No mutable source access and no promotion API are exposed.
+    pub fn destination_guard_mut(&mut self) -> &mut RecordedCorpusProducerGuard {
+        let index = self.handoff.stage_guard_index;
+        &mut self.handoff.guards[index]
+    }
+
+    /// Recheck both retained root generations and coordination handles.
+    pub fn verify(&self) -> Result<(), SourceUnavailable> {
+        self.handoff.verify()
+    }
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn atomic_promote_recorded_corpus_roots(
     final_guard: &RecordedCorpusProducerGuard,
@@ -7554,6 +7612,83 @@ mod tests {
         }
         drop(handoff);
         drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn derivation_guards_sort_source_and_destination_without_promotion_capability() {
+        let container = unique_root("derivation-guards");
+        std::fs::create_dir_all(&container).expect("container");
+        let source = container.join("z-source");
+        let destination = container.join("a-destination");
+        std::fs::create_dir(&source).expect("source");
+
+        let mut guards = RecordedCorpusDerivationGuards::try_acquire(&source, &destination)
+            .expect("sorted derivation authority");
+        assert_eq!(
+            guards.source_guard().root(),
+            std::fs::canonicalize(&source).expect("canonical source")
+        );
+        assert_eq!(
+            guards.destination_guard().root(),
+            std::fs::canonicalize(&container)
+                .expect("canonical container")
+                .join("a-destination")
+        );
+        assert!(!guards.destination_guard().root_exists());
+        guards
+            .destination_guard_mut()
+            .ensure_root()
+            .expect("create guarded destination");
+        guards.verify().expect("both generations remain guarded");
+
+        for root in [&source, &destination] {
+            let busy = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect_err("derivation retains both exclusive guards");
+            assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        }
+        drop(guards);
+        for root in [&source, &destination] {
+            let probe = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("derivation releases both guards together");
+            drop(probe);
+        }
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn derivation_guards_reject_aliases_and_release_partial_sorted_acquisition() {
+        let container = unique_root("derivation-guards-alias");
+        std::fs::create_dir_all(&container).expect("container");
+        let source = container.join("z-source");
+        let destination = container.join("a-destination");
+        std::fs::create_dir(&source).expect("source");
+        std::fs::create_dir(&destination).expect("destination");
+
+        let alias = RecordedCorpusDerivationGuards::try_acquire(
+            &source,
+            container.join(".").join("z-source"),
+        )
+        .expect_err("in-place canonical alias is refused");
+        assert!(alias.reason.contains("same canonical root"), "{alias}");
+
+        let blocker = RecordedCorpusProducerGuard::try_acquire(&source).expect("source blocker");
+        let busy = RecordedCorpusDerivationGuards::try_acquire(&source, &destination)
+            .expect_err("later sorted source contention fails atomically");
+        assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        let destination_probe = RecordedCorpusProducerGuard::try_acquire(&destination)
+            .expect("earlier sorted destination acquisition was released");
+        drop(destination_probe);
+        drop(blocker);
+
+        #[cfg(unix)]
+        {
+            let link = container.join("source-link");
+            std::os::unix::fs::symlink(&source, &link).expect("source symlink");
+            let error = RecordedCorpusDerivationGuards::try_acquire(&link, &destination)
+                .expect_err("symlink root is terminal");
+            assert!(error.reason.contains("not a real non-symlink"), "{error}");
+        }
         let _ = std::fs::remove_dir_all(container);
     }
 

--- a/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
+++ b/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
@@ -330,11 +330,10 @@ fn validate_binding_role(
 }
 
 fn validate_role_inventory(root: &Path, role: RecordedCorpusRole) -> Result<(), SourceUnavailable> {
-    const COMPILE_ONLY: [&str; 19] = [
+    const COMPILE_ONLY: [&str; 18] = [
         "corpus.meta",
         "corpus.records",
         "corpus.records.hidden",
-        "tokenizer.bin",
         "tless_artifacts.bin",
         "tless_store.bin",
         "hamming_calibration.json",
@@ -638,7 +637,7 @@ impl VerifiedCorpusMember {
     }
 }
 
-impl Read for VerifiedCorpusMember {
+impl std::io::Read for VerifiedCorpusMember {
     fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
         let remaining = self.len().saturating_sub(self.position);
         if remaining == 0 || buffer.is_empty() {
@@ -659,27 +658,28 @@ impl Read for VerifiedCorpusMember {
     }
 }
 
-impl Seek for VerifiedCorpusMember {
+impl std::io::Seek for VerifiedCorpusMember {
     fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
         let target = match position {
-            SeekFrom::Start(target) => target,
-            SeekFrom::End(offset) => bounded_seek_target(self.len(), offset)?,
-            SeekFrom::Current(offset) => bounded_seek_target(self.position, offset)?,
-        };
+            SeekFrom::Start(target) => Some(target),
+            SeekFrom::End(offset) => bounded_seek_target(self.len(), offset),
+            SeekFrom::Current(offset) => bounded_seek_target(self.position, offset),
+        }
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "verified corpus member seek is outside the u64 address space",
+            )
+        })?;
         self.file.seek(SeekFrom::Start(target))?;
         self.position = target;
         Ok(target)
     }
 }
 
-fn bounded_seek_target(base: u64, offset: i64) -> std::io::Result<u64> {
+fn bounded_seek_target(base: u64, offset: i64) -> Option<u64> {
     let target = i128::from(base) + i128::from(offset);
-    u64::try_from(target).map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "verified corpus member seek is outside the u64 address space",
-        )
-    })
+    u64::try_from(target).ok()
 }
 
 /// Small provenance/metadata plus retained verified handles for large corpus
@@ -1061,6 +1061,35 @@ impl RecordedCorpusProducerGuard {
         }
         self.verify_root()?;
         Ok(!residues.temporaries.is_empty())
+    }
+
+    /// Reclaim only non-authoritative binding `.writing` inodes after the
+    /// complete role namespace has been validated under this retained root.
+    /// A canonical `.tmp` is an authoritative recoverable commit candidate
+    /// and is never discarded here; the caller must promote it through
+    /// [`publish_binding`] before deciding whether the generation is bound.
+    pub fn reclaim_uncommitted_binding_writings_for(
+        &self,
+        role: RecordedCorpusRole,
+    ) -> Result<(), SourceUnavailable> {
+        self.verify_root()?;
+        if self.preflight_publication_namespace_for(role)? {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains an authoritative recoverable binding temporary; refusing to discard publication evidence",
+                self.root.display()
+            )));
+        }
+        let residues = binding_publication_residues(&self.root, true)?;
+        for (path, bytes) in residues.writings {
+            remove_exact_owned_binding_residue(
+                self,
+                &path,
+                &bytes,
+                "non-authoritative binding staging",
+            )?;
+        }
+        self.sync_owned_root()?;
+        self.verify_root()
     }
 
     /// Durably declare a compile-style mutation attempt before the first
@@ -2108,10 +2137,10 @@ impl RecordedCorpusProducerHandoff {
             unique.push(expected);
         }
 
-        let guards = unique
-            .into_iter()
-            .map(acquire_expected)
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut guards = Vec::with_capacity(unique.len());
+        for expected in unique {
+            guards.push(acquire_expected(expected)?);
+        }
         let locate_guard = |expected: &RecordedCorpusRootGeneration| {
             guards
                 .iter()
@@ -2695,10 +2724,10 @@ impl RecordedCorpusReaderPins {
             roots,
             "recorded corpus reader-pin acquisition",
         )?;
-        let mut generations = roots
-            .into_iter()
-            .map(RecordedCorpusRootGeneration::capture)
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut generations = Vec::with_capacity(roots.len());
+        for root in roots {
+            generations.push(RecordedCorpusRootGeneration::capture(root)?);
+        }
         if generations.is_empty() {
             return Err(SourceUnavailable::new(
                 "recorded corpus reader pins require at least one logical root",
@@ -2722,107 +2751,10 @@ impl RecordedCorpusReaderPins {
             unique.push(generation);
         }
 
-        let pins = unique
-            .into_iter()
-            .map(RecordedCorpusReaderPin::try_acquire)
-            .collect::<Result<Vec<_>, _>>()?;
-        let result = Self { pins };
-        result.verify()?;
-        Ok(result)
-    }
-
-    /// Acquire shared pins for a writable managed namespace, creating every
-    /// permanent coordination inode before downgrading a canonically sorted
-    /// exclusive lock set to shared ownership. Unlike the read-only variant,
-    /// typed-absent roots are therefore actively protected: a cooperating
-    /// producer cannot create a newly preferred sibling until these pins are
-    /// dropped.
-    ///
-    /// Callers must hold their writer-specific outer inventory/session lock
-    /// before this method, matching the producer acquisition order.
-    pub fn try_acquire_managed<I, P>(roots: I) -> Result<Self, SourceUnavailable>
-    where
-        I: IntoIterator<Item = P>,
-        P: AsRef<Path>,
-    {
-        let roots = collect_bounded_recorded_corpus_root_paths(
-            roots,
-            "managed recorded corpus reader-pin acquisition",
-        )?;
-        let mut generations = roots
-            .into_iter()
-            .map(RecordedCorpusRootGeneration::capture)
-            .collect::<Result<Vec<_>, _>>()?;
-        if generations.is_empty() {
-            return Err(SourceUnavailable::new(
-                "managed recorded corpus reader pins require at least one logical root",
-            ));
+        let mut pins = Vec::with_capacity(unique.len());
+        for generation in unique {
+            pins.push(RecordedCorpusReaderPin::try_acquire(generation)?);
         }
-        generations.sort_by(|left, right| left.root.cmp(&right.root));
-        let mut unique = Vec::<RecordedCorpusRootGeneration>::new();
-        for generation in generations {
-            if let Some(previous) = unique.last()
-                && previous.root == generation.root
-            {
-                if !previous.same_generation(&generation)? {
-                    return Err(SourceUnavailable::new(format!(
-                        "managed recorded corpus reader pin root {} changed generation while aliases were canonicalized",
-                        generation.root.display()
-                    )));
-                }
-                continue;
-            }
-            unique.push(generation);
-        }
-
-        let mut guards = Vec::with_capacity(unique.len());
-        for generation in &unique {
-            let guard = RecordedCorpusProducerGuard::try_acquire(&generation.root)?;
-            if !generation.matches_guard(&guard)? {
-                return Err(SourceUnavailable::new(format!(
-                    "managed recorded corpus root {} changed generation while its coordination inode was seeded",
-                    generation.root.display()
-                )));
-            }
-            guards.push(guard);
-        }
-
-        // Downgrade in canonical order while every not-yet-downgraded root is
-        // still exclusive. There is no interval in which a seeded root is
-        // unlocked before the complete shared set exists.
-        for guard in &guards {
-            guard._file.try_lock_shared().map_err(|error| match error {
-                std::fs::TryLockError::WouldBlock => SourceUnavailable::new(format!(
-                    "recorded corpus root {} is BUSY while managed reader ownership is downgraded",
-                    guard.root.display()
-                )),
-                std::fs::TryLockError::Error(error) => SourceUnavailable::new(format!(
-                    "recorded corpus reader coordination for {} cannot be downgraded to shared: {error}",
-                    guard.root.display()
-                )),
-            })?;
-        }
-
-        let pins = unique
-            .into_iter()
-            .zip(guards)
-            .map(|(generation, guard)| {
-                let coordination_path = generation
-                    .parent
-                    .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
-                let lock_path =
-                    coordination_path.join(generation.root.file_name().ok_or_else(|| {
-                        SourceUnavailable::new("managed recorded corpus root has no name")
-                    })?);
-                Ok(RecordedCorpusReaderPin {
-                    generation,
-                    coordination_path,
-                    coordination_file: Some(guard._coordination_file),
-                    lock_path,
-                    lock_file: Some(guard._file),
-                })
-            })
-            .collect::<Result<Vec<_>, SourceUnavailable>>()?;
         let result = Self { pins };
         result.verify()?;
         Ok(result)
@@ -5187,10 +5119,75 @@ pub fn preflight_source_update_publication(
             !attempt_active,
         )?;
     }
+    if stable && attempt_active {
+        // The compile-attempt marker records only the producer role.  It is
+        // deliberately not an authority to splice a different manifest or
+        // arithmetic era onto corpus bytes advanced by a resume checkpoint.
+        // A legitimate A -> B source resume may change metadata/records while
+        // retaining the last-good binding A, but every provenance member must
+        // still equal the generation that authorized that resume.
+        preflight_stable_binding_provenance_matches_current(guard, corpus_meta, corpus_records)?;
+    }
     Ok(SourceUpdatePublicationState {
         recoverable_binding,
         attempt_active,
     })
+}
+
+fn preflight_stable_binding_provenance_matches_current(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<(), SourceUnavailable> {
+    guard.verify_root()?;
+    let (root, resolved_meta, resolved_records) =
+        resolved_corpus_paths(corpus_meta, corpus_records)?;
+    if root != guard.root {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus producer guard owns {}, but source-resume provenance preflight resolved to {}",
+            guard.root.display(),
+            root.display()
+        )));
+    }
+    if !is_canonical_pair(&resolved_meta, &resolved_records) {
+        return Err(SourceUnavailable::new(
+            "source-resume provenance preflight requires canonical corpus.meta/corpus.records",
+        ));
+    }
+    let stable_path = binding_path(&root);
+    let stable_bytes = capture_optional_control_file(
+        &stable_path,
+        "stable recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
+    )?
+    .ok_or_else(|| {
+        SourceUnavailable::new(
+            "source-resume provenance preflight requires the observed stable binding",
+        )
+    })?;
+    let stable = parse_binding_bytes(&stable_path, &stable_bytes)?;
+    validate_binding_role(&stable, RecordedCorpusRole::Compile, &stable_path)?;
+    let provenance = capture_provenance(&root)?;
+    let context = format!(
+        "stable recorded corpus binding {} source-resume provenance",
+        stable_path.display()
+    );
+    stable.manifest.validate(
+        observation::MANIFEST_FILE,
+        provenance[0].as_deref(),
+        &context,
+    )?;
+    stable.attention_operator.validate(
+        ATTENTION_OPERATOR_BINDING_FILE,
+        provenance[1].as_deref(),
+        &context,
+    )?;
+    stable.dense_operator.validate(
+        DENSE_OPERATOR_BINDING_FILE,
+        provenance[2].as_deref(),
+        &context,
+    )?;
+    guard.verify_root()
 }
 
 fn preflight_binding_evidence_matches_current_inner(
@@ -6374,6 +6371,23 @@ mod tests {
     }
 
     #[test]
+    fn tokenizer_payload_is_shared_between_compile_and_observation_roles() {
+        let root = unique_root("shared-tokenizer-role-inventory");
+        let guard = producer_guard(&root);
+        std::fs::write(root.join("tokenizer.bin"), b"shared tokenizer payload")
+            .expect("tokenizer payload");
+
+        guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Compile)
+            .expect("compile role accepts its tokenizer payload");
+        guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect("observation resume accepts its tokenizer payload");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn compile_attempt_marker_bytes_digest_and_lifecycle_are_pinned() {
         let expected = b"{\n  \"schema\": \"uor-r4-recorded-corpus-compile-attempt/1\",\n  \"role\": \"compile\"\n}\n";
         let canonical = RecordedCorpusCompileAttempt::compile()
@@ -6542,6 +6556,41 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(interrupted);
         let _ = std::fs::remove_dir_all(unowned);
+    }
+
+    #[test]
+    fn active_source_update_never_authorizes_mixed_provenance() {
+        let root = unique_root("source-update-mixed-provenance");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 53);
+        publish_compile_binding(&guard, &meta, &records);
+        guard.finish_compile_attempt().expect("finish generation A");
+        guard.begin_compile_attempt().expect("begin generation B");
+        let _ = complete_source_corpus(&root, 71);
+
+        let mut attention = serde_json::to_vec_pretty(&AttentionOperatorSpec::standard_v2())
+            .expect("serialize injected provenance");
+        attention.push(b'\n');
+        std::fs::write(root.join(ATTENTION_OPERATOR_BINDING_FILE), attention)
+            .expect("inject different current provenance");
+        let binding_before =
+            std::fs::read(root.join(RECORDED_CORPUS_BINDING_FILE)).expect("binding before");
+        let records_before = std::fs::read(&records).expect("records before");
+
+        let error = preflight_source_update_publication(&guard, &meta, &records)
+            .expect_err("role-only attempt marker cannot authorize mixed provenance");
+        assert!(error.reason.contains("does not match"), "{error}");
+        assert_eq!(
+            std::fs::read(root.join(RECORDED_CORPUS_BINDING_FILE)).expect("binding after"),
+            binding_before
+        );
+        assert_eq!(
+            std::fs::read(&records).expect("records after"),
+            records_before
+        );
+        assert!(root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE).exists());
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -7077,10 +7126,12 @@ mod tests {
         let (state, merged) =
             write_corpus_pair(&top_manifest_root, observation::STATE_FILE, "merged.bin");
         let mut duplicate_top = manifest_json
-            .strip_suffix('}')
+            .strip_suffix(char::from(125))
             .expect("manifest object")
             .to_owned();
-        duplicate_top.push_str(&format!(",\"dense_operator\":{dense_json}}}"));
+        duplicate_top.push_str(",\"dense_operator\":");
+        duplicate_top.push_str(&dense_json);
+        duplicate_top.push(char::from(125));
         std::fs::write(
             top_manifest_root.join(observation::MANIFEST_FILE),
             duplicate_top,
@@ -7873,58 +7924,6 @@ mod tests {
             .expect("read-only over-limit pins retained no lock");
         drop(probe);
         let _ = std::fs::remove_dir_all(duplicate_container);
-
-        let unique_container = unique_root("managed-reader-pin-root-ceiling-unique");
-        std::fs::create_dir_all(&unique_container).expect("unique container");
-        let unique_roots = (0..=RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES)
-            .map(|index| unique_container.join(format!("absent-{index:02}")))
-            .collect::<Vec<_>>();
-        let error = RecordedCorpusReaderPins::try_acquire_managed(&unique_roots)
-            .expect_err("unique over-limit managed pins must fail closed");
-        assert!(
-            error.reason.contains("fixed 16-entry logical-root ceiling"),
-            "{error}"
-        );
-        assert!(
-            !unique_container
-                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
-                .exists(),
-            "managed ceiling is checked before generation capture or lock seeding"
-        );
-        for root in &unique_roots {
-            let probe = RecordedCorpusProducerGuard::try_acquire(root)
-                .expect("managed over-limit pins retained no unique-root lock");
-            drop(probe);
-        }
-        let _ = std::fs::remove_dir_all(unique_container);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn managed_reader_pins_seed_unseen_absent_roots_without_an_unlock_gap() {
-        let container = unique_root("managed-reader-pins-absent");
-        std::fs::create_dir_all(&container).expect("container");
-        let conventional = container.join("conventional");
-        let current = container.join("current");
-        let composite = container.join("composite");
-        std::fs::create_dir(&conventional).expect("existing conventional root");
-
-        let pins =
-            RecordedCorpusReaderPins::try_acquire_managed([&conventional, &current, &composite])
-                .expect("managed pins seed all three lock inodes");
-        assert!(!current.exists());
-        assert!(!composite.exists());
-        for root in [&conventional, &current, &composite] {
-            let busy = RecordedCorpusProducerGuard::try_acquire(root)
-                .expect_err("managed shared pin excludes every producer");
-            assert!(is_recorded_corpus_busy(&busy), "{busy}");
-        }
-        pins.verify().expect("managed pins remain exact");
-        drop(pins);
-        let writer = RecordedCorpusProducerGuard::try_acquire(&composite)
-            .expect("producer proceeds after managed pins drop");
-        drop(writer);
-        let _ = std::fs::remove_dir_all(container);
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
+++ b/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
@@ -27,11 +27,33 @@ pub const RECORDED_CORPUS_BINDING_SCHEMA: &str = "uor-r4-recorded-corpus-binding
 pub const RECORDED_CORPUS_COMPILE_ATTEMPT_FILE: &str = "recorded_corpus_compile_attempt.json";
 pub const RECORDED_CORPUS_COMPILE_ATTEMPT_SCHEMA: &str = "uor-r4-recorded-corpus-compile-attempt/1";
 pub const PLANNED_OUTPUT_RESERVED_PREFIX: &str = ".uor-r4-planned-output--";
-const RECORDED_CORPUS_PRODUCER_COORDINATION_DIR: &str = ".uor-r4-recorded-corpus-producers";
+pub const RECORDED_CORPUS_PRODUCER_COORDINATION_DIR: &str = ".uor-r4-recorded-corpus-producers";
 const STREAM_BINDING_BUFFER_BYTES: usize = 64 * 1024;
+const BINDING_CONTROL_MAX_BYTES: u64 = 16 * 1024;
+const COMPILE_ATTEMPT_CONTROL_MAX_BYTES: u64 = 1024;
+const PROVENANCE_CONTROL_MAX_BYTES: u64 = 1024 * 1024;
+const METADATA_CONTROL_MAX_BYTES: u64 = 1024 * 1024;
+const RESERVED_RESIDUE_MAX_ENTRIES: usize = 64;
+const RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES: usize = 16;
 
 static RECORDED_CORPUS_BINDING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static RECORDED_CORPUS_COMPILE_ATTEMPT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Stable classification for nonblocking recorded-corpus coordination.
+///
+/// Callers should not duplicate the protocol's error wording when deciding
+/// whether a retry is appropriate. Malformed or identity-raced coordination
+/// remains terminal and deliberately does not satisfy this predicate.
+pub fn is_recorded_corpus_busy(error: &SourceUnavailable) -> bool {
+    is_recorded_corpus_busy_message(&error.reason)
+}
+
+/// String-boundary companion for servers which preserve their historical
+/// public error type while mapping only the lower protocol's stable transient
+/// classification.
+pub fn is_recorded_corpus_busy_message(error: &str) -> bool {
+    error.contains(" is BUSY under another active producer session")
+}
 
 /// The two canonical member pairs that a recorded-corpus binding may commit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,6 +79,8 @@ impl RecordedCorpusRole {
 /// graph CLI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlannedOutputMember {
+    AttentionOperator,
+    DenseOperator,
     Artifact,
     Store,
     Calibration,
@@ -77,8 +101,22 @@ impl PlannedOutputMember {
         Self::Metadata,
     ];
 
+    pub const REGISTERED: [Self; 9] = [
+        Self::AttentionOperator,
+        Self::DenseOperator,
+        Self::Artifact,
+        Self::Store,
+        Self::Calibration,
+        Self::HierarchicalCodes,
+        Self::Records,
+        Self::Hidden,
+        Self::Metadata,
+    ];
+
     pub const fn stable_name(self) -> &'static str {
         match self {
+            Self::AttentionOperator => ATTENTION_OPERATOR_BINDING_FILE,
+            Self::DenseOperator => DENSE_OPERATOR_BINDING_FILE,
             Self::Artifact => "tless_artifacts.bin",
             Self::Store => "tless_store.bin",
             Self::Calibration => "hamming_calibration.json",
@@ -154,6 +192,30 @@ impl RecordedCorpusFileBinding {
         }
         Ok(())
     }
+
+    fn validate_shape(&self, expected_name: &str, context: &str) -> Result<(), SourceUnavailable> {
+        if self.name != expected_name {
+            return Err(SourceUnavailable::new(format!(
+                "{context} binds filename {:?}, expected exact member {expected_name:?}",
+                self.name
+            )));
+        }
+        match (self.present, self.length, self.blake3.as_deref()) {
+            (false, None, None) => Ok(()),
+            (true, Some(_), Some(digest))
+                if digest.len() == "blake3:".len() + 64
+                    && digest.starts_with("blake3:")
+                    && digest["blake3:".len()..]
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)) =>
+            {
+                Ok(())
+            }
+            _ => Err(SourceUnavailable::new(format!(
+                "{context} has an invalid typed presence/length/BLAKE3 tuple for {expected_name}"
+            ))),
+        }
+    }
 }
 
 /// Canonical commit record for one recorded-corpus generation.
@@ -184,6 +246,40 @@ impl RecordedCorpusBinding {
             blake3::hash(&self.canonical_bytes()?).to_hex()
         ))
     }
+
+    fn validate_shape(&self, context: &str) -> Result<RecordedCorpusRole, SourceUnavailable> {
+        self.manifest
+            .validate_shape(observation::MANIFEST_FILE, context)?;
+        self.attention_operator
+            .validate_shape(ATTENTION_OPERATOR_BINDING_FILE, context)?;
+        self.dense_operator
+            .validate_shape(DENSE_OPERATOR_BINDING_FILE, context)?;
+        let role = match (self.metadata.name.as_str(), self.records.name.as_str()) {
+            ("corpus.meta", "corpus.records") => RecordedCorpusRole::Compile,
+            (metadata, "merged.bin") if metadata == observation::STATE_FILE => {
+                RecordedCorpusRole::Observation
+            }
+            _ => {
+                return Err(SourceUnavailable::new(format!(
+                    "{context} does not name one exact registered metadata/records pair"
+                )));
+            }
+        };
+        let (metadata, records) = role.member_names();
+        self.metadata.validate_shape(metadata, context)?;
+        self.records.validate_shape(records, context)?;
+        let expected_hidden = hidden_path(Path::new(records));
+        let expected_hidden = expected_hidden.to_str().ok_or_else(|| {
+            SourceUnavailable::new("registered hidden member name is not Unicode")
+        })?;
+        self.hidden.validate_shape(expected_hidden, context)?;
+        if role == RecordedCorpusRole::Observation && self.hidden.present {
+            return Err(SourceUnavailable::new(format!(
+                "{context} declares a hidden stream for the observation role, which has no registered hidden member"
+            )));
+        }
+        Ok(role)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -206,6 +302,14 @@ impl RecordedCorpusCompileAttempt {
         bytes.push(b'\n');
         Ok(bytes)
     }
+}
+
+/// Canonical bytes of the lower compile-role coordination marker. External
+/// managed publishers use this exact record when classifying/excluding the
+/// transient marker; re-serializing an ad-hoc JSON map could change field
+/// order and falsely reject the lower protocol's own bytes.
+pub fn recorded_corpus_compile_attempt_bytes() -> Result<Vec<u8>, SourceUnavailable> {
+    RecordedCorpusCompileAttempt::compile().canonical_bytes()
 }
 
 fn validate_binding_role(
@@ -248,6 +352,9 @@ fn validate_role_inventory(root: &Path, role: RecordedCorpusRole) -> Result<(), 
         "instruction-eval.json",
     ];
     fn compile_only_name(name: &str) -> bool {
+        if name.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX) {
+            return true;
+        }
         if COMPILE_ONLY.contains(&name) {
             return true;
         }
@@ -318,10 +425,14 @@ fn validate_role_inventory(root: &Path, role: RecordedCorpusRole) -> Result<(), 
                 {
                     use std::os::unix::ffi::OsStrExt;
                     let raw = entry.file_name();
-                    if COMPILE_ONLY.iter().any(|stable| {
-                        raw.as_bytes() == stable.as_bytes()
-                            || raw.as_bytes().starts_with(format!(".{stable}.").as_bytes())
-                    }) {
+                    if raw
+                        .as_bytes()
+                        .starts_with(PLANNED_OUTPUT_RESERVED_PREFIX.as_bytes())
+                        || COMPILE_ONLY.iter().any(|stable| {
+                            raw.as_bytes() == stable.as_bytes()
+                                || raw.as_bytes().starts_with(format!(".{stable}.").as_bytes())
+                        })
+                    {
                         return Err(SourceUnavailable::new(format!(
                             "recorded corpus root {} contains a non-UTF-8 entry in a reserved compile-role namespace",
                             root.display()
@@ -473,6 +584,7 @@ pub struct VerifiedCorpusMember {
     file: std::fs::File,
     initial: Metadata,
     binding: RecordedCorpusFileBinding,
+    position: u64,
     context: &'static str,
 }
 
@@ -528,14 +640,46 @@ impl VerifiedCorpusMember {
 
 impl Read for VerifiedCorpusMember {
     fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
-        self.file.read(buffer)
+        let remaining = self.len().saturating_sub(self.position);
+        if remaining == 0 || buffer.is_empty() {
+            return Ok(0);
+        }
+        let limit = usize::try_from(remaining.min(buffer.len() as u64)).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "verified corpus member read length does not fit usize",
+            )
+        })?;
+        let read = self.file.read(&mut buffer[..limit])?;
+        self.position = self
+            .position
+            .checked_add(read as u64)
+            .ok_or_else(|| std::io::Error::other("verified corpus member position overflow"))?;
+        Ok(read)
     }
 }
 
 impl Seek for VerifiedCorpusMember {
     fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
-        self.file.seek(position)
+        let target = match position {
+            SeekFrom::Start(target) => target,
+            SeekFrom::End(offset) => bounded_seek_target(self.len(), offset)?,
+            SeekFrom::Current(offset) => bounded_seek_target(self.position, offset)?,
+        };
+        self.file.seek(SeekFrom::Start(target))?;
+        self.position = target;
+        Ok(target)
     }
+}
+
+fn bounded_seek_target(base: u64, offset: i64) -> std::io::Result<u64> {
+    let target = i128::from(base) + i128::from(offset);
+    u64::try_from(target).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "verified corpus member seek is outside the u64 address space",
+        )
+    })
 }
 
 /// Small provenance/metadata plus retained verified handles for large corpus
@@ -560,6 +704,75 @@ pub struct RecordedCorpusStreamSnapshot {
 }
 
 impl RecordedCorpusStreamSnapshot {
+    /// Materialize the record stream required by the existing compiler while
+    /// retaining opaque model-width hidden rows as a verified summary only.
+    /// The compiler consumes hidden rows exclusively at its fixed `D` width;
+    /// GPT-2 source rows (for example width 768) are provenance-bound but are
+    /// not duplicated into a multi-gigabyte `Vec` that the compiler discards.
+    pub fn materialize_compiler_corpus_bytes(
+        &mut self,
+    ) -> Result<(Vec<u8>, Option<Vec<u8>>), SourceUnavailable> {
+        fn read_member(
+            member: &mut VerifiedCorpusMember,
+            label: &str,
+        ) -> Result<Vec<u8>, SourceUnavailable> {
+            let length = usize::try_from(member.len()).map_err(|_| {
+                SourceUnavailable::new(format!(
+                    "{label} length {} cannot be represented on this host",
+                    member.len()
+                ))
+            })?;
+            member
+                .seek(SeekFrom::Start(0))
+                .map_err(SourceUnavailable::new)?;
+            let mut bytes = Vec::new();
+            bytes.try_reserve_exact(length).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "cannot reserve {length} bytes for {label}: {error}"
+                ))
+            })?;
+            bytes.resize(length, 0);
+            member.read_exact(&mut bytes).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "{label} ended before its declared {length} bytes: {error}"
+                ))
+            })?;
+            let mut extra = [0u8; 1];
+            if member.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+                return Err(SourceUnavailable::new(format!(
+                    "{label} grew beyond its declared {length} bytes"
+                )));
+            }
+            Ok(bytes)
+        }
+
+        let records = read_member(&mut self.records, "recorded corpus records")?;
+        let hidden = match self.hidden.as_mut() {
+            Some(hidden) => {
+                let rows = self
+                    .meta_bytes
+                    .get(0..8)
+                    .and_then(|bytes| bytes.try_into().ok())
+                    .map(u64::from_le_bytes);
+                let runtime_hidden_length = rows.and_then(|rows| {
+                    rows.checked_mul(uor_r4_core::transformerless::compiler::D as u64)?
+                        .checked_mul(std::mem::size_of::<f32>() as u64)
+                });
+                if runtime_hidden_length == Some(hidden.len()) {
+                    Some(read_member(
+                        hidden,
+                        "recorded corpus compiler-width hidden rows",
+                    )?)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+        self.verify_generation()?;
+        Ok((records, hidden))
+    }
+
     /// Final generation check after a consumer finishes reading/seeking every
     /// retained member and before it publishes any derived generation.
     pub fn verify_generation(&self) -> Result<(), SourceUnavailable> {
@@ -573,21 +786,24 @@ impl RecordedCorpusStreamSnapshot {
                 None,
             )?;
         }
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             &self.meta_path,
             "recorded corpus metadata",
             Some(&self.meta_bytes),
+            METADATA_CONTROL_MAX_BYTES,
         )?;
         verify_provenance(&self.root, &self.provenance)?;
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             &self.binding_path,
             "recorded corpus generation binding",
             self.binding_bytes.as_deref(),
+            BINDING_CONTROL_MAX_BYTES,
         )?;
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             &self.marker_path,
             "recorded corpus compile-attempt marker",
             self.marker_bytes.as_deref(),
+            COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
         )?;
         require_no_binding_temporaries(&self.root)
     }
@@ -600,7 +816,18 @@ impl RecordedCorpusStreamSnapshot {
 /// Every producer acquires any writer-specific outer session first and this
 /// guard second, then holds both from the first corpus/provenance mutation
 /// through final [`publish_binding`]. No producer may acquire another outer
-/// session or a second recorded-corpus guard while this value is live.
+/// session or an independent second recorded-corpus guard while this value is
+/// live. The sole multi-root exception is
+/// [`RecordedCorpusProducerHandoff`], which canonicalizes and acquires its
+/// complete set in one sorted, failure-atomic operation.
+///
+/// This is a cooperative repository-writer protocol, not a claim that every
+/// legacy pathname write is mutation-proof against an arbitrary process that
+/// ignores the coordination inode. Supported writers must hold the guard for
+/// their complete mutation interval. Retained parent/root handles make the
+/// transaction commit primitives and verified reads no-follow and
+/// generation-bound, so a pathname replacement is detected or the commit
+/// remains attached to the retained inode.
 #[derive(Debug)]
 pub struct RecordedCorpusProducerGuard {
     root: PathBuf,
@@ -795,9 +1022,11 @@ impl RecordedCorpusProducerGuard {
     pub fn preflight_publication_namespace(&self) -> Result<bool, SourceUnavailable> {
         self.verify_root()?;
         let stable_path = binding_path(&self.root);
-        if let Some(bytes) =
-            capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
-        {
+        if let Some(bytes) = capture_optional_control_file(
+            &stable_path,
+            "recorded corpus generation binding",
+            BINDING_CONTROL_MAX_BYTES,
+        )? {
             let _ = parse_binding_bytes(&stable_path, &bytes)?;
         }
         let residues = binding_publication_residues(&self.root, true)?;
@@ -817,9 +1046,11 @@ impl RecordedCorpusProducerGuard {
         validate_role_inventory(&self.root, role)?;
         validate_compile_attempt_namespace(&self.root, role)?;
         let stable_path = binding_path(&self.root);
-        if let Some(bytes) =
-            capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
-        {
+        if let Some(bytes) = capture_optional_control_file(
+            &stable_path,
+            "recorded corpus generation binding",
+            BINDING_CONTROL_MAX_BYTES,
+        )? {
             let binding = parse_binding_bytes(&stable_path, &bytes)?;
             validate_binding_role(&binding, role, &stable_path)?;
         }
@@ -838,7 +1069,7 @@ impl RecordedCorpusProducerGuard {
     /// the canonical recorded-corpus binding schema.
     pub fn begin_compile_attempt(&self) -> Result<(), SourceUnavailable> {
         self.verify_root()?;
-        self.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+        self.preflight_planned_output_scope(&PlannedOutputMember::REGISTERED)?;
         let _ = self.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
         publish_compile_attempt_marker(self)?;
         self.verify_root()
@@ -851,9 +1082,10 @@ impl RecordedCorpusProducerGuard {
     pub fn finish_compile_attempt(&self) -> Result<(), SourceUnavailable> {
         self.verify_root()?;
         let stable_binding = binding_path(&self.root);
-        let bytes = capture_optional_regular_file(
+        let bytes = capture_optional_control_file(
             &stable_binding,
             "recorded corpus generation binding",
+            BINDING_CONTROL_MAX_BYTES,
         )?
         .ok_or_else(|| {
             SourceUnavailable::new(
@@ -862,6 +1094,11 @@ impl RecordedCorpusProducerGuard {
         })?;
         let binding = parse_binding_bytes(&stable_binding, &bytes)?;
         validate_binding_role(&binding, RecordedCorpusRole::Compile, &stable_binding)?;
+        preflight_binding_evidence_matches_current(
+            self,
+            &self.root.join("corpus.meta"),
+            &self.root.join("corpus.records"),
+        )?;
         finish_compile_attempt_marker(self)?;
         self.verify_root()
     }
@@ -873,11 +1110,14 @@ impl RecordedCorpusProducerGuard {
         self.verify_root()?;
         validate_compile_attempt_namespace(&self.root, RecordedCorpusRole::Compile)?;
         let path = compile_attempt_path(&self.root);
-        let active =
-            capture_optional_regular_file(&path, "recorded corpus compile-attempt marker")?
-                .map(|bytes| parse_compile_attempt_bytes(&path, &bytes))
-                .transpose()?
-                .is_some();
+        let active = capture_optional_control_file(
+            &path,
+            "recorded corpus compile-attempt marker",
+            COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        )?
+        .map(|bytes| parse_compile_attempt_bytes(&path, &bytes))
+        .transpose()?
+        .is_some();
         self.verify_root()?;
         Ok(active)
     }
@@ -943,6 +1183,26 @@ impl RecordedCorpusProducerGuard {
         &self,
         allowed: &[PlannedOutputMember],
     ) -> Result<(), SourceUnavailable> {
+        self.preflight_deterministic_compile_inventory_inner(allowed, false)
+    }
+
+    /// Ready-only inventory for an already exact, stable deterministic
+    /// compile generation. The two well-known downstream graph directories
+    /// may coexist because this path performs no corpus/member recovery or
+    /// publication. Every other foreign leaf remains terminal, and either
+    /// graph entry must itself be a real non-symlink directory.
+    pub fn preflight_ready_deterministic_compile_inventory(
+        &self,
+        allowed: &[PlannedOutputMember],
+    ) -> Result<(), SourceUnavailable> {
+        self.preflight_deterministic_compile_inventory_inner(allowed, true)
+    }
+
+    fn preflight_deterministic_compile_inventory_inner(
+        &self,
+        allowed: &[PlannedOutputMember],
+        allow_ready_graph_outputs: bool,
+    ) -> Result<(), SourceUnavailable> {
         self.verify_root()?;
         self.preflight_planned_output_scope(allowed)?;
         let _ = self.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
@@ -968,6 +1228,17 @@ impl RecordedCorpusProducerGuard {
                 || name.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX);
             if stable_allowed || shared_stable || shared_reserved {
                 continue;
+            }
+            if allow_ready_graph_outputs && matches!(name, "graph" | "graph-cover") {
+                let metadata =
+                    std::fs::symlink_metadata(entry.path()).map_err(SourceUnavailable::new)?;
+                if metadata.file_type().is_dir() {
+                    continue;
+                }
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains ready-only downstream entry {name}, but it is not a real non-symlink directory",
+                    self.root.display()
+                )));
             }
             return Err(SourceUnavailable::new(format!(
                 "recorded corpus root {} contains unowned compile-style entry {name}; refusing deterministic corpus publication",
@@ -995,26 +1266,63 @@ impl RecordedCorpusProducerGuard {
         &self,
         member: PlannedOutputMember,
     ) -> Result<(), SourceUnavailable> {
+        self.reclaim_planned_output_residues_with_hook(member, || {})
+    }
+
+    fn reclaim_planned_output_residues_with_hook<F>(
+        &self,
+        member: PlannedOutputMember,
+        before_unlink: F,
+    ) -> Result<(), SourceUnavailable>
+    where
+        F: FnOnce(),
+    {
         let residues = self.planned_output_residues()?;
+        before_unlink();
         for residue in residues
             .into_iter()
             .filter(|residue| residue.member == member)
         {
-            remove_planned_output_residue(&residue)?;
+            self.remove_owned_planned_output_residue(&residue)?;
         }
+        self.sync_owned_root()?;
         self.verify_root()
+    }
+
+    fn remove_owned_planned_output_residue(
+        &self,
+        residue: &PlannedOutputResidue,
+    ) -> Result<(), SourceUnavailable> {
+        let name = residue.path.file_name().ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "planned-output staging entry {} has no leaf name",
+                residue.path.display()
+            ))
+        })?;
+        let file = self.open_owned_entry_for_read(name)?;
+        let metadata = file.metadata().map_err(SourceUnavailable::new)?;
+        if !metadata.file_type().is_file()
+            || !opened_file_generation_matches(&residue.metadata, &metadata)
+        {
+            return Err(SourceUnavailable::new(format!(
+                "planned-output staging entry {} changed type or generation before guarded recovery",
+                residue.path.display()
+            )));
+        }
+        self.unlink_owned_entry(name)
     }
 
     fn planned_output_residues(&self) -> Result<Vec<PlannedOutputResidue>, SourceUnavailable> {
         self.verify_root()?;
         let mut residues = Vec::new();
+        let mut reserved_count = 0usize;
         for entry in std::fs::read_dir(&self.root).map_err(SourceUnavailable::new)? {
             let entry = entry.map_err(SourceUnavailable::new)?;
             let Some(name) = reserved_planned_output_entry_name(&self.root, &entry.file_name())?
             else {
                 continue;
             };
-            let member = PlannedOutputMember::ALL
+            let member = PlannedOutputMember::REGISTERED
                 .into_iter()
                 .find(|member| planned_output_staging_name(*member, &name))
                 .ok_or_else(|| {
@@ -1023,6 +1331,15 @@ impl RecordedCorpusProducerGuard {
                         self.root.display()
                     ))
                 })?;
+            reserved_count = reserved_count
+                .checked_add(1)
+                .ok_or_else(|| SourceUnavailable::new("planned-output residue count overflow"))?;
+            if reserved_count > RESERVED_RESIDUE_MAX_ENTRIES {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} exceeds the fixed {RESERVED_RESIDUE_MAX_ENTRIES}-entry planned-output residue ceiling",
+                    self.root.display()
+                )));
+            }
             let path = entry.path();
             let mut options = OpenOptions::new();
             options.read(true);
@@ -1064,21 +1381,78 @@ impl RecordedCorpusProducerGuard {
     /// reverified. This is the only supported transition from a path lock to
     /// a mutable recorded-corpus directory.
     pub fn ensure_root(&mut self) -> Result<&Path, SourceUnavailable> {
+        self.ensure_root_with_hook(|| {})
+    }
+
+    fn ensure_root_with_hook<F>(
+        &mut self,
+        after_parent_check: F,
+    ) -> Result<&Path, SourceUnavailable>
+    where
+        F: FnOnce(),
+    {
         self.verify_parent()?;
+        after_parent_check();
         if self.root_file.is_none() {
-            std::fs::create_dir(&self.root).map_err(|error| {
-                SourceUnavailable::new(format!(
-                    "recorded corpus producer root {} cannot be created under exclusive ownership: {error}",
-                    self.root.display()
-                ))
-            })?;
-            self._parent_file
-                .sync_all()
-                .map_err(SourceUnavailable::new)?;
-            self.root_file = Some(open_directory_nofollow(
-                &self.root,
-                "recorded corpus producer root",
-            )?);
+            #[cfg(unix)]
+            {
+                use std::os::fd::{AsRawFd, FromRawFd};
+
+                let root_name = self.root.file_name().ok_or_else(|| {
+                    SourceUnavailable::new("recorded corpus producer root has no leaf name")
+                })?;
+                let root_name = owned_leaf_cstring(root_name)?;
+                // SAFETY: the retained parent is a live directory descriptor
+                // and `root_name` is one validated NUL-free leaf.
+                let result = unsafe {
+                    libc::mkdirat(self._parent_file.as_raw_fd(), root_name.as_ptr(), 0o700)
+                };
+                if result != 0 {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus producer root {} cannot be created under exclusive ownership: {}",
+                        self.root.display(),
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                self._parent_file
+                    .sync_all()
+                    .map_err(SourceUnavailable::new)?;
+                // SAFETY: the same retained parent and leaf identify the
+                // directory just created; a successful fd is immediately
+                // transferred into `File` ownership.
+                let fd = unsafe {
+                    libc::openat(
+                        self._parent_file.as_raw_fd(),
+                        root_name.as_ptr(),
+                        libc::O_RDONLY
+                            | libc::O_DIRECTORY
+                            | libc::O_NOFOLLOW
+                            | libc::O_CLOEXEC
+                            | libc::O_NONBLOCK,
+                    )
+                };
+                if fd < 0 {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus producer root {} cannot be reopened through its retained parent: {}",
+                        self.root.display(),
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                // SAFETY: `openat` returned a new owned descriptor.
+                let root_file = unsafe { std::fs::File::from_raw_fd(fd) };
+                let metadata = root_file.metadata().map_err(SourceUnavailable::new)?;
+                if !metadata.file_type().is_dir() {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus producer root {} is not a retained directory",
+                        self.root.display()
+                    )));
+                }
+                self.root_file = Some(root_file);
+            }
+            #[cfg(not(unix))]
+            {
+                return Err(owned_root_relative_unsupported());
+            }
         }
         self.verify_root()?;
         Ok(&self.root)
@@ -1119,6 +1493,323 @@ impl RecordedCorpusProducerGuard {
         self.verify_root()
     }
 
+    /// Create one new regular staging leaf relative to the retained root
+    /// directory handle. This cannot be redirected by replacing `self.root`.
+    pub fn create_new_owned_entry(&self, name: &OsStr) -> Result<std::fs::File, SourceUnavailable> {
+        validate_owned_leaf(name)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::{AsRawFd, FromRawFd};
+
+            let name = owned_leaf_cstring(name)?;
+            let root = self
+                .root_file
+                .as_ref()
+                .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?;
+            // SAFETY: `root` is a live directory descriptor, `name` is a
+            // NUL-free single leaf, and a successful fd is immediately owned.
+            let fd = unsafe {
+                libc::openat(
+                    root.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_WRONLY
+                        | libc::O_CREAT
+                        | libc::O_EXCL
+                        | libc::O_NOFOLLOW
+                        | libc::O_CLOEXEC
+                        | libc::O_NONBLOCK,
+                    0o600,
+                )
+            };
+            if fd < 0 {
+                return Err(SourceUnavailable::new(std::io::Error::last_os_error()));
+            }
+            // SAFETY: `openat` returned a new owned descriptor.
+            let file = unsafe { std::fs::File::from_raw_fd(fd) };
+            let metadata = file.metadata().map_err(SourceUnavailable::new)?;
+            if !metadata.file_type().is_file() {
+                return Err(SourceUnavailable::new(format!(
+                    "owned staging entry {name:?} is not a regular file"
+                )));
+            }
+            Ok(file)
+        }
+        #[cfg(not(unix))]
+        {
+            Err(owned_root_relative_unsupported())
+        }
+    }
+
+    /// Create a no-clobber hard link between two retained-root leaves.
+    pub fn link_owned_entry(&self, from: &OsStr, to: &OsStr) -> Result<(), SourceUnavailable> {
+        validate_owned_leaf(from)?;
+        validate_owned_leaf(to)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let from = owned_leaf_cstring(from)?;
+            let to = owned_leaf_cstring(to)?;
+            let root = self
+                .root_file
+                .as_ref()
+                .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?;
+            // SAFETY: both names are validated single leaves under one live
+            // retained directory descriptor.
+            let result = unsafe {
+                libc::linkat(
+                    root.as_raw_fd(),
+                    from.as_ptr(),
+                    root.as_raw_fd(),
+                    to.as_ptr(),
+                    0,
+                )
+            };
+            if result != 0 {
+                return Err(SourceUnavailable::new(std::io::Error::last_os_error()));
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            Err(owned_root_relative_unsupported())
+        }
+    }
+
+    /// Atomically rename one retained-root leaf over another.
+    pub fn rename_owned_entry(&self, from: &OsStr, to: &OsStr) -> Result<(), SourceUnavailable> {
+        validate_owned_leaf(from)?;
+        validate_owned_leaf(to)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let from = owned_leaf_cstring(from)?;
+            let to = owned_leaf_cstring(to)?;
+            let root = self
+                .root_file
+                .as_ref()
+                .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?;
+            // SAFETY: both names are validated leaves under the retained fd.
+            let result = unsafe {
+                libc::renameat(
+                    root.as_raw_fd(),
+                    from.as_ptr(),
+                    root.as_raw_fd(),
+                    to.as_ptr(),
+                )
+            };
+            if result != 0 {
+                return Err(SourceUnavailable::new(std::io::Error::last_os_error()));
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            Err(owned_root_relative_unsupported())
+        }
+    }
+
+    /// Unlink one retained-root leaf without following it.
+    pub fn unlink_owned_entry(&self, name: &OsStr) -> Result<(), SourceUnavailable> {
+        validate_owned_leaf(name)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let name = owned_leaf_cstring(name)?;
+            let root = self
+                .root_file
+                .as_ref()
+                .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?;
+            // SAFETY: `name` is one validated leaf and flags=0 refuses dirs.
+            let result = unsafe { libc::unlinkat(root.as_raw_fd(), name.as_ptr(), 0) };
+            if result != 0 {
+                return Err(SourceUnavailable::new(std::io::Error::last_os_error()));
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            Err(owned_root_relative_unsupported())
+        }
+    }
+
+    /// Durably synchronize the retained root directory inode.
+    pub fn sync_owned_root(&self) -> Result<(), SourceUnavailable> {
+        self.root_file
+            .as_ref()
+            .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?
+            .sync_all()
+            .map_err(SourceUnavailable::new)
+    }
+
+    /// Allocation-free exact-byte verification through the retained root.
+    pub fn verify_owned_entry_bytes(
+        &self,
+        name: &OsStr,
+        expected: &[u8],
+        max_bytes: u64,
+        context: &str,
+    ) -> Result<(), SourceUnavailable> {
+        if !self.verify_optional_owned_entry_bytes(name, expected, max_bytes, context)? {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} is absent"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Verify an optional exact-byte leaf. `false` means only exact ENOENT.
+    pub fn verify_optional_owned_entry_bytes(
+        &self,
+        name: &OsStr,
+        expected: &[u8],
+        max_bytes: u64,
+        context: &str,
+    ) -> Result<bool, SourceUnavailable> {
+        if expected.len() as u64 > max_bytes {
+            return Err(SourceUnavailable::new(format!(
+                "{context} exceeds the registered {max_bytes}-byte schema cap"
+            )));
+        }
+        let Some(mut file) = self.open_optional_owned_entry_for_read(name)? else {
+            return Ok(false);
+        };
+        let initial = file.metadata().map_err(SourceUnavailable::new)?;
+        if !initial.file_type().is_file() || initial.len() != expected.len() as u64 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} has the wrong type or length"
+            )));
+        }
+        verify_file_bytes_without_path(&mut file, expected, &initial, context)?;
+        let current = self.open_owned_entry_for_read(name)?;
+        let current = current.metadata().map_err(SourceUnavailable::new)?;
+        if !opened_file_identity_matches(&initial, &current) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} changed identity after verification"
+            )));
+        }
+        Ok(true)
+    }
+
+    /// Streaming length+BLAKE3 verification through the retained root.
+    pub fn verify_owned_entry_summary(
+        &self,
+        name: &OsStr,
+        expected: &RecordedCorpusMemberSummary,
+        context: &str,
+    ) -> Result<(), SourceUnavailable> {
+        if !self.verify_optional_owned_entry_summary(name, expected, context)? {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} is absent"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Verify an optional streaming summary. `false` means only exact ENOENT.
+    pub fn verify_optional_owned_entry_summary(
+        &self,
+        name: &OsStr,
+        expected: &RecordedCorpusMemberSummary,
+        context: &str,
+    ) -> Result<bool, SourceUnavailable> {
+        let Some(mut file) = self.open_optional_owned_entry_for_read(name)? else {
+            return Ok(false);
+        };
+        let initial = file.metadata().map_err(SourceUnavailable::new)?;
+        if !initial.file_type().is_file() || initial.len() != expected.length {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} has the wrong type or length"
+            )));
+        }
+        let mut remaining = expected.length;
+        let mut hasher = blake3::Hasher::new();
+        let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
+        while remaining != 0 {
+            let limit = usize::try_from(remaining.min(buffer.len() as u64))
+                .map_err(SourceUnavailable::new)?;
+            let read = file
+                .read(&mut buffer[..limit])
+                .map_err(SourceUnavailable::new)?;
+            if read == 0 {
+                return Err(SourceUnavailable::new(format!(
+                    "{context} ended before its declared length"
+                )));
+            }
+            hasher.update(&buffer[..read]);
+            remaining -= read as u64;
+        }
+        let mut extra = [0u8; 1];
+        if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} grew beyond its declared length"
+            )));
+        }
+        let final_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+        let digest = format!("blake3:{}", hasher.finalize().to_hex());
+        if !opened_file_generation_matches(&initial, &final_metadata) || digest != expected.blake3 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} does not match the exact retained-root generation summary"
+            )));
+        }
+        let current = self.open_owned_entry_for_read(name)?;
+        let current = current.metadata().map_err(SourceUnavailable::new)?;
+        if !opened_file_identity_matches(&initial, &current) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} retained-root entry {name:?} changed identity after verification"
+            )));
+        }
+        Ok(true)
+    }
+
+    fn open_owned_entry_for_read(&self, name: &OsStr) -> Result<std::fs::File, SourceUnavailable> {
+        self.open_optional_owned_entry_for_read(name)?
+            .ok_or_else(|| {
+                SourceUnavailable::new(format!("retained-root entry {name:?} is absent"))
+            })
+    }
+
+    fn open_optional_owned_entry_for_read(
+        &self,
+        name: &OsStr,
+    ) -> Result<Option<std::fs::File>, SourceUnavailable> {
+        validate_owned_leaf(name)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::{AsRawFd, FromRawFd};
+
+            let name = owned_leaf_cstring(name)?;
+            let root = self
+                .root_file
+                .as_ref()
+                .ok_or_else(|| SourceUnavailable::new("recorded corpus producer root is absent"))?;
+            // SAFETY: `root` and `name` satisfy the openat contract; the new
+            // descriptor is transferred immediately into `File`.
+            let fd = unsafe {
+                libc::openat(
+                    root.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+                )
+            };
+            if fd < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(None);
+                }
+                return Err(SourceUnavailable::new(error));
+            }
+            // SAFETY: `openat` returned a new owned descriptor.
+            Ok(Some(unsafe { std::fs::File::from_raw_fd(fd) }))
+        }
+        #[cfg(not(unix))]
+        {
+            Err(owned_root_relative_unsupported())
+        }
+    }
+
     /// Compare another directory to the guarded root by opened directory
     /// identity, not caller spelling. This catches case/Unicode aliases on
     /// filesystems whose canonicalize operation preserves the input case.
@@ -1139,7 +1830,7 @@ impl RecordedCorpusProducerGuard {
                 .metadata()
                 .map_err(SourceUnavailable::new)?;
             let other = other.metadata().map_err(SourceUnavailable::new)?;
-            return Ok(opened_file_identity_matches(&guarded, &other));
+            Ok(opened_file_identity_matches(&guarded, &other))
         }
         #[cfg(not(unix))]
         {
@@ -1147,6 +1838,514 @@ impl RecordedCorpusProducerGuard {
             Ok(canonical == self.root)
         }
     }
+}
+
+/// One canonical logical-root generation captured without creating producer
+/// coordination state.
+///
+/// `exists() == false` is a typed absence pinned by the retained parent
+/// directory handle. An existing generation retains the exact directory inode,
+/// so a same-byte remove/recreate is still a failed compare-and-swap.
+#[derive(Debug)]
+pub struct RecordedCorpusRootGeneration {
+    root: PathBuf,
+    root_file: Option<std::fs::File>,
+    parent: PathBuf,
+    parent_file: std::fs::File,
+}
+
+impl RecordedCorpusRootGeneration {
+    /// Capture one canonical root or its typed absence using read-only,
+    /// no-follow handles. The parent must already exist.
+    pub fn capture(root: impl AsRef<Path>) -> Result<Self, SourceUnavailable> {
+        let requested = root.as_ref();
+        let root_name = requested.file_name().ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus generation subject {} has no final component",
+                requested.display()
+            ))
+        })?;
+        validate_owned_leaf(root_name)?;
+        if root_name == OsStr::new(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root name {RECORDED_CORPUS_PRODUCER_COORDINATION_DIR:?} is reserved for sibling coordination"
+            )));
+        }
+        let requested_parent = requested
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let parent = std::fs::canonicalize(requested_parent).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus generation parent {} cannot be canonicalized: {error}",
+                requested_parent.display()
+            ))
+        })?;
+        let parent_file =
+            open_directory_nofollow(&parent, "recorded corpus generation canonical parent")?;
+        verify_directory_handle(
+            &parent,
+            &parent_file,
+            "recorded corpus generation canonical parent",
+        )?;
+        let requested_root = parent.join(root_name);
+        let root_file = match std::fs::symlink_metadata(&requested_root) {
+            Ok(metadata) if metadata.file_type().is_dir() => Some(open_directory_nofollow(
+                &requested_root,
+                "recorded corpus generation root",
+            )?),
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus generation root {} is not a real non-symlink directory",
+                    requested_root.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        };
+        let root = match root_file.as_ref() {
+            Some(file) => canonical_existing_root_path(&parent, &requested_root, file)?,
+            None => requested_root,
+        };
+        let generation = Self {
+            root,
+            root_file,
+            parent,
+            parent_file,
+        };
+        generation.verify()?;
+        Ok(generation)
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn exists(&self) -> bool {
+        self.root_file.is_some()
+    }
+
+    /// Recheck the exact directory inode or typed absence captured initially.
+    pub fn verify(&self) -> Result<(), SourceUnavailable> {
+        verify_directory_handle(
+            &self.parent,
+            &self.parent_file,
+            "recorded corpus generation canonical parent",
+        )?;
+        verify_optional_root_generation(&self.root, self.root_file.as_ref())
+    }
+
+    fn matches_guard(
+        &self,
+        guard: &RecordedCorpusProducerGuard,
+    ) -> Result<bool, SourceUnavailable> {
+        self.verify()?;
+        guard.verify_parent()?;
+        verify_optional_root_generation(&guard.root, guard.root_file.as_ref())?;
+        if self.root != guard.root {
+            return Ok(false);
+        }
+        let expected_parent = self
+            .parent_file
+            .metadata()
+            .map_err(SourceUnavailable::new)?;
+        let guarded_parent = guard
+            ._parent_file
+            .metadata()
+            .map_err(SourceUnavailable::new)?;
+        if !opened_file_identity_matches(&expected_parent, &guarded_parent) {
+            return Ok(false);
+        }
+        match (self.root_file.as_ref(), guard.root_file.as_ref()) {
+            (Some(expected), Some(guarded)) => {
+                let expected = expected.metadata().map_err(SourceUnavailable::new)?;
+                let guarded = guarded.metadata().map_err(SourceUnavailable::new)?;
+                Ok(opened_file_identity_matches(&expected, &guarded))
+            }
+            (None, None) => Ok(true),
+            _ => Ok(false),
+        }
+    }
+
+    fn same_generation(&self, other: &Self) -> Result<bool, SourceUnavailable> {
+        self.verify()?;
+        other.verify()?;
+        if self.root != other.root {
+            return Ok(false);
+        }
+        match (self.root_file.as_ref(), other.root_file.as_ref()) {
+            (Some(left), Some(right)) => {
+                let left = left.metadata().map_err(SourceUnavailable::new)?;
+                let right = right.metadata().map_err(SourceUnavailable::new)?;
+                Ok(opened_file_identity_matches(&left, &right))
+            }
+            (None, None) => Ok(true),
+            _ => Ok(false),
+        }
+    }
+
+    fn protects_directory(&self, directory: &Path) -> Result<bool, SourceUnavailable> {
+        let Some(root_file) = self.root_file.as_ref() else {
+            self.verify()?;
+            return Ok(false);
+        };
+        self.verify()?;
+        let other = open_directory_nofollow(directory, "recorded corpus pinned comparison root")?;
+        let root = root_file.metadata().map_err(SourceUnavailable::new)?;
+        let other = other.metadata().map_err(SourceUnavailable::new)?;
+        Ok(opened_file_identity_matches(&root, &other))
+    }
+}
+
+fn collect_bounded_recorded_corpus_root_paths<I, P>(
+    roots: I,
+    acquisition: &str,
+) -> Result<Vec<PathBuf>, SourceUnavailable>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    let mut bounded = Vec::with_capacity(RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES);
+    for root in roots {
+        if bounded.len() == RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES {
+            return Err(SourceUnavailable::new(format!(
+                "{acquisition} exceeds the fixed {RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES}-entry logical-root ceiling"
+            )));
+        }
+        bounded.push(root.as_ref().to_path_buf());
+    }
+    Ok(bounded)
+}
+
+/// Canonically sorted, failure-atomic exclusive ownership of a complete root
+/// selection set during compare-and-swap publication.
+///
+/// This is the protocol's only supported multi-producer-guard acquisition. It
+/// must itself follow every writer-specific outer session. The standalone stage
+/// compiler releases its own guard before this handoff is acquired, avoiding
+/// self-contention while every conventional/current/composite candidate plus
+/// the private stage generation is revalidated by inode.
+#[derive(Debug)]
+pub struct RecordedCorpusProducerHandoff {
+    guards: Vec<RecordedCorpusProducerGuard>,
+    final_guard_index: usize,
+    stage_guard_index: usize,
+    promoted: bool,
+}
+
+impl RecordedCorpusProducerHandoff {
+    /// Acquire every expected selection root in canonical lexical order.
+    ///
+    /// `final_index` and `stage_index` address the caller's unsorted witness
+    /// slice. Canonical aliases are deduplicated only after proving that they
+    /// name the same captured generation. The designated final and stage must
+    /// remain distinct logical roots.
+    pub fn try_acquire(
+        expected_roots: &[RecordedCorpusRootGeneration],
+        final_index: usize,
+        stage_index: usize,
+    ) -> Result<Self, SourceUnavailable> {
+        if expected_roots.len() > RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus handoff exceeds the fixed {RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES}-entry logical-root ceiling"
+            )));
+        }
+        if expected_roots.len() < 2 {
+            return Err(SourceUnavailable::new(
+                "recorded corpus handoff requires at least a final and stage root generation",
+            ));
+        }
+        let expected_final = expected_roots.get(final_index).ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus handoff final index {final_index} is outside {} root generations",
+                expected_roots.len()
+            ))
+        })?;
+        let expected_stage = expected_roots.get(stage_index).ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus handoff stage index {stage_index} is outside {} root generations",
+                expected_roots.len()
+            ))
+        })?;
+        for expected in expected_roots {
+            expected.verify()?;
+        }
+        if expected_final.root == expected_stage.root {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus handoff final and stage resolve to the same canonical root {}",
+                expected_final.root.display()
+            )));
+        }
+
+        fn acquire_expected(
+            expected: &RecordedCorpusRootGeneration,
+        ) -> Result<RecordedCorpusProducerGuard, SourceUnavailable> {
+            let guard = RecordedCorpusProducerGuard::try_acquire(&expected.root)?;
+            if !expected.matches_guard(&guard)? {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} changed generation while its producer handoff was acquired",
+                    expected.root.display()
+                )));
+            }
+            Ok(guard)
+        }
+
+        let mut ordered = expected_roots.iter().collect::<Vec<_>>();
+        ordered.sort_by(|left, right| left.root.cmp(&right.root));
+        let mut unique = Vec::<&RecordedCorpusRootGeneration>::new();
+        for expected in ordered {
+            if let Some(previous) = unique.last()
+                && previous.root == expected.root
+            {
+                if !previous.same_generation(expected)? {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus handoff root {} changed generation while aliases were canonicalized",
+                        expected.root.display()
+                    )));
+                }
+                continue;
+            }
+            unique.push(expected);
+        }
+
+        let guards = unique
+            .into_iter()
+            .map(acquire_expected)
+            .collect::<Result<Vec<_>, _>>()?;
+        let locate_guard = |expected: &RecordedCorpusRootGeneration| {
+            guards
+                .iter()
+                .position(|guard| guard.root == expected.root)
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus handoff lost canonical root {} while acquiring its selection set",
+                        expected.root.display()
+                    ))
+                })
+        };
+        let final_guard_index = locate_guard(expected_final)?;
+        let stage_guard_index = locate_guard(expected_stage)?;
+        for expected in expected_roots {
+            let guard = &guards[locate_guard(expected)?];
+            if !expected.matches_guard(guard)? {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} changed generation while its complete producer handoff was acquired",
+                    expected.root.display()
+                )));
+            }
+        }
+        let handoff = Self {
+            guards,
+            final_guard_index,
+            stage_guard_index,
+            promoted: false,
+        };
+        handoff.verify()?;
+        Ok(handoff)
+    }
+
+    pub fn final_guard(&self) -> &RecordedCorpusProducerGuard {
+        &self.guards[self.final_guard_index]
+    }
+
+    pub fn stage_guard(&self) -> &RecordedCorpusProducerGuard {
+        &self.guards[self.stage_guard_index]
+    }
+
+    pub fn guards(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &RecordedCorpusProducerGuard> + DoubleEndedIterator {
+        self.guards.iter()
+    }
+
+    /// Recheck every current logical name against its retained root handle (or
+    /// retained typed absence).
+    pub fn verify(&self) -> Result<(), SourceUnavailable> {
+        for guard in &self.guards {
+            guard.verify_parent()?;
+            verify_optional_root_generation(&guard.root, guard.root_file.as_ref())?;
+        }
+        Ok(())
+    }
+
+    /// Atomically promote the guarded stage name to the guarded final name.
+    /// Existing finals are exchanged; typed-absent finals use no-replace rename.
+    /// Afterward the final guard adopts the promoted directory handle, so its
+    /// path-keyed exclusive lock and inode ownership remain valid until drop.
+    pub fn promote_stage(&mut self) -> Result<(), SourceUnavailable> {
+        self.promote_stage_if(|_| Ok(()))
+    }
+
+    /// Validate a caller-defined content/selection compare-and-swap predicate
+    /// under the complete sorted guard set immediately before the atomic
+    /// namespace operation. [`RecordedCorpusRootGeneration`] deliberately
+    /// pins directory identity/absence only; a publisher whose logical
+    /// generation includes member content must supply that typed predicate
+    /// here so an in-place same-directory commit cannot be overwritten.
+    pub fn promote_stage_if<F>(&mut self, validate_content: F) -> Result<(), SourceUnavailable>
+    where
+        F: FnOnce(&Self) -> Result<(), SourceUnavailable>,
+    {
+        self.promote_stage_with_hook(validate_content)
+    }
+
+    fn promote_stage_with_hook<F>(
+        &mut self,
+        before_final_compare: F,
+    ) -> Result<(), SourceUnavailable>
+    where
+        F: FnOnce(&Self) -> Result<(), SourceUnavailable>,
+    {
+        if self.promoted {
+            return Err(SourceUnavailable::new(
+                "recorded corpus stage handoff was already promoted",
+            ));
+        }
+        self.verify()?;
+        if self.stage_guard().root_file.is_none() {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus handoff stage {} is absent",
+                self.stage_guard().root.display()
+            )));
+        }
+        before_final_compare(self)?;
+        // This is the final userspace CAS immediately before the one atomic
+        // namespace operation. Cooperative writers cannot cross the held lock;
+        // a process ignoring it and racing inside the syscall is outside the
+        // documented repository-writer threat boundary.
+        self.verify()?;
+        let final_existed = self.final_guard().root_file.is_some();
+        atomic_promote_recorded_corpus_roots(
+            self.final_guard(),
+            self.stage_guard(),
+            final_existed,
+        )?;
+
+        let previous_final = self.guards[self.final_guard_index].root_file.take();
+        let promoted = self.guards[self.stage_guard_index]
+            .root_file
+            .take()
+            .ok_or_else(|| {
+                SourceUnavailable::new("recorded corpus handoff lost its retained stage handle")
+            })?;
+        self.guards[self.final_guard_index].root_file = Some(promoted);
+        self.guards[self.stage_guard_index].root_file = previous_final;
+        self.promoted = true;
+
+        let final_sync = self.guards[self.final_guard_index]
+            ._parent_file
+            .sync_all()
+            .map_err(SourceUnavailable::new);
+        let stage_sync = self.guards[self.stage_guard_index]
+            ._parent_file
+            .sync_all()
+            .map_err(SourceUnavailable::new);
+        match (final_sync, stage_sync) {
+            (Ok(()), Ok(())) => {}
+            (Err(error), Ok(())) | (Ok(()), Err(error)) => return Err(error),
+            (Err(final_error), Err(stage_error)) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus handoff parent synchronization failed: {final_error}; {stage_error}"
+                )));
+            }
+        }
+        self.verify()
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn atomic_promote_recorded_corpus_roots(
+    final_guard: &RecordedCorpusProducerGuard,
+    stage_guard: &RecordedCorpusProducerGuard,
+    final_existed: bool,
+) -> Result<(), SourceUnavailable> {
+    use std::os::fd::AsRawFd;
+
+    let final_name = owned_leaf_cstring(final_guard.root.file_name().ok_or_else(|| {
+        SourceUnavailable::new("recorded corpus final handoff root has no leaf name")
+    })?)?;
+    let stage_name = owned_leaf_cstring(stage_guard.root.file_name().ok_or_else(|| {
+        SourceUnavailable::new("recorded corpus stage handoff root has no leaf name")
+    })?)?;
+    let flags = if final_existed {
+        libc::RENAME_EXCHANGE
+    } else {
+        libc::RENAME_NOREPLACE
+    };
+    // SAFETY: both retained descriptors are live directory handles; both C
+    // strings are validated single leaves and remain live for the call.
+    let result = unsafe {
+        libc::renameat2(
+            stage_guard._parent_file.as_raw_fd(),
+            stage_name.as_ptr(),
+            final_guard._parent_file.as_raw_fd(),
+            final_name.as_ptr(),
+            flags,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(SourceUnavailable::new(format!(
+            "recorded corpus atomic stage promotion {} -> {} failed: {}",
+            stage_guard.root.display(),
+            final_guard.root.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn atomic_promote_recorded_corpus_roots(
+    final_guard: &RecordedCorpusProducerGuard,
+    stage_guard: &RecordedCorpusProducerGuard,
+    final_existed: bool,
+) -> Result<(), SourceUnavailable> {
+    use std::os::fd::AsRawFd;
+
+    let final_name = owned_leaf_cstring(final_guard.root.file_name().ok_or_else(|| {
+        SourceUnavailable::new("recorded corpus final handoff root has no leaf name")
+    })?)?;
+    let stage_name = owned_leaf_cstring(stage_guard.root.file_name().ok_or_else(|| {
+        SourceUnavailable::new("recorded corpus stage handoff root has no leaf name")
+    })?)?;
+    let flags = if final_existed {
+        libc::RENAME_SWAP
+    } else {
+        libc::RENAME_EXCL
+    };
+    // SAFETY: both retained descriptors are live directory handles; both C
+    // strings are validated single leaves and remain live for the call.
+    let result = unsafe {
+        libc::renameatx_np(
+            stage_guard._parent_file.as_raw_fd(),
+            stage_name.as_ptr(),
+            final_guard._parent_file.as_raw_fd(),
+            final_name.as_ptr(),
+            flags,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(SourceUnavailable::new(format!(
+            "recorded corpus atomic stage promotion {} -> {} failed: {}",
+            stage_guard.root.display(),
+            final_guard.root.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_vendor = "apple")))]
+fn atomic_promote_recorded_corpus_roots(
+    _final_guard: &RecordedCorpusProducerGuard,
+    _stage_guard: &RecordedCorpusProducerGuard,
+    _final_existed: bool,
+) -> Result<(), SourceUnavailable> {
+    Err(SourceUnavailable::new(
+        "atomic recorded-corpus root promotion is unsupported without a no-replace/exchange *at primitive",
+    ))
 }
 
 /// Non-mutating shared coordination for a bounded recorded-corpus read.
@@ -1328,10 +2527,407 @@ impl RecordedCorpusReaderGuard {
 }
 
 #[derive(Debug)]
+struct RecordedCorpusReaderPin {
+    generation: RecordedCorpusRootGeneration,
+    coordination_path: PathBuf,
+    coordination_file: Option<std::fs::File>,
+    lock_path: PathBuf,
+    lock_file: Option<std::fs::File>,
+}
+
+impl RecordedCorpusReaderPin {
+    fn try_acquire(generation: RecordedCorpusRootGeneration) -> Result<Self, SourceUnavailable> {
+        generation.verify()?;
+        let coordination_path = generation
+            .parent
+            .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+        let coordination_file = match std::fs::symlink_metadata(&coordination_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+            Ok(metadata) if metadata.file_type().is_dir() => Some(open_directory_nofollow(
+                &coordination_path,
+                "recorded corpus pinned-reader coordination directory",
+            )?),
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus pinned-reader coordination {} is not a real non-symlink directory",
+                    coordination_path.display()
+                )));
+            }
+        };
+        let lock_path = coordination_path.join(generation.root.file_name().ok_or_else(|| {
+            SourceUnavailable::new("canonical recorded corpus pinned-reader root has no name")
+        })?);
+        let lock_file = if coordination_file.is_some() {
+            match std::fs::symlink_metadata(&lock_path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => return Err(SourceUnavailable::new(error)),
+                Ok(metadata) if metadata.file_type().is_file() => {
+                    let mut options = OpenOptions::new();
+                    options.read(true);
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::OpenOptionsExt;
+                        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+                    }
+                    let file = options.open(&lock_path).map_err(SourceUnavailable::new)?;
+                    let opened = file.metadata().map_err(SourceUnavailable::new)?;
+                    let path =
+                        std::fs::symlink_metadata(&lock_path).map_err(SourceUnavailable::new)?;
+                    if !opened.file_type().is_file()
+                        || !path.file_type().is_file()
+                        || !opened_file_identity_matches(&path, &opened)
+                    {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus pinned-reader coordination {} changed identity or type",
+                            lock_path.display()
+                        )));
+                    }
+                    match file.try_lock_shared() {
+                        Ok(()) => Some(file),
+                        Err(std::fs::TryLockError::WouldBlock) => {
+                            return Err(SourceUnavailable::new(format!(
+                                "recorded corpus root {} is BUSY under another active producer session",
+                                generation.root.display()
+                            )));
+                        }
+                        Err(std::fs::TryLockError::Error(error)) => {
+                            return Err(SourceUnavailable::new(format!(
+                                "recorded corpus pinned-reader coordination {} cannot be locked: {error}",
+                                lock_path.display()
+                            )));
+                        }
+                    }
+                }
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus pinned-reader coordination {} is not a regular non-symlink file",
+                        lock_path.display()
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+        let pin = Self {
+            generation,
+            coordination_path,
+            coordination_file,
+            lock_path,
+            lock_file,
+        };
+        pin.verify()?;
+        Ok(pin)
+    }
+
+    fn verify(&self) -> Result<(), SourceUnavailable> {
+        self.generation.verify()?;
+        match self.coordination_file.as_ref() {
+            Some(file) => verify_directory_handle(
+                &self.coordination_path,
+                file,
+                "recorded corpus pinned-reader coordination directory",
+            )?,
+            None => match std::fs::symlink_metadata(&self.coordination_path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(SourceUnavailable::new(error)),
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus pinned-reader coordination {} appeared during an uncoordinated legacy read",
+                        self.coordination_path.display()
+                    )));
+                }
+            },
+        }
+        match self.lock_file.as_ref() {
+            Some(file) => {
+                let path =
+                    std::fs::symlink_metadata(&self.lock_path).map_err(SourceUnavailable::new)?;
+                let opened = file.metadata().map_err(SourceUnavailable::new)?;
+                if !path.file_type().is_file()
+                    || !opened.file_type().is_file()
+                    || !opened_file_identity_matches(&path, &opened)
+                {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus pinned-reader coordination {} changed identity or type",
+                        self.lock_path.display()
+                    )));
+                }
+            }
+            None if self.coordination_file.is_some() => {
+                match std::fs::symlink_metadata(&self.lock_path) {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(SourceUnavailable::new(error)),
+                    Ok(_) => {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus pinned-reader coordination {} appeared during an uncoordinated legacy read",
+                            self.lock_path.display()
+                        )));
+                    }
+                }
+            }
+            None => {}
+        }
+        self.generation.verify()
+    }
+}
+
+/// Canonically sorted, failure-atomic shared pins for one or more logical
+/// recorded-corpus roots.
+///
+/// Existing roots and typed absence are both retained by inode-bearing parent
+/// handles. Acquisition is read-only: copied archives and read-only parents
+/// without producer coordination remain usable. When coordination exists,
+/// each permanent lock inode is held shared and therefore contends with every
+/// cooperating producer until this value is dropped.
+#[derive(Debug)]
+pub struct RecordedCorpusReaderPins {
+    pins: Vec<RecordedCorpusReaderPin>,
+}
+
+impl RecordedCorpusReaderPins {
+    pub fn try_acquire<I, P>(roots: I) -> Result<Self, SourceUnavailable>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let roots = collect_bounded_recorded_corpus_root_paths(
+            roots,
+            "recorded corpus reader-pin acquisition",
+        )?;
+        let mut generations = roots
+            .into_iter()
+            .map(RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()?;
+        if generations.is_empty() {
+            return Err(SourceUnavailable::new(
+                "recorded corpus reader pins require at least one logical root",
+            ));
+        }
+        generations.sort_by(|left, right| left.root.cmp(&right.root));
+
+        let mut unique = Vec::<RecordedCorpusRootGeneration>::new();
+        for generation in generations {
+            if let Some(previous) = unique.last()
+                && previous.root == generation.root
+            {
+                if !previous.same_generation(&generation)? {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus reader pin root {} changed generation while aliases were canonicalized",
+                        generation.root.display()
+                    )));
+                }
+                continue;
+            }
+            unique.push(generation);
+        }
+
+        let pins = unique
+            .into_iter()
+            .map(RecordedCorpusReaderPin::try_acquire)
+            .collect::<Result<Vec<_>, _>>()?;
+        let result = Self { pins };
+        result.verify()?;
+        Ok(result)
+    }
+
+    /// Acquire shared pins for a writable managed namespace, creating every
+    /// permanent coordination inode before downgrading a canonically sorted
+    /// exclusive lock set to shared ownership. Unlike the read-only variant,
+    /// typed-absent roots are therefore actively protected: a cooperating
+    /// producer cannot create a newly preferred sibling until these pins are
+    /// dropped.
+    ///
+    /// Callers must hold their writer-specific outer inventory/session lock
+    /// before this method, matching the producer acquisition order.
+    pub fn try_acquire_managed<I, P>(roots: I) -> Result<Self, SourceUnavailable>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let roots = collect_bounded_recorded_corpus_root_paths(
+            roots,
+            "managed recorded corpus reader-pin acquisition",
+        )?;
+        let mut generations = roots
+            .into_iter()
+            .map(RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()?;
+        if generations.is_empty() {
+            return Err(SourceUnavailable::new(
+                "managed recorded corpus reader pins require at least one logical root",
+            ));
+        }
+        generations.sort_by(|left, right| left.root.cmp(&right.root));
+        let mut unique = Vec::<RecordedCorpusRootGeneration>::new();
+        for generation in generations {
+            if let Some(previous) = unique.last()
+                && previous.root == generation.root
+            {
+                if !previous.same_generation(&generation)? {
+                    return Err(SourceUnavailable::new(format!(
+                        "managed recorded corpus reader pin root {} changed generation while aliases were canonicalized",
+                        generation.root.display()
+                    )));
+                }
+                continue;
+            }
+            unique.push(generation);
+        }
+
+        let mut guards = Vec::with_capacity(unique.len());
+        for generation in &unique {
+            let guard = RecordedCorpusProducerGuard::try_acquire(&generation.root)?;
+            if !generation.matches_guard(&guard)? {
+                return Err(SourceUnavailable::new(format!(
+                    "managed recorded corpus root {} changed generation while its coordination inode was seeded",
+                    generation.root.display()
+                )));
+            }
+            guards.push(guard);
+        }
+
+        // Downgrade in canonical order while every not-yet-downgraded root is
+        // still exclusive. There is no interval in which a seeded root is
+        // unlocked before the complete shared set exists.
+        for guard in &guards {
+            guard._file.try_lock_shared().map_err(|error| match error {
+                std::fs::TryLockError::WouldBlock => SourceUnavailable::new(format!(
+                    "recorded corpus root {} is BUSY while managed reader ownership is downgraded",
+                    guard.root.display()
+                )),
+                std::fs::TryLockError::Error(error) => SourceUnavailable::new(format!(
+                    "recorded corpus reader coordination for {} cannot be downgraded to shared: {error}",
+                    guard.root.display()
+                )),
+            })?;
+        }
+
+        let pins = unique
+            .into_iter()
+            .zip(guards)
+            .map(|(generation, guard)| {
+                let coordination_path = generation
+                    .parent
+                    .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+                let lock_path =
+                    coordination_path.join(generation.root.file_name().ok_or_else(|| {
+                        SourceUnavailable::new("managed recorded corpus root has no name")
+                    })?);
+                Ok(RecordedCorpusReaderPin {
+                    generation,
+                    coordination_path,
+                    coordination_file: Some(guard._coordination_file),
+                    lock_path,
+                    lock_file: Some(guard._file),
+                })
+            })
+            .collect::<Result<Vec<_>, SourceUnavailable>>()?;
+        let result = Self { pins };
+        result.verify()?;
+        Ok(result)
+    }
+
+    pub fn generations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &RecordedCorpusRootGeneration> + DoubleEndedIterator {
+        self.pins.iter().map(|pin| &pin.generation)
+    }
+
+    pub fn verify(&self) -> Result<(), SourceUnavailable> {
+        for pin in &self.pins {
+            pin.verify()?;
+        }
+        Ok(())
+    }
+
+    fn protects_directory(&self, directory: &Path) -> Result<bool, SourceUnavailable> {
+        for pin in &self.pins {
+            if pin.generation.protects_directory(directory)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[derive(Debug)]
 struct PlannedOutputResidue {
     member: PlannedOutputMember,
     path: PathBuf,
     metadata: Metadata,
+}
+
+fn validate_owned_leaf(name: &OsStr) -> Result<(), SourceUnavailable> {
+    let path = Path::new(name);
+    let mut components = path.components();
+    if !matches!(components.next(), Some(std::path::Component::Normal(_)))
+        || components.next().is_some()
+        || name == OsStr::new(".")
+        || name == OsStr::new("..")
+    {
+        return Err(SourceUnavailable::new(format!(
+            "owned recorded-corpus entry {name:?} must be one exact basename"
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        if name.as_bytes().contains(&0) || name.as_bytes().contains(&b'/') {
+            return Err(SourceUnavailable::new(format!(
+                "owned recorded-corpus entry {name:?} contains a forbidden slash or NUL"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn owned_leaf_cstring(name: &OsStr) -> Result<std::ffi::CString, SourceUnavailable> {
+    use std::os::unix::ffi::OsStrExt;
+    std::ffi::CString::new(name.as_bytes()).map_err(SourceUnavailable::new)
+}
+
+#[cfg(not(unix))]
+fn owned_root_relative_unsupported() -> SourceUnavailable {
+    SourceUnavailable::new(
+        "retained-root relative mutation is unsupported without platform file-ID and *at equivalents",
+    )
+}
+
+fn verify_file_bytes_without_path(
+    file: &mut std::fs::File,
+    expected: &[u8],
+    initial: &Metadata,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let mut offset = 0usize;
+    let mut buffer = [0u8; 8192];
+    while offset != expected.len() {
+        let limit = (expected.len() - offset).min(buffer.len());
+        let read = file
+            .read(&mut buffer[..limit])
+            .map_err(SourceUnavailable::new)?;
+        if read == 0 || expected.get(offset..offset + read) != Some(&buffer[..read]) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} changed content during retained-root verification"
+            )));
+        }
+        offset += read;
+    }
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} grew during retained-root verification"
+        )));
+    }
+    let final_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    if !opened_file_generation_matches(initial, &final_metadata) {
+        return Err(SourceUnavailable::new(format!(
+            "{context} changed generation during retained-root verification"
+        )));
+    }
+    Ok(())
 }
 
 fn planned_output_staging_name(member: PlannedOutputMember, name: &str) -> bool {
@@ -1364,14 +2960,14 @@ fn reserved_planned_output_entry_name(
         if !bytes.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX.as_bytes()) {
             return Ok(None);
         }
-        return std::str::from_utf8(bytes)
+        std::str::from_utf8(bytes)
             .map(|name| Some(name.to_owned()))
             .map_err(|_| {
                 SourceUnavailable::new(format!(
                     "recorded corpus root {} contains a non-UTF-8 entry in the reserved planned-output staging namespace",
                     root.display()
                 ))
-            });
+            })
     }
 
     #[cfg(not(unix))]
@@ -1387,35 +2983,6 @@ fn reserved_planned_output_entry_name(
             ))
         })
     }
-}
-
-fn remove_planned_output_residue(residue: &PlannedOutputResidue) -> Result<(), SourceUnavailable> {
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-    }
-    let file = options.open(&residue.path).map_err(|error| {
-        SourceUnavailable::new(format!(
-            "planned-output staging entry {} cannot be reopened without following links: {error}",
-            residue.path.display()
-        ))
-    })?;
-    let path_metadata = std::fs::symlink_metadata(&residue.path).map_err(SourceUnavailable::new)?;
-    let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
-    if !path_metadata.file_type().is_file()
-        || !file_metadata.file_type().is_file()
-        || !opened_file_identity_matches(&path_metadata, &file_metadata)
-        || !opened_file_generation_matches(&residue.metadata, &file_metadata)
-    {
-        return Err(SourceUnavailable::new(format!(
-            "planned-output staging entry {} changed identity, type, or generation before guarded recovery",
-            residue.path.display()
-        )));
-    }
-    std::fs::remove_file(&residue.path).map_err(SourceUnavailable::new)
 }
 
 fn open_directory_nofollow(path: &Path, context: &str) -> Result<std::fs::File, SourceUnavailable> {
@@ -1553,7 +3120,7 @@ fn canonical_existing_root_path(
                 canonical_parent.display()
             )));
         }
-        return Ok(matches.remove(0));
+        Ok(matches.remove(0))
     }
 
     #[cfg(not(unix))]
@@ -1576,7 +3143,11 @@ fn opened_file_identity_matches(path: &Metadata, file: &Metadata) -> bool {
 
 #[cfg(not(unix))]
 fn opened_file_identity_matches(_path: &Metadata, _file: &Metadata) -> bool {
-    true
+    // The portable Metadata API exposes no stable file ID. Treating two
+    // snapshots as identical from length/timestamps alone permits ABA. A
+    // platform implementation must supply real volume/file IDs before this
+    // transaction protocol is enabled there.
+    false
 }
 
 #[cfg(unix)]
@@ -1641,16 +3212,30 @@ fn capture_optional_regular_file(
         )));
     }
 
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).map_err(|error| {
+    let length = usize::try_from(initial_file.len()).map_err(|_| {
         SourceUnavailable::new(format!(
-            "{context} {} cannot be read: {error}",
+            "{context} {} length cannot be represented on this host",
             path.display()
         ))
     })?;
-    if initial_file.len() != bytes.len() as u64 {
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(length).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot reserve its declared {length} bytes: {error}",
+            path.display()
+        ))
+    })?;
+    bytes.resize(length, 0);
+    file.read_exact(&mut bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} changed or ended before its declared length: {error}",
+            path.display()
+        ))
+    })?;
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
         return Err(SourceUnavailable::new(format!(
-            "{context} {} changed length while it was captured",
+            "{context} {} grew beyond its captured length",
             path.display()
         )));
     }
@@ -1664,15 +3249,114 @@ fn capture_optional_regular_file(
     Ok(Some(bytes))
 }
 
+fn capture_optional_control_file(
+    path: &Path,
+    context: &str,
+    max_bytes: u64,
+) -> Result<Option<Vec<u8>>, SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} is not a regular file or cannot be opened without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let initial_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let initial_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial_file.file_type().is_file()
+        || !initial_path.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path, &initial_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not the opened regular non-symlink file",
+            path.display()
+        )));
+    }
+    if initial_file.len() > max_bytes {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is {} bytes, exceeding the registered {max_bytes}-byte schema cap",
+            path.display(),
+            initial_file.len()
+        )));
+    }
+    let length = usize::try_from(initial_file.len()).map_err(|_| {
+        SourceUnavailable::new(format!(
+            "{context} {} length cannot be represented on this host",
+            path.display()
+        ))
+    })?;
+    let mut bytes = vec![0u8; length];
+    file.read_exact(&mut bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} changed or ended before its declared length: {error}",
+            path.display()
+        ))
+    })?;
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} grew beyond its captured length",
+            path.display()
+        )));
+    }
+    file.seek(SeekFrom::Start(0))
+        .map_err(SourceUnavailable::new)?;
+    verify_opened_bytes(&mut file, path, context, &bytes, &initial_file)?;
+    Ok(Some(bytes))
+}
+
 /// Capture only the typed presence/length/content address of a regular file.
 /// The payload is streamed through one no-follow handle and never retained;
 /// initial/final path and handle generation checks bind the digest to that
 /// exact inode generation.
-fn stream_regular_file_binding(
+struct StreamedGeneration {
+    path: PathBuf,
+    opened: Option<(std::fs::File, Metadata)>,
+}
+
+impl StreamedGeneration {
+    fn verify(&self, context: &str) -> Result<(), SourceUnavailable> {
+        let Some((file, initial)) = self.opened.as_ref() else {
+            return match std::fs::symlink_metadata(&self.path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(SourceUnavailable::new(error)),
+                Ok(_) => Err(SourceUnavailable::new(format!(
+                    "{context} {} appeared after typed absence was captured",
+                    self.path.display()
+                ))),
+            };
+        };
+        let current_file = file.metadata().map_err(SourceUnavailable::new)?;
+        let current_path = std::fs::symlink_metadata(&self.path).map_err(SourceUnavailable::new)?;
+        if !current_file.file_type().is_file()
+            || !current_path.file_type().is_file()
+            || !opened_file_generation_matches(initial, &current_file)
+            || !opened_file_identity_matches(&current_path, &current_file)
+        {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed generation before binding commit",
+                self.path.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn stream_regular_file_binding_retained(
     path: &Path,
     expected_name: &str,
     context: &str,
-) -> Result<RecordedCorpusFileBinding, SourceUnavailable> {
+) -> Result<(RecordedCorpusFileBinding, StreamedGeneration), SourceUnavailable> {
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -1683,7 +3367,13 @@ fn stream_regular_file_binding(
     let mut file = match options.open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return RecordedCorpusFileBinding::from_bytes(expected_name, None);
+            return Ok((
+                RecordedCorpusFileBinding::from_bytes(expected_name, None)?,
+                StreamedGeneration {
+                    path: path.to_path_buf(),
+                    opened: None,
+                },
+            ));
         }
         Err(error) => {
             return Err(SourceUnavailable::new(format!(
@@ -1705,21 +3395,35 @@ fn stream_regular_file_binding(
     }
     let mut hasher = blake3::Hasher::new();
     let mut length = 0u64;
+    let mut remaining = initial_file.len();
     let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
-    loop {
-        let read = file.read(&mut buffer).map_err(|error| {
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| SourceUnavailable::new(format!("{context} length overflows usize")))?;
+        let read = file.read(&mut buffer[..limit]).map_err(|error| {
             SourceUnavailable::new(format!(
                 "{context} {} cannot be streamed: {error}",
                 path.display()
             ))
         })?;
         if read == 0 {
-            break;
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} ended before its initial declared length",
+                path.display()
+            )));
         }
         length = length
             .checked_add(read as u64)
             .ok_or_else(|| SourceUnavailable::new(format!("{context} length overflows u64")))?;
         hasher.update(&buffer[..read]);
+        remaining -= read as u64;
+    }
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} grew beyond its initial declared length",
+            path.display()
+        )));
     }
     let final_file = file.metadata().map_err(SourceUnavailable::new)?;
     let final_path = std::fs::symlink_metadata(path).map_err(|error| {
@@ -1738,12 +3442,18 @@ fn stream_regular_file_binding(
             path.display()
         )));
     }
-    Ok(RecordedCorpusFileBinding {
-        name: expected_name.to_owned(),
-        present: true,
-        length: Some(length),
-        blake3: Some(format!("blake3:{}", hasher.finalize().to_hex())),
-    })
+    Ok((
+        RecordedCorpusFileBinding {
+            name: expected_name.to_owned(),
+            present: true,
+            length: Some(length),
+            blake3: Some(format!("blake3:{}", hasher.finalize().to_hex())),
+        },
+        StreamedGeneration {
+            path: path.to_path_buf(),
+            opened: Some((file, initial_file)),
+        },
+    ))
 }
 
 fn open_verified_corpus_member(
@@ -1752,6 +3462,19 @@ fn open_verified_corpus_member(
     context: &'static str,
     expected: Option<&RecordedCorpusFileBinding>,
 ) -> Result<Option<VerifiedCorpusMember>, SourceUnavailable> {
+    open_verified_corpus_member_with_hook(path, expected_name, context, expected, || {})
+}
+
+fn open_verified_corpus_member_with_hook<F>(
+    path: &Path,
+    expected_name: &str,
+    context: &'static str,
+    expected: Option<&RecordedCorpusFileBinding>,
+    after_metadata: F,
+) -> Result<Option<VerifiedCorpusMember>, SourceUnavailable>
+where
+    F: FnOnce(),
+{
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -1786,18 +3509,52 @@ fn open_verified_corpus_member(
             path.display()
         )));
     }
-    let mut hasher = blake3::Hasher::new();
-    let mut length = 0u64;
-    let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
-    loop {
-        let read = file.read(&mut buffer).map_err(SourceUnavailable::new)?;
-        if read == 0 {
-            break;
+    if let Some(expected) = expected {
+        if !expected.present {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} is present, but the canonical generation binding declares it absent",
+                path.display()
+            )));
         }
-        length = length
-            .checked_add(read as u64)
-            .ok_or_else(|| SourceUnavailable::new(format!("{context} length overflows u64")))?;
+        let expected_length = expected.length.ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "{context} canonical generation binding omits the required present length"
+            ))
+        })?;
+        if initial.len() != expected_length {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} has length {}, but the canonical generation binding declares {expected_length}; refusing before body hashing",
+                path.display(),
+                initial.len()
+            )));
+        }
+    }
+    after_metadata();
+    let mut hasher = blake3::Hasher::new();
+    let length = initial.len();
+    let mut remaining = length;
+    let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
+    while remaining != 0 {
+        let limit =
+            usize::try_from(remaining.min(buffer.len() as u64)).map_err(SourceUnavailable::new)?;
+        let read = file
+            .read(&mut buffer[..limit])
+            .map_err(SourceUnavailable::new)?;
+        if read == 0 {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} ended before its initial {length}-byte generation",
+                path.display()
+            )));
+        }
+        remaining -= read as u64;
         hasher.update(&buffer[..read]);
+    }
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).map_err(SourceUnavailable::new)? != 0 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} grew beyond its initial {length}-byte generation",
+            path.display()
+        )));
     }
     let binding = RecordedCorpusFileBinding {
         name: expected_name.to_owned(),
@@ -1815,6 +3572,7 @@ fn open_verified_corpus_member(
         file,
         initial,
         binding,
+        position: 0,
         context,
     };
     member.verify_generation()?;
@@ -1885,19 +3643,47 @@ fn verify_captured_optional_regular_file(
             ))),
         };
     };
-    let actual = capture_optional_regular_file(path, context)?.ok_or_else(|| {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path).map_err(|error| {
         SourceUnavailable::new(format!(
-            "{context} {} disappeared after capture",
+            "{context} {} disappeared or cannot be reopened without following links: {error}",
             path.display()
         ))
     })?;
-    if actual != expected {
+    let initial_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let initial_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial_file.file_type().is_file()
+        || !initial_path.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path, &initial_file)
+        || initial_file.len() != expected.len() as u64
+    {
         return Err(SourceUnavailable::new(format!(
-            "{context} {} changed after capture",
+            "{context} {} changed identity, type, or length after capture",
             path.display()
         )));
     }
-    Ok(())
+    verify_opened_bytes(&mut file, path, context, expected, &initial_file)
+}
+
+fn verify_captured_optional_control_file(
+    path: &Path,
+    context: &str,
+    expected: Option<&[u8]>,
+    max_bytes: u64,
+) -> Result<(), SourceUnavailable> {
+    if expected.is_some_and(|bytes| bytes.len() as u64 > max_bytes) {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} exceeds the registered {max_bytes}-byte schema cap",
+            path.display()
+        )));
+    }
+    verify_captured_optional_regular_file(path, context, expected)
 }
 
 fn canonical_parent(path: &Path, label: &str) -> Result<PathBuf, SourceUnavailable> {
@@ -1989,17 +3775,22 @@ fn capture_provenance(root: &Path) -> Result<ProvenanceBytes, SourceUnavailable>
     let paths = provenance_paths(root);
     let mut bytes: ProvenanceBytes = [None, None, None];
     for (slot, path) in paths.iter().enumerate() {
-        bytes[slot] = capture_optional_regular_file(path, "recorded corpus provenance")?;
+        bytes[slot] = capture_optional_control_file(
+            path,
+            "recorded corpus provenance",
+            PROVENANCE_CONTROL_MAX_BYTES,
+        )?;
     }
     Ok(bytes)
 }
 
 fn verify_provenance(root: &Path, bytes: &ProvenanceBytes) -> Result<(), SourceUnavailable> {
     for (path, expected) in provenance_paths(root).iter().zip(bytes.iter()) {
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             path,
             "recorded corpus provenance",
             expected.as_deref(),
+            PROVENANCE_CONTROL_MAX_BYTES,
         )?;
     }
     Ok(())
@@ -2042,6 +3833,7 @@ fn parse_binding_bytes(
             binding.schema
         )));
     }
+    let _ = binding.validate_shape(&format!("recorded corpus binding {}", path.display()))?;
     if binding.canonical_bytes()? != bytes {
         return Err(SourceUnavailable::new(format!(
             "recorded corpus binding {} is not canonical pretty JSON with one trailing newline",
@@ -2106,14 +3898,14 @@ fn reserved_compile_attempt_entry_name(
         if !bytes.starts_with(prefix.as_bytes()) {
             return Ok(None);
         }
-        return std::str::from_utf8(bytes)
+        std::str::from_utf8(bytes)
             .map(|name| Some(name.to_owned()))
             .map_err(|_| {
                 SourceUnavailable::new(format!(
                     "recorded corpus root {} contains a non-UTF-8 entry in the reserved compile-attempt namespace",
                     root.display()
                 ))
-            });
+            })
     }
     #[cfg(not(unix))]
     {
@@ -2132,6 +3924,7 @@ fn reserved_compile_attempt_entry_name(
 
 fn compile_attempt_residues(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, SourceUnavailable> {
     let mut residues = Vec::new();
+    let mut reserved_count = 0usize;
     for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
         let entry = entry.map_err(SourceUnavailable::new)?;
         let Some(name) = reserved_compile_attempt_entry_name(root, &entry.file_name())? else {
@@ -2143,15 +3936,27 @@ fn compile_attempt_residues(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, Sour
                 root.display()
             )));
         }
+        reserved_count = reserved_count
+            .checked_add(1)
+            .ok_or_else(|| SourceUnavailable::new("compile-attempt residue count overflow"))?;
+        if reserved_count > RESERVED_RESIDUE_MAX_ENTRIES {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} exceeds the fixed {RESERVED_RESIDUE_MAX_ENTRIES}-entry compile-attempt residue ceiling",
+                root.display()
+            )));
+        }
         let path = entry.path();
-        let bytes =
-            capture_optional_regular_file(&path, "recorded corpus compile-attempt staging")?
-                .ok_or_else(|| {
-                    SourceUnavailable::new(format!(
-                        "recorded corpus compile-attempt staging {} disappeared",
-                        path.display()
-                    ))
-                })?;
+        let bytes = capture_optional_control_file(
+            &path,
+            "recorded corpus compile-attempt staging",
+            COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        )?
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus compile-attempt staging {} disappeared",
+                path.display()
+            ))
+        })?;
         residues.push((path, bytes));
     }
     residues.sort_by(|left, right| left.0.cmp(&right.0));
@@ -2163,8 +3968,11 @@ fn validate_compile_attempt_namespace(
     role: RecordedCorpusRole,
 ) -> Result<(), SourceUnavailable> {
     let stable = compile_attempt_path(root);
-    let stable_present =
-        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?;
+    let stable_present = capture_optional_control_file(
+        &stable,
+        "recorded corpus compile-attempt marker",
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+    )?;
     if let Some(bytes) = stable_present.as_deref() {
         parse_compile_attempt_bytes(&stable, bytes)?;
     }
@@ -2182,87 +3990,141 @@ fn validate_compile_attempt_namespace(
 fn publish_compile_attempt_marker(
     guard: &RecordedCorpusProducerGuard,
 ) -> Result<(), SourceUnavailable> {
+    publish_compile_attempt_marker_with_hook(guard, || {})
+}
+
+fn publish_compile_attempt_marker_with_hook<F>(
+    guard: &RecordedCorpusProducerGuard,
+    before_link: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnOnce(),
+{
+    guard.verify_root()?;
     validate_compile_attempt_namespace(&guard.root, RecordedCorpusRole::Compile)?;
     let expected = RecordedCorpusCompileAttempt::compile().canonical_bytes()?;
     let stable = compile_attempt_path(&guard.root);
-    if let Some(bytes) =
-        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
-    {
-        if bytes != expected {
-            return Err(SourceUnavailable::new(
-                "recorded corpus compile-attempt marker conflicts with compile/1",
-            ));
+    let stable_name = OsStr::new(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE);
+    let stable_present = guard.verify_optional_owned_entry_bytes(
+        stable_name,
+        &expected,
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        "recorded corpus compile-attempt marker",
+    )?;
+    let residues = compile_attempt_residues(&guard.root)?;
+    guard.verify_root()?;
+    if stable_present {
+        for (path, bytes) in residues {
+            remove_exact_owned_binding_residue(guard, &path, &bytes, "compile-attempt staging")?;
         }
-        for (path, bytes) in compile_attempt_residues(&guard.root)? {
-            remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
-        }
-        return sync_binding_directory(&guard.root);
+        guard.sync_owned_root()?;
+        return guard.verify_root();
     }
-    for (path, bytes) in compile_attempt_residues(&guard.root)? {
-        remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
+    for (path, bytes) in residues {
+        remove_exact_owned_binding_residue(guard, &path, &bytes, "compile-attempt staging")?;
     }
     let (staging, mut file) = loop {
         let sequence = RECORDED_CORPUS_COMPILE_ATTEMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-        let candidate = guard.root.join(format!(
+        let candidate = std::ffi::OsString::from(format!(
             ".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.{}.{}.writing",
             std::process::id(),
             sequence
         ));
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options
-                .mode(0o600)
-                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-        }
-        match options.open(&candidate) {
+        match guard.create_new_owned_entry(&candidate) {
             Ok(file) => break (candidate, file),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(SourceUnavailable::new(error)),
+            Err(error) => {
+                if guard
+                    .open_optional_owned_entry_for_read(&candidate)?
+                    .is_some()
+                {
+                    continue;
+                }
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus compile-attempt staging {candidate:?} cannot be created: {error}"
+                )));
+            }
         }
     };
     file.write_all(&expected)
         .and_then(|()| file.sync_all())
         .map_err(SourceUnavailable::new)?;
+    drop(file);
     guard.verify_root()?;
-    match std::fs::hard_link(&staging, &stable) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let current =
-                capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
-                    .ok_or_else(|| SourceUnavailable::new("compile-attempt marker disappeared"))?;
-            if current != expected {
-                return Err(SourceUnavailable::new(
-                    "recorded corpus compile-attempt marker appeared with conflicting bytes",
-                ));
+    before_link();
+    if let Err(error) = guard.link_owned_entry(&staging, stable_name) {
+        match guard.verify_optional_owned_entry_bytes(
+            stable_name,
+            &expected,
+            COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+            "recorded corpus compile-attempt marker",
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus compile-attempt publication failed: {error}"
+                )));
             }
+            Err(conflict) => return Err(conflict),
         }
-        Err(error) => return Err(SourceUnavailable::new(error)),
     }
-    std::fs::remove_file(&staging).map_err(SourceUnavailable::new)?;
-    sync_binding_directory(&guard.root)?;
-    let current = capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
-        .ok_or_else(|| SourceUnavailable::new("compile-attempt marker disappeared"))?;
-    parse_compile_attempt_bytes(&stable, &current)
+    guard.unlink_owned_entry(&staging)?;
+    guard.sync_owned_root()?;
+    guard.verify_owned_entry_bytes(
+        stable_name,
+        &expected,
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        "recorded corpus compile-attempt marker",
+    )?;
+    parse_compile_attempt_bytes(&stable, &expected)?;
+    guard.verify_root()
 }
 
 fn finish_compile_attempt_marker(
     guard: &RecordedCorpusProducerGuard,
 ) -> Result<(), SourceUnavailable> {
+    finish_compile_attempt_marker_with_hook(guard, || {})
+}
+
+fn finish_compile_attempt_marker_with_hook<F>(
+    guard: &RecordedCorpusProducerGuard,
+    before_unlink: F,
+) -> Result<(), SourceUnavailable>
+where
+    F: FnOnce(),
+{
+    guard.verify_root()?;
     validate_compile_attempt_namespace(&guard.root, RecordedCorpusRole::Compile)?;
     let stable = compile_attempt_path(&guard.root);
-    if let Some(bytes) =
-        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
-    {
-        parse_compile_attempt_bytes(&stable, &bytes)?;
-        remove_exact_binding_residue(&stable, &bytes, "recorded corpus compile-attempt marker")?;
+    let expected = RecordedCorpusCompileAttempt::compile().canonical_bytes()?;
+    let stable_name = OsStr::new(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE);
+    let stable_present = guard.verify_optional_owned_entry_bytes(
+        stable_name,
+        &expected,
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        "recorded corpus compile-attempt marker",
+    )?;
+    let residues = compile_attempt_residues(&guard.root)?;
+    guard.verify_root()?;
+    before_unlink();
+    if stable_present {
+        guard.unlink_owned_entry(stable_name)?;
     }
-    for (path, bytes) in compile_attempt_residues(&guard.root)? {
-        remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
+    for (path, bytes) in residues {
+        remove_exact_owned_binding_residue(guard, &path, &bytes, "compile-attempt staging")?;
     }
-    sync_binding_directory(&guard.root)
+    guard.sync_owned_root()?;
+    if guard.verify_optional_owned_entry_bytes(
+        stable_name,
+        &expected,
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+        "recorded corpus compile-attempt marker",
+    )? {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus compile-attempt marker {} remained after guarded finish",
+            stable.display()
+        )));
+    }
+    guard.verify_root()
 }
 
 fn binding_temporary_name(name: &str) -> bool {
@@ -2351,21 +4213,41 @@ fn binding_publication_residues(
     capture_writings: bool,
 ) -> Result<BindingPublicationResidues, SourceUnavailable> {
     let mut residues = BindingPublicationResidues::default();
+    let mut reserved_count = 0usize;
     for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
         let entry = entry.map_err(SourceUnavailable::new)?;
         let name = entry.file_name();
         let Some(name) = reserved_binding_entry_name(root, &name)? else {
             continue;
         };
+        if !binding_temporary_name(&name) && !binding_writing_name(&name) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains unrecognized entry {name:?} in the reserved binding publication namespace",
+                root.display()
+            )));
+        }
+        reserved_count = reserved_count
+            .checked_add(1)
+            .ok_or_else(|| SourceUnavailable::new("binding residue count overflow"))?;
+        if reserved_count > RESERVED_RESIDUE_MAX_ENTRIES {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} exceeds the fixed {RESERVED_RESIDUE_MAX_ENTRIES}-entry binding residue ceiling",
+                root.display()
+            )));
+        }
         if binding_temporary_name(&name) {
             let path = entry.path();
-            let bytes = capture_optional_regular_file(&path, "recorded corpus binding temporary")?
-                .ok_or_else(|| {
-                    SourceUnavailable::new(format!(
-                        "recorded corpus binding temporary {} disappeared during validation",
-                        path.display()
-                    ))
-                })?;
+            let bytes = capture_optional_control_file(
+                &path,
+                "recorded corpus binding temporary",
+                BINDING_CONTROL_MAX_BYTES,
+            )?
+            .ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "recorded corpus binding temporary {} disappeared during validation",
+                    path.display()
+                ))
+            })?;
             let _ = parse_binding_bytes(&path, &bytes)?;
             residues.temporaries.push((path, bytes));
         } else if binding_writing_name(&name) {
@@ -2374,9 +4256,10 @@ fn binding_publication_residues(
             // reclaim it before beginning a new publication attempt.
             if capture_writings {
                 let path = entry.path();
-                let bytes = capture_optional_regular_file(
+                let bytes = capture_optional_control_file(
                     &path,
                     "recorded corpus non-authoritative binding staging file",
+                    BINDING_CONTROL_MAX_BYTES,
                 )?
                 .ok_or_else(|| {
                     SourceUnavailable::new(format!(
@@ -2386,11 +4269,6 @@ fn binding_publication_residues(
                 })?;
                 residues.writings.push((path, bytes));
             }
-        } else {
-            return Err(SourceUnavailable::new(format!(
-                "recorded corpus root {} contains unrecognized entry {name:?} in the reserved binding publication namespace",
-                root.display()
-            )));
         }
     }
     residues
@@ -2402,19 +4280,43 @@ fn binding_publication_residues(
     Ok(residues)
 }
 
+#[cfg(test)]
 fn binding_temporaries(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, SourceUnavailable> {
     Ok(binding_publication_residues(root, false)?.temporaries)
 }
 
 fn require_no_binding_temporaries(root: &Path) -> Result<(), SourceUnavailable> {
-    let temporaries = binding_temporaries(root)?;
-    if temporaries.is_empty() {
-        return Ok(());
+    let mut reserved_count = 0usize;
+    for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let raw_name = entry.file_name();
+        let Some(name) = reserved_binding_entry_name(root, &raw_name)? else {
+            continue;
+        };
+        if !binding_temporary_name(&name) && !binding_writing_name(&name) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains unrecognized entry {name:?} in the reserved binding publication namespace",
+                root.display()
+            )));
+        }
+        reserved_count = reserved_count
+            .checked_add(1)
+            .ok_or_else(|| SourceUnavailable::new("binding residue count overflow"))?;
+        if reserved_count > RESERVED_RESIDUE_MAX_ENTRIES {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} exceeds the fixed {RESERVED_RESIDUE_MAX_ENTRIES}-entry binding residue ceiling",
+                root.display()
+            )));
+        }
+        if binding_temporary_name(&name) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains an unpublished canonical binding temporary {}; writer recovery is required before reading",
+                root.display(),
+                entry.path().display()
+            )));
+        }
     }
-    Err(SourceUnavailable::new(format!(
-        "recorded corpus root {} contains an unpublished canonical binding temporary; writer recovery is required before reading",
-        root.display()
-    )))
+    Ok(())
 }
 
 fn make_streaming_binding(
@@ -2424,10 +4326,50 @@ fn make_streaming_binding(
     provenance: &ProvenanceBytes,
     meta_bytes: &[u8],
 ) -> Result<RecordedCorpusBinding, SourceUnavailable> {
+    make_streaming_binding_retained(
+        meta_path,
+        records_path,
+        hidden_path,
+        provenance,
+        meta_bytes,
+        || {},
+    )
+    .map(|(binding, _, _)| binding)
+}
+
+fn make_streaming_binding_retained<F>(
+    meta_path: &Path,
+    records_path: &Path,
+    hidden_path: &Path,
+    provenance: &ProvenanceBytes,
+    meta_bytes: &[u8],
+    after_records_capture: F,
+) -> Result<
+    (
+        RecordedCorpusBinding,
+        StreamedGeneration,
+        StreamedGeneration,
+    ),
+    SourceUnavailable,
+>
+where
+    F: FnOnce(),
+{
     let metadata_name = utf8_file_name(meta_path, "recorded corpus metadata")?;
     let records_name = utf8_file_name(records_path, "recorded corpus records")?;
     let hidden_name = utf8_file_name(hidden_path, "recorded corpus hidden stream")?;
-    Ok(RecordedCorpusBinding {
+    let (records, records_generation) = stream_regular_file_binding_retained(
+        records_path,
+        &records_name,
+        "recorded corpus records",
+    )?;
+    after_records_capture();
+    let (hidden, hidden_generation) = stream_regular_file_binding_retained(
+        hidden_path,
+        &hidden_name,
+        "recorded corpus hidden stream",
+    )?;
+    let binding = RecordedCorpusBinding {
         schema: RECORDED_CORPUS_BINDING_SCHEMA.to_owned(),
         manifest: RecordedCorpusFileBinding::from_bytes(
             observation::MANIFEST_FILE,
@@ -2442,17 +4384,10 @@ fn make_streaming_binding(
             provenance[2].as_deref(),
         )?,
         metadata: RecordedCorpusFileBinding::from_bytes(&metadata_name, Some(meta_bytes))?,
-        records: stream_regular_file_binding(
-            records_path,
-            &records_name,
-            "recorded corpus records",
-        )?,
-        hidden: stream_regular_file_binding(
-            hidden_path,
-            &hidden_name,
-            "recorded corpus hidden stream",
-        )?,
-    })
+        records,
+        hidden,
+    };
+    Ok((binding, records_generation, hidden_generation))
 }
 
 fn validate_finalized_corpus_shape(
@@ -2729,16 +4664,20 @@ where
         resolved_corpus_paths(corpus_meta, corpus_records)?;
     require_no_binding_temporaries(&root)?;
     let stable_binding_path = binding_path(&root);
-    let binding_bytes =
-        capture_optional_regular_file(&stable_binding_path, "recorded corpus generation binding")?;
+    let binding_bytes = capture_optional_control_file(
+        &stable_binding_path,
+        "recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
+    )?;
     let binding = binding_bytes
         .as_deref()
         .map(|bytes| parse_binding_bytes(&stable_binding_path, bytes))
         .transpose()?;
     let compile_attempt_path = compile_attempt_path(&root);
-    let compile_attempt = capture_optional_regular_file(
+    let compile_attempt = capture_optional_control_file(
         &compile_attempt_path,
         "recorded corpus compile-attempt marker",
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
     )?;
     if let Some(bytes) = compile_attempt.as_deref() {
         parse_compile_attempt_bytes(&compile_attempt_path, bytes)?;
@@ -2758,13 +4697,17 @@ where
     let provenance = capture_provenance(&root)?;
     after_provenance_capture();
 
-    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
-        .ok_or_else(|| {
-            SourceUnavailable::new(format!(
-                "recorded corpus metadata {} disappeared during capture",
-                resolved_meta.display()
-            ))
-        })?;
+    let meta_bytes = capture_optional_control_file(
+        &resolved_meta,
+        "recorded corpus metadata",
+        METADATA_CONTROL_MAX_BYTES,
+    )?
+    .ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "recorded corpus metadata {} disappeared during capture",
+            resolved_meta.display()
+        ))
+    })?;
     let records_bytes =
         capture_optional_regular_file(&resolved_records, "recorded corpus records")?.ok_or_else(
             || {
@@ -2803,10 +4746,11 @@ where
         // cross-file transaction: only the canonical binding supplies that
         // guarantee.
         verify_provenance(&root, &provenance)?;
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             &resolved_meta,
             "recorded corpus metadata",
             Some(meta_bytes.as_slice()),
+            METADATA_CONTROL_MAX_BYTES,
         )?;
         verify_captured_optional_regular_file(
             &resolved_records,
@@ -2818,10 +4762,11 @@ where
             "recorded corpus hidden stream",
             hidden_bytes.as_deref(),
         )?;
-        verify_captured_optional_regular_file(
+        verify_captured_optional_control_file(
             &stable_binding_path,
             "recorded corpus generation binding",
             None,
+            BINDING_CONTROL_MAX_BYTES,
         )?;
         require_no_binding_temporaries(&root)?;
         if let Some(dense) = execution.dense_operator.as_ref() {
@@ -2861,9 +4806,12 @@ pub fn capture(
 /// no-follow handles and rewound; their bodies are never accumulated here.
 /// A consumer may seek/read those handles and must call
 /// [`RecordedCorpusStreamSnapshot::verify_generation`] after its final read
-/// and immediately before publishing any derived generation. Markerless
-/// compatibility callers additionally hold a [`RecordedCorpusProducerGuard`]
-/// for the source while opening, reading, and performing that final check.
+/// and immediately before publishing any derived generation. A canonical
+/// binding supplies the cross-file generation commit. Markerless snapshots
+/// retain and recheck every opened generation, but cannot by themselves
+/// exclude a non-cooperating cross-file ABA publisher; production derivations
+/// therefore hold a source [`RecordedCorpusProducerGuard`] across open, read,
+/// and final verification for that compatibility lane.
 pub fn open_stream(
     corpus_meta: &Path,
     corpus_records: &Path,
@@ -2872,15 +4820,21 @@ pub fn open_stream(
         resolved_corpus_paths(corpus_meta, corpus_records)?;
     require_no_binding_temporaries(&root)?;
     let stable_path = binding_path(&root);
-    let binding_bytes =
-        capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?;
+    let binding_bytes = capture_optional_control_file(
+        &stable_path,
+        "recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
+    )?;
     let binding = binding_bytes
         .as_deref()
         .map(|bytes| parse_binding_bytes(&stable_path, bytes))
         .transpose()?;
     let marker_path = compile_attempt_path(&root);
-    let marker_bytes =
-        capture_optional_regular_file(&marker_path, "recorded corpus compile-attempt marker")?;
+    let marker_bytes = capture_optional_control_file(
+        &marker_path,
+        "recorded corpus compile-attempt marker",
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+    )?;
     if let Some(bytes) = marker_bytes.as_deref() {
         parse_compile_attempt_bytes(&marker_path, bytes)?;
         match binding.as_ref() {
@@ -2897,8 +4851,12 @@ pub fn open_stream(
     }
 
     let provenance = capture_provenance(&root)?;
-    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
-        .ok_or_else(|| SourceUnavailable::new("recorded corpus metadata is absent"))?;
+    let meta_bytes = capture_optional_control_file(
+        &resolved_meta,
+        "recorded corpus metadata",
+        METADATA_CONTROL_MAX_BYTES,
+    )?
+    .ok_or_else(|| SourceUnavailable::new("recorded corpus metadata is absent"))?;
     let hidden = hidden_path(&resolved_records);
     let records_name = utf8_file_name(&resolved_records, "recorded corpus records")?;
     let hidden_name = utf8_file_name(&hidden, "recorded corpus hidden stream")?;
@@ -3013,98 +4971,157 @@ pub fn open_stream_under_guard(
     Ok(snapshot)
 }
 
-fn sync_binding_directory(root: &Path) -> Result<(), SourceUnavailable> {
-    std::fs::File::open(root)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| {
-            SourceUnavailable::new(format!(
-                "recorded corpus root {} cannot be synchronized after binding publication: {error}",
-                root.display()
-            ))
-        })
+/// Resolve only the execution identity while the caller retains exclusive
+/// ownership of the exact producer root. This is the identity-only companion
+/// to [`open_stream_under_guard`] and cannot self-contend on the same lock.
+pub fn execution_identity_under_producer_guard(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let snapshot = open_stream_under_guard(guard, corpus_meta, corpus_records)?;
+    snapshot.verify_generation()?;
+    guard.verify_owned_root()?;
+    Ok(snapshot.execution)
 }
 
-fn create_binding_temporary(root: &Path, bytes: &[u8]) -> Result<PathBuf, SourceUnavailable> {
+/// Open a stream under a caller-owned sorted reader-pin set. At least one pin
+/// must identify the exact corpus directory; unrelated or typed-absent pins do
+/// not authorize a pathname read.
+pub fn open_stream_under_reader_pins(
+    pins: &RecordedCorpusReaderPins,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusStreamSnapshot, SourceUnavailable> {
+    let (root, _, _) = resolved_corpus_paths(corpus_meta, corpus_records)?;
+    if !pins.protects_directory(&root)? {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus reader pins do not protect stream root {}",
+            root.display()
+        )));
+    }
+    let snapshot = open_stream(corpus_meta, corpus_records)?;
+    snapshot.verify_generation()?;
+    pins.verify()?;
+    Ok(snapshot)
+}
+
+/// Resolve only the execution identity under one retained shared-pin
+/// authority, avoiding a nested reader acquisition and its avoidable race.
+pub fn execution_identity_under_reader_pins(
+    pins: &RecordedCorpusReaderPins,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let snapshot = open_stream_under_reader_pins(pins, corpus_meta, corpus_records)?;
+    snapshot.verify_generation()?;
+    pins.verify()?;
+    Ok(snapshot.execution)
+}
+
+/// Open a source generation for a production derivation. Bound generations
+/// need no writer lock because the canonical binding commits every captured
+/// member. Markerless legacy/attention-only inputs are reopened under an
+/// exclusive producer guard, which the caller retains until its final source
+/// verification and derived-byte staging are complete.
+pub fn open_stream_for_derivation(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<
+    (
+        RecordedCorpusStreamSnapshot,
+        Option<RecordedCorpusProducerGuard>,
+    ),
+    SourceUnavailable,
+> {
+    let initial = open_stream(corpus_meta, corpus_records)?;
+    if initial.binding_cid.is_some() {
+        return Ok((initial, None));
+    }
+    drop(initial);
+    let (root, _, _) = resolved_corpus_paths(corpus_meta, corpus_records)?;
+    let guard = RecordedCorpusProducerGuard::try_acquire(&root)?;
+    let snapshot = open_stream_under_guard(&guard, corpus_meta, corpus_records)?;
+    if snapshot.binding_cid.is_some() {
+        // A cooperating writer cannot publish while this exclusive guard is
+        // held; reaching a bound generation here therefore means the first
+        // markerless read raced an uncoordinated publisher. Fail closed rather
+        // than silently changing the derivation contract mid-open.
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus {} changed from markerless to binding-committed while derivation ownership was acquired",
+            root.display()
+        )));
+    }
+    Ok((snapshot, Some(guard)))
+}
+
+fn create_binding_temporary(
+    guard: &RecordedCorpusProducerGuard,
+    bytes: &[u8],
+) -> Result<std::ffi::OsString, SourceUnavailable> {
     loop {
         let sequence = RECORDED_CORPUS_BINDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-        let writing = root.join(format!(
+        let writing = std::ffi::OsString::from(format!(
             ".{RECORDED_CORPUS_BINDING_FILE}.{}.{}.writing",
             std::process::id(),
             sequence
         ));
-        let temporary = root.join(format!(
+        let temporary = std::ffi::OsString::from(format!(
             ".{RECORDED_CORPUS_BINDING_FILE}.{}.{}.tmp",
             std::process::id(),
             sequence
         ));
-        match std::fs::symlink_metadata(&temporary) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Ok(_) => continue,
-            Err(error) => {
-                return Err(SourceUnavailable::new(format!(
-                    "recorded corpus binding temporary {} cannot be inspected: {error}",
-                    temporary.display()
-                )));
-            }
-        }
-        match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&writing)
+        if guard
+            .open_optional_owned_entry_for_read(&temporary)?
+            .is_some()
         {
+            continue;
+        }
+        match guard.create_new_owned_entry(&writing) {
             Ok(mut file) => {
                 if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
-                    let _ = std::fs::remove_file(&writing);
+                    let _ = guard.unlink_owned_entry(&writing);
                     return Err(SourceUnavailable::new(format!(
-                        "recorded corpus binding staging file {} cannot be written: {error}",
-                        writing.display()
+                        "recorded corpus binding staging file {writing:?} cannot be written: {error}",
                     )));
                 }
                 drop(file);
-                std::fs::rename(&writing, &temporary).map_err(|error| {
+                guard.rename_owned_entry(&writing, &temporary).map_err(|error| {
                     SourceUnavailable::new(format!(
-                        "recorded corpus binding staging promotion {} -> {} failed: {error}",
-                        writing.display(),
-                        temporary.display()
+                        "recorded corpus binding staging promotion {writing:?} -> {temporary:?} failed: {error}",
                     ))
                 })?;
-                sync_binding_directory(root)?;
+                guard.sync_owned_root()?;
                 return Ok(temporary);
             }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
+                if guard
+                    .open_optional_owned_entry_for_read(&writing)?
+                    .is_some()
+                {
+                    continue;
+                }
                 return Err(SourceUnavailable::new(format!(
-                    "recorded corpus binding staging file {} cannot be created: {error}",
-                    writing.display()
+                    "recorded corpus binding staging file {writing:?} cannot be created: {error}",
                 )));
             }
         }
     }
 }
 
-fn remove_exact_binding_residue(
+fn remove_exact_owned_binding_residue(
+    guard: &RecordedCorpusProducerGuard,
     path: &Path,
     expected: &[u8],
     context: &str,
 ) -> Result<(), SourceUnavailable> {
-    let current = capture_optional_regular_file(path, context)?.ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "{context} {} disappeared before recovery",
-            path.display()
-        ))
+    let name = path.file_name().ok_or_else(|| {
+        SourceUnavailable::new(format!("{context} {} has no leaf name", path.display()))
     })?;
-    if current != expected {
-        return Err(SourceUnavailable::new(format!(
-            "{context} {} changed before recovery",
-            path.display()
-        )));
-    }
-    std::fs::remove_file(path).map_err(|error| {
-        SourceUnavailable::new(format!(
-            "{context} {} cannot be reclaimed: {error}",
-            path.display()
-        ))
-    })
+    let max_bytes = u64::try_from(expected.len())
+        .map_err(|_| SourceUnavailable::new(format!("{context} length overflows u64")))?;
+    guard.verify_owned_entry_bytes(name, expected, max_bytes, context)?;
+    guard.unlink_owned_entry(name)
 }
 
 /// Read-only verification that every stable/recoverable binding record, when
@@ -3148,14 +5165,18 @@ pub fn preflight_source_update_publication(
     let recoverable_binding =
         guard.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
     let marker = compile_attempt_path(&guard.root);
-    let attempt_active =
-        capture_optional_regular_file(&marker, "recorded corpus compile-attempt marker")?
-            .map(|bytes| parse_compile_attempt_bytes(&marker, &bytes))
-            .transpose()?
-            .is_some();
-    let stable = capture_optional_regular_file(
+    let attempt_active = capture_optional_control_file(
+        &marker,
+        "recorded corpus compile-attempt marker",
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+    )?
+    .map(|bytes| parse_compile_attempt_bytes(&marker, &bytes))
+    .transpose()?
+    .is_some();
+    let stable = capture_optional_control_file(
         &binding_path(&guard.root),
         "recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
     )?
     .is_some();
     if recoverable_binding || (stable && !attempt_active) {
@@ -3201,8 +5222,12 @@ fn preflight_binding_evidence_matches_current_inner(
     validate_role_inventory(&root, role)?;
     validate_compile_attempt_namespace(&root, role)?;
     let provenance = capture_provenance(&root)?;
-    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
-        .ok_or_else(|| SourceUnavailable::new("binding preflight metadata is absent"))?;
+    let meta_bytes = capture_optional_control_file(
+        &resolved_meta,
+        "recorded corpus metadata",
+        METADATA_CONTROL_MAX_BYTES,
+    )?
+    .ok_or_else(|| SourceUnavailable::new("binding preflight metadata is absent"))?;
     let resolved_hidden = hidden_path(&resolved_records);
     let execution =
         parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
@@ -3223,9 +5248,12 @@ fn preflight_binding_evidence_matches_current_inner(
     }
     let expected = binding.canonical_bytes()?;
     let stable_path = binding_path(&root);
-    if let Some(bytes) =
-        capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
-            .filter(|_| check_stable)
+    if let Some(bytes) = capture_optional_control_file(
+        &stable_path,
+        "recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
+    )?
+    .filter(|_| check_stable)
     {
         let binding = parse_binding_bytes(&stable_path, &bytes)?;
         validate_binding_role(&binding, role, &stable_path)?;
@@ -3269,6 +5297,48 @@ pub fn publish_binding(
     corpus_meta: &Path,
     corpus_records: &Path,
 ) -> Result<String, SourceUnavailable> {
+    publish_binding_with_hooks(guard, corpus_meta, corpus_records, || {}, || {})
+}
+
+fn verify_publication_generation(
+    guard: &RecordedCorpusProducerGuard,
+    provenance: &ProvenanceBytes,
+    meta_path: &Path,
+    meta_bytes: &[u8],
+    marker_bytes: Option<&[u8]>,
+    records_generation: &StreamedGeneration,
+    hidden_generation: &StreamedGeneration,
+) -> Result<(), SourceUnavailable> {
+    guard.verify_root()?;
+    verify_provenance(&guard.root, provenance)?;
+    verify_captured_optional_control_file(
+        meta_path,
+        "recorded corpus metadata",
+        Some(meta_bytes),
+        METADATA_CONTROL_MAX_BYTES,
+    )?;
+    verify_captured_optional_control_file(
+        &compile_attempt_path(&guard.root),
+        "recorded corpus compile-attempt marker",
+        marker_bytes,
+        COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
+    )?;
+    records_generation.verify("recorded corpus records")?;
+    hidden_generation.verify("recorded corpus hidden stream")?;
+    guard.verify_root()
+}
+
+fn publish_binding_with_hooks<F, G>(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    after_records_capture: F,
+    before_commit: G,
+) -> Result<String, SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
     guard.verify_root()?;
     let (root, resolved_meta, resolved_records) =
         resolved_corpus_paths(corpus_meta, corpus_records)?;
@@ -3294,11 +5364,12 @@ pub fn publish_binding(
     };
     validate_role_inventory(&root, intended_role)?;
     validate_compile_attempt_namespace(&root, intended_role)?;
-    if intended_role == RecordedCorpusRole::Compile {
+    let marker_bytes = if intended_role == RecordedCorpusRole::Compile {
         let marker_path = compile_attempt_path(&root);
-        let marker = capture_optional_regular_file(
+        let marker = capture_optional_control_file(
             &marker_path,
             "recorded corpus compile-attempt marker",
+            COMPILE_ATTEMPT_CONTROL_MAX_BYTES,
         )?
         .ok_or_else(|| {
             SourceUnavailable::new(format!(
@@ -3307,24 +5378,41 @@ pub fn publish_binding(
             ))
         })?;
         parse_compile_attempt_bytes(&marker_path, &marker)?;
-    }
+        Some(marker)
+    } else {
+        None
+    };
     let provenance = capture_provenance(&root)?;
-    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
-        .ok_or_else(|| {
-            SourceUnavailable::new(format!(
-                "recorded corpus metadata {} is absent during binding publication",
-                resolved_meta.display()
-            ))
-        })?;
+    let meta_bytes = capture_optional_control_file(
+        &resolved_meta,
+        "recorded corpus metadata",
+        METADATA_CONTROL_MAX_BYTES,
+    )?
+    .ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "recorded corpus metadata {} is absent during binding publication",
+            resolved_meta.display()
+        ))
+    })?;
     let resolved_hidden = hidden_path(&resolved_records);
     let execution =
         parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
-    let binding = make_streaming_binding(
+    let (binding, records_generation, hidden_generation) = make_streaming_binding_retained(
         &resolved_meta,
         &resolved_records,
         &resolved_hidden,
         &provenance,
         &meta_bytes,
+        after_records_capture,
+    )?;
+    verify_publication_generation(
+        guard,
+        &provenance,
+        &resolved_meta,
+        &meta_bytes,
+        marker_bytes.as_deref(),
+        &records_generation,
+        &hidden_generation,
     )?;
     if !binding.records.present {
         return Err(SourceUnavailable::new(format!(
@@ -3345,7 +5433,11 @@ pub fn publish_binding(
     let expected = binding.canonical_bytes()?;
     let expected_cid = format!("blake3:{}", blake3::hash(&expected).to_hex());
     let stable_path = binding_path(&root);
-    let stable = capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?;
+    let stable = capture_optional_control_file(
+        &stable_path,
+        "recorded corpus generation binding",
+        BINDING_CONTROL_MAX_BYTES,
+    )?;
     if let Some(bytes) = stable.as_deref() {
         let existing = parse_binding_bytes(&stable_path, bytes)?;
         validate_binding_role(&existing, intended_role, &stable_path)?;
@@ -3363,23 +5455,68 @@ pub fn publish_binding(
         )));
     }
 
+    verify_publication_generation(
+        guard,
+        &provenance,
+        &resolved_meta,
+        &meta_bytes,
+        marker_bytes.as_deref(),
+        &records_generation,
+        &hidden_generation,
+    )?;
+
+    let mut before_commit = Some(before_commit);
     if stable.as_deref() == Some(expected.as_slice()) {
+        before_commit
+            .take()
+            .expect("publication hook is called exactly once")();
+        verify_publication_generation(
+            guard,
+            &provenance,
+            &resolved_meta,
+            &meta_bytes,
+            marker_bytes.as_deref(),
+            &records_generation,
+            &hidden_generation,
+        )?;
         for (path, bytes) in temporaries {
-            remove_exact_binding_residue(&path, &bytes, "recorded corpus binding temporary")?;
+            remove_exact_owned_binding_residue(
+                guard,
+                &path,
+                &bytes,
+                "recorded corpus binding temporary",
+            )?;
         }
         for (path, bytes) in writings {
-            remove_exact_binding_residue(
+            remove_exact_owned_binding_residue(
+                guard,
                 &path,
                 &bytes,
                 "recorded corpus non-authoritative binding staging file",
             )?;
         }
-        sync_binding_directory(&root)?;
+        guard.sync_owned_root()?;
+        guard.verify_owned_entry_bytes(
+            OsStr::new(RECORDED_CORPUS_BINDING_FILE),
+            &expected,
+            BINDING_CONTROL_MAX_BYTES,
+            "stable recorded corpus generation binding",
+        )?;
+        verify_publication_generation(
+            guard,
+            &provenance,
+            &resolved_meta,
+            &meta_bytes,
+            marker_bytes.as_deref(),
+            &records_generation,
+            &hidden_generation,
+        )?;
         return Ok(expected_cid);
     }
 
     for (path, bytes) in writings {
-        remove_exact_binding_residue(
+        remove_exact_owned_binding_residue(
+            guard,
             &path,
             &bytes,
             "recorded corpus non-authoritative binding staging file",
@@ -3388,57 +5525,77 @@ pub fn publish_binding(
 
     let selected = match temporaries.first() {
         Some((path, bytes)) => {
-            let current = capture_optional_regular_file(path, "recorded corpus binding temporary")?
-                .ok_or_else(|| {
-                    SourceUnavailable::new(format!(
-                        "recorded corpus binding temporary {} disappeared before publication",
-                        path.display()
-                    ))
-                })?;
-            if current.as_slice() != bytes.as_slice() || current != expected {
+            let name = path.file_name().ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "recorded corpus binding temporary {} has no leaf name",
+                    path.display()
+                ))
+            })?;
+            guard.verify_owned_entry_bytes(
+                name,
+                bytes,
+                BINDING_CONTROL_MAX_BYTES,
+                "recorded corpus binding temporary",
+            )?;
+            if bytes.as_slice() != expected.as_slice() {
                 return Err(SourceUnavailable::new(format!(
                     "recorded corpus binding temporary {} changed before publication",
                     path.display()
                 )));
             }
-            path.clone()
+            name.to_os_string()
         }
-        None => create_binding_temporary(&root, &expected)?,
+        None => create_binding_temporary(guard, &expected)?,
     };
 
-    #[cfg(windows)]
-    if stable.is_some() {
-        std::fs::remove_file(&stable_path).map_err(SourceUnavailable::new)?;
-    }
-    std::fs::rename(&selected, &stable_path).map_err(|error| {
-        SourceUnavailable::new(format!(
-            "recorded corpus binding publication {} -> {} failed: {error}",
-            selected.display(),
-            stable_path.display()
-        ))
-    })?;
+    verify_publication_generation(
+        guard,
+        &provenance,
+        &resolved_meta,
+        &meta_bytes,
+        marker_bytes.as_deref(),
+        &records_generation,
+        &hidden_generation,
+    )?;
+
+    before_commit
+        .take()
+        .expect("publication hook is called exactly once")();
+
+    guard
+        .rename_owned_entry(&selected, OsStr::new(RECORDED_CORPUS_BINDING_FILE))
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus binding publication {selected:?} -> {} failed: {error}",
+                stable_path.display(),
+            ))
+        })?;
     for (path, bytes) in temporaries {
-        if path != selected {
-            remove_exact_binding_residue(&path, &bytes, "recorded corpus binding temporary")?;
+        if path.file_name() != Some(selected.as_os_str()) {
+            remove_exact_owned_binding_residue(
+                guard,
+                &path,
+                &bytes,
+                "recorded corpus binding temporary",
+            )?;
         }
     }
-    sync_binding_directory(&root)?;
-    let published = capture_optional_regular_file(
-        &stable_path,
+    guard.sync_owned_root()?;
+    guard.verify_owned_entry_bytes(
+        OsStr::new(RECORDED_CORPUS_BINDING_FILE),
+        &expected,
+        BINDING_CONTROL_MAX_BYTES,
         "published recorded corpus generation binding",
-    )?
-    .ok_or_else(|| {
-        SourceUnavailable::new(format!(
-            "published recorded corpus binding {} disappeared",
-            stable_path.display()
-        ))
-    })?;
-    if published != expected {
-        return Err(SourceUnavailable::new(format!(
-            "published recorded corpus binding {} does not match the intended current generation",
-            stable_path.display()
-        )));
-    }
+    )?;
+    verify_publication_generation(
+        guard,
+        &provenance,
+        &resolved_meta,
+        &meta_bytes,
+        marker_bytes.as_deref(),
+        &records_generation,
+        &hidden_generation,
+    )?;
     Ok(expected_cid)
 }
 
@@ -3753,6 +5910,47 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn producer_guard_absent_root_creation_stays_with_retained_parent() {
+        let parent = unique_root("producer-guard-parent-generation");
+        let replacement = unique_root("producer-guard-parent-replacement");
+        std::fs::create_dir_all(&parent).expect("original parent");
+        std::fs::create_dir_all(&replacement).expect("replacement template");
+        std::fs::write(replacement.join("sentinel"), b"untouched").expect("sentinel");
+        let root = parent.join("corpus");
+        let mut guard = RecordedCorpusProducerGuard::try_acquire(&root).expect("absent guard");
+        let displaced = parent.with_extension("displaced");
+
+        let error = guard
+            .ensure_root_with_hook(|| {
+                std::fs::rename(&parent, &displaced).expect("displace retained parent");
+                std::fs::rename(&replacement, &parent).expect("install replacement parent");
+            })
+            .expect_err("replacement parent cannot receive root creation");
+        assert!(
+            error.reason.contains("changed")
+                || error.reason.contains("cannot be inspected")
+                || error.reason.contains("No such file"),
+            "{error}"
+        );
+        assert!(
+            displaced.join("corpus").is_dir(),
+            "mkdirat creates only below the retained parent inode"
+        );
+        assert!(!parent.join("corpus").exists());
+        assert_eq!(
+            std::fs::read(parent.join("sentinel")).unwrap(),
+            b"untouched"
+        );
+
+        drop(guard);
+        std::fs::rename(&parent, &replacement).expect("restore replacement template");
+        std::fs::rename(&displaced, &parent).expect("restore original parent");
+        let _ = std::fs::remove_dir_all(parent);
+        let _ = std::fs::remove_dir_all(replacement);
+    }
+
     #[test]
     fn dense_generation_requires_and_roundtrips_canonical_binding() {
         let root = unique_root("dense-binding-roundtrip");
@@ -3794,6 +5992,310 @@ mod tests {
                 .expect("canonical bytes"),
             bytes
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn binding_shape_rejects_invalid_fixed_slots_before_recovery() {
+        let root = unique_root("binding-shape");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 19);
+        let _ = publish_compile_binding(&guard, &meta, &records);
+        let stable = root.join(RECORDED_CORPUS_BINDING_FILE);
+        let canonical = std::fs::read(&stable).expect("canonical binding");
+
+        let mut invalid: serde_json::Value = serde_json::from_slice(&canonical).unwrap();
+        invalid["records"]["blake3"] = serde_json::json!("blake3:NOT-A-DIGEST");
+        let mut invalid_bytes = serde_json::to_vec_pretty(&invalid).unwrap();
+        invalid_bytes.push(b'\n');
+        let error = parse_binding_bytes(&stable, &invalid_bytes)
+            .expect_err("digest syntax is structural, not recovery-time");
+        assert!(error.reason.contains("invalid typed"), "{error}");
+
+        let mut invalid: serde_json::Value = serde_json::from_slice(&canonical).unwrap();
+        invalid["hidden"]["name"] = serde_json::json!("wrong.hidden");
+        let mut invalid_bytes = serde_json::to_vec_pretty(&invalid).unwrap();
+        invalid_bytes.push(b'\n');
+        let error = parse_binding_bytes(&stable, &invalid_bytes)
+            .expect_err("hidden slot name is role-specific");
+        assert!(error.reason.contains("expected exact member"), "{error}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn binding_publication_rechecks_records_and_hidden_as_one_generation() {
+        let root = unique_root("binding-joint-generation");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 23);
+        let hidden = hidden_path(&records);
+        std::fs::write(&hidden, b"hidden generation B").expect("hidden B");
+        guard.begin_compile_attempt().expect("compile attempt");
+        let old_records = root.join("records-generation-a");
+        let error = publish_binding_with_hooks(
+            &guard,
+            &meta,
+            &records,
+            || {
+                std::fs::rename(&records, &old_records).expect("retain records A");
+                std::fs::write(&records, b"records generation B").expect("publish records B");
+            },
+            || {},
+        )
+        .expect_err("records A plus hidden B cannot commit");
+        assert!(error.reason.contains("changed generation"), "{error}");
+        assert!(!root.join(RECORDED_CORPUS_BINDING_FILE).exists());
+        assert!(binding_temporaries(&root).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn binding_publication_commit_cannot_be_redirected_after_last_check() {
+        let root = unique_root("binding-root-generation");
+        let wrong = unique_root("binding-wrong-root");
+        std::fs::create_dir_all(&wrong).expect("wrong root");
+        std::fs::write(wrong.join("sentinel"), b"untouched").expect("wrong sentinel");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 29);
+        guard.begin_compile_attempt().expect("compile attempt");
+        let displaced = root.with_extension("displaced");
+        let error = publish_binding_with_hooks(
+            &guard,
+            &meta,
+            &records,
+            || {},
+            || {
+                std::fs::rename(&root, &displaced).expect("displace guarded root");
+                std::os::unix::fs::symlink(&wrong, &root).expect("redirect root path");
+            },
+        )
+        .expect_err("replacement root cannot receive a commit");
+        assert!(
+            error.reason.contains("changed identity")
+                || error.reason.contains("real non-symlink directory"),
+            "{error}"
+        );
+        assert!(!root.join(RECORDED_CORPUS_BINDING_FILE).exists());
+        assert!(
+            displaced.join(RECORDED_CORPUS_BINDING_FILE).exists(),
+            "retained-dirfd commit stays with the guarded inode"
+        );
+        assert_eq!(std::fs::read(wrong.join("sentinel")).unwrap(), b"untouched");
+        assert_eq!(std::fs::read_dir(&wrong).unwrap().count(), 1);
+        std::fs::remove_file(&root).expect("remove redirect symlink");
+        std::fs::rename(&displaced, &root).expect("restore guarded root");
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(wrong);
+    }
+
+    #[test]
+    fn idempotent_binding_publication_rechecks_stable_bytes_after_hook() {
+        let root = unique_root("binding-idempotent-stable-recheck");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 31);
+        let _ = publish_compile_binding(&guard, &meta, &records);
+        let stable = root.join(RECORDED_CORPUS_BINDING_FILE);
+
+        let error = publish_binding_with_hooks(
+            &guard,
+            &meta,
+            &records,
+            || {},
+            || std::fs::write(&stable, b"conflicting stable binding").expect("replace stable"),
+        )
+        .expect_err("idempotent publication cannot bless replaced stable bytes");
+        assert!(
+            error.reason.contains("wrong type or length")
+                || error.reason.contains("changed content"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(&stable).unwrap(),
+            b"conflicting stable binding"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bounded_binding_control_refuses_oversize_residue_without_mutation() {
+        let root = unique_root("binding-control-cap");
+        let guard = producer_guard(&root);
+        let residue = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.91.7.writing"));
+        let bytes = vec![b'x'; BINDING_CONTROL_MAX_BYTES as usize + 1];
+        std::fs::write(&residue, &bytes).expect("oversize residue");
+        let error = guard
+            .preflight_publication_namespace()
+            .expect_err("oversize control residue is terminal");
+        assert!(error.reason.contains("schema cap"), "{error}");
+        assert_eq!(std::fs::read(&residue).unwrap(), bytes);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn reserved_residue_namespaces_have_fixed_aggregate_ceilings() {
+        let binding_root = unique_root("binding-residue-count-cap");
+        let binding_guard = producer_guard(&binding_root);
+        let mut binding_paths = Vec::new();
+        for sequence in 0..=RESERVED_RESIDUE_MAX_ENTRIES {
+            let path = binding_root.join(format!(
+                ".{RECORDED_CORPUS_BINDING_FILE}.901.{sequence}.writing"
+            ));
+            std::fs::write(&path, b"partial binding staging").expect("binding residue");
+            binding_paths.push(path);
+        }
+        let error = binding_guard
+            .preflight_publication_namespace()
+            .expect_err("binding residue count is bounded");
+        assert!(error.reason.contains("binding residue ceiling"), "{error}");
+        for path in &binding_paths {
+            assert_eq!(std::fs::read(path).unwrap(), b"partial binding staging");
+        }
+
+        let attempt_root = unique_root("attempt-residue-count-cap");
+        let attempt_guard = producer_guard(&attempt_root);
+        let mut attempt_paths = Vec::new();
+        for sequence in 0..=RESERVED_RESIDUE_MAX_ENTRIES {
+            let path = attempt_root.join(format!(
+                ".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.902.{sequence}.writing"
+            ));
+            std::fs::write(&path, b"partial attempt staging").expect("attempt residue");
+            attempt_paths.push(path);
+        }
+        let error = attempt_guard
+            .begin_compile_attempt()
+            .expect_err("compile-attempt residue count is bounded");
+        assert!(
+            error.reason.contains("compile-attempt residue ceiling"),
+            "{error}"
+        );
+        assert!(
+            !attempt_root
+                .join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists()
+        );
+        for path in &attempt_paths {
+            assert_eq!(std::fs::read(path).unwrap(), b"partial attempt staging");
+        }
+
+        let planned_root = unique_root("planned-residue-count-cap");
+        let planned_guard = producer_guard(&planned_root);
+        let mut planned_paths = Vec::new();
+        for sequence in 0..=RESERVED_RESIDUE_MAX_ENTRIES {
+            let path = planned_root.join(format!(
+                "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--903.{sequence}.writing",
+                PlannedOutputMember::Records.stable_name()
+            ));
+            std::fs::write(&path, b"partial planned staging").expect("planned residue");
+            planned_paths.push(path);
+        }
+        let error = planned_guard
+            .preflight_planned_output_scope(&[PlannedOutputMember::Records])
+            .expect_err("planned-output residue count is bounded");
+        assert!(
+            error.reason.contains("planned-output residue ceiling"),
+            "{error}"
+        );
+        for path in &planned_paths {
+            assert_eq!(std::fs::read(path).unwrap(), b"partial planned staging");
+        }
+
+        let reader_root = unique_root("binding-reader-first-temp");
+        std::fs::create_dir_all(&reader_root).expect("reader root");
+        let temporary = reader_root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.904.1.tmp"));
+        let file = std::fs::File::create(&temporary).expect("reader temporary");
+        file.set_len(1u64 << 40).expect("sparse reader temporary");
+        let error = require_no_binding_temporaries(&reader_root)
+            .expect_err("reader rejects the first temporary without reading its body");
+        assert!(
+            error.reason.contains("writer recovery is required"),
+            "{error}"
+        );
+        assert_eq!(std::fs::metadata(&temporary).unwrap().len(), 1u64 << 40);
+
+        let _ = std::fs::remove_dir_all(binding_root);
+        let _ = std::fs::remove_dir_all(attempt_root);
+        let _ = std::fs::remove_dir_all(planned_root);
+        let _ = std::fs::remove_dir_all(reader_root);
+    }
+
+    #[test]
+    fn final_control_rechecks_reject_oversize_post_capture_replacements() {
+        for (label, name, replacement_bytes) in [
+            (
+                "manifest",
+                observation::MANIFEST_FILE,
+                PROVENANCE_CONTROL_MAX_BYTES + 1,
+            ),
+            (
+                "attention",
+                ATTENTION_OPERATOR_BINDING_FILE,
+                PROVENANCE_CONTROL_MAX_BYTES + 1,
+            ),
+            (
+                "dense",
+                DENSE_OPERATOR_BINDING_FILE,
+                PROVENANCE_CONTROL_MAX_BYTES + 1,
+            ),
+            ("metadata", "corpus.meta", METADATA_CONTROL_MAX_BYTES + 1),
+            (
+                "binding",
+                RECORDED_CORPUS_BINDING_FILE,
+                BINDING_CONTROL_MAX_BYTES + 1,
+            ),
+            (
+                "marker",
+                RECORDED_CORPUS_COMPILE_ATTEMPT_FILE,
+                COMPILE_ATTEMPT_CONTROL_MAX_BYTES + 1,
+            ),
+        ] {
+            let root = unique_root(&format!("oversize-final-{label}"));
+            let guard = producer_guard(&root);
+            let (meta, records) = complete_source_corpus(&root, 73);
+            write_execution_pair(&root, 2);
+            let _ = publish_compile_binding(&guard, &meta, &records);
+            let snapshot = open_stream(&meta, &records).expect("open exact generation");
+            let replacement = vec![b'x'; replacement_bytes as usize];
+            std::fs::write(root.join(name), replacement).expect("oversize replacement");
+
+            let error = snapshot
+                .verify_generation()
+                .expect_err("oversize control replacement is terminal");
+            assert!(
+                error.reason.contains("appeared")
+                    || error.reason.contains("length")
+                    || error.reason.contains("generation"),
+                "{label}: {error}"
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn observation_role_rejects_non_utf8_planned_output_prefix() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = unique_root("observation-nonutf-planned");
+        let guard = producer_guard(&root);
+        let mut name = PLANNED_OUTPUT_RESERVED_PREFIX.as_bytes().to_vec();
+        name.extend_from_slice(b"corpus.records--12.3.writing");
+        name.push(0xff);
+        let residue = root.join(std::ffi::OsString::from_vec(name));
+        if let Err(error) = std::fs::write(&residue, b"partial") {
+            // APFS may reject non-UTF-8 directory entries at the VFS boundary;
+            // Linux permits them and exercises the classifier below.
+            if error.raw_os_error() == Some(92) {
+                let _ = std::fs::remove_dir_all(root);
+                return;
+            }
+            panic!("non-UTF-8 planned residue: {error}");
+        }
+        let error = guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect_err("observation role owns no planned-output residue");
+        assert!(error.reason.contains("non-UTF-8"), "{error}");
+        assert_eq!(std::fs::read(&residue).unwrap(), b"partial");
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -3912,6 +6414,92 @@ mod tests {
                 .binding_cid,
             Some(cid)
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_attempt_begin_commit_cannot_be_redirected_after_last_check() {
+        let root = unique_root("compile-attempt-begin-root-generation");
+        let wrong = unique_root("compile-attempt-begin-wrong-root");
+        std::fs::create_dir_all(&wrong).expect("wrong root");
+        std::fs::write(wrong.join("sentinel"), b"untouched").expect("wrong sentinel");
+        let guard = producer_guard(&root);
+        let displaced = root.with_extension("displaced");
+
+        let error = publish_compile_attempt_marker_with_hook(&guard, || {
+            std::fs::rename(&root, &displaced).expect("displace guarded root");
+            std::os::unix::fs::symlink(&wrong, &root).expect("redirect root path");
+        })
+        .expect_err("replacement root cannot receive the attempt marker");
+        assert!(
+            error.reason.contains("changed identity")
+                || error.reason.contains("real non-symlink directory"),
+            "{error}"
+        );
+        assert!(
+            displaced
+                .join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists(),
+            "retained-dirfd marker commit stays with the guarded inode"
+        );
+        assert_eq!(std::fs::read(wrong.join("sentinel")).unwrap(), b"untouched");
+        assert_eq!(std::fs::read_dir(&wrong).unwrap().count(), 1);
+
+        std::fs::remove_file(&root).expect("remove redirect symlink");
+        std::fs::rename(&displaced, &root).expect("restore guarded root");
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(wrong);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_attempt_finish_commit_cannot_be_redirected_after_last_check() {
+        let root = unique_root("compile-attempt-finish-root-generation");
+        let wrong = unique_root("compile-attempt-finish-wrong-root");
+        std::fs::create_dir_all(&wrong).expect("wrong root");
+        std::fs::write(wrong.join("sentinel"), b"untouched").expect("wrong sentinel");
+        let guard = producer_guard(&root);
+        guard.begin_compile_attempt().expect("begin attempt");
+        let displaced = root.with_extension("displaced");
+
+        let error = finish_compile_attempt_marker_with_hook(&guard, || {
+            std::fs::rename(&root, &displaced).expect("displace guarded root");
+            std::os::unix::fs::symlink(&wrong, &root).expect("redirect root path");
+        })
+        .expect_err("replacement root cannot receive marker cleanup");
+        assert!(
+            error.reason.contains("changed identity")
+                || error.reason.contains("real non-symlink directory"),
+            "{error}"
+        );
+        assert!(
+            !displaced
+                .join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+                .exists(),
+            "retained-dirfd marker cleanup stays with the guarded inode"
+        );
+        assert_eq!(std::fs::read(wrong.join("sentinel")).unwrap(), b"untouched");
+        assert_eq!(std::fs::read_dir(&wrong).unwrap().count(), 1);
+
+        std::fs::remove_file(&root).expect("remove redirect symlink");
+        std::fs::rename(&displaced, &root).expect("restore guarded root");
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(wrong);
+    }
+
+    #[test]
+    fn finish_compile_attempt_requires_binding_for_exact_current_members() {
+        let root = unique_root("finish-exact-current");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 31);
+        let _ = publish_compile_binding(&guard, &meta, &records);
+        std::fs::write(&records, b"different current records").expect("advance records");
+        let error = guard
+            .finish_compile_attempt()
+            .expect_err("stale stable binding cannot finish current attempt");
+        assert!(error.reason.contains("exact planned generation"), "{error}");
+        assert!(root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE).exists());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -4069,6 +6657,45 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn planned_output_recovery_cannot_be_redirected_after_last_check() {
+        let root = unique_root("planned-output-recovery-root-generation");
+        let wrong = unique_root("planned-output-recovery-wrong-root");
+        std::fs::create_dir_all(&wrong).expect("wrong root");
+        std::fs::write(wrong.join("sentinel"), b"untouched").expect("wrong sentinel");
+        let guard = producer_guard(&root);
+        let residue_name = format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.77.writing",
+            PlannedOutputMember::Records.stable_name()
+        );
+        std::fs::write(root.join(&residue_name), b"partial records").expect("residue");
+        let displaced = root.with_extension("displaced");
+
+        let error = guard
+            .reclaim_planned_output_residues_with_hook(PlannedOutputMember::Records, || {
+                std::fs::rename(&root, &displaced).expect("displace guarded root");
+                std::os::unix::fs::symlink(&wrong, &root).expect("redirect root path");
+            })
+            .expect_err("replacement root cannot receive residue cleanup");
+        assert!(
+            error.reason.contains("changed identity")
+                || error.reason.contains("real non-symlink directory"),
+            "{error}"
+        );
+        assert!(
+            !displaced.join(&residue_name).exists(),
+            "retained-dirfd cleanup unlinks only from the guarded inode"
+        );
+        assert_eq!(std::fs::read(wrong.join("sentinel")).unwrap(), b"untouched");
+        assert_eq!(std::fs::read_dir(&wrong).unwrap().count(), 1);
+
+        std::fs::remove_file(&root).expect("remove redirect symlink");
+        std::fs::rename(&displaced, &root).expect("restore guarded root");
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(wrong);
     }
 
     #[cfg(unix)]
@@ -4347,7 +6974,10 @@ mod tests {
         )
         .expect_err("provenance A cannot label corpus B");
         assert!(
-            error.reason.contains("changed after capture"),
+            error.reason.contains("changed after capture")
+                || error
+                    .reason
+                    .contains("changed identity, type, or length after capture"),
             "unexpected error: {error}"
         );
 
@@ -4467,5 +7097,892 @@ mod tests {
         ] {
             let _ = std::fs::remove_dir_all(root);
         }
+    }
+
+    #[test]
+    fn open_stream_rewinds_retained_records_and_hidden_handles() {
+        let root = unique_root("open-stream-rewind");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 41);
+        let hidden_path = hidden_path(&records);
+        let hidden_bytes = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        std::fs::write(&hidden_path, hidden_bytes).expect("hidden rows");
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+
+        let expected_records = std::fs::read(&records).expect("expected records");
+        let mut stream = open_stream_under_guard(&guard, &meta, &records).expect("open stream");
+        let mut captured_records = Vec::new();
+        stream
+            .records
+            .read_to_end(&mut captured_records)
+            .expect("read records from offset zero");
+        let mut captured_hidden = Vec::new();
+        stream
+            .hidden
+            .as_mut()
+            .expect("hidden handle")
+            .read_to_end(&mut captured_hidden)
+            .expect("read hidden from offset zero");
+        assert_eq!(captured_records, expected_records);
+        assert_eq!(captured_hidden, hidden_bytes);
+        stream.verify_generation().expect("final generation");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn verified_member_read_and_end_seek_remain_bounded_after_append() {
+        let root = unique_root("open-stream-bounded-live-eof");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 41);
+        let expected = std::fs::read(&records).expect("initial records");
+        let mut stream = open_stream_under_guard(&guard, &meta, &records).expect("open stream");
+
+        let mut append = OpenOptions::new()
+            .append(true)
+            .open(&records)
+            .expect("append handle");
+        append
+            .write_all(b"bytes beyond the committed generation")
+            .expect("append records");
+        append.sync_all().expect("sync append");
+
+        assert_eq!(
+            stream
+                .records
+                .seek(SeekFrom::End(0))
+                .expect("bounded logical end"),
+            expected.len() as u64
+        );
+        stream
+            .records
+            .seek(SeekFrom::Start(0))
+            .expect("rewind bounded member");
+        let mut captured = Vec::new();
+        stream
+            .records
+            .read_to_end(&mut captured)
+            .expect("bounded read to end");
+        assert_eq!(
+            captured, expected,
+            "live append is outside the bounded view"
+        );
+        let error = stream
+            .verify_generation()
+            .expect_err("final generation check still rejects the append");
+        assert!(error.reason.contains("changed generation"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn verified_member_hashing_is_bounded_to_the_initial_length() {
+        let root = unique_root("open-stream-initial-length");
+        let (_meta, records) = complete_source_corpus(&root, 42);
+        let error = open_verified_corpus_member_with_hook(
+            &records,
+            "corpus.records",
+            "recorded corpus records",
+            None,
+            || {
+                let mut file = OpenOptions::new()
+                    .append(true)
+                    .open(&records)
+                    .expect("append records");
+                file.write_all(b"growth after metadata")
+                    .expect("append growth");
+                file.sync_all().expect("sync growth");
+            },
+        )
+        .expect_err("post-metadata growth cannot extend the hashed generation");
+        assert!(error.reason.contains("grew beyond its initial"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn verified_member_rejects_binding_presence_and_length_before_hashing() {
+        let root = unique_root("open-stream-prehash-binding-shape");
+        std::fs::create_dir_all(&root).expect("root");
+        let records = root.join("corpus.records");
+        std::fs::write(&records, b"present").expect("records");
+
+        let absent =
+            RecordedCorpusFileBinding::from_bytes("corpus.records", None).expect("absent binding");
+        let entered = std::cell::Cell::new(false);
+        let error = open_verified_corpus_member_with_hook(
+            &records,
+            "corpus.records",
+            "recorded corpus records",
+            Some(&absent),
+            || entered.set(true),
+        )
+        .expect_err("declared absence rejects a present file before hashing");
+        assert!(error.reason.contains("declares it absent"), "{error}");
+        assert!(!entered.get(), "declared-absence mismatch entered hashing");
+
+        let expected = RecordedCorpusFileBinding::from_bytes("corpus.records", Some(b"small"))
+            .expect("small binding");
+        let sparse = OpenOptions::new()
+            .write(true)
+            .open(&records)
+            .expect("sparse records");
+        sparse.set_len(1u64 << 40).expect("sparse oversized file");
+        sparse.sync_all().expect("sync sparse length");
+        let entered = std::cell::Cell::new(false);
+        let error = open_verified_corpus_member_with_hook(
+            &records,
+            "corpus.records",
+            "recorded corpus records",
+            Some(&expected),
+            || entered.set(true),
+        )
+        .expect_err("declared length rejects an oversized sparse file before hashing");
+        assert!(error.reason.contains("before body hashing"), "{error}");
+        assert!(!entered.get(), "length mismatch entered hashing");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn open_stream_final_check_covers_every_member_and_typed_hidden_absence() {
+        fn assert_change_rejected<F>(label: &str, with_hidden: bool, mutate: F)
+        where
+            F: FnOnce(&Path, &Path, &Path),
+        {
+            let root = unique_root(label);
+            let guard = producer_guard(&root);
+            let (meta, records) = complete_source_corpus(&root, 43);
+            let hidden = hidden_path(&records);
+            if with_hidden {
+                std::fs::write(&hidden, b"initial hidden").expect("initial hidden");
+            }
+            write_execution_pair(&root, 2);
+            publish_compile_binding(&guard, &meta, &records);
+            let stream = open_stream_under_guard(&guard, &meta, &records).expect("open stream");
+            mutate(&root, &meta, &records);
+            let error = stream
+                .verify_generation()
+                .expect_err("changed member must invalidate stream");
+            assert!(
+                error.reason.contains("changed")
+                    || error.reason.contains("appeared")
+                    || error.reason.contains("after capture"),
+                "{label}: {error}"
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+
+        assert_change_rejected("stream-records-change", false, |_, _, records| {
+            std::fs::write(records, b"changed records").expect("change records");
+        });
+        assert_change_rejected("stream-meta-change", false, |_, meta, _| {
+            std::fs::write(meta, b"changed metadata").expect("change metadata");
+        });
+        assert_change_rejected("stream-hidden-change", true, |_, _, records| {
+            std::fs::write(hidden_path(records), b"changed hidden").expect("change hidden");
+        });
+        assert_change_rejected("stream-hidden-appearance", false, |_, _, records| {
+            std::fs::write(hidden_path(records), b"appeared hidden").expect("add hidden");
+        });
+        assert_change_rejected("stream-provenance-change", false, |root, _, _| {
+            write_operator(
+                &root.join(ATTENTION_OPERATOR_BINDING_FILE),
+                &AttentionOperatorSpec::learned_absolute_v1(),
+            );
+        });
+        assert_change_rejected("stream-binding-change", false, |root, _, _| {
+            std::fs::write(root.join(RECORDED_CORPUS_BINDING_FILE), b"changed binding")
+                .expect("change binding");
+        });
+        assert_change_rejected("stream-marker-change", false, |root, _, _| {
+            std::fs::write(
+                root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE),
+                b"changed marker",
+            )
+            .expect("change marker");
+        });
+    }
+
+    #[test]
+    fn open_stream_hashes_sparse_hidden_without_materializing_its_body() {
+        let root = unique_root("open-stream-sparse-hidden");
+        let guard = producer_guard(&root);
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        let rows = 4_096u64;
+        let mut meta_bytes = [0u8; 25];
+        meta_bytes[0..8].copy_from_slice(&rows.to_le_bytes());
+        meta_bytes[8..16].copy_from_slice(&8u64.to_le_bytes());
+        meta_bytes[16..24].copy_from_slice(&7u64.to_le_bytes());
+        meta_bytes[24] = 1;
+        std::fs::write(&meta, meta_bytes).expect("metadata");
+        let records_file = std::fs::File::create(&records).expect("records file");
+        records_file.set_len(rows * 88).expect("sparse records");
+        let hidden = hidden_path(&records);
+        let hidden_file = std::fs::File::create(&hidden).expect("hidden file");
+        let hidden_len = rows * 4_096;
+        hidden_file.set_len(hidden_len).expect("sparse hidden");
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+
+        let mut stream = open_stream_under_guard(&guard, &meta, &records).expect("bounded stream");
+        assert_eq!(stream.records.len(), rows * 88);
+        assert_eq!(stream.hidden.as_ref().expect("hidden").len(), hidden_len);
+        assert_eq!(stream.meta_bytes, meta_bytes);
+        let (records_bytes, compiler_hidden) = stream
+            .materialize_compiler_corpus_bytes()
+            .expect("materialize compiler inputs");
+        assert_eq!(records_bytes.len() as u64, rows * 88);
+        assert!(
+            compiler_hidden.is_none(),
+            "opaque non-D hidden rows stay stream-only"
+        );
+        stream
+            .verify_generation()
+            .expect("stable sparse generation");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn identity_reader_is_non_mutating_for_markerless_archives_and_busy_for_writers() {
+        let container = unique_root("identity-reader-container");
+        let root = container.join("archive");
+        let (meta, records) = complete_source_corpus(&root, 47);
+        write_operator(
+            &root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        let coordination = container.join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+        assert!(!coordination.exists());
+        let identity = execution_identity(&meta, &records).expect("markerless identity");
+        assert_eq!(
+            identity.attention_operator,
+            Some(AttentionOperatorSpec::learned_absolute_v2())
+        );
+        assert_eq!(identity.dense_operator, None);
+        assert!(
+            !coordination.exists(),
+            "read-only identity resolution cannot create coordination state"
+        );
+
+        let producer = RecordedCorpusProducerGuard::try_acquire(&root).expect("producer");
+        let busy = execution_identity(&meta, &records).expect_err("writer excludes reader");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        drop(producer);
+        execution_identity(&meta, &records).expect("reader after writer drop");
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn derivation_reader_locks_only_markerless_sources() {
+        let markerless = unique_root("derivation-reader-markerless");
+        let (meta, records) = complete_source_corpus(&markerless, 59);
+        write_operator(
+            &markerless.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        let (snapshot, source_guard) =
+            open_stream_for_derivation(&meta, &records).expect("markerless derivation");
+        assert!(source_guard.is_some(), "markerless source needs ownership");
+        let busy = RecordedCorpusProducerGuard::try_acquire(&markerless)
+            .expect_err("retained markerless guard excludes writers");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        snapshot.verify_generation().expect("markerless generation");
+        drop(source_guard);
+
+        let bound = unique_root("derivation-reader-bound");
+        let guard = producer_guard(&bound);
+        let (meta, records) = complete_source_corpus(&bound, 61);
+        write_execution_pair(&bound, 2);
+        publish_compile_binding(&guard, &meta, &records);
+        drop(guard);
+        let (snapshot, source_guard) =
+            open_stream_for_derivation(&meta, &records).expect("bound derivation");
+        assert!(
+            source_guard.is_none(),
+            "binding commits the bound generation"
+        );
+        snapshot.verify_generation().expect("bound generation");
+
+        let _ = std::fs::remove_dir_all(markerless);
+        let _ = std::fs::remove_dir_all(bound);
+    }
+
+    #[test]
+    fn ready_deterministic_inventory_allows_only_real_graph_directories() {
+        let root = unique_root("ready-deterministic-inventory");
+        let guard = producer_guard(&root);
+        let _ = complete_source_corpus(&root, 67);
+        std::fs::create_dir(root.join("graph")).expect("graph directory");
+        std::fs::create_dir(root.join("graph-cover")).expect("cover directory");
+        guard
+            .preflight_ready_deterministic_compile_inventory(&[
+                PlannedOutputMember::Records,
+                PlannedOutputMember::Metadata,
+            ])
+            .expect("exact ready generation may retain downstream graph directories");
+
+        let foreign = root.join("compile_report.json");
+        std::fs::write(&foreign, b"foreign").expect("foreign report");
+        let error = guard
+            .preflight_ready_deterministic_compile_inventory(&[
+                PlannedOutputMember::Records,
+                PlannedOutputMember::Metadata,
+            ])
+            .expect_err("foreign root report is terminal even on a ready generation");
+        assert!(error.reason.contains("unowned"), "{error}");
+        assert_eq!(std::fs::read(&foreign).unwrap(), b"foreign");
+        std::fs::remove_file(&foreign).expect("remove foreign report");
+
+        std::fs::remove_dir(root.join("graph")).expect("remove graph directory");
+        std::fs::write(root.join("graph"), b"not a directory").expect("graph file");
+        let error = guard
+            .preflight_ready_deterministic_compile_inventory(&[
+                PlannedOutputMember::Records,
+                PlannedOutputMember::Metadata,
+            ])
+            .expect_err("ready graph name must be a real directory");
+        assert!(
+            error.reason.contains("not a real non-symlink directory"),
+            "{error}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn producer_handoff_sorts_full_selection_failure_atomically_and_contends() {
+        let container = unique_root("producer-handoff-selection");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("z-conventional");
+        let current = container.join("m-current");
+        let composite = container.join("b-composite");
+        let stage = container.join("a-stage");
+        for root in [&conventional, &current, &composite, &stage] {
+            std::fs::create_dir(root).expect("selection root");
+        }
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&conventional).expect("conventional"),
+            RecordedCorpusRootGeneration::capture(&current).expect("current"),
+            RecordedCorpusRootGeneration::capture(&composite).expect("composite"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage"),
+            RecordedCorpusRootGeneration::capture(&current).expect("current alias"),
+        ];
+
+        let blocker = RecordedCorpusProducerGuard::try_acquire(&conventional).expect("blocker");
+        let busy = RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3)
+            .expect_err("last sorted root blocks the complete acquisition");
+        assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        for root in [&stage, &composite, &current] {
+            let probe = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("earlier sorted acquisition was released on failure");
+            drop(probe);
+        }
+        drop(blocker);
+
+        let handoff =
+            RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3).expect("complete handoff");
+        let guarded = handoff
+            .guards()
+            .map(|guard| guard.root().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            guarded,
+            vec![
+                expected[3].root().to_owned(),
+                expected[2].root().to_owned(),
+                expected[1].root().to_owned(),
+                expected[0].root().to_owned(),
+            ]
+        );
+        assert_eq!(handoff.final_guard().root(), expected[1].root());
+        assert_eq!(handoff.stage_guard().root(), expected[3].root());
+        for root in [&conventional, &current, &composite, &stage] {
+            let busy = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect_err("handoff excludes an independent producer");
+            assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        }
+        drop(handoff);
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn producer_handoff_root_ceiling_counts_unique_and_duplicate_entries_before_locking() {
+        let unique_container = unique_root("producer-handoff-root-ceiling-unique");
+        std::fs::create_dir_all(&unique_container).expect("unique container");
+        let unique_roots = (0..=RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES)
+            .map(|index| unique_container.join(format!("root-{index:02}")))
+            .collect::<Vec<_>>();
+        for root in &unique_roots {
+            std::fs::create_dir(root).expect("unique root");
+        }
+        let unique_generations = unique_roots
+            .iter()
+            .map(RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("unique generations");
+        let error = RecordedCorpusProducerHandoff::try_acquire(&unique_generations, 0, 1)
+            .expect_err("unique over-limit handoff must fail closed");
+        assert!(
+            error.reason.contains("fixed 16-entry logical-root ceiling"),
+            "{error}"
+        );
+        assert!(
+            !unique_container
+                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
+                .exists(),
+            "over-limit handoff cannot create or retain coordination state"
+        );
+        for root in &unique_roots {
+            let probe = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("over-limit handoff retained no unique-root lock");
+            drop(probe);
+        }
+        drop(unique_generations);
+        let _ = std::fs::remove_dir_all(unique_container);
+
+        let duplicate_container = unique_root("producer-handoff-root-ceiling-duplicate");
+        std::fs::create_dir_all(&duplicate_container).expect("duplicate container");
+        let duplicate_root = duplicate_container.join("root");
+        std::fs::create_dir(&duplicate_root).expect("duplicate root");
+        let duplicate_generations = (0..=RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES)
+            .map(|_| RecordedCorpusRootGeneration::capture(&duplicate_root))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("duplicate generations");
+        let error = RecordedCorpusProducerHandoff::try_acquire(&duplicate_generations, 0, 1)
+            .expect_err("duplicates cannot bypass the raw handoff ceiling");
+        assert!(
+            error.reason.contains("fixed 16-entry logical-root ceiling"),
+            "{error}"
+        );
+        assert!(
+            !duplicate_container
+                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
+                .exists(),
+            "duplicate over-limit handoff cannot acquire a lock"
+        );
+        let probe = RecordedCorpusProducerGuard::try_acquire(&duplicate_root)
+            .expect("duplicate over-limit handoff retained no lock");
+        drop(probe);
+        drop(duplicate_generations);
+        let _ = std::fs::remove_dir_all(duplicate_container);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+    #[test]
+    fn producer_handoff_promotes_into_absent_final_and_adopts_inode() {
+        let container = unique_root("producer-handoff-absent-final");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("conventional");
+        let final_root = container.join("current");
+        let composite = container.join("composite");
+        let stage = container.join("stage");
+        for root in [&conventional, &composite, &stage] {
+            std::fs::create_dir(root).expect("selection root");
+        }
+        std::fs::write(stage.join("sentinel"), b"promoted").expect("stage sentinel");
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&conventional).expect("conventional"),
+            RecordedCorpusRootGeneration::capture(&final_root).expect("absent final"),
+            RecordedCorpusRootGeneration::capture(&composite).expect("composite"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage"),
+        ];
+        assert!(!expected[1].exists());
+
+        let mut handoff =
+            RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3).expect("complete handoff");
+        handoff.promote_stage().expect("no-replace promotion");
+        assert_eq!(
+            std::fs::read(final_root.join("sentinel")).unwrap(),
+            b"promoted"
+        );
+        assert!(!stage.exists(), "typed-absent final leaves stage absent");
+        handoff
+            .verify()
+            .expect("adopted post-promotion generations");
+        handoff
+            .final_guard()
+            .verify_owned_root()
+            .expect("final guard adopted promoted inode");
+        let busy = RecordedCorpusProducerGuard::try_acquire(&final_root)
+            .expect_err("adopted final ownership remains exclusive");
+        assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        drop(handoff);
+        let probe = RecordedCorpusProducerGuard::try_acquire(&final_root)
+            .expect("final becomes available after handoff drop");
+        drop(probe);
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+    #[test]
+    fn producer_handoff_exchanges_existing_roots_and_rebinds_both_guards() {
+        let container = unique_root("producer-handoff-exchange");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("conventional");
+        let final_root = container.join("current");
+        let composite = container.join("composite");
+        let stage = container.join("stage");
+        for root in [&conventional, &final_root, &composite, &stage] {
+            std::fs::create_dir(root).expect("selection root");
+        }
+        std::fs::write(final_root.join("sentinel"), b"old-final").expect("old final");
+        std::fs::write(stage.join("sentinel"), b"new-stage").expect("new stage");
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&conventional).expect("conventional"),
+            RecordedCorpusRootGeneration::capture(&final_root).expect("final"),
+            RecordedCorpusRootGeneration::capture(&composite).expect("composite"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage"),
+        ];
+
+        let mut handoff =
+            RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3).expect("complete handoff");
+        handoff.promote_stage().expect("atomic exchange");
+        assert_eq!(
+            std::fs::read(final_root.join("sentinel")).unwrap(),
+            b"new-stage"
+        );
+        assert_eq!(std::fs::read(stage.join("sentinel")).unwrap(), b"old-final");
+        handoff.verify().expect("exchanged generations adopted");
+        handoff
+            .final_guard()
+            .verify_owned_root()
+            .expect("final guard rebound");
+        handoff
+            .stage_guard()
+            .verify_owned_root()
+            .expect("stage guard rebound");
+        let repeated = handoff
+            .promote_stage()
+            .expect_err("one handoff cannot promote twice");
+        assert!(repeated.reason.contains("already promoted"), "{repeated}");
+        drop(handoff);
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+    #[test]
+    fn producer_handoff_cas_rechecks_non_designated_selection_root_before_exchange() {
+        let container = unique_root("producer-handoff-selection-cas");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("conventional");
+        let final_root = container.join("current");
+        let composite = container.join("composite");
+        let stage = container.join("stage");
+        for root in [&conventional, &final_root, &composite, &stage] {
+            std::fs::create_dir(root).expect("selection root");
+        }
+        std::fs::write(final_root.join("sentinel"), b"old-final").expect("old final");
+        std::fs::write(stage.join("sentinel"), b"new-stage").expect("new stage");
+        std::fs::write(composite.join("sentinel"), b"selected-old").expect("selected old");
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&conventional).expect("conventional"),
+            RecordedCorpusRootGeneration::capture(&final_root).expect("final"),
+            RecordedCorpusRootGeneration::capture(&composite).expect("composite"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage"),
+        ];
+        let displaced = container.join("displaced-composite");
+        let mut handoff =
+            RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3).expect("complete handoff");
+        let conflict = handoff
+            .promote_stage_with_hook(|_| {
+                std::fs::rename(&composite, &displaced).expect("replace selected root");
+                std::fs::create_dir(&composite).expect("replacement selected root");
+                std::fs::write(composite.join("sentinel"), b"selected-new")
+                    .expect("replacement sentinel");
+                Ok(())
+            })
+            .expect_err("selection replacement must fail the final CAS");
+        assert!(
+            conflict.reason.contains("changed identity")
+                || conflict.reason.contains("changed generation"),
+            "{conflict}"
+        );
+        assert_eq!(
+            std::fs::read(final_root.join("sentinel")).unwrap(),
+            b"old-final"
+        );
+        assert_eq!(std::fs::read(stage.join("sentinel")).unwrap(), b"new-stage");
+        assert_eq!(
+            std::fs::read(composite.join("sentinel")).unwrap(),
+            b"selected-new"
+        );
+        drop(handoff);
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn producer_handoff_rejects_a_preexisting_generation_conflict_without_mutation() {
+        let container = unique_root("producer-handoff-initial-cas");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("conventional");
+        let final_root = container.join("current");
+        let composite = container.join("composite");
+        let stage = container.join("stage");
+        for root in [&conventional, &final_root, &composite, &stage] {
+            std::fs::create_dir(root).expect("selection root");
+        }
+        std::fs::write(final_root.join("sentinel"), b"old-final").expect("old final");
+        std::fs::write(stage.join("sentinel"), b"new-stage").expect("new stage");
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&conventional).expect("conventional"),
+            RecordedCorpusRootGeneration::capture(&final_root).expect("final"),
+            RecordedCorpusRootGeneration::capture(&composite).expect("composite"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage"),
+        ];
+        let displaced = container.join("displaced-conventional");
+        std::fs::rename(&conventional, &displaced).expect("displace conventional");
+        std::fs::create_dir(&conventional).expect("replacement conventional");
+
+        let conflict = RecordedCorpusProducerHandoff::try_acquire(&expected, 1, 3)
+            .expect_err("stale root witness is terminal");
+        assert!(
+            conflict.reason.contains("changed identity")
+                || conflict.reason.contains("changed generation"),
+            "{conflict}"
+        );
+        assert_eq!(
+            std::fs::read(final_root.join("sentinel")).unwrap(),
+            b"old-final"
+        );
+        assert_eq!(std::fs::read(stage.join("sentinel")).unwrap(), b"new-stage");
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+    #[test]
+    fn producer_handoff_content_predicate_refuses_same_directory_commit() {
+        let container = unique_root("producer-handoff-content-cas");
+        std::fs::create_dir_all(&container).expect("container");
+        let final_root = container.join("current");
+        let stage = container.join("stage");
+        std::fs::create_dir(&final_root).expect("final root");
+        std::fs::create_dir(&stage).expect("stage root");
+        std::fs::write(final_root.join("binding"), b"generation-a").expect("base A");
+        std::fs::write(stage.join("binding"), b"generation-stage").expect("stage");
+        let expected = vec![
+            RecordedCorpusRootGeneration::capture(&final_root).expect("final witness"),
+            RecordedCorpusRootGeneration::capture(&stage).expect("stage witness"),
+        ];
+        // A cooperating writer committed B in-place during the long build;
+        // the directory inode is intentionally unchanged.
+        std::fs::write(final_root.join("binding"), b"generation-b").expect("commit B");
+        let mut handoff =
+            RecordedCorpusProducerHandoff::try_acquire(&expected, 0, 1).expect("inode handoff");
+        let error = handoff
+            .promote_stage_if(|_| {
+                if std::fs::read(final_root.join("binding")).unwrap() != b"generation-a" {
+                    return Err(SourceUnavailable::new(
+                        "typed selection content changed from generation A",
+                    ));
+                }
+                Ok(())
+            })
+            .expect_err("content predicate must preserve B");
+        assert!(error.reason.contains("content changed"), "{error}");
+        assert_eq!(
+            std::fs::read(final_root.join("binding")).unwrap(),
+            b"generation-b"
+        );
+        assert_eq!(
+            std::fs::read(stage.join("binding")).unwrap(),
+            b"generation-stage"
+        );
+        drop(handoff);
+        drop(expected);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reader_pins_cover_absence_read_only_parents_shared_locks_and_busy() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let container = unique_root("reader-pins");
+        std::fs::create_dir_all(&container).expect("container");
+        let existing = container.join("z-existing");
+        let absent = container.join("a-absent");
+        std::fs::create_dir(&existing).expect("existing root");
+
+        let existing_seed =
+            RecordedCorpusProducerGuard::try_acquire(&existing).expect("seed existing lock");
+        drop(existing_seed);
+        let absent_seed =
+            RecordedCorpusProducerGuard::try_acquire(&absent).expect("seed absent lock");
+        drop(absent_seed);
+        std::fs::set_permissions(&container, std::fs::Permissions::from_mode(0o555))
+            .expect("read-only parent");
+
+        let pins = RecordedCorpusReaderPins::try_acquire([&existing, &absent])
+            .expect("read-only multi-root pins");
+        let generations = pins.generations().collect::<Vec<_>>();
+        assert_eq!(generations[0].root().file_name(), absent.file_name());
+        assert!(!generations[0].exists());
+        assert_eq!(generations[1].root().file_name(), existing.file_name());
+        assert!(generations[1].exists());
+        pins.verify().expect("stable pinned generations");
+        let second = RecordedCorpusReaderPins::try_acquire([&absent, &existing])
+            .expect("shared pins coexist");
+        for root in [&absent, &existing] {
+            let busy = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect_err("shared pin excludes producer");
+            assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        }
+        drop(second);
+        drop(pins);
+        std::fs::set_permissions(&container, std::fs::Permissions::from_mode(0o755))
+            .expect("restore parent");
+
+        let producer =
+            RecordedCorpusProducerGuard::try_acquire(&existing).expect("active producer");
+        let busy = RecordedCorpusReaderPins::try_acquire([&existing, &absent])
+            .expect_err("producer excludes complete shared-pin acquisition");
+        assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        let absent_probe = RecordedCorpusProducerGuard::try_acquire(&absent)
+            .expect("earlier shared pin released on later-root failure");
+        drop(absent_probe);
+        drop(producer);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn reader_pin_mode_root_ceilings_reject_duplicates_and_unique_roots_without_locks() {
+        let duplicate_container = unique_root("reader-pin-root-ceiling-duplicate");
+        std::fs::create_dir_all(&duplicate_container).expect("duplicate container");
+        let duplicate_root = duplicate_container.join("root");
+        std::fs::create_dir(&duplicate_root).expect("duplicate root");
+        let duplicate_roots =
+            vec![duplicate_root.clone(); RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES + 1];
+        let error = RecordedCorpusReaderPins::try_acquire(&duplicate_roots)
+            .expect_err("duplicates cannot bypass the read-only reader-pin ceiling");
+        assert!(
+            error.reason.contains("fixed 16-entry logical-root ceiling"),
+            "{error}"
+        );
+        assert!(
+            !duplicate_container
+                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
+                .exists(),
+            "reader ceiling is checked before coordination capture"
+        );
+        let probe = RecordedCorpusProducerGuard::try_acquire(&duplicate_root)
+            .expect("read-only over-limit pins retained no lock");
+        drop(probe);
+        let _ = std::fs::remove_dir_all(duplicate_container);
+
+        let unique_container = unique_root("managed-reader-pin-root-ceiling-unique");
+        std::fs::create_dir_all(&unique_container).expect("unique container");
+        let unique_roots = (0..=RECORDED_CORPUS_MULTI_ROOT_MAX_ENTRIES)
+            .map(|index| unique_container.join(format!("absent-{index:02}")))
+            .collect::<Vec<_>>();
+        let error = RecordedCorpusReaderPins::try_acquire_managed(&unique_roots)
+            .expect_err("unique over-limit managed pins must fail closed");
+        assert!(
+            error.reason.contains("fixed 16-entry logical-root ceiling"),
+            "{error}"
+        );
+        assert!(
+            !unique_container
+                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
+                .exists(),
+            "managed ceiling is checked before generation capture or lock seeding"
+        );
+        for root in &unique_roots {
+            let probe = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("managed over-limit pins retained no unique-root lock");
+            drop(probe);
+        }
+        let _ = std::fs::remove_dir_all(unique_container);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_reader_pins_seed_unseen_absent_roots_without_an_unlock_gap() {
+        let container = unique_root("managed-reader-pins-absent");
+        std::fs::create_dir_all(&container).expect("container");
+        let conventional = container.join("conventional");
+        let current = container.join("current");
+        let composite = container.join("composite");
+        std::fs::create_dir(&conventional).expect("existing conventional root");
+
+        let pins =
+            RecordedCorpusReaderPins::try_acquire_managed([&conventional, &current, &composite])
+                .expect("managed pins seed all three lock inodes");
+        assert!(!current.exists());
+        assert!(!composite.exists());
+        for root in [&conventional, &current, &composite] {
+            let busy = RecordedCorpusProducerGuard::try_acquire(root)
+                .expect_err("managed shared pin excludes every producer");
+            assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        }
+        pins.verify().expect("managed pins remain exact");
+        drop(pins);
+        let writer = RecordedCorpusProducerGuard::try_acquire(&composite)
+            .expect("producer proceeds after managed pins drop");
+        drop(writer);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[test]
+    fn retained_authority_stream_and_identity_helpers_avoid_self_busy() {
+        let container = unique_root("retained-authority-helpers");
+        let root = container.join("corpus");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 71);
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+        guard
+            .finish_compile_attempt()
+            .expect("finish compile attempt");
+
+        let identity = execution_identity_under_producer_guard(&guard, &meta, &records)
+            .expect("identity under producer authority");
+        assert_eq!(identity.dense_operator, Some(DenseOperatorSpec::gpt2_v2()));
+        let busy = execution_identity(&meta, &records).expect_err("nested reader self-contends");
+        assert!(is_recorded_corpus_busy(&busy), "{busy}");
+        drop(guard);
+
+        let pins = RecordedCorpusReaderPins::try_acquire([&root]).expect("reader pins");
+        let stream = open_stream_under_reader_pins(&pins, &meta, &records)
+            .expect("stream under retained pins");
+        stream.verify_generation().expect("stream generation");
+        let identity = execution_identity_under_reader_pins(&pins, &meta, &records)
+            .expect("identity under retained pins");
+        assert_eq!(identity.dense_operator, Some(DenseOperatorSpec::gpt2_v2()));
+        pins.verify().expect("reader authority remains valid");
+        drop(pins);
+        let _ = std::fs::remove_dir_all(container);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reader_accepts_a_read_only_existing_archive() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let container = unique_root("identity-reader-read-only");
+        let root = container.join("archive");
+        let (meta, records) = complete_source_corpus(&root, 53);
+        write_operator(
+            &root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o555))
+            .expect("read-only root");
+        std::fs::set_permissions(&container, std::fs::Permissions::from_mode(0o555))
+            .expect("read-only parent");
+        let identity = execution_identity(&meta, &records).expect("read-only identity");
+        assert_eq!(
+            identity.attention_operator,
+            Some(AttentionOperatorSpec::learned_absolute_v2())
+        );
+        std::fs::set_permissions(&container, std::fs::Permissions::from_mode(0o755))
+            .expect("restore parent");
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755))
+            .expect("restore root");
+        let _ = std::fs::remove_dir_all(container);
     }
 }

--- a/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
+++ b/crates/uor-r4-graph-compiler/src/recorded_corpus.rs
@@ -1,0 +1,4471 @@
+//! One coherent, no-following capture of a recorded corpus and the source
+//! execution identity that produced it.
+//!
+//! New dense-present generations publish [`RECORDED_CORPUS_BINDING_FILE`]
+//! last. That canonical commit record binds every provenance/corpus member by
+//! exact filename, typed presence, length, and BLAKE3 content address.
+//! Compilation consumes the captured bytes directly, so arbitrary cross-file
+//! replacement cannot assemble an operator era and corpus from two committed
+//! generations. Markerless legacy and attention-only corpora remain readable
+//! through the explicitly weaker compatibility path.
+
+use crate::observation::{self, ObservationManifest};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
+use std::fs::{Metadata, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use uor_r4_model_source::SourceUnavailable;
+use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
+
+pub const ATTENTION_OPERATOR_BINDING_FILE: &str = "attention_operator.json";
+pub const DENSE_OPERATOR_BINDING_FILE: &str = "dense_operator.json";
+pub const RECORDED_CORPUS_BINDING_FILE: &str = "recorded_corpus_binding.json";
+pub const RECORDED_CORPUS_BINDING_SCHEMA: &str = "uor-r4-recorded-corpus-binding/1";
+pub const RECORDED_CORPUS_COMPILE_ATTEMPT_FILE: &str = "recorded_corpus_compile_attempt.json";
+pub const RECORDED_CORPUS_COMPILE_ATTEMPT_SCHEMA: &str = "uor-r4-recorded-corpus-compile-attempt/1";
+pub const PLANNED_OUTPUT_RESERVED_PREFIX: &str = ".uor-r4-planned-output--";
+const RECORDED_CORPUS_PRODUCER_COORDINATION_DIR: &str = ".uor-r4-recorded-corpus-producers";
+const STREAM_BINDING_BUFFER_BYTES: usize = 64 * 1024;
+
+static RECORDED_CORPUS_BINDING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static RECORDED_CORPUS_COMPILE_ATTEMPT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// The two canonical member pairs that a recorded-corpus binding may commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordedCorpusRole {
+    /// Compiler/subsample corpus: `corpus.meta` plus `corpus.records`.
+    Compile,
+    /// Observation corpus: `state.bin` plus `merged.bin`.
+    Observation,
+}
+
+impl RecordedCorpusRole {
+    fn member_names(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Compile => ("corpus.meta", "corpus.records"),
+            Self::Observation => (observation::STATE_FILE, "merged.bin"),
+        }
+    }
+}
+
+/// A deterministic compile-style output member with an owner-only staging
+/// namespace. The enum and parser live here so every producer agrees on the
+/// complete reserved namespace, even when the publisher itself lives in the
+/// graph CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlannedOutputMember {
+    Artifact,
+    Store,
+    Calibration,
+    HierarchicalCodes,
+    Records,
+    Hidden,
+    Metadata,
+}
+
+impl PlannedOutputMember {
+    pub const ALL: [Self; 7] = [
+        Self::Artifact,
+        Self::Store,
+        Self::Calibration,
+        Self::HierarchicalCodes,
+        Self::Records,
+        Self::Hidden,
+        Self::Metadata,
+    ];
+
+    pub const fn stable_name(self) -> &'static str {
+        match self {
+            Self::Artifact => "tless_artifacts.bin",
+            Self::Store => "tless_store.bin",
+            Self::Calibration => "hamming_calibration.json",
+            Self::HierarchicalCodes => "hierarchical_codes.json",
+            Self::Records => "corpus.records",
+            Self::Hidden => "corpus.records.hidden",
+            Self::Metadata => "corpus.meta",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecordedCorpusFileBinding {
+    name: String,
+    present: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    length: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blake3: Option<String>,
+}
+
+impl RecordedCorpusFileBinding {
+    fn from_bytes(name: &str, bytes: Option<&[u8]>) -> Result<Self, SourceUnavailable> {
+        let length = bytes
+            .map(|bytes| {
+                u64::try_from(bytes.len()).map_err(|_| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus member {name} is too large for its u64 binding length"
+                    ))
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            name: name.to_owned(),
+            present: bytes.is_some(),
+            length,
+            blake3: bytes.map(|bytes| format!("blake3:{}", blake3::hash(bytes).to_hex())),
+        })
+    }
+
+    fn validate(
+        &self,
+        expected_name: &str,
+        bytes: Option<&[u8]>,
+        context: &str,
+    ) -> Result<(), SourceUnavailable> {
+        if self.name != expected_name {
+            return Err(SourceUnavailable::new(format!(
+                "{context} binds filename {:?}, expected exact member {expected_name:?}",
+                self.name
+            )));
+        }
+        let expected = Self::from_bytes(expected_name, bytes)?;
+        if self != &expected {
+            return Err(SourceUnavailable::new(format!(
+                "{context} does not match the typed presence, length, and BLAKE3 of {expected_name}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_record(
+        &self,
+        expected_name: &str,
+        actual: &Self,
+        context: &str,
+    ) -> Result<(), SourceUnavailable> {
+        if self.name != expected_name || actual.name != expected_name || self != actual {
+            return Err(SourceUnavailable::new(format!(
+                "{context} does not match the exact streamed presence, length, and BLAKE3 of {expected_name}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Canonical commit record for one recorded-corpus generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordedCorpusBinding {
+    schema: String,
+    manifest: RecordedCorpusFileBinding,
+    attention_operator: RecordedCorpusFileBinding,
+    dense_operator: RecordedCorpusFileBinding,
+    metadata: RecordedCorpusFileBinding,
+    records: RecordedCorpusFileBinding,
+    hidden: RecordedCorpusFileBinding,
+}
+
+impl RecordedCorpusBinding {
+    fn canonical_bytes(&self) -> Result<Vec<u8>, SourceUnavailable> {
+        let mut bytes = serde_json::to_vec_pretty(self).map_err(SourceUnavailable::new)?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+
+    /// Content address of the canonical binding bytes. This is a derived
+    /// corpus identity, never a source-manifest kappa.
+    pub fn declared_digest(&self) -> Result<String, SourceUnavailable> {
+        Ok(format!(
+            "blake3:{}",
+            blake3::hash(&self.canonical_bytes()?).to_hex()
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecordedCorpusCompileAttempt {
+    schema: String,
+    role: String,
+}
+
+impl RecordedCorpusCompileAttempt {
+    fn compile() -> Self {
+        Self {
+            schema: RECORDED_CORPUS_COMPILE_ATTEMPT_SCHEMA.to_owned(),
+            role: "compile".to_owned(),
+        }
+    }
+
+    fn canonical_bytes(&self) -> Result<Vec<u8>, SourceUnavailable> {
+        let mut bytes = serde_json::to_vec_pretty(self).map_err(SourceUnavailable::new)?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+}
+
+fn validate_binding_role(
+    binding: &RecordedCorpusBinding,
+    role: RecordedCorpusRole,
+    path: &Path,
+) -> Result<(), SourceUnavailable> {
+    let (metadata, records) = role.member_names();
+    if binding.metadata.name != metadata || binding.records.name != records {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus binding {} commits canonical pair {}/{}, but this producer requires {metadata}/{records}; refusing cross-role mutation",
+            path.display(),
+            binding.metadata.name,
+            binding.records.name
+        )));
+    }
+    Ok(())
+}
+
+fn validate_role_inventory(root: &Path, role: RecordedCorpusRole) -> Result<(), SourceUnavailable> {
+    const COMPILE_ONLY: [&str; 19] = [
+        "corpus.meta",
+        "corpus.records",
+        "corpus.records.hidden",
+        "tokenizer.bin",
+        "tless_artifacts.bin",
+        "tless_store.bin",
+        "hamming_calibration.json",
+        "hierarchical_codes.json",
+        "space_manifest.json",
+        "compile_report.json",
+        "tokenizer_adapter.json",
+        RECORDED_CORPUS_COMPILE_ATTEMPT_FILE,
+        "source_compile_preflight.json",
+        "source_manifest_kappa.json",
+        "compiled_bundle_completion.json",
+        ".compiled_bundle_stage.json",
+        "graph",
+        "graph-cover",
+        "instruction-eval.json",
+    ];
+    fn compile_only_name(name: &str) -> bool {
+        if COMPILE_ONLY.contains(&name) {
+            return true;
+        }
+        // Server/source publishers use the same stable-name + numeric owner
+        // convention for their recoverable identity/completion temporaries.
+        // A temp-only crash prefix is just as role-defining as its stable
+        // destination and must keep an observation writer out.
+        COMPILE_ONLY.iter().any(|stable| {
+            let prefix = format!(".{stable}.");
+            name.starts_with(&prefix)
+                && (name.ends_with(".tmp")
+                    || name.ends_with(".writing")
+                    || name.ends_with(".replace.tmp"))
+        })
+    }
+
+    if role == RecordedCorpusRole::Compile {
+        for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+            let entry = entry.map_err(SourceUnavailable::new)?;
+            let raw_name = entry.file_name();
+            let Some(name) = raw_name.to_str().map(str::to_owned) else {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::ffi::OsStrExt;
+                    let bytes = raw_name.as_bytes();
+                    if [
+                        b"manifest.json".as_slice(),
+                        b"state.bin".as_slice(),
+                        b"raw-committed.bin".as_slice(),
+                        b"committed.bin".as_slice(),
+                        b"merged.bin".as_slice(),
+                        b"stories.jsonl".as_slice(),
+                        b"stories.tmp".as_slice(),
+                        b"shard-".as_slice(),
+                        b".manifest.json.tmp".as_slice(),
+                        b".raw-committed.bin.tmp".as_slice(),
+                        b".state.bin.tmp".as_slice(),
+                        b".committed.bin.tmp".as_slice(),
+                    ]
+                    .iter()
+                    .any(|prefix| bytes.starts_with(prefix))
+                    {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus root {} contains a non-UTF-8 entry in a reserved observation-role namespace",
+                            root.display()
+                        )));
+                    }
+                }
+                continue;
+            };
+            if observation::is_observation_exclusive_entry_name(&name) {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains foreign observation-role member {name}; refusing compile mutation",
+                    root.display()
+                )));
+            }
+        }
+    } else {
+        for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+            let entry = entry.map_err(SourceUnavailable::new)?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                // An unrelated non-Unicode file remains compatible, but a
+                // reserved ASCII prefix represented by non-Unicode bytes is
+                // terminal on Unix. The lossy form is used only as a prefix
+                // classifier and never as a path to follow.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::ffi::OsStrExt;
+                    let raw = entry.file_name();
+                    if COMPILE_ONLY.iter().any(|stable| {
+                        raw.as_bytes() == stable.as_bytes()
+                            || raw.as_bytes().starts_with(format!(".{stable}.").as_bytes())
+                    }) {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus root {} contains a non-UTF-8 entry in a reserved compile-role namespace",
+                            root.display()
+                        )));
+                    }
+                }
+                continue;
+            };
+            if compile_only_name(name) {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains foreign compile-role member {name}; refusing observation mutation",
+                    root.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse a JSON document solely to reject duplicate object keys at every
+/// nesting level. `serde_json::Value` is last-key-wins, which is unsuitable
+/// for provenance records where duplicated fields could spell two arithmetic
+/// eras in one document.
+pub struct DuplicateRejectingJson;
+
+impl<'de> serde::Deserialize<'de> for DuplicateRejectingJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = DuplicateRejectingJson;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("JSON without duplicate object keys")
+            }
+
+            fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <DuplicateRejectingJson as serde::Deserialize>::deserialize(deserializer)
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                while sequence.next_element::<DuplicateRejectingJson>()?.is_some() {}
+                Ok(DuplicateRejectingJson)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut keys = std::collections::BTreeSet::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if !keys.insert(key.clone()) {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate JSON field {key:?}"
+                        )));
+                    }
+                    map.next_value::<DuplicateRejectingJson>()?;
+                }
+                Ok(DuplicateRejectingJson)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Reject duplicate object keys recursively before any typed/`Value` parse.
+pub fn reject_duplicate_json(bytes: &[u8], context: &str) -> Result<(), SourceUnavailable> {
+    serde_json::from_slice::<DuplicateRejectingJson>(bytes)
+        .map(|_| ())
+        .map_err(|error| SourceUnavailable::new(format!("{context}: malformed JSON: {error}")))
+}
+
+/// Exact registered source-execution pair captured beside a recorded corpus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedCorpusExecutionIdentity {
+    pub attention_operator: Option<AttentionOperatorSpec>,
+    pub dense_operator: Option<DenseOperatorSpec>,
+}
+
+/// Corpus bytes and execution provenance captured and reverified as one unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedCorpusSnapshot {
+    pub execution: RecordedCorpusExecutionIdentity,
+    /// Exact captured `attention_operator.json` bytes, when present. These
+    /// bytes are the same generation that was registry- and binding-checked;
+    /// callers must not reopen the pathname to derive durable evidence.
+    pub attention_operator_bytes: Option<Vec<u8>>,
+    /// Exact captured `dense_operator.json` bytes, when present.
+    pub dense_operator_bytes: Option<Vec<u8>>,
+    pub meta_bytes: Vec<u8>,
+    pub records_bytes: Vec<u8>,
+    pub hidden_bytes: Option<Vec<u8>>,
+    /// Exact canonical generation binding, when the producer committed one.
+    pub binding: Option<RecordedCorpusBinding>,
+    /// BLAKE3 CID of the exact canonical binding bytes. This is derived
+    /// corpus provenance and is deliberately distinct from source kappa.
+    pub binding_cid: Option<String>,
+}
+
+/// One no-follow corpus member whose complete content address was validated
+/// while this exact handle remained open. Consumers may seek/read it without
+/// materializing the body and must call [`Self::verify_generation`] after the
+/// final read before committing derived output.
+#[derive(Debug)]
+pub struct VerifiedCorpusMember {
+    path: PathBuf,
+    file: std::fs::File,
+    initial: Metadata,
+    binding: RecordedCorpusFileBinding,
+    context: &'static str,
+}
+
+/// Bounded-memory length/content address of one exact regular member.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedCorpusMemberSummary {
+    pub length: u64,
+    pub blake3: String,
+}
+
+impl VerifiedCorpusMember {
+    pub fn len(&self) -> u64 {
+        self.binding.length.unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn declared_digest(&self) -> &str {
+        self.binding.blake3.as_deref().unwrap_or("")
+    }
+
+    pub fn summary(&self) -> RecordedCorpusMemberSummary {
+        RecordedCorpusMemberSummary {
+            length: self.len(),
+            blake3: self.declared_digest().to_owned(),
+        }
+    }
+
+    pub fn verify_generation(&self) -> Result<(), SourceUnavailable> {
+        let final_file = self.file.metadata().map_err(SourceUnavailable::new)?;
+        let final_path = std::fs::symlink_metadata(&self.path).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{} {} changed or disappeared: {error}",
+                self.context,
+                self.path.display()
+            ))
+        })?;
+        if !final_path.file_type().is_file()
+            || !opened_file_generation_matches(&self.initial, &final_file)
+            || !opened_file_identity_matches(&final_path, &final_file)
+        {
+            return Err(SourceUnavailable::new(format!(
+                "{} {} changed generation after its verified stream was opened",
+                self.context,
+                self.path.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Read for VerifiedCorpusMember {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.file.read(buffer)
+    }
+}
+
+impl Seek for VerifiedCorpusMember {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.file.seek(position)
+    }
+}
+
+/// Small provenance/metadata plus retained verified handles for large corpus
+/// members. This is the bounded-memory source for derivation/status paths.
+#[derive(Debug)]
+pub struct RecordedCorpusStreamSnapshot {
+    pub execution: RecordedCorpusExecutionIdentity,
+    pub attention_operator_bytes: Option<Vec<u8>>,
+    pub dense_operator_bytes: Option<Vec<u8>>,
+    pub meta_bytes: Vec<u8>,
+    pub records: VerifiedCorpusMember,
+    pub hidden: Option<VerifiedCorpusMember>,
+    pub binding_cid: Option<String>,
+    root: PathBuf,
+    provenance: ProvenanceBytes,
+    meta_path: PathBuf,
+    binding_path: PathBuf,
+    binding_bytes: Option<Vec<u8>>,
+    marker_path: PathBuf,
+    marker_bytes: Option<Vec<u8>>,
+    hidden_path: PathBuf,
+}
+
+impl RecordedCorpusStreamSnapshot {
+    /// Final generation check after a consumer finishes reading/seeking every
+    /// retained member and before it publishes any derived generation.
+    pub fn verify_generation(&self) -> Result<(), SourceUnavailable> {
+        self.records.verify_generation()?;
+        if let Some(hidden) = self.hidden.as_ref() {
+            hidden.verify_generation()?;
+        } else {
+            verify_captured_optional_regular_file(
+                &self.hidden_path,
+                "recorded corpus hidden stream",
+                None,
+            )?;
+        }
+        verify_captured_optional_regular_file(
+            &self.meta_path,
+            "recorded corpus metadata",
+            Some(&self.meta_bytes),
+        )?;
+        verify_provenance(&self.root, &self.provenance)?;
+        verify_captured_optional_regular_file(
+            &self.binding_path,
+            "recorded corpus generation binding",
+            self.binding_bytes.as_deref(),
+        )?;
+        verify_captured_optional_regular_file(
+            &self.marker_path,
+            "recorded corpus compile-attempt marker",
+            self.marker_bytes.as_deref(),
+        )?;
+        require_no_binding_temporaries(&self.root)
+    }
+}
+
+/// Nonblocking, process-crash-safe exclusive guard for one canonical recorded
+/// corpus root.
+///
+/// The permanent sibling inode is coordination metadata, not corpus payload.
+/// Every producer acquires any writer-specific outer session first and this
+/// guard second, then holds both from the first corpus/provenance mutation
+/// through final [`publish_binding`]. No producer may acquire another outer
+/// session or a second recorded-corpus guard while this value is live.
+#[derive(Debug)]
+pub struct RecordedCorpusProducerGuard {
+    root: PathBuf,
+    _file: std::fs::File,
+    root_file: Option<std::fs::File>,
+    _coordination_file: std::fs::File,
+    _parent_file: std::fs::File,
+}
+
+impl RecordedCorpusProducerGuard {
+    /// Try to acquire exclusive producer ownership without waiting. A live
+    /// cooperating producer returns an explicit `BUSY` error; malformed,
+    /// symlinked, special, or identity-raced coordination entries fail closed.
+    pub fn try_acquire(root: impl AsRef<Path>) -> Result<Self, SourceUnavailable> {
+        Self::try_acquire_with_root_hook(root.as_ref(), || {})
+    }
+
+    fn try_acquire_with_root_hook<F>(
+        root: &Path,
+        after_root_open: F,
+    ) -> Result<Self, SourceUnavailable>
+    where
+        F: FnOnce(),
+    {
+        let root_name = root.file_name().ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus producer subject {} must end in one exact directory name, not '.', '..', or a filesystem root",
+                root.display()
+            ))
+        })?;
+        if root_name == OsStr::new(".") || root_name == OsStr::new("..") {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer subject {} cannot use '.' or '..' as its root name",
+                root.display()
+            )));
+        }
+        if root_name == OsStr::new(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer root name {RECORDED_CORPUS_PRODUCER_COORDINATION_DIR:?} is reserved for sibling coordination"
+            )));
+        }
+        let requested_parent = root
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let canonical_parent = std::fs::canonicalize(requested_parent).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus producer parent {} cannot be canonicalized: {error}",
+                requested_parent.display()
+            ))
+        })?;
+        let parent_file = open_directory_nofollow(
+            &canonical_parent,
+            "recorded corpus producer canonical parent",
+        )?;
+        verify_directory_handle(
+            &canonical_parent,
+            &parent_file,
+            "recorded corpus producer canonical parent",
+        )?;
+        let requested_root = canonical_parent.join(root_name);
+        let root_file = match std::fs::symlink_metadata(&requested_root) {
+            Ok(metadata) if metadata.file_type().is_dir() => Some(open_directory_nofollow(
+                &requested_root,
+                "recorded corpus producer root",
+            )?),
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus producer root {} is not a real non-symlink directory",
+                    requested_root.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        };
+        if let Some(file) = root_file.as_ref() {
+            verify_directory_handle(&requested_root, file, "recorded corpus producer root")?;
+        }
+        after_root_open();
+        verify_directory_handle(
+            &canonical_parent,
+            &parent_file,
+            "recorded corpus producer canonical parent",
+        )?;
+        verify_optional_root_generation(&requested_root, root_file.as_ref())?;
+        let canonical = match root_file.as_ref() {
+            Some(file) => canonical_existing_root_path(&canonical_parent, &requested_root, file)?,
+            None => requested_root,
+        };
+        let canonical_name = canonical.file_name().ok_or_else(|| {
+            SourceUnavailable::new("canonical recorded corpus root has no final component")
+        })?;
+        let coordination_path = canonical_parent.join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+        let coordination_file =
+            open_or_create_coordination_directory(&canonical_parent, &parent_file)?;
+        let lock_path = coordination_path.join(canonical_name);
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        }
+        let file = options.open(&lock_path).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus producer coordination {} cannot be opened without following links: {error}",
+                lock_path.display()
+            ))
+        })?;
+        let initial_path = std::fs::symlink_metadata(&lock_path).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus producer coordination {} cannot be inspected: {error}",
+                lock_path.display()
+            ))
+        })?;
+        let initial_file = file.metadata().map_err(SourceUnavailable::new)?;
+        if !initial_path.file_type().is_file()
+            || !initial_file.file_type().is_file()
+            || !opened_file_identity_matches(&initial_path, &initial_file)
+        {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer coordination {} is not one stable regular non-symlink inode",
+                lock_path.display()
+            )));
+        }
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(std::fs::TryLockError::WouldBlock) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} is BUSY under another active producer session",
+                    canonical.display()
+                )));
+            }
+            Err(std::fs::TryLockError::Error(error)) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus producer coordination {} cannot be locked: {error}",
+                    lock_path.display()
+                )));
+            }
+        }
+        let final_path = std::fs::symlink_metadata(&lock_path).map_err(SourceUnavailable::new)?;
+        let final_file = file.metadata().map_err(SourceUnavailable::new)?;
+        if !final_path.file_type().is_file()
+            || !final_file.file_type().is_file()
+            || !opened_file_identity_matches(&initial_file, &final_file)
+            || !opened_file_identity_matches(&final_path, &final_file)
+        {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer coordination {} changed identity or type while its lock was acquired",
+                lock_path.display()
+            )));
+        }
+        verify_directory_handle(
+            &canonical_parent,
+            &parent_file,
+            "recorded corpus producer canonical parent",
+        )?;
+        verify_directory_handle(
+            &coordination_path,
+            &coordination_file,
+            "recorded corpus producer coordination directory",
+        )?;
+        verify_optional_root_generation(&canonical, root_file.as_ref())?;
+        Ok(Self {
+            root: canonical,
+            _file: file,
+            root_file,
+            _coordination_file: coordination_file,
+            _parent_file: parent_file,
+        })
+    }
+
+    /// Canonical root protected by this guard.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Whether the logical root existed when acquired (or has since been
+    /// created by [`Self::ensure_root`]).
+    pub fn root_exists(&self) -> bool {
+        self.root_file.is_some()
+    }
+
+    /// Validate every stable/reserved binding entry before a caller mutates
+    /// any generation member. Returns `true` when a canonical, fully parsed
+    /// publication temporary needs exact-generation recovery by
+    /// [`publish_binding`]. Non-authoritative `.writing` residue may be
+    /// reclaimed only by that publisher while this guard remains live.
+    pub fn preflight_publication_namespace(&self) -> Result<bool, SourceUnavailable> {
+        self.verify_root()?;
+        let stable_path = binding_path(&self.root);
+        if let Some(bytes) =
+            capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
+        {
+            let _ = parse_binding_bytes(&stable_path, &bytes)?;
+        }
+        let residues = binding_publication_residues(&self.root, true)?;
+        self.verify_root()?;
+        Ok(!residues.temporaries.is_empty())
+    }
+
+    /// Validate the binding namespace and require every stable or recoverable
+    /// commit record to name the caller's canonical member pair. This keeps an
+    /// observation writer from mutating a compile/subsample root (and vice
+    /// versa) before binding-last publication discovers the role conflict.
+    pub fn preflight_publication_namespace_for(
+        &self,
+        role: RecordedCorpusRole,
+    ) -> Result<bool, SourceUnavailable> {
+        self.verify_root()?;
+        validate_role_inventory(&self.root, role)?;
+        validate_compile_attempt_namespace(&self.root, role)?;
+        let stable_path = binding_path(&self.root);
+        if let Some(bytes) =
+            capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
+        {
+            let binding = parse_binding_bytes(&stable_path, &bytes)?;
+            validate_binding_role(&binding, role, &stable_path)?;
+        }
+        let residues = binding_publication_residues(&self.root, true)?;
+        for (path, bytes) in &residues.temporaries {
+            let binding = parse_binding_bytes(path, bytes)?;
+            validate_binding_role(&binding, role, path)?;
+        }
+        self.verify_root()?;
+        Ok(!residues.temporaries.is_empty())
+    }
+
+    /// Durably declare a compile-style mutation attempt before the first
+    /// sidecar or corpus member is published. The fixed marker disambiguates
+    /// sidecar-only crash prefixes from observation roots without changing
+    /// the canonical recorded-corpus binding schema.
+    pub fn begin_compile_attempt(&self) -> Result<(), SourceUnavailable> {
+        self.verify_root()?;
+        self.preflight_planned_output_scope(&PlannedOutputMember::ALL)?;
+        let _ = self.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+        publish_compile_attempt_marker(self)?;
+        self.verify_root()
+    }
+
+    /// Remove the compile-attempt marker only after a stable same-role corpus
+    /// binding exists. A crash before removal leaves a readable committed
+    /// generation plus explicit retry evidence; removal and directory sync
+    /// are idempotent under the retained guard.
+    pub fn finish_compile_attempt(&self) -> Result<(), SourceUnavailable> {
+        self.verify_root()?;
+        let stable_binding = binding_path(&self.root);
+        let bytes = capture_optional_regular_file(
+            &stable_binding,
+            "recorded corpus generation binding",
+        )?
+        .ok_or_else(|| {
+            SourceUnavailable::new(
+                "cannot finish recorded-corpus compile attempt before its stable generation binding",
+            )
+        })?;
+        let binding = parse_binding_bytes(&stable_binding, &bytes)?;
+        validate_binding_role(&binding, RecordedCorpusRole::Compile, &stable_binding)?;
+        finish_compile_attempt_marker(self)?;
+        self.verify_root()
+    }
+
+    /// Whether this compile-role root carries the exact durable attempt
+    /// marker. The namespace is fully validated before the answer is
+    /// returned, so malformed or special residue remains terminal.
+    pub fn compile_attempt_active(&self) -> Result<bool, SourceUnavailable> {
+        self.verify_root()?;
+        validate_compile_attempt_namespace(&self.root, RecordedCorpusRole::Compile)?;
+        let path = compile_attempt_path(&self.root);
+        let active =
+            capture_optional_regular_file(&path, "recorded corpus compile-attempt marker")?
+                .map(|bytes| parse_compile_attempt_bytes(&path, &bytes))
+                .transpose()?
+                .is_some();
+        self.verify_root()?;
+        Ok(active)
+    }
+
+    /// Validate the complete shared planned-output staging namespace and
+    /// reject residue owned by any member outside `allowed`. All recognized
+    /// entries are opened nofollow and bound to one regular inode before the
+    /// owner filter is applied; malformed or special entries are terminal.
+    pub fn preflight_planned_output_scope(
+        &self,
+        allowed: &[PlannedOutputMember],
+    ) -> Result<(), SourceUnavailable> {
+        let residues = self.planned_output_residues()?;
+        if let Some(residue) = residues
+            .iter()
+            .find(|residue| !allowed.contains(&residue.member))
+        {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains reserved staging residue {} for foreign member {}; refusing a partial-plan publication",
+                self.root.display(),
+                residue.path.display(),
+                residue.member.stable_name()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Reject stable deterministic members outside a partial producer's
+    /// declared plan. Staging ownership alone is insufficient: a subsample
+    /// must not commit new corpus bytes beside stale compile artifacts.
+    pub fn preflight_planned_output_stable_scope(
+        &self,
+        allowed: &[PlannedOutputMember],
+    ) -> Result<(), SourceUnavailable> {
+        self.verify_root()?;
+        for member in PlannedOutputMember::ALL {
+            if allowed.contains(&member) {
+                continue;
+            }
+            let path = self.root.join(member.stable_name());
+            match std::fs::symlink_metadata(&path) {
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus root {} contains foreign stable planned member {}; refusing a partial-plan publication",
+                        self.root.display(),
+                        member.stable_name()
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(SourceUnavailable::new(error)),
+            }
+        }
+        self.verify_root()
+    }
+
+    /// Require a deterministic compile-style destination to contain only the
+    /// exact members that this command can reproduce, plus the shared
+    /// execution/binding/attempt namespaces. This is deliberately stricter
+    /// than the broad Compile role: source bundles and server stages carry
+    /// additional valid compile-role leaves that a corpus derivation must not
+    /// silently preserve beside a newly committed generation.
+    pub fn preflight_deterministic_compile_inventory(
+        &self,
+        allowed: &[PlannedOutputMember],
+    ) -> Result<(), SourceUnavailable> {
+        self.verify_root()?;
+        self.preflight_planned_output_scope(allowed)?;
+        let _ = self.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+        for entry in std::fs::read_dir(&self.root).map_err(SourceUnavailable::new)? {
+            let entry = entry.map_err(SourceUnavailable::new)?;
+            let os_name = entry.file_name();
+            let Some(name) = os_name.to_str() else {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains a non-Unicode entry outside this deterministic compile plan",
+                    self.root.display()
+                )));
+            };
+            let stable_allowed = allowed.iter().any(|member| member.stable_name() == name);
+            let shared_stable = matches!(
+                name,
+                ATTENTION_OPERATOR_BINDING_FILE
+                    | DENSE_OPERATOR_BINDING_FILE
+                    | RECORDED_CORPUS_BINDING_FILE
+                    | RECORDED_CORPUS_COMPILE_ATTEMPT_FILE
+            );
+            let shared_reserved = name.starts_with(&format!(".{RECORDED_CORPUS_BINDING_FILE}."))
+                || name.starts_with(&format!(".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}."))
+                || name.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX);
+            if stable_allowed || shared_stable || shared_reserved {
+                continue;
+            }
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains unowned compile-style entry {name}; refusing deterministic corpus publication",
+                self.root.display()
+            )));
+        }
+        self.verify_root()
+    }
+
+    /// Whether a validated regular staging residue exists for `member`.
+    pub fn has_planned_output_residue(
+        &self,
+        member: PlannedOutputMember,
+    ) -> Result<bool, SourceUnavailable> {
+        Ok(self
+            .planned_output_residues()?
+            .iter()
+            .any(|residue| residue.member == member))
+    }
+
+    /// Reclaim only validated regular residue owned by `member`. The initial
+    /// generation is rechecked through a nofollow handle immediately before
+    /// unlink so process death recovery is O(1) in staged payload size.
+    pub fn reclaim_planned_output_residues(
+        &self,
+        member: PlannedOutputMember,
+    ) -> Result<(), SourceUnavailable> {
+        let residues = self.planned_output_residues()?;
+        for residue in residues
+            .into_iter()
+            .filter(|residue| residue.member == member)
+        {
+            remove_planned_output_residue(&residue)?;
+        }
+        self.verify_root()
+    }
+
+    fn planned_output_residues(&self) -> Result<Vec<PlannedOutputResidue>, SourceUnavailable> {
+        self.verify_root()?;
+        let mut residues = Vec::new();
+        for entry in std::fs::read_dir(&self.root).map_err(SourceUnavailable::new)? {
+            let entry = entry.map_err(SourceUnavailable::new)?;
+            let Some(name) = reserved_planned_output_entry_name(&self.root, &entry.file_name())?
+            else {
+                continue;
+            };
+            let member = PlannedOutputMember::ALL
+                .into_iter()
+                .find(|member| planned_output_staging_name(*member, &name))
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus root {} contains unrecognized reserved planned-output staging entry {name:?}",
+                        self.root.display()
+                    ))
+                })?;
+            let path = entry.path();
+            let mut options = OpenOptions::new();
+            options.read(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+            }
+            let file = options.open(&path).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "planned-output staging entry {} cannot be opened without following links: {error}",
+                    path.display()
+                ))
+            })?;
+            let path_metadata = std::fs::symlink_metadata(&path).map_err(SourceUnavailable::new)?;
+            let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+            if !path_metadata.file_type().is_file()
+                || !file_metadata.file_type().is_file()
+                || !opened_file_identity_matches(&path_metadata, &file_metadata)
+            {
+                return Err(SourceUnavailable::new(format!(
+                    "planned-output staging entry {} is not one stable regular non-symlink inode",
+                    path.display()
+                )));
+            }
+            residues.push(PlannedOutputResidue {
+                member,
+                path,
+                metadata: file_metadata,
+            });
+        }
+        residues.sort_by(|left, right| left.path.cmp(&right.path));
+        self.verify_root()?;
+        Ok(residues)
+    }
+
+    /// Create and bind a previously absent logical root after all caller
+    /// semantic/input preflights have succeeded. Existing roots are merely
+    /// reverified. This is the only supported transition from a path lock to
+    /// a mutable recorded-corpus directory.
+    pub fn ensure_root(&mut self) -> Result<&Path, SourceUnavailable> {
+        self.verify_parent()?;
+        if self.root_file.is_none() {
+            std::fs::create_dir(&self.root).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "recorded corpus producer root {} cannot be created under exclusive ownership: {error}",
+                    self.root.display()
+                ))
+            })?;
+            self._parent_file
+                .sync_all()
+                .map_err(SourceUnavailable::new)?;
+            self.root_file = Some(open_directory_nofollow(
+                &self.root,
+                "recorded corpus producer root",
+            )?);
+        }
+        self.verify_root()?;
+        Ok(&self.root)
+    }
+
+    fn verify_parent(&self) -> Result<(), SourceUnavailable> {
+        verify_directory_handle(
+            self.root.parent().ok_or_else(|| {
+                SourceUnavailable::new("recorded corpus producer root has no canonical parent")
+            })?,
+            &self._parent_file,
+            "recorded corpus producer canonical parent",
+        )?;
+        verify_directory_handle(
+            &self
+                .root
+                .parent()
+                .expect("validated canonical root parent")
+                .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR),
+            &self._coordination_file,
+            "recorded corpus producer coordination directory",
+        )
+    }
+
+    fn verify_root(&self) -> Result<(), SourceUnavailable> {
+        let file = self.root_file.as_ref().ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus producer root {} is still absent; call ensure_root only after semantic preflight and before mutation",
+                self.root.display()
+            ))
+        })?;
+        verify_directory_handle(&self.root, file, "recorded corpus producer root")
+    }
+
+    /// Revalidate the guarded root handle before a higher-level producer
+    /// publishes another generation member.
+    pub fn verify_owned_root(&self) -> Result<(), SourceUnavailable> {
+        self.verify_root()
+    }
+
+    /// Compare another directory to the guarded root by opened directory
+    /// identity, not caller spelling. This catches case/Unicode aliases on
+    /// filesystems whose canonicalize operation preserves the input case.
+    pub fn protects_directory(&self, directory: &Path) -> Result<bool, SourceUnavailable> {
+        if self.root_file.is_none() {
+            self.verify_parent()?;
+            verify_optional_root_generation(&self.root, None)?;
+            return Ok(false);
+        }
+        self.verify_root()?;
+        let other = open_directory_nofollow(directory, "recorded corpus comparison directory")?;
+        #[cfg(unix)]
+        {
+            let guarded = self
+                .root_file
+                .as_ref()
+                .expect("verified recorded corpus root")
+                .metadata()
+                .map_err(SourceUnavailable::new)?;
+            let other = other.metadata().map_err(SourceUnavailable::new)?;
+            return Ok(opened_file_identity_matches(&guarded, &other));
+        }
+        #[cfg(not(unix))]
+        {
+            let canonical = std::fs::canonicalize(directory).map_err(SourceUnavailable::new)?;
+            Ok(canonical == self.root)
+        }
+    }
+}
+
+/// Non-mutating shared coordination for a bounded recorded-corpus read.
+///
+/// When a producer coordination inode already exists, readers take its shared
+/// lock and therefore return `BUSY` while an exclusive producer is live. A
+/// copied/read-only legacy archive may have no coordination directory or lock;
+/// this guard never creates either and instead pins their typed absence plus
+/// the parent/root directory handles for a final recheck.
+#[derive(Debug)]
+pub struct RecordedCorpusReaderGuard {
+    root: PathBuf,
+    root_file: std::fs::File,
+    parent: PathBuf,
+    parent_file: std::fs::File,
+    coordination_path: PathBuf,
+    coordination_file: Option<std::fs::File>,
+    lock_path: PathBuf,
+    lock_file: Option<std::fs::File>,
+}
+
+impl RecordedCorpusReaderGuard {
+    pub fn try_acquire(root: impl AsRef<Path>) -> Result<Self, SourceUnavailable> {
+        let requested = root.as_ref();
+        let root_name = requested.file_name().ok_or_else(|| {
+            SourceUnavailable::new("recorded corpus reader root has no final component")
+        })?;
+        let requested_parent = requested
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let parent = std::fs::canonicalize(requested_parent).map_err(SourceUnavailable::new)?;
+        let parent_file =
+            open_directory_nofollow(&parent, "recorded corpus reader canonical parent")?;
+        let requested_root = parent.join(root_name);
+        let root_file = open_directory_nofollow(&requested_root, "recorded corpus reader root")?;
+        let root = canonical_existing_root_path(&parent, &requested_root, &root_file)?;
+        verify_directory_handle(&root, &root_file, "recorded corpus reader root")?;
+
+        let coordination_path = parent.join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+        let coordination_file = match std::fs::symlink_metadata(&coordination_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+            Ok(metadata) if metadata.file_type().is_dir() => Some(open_directory_nofollow(
+                &coordination_path,
+                "recorded corpus reader coordination directory",
+            )?),
+            Ok(_) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus reader coordination {} is not a real non-symlink directory",
+                    coordination_path.display()
+                )));
+            }
+        };
+        let lock_path = coordination_path.join(root.file_name().ok_or_else(|| {
+            SourceUnavailable::new("canonical recorded corpus reader root has no name")
+        })?);
+        let lock_file = if coordination_file.is_some() {
+            match std::fs::symlink_metadata(&lock_path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => return Err(SourceUnavailable::new(error)),
+                Ok(metadata) if metadata.file_type().is_file() => {
+                    let mut options = OpenOptions::new();
+                    options.read(true);
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::OpenOptionsExt;
+                        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+                    }
+                    let file = options.open(&lock_path).map_err(SourceUnavailable::new)?;
+                    let opened = file.metadata().map_err(SourceUnavailable::new)?;
+                    let path =
+                        std::fs::symlink_metadata(&lock_path).map_err(SourceUnavailable::new)?;
+                    if !opened.file_type().is_file()
+                        || !path.file_type().is_file()
+                        || !opened_file_identity_matches(&path, &opened)
+                    {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus reader coordination {} changed identity or type",
+                            lock_path.display()
+                        )));
+                    }
+                    match file.try_lock_shared() {
+                        Ok(()) => Some(file),
+                        Err(std::fs::TryLockError::WouldBlock) => {
+                            return Err(SourceUnavailable::new(format!(
+                                "recorded corpus root {} is BUSY under another active producer session",
+                                root.display()
+                            )));
+                        }
+                        Err(std::fs::TryLockError::Error(error)) => {
+                            return Err(SourceUnavailable::new(format!(
+                                "recorded corpus reader coordination {} cannot be locked: {error}",
+                                lock_path.display()
+                            )));
+                        }
+                    }
+                }
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus reader coordination {} is not a regular non-symlink file",
+                        lock_path.display()
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+
+        let guard = Self {
+            root,
+            root_file,
+            parent,
+            parent_file,
+            coordination_path,
+            coordination_file,
+            lock_path,
+            lock_file,
+        };
+        guard.verify()?;
+        Ok(guard)
+    }
+
+    pub fn verify(&self) -> Result<(), SourceUnavailable> {
+        verify_directory_handle(
+            &self.parent,
+            &self.parent_file,
+            "recorded corpus reader canonical parent",
+        )?;
+        verify_directory_handle(&self.root, &self.root_file, "recorded corpus reader root")?;
+        match self.coordination_file.as_ref() {
+            Some(file) => verify_directory_handle(
+                &self.coordination_path,
+                file,
+                "recorded corpus reader coordination directory",
+            )?,
+            None => match std::fs::symlink_metadata(&self.coordination_path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(SourceUnavailable::new(error)),
+                Ok(_) => {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus reader coordination {} appeared during an uncoordinated legacy read",
+                        self.coordination_path.display()
+                    )));
+                }
+            },
+        }
+        match self.lock_file.as_ref() {
+            Some(file) => {
+                let path =
+                    std::fs::symlink_metadata(&self.lock_path).map_err(SourceUnavailable::new)?;
+                let opened = file.metadata().map_err(SourceUnavailable::new)?;
+                if !path.file_type().is_file()
+                    || !opened.file_type().is_file()
+                    || !opened_file_identity_matches(&path, &opened)
+                {
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus reader coordination {} changed identity or type",
+                        self.lock_path.display()
+                    )));
+                }
+            }
+            None if self.coordination_file.is_some() => {
+                match std::fs::symlink_metadata(&self.lock_path) {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(SourceUnavailable::new(error)),
+                    Ok(_) => {
+                        return Err(SourceUnavailable::new(format!(
+                            "recorded corpus reader coordination {} appeared during an uncoordinated legacy read",
+                            self.lock_path.display()
+                        )));
+                    }
+                }
+            }
+            None => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct PlannedOutputResidue {
+    member: PlannedOutputMember,
+    path: PathBuf,
+    metadata: Metadata,
+}
+
+fn planned_output_staging_name(member: PlannedOutputMember, name: &str) -> bool {
+    let prefix = format!("{PLANNED_OUTPUT_RESERVED_PREFIX}{}--", member.stable_name());
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".writing"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn reserved_planned_output_entry_name(
+    root: &Path,
+    name: &OsStr,
+) -> Result<Option<String>, SourceUnavailable> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = name.as_bytes();
+        if !bytes.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX.as_bytes()) {
+            return Ok(None);
+        }
+        return std::str::from_utf8(bytes)
+            .map(|name| Some(name.to_owned()))
+            .map_err(|_| {
+                SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains a non-UTF-8 entry in the reserved planned-output staging namespace",
+                    root.display()
+                ))
+            });
+    }
+
+    #[cfg(not(unix))]
+    {
+        let lossy = name.to_string_lossy();
+        if !lossy.starts_with(PLANNED_OUTPUT_RESERVED_PREFIX) {
+            return Ok(None);
+        }
+        name.to_str().map(|name| Some(name.to_owned())).ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus root {} contains a non-Unicode entry in the reserved planned-output staging namespace",
+                root.display()
+            ))
+        })
+    }
+}
+
+fn remove_planned_output_residue(residue: &PlannedOutputResidue) -> Result<(), SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(&residue.path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "planned-output staging entry {} cannot be reopened without following links: {error}",
+            residue.path.display()
+        ))
+    })?;
+    let path_metadata = std::fs::symlink_metadata(&residue.path).map_err(SourceUnavailable::new)?;
+    let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    if !path_metadata.file_type().is_file()
+        || !file_metadata.file_type().is_file()
+        || !opened_file_identity_matches(&path_metadata, &file_metadata)
+        || !opened_file_generation_matches(&residue.metadata, &file_metadata)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "planned-output staging entry {} changed identity, type, or generation before guarded recovery",
+            residue.path.display()
+        )));
+    }
+    std::fs::remove_file(&residue.path).map_err(SourceUnavailable::new)
+}
+
+fn open_directory_nofollow(path: &Path, context: &str) -> Result<std::fs::File, SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.custom_flags(
+            libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        );
+    }
+    let file = options.open(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be opened without following links: {error}",
+            path.display()
+        ))
+    })?;
+    if !file
+        .metadata()
+        .map_err(SourceUnavailable::new)?
+        .file_type()
+        .is_dir()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not a directory",
+            path.display()
+        )));
+    }
+    Ok(file)
+}
+
+fn verify_directory_handle(
+    path: &Path,
+    file: &std::fs::File,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let path_metadata = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+    if !path_metadata.file_type().is_dir()
+        || !file_metadata.file_type().is_dir()
+        || !opened_file_identity_matches(&path_metadata, &file_metadata)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed identity or is not a real non-symlink directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn open_or_create_coordination_directory(
+    canonical_parent: &Path,
+    parent_file: &std::fs::File,
+) -> Result<std::fs::File, SourceUnavailable> {
+    verify_directory_handle(
+        canonical_parent,
+        parent_file,
+        "recorded corpus producer canonical parent",
+    )?;
+    let path = canonical_parent.join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR);
+    match std::fs::create_dir(&path) {
+        Ok(()) => parent_file.sync_all().map_err(SourceUnavailable::new)?,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer coordination directory {} cannot be created: {error}",
+                path.display()
+            )));
+        }
+    }
+    let file = open_directory_nofollow(&path, "recorded corpus producer coordination directory")?;
+    verify_directory_handle(
+        &path,
+        &file,
+        "recorded corpus producer coordination directory",
+    )?;
+    verify_directory_handle(
+        canonical_parent,
+        parent_file,
+        "recorded corpus producer canonical parent",
+    )?;
+    Ok(file)
+}
+
+fn verify_optional_root_generation(
+    root: &Path,
+    file: Option<&std::fs::File>,
+) -> Result<(), SourceUnavailable> {
+    match file {
+        Some(file) => verify_directory_handle(root, file, "recorded corpus producer root"),
+        None => match std::fs::symlink_metadata(root) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(SourceUnavailable::new(error)),
+            Ok(_) => Err(SourceUnavailable::new(format!(
+                "recorded corpus producer root {} appeared while its absent logical path was being locked",
+                root.display()
+            ))),
+        },
+    }
+}
+
+fn canonical_existing_root_path(
+    canonical_parent: &Path,
+    requested_root: &Path,
+    file: &std::fs::File,
+) -> Result<PathBuf, SourceUnavailable> {
+    #[cfg(unix)]
+    {
+        let file_metadata = file.metadata().map_err(SourceUnavailable::new)?;
+        let mut matches = Vec::new();
+        for entry in std::fs::read_dir(canonical_parent).map_err(SourceUnavailable::new)? {
+            let entry = entry.map_err(SourceUnavailable::new)?;
+            let metadata = match std::fs::symlink_metadata(entry.path()) {
+                Ok(metadata) => metadata,
+                // Unrelated siblings may be removed concurrently. The opened
+                // target handle and its exact requested path are rechecked
+                // below, so a vanished nonmatching sibling is irrelevant.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(SourceUnavailable::new(error)),
+            };
+            if metadata.file_type().is_dir()
+                && opened_file_identity_matches(&metadata, &file_metadata)
+            {
+                matches.push(entry.path());
+            }
+        }
+        matches.sort();
+        if matches.len() != 1 {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus producer root {} resolves to {} real directory entries in {}; refusing an ambiguous OS-equivalence class",
+                requested_root.display(),
+                matches.len(),
+                canonical_parent.display()
+            )));
+        }
+        return Ok(matches.remove(0));
+    }
+
+    #[cfg(not(unix))]
+    std::fs::canonicalize(requested_root).map_err(SourceUnavailable::new)
+}
+
+#[cfg(test)]
+fn producer_lock_path(canonical_parent: &Path, root_name: &OsStr) -> PathBuf {
+    canonical_parent
+        .join(RECORDED_CORPUS_PRODUCER_COORDINATION_DIR)
+        .join(root_name)
+}
+
+#[cfg(unix)]
+fn opened_file_identity_matches(path: &Metadata, file: &Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    path.dev() == file.dev() && path.ino() == file.ino()
+}
+
+#[cfg(not(unix))]
+fn opened_file_identity_matches(_path: &Metadata, _file: &Metadata) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn opened_file_generation_matches(initial: &Metadata, final_metadata: &Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    opened_file_identity_matches(initial, final_metadata)
+        && initial.len() == final_metadata.len()
+        && initial.mtime() == final_metadata.mtime()
+        && initial.mtime_nsec() == final_metadata.mtime_nsec()
+        && initial.ctime() == final_metadata.ctime()
+        && initial.ctime_nsec() == final_metadata.ctime_nsec()
+}
+
+#[cfg(not(unix))]
+fn opened_file_generation_matches(initial: &Metadata, final_metadata: &Metadata) -> bool {
+    opened_file_identity_matches(initial, final_metadata)
+        && initial.len() == final_metadata.len()
+        && initial.modified().ok() == final_metadata.modified().ok()
+}
+
+fn capture_optional_regular_file(
+    path: &Path,
+    context: &str,
+) -> Result<Option<Vec<u8>>, SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} is not a regular file or cannot be opened without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let initial_file = file.metadata().map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} opened handle cannot be inspected: {error}",
+            path.display()
+        ))
+    })?;
+    let initial_path = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be inspected after open: {error}",
+            path.display()
+        ))
+    })?;
+    if !initial_file.file_type().is_file()
+        || !initial_path.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path, &initial_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not the opened regular non-symlink file",
+            path.display()
+        )));
+    }
+
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be read: {error}",
+            path.display()
+        ))
+    })?;
+    if initial_file.len() != bytes.len() as u64 {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed length while it was captured",
+            path.display()
+        )));
+    }
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be rewound for verification: {error}",
+            path.display()
+        ))
+    })?;
+    verify_opened_bytes(&mut file, path, context, &bytes, &initial_file)?;
+    Ok(Some(bytes))
+}
+
+/// Capture only the typed presence/length/content address of a regular file.
+/// The payload is streamed through one no-follow handle and never retained;
+/// initial/final path and handle generation checks bind the digest to that
+/// exact inode generation.
+fn stream_regular_file_binding(
+    path: &Path,
+    expected_name: &str,
+    context: &str,
+) -> Result<RecordedCorpusFileBinding, SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return RecordedCorpusFileBinding::from_bytes(expected_name, None);
+        }
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} cannot be opened without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let initial_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let initial_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial_file.file_type().is_file()
+        || !initial_path.file_type().is_file()
+        || !opened_file_identity_matches(&initial_path, &initial_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not one regular non-symlink inode",
+            path.display()
+        )));
+    }
+    let mut hasher = blake3::Hasher::new();
+    let mut length = 0u64;
+    let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context} {} cannot be streamed: {error}",
+                path.display()
+            ))
+        })?;
+        if read == 0 {
+            break;
+        }
+        length = length
+            .checked_add(read as u64)
+            .ok_or_else(|| SourceUnavailable::new(format!("{context} length overflows u64")))?;
+        hasher.update(&buffer[..read]);
+    }
+    let final_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let final_path = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} changed or disappeared while hashed: {error}",
+            path.display()
+        ))
+    })?;
+    if length != initial_file.len()
+        || !final_path.file_type().is_file()
+        || !opened_file_generation_matches(&initial_file, &final_file)
+        || !opened_file_identity_matches(&final_path, &final_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed generation while it was streamed",
+            path.display()
+        )));
+    }
+    Ok(RecordedCorpusFileBinding {
+        name: expected_name.to_owned(),
+        present: true,
+        length: Some(length),
+        blake3: Some(format!("blake3:{}", hasher.finalize().to_hex())),
+    })
+}
+
+fn open_verified_corpus_member(
+    path: &Path,
+    expected_name: &str,
+    context: &'static str,
+    expected: Option<&RecordedCorpusFileBinding>,
+) -> Result<Option<VerifiedCorpusMember>, SourceUnavailable> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let actual = RecordedCorpusFileBinding::from_bytes(expected_name, None)?;
+            if let Some(expected) = expected {
+                expected.validate_record(expected_name, &actual, context)?;
+            }
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} cannot be opened without following links: {error}",
+                path.display()
+            )));
+        }
+    };
+    let initial = file.metadata().map_err(SourceUnavailable::new)?;
+    let path_metadata = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if !initial.file_type().is_file()
+        || !path_metadata.file_type().is_file()
+        || !opened_file_identity_matches(&path_metadata, &initial)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} is not one regular non-symlink inode",
+            path.display()
+        )));
+    }
+    let mut hasher = blake3::Hasher::new();
+    let mut length = 0u64;
+    let mut buffer = [0u8; STREAM_BINDING_BUFFER_BYTES];
+    loop {
+        let read = file.read(&mut buffer).map_err(SourceUnavailable::new)?;
+        if read == 0 {
+            break;
+        }
+        length = length
+            .checked_add(read as u64)
+            .ok_or_else(|| SourceUnavailable::new(format!("{context} length overflows u64")))?;
+        hasher.update(&buffer[..read]);
+    }
+    let binding = RecordedCorpusFileBinding {
+        name: expected_name.to_owned(),
+        present: true,
+        length: Some(length),
+        blake3: Some(format!("blake3:{}", hasher.finalize().to_hex())),
+    };
+    if let Some(expected) = expected {
+        expected.validate_record(expected_name, &binding, context)?;
+    }
+    file.seek(SeekFrom::Start(0))
+        .map_err(SourceUnavailable::new)?;
+    let member = VerifiedCorpusMember {
+        path: path.to_path_buf(),
+        file,
+        initial,
+        binding,
+        context,
+    };
+    member.verify_generation()?;
+    Ok(Some(member))
+}
+
+fn verify_opened_bytes(
+    file: &mut std::fs::File,
+    path: &Path,
+    context: &str,
+    expected: &[u8],
+    initial_file: &Metadata,
+) -> Result<(), SourceUnavailable> {
+    let mut offset = 0usize;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let count = file.read(&mut buffer).map_err(|error| {
+            SourceUnavailable::new(format!(
+                "{context} {} cannot be verified: {error}",
+                path.display()
+            ))
+        })?;
+        if count == 0 {
+            break;
+        }
+        let end = offset
+            .checked_add(count)
+            .ok_or_else(|| SourceUnavailable::new(format!("{context} byte count overflow")))?;
+        if expected.get(offset..end) != Some(&buffer[..count]) {
+            return Err(SourceUnavailable::new(format!(
+                "{context} {} changed content during capture",
+                path.display()
+            )));
+        }
+        offset = end;
+    }
+    let final_file = file.metadata().map_err(SourceUnavailable::new)?;
+    let final_path = std::fs::symlink_metadata(path).map_err(SourceUnavailable::new)?;
+    if offset != expected.len()
+        || !final_file.file_type().is_file()
+        || !final_path.file_type().is_file()
+        || !opened_file_generation_matches(initial_file, &final_file)
+        || !opened_file_identity_matches(&final_path, &final_file)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed identity, type, length, content, or generation during capture",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn verify_captured_optional_regular_file(
+    path: &Path,
+    context: &str,
+    expected: Option<&[u8]>,
+) -> Result<(), SourceUnavailable> {
+    let Some(expected) = expected else {
+        return match std::fs::symlink_metadata(path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(SourceUnavailable::new(format!(
+                "{context} {} cannot be reinspected: {error}",
+                path.display()
+            ))),
+            Ok(_) => Err(SourceUnavailable::new(format!(
+                "{context} {} appeared after typed absence was captured",
+                path.display()
+            ))),
+        };
+    };
+    let actual = capture_optional_regular_file(path, context)?.ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{context} {} disappeared after capture",
+            path.display()
+        ))
+    })?;
+    if actual != expected {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed after capture",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn canonical_parent(path: &Path, label: &str) -> Result<PathBuf, SourceUnavailable> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} {} cannot be inspected: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SourceUnavailable::new(format!(
+            "{label} {} is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let canonical = std::fs::canonicalize(parent).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{label} parent {} cannot be resolved: {error}",
+            parent.display()
+        ))
+    })?;
+    if !std::fs::metadata(&canonical)
+        .map_err(SourceUnavailable::new)?
+        .is_dir()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{label} parent {} is not a directory",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn resolved_corpus_paths(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<(PathBuf, PathBuf, PathBuf), SourceUnavailable> {
+    let meta_root = canonical_parent(corpus_meta, "corpus metadata")?;
+    let records_root = canonical_parent(corpus_records, "corpus records")?;
+    if meta_root != records_root {
+        return Err(SourceUnavailable::new(format!(
+            "corpus metadata and records have different canonical parent roots ({} versus {}); no cryptographic cross-directory pairing exists",
+            meta_root.display(),
+            records_root.display()
+        )));
+    }
+    let meta_name = corpus_meta
+        .file_name()
+        .ok_or_else(|| SourceUnavailable::new("corpus metadata path has no filename"))?;
+    let records_name = corpus_records
+        .file_name()
+        .ok_or_else(|| SourceUnavailable::new("corpus records path has no filename"))?;
+    Ok((
+        meta_root.clone(),
+        meta_root.join(meta_name),
+        meta_root.join(records_name),
+    ))
+}
+
+fn is_canonical_pair(corpus_meta: &Path, corpus_records: &Path) -> bool {
+    matches!(
+        (corpus_meta.file_name(), corpus_records.file_name()),
+        (Some(meta), Some(records))
+            if (meta == OsStr::new("corpus.meta") && records == OsStr::new("corpus.records"))
+                || (meta == OsStr::new(observation::STATE_FILE)
+                    && records == OsStr::new("merged.bin"))
+    )
+}
+
+fn hidden_path(corpus_records: &Path) -> PathBuf {
+    uor_r4_core::transformerless::compiler::corpus_hidden_path(corpus_records)
+}
+
+type ProvenanceBytes = [Option<Vec<u8>>; 3];
+
+fn provenance_paths(root: &Path) -> [PathBuf; 3] {
+    [
+        root.join(observation::MANIFEST_FILE),
+        root.join(ATTENTION_OPERATOR_BINDING_FILE),
+        root.join(DENSE_OPERATOR_BINDING_FILE),
+    ]
+}
+
+fn capture_provenance(root: &Path) -> Result<ProvenanceBytes, SourceUnavailable> {
+    let paths = provenance_paths(root);
+    let mut bytes: ProvenanceBytes = [None, None, None];
+    for (slot, path) in paths.iter().enumerate() {
+        bytes[slot] = capture_optional_regular_file(path, "recorded corpus provenance")?;
+    }
+    Ok(bytes)
+}
+
+fn verify_provenance(root: &Path, bytes: &ProvenanceBytes) -> Result<(), SourceUnavailable> {
+    for (path, expected) in provenance_paths(root).iter().zip(bytes.iter()) {
+        verify_captured_optional_regular_file(
+            path,
+            "recorded corpus provenance",
+            expected.as_deref(),
+        )?;
+    }
+    Ok(())
+}
+
+fn utf8_file_name(path: &Path, label: &str) -> Result<String, SourceUnavailable> {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "{label} {} has no UTF-8 filename for canonical binding",
+                path.display()
+            ))
+        })
+}
+
+fn binding_path(root: &Path) -> PathBuf {
+    root.join(RECORDED_CORPUS_BINDING_FILE)
+}
+
+fn parse_binding_bytes(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<RecordedCorpusBinding, SourceUnavailable> {
+    reject_duplicate_json(
+        bytes,
+        &format!("recorded corpus binding {}", path.display()),
+    )?;
+    let binding: RecordedCorpusBinding = serde_json::from_slice(bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "invalid recorded corpus binding {}: {error}",
+            path.display()
+        ))
+    })?;
+    if binding.schema != RECORDED_CORPUS_BINDING_SCHEMA {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus binding {} has unsupported schema {:?}",
+            path.display(),
+            binding.schema
+        )));
+    }
+    if binding.canonical_bytes()? != bytes {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus binding {} is not canonical pretty JSON with one trailing newline",
+            path.display()
+        )));
+    }
+    Ok(binding)
+}
+
+fn compile_attempt_path(root: &Path) -> PathBuf {
+    root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+}
+
+fn parse_compile_attempt_bytes(path: &Path, bytes: &[u8]) -> Result<(), SourceUnavailable> {
+    reject_duplicate_json(
+        bytes,
+        &format!("recorded corpus compile-attempt marker {}", path.display()),
+    )?;
+    let marker: RecordedCorpusCompileAttempt = serde_json::from_slice(bytes).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "invalid recorded corpus compile-attempt marker {}: {error}",
+            path.display()
+        ))
+    })?;
+    let expected = RecordedCorpusCompileAttempt::compile();
+    if marker != expected || marker.canonical_bytes()? != bytes {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus compile-attempt marker {} is not the exact canonical compile/1 record",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn compile_attempt_writing_name(name: &str) -> bool {
+    let prefix = format!(".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".writing"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn reserved_compile_attempt_entry_name(
+    root: &Path,
+    name: &OsStr,
+) -> Result<Option<String>, SourceUnavailable> {
+    let prefix = format!(".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.");
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = name.as_bytes();
+        if !bytes.starts_with(prefix.as_bytes()) {
+            return Ok(None);
+        }
+        return std::str::from_utf8(bytes)
+            .map(|name| Some(name.to_owned()))
+            .map_err(|_| {
+                SourceUnavailable::new(format!(
+                    "recorded corpus root {} contains a non-UTF-8 entry in the reserved compile-attempt namespace",
+                    root.display()
+                ))
+            });
+    }
+    #[cfg(not(unix))]
+    {
+        let lossy = name.to_string_lossy();
+        if !lossy.starts_with(&prefix) {
+            return Ok(None);
+        }
+        name.to_str().map(|name| Some(name.to_owned())).ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus root {} contains a non-Unicode entry in the reserved compile-attempt namespace",
+                root.display()
+            ))
+        })
+    }
+}
+
+fn compile_attempt_residues(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, SourceUnavailable> {
+    let mut residues = Vec::new();
+    for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let Some(name) = reserved_compile_attempt_entry_name(root, &entry.file_name())? else {
+            continue;
+        };
+        if !compile_attempt_writing_name(&name) {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains unrecognized reserved compile-attempt entry {name:?}",
+                root.display()
+            )));
+        }
+        let path = entry.path();
+        let bytes =
+            capture_optional_regular_file(&path, "recorded corpus compile-attempt staging")?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus compile-attempt staging {} disappeared",
+                        path.display()
+                    ))
+                })?;
+        residues.push((path, bytes));
+    }
+    residues.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(residues)
+}
+
+fn validate_compile_attempt_namespace(
+    root: &Path,
+    role: RecordedCorpusRole,
+) -> Result<(), SourceUnavailable> {
+    let stable = compile_attempt_path(root);
+    let stable_present =
+        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?;
+    if let Some(bytes) = stable_present.as_deref() {
+        parse_compile_attempt_bytes(&stable, bytes)?;
+    }
+    let residues = compile_attempt_residues(root)?;
+    if role == RecordedCorpusRole::Observation && (stable_present.is_some() || !residues.is_empty())
+    {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus root {} contains compile-attempt evidence; refusing observation mutation",
+            root.display()
+        )));
+    }
+    Ok(())
+}
+
+fn publish_compile_attempt_marker(
+    guard: &RecordedCorpusProducerGuard,
+) -> Result<(), SourceUnavailable> {
+    validate_compile_attempt_namespace(&guard.root, RecordedCorpusRole::Compile)?;
+    let expected = RecordedCorpusCompileAttempt::compile().canonical_bytes()?;
+    let stable = compile_attempt_path(&guard.root);
+    if let Some(bytes) =
+        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
+    {
+        if bytes != expected {
+            return Err(SourceUnavailable::new(
+                "recorded corpus compile-attempt marker conflicts with compile/1",
+            ));
+        }
+        for (path, bytes) in compile_attempt_residues(&guard.root)? {
+            remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
+        }
+        return sync_binding_directory(&guard.root);
+    }
+    for (path, bytes) in compile_attempt_residues(&guard.root)? {
+        remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
+    }
+    let (staging, mut file) = loop {
+        let sequence = RECORDED_CORPUS_COMPILE_ATTEMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = guard.root.join(format!(
+            ".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.{}.{}.writing",
+            std::process::id(),
+            sequence
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        }
+        match options.open(&candidate) {
+            Ok(file) => break (candidate, file),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(SourceUnavailable::new(error)),
+        }
+    };
+    file.write_all(&expected)
+        .and_then(|()| file.sync_all())
+        .map_err(SourceUnavailable::new)?;
+    guard.verify_root()?;
+    match std::fs::hard_link(&staging, &stable) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let current =
+                capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
+                    .ok_or_else(|| SourceUnavailable::new("compile-attempt marker disappeared"))?;
+            if current != expected {
+                return Err(SourceUnavailable::new(
+                    "recorded corpus compile-attempt marker appeared with conflicting bytes",
+                ));
+            }
+        }
+        Err(error) => return Err(SourceUnavailable::new(error)),
+    }
+    std::fs::remove_file(&staging).map_err(SourceUnavailable::new)?;
+    sync_binding_directory(&guard.root)?;
+    let current = capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
+        .ok_or_else(|| SourceUnavailable::new("compile-attempt marker disappeared"))?;
+    parse_compile_attempt_bytes(&stable, &current)
+}
+
+fn finish_compile_attempt_marker(
+    guard: &RecordedCorpusProducerGuard,
+) -> Result<(), SourceUnavailable> {
+    validate_compile_attempt_namespace(&guard.root, RecordedCorpusRole::Compile)?;
+    let stable = compile_attempt_path(&guard.root);
+    if let Some(bytes) =
+        capture_optional_regular_file(&stable, "recorded corpus compile-attempt marker")?
+    {
+        parse_compile_attempt_bytes(&stable, &bytes)?;
+        remove_exact_binding_residue(&stable, &bytes, "recorded corpus compile-attempt marker")?;
+    }
+    for (path, bytes) in compile_attempt_residues(&guard.root)? {
+        remove_exact_binding_residue(&path, &bytes, "compile-attempt staging")?;
+    }
+    sync_binding_directory(&guard.root)
+}
+
+fn binding_temporary_name(name: &str) -> bool {
+    let prefix = format!(".{RECORDED_CORPUS_BINDING_FILE}.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn binding_writing_name(name: &str) -> bool {
+    let prefix = format!(".{RECORDED_CORPUS_BINDING_FILE}.");
+    let Some(sequence) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".writing"))
+    else {
+        return false;
+    };
+    let mut parts = sequence.split('.');
+    parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn reserved_binding_entry_name(
+    root: &Path,
+    name: &OsStr,
+) -> Result<Option<String>, SourceUnavailable> {
+    let prefix = format!(".{RECORDED_CORPUS_BINDING_FILE}.");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = name.as_bytes();
+        if !bytes.starts_with(prefix.as_bytes()) {
+            return Ok(None);
+        }
+        let name = std::str::from_utf8(bytes).map_err(|_| {
+            SourceUnavailable::new(format!(
+                "recorded corpus root {} contains a non-UTF-8 entry in the reserved binding publication namespace",
+                root.display()
+            ))
+        })?;
+        Ok(Some(name.to_owned()))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let lossy = name.to_string_lossy();
+        if !lossy.starts_with(&prefix) {
+            return Ok(None);
+        }
+        let name = name.to_str().ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus root {} contains a non-Unicode entry in the reserved binding publication namespace",
+                root.display()
+            ))
+        })?;
+        Ok(Some(name.to_owned()))
+    }
+}
+
+#[derive(Default)]
+struct BindingPublicationResidues {
+    temporaries: Vec<(PathBuf, Vec<u8>)>,
+    writings: Vec<(PathBuf, Vec<u8>)>,
+}
+
+fn binding_publication_residues(
+    root: &Path,
+    capture_writings: bool,
+) -> Result<BindingPublicationResidues, SourceUnavailable> {
+    let mut residues = BindingPublicationResidues::default();
+    for entry in std::fs::read_dir(root).map_err(SourceUnavailable::new)? {
+        let entry = entry.map_err(SourceUnavailable::new)?;
+        let name = entry.file_name();
+        let Some(name) = reserved_binding_entry_name(root, &name)? else {
+            continue;
+        };
+        if binding_temporary_name(&name) {
+            let path = entry.path();
+            let bytes = capture_optional_regular_file(&path, "recorded corpus binding temporary")?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus binding temporary {} disappeared during validation",
+                        path.display()
+                    ))
+                })?;
+            let _ = parse_binding_bytes(&path, &bytes)?;
+            residues.temporaries.push((path, bytes));
+        } else if binding_writing_name(&name) {
+            // A `.writing` inode is deliberately non-authoritative: readers
+            // ignore it, while the exclusive publisher may validate and
+            // reclaim it before beginning a new publication attempt.
+            if capture_writings {
+                let path = entry.path();
+                let bytes = capture_optional_regular_file(
+                    &path,
+                    "recorded corpus non-authoritative binding staging file",
+                )?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus binding staging file {} disappeared during validation",
+                        path.display()
+                    ))
+                })?;
+                residues.writings.push((path, bytes));
+            }
+        } else {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus root {} contains unrecognized entry {name:?} in the reserved binding publication namespace",
+                root.display()
+            )));
+        }
+    }
+    residues
+        .temporaries
+        .sort_by(|left, right| left.0.cmp(&right.0));
+    residues
+        .writings
+        .sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(residues)
+}
+
+fn binding_temporaries(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>, SourceUnavailable> {
+    Ok(binding_publication_residues(root, false)?.temporaries)
+}
+
+fn require_no_binding_temporaries(root: &Path) -> Result<(), SourceUnavailable> {
+    let temporaries = binding_temporaries(root)?;
+    if temporaries.is_empty() {
+        return Ok(());
+    }
+    Err(SourceUnavailable::new(format!(
+        "recorded corpus root {} contains an unpublished canonical binding temporary; writer recovery is required before reading",
+        root.display()
+    )))
+}
+
+fn make_streaming_binding(
+    meta_path: &Path,
+    records_path: &Path,
+    hidden_path: &Path,
+    provenance: &ProvenanceBytes,
+    meta_bytes: &[u8],
+) -> Result<RecordedCorpusBinding, SourceUnavailable> {
+    let metadata_name = utf8_file_name(meta_path, "recorded corpus metadata")?;
+    let records_name = utf8_file_name(records_path, "recorded corpus records")?;
+    let hidden_name = utf8_file_name(hidden_path, "recorded corpus hidden stream")?;
+    Ok(RecordedCorpusBinding {
+        schema: RECORDED_CORPUS_BINDING_SCHEMA.to_owned(),
+        manifest: RecordedCorpusFileBinding::from_bytes(
+            observation::MANIFEST_FILE,
+            provenance[0].as_deref(),
+        )?,
+        attention_operator: RecordedCorpusFileBinding::from_bytes(
+            ATTENTION_OPERATOR_BINDING_FILE,
+            provenance[1].as_deref(),
+        )?,
+        dense_operator: RecordedCorpusFileBinding::from_bytes(
+            DENSE_OPERATOR_BINDING_FILE,
+            provenance[2].as_deref(),
+        )?,
+        metadata: RecordedCorpusFileBinding::from_bytes(&metadata_name, Some(meta_bytes))?,
+        records: stream_regular_file_binding(
+            records_path,
+            &records_name,
+            "recorded corpus records",
+        )?,
+        hidden: stream_regular_file_binding(
+            hidden_path,
+            &hidden_name,
+            "recorded corpus hidden stream",
+        )?,
+    })
+}
+
+fn validate_finalized_corpus_shape(
+    meta_bytes: &[u8],
+    records: &RecordedCorpusFileBinding,
+) -> Result<(), SourceUnavailable> {
+    if meta_bytes.len() != 25 || meta_bytes[24] != 1 {
+        return Err(SourceUnavailable::new(
+            "recorded corpus binding requires one exact finalized 25-byte metadata checkpoint",
+        ));
+    }
+    let count = u64::from_le_bytes(
+        meta_bytes[0..8]
+            .try_into()
+            .map_err(|_| SourceUnavailable::new("invalid finalized corpus count"))?,
+    );
+    let length = records.length.ok_or_else(|| {
+        SourceUnavailable::new("recorded corpus records are absent during binding publication")
+    })?;
+    if count == 0
+        || ![88u64, 48, 32, 12]
+            .into_iter()
+            .any(|width| count.checked_mul(width) == Some(length))
+    {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus has {count} rows and {length} record bytes, not one exact registered finalized layout"
+        )));
+    }
+    Ok(())
+}
+
+struct CapturedBindingMembers<'a> {
+    meta_path: &'a Path,
+    records_path: &'a Path,
+    hidden_path: &'a Path,
+    provenance: &'a ProvenanceBytes,
+    meta_bytes: &'a [u8],
+    records_bytes: &'a [u8],
+    hidden_bytes: Option<&'a [u8]>,
+}
+
+fn validate_binding_generation(
+    binding: &RecordedCorpusBinding,
+    members: &CapturedBindingMembers<'_>,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    binding.manifest.validate(
+        observation::MANIFEST_FILE,
+        members.provenance[0].as_deref(),
+        context,
+    )?;
+    binding.attention_operator.validate(
+        ATTENTION_OPERATOR_BINDING_FILE,
+        members.provenance[1].as_deref(),
+        context,
+    )?;
+    binding.dense_operator.validate(
+        DENSE_OPERATOR_BINDING_FILE,
+        members.provenance[2].as_deref(),
+        context,
+    )?;
+    binding.metadata.validate(
+        &utf8_file_name(members.meta_path, "recorded corpus metadata")?,
+        Some(members.meta_bytes),
+        context,
+    )?;
+    binding.records.validate(
+        &utf8_file_name(members.records_path, "recorded corpus records")?,
+        Some(members.records_bytes),
+        context,
+    )?;
+    binding.hidden.validate(
+        &utf8_file_name(members.hidden_path, "recorded corpus hidden stream")?,
+        members.hidden_bytes,
+        context,
+    )
+}
+
+fn parse_execution_identity(
+    root: &Path,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    bytes: &ProvenanceBytes,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let manifest_path = root.join(observation::MANIFEST_FILE);
+    let manifest = bytes[0]
+        .as_deref()
+        .map(|bytes| {
+            reject_duplicate_json(
+                bytes,
+                &format!("observation manifest {}", manifest_path.display()),
+            )
+            .map_err(|mut error| {
+                error.reason = format!(
+                    "{}: malformed observation manifest: {}",
+                    manifest_path.display(),
+                    error.reason
+                );
+                error
+            })?;
+            ObservationManifest::parse_captured_execution_identity(root, &manifest_path, bytes)
+                .map_err(|mut error| {
+                    error.reason = format!(
+                        "{}: malformed observation manifest: {}",
+                        manifest_path.display(),
+                        error.reason
+                    );
+                    error
+                })
+        })
+        .transpose()?;
+    let manifest_present = manifest.is_some();
+
+    let attention_path = root.join(ATTENTION_OPERATOR_BINDING_FILE);
+    let sidecar_attention = bytes[1]
+        .as_deref()
+        .map(|bytes| {
+            reject_duplicate_json(
+                bytes,
+                &format!("attention operator sidecar {}", attention_path.display()),
+            )?;
+            let operator: AttentionOperatorSpec =
+                serde_json::from_slice(bytes).map_err(|error| {
+                    SourceUnavailable::new(format!(
+                        "invalid attention operator sidecar {}: {error}",
+                        attention_path.display()
+                    ))
+                })?;
+            observation::validate_registered_source_attention_operator(&operator)?;
+            Ok::<_, SourceUnavailable>(operator)
+        })
+        .transpose()?;
+    let dense_path = root.join(DENSE_OPERATOR_BINDING_FILE);
+    let sidecar_dense = bytes[2]
+        .as_deref()
+        .map(|bytes| {
+            reject_duplicate_json(
+                bytes,
+                &format!("dense operator sidecar {}", dense_path.display()),
+            )?;
+            let operator: DenseOperatorSpec = serde_json::from_slice(bytes).map_err(|error| {
+                SourceUnavailable::new(format!(
+                    "invalid dense operator sidecar {}: {error}",
+                    dense_path.display()
+                ))
+            })?;
+            observation::validate_registered_source_dense_operator(&operator)?;
+            Ok::<_, SourceUnavailable>(operator)
+        })
+        .transpose()?;
+    let manifest_attention = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.attention_operator.clone());
+    let manifest_dense = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.dense_operator.clone());
+
+    if (manifest_present || sidecar_attention.is_some() || sidecar_dense.is_some())
+        && !is_canonical_pair(corpus_meta, corpus_records)
+    {
+        return Err(SourceUnavailable::new(format!(
+            "recorded-corpus provenance in {} applies only to the canonical corpus.meta/corpus.records or state.bin/merged.bin pair; refusing to attach it to {}/{}",
+            root.display(),
+            corpus_meta.display(),
+            corpus_records.display()
+        )));
+    }
+    if let Some(sidecar) = sidecar_attention.as_ref()
+        && manifest_present
+        && manifest_attention.is_none()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{} declares attention operator {}/{} but {} records the legacy operatorless era",
+            attention_path.display(),
+            sidecar.id,
+            sidecar.version,
+            manifest_path.display()
+        )));
+    }
+    if let Some(sidecar) = sidecar_dense.as_ref()
+        && manifest_present
+        && manifest_dense.is_none()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "{} declares dense operator {}/{} but {} records the dense-operator-absent era",
+            dense_path.display(),
+            sidecar.id,
+            sidecar.version,
+            manifest_path.display()
+        )));
+    }
+
+    let attention_operator = match (sidecar_attention, manifest_attention) {
+        (Some(sidecar), Some(manifest)) if sidecar != manifest => {
+            return Err(SourceUnavailable::new(format!(
+                "{} and {} declare different attention operators",
+                attention_path.display(),
+                manifest_path.display()
+            )));
+        }
+        (Some(sidecar), _) => Some(sidecar),
+        (None, manifest) => manifest,
+    };
+    let dense_operator = match (sidecar_dense, manifest_dense) {
+        (Some(sidecar), Some(manifest)) if sidecar != manifest => {
+            return Err(SourceUnavailable::new(format!(
+                "{} and {} declare different dense operators",
+                dense_path.display(),
+                manifest_path.display()
+            )));
+        }
+        (Some(sidecar), _) => Some(sidecar),
+        (None, manifest) => manifest,
+    };
+    if attention_operator.is_none()
+        && let Some(dense) = dense_operator.as_ref()
+    {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus declares dense operator {}/{} without an attention operator",
+            dense.id, dense.version
+        )));
+    }
+    observation::validate_source_execution_identity(
+        attention_operator.as_ref(),
+        dense_operator.as_ref(),
+        "recorded corpus provenance",
+    )?;
+    Ok(RecordedCorpusExecutionIdentity {
+        attention_operator,
+        dense_operator,
+    })
+}
+
+/// Require the caller-declared pair to equal the exact recorded pair. Typed
+/// absence is significant: a current dense corpus cannot be relabeled by
+/// omitting `--dense-operator`, and a legacy corpus cannot acquire one.
+pub fn require_execution_identity(
+    recorded: &RecordedCorpusExecutionIdentity,
+    attention: Option<&AttentionOperatorSpec>,
+    dense: Option<&DenseOperatorSpec>,
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    if let Some(attention) = attention {
+        observation::validate_registered_source_attention_operator(attention)?;
+    }
+    if let Some(dense) = dense {
+        observation::validate_registered_source_dense_operator(dense)?;
+    }
+    observation::validate_source_execution_identity(attention, dense, context)?;
+    if recorded.attention_operator.as_ref() != attention {
+        return Err(SourceUnavailable::new(format!(
+            "{context}: requested attention execution identity does not match the recorded corpus; refusing before output mutation"
+        )));
+    }
+    if recorded.dense_operator.as_ref() != dense {
+        return Err(SourceUnavailable::new(format!(
+            "{context}: requested dense execution identity does not match the recorded corpus; refusing before output mutation"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn capture_with_hooks<F, G>(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    after_provenance_capture: F,
+    after_corpus_capture: G,
+) -> Result<RecordedCorpusSnapshot, SourceUnavailable>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    let (root, resolved_meta, resolved_records) =
+        resolved_corpus_paths(corpus_meta, corpus_records)?;
+    require_no_binding_temporaries(&root)?;
+    let stable_binding_path = binding_path(&root);
+    let binding_bytes =
+        capture_optional_regular_file(&stable_binding_path, "recorded corpus generation binding")?;
+    let binding = binding_bytes
+        .as_deref()
+        .map(|bytes| parse_binding_bytes(&stable_binding_path, bytes))
+        .transpose()?;
+    let compile_attempt_path = compile_attempt_path(&root);
+    let compile_attempt = capture_optional_regular_file(
+        &compile_attempt_path,
+        "recorded corpus compile-attempt marker",
+    )?;
+    if let Some(bytes) = compile_attempt.as_deref() {
+        parse_compile_attempt_bytes(&compile_attempt_path, bytes)?;
+        match binding.as_ref() {
+            Some(binding) => {
+                validate_binding_role(binding, RecordedCorpusRole::Compile, &stable_binding_path)?
+            }
+            None => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} has an unfinished compile attempt without a stable generation binding",
+                    root.display()
+                )));
+            }
+        }
+    }
+
+    let provenance = capture_provenance(&root)?;
+    after_provenance_capture();
+
+    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus metadata {} disappeared during capture",
+                resolved_meta.display()
+            ))
+        })?;
+    let records_bytes =
+        capture_optional_regular_file(&resolved_records, "recorded corpus records")?.ok_or_else(
+            || {
+                SourceUnavailable::new(format!(
+                    "recorded corpus records {} disappeared during capture",
+                    resolved_records.display()
+                ))
+            },
+        )?;
+    let hidden_path = hidden_path(&resolved_records);
+    let hidden_bytes =
+        capture_optional_regular_file(&hidden_path, "recorded corpus hidden stream")?;
+
+    after_corpus_capture();
+    let execution =
+        parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
+
+    let binding_cid = if let (Some(binding), Some(bytes)) = (&binding, binding_bytes.as_deref()) {
+        validate_binding_generation(
+            binding,
+            &CapturedBindingMembers {
+                meta_path: &resolved_meta,
+                records_path: &resolved_records,
+                hidden_path: &hidden_path,
+                provenance: &provenance,
+                meta_bytes: &meta_bytes,
+                records_bytes: &records_bytes,
+                hidden_bytes: hidden_bytes.as_deref(),
+            },
+            &format!("recorded corpus binding {}", stable_binding_path.display()),
+        )?;
+        Some(format!("blake3:{}", blake3::hash(bytes).to_hex()))
+    } else {
+        // Markerless compatibility retains the historical repeated-read
+        // defense. It is intentionally not advertised as an adversarial
+        // cross-file transaction: only the canonical binding supplies that
+        // guarantee.
+        verify_provenance(&root, &provenance)?;
+        verify_captured_optional_regular_file(
+            &resolved_meta,
+            "recorded corpus metadata",
+            Some(meta_bytes.as_slice()),
+        )?;
+        verify_captured_optional_regular_file(
+            &resolved_records,
+            "recorded corpus records",
+            Some(records_bytes.as_slice()),
+        )?;
+        verify_captured_optional_regular_file(
+            &hidden_path,
+            "recorded corpus hidden stream",
+            hidden_bytes.as_deref(),
+        )?;
+        verify_captured_optional_regular_file(
+            &stable_binding_path,
+            "recorded corpus generation binding",
+            None,
+        )?;
+        require_no_binding_temporaries(&root)?;
+        if let Some(dense) = execution.dense_operator.as_ref() {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus in {} declares dense operator {}/{} but has no canonical {}; dense-present generations must be committed last before use",
+                root.display(),
+                dense.id,
+                dense.version,
+                RECORDED_CORPUS_BINDING_FILE
+            )));
+        }
+        None
+    };
+    Ok(RecordedCorpusSnapshot {
+        execution,
+        attention_operator_bytes: provenance[1].clone(),
+        dense_operator_bytes: provenance[2].clone(),
+        meta_bytes,
+        records_bytes,
+        hidden_bytes,
+        binding,
+        binding_cid,
+    })
+}
+
+/// Capture and reverify provenance and corpus bytes as one transaction.
+pub fn capture(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusSnapshot, SourceUnavailable> {
+    capture_with_hooks(corpus_meta, corpus_records, || {}, || {})
+}
+
+/// Open one bounded-memory recorded-corpus generation.
+///
+/// Large records and hidden-state members are hashed through retained
+/// no-follow handles and rewound; their bodies are never accumulated here.
+/// A consumer may seek/read those handles and must call
+/// [`RecordedCorpusStreamSnapshot::verify_generation`] after its final read
+/// and immediately before publishing any derived generation. Markerless
+/// compatibility callers additionally hold a [`RecordedCorpusProducerGuard`]
+/// for the source while opening, reading, and performing that final check.
+pub fn open_stream(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusStreamSnapshot, SourceUnavailable> {
+    let (root, resolved_meta, resolved_records) =
+        resolved_corpus_paths(corpus_meta, corpus_records)?;
+    require_no_binding_temporaries(&root)?;
+    let stable_path = binding_path(&root);
+    let binding_bytes =
+        capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?;
+    let binding = binding_bytes
+        .as_deref()
+        .map(|bytes| parse_binding_bytes(&stable_path, bytes))
+        .transpose()?;
+    let marker_path = compile_attempt_path(&root);
+    let marker_bytes =
+        capture_optional_regular_file(&marker_path, "recorded corpus compile-attempt marker")?;
+    if let Some(bytes) = marker_bytes.as_deref() {
+        parse_compile_attempt_bytes(&marker_path, bytes)?;
+        match binding.as_ref() {
+            Some(binding) => {
+                validate_binding_role(binding, RecordedCorpusRole::Compile, &stable_path)?
+            }
+            None => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus root {} has an unfinished compile attempt without a stable generation binding",
+                    root.display()
+                )));
+            }
+        }
+    }
+
+    let provenance = capture_provenance(&root)?;
+    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
+        .ok_or_else(|| SourceUnavailable::new("recorded corpus metadata is absent"))?;
+    let hidden = hidden_path(&resolved_records);
+    let records_name = utf8_file_name(&resolved_records, "recorded corpus records")?;
+    let hidden_name = utf8_file_name(&hidden, "recorded corpus hidden stream")?;
+    let records = open_verified_corpus_member(
+        &resolved_records,
+        &records_name,
+        "recorded corpus records",
+        binding.as_ref().map(|binding| &binding.records),
+    )?
+    .ok_or_else(|| SourceUnavailable::new("recorded corpus records are absent"))?;
+    let hidden_member = open_verified_corpus_member(
+        &hidden,
+        &hidden_name,
+        "recorded corpus hidden stream",
+        binding.as_ref().map(|binding| &binding.hidden),
+    )?;
+    let execution =
+        parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
+
+    let binding_cid = if let (Some(binding), Some(bytes)) =
+        (binding.as_ref(), binding_bytes.as_deref())
+    {
+        let context = format!("recorded corpus binding {}", stable_path.display());
+        binding.manifest.validate(
+            observation::MANIFEST_FILE,
+            provenance[0].as_deref(),
+            &context,
+        )?;
+        binding.attention_operator.validate(
+            ATTENTION_OPERATOR_BINDING_FILE,
+            provenance[1].as_deref(),
+            &context,
+        )?;
+        binding.dense_operator.validate(
+            DENSE_OPERATOR_BINDING_FILE,
+            provenance[2].as_deref(),
+            &context,
+        )?;
+        binding.metadata.validate(
+            &utf8_file_name(&resolved_meta, "recorded corpus metadata")?,
+            Some(&meta_bytes),
+            &context,
+        )?;
+        Some(format!("blake3:{}", blake3::hash(bytes).to_hex()))
+    } else {
+        if let Some(dense) = execution.dense_operator.as_ref() {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus in {} declares dense operator {}/{} but has no canonical {}; dense-present generations must be committed last before use",
+                root.display(),
+                dense.id,
+                dense.version,
+                RECORDED_CORPUS_BINDING_FILE
+            )));
+        }
+        None
+    };
+
+    let snapshot = RecordedCorpusStreamSnapshot {
+        execution,
+        attention_operator_bytes: provenance[1].clone(),
+        dense_operator_bytes: provenance[2].clone(),
+        meta_bytes,
+        records,
+        hidden: hidden_member,
+        binding_cid,
+        root,
+        provenance,
+        meta_path: resolved_meta,
+        binding_path: stable_path,
+        binding_bytes,
+        marker_path,
+        marker_bytes,
+        hidden_path: hidden,
+    };
+    snapshot.verify_generation()?;
+    Ok(snapshot)
+}
+
+/// Bounded-memory identity resolver for status/copy callers. It validates the
+/// complete bound generation while retaining no corpus body in memory.
+pub fn execution_identity(
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusExecutionIdentity, SourceUnavailable> {
+    let (root, _, _) = resolved_corpus_paths(corpus_meta, corpus_records)?;
+    let source_guard = RecordedCorpusReaderGuard::try_acquire(&root)?;
+    let snapshot = open_stream(corpus_meta, corpus_records)?;
+    snapshot.verify_generation()?;
+    source_guard.verify()?;
+    Ok(snapshot.execution)
+}
+
+/// Open a stream while the caller already owns the exact producer root. This
+/// avoids self-contention in source/server publication paths while preserving
+/// the same root-identity and final-generation checks.
+pub fn open_stream_under_guard(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<RecordedCorpusStreamSnapshot, SourceUnavailable> {
+    let (root, _, _) = resolved_corpus_paths(corpus_meta, corpus_records)?;
+    if !guard.protects_directory(&root)? {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus producer guard for {} does not own stream root {}",
+            guard.root().display(),
+            root.display()
+        )));
+    }
+    let snapshot = open_stream(corpus_meta, corpus_records)?;
+    snapshot.verify_generation()?;
+    guard.verify_owned_root()?;
+    Ok(snapshot)
+}
+
+fn sync_binding_directory(root: &Path) -> Result<(), SourceUnavailable> {
+    std::fs::File::open(root)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            SourceUnavailable::new(format!(
+                "recorded corpus root {} cannot be synchronized after binding publication: {error}",
+                root.display()
+            ))
+        })
+}
+
+fn create_binding_temporary(root: &Path, bytes: &[u8]) -> Result<PathBuf, SourceUnavailable> {
+    loop {
+        let sequence = RECORDED_CORPUS_BINDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let writing = root.join(format!(
+            ".{RECORDED_CORPUS_BINDING_FILE}.{}.{}.writing",
+            std::process::id(),
+            sequence
+        ));
+        let temporary = root.join(format!(
+            ".{RECORDED_CORPUS_BINDING_FILE}.{}.{}.tmp",
+            std::process::id(),
+            sequence
+        ));
+        match std::fs::symlink_metadata(&temporary) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(_) => continue,
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus binding temporary {} cannot be inspected: {error}",
+                    temporary.display()
+                )));
+            }
+        }
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&writing)
+        {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+                    let _ = std::fs::remove_file(&writing);
+                    return Err(SourceUnavailable::new(format!(
+                        "recorded corpus binding staging file {} cannot be written: {error}",
+                        writing.display()
+                    )));
+                }
+                drop(file);
+                std::fs::rename(&writing, &temporary).map_err(|error| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus binding staging promotion {} -> {} failed: {error}",
+                        writing.display(),
+                        temporary.display()
+                    ))
+                })?;
+                sync_binding_directory(root)?;
+                return Ok(temporary);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus binding staging file {} cannot be created: {error}",
+                    writing.display()
+                )));
+            }
+        }
+    }
+}
+
+fn remove_exact_binding_residue(
+    path: &Path,
+    expected: &[u8],
+    context: &str,
+) -> Result<(), SourceUnavailable> {
+    let current = capture_optional_regular_file(path, context)?.ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{context} {} disappeared before recovery",
+            path.display()
+        ))
+    })?;
+    if current != expected {
+        return Err(SourceUnavailable::new(format!(
+            "{context} {} changed before recovery",
+            path.display()
+        )));
+    }
+    std::fs::remove_file(path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "{context} {} cannot be reclaimed: {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Read-only verification that every stable/recoverable binding record, when
+/// present, is the canonical binding for the exact current member bytes.
+/// Deterministic producers call this after all destination-member preflights
+/// and before publishing their compile-attempt marker, so a terminal recovery
+/// conflict leaves the corpus root byte-identical.
+pub fn preflight_binding_evidence_matches_current(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<(), SourceUnavailable> {
+    preflight_binding_evidence_matches_current_inner(guard, corpus_meta, corpus_records, true)
+}
+
+/// Publication state accepted for a resumable source-generation update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceUpdatePublicationState {
+    /// An exact canonical binding temporary commits the current member bytes
+    /// and must be promoted before the generator changes them again.
+    pub recoverable_binding: bool,
+    /// A stable compile-attempt marker proves an interrupted same-role update.
+    pub attempt_active: bool,
+}
+
+/// Validate source-update binding evidence without confusing an honest
+/// binding-last crash with a deterministic-output conflict.
+///
+/// With no active compile marker, every stable binding and temporary must
+/// commit the exact current member bytes. With an active marker, a stable
+/// binding may remain the canonical last-good generation while the
+/// authoritative resume checkpoint has advanced; canonical temporaries must
+/// still match the current bytes exactly. The caller is responsible for
+/// validating that checkpoint before invoking this seam.
+pub fn preflight_source_update_publication(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<SourceUpdatePublicationState, SourceUnavailable> {
+    guard.verify_root()?;
+    let recoverable_binding =
+        guard.preflight_publication_namespace_for(RecordedCorpusRole::Compile)?;
+    let marker = compile_attempt_path(&guard.root);
+    let attempt_active =
+        capture_optional_regular_file(&marker, "recorded corpus compile-attempt marker")?
+            .map(|bytes| parse_compile_attempt_bytes(&marker, &bytes))
+            .transpose()?
+            .is_some();
+    let stable = capture_optional_regular_file(
+        &binding_path(&guard.root),
+        "recorded corpus generation binding",
+    )?
+    .is_some();
+    if recoverable_binding || (stable && !attempt_active) {
+        preflight_binding_evidence_matches_current_inner(
+            guard,
+            corpus_meta,
+            corpus_records,
+            !attempt_active,
+        )?;
+    }
+    Ok(SourceUpdatePublicationState {
+        recoverable_binding,
+        attempt_active,
+    })
+}
+
+fn preflight_binding_evidence_matches_current_inner(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+    check_stable: bool,
+) -> Result<(), SourceUnavailable> {
+    guard.verify_root()?;
+    let (root, resolved_meta, resolved_records) =
+        resolved_corpus_paths(corpus_meta, corpus_records)?;
+    if root != guard.root {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus producer guard owns {}, but binding preflight resolved to {}",
+            guard.root.display(),
+            root.display()
+        )));
+    }
+    if !is_canonical_pair(&resolved_meta, &resolved_records) {
+        return Err(SourceUnavailable::new(
+            "binding preflight requires a canonical corpus.meta/corpus.records or state.bin/merged.bin pair",
+        ));
+    }
+    let role = if resolved_meta.file_name() == Some(OsStr::new("corpus.meta")) {
+        RecordedCorpusRole::Compile
+    } else {
+        RecordedCorpusRole::Observation
+    };
+    validate_role_inventory(&root, role)?;
+    validate_compile_attempt_namespace(&root, role)?;
+    let provenance = capture_provenance(&root)?;
+    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
+        .ok_or_else(|| SourceUnavailable::new("binding preflight metadata is absent"))?;
+    let resolved_hidden = hidden_path(&resolved_records);
+    let execution =
+        parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
+    let binding = make_streaming_binding(
+        &resolved_meta,
+        &resolved_records,
+        &resolved_hidden,
+        &provenance,
+        &meta_bytes,
+    )?;
+    if !binding.records.present {
+        return Err(SourceUnavailable::new(
+            "binding preflight records are absent",
+        ));
+    }
+    if execution.dense_operator.is_some() {
+        validate_finalized_corpus_shape(&meta_bytes, &binding.records)?;
+    }
+    let expected = binding.canonical_bytes()?;
+    let stable_path = binding_path(&root);
+    if let Some(bytes) =
+        capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?
+            .filter(|_| check_stable)
+    {
+        let binding = parse_binding_bytes(&stable_path, &bytes)?;
+        validate_binding_role(&binding, role, &stable_path)?;
+        if bytes != expected {
+            return Err(SourceUnavailable::new(format!(
+                "stable recorded corpus binding {} does not commit the exact planned generation",
+                stable_path.display()
+            )));
+        }
+    }
+    let residues = binding_publication_residues(&root, true)?;
+    for (path, bytes) in residues.temporaries {
+        let binding = parse_binding_bytes(&path, &bytes)?;
+        validate_binding_role(&binding, role, &path)?;
+        if bytes != expected {
+            return Err(SourceUnavailable::new(format!(
+                "recorded corpus binding temporary {} does not commit the exact planned generation",
+                path.display()
+            )));
+        }
+    }
+    guard.verify_root()
+}
+
+/// Publish or repair the canonical generation binding after a producer has
+/// completed a canonical corpus pair. The binding is the final commit point.
+///
+/// Canonical publisher temporaries are recovered only when every byte exactly
+/// matches the intended current generation. Malformed, nonregular, unknown,
+/// or conflicting canonical residue remains untouched and terminal.
+///
+/// The reserved `.{RECORDED_CORPUS_BINDING_FILE}.<pid>.<sequence>.writing`
+/// namespace is non-authoritative and ignored by readers. This function may
+/// reclaim registry-shaped regular `.writing` residue, including zero or
+/// partial bytes left by process death, only under this API's hard precondition
+/// that its caller holds exclusive producer ownership of the corpus root for
+/// the entire publication attempt. Callers must not use this function as an
+/// unlocked cleanup utility.
+pub fn publish_binding(
+    guard: &RecordedCorpusProducerGuard,
+    corpus_meta: &Path,
+    corpus_records: &Path,
+) -> Result<String, SourceUnavailable> {
+    guard.verify_root()?;
+    let (root, resolved_meta, resolved_records) =
+        resolved_corpus_paths(corpus_meta, corpus_records)?;
+    if root != guard.root {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus producer guard owns {}, but binding publication resolved to {}; refusing cross-root publication before mutation",
+            guard.root.display(),
+            root.display()
+        )));
+    }
+    guard.verify_root()?;
+    if !is_canonical_pair(&resolved_meta, &resolved_records) {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus generation bindings are supported only for canonical corpus.meta/corpus.records or state.bin/merged.bin pairs, not {}/{}",
+            resolved_meta.display(),
+            resolved_records.display()
+        )));
+    }
+    let intended_role = if resolved_meta.file_name() == Some(OsStr::new("corpus.meta")) {
+        RecordedCorpusRole::Compile
+    } else {
+        RecordedCorpusRole::Observation
+    };
+    validate_role_inventory(&root, intended_role)?;
+    validate_compile_attempt_namespace(&root, intended_role)?;
+    if intended_role == RecordedCorpusRole::Compile {
+        let marker_path = compile_attempt_path(&root);
+        let marker = capture_optional_regular_file(
+            &marker_path,
+            "recorded corpus compile-attempt marker",
+        )?
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "compile-role binding publication in {} requires an exact stable {RECORDED_CORPUS_COMPILE_ATTEMPT_FILE} marker before any commit mutation",
+                root.display()
+            ))
+        })?;
+        parse_compile_attempt_bytes(&marker_path, &marker)?;
+    }
+    let provenance = capture_provenance(&root)?;
+    let meta_bytes = capture_optional_regular_file(&resolved_meta, "recorded corpus metadata")?
+        .ok_or_else(|| {
+            SourceUnavailable::new(format!(
+                "recorded corpus metadata {} is absent during binding publication",
+                resolved_meta.display()
+            ))
+        })?;
+    let resolved_hidden = hidden_path(&resolved_records);
+    let execution =
+        parse_execution_identity(&root, &resolved_meta, &resolved_records, &provenance)?;
+    let binding = make_streaming_binding(
+        &resolved_meta,
+        &resolved_records,
+        &resolved_hidden,
+        &provenance,
+        &meta_bytes,
+    )?;
+    if !binding.records.present {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus records {} are absent during binding publication",
+            resolved_records.display()
+        )));
+    }
+    if execution.dense_operator.is_some() {
+        validate_finalized_corpus_shape(&meta_bytes, &binding.records).map_err(|mut error| {
+            error.reason = format!(
+                "dense-present recorded corpus in {} is incomplete or malformed: {}",
+                root.display(),
+                error.reason
+            );
+            error
+        })?;
+    }
+    let expected = binding.canonical_bytes()?;
+    let expected_cid = format!("blake3:{}", blake3::hash(&expected).to_hex());
+    let stable_path = binding_path(&root);
+    let stable = capture_optional_regular_file(&stable_path, "recorded corpus generation binding")?;
+    if let Some(bytes) = stable.as_deref() {
+        let existing = parse_binding_bytes(&stable_path, bytes)?;
+        validate_binding_role(&existing, intended_role, &stable_path)?;
+    }
+    let residues = binding_publication_residues(&root, true)?;
+    let temporaries = residues.temporaries;
+    let writings = residues.writings;
+    if let Some((path, _)) = temporaries
+        .iter()
+        .find(|(_, bytes)| bytes.as_slice() != expected.as_slice())
+    {
+        return Err(SourceUnavailable::new(format!(
+            "recorded corpus binding temporary {} conflicts with the intended current generation; refusing recovery before mutation",
+            path.display()
+        )));
+    }
+
+    if stable.as_deref() == Some(expected.as_slice()) {
+        for (path, bytes) in temporaries {
+            remove_exact_binding_residue(&path, &bytes, "recorded corpus binding temporary")?;
+        }
+        for (path, bytes) in writings {
+            remove_exact_binding_residue(
+                &path,
+                &bytes,
+                "recorded corpus non-authoritative binding staging file",
+            )?;
+        }
+        sync_binding_directory(&root)?;
+        return Ok(expected_cid);
+    }
+
+    for (path, bytes) in writings {
+        remove_exact_binding_residue(
+            &path,
+            &bytes,
+            "recorded corpus non-authoritative binding staging file",
+        )?;
+    }
+
+    let selected = match temporaries.first() {
+        Some((path, bytes)) => {
+            let current = capture_optional_regular_file(path, "recorded corpus binding temporary")?
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "recorded corpus binding temporary {} disappeared before publication",
+                        path.display()
+                    ))
+                })?;
+            if current.as_slice() != bytes.as_slice() || current != expected {
+                return Err(SourceUnavailable::new(format!(
+                    "recorded corpus binding temporary {} changed before publication",
+                    path.display()
+                )));
+            }
+            path.clone()
+        }
+        None => create_binding_temporary(&root, &expected)?,
+    };
+
+    #[cfg(windows)]
+    if stable.is_some() {
+        std::fs::remove_file(&stable_path).map_err(SourceUnavailable::new)?;
+    }
+    std::fs::rename(&selected, &stable_path).map_err(|error| {
+        SourceUnavailable::new(format!(
+            "recorded corpus binding publication {} -> {} failed: {error}",
+            selected.display(),
+            stable_path.display()
+        ))
+    })?;
+    for (path, bytes) in temporaries {
+        if path != selected {
+            remove_exact_binding_residue(&path, &bytes, "recorded corpus binding temporary")?;
+        }
+    }
+    sync_binding_directory(&root)?;
+    let published = capture_optional_regular_file(
+        &stable_path,
+        "published recorded corpus generation binding",
+    )?
+    .ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "published recorded corpus binding {} disappeared",
+            stable_path.display()
+        ))
+    })?;
+    if published != expected {
+        return Err(SourceUnavailable::new(format!(
+            "published recorded corpus binding {} does not match the intended current generation",
+            stable_path.display()
+        )));
+    }
+    Ok(expected_cid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "uor-r4-recorded-corpus-{label}-{}-{}",
+            std::process::id(),
+            NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn write_operator<T: serde::Serialize>(path: &Path, operator: &T) {
+        let mut bytes = serde_json::to_vec_pretty(operator).expect("operator JSON");
+        bytes.push(b'\n');
+        std::fs::write(path, bytes).expect("operator sidecar");
+    }
+
+    fn write_corpus_pair(root: &Path, meta_name: &str, records_name: &str) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(root).expect("root");
+        let meta = root.join(meta_name);
+        let records = root.join(records_name);
+        std::fs::write(&meta, b"captured metadata").expect("metadata");
+        std::fs::write(&records, b"captured records").expect("records");
+        (meta, records)
+    }
+
+    fn complete_source_corpus(root: &Path, next: u32) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(root).expect("root");
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        let mut meta_bytes = [0u8; 25];
+        meta_bytes[0..8].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+        meta_bytes[16..24].copy_from_slice(&7u64.to_le_bytes());
+        meta_bytes[24] = 1;
+        let mut record = [0u8; 48];
+        record[4..8].copy_from_slice(&next.to_le_bytes());
+        record[20..24].copy_from_slice(&34u32.to_le_bytes());
+        record[24..28].copy_from_slice(&33u32.to_le_bytes());
+        record[28..32].copy_from_slice(&33u32.to_le_bytes());
+        record[36..40].copy_from_slice(&1u32.to_le_bytes());
+        record[40..44].copy_from_slice(&u32::MAX.to_le_bytes());
+        record[44..48].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(&meta, meta_bytes).expect("complete metadata");
+        std::fs::write(&records, record).expect("complete records");
+        (meta, records)
+    }
+
+    fn write_execution_pair(root: &Path, version: u32) {
+        let attention = if version == 1 {
+            AttentionOperatorSpec::learned_absolute_v1()
+        } else {
+            AttentionOperatorSpec::learned_absolute_v2()
+        };
+        let dense = if version == 1 {
+            DenseOperatorSpec::gpt2_v1()
+        } else {
+            DenseOperatorSpec::gpt2_v2()
+        };
+        write_operator(&root.join(ATTENTION_OPERATOR_BINDING_FILE), &attention);
+        write_operator(&root.join(DENSE_OPERATOR_BINDING_FILE), &dense);
+    }
+
+    fn producer_guard(root: &Path) -> RecordedCorpusProducerGuard {
+        std::fs::create_dir_all(root).expect("producer root");
+        RecordedCorpusProducerGuard::try_acquire(root).expect("producer guard")
+    }
+
+    fn publish_compile_binding(
+        guard: &RecordedCorpusProducerGuard,
+        meta: &Path,
+        records: &Path,
+    ) -> String {
+        guard
+            .begin_compile_attempt()
+            .expect("begin compile attempt");
+        publish_binding(guard, meta, records).expect("publish compile binding")
+    }
+
+    #[test]
+    fn canonical_binding_v1_bytes_and_cid_are_literal_pinned() {
+        let binding = RecordedCorpusBinding {
+            schema: "uor-r4-recorded-corpus-binding/1".to_owned(),
+            manifest: RecordedCorpusFileBinding {
+                name: "observation.manifest.json".to_owned(),
+                present: false,
+                length: None,
+                blake3: None,
+            },
+            attention_operator: RecordedCorpusFileBinding {
+                name: "attention_operator.json".to_owned(),
+                present: false,
+                length: None,
+                blake3: None,
+            },
+            dense_operator: RecordedCorpusFileBinding {
+                name: "dense_operator.json".to_owned(),
+                present: false,
+                length: None,
+                blake3: None,
+            },
+            metadata: RecordedCorpusFileBinding {
+                name: "corpus.meta".to_owned(),
+                present: true,
+                length: Some(1),
+                blake3: Some(
+                    "blake3:83d9dab06011479163c7c4d5fa735f911bac86729f56aaa115b7eed2eb66e022"
+                        .to_owned(),
+                ),
+            },
+            records: RecordedCorpusFileBinding {
+                name: "corpus.records".to_owned(),
+                present: true,
+                length: Some(1),
+                blake3: Some(
+                    "blake3:b2dea48d667b2821a9bcf69eded39a2458a1d8165ca7fcac64c3557b69a7ea08"
+                        .to_owned(),
+                ),
+            },
+            hidden: RecordedCorpusFileBinding {
+                name: "corpus.records.hidden".to_owned(),
+                present: false,
+                length: None,
+                blake3: None,
+            },
+        };
+        let expected = b"{\n  \"schema\": \"uor-r4-recorded-corpus-binding/1\",\n  \"manifest\": {\n    \"name\": \"observation.manifest.json\",\n    \"present\": false\n  },\n  \"attention_operator\": {\n    \"name\": \"attention_operator.json\",\n    \"present\": false\n  },\n  \"dense_operator\": {\n    \"name\": \"dense_operator.json\",\n    \"present\": false\n  },\n  \"metadata\": {\n    \"name\": \"corpus.meta\",\n    \"present\": true,\n    \"length\": 1,\n    \"blake3\": \"blake3:83d9dab06011479163c7c4d5fa735f911bac86729f56aaa115b7eed2eb66e022\"\n  },\n  \"records\": {\n    \"name\": \"corpus.records\",\n    \"present\": true,\n    \"length\": 1,\n    \"blake3\": \"blake3:b2dea48d667b2821a9bcf69eded39a2458a1d8165ca7fcac64c3557b69a7ea08\"\n  },\n  \"hidden\": {\n    \"name\": \"corpus.records.hidden\",\n    \"present\": false\n  }\n}\n";
+        assert_eq!(
+            binding.canonical_bytes().expect("canonical bytes"),
+            expected
+        );
+        assert_eq!(
+            binding.declared_digest().expect("binding CID"),
+            "blake3:aea2551ba82356375580a480d338b076488354c4b6bcab59bb22c26af9bcdafc"
+        );
+    }
+
+    #[test]
+    fn producer_guard_is_alias_stable_nonblocking_and_reacquirable() {
+        let root = unique_root("producer-guard-busy");
+        std::fs::create_dir_all(&root).expect("producer root");
+        let first = RecordedCorpusProducerGuard::try_acquire(&root).expect("first guard");
+        let before: Vec<_> = std::fs::read_dir(&root)
+            .expect("root inventory")
+            .map(|entry| entry.expect("entry").file_name())
+            .collect();
+        let alias = root
+            .parent()
+            .expect("root parent")
+            .join(".")
+            .join(root.file_name().expect("root name"));
+        let busy = RecordedCorpusProducerGuard::try_acquire(&alias)
+            .expect_err("alias contender is nonblocking");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        let after: Vec<_> = std::fs::read_dir(&root)
+            .expect("root inventory after BUSY")
+            .map(|entry| entry.expect("entry").file_name())
+            .collect();
+        assert_eq!(after, before, "BUSY refusal cannot mutate corpus root");
+        drop(first);
+        let retry = RecordedCorpusProducerGuard::try_acquire(&alias).expect("retry after drop");
+        assert_eq!(retry.root(), std::fs::canonicalize(&root).unwrap());
+        drop(retry);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn producer_guard_case_aliases_contend_when_the_filesystem_equates_them() {
+        let root = unique_root("producer-guard-case-alias");
+        std::fs::create_dir_all(&root).expect("producer root");
+        let alias = root.parent().expect("root parent").join(
+            root.file_name()
+                .expect("root name")
+                .to_string_lossy()
+                .to_uppercase(),
+        );
+        let Ok(alias_metadata) = std::fs::symlink_metadata(&alias) else {
+            // Case-sensitive filesystems have no equivalent alias to test.
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        };
+        let root_metadata = std::fs::symlink_metadata(&root).expect("root metadata");
+        if !opened_file_identity_matches(&root_metadata, &alias_metadata) {
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+
+        let first = RecordedCorpusProducerGuard::try_acquire(&root).expect("first spelling");
+        let busy = RecordedCorpusProducerGuard::try_acquire(&alias)
+            .expect_err("equivalent final-component spelling must contend");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        assert_eq!(first.root(), std::fs::canonicalize(&root).unwrap());
+        drop(first);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn producer_guard_refuses_cross_root_publication_before_mutation() {
+        let owned = unique_root("producer-guard-owned");
+        let other = unique_root("producer-guard-other");
+        let guard = producer_guard(&owned);
+        let (meta, records) = complete_source_corpus(&other, 37);
+        write_execution_pair(&other, 2);
+        let meta_before = std::fs::read(&meta).expect("metadata before");
+        let records_before = std::fs::read(&records).expect("records before");
+        let error =
+            publish_binding(&guard, &meta, &records).expect_err("cross-root guard is terminal");
+        assert!(error.reason.contains("cross-root"), "{error}");
+        assert_eq!(std::fs::read(&meta).unwrap(), meta_before);
+        assert_eq!(std::fs::read(&records).unwrap(), records_before);
+        assert!(!other.join(RECORDED_CORPUS_BINDING_FILE).exists());
+        let _ = std::fs::remove_dir_all(owned);
+        let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn producer_guard_rejects_symlink_coordination_without_following() {
+        let root = unique_root("producer-guard-symlink");
+        std::fs::create_dir_all(&root).expect("producer root");
+        let canonical = std::fs::canonicalize(&root).expect("canonical root");
+        let lock_path = producer_lock_path(
+            canonical.parent().expect("canonical parent"),
+            canonical.file_name().expect("canonical root name"),
+        );
+        std::fs::create_dir_all(lock_path.parent().expect("coordination parent"))
+            .expect("coordination directory");
+        let sentinel = root.parent().expect("root parent").join(format!(
+            "{}.sentinel",
+            root.file_name().unwrap().to_string_lossy()
+        ));
+        std::fs::write(&sentinel, b"sentinel").expect("sentinel");
+        std::os::unix::fs::symlink(&sentinel, &lock_path).expect("coordination symlink");
+        let error = RecordedCorpusProducerGuard::try_acquire(&root)
+            .expect_err("coordination symlink is terminal");
+        assert!(error.reason.contains("without following"), "{error}");
+        assert_eq!(
+            std::fs::read(&sentinel).expect("sentinel preserved"),
+            b"sentinel"
+        );
+        assert!(
+            std::fs::symlink_metadata(&lock_path)
+                .expect("symlink preserved")
+                .file_type()
+                .is_symlink()
+        );
+        std::fs::remove_file(lock_path).expect("remove test coordination symlink");
+        let _ = std::fs::remove_file(sentinel);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn producer_guard_rejects_root_replaced_by_symlink_during_acquisition() {
+        let root = unique_root("producer-guard-root-swap");
+        let displaced = root.with_extension("displaced");
+        let other = unique_root("producer-guard-root-swap-target");
+        std::fs::create_dir_all(&root).expect("producer root");
+        std::fs::create_dir_all(&other).expect("other root");
+        std::fs::write(other.join("sentinel"), b"other").expect("other sentinel");
+
+        let error = RecordedCorpusProducerGuard::try_acquire_with_root_hook(&root, || {
+            std::fs::rename(&root, &displaced).expect("displace opened root");
+            std::os::unix::fs::symlink(&other, &root).expect("replace root with symlink");
+        })
+        .expect_err("root replacement is terminal");
+        assert!(
+            error.reason.contains("changed identity")
+                || error.reason.contains("real non-symlink directory"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(other.join("sentinel")).unwrap(), b"other");
+        assert!(
+            std::fs::symlink_metadata(&root)
+                .expect("replacement preserved")
+                .file_type()
+                .is_symlink()
+        );
+
+        std::fs::remove_file(&root).expect("remove test symlink");
+        std::fs::rename(&displaced, &root).expect("restore root");
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[test]
+    fn producer_guard_locks_absent_logical_root_before_exact_creation() {
+        let root = unique_root("producer-guard-absent");
+        assert!(!root.exists());
+        let mut first =
+            RecordedCorpusProducerGuard::try_acquire(&root).expect("lock absent logical root");
+        assert!(!root.exists(), "lock acquisition alone is failure-atomic");
+        let busy = RecordedCorpusProducerGuard::try_acquire(&root)
+            .expect_err("absent-root contender is nonblocking");
+        assert!(busy.reason.contains("BUSY"), "{busy}");
+        assert!(!root.exists(), "BUSY cannot create the logical root");
+        assert_eq!(
+            first.ensure_root().expect("create root after preflight"),
+            std::fs::canonicalize(&root).unwrap()
+        );
+        drop(first);
+        let retry = RecordedCorpusProducerGuard::try_acquire(&root).expect("retry existing root");
+        assert_eq!(retry.root(), std::fs::canonicalize(&root).unwrap());
+        drop(retry);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn dense_generation_requires_and_roundtrips_canonical_binding() {
+        let root = unique_root("dense-binding-roundtrip");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 17);
+        write_execution_pair(&root, 2);
+
+        let missing = capture(&meta, &records).expect_err("dense without commit is terminal");
+        assert!(
+            missing.reason.contains(RECORDED_CORPUS_BINDING_FILE),
+            "{missing}"
+        );
+        let cid = publish_compile_binding(&guard, &meta, &records);
+        let snapshot = capture(&meta, &records).expect("capture committed generation");
+        assert_eq!(snapshot.binding_cid.as_deref(), Some(cid.as_str()));
+        assert_eq!(
+            snapshot.execution,
+            RecordedCorpusExecutionIdentity {
+                attention_operator: Some(AttentionOperatorSpec::learned_absolute_v2()),
+                dense_operator: Some(DenseOperatorSpec::gpt2_v2()),
+            }
+        );
+        assert_eq!(
+            snapshot
+                .binding
+                .as_ref()
+                .expect("typed binding")
+                .declared_digest()
+                .expect("binding digest"),
+            cid
+        );
+
+        let bytes = std::fs::read(root.join(RECORDED_CORPUS_BINDING_FILE))
+            .expect("canonical binding bytes");
+        assert_eq!(
+            parse_binding_bytes(&root.join(RECORDED_CORPUS_BINDING_FILE), &bytes)
+                .expect("canonical binding")
+                .canonical_bytes()
+                .expect("canonical bytes"),
+            bytes
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn role_preflight_and_publication_reject_cross_role_generations() {
+        let compile_root = unique_root("compile-role-binding");
+        let compile_guard = producer_guard(&compile_root);
+        let (compile_meta, compile_records) = complete_source_corpus(&compile_root, 41);
+        publish_compile_binding(&compile_guard, &compile_meta, &compile_records);
+        compile_guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Compile)
+            .expect("matching compile role");
+        let error = compile_guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect_err("observation cannot enter a compile root");
+        assert!(error.reason.contains("compile-role"), "{error}");
+        let compile_binding =
+            std::fs::read(compile_root.join(RECORDED_CORPUS_BINDING_FILE)).unwrap();
+        let (state, merged) =
+            write_corpus_pair(&compile_root, observation::STATE_FILE, "merged.bin");
+        let error = publish_binding(&compile_guard, &state, &merged)
+            .expect_err("public publisher cannot replace a compile binding with observation role");
+        assert!(
+            error.reason.contains("cross-role") || error.reason.contains("compile-role"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(compile_root.join(RECORDED_CORPUS_BINDING_FILE)).unwrap(),
+            compile_binding
+        );
+
+        let observation_root = unique_root("observation-role-binding");
+        let observation_guard = producer_guard(&observation_root);
+        let (state, merged) =
+            write_corpus_pair(&observation_root, observation::STATE_FILE, "merged.bin");
+        publish_binding(&observation_guard, &state, &merged).expect("observation-role binding");
+        observation_guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect("matching observation role");
+        let error = observation_guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Compile)
+            .expect_err("compile cannot enter an observation root");
+        assert!(error.reason.contains("observation-role"), "{error}");
+        let observation_binding =
+            std::fs::read(observation_root.join(RECORDED_CORPUS_BINDING_FILE)).unwrap();
+        let marker = RecordedCorpusCompileAttempt::compile()
+            .canonical_bytes()
+            .expect("marker bytes");
+        std::fs::write(
+            observation_root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE),
+            marker,
+        )
+        .expect("inject wrong-role marker");
+        let error = capture(&state, &merged)
+            .expect_err("an observation binding plus compile marker is not one generation");
+        assert!(
+            error.reason.contains("requires corpus.meta/corpus.records"),
+            "{error}"
+        );
+        std::fs::remove_file(observation_root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE))
+            .expect("remove injected marker");
+        let (meta, records) = complete_source_corpus(&observation_root, 43);
+        let error = publish_binding(&observation_guard, &meta, &records)
+            .expect_err("public publisher cannot replace an observation binding with compile role");
+        assert!(
+            error.reason.contains("cross-role") || error.reason.contains("observation-role"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(observation_root.join(RECORDED_CORPUS_BINDING_FILE)).unwrap(),
+            observation_binding
+        );
+
+        let _ = std::fs::remove_dir_all(compile_root);
+        let _ = std::fs::remove_dir_all(observation_root);
+    }
+
+    #[test]
+    fn compile_attempt_marker_bytes_digest_and_lifecycle_are_pinned() {
+        let expected = b"{\n  \"schema\": \"uor-r4-recorded-corpus-compile-attempt/1\",\n  \"role\": \"compile\"\n}\n";
+        let canonical = RecordedCorpusCompileAttempt::compile()
+            .canonical_bytes()
+            .expect("canonical marker");
+        assert_eq!(canonical, expected);
+        assert_eq!(
+            format!("blake3:{}", blake3::hash(&canonical).to_hex()),
+            "blake3:06c2257b2d374860717cac12285e7ba0cf9a414f88d89596d5380168e1e0ac52"
+        );
+
+        let root = unique_root("compile-attempt-lifecycle");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 53);
+        guard.begin_compile_attempt().expect("begin marker");
+        assert_eq!(
+            std::fs::read(root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)).unwrap(),
+            expected
+        );
+        let error = capture(&meta, &records).expect_err("attempt without commit is terminal");
+        assert!(
+            error.reason.contains("unfinished compile attempt"),
+            "{error}"
+        );
+        let cid = publish_binding(&guard, &meta, &records).expect("publish under marker");
+        assert_eq!(
+            capture(&meta, &records)
+                .expect("committed generation remains readable before cleanup")
+                .binding_cid
+                .as_deref(),
+            Some(cid.as_str())
+        );
+        guard.finish_compile_attempt().expect("finish marker");
+        assert!(!root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE).exists());
+        assert_eq!(
+            capture(&meta, &records)
+                .expect("finished generation")
+                .binding_cid,
+            Some(cid)
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_update_requires_marker_for_same_role_generation_transition() {
+        let interrupted = unique_root("source-update-interrupted");
+        let guard = producer_guard(&interrupted);
+        let (meta, records) = complete_source_corpus(&interrupted, 53);
+        let old_cid = publish_compile_binding(&guard, &meta, &records);
+        guard.finish_compile_attempt().expect("finish generation A");
+        guard.begin_compile_attempt().expect("begin generation B");
+        let _ = complete_source_corpus(&interrupted, 71);
+        let state = preflight_source_update_publication(&guard, &meta, &records)
+            .expect("active marker permits canonical last-good binding A beside resumed members B");
+        assert!(state.attempt_active);
+        assert!(!state.recoverable_binding);
+        let new_cid = publish_binding(&guard, &meta, &records).expect("commit generation B");
+        assert_ne!(new_cid, old_cid);
+        guard.finish_compile_attempt().expect("finish generation B");
+        assert_eq!(capture(&meta, &records).unwrap().binding_cid, Some(new_cid));
+
+        let unowned = unique_root("source-update-without-marker");
+        let guard = producer_guard(&unowned);
+        let (meta, records) = complete_source_corpus(&unowned, 53);
+        publish_compile_binding(&guard, &meta, &records);
+        guard.finish_compile_attempt().expect("finish generation A");
+        let _ = complete_source_corpus(&unowned, 71);
+        let before_binding = std::fs::read(unowned.join(RECORDED_CORPUS_BINDING_FILE)).unwrap();
+        let before_meta = std::fs::read(&meta).unwrap();
+        let before_records = std::fs::read(&records).unwrap();
+        let error = preflight_source_update_publication(&guard, &meta, &records)
+            .expect_err("member drift without an active attempt marker is terminal");
+        assert!(error.reason.contains("does not commit"), "{error}");
+        assert_eq!(
+            std::fs::read(unowned.join(RECORDED_CORPUS_BINDING_FILE)).unwrap(),
+            before_binding
+        );
+        assert_eq!(std::fs::read(&meta).unwrap(), before_meta);
+        assert_eq!(std::fs::read(&records).unwrap(), before_records);
+
+        let _ = std::fs::remove_dir_all(interrupted);
+        let _ = std::fs::remove_dir_all(unowned);
+    }
+
+    #[test]
+    fn compile_attempt_crash_residue_is_recovered_but_observation_refuses_it() {
+        let root = unique_root("compile-attempt-writing");
+        let guard = producer_guard(&root);
+        let writing = root.join(format!(
+            ".{RECORDED_CORPUS_COMPILE_ATTEMPT_FILE}.999.1.writing"
+        ));
+        std::fs::write(&writing, b"partial").expect("partial marker staging");
+        let error = guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect_err("observation rejects compile staging evidence");
+        assert!(error.reason.contains("compile-attempt"), "{error}");
+        assert_eq!(std::fs::read(&writing).unwrap(), b"partial");
+        guard
+            .begin_compile_attempt()
+            .expect("compile retry reclaims staging");
+        assert!(!writing.exists());
+        assert!(root.join(RECORDED_CORPUS_COMPILE_ATTEMPT_FILE).exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn role_preflight_rejects_foreign_prefix_and_temporary_without_mutation() {
+        for foreign in [
+            "shard-00.bin",
+            "shard-not-a-number.bin",
+            observation::RAW_COMMITTED_FILE,
+            "tokenizer_adapter.json",
+            ".source_compile_preflight.json.800.1.tmp",
+            ".compiled_bundle_completion.json.801.2.tmp",
+        ] {
+            let root = unique_root(&format!("foreign-role-{}", foreign.replace('.', "-")));
+            let guard = producer_guard(&root);
+            let path = root.join(foreign);
+            std::fs::write(&path, b"foreign crash prefix").expect("foreign prefix");
+            let before = std::fs::read(&path).unwrap();
+            let role =
+                if foreign.starts_with("shard-") || foreign == observation::RAW_COMMITTED_FILE {
+                    RecordedCorpusRole::Compile
+                } else {
+                    RecordedCorpusRole::Observation
+                };
+            let error = guard
+                .preflight_publication_namespace_for(role)
+                .expect_err("foreign role prefix is terminal");
+            assert!(error.reason.contains("foreign"), "{error}");
+            assert_eq!(std::fs::read(&path).unwrap(), before);
+            let _ = std::fs::remove_dir_all(root);
+        }
+
+        let root = unique_root("cross-role-binding-temp");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 47);
+        publish_compile_binding(&guard, &meta, &records);
+        let stable = root.join(RECORDED_CORPUS_BINDING_FILE);
+        let temporary = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.777.1.tmp"));
+        std::fs::rename(&stable, &temporary).expect("binding crash temp");
+        let before = std::fs::read(&temporary).unwrap();
+        let error = guard
+            .preflight_publication_namespace_for(RecordedCorpusRole::Observation)
+            .expect_err("cross-role canonical temp is terminal");
+        assert!(error.reason.contains("cross-role") || error.reason.contains("compile-role"));
+        assert_eq!(std::fs::read(&temporary).unwrap(), before);
+        assert!(!stable.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn shared_planned_output_scope_is_global_and_recovery_is_owner_exact() {
+        let root = unique_root("planned-output-scope");
+        let guard = producer_guard(&root);
+        let records_residue = root.join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.1.writing",
+            PlannedOutputMember::Records.stable_name()
+        ));
+        std::fs::write(&records_residue, b"partial records").expect("records residue");
+        guard
+            .preflight_planned_output_scope(&[PlannedOutputMember::Records])
+            .expect("declared owner accepts its regular residue");
+        assert!(
+            guard
+                .has_planned_output_residue(PlannedOutputMember::Records)
+                .unwrap()
+        );
+        let error = guard
+            .preflight_planned_output_scope(&[])
+            .expect_err("partial-plan writer owns no residue");
+        assert!(error.reason.contains("foreign member"), "{error}");
+        assert_eq!(std::fs::read(&records_residue).unwrap(), b"partial records");
+        guard
+            .reclaim_planned_output_residues(PlannedOutputMember::Records)
+            .expect("owner reclaims exact regular residue");
+        assert!(!records_residue.exists());
+
+        let artifact_residue = root.join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.2.writing",
+            PlannedOutputMember::Artifact.stable_name()
+        ));
+        std::fs::write(&artifact_residue, b"foreign artifact").expect("artifact residue");
+        let error = guard
+            .preflight_planned_output_scope(&[
+                PlannedOutputMember::Records,
+                PlannedOutputMember::Hidden,
+                PlannedOutputMember::Metadata,
+            ])
+            .expect_err("subsample cannot ignore another plan's residue");
+        assert!(error.reason.contains("tless_artifacts.bin"), "{error}");
+        assert_eq!(
+            std::fs::read(&artifact_residue).unwrap(),
+            b"foreign artifact"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_planned_output_scope_rejects_symlink_and_nonregular_entries() {
+        let root = unique_root("planned-output-special");
+        let guard = producer_guard(&root);
+        let symlink = root.join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.3.writing",
+            PlannedOutputMember::Hidden.stable_name()
+        ));
+        std::os::unix::fs::symlink("missing-target", &symlink).expect("reserved symlink");
+        let error = guard
+            .preflight_planned_output_scope(&PlannedOutputMember::ALL)
+            .expect_err("reserved symlink is terminal");
+        assert!(error.reason.contains("without following links"), "{error}");
+        assert!(
+            std::fs::symlink_metadata(&symlink)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        std::fs::remove_file(&symlink).unwrap();
+
+        let directory = root.join(format!(
+            "{PLANNED_OUTPUT_RESERVED_PREFIX}{}--999.4.writing",
+            PlannedOutputMember::Metadata.stable_name()
+        ));
+        std::fs::create_dir(&directory).expect("reserved directory");
+        let error = guard
+            .preflight_planned_output_scope(&PlannedOutputMember::ALL)
+            .expect_err("reserved directory is terminal");
+        assert!(
+            error.reason.contains("without following links") || error.reason.contains("regular")
+        );
+        assert!(
+            std::fs::symlink_metadata(&directory)
+                .unwrap()
+                .file_type()
+                .is_dir()
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn binding_rejects_stronger_pair_corpus_aba_even_when_pair_and_marker_restore() {
+        let root = unique_root("binding-aba");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 11);
+        write_execution_pair(&root, 1);
+        publish_compile_binding(&guard, &meta, &records);
+        let attention_a =
+            std::fs::read(root.join(ATTENTION_OPERATOR_BINDING_FILE)).expect("attention A");
+        let dense_a = std::fs::read(root.join(DENSE_OPERATOR_BINDING_FILE)).expect("dense A");
+        let binding_a = std::fs::read(root.join(RECORDED_CORPUS_BINDING_FILE)).expect("binding A");
+
+        let error = capture_with_hooks(
+            &meta,
+            &records,
+            || {
+                write_execution_pair(&root, 2);
+                let _ = complete_source_corpus(&root, 29);
+                publish_binding(&guard, &meta, &records).expect("publish B");
+            },
+            || {
+                std::fs::write(root.join(ATTENTION_OPERATOR_BINDING_FILE), &attention_a)
+                    .expect("restore attention A");
+                std::fs::write(root.join(DENSE_OPERATOR_BINDING_FILE), &dense_a)
+                    .expect("restore dense A");
+                std::fs::write(root.join(RECORDED_CORPUS_BINDING_FILE), &binding_a)
+                    .expect("restore binding A");
+            },
+        )
+        .expect_err("binding A cannot authorize corpus B");
+        assert!(
+            error.reason.contains("does not match")
+                && (error.reason.contains("metadata") || error.reason.contains("records")),
+            "unexpected error: {error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn markerless_attention_only_remains_explicit_compatibility() {
+        let root = unique_root("markerless-attention-only");
+        let (meta, records) = complete_source_corpus(&root, 5);
+        write_operator(
+            &root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        let snapshot = capture(&meta, &records).expect("attention-only compatibility");
+        assert!(snapshot.binding.is_none());
+        assert!(snapshot.binding_cid.is_none());
+        assert_eq!(snapshot.execution.dense_operator, None);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn binding_temporary_recovery_is_exact_and_conflicts_are_preserved() {
+        let root = unique_root("binding-temp-recovery");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 7);
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+        let stable = root.join(RECORDED_CORPUS_BINDING_FILE);
+        let expected = std::fs::read(&stable).expect("stable binding");
+        let recoverable = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.1.tmp"));
+        std::fs::rename(&stable, &recoverable).expect("simulate pre-publish crash");
+        let recovered_cid =
+            publish_binding(&guard, &meta, &records).expect("recover exact temporary");
+        assert_eq!(
+            recovered_cid,
+            format!("blake3:{}", blake3::hash(&expected).to_hex())
+        );
+        assert!(!recoverable.exists());
+
+        let conflicting = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.2.tmp"));
+        let mut conflict = expected.clone();
+        let schema = RECORDED_CORPUS_BINDING_SCHEMA.as_bytes();
+        let offset = conflict
+            .windows(schema.len())
+            .position(|window| window == schema)
+            .expect("schema bytes");
+        conflict[offset] = b'X';
+        std::fs::write(&conflicting, &conflict).expect("conflicting temporary");
+        let before = std::fs::read(&conflicting).expect("conflict before");
+        let error =
+            publish_binding(&guard, &meta, &records).expect_err("malformed temp is terminal");
+        assert!(error.reason.contains("binding"), "{error}");
+        assert_eq!(
+            std::fs::read(&conflicting).expect("conflict preserved"),
+            before
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn binding_writing_crash_residue_is_ignored_and_reclaimed_by_exact_retry() {
+        let root = unique_root("binding-writing-recovery");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 13);
+        write_execution_pair(&root, 2);
+        let zero = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.10.writing"));
+        let partial = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.11.writing"));
+        std::fs::write(&zero, b"").expect("zero-byte staging residue");
+        std::fs::write(&partial, b"partial canonical JSON").expect("partial staging residue");
+
+        publish_compile_binding(&guard, &meta, &records);
+        assert!(!zero.exists());
+        assert!(!partial.exists());
+
+        let ignored = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.12.writing"));
+        std::fs::write(&ignored, b"unfinished").expect("reader-ignored staging residue");
+        capture(&meta, &records).expect("reader ignores non-authoritative staging residue");
+        assert_eq!(
+            std::fs::read(&ignored).expect("reader preserves staging residue"),
+            b"unfinished"
+        );
+        publish_binding(&guard, &meta, &records).expect("publisher reclaims ignored residue");
+        assert!(!ignored.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn unrecognized_binding_publication_residue_is_terminal_and_preserved() {
+        let root = unique_root("binding-unrecognized-residue");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 19);
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+        let unrecognized = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.unowned.writing"));
+        std::fs::write(&unrecognized, b"unowned").expect("unrecognized residue");
+        let before = std::fs::read(&unrecognized).expect("residue before");
+        let error =
+            publish_binding(&guard, &meta, &records).expect_err("unrecognized residue is terminal");
+        assert!(error.reason.contains("reserved"), "{error}");
+        assert_eq!(
+            std::fs::read(&unrecognized).expect("residue preserved"),
+            before
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn binding_namespace_ignores_unrelated_non_utf8_but_rejects_reserved_non_utf8() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = unique_root("binding-non-utf8");
+        let (meta, records) = complete_source_corpus(&root, 23);
+        write_operator(
+            &root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &AttentionOperatorSpec::learned_absolute_v2(),
+        );
+        let unrelated = root.join(OsString::from_vec(vec![b'u', 0xff, b'x']));
+        std::fs::write(&unrelated, b"unrelated").expect("unrelated non-UTF-8 entry");
+        capture(&meta, &records).expect("unrelated non-UTF-8 entry is outside namespace");
+
+        let mut reserved = format!(".{RECORDED_CORPUS_BINDING_FILE}.").into_bytes();
+        reserved.extend_from_slice(&[0xff, b'.', b't', b'm', b'p']);
+        let reserved = root.join(OsString::from_vec(reserved));
+        std::fs::write(&reserved, b"reserved").expect("reserved non-UTF-8 entry");
+        let error = capture(&meta, &records).expect_err("reserved non-UTF-8 entry is terminal");
+        assert!(error.reason.contains("non-UTF-8"), "{error}");
+        assert_eq!(
+            std::fs::read(&reserved).expect("reserved entry preserved"),
+            b"reserved"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publisher_rejects_symlink_binding_writing_residue_without_mutation() {
+        let root = unique_root("binding-writing-symlink");
+        let guard = producer_guard(&root);
+        let (meta, records) = complete_source_corpus(&root, 31);
+        write_execution_pair(&root, 2);
+        publish_compile_binding(&guard, &meta, &records);
+        let writing = root.join(format!(".{RECORDED_CORPUS_BINDING_FILE}.999.20.writing"));
+        std::os::unix::fs::symlink("missing-target", &writing).expect("staging symlink");
+        capture(&meta, &records).expect("reader ignores non-authoritative staging symlink");
+        let error = publish_binding(&guard, &meta, &records)
+            .expect_err("publisher rejects staging symlink");
+        assert!(
+            error.reason.contains("not a regular file")
+                || error.reason.contains("without following links"),
+            "{error}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&writing)
+                .expect("symlink preserved")
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            std::fs::read_link(&writing).expect("symlink target preserved"),
+            PathBuf::from("missing-target")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lower_hidden_path_changes_only_the_filename() {
+        let records = Path::new("/tmp/parent_recs.bin/corpus_recs.bin");
+        assert_eq!(
+            hidden_path(records),
+            PathBuf::from("/tmp/parent_recs.bin/corpus_hidden.bin")
+        );
+    }
+
+    #[test]
+    fn composite_capture_rejects_execution_swap_between_provenance_and_corpus() {
+        let root = unique_root("inter-phase-swap");
+        std::fs::create_dir_all(&root).expect("root");
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        std::fs::write(&meta, b"corpus A metadata").expect("metadata A");
+        std::fs::write(&records, b"corpus A records").expect("records A");
+        let attention = root.join(ATTENTION_OPERATOR_BINDING_FILE);
+        let dense = root.join(DENSE_OPERATOR_BINDING_FILE);
+        write_operator(&attention, &AttentionOperatorSpec::learned_absolute_v1());
+        write_operator(&dense, &DenseOperatorSpec::gpt2_v1());
+
+        let error = capture_with_hooks(
+            &meta,
+            &records,
+            || {
+                write_operator(&attention, &AttentionOperatorSpec::learned_absolute_v2());
+                write_operator(&dense, &DenseOperatorSpec::gpt2_v2());
+                std::fs::write(&meta, b"corpus B metadata").expect("metadata B");
+                std::fs::write(&records, b"corpus B records").expect("records B");
+            },
+            || {},
+        )
+        .expect_err("provenance A cannot label corpus B");
+        assert!(
+            error.reason.contains("changed after capture"),
+            "unexpected error: {error}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn exact_pair_reconciliation_treats_absence_and_version_as_identity() {
+        let recorded = RecordedCorpusExecutionIdentity {
+            attention_operator: Some(AttentionOperatorSpec::learned_absolute_v2()),
+            dense_operator: Some(DenseOperatorSpec::gpt2_v2()),
+        };
+        assert!(
+            require_execution_identity(
+                &recorded,
+                Some(&AttentionOperatorSpec::learned_absolute_v2()),
+                Some(&DenseOperatorSpec::gpt2_v2()),
+                "test compile",
+            )
+            .is_ok()
+        );
+        let absent_dense = require_execution_identity(
+            &recorded,
+            Some(&AttentionOperatorSpec::learned_absolute_v2()),
+            None,
+            "test compile",
+        )
+        .expect_err("dense absence cannot relabel v2");
+        assert!(absent_dense.reason.contains("dense execution identity"));
+        let wrong_era = require_execution_identity(
+            &recorded,
+            Some(&AttentionOperatorSpec::learned_absolute_v1()),
+            Some(&DenseOperatorSpec::gpt2_v1()),
+            "test compile",
+        )
+        .expect_err("v1 cannot relabel v2");
+        assert!(wrong_era.reason.contains("attention execution identity"));
+    }
+
+    #[test]
+    fn recursive_duplicate_keys_are_terminal_in_both_sidecars_and_manifest() {
+        let attention_v2 = AttentionOperatorSpec::learned_absolute_v2();
+        let dense_v2 = DenseOperatorSpec::gpt2_v2();
+
+        let attention_root = unique_root("duplicate-attention-sidecar");
+        let (meta, records) = write_corpus_pair(&attention_root, "corpus.meta", "corpus.records");
+        let attention_json = serde_json::to_string(&attention_v2).expect("attention JSON");
+        let duplicate_attention =
+            attention_json.replacen("\"version\":2", "\"version\":2,\"version\":1", 1);
+        assert_ne!(duplicate_attention, attention_json);
+        std::fs::write(
+            attention_root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            duplicate_attention,
+        )
+        .expect("duplicate attention sidecar");
+        write_operator(&attention_root.join(DENSE_OPERATOR_BINDING_FILE), &dense_v2);
+        let error = capture(&meta, &records).expect_err("duplicate attention key is terminal");
+        assert!(error.reason.contains("duplicate JSON field"), "{error}");
+
+        let dense_root = unique_root("duplicate-dense-sidecar");
+        let (meta, records) = write_corpus_pair(&dense_root, "corpus.meta", "corpus.records");
+        write_operator(
+            &dense_root.join(ATTENTION_OPERATOR_BINDING_FILE),
+            &attention_v2,
+        );
+        let dense_json = serde_json::to_string(&dense_v2).expect("dense JSON");
+        let duplicate_dense =
+            dense_json.replacen("\"version\":2", "\"version\":2,\"version\":1", 1);
+        assert_ne!(duplicate_dense, dense_json);
+        std::fs::write(
+            dense_root.join(DENSE_OPERATOR_BINDING_FILE),
+            duplicate_dense,
+        )
+        .expect("duplicate dense sidecar");
+        let error = capture(&meta, &records).expect_err("duplicate dense key is terminal");
+        assert!(error.reason.contains("duplicate JSON field"), "{error}");
+
+        let nested_manifest_root = unique_root("duplicate-nested-manifest");
+        let (state, merged) =
+            write_corpus_pair(&nested_manifest_root, observation::STATE_FILE, "merged.bin");
+        let mut manifest = ObservationManifest::new(1);
+        manifest.attention_operator = Some(attention_v2.clone());
+        manifest.dense_operator = Some(dense_v2.clone());
+        let manifest_json = serde_json::to_string(&manifest).expect("manifest JSON");
+        let duplicate_nested =
+            manifest_json.replacen("\"version\":2", "\"version\":2,\"version\":1", 1);
+        assert_ne!(duplicate_nested, manifest_json);
+        std::fs::write(
+            nested_manifest_root.join(observation::MANIFEST_FILE),
+            duplicate_nested,
+        )
+        .expect("nested duplicate manifest");
+        let error = capture(&state, &merged).expect_err("nested duplicate key is terminal");
+        assert!(error.reason.contains("duplicate JSON field"), "{error}");
+
+        let top_manifest_root = unique_root("duplicate-top-manifest");
+        let (state, merged) =
+            write_corpus_pair(&top_manifest_root, observation::STATE_FILE, "merged.bin");
+        let mut duplicate_top = manifest_json
+            .strip_suffix('}')
+            .expect("manifest object")
+            .to_owned();
+        duplicate_top.push_str(&format!(",\"dense_operator\":{dense_json}}}"));
+        std::fs::write(
+            top_manifest_root.join(observation::MANIFEST_FILE),
+            duplicate_top,
+        )
+        .expect("top-level duplicate manifest");
+        let error = capture(&state, &merged).expect_err("top-level duplicate key is terminal");
+        assert!(error.reason.contains("duplicate JSON field"), "{error}");
+
+        for root in [
+            attention_root,
+            dense_root,
+            nested_manifest_root,
+            top_manifest_root,
+        ] {
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+}

--- a/crates/uor-r4-graph-compiler/tests/observe.rs
+++ b/crates/uor-r4-graph-compiler/tests/observe.rs
@@ -1828,13 +1828,14 @@ fn trace_profile_persists_in_the_manifest() {
 }
 
 /// #603 bundle identity: `identity_bundle_digest` moves when ANY of the
-/// six components changes, is independent of the order the components
+/// seven components changes, is independent of the order the components
 /// were recorded in, and distinguishes an ABSENT component from an
 /// empty one (absence is an explicit marker in the digest input, never
 /// a zero/default value).
 #[test]
 fn identity_bundle_digest_covers_components_order_and_absence() {
     use uor_r4_model_source::attention::AttentionOperatorSpec;
+    use uor_r4_model_source::dense::DenseOperatorSpec;
 
     let base = ObservationManifest::new(2);
     let mut digests = vec![base.identity_bundle_digest()];
@@ -1851,9 +1852,23 @@ fn identity_bundle_digest_covers_components_order_and_absence() {
     with_geometry.geometry = Some(GeometryProjection::bucket_average(576, 288));
     digests.push(with_geometry.identity_bundle_digest());
 
+    let tokenizer_json = r#"{
+        "pre_tokenizer": {"type": "ByteLevel", "add_prefix_space": false},
+        "model": {"type": "BPE", "vocab": {"a": 0, "b": 1, "ab": 2}, "merges": ["a b"]}
+    }"#;
+    let tokenizer = fixture_byte_bpe_adapter(tokenizer_json);
+    let mut with_tokenizer = base.clone();
+    with_tokenizer.tokenizer_adapter = Some(tokenizer.clone());
+    digests.push(with_tokenizer.identity_bundle_digest());
+
     let mut with_operator = base.clone();
     with_operator.attention_operator = Some(AttentionOperatorSpec::standard());
     digests.push(with_operator.identity_bundle_digest());
+
+    let mut with_dense = base.clone();
+    with_dense.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+    with_dense.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+    digests.push(with_dense.identity_bundle_digest());
 
     let mut with_profile = base.clone();
     with_profile.trace_profile = Some(TraceProfile::layer(&[0]));
@@ -1893,11 +1908,29 @@ fn identity_bundle_digest_covers_components_order_and_absence() {
     let mut writer = ObservationShardWriter::open(&dir_a, 2).expect("writer a");
     writer.set_input_cid(&cid).expect("cid first");
     writer.set_geometry(&geometry).expect("geometry second");
+    writer
+        .set_tokenizer_adapter(&tokenizer)
+        .expect("tokenizer third");
+    writer
+        .set_attention_operator(&AttentionOperatorSpec::learned_absolute_v2())
+        .expect("attention before dense");
+    writer
+        .set_dense_operator(&DenseOperatorSpec::gpt2_v2())
+        .expect("dense last");
     drop(writer);
     let dir_b = unique_path("bundle-order-b");
     let mut writer = ObservationShardWriter::open(&dir_b, 2).expect("writer b");
+    writer
+        .set_tokenizer_adapter(&tokenizer)
+        .expect("tokenizer first");
     writer.set_geometry(&geometry).expect("geometry first");
     writer.set_input_cid(&cid).expect("cid second");
+    writer
+        .set_attention_operator(&AttentionOperatorSpec::learned_absolute_v2())
+        .expect("attention before dense");
+    writer
+        .set_dense_operator(&DenseOperatorSpec::gpt2_v2())
+        .expect("dense after attention");
     drop(writer);
     let manifest_a = ObservationManifest::load(&dir_a)
         .expect("io a")
@@ -1913,6 +1946,123 @@ fn identity_bundle_digest_covers_components_order_and_absence() {
     for dir in [&dir_a, &dir_b] {
         let _ = std::fs::remove_dir_all(dir);
     }
+}
+
+/// Exact checkpoint-identity fixtures. Dense absence must retain the historical
+/// `/1` bytes and digest; a present current GPT-2 dense record selects `/2`
+/// and is ordered between attention and trace.
+#[test]
+fn identity_bundle_exact_legacy_and_dense_fixtures() {
+    use uor_r4_model_source::attention::AttentionOperatorSpec;
+    use uor_r4_model_source::dense::DenseOperatorSpec;
+
+    let tokenizer_json = r#"{
+        "pre_tokenizer": {"type": "ByteLevel", "add_prefix_space": false},
+        "model": {"type": "BPE", "vocab": {"a": 0, "b": 1, "ab": 2}, "merges": ["a b"]}
+    }"#;
+    let mut legacy = ObservationManifest::new(2);
+    legacy.input_cid = Some(format!("blake3:{}", "1".repeat(64)));
+    legacy.source_manifest_kappa = Some(format!("blake3:{}", "2".repeat(64)));
+    legacy.geometry = Some(GeometryProjection::bucket_average(576, 288));
+    legacy.tokenizer_adapter = Some(fixture_byte_bpe_adapter(tokenizer_json));
+    legacy.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v1());
+    legacy.trace_profile = Some(TraceProfile::layer(&[0]));
+
+    let mut current = legacy.clone();
+    current.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+    current.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+
+    let expected_legacy = concat!(
+        "uor-r4-observation-identity-bundle/1\n",
+        "input_cid=present:blake3:1111111111111111111111111111111111111111111111111111111111111111\n",
+        "source_manifest_kappa=present:blake3:2222222222222222222222222222222222222222222222222222222222222222\n",
+        "geometry=present:blake3:165f3f926fc96125e19f98341ac5874ce2812054d6f8e55f1e95b602bdc81550\n",
+        "tokenizer_adapter=present:blake3:7f8182ff516eeef7532ba99c2b1619b0b9d7ceaa87b878259480dd1ba7a5705b\n",
+        "attention_operator=present:blake3:00088e46d2b68616f8e58c33ce6b621925f82be5b22607f080e5f142e753796f\n",
+        "trace_profile=present:blake3:6481c41234c9cca7688661242076083630cb559b0afb309ba932875918b236a4\n",
+    );
+    assert_eq!(legacy.identity_bundle_bytes(), expected_legacy.as_bytes());
+    assert_eq!(
+        legacy.identity_bundle_digest(),
+        "blake3:c5ed023f5514b886bca0aa343432930568dffe536974062e4aad93e9b51aa6f9"
+    );
+
+    let expected_current = concat!(
+        "uor-r4-observation-identity-bundle/2\n",
+        "input_cid=present:blake3:1111111111111111111111111111111111111111111111111111111111111111\n",
+        "source_manifest_kappa=present:blake3:2222222222222222222222222222222222222222222222222222222222222222\n",
+        "geometry=present:blake3:165f3f926fc96125e19f98341ac5874ce2812054d6f8e55f1e95b602bdc81550\n",
+        "tokenizer_adapter=present:blake3:7f8182ff516eeef7532ba99c2b1619b0b9d7ceaa87b878259480dd1ba7a5705b\n",
+        "attention_operator=present:blake3:ba36fd1fef53a2e3744e1fee60e72677870d1cd2f2b484db755c0a5a74727231\n",
+        "dense_operator=present:blake3:3a61d92e61b2a322e086162767173aca8439dffd1ddc7443f1d8b44ee1b1eaf6\n",
+        "trace_profile=present:blake3:6481c41234c9cca7688661242076083630cb559b0afb309ba932875918b236a4\n",
+    );
+    assert_eq!(current.identity_bundle_bytes(), expected_current.as_bytes());
+    assert_eq!(
+        current.identity_bundle_digest(),
+        "blake3:3623409e7e50b64024447d687f58a5c599729c856b1bed732a6fe2d563b93d9a"
+    );
+
+    assert_ne!(
+        legacy.identity_bundle_bytes(),
+        current.identity_bundle_bytes()
+    );
+    assert_ne!(
+        legacy.identity_bundle_digest(),
+        current.identity_bundle_digest()
+    );
+}
+
+#[test]
+fn manifest_load_rejects_unregistered_or_impossible_dense_identity_without_mutation() {
+    use uor_r4_model_source::attention::AttentionOperatorSpec;
+    use uor_r4_model_source::dense::DenseOperatorSpec;
+
+    fn assert_rejected(label: &str, manifest: &ObservationManifest) {
+        let dir = unique_path(label);
+        std::fs::create_dir_all(&dir).expect("create manifest fixture directory");
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            serde_json::to_vec_pretty(manifest).expect("serialize manifest fixture"),
+        )
+        .expect("write manifest fixture");
+        let before = directory_bytes(&dir);
+        let error = ObservationManifest::load(&dir)
+            .expect_err("invalid dense execution identity must be rejected");
+        assert!(
+            error.reason.contains("dense") || error.reason.contains("source execution pair"),
+            "{label}: focused dense provenance diagnostic: {error}"
+        );
+        assert_eq!(
+            directory_bytes(&dir),
+            before,
+            "{label}: manifest refusal mutated observation bytes"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    let mut dense_only = ObservationManifest::new(0);
+    dense_only.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+    assert_rejected("manifest-dense-only", &dense_only);
+
+    let mut cross_era = ObservationManifest::new(0);
+    cross_era.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v1());
+    cross_era.dense_operator = Some(DenseOperatorSpec::gpt2_v2());
+    assert_rejected("manifest-cross-era-dense", &cross_era);
+
+    let mut unknown = ObservationManifest::new(0);
+    unknown.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+    let mut unknown_dense = DenseOperatorSpec::gpt2_v2();
+    unknown_dense.version = u32::MAX;
+    unknown.dense_operator = Some(unknown_dense);
+    assert_rejected("manifest-unknown-dense", &unknown);
+
+    let mut tampered = ObservationManifest::new(0);
+    tampered.attention_operator = Some(AttentionOperatorSpec::learned_absolute_v2());
+    let mut tampered_dense = DenseOperatorSpec::gpt2_v2();
+    tampered_dense.implementation_digest = "blake3:tampered".to_owned();
+    tampered.dense_operator = Some(tampered_dense);
+    assert_rejected("manifest-tampered-dense", &tampered);
 }
 
 /// A deterministic capture-capable oracle: logits, hidden state, and

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -608,10 +608,11 @@ impl AttentionOperatorSpec {
         record
     }
 
-    /// Immutable current `learned-absolute-source-attention/2` entry. GPT-2's
-    /// projections stay conventional; Q·K/value use certified-native cells
-    /// with the pinned exact fallback, and normalization retains reciprocal
-    /// multiplication rather than Llama's divisions.
+    /// Immutable current `learned-absolute-source-attention/2` entry. Its
+    /// projection fields declare GPT-2 topology; when a dense record is
+    /// present, that separate record owns projection arithmetic. Q·K/value use
+    /// certified-native cells with the pinned exact fallback, and normalization
+    /// retains reciprocal multiplication rather than Llama's divisions.
     pub fn learned_absolute_v2() -> Self {
         let mut record = Self {
             id: Self::LEARNED_ABSOLUTE_ID.to_owned(),

--- a/crates/uor-r4-model-source/src/dense.rs
+++ b/crates/uor-r4-model-source/src/dense.rs
@@ -1,0 +1,296 @@
+//! Immutable source-dense operator identities.
+//!
+//! Dense arithmetic is execution provenance for the offline teacher. It does
+//! not change the source snapshot kappa and is not a deployed-runtime
+//! operation. A registry version names stable output semantics; proof-bound
+//! refinements that preserve every output bit remain within that version.
+
+use serde::{Deserialize, Serialize};
+
+/// Typed, versioned record of one source-dense operator.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenseOperatorSpec {
+    /// Registry id of the operator.
+    #[serde(default)]
+    pub id: String,
+    /// Immutable registry version.
+    #[serde(default)]
+    pub version: u32,
+    /// Logical Conv1D weight orientation and traversal domain.
+    #[serde(default)]
+    pub conv1d_weight_layout: String,
+    /// Dot-product semantics used by every Conv1D projection.
+    #[serde(default)]
+    pub conv1d_accumulation: String,
+    /// Placement and rounding semantics of the Conv1D bias.
+    #[serde(default)]
+    pub conv1d_bias: String,
+    /// Logical tied-lm-head weight orientation.
+    #[serde(default)]
+    pub lm_head_weight_layout: String,
+    /// Dot-product and bias semantics of the tied lm-head.
+    #[serde(default)]
+    pub lm_head_accumulation: String,
+    /// Owner that establishes the declared output bits.
+    #[serde(default)]
+    pub arithmetic_owner: String,
+    /// Host-side operation class; this is not the deployed integer runtime.
+    #[serde(default)]
+    pub permitted_operation_class: String,
+    /// `blake3:<hex>` over [`Self::canonical_bytes`].
+    #[serde(default)]
+    pub implementation_digest: String,
+}
+
+impl DenseOperatorSpec {
+    /// GPT-2 source-dense registry id.
+    pub const GPT2_ID: &'static str = "gpt2-source-dense";
+    /// Historical conventional GPT-2 dense arithmetic.
+    pub const GPT2_V1_VERSION: u32 = 1;
+    /// Current correctly-rounded exact-real-dot GPT-2 dense arithmetic.
+    pub const GPT2_V2_VERSION: u32 = 2;
+    /// Current GPT-2 dense registry version.
+    pub const GPT2_VERSION: u32 = Self::GPT2_V2_VERSION;
+
+    /// Immutable historical `gpt2-source-dense/1` record.
+    pub fn gpt2_v1() -> Self {
+        let mut record = Self {
+            id: Self::GPT2_ID.to_owned(),
+            version: Self::GPT2_V1_VERSION,
+            conv1d_weight_layout: "input-major-row-major-[in,out]".to_owned(),
+            conv1d_accumulation:
+                "input-index-ascending-binary32-product-add-left-fold-zero-input-skipped".to_owned(),
+            conv1d_bias: "bias-seeds-fold-before-input-products".to_owned(),
+            lm_head_weight_layout: "tied-wte-row-major-[vocab,in]".to_owned(),
+            lm_head_accumulation:
+                "zero-seeded-input-index-ascending-binary32-product-add-left-fold-no-bias"
+                    .to_owned(),
+            arithmetic_owner: "scalar-conventional-binary32".to_owned(),
+            permitted_operation_class: "host-source-f32".to_owned(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Immutable current `gpt2-source-dense/2` record. The production owner
+    /// establishes these bits with certified-native arithmetic and the pinned
+    /// exact fallback. Those proof mechanics are intentionally noncanonical:
+    /// a bit-preserving certificate refinement does not create v3.
+    pub fn gpt2_v2() -> Self {
+        let mut record = Self {
+            id: Self::GPT2_ID.to_owned(),
+            version: Self::GPT2_V2_VERSION,
+            conv1d_weight_layout: "input-major-row-major-[in,out]".to_owned(),
+            conv1d_accumulation: "correctly-rounded-binary32-exact-real-dot".to_owned(),
+            conv1d_bias: "one-binary32-add-after-dot".to_owned(),
+            lm_head_weight_layout: "tied-wte-row-major-[vocab,in]".to_owned(),
+            lm_head_accumulation: "correctly-rounded-binary32-exact-real-dot-no-bias".to_owned(),
+            arithmetic_owner: "correctly-rounded-binary32-exact-real-result".to_owned(),
+            permitted_operation_class: "host-source-f32-f64-exact-real-result".to_owned(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// Current GPT-2 source-dense record.
+    pub fn gpt2_source_dense() -> Self {
+        Self::gpt2_v2()
+    }
+
+    /// Fixed-order canonical serialization of the declared identity.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "uor-r4-dense-operator/1\n\
+             id={}\n\
+             version={}\n\
+             conv1d_weight_layout={}\n\
+             conv1d_accumulation={}\n\
+             conv1d_bias={}\n\
+             lm_head_weight_layout={}\n\
+             lm_head_accumulation={}\n\
+             arithmetic_owner={}\n\
+             permitted_operation_class={}\n",
+            self.id,
+            self.version,
+            self.conv1d_weight_layout,
+            self.conv1d_accumulation,
+            self.conv1d_bias,
+            self.lm_head_weight_layout,
+            self.lm_head_accumulation,
+            self.arithmetic_owner,
+            self.permitted_operation_class,
+        )
+        .into_bytes()
+    }
+
+    /// Digest implied by the canonical declared identity.
+    pub fn declared_digest(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.canonical_bytes()).to_hex())
+    }
+}
+
+/// Versioned dense-operator registry. Unknown pairs fail closed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn operator_spec(
+    id: &str,
+    version: u32,
+) -> Result<DenseOperatorSpec, crate::SourceUnavailable> {
+    match (id, version) {
+        (DenseOperatorSpec::GPT2_ID, DenseOperatorSpec::GPT2_V1_VERSION) => {
+            Ok(DenseOperatorSpec::gpt2_v1())
+        }
+        (DenseOperatorSpec::GPT2_ID, DenseOperatorSpec::GPT2_V2_VERSION) => {
+            Ok(DenseOperatorSpec::gpt2_source_dense())
+        }
+        _ => Err(crate::SourceIngestKind::UnknownDenseOperator {
+            id: id.to_owned(),
+            version,
+        }
+        .into()),
+    }
+}
+
+/// Validate one jointly declared source-attention/source-dense identity.
+///
+/// Absence of a dense record preserves legacy and non-GPT-2 producers. Once
+/// GPT-2 dense provenance is present, its version must form one registered
+/// execution era with learned-absolute GPT-2 attention; an absent or Llama
+/// attention record is never silently paired with it.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn validate_source_execution_pair(
+    attention: Option<&crate::attention::AttentionOperatorSpec>,
+    dense: Option<&DenseOperatorSpec>,
+) -> Result<(), crate::SourceUnavailable> {
+    let Some(dense) = dense else {
+        return Ok(());
+    };
+    let valid = attention.is_some_and(|attention| {
+        matches!(
+            (
+                attention.id.as_str(),
+                attention.version,
+                dense.id.as_str(),
+                dense.version,
+            ),
+            (
+                crate::attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                crate::attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_V1_VERSION,
+                DenseOperatorSpec::GPT2_ID,
+                DenseOperatorSpec::GPT2_V1_VERSION,
+            ) | (
+                crate::attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
+                crate::attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_V2_VERSION,
+                DenseOperatorSpec::GPT2_ID,
+                DenseOperatorSpec::GPT2_V2_VERSION,
+            )
+        )
+    });
+    if valid {
+        Ok(())
+    } else {
+        let attention = attention.map_or_else(
+            || "absent".to_owned(),
+            |record| format!("{}/{}", record.id, record.version),
+        );
+        Err(crate::SourceUnavailable::new(format!(
+            "source execution pair is not registered: attention={attention}, dense={}/{}",
+            dense.id, dense.version
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_alias_and_registry_are_exact() {
+        assert_eq!(
+            DenseOperatorSpec::gpt2_source_dense(),
+            DenseOperatorSpec::gpt2_v2()
+        );
+        assert_eq!(
+            DenseOperatorSpec::GPT2_VERSION,
+            DenseOperatorSpec::GPT2_V2_VERSION
+        );
+        assert_eq!(
+            operator_spec(
+                DenseOperatorSpec::GPT2_ID,
+                DenseOperatorSpec::GPT2_V1_VERSION
+            )
+            .expect("registered v1"),
+            DenseOperatorSpec::gpt2_v1()
+        );
+        assert_eq!(
+            operator_spec(
+                DenseOperatorSpec::GPT2_ID,
+                DenseOperatorSpec::GPT2_V2_VERSION
+            )
+            .expect("registered v2"),
+            DenseOperatorSpec::gpt2_v2()
+        );
+        assert!(operator_spec(DenseOperatorSpec::GPT2_ID, 3).is_err());
+    }
+
+    #[test]
+    fn canonical_literals_and_digests_are_pinned() {
+        let v1 = DenseOperatorSpec::gpt2_v1();
+        assert_eq!(
+            v1.canonical_bytes(),
+            b"uor-r4-dense-operator/1\n\
+id=gpt2-source-dense\n\
+version=1\n\
+conv1d_weight_layout=input-major-row-major-[in,out]\n\
+conv1d_accumulation=input-index-ascending-binary32-product-add-left-fold-zero-input-skipped\n\
+conv1d_bias=bias-seeds-fold-before-input-products\n\
+lm_head_weight_layout=tied-wte-row-major-[vocab,in]\n\
+lm_head_accumulation=zero-seeded-input-index-ascending-binary32-product-add-left-fold-no-bias\n\
+arithmetic_owner=scalar-conventional-binary32\n\
+permitted_operation_class=host-source-f32\n"
+        );
+        assert_eq!(
+            v1.implementation_digest,
+            "blake3:b16a2a7f14828f854a7784d33cea9b49631136dbda77491899f2171cec011033"
+        );
+
+        let v2 = DenseOperatorSpec::gpt2_v2();
+        assert_eq!(
+            v2.canonical_bytes(),
+            b"uor-r4-dense-operator/1\n\
+id=gpt2-source-dense\n\
+version=2\n\
+conv1d_weight_layout=input-major-row-major-[in,out]\n\
+conv1d_accumulation=correctly-rounded-binary32-exact-real-dot\n\
+conv1d_bias=one-binary32-add-after-dot\n\
+lm_head_weight_layout=tied-wte-row-major-[vocab,in]\n\
+lm_head_accumulation=correctly-rounded-binary32-exact-real-dot-no-bias\n\
+arithmetic_owner=correctly-rounded-binary32-exact-real-result\n\
+permitted_operation_class=host-source-f32-f64-exact-real-result\n"
+        );
+        assert_eq!(
+            v2.implementation_digest,
+            "blake3:3a61d92e61b2a322e086162767173aca8439dffd1ddc7443f1d8b44ee1b1eaf6"
+        );
+    }
+
+    #[test]
+    fn source_execution_pairs_fail_closed() {
+        let learned_v1 = crate::attention::AttentionOperatorSpec::learned_absolute_v1();
+        let learned_v2 = crate::attention::AttentionOperatorSpec::learned_absolute_v2();
+        let standard = crate::attention::AttentionOperatorSpec::standard();
+        let dense_v1 = DenseOperatorSpec::gpt2_v1();
+        let dense_v2 = DenseOperatorSpec::gpt2_v2();
+
+        assert!(validate_source_execution_pair(None, None).is_ok());
+        assert!(validate_source_execution_pair(Some(&standard), None).is_ok());
+        assert!(validate_source_execution_pair(Some(&learned_v1), Some(&dense_v1)).is_ok());
+        assert!(validate_source_execution_pair(Some(&learned_v2), Some(&dense_v2)).is_ok());
+        assert!(validate_source_execution_pair(None, Some(&dense_v2)).is_err());
+        assert!(validate_source_execution_pair(Some(&standard), Some(&dense_v2)).is_err());
+        assert!(validate_source_execution_pair(Some(&learned_v1), Some(&dense_v2)).is_err());
+        assert!(validate_source_execution_pair(Some(&learned_v2), Some(&dense_v1)).is_err());
+    }
+}

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -159,6 +159,11 @@ pub struct Gpt2 {
     pub(crate) ln_f_b: Vec<f32>,
     pub(crate) kappa: String,
     pub(crate) source_bytes: usize,
+    /// Immutable once-prepared dense bounds and tied-head transpose. All
+    /// mutable proof/intermediate storage belongs to `Gpt2State`, so one
+    /// loaded model may be shared across independent callers without a
+    /// mutable-model race.
+    dense_prepared: Gpt2ProductionDensePrepared,
 }
 
 /// The tensors the GPT-2 geometry requires, with the shapes `config.json`
@@ -254,6 +259,8 @@ impl Gpt2 {
         }
         let ln_f_w = load("ln_f.weight")?;
         let ln_f_b = load("ln_f.bias")?;
+        let dense_prepared = Gpt2ProductionDensePrepared::prepare(&cfg, &wte, &layers)
+            .ok_or_else(|| SourceUnavailable::new("GPT-2 dense preparation geometry overflow"))?;
         Ok(Self {
             cfg,
             wte,
@@ -263,6 +270,7 @@ impl Gpt2 {
             ln_f_b,
             kappa: snapshot.kappa().to_owned(),
             source_bytes: snapshot.source_bytes(),
+            dense_prepared,
         })
     }
 
@@ -310,6 +318,600 @@ fn conv1d(x: &[f32], w: &[f32], bias: &[f32], out_dim: usize, out: &mut [f32]) {
         let row = &w[i * out_dim..(i + 1) * out_dim];
         for o in 0..out_dim {
             out[o] += xi * row[o];
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DenseCertificationRejection {
+    Nonfinite,
+    Zero,
+    Overflow,
+    Cell,
+}
+
+#[inline]
+fn dense_next_up_f64(value: f64) -> f64 {
+    if value.is_nan() || value == f64::INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f64::from_bits(1);
+    }
+    let bits = value.to_bits();
+    f64::from_bits(if value > 0.0 { bits + 1 } else { bits - 1 })
+}
+
+#[inline]
+fn dense_next_down_f64(value: f64) -> f64 {
+    if value.is_nan() || value == f64::NEG_INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f64::from_bits((1u64 << 63) | 1);
+    }
+    let bits = value.to_bits();
+    f64::from_bits(if value > 0.0 { bits - 1 } else { bits + 1 })
+}
+
+#[inline]
+fn dense_next_up_f32(value: f32) -> f32 {
+    if value.is_nan() || value == f32::INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits(1);
+    }
+    let bits = value.to_bits();
+    f32::from_bits(if value > 0.0 { bits + 1 } else { bits - 1 })
+}
+
+#[inline]
+fn dense_next_down_f32(value: f32) -> f32 {
+    if value.is_nan() || value == f32::NEG_INFINITY {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits((1u32 << 31) | 1);
+    }
+    let bits = value.to_bits();
+    f32::from_bits(if value > 0.0 { bits - 1 } else { bits + 1 })
+}
+
+/// Outward `gamma_k = ku / (1-ku)` for binary64 round-to-nearest addition.
+#[inline]
+fn dense_gamma(k: usize) -> Option<f64> {
+    if (k as u128) > (1u128 << f64::MANTISSA_DIGITS) {
+        return None;
+    }
+    const UNIT_ROUNDOFF: f64 = 1.0 / ((1u64 << 53) as f64);
+    let mu = dense_next_up_f64((k as f64) * UNIT_ROUNDOFF);
+    if mu >= 1.0 {
+        return None;
+    }
+    let denominator = dense_next_down_f64(1.0 - mu);
+    (denominator > 0.0).then(|| dense_next_up_f64(mu / denominator))
+}
+
+/// Convert a rounded nonnegative binary64 sum into an outward upper bound on
+/// its exact sum. For `Ahat = fl(sum a_i)`, `|Ahat-A| <= gamma_k A`, hence
+/// `A <= Ahat/(1-gamma_k)`.
+#[inline]
+fn dense_positive_sum_upper(approximate: f64, k: usize) -> Option<f64> {
+    if !approximate.is_finite() || approximate < 0.0 {
+        return None;
+    }
+    let gamma = dense_gamma(k)?;
+    let denominator = dense_next_down_f64(1.0 - gamma);
+    if denominator <= 0.0 {
+        return None;
+    }
+    let upper = dense_next_up_f64(approximate / denominator);
+    upper.is_finite().then_some(upper)
+}
+
+#[inline]
+fn dense_rounding_cell_contains(
+    approximate: f64,
+    lower: f64,
+    upper: f64,
+) -> Result<f32, DenseCertificationRejection> {
+    if !approximate.is_finite() || !lower.is_finite() || !upper.is_finite() {
+        return Err(DenseCertificationRejection::Nonfinite);
+    }
+    let candidate = approximate as f32;
+    if candidate == 0.0 {
+        return Err(DenseCertificationRejection::Zero);
+    }
+    if !candidate.is_finite() || candidate.abs() == f32::MAX {
+        return Err(DenseCertificationRejection::Overflow);
+    }
+    let previous = dense_next_down_f32(candidate);
+    let next = dense_next_up_f32(candidate);
+    if !previous.is_finite() || !next.is_finite() {
+        return Err(DenseCertificationRejection::Overflow);
+    }
+    // Both binary32 values and their midpoint are represented exactly in
+    // binary64. Strict containment rejects midpoint ties without a parity arm.
+    let cell_lower = (f64::from(previous) + f64::from(candidate)) * 0.5;
+    let cell_upper = (f64::from(candidate) + f64::from(next)) * 0.5;
+    if lower > cell_lower && upper < cell_upper {
+        Ok(candidate)
+    } else {
+        Err(DenseCertificationRejection::Cell)
+    }
+}
+
+/// Certify a binary64 left fold using an independently supplied outward upper
+/// bound on `sum_i |x_i*w_i|`.
+#[inline]
+fn certify_dense_sum(
+    approximate: f64,
+    sum_abs_upper: f64,
+    k: usize,
+) -> Result<f32, DenseCertificationRejection> {
+    if !approximate.is_finite() || !sum_abs_upper.is_finite() {
+        return Err(DenseCertificationRejection::Nonfinite);
+    }
+    let gamma = dense_gamma(k).ok_or(DenseCertificationRejection::Cell)?;
+    let error = dense_next_up_f64(gamma * sum_abs_upper);
+    if !error.is_finite() {
+        return Err(DenseCertificationRejection::Cell);
+    }
+    let lower = dense_next_down_f64(approximate - error);
+    let upper = dense_next_up_f64(approximate + error);
+    dense_rounding_cell_contains(approximate, lower, upper)
+}
+
+/// Knuth TwoSum: absent overflow, `sum + error == left + right` exactly.
+#[inline]
+fn dense_two_sum(left: f64, right: f64) -> (f64, f64) {
+    let sum = left + right;
+    let right_virtual = sum - left;
+    let left_virtual = sum - right_virtual;
+    let right_error = right - right_virtual;
+    let left_error = left - left_virtual;
+    (sum, left_error + right_error)
+}
+
+/// Scalar refinement for a lane rejected by the coarse weight-magnitude
+/// bound. TwoSum records every primary-fold error exactly. Only the secondary
+/// fold of those errors rounds, so its much smaller residual is bounded with a
+/// second gamma enclosure before the same strict binary32 cell test.
+fn refine_dense_lane(
+    x: &[f32],
+    w: &[f32],
+    out_dim: usize,
+    lane: usize,
+) -> Result<f32, DenseCertificationRejection> {
+    let mut high = 0.0f64;
+    let mut correction = 0.0f64;
+    let mut correction_abs = 0.0f64;
+    for (input_index, &activation) in x.iter().enumerate() {
+        let weight = w[input_index * out_dim + lane];
+        if !activation.is_finite() || !weight.is_finite() {
+            return Err(DenseCertificationRejection::Nonfinite);
+        }
+        // A finite binary32 product has at most 48 significant bits and is
+        // therefore exact in binary64.
+        let product = f64::from(activation) * f64::from(weight);
+        let (next, error) = dense_two_sum(high, product);
+        high = next;
+        correction += error;
+        correction_abs += error.abs();
+    }
+    if !high.is_finite() || !correction.is_finite() || !correction_abs.is_finite() {
+        return Err(DenseCertificationRejection::Nonfinite);
+    }
+    let correction_abs_upper = dense_positive_sum_upper(correction_abs, x.len())
+        .ok_or(DenseCertificationRejection::Cell)?;
+    let gamma = dense_gamma(x.len()).ok_or(DenseCertificationRejection::Cell)?;
+    let error = dense_next_up_f64(gamma * correction_abs_upper);
+    if !error.is_finite() {
+        return Err(DenseCertificationRejection::Cell);
+    }
+
+    // `high + correction` itself is represented as a TwoSum pair. Outward
+    // evaluation of that exact pair avoids silently losing its low word.
+    let (center_high, center_low) = dense_two_sum(high, correction);
+    let approximate = center_high + center_low;
+    let tail_lower = dense_next_down_f64(center_low - error);
+    let tail_upper = dense_next_up_f64(center_low + error);
+    let lower = dense_next_down_f64(center_high + tail_lower);
+    let upper = dense_next_up_f64(center_high + tail_upper);
+    dense_rounding_cell_contains(approximate, lower, upper)
+}
+
+fn exact_dense_lane(x: &[f32], w: &[f32], out_dim: usize, lane: usize) -> f32 {
+    if x.is_empty() {
+        return 0.0;
+    }
+    let stride = isize::try_from(out_dim).expect("validated dense row stride fits isize");
+    let left = uor_matmul::MatView::row_major(x, 1, x.len())
+        .expect("validated dense activation row has its declared extent");
+    let right = uor_matmul::MatView::new(
+        &w[lane..],
+        x.len(),
+        1,
+        uor_matmul::Strides { rs: stride, cs: 1 },
+    )
+    .expect("validated immutable dense weight column has its declared extent");
+    let mut value = [0.0f32];
+    let sink = uor_matmul::MatViewMut::row_major(&mut value, 1, 1)
+        .expect("one dense output cell has its declared extent");
+    let mut product = uor_matmul::Triple::new(left, right, sink)
+        .expect("validated dense row and column form a product");
+    uor_matmul::driver::gemm_float(
+        &mut product,
+        &uor_matmul::Linear::OVERWRITE,
+        uor_matmul::GemmOptions::default(),
+    );
+    value[0]
+}
+
+fn exact_dense_projection(out: &mut [f32], x: &[f32], w: &[f32], out_dim: usize) {
+    uor_matmul::slice::gemm_float(1, x.len(), out_dim, x, w, out, &mut [], &mut [])
+        .expect("validated contiguous dense operands form a product");
+}
+
+fn certified_dense_dots_with_scratch(
+    out: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    out_dim: usize,
+    sums: &mut [f64],
+    sum_abs_weight_upper: &[f64],
+) -> Gpt2DenseCanaryCensus {
+    sums.fill(0.0);
+    let mut max_activation_abs = 0.0f64;
+    for (input_index, &activation) in x.iter().enumerate() {
+        let activation = f64::from(activation);
+        max_activation_abs = max_activation_abs.max(activation.abs());
+        let row = &w[input_index * out_dim..(input_index + 1) * out_dim];
+        for output_index in 0..out_dim {
+            sums[output_index] += activation * f64::from(row[output_index]);
+        }
+    }
+
+    let mut census = Gpt2DenseCanaryCensus {
+        lanes: out_dim,
+        ..Gpt2DenseCanaryCensus::default()
+    };
+    for lane in 0..out_dim {
+        let sum_abs_upper = dense_next_up_f64(max_activation_abs * sum_abs_weight_upper[lane]);
+        let dot = match certify_dense_sum(sums[lane], sum_abs_upper, x.len()) {
+            Ok(value) => {
+                census.fast_certified += 1;
+                value
+            }
+            Err(DenseCertificationRejection::Nonfinite) => {
+                census.reject(DenseCertificationRejection::Nonfinite);
+                exact_dense_lane(x, w, out_dim, lane)
+            }
+            Err(_) => match refine_dense_lane(x, w, out_dim, lane) {
+                Ok(value) => {
+                    census.refined_certified += 1;
+                    value
+                }
+                Err(reason) => {
+                    census.reject(reason);
+                    exact_dense_lane(x, w, out_dim, lane)
+                }
+            },
+        };
+        out[lane] = dot;
+    }
+    debug_assert_eq!(
+        census.fast_certified + census.refined_certified + census.fallbacks().unwrap_or(usize::MAX),
+        census.lanes
+    );
+    census
+}
+
+fn certified_dense_projection(
+    out: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    bias: &[f32],
+    workspace: &mut Gpt2DenseCanaryWorkspace,
+) -> Gpt2DenseCanaryCensus {
+    let census = certified_dense_dots_with_scratch(
+        out,
+        x,
+        w,
+        workspace.out_dim,
+        &mut workspace.sums,
+        &workspace.sum_abs_weight_upper,
+    );
+    // #704's Conv1D semantics are one correctly-rounded dot followed by the
+    // historical single binary32 bias addition.
+    for (value, &addend) in out.iter_mut().zip(bias) {
+        *value += addend;
+    }
+    census
+}
+
+fn conventional_dense_dots(out: &mut [f32], x: &[f32], w: &[f32], out_dim: usize) {
+    out[..out_dim].fill(0.0);
+    for (input_index, &activation) in x.iter().enumerate() {
+        if activation == 0.0 {
+            continue;
+        }
+        let row = &w[input_index * out_dim..(input_index + 1) * out_dim];
+        for output_index in 0..out_dim {
+            out[output_index] += activation * row[output_index];
+        }
+    }
+}
+
+fn conventional_lm_head(out: &mut [f32], hidden: &[f32], wte: &[f32], width: usize) {
+    for (vocabulary_index, output) in out.iter_mut().enumerate() {
+        let row = &wte[vocabulary_index * width..(vocabulary_index + 1) * width];
+        let mut accumulator = 0.0f32;
+        for input_index in 0..width {
+            accumulator += hidden[input_index] * row[input_index];
+        }
+        *output = accumulator;
+    }
+}
+
+fn controlled_dense_projection(
+    out: &mut [f32],
+    x: &[f32],
+    weights: &[f32],
+    bias: Option<&[f32]>,
+    prepared: &mut DensePreparedMatrix,
+    mode: Gpt2DenseCanaryMode,
+) -> Gpt2DenseCanaryCensus {
+    let out_dim = prepared.out_dim;
+    let mut census = Gpt2DenseCanaryCensus {
+        lanes: out_dim,
+        ..Gpt2DenseCanaryCensus::default()
+    };
+    match mode {
+        Gpt2DenseCanaryMode::Conventional => {
+            if let Some(bias) = bias {
+                conv1d(x, weights, bias, out_dim, out);
+            } else {
+                conventional_dense_dots(out, x, weights, out_dim);
+            }
+            census.conventional = out_dim;
+        }
+        Gpt2DenseCanaryMode::Exact => {
+            exact_dense_projection(out, x, weights, out_dim);
+            if let Some(bias) = bias {
+                for (value, &addend) in out.iter_mut().zip(bias) {
+                    *value += addend;
+                }
+            }
+            census.exact_control = out_dim;
+        }
+        Gpt2DenseCanaryMode::CertifiedNative => {
+            census = certified_dense_dots_with_scratch(
+                out,
+                x,
+                weights,
+                out_dim,
+                &mut prepared.sums,
+                &prepared.sum_abs_weight_upper,
+            );
+            if let Some(bias) = bias {
+                for (value, &addend) in out.iter_mut().zip(bias) {
+                    *value += addend;
+                }
+            }
+        }
+    }
+    census
+}
+
+#[allow(clippy::too_many_arguments)]
+fn certified_dense_dots_batched_with_scratch(
+    out: &mut [f32],
+    x: &[f32],
+    weights: &[f32],
+    batch: usize,
+    in_dim: usize,
+    out_dim: usize,
+    sums: &mut [f64],
+    max_activation_abs: &mut [f64],
+    sum_abs_weight_upper: &[f64],
+) -> Gpt2DenseCanaryCensus {
+    sums[..batch * out_dim].fill(0.0);
+    max_activation_abs[..batch].fill(0.0);
+    for input_index in 0..in_dim {
+        let row = &weights[input_index * out_dim..(input_index + 1) * out_dim];
+        for batch_index in 0..batch {
+            let activation = f64::from(x[batch_index * in_dim + input_index]);
+            max_activation_abs[batch_index] = max_activation_abs[batch_index].max(activation.abs());
+            let output = &mut sums[batch_index * out_dim..(batch_index + 1) * out_dim];
+            for output_index in 0..out_dim {
+                output[output_index] += activation * f64::from(row[output_index]);
+            }
+        }
+    }
+
+    let mut census = Gpt2DenseCanaryCensus {
+        lanes: batch * out_dim,
+        ..Gpt2DenseCanaryCensus::default()
+    };
+    for batch_index in 0..batch {
+        let input = &x[batch_index * in_dim..(batch_index + 1) * in_dim];
+        for (lane, &weight_bound) in sum_abs_weight_upper.iter().enumerate().take(out_dim) {
+            let index = batch_index * out_dim + lane;
+            let sum_abs_upper = dense_next_up_f64(max_activation_abs[batch_index] * weight_bound);
+            let dot = match certify_dense_sum(sums[index], sum_abs_upper, in_dim) {
+                Ok(value) => {
+                    census.fast_certified += 1;
+                    value
+                }
+                Err(DenseCertificationRejection::Nonfinite) => {
+                    census.reject(DenseCertificationRejection::Nonfinite);
+                    exact_dense_lane(input, weights, out_dim, lane)
+                }
+                Err(_) => match refine_dense_lane(input, weights, out_dim, lane) {
+                    Ok(value) => {
+                        census.refined_certified += 1;
+                        value
+                    }
+                    Err(reason) => {
+                        census.reject(reason);
+                        exact_dense_lane(input, weights, out_dim, lane)
+                    }
+                },
+            };
+            out[index] = dot;
+        }
+    }
+    debug_assert_eq!(
+        census.fast_certified + census.refined_certified + census.fallbacks().unwrap_or(usize::MAX),
+        census.lanes
+    );
+    census
+}
+
+#[allow(clippy::too_many_arguments)]
+fn controlled_dense_projection_batched(
+    out: &mut [f32],
+    x: &[f32],
+    weights: &[f32],
+    bias: Option<&[f32]>,
+    batch: usize,
+    prepared: &DensePreparedMatrix,
+    sums: &mut [f64],
+    max_activation_abs: &mut [f64],
+    mode: Gpt2DenseCanaryMode,
+) -> Gpt2DenseCanaryCensus {
+    let in_dim = prepared.in_dim;
+    let out_dim = prepared.out_dim;
+    let lanes = batch * out_dim;
+    let mut census = Gpt2DenseCanaryCensus {
+        lanes,
+        batch_rows: batch,
+        ..Gpt2DenseCanaryCensus::default()
+    };
+    match mode {
+        Gpt2DenseCanaryMode::Conventional => {
+            if let Some(bias) = bias {
+                conv1d_batched(out, x, weights, bias, out_dim, in_dim, batch);
+            } else {
+                out[..lanes].fill(0.0);
+                for input_index in 0..in_dim {
+                    let row = &weights[input_index * out_dim..(input_index + 1) * out_dim];
+                    for batch_index in 0..batch {
+                        let activation = x[batch_index * in_dim + input_index];
+                        if activation == 0.0 {
+                            continue;
+                        }
+                        let output = &mut out[batch_index * out_dim..(batch_index + 1) * out_dim];
+                        for output_index in 0..out_dim {
+                            output[output_index] += activation * row[output_index];
+                        }
+                    }
+                }
+            }
+            census.conventional = lanes;
+        }
+        Gpt2DenseCanaryMode::Exact => {
+            for batch_index in 0..batch {
+                let input = &x[batch_index * in_dim..(batch_index + 1) * in_dim];
+                for lane in 0..out_dim {
+                    out[batch_index * out_dim + lane] =
+                        exact_dense_lane(input, weights, out_dim, lane);
+                }
+            }
+            if let Some(bias) = bias {
+                for output in out[..lanes].chunks_exact_mut(out_dim) {
+                    for (value, &addend) in output.iter_mut().zip(bias) {
+                        *value += addend;
+                    }
+                }
+            }
+            census.exact_control = lanes;
+        }
+        Gpt2DenseCanaryMode::CertifiedNative => {
+            census = certified_dense_dots_batched_with_scratch(
+                out,
+                x,
+                weights,
+                batch,
+                in_dim,
+                out_dim,
+                sums,
+                max_activation_abs,
+                &prepared.sum_abs_weight_upper,
+            );
+            census.batch_rows = batch;
+            if let Some(bias) = bias {
+                for output in out[..lanes].chunks_exact_mut(out_dim) {
+                    for (value, &addend) in output.iter_mut().zip(bias) {
+                        *value += addend;
+                    }
+                }
+            }
+        }
+    }
+    census
+}
+
+/// Production-shaped certified projection over caller-owned state lanes.
+/// Each immutable weight row is fetched once, then reused across the batch;
+/// within every lane the f64 accumulation still visits input indices in the
+/// same ascending order as the serial one-row call.
+fn production_dense_projection_batched(
+    states: &mut [Gpt2State],
+    weights: &[f32],
+    bias: Option<&[f32]>,
+    metadata: &DenseWeightMetadata,
+) {
+    let in_dim = metadata.in_dim;
+    let out_dim = metadata.out_dim;
+    debug_assert_eq!(weights.len(), in_dim * out_dim);
+    debug_assert_eq!(metadata.sum_abs_weight_upper.len(), out_dim);
+    debug_assert!(bias.is_none_or(|bias| bias.len() >= out_dim));
+
+    for state in states.iter_mut() {
+        debug_assert!(state.dense_scratch.input.len() >= in_dim);
+        debug_assert!(state.dense_scratch.output.len() >= out_dim);
+        debug_assert!(state.dense_scratch.sums.len() >= out_dim);
+        state.dense_scratch.sums[..out_dim].fill(0.0);
+        state.dense_scratch.max_activation_abs = 0.0;
+    }
+
+    for input_index in 0..in_dim {
+        let row = &weights[input_index * out_dim..(input_index + 1) * out_dim];
+        for state in states.iter_mut() {
+            let activation = f64::from(state.dense_scratch.input[input_index]);
+            state.dense_scratch.max_activation_abs =
+                state.dense_scratch.max_activation_abs.max(activation.abs());
+            let sums = &mut state.dense_scratch.sums[..out_dim];
+            for output_index in 0..out_dim {
+                sums[output_index] += activation * f64::from(row[output_index]);
+            }
+        }
+    }
+
+    for state in states {
+        let Gpt2ProductionDenseScratch {
+            input,
+            output,
+            sums,
+            max_activation_abs,
+            ..
+        } = &mut state.dense_scratch;
+        let input = &input[..in_dim];
+        for lane in 0..out_dim {
+            let sum_abs_upper =
+                dense_next_up_f64(*max_activation_abs * metadata.sum_abs_weight_upper[lane]);
+            let dot = match certify_dense_sum(sums[lane], sum_abs_upper, in_dim) {
+                Ok(value) => value,
+                Err(DenseCertificationRejection::Nonfinite) => {
+                    exact_dense_lane(input, weights, out_dim, lane)
+                }
+                Err(_) => refine_dense_lane(input, weights, out_dim, lane)
+                    .unwrap_or_else(|_| exact_dense_lane(input, weights, out_dim, lane)),
+            };
+            output[lane] = bias.map_or(dot, |bias| dot + bias[lane]);
         }
     }
 }
@@ -399,7 +1001,7 @@ pub(crate) fn attention_weights_with_arithmetic(
 
 /// Recurrent decode state: per-layer key/value caches, the working
 /// residual, the final hidden state, and the last step's logits.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Gpt2State {
     k_cache: Vec<f32>,
     v_cache: Vec<f32>,
@@ -408,6 +1010,61 @@ pub struct Gpt2State {
     /// Final hidden state (post `ln_f`) of the last step (`n_embd`).
     pub hidden: Vec<f32>,
     x: Vec<f32>,
+    dense_scratch: Gpt2ProductionDenseScratch,
+}
+
+// `Gpt2State` exposed logical equality before production dense scratch became
+// state-local. Preserve that public contract: opaque workspace residue is not
+// recurrent model state and must not make two otherwise identical states
+// unequal.
+impl PartialEq for Gpt2State {
+    fn eq(&self, other: &Self) -> bool {
+        self.k_cache == other.k_cache
+            && self.v_cache == other.v_cache
+            && self.logits == other.logits
+            && self.hidden == other.hidden
+            && self.x == other.x
+    }
+}
+
+/// Per-state production scratch. Keeping it with the recurrent state makes
+/// the shared model immutable and gives an arbitrary-size batch one scratch
+/// lane per caller-owned sequence without a shared capacity or lock.
+#[derive(Clone, Debug)]
+struct Gpt2ProductionDenseScratch {
+    input: Vec<f32>,
+    output: Vec<f32>,
+    sums: Vec<f64>,
+    max_activation_abs: f64,
+    attention: Vec<f32>,
+    scores: Vec<f32>,
+}
+
+impl Gpt2ProductionDenseScratch {
+    fn new(cfg: &Gpt2Config) -> Self {
+        let maximum_input = cfg.n_inner.max(cfg.n_embd);
+        let maximum_output = cfg
+            .vocab
+            .max(cfg.n_inner)
+            .max(3usize.saturating_mul(cfg.n_embd));
+        Self {
+            input: vec![0.0; maximum_input],
+            output: vec![0.0; maximum_output],
+            sums: vec![0.0; maximum_output],
+            max_activation_abs: 0.0,
+            attention: vec![0.0; cfg.n_embd],
+            scores: vec![0.0; cfg.seq_len],
+        }
+    }
+
+    fn reset(&mut self) {
+        self.input.fill(0.0);
+        self.output.fill(0.0);
+        self.sums.fill(0.0);
+        self.max_activation_abs = 0.0;
+        self.attention.fill(0.0);
+        self.scores.fill(0.0);
+    }
 }
 
 /// Arithmetic arm selected by the checked, evidence-only GPT-2 attention
@@ -506,6 +1163,196 @@ pub struct Gpt2AttentionCanaryCensus {
     value: Gpt2AttentionCanaryDotCensus,
 }
 
+/// Arithmetic arm selected by the checked GPT-2 dense differential controls.
+/// Production executes the certified-native v2 arm; conventional and exact
+/// remain explicit comparison owners.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Gpt2DenseCanaryMode {
+    /// Historical bias-seeded sequential binary32 Conv1D.
+    Conventional,
+    /// Pinned correctly-rounded exact dot, followed by one binary32 bias add.
+    Exact,
+    /// Native binary64 candidate with a proof/refinement/exact-fallback chain.
+    CertifiedNative,
+}
+
+/// Per-output verdict census for the checked #704 dense canary.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Gpt2DenseCanaryCensus {
+    lanes: usize,
+    batch_rows: usize,
+    conventional: usize,
+    exact_control: usize,
+    fast_certified: usize,
+    refined_certified: usize,
+    fallback_nonfinite: usize,
+    fallback_zero: usize,
+    fallback_overflow: usize,
+    fallback_cell: usize,
+}
+
+impl Gpt2DenseCanaryCensus {
+    pub const fn lanes(self) -> usize {
+        self.lanes
+    }
+
+    /// Sequence rows processed by the production-shaped row-reuse batch
+    /// kernel. Serial controls report zero.
+    pub const fn batch_rows(self) -> usize {
+        self.batch_rows
+    }
+
+    pub const fn conventional(self) -> usize {
+        self.conventional
+    }
+
+    pub const fn exact_control(self) -> usize {
+        self.exact_control
+    }
+
+    pub const fn fast_certified(self) -> usize {
+        self.fast_certified
+    }
+
+    pub const fn refined_certified(self) -> usize {
+        self.refined_certified
+    }
+
+    pub const fn fallback_nonfinite(self) -> usize {
+        self.fallback_nonfinite
+    }
+
+    pub const fn fallback_zero(self) -> usize {
+        self.fallback_zero
+    }
+
+    pub const fn fallback_overflow(self) -> usize {
+        self.fallback_overflow
+    }
+
+    pub const fn fallback_cell(self) -> usize {
+        self.fallback_cell
+    }
+
+    pub fn fallbacks(self) -> Option<usize> {
+        self.fallback_nonfinite
+            .checked_add(self.fallback_zero)?
+            .checked_add(self.fallback_overflow)?
+            .checked_add(self.fallback_cell)
+    }
+
+    /// Merge a projection census atomically. `None` leaves `self` unchanged.
+    pub fn merge(&mut self, other: Self) -> Option<()> {
+        let merged = Self {
+            lanes: self.lanes.checked_add(other.lanes)?,
+            batch_rows: self.batch_rows.checked_add(other.batch_rows)?,
+            conventional: self.conventional.checked_add(other.conventional)?,
+            exact_control: self.exact_control.checked_add(other.exact_control)?,
+            fast_certified: self.fast_certified.checked_add(other.fast_certified)?,
+            refined_certified: self
+                .refined_certified
+                .checked_add(other.refined_certified)?,
+            fallback_nonfinite: self
+                .fallback_nonfinite
+                .checked_add(other.fallback_nonfinite)?,
+            fallback_zero: self.fallback_zero.checked_add(other.fallback_zero)?,
+            fallback_overflow: self
+                .fallback_overflow
+                .checked_add(other.fallback_overflow)?,
+            fallback_cell: self.fallback_cell.checked_add(other.fallback_cell)?,
+        };
+        *self = merged;
+        Some(())
+    }
+
+    fn reject(&mut self, reason: DenseCertificationRejection) {
+        match reason {
+            DenseCertificationRejection::Nonfinite => self.fallback_nonfinite += 1,
+            DenseCertificationRejection::Zero => self.fallback_zero += 1,
+            DenseCertificationRejection::Overflow => self.fallback_overflow += 1,
+            DenseCertificationRejection::Cell => self.fallback_cell += 1,
+        }
+    }
+}
+
+/// Dense owner selected by the checked matrix-level and whole-model controls.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Gpt2DenseControlSite {
+    CAttn,
+    AttentionCProj,
+    MlpCFc,
+    MlpCProj,
+    LmHead,
+}
+
+/// Four projection censuses for one GPT-2 transformer layer.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Gpt2DenseLayerCensus {
+    c_attn: Gpt2DenseCanaryCensus,
+    attention_c_proj: Gpt2DenseCanaryCensus,
+    mlp_c_fc: Gpt2DenseCanaryCensus,
+    mlp_c_proj: Gpt2DenseCanaryCensus,
+}
+
+impl Gpt2DenseLayerCensus {
+    pub const fn c_attn(self) -> Gpt2DenseCanaryCensus {
+        self.c_attn
+    }
+
+    pub const fn attention_c_proj(self) -> Gpt2DenseCanaryCensus {
+        self.attention_c_proj
+    }
+
+    pub const fn mlp_c_fc(self) -> Gpt2DenseCanaryCensus {
+        self.mlp_c_fc
+    }
+
+    pub const fn mlp_c_proj(self) -> Gpt2DenseCanaryCensus {
+        self.mlp_c_proj
+    }
+
+    pub fn merge(&mut self, other: Self) -> Option<()> {
+        let mut c_attn = self.c_attn;
+        let mut attention_c_proj = self.attention_c_proj;
+        let mut mlp_c_fc = self.mlp_c_fc;
+        let mut mlp_c_proj = self.mlp_c_proj;
+        c_attn.merge(other.c_attn)?;
+        attention_c_proj.merge(other.attention_c_proj)?;
+        mlp_c_fc.merge(other.mlp_c_fc)?;
+        mlp_c_proj.merge(other.mlp_c_proj)?;
+        *self = Self {
+            c_attn,
+            attention_c_proj,
+            mlp_c_fc,
+            mlp_c_proj,
+        };
+        Some(())
+    }
+}
+
+/// Borrowed, allocation-free census from one checked serial, trace, or batch
+/// control call. The slice has exactly one row per model layer.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug)]
+pub struct Gpt2DenseControlCensus<'a> {
+    layers: &'a [Gpt2DenseLayerCensus],
+    lm_head: Gpt2DenseCanaryCensus,
+}
+
+impl<'a> Gpt2DenseControlCensus<'a> {
+    pub const fn layers(self) -> &'a [Gpt2DenseLayerCensus] {
+        self.layers
+    }
+
+    pub const fn lm_head(self) -> Gpt2DenseCanaryCensus {
+        self.lm_head
+    }
+}
+
 impl Gpt2AttentionCanaryCensus {
     pub const fn qk(self) -> Gpt2AttentionCanaryDotCensus {
         self.qk
@@ -548,6 +1395,7 @@ impl Gpt2State {
             logits: vec![0.0; cfg.vocab],
             hidden: vec![0.0; cfg.n_embd],
             x: vec![0.0; cfg.n_embd],
+            dense_scratch: Gpt2ProductionDenseScratch::new(cfg),
         }
     }
 
@@ -558,6 +1406,58 @@ impl Gpt2State {
         self.logits.fill(0.0);
         self.hidden.fill(0.0);
         self.x.fill(0.0);
+        self.dense_scratch.reset();
+    }
+
+    /// Bitwise comparison for the evidence-only dense controls, including
+    /// recurrent caches and the private residual buffer.
+    #[doc(hidden)]
+    pub fn dense_control_bit_identical(&self, other: &Self) -> bool {
+        let bits_equal = |left: &[f32], right: &[f32]| {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| left.to_bits() == right.to_bits())
+        };
+        bits_equal(&self.k_cache, &other.k_cache)
+            && bits_equal(&self.v_cache, &other.v_cache)
+            && bits_equal(&self.logits, &other.logits)
+            && bits_equal(&self.hidden, &other.hidden)
+            && bits_equal(&self.x, &other.x)
+    }
+
+    /// Test-only comparison of every logical and scratch bit. Public
+    /// [`PartialEq`] deliberately excludes the opaque production workspace,
+    /// while failure-atomicity tests must still prove that rejected calls do
+    /// not alter it.
+    #[cfg(test)]
+    fn full_storage_bit_identical(&self, other: &Self) -> bool {
+        let f32_bits_equal = |left: &[f32], right: &[f32]| {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| left.to_bits() == right.to_bits())
+        };
+        let f64_bits_equal = |left: &[f64], right: &[f64]| {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| left.to_bits() == right.to_bits())
+        };
+        self.dense_control_bit_identical(other)
+            && f32_bits_equal(&self.dense_scratch.input, &other.dense_scratch.input)
+            && f32_bits_equal(&self.dense_scratch.output, &other.dense_scratch.output)
+            && f64_bits_equal(&self.dense_scratch.sums, &other.dense_scratch.sums)
+            && self.dense_scratch.max_activation_abs.to_bits()
+                == other.dense_scratch.max_activation_abs.to_bits()
+            && f32_bits_equal(
+                &self.dense_scratch.attention,
+                &other.dense_scratch.attention,
+            )
+            && f32_bits_equal(&self.dense_scratch.scores, &other.dense_scratch.scores)
     }
 }
 
@@ -574,6 +1474,314 @@ pub struct Gpt2AttentionCanaryWorkspace {
     inner: Vec<f32>,
     mlp_out: Vec<f32>,
     scores: Vec<f32>,
+}
+
+/// Opaque caller-owned scratch for #704's layer-0 fused-QKV experiment.
+/// Construction scans the immutable weight once and is outside the measured
+/// hot path. A checked call then reuses the single binary64 sum vector without
+/// allocation or weight rewriting.
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gpt2DenseCanaryWorkspace {
+    weight_address: usize,
+    weight_len: usize,
+    source_kappa: String,
+    in_dim: usize,
+    out_dim: usize,
+    sums: Vec<f64>,
+    sum_abs_weight_upper: Vec<f64>,
+}
+
+const DENSE_CONTROL_SITES_PER_LAYER: usize = 4;
+
+/// Immutable proof metadata for one production `[in,out]` dense weight.
+#[derive(Debug)]
+struct DenseWeightMetadata {
+    in_dim: usize,
+    out_dim: usize,
+    sum_abs_weight_upper: Vec<f64>,
+}
+
+impl DenseWeightMetadata {
+    fn prepare(weights: &[f32], in_dim: usize, out_dim: usize) -> Option<Self> {
+        if weights.len() != in_dim.checked_mul(out_dim)? {
+            return None;
+        }
+        let mut sum_abs_weight_upper = vec![0.0f64; out_dim];
+        for input_index in 0..in_dim {
+            let row = &weights[input_index * out_dim..(input_index + 1) * out_dim];
+            for output_index in 0..out_dim {
+                sum_abs_weight_upper[output_index] += f64::from(row[output_index]).abs();
+            }
+        }
+        for bound in &mut sum_abs_weight_upper {
+            *bound = dense_positive_sum_upper(*bound, in_dim).unwrap_or(f64::INFINITY);
+        }
+        Some(Self {
+            in_dim,
+            out_dim,
+            sum_abs_weight_upper,
+        })
+    }
+}
+
+/// Immutable production preparation for all 48 Conv1Ds and the tied head.
+#[derive(Debug)]
+struct Gpt2ProductionDensePrepared {
+    geometry: Gpt2ProductionGeometry,
+    matrices: Vec<DenseWeightMetadata>,
+    lm_head_transposed: Vec<f32>,
+    lm_head: DenseWeightMetadata,
+}
+
+/// Load-time geometry bound to immutable weights and dense preparation.
+/// `Gpt2::cfg` predates the prepared executor and remains public for API
+/// compatibility, so every production call compares it with this snapshot
+/// before touching caller state.
+#[derive(Clone, Copy, Debug)]
+struct Gpt2ProductionGeometry {
+    n_embd: usize,
+    n_head: usize,
+    n_layer: usize,
+    n_positions: usize,
+    n_inner: usize,
+    vocab: usize,
+    layer_norm_eps_bits: u32,
+}
+
+impl Gpt2ProductionGeometry {
+    fn from_config(cfg: &Gpt2Config) -> Self {
+        Self {
+            n_embd: cfg.n_embd,
+            n_head: cfg.n_head,
+            n_layer: cfg.n_layer,
+            n_positions: cfg.n_positions,
+            n_inner: cfg.n_inner,
+            vocab: cfg.vocab,
+            layer_norm_eps_bits: cfg.layer_norm_eps.to_bits(),
+        }
+    }
+
+    fn matches_config(self, cfg: &Gpt2Config) -> bool {
+        self.n_embd == cfg.n_embd
+            && self.n_head == cfg.n_head
+            && self.n_layer == cfg.n_layer
+            && self.n_positions == cfg.n_positions
+            && self.n_inner == cfg.n_inner
+            && self.vocab == cfg.vocab
+            && self.layer_norm_eps_bits == cfg.layer_norm_eps.to_bits()
+    }
+}
+
+impl Gpt2ProductionDensePrepared {
+    fn prepare(cfg: &Gpt2Config, wte: &[f32], layers: &[Gpt2Layer]) -> Option<Self> {
+        let d = cfg.n_embd;
+        let expected_layers = cfg.n_layer;
+        if layers.len() != expected_layers || wte.len() != cfg.vocab.checked_mul(d)? {
+            return None;
+        }
+        let mut matrices =
+            Vec::with_capacity(expected_layers.checked_mul(DENSE_CONTROL_SITES_PER_LAYER)?);
+        for layer in layers {
+            matrices.push(DenseWeightMetadata::prepare(
+                &layer.c_attn_w,
+                d,
+                3usize.checked_mul(d)?,
+            )?);
+            matrices.push(DenseWeightMetadata::prepare(&layer.c_proj_w, d, d)?);
+            matrices.push(DenseWeightMetadata::prepare(&layer.fc_w, d, cfg.n_inner)?);
+            matrices.push(DenseWeightMetadata::prepare(&layer.mlp_w, cfg.n_inner, d)?);
+        }
+
+        let mut lm_head_transposed = vec![0.0f32; d.checked_mul(cfg.vocab)?];
+        for vocabulary_index in 0..cfg.vocab {
+            let row = &wte[vocabulary_index * d..(vocabulary_index + 1) * d];
+            for input_index in 0..d {
+                lm_head_transposed[input_index * cfg.vocab + vocabulary_index] = row[input_index];
+            }
+        }
+        let lm_head = DenseWeightMetadata::prepare(&lm_head_transposed, d, cfg.vocab)?;
+        Some(Self {
+            geometry: Gpt2ProductionGeometry::from_config(cfg),
+            matrices,
+            lm_head_transposed,
+            lm_head,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DensePreparedMatrix {
+    in_dim: usize,
+    out_dim: usize,
+    sums: Vec<f64>,
+    sum_abs_weight_upper: Vec<f64>,
+}
+
+impl DensePreparedMatrix {
+    fn prepare(weights: &[f32], in_dim: usize, out_dim: usize) -> Option<Self> {
+        if weights.len() != in_dim.checked_mul(out_dim)? {
+            return None;
+        }
+        let mut sum_abs_weight_upper = vec![0.0f64; out_dim];
+        for input_index in 0..in_dim {
+            let row = &weights[input_index * out_dim..(input_index + 1) * out_dim];
+            for output_index in 0..out_dim {
+                sum_abs_weight_upper[output_index] += f64::from(row[output_index]).abs();
+            }
+        }
+        for bound in &mut sum_abs_weight_upper {
+            *bound = dense_positive_sum_upper(*bound, in_dim).unwrap_or(f64::INFINITY);
+        }
+        Some(Self {
+            in_dim,
+            out_dim,
+            sums: vec![0.0; out_dim],
+            sum_abs_weight_upper,
+        })
+    }
+
+    fn has_shape(&self, in_dim: usize, out_dim: usize) -> bool {
+        self.in_dim == in_dim
+            && self.out_dim == out_dim
+            && self.sums.len() == out_dim
+            && self.sum_abs_weight_upper.len() == out_dim
+    }
+}
+
+/// Caller-owned, model-bound scratch for the evidence-only whole-GPT-2 dense
+/// control. Every projection bound and the tied-lm-head transpose are prepared
+/// once at construction; serial, trace, and batch hot calls allocate nothing.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct Gpt2DenseControlWorkspace {
+    source_kappa: String,
+    max_batch: usize,
+    model_weight_addresses: Vec<usize>,
+    model_weight_lengths: Vec<usize>,
+    wte_address: usize,
+    wte_len: usize,
+    prepared: Vec<DensePreparedMatrix>,
+    lm_head_transposed: Vec<f32>,
+    lm_head: DensePreparedMatrix,
+    normed: Vec<f32>,
+    qkv: Vec<f32>,
+    attn: Vec<f32>,
+    proj: Vec<f32>,
+    inner: Vec<f32>,
+    mlp_out: Vec<f32>,
+    scores: Vec<f32>,
+    batch_normed: Vec<f32>,
+    batch_qkv: Vec<f32>,
+    batch_attn: Vec<f32>,
+    batch_proj: Vec<f32>,
+    batch_inner: Vec<f32>,
+    batch_mlp_out: Vec<f32>,
+    batch_logits: Vec<f32>,
+    batch_sums: Vec<f64>,
+    batch_max_activation_abs: Vec<f64>,
+    step_layers: Vec<Gpt2DenseLayerCensus>,
+    step_lm_head: Gpt2DenseCanaryCensus,
+    batch_layers: Vec<Gpt2DenseLayerCensus>,
+    batch_lm_head: Gpt2DenseCanaryCensus,
+}
+
+/// Logical owned-capacity accounting for a prepared whole-model dense
+/// workspace. Allocator bookkeeping and the caller's recurrent state are not
+/// included; the reported total is the workspace value plus every heap byte
+/// its vectors and string have reserved.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Gpt2DenseControlWorkspaceBytes {
+    lm_head_transpose: usize,
+    matrix_bounds: usize,
+    f64_sum_scratch: usize,
+    intermediate_scratch: usize,
+    metadata: usize,
+    total: usize,
+}
+
+impl Gpt2DenseControlWorkspaceBytes {
+    pub const fn lm_head_transpose(self) -> usize {
+        self.lm_head_transpose
+    }
+
+    pub const fn matrix_bounds(self) -> usize {
+        self.matrix_bounds
+    }
+
+    pub const fn f64_sum_scratch(self) -> usize {
+        self.f64_sum_scratch
+    }
+
+    pub const fn intermediate_scratch(self) -> usize {
+        self.intermediate_scratch
+    }
+
+    pub const fn metadata(self) -> usize {
+        self.metadata
+    }
+
+    pub const fn total(self) -> usize {
+        self.total
+    }
+}
+
+/// Deterministic digest over every logical workspace field and vector
+/// capacity. This permits failure-atomicity checks without cloning the
+/// 154-MB-class tied-head transpose.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Gpt2DenseControlWorkspaceFingerprint([u8; 32]);
+
+impl Gpt2DenseControlWorkspaceFingerprint {
+    pub const fn bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+fn dense_fingerprint_usize(hasher: &mut blake3::Hasher, value: usize) {
+    hasher.update(&value.to_le_bytes());
+}
+
+fn dense_fingerprint_f32_slice(hasher: &mut blake3::Hasher, values: &[f32], capacity: usize) {
+    dense_fingerprint_usize(hasher, values.len());
+    dense_fingerprint_usize(hasher, capacity);
+    for value in values {
+        hasher.update(&value.to_bits().to_le_bytes());
+    }
+}
+
+fn dense_fingerprint_f64_slice(hasher: &mut blake3::Hasher, values: &[f64], capacity: usize) {
+    dense_fingerprint_usize(hasher, values.len());
+    dense_fingerprint_usize(hasher, capacity);
+    for value in values {
+        hasher.update(&value.to_bits().to_le_bytes());
+    }
+}
+
+fn dense_fingerprint_census(hasher: &mut blake3::Hasher, census: Gpt2DenseCanaryCensus) {
+    for value in [
+        census.lanes,
+        census.batch_rows,
+        census.conventional,
+        census.exact_control,
+        census.fast_certified,
+        census.refined_certified,
+        census.fallback_nonfinite,
+        census.fallback_zero,
+        census.fallback_overflow,
+        census.fallback_cell,
+    ] {
+        dense_fingerprint_usize(hasher, value);
+    }
+}
+
+fn dense_fingerprint_layer_census(hasher: &mut blake3::Hasher, layer: Gpt2DenseLayerCensus) {
+    dense_fingerprint_census(hasher, layer.c_attn);
+    dense_fingerprint_census(hasher, layer.attention_c_proj);
+    dense_fingerprint_census(hasher, layer.mlp_c_fc);
+    dense_fingerprint_census(hasher, layer.mlp_c_proj);
 }
 
 impl Gpt2AttentionCanaryWorkspace {
@@ -758,11 +1966,177 @@ impl Gpt2 {
         .then_some(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn block_attention_production(
+        &self,
+        key_cache: &mut [f32],
+        value_cache: &mut [f32],
+        layer_index: usize,
+        position: usize,
+        qkv: &[f32],
+        attention: &mut [f32],
+        scores: &mut [f32],
+        request: Option<&crate::TraceCaptureRequest<'_>>,
+        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+    ) {
+        let d = self.cfg.n_embd;
+        let head_size = self.cfg.head_size();
+        let sequence_length = self.cfg.seq_len;
+        let base = (layer_index * sequence_length + position) * d;
+        key_cache[base..base + d].copy_from_slice(&qkv[d..2 * d]);
+        value_cache[base..base + d].copy_from_slice(&qkv[2 * d..3 * d]);
+
+        if request.is_some_and(|request| request.qkv_layers.contains(&layer_index)) {
+            if let Some(sinks) = sinks.as_deref_mut() {
+                (sinks.qkv)(layer_index, &qkv[..d], &qkv[d..2 * d], &qkv[2 * d..3 * d]);
+            }
+        }
+
+        debug_assert_eq!(scores.len(), position + 1);
+        let layer_keys =
+            &key_cache[layer_index * sequence_length * d..(layer_index + 1) * sequence_length * d];
+        let layer_values = &value_cache
+            [layer_index * sequence_length * d..(layer_index + 1) * sequence_length * d];
+        for head in 0..self.cfg.n_head {
+            let query = &qkv[head * head_size..(head + 1) * head_size];
+            let _ = attention_weights_with_arithmetic(
+                scores,
+                query,
+                layer_keys,
+                head * head_size,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
+            if request.is_some_and(|request| request.attention_layers.contains(&layer_index)) {
+                if let Some(sinks) = sinks.as_deref_mut() {
+                    (sinks.attention)(layer_index, head, scores);
+                }
+            }
+            let output = &mut attention[head * head_size..(head + 1) * head_size];
+            let _ = crate::attention::head_attention_value_aggregate_with_arithmetic(
+                output,
+                scores,
+                layer_values,
+                head * head_size,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
+        }
+    }
+
+    fn block_forward_production(
+        &self,
+        state: &mut Gpt2State,
+        layer_index: usize,
+        position: usize,
+        request: Option<&crate::TraceCaptureRequest<'_>>,
+        sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+    ) {
+        let d = self.cfg.n_embd;
+        let inner_dim = self.cfg.n_inner;
+        let layer = &self.layers[layer_index];
+        let base = layer_index * DENSE_CONTROL_SITES_PER_LAYER;
+
+        layer_norm(
+            &state.x,
+            &layer.ln1_w,
+            &layer.ln1_b,
+            self.cfg.layer_norm_eps,
+            &mut state.dense_scratch.input[..d],
+        );
+        production_dense_projection_batched(
+            std::slice::from_mut(state),
+            &layer.c_attn_w,
+            Some(&layer.c_attn_b),
+            &self.dense_prepared.matrices[base],
+        );
+        {
+            let Gpt2State {
+                k_cache,
+                v_cache,
+                dense_scratch,
+                ..
+            } = state;
+            self.block_attention_production(
+                k_cache,
+                v_cache,
+                layer_index,
+                position,
+                &dense_scratch.output[..3 * d],
+                &mut dense_scratch.attention[..d],
+                &mut dense_scratch.scores[..=position],
+                request,
+                sinks,
+            );
+        }
+
+        state.dense_scratch.input[..d].copy_from_slice(&state.dense_scratch.attention[..d]);
+        production_dense_projection_batched(
+            std::slice::from_mut(state),
+            &layer.c_proj_w,
+            Some(&layer.c_proj_b),
+            &self.dense_prepared.matrices[base + 1],
+        );
+        for input_index in 0..d {
+            state.x[input_index] += state.dense_scratch.output[input_index];
+        }
+
+        layer_norm(
+            &state.x,
+            &layer.ln2_w,
+            &layer.ln2_b,
+            self.cfg.layer_norm_eps,
+            &mut state.dense_scratch.input[..d],
+        );
+        production_dense_projection_batched(
+            std::slice::from_mut(state),
+            &layer.fc_w,
+            Some(&layer.fc_b),
+            &self.dense_prepared.matrices[base + 2],
+        );
+        for value in &mut state.dense_scratch.output[..inner_dim] {
+            *value = gelu_new(*value);
+        }
+        state.dense_scratch.input[..inner_dim]
+            .copy_from_slice(&state.dense_scratch.output[..inner_dim]);
+        production_dense_projection_batched(
+            std::slice::from_mut(state),
+            &layer.mlp_w,
+            Some(&layer.mlp_b),
+            &self.dense_prepared.matrices[base + 3],
+        );
+        for input_index in 0..d {
+            state.x[input_index] += state.dense_scratch.output[input_index];
+        }
+    }
+
+    fn finish_forward_production(&self, state: &mut Gpt2State) {
+        let d = self.cfg.n_embd;
+        layer_norm(
+            &state.x,
+            &self.ln_f_w,
+            &self.ln_f_b,
+            self.cfg.layer_norm_eps,
+            &mut state.hidden,
+        );
+        state.dense_scratch.input[..d].copy_from_slice(&state.hidden);
+        production_dense_projection_batched(
+            std::slice::from_mut(state),
+            &self.dense_prepared.lm_head_transposed,
+            None,
+            &self.dense_prepared.lm_head,
+        );
+        state
+            .logits
+            .copy_from_slice(&state.dense_scratch.output[..self.cfg.vocab]);
+    }
+
     /// One teacher-forced forward step at `pos` (0-based), leaving logits
     /// and the final hidden state in `st`. `capture` receives the
     /// post-block residual stream for each declared layer index, in
     /// ascending order — the #599 conformance-trace tap (a no-op closure
-    /// captures nothing).
+    /// captures nothing). Invalid state/token/position/capture extents are
+    /// rejected before mutation or a sink call.
     pub fn forward(
         &self,
         st: &mut Gpt2State,
@@ -771,37 +2145,23 @@ impl Gpt2 {
         capture: &[usize],
         sink: &mut dyn FnMut(usize, &[f32]),
     ) {
+        if self.validate_production_step(st, token, pos).is_none()
+            || capture.iter().any(|&layer| layer >= self.cfg.n_layer)
+        {
+            return;
+        }
         let d = self.cfg.n_embd;
         // token + learned absolute position embedding.
         for i in 0..d {
             st.x[i] = self.wte[token * d + i] + self.wpe[pos * d + i];
         }
-        // scratch buffers reused across layers.
-        let mut normed = vec![0.0f32; d];
-        let mut qkv = vec![0.0f32; 3 * d];
-        let mut attn = vec![0.0f32; d];
-        let mut proj = vec![0.0f32; d];
-        let mut inner = vec![0.0f32; self.cfg.n_inner];
-        let mut mlp_out = vec![0.0f32; d];
         for l in 0..self.cfg.n_layer {
-            self.block_forward(
-                st,
-                l,
-                pos,
-                &mut normed,
-                &mut qkv,
-                &mut attn,
-                &mut proj,
-                &mut inner,
-                &mut mlp_out,
-                None,
-                None,
-            );
+            self.block_forward_production(st, l, pos, None, None);
             if capture.contains(&l) {
                 sink(l, &st.x);
             }
         }
-        self.finish_forward(st);
+        self.finish_forward_production(st);
     }
 
     fn forward_with_attention_arithmetic_unchecked(
@@ -846,10 +2206,1128 @@ impl Gpt2 {
         Ok(Gpt2AttentionCanaryWorkspace::new(&self.cfg))
     }
 
+    /// Prepare model-bound scratch and an outward per-column
+    /// `sum_i |weight_i|` bound for the real layer-0 fused QKV projection.
+    /// This one-time weight scan is deliberately outside the candidate hot
+    /// path. The returned workspace cannot be reused with another model.
+    #[doc(hidden)]
+    pub fn dense_canary_workspace(&self) -> Option<Gpt2DenseCanaryWorkspace> {
+        self.validate_production_geometry()?;
+        self.validate_attention_canary_model().ok()?;
+        let in_dim = self.cfg.n_embd;
+        let out_dim = canary_product("3 * n_embd", &[3, in_dim]).ok()?;
+        let layer = self.layers.first()?;
+        let mut sum_abs_weight_upper = vec![0.0f64; out_dim];
+        for input_index in 0..in_dim {
+            let row = &layer.c_attn_w[input_index * out_dim..(input_index + 1) * out_dim];
+            for output_index in 0..out_dim {
+                sum_abs_weight_upper[output_index] += f64::from(row[output_index]).abs();
+            }
+        }
+        for bound in &mut sum_abs_weight_upper {
+            *bound = dense_positive_sum_upper(*bound, in_dim).unwrap_or(f64::INFINITY);
+        }
+        Some(Gpt2DenseCanaryWorkspace {
+            weight_address: layer.c_attn_w.as_ptr() as usize,
+            weight_len: layer.c_attn_w.len(),
+            source_kappa: self.kappa.clone(),
+            in_dim,
+            out_dim,
+            sums: vec![0.0; out_dim],
+            sum_abs_weight_upper,
+        })
+    }
+
+    fn validate_dense_canary_inputs(
+        &self,
+        input: &[f32],
+        output: &[f32],
+        workspace: &Gpt2DenseCanaryWorkspace,
+    ) -> Option<()> {
+        self.validate_production_geometry()?;
+        self.validate_attention_canary_model().ok()?;
+        let layer = self.layers.first()?;
+        let in_dim = self.cfg.n_embd;
+        let out_dim = canary_product("3 * n_embd", &[3, in_dim]).ok()?;
+        (input.len() == in_dim
+            && output.len() == out_dim
+            && workspace.weight_address == layer.c_attn_w.as_ptr() as usize
+            && workspace.weight_len == layer.c_attn_w.len()
+            && workspace.source_kappa == self.kappa
+            && workspace.in_dim == in_dim
+            && workspace.out_dim == out_dim
+            && workspace.sums.len() == out_dim
+            && workspace.sum_abs_weight_upper.len() == out_dim)
+            .then_some(())
+    }
+
+    /// Materialize the real token-plus-position then layer-0 LayerNorm input
+    /// consumed by fused `c_attn`. Validation completes before `out` changes.
+    #[doc(hidden)]
+    pub fn layer0_c_attn_canary_input(
+        &self,
+        token: usize,
+        position: usize,
+        out: &mut [f32],
+    ) -> Option<()> {
+        self.validate_production_geometry()?;
+        self.validate_attention_canary_model().ok()?;
+        let layer = self.layers.first()?;
+        let d = self.cfg.n_embd;
+        if token >= self.cfg.vocab || position >= self.cfg.n_positions || out.len() != d {
+            return None;
+        }
+        for (index, value) in out.iter_mut().enumerate() {
+            *value = self.wte[token * d + index] + self.wpe[position * d + index];
+        }
+        // LayerNorm cannot be safely in-place because it reads the complete
+        // input to determine mean and variance. Reproduce its scalar order
+        // directly while retaining the embedding vector in caller scratch.
+        let n = d as f32;
+        let mean = out.iter().sum::<f32>() / n;
+        let variance = out
+            .iter()
+            .map(|value| (*value - mean) * (*value - mean))
+            .sum::<f32>()
+            / n;
+        let inverse = 1.0 / (variance + self.cfg.layer_norm_eps).sqrt();
+        for (index, value) in out.iter_mut().enumerate() {
+            *value = (*value - mean) * inverse * layer.ln1_w[index] + layer.ln1_b[index];
+        }
+        Some(())
+    }
+
+    /// Execute one checked real layer-0 fused-QKV projection. Caller shape,
+    /// model/workspace binding, and all derived extents are validated before
+    /// either output or workspace is mutated; invalid input returns `None`.
+    #[doc(hidden)]
+    pub fn layer0_c_attn_canary(
+        &self,
+        input: &[f32],
+        output: &mut [f32],
+        workspace: &mut Gpt2DenseCanaryWorkspace,
+        mode: Gpt2DenseCanaryMode,
+    ) -> Option<Gpt2DenseCanaryCensus> {
+        self.validate_dense_canary_inputs(input, output, workspace)?;
+        let layer = self.layers.first()?;
+        let out_dim = workspace.out_dim;
+        let mut census = Gpt2DenseCanaryCensus {
+            lanes: out_dim,
+            ..Gpt2DenseCanaryCensus::default()
+        };
+        match mode {
+            Gpt2DenseCanaryMode::Conventional => {
+                conv1d(input, &layer.c_attn_w, &layer.c_attn_b, out_dim, output);
+                census.conventional = out_dim;
+            }
+            Gpt2DenseCanaryMode::Exact => {
+                exact_dense_projection(output, input, &layer.c_attn_w, out_dim);
+                for (value, &bias) in output.iter_mut().zip(&layer.c_attn_b) {
+                    *value += bias;
+                }
+                census.exact_control = out_dim;
+            }
+            Gpt2DenseCanaryMode::CertifiedNative => {
+                census = certified_dense_projection(
+                    output,
+                    input,
+                    &layer.c_attn_w,
+                    &layer.c_attn_b,
+                    workspace,
+                );
+            }
+        }
+        Some(census)
+    }
+
+    fn dense_control_layer_matrix(
+        &self,
+        layer_index: usize,
+        site_offset: usize,
+    ) -> Option<(&[f32], &[f32], usize, usize)> {
+        let layer = self.layers.get(layer_index)?;
+        let d = self.cfg.n_embd;
+        match site_offset {
+            0 => Some((&layer.c_attn_w, &layer.c_attn_b, d, 3 * d)),
+            1 => Some((&layer.c_proj_w, &layer.c_proj_b, d, d)),
+            2 => Some((&layer.fc_w, &layer.fc_b, d, self.cfg.n_inner)),
+            3 => Some((&layer.mlp_w, &layer.mlp_b, self.cfg.n_inner, d)),
+            _ => None,
+        }
+    }
+
+    fn dense_control_prepared_index(layer_index: usize, site_offset: usize) -> Option<usize> {
+        layer_index
+            .checked_mul(DENSE_CONTROL_SITES_PER_LAYER)?
+            .checked_add(site_offset)
+    }
+
+    /// Prepare every remaining GPT-2 dense owner for a serial checked control.
+    #[doc(hidden)]
+    pub fn dense_control_workspace(&self) -> Option<Gpt2DenseControlWorkspace> {
+        self.dense_control_workspace_for_batch(1)
+    }
+
+    /// Prepare every dense owner and caller scratch for up to `max_batch`
+    /// sequence-major rows. This includes a `[n_embd, vocab]` transpose of
+    /// tied `wte`, so the exact and certified lm-heads use the same `[in,out]`
+    /// row-reuse kernel without a hot-path gather or weight rewrite.
+    #[doc(hidden)]
+    pub fn dense_control_workspace_for_batch(
+        &self,
+        max_batch: usize,
+    ) -> Option<Gpt2DenseControlWorkspace> {
+        self.validate_production_geometry()?;
+        self.validate_attention_canary_model().ok()?;
+        if max_batch == 0 {
+            return None;
+        }
+        let d = self.cfg.n_embd;
+        let matrix_count = self
+            .cfg
+            .n_layer
+            .checked_mul(DENSE_CONTROL_SITES_PER_LAYER)?;
+        let mut prepared = Vec::with_capacity(matrix_count);
+        let mut model_weight_addresses = Vec::with_capacity(matrix_count);
+        let mut model_weight_lengths = Vec::with_capacity(matrix_count);
+        for layer_index in 0..self.cfg.n_layer {
+            for site_offset in 0..DENSE_CONTROL_SITES_PER_LAYER {
+                let (weights, _, in_dim, out_dim) =
+                    self.dense_control_layer_matrix(layer_index, site_offset)?;
+                prepared.push(DensePreparedMatrix::prepare(weights, in_dim, out_dim)?);
+                model_weight_addresses.push(weights.as_ptr() as usize);
+                model_weight_lengths.push(weights.len());
+            }
+        }
+
+        let transpose_len = d.checked_mul(self.cfg.vocab)?;
+        let mut lm_head_transposed = vec![0.0f32; transpose_len];
+        for vocabulary_index in 0..self.cfg.vocab {
+            let row = &self.wte[vocabulary_index * d..(vocabulary_index + 1) * d];
+            for input_index in 0..d {
+                lm_head_transposed[input_index * self.cfg.vocab + vocabulary_index] =
+                    row[input_index];
+            }
+        }
+        let lm_head = DensePreparedMatrix::prepare(&lm_head_transposed, d, self.cfg.vocab)?;
+        let maximum_output = self
+            .cfg
+            .vocab
+            .max(self.cfg.n_inner)
+            .max(3usize.checked_mul(d)?);
+
+        Some(Gpt2DenseControlWorkspace {
+            source_kappa: self.kappa.clone(),
+            max_batch,
+            model_weight_addresses,
+            model_weight_lengths,
+            wte_address: self.wte.as_ptr() as usize,
+            wte_len: self.wte.len(),
+            prepared,
+            lm_head_transposed,
+            lm_head,
+            normed: vec![0.0; d],
+            qkv: vec![0.0; 3 * d],
+            attn: vec![0.0; d],
+            proj: vec![0.0; d],
+            inner: vec![0.0; self.cfg.n_inner],
+            mlp_out: vec![0.0; d],
+            scores: vec![0.0; self.cfg.seq_len],
+            batch_normed: vec![0.0; max_batch.checked_mul(d)?],
+            batch_qkv: vec![0.0; max_batch.checked_mul(3usize.checked_mul(d)?)?],
+            batch_attn: vec![0.0; max_batch.checked_mul(d)?],
+            batch_proj: vec![0.0; max_batch.checked_mul(d)?],
+            batch_inner: vec![0.0; max_batch.checked_mul(self.cfg.n_inner)?],
+            batch_mlp_out: vec![0.0; max_batch.checked_mul(d)?],
+            batch_logits: vec![0.0; max_batch.checked_mul(self.cfg.vocab)?],
+            batch_sums: vec![0.0; max_batch.checked_mul(maximum_output)?],
+            batch_max_activation_abs: vec![0.0; max_batch],
+            step_layers: vec![Gpt2DenseLayerCensus::default(); self.cfg.n_layer],
+            step_lm_head: Gpt2DenseCanaryCensus::default(),
+            batch_layers: vec![Gpt2DenseLayerCensus::default(); self.cfg.n_layer],
+            batch_lm_head: Gpt2DenseCanaryCensus::default(),
+        })
+    }
+
+    /// Report the prepared workspace's owned capacity by purpose. This is a
+    /// deterministic byte census for the transpose tradeoff, not an RSS or
+    /// allocator-overhead measurement.
+    #[doc(hidden)]
+    pub fn dense_control_workspace_bytes(
+        &self,
+        workspace: &Gpt2DenseControlWorkspace,
+    ) -> Option<Gpt2DenseControlWorkspaceBytes> {
+        self.validate_dense_control_workspace(workspace)?;
+        let bytes = |count: usize, element: usize| count.checked_mul(element);
+        let add = |left: usize, right: usize| left.checked_add(right);
+
+        let mut bound_elements = workspace.lm_head.sum_abs_weight_upper.capacity();
+        let mut sum_elements = workspace.lm_head.sums.capacity();
+        for matrix in &workspace.prepared {
+            bound_elements = bound_elements.checked_add(matrix.sum_abs_weight_upper.capacity())?;
+            sum_elements = sum_elements.checked_add(matrix.sums.capacity())?;
+        }
+        let matrix_bounds = bytes(bound_elements, std::mem::size_of::<f64>())?;
+        sum_elements = sum_elements
+            .checked_add(workspace.batch_sums.capacity())?
+            .checked_add(workspace.batch_max_activation_abs.capacity())?;
+        let f64_sum_scratch = bytes(sum_elements, std::mem::size_of::<f64>())?;
+        let lm_head_transpose = bytes(
+            workspace.lm_head_transposed.capacity(),
+            std::mem::size_of::<f32>(),
+        )?;
+
+        let intermediate_elements = workspace
+            .normed
+            .capacity()
+            .checked_add(workspace.qkv.capacity())?
+            .checked_add(workspace.attn.capacity())?
+            .checked_add(workspace.proj.capacity())?
+            .checked_add(workspace.inner.capacity())?
+            .checked_add(workspace.mlp_out.capacity())?
+            .checked_add(workspace.scores.capacity())?
+            .checked_add(workspace.batch_normed.capacity())?
+            .checked_add(workspace.batch_qkv.capacity())?
+            .checked_add(workspace.batch_attn.capacity())?
+            .checked_add(workspace.batch_proj.capacity())?
+            .checked_add(workspace.batch_inner.capacity())?
+            .checked_add(workspace.batch_mlp_out.capacity())?
+            .checked_add(workspace.batch_logits.capacity())?;
+        let intermediate_scratch = bytes(intermediate_elements, std::mem::size_of::<f32>())?;
+
+        let mut metadata = std::mem::size_of::<Gpt2DenseControlWorkspace>();
+        metadata = add(metadata, workspace.source_kappa.capacity())?;
+        metadata = add(
+            metadata,
+            bytes(
+                workspace.model_weight_addresses.capacity(),
+                std::mem::size_of::<usize>(),
+            )?,
+        )?;
+        metadata = add(
+            metadata,
+            bytes(
+                workspace.model_weight_lengths.capacity(),
+                std::mem::size_of::<usize>(),
+            )?,
+        )?;
+        metadata = add(
+            metadata,
+            bytes(
+                workspace.prepared.capacity(),
+                std::mem::size_of::<DensePreparedMatrix>(),
+            )?,
+        )?;
+        metadata = add(
+            metadata,
+            bytes(
+                workspace.step_layers.capacity(),
+                std::mem::size_of::<Gpt2DenseLayerCensus>(),
+            )?,
+        )?;
+        metadata = add(
+            metadata,
+            bytes(
+                workspace.batch_layers.capacity(),
+                std::mem::size_of::<Gpt2DenseLayerCensus>(),
+            )?,
+        )?;
+        let total = lm_head_transpose
+            .checked_add(matrix_bounds)?
+            .checked_add(f64_sum_scratch)?
+            .checked_add(intermediate_scratch)?
+            .checked_add(metadata)?;
+        Some(Gpt2DenseControlWorkspaceBytes {
+            lm_head_transpose,
+            matrix_bounds,
+            f64_sum_scratch,
+            intermediate_scratch,
+            metadata,
+            total,
+        })
+    }
+
+    /// Fingerprint all prepared metadata, proof scratch, batch scratch, and
+    /// census storage without allocating or copying the tied-head transpose.
+    #[doc(hidden)]
+    pub fn dense_control_workspace_fingerprint(
+        &self,
+        workspace: &Gpt2DenseControlWorkspace,
+    ) -> Option<Gpt2DenseControlWorkspaceFingerprint> {
+        self.validate_dense_control_workspace(workspace)?;
+        let mut hasher = blake3::Hasher::new();
+        dense_fingerprint_usize(&mut hasher, workspace.source_kappa.len());
+        dense_fingerprint_usize(&mut hasher, workspace.source_kappa.capacity());
+        hasher.update(workspace.source_kappa.as_bytes());
+        dense_fingerprint_usize(&mut hasher, workspace.max_batch);
+        dense_fingerprint_usize(&mut hasher, workspace.model_weight_addresses.len());
+        dense_fingerprint_usize(&mut hasher, workspace.model_weight_addresses.capacity());
+        for &value in &workspace.model_weight_addresses {
+            dense_fingerprint_usize(&mut hasher, value);
+        }
+        dense_fingerprint_usize(&mut hasher, workspace.model_weight_lengths.len());
+        dense_fingerprint_usize(&mut hasher, workspace.model_weight_lengths.capacity());
+        for &value in &workspace.model_weight_lengths {
+            dense_fingerprint_usize(&mut hasher, value);
+        }
+        dense_fingerprint_usize(&mut hasher, workspace.wte_address);
+        dense_fingerprint_usize(&mut hasher, workspace.wte_len);
+        dense_fingerprint_usize(&mut hasher, workspace.prepared.len());
+        dense_fingerprint_usize(&mut hasher, workspace.prepared.capacity());
+        for matrix in &workspace.prepared {
+            dense_fingerprint_usize(&mut hasher, matrix.in_dim);
+            dense_fingerprint_usize(&mut hasher, matrix.out_dim);
+            dense_fingerprint_f64_slice(&mut hasher, &matrix.sums, matrix.sums.capacity());
+            dense_fingerprint_f64_slice(
+                &mut hasher,
+                &matrix.sum_abs_weight_upper,
+                matrix.sum_abs_weight_upper.capacity(),
+            );
+        }
+        dense_fingerprint_f32_slice(
+            &mut hasher,
+            &workspace.lm_head_transposed,
+            workspace.lm_head_transposed.capacity(),
+        );
+        dense_fingerprint_usize(&mut hasher, workspace.lm_head.in_dim);
+        dense_fingerprint_usize(&mut hasher, workspace.lm_head.out_dim);
+        dense_fingerprint_f64_slice(
+            &mut hasher,
+            &workspace.lm_head.sums,
+            workspace.lm_head.sums.capacity(),
+        );
+        dense_fingerprint_f64_slice(
+            &mut hasher,
+            &workspace.lm_head.sum_abs_weight_upper,
+            workspace.lm_head.sum_abs_weight_upper.capacity(),
+        );
+        for values in [
+            &workspace.normed,
+            &workspace.qkv,
+            &workspace.attn,
+            &workspace.proj,
+            &workspace.inner,
+            &workspace.mlp_out,
+            &workspace.scores,
+            &workspace.batch_normed,
+            &workspace.batch_qkv,
+            &workspace.batch_attn,
+            &workspace.batch_proj,
+            &workspace.batch_inner,
+            &workspace.batch_mlp_out,
+            &workspace.batch_logits,
+        ] {
+            dense_fingerprint_f32_slice(&mut hasher, values, values.capacity());
+        }
+        dense_fingerprint_f64_slice(
+            &mut hasher,
+            &workspace.batch_sums,
+            workspace.batch_sums.capacity(),
+        );
+        dense_fingerprint_f64_slice(
+            &mut hasher,
+            &workspace.batch_max_activation_abs,
+            workspace.batch_max_activation_abs.capacity(),
+        );
+        dense_fingerprint_usize(&mut hasher, workspace.step_layers.len());
+        dense_fingerprint_usize(&mut hasher, workspace.step_layers.capacity());
+        for &layer in &workspace.step_layers {
+            dense_fingerprint_layer_census(&mut hasher, layer);
+        }
+        dense_fingerprint_census(&mut hasher, workspace.step_lm_head);
+        dense_fingerprint_usize(&mut hasher, workspace.batch_layers.len());
+        dense_fingerprint_usize(&mut hasher, workspace.batch_layers.capacity());
+        for &layer in &workspace.batch_layers {
+            dense_fingerprint_layer_census(&mut hasher, layer);
+        }
+        dense_fingerprint_census(&mut hasher, workspace.batch_lm_head);
+        Some(Gpt2DenseControlWorkspaceFingerprint(
+            *hasher.finalize().as_bytes(),
+        ))
+    }
+
+    fn validate_dense_control_workspace(
+        &self,
+        workspace: &Gpt2DenseControlWorkspace,
+    ) -> Option<()> {
+        self.validate_production_geometry()?;
+        self.validate_attention_canary_model().ok()?;
+        let d = self.cfg.n_embd;
+        let matrix_count = self
+            .cfg
+            .n_layer
+            .checked_mul(DENSE_CONTROL_SITES_PER_LAYER)?;
+        let maximum_output = self
+            .cfg
+            .vocab
+            .max(self.cfg.n_inner)
+            .max(3usize.checked_mul(d)?);
+        if workspace.source_kappa != self.kappa
+            || workspace.max_batch == 0
+            || workspace.model_weight_addresses.len() != matrix_count
+            || workspace.model_weight_lengths.len() != matrix_count
+            || workspace.prepared.len() != matrix_count
+            || workspace.wte_address != self.wte.as_ptr() as usize
+            || workspace.wte_len != self.wte.len()
+            || workspace.lm_head_transposed.len() != d.checked_mul(self.cfg.vocab)?
+            || !workspace.lm_head.has_shape(d, self.cfg.vocab)
+            || workspace.normed.len() != d
+            || workspace.qkv.len() != 3usize.checked_mul(d)?
+            || workspace.attn.len() != d
+            || workspace.proj.len() != d
+            || workspace.inner.len() != self.cfg.n_inner
+            || workspace.mlp_out.len() != d
+            || workspace.scores.len() != self.cfg.seq_len
+            || workspace.batch_normed.len() != workspace.max_batch.checked_mul(d)?
+            || workspace.batch_qkv.len()
+                != workspace.max_batch.checked_mul(3usize.checked_mul(d)?)?
+            || workspace.batch_attn.len() != workspace.max_batch.checked_mul(d)?
+            || workspace.batch_proj.len() != workspace.max_batch.checked_mul(d)?
+            || workspace.batch_inner.len() != workspace.max_batch.checked_mul(self.cfg.n_inner)?
+            || workspace.batch_mlp_out.len() != workspace.max_batch.checked_mul(d)?
+            || workspace.batch_logits.len() != workspace.max_batch.checked_mul(self.cfg.vocab)?
+            || workspace.batch_sums.len() != workspace.max_batch.checked_mul(maximum_output)?
+            || workspace.batch_max_activation_abs.len() != workspace.max_batch
+            || workspace.step_layers.len() != self.cfg.n_layer
+            || workspace.batch_layers.len() != self.cfg.n_layer
+        {
+            return None;
+        }
+        for layer_index in 0..self.cfg.n_layer {
+            for site_offset in 0..DENSE_CONTROL_SITES_PER_LAYER {
+                let index = Self::dense_control_prepared_index(layer_index, site_offset)?;
+                let (weights, _, in_dim, out_dim) =
+                    self.dense_control_layer_matrix(layer_index, site_offset)?;
+                if workspace.model_weight_addresses[index] != weights.as_ptr() as usize
+                    || workspace.model_weight_lengths[index] != weights.len()
+                    || !workspace.prepared[index].has_shape(in_dim, out_dim)
+                {
+                    return None;
+                }
+            }
+        }
+        Some(())
+    }
+
+    fn validate_dense_control_state(&self, state: &Gpt2State) -> Option<()> {
+        let d = self.cfg.n_embd;
+        let cache = canary_product(
+            "n_layer * seq_len * n_embd",
+            &[self.cfg.n_layer, self.cfg.seq_len, d],
+        )
+        .ok()?;
+        (state.k_cache.len() == cache
+            && state.v_cache.len() == cache
+            && state.logits.len() == self.cfg.vocab
+            && state.hidden.len() == d
+            && state.x.len() == d)
+            .then_some(())
+    }
+
+    /// O(1) load-geometry binding for the production executor. The public
+    /// config remains mutable for source compatibility, but weights and dense
+    /// proof preparation are immutable products of the load-time geometry.
+    /// Reject any drift before cfg-derived indexing or arithmetic can run.
+    fn validate_production_geometry(&self) -> Option<()> {
+        let geometry = self.dense_prepared.geometry;
+        if !geometry.matches_config(&self.cfg) {
+            return None;
+        }
+        let embedding_values = geometry.vocab.checked_mul(geometry.n_embd)?;
+        let position_values = geometry.n_positions.checked_mul(geometry.n_embd)?;
+        let prepared_matrices = geometry
+            .n_layer
+            .checked_mul(DENSE_CONTROL_SITES_PER_LAYER)?;
+        (geometry.n_head != 0
+            && geometry.n_embd.is_multiple_of(geometry.n_head)
+            && self.cfg.seq_len != 0
+            && self.cfg.seq_len <= geometry.n_positions
+            && self.wte.len() == embedding_values
+            && self.wpe.len() == position_values
+            && self.layers.len() == geometry.n_layer
+            && self.ln_f_w.len() == geometry.n_embd
+            && self.ln_f_b.len() == geometry.n_embd
+            && self.dense_prepared.matrices.len() == prepared_matrices
+            && self.dense_prepared.lm_head_transposed.len() == embedding_values
+            && self.dense_prepared.lm_head.in_dim == geometry.n_embd
+            && self.dense_prepared.lm_head.out_dim == geometry.vocab
+            && self.dense_prepared.lm_head.sum_abs_weight_upper.len() == geometry.vocab)
+            .then_some(())
+    }
+
+    fn validate_production_state(&self, state: &Gpt2State) -> Option<()> {
+        self.validate_production_geometry()?;
+        self.validate_dense_control_state(state)?;
+        let d = self.cfg.n_embd;
+        let maximum_input = self.cfg.n_inner.max(d);
+        let maximum_output = self
+            .cfg
+            .vocab
+            .max(self.cfg.n_inner)
+            .max(3usize.checked_mul(d)?);
+        (state.dense_scratch.input.len() == maximum_input
+            && state.dense_scratch.output.len() == maximum_output
+            && state.dense_scratch.sums.len() == maximum_output
+            && state.dense_scratch.attention.len() == d
+            && state.dense_scratch.scores.len() == self.cfg.seq_len)
+            .then_some(())
+    }
+
+    fn validate_production_step(
+        &self,
+        state: &Gpt2State,
+        token: usize,
+        position: usize,
+    ) -> Option<()> {
+        self.validate_production_state(state)?;
+        (token < self.cfg.vocab && position < self.cfg.seq_len).then_some(())
+    }
+
+    fn validate_dense_control_step(
+        &self,
+        state: &Gpt2State,
+        workspace: &Gpt2DenseControlWorkspace,
+        token: usize,
+        position: usize,
+    ) -> Option<()> {
+        self.validate_dense_control_workspace(workspace)?;
+        self.validate_dense_control_state(state)?;
+        (token < self.cfg.vocab && position < self.cfg.seq_len).then_some(())
+    }
+
+    fn validate_dense_trace_request(&self, request: &crate::TraceCaptureRequest<'_>) -> Option<()> {
+        request
+            .residual_layers
+            .iter()
+            .chain(request.qkv_layers)
+            .chain(request.attention_layers)
+            .all(|&layer| layer < self.cfg.n_layer)
+            .then_some(())
+    }
+
+    /// Checked matrix-level seam used to differentially exercise every real
+    /// projection shape through the same arithmetic owner as the whole-model
+    /// serial, trace, and batch controls.
+    #[doc(hidden)]
+    pub fn dense_control_matrix_canary(
+        &self,
+        workspace: &mut Gpt2DenseControlWorkspace,
+        layer_index: Option<usize>,
+        site: Gpt2DenseControlSite,
+        input: &[f32],
+        output: &mut [f32],
+        mode: Gpt2DenseCanaryMode,
+    ) -> Option<Gpt2DenseCanaryCensus> {
+        self.validate_dense_control_workspace(workspace)?;
+        match site {
+            Gpt2DenseControlSite::LmHead => {
+                if layer_index.is_some()
+                    || input.len() != self.cfg.n_embd
+                    || output.len() != self.cfg.vocab
+                {
+                    return None;
+                }
+                if mode == Gpt2DenseCanaryMode::Conventional {
+                    conventional_lm_head(output, input, &self.wte, self.cfg.n_embd);
+                    Some(Gpt2DenseCanaryCensus {
+                        lanes: self.cfg.vocab,
+                        conventional: self.cfg.vocab,
+                        ..Gpt2DenseCanaryCensus::default()
+                    })
+                } else {
+                    Some(controlled_dense_projection(
+                        output,
+                        input,
+                        &workspace.lm_head_transposed,
+                        None,
+                        &mut workspace.lm_head,
+                        mode,
+                    ))
+                }
+            }
+            _ => {
+                let layer_index = layer_index?;
+                let site_offset = match site {
+                    Gpt2DenseControlSite::CAttn => 0,
+                    Gpt2DenseControlSite::AttentionCProj => 1,
+                    Gpt2DenseControlSite::MlpCFc => 2,
+                    Gpt2DenseControlSite::MlpCProj => 3,
+                    Gpt2DenseControlSite::LmHead => unreachable!(),
+                };
+                let index = Self::dense_control_prepared_index(layer_index, site_offset)?;
+                let (weights, bias, in_dim, out_dim) =
+                    self.dense_control_layer_matrix(layer_index, site_offset)?;
+                if input.len() != in_dim || output.len() != out_dim {
+                    return None;
+                }
+                Some(controlled_dense_projection(
+                    output,
+                    input,
+                    weights,
+                    Some(bias),
+                    &mut workspace.prepared[index],
+                    mode,
+                ))
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn block_attention_dense_control(
+        &self,
+        state: &mut Gpt2State,
+        layer_index: usize,
+        position: usize,
+        qkv: &[f32],
+        attention: &mut [f32],
+        scores: &mut [f32],
+        request: Option<&crate::TraceCaptureRequest<'_>>,
+        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+    ) {
+        let d = self.cfg.n_embd;
+        let head_size = self.cfg.head_size();
+        let sequence_length = self.cfg.seq_len;
+        let base = (layer_index * sequence_length + position) * d;
+        state.k_cache[base..base + d].copy_from_slice(&qkv[d..2 * d]);
+        state.v_cache[base..base + d].copy_from_slice(&qkv[2 * d..3 * d]);
+
+        if request.is_some_and(|request| request.qkv_layers.contains(&layer_index)) {
+            if let Some(sinks) = sinks.as_deref_mut() {
+                (sinks.qkv)(layer_index, &qkv[..d], &qkv[d..2 * d], &qkv[2 * d..3 * d]);
+            }
+        }
+
+        debug_assert_eq!(scores.len(), position + 1);
+        let key_cache = &state.k_cache
+            [layer_index * sequence_length * d..(layer_index + 1) * sequence_length * d];
+        let value_cache = &state.v_cache
+            [layer_index * sequence_length * d..(layer_index + 1) * sequence_length * d];
+        for head in 0..self.cfg.n_head {
+            let query = &qkv[head * head_size..(head + 1) * head_size];
+            let _ = attention_weights_with_arithmetic(
+                scores,
+                query,
+                key_cache,
+                head * head_size,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
+            if request.is_some_and(|request| request.attention_layers.contains(&layer_index)) {
+                if let Some(sinks) = sinks.as_deref_mut() {
+                    (sinks.attention)(layer_index, head, scores);
+                }
+            }
+            let output = &mut attention[head * head_size..(head + 1) * head_size];
+            let _ = crate::attention::head_attention_value_aggregate_with_arithmetic(
+                output,
+                scores,
+                value_cache,
+                head * head_size,
+                d,
+                crate::attention::AttentionArithmetic::CertifiedNative,
+            );
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward_dense_control_unchecked(
+        &self,
+        state: &mut Gpt2State,
+        workspace: &mut Gpt2DenseControlWorkspace,
+        token: usize,
+        position: usize,
+        mode: Gpt2DenseCanaryMode,
+        request: Option<&crate::TraceCaptureRequest<'_>>,
+        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
+    ) {
+        let d = self.cfg.n_embd;
+        workspace.step_layers.fill(Gpt2DenseLayerCensus::default());
+        workspace.step_lm_head = Gpt2DenseCanaryCensus::default();
+
+        for input_index in 0..d {
+            state.x[input_index] =
+                self.wte[token * d + input_index] + self.wpe[position * d + input_index];
+        }
+
+        for layer_index in 0..self.cfg.n_layer {
+            let layer = &self.layers[layer_index];
+            layer_norm(
+                &state.x,
+                &layer.ln1_w,
+                &layer.ln1_b,
+                self.cfg.layer_norm_eps,
+                &mut workspace.normed,
+            );
+
+            let c_attn_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER;
+            workspace.step_layers[layer_index].c_attn = controlled_dense_projection(
+                &mut workspace.qkv,
+                &workspace.normed,
+                &layer.c_attn_w,
+                Some(&layer.c_attn_b),
+                &mut workspace.prepared[c_attn_index],
+                mode,
+            );
+            self.block_attention_dense_control(
+                state,
+                layer_index,
+                position,
+                &workspace.qkv,
+                &mut workspace.attn,
+                &mut workspace.scores[..=position],
+                request,
+                sinks.as_deref_mut(),
+            );
+
+            let attention_projection_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 1;
+            workspace.step_layers[layer_index].attention_c_proj = controlled_dense_projection(
+                &mut workspace.proj,
+                &workspace.attn,
+                &layer.c_proj_w,
+                Some(&layer.c_proj_b),
+                &mut workspace.prepared[attention_projection_index],
+                mode,
+            );
+            for (value, &projection) in state.x.iter_mut().zip(&workspace.proj) {
+                *value += projection;
+            }
+
+            layer_norm(
+                &state.x,
+                &layer.ln2_w,
+                &layer.ln2_b,
+                self.cfg.layer_norm_eps,
+                &mut workspace.normed,
+            );
+            let fc_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 2;
+            workspace.step_layers[layer_index].mlp_c_fc = controlled_dense_projection(
+                &mut workspace.inner,
+                &workspace.normed,
+                &layer.fc_w,
+                Some(&layer.fc_b),
+                &mut workspace.prepared[fc_index],
+                mode,
+            );
+            for value in &mut workspace.inner {
+                *value = gelu_new(*value);
+            }
+
+            let mlp_projection_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 3;
+            workspace.step_layers[layer_index].mlp_c_proj = controlled_dense_projection(
+                &mut workspace.mlp_out,
+                &workspace.inner,
+                &layer.mlp_w,
+                Some(&layer.mlp_b),
+                &mut workspace.prepared[mlp_projection_index],
+                mode,
+            );
+            for (value, &projection) in state.x.iter_mut().zip(&workspace.mlp_out) {
+                *value += projection;
+            }
+            if request.is_some_and(|request| request.residual_layers.contains(&layer_index)) {
+                if let Some(sinks) = sinks.as_deref_mut() {
+                    (sinks.residual)(layer_index, &state.x);
+                }
+            }
+        }
+
+        layer_norm(
+            &state.x,
+            &self.ln_f_w,
+            &self.ln_f_b,
+            self.cfg.layer_norm_eps,
+            &mut state.hidden,
+        );
+        workspace.step_lm_head = if mode == Gpt2DenseCanaryMode::Conventional {
+            conventional_lm_head(&mut state.logits, &state.hidden, &self.wte, d);
+            Gpt2DenseCanaryCensus {
+                lanes: self.cfg.vocab,
+                conventional: self.cfg.vocab,
+                ..Gpt2DenseCanaryCensus::default()
+            }
+        } else {
+            controlled_dense_projection(
+                &mut state.logits,
+                &state.hidden,
+                &workspace.lm_head_transposed,
+                None,
+                &mut workspace.lm_head,
+                mode,
+            )
+        };
+    }
+
+    /// Run one evidence-only whole-model dense control. Attention arithmetic
+    /// is hard-bound to the production certified-native path for every arm;
+    /// only the five dense owner classes vary.
+    #[doc(hidden)]
+    pub fn forward_dense_control<'workspace>(
+        &self,
+        state: &mut Gpt2State,
+        workspace: &'workspace mut Gpt2DenseControlWorkspace,
+        token: usize,
+        position: usize,
+        mode: Gpt2DenseCanaryMode,
+    ) -> Option<Gpt2DenseControlCensus<'workspace>> {
+        self.validate_dense_control_step(state, workspace, token, position)?;
+        self.forward_dense_control_unchecked(state, workspace, token, position, mode, None, None);
+        Some(Gpt2DenseControlCensus {
+            layers: &workspace.step_layers,
+            lm_head: workspace.step_lm_head,
+        })
+    }
+
+    /// Trace-capable form of [`Self::forward_dense_control`]. All requested
+    /// layer extents are validated before state, workspace, or any sink is
+    /// touched.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_dense_control_capturing_trace<'workspace>(
+        &self,
+        state: &mut Gpt2State,
+        workspace: &'workspace mut Gpt2DenseControlWorkspace,
+        token: usize,
+        position: usize,
+        mode: Gpt2DenseCanaryMode,
+        request: &crate::TraceCaptureRequest<'_>,
+        sinks: &mut crate::TraceCaptureSinks<'_, '_>,
+    ) -> Option<Gpt2DenseControlCensus<'workspace>> {
+        self.validate_dense_control_step(state, workspace, token, position)?;
+        self.validate_dense_trace_request(request)?;
+        self.forward_dense_control_unchecked(
+            state,
+            workspace,
+            token,
+            position,
+            mode,
+            Some(request),
+            Some(sinks),
+        );
+        Some(Gpt2DenseControlCensus {
+            layers: &workspace.step_layers,
+            lm_head: workspace.step_lm_head,
+        })
+    }
+
+    /// Differential row-reuse batch control. Every projection visits inputs
+    /// in the serial order for each sequence while sharing each immutable
+    /// weight row across the batch. The production batch uses the same
+    /// certified projection owner with state-local scratch.
+    #[doc(hidden)]
+    // Indexed sequence-major loops keep every residual/cache/scratch row in
+    // lockstep while each projection reuses immutable weight rows.
+    #[allow(clippy::needless_range_loop)]
+    pub fn forward_batch_dense_control<'workspace>(
+        &self,
+        states: &mut [Gpt2State],
+        tokens: &[usize],
+        positions: &[usize],
+        workspace: &'workspace mut Gpt2DenseControlWorkspace,
+        mode: Gpt2DenseCanaryMode,
+    ) -> Option<Gpt2DenseControlCensus<'workspace>> {
+        self.validate_dense_control_workspace(workspace)?;
+        if states.len() != tokens.len() || states.len() != positions.len() {
+            return None;
+        }
+        if states.len() > workspace.max_batch {
+            return None;
+        }
+        for ((state, &token), &position) in states.iter().zip(tokens).zip(positions) {
+            self.validate_dense_control_state(state)?;
+            if token >= self.cfg.vocab || position >= self.cfg.seq_len {
+                return None;
+            }
+        }
+        for layer_index in 0..self.cfg.n_layer {
+            for site_offset in 0..DENSE_CONTROL_SITES_PER_LAYER {
+                let (_, _, _, out_dim) =
+                    self.dense_control_layer_matrix(layer_index, site_offset)?;
+                out_dim.checked_mul(states.len())?;
+            }
+        }
+        self.cfg.vocab.checked_mul(states.len())?;
+
+        let batch = states.len();
+        let d = self.cfg.n_embd;
+        let inner_dim = self.cfg.n_inner;
+        workspace.batch_layers.fill(Gpt2DenseLayerCensus::default());
+        workspace.batch_lm_head = Gpt2DenseCanaryCensus::default();
+        if batch == 0 {
+            return Some(Gpt2DenseControlCensus {
+                layers: &workspace.batch_layers,
+                lm_head: workspace.batch_lm_head,
+            });
+        }
+
+        for batch_index in 0..batch {
+            for input_index in 0..d {
+                states[batch_index].x[input_index] = self.wte
+                    [tokens[batch_index] * d + input_index]
+                    + self.wpe[positions[batch_index] * d + input_index];
+            }
+        }
+
+        for layer_index in 0..self.cfg.n_layer {
+            let layer = &self.layers[layer_index];
+            for batch_index in 0..batch {
+                layer_norm(
+                    &states[batch_index].x,
+                    &layer.ln1_w,
+                    &layer.ln1_b,
+                    self.cfg.layer_norm_eps,
+                    &mut workspace.batch_normed[batch_index * d..(batch_index + 1) * d],
+                );
+            }
+
+            let c_attn_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER;
+            workspace.batch_layers[layer_index].c_attn = controlled_dense_projection_batched(
+                &mut workspace.batch_qkv[..batch * 3 * d],
+                &workspace.batch_normed[..batch * d],
+                &layer.c_attn_w,
+                Some(&layer.c_attn_b),
+                batch,
+                &workspace.prepared[c_attn_index],
+                &mut workspace.batch_sums[..batch * 3 * d],
+                &mut workspace.batch_max_activation_abs[..batch],
+                mode,
+            );
+            for batch_index in 0..batch {
+                self.block_attention_dense_control(
+                    &mut states[batch_index],
+                    layer_index,
+                    positions[batch_index],
+                    &workspace.batch_qkv[batch_index * 3 * d..(batch_index + 1) * 3 * d],
+                    &mut workspace.batch_attn[batch_index * d..(batch_index + 1) * d],
+                    &mut workspace.scores[..=positions[batch_index]],
+                    None,
+                    None,
+                );
+            }
+
+            let attention_projection_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 1;
+            workspace.batch_layers[layer_index].attention_c_proj =
+                controlled_dense_projection_batched(
+                    &mut workspace.batch_proj[..batch * d],
+                    &workspace.batch_attn[..batch * d],
+                    &layer.c_proj_w,
+                    Some(&layer.c_proj_b),
+                    batch,
+                    &workspace.prepared[attention_projection_index],
+                    &mut workspace.batch_sums[..batch * d],
+                    &mut workspace.batch_max_activation_abs[..batch],
+                    mode,
+                );
+            for batch_index in 0..batch {
+                for input_index in 0..d {
+                    states[batch_index].x[input_index] +=
+                        workspace.batch_proj[batch_index * d + input_index];
+                }
+                layer_norm(
+                    &states[batch_index].x,
+                    &layer.ln2_w,
+                    &layer.ln2_b,
+                    self.cfg.layer_norm_eps,
+                    &mut workspace.batch_normed[batch_index * d..(batch_index + 1) * d],
+                );
+            }
+
+            let fc_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 2;
+            workspace.batch_layers[layer_index].mlp_c_fc = controlled_dense_projection_batched(
+                &mut workspace.batch_inner[..batch * inner_dim],
+                &workspace.batch_normed[..batch * d],
+                &layer.fc_w,
+                Some(&layer.fc_b),
+                batch,
+                &workspace.prepared[fc_index],
+                &mut workspace.batch_sums[..batch * inner_dim],
+                &mut workspace.batch_max_activation_abs[..batch],
+                mode,
+            );
+            for value in &mut workspace.batch_inner[..batch * inner_dim] {
+                *value = gelu_new(*value);
+            }
+
+            let mlp_projection_index = layer_index * DENSE_CONTROL_SITES_PER_LAYER + 3;
+            workspace.batch_layers[layer_index].mlp_c_proj = controlled_dense_projection_batched(
+                &mut workspace.batch_mlp_out[..batch * d],
+                &workspace.batch_inner[..batch * inner_dim],
+                &layer.mlp_w,
+                Some(&layer.mlp_b),
+                batch,
+                &workspace.prepared[mlp_projection_index],
+                &mut workspace.batch_sums[..batch * d],
+                &mut workspace.batch_max_activation_abs[..batch],
+                mode,
+            );
+            for batch_index in 0..batch {
+                for input_index in 0..d {
+                    states[batch_index].x[input_index] +=
+                        workspace.batch_mlp_out[batch_index * d + input_index];
+                }
+            }
+        }
+
+        for batch_index in 0..batch {
+            layer_norm(
+                &states[batch_index].x,
+                &self.ln_f_w,
+                &self.ln_f_b,
+                self.cfg.layer_norm_eps,
+                &mut workspace.batch_normed[batch_index * d..(batch_index + 1) * d],
+            );
+            states[batch_index]
+                .hidden
+                .copy_from_slice(&workspace.batch_normed[batch_index * d..(batch_index + 1) * d]);
+        }
+        workspace.batch_lm_head = if mode == Gpt2DenseCanaryMode::Conventional {
+            for vocabulary_index in 0..self.cfg.vocab {
+                let row = &self.wte[vocabulary_index * d..(vocabulary_index + 1) * d];
+                for batch_index in 0..batch {
+                    let hidden = &workspace.batch_normed[batch_index * d..(batch_index + 1) * d];
+                    let mut accumulator = 0.0f32;
+                    for input_index in 0..d {
+                        accumulator += hidden[input_index] * row[input_index];
+                    }
+                    workspace.batch_logits[batch_index * self.cfg.vocab + vocabulary_index] =
+                        accumulator;
+                }
+            }
+            Gpt2DenseCanaryCensus {
+                lanes: batch * self.cfg.vocab,
+                batch_rows: batch,
+                conventional: batch * self.cfg.vocab,
+                ..Gpt2DenseCanaryCensus::default()
+            }
+        } else {
+            controlled_dense_projection_batched(
+                &mut workspace.batch_logits[..batch * self.cfg.vocab],
+                &workspace.batch_normed[..batch * d],
+                &workspace.lm_head_transposed,
+                None,
+                batch,
+                &workspace.lm_head,
+                &mut workspace.batch_sums[..batch * self.cfg.vocab],
+                &mut workspace.batch_max_activation_abs[..batch],
+                mode,
+            )
+        };
+        for batch_index in 0..batch {
+            states[batch_index].logits.copy_from_slice(
+                &workspace.batch_logits
+                    [batch_index * self.cfg.vocab..(batch_index + 1) * self.cfg.vocab],
+            );
+        }
+        Some(Gpt2DenseControlCensus {
+            layers: &workspace.batch_layers,
+            lm_head: workspace.batch_lm_head,
+        })
+    }
+
     /// Execute one matched attention-canary step after validating every model,
     /// state, workspace, token, position, and derived slice extent. Validation
     /// completes before any mutable byte is touched, so `None` is failure
-    /// atomic. Production [`Self::forward`] remains the normal executor.
+    /// atomic. Its dense arithmetic intentionally stays conventional so the
+    /// historical attention-only experiment continues to vary attention only.
     #[doc(hidden)]
     pub fn forward_attention_canary(
         &self,
@@ -895,38 +3373,15 @@ impl Gpt2 {
         }
     }
 
-    /// Final `ln_f` LayerNorm into `st.hidden` and the tied lm-head into
-    /// `st.logits`. Shared by [`Gpt2::forward`] and
-    /// [`Gpt2::forward_capturing_trace`] so a traced step finishes through
-    /// the exact same arithmetic.
-    fn finish_forward(&self, st: &mut Gpt2State) {
-        let d = self.cfg.n_embd;
-        layer_norm(
-            &st.x,
-            &self.ln_f_w,
-            &self.ln_f_b,
-            self.cfg.layer_norm_eps,
-            &mut st.hidden,
-        );
-        let hidden = st.hidden.clone();
-        for v in 0..self.cfg.vocab {
-            let row = &self.wte[v * d..(v + 1) * d];
-            let mut acc = 0.0f32;
-            for i in 0..d {
-                acc += hidden[i] * row[i];
-            }
-            st.logits[v] = acc;
-        }
-    }
-
     /// One teacher-forced forward step at `pos` with the #603 trace lanes
-    /// captured through the exact executor path: the post-block residual
+    /// captured through the production v2 executor path: the post-block residual
     /// stream, the current-position q/k/v, and the per-head softmax
     /// attention weights, each for the layer indices `request` declares.
     /// A traced step leaves the same logits, hidden state, and k/v caches
     /// as [`Gpt2::forward`] — the taps read the executor's own
     /// intermediates, they never recompute. Sinks fire in ascending layer
-    /// order (heads ascending within a layer for the attention lane).
+    /// order (heads ascending within a layer for the attention lane). Invalid
+    /// caller extents leave state and sinks untouched.
     pub fn forward_capturing_trace(
         &self,
         st: &mut Gpt2State,
@@ -935,36 +3390,23 @@ impl Gpt2 {
         request: &crate::TraceCaptureRequest<'_>,
         sinks: &mut crate::TraceCaptureSinks<'_, '_>,
     ) {
+        if self.validate_production_step(st, token, pos).is_none()
+            || self.validate_dense_trace_request(request).is_none()
+        {
+            return;
+        }
         let d = self.cfg.n_embd;
         // token + learned absolute position embedding.
         for i in 0..d {
             st.x[i] = self.wte[token * d + i] + self.wpe[pos * d + i];
         }
-        let mut normed = vec![0.0f32; d];
-        let mut qkv = vec![0.0f32; 3 * d];
-        let mut attn = vec![0.0f32; d];
-        let mut proj = vec![0.0f32; d];
-        let mut inner = vec![0.0f32; self.cfg.n_inner];
-        let mut mlp_out = vec![0.0f32; d];
         for l in 0..self.cfg.n_layer {
-            self.block_forward(
-                st,
-                l,
-                pos,
-                &mut normed,
-                &mut qkv,
-                &mut attn,
-                &mut proj,
-                &mut inner,
-                &mut mlp_out,
-                Some(request),
-                Some(&mut *sinks),
-            );
+            self.block_forward_production(st, l, pos, Some(request), Some(&mut *sinks));
             if request.residual_layers.contains(&l) {
                 (sinks.residual)(l, &st.x);
             }
         }
-        self.finish_forward(st);
+        self.finish_forward_production(st);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1026,57 +3468,6 @@ impl Gpt2 {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn block_forward(
-        &self,
-        st: &mut Gpt2State,
-        l: usize,
-        pos: usize,
-        normed: &mut [f32],
-        qkv: &mut [f32],
-        attn: &mut [f32],
-        proj: &mut [f32],
-        inner: &mut [f32],
-        mlp_out: &mut [f32],
-        request: Option<&crate::TraceCaptureRequest<'_>>,
-        sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
-    ) {
-        let d = self.cfg.n_embd;
-        let layer = &self.layers[l];
-
-        // --- attention ---
-        layer_norm(
-            &st.x,
-            &layer.ln1_w,
-            &layer.ln1_b,
-            self.cfg.layer_norm_eps,
-            normed,
-        );
-        conv1d(normed, &layer.c_attn_w, &layer.c_attn_b, 3 * d, qkv);
-        self.block_attention(st, l, pos, qkv, attn, request, sinks);
-        conv1d(attn, &layer.c_proj_w, &layer.c_proj_b, d, proj);
-        for (xi, &p) in st.x.iter_mut().zip(&proj[..d]) {
-            *xi += p;
-        }
-
-        // --- MLP ---
-        layer_norm(
-            &st.x,
-            &layer.ln2_w,
-            &layer.ln2_b,
-            self.cfg.layer_norm_eps,
-            normed,
-        );
-        conv1d(normed, &layer.fc_w, &layer.fc_b, self.cfg.n_inner, inner);
-        for v in inner.iter_mut() {
-            *v = gelu_new(*v);
-        }
-        conv1d(inner, &layer.mlp_w, &layer.mlp_b, d, mlp_out);
-        for (xi, &m) in st.x.iter_mut().zip(&mlp_out[..d]) {
-            *xi += m;
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
     fn block_attention_with_arithmetic(
         &self,
         st: &mut Gpt2State,
@@ -1124,86 +3515,12 @@ impl Gpt2 {
         census
     }
 
-    /// The per-sequence attention sub-block shared by [`Gpt2::block_forward`]
-    /// (serial) and [`Gpt2::forward_batch`] (batched): cache this position's
-    /// k/v from the fused `qkv` projection, then for each head compute the
-    /// scaled dot-product scores, the max-subtracted softmax (normalized in
-    /// place), and the value aggregation into `attn`. Optional #603 taps
-    /// (q/k/v and the per-head weights) fire for a requested layer. Sharing
-    /// it keeps the serial and batched executors bit-identical by
-    /// construction.
-    #[allow(clippy::too_many_arguments)]
-    fn block_attention(
-        &self,
-        st: &mut Gpt2State,
-        l: usize,
-        pos: usize,
-        qkv: &[f32],
-        attn: &mut [f32],
-        request: Option<&crate::TraceCaptureRequest<'_>>,
-        mut sinks: Option<&mut crate::TraceCaptureSinks<'_, '_>>,
-    ) {
-        let d = self.cfg.n_embd;
-        let hs = self.cfg.head_size();
-        let seq = self.cfg.seq_len;
-        // store this position's k, v (thirds 1 and 2 of the fused qkv).
-        let base = (l * seq + pos) * d;
-        st.k_cache[base..base + d].copy_from_slice(&qkv[d..2 * d]);
-        st.v_cache[base..base + d].copy_from_slice(&qkv[2 * d..3 * d]);
-        // #603 q/k/v tap at this position (q = all heads, then the just-cached
-        // k and v rows), emitted only for a requested layer. GPT-2 is plain
-        // MHA (kv heads == query heads), so every row is `d` wide.
-        if let Some(request) = request {
-            if request.qkv_layers.contains(&l) {
-                if let Some(sinks) = sinks.as_deref_mut() {
-                    (sinks.qkv)(l, &qkv[..d], &qkv[d..2 * d], &qkv[2 * d..3 * d]);
-                }
-            }
-        }
-        let mut scores = vec![0.0f32; pos + 1];
-        let key_cache = &st.k_cache[l * seq * d..(l + 1) * seq * d];
-        let value_cache = &st.v_cache[l * seq * d..(l + 1) * seq * d];
-        for h in 0..self.cfg.n_head {
-            let qh = &qkv[h * hs..(h + 1) * hs];
-            let _ = attention_weights_with_arithmetic(
-                &mut scores,
-                qh,
-                key_cache,
-                h * hs,
-                d,
-                crate::attention::AttentionArithmetic::CertifiedNative,
-            );
-            // #603 per-head attention-weight tap over positions 0..=pos.
-            if let Some(request) = request {
-                if request.attention_layers.contains(&l) {
-                    if let Some(sinks) = sinks.as_deref_mut() {
-                        (sinks.attention)(l, h, &scores);
-                    }
-                }
-            }
-            let ao = &mut attn[h * hs..(h + 1) * hs];
-            let _ = crate::attention::head_attention_value_aggregate_with_arithmetic(
-                ao,
-                &scores,
-                value_cache,
-                h * hs,
-                d,
-                crate::attention::AttentionArithmetic::CertifiedNative,
-            );
-        }
-    }
-
     /// Batched forward: advance `states.len()` independent sequences by one
     /// position each — sequence `bi` steps `tokens[bi]` at `positions[bi]`
-    /// against its own k/v cache in `states[bi]`. The projection Conv1Ds
-    /// (`c_attn`, `c_proj`, `fc`, `mlp`) run once over the whole batch via
-    /// the amortized [`conv1d_batched`], and the tied lm-head reuses each
-    /// `wte` row across the batch — the same memory-amortization Llama's
-    /// `forward_batch` gets from `matmul_batched`. Every per-sequence op
-    /// (embedding, LayerNorm, attention via the shared
-    /// [`Gpt2::block_attention`], GELU, residual) mirrors [`Gpt2::forward`]
-    /// and keeps the serial accumulation order, so this is bit-identical to
-    /// calling `forward` on each sequence.
+    /// against its own k/v cache in `states[bi]`. Every projection, including
+    /// the tied lm-head, runs through the certified row-reuse kernel while
+    /// preserving each sequence's serial input-index accumulation order. The
+    /// complete batch is validated before the first state byte changes.
     // Sequence-major index loops are deliberate here: the accumulation order
     // must match the serial `forward` byte-for-byte, and the offsets index
     // several stacked scratch buffers in lockstep.
@@ -1212,18 +3529,22 @@ impl Gpt2 {
         let d = self.cfg.n_embd;
         let inner_dim = self.cfg.n_inner;
         let b = states.len();
-        debug_assert_eq!(tokens.len(), b);
-        debug_assert_eq!(positions.len(), b);
+        if tokens.len() != b
+            || positions.len() != b
+            || states
+                .iter()
+                .zip(tokens)
+                .zip(positions)
+                .any(|((state, &token), &position)| {
+                    self.validate_production_step(state, token, position)
+                        .is_none()
+                })
+        {
+            return;
+        }
         if b == 0 {
             return;
         }
-
-        let mut normed = vec![0.0f32; b * d];
-        let mut qkv = vec![0.0f32; b * 3 * d];
-        let mut attn = vec![0.0f32; b * d];
-        let mut proj = vec![0.0f32; b * d];
-        let mut inner = vec![0.0f32; b * inner_dim];
-        let mut mlp_out = vec![0.0f32; b * d];
 
         // token + learned absolute position embedding, per sequence.
         for bi in 0..b {
@@ -1236,40 +3557,52 @@ impl Gpt2 {
 
         for l in 0..self.cfg.n_layer {
             let layer = &self.layers[l];
+            let base = l * DENSE_CONTROL_SITES_PER_LAYER;
             for bi in 0..b {
                 layer_norm(
                     &states[bi].x,
                     &layer.ln1_w,
                     &layer.ln1_b,
                     self.cfg.layer_norm_eps,
-                    &mut normed[bi * d..(bi + 1) * d],
+                    &mut states[bi].dense_scratch.input[..d],
                 );
             }
-            conv1d_batched(
-                &mut qkv,
-                &normed,
+            production_dense_projection_batched(
+                states,
                 &layer.c_attn_w,
-                &layer.c_attn_b,
-                3 * d,
-                d,
-                b,
+                Some(&layer.c_attn_b),
+                &self.dense_prepared.matrices[base],
             );
             for bi in 0..b {
-                self.block_attention(
-                    &mut states[bi],
+                let Gpt2State {
+                    k_cache,
+                    v_cache,
+                    dense_scratch,
+                    ..
+                } = &mut states[bi];
+                self.block_attention_production(
+                    k_cache,
+                    v_cache,
                     l,
                     positions[bi],
-                    &qkv[bi * 3 * d..(bi + 1) * 3 * d],
-                    &mut attn[bi * d..(bi + 1) * d],
+                    &dense_scratch.output[..3 * d],
+                    &mut dense_scratch.attention[..d],
+                    &mut dense_scratch.scores[..=positions[bi]],
                     None,
                     None,
                 );
+                dense_scratch.input[..d].copy_from_slice(&dense_scratch.attention[..d]);
             }
-            conv1d_batched(&mut proj, &attn, &layer.c_proj_w, &layer.c_proj_b, d, d, b);
+            production_dense_projection_batched(
+                states,
+                &layer.c_proj_w,
+                Some(&layer.c_proj_b),
+                &self.dense_prepared.matrices[base + 1],
+            );
             for bi in 0..b {
                 let x = &mut states[bi].x;
                 for i in 0..d {
-                    x[i] += proj[bi * d + i];
+                    x[i] += states[bi].dense_scratch.output[i];
                 }
             }
             for bi in 0..b {
@@ -1278,41 +3611,38 @@ impl Gpt2 {
                     &layer.ln2_w,
                     &layer.ln2_b,
                     self.cfg.layer_norm_eps,
-                    &mut normed[bi * d..(bi + 1) * d],
+                    &mut states[bi].dense_scratch.input[..d],
                 );
             }
-            conv1d_batched(
-                &mut inner,
-                &normed,
+            production_dense_projection_batched(
+                states,
                 &layer.fc_w,
-                &layer.fc_b,
-                inner_dim,
-                d,
-                b,
+                Some(&layer.fc_b),
+                &self.dense_prepared.matrices[base + 2],
             );
-            for v in inner.iter_mut() {
-                *v = gelu_new(*v);
+            for state in states.iter_mut() {
+                for value in &mut state.dense_scratch.output[..inner_dim] {
+                    *value = gelu_new(*value);
+                }
+                state.dense_scratch.input[..inner_dim]
+                    .copy_from_slice(&state.dense_scratch.output[..inner_dim]);
             }
-            conv1d_batched(
-                &mut mlp_out,
-                &inner,
+            production_dense_projection_batched(
+                states,
                 &layer.mlp_w,
-                &layer.mlp_b,
-                d,
-                inner_dim,
-                b,
+                Some(&layer.mlp_b),
+                &self.dense_prepared.matrices[base + 3],
             );
             for bi in 0..b {
                 let x = &mut states[bi].x;
                 for i in 0..d {
-                    x[i] += mlp_out[bi * d + i];
+                    x[i] += states[bi].dense_scratch.output[i];
                 }
             }
         }
 
-        // final ln_f into each state's hidden, then the tied lm-head with
-        // each wte row reused across the batch (naive sequential dot per
-        // sequence — bit-identical to `finish_forward`).
+        // Final LayerNorm followed by the same row-reuse certified kernel over
+        // the immutable input-major tied-head preparation.
         for bi in 0..b {
             let st = &mut states[bi];
             layer_norm(
@@ -1322,17 +3652,18 @@ impl Gpt2 {
                 self.cfg.layer_norm_eps,
                 &mut st.hidden,
             );
+            st.dense_scratch.input[..d].copy_from_slice(&st.hidden);
         }
-        for v in 0..self.cfg.vocab {
-            let row = &self.wte[v * d..(v + 1) * d];
-            for bi in 0..b {
-                let st = &mut states[bi];
-                let mut acc = 0.0f32;
-                for i in 0..d {
-                    acc += st.hidden[i] * row[i];
-                }
-                st.logits[v] = acc;
-            }
+        production_dense_projection_batched(
+            states,
+            &self.dense_prepared.lm_head_transposed,
+            None,
+            &self.dense_prepared.lm_head,
+        );
+        for state in states {
+            state
+                .logits
+                .copy_from_slice(&state.dense_scratch.output[..self.cfg.vocab]);
         }
     }
 }
@@ -1357,6 +3688,645 @@ mod tests {
             workspace, workspace_before,
             "invalid canary call mutated workspace"
         );
+    }
+
+    fn assert_production_geometry_rejected_without_mutation(
+        model: &Gpt2,
+        template: &Gpt2State,
+        context: &str,
+    ) {
+        let mut serial = template.clone();
+        let serial_before = serial.clone();
+        let serial_sink_hits = std::cell::Cell::new(0usize);
+        let mut serial_sink = |_: usize, _: &[f32]| {
+            serial_sink_hits.set(serial_sink_hits.get() + 1);
+        };
+        model.forward(&mut serial, 0, 0, &[0], &mut serial_sink);
+        assert_eq!(serial_sink_hits.get(), 0, "{context}: serial sink fired");
+        assert!(
+            serial.full_storage_bit_identical(&serial_before),
+            "{context}: rejected serial call changed logical or scratch state"
+        );
+
+        let mut traced = template.clone();
+        let traced_before = traced.clone();
+        let trace_sink_hits = std::cell::Cell::new(0usize);
+        let mut residual = |_: usize, _: &[f32]| {
+            trace_sink_hits.set(trace_sink_hits.get() + 1);
+        };
+        let mut qkv = |_: usize, _: &[f32], _: &[f32], _: &[f32]| {
+            trace_sink_hits.set(trace_sink_hits.get() + 1);
+        };
+        let mut attention = |_: usize, _: usize, _: &[f32]| {
+            trace_sink_hits.set(trace_sink_hits.get() + 1);
+        };
+        let request = crate::TraceCaptureRequest {
+            residual_layers: &[0],
+            qkv_layers: &[0],
+            attention_layers: &[0],
+        };
+        let mut sinks = crate::TraceCaptureSinks {
+            residual: &mut residual,
+            qkv: &mut qkv,
+            attention: &mut attention,
+        };
+        model.forward_capturing_trace(&mut traced, 0, 0, &request, &mut sinks);
+        assert_eq!(trace_sink_hits.get(), 0, "{context}: trace sink fired");
+        assert!(
+            traced.full_storage_bit_identical(&traced_before),
+            "{context}: rejected trace call changed logical or scratch state"
+        );
+
+        let mut batch = vec![template.clone(), template.clone()];
+        let batch_before = batch.clone();
+        model.forward_batch(&mut batch, &[0, 0], &[0, 0]);
+        assert!(
+            batch
+                .iter()
+                .zip(&batch_before)
+                .all(|(state, before)| state.full_storage_bit_identical(before)),
+            "{context}: rejected batch call changed logical or scratch state"
+        );
+    }
+
+    #[test]
+    fn state_partial_eq_excludes_only_opaque_production_scratch() {
+        let model = Gpt2::load(fixture_dir(), None).unwrap();
+        let state = Gpt2State::new(&model.cfg);
+        let mut scratch_changed = state.clone();
+        scratch_changed.dense_scratch.input[0] = 1.0;
+        scratch_changed.dense_scratch.output[0] = -2.0;
+        scratch_changed.dense_scratch.sums[0] = 3.0;
+        scratch_changed.dense_scratch.max_activation_abs = 4.0;
+        scratch_changed.dense_scratch.attention[0] = -5.0;
+        scratch_changed.dense_scratch.scores[0] = 6.0;
+        assert_eq!(
+            state, scratch_changed,
+            "opaque dense workspace residue changed logical state equality"
+        );
+        assert!(
+            !state.full_storage_bit_identical(&scratch_changed),
+            "full-storage test helper did not observe scratch drift"
+        );
+
+        for logical_field in 0..5 {
+            let mut changed = state.clone();
+            match logical_field {
+                0 => changed.k_cache[0] = 1.0,
+                1 => changed.v_cache[0] = 1.0,
+                2 => changed.logits[0] = 1.0,
+                3 => changed.hidden[0] = 1.0,
+                4 => changed.x[0] = 1.0,
+                _ => unreachable!(),
+            }
+            assert_ne!(
+                state, changed,
+                "historical logical field {logical_field} was omitted from equality"
+            );
+        }
+    }
+
+    #[test]
+    fn production_preflight_binds_load_geometry_before_all_mutation() {
+        let mut zero_head = Gpt2::load(fixture_dir(), None).unwrap();
+        let mut existing_state = Gpt2State::new(&zero_head.cfg);
+        zero_head.forward(&mut existing_state, 1, 0, &[], &mut |_, _| {});
+        zero_head.cfg.n_head = 0;
+        assert_production_geometry_rejected_without_mutation(
+            &zero_head,
+            &existing_state,
+            "zero-head drift",
+        );
+
+        let mut layer_drift = Gpt2::load(fixture_dir(), None).unwrap();
+        let mut existing_state = Gpt2State::new(&layer_drift.cfg);
+        layer_drift.forward(&mut existing_state, 1, 0, &[], &mut |_, _| {});
+        layer_drift.cfg.n_layer += 1;
+        assert_production_geometry_rejected_without_mutation(
+            &layer_drift,
+            &existing_state,
+            "layer-count drift",
+        );
+
+        let mut width_drift = Gpt2::load(fixture_dir(), None).unwrap();
+        width_drift.cfg.n_embd += width_drift.cfg.n_head;
+        let newly_constructed_for_mutated_cfg = Gpt2State::new(&width_drift.cfg);
+        assert_production_geometry_rejected_without_mutation(
+            &width_drift,
+            &newly_constructed_for_mutated_cfg,
+            "width drift with newly constructed state",
+        );
+
+        // BOS/EOS are caller token-selection policy, not executor geometry.
+        // Preserve the historical ability to adjust them without disabling a
+        // direct explicit-token forward call.
+        let baseline = Gpt2::load(fixture_dir(), None).unwrap();
+        let mut policy_adjusted = Gpt2::load(fixture_dir(), None).unwrap();
+        policy_adjusted.cfg.bos = (policy_adjusted.cfg.bos + 1) % policy_adjusted.cfg.vocab;
+        policy_adjusted.cfg.eos = (policy_adjusted.cfg.eos + 2) % policy_adjusted.cfg.vocab;
+        let mut baseline_state = Gpt2State::new(&baseline.cfg);
+        let mut policy_state = Gpt2State::new(&policy_adjusted.cfg);
+        baseline.forward(&mut baseline_state, 1, 0, &[], &mut |_, _| {});
+        policy_adjusted.forward(&mut policy_state, 1, 0, &[], &mut |_, _| {});
+        assert!(
+            policy_state.full_storage_bit_identical(&baseline_state),
+            "BOS/EOS policy changes altered explicit-token production execution"
+        );
+
+        // The working context is caller-selected execution capacity rather
+        // than checkpoint geometry. A safe in-range adjustment with a newly
+        // sized state must behave exactly like loading at that context length.
+        let full_context = Gpt2::load(fixture_dir(), None).unwrap();
+        let shorter_context = (full_context.cfg.seq_len / 2).max(1);
+        assert!(shorter_context < full_context.cfg.seq_len);
+        let reference_short = Gpt2::load(fixture_dir(), Some(shorter_context)).unwrap();
+        let mut adjusted_context = full_context;
+        adjusted_context.cfg.seq_len = shorter_context;
+        let mut reference_state = Gpt2State::new(&reference_short.cfg);
+        let mut adjusted_state = Gpt2State::new(&adjusted_context.cfg);
+        reference_short.forward(&mut reference_state, 1, 0, &[], &mut |_, _| {});
+        adjusted_context.forward(&mut adjusted_state, 1, 0, &[], &mut |_, _| {});
+        assert!(
+            adjusted_state.full_storage_bit_identical(&reference_state),
+            "safe working-context adjustment diverged from bounded load"
+        );
+    }
+
+    fn assert_dense_evidence_rejects_post_workspace_geometry_drift(
+        mut model: Gpt2,
+        drift: impl FnOnce(&mut Gpt2Config),
+        context: &str,
+    ) {
+        let original_cfg = model.cfg.clone();
+        let mut layer0_workspace = model.dense_canary_workspace().unwrap();
+        let layer0_workspace_before = layer0_workspace.clone();
+        let mut whole_workspace = model.dense_control_workspace_for_batch(2).unwrap();
+        let whole_workspace_before = model
+            .dense_control_workspace_fingerprint(&whole_workspace)
+            .unwrap();
+
+        let mut state = Gpt2State::new(&model.cfg);
+        model.forward(&mut state, 1, 0, &[], &mut |_, _| {});
+        let state_before = state.clone();
+        let mut traced = state.clone();
+        let traced_before = traced.clone();
+        let mut batch = vec![state.clone(), state.clone()];
+        let batch_before = batch.clone();
+
+        let d = model.cfg.n_embd;
+        let mut layer0_input = vec![f32::from_bits(0x7fc0_0704); d];
+        let layer0_input_before = layer0_input.clone();
+        let dense_input = vec![0.25f32; d];
+        let mut dense_output = vec![f32::from_bits(0x7fc0_0704); 3 * d];
+        let dense_output_before = dense_output.clone();
+
+        drift(&mut model.cfg);
+
+        assert!(
+            model.dense_canary_workspace().is_none(),
+            "{context}: layer-0 workspace construction accepted cfg drift"
+        );
+        assert!(
+            model.dense_control_workspace().is_none(),
+            "{context}: whole workspace construction accepted cfg drift"
+        );
+        assert!(
+            model
+                .layer0_c_attn_canary_input(1, 0, &mut layer0_input)
+                .is_none(),
+            "{context}: layer-0 input helper accepted cfg drift"
+        );
+        assert_dense_bits(
+            &layer0_input,
+            &layer0_input_before,
+            &format!("{context}: rejected layer-0 input helper"),
+        );
+        assert!(
+            model
+                .layer0_c_attn_canary(
+                    &dense_input,
+                    &mut dense_output,
+                    &mut layer0_workspace,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .is_none(),
+            "{context}: layer-0 projection accepted cfg drift"
+        );
+        assert_dense_bits(
+            &dense_output,
+            &dense_output_before,
+            &format!("{context}: rejected layer-0 projection"),
+        );
+        assert_eq!(
+            layer0_workspace, layer0_workspace_before,
+            "{context}: rejected layer-0 projection mutated workspace"
+        );
+
+        assert!(
+            model
+                .forward_dense_control(
+                    &mut state,
+                    &mut whole_workspace,
+                    1,
+                    1,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .is_none(),
+            "{context}: serial dense control accepted cfg drift"
+        );
+        assert!(
+            state.full_storage_bit_identical(&state_before),
+            "{context}: rejected serial dense control mutated state"
+        );
+
+        let sink_hits = std::cell::Cell::new(0usize);
+        let mut residual = |_: usize, _: &[f32]| sink_hits.set(sink_hits.get() + 1);
+        let mut qkv = |_: usize, _: &[f32], _: &[f32], _: &[f32]| {
+            sink_hits.set(sink_hits.get() + 1);
+        };
+        let mut attention = |_: usize, _: usize, _: &[f32]| {
+            sink_hits.set(sink_hits.get() + 1);
+        };
+        let request = crate::TraceCaptureRequest {
+            residual_layers: &[0],
+            qkv_layers: &[0],
+            attention_layers: &[0],
+        };
+        let mut sinks = crate::TraceCaptureSinks {
+            residual: &mut residual,
+            qkv: &mut qkv,
+            attention: &mut attention,
+        };
+        assert!(
+            model
+                .forward_dense_control_capturing_trace(
+                    &mut traced,
+                    &mut whole_workspace,
+                    1,
+                    1,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                    &request,
+                    &mut sinks,
+                )
+                .is_none(),
+            "{context}: traced dense control accepted cfg drift"
+        );
+        assert_eq!(sink_hits.get(), 0, "{context}: trace sink fired");
+        assert!(
+            traced.full_storage_bit_identical(&traced_before),
+            "{context}: rejected traced dense control mutated state"
+        );
+
+        assert!(
+            model
+                .forward_batch_dense_control(
+                    &mut batch,
+                    &[1, 2],
+                    &[1, 1],
+                    &mut whole_workspace,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .is_none(),
+            "{context}: batch dense control accepted cfg drift"
+        );
+        assert!(
+            batch
+                .iter()
+                .zip(&batch_before)
+                .all(|(state, before)| state.full_storage_bit_identical(before)),
+            "{context}: rejected batch dense control mutated state"
+        );
+
+        assert!(
+            model
+                .dense_control_workspace_fingerprint(&whole_workspace)
+                .is_none(),
+            "{context}: workspace validator accepted cfg drift"
+        );
+        model.cfg = original_cfg;
+        assert_eq!(
+            model
+                .dense_control_workspace_fingerprint(&whole_workspace)
+                .unwrap(),
+            whole_workspace_before,
+            "{context}: rejected dense controls mutated whole workspace"
+        );
+    }
+
+    #[test]
+    fn dense_evidence_workspaces_bind_frozen_arithmetic_geometry() {
+        assert_dense_evidence_rejects_post_workspace_geometry_drift(
+            Gpt2::load(fixture_dir(), None).unwrap(),
+            |cfg| cfg.layer_norm_eps = f32::from_bits(cfg.layer_norm_eps.to_bits() ^ 1),
+            "layer-norm epsilon drift",
+        );
+        assert_dense_evidence_rejects_post_workspace_geometry_drift(
+            Gpt2::load(fixture_dir(), None).unwrap(),
+            |cfg| {
+                cfg.n_head = (1..=cfg.n_embd)
+                    .find(|&heads| heads != cfg.n_head && cfg.n_embd.is_multiple_of(heads))
+                    .expect("tiny fixture has an alternate valid head count");
+            },
+            "alternate valid head-count drift",
+        );
+    }
+
+    fn dense_test_workspace(
+        weights: &[f32],
+        in_dim: usize,
+        out_dim: usize,
+    ) -> Gpt2DenseCanaryWorkspace {
+        let mut sum_abs_weight_upper = vec![0.0f64; out_dim];
+        for input_index in 0..in_dim {
+            for output_index in 0..out_dim {
+                sum_abs_weight_upper[output_index] +=
+                    f64::from(weights[input_index * out_dim + output_index]).abs();
+            }
+        }
+        for bound in &mut sum_abs_weight_upper {
+            *bound = dense_positive_sum_upper(*bound, in_dim).expect("finite test weight bound");
+        }
+        Gpt2DenseCanaryWorkspace {
+            weight_address: weights.as_ptr() as usize,
+            weight_len: weights.len(),
+            source_kappa: "test".to_owned(),
+            in_dim,
+            out_dim,
+            sums: vec![0.0; out_dim],
+            sum_abs_weight_upper,
+        }
+    }
+
+    fn assert_dense_bits(got: &[f32], expected: &[f32], context: &str) {
+        for (lane, (&got, &expected)) in got.iter().zip(expected).enumerate() {
+            assert_eq!(got.to_bits(), expected.to_bits(), "{context}: lane {lane}");
+        }
+    }
+
+    #[test]
+    fn dense_refinement_and_exact_fallback_are_bit_identical_to_exact_owner() {
+        let input = [1.0f32, -2.0, 0.25, 4.0];
+        let weights = [
+            0.5f32, -0.25, 2.0, 0.75, 0.5, -1.0, -2.0, 4.0, 0.125, 0.25, -0.5, 0.75,
+        ];
+        let bias = [0.125f32, -0.25, 0.5];
+        let mut workspace = dense_test_workspace(&weights, input.len(), bias.len());
+        // A deliberately loose but still valid upper bound forces every fast
+        // lane through the TwoSum refinement without changing the proof.
+        workspace.sum_abs_weight_upper.fill(1.0e300);
+        let mut candidate = [0.0f32; 3];
+        let census =
+            certified_dense_projection(&mut candidate, &input, &weights, &bias, &mut workspace);
+        let mut exact = [0.0f32; 3];
+        exact_dense_projection(&mut exact, &input, &weights, bias.len());
+        for (value, addend) in exact.iter_mut().zip(bias) {
+            *value += addend;
+        }
+        assert_dense_bits(&candidate, &exact, "TwoSum refinement");
+        assert_eq!(census.fast_certified, 0);
+        assert_eq!(census.refined_certified, bias.len());
+        assert_eq!(census.fallbacks(), Some(0));
+
+        // 1 + 2^-24 is exactly the midpoint between 1 and its successor.
+        // Strict containment must refuse both cells and delegate ties-to-even
+        // to the pinned exact owner.
+        let tie_term = f32::from_bits(115 << 23);
+        let tie_input = [1.0f32, tie_term];
+        let tie_weights = [1.0f32, tie_term];
+        let tie_bias = [f32::from_bits(0x3380_0000)];
+        let mut tie_workspace = dense_test_workspace(&tie_weights, 2, 1);
+        let mut tie_candidate = [0.0f32];
+        let tie_census = certified_dense_projection(
+            &mut tie_candidate,
+            &tie_input,
+            &tie_weights,
+            &tie_bias,
+            &mut tie_workspace,
+        );
+        let mut tie_exact = [0.0f32];
+        exact_dense_projection(&mut tie_exact, &tie_input, &tie_weights, 1);
+        tie_exact[0] += tie_bias[0];
+        assert_dense_bits(&tie_candidate, &tie_exact, "midpoint fallback");
+        assert_eq!(tie_census.fallback_cell, 1);
+
+        let zero_input = [0.0f32, 0.0];
+        let mut zero_candidate = [0.0f32];
+        let zero_census = certified_dense_projection(
+            &mut zero_candidate,
+            &zero_input,
+            &tie_weights,
+            &tie_bias,
+            &mut tie_workspace,
+        );
+        assert_eq!(zero_candidate.map(f32::to_bits), tie_bias.map(f32::to_bits));
+        assert_eq!(zero_census.fallback_zero, 1);
+
+        let overflow_input = [f32::MAX];
+        let overflow_weights = [f32::MAX];
+        let overflow_bias = [0.0f32];
+        let mut overflow_workspace = dense_test_workspace(&overflow_weights, 1, 1);
+        let mut overflow_candidate = [0.0f32];
+        let overflow_census = certified_dense_projection(
+            &mut overflow_candidate,
+            &overflow_input,
+            &overflow_weights,
+            &overflow_bias,
+            &mut overflow_workspace,
+        );
+        let mut overflow_exact = [0.0f32];
+        exact_dense_projection(&mut overflow_exact, &overflow_input, &overflow_weights, 1);
+        assert_dense_bits(&overflow_candidate, &overflow_exact, "overflow fallback");
+        assert_eq!(overflow_census.fallback_overflow, 1);
+    }
+
+    #[test]
+    fn dense_row_reuse_batch_dispatch_preserves_cancellation_bits() {
+        let in_dim = 3;
+        let out_dim = 2;
+        let batch = 3;
+        let weights = [
+            1.0f32,
+            -1.0,
+            f32::from_bits(0x3380_0000),
+            f32::from_bits(0xb380_0000),
+            -1.0,
+            1.0,
+        ];
+        let bias = [0.25f32, -0.5];
+        let inputs = [1.0f32, 1.0, 1.0, 1.0, -1.0, 0.5, 0.0, 0.0, 0.0];
+        let prepared = DensePreparedMatrix::prepare(&weights, in_dim, out_dim).unwrap();
+        let mut batch_sums = vec![0.0f64; batch * out_dim];
+        let mut batch_max = vec![0.0f64; batch];
+        let mut batched = vec![0.0f32; batch * out_dim];
+        let batch_census = controlled_dense_projection_batched(
+            &mut batched,
+            &inputs,
+            &weights,
+            Some(&bias),
+            batch,
+            &prepared,
+            &mut batch_sums,
+            &mut batch_max,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        );
+        assert_eq!(batch_census.batch_rows, batch);
+        assert_eq!(batch_census.lanes, batch * out_dim);
+        assert!(batch_census.fallback_zero > 0);
+
+        let mut serial_prepared = prepared.clone();
+        for batch_index in 0..batch {
+            let mut serial = [0.0f32; 2];
+            let serial_census = controlled_dense_projection(
+                &mut serial,
+                &inputs[batch_index * in_dim..(batch_index + 1) * in_dim],
+                &weights,
+                Some(&bias),
+                &mut serial_prepared,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            );
+            assert_eq!(serial_census.batch_rows, 0);
+            assert_dense_bits(
+                &batched[batch_index * out_dim..(batch_index + 1) * out_dim],
+                &serial,
+                "row-reuse batch/serial cancellation",
+            );
+        }
+
+        let mut exact = vec![0.0f32; batch * out_dim];
+        let mut exact_sums = vec![0.0f64; batch * out_dim];
+        let mut exact_max = vec![0.0f64; batch];
+        let exact_census = controlled_dense_projection_batched(
+            &mut exact,
+            &inputs,
+            &weights,
+            Some(&bias),
+            batch,
+            &prepared,
+            &mut exact_sums,
+            &mut exact_max,
+            Gpt2DenseCanaryMode::Exact,
+        );
+        assert_eq!(exact_census.batch_rows, batch);
+        assert_dense_bits(&batched, &exact, "row-reuse batch/exact cancellation");
+    }
+
+    #[test]
+    fn dense_census_overflow_is_atomic_and_full_controls_leave_weights_immutable() {
+        let mut census = Gpt2DenseCanaryCensus {
+            lanes: usize::MAX,
+            ..Gpt2DenseCanaryCensus::default()
+        };
+        let before = census;
+        assert_eq!(
+            census.merge(Gpt2DenseCanaryCensus {
+                lanes: 1,
+                ..Gpt2DenseCanaryCensus::default()
+            }),
+            None
+        );
+        assert_eq!(census, before, "overflowing census merge was not atomic");
+        let mut layer_census = Gpt2DenseLayerCensus {
+            c_attn: before,
+            ..Gpt2DenseLayerCensus::default()
+        };
+        let layer_before = layer_census;
+        assert_eq!(
+            layer_census.merge(Gpt2DenseLayerCensus {
+                c_attn: Gpt2DenseCanaryCensus {
+                    lanes: 1,
+                    ..Gpt2DenseCanaryCensus::default()
+                },
+                ..Gpt2DenseLayerCensus::default()
+            }),
+            None
+        );
+        assert_eq!(
+            layer_census, layer_before,
+            "overflowing layer census merge was not atomic"
+        );
+
+        let model = Gpt2::load(fixture_dir(), None).unwrap();
+        assert!(model.dense_control_workspace_for_batch(0).is_none());
+        let wte = model.wte.clone();
+        let layer_weights: Vec<_> = model
+            .layers
+            .iter()
+            .map(|layer| {
+                (
+                    layer.c_attn_w.clone(),
+                    layer.c_proj_w.clone(),
+                    layer.fc_w.clone(),
+                    layer.mlp_w.clone(),
+                )
+            })
+            .collect();
+        let production_transpose = model.dense_prepared.lm_head_transposed.clone();
+        let production_bounds: Vec<Vec<f64>> = model
+            .dense_prepared
+            .matrices
+            .iter()
+            .map(|matrix| matrix.sum_abs_weight_upper.clone())
+            .chain(std::iter::once(
+                model.dense_prepared.lm_head.sum_abs_weight_upper.clone(),
+            ))
+            .collect();
+        let mut workspace = model.dense_control_workspace_for_batch(2).unwrap();
+        let mut serial = Gpt2State::new(&model.cfg);
+        let _ = model
+            .forward_dense_control(
+                &mut serial,
+                &mut workspace,
+                1,
+                0,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .unwrap();
+        let mut states = vec![Gpt2State::new(&model.cfg); 2];
+        let _ = model
+            .forward_batch_dense_control(
+                &mut states,
+                &[1, 2],
+                &[0, 0],
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .unwrap();
+        let mut production = Gpt2State::new(&model.cfg);
+        model.forward(&mut production, 1, 0, &[], &mut |_, _| {});
+        let mut production_batch = vec![Gpt2State::new(&model.cfg); 2];
+        model.forward_batch(&mut production_batch, &[1, 2], &[0, 0]);
+        assert_dense_bits(&model.wte, &wte, "tied embedding weights");
+        for (layer, expected) in model.layers.iter().zip(layer_weights) {
+            assert_dense_bits(&layer.c_attn_w, &expected.0, "c_attn weights");
+            assert_dense_bits(&layer.c_proj_w, &expected.1, "attention c_proj weights");
+            assert_dense_bits(&layer.fc_w, &expected.2, "MLP c_fc weights");
+            assert_dense_bits(&layer.mlp_w, &expected.3, "MLP c_proj weights");
+        }
+        assert_dense_bits(
+            &model.dense_prepared.lm_head_transposed,
+            &production_transpose,
+            "production tied-head preparation",
+        );
+        for (matrix, expected) in model
+            .dense_prepared
+            .matrices
+            .iter()
+            .chain(std::iter::once(&model.dense_prepared.lm_head))
+            .zip(production_bounds)
+        {
+            assert_eq!(
+                matrix
+                    .sum_abs_weight_upper
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                expected
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                "production dense bounds mutated",
+            );
+        }
     }
 
     #[test]
@@ -1482,6 +4452,11 @@ mod tests {
         assert_eq!(
             error.reason,
             "invalid GPT-2 attention canary geometry: n_head must be nonzero and divide n_embd"
+        );
+        assert_eq!(
+            model.dense_canary_workspace(),
+            None,
+            "dense workspace construction uses the checked Option seam"
         );
         let result = model.forward_attention_canary(
             &mut state,
@@ -1661,19 +4636,19 @@ mod tests {
         }
     }
 
-    /// #668: the GPT-2 oracle reports the truthful learned-absolute
-    /// operator record, and it resolves through the versioned registry.
+    /// The GPT-2 oracle reports the truthful learned-absolute attention and
+    /// dense-v2 execution pair, and both resolve through their registries.
     /// Its positional action is NOT RoPE, so it is a distinct identity
     /// from current `standard-source-attention/2` — reusing that record would be
     /// a false operator identity.
     #[test]
-    fn gpt2_oracle_reports_learned_absolute_operator() {
+    fn gpt2_oracle_reports_registered_source_execution_pair() {
         use crate::attention::{operator_spec, AttentionOperatorSpec};
-        use crate::TeacherOracle;
+        use crate::dense::{self, DenseOperatorSpec};
+        use crate::{BatchedTeacher, TeacherOracle};
 
         let oracle = HuggingFaceGpt2Oracle::load(fixture_dir()).expect("load tiny gpt2 oracle");
-        let spec = oracle
-            .attention_operator_spec()
+        let spec = TeacherOracle::attention_operator_spec(&oracle)
             .expect("gpt2 oracle declares an attention operator");
 
         assert_eq!(
@@ -1696,6 +4671,20 @@ mod tests {
         let standard = AttentionOperatorSpec::standard();
         assert_ne!(spec.positional_action, standard.positional_action);
         assert_ne!(spec.implementation_digest, standard.implementation_digest);
+
+        let dense_spec = TeacherOracle::dense_operator_spec(&oracle)
+            .expect("gpt2 oracle declares dense provenance");
+        assert_eq!(dense_spec, DenseOperatorSpec::gpt2_source_dense());
+        assert_eq!(
+            <HuggingFaceGpt2Oracle as BatchedTeacher>::dense_operator_spec(&oracle),
+            Some(dense_spec.clone())
+        );
+        assert_eq!(
+            dense::operator_spec(&dense_spec.id, dense_spec.version).expect("registered dense"),
+            dense_spec
+        );
+        dense::validate_source_execution_pair(Some(&spec), Some(&dense_spec))
+            .expect("current GPT-2 execution pair is registered");
     }
 
     /// #601 (item 4 of #657): the GPT-2 oracle declares the byte-level BPE
@@ -2064,6 +5053,9 @@ impl crate::TeacherOracle for HuggingFaceGpt2Oracle {
         // action, so this is its own registered `(id, version)`.
         Some(crate::attention::AttentionOperatorSpec::learned_absolute_source_attention())
     }
+    fn dense_operator_spec(&self) -> Option<crate::dense::DenseOperatorSpec> {
+        Some(crate::dense::DenseOperatorSpec::gpt2_source_dense())
+    }
     fn hidden_state(&self) -> Option<&[f32]> {
         Some(&self.state.hidden)
     }
@@ -2090,7 +5082,7 @@ impl crate::TeacherOracle for HuggingFaceGpt2Oracle {
         request: &crate::TraceCaptureRequest<'_>,
         sinks: &mut crate::TraceCaptureSinks<'_, '_>,
     ) -> bool {
-        // #603: capture through the exact executor path — a traced step
+        // #603: capture through the production v2 path — a traced step
         // leaves the same logits as the plain `step`.
         self.model
             .forward_capturing_trace(&mut self.state, token, pos, request, sinks);
@@ -2121,6 +5113,9 @@ impl crate::BatchedTeacher for HuggingFaceGpt2Oracle {
     }
     fn attention_operator_spec(&self) -> Option<crate::attention::AttentionOperatorSpec> {
         <Self as crate::TeacherOracle>::attention_operator_spec(self)
+    }
+    fn dense_operator_spec(&self) -> Option<crate::dense::DenseOperatorSpec> {
+        <Self as crate::TeacherOracle>::dense_operator_spec(self)
     }
     fn forward_batch_into(&self, states: &mut [Gpt2State], tokens: &[usize], positions: &[usize]) {
         self.model.forward_batch(states, tokens, positions);

--- a/crates/uor-r4-model-source/src/gpt2.rs
+++ b/crates/uor-r4-model-source/src/gpt2.rs
@@ -330,6 +330,12 @@ enum DenseCertificationRejection {
     Cell,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum DenseCertificationOutcome {
+    Certified(f32),
+    Rejected(DenseCertificationRejection),
+}
+
 #[inline]
 fn dense_next_up_f64(value: f64) -> f64 {
     if value.is_nan() || value == f64::INFINITY {
@@ -415,48 +421,46 @@ fn dense_rounding_cell_contains(
     approximate: f64,
     lower: f64,
     upper: f64,
-) -> Result<f32, DenseCertificationRejection> {
+) -> DenseCertificationOutcome {
     if !approximate.is_finite() || !lower.is_finite() || !upper.is_finite() {
-        return Err(DenseCertificationRejection::Nonfinite);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite);
     }
     let candidate = approximate as f32;
     if candidate == 0.0 {
-        return Err(DenseCertificationRejection::Zero);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Zero);
     }
     if !candidate.is_finite() || candidate.abs() == f32::MAX {
-        return Err(DenseCertificationRejection::Overflow);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Overflow);
     }
     let previous = dense_next_down_f32(candidate);
     let next = dense_next_up_f32(candidate);
     if !previous.is_finite() || !next.is_finite() {
-        return Err(DenseCertificationRejection::Overflow);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Overflow);
     }
     // Both binary32 values and their midpoint are represented exactly in
     // binary64. Strict containment rejects midpoint ties without a parity arm.
     let cell_lower = (f64::from(previous) + f64::from(candidate)) * 0.5;
     let cell_upper = (f64::from(candidate) + f64::from(next)) * 0.5;
     if lower > cell_lower && upper < cell_upper {
-        Ok(candidate)
+        DenseCertificationOutcome::Certified(candidate)
     } else {
-        Err(DenseCertificationRejection::Cell)
+        DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell)
     }
 }
 
 /// Certify a binary64 left fold using an independently supplied outward upper
 /// bound on `sum_i |x_i*w_i|`.
 #[inline]
-fn certify_dense_sum(
-    approximate: f64,
-    sum_abs_upper: f64,
-    k: usize,
-) -> Result<f32, DenseCertificationRejection> {
+fn certify_dense_sum(approximate: f64, sum_abs_upper: f64, k: usize) -> DenseCertificationOutcome {
     if !approximate.is_finite() || !sum_abs_upper.is_finite() {
-        return Err(DenseCertificationRejection::Nonfinite);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite);
     }
-    let gamma = dense_gamma(k).ok_or(DenseCertificationRejection::Cell)?;
+    let Some(gamma) = dense_gamma(k) else {
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell);
+    };
     let error = dense_next_up_f64(gamma * sum_abs_upper);
     if !error.is_finite() {
-        return Err(DenseCertificationRejection::Cell);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell);
     }
     let lower = dense_next_down_f64(approximate - error);
     let upper = dense_next_up_f64(approximate + error);
@@ -483,14 +487,14 @@ fn refine_dense_lane(
     w: &[f32],
     out_dim: usize,
     lane: usize,
-) -> Result<f32, DenseCertificationRejection> {
+) -> DenseCertificationOutcome {
     let mut high = 0.0f64;
     let mut correction = 0.0f64;
     let mut correction_abs = 0.0f64;
     for (input_index, &activation) in x.iter().enumerate() {
         let weight = w[input_index * out_dim + lane];
         if !activation.is_finite() || !weight.is_finite() {
-            return Err(DenseCertificationRejection::Nonfinite);
+            return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite);
         }
         // A finite binary32 product has at most 48 significant bits and is
         // therefore exact in binary64.
@@ -501,14 +505,17 @@ fn refine_dense_lane(
         correction_abs += error.abs();
     }
     if !high.is_finite() || !correction.is_finite() || !correction_abs.is_finite() {
-        return Err(DenseCertificationRejection::Nonfinite);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite);
     }
-    let correction_abs_upper = dense_positive_sum_upper(correction_abs, x.len())
-        .ok_or(DenseCertificationRejection::Cell)?;
-    let gamma = dense_gamma(x.len()).ok_or(DenseCertificationRejection::Cell)?;
+    let Some(correction_abs_upper) = dense_positive_sum_upper(correction_abs, x.len()) else {
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell);
+    };
+    let Some(gamma) = dense_gamma(x.len()) else {
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell);
+    };
     let error = dense_next_up_f64(gamma * correction_abs_upper);
     if !error.is_finite() {
-        return Err(DenseCertificationRejection::Cell);
+        return DenseCertificationOutcome::Rejected(DenseCertificationRejection::Cell);
     }
 
     // `high + correction` itself is represented as a TwoSum pair. Outward
@@ -580,24 +587,26 @@ fn certified_dense_dots_with_scratch(
     for lane in 0..out_dim {
         let sum_abs_upper = dense_next_up_f64(max_activation_abs * sum_abs_weight_upper[lane]);
         let dot = match certify_dense_sum(sums[lane], sum_abs_upper, x.len()) {
-            Ok(value) => {
+            DenseCertificationOutcome::Certified(value) => {
                 census.fast_certified += 1;
                 value
             }
-            Err(DenseCertificationRejection::Nonfinite) => {
+            DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite) => {
                 census.reject(DenseCertificationRejection::Nonfinite);
                 exact_dense_lane(x, w, out_dim, lane)
             }
-            Err(_) => match refine_dense_lane(x, w, out_dim, lane) {
-                Ok(value) => {
-                    census.refined_certified += 1;
-                    value
+            DenseCertificationOutcome::Rejected(_) => {
+                match refine_dense_lane(x, w, out_dim, lane) {
+                    DenseCertificationOutcome::Certified(value) => {
+                        census.refined_certified += 1;
+                        value
+                    }
+                    DenseCertificationOutcome::Rejected(reason) => {
+                        census.reject(reason);
+                        exact_dense_lane(x, w, out_dim, lane)
+                    }
                 }
-                Err(reason) => {
-                    census.reject(reason);
-                    exact_dense_lane(x, w, out_dim, lane)
-                }
-            },
+            }
         };
         out[lane] = dot;
     }
@@ -741,24 +750,26 @@ fn certified_dense_dots_batched_with_scratch(
             let index = batch_index * out_dim + lane;
             let sum_abs_upper = dense_next_up_f64(max_activation_abs[batch_index] * weight_bound);
             let dot = match certify_dense_sum(sums[index], sum_abs_upper, in_dim) {
-                Ok(value) => {
+                DenseCertificationOutcome::Certified(value) => {
                     census.fast_certified += 1;
                     value
                 }
-                Err(DenseCertificationRejection::Nonfinite) => {
+                DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite) => {
                     census.reject(DenseCertificationRejection::Nonfinite);
                     exact_dense_lane(input, weights, out_dim, lane)
                 }
-                Err(_) => match refine_dense_lane(input, weights, out_dim, lane) {
-                    Ok(value) => {
-                        census.refined_certified += 1;
-                        value
+                DenseCertificationOutcome::Rejected(_) => {
+                    match refine_dense_lane(input, weights, out_dim, lane) {
+                        DenseCertificationOutcome::Certified(value) => {
+                            census.refined_certified += 1;
+                            value
+                        }
+                        DenseCertificationOutcome::Rejected(reason) => {
+                            census.reject(reason);
+                            exact_dense_lane(input, weights, out_dim, lane)
+                        }
                     }
-                    Err(reason) => {
-                        census.reject(reason);
-                        exact_dense_lane(input, weights, out_dim, lane)
-                    }
-                },
+                }
             };
             out[index] = dot;
         }
@@ -904,12 +915,18 @@ fn production_dense_projection_batched(
             let sum_abs_upper =
                 dense_next_up_f64(*max_activation_abs * metadata.sum_abs_weight_upper[lane]);
             let dot = match certify_dense_sum(sums[lane], sum_abs_upper, in_dim) {
-                Ok(value) => value,
-                Err(DenseCertificationRejection::Nonfinite) => {
+                DenseCertificationOutcome::Certified(value) => value,
+                DenseCertificationOutcome::Rejected(DenseCertificationRejection::Nonfinite) => {
                     exact_dense_lane(input, weights, out_dim, lane)
                 }
-                Err(_) => refine_dense_lane(input, weights, out_dim, lane)
-                    .unwrap_or_else(|_| exact_dense_lane(input, weights, out_dim, lane)),
+                DenseCertificationOutcome::Rejected(_) => {
+                    match refine_dense_lane(input, weights, out_dim, lane) {
+                        DenseCertificationOutcome::Certified(value) => value,
+                        DenseCertificationOutcome::Rejected(_) => {
+                            exact_dense_lane(input, weights, out_dim, lane)
+                        }
+                    }
+                }
             };
             output[lane] = bias.map_or(dot, |bias| dot + bias[lane]);
         }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -3,13 +3,13 @@
 //! rmsnorm/softmax/RoPE/SwiGLU op-for-op, libm via glibc on gnu targets.
 //! The Safetensors adapter also loads pinned Hugging Face SmolLM2 weights
 //! into this same source-only teacher surface. Llama/shared projections use the
-//! pinned portable exact `uor-matmul` owner. GPT-2 keeps its declared
-//! conventional dense sites and uses certified-native/exact-fallback current
-//! attention; canonical mode separately selects the remaining libm and
-//! ordered-reduction family.
+//! pinned portable exact `uor-matmul` owner. GPT-2 uses its declared
+//! certified-native/exact-fallback dense and attention owners; canonical mode
+//! separately selects the remaining libm and ordered-reduction family.
 
 pub mod attention;
 pub mod conformance;
+pub mod dense;
 pub mod geometry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gpt2;
@@ -1004,6 +1004,14 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
         None
     }
 
+    /// Typed identity of the source-dense arithmetic executed by
+    /// [`BehaviorSource::step`], when the oracle declares one. `None` keeps
+    /// historical and non-dense-registry teachers compatible without
+    /// relabelling them.
+    fn dense_operator_spec(&self) -> Option<dense::DenseOperatorSpec> {
+        None
+    }
+
     /// Optional compiler-only trace surface (graph-compiler plan §5 Phase
     /// 2): the final hidden state (post-final-rmsnorm activation) of the
     /// last `step`, if the oracle retains it. Defaults to `None` so
@@ -1034,7 +1042,7 @@ pub trait TeacherOracle: RepresentationSource + BehaviorSource {
     }
 
     /// Optional compiler-only #603 trace-capture step: one forward step
-    /// with the declared lanes captured through the exact executor path
+    /// with the declared lanes captured through the production executor path
     /// (`Llama::forward_capturing_trace`, the #599 `forward_capturing`
     /// discipline extended with the q/k/v and per-head attention taps).
     /// Returns `true` when the oracle captured through its executor;
@@ -1619,6 +1627,15 @@ pub enum SourceIngestKind {
         /// The requested operator version.
         version: u32,
     },
+    /// Source-dense operator registry: a caller named an `(id, version)`
+    /// outside [`dense::operator_spec`]. Unknown entries are never
+    /// approximated by a nearby arithmetic version.
+    UnknownDenseOperator {
+        /// The requested dense operator id.
+        id: String,
+        /// The requested dense operator version.
+        version: u32,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1717,6 +1734,15 @@ impl std::fmt::Display for SourceIngestKind {
                 attention::AttentionOperatorSpec::LEARNED_ABSOLUTE_V2_VERSION,
                 attention::AttentionOperatorSpec::R4_ROUTE_ID,
                 attention::AttentionOperatorSpec::R4_ROUTE_VERSION,
+            ),
+            Self::UnknownDenseOperator { id, version } => write!(
+                f,
+                "dense operator {id}/{version} is not in the versioned operator registry \
+                 (registered entries: {}/{}, {}/{})",
+                dense::DenseOperatorSpec::GPT2_ID,
+                dense::DenseOperatorSpec::GPT2_V1_VERSION,
+                dense::DenseOperatorSpec::GPT2_ID,
+                dense::DenseOperatorSpec::GPT2_V2_VERSION,
             ),
         }
     }
@@ -2255,6 +2281,11 @@ pub trait BatchedTeacher {
     fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
         None
     }
+    /// Registered source-dense identity executed by this batched producer.
+    /// `None` denotes an unbound or inapplicable source family.
+    fn dense_operator_spec(&self) -> Option<dense::DenseOperatorSpec> {
+        None
+    }
     /// Advance `states.len()` sequences one position each: sequence `b` steps
     /// `tokens[b]` at `positions[b]`, leaving its logits reachable through
     /// [`BatchedTeacher::logits_mut`].
@@ -2283,6 +2314,9 @@ impl BatchedTeacher for HuggingFaceLlamaOracle {
     }
     fn attention_operator_spec(&self) -> Option<attention::AttentionOperatorSpec> {
         <Self as TeacherOracle>::attention_operator_spec(self)
+    }
+    fn dense_operator_spec(&self) -> Option<dense::DenseOperatorSpec> {
+        <Self as TeacherOracle>::dense_operator_spec(self)
     }
     fn forward_batch_into(&self, states: &mut [State], tokens: &[usize], positions: &[usize]) {
         self.model
@@ -2857,11 +2891,13 @@ mod tests {
             oracle.attention_operator_spec(),
             Some(attention::AttentionOperatorSpec::standard())
         );
+        assert_eq!(oracle.dense_operator_spec(), None);
         oracle.model.cfg.r4_attention = true;
         assert_eq!(
             oracle.attention_operator_spec(),
             Some(attention::AttentionOperatorSpec::experimental_r4())
         );
+        assert_eq!(oracle.dense_operator_spec(), None);
     }
 
     /// #603: the traced forward IS the exact executor — a

--- a/crates/uor-r4-model-source/src/teacher.rs
+++ b/crates/uor-r4-model-source/src/teacher.rs
@@ -204,6 +204,9 @@ impl TeacherOracle for Teacher {
     fn attention_operator_spec(&self) -> Option<crate::attention::AttentionOperatorSpec> {
         self.as_oracle().attention_operator_spec()
     }
+    fn dense_operator_spec(&self) -> Option<crate::dense::DenseOperatorSpec> {
+        self.as_oracle().dense_operator_spec()
+    }
     fn hidden_state(&self) -> Option<&[f32]> {
         self.as_oracle().hidden_state()
     }
@@ -248,6 +251,18 @@ mod tests {
         ));
         assert!(family_for_model_type(Some("mistral")).is_err());
         assert!(family_for_model_type(Some("")).is_err());
+    }
+
+    #[test]
+    fn teacher_delegates_gpt2_dense_provenance() {
+        let source =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-tiny");
+        let teacher = Teacher::load(source).expect("load tiny GPT-2 through Teacher");
+        assert!(matches!(teacher, Teacher::Gpt2(_)));
+        assert_eq!(
+            teacher.dense_operator_spec(),
+            Some(crate::dense::DenseOperatorSpec::gpt2_source_dense())
+        );
     }
 
     // #657 regression gate: routing a Llama/SmolLM2 source through `Teacher`

--- a/crates/uor-r4-model-source/tests/certified_native_attention.rs
+++ b/crates/uor-r4-model-source/tests/certified_native_attention.rs
@@ -206,20 +206,18 @@ fn production_attention_identity_is_hard_bound() {
 }
 
 #[test]
-fn checked_canary_facade_matches_production_and_exact_without_allocating() {
+fn checked_attention_canary_matches_exact_without_allocating() {
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-tiny");
     let model = Gpt2::load(&fixture, None).expect("load tiny GPT-2 fixture");
     let mut workspace = model
         .attention_canary_workspace()
         .expect("valid tiny model admits canary workspace");
-    let mut production = Gpt2State::new(&model.cfg);
     let mut certified = Gpt2State::new(&model.cfg);
     let mut exact = Gpt2State::new(&model.cfg);
     let mut conventional = Gpt2State::new(&model.cfg);
     let mut census = Gpt2AttentionCanaryCensus::default();
 
     for (position, token) in [1usize, 3, 2].into_iter().enumerate() {
-        model.forward(&mut production, token, position, &[], &mut |_, _| {});
         census
             .merge(
                 model
@@ -251,18 +249,13 @@ fn checked_canary_facade_matches_production_and_exact_without_allocating() {
                 Gpt2AttentionCanaryMode::Conventional,
             )
             .expect("checked conventional step");
-        assert_bits(
-            &certified.logits,
-            &production.logits,
-            "certified/production",
-        );
         assert_bits(&certified.logits, &exact.logits, "certified/exact");
     }
     assert!(census.qk().lanes() > 0);
     assert!(census.value().lanes() > 0);
     assert!(census.qk().certified() > 0);
     assert!(census.value().certified() > 0);
-    assert!(production
+    assert!(exact
         .logits
         .iter()
         .zip(&conventional.logits)
@@ -423,11 +416,10 @@ fn median_five(mut values: [f64; GPT2_PAIRS]) -> f64 {
     values[GPT2_PAIRS / 2]
 }
 
-/// Hard gate only: one real GPT-2 32-token story, five alternating pairs.
-/// Exact is the checked preflight oracle; only conventional and certified are
-/// timed. The `<=1.10x` threshold is the posted #704 Choice-A consumer
-/// contract; this local certified-native path does not claim compliance with
-/// upstream #38's distinct arithmetic policy.
+/// Historical attention-only gate: one real GPT-2 32-token story, five
+/// alternating pairs. Both timed arms intentionally retain conventional dense
+/// arithmetic, so this isolates attention and is not the current whole-model
+/// production default. Exact is the checked attention preflight oracle.
 #[test]
 #[ignore = "release-only, hard-bound real GPT-2 certified-attention canary"]
 #[allow(clippy::assertions_on_constants)]
@@ -445,32 +437,6 @@ fn real_gpt2_certified_attention_32_token_gate() {
     let mut workspace = model
         .attention_canary_workspace()
         .expect("hard-bound model admits checked canary workspace");
-
-    let mut production_state = Gpt2State::new(&model.cfg);
-    let mut production_control_state = Gpt2State::new(&model.cfg);
-    let mut production_control_census = Gpt2AttentionCanaryCensus::default();
-    for (position, &token) in tokens.iter().enumerate() {
-        model.forward(&mut production_state, token, position, &[], &mut |_, _| {});
-        production_control_census
-            .merge(
-                model
-                    .forward_attention_canary(
-                        &mut production_control_state,
-                        &mut workspace,
-                        token,
-                        position,
-                        Gpt2AttentionCanaryMode::CertifiedNative,
-                    )
-                    .expect("production-control canary inputs"),
-            )
-            .expect("production-control census fits usize");
-        assert_bits(
-            &production_control_state.logits,
-            &production_state.logits,
-            &format!("real production/default v2 position {position}"),
-        );
-    }
-    assert_nonvacuous_candidate_census("production-control", production_control_census);
 
     let mut conventional_state = Gpt2State::new(&model.cfg);
     let mut exact_state = Gpt2State::new(&model.cfg);
@@ -600,7 +566,7 @@ fn real_gpt2_certified_attention_32_token_gate() {
     let qk_rate = timed_census.qk().certified() as f64 / timed_census.qk().lanes() as f64;
     let value_rate = timed_census.value().certified() as f64 / timed_census.value().lanes() as f64;
     eprintln!(
-        "CERTIFIED_ATTENTION_RESULT arithmetic_id={CERTIFIED_NATIVE_ARITHMETIC_ID} learned_absolute_v2_digest={learned_absolute_v2_digest} uor_matmul_rev={UOR_MATMUL_REV} steps={GPT2_STEPS} pairs={GPT2_PAIRS} candidate_median_ns={:.0} conventional_median_ns={:.0} paired_median_ratio={median_ratio:.9} raw_ratios={ratios:?} qk_certification_rate={qk_rate:.9} value_certification_rate={value_rate:.9} timed_census={timed_census:?} preflight_census={preflight:?} production_control_census={production_control_census:?} threshold={MAXIMUM_RATIO:.2} threshold_rule=less-than-or-equal",
+        "CERTIFIED_ATTENTION_RESULT arithmetic_id={CERTIFIED_NATIVE_ARITHMETIC_ID} learned_absolute_v2_digest={learned_absolute_v2_digest} uor_matmul_rev={UOR_MATMUL_REV} steps={GPT2_STEPS} pairs={GPT2_PAIRS} candidate_median_ns={:.0} conventional_median_ns={:.0} paired_median_ratio={median_ratio:.9} raw_ratios={ratios:?} qk_certification_rate={qk_rate:.9} value_certification_rate={value_rate:.9} timed_census={timed_census:?} preflight_census={preflight:?} dense_arithmetic=conventional-both-arms threshold={MAXIMUM_RATIO:.2} threshold_rule=less-than-or-equal",
         candidate_median * 1e9,
         conventional_median * 1e9,
     );

--- a/crates/uor-r4-model-source/tests/certified_native_dense.rs
+++ b/crates/uor-r4-model-source/tests/certified_native_dense.rs
@@ -1,0 +1,2634 @@
+//! #704 Choice-A dense arithmetic differential and cheap-gate harness.
+//!
+//! The checked controls preserve the binding whole-model PASS and remain the
+//! production differential oracle. Every Conv1D candidate is compared bit-for-bit with one pinned
+//! correctly-rounded dot plus one binary32 bias add; tied lm-head dots have no
+//! bias. Workspace construction and source binding remain outside timing.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use uor_r4_model_source::gpt2::{
+    Gpt2, Gpt2DenseCanaryCensus, Gpt2DenseCanaryMode, Gpt2DenseControlCensus, Gpt2DenseControlSite,
+    Gpt2DenseLayerCensus, Gpt2State,
+};
+use uor_r4_model_source::{TraceCaptureRequest, TraceCaptureSinks};
+
+const GPT2_REPOSITORY: &str = "openai-community/gpt2";
+const GPT2_REVISION: &str = "607a30d783dfa663caf39e06633721c8d4cfcd7e";
+const GPT2_MODEL_KAPPA: &str =
+    "blake3:3bca1b7f6c327daecafc16e52d1319375299354e35413fb4e18d24e59b77ce06";
+const GPT2_CONFIG_KAPPA: &str =
+    "blake3:23e4471d412e06128072b559c031207de920b8a56d7108879d4b487c079a310c";
+const GPT2_MODEL_BYTES: usize = 548_105_171;
+const GPT2_CONFIG_BYTES: usize = 665;
+const UOR_MATMUL_REV: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+const BASE_HEAD: &str = "6fbf718b4115859df6544545a5c43d7638a6ad0a";
+const PINNED_RUSTC_RELEASE: &str = "1.97.1";
+const PINNED_RUSTC_HOST: &str = "aarch64-apple-darwin";
+const DENSE_ARITHMETIC_ID: &str = "gpt2-c-attn-exact-real-dot-certified-native-f64-sum-maxabsx-sumabsw-outward-cell-twosum-refine-or-pinned-uor-matmul-exact-fallback/1";
+const LEGACY_C_ATTN_GPT2_SHA256: &str =
+    "9c3435636638c63d2baac3545480dfb694db923c14b0c5ad8fde7c8c7dcff167";
+const LEGACY_C_ATTN_HARNESS_SHA256: &str =
+    "ea823d27a74ac4cd4168f0ab6d7d1da4c92678ecb178489c0be90d67f3082685";
+const BINDING_WHOLE_GPT2_SHA256: &str =
+    "1a945487fb9ec350fd8f670b8c04dacaf6b66e2339ee96b6b3883082e4de4bf8";
+const BINDING_WHOLE_HARNESS_SHA256: &str =
+    "144fd32d35292a6fd3e949bc7040b7e14c58563bdc31924b66d38bc1db547d89";
+const BOOTSTRAP_ALGORITHM_ID: &str =
+    "empirical-bootstrap-median-exact-order-statistic-n9-one-sided-upper-95/1";
+const REAL_PAIRS: usize = 9;
+const REAL_WARMUPS_PER_ARM: usize = 20;
+const REAL_OUTPUT_LANES: usize = 2304;
+const MAXIMUM_UPPER_RATIO: f64 = 4.0;
+const WHOLE_DENSE_ARITHMETIC_ID: &str = "gpt2-all-dense-exact-dot-plus-f32-bias-certified-native-f64-sum-maxabsx-sumabsw-outward-cell-twosum-refine-or-pinned-uor-matmul-exact-fallback-tied-head-transpose/1";
+const WHOLE_BOOTSTRAP_ALGORITHM_ID: &str = "whole-gpt2-11-step-3-story-paired-empirical-bootstrap-median-exact-order-statistic-n9-one-sided-upper-95/1";
+const WHOLE_REAL_PAIRS: usize = 9;
+const WHOLE_WARMUP_SUITES_PER_ARM: usize = 2;
+const WHOLE_STEPS: usize = 11;
+const WHOLE_OWNER_CALLS: usize = 539;
+const WHOLE_LANES: usize = 1_465_211;
+const WHOLE_MAXIMUM_UPPER_RATIO: f64 = 3.0;
+const WHOLE_EXPECTED_GPT2_SHA256_ENV: &str = "UOR_DENSE_EXPECTED_GPT2_SHA256";
+const WHOLE_EXPECTED_HARNESS_SHA256_ENV: &str = "UOR_DENSE_EXPECTED_HARNESS_SHA256";
+const OUTPUT_POISON_BITS: u32 = 0x7fc0_704d;
+
+#[derive(Clone, Copy)]
+struct DenseGateContract {
+    arithmetic_id: &'static str,
+    bootstrap_id: &'static str,
+    pairs: usize,
+    warmups_per_arm: usize,
+    threshold: f64,
+    threshold_rule: &'static str,
+}
+
+struct CountingAllocator;
+
+thread_local! {
+    static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record_allocation(pointer: *mut u8) {
+    if !pointer.is_null() {
+        let _ = COUNT_ALLOCATIONS.try_with(|gate| {
+            if gate.get() {
+                let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+            }
+        });
+    }
+}
+
+// SAFETY: every request is forwarded unchanged to `System`; the thread-local
+// cells are observational and never participate in allocation.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let pointer = unsafe { System.alloc(layout) };
+        record_allocation(pointer);
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the allocation came from `System` with this layout.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(pointer);
+        pointer
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        // SAFETY: the backing allocator receives the original request.
+        let resized = unsafe { System.realloc(pointer, layout, size) };
+        record_allocation(resized);
+        resized
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+struct AllocationMeasurement;
+
+impl Drop for AllocationMeasurement {
+    fn drop(&mut self) {
+        COUNT_ALLOCATIONS.with(|gate| gate.set(false));
+    }
+}
+
+fn counted_allocations<T>(operation: impl FnOnce() -> T) -> (T, usize) {
+    ALLOCATIONS.with(|count| count.set(0));
+    COUNT_ALLOCATIONS.with(|gate| {
+        assert!(!gate.replace(true), "nested allocation measurement");
+    });
+    let measurement = AllocationMeasurement;
+    let result = operation();
+    drop(measurement);
+    (result, ALLOCATIONS.with(Cell::get))
+}
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-tiny")
+}
+
+fn real_source() -> PathBuf {
+    std::env::var_os("UOR_GPT2_SOURCE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join(".uor-models/sources/gpt2-124m")
+        })
+}
+
+fn assert_bits(got: &[f32], expected: &[f32], context: &str) {
+    assert_eq!(got.len(), expected.len(), "{context}: output length");
+    for (lane, (&got, &expected)) in got.iter().zip(expected).enumerate() {
+        assert_eq!(
+            got.to_bits(),
+            expected.to_bits(),
+            "{context}: lane {lane}: got={got:?}, expected={expected:?}"
+        );
+    }
+}
+
+fn poison_output(output: &mut [f32]) {
+    output.fill(f32::from_bits(OUTPUT_POISON_BITS));
+}
+
+fn assert_output_overwritten(output: &[f32], context: &str) {
+    for (lane, value) in output.iter().enumerate() {
+        assert_ne!(
+            value.to_bits(),
+            OUTPUT_POISON_BITS,
+            "{context}: lane {lane} retained the output poison"
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DenseCensusTotal {
+    calls: usize,
+    lanes: usize,
+    fast: usize,
+    refined: usize,
+    fallback_nonfinite: usize,
+    fallback_zero: usize,
+    fallback_overflow: usize,
+    fallback_cell: usize,
+}
+
+impl DenseCensusTotal {
+    fn observe_candidate(&mut self, census: Gpt2DenseCanaryCensus, expected_lanes: usize) {
+        assert_eq!(census.lanes(), expected_lanes, "candidate lane count");
+        assert_eq!(census.conventional(), 0, "candidate conventional count");
+        assert_eq!(census.exact_control(), 0, "candidate exact-control count");
+        assert_candidate_partition(census);
+        self.calls += 1;
+        self.lanes += census.lanes();
+        self.fast += census.fast_certified();
+        self.refined += census.refined_certified();
+        self.fallback_nonfinite += census.fallback_nonfinite();
+        self.fallback_zero += census.fallback_zero();
+        self.fallback_overflow += census.fallback_overflow();
+        self.fallback_cell += census.fallback_cell();
+    }
+
+    fn fallbacks(self) -> usize {
+        self.fallback_nonfinite + self.fallback_zero + self.fallback_overflow + self.fallback_cell
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn sha256_file(path: &Path) -> String {
+    let output = Command::new("shasum")
+        .args(["-a", "256"])
+        .arg(path)
+        .output()
+        .unwrap_or_else(|error| panic!("hash {}: {error}", path.display()));
+    assert!(
+        output.status.success(),
+        "shasum failed for {}",
+        path.display()
+    );
+    String::from_utf8(output.stdout)
+        .expect("shasum output is UTF-8")
+        .split_whitespace()
+        .next()
+        .expect("shasum reports a digest")
+        .to_owned()
+}
+
+#[derive(Deserialize)]
+struct SourceManifest {
+    schema: String,
+    repository: String,
+    revision: String,
+    files: Vec<SourceManifestFile>,
+}
+
+#[derive(Deserialize)]
+struct SourceManifestFile {
+    path: String,
+    bytes: usize,
+    kappa: String,
+}
+
+fn assert_manifest_file(
+    manifest: &SourceManifest,
+    path: &str,
+    expected_bytes: usize,
+    expected_kappa: &str,
+) {
+    let file = manifest
+        .files
+        .iter()
+        .find(|file| file.path == path)
+        .unwrap_or_else(|| panic!("source manifest is missing {path}"));
+    assert_eq!(file.bytes, expected_bytes, "{path} manifest bytes");
+    assert_eq!(file.kappa, expected_kappa, "{path} manifest kappa");
+}
+
+fn bind_dense_identity(path: &Path, model: &Gpt2, contract: DenseGateContract) {
+    let root = workspace_root();
+    let canonical = path.canonicalize().expect("canonicalize GPT-2 source");
+    assert_eq!(model.attention_control_source_kappa(), GPT2_MODEL_KAPPA);
+    assert_eq!(model.attention_control_source_bytes(), GPT2_MODEL_BYTES);
+
+    let config = std::fs::read(path.join("config.json")).expect("read GPT-2 config");
+    assert_eq!(config.len(), GPT2_CONFIG_BYTES);
+    assert_eq!(
+        format!("blake3:{}", blake3::hash(&config).to_hex()),
+        GPT2_CONFIG_KAPPA
+    );
+
+    let manifest: SourceManifest = serde_json::from_slice(
+        &std::fs::read(path.join("source_manifest.json")).expect("read source manifest"),
+    )
+    .expect("parse source manifest");
+    assert_eq!(manifest.schema, "uor-r4-source-manifest/1");
+    assert_eq!(manifest.repository, GPT2_REPOSITORY);
+    assert_eq!(manifest.revision, GPT2_REVISION);
+    assert_manifest_file(
+        &manifest,
+        "model.safetensors",
+        GPT2_MODEL_BYTES,
+        GPT2_MODEL_KAPPA,
+    );
+    assert_manifest_file(
+        &manifest,
+        "config.json",
+        GPT2_CONFIG_BYTES,
+        GPT2_CONFIG_KAPPA,
+    );
+
+    let model_source_manifest =
+        std::fs::read_to_string(root.join("crates/uor-r4-model-source/Cargo.toml"))
+            .expect("read model-source Cargo.toml");
+    assert!(
+        model_source_manifest.contains(&format!("rev = \"{UOR_MATMUL_REV}\"")),
+        "model-source Cargo.toml does not pin the declared uor-matmul revision"
+    );
+    let lockfile = std::fs::read_to_string(root.join("Cargo.lock")).expect("read Cargo.lock");
+    assert!(
+        lockfile.contains(&format!("?rev={UOR_MATMUL_REV}#{UOR_MATMUL_REV}")),
+        "Cargo.lock does not resolve the declared uor-matmul revision"
+    );
+
+    let head = Command::new("git")
+        .current_dir(&root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("read dense canary HEAD");
+    assert!(head.status.success(), "git rev-parse HEAD failed");
+    let head = String::from_utf8(head.stdout).expect("git HEAD is UTF-8");
+    assert_eq!(
+        head.trim(),
+        BASE_HEAD,
+        "dense canary must run from its exact declared base"
+    );
+    let status = Command::new("git")
+        .current_dir(&root)
+        .args(["status", "--porcelain=v1", "--untracked-files=all"])
+        .output()
+        .expect("read dense canary worktree status");
+    assert!(status.status.success(), "git status --porcelain failed");
+    let status = String::from_utf8(status.stdout).expect("git status is UTF-8");
+    let mut declared_paths = Vec::new();
+    for line in status.lines() {
+        assert!(line.len() >= 4, "malformed git porcelain line: {line:?}");
+        let (code, path) = line.split_at(3);
+        match path {
+            "crates/uor-r4-model-source/src/gpt2.rs" => {
+                assert_eq!(code.trim(), "M", "gpt2.rs must be the one modified path")
+            }
+            "crates/uor-r4-model-source/tests/certified_native_dense.rs" => {
+                assert_eq!(code.trim(), "??", "dense harness must be untracked")
+            }
+            _ => panic!("undeclared dirty path invalidates dense timing identity: {line}"),
+        }
+        declared_paths.push(path);
+    }
+    declared_paths.sort_unstable();
+    assert_eq!(
+        declared_paths,
+        [
+            "crates/uor-r4-model-source/src/gpt2.rs",
+            "crates/uor-r4-model-source/tests/certified_native_dense.rs",
+        ],
+        "dense timing requires exactly the two declared candidate paths"
+    );
+
+    let toolchain = std::fs::read_to_string(root.join("rust-toolchain.toml"))
+        .expect("read pinned rust toolchain");
+    assert!(toolchain
+        .lines()
+        .any(|line| line.trim() == format!("channel = \"{PINNED_RUSTC_RELEASE}\"")));
+    let forbidden_build_overrides: Vec<(String, String)> = std::env::vars()
+        .filter(|(key, value)| {
+            !value.is_empty()
+                && (key.contains("RUSTFLAGS")
+                    || key.starts_with("CARGO_PROFILE_RELEASE_")
+                    || matches!(
+                        key.as_str(),
+                        "RUSTC"
+                            | "RUSTC_BOOTSTRAP"
+                            | "RUSTC_WRAPPER"
+                            | "RUSTC_WORKSPACE_WRAPPER"
+                            | "CARGO_BUILD_TARGET"
+                            | "CARGO_INCREMENTAL"
+                    )
+                    || (key.starts_with("CARGO_TARGET_")
+                        && (key.ends_with("_LINKER") || key.ends_with("_RUNNER"))))
+        })
+        .collect();
+    assert!(
+        forbidden_build_overrides.is_empty(),
+        "release canary forbids external codegen/release overrides: {forbidden_build_overrides:?}"
+    );
+
+    let rustc = Command::new("rustc")
+        .current_dir(&root)
+        .args(["--version", "--verbose"])
+        .output()
+        .expect("query rustc identity");
+    assert!(rustc.status.success());
+    let rustc_identity = String::from_utf8(rustc.stdout).expect("rustc identity is UTF-8");
+    let rustc_release = rustc_identity
+        .lines()
+        .find_map(|line| line.strip_prefix("release: "))
+        .expect("rustc -vV reports release");
+    let rustc_host = rustc_identity
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .expect("rustc -vV reports host");
+    assert_eq!(rustc_release, PINNED_RUSTC_RELEASE);
+    assert_eq!(rustc_host, PINNED_RUSTC_HOST);
+    assert_eq!(std::env::consts::ARCH, "aarch64");
+    assert_eq!(std::env::consts::OS, "macos");
+
+    eprintln!(
+        "CERTIFIED_DENSE_IDENTITY repository={GPT2_REPOSITORY} revision={GPT2_REVISION} model_kappa={GPT2_MODEL_KAPPA} model_bytes={GPT2_MODEL_BYTES} config_kappa={GPT2_CONFIG_KAPPA} config_bytes={GPT2_CONFIG_BYTES} source_path={} arithmetic_id={} bootstrap_algorithm_id={} base_head={BASE_HEAD} uor_matmul_rev={UOR_MATMUL_REV} arch={} os={} rustc_release={PINNED_RUSTC_RELEASE} rustc_host={PINNED_RUSTC_HOST} build_overrides=none pairs={} warmups_per_arm={} threshold={:.1} threshold_rule={}",
+        canonical.display(),
+        contract.arithmetic_id,
+        contract.bootstrap_id,
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+        contract.pairs,
+        contract.warmups_per_arm,
+        contract.threshold,
+        contract.threshold_rule,
+    );
+    for line in rustc_identity.lines() {
+        eprintln!("CERTIFIED_DENSE_RUSTC {line}");
+    }
+}
+
+fn splitmix(seed: &mut u64) -> u64 {
+    *seed = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut value = *seed;
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn moderate_finite(seed: &mut u64) -> f32 {
+    let bits = splitmix(seed);
+    let sign = ((bits >> 63) as u32) << 31;
+    let exponent = 112 + ((bits >> 32) as u32 % 31);
+    let fraction = bits as u32 & 0x007f_ffff;
+    f32::from_bits(sign | (exponent << 23) | fraction)
+}
+
+fn assert_candidate_partition(part: Gpt2DenseCanaryCensus) {
+    // The public census intentionally exposes no mutable raw counters. These
+    // totals are only the observations needed by this differential harness.
+    assert_eq!(
+        part.fast_certified()
+            + part.refined_certified()
+            + part.fallbacks().expect("fallback count fits usize"),
+        part.lanes(),
+        "candidate verdicts partition the output lanes"
+    );
+}
+
+fn assert_state_bits(got: &Gpt2State, expected: &Gpt2State, context: &str) {
+    assert!(
+        got.dense_control_bit_identical(expected),
+        "{context}: recurrent state differs bit-for-bit"
+    );
+}
+
+fn assert_mode_census(
+    census: Gpt2DenseCanaryCensus,
+    expected_lanes: usize,
+    mode: Gpt2DenseCanaryMode,
+) {
+    match mode {
+        Gpt2DenseCanaryMode::Conventional => assert_conventional_census(census, expected_lanes),
+        Gpt2DenseCanaryMode::Exact => assert_exact_control_census(census, expected_lanes),
+        Gpt2DenseCanaryMode::CertifiedNative => {
+            assert_eq!(census.lanes(), expected_lanes);
+            assert_eq!(census.conventional(), 0);
+            assert_eq!(census.exact_control(), 0);
+            assert_candidate_partition(census);
+        }
+    }
+}
+
+fn assert_whole_census(
+    census: Gpt2DenseControlCensus<'_>,
+    model: &Gpt2,
+    batch: usize,
+    row_reuse_rows: usize,
+    mode: Gpt2DenseCanaryMode,
+) -> DenseCensusTotal {
+    assert_whole_census_parts(
+        census.layers(),
+        census.lm_head(),
+        model,
+        batch,
+        row_reuse_rows,
+        mode,
+    )
+}
+
+fn assert_whole_census_parts(
+    layers: &[Gpt2DenseLayerCensus],
+    lm_head: Gpt2DenseCanaryCensus,
+    model: &Gpt2,
+    batch: usize,
+    row_reuse_rows: usize,
+    mode: Gpt2DenseCanaryMode,
+) -> DenseCensusTotal {
+    assert_eq!(layers.len(), model.cfg.n_layer);
+    let expected = [
+        3 * model.cfg.n_embd,
+        model.cfg.n_embd,
+        model.cfg.n_inner,
+        model.cfg.n_embd,
+    ];
+    let mut candidate = DenseCensusTotal::default();
+    for layer in layers {
+        for (part, lanes) in [
+            (layer.c_attn(), expected[0]),
+            (layer.attention_c_proj(), expected[1]),
+            (layer.mlp_c_fc(), expected[2]),
+            (layer.mlp_c_proj(), expected[3]),
+        ] {
+            let lanes = batch * lanes;
+            assert_eq!(part.batch_rows(), row_reuse_rows);
+            assert_mode_census(part, lanes, mode);
+            if mode == Gpt2DenseCanaryMode::CertifiedNative {
+                candidate.observe_candidate(part, lanes);
+            }
+        }
+    }
+    let head_lanes = batch * model.cfg.vocab;
+    assert_eq!(lm_head.batch_rows(), row_reuse_rows);
+    assert_mode_census(lm_head, head_lanes, mode);
+    if mode == Gpt2DenseCanaryMode::CertifiedNative {
+        candidate.observe_candidate(lm_head, head_lanes);
+    }
+    candidate
+}
+
+#[test]
+fn checked_dense_canary_matches_exact_on_adversarial_and_random_inputs() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let d = model.cfg.n_embd;
+    let out_dim = 3 * d;
+    let mut workspace = model
+        .dense_canary_workspace()
+        .expect("valid model admits dense scratch");
+    let mut exact = vec![0.0f32; out_dim];
+    let mut candidate = vec![0.0f32; out_dim];
+    let mut input = vec![0.0f32; d];
+    let mut observed_fast = 0usize;
+    let mut observed_refined = 0usize;
+
+    model
+        .layer0_c_attn_canary_input(3, 2, &mut input)
+        .expect("real fixture activation extent is valid");
+    for case in 0..96 {
+        if case != 0 {
+            let mut seed = 0x704d_e15e_0000_0000u64 ^ case as u64;
+            for value in &mut input {
+                *value = moderate_finite(&mut seed);
+            }
+        }
+        let exact_census = model
+            .layer0_c_attn_canary(
+                &input,
+                &mut exact,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("checked exact control");
+        assert_eq!(exact_census.exact_control(), out_dim);
+        let census = model
+            .layer0_c_attn_canary(
+                &input,
+                &mut candidate,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("checked certified candidate");
+        assert_bits(&candidate, &exact, &format!("finite case {case}"));
+        assert_candidate_partition(census);
+        observed_fast += census.fast_certified();
+        observed_refined += census.refined_certified();
+    }
+    assert!(
+        observed_fast > 0,
+        "random corpus never certified a fast lane"
+    );
+    eprintln!("DENSE_RANDOM_CENSUS fast={observed_fast} refined={observed_refined}");
+
+    // Exact cancellation is deliberately delegated, including signed-zero
+    // selection, and the single f32 bias epilogue must still match exactly.
+    input.fill(0.0);
+    model
+        .layer0_c_attn_canary(
+            &input,
+            &mut exact,
+            &mut workspace,
+            Gpt2DenseCanaryMode::Exact,
+        )
+        .expect("zero exact control");
+    let zero = model
+        .layer0_c_attn_canary(
+            &input,
+            &mut candidate,
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .expect("zero certified candidate");
+    assert_bits(&candidate, &exact, "zero fallback");
+    assert_eq!(zero.fallback_zero(), out_dim);
+}
+
+#[test]
+fn checked_dense_canary_is_failure_atomic_and_allocation_free() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let other = Gpt2::load(fixture_dir(), None).expect("load independent fixture model");
+    let d = model.cfg.n_embd;
+    let out_dim = 3 * d;
+    let input = vec![0.25f32; d];
+    let mut output = vec![f32::from_bits(0x7fc0_704d); out_dim];
+    let mut workspace = model
+        .dense_canary_workspace()
+        .expect("valid model admits dense scratch");
+
+    let output_before = output.clone();
+    let workspace_before = workspace.clone();
+    assert_eq!(
+        other.layer0_c_attn_canary(
+            &input,
+            &mut output,
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        ),
+        None,
+        "workspace from another model must be rejected"
+    );
+    assert_bits(
+        &output,
+        &output_before,
+        "foreign-workspace failure atomicity",
+    );
+    assert_eq!(workspace, workspace_before);
+
+    let mut untouched_output = output_before.clone();
+    let workspace_before = workspace.clone();
+    assert_eq!(
+        model.layer0_c_attn_canary(
+            &input[..d - 1],
+            &mut untouched_output,
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        ),
+        None
+    );
+    assert_bits(
+        &untouched_output,
+        &output_before,
+        "short-input failure atomicity",
+    );
+    assert_eq!(workspace, workspace_before);
+
+    let mut short_output = vec![0.0f32; out_dim - 1];
+    let short_before = short_output.clone();
+    let workspace_before = workspace.clone();
+    assert_eq!(
+        model.layer0_c_attn_canary(
+            &input,
+            &mut short_output,
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        ),
+        None
+    );
+    assert_eq!(short_output, short_before);
+    assert_eq!(workspace, workspace_before);
+
+    let (census, allocations) = counted_allocations(|| {
+        model
+            .layer0_c_attn_canary(
+                &input,
+                &mut output,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("valid checked candidate")
+    });
+    assert_eq!(allocations, 0, "dense candidate hot call allocated");
+    assert_eq!(
+        census.fast_certified()
+            + census.refined_certified()
+            + census.fallbacks().expect("fallback count fits usize"),
+        out_dim
+    );
+
+    let zero_input = vec![0.0f32; d];
+    let (fallback_census, fallback_allocations) = counted_allocations(|| {
+        model
+            .layer0_c_attn_canary(
+                &zero_input,
+                &mut output,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("valid checked exact-fallback candidate")
+    });
+    assert_eq!(
+        fallback_allocations, 0,
+        "dense exact-fallback hot call allocated"
+    );
+    assert_eq!(fallback_census.fallback_zero(), out_dim);
+}
+
+#[test]
+fn public_nonfinite_dense_inputs_use_bit_exact_allocation_free_fallback() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let d = model.cfg.n_embd;
+    let out_dim = 3 * d;
+    let mut workspace = model
+        .dense_canary_workspace()
+        .expect("valid model admits dense scratch");
+    let mut exact = vec![0.0f32; out_dim];
+    let mut candidate = vec![0.0f32; out_dim];
+
+    for (case, nonfinite) in [
+        ("quiet NaN", f32::from_bits(0x7fc0_0704)),
+        ("positive infinity", f32::INFINITY),
+        ("negative infinity", f32::NEG_INFINITY),
+    ] {
+        let mut input = vec![0.25f32; d];
+        input[d / 2] = nonfinite;
+        let input_before: Vec<u32> = input.iter().map(|value| value.to_bits()).collect();
+        poison_output(&mut exact);
+        model
+            .layer0_c_attn_canary(
+                &input,
+                &mut exact,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("checked pinned exact nonfinite control");
+        assert_output_overwritten(&exact, &format!("{case} exact control"));
+
+        poison_output(&mut candidate);
+        let (census, allocations) = counted_allocations(|| {
+            model
+                .layer0_c_attn_canary(
+                    &input,
+                    &mut candidate,
+                    &mut workspace,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .expect("checked nonfinite candidate")
+        });
+        assert_eq!(allocations, 0, "{case} exact fallback allocated");
+        assert_output_overwritten(&candidate, &format!("{case} candidate"));
+        assert_bits(&candidate, &exact, &format!("{case} pinned fallback"));
+        assert_eq!(census.lanes(), out_dim);
+        assert_eq!(census.fast_certified(), 0);
+        assert_eq!(census.refined_certified(), 0);
+        assert_eq!(census.fallback_nonfinite(), out_dim);
+        assert_eq!(census.fallback_zero(), 0);
+        assert_eq!(census.fallback_overflow(), 0);
+        assert_eq!(census.fallback_cell(), 0);
+        assert_eq!(
+            input
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            input_before,
+            "{case} mutated caller input"
+        );
+    }
+}
+
+#[test]
+fn every_dense_owner_shape_matches_exact_for_random_zero_and_nonfinite_inputs() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let mut workspace = model
+        .dense_control_workspace()
+        .expect("prepare whole-model dense workspace");
+    let d = model.cfg.n_embd;
+    let mut observed_fast = 0usize;
+    let mut seed = 0x704d_5eed_0000_0001u64;
+
+    for layer in 0..model.cfg.n_layer {
+        for (site, in_dim, out_dim) in [
+            (Gpt2DenseControlSite::CAttn, d, 3 * d),
+            (Gpt2DenseControlSite::AttentionCProj, d, d),
+            (Gpt2DenseControlSite::MlpCFc, d, model.cfg.n_inner),
+            (Gpt2DenseControlSite::MlpCProj, model.cfg.n_inner, d),
+        ] {
+            let mut input = vec![0.0f32; in_dim];
+            for value in &mut input {
+                *value = moderate_finite(&mut seed);
+            }
+            let input_before: Vec<u32> = input.iter().map(|value| value.to_bits()).collect();
+            let mut exact = vec![0.0f32; out_dim];
+            let mut candidate = vec![0.0f32; out_dim];
+            model
+                .dense_control_matrix_canary(
+                    &mut workspace,
+                    Some(layer),
+                    site,
+                    &input,
+                    &mut exact,
+                    Gpt2DenseCanaryMode::Exact,
+                )
+                .expect("valid exact matrix control");
+            poison_output(&mut candidate);
+            let (census, allocations) = counted_allocations(|| {
+                model
+                    .dense_control_matrix_canary(
+                        &mut workspace,
+                        Some(layer),
+                        site,
+                        &input,
+                        &mut candidate,
+                        Gpt2DenseCanaryMode::CertifiedNative,
+                    )
+                    .expect("valid candidate matrix control")
+            });
+            assert_eq!(allocations, 0, "{site:?} candidate allocated");
+            assert_output_overwritten(&candidate, &format!("{site:?} random"));
+            assert_bits(&candidate, &exact, &format!("layer {layer} {site:?}"));
+            assert_candidate_partition(census);
+            observed_fast += census.fast_certified();
+            assert_eq!(
+                input
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                input_before,
+                "{site:?} mutated its input"
+            );
+
+            input.fill(0.0);
+            model
+                .dense_control_matrix_canary(
+                    &mut workspace,
+                    Some(layer),
+                    site,
+                    &input,
+                    &mut exact,
+                    Gpt2DenseCanaryMode::Exact,
+                )
+                .expect("zero exact matrix control");
+            let zero = model
+                .dense_control_matrix_canary(
+                    &mut workspace,
+                    Some(layer),
+                    site,
+                    &input,
+                    &mut candidate,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .expect("zero candidate matrix control");
+            assert_bits(&candidate, &exact, &format!("layer {layer} {site:?} zero"));
+            assert_eq!(zero.fallback_zero(), out_dim);
+
+            input.fill(0.25);
+            input[in_dim / 2] = f32::from_bits(0x7fc0_704d);
+            let input_before: Vec<u32> = input.iter().map(|value| value.to_bits()).collect();
+            poison_output(&mut exact);
+            model
+                .dense_control_matrix_canary(
+                    &mut workspace,
+                    Some(layer),
+                    site,
+                    &input,
+                    &mut exact,
+                    Gpt2DenseCanaryMode::Exact,
+                )
+                .expect("nonfinite exact matrix control");
+            assert_output_overwritten(&exact, "nonfinite exact matrix output");
+            poison_output(&mut candidate);
+            let (nonfinite, allocations) = counted_allocations(|| {
+                model
+                    .dense_control_matrix_canary(
+                        &mut workspace,
+                        Some(layer),
+                        site,
+                        &input,
+                        &mut candidate,
+                        Gpt2DenseCanaryMode::CertifiedNative,
+                    )
+                    .expect("nonfinite candidate matrix control")
+            });
+            assert_eq!(allocations, 0, "{site:?} nonfinite fallback allocated");
+            assert_output_overwritten(&candidate, "nonfinite candidate matrix output");
+            assert_bits(
+                &candidate,
+                &exact,
+                &format!("layer {layer} {site:?} nonfinite"),
+            );
+            assert_eq!(nonfinite.fallback_nonfinite(), out_dim);
+            assert_eq!(
+                input
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                input_before,
+                "{site:?} nonfinite fallback mutated its input"
+            );
+        }
+    }
+
+    for case in 0..3 {
+        let mut input = vec![0.0f32; d];
+        for value in &mut input {
+            *value = moderate_finite(&mut seed);
+        }
+        if case == 1 {
+            input.fill(0.0);
+        } else if case == 2 {
+            input[d / 2] = f32::NEG_INFINITY;
+        }
+        let input_before: Vec<u32> = input.iter().map(|value| value.to_bits()).collect();
+        let mut exact = vec![0.0f32; model.cfg.vocab];
+        let mut candidate = vec![0.0f32; model.cfg.vocab];
+        poison_output(&mut exact);
+        model
+            .dense_control_matrix_canary(
+                &mut workspace,
+                None,
+                Gpt2DenseControlSite::LmHead,
+                &input,
+                &mut exact,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("valid exact lm-head control");
+        assert_output_overwritten(&exact, "exact lm-head output");
+        poison_output(&mut candidate);
+        let (census, allocations) = counted_allocations(|| {
+            model
+                .dense_control_matrix_canary(
+                    &mut workspace,
+                    None,
+                    Gpt2DenseControlSite::LmHead,
+                    &input,
+                    &mut candidate,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .expect("valid candidate lm-head control")
+        });
+        assert_eq!(allocations, 0, "lm-head case {case} allocated");
+        assert_output_overwritten(&candidate, "candidate lm-head output");
+        assert_bits(&candidate, &exact, &format!("lm-head case {case}"));
+        assert_candidate_partition(census);
+        observed_fast += census.fast_certified();
+        if case == 1 {
+            assert_eq!(census.fallback_zero(), model.cfg.vocab);
+        }
+        if case == 2 {
+            assert_eq!(census.fallback_nonfinite(), model.cfg.vocab);
+        }
+        assert_eq!(
+            input
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            input_before,
+            "lm-head case {case} mutated its input"
+        );
+    }
+    assert!(
+        observed_fast > 0,
+        "matrix sweep never certified a fast lane"
+    );
+}
+
+#[test]
+fn production_dense_is_recurrently_exact_and_allocation_free() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let mut conventional_state = Gpt2State::new(&model.cfg);
+    let mut production_state = Gpt2State::new(&model.cfg);
+    let mut exact_state = Gpt2State::new(&model.cfg);
+    let mut candidate_state = Gpt2State::new(&model.cfg);
+    let mut conventional_workspace = model
+        .dense_control_workspace()
+        .expect("prepare conventional workspace");
+    let mut exact_workspace = model
+        .dense_control_workspace()
+        .expect("prepare exact workspace");
+    let mut candidate_workspace = model
+        .dense_control_workspace()
+        .expect("prepare candidate workspace");
+
+    let bytes = model
+        .dense_control_workspace_bytes(&candidate_workspace)
+        .expect("workspace byte census");
+    assert_eq!(bytes.lm_head_transpose(), 32 * 24 * 4);
+    assert_eq!(bytes.matrix_bounds(), 600 * 8);
+    assert_eq!(bytes.f64_sum_scratch(), (600 + 128 + 1) * 8);
+    assert_eq!(bytes.intermediate_scratch(), (368 + 376) * 4);
+    assert!(bytes.metadata() > 0);
+    assert_eq!(
+        bytes.total(),
+        bytes.lm_head_transpose()
+            + bytes.matrix_bounds()
+            + bytes.f64_sum_scratch()
+            + bytes.intermediate_scratch()
+            + bytes.metadata()
+    );
+
+    let mut aggregate = DenseCensusTotal::default();
+    for (position, token) in [1usize, 3, 2].into_iter().enumerate() {
+        model.forward(&mut production_state, token, position, &[], &mut |_, _| {});
+        let conventional = model
+            .forward_dense_control(
+                &mut conventional_state,
+                &mut conventional_workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::Conventional,
+            )
+            .expect("valid conventional whole step");
+        assert_whole_census(
+            conventional,
+            &model,
+            1,
+            0,
+            Gpt2DenseCanaryMode::Conventional,
+        );
+        exact_state.logits.fill(f32::from_bits(OUTPUT_POISON_BITS));
+        exact_state.hidden.fill(f32::from_bits(OUTPUT_POISON_BITS));
+        candidate_state
+            .logits
+            .fill(f32::from_bits(OUTPUT_POISON_BITS));
+        candidate_state
+            .hidden
+            .fill(f32::from_bits(OUTPUT_POISON_BITS));
+        let exact = model
+            .forward_dense_control(
+                &mut exact_state,
+                &mut exact_workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("valid exact whole step");
+        assert_whole_census(exact, &model, 1, 0, Gpt2DenseCanaryMode::Exact);
+        let candidate = model
+            .forward_dense_control(
+                &mut candidate_state,
+                &mut candidate_workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("valid candidate whole step");
+        let observed = assert_whole_census(
+            candidate,
+            &model,
+            1,
+            0,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        );
+        aggregate.calls += observed.calls;
+        aggregate.lanes += observed.lanes;
+        aggregate.fast += observed.fast;
+        aggregate.refined += observed.refined;
+        aggregate.fallback_nonfinite += observed.fallback_nonfinite;
+        aggregate.fallback_zero += observed.fallback_zero;
+        aggregate.fallback_overflow += observed.fallback_overflow;
+        aggregate.fallback_cell += observed.fallback_cell;
+        assert_output_overwritten(&candidate_state.logits, "whole candidate logits");
+        assert_output_overwritten(&candidate_state.hidden, "whole candidate hidden");
+        assert_state_bits(
+            &candidate_state,
+            &exact_state,
+            &format!("candidate/exact position {position}"),
+        );
+        assert_state_bits(
+            &production_state,
+            &exact_state,
+            &format!("production/exact position {position}"),
+        );
+    }
+    assert_eq!(aggregate.calls, 3 * (4 * model.cfg.n_layer + 1));
+    assert_eq!(aggregate.lanes, 3 * 600);
+    assert!(
+        aggregate.fast > 0,
+        "whole candidate never certified a fast lane"
+    );
+
+    let position = 3;
+    let token = 4;
+    exact_state.logits.fill(f32::from_bits(OUTPUT_POISON_BITS));
+    candidate_state
+        .logits
+        .fill(f32::from_bits(OUTPUT_POISON_BITS));
+    production_state
+        .logits
+        .fill(f32::from_bits(OUTPUT_POISON_BITS));
+    let (_, production_allocations) = counted_allocations(|| {
+        model.forward(&mut production_state, token, position, &[], &mut |_, _| {});
+    });
+    assert_eq!(production_allocations, 0, "production dense step allocated");
+    let (_, exact_allocations) = counted_allocations(|| {
+        let census = model
+            .forward_dense_control(
+                &mut exact_state,
+                &mut exact_workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("allocation-counted exact whole step");
+        assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::Exact);
+    });
+    assert_eq!(exact_allocations, 0, "exact whole hot step allocated");
+    let (_, candidate_allocations) = counted_allocations(|| {
+        let census = model
+            .forward_dense_control(
+                &mut candidate_state,
+                &mut candidate_workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("allocation-counted candidate whole step");
+        assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::CertifiedNative);
+    });
+    assert_eq!(
+        candidate_allocations, 0,
+        "candidate whole hot step allocated"
+    );
+    assert_state_bits(
+        &candidate_state,
+        &exact_state,
+        "allocation-counted whole step",
+    );
+    assert_state_bits(
+        &production_state,
+        &exact_state,
+        "allocation-counted production/exact step",
+    );
+    assert_eq!(
+        model
+            .dense_control_workspace_bytes(&candidate_workspace)
+            .expect("post-run workspace byte census"),
+        bytes,
+        "hot calls changed prepared workspace capacities"
+    );
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TraceBits {
+    residual: Vec<(usize, Vec<u32>)>,
+    qkv: Vec<QkvTraceBits>,
+    attention: Vec<(usize, usize, Vec<u32>)>,
+}
+
+type QkvTraceBits = (usize, Vec<u32>, Vec<u32>, Vec<u32>);
+
+fn bits(values: &[f32]) -> Vec<u32> {
+    values.iter().map(|value| value.to_bits()).collect()
+}
+
+fn capture_production_trace(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    token: usize,
+    position: usize,
+) -> TraceBits {
+    let residual_layers = [0usize, 1];
+    let qkv_layers = [0usize, 1];
+    let attention_layers = [0usize, 1];
+    let request = TraceCaptureRequest {
+        residual_layers: &residual_layers,
+        qkv_layers: &qkv_layers,
+        attention_layers: &attention_layers,
+    };
+    let mut trace = TraceBits::default();
+    {
+        let mut residual = |layer: usize, values: &[f32]| {
+            trace.residual.push((layer, bits(values)));
+        };
+        let mut qkv = |layer: usize, q: &[f32], k: &[f32], v: &[f32]| {
+            trace.qkv.push((layer, bits(q), bits(k), bits(v)));
+        };
+        let mut attention = |layer: usize, head: usize, values: &[f32]| {
+            trace.attention.push((layer, head, bits(values)));
+        };
+        let mut sinks = TraceCaptureSinks {
+            residual: &mut residual,
+            qkv: &mut qkv,
+            attention: &mut attention,
+        };
+        model.forward_capturing_trace(state, token, position, &request, &mut sinks);
+    }
+    trace
+}
+
+fn capture_dense_trace(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    workspace: &mut uor_r4_model_source::gpt2::Gpt2DenseControlWorkspace,
+    token: usize,
+    position: usize,
+    mode: Gpt2DenseCanaryMode,
+) -> TraceBits {
+    let residual_layers = [0usize, 1];
+    let qkv_layers = [0usize, 1];
+    let attention_layers = [0usize, 1];
+    let request = TraceCaptureRequest {
+        residual_layers: &residual_layers,
+        qkv_layers: &qkv_layers,
+        attention_layers: &attention_layers,
+    };
+    let mut trace = TraceBits::default();
+    {
+        let mut residual = |layer: usize, values: &[f32]| {
+            trace.residual.push((layer, bits(values)));
+        };
+        let mut qkv = |layer: usize, q: &[f32], k: &[f32], v: &[f32]| {
+            trace.qkv.push((layer, bits(q), bits(k), bits(v)));
+        };
+        let mut attention = |layer: usize, head: usize, values: &[f32]| {
+            trace.attention.push((layer, head, bits(values)));
+        };
+        let mut sinks = TraceCaptureSinks {
+            residual: &mut residual,
+            qkv: &mut qkv,
+            attention: &mut attention,
+        };
+        let census = model
+            .forward_dense_control_capturing_trace(
+                state, workspace, token, position, mode, &request, &mut sinks,
+            )
+            .expect("valid traced dense-control step");
+        assert_whole_census(census, model, 1, 0, mode);
+    }
+    trace
+}
+
+#[test]
+fn dense_trace_uses_the_same_owner_and_preserves_every_tap_bit() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let mut production_state = Gpt2State::new(&model.cfg);
+    let mut conventional_state = Gpt2State::new(&model.cfg);
+    let mut exact_state = Gpt2State::new(&model.cfg);
+    let mut candidate_state = Gpt2State::new(&model.cfg);
+    let mut plain_candidate_state = Gpt2State::new(&model.cfg);
+    let mut conventional_workspace = model.dense_control_workspace().expect("workspace");
+    let mut exact_workspace = model.dense_control_workspace().expect("workspace");
+    let mut candidate_workspace = model.dense_control_workspace().expect("workspace");
+    let mut plain_workspace = model.dense_control_workspace().expect("workspace");
+
+    let production = capture_production_trace(&model, &mut production_state, 3, 0);
+    let conventional = capture_dense_trace(
+        &model,
+        &mut conventional_state,
+        &mut conventional_workspace,
+        3,
+        0,
+        Gpt2DenseCanaryMode::Conventional,
+    );
+    assert_ne!(
+        conventional, production,
+        "conventional dense unexpectedly equals v2"
+    );
+
+    let exact = capture_dense_trace(
+        &model,
+        &mut exact_state,
+        &mut exact_workspace,
+        3,
+        0,
+        Gpt2DenseCanaryMode::Exact,
+    );
+    let candidate = capture_dense_trace(
+        &model,
+        &mut candidate_state,
+        &mut candidate_workspace,
+        3,
+        0,
+        Gpt2DenseCanaryMode::CertifiedNative,
+    );
+    assert_eq!(candidate, exact);
+    assert_state_bits(&candidate_state, &exact_state, "traced candidate/exact");
+    assert_eq!(candidate, production);
+    assert_state_bits(
+        &candidate_state,
+        &production_state,
+        "traced candidate/production",
+    );
+
+    let census = model
+        .forward_dense_control(
+            &mut plain_candidate_state,
+            &mut plain_workspace,
+            3,
+            0,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .expect("plain candidate step");
+    assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::CertifiedNative);
+    assert_state_bits(
+        &plain_candidate_state,
+        &candidate_state,
+        "trace/plain candidate",
+    );
+
+    let mut allocation_state = Gpt2State::new(&model.cfg);
+    let residual_layers = [0usize, 1];
+    let qkv_layers = [0usize, 1];
+    let attention_layers = [0usize, 1];
+    let request = TraceCaptureRequest {
+        residual_layers: &residual_layers,
+        qkv_layers: &qkv_layers,
+        attention_layers: &attention_layers,
+    };
+    let mut residual = |_: usize, _: &[f32]| {};
+    let mut qkv = |_: usize, _: &[f32], _: &[f32], _: &[f32]| {};
+    let mut attention = |_: usize, _: usize, _: &[f32]| {};
+    let mut sinks = TraceCaptureSinks {
+        residual: &mut residual,
+        qkv: &mut qkv,
+        attention: &mut attention,
+    };
+    let (_, allocations) = counted_allocations(|| {
+        model.forward_capturing_trace(&mut allocation_state, 3, 0, &request, &mut sinks);
+    });
+    assert_eq!(allocations, 0, "production trace hot step allocated");
+}
+
+#[test]
+fn production_dense_model_is_shareable_and_state_scratch_is_independent() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Gpt2>();
+    assert_send_sync::<Gpt2State>();
+
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let mut first = Gpt2State::new(&model.cfg);
+    let second = Gpt2State::new(&model.cfg);
+    let second_before = second.clone();
+    model.forward(&mut first, 1, 0, &[], &mut |_, _| {});
+    assert_eq!(
+        second, second_before,
+        "one state mutated another state scratch"
+    );
+}
+
+#[test]
+fn production_dense_validation_is_failure_atomic() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+
+    let mut malformed = Gpt2State::new(&model.cfg);
+    malformed.logits.pop();
+    let malformed_before = malformed.clone();
+    model.forward(&mut malformed, 1, 0, &[], &mut |_, _| {});
+    assert_eq!(malformed, malformed_before);
+
+    let mut bad_token = Gpt2State::new(&model.cfg);
+    let bad_token_before = bad_token.clone();
+    let mut sink_hits = 0usize;
+    model.forward(&mut bad_token, model.cfg.vocab, 0, &[0], &mut |_, _| {
+        sink_hits += 1
+    });
+    assert_eq!(bad_token, bad_token_before);
+    assert_eq!(sink_hits, 0);
+
+    let mut traced = Gpt2State::new(&model.cfg);
+    let traced_before = traced.clone();
+    let invalid_layer = [model.cfg.n_layer];
+    let request = TraceCaptureRequest {
+        residual_layers: &invalid_layer,
+        qkv_layers: &[],
+        attention_layers: &[],
+    };
+    let mut residual_hits = 0usize;
+    {
+        let mut residual = |_: usize, _: &[f32]| residual_hits += 1;
+        let mut qkv = |_: usize, _: &[f32], _: &[f32], _: &[f32]| {};
+        let mut attention = |_: usize, _: usize, _: &[f32]| {};
+        let mut sinks = TraceCaptureSinks {
+            residual: &mut residual,
+            qkv: &mut qkv,
+            attention: &mut attention,
+        };
+        model.forward_capturing_trace(&mut traced, 1, 0, &request, &mut sinks);
+    }
+    assert_eq!(traced, traced_before);
+    assert_eq!(residual_hits, 0);
+
+    let mut states = vec![Gpt2State::new(&model.cfg); 3];
+    states[2].logits.pop();
+    let states_before = states.clone();
+    model.forward_batch(&mut states, &[1, 2, 3], &[0, 0, 0]);
+    assert_eq!(states, states_before);
+
+    let mut states = vec![Gpt2State::new(&model.cfg); 3];
+    let states_before = states.clone();
+    model.forward_batch(&mut states, &[1, 2, model.cfg.vocab], &[0, 0, 0]);
+    assert_eq!(states, states_before);
+    model.forward_batch(&mut states, &[1, 2], &[0, 0, 0]);
+    assert_eq!(states, states_before);
+}
+
+fn prefill_dense_states(
+    model: &Gpt2,
+    histories: &[&[usize]],
+    mode: Gpt2DenseCanaryMode,
+) -> Vec<Gpt2State> {
+    let mut states = vec![Gpt2State::new(&model.cfg); histories.len()];
+    let mut workspace = model.dense_control_workspace().expect("serial workspace");
+    for (state, history) in states.iter_mut().zip(histories) {
+        for (position, &token) in history.iter().enumerate() {
+            let census = model
+                .forward_dense_control(state, &mut workspace, token, position, mode)
+                .expect("valid dense prefill step");
+            assert_whole_census(census, model, 1, 0, mode);
+        }
+    }
+    states
+}
+
+fn prefill_production_states(model: &Gpt2, histories: &[&[usize]]) -> Vec<Gpt2State> {
+    let mut states = vec![Gpt2State::new(&model.cfg); histories.len()];
+    for (state, history) in states.iter_mut().zip(histories) {
+        for (position, &token) in history.iter().enumerate() {
+            model.forward(state, token, position, &[], &mut |_, _| {});
+        }
+    }
+    states
+}
+
+#[test]
+fn row_reuse_batch_control_matches_serial_for_all_modes_and_divergent_positions() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let histories: [&[usize]; 3] = [&[1], &[2, 3], &[4, 5, 6]];
+    let tokens = [7usize, 8, 9];
+    let positions = [1usize, 2, 3];
+
+    for mode in [
+        Gpt2DenseCanaryMode::Conventional,
+        Gpt2DenseCanaryMode::Exact,
+        Gpt2DenseCanaryMode::CertifiedNative,
+    ] {
+        let base = prefill_dense_states(&model, &histories, mode);
+        let mut serial = base.clone();
+        let mut batched = base;
+        let mut serial_workspace = model.dense_control_workspace().expect("serial workspace");
+        let mut batch_workspace = model
+            .dense_control_workspace_for_batch(3)
+            .expect("three-row workspace");
+        for state_index in 0..serial.len() {
+            let census = model
+                .forward_dense_control(
+                    &mut serial[state_index],
+                    &mut serial_workspace,
+                    tokens[state_index],
+                    positions[state_index],
+                    mode,
+                )
+                .expect("valid serial reference step");
+            assert_whole_census(census, &model, 1, 0, mode);
+        }
+        let (_, allocations) = counted_allocations(|| {
+            let census = model
+                .forward_batch_dense_control(
+                    &mut batched,
+                    &tokens,
+                    &positions,
+                    &mut batch_workspace,
+                    mode,
+                )
+                .expect("valid row-reuse batch step");
+            assert_whole_census(census, &model, 3, 3, mode);
+        });
+        assert_eq!(allocations, 0, "{mode:?} row-reuse batch allocated");
+        for state_index in 0..serial.len() {
+            assert_state_bits(
+                &batched[state_index],
+                &serial[state_index],
+                &format!("{mode:?} batch/serial state {state_index}"),
+            );
+        }
+    }
+
+    let lockstep_histories: [&[usize]; 3] = [&[10], &[11], &[12]];
+    let lockstep_tokens = [13usize, 14, 15];
+    let lockstep_positions = [1usize, 1, 1];
+    for mode in [
+        Gpt2DenseCanaryMode::Conventional,
+        Gpt2DenseCanaryMode::Exact,
+        Gpt2DenseCanaryMode::CertifiedNative,
+    ] {
+        let base = prefill_dense_states(&model, &lockstep_histories, mode);
+        let mut serial = base.clone();
+        let mut batched = base;
+        let mut serial_workspace = model.dense_control_workspace().expect("serial workspace");
+        let mut batch_workspace = model
+            .dense_control_workspace_for_batch(3)
+            .expect("lockstep row-reuse workspace");
+        for state_index in 0..serial.len() {
+            let census = model
+                .forward_dense_control(
+                    &mut serial[state_index],
+                    &mut serial_workspace,
+                    lockstep_tokens[state_index],
+                    lockstep_positions[state_index],
+                    mode,
+                )
+                .expect("valid lockstep serial step");
+            assert_whole_census(census, &model, 1, 0, mode);
+        }
+        let census = model
+            .forward_batch_dense_control(
+                &mut batched,
+                &lockstep_tokens,
+                &lockstep_positions,
+                &mut batch_workspace,
+                mode,
+            )
+            .expect("valid lockstep row-reuse batch step");
+        assert_whole_census(census, &model, 3, 3, mode);
+        for state_index in 0..serial.len() {
+            assert_state_bits(
+                &batched[state_index],
+                &serial[state_index],
+                &format!("{mode:?} lockstep batch/serial state {state_index}"),
+            );
+        }
+        if mode == Gpt2DenseCanaryMode::CertifiedNative {
+            let mut production = prefill_production_states(&model, &lockstep_histories);
+            let (_, allocations) = counted_allocations(|| {
+                model.forward_batch(&mut production, &lockstep_tokens, &lockstep_positions);
+            });
+            assert_eq!(allocations, 0, "production lockstep batch allocated");
+            for state_index in 0..production.len() {
+                assert_state_bits(
+                    &batched[state_index],
+                    &production[state_index],
+                    &format!("candidate/production lockstep state {state_index}"),
+                );
+            }
+        }
+    }
+
+    let mut production = prefill_production_states(&model, &histories);
+    let mut exact = prefill_dense_states(&model, &histories, Gpt2DenseCanaryMode::Exact);
+    for state_index in 0..production.len() {
+        assert_state_bits(
+            &exact[state_index],
+            &production[state_index],
+            &format!("exact/production prefill {state_index}"),
+        );
+    }
+    let (_, production_allocations) = counted_allocations(|| {
+        model.forward_batch(&mut production, &tokens, &positions);
+    });
+    assert_eq!(
+        production_allocations, 0,
+        "production divergent batch allocated"
+    );
+    let mut workspace = model
+        .dense_control_workspace_for_batch(3)
+        .expect("three-row exact workspace");
+    let census = model
+        .forward_batch_dense_control(
+            &mut exact,
+            &tokens,
+            &positions,
+            &mut workspace,
+            Gpt2DenseCanaryMode::Exact,
+        )
+        .expect("valid exact batch control");
+    assert_whole_census(census, &model, 3, 3, Gpt2DenseCanaryMode::Exact);
+    for state_index in 0..production.len() {
+        assert_state_bits(
+            &exact[state_index],
+            &production[state_index],
+            &format!("exact/production batch {state_index}"),
+        );
+    }
+}
+
+#[test]
+fn whole_dense_checked_facades_are_failure_atomic() {
+    let model = Gpt2::load(fixture_dir(), None).expect("load tiny GPT-2 fixture");
+    let other = Gpt2::load(fixture_dir(), None).expect("load independent fixture model");
+    let mut state = Gpt2State::new(&model.cfg);
+    let state_before = state.clone();
+    let mut foreign_workspace = other.dense_control_workspace().expect("foreign workspace");
+    let workspace_before = other
+        .dense_control_workspace_fingerprint(&foreign_workspace)
+        .expect("foreign workspace fingerprint");
+    assert!(model
+        .forward_dense_control(
+            &mut state,
+            &mut foreign_workspace,
+            1,
+            0,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .is_none());
+    assert_state_bits(&state, &state_before, "foreign-workspace state");
+    assert_eq!(
+        other
+            .dense_control_workspace_fingerprint(&foreign_workspace)
+            .expect("post-rejection foreign workspace fingerprint"),
+        workspace_before
+    );
+
+    let mut workspace = model
+        .dense_control_workspace_for_batch(3)
+        .expect("three-row workspace");
+    for (token, position) in [(model.cfg.vocab, 0), (1, model.cfg.seq_len)] {
+        let mut invalid_state = Gpt2State::new(&model.cfg);
+        let state_before = invalid_state.clone();
+        let workspace_before = model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("workspace fingerprint");
+        assert!(model
+            .forward_dense_control(
+                &mut invalid_state,
+                &mut workspace,
+                token,
+                position,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .is_none());
+        assert_state_bits(&invalid_state, &state_before, "invalid serial extent");
+        assert_eq!(
+            model
+                .dense_control_workspace_fingerprint(&workspace)
+                .expect("post-rejection workspace fingerprint"),
+            workspace_before
+        );
+    }
+
+    let mut malformed = vec![Gpt2State::new(&model.cfg); 3];
+    malformed[2].logits.pop();
+    let malformed_before = malformed.clone();
+    let workspace_before = model
+        .dense_control_workspace_fingerprint(&workspace)
+        .expect("workspace fingerprint");
+    assert!(model
+        .forward_batch_dense_control(
+            &mut malformed,
+            &[1, 2, 3],
+            &[0, 0, 0],
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .is_none());
+    assert_eq!(malformed, malformed_before);
+    assert_eq!(
+        model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("post-rejection workspace fingerprint"),
+        workspace_before
+    );
+
+    for (tokens, positions) in [
+        (vec![1, 2, model.cfg.vocab], vec![0, 0, 0]),
+        (vec![1, 2, 3], vec![0, 0, model.cfg.seq_len]),
+        (vec![1, 2], vec![0, 0, 0]),
+    ] {
+        let mut states = vec![Gpt2State::new(&model.cfg); 3];
+        let states_before = states.clone();
+        let workspace_before = model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("workspace fingerprint");
+        assert!(model
+            .forward_batch_dense_control(
+                &mut states,
+                &tokens,
+                &positions,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .is_none());
+        assert_eq!(states, states_before);
+        assert_eq!(
+            model
+                .dense_control_workspace_fingerprint(&workspace)
+                .expect("post-rejection workspace fingerprint"),
+            workspace_before
+        );
+    }
+
+    let mut four_states = vec![Gpt2State::new(&model.cfg); 4];
+    let four_before = four_states.clone();
+    let workspace_before = model
+        .dense_control_workspace_fingerprint(&workspace)
+        .expect("workspace fingerprint");
+    assert!(model
+        .forward_batch_dense_control(
+            &mut four_states,
+            &[1, 2, 3, 4],
+            &[0, 0, 0, 0],
+            &mut workspace,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .is_none());
+    assert_eq!(four_states, four_before);
+    assert_eq!(
+        model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("post-rejection workspace fingerprint"),
+        workspace_before
+    );
+
+    let bad_layer = [model.cfg.n_layer];
+    let request = TraceCaptureRequest {
+        residual_layers: &bad_layer,
+        qkv_layers: &[],
+        attention_layers: &[],
+    };
+    let sink_hits = Cell::new(0usize);
+    let mut residual = |_: usize, _: &[f32]| sink_hits.set(sink_hits.get() + 1);
+    let mut qkv = |_: usize, _: &[f32], _: &[f32], _: &[f32]| {
+        sink_hits.set(sink_hits.get() + 1);
+    };
+    let mut attention = |_: usize, _: usize, _: &[f32]| sink_hits.set(sink_hits.get() + 1);
+    let mut sinks = TraceCaptureSinks {
+        residual: &mut residual,
+        qkv: &mut qkv,
+        attention: &mut attention,
+    };
+    let mut traced = Gpt2State::new(&model.cfg);
+    let traced_before = traced.clone();
+    let workspace_before = model
+        .dense_control_workspace_fingerprint(&workspace)
+        .expect("workspace fingerprint");
+    assert!(model
+        .forward_dense_control_capturing_trace(
+            &mut traced,
+            &mut workspace,
+            1,
+            0,
+            Gpt2DenseCanaryMode::CertifiedNative,
+            &request,
+            &mut sinks,
+        )
+        .is_none());
+    assert_eq!(sink_hits.get(), 0);
+    assert_state_bits(&traced, &traced_before, "invalid trace request");
+    assert_eq!(
+        model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("post-rejection workspace fingerprint"),
+        workspace_before
+    );
+
+    let input = vec![0.25f32; model.cfg.n_embd - 1];
+    let mut output = vec![f32::from_bits(OUTPUT_POISON_BITS); 3 * model.cfg.n_embd];
+    let output_before = output.clone();
+    let workspace_before = model
+        .dense_control_workspace_fingerprint(&workspace)
+        .expect("workspace fingerprint");
+    assert!(model
+        .dense_control_matrix_canary(
+            &mut workspace,
+            Some(0),
+            Gpt2DenseControlSite::CAttn,
+            &input,
+            &mut output,
+            Gpt2DenseCanaryMode::CertifiedNative,
+        )
+        .is_none());
+    assert_bits(&output, &output_before, "invalid matrix extent");
+    assert_eq!(
+        model
+            .dense_control_workspace_fingerprint(&workspace)
+            .expect("post-rejection workspace fingerprint"),
+        workspace_before
+    );
+}
+
+fn median_nine(mut values: [f64; REAL_PAIRS]) -> f64 {
+    values.sort_by(f64::total_cmp);
+    values[values.len() / 2]
+}
+
+fn empirical_bootstrap_median_upper_95_nine(mut values: [f64; REAL_PAIRS]) -> f64 {
+    assert!(values
+        .iter()
+        .all(|value| value.is_finite() && *value >= 0.0));
+    values.sort_by(f64::total_cmp);
+    const CHOOSE_NINE: [u128; 10] = [1, 9, 36, 84, 126, 126, 84, 36, 9, 1];
+    const TOTAL_RESAMPLES: u128 = 9u128.pow(9);
+
+    // For one empirical value `v`, let `j` observations be <= v. Across all
+    // 9^9 equiprobable bootstrap resamples, the resampled median is <= v iff
+    // at least five draws land among those j observations. Count that event
+    // exactly with the binomial polynomial and take the smallest v whose CDF
+    // is at least 95%; no RNG or floating probability comparison participates.
+    for &candidate in &values {
+        let less_or_equal = values.iter().filter(|&&value| value <= candidate).count() as u128;
+        let greater = REAL_PAIRS as u128 - less_or_equal;
+        let cumulative: u128 = (5..=9)
+            .map(|successes| {
+                CHOOSE_NINE[successes]
+                    * less_or_equal.pow(successes as u32)
+                    * greater.pow((9 - successes) as u32)
+            })
+            .sum();
+        if cumulative * 100 >= TOTAL_RESAMPLES * 95 {
+            return candidate;
+        }
+    }
+    unreachable!("the maximum empirical value has bootstrap CDF one")
+}
+
+#[test]
+fn exact_empirical_bootstrap_upper_95_has_the_expected_nine_sample_rank() {
+    let ordered = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    assert_eq!(median_nine(ordered), 5.0);
+    assert_eq!(empirical_bootstrap_median_upper_95_nine(ordered), 7.0);
+
+    let permuted = [9.0, 1.0, 6.0, 3.0, 8.0, 2.0, 7.0, 5.0, 4.0];
+    assert_eq!(empirical_bootstrap_median_upper_95_nine(permuted), 7.0);
+
+    // Ties are grouped through the empirical CDF, not broken by array index.
+    assert_eq!(
+        empirical_bootstrap_median_upper_95_nine([1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 4.0]),
+        4.0
+    );
+}
+
+fn assert_exact_control_census(census: Gpt2DenseCanaryCensus, expected_lanes: usize) {
+    assert_eq!(census.lanes(), expected_lanes);
+    assert_eq!(census.exact_control(), expected_lanes);
+    assert_eq!(census.conventional(), 0);
+    assert_eq!(census.fast_certified(), 0);
+    assert_eq!(census.refined_certified(), 0);
+    assert_eq!(census.fallbacks(), Some(0));
+}
+
+fn assert_conventional_census(census: Gpt2DenseCanaryCensus, expected_lanes: usize) {
+    assert_eq!(census.lanes(), expected_lanes);
+    assert_eq!(census.conventional(), expected_lanes);
+    assert_eq!(census.exact_control(), 0);
+    assert_eq!(census.fast_certified(), 0);
+    assert_eq!(census.refined_certified(), 0);
+    assert_eq!(census.fallbacks(), Some(0));
+}
+
+fn timed_dense_call(
+    model: &Gpt2,
+    input: &[f32],
+    output: &mut [f32],
+    workspace: &mut uor_r4_model_source::gpt2::Gpt2DenseCanaryWorkspace,
+    mode: Gpt2DenseCanaryMode,
+) -> (Duration, Gpt2DenseCanaryCensus) {
+    let ((elapsed, census), allocations) = counted_allocations(|| {
+        let started = Instant::now();
+        let census = model
+            .layer0_c_attn_canary(input, output, workspace, mode)
+            .expect("hard-bound timed dense call is valid");
+        (started.elapsed(), census)
+    });
+    assert_eq!(allocations, 0, "timed dense call allocated");
+    (elapsed, census)
+}
+
+/// Cheap consumer hard gate only. Workspace preparation and exact preflight
+/// are outside timing; nine alternating matched inputs measure historical
+/// Conv1D against the certified-native candidate. The verdict is the strict
+/// one-sided 95% exact empirical-bootstrap upper quantile of the paired median.
+#[test]
+#[ignore = "requires the real pinned GPT-2 124M source and is a local #704 timing gate"]
+#[allow(clippy::assertions_on_constants)]
+fn real_layer0_c_attn_certified_native_consumer_gate() {
+    let root = workspace_root();
+    assert_eq!(
+        sha256_file(&root.join("crates/uor-r4-model-source/src/gpt2.rs")),
+        LEGACY_C_ATTN_GPT2_SHA256,
+        "the legacy c_attn gate is superseded: refuse to time changed whole-owner source under the old contract"
+    );
+    assert_eq!(
+        sha256_file(&root.join("crates/uor-r4-model-source/tests/certified_native_dense.rs")),
+        LEGACY_C_ATTN_HARNESS_SHA256,
+        "the legacy c_attn gate is superseded: refuse to time a changed harness under the old contract"
+    );
+    assert!(!cfg!(debug_assertions), "run the dense gate with --release");
+    let source = real_source();
+    for required in ["model.safetensors", "config.json", "source_manifest.json"] {
+        assert!(
+            source.join(required).is_file(),
+            "hard-bound real GPT-2 fixture is missing {} (set UOR_GPT2_SOURCE or install the repo-relative fixture)",
+            source.join(required).display()
+        );
+    }
+    let model = Gpt2::load(&source, Some(1)).expect("load real pinned GPT-2");
+    bind_dense_identity(
+        &source,
+        &model,
+        DenseGateContract {
+            arithmetic_id: DENSE_ARITHMETIC_ID,
+            bootstrap_id: BOOTSTRAP_ALGORITHM_ID,
+            pairs: REAL_PAIRS,
+            warmups_per_arm: REAL_WARMUPS_PER_ARM,
+            threshold: MAXIMUM_UPPER_RATIO,
+            threshold_rule: "strict-less-than",
+        },
+    );
+    assert_eq!(model.cfg.n_head, 12);
+    assert_eq!(model.cfg.n_layer, 12);
+    let d = model.cfg.n_embd;
+    let out_dim = 3 * d;
+    assert_eq!((d, out_dim), (768, REAL_OUTPUT_LANES));
+
+    let mut workspace = model
+        .dense_canary_workspace()
+        .expect("real model admits prepared dense scratch");
+    let mut inputs = vec![vec![0.0f32; d]; REAL_PAIRS];
+    for (token, input) in inputs.iter_mut().enumerate() {
+        model
+            .layer0_c_attn_canary_input(token, 0, input)
+            .expect("hard-bound real input is valid");
+    }
+
+    let mut exact = vec![0.0f32; out_dim];
+    let mut candidate = vec![0.0f32; out_dim];
+    let mut conventional = vec![0.0f32; out_dim];
+    let mut expected_outputs = Vec::with_capacity(REAL_PAIRS);
+    let mut preflight_census = DenseCensusTotal::default();
+    for (case, input) in inputs.iter().enumerate() {
+        poison_output(&mut exact);
+        let exact_census = model
+            .layer0_c_attn_canary(
+                input,
+                &mut exact,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Exact,
+            )
+            .expect("exact preflight");
+        assert_exact_control_census(exact_census, out_dim);
+        assert_output_overwritten(&exact, &format!("real exact preflight {case}"));
+        expected_outputs.push(exact.clone());
+
+        poison_output(&mut candidate);
+        let census = model
+            .layer0_c_attn_canary(
+                input,
+                &mut candidate,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("candidate preflight");
+        assert_output_overwritten(&candidate, &format!("real candidate preflight {case}"));
+        assert_bits(
+            &candidate,
+            &expected_outputs[case],
+            &format!("real candidate/exact preflight {case}"),
+        );
+        preflight_census.observe_candidate(census, out_dim);
+    }
+    assert!(
+        preflight_census.fast > 0,
+        "real preflight has no fast-certified lane"
+    );
+    assert!(
+        preflight_census.refined > 0,
+        "real preflight never exercised TwoSum refinement"
+    );
+    assert_eq!(
+        preflight_census.fallbacks(),
+        0,
+        "real preflight required exact fallback"
+    );
+
+    // Fixed predeclared warmup: exactly 20 calls per arm, candidate then
+    // conventional for each deterministic input in round-robin order.
+    let mut warmup_census = DenseCensusTotal::default();
+    for warmup in 0..REAL_WARMUPS_PER_ARM {
+        let input_index = warmup % REAL_PAIRS;
+        poison_output(&mut candidate);
+        let census = model
+            .layer0_c_attn_canary(
+                &inputs[input_index],
+                &mut candidate,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            )
+            .expect("candidate warmup");
+        warmup_census.observe_candidate(census, out_dim);
+        assert_output_overwritten(&candidate, &format!("candidate warmup {warmup}"));
+        assert_bits(
+            &candidate,
+            &expected_outputs[input_index],
+            &format!("candidate/exact warmup {warmup}"),
+        );
+
+        poison_output(&mut conventional);
+        let census = model
+            .layer0_c_attn_canary(
+                &inputs[input_index],
+                &mut conventional,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Conventional,
+            )
+            .expect("conventional warmup");
+        assert_conventional_census(census, out_dim);
+        assert_output_overwritten(&conventional, &format!("conventional warmup {warmup}"));
+    }
+    assert_eq!(warmup_census.calls, REAL_WARMUPS_PER_ARM);
+    assert_eq!(warmup_census.fallbacks(), 0);
+    eprintln!(
+        "CERTIFIED_DENSE_WARMUP calls_per_arm={REAL_WARMUPS_PER_ARM} order=candidate-then-conventional census={warmup_census:?}"
+    );
+
+    let mut candidate_seconds = [0.0f64; REAL_PAIRS];
+    let mut conventional_seconds = [0.0f64; REAL_PAIRS];
+    let mut timed_census = DenseCensusTotal::default();
+    for (pair, input) in inputs.iter().enumerate() {
+        let candidate_first = pair.is_multiple_of(2);
+        let (candidate_elapsed, candidate_census, control_elapsed, control_census);
+        if pair.is_multiple_of(2) {
+            poison_output(&mut candidate);
+            (candidate_elapsed, candidate_census) = timed_dense_call(
+                &model,
+                input,
+                &mut candidate,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            );
+            poison_output(&mut conventional);
+            (control_elapsed, control_census) = timed_dense_call(
+                &model,
+                input,
+                &mut conventional,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Conventional,
+            );
+        } else {
+            poison_output(&mut conventional);
+            (control_elapsed, control_census) = timed_dense_call(
+                &model,
+                input,
+                &mut conventional,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Conventional,
+            );
+            poison_output(&mut candidate);
+            (candidate_elapsed, candidate_census) = timed_dense_call(
+                &model,
+                input,
+                &mut candidate,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            );
+        }
+
+        assert_output_overwritten(&candidate, &format!("timed candidate pair {pair}"));
+        assert_bits(
+            &candidate,
+            &expected_outputs[pair],
+            &format!("timed candidate/exact pair {pair}"),
+        );
+        timed_census.observe_candidate(candidate_census, out_dim);
+        assert_conventional_census(control_census, out_dim);
+        assert_output_overwritten(&conventional, &format!("timed conventional pair {pair}"));
+        std::hint::black_box(&candidate);
+        std::hint::black_box(&conventional);
+        candidate_seconds[pair] = candidate_elapsed.as_secs_f64();
+        conventional_seconds[pair] = control_elapsed.as_secs_f64();
+        eprintln!(
+            "CERTIFIED_DENSE_SAMPLE pair={pair} first={} candidate_ns={} conventional_ns={} paired_ratio={:.9} candidate_census={candidate_census:?}",
+            if candidate_first {
+                "candidate"
+            } else {
+                "conventional"
+            },
+            candidate_elapsed.as_nanos(),
+            control_elapsed.as_nanos(),
+            candidate_seconds[pair] / conventional_seconds[pair],
+        );
+    }
+    assert_eq!(timed_census.calls, REAL_PAIRS);
+    assert_eq!(timed_census.lanes, REAL_PAIRS * REAL_OUTPUT_LANES);
+    assert!(
+        timed_census.fast > 0,
+        "timed run has no fast-certified lane"
+    );
+    assert!(
+        timed_census.refined > 0,
+        "timed run never exercised TwoSum refinement"
+    );
+    assert_eq!(
+        timed_census.fallbacks(),
+        0,
+        "pinned real timed gate used an exact fallback"
+    );
+
+    let paired_ratios =
+        std::array::from_fn(|pair| candidate_seconds[pair] / conventional_seconds[pair]);
+    let paired_median_ratio = median_nine(paired_ratios);
+    let candidate_median = median_nine(candidate_seconds);
+    let conventional_median = median_nine(conventional_seconds);
+    let ratio_of_medians = candidate_median / conventional_median;
+    let bootstrap_median_upper_95 = empirical_bootstrap_median_upper_95_nine(paired_ratios);
+    eprintln!(
+        "CERTIFIED_DENSE_RESULT arithmetic_id={DENSE_ARITHMETIC_ID} bootstrap_algorithm_id={BOOTSTRAP_ALGORITHM_ID} base_head={BASE_HEAD} uor_matmul_rev={UOR_MATMUL_REV} pairs={REAL_PAIRS} warmups_per_arm={REAL_WARMUPS_PER_ARM} candidate_seconds={candidate_seconds:?} conventional_seconds={conventional_seconds:?} paired_ratios={paired_ratios:?} candidate_median_ns={:.0} conventional_median_ns={:.0} paired_median_ratio={paired_median_ratio:.9} ratio_of_medians={ratio_of_medians:.9} bootstrap_median_upper_95={bootstrap_median_upper_95:.9} timed_census={timed_census:?} preflight_census={preflight_census:?} threshold={MAXIMUM_UPPER_RATIO:.1} threshold_rule=strict-less-than",
+        candidate_median * 1e9,
+        conventional_median * 1e9,
+    );
+    assert!(
+        bootstrap_median_upper_95 < MAXIMUM_UPPER_RATIO,
+        "real layer-0 c_attn one-sided 95% bootstrap median upper {bootstrap_median_upper_95:.9} is not strictly below {MAXIMUM_UPPER_RATIO:.1}"
+    );
+}
+
+const WHOLE_STORIES: [&[usize]; 3] = [
+    &[464, 3290, 373, 257],
+    &[15496, 995],
+    &[50256, 464, 968, 1971, 318],
+];
+
+#[derive(Clone, Copy)]
+struct WholeCensusSnapshot {
+    layers: [Gpt2DenseLayerCensus; 12],
+    lm_head: Gpt2DenseCanaryCensus,
+}
+
+fn merge_dense_total(total: &mut DenseCensusTotal, observed: DenseCensusTotal) {
+    total.calls += observed.calls;
+    total.lanes += observed.lanes;
+    total.fast += observed.fast;
+    total.refined += observed.refined;
+    total.fallback_nonfinite += observed.fallback_nonfinite;
+    total.fallback_zero += observed.fallback_zero;
+    total.fallback_overflow += observed.fallback_overflow;
+    total.fallback_cell += observed.fallback_cell;
+}
+
+fn assert_real_candidate_structure(total: DenseCensusTotal, context: &str) {
+    assert_eq!(total.calls, WHOLE_OWNER_CALLS, "{context}: owner calls");
+    assert_eq!(total.lanes, WHOLE_LANES, "{context}: output lanes");
+    assert!(total.fast > 0, "{context}: no fast-certified lane");
+    assert!(total.refined > 0, "{context}: no refined-certified lane");
+    assert_eq!(
+        total.fallbacks(),
+        0,
+        "{context}: exact fallback must be priced before timing"
+    );
+}
+
+fn measured_whole_dense_call(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    workspace: &mut uor_r4_model_source::gpt2::Gpt2DenseControlWorkspace,
+    token: usize,
+    position: usize,
+    mode: Gpt2DenseCanaryMode,
+) -> (Duration, WholeCensusSnapshot) {
+    ALLOCATIONS.with(|count| count.set(0));
+    COUNT_ALLOCATIONS.with(|gate| {
+        assert!(!gate.replace(true), "nested whole-dense measurement");
+    });
+    let measurement = AllocationMeasurement;
+    let started = Instant::now();
+    let census = model
+        .forward_dense_control(state, workspace, token, position, mode)
+        .expect("hard-bound whole-dense call is valid");
+    let elapsed = started.elapsed();
+    drop(measurement);
+    let allocations = ALLOCATIONS.with(Cell::get);
+    assert_eq!(allocations, 0, "whole-dense hot call allocated");
+    assert_eq!(census.layers().len(), 12, "hard-bound GPT-2 layer count");
+    let mut layers = [Gpt2DenseLayerCensus::default(); 12];
+    layers.copy_from_slice(census.layers());
+    (
+        elapsed,
+        WholeCensusSnapshot {
+            layers,
+            lm_head: census.lm_head(),
+        },
+    )
+}
+
+fn timed_whole_suite(
+    model: &Gpt2,
+    state: &mut Gpt2State,
+    workspace: &mut uor_r4_model_source::gpt2::Gpt2DenseControlWorkspace,
+    mode: Gpt2DenseCanaryMode,
+    expected_steps: &[Gpt2State],
+) -> (Duration, DenseCensusTotal) {
+    let mut elapsed = Duration::ZERO;
+    let mut total = DenseCensusTotal::default();
+    let mut expected_index = 0usize;
+    for story in WHOLE_STORIES {
+        state.reset();
+        for (position, &token) in story.iter().enumerate() {
+            state.logits.fill(f32::from_bits(OUTPUT_POISON_BITS));
+            state.hidden.fill(f32::from_bits(OUTPUT_POISON_BITS));
+            let (call_elapsed, census) =
+                measured_whole_dense_call(model, state, workspace, token, position, mode);
+            elapsed += call_elapsed;
+            let observed =
+                assert_whole_census_parts(&census.layers, census.lm_head, model, 1, 0, mode);
+            merge_dense_total(&mut total, observed);
+            assert_output_overwritten(&state.logits, "timed whole logits");
+            assert_output_overwritten(&state.hidden, "timed whole hidden");
+            if mode == Gpt2DenseCanaryMode::CertifiedNative {
+                assert_state_bits(
+                    state,
+                    &expected_steps[expected_index],
+                    &format!("timed candidate step {expected_index}"),
+                );
+            }
+            expected_index += 1;
+        }
+    }
+    assert_eq!(expected_index, WHOLE_STEPS);
+    (elapsed, total)
+}
+
+/// Frozen binding whole-GPT-2 PASS contract. Its reviewed source/harness
+/// hashes predate production integration, so the first checks deliberately
+/// refuse every rerun rather than timing changed bytes under the old result.
+#[test]
+#[ignore = "binding whole-dense PASS is frozen; production integration supersedes this timing candidate"]
+#[allow(clippy::assertions_on_constants)]
+fn real_whole_gpt2_certified_dense_consumer_gate() {
+    assert!(
+        !cfg!(debug_assertions),
+        "run the whole dense gate with --release"
+    );
+    assert_eq!(
+        WHOLE_STORIES.iter().map(|story| story.len()).sum::<usize>(),
+        WHOLE_STEPS
+    );
+    let root = workspace_root();
+    assert_eq!(
+        sha256_file(&root.join("crates/uor-r4-model-source/src/gpt2.rs")),
+        BINDING_WHOLE_GPT2_SHA256,
+        "binding whole-dense PASS is frozen: refuse to rerun after production integration"
+    );
+    assert_eq!(
+        sha256_file(&root.join("crates/uor-r4-model-source/tests/certified_native_dense.rs")),
+        BINDING_WHOLE_HARNESS_SHA256,
+        "binding whole-dense PASS harness is frozen: refuse to rerun changed evidence"
+    );
+    let expected_gpt2_sha256 = std::env::var(WHOLE_EXPECTED_GPT2_SHA256_ENV)
+        .unwrap_or_else(|_| panic!("whole dense gate requires {WHOLE_EXPECTED_GPT2_SHA256_ENV}"));
+    let expected_harness_sha256 =
+        std::env::var(WHOLE_EXPECTED_HARNESS_SHA256_ENV).unwrap_or_else(|_| {
+            panic!("whole dense gate requires {WHOLE_EXPECTED_HARNESS_SHA256_ENV}")
+        });
+    let gpt2_sha256 = sha256_file(&root.join("crates/uor-r4-model-source/src/gpt2.rs"));
+    let harness_sha256 =
+        sha256_file(&root.join("crates/uor-r4-model-source/tests/certified_native_dense.rs"));
+    assert_eq!(
+        gpt2_sha256, expected_gpt2_sha256,
+        "gpt2.rs differs from the maintainer-frozen whole-dense candidate"
+    );
+    assert_eq!(
+        harness_sha256, expected_harness_sha256,
+        "certified_native_dense.rs differs from the maintainer-frozen whole-dense harness"
+    );
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_SOURCE_HASHES gpt2_sha256={gpt2_sha256} harness_sha256={harness_sha256}"
+    );
+    let source = real_source();
+    for required in ["model.safetensors", "config.json", "source_manifest.json"] {
+        assert!(
+            source.join(required).is_file(),
+            "hard-bound real GPT-2 fixture is missing {} (set UOR_GPT2_SOURCE or install the repo-relative fixture)",
+            source.join(required).display()
+        );
+    }
+    let model = Gpt2::load(&source, Some(WHOLE_STEPS)).expect("load real pinned GPT-2");
+    bind_dense_identity(
+        &source,
+        &model,
+        DenseGateContract {
+            arithmetic_id: WHOLE_DENSE_ARITHMETIC_ID,
+            bootstrap_id: WHOLE_BOOTSTRAP_ALGORITHM_ID,
+            pairs: WHOLE_REAL_PAIRS,
+            warmups_per_arm: WHOLE_WARMUP_SUITES_PER_ARM,
+            threshold: WHOLE_MAXIMUM_UPPER_RATIO,
+            threshold_rule: "less-than-or-equal",
+        },
+    );
+    assert_eq!(model.cfg.n_embd, 768);
+    assert_eq!(model.cfg.n_head, 12);
+    assert_eq!(model.cfg.n_layer, 12);
+    assert_eq!(model.cfg.n_inner, 3072);
+    assert_eq!(model.cfg.vocab, 50257);
+    assert_eq!(model.cfg.seq_len, WHOLE_STEPS);
+
+    let preparation_started = Instant::now();
+    let mut workspace = model
+        .dense_control_workspace()
+        .expect("prepare model-bound whole-dense workspace");
+    let preparation_elapsed = preparation_started.elapsed();
+    let workspace_bytes = model
+        .dense_control_workspace_bytes(&workspace)
+        .expect("whole-dense workspace byte accounting");
+    assert_eq!(workspace_bytes.lm_head_transpose(), 154_389_504);
+    assert_eq!(workspace_bytes.matrix_bounds(), 1_065_608);
+    assert_eq!(workspace_bytes.f64_sum_scratch(), 1_467_672);
+    assert_eq!(workspace_bytes.intermediate_scratch(), 268_656);
+    assert_eq!(
+        workspace_bytes.total(),
+        workspace_bytes.lm_head_transpose()
+            + workspace_bytes.matrix_bounds()
+            + workspace_bytes.f64_sum_scratch()
+            + workspace_bytes.intermediate_scratch()
+            + workspace_bytes.metadata()
+    );
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_WORKSPACE transpose_bytes={} matrix_bound_bytes={} f64_sum_scratch_bytes={} intermediate_scratch_bytes={} metadata_bytes={} total_caller_owned_bytes={} max_batch=1 model_bound=true preparation_ns={} preparation_in_benchmark=false",
+        workspace_bytes.lm_head_transpose(),
+        workspace_bytes.matrix_bounds(),
+        workspace_bytes.f64_sum_scratch(),
+        workspace_bytes.intermediate_scratch(),
+        workspace_bytes.metadata(),
+        workspace_bytes.total(),
+        preparation_elapsed.as_nanos(),
+    );
+
+    // Bind the timing control to both the current production executor and the
+    // independent numpy golden before any candidate gate. Nothing here is in
+    // a measured region, and the checked-in golden is never regenerated.
+    let golden_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gpt2-real/golden.json");
+    assert!(
+        golden_path.is_file(),
+        "hard-bound independent GPT-2 golden is missing at {}",
+        golden_path.display()
+    );
+    let golden: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&golden_path).expect("read independent GPT-2 golden"),
+    )
+    .expect("parse independent GPT-2 golden");
+    let golden_cases = golden["cases"].as_array().expect("golden cases array");
+    assert_eq!(golden_cases.len(), WHOLE_STORIES.len());
+    let mut production_state = Gpt2State::new(&model.cfg);
+    let mut conventional_state = Gpt2State::new(&model.cfg);
+    for (story_index, story) in WHOLE_STORIES.iter().enumerate() {
+        let golden_case = &golden_cases[story_index];
+        let golden_tokens: Vec<usize> = golden_case["tokens"]
+            .as_array()
+            .expect("golden tokens")
+            .iter()
+            .map(|value| value.as_u64().expect("golden token integer") as usize)
+            .collect();
+        assert_eq!(&golden_tokens, story, "golden story {story_index}");
+        production_state.reset();
+        conventional_state.reset();
+        for (position, &token) in story.iter().enumerate() {
+            model.forward(&mut production_state, token, position, &[], &mut |_, _| {});
+            let census = model
+                .forward_dense_control(
+                    &mut conventional_state,
+                    &mut workspace,
+                    token,
+                    position,
+                    Gpt2DenseCanaryMode::Conventional,
+                )
+                .expect("real production-baseline control step");
+            assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::Conventional);
+            assert_state_bits(
+                &conventional_state,
+                &production_state,
+                &format!("real production/conventional story {story_index} position {position}"),
+            );
+        }
+
+        let golden_hidden: Vec<f32> = golden_case["hidden"]
+            .as_array()
+            .expect("golden hidden")
+            .iter()
+            .map(|value| value.as_f64().expect("golden hidden float") as f32)
+            .collect();
+        assert_eq!(golden_hidden.len(), model.cfg.n_embd);
+        let worst_hidden = production_state
+            .hidden
+            .iter()
+            .zip(&golden_hidden)
+            .map(|(&actual, &expected)| (actual - expected).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            worst_hidden < 5e-2,
+            "independent golden hidden delta {worst_hidden:e} for story {story_index}"
+        );
+
+        let mut order: Vec<usize> = (0..model.cfg.vocab).collect();
+        order.sort_by(|&left, &right| {
+            production_state.logits[right]
+                .total_cmp(&production_state.logits[left])
+                .then_with(|| left.cmp(&right))
+        });
+        assert_eq!(
+            order[0],
+            golden_case["argmax"]
+                .as_u64()
+                .expect("golden argmax integer") as usize,
+            "independent golden argmax story {story_index}"
+        );
+        let golden_top_five: std::collections::BTreeSet<usize> = golden_case["top_k"]
+            .as_array()
+            .expect("golden top-k")
+            .iter()
+            .take(5)
+            .map(|entry| {
+                entry.as_array().expect("golden top-k pair")[0]
+                    .as_u64()
+                    .expect("golden top-k token") as usize
+            })
+            .collect();
+        let actual_top_five: std::collections::BTreeSet<usize> =
+            order.iter().copied().take(5).collect();
+        assert_eq!(
+            actual_top_five, golden_top_five,
+            "independent golden top-5 story {story_index}"
+        );
+    }
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_BASELINE production_conventional_full_state_bits=PASS independent_golden_hidden_argmax_top5=PASS stories=3"
+    );
+
+    // Binding structural gate: candidate only, before the expensive exact
+    // owner. Any fallback or incomplete owner census stops the run here.
+    let mut structural_state = Gpt2State::new(&model.cfg);
+    let mut structural_total = DenseCensusTotal::default();
+    for story in WHOLE_STORIES {
+        structural_state.reset();
+        for (position, &token) in story.iter().enumerate() {
+            structural_state
+                .logits
+                .fill(f32::from_bits(OUTPUT_POISON_BITS));
+            structural_state
+                .hidden
+                .fill(f32::from_bits(OUTPUT_POISON_BITS));
+            let census = model
+                .forward_dense_control(
+                    &mut structural_state,
+                    &mut workspace,
+                    token,
+                    position,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .expect("hard-bound structural candidate step");
+            let observed =
+                assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::CertifiedNative);
+            merge_dense_total(&mut structural_total, observed);
+            assert_output_overwritten(&structural_state.logits, "structural logits");
+            assert_output_overwritten(&structural_state.hidden, "structural hidden");
+        }
+    }
+    assert_real_candidate_structure(structural_total, "structural gate");
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_STRUCTURAL verdict=PROCEED census={structural_total:?} expected_calls={WHOLE_OWNER_CALLS} expected_lanes={WHOLE_LANES}"
+    );
+
+    // Exact preflight stores the complete expected recurrent state after each
+    // deterministic token. Candidate and exact share the prepared workspace
+    // sequentially and are compared after every step.
+    let mut exact_state = Gpt2State::new(&model.cfg);
+    let mut candidate_state = Gpt2State::new(&model.cfg);
+    let mut expected_steps = Vec::with_capacity(WHOLE_STEPS);
+    let mut preflight_total = DenseCensusTotal::default();
+    for story in WHOLE_STORIES {
+        exact_state.reset();
+        candidate_state.reset();
+        for (position, &token) in story.iter().enumerate() {
+            exact_state.logits.fill(f32::from_bits(OUTPUT_POISON_BITS));
+            exact_state.hidden.fill(f32::from_bits(OUTPUT_POISON_BITS));
+            let exact = model
+                .forward_dense_control(
+                    &mut exact_state,
+                    &mut workspace,
+                    token,
+                    position,
+                    Gpt2DenseCanaryMode::Exact,
+                )
+                .expect("hard-bound exact preflight step");
+            assert_whole_census(exact, &model, 1, 0, Gpt2DenseCanaryMode::Exact);
+            assert_output_overwritten(&exact_state.logits, "exact preflight logits");
+            assert_output_overwritten(&exact_state.hidden, "exact preflight hidden");
+            expected_steps.push(exact_state.clone());
+
+            candidate_state
+                .logits
+                .fill(f32::from_bits(OUTPUT_POISON_BITS));
+            candidate_state
+                .hidden
+                .fill(f32::from_bits(OUTPUT_POISON_BITS));
+            let candidate = model
+                .forward_dense_control(
+                    &mut candidate_state,
+                    &mut workspace,
+                    token,
+                    position,
+                    Gpt2DenseCanaryMode::CertifiedNative,
+                )
+                .expect("hard-bound candidate preflight step");
+            let observed = assert_whole_census(
+                candidate,
+                &model,
+                1,
+                0,
+                Gpt2DenseCanaryMode::CertifiedNative,
+            );
+            merge_dense_total(&mut preflight_total, observed);
+            assert_state_bits(
+                &candidate_state,
+                &exact_state,
+                &format!("whole exact preflight token {}", expected_steps.len() - 1),
+            );
+        }
+    }
+    assert_eq!(expected_steps.len(), WHOLE_STEPS);
+    assert_real_candidate_structure(preflight_total, "exact preflight");
+
+    // Fixed predeclared warmup: two complete three-story suites per arm. The
+    // order is candidate then conventional for each warmup index.
+    let mut warmup_state = Gpt2State::new(&model.cfg);
+    for warmup in 0..WHOLE_WARMUP_SUITES_PER_ARM {
+        let mut expected_index = 0usize;
+        let mut candidate_total = DenseCensusTotal::default();
+        for story in WHOLE_STORIES {
+            warmup_state.reset();
+            for (position, &token) in story.iter().enumerate() {
+                let census = model
+                    .forward_dense_control(
+                        &mut warmup_state,
+                        &mut workspace,
+                        token,
+                        position,
+                        Gpt2DenseCanaryMode::CertifiedNative,
+                    )
+                    .expect("candidate warmup step");
+                let observed =
+                    assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::CertifiedNative);
+                merge_dense_total(&mut candidate_total, observed);
+                assert_state_bits(
+                    &warmup_state,
+                    &expected_steps[expected_index],
+                    &format!("candidate warmup {warmup} step {expected_index}"),
+                );
+                expected_index += 1;
+            }
+        }
+        assert_real_candidate_structure(candidate_total, "candidate warmup");
+        for story in WHOLE_STORIES {
+            warmup_state.reset();
+            for (position, &token) in story.iter().enumerate() {
+                let census = model
+                    .forward_dense_control(
+                        &mut warmup_state,
+                        &mut workspace,
+                        token,
+                        position,
+                        Gpt2DenseCanaryMode::Conventional,
+                    )
+                    .expect("conventional warmup step");
+                assert_whole_census(census, &model, 1, 0, Gpt2DenseCanaryMode::Conventional);
+            }
+        }
+    }
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_WARMUP suites_per_arm={WHOLE_WARMUP_SUITES_PER_ARM} stories_per_suite=3 tokens_per_suite={WHOLE_STEPS} order=candidate-then-conventional"
+    );
+
+    let mut candidate_seconds = [0.0f64; WHOLE_REAL_PAIRS];
+    let mut conventional_seconds = [0.0f64; WHOLE_REAL_PAIRS];
+    let mut timed_total = DenseCensusTotal::default();
+    let mut timed_state = Gpt2State::new(&model.cfg);
+    for pair in 0..WHOLE_REAL_PAIRS {
+        let candidate_first = pair.is_multiple_of(2);
+        let (candidate_elapsed, candidate_census, conventional_elapsed);
+        if candidate_first {
+            (candidate_elapsed, candidate_census) = timed_whole_suite(
+                &model,
+                &mut timed_state,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+                &expected_steps,
+            );
+            (conventional_elapsed, _) = timed_whole_suite(
+                &model,
+                &mut timed_state,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Conventional,
+                &expected_steps,
+            );
+        } else {
+            (conventional_elapsed, _) = timed_whole_suite(
+                &model,
+                &mut timed_state,
+                &mut workspace,
+                Gpt2DenseCanaryMode::Conventional,
+                &expected_steps,
+            );
+            (candidate_elapsed, candidate_census) = timed_whole_suite(
+                &model,
+                &mut timed_state,
+                &mut workspace,
+                Gpt2DenseCanaryMode::CertifiedNative,
+                &expected_steps,
+            );
+        }
+        assert_real_candidate_structure(candidate_census, "timed candidate suite");
+        merge_dense_total(&mut timed_total, candidate_census);
+        candidate_seconds[pair] = candidate_elapsed.as_secs_f64();
+        conventional_seconds[pair] = conventional_elapsed.as_secs_f64();
+        eprintln!(
+            "CERTIFIED_WHOLE_DENSE_SAMPLE pair={pair} first={} candidate_total_ns={} conventional_total_ns={} candidate_ns_per_token={:.0} conventional_ns_per_token={:.0} paired_ratio={:.9} candidate_census={candidate_census:?}",
+            if candidate_first {
+                "candidate"
+            } else {
+                "conventional"
+            },
+            candidate_elapsed.as_nanos(),
+            conventional_elapsed.as_nanos(),
+            candidate_elapsed.as_nanos() as f64 / WHOLE_STEPS as f64,
+            conventional_elapsed.as_nanos() as f64 / WHOLE_STEPS as f64,
+            candidate_seconds[pair] / conventional_seconds[pair],
+        );
+    }
+    assert_eq!(timed_total.calls, WHOLE_REAL_PAIRS * WHOLE_OWNER_CALLS);
+    assert_eq!(timed_total.lanes, WHOLE_REAL_PAIRS * WHOLE_LANES);
+    assert!(timed_total.fast > 0);
+    assert!(timed_total.refined > 0);
+    assert_eq!(timed_total.fallbacks(), 0);
+
+    let paired_ratios =
+        std::array::from_fn(|pair| candidate_seconds[pair] / conventional_seconds[pair]);
+    let paired_median_ratio = median_nine(paired_ratios);
+    let candidate_median = median_nine(candidate_seconds);
+    let conventional_median = median_nine(conventional_seconds);
+    let ratio_of_medians = candidate_median / conventional_median;
+    let bootstrap_median_upper_95 = empirical_bootstrap_median_upper_95_nine(paired_ratios);
+    eprintln!(
+        "CERTIFIED_WHOLE_DENSE_RESULT arithmetic_id={WHOLE_DENSE_ARITHMETIC_ID} bootstrap_algorithm_id={WHOLE_BOOTSTRAP_ALGORITHM_ID} pairs={WHOLE_REAL_PAIRS} warmup_suites_per_arm={WHOLE_WARMUP_SUITES_PER_ARM} stories=3 tokens_per_suite={WHOLE_STEPS} candidate_seconds={candidate_seconds:?} conventional_seconds={conventional_seconds:?} paired_ratios={paired_ratios:?} candidate_median_ns_per_token={:.0} conventional_median_ns_per_token={:.0} paired_median_ratio={paired_median_ratio:.9} ratio_of_medians={ratio_of_medians:.9} bootstrap_median_upper_95={bootstrap_median_upper_95:.9} timed_census={timed_total:?} preflight_census={preflight_total:?} structural_census={structural_total:?} workspace_bytes={} threshold={WHOLE_MAXIMUM_UPPER_RATIO:.1} threshold_rule=less-than-or-equal",
+        candidate_median * 1e9 / WHOLE_STEPS as f64,
+        conventional_median * 1e9 / WHOLE_STEPS as f64,
+        workspace_bytes.total(),
+    );
+    assert!(
+        bootstrap_median_upper_95 <= WHOLE_MAXIMUM_UPPER_RATIO,
+        "whole GPT-2 one-sided 95% bootstrap median upper {bootstrap_median_upper_95:.9} exceeds {WHOLE_MAXIMUM_UPPER_RATIO:.1}"
+    );
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -170,25 +170,27 @@ Written under `.uor-models/` (or `UOR_MODEL_STORE`):
 | `last_model.txt` / `last_model_name.txt` | Orchestrator's last model selection |
 | `last_engine.txt` | Persisted engine preference; **silently pins the cascade** for requests that omit `engine` |
 | `sources/<name>/` | Downloaded Hugging Face teacher sources |
-| `compiled/<name>/` | Compiled bundles: `score.r4g1`, `tless_artifacts.bin`, `tless_store.bin`, deployed `tokenizer.bin`, full source binding `tokenizer_adapter.json`, source-attention binding `attention_operator.json` (both used to fail-close corpus resume/evaluation), `corpus.meta`, and `corpus.records` |
-| `compiled/<name>-attention-v2/` | Browser-compile output when `compiled/<name>/` is already populated by the implicit or explicit source-attention v1 era. The server preserves the v1 root byte-for-byte and deterministically writes/resumes v2 here; restart discovery prefers this exact current-v2 sibling and maps the exact suffix back to `sources/<name>/`. Malformed, nonregular, conflicting, or unbound-populated v2 provenance is a hard error. Explicit CLI `--output` paths are never auto-rerouted. |
+| `compiled/<name>/` | Base compiled bundle. It may hold legacy absence, an explicit historical attention/1+dense/1 pair, or a fresh current attention/2 bundle with dense absent. Inventory includes graph/artifact outputs, `tokenizer.bin`, `tokenizer_adapter.json`, `attention_operator.json`, optional `dense_operator.json`, `corpus.meta`, and `corpus.records`. |
+| `compiled/<name>-attention-v2/` | Resolver-owned current attention/2 root with dense absent, used when a historical base must remain immutable. |
+| `compiled/<name>-attention-v2-dense-v2/` | Resolver-owned current GPT-2 root. It must carry learned-absolute attention/2 plus `gpt2-source-dense/2`; current dense provenance is invalid in either lower-precedence root. |
 | `corpora/` | Observation corpora |
 
-### Managed attention-era resolver (2026-08-15)
+### Managed source-execution-era resolver (2026-08-15)
 
-`-attention-v2` is reserved for the server's physical era root; a downloaded
-source basename ending in that token is refused before compilation mutates an
-output. The base and exact-suffix reload names are aliases for one logical
-model. Both attach to `sources/<logical-name>/`, and status reports the
-selected physical root separately. A missing source is allowed for the #718
-decode-only path; a source entry that exists but is not a usable directory is
-an error.
+`-attention-v2` and `-attention-v2-dense-v2` are reserved physical-root
+suffixes; downloaded source basenames ending in either are refused before
+mutation. Suffix stripping uses longest match. The base and exact-suffix reload
+names are aliases for one logical model, attach to `sources/<logical-name>/`,
+and report the selected physical root plus optional attention/dense records.
+A missing source is allowed for the #718 decode-only path; a present-invalid
+source is terminal.
 
-Every managed operation inspects both physical roots before choosing either
-one. A malformed/nonregular binding, an unbound populated suffix, a future
-version, conflicting operator families, or two current roots is terminal.
-Current-v2 startup/reload also requires the canonical corpus pair and
-`graph-cover/cover_report.json` to carry the same registry-exact operator as
-the root sidecar. Historical v1 remains readable when those newer supporting
-records are genuinely absent. These checks reconcile the available metadata;
-they do not add the graph-byte provenance section tracked separately by #637.
+Every managed operation inspects all three roots before choosing one. A
+malformed/nonregular binding, an unbound populated suffix, a future version,
+an impossible attention+dense pair, duplicate semantic identities, or an
+unfinished lower-precedence identity is terminal and byte-preserving. Current
+startup/reload also requires the canonical corpus pair and
+`graph-cover/cover_report.json` to carry the same registry-exact execution pair
+as the root sidecars. Historical v1 and dense absence remain readable where
+documented. These checks reconcile metadata; they do not add the graph-byte
+PROV section tracked separately by #637.

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -84,8 +84,17 @@ accept `--source-manifest-kappa`, recording it as the optional
 `source_manifest_kappa` field of the cover/compile report and the observation
 manifest; `uor-r4-api`'s `CompileRequest.source_manifest_kappa` forwards it to
 the cover stage; and the HTTP server's compile job binds it automatically when
-the downloaded snapshot carries a `source_manifest.json`. Legacy inputs
-without a manifest compile exactly as before, with the field absent.
+the downloaded snapshot carries a `source_manifest.json`. Direct legacy inputs
+without a manifest compile with the field absent; the managed-server
+compatibility exception is documented next.
+
+**Known pre-existing type limitation.** The managed-server compatibility path
+also computes a domain-separated tree digest for an admitted manifestless
+source so resume remains byte-bound. Historical server plumbing carries that
+digest through the scalar field named `source_manifest_kappa`; it is **not** a
+κ of a nonexistent `source_manifest.json` and must not be cited as one. A
+separate provenance-schema migration will distinguish `{manifest, tree}`
+without changing #704's pinned observation `/1` and `/2` identity bytes.
 
 **Migration note.** Descriptor κs minted before #597 with
 `source_kappa_scope = "model.safetensors"` (e.g. `source_kappa` in
@@ -94,8 +103,9 @@ the `model.safetensors` bytes and nothing else. They are NOT relabeled and do
 not become snapshot identities; the snapshot-wide identity is only the
 `source_manifest.json` root κ described above. Neither identity includes the
 executor's arithmetic: changing a reduction leaves the source bytes and both
-source κs unchanged. The versioned `attention_operator` record, rather than a
-source κ re-pin, carries that arithmetic-era distinction.
+source κs unchanged. The versioned `attention_operator` and optional
+`dense_operator` execution records, rather than a source κ re-pin, carry that
+arithmetic-era distinction.
 
 #### Sharded snapshots (#598)
 
@@ -186,50 +196,51 @@ everywhere). Hugging Face compilation defaults to
 attention cost and KV memory proportional to the eight-token deployed runtime
 window; increase `--target` or `--sequence-length` explicitly for quality
 experiments. Repeat the same command to resume an incomplete corpus.
-Stage A writes a registry-validated `attention_operator.json` before corpus
-rows. A resume must reproduce that exact operator; an existing payload with a
-missing or different binding is refused before mutation rather than being
-silently relabelled or mixed across arithmetic eras.
+Stage A writes a registry-validated `attention_operator.json` and, when the
+teacher declares one, `dense_operator.json` before corpus rows. A resume must
+reproduce the registered pair; dense-without-attention and cross-era pairs are
+refused before either sidecar or payload is mutated. Llama and historical
+dense-absent records remain explicit compatibility states.
 
-The browser compile endpoint additionally protects the conventional
-`.uor-models/compiled/<name>` root across the v1→v2 transition. If that root is
-populated and carries an explicit source-attention v1 binding (or has legacy
-payload with no binding), the endpoint leaves it byte-for-byte untouched and
-uses `.uor-models/compiled/<name>-attention-v2`. A matching v2 root resumes;
-malformed, nonregular, or conflicting provenance is a hard error rather than a
-reason to route around the evidence. On restart, discovery prefers the exact
-current-v2 sibling for the same base model and maps only that exact suffix back
-to `.uor-models/sources/<name>`. Explicit CLI `--output` paths retain the
-stricter existing behavior: an incompatible era is refused and the caller
-chooses a fresh directory.
+The browser compile endpoint protects `.uor-models/compiled/<name>` across
+arithmetic-era transitions. The resolver inspects, in order,
+`<name>-attention-v2-dense-v2`, `<name>-attention-v2`, and `<name>`. Current
+GPT-2 dense/2 is composite-only; attention-v2 with dense absent may occupy a
+fresh base or the attention-only root, and historical v1/v1 may remain at the
+base. A matching root resumes. Malformed, nonregular, unfinished
+lower-precedence, duplicate, or conflicting provenance is terminal rather than
+a reason to route around the evidence. Explicit CLI `--output` paths retain the
+stricter behavior: an incompatible era is refused and the caller chooses a
+fresh directory.
 
 **Managed resolver hardening addendum (2026-08-15).** The server owns the exact
-`-attention-v2` suffix and rejects a downloaded source basename ending in it
-before creating or resuming output. Compile selection now inspects both roots
-even when the conventional root is already current, so a duplicate current
-root or malformed suffix cannot be hidden. Automatic restart, reload, model
-listing, and status use the same paired-root resolver. It returns the logical
-source name, selected physical root, graph, teacher artifact, and exact
-operator as one value. Base reload and the exact suffix alias therefore choose
-the same bundle and attach `.uor-models/sources/<logical-name>`; status exposes
-the physical root separately.
+`-attention-v2` and `-attention-v2-dense-v2` suffixes and rejects downloaded
+source basenames ending in either before creating or resuming output. Compile
+selection inspects all three roots even when the base is already current, so a
+duplicate identity or malformed preferred root cannot be hidden. Automatic
+restart, reload, model listing, and both status surfaces use the same resolver.
+It returns the logical source name, selected physical root, graph, teacher
+artifact, and optional attention/dense records as one value. Base reload and
+either exact suffix alias therefore choose the same logical model and attach
+`.uor-models/sources/<logical-name>`; status exposes the physical root and
+execution records separately.
 
 A populated preferred root is authoritative: a graph/tokenizer load error does
 not fall through to a historical sibling. A genuinely absent source still
 permits #718 token-window/decode-only loading, while a present-invalid source
-is terminal. Before current-v2 install, the server exact-compares the root
-sidecar with the canonical corpus/observation record and requires the same
-operator in `graph-cover/cover_report.json`, then re-reads the resolved
-binding. Historical v1 bundles retain compatibility when those supporting
-records are genuinely absent. This is a consistency check over recorded
-metadata, not a claim that the score graph bytes themselves carry the operator;
-that R4G1 PROV binding remains tracked by #637.
+is terminal. Before current-v2 install, the server compares both root sidecars
+with the canonical corpus/observation pair and requires the same pair in
+`graph-cover/cover_report.json`, then re-reads the resolved bindings. Historical
+v1 and dense-absent bundles retain compatibility only when those records are
+genuinely absent. This is a consistency check over recorded metadata, not a
+claim that the score graph bytes themselves carry the records; that R4G1 PROV
+binding remains tracked by #637.
 
 Offline Llama/shared teacher projections use the pinned portable exact
 `uor-matmul` owner on every host; there is no alternate Accelerate, NEON,
-AVX2/FMA, or scalar projection route for those sites. GPT-2 Conv1D/MLP and its
-tied `lm_head` remain explicitly conventional, while current-v2 QK/value
-attention uses the certified-native/exact-fallback owner described below.
+AVX2/FMA, or scalar projection route for those sites. Current GPT-2 Conv1D,
+MLP, tied `lm_head`, QK, and weighted-value folds use their separately
+versioned certified-native/exact-fallback owners described below.
 `TLESS_EXACT_SCALAR` remains accepted only so older scripts do not fail and no
 longer changes Llama projection arithmetic. `TLESS_CANONICAL_DETERMINISTIC=1`
 still selects the portable libm/reduction family for the other κ-sensitive
@@ -244,6 +255,7 @@ tless_store.bin           # TLS1 graded continuation evidence
 tokenizer.bin             # deployed token table (tagged decode-only for SentencePiece)
 tokenizer_adapter.json    # full source adapter binding for corpus resume/evaluation
 attention_operator.json   # registered source-attention binding for corpus resume/cover
+dense_operator.json       # optional registered source-dense binding (current GPT-2)
 corpus.meta               # observation-corpus metadata
 corpus.records            # deterministic observation records
 hamming_calibration.json
@@ -609,9 +621,10 @@ resolves all six source records exactly.
   the switch) retains learned absolute positions and the historical GPT-2
   reciprocal-multiply ordering: scores multiply the precomputed
   `1/sqrt(head_size)`, and softmax computes one reciprocal before multiplying
-  each weight. Only Q·K and weighted-value folds are certified-exact. Dense
-  GPT-2 `c_attn`, `c_proj`, MLP projections, and `lm_head` remain conventional;
-  v2 makes no claim that they moved.
+  each weight. Q·K and weighted-value folds are certified-native under the
+  attention/2 record. GPT-2's Conv1D, MLP, and tied `lm_head` arithmetic is
+  named separately by the dense record below; the attention record does not
+  absorb or relabel that evidence.
 
 The current shared seams preserve caller-owned output/scratch storage and keep
 the certified and exact-fallback arms allocation-free after setup. Tests pin
@@ -619,36 +632,61 @@ the full/scored domains, GPT-2's reciprocal order, Llama's per-score division,
 the experimental tail policy, exact-bit parity, forced certificate rejection,
 and the registry's immutable v1/v2 bytes.
 
-The record threads into provenance alongside the #597 manifest κ, the #600
-geometry record, and the #601 tokenizer record. Observe drivers record the
-oracle's exact declaration in the observation manifest (`attention_operator`,
-an optional serde-defaulted field), and all shipped Llama/GPT-2 source oracles
-declare their registered operator. Direct source compilation publishes the
-same record atomically as `attention_operator.json` before corpus bytes; resume
-requires exact equality and refuses a missing, malformed, unregistered, or
-different binding before mutation. The cover stages (`transformerless cover`,
-`graph-compile`) accept `--attention-operator <json>` and bind it as the
-optional `attention_operator` field of the cover/compile report. The typed API
-and HTTP server forward the registry-validated stage-A/recorded binding rather
-than reconstructing it from the `r4_attention` policy bit, which preserves
-GPT-2's learned-absolute identity. `compile-recorded` likewise propagates an
-explicit observation-manifest record. New source compiles and observations
-declare the exact current-v2 record selected by architecture/switch; readers
-continue to accept exact immutable v1 records, but every resume, cover, and
-evaluation seam compares the whole record and refuses cross-era replay.
+#### GPT-2 dense execution identity (#704)
 
-An absent record remains the implicit legacy era: documents produced before
-#602 are not rewritten, and a genuinely operator-less caller-supplied corpus
-may be interpreted as `standard-source-attention/1`. That compatibility does
-not authorize adding current source-teacher rows to unbound bytes; source
-compile/resume requires the explicit sidecar. **Honesty item:** the
-score/certify report structs in
-`uor-r4-graph-certify` carry no attention-operator field — that stage
-reads corpus, cover, and artifact bytes with no teacher oracle in reach
-(the #597 source κ and #600 geometry records are likewise absent there),
-so #602 records the gap instead of inventing plumbing; an
-operator-specific experiment should thread the record through the cover
-report it already consumes.
+GPT-2's fixed-weight Conv1D projections (`c_attn`, `c_proj`, and both MLP
+projections) and tied `lm_head` are a second host-side arithmetic identity.
+`uor-r4-model-source::dense::DenseOperatorSpec` records the weight layouts,
+accumulation semantics, bias placement, arithmetic owner, permitted host
+operation class, and implementation digest. The registry contains immutable
+`gpt2-source-dense/1` (the historical sequential binary32 folds) and current
+`gpt2-source-dense/2` (the correctly-rounded binary32 result of the exact-real
+dot, produced by certified-native preparation/refinement with pinned exact
+fallback). The stable public constructor names v2; v1 remains readable and is
+never rewritten.
+
+Dense provenance is optional because Llama has no separate dense record and
+pre-#704 observations genuinely lack one. When present, it forms one registered
+source-execution pair: learned-absolute attention/1+dense/1 or learned-absolute
+attention/2+dense/2. Dense without attention, a non-GPT-2 attention family, or
+cross-era versions fail before mutation. A present dense record selects
+observation identity bundle `/2`; absence preserves the exact historical `/1`
+byte stream and digest. See [gpt2_dense_704.md](gpt2_dense_704.md) for the
+measurement contract and adoption evidence.
+
+**Pre-1.0 source migration.** Adding optional dense provenance is an
+intentional additive source-level change to public record structs including
+`ObservationManifest`, `GraphCompileOptions`, `CoverReport`,
+`ScreenIdentities`, and the focused `SourceIngestKind` error inventory. Public
+session functions keep their historical positional signatures as dense-absent
+wrappers and expose explicit `*_with_dense` variants. External Rust struct
+literals must add the optional field (normally `None`) or use the available
+constructor/default and then set fields. The records are not marked
+`#[non_exhaustive]` retroactively because doing so would be a separate breaking
+change for existing literals and exhaustive matches.
+
+The execution pair threads into provenance alongside the #597 manifest κ, the
+#600 geometry record, and the #601 tokenizer record. Observe drivers record the
+oracle's declarations as optional serde-defaulted `attention_operator` and
+`dense_operator` fields. Direct source compilation publishes the same records
+atomically as `attention_operator.json` and optional `dense_operator.json`
+before corpus bytes; all pair checks run before either setter. Cover accepts
+`--attention-operator <json>` and `--dense-operator <json>` and persists the
+validated pair in its report. The typed API, `compile-recorded`, evaluation,
+certification, completion inventory, server reload, and both status surfaces
+propagate or expose the same records rather than reconstructing them from a
+policy bit. Readers accept immutable v1/v1 and dense absence, but every current
+resume/cover/evaluation boundary compares the complete available pair and
+refuses cross-era replay.
+
+An absent attention record remains the implicit legacy era: documents produced
+before #602 are not rewritten, and a genuinely operator-less caller-supplied
+corpus may be interpreted as `standard-source-attention/1`. Dense absence is
+typed independently and remains valid for Llama and historical GPT-2 evidence.
+Neither compatibility rule authorizes adding current source-teacher rows to
+unbound bytes. The octeract trace screen registry-validates the pair from the
+observation manifest and persists the optional source dense digest in
+`ScreenIdentities`; it does not invent a teacher identity from artifact bytes.
 
 **Boundary note.** These specs describe HOST-SIDE source-teacher
 computation (f32 dot products, `exp`, division). The deployed inference
@@ -780,14 +818,14 @@ probability rows, trace rows, text `committed.bin`, `state.bin`, merged bytes,
 and public readers keep their historical layouts.
 
 **Bundle identity.** The manifest's identity seam is ONE stable bundle:
-`ObservationManifest::identity_bundle_digest()` computes a canonical
-blake3 over the five existing identity fields (`input_cid`,
-`source_manifest_kappa` #597, `geometry` #600, `tokenizer_adapter`
-#601, `attention_operator` #602) plus the #603 `trace_profile`, in a
-fixed order with explicit `absent` / `present:<value>` markers per
-component — so the digest moves when any component changes, is
-independent of the order the fields were recorded in, and an absent
-component is never confusable with an empty or zero one.
+`ObservationManifest::identity_bundle_digest()` computes a canonical blake3
+over seven components: `input_cid`, `source_manifest_kappa` #597, `geometry`
+#600, `tokenizer_adapter` #601, `attention_operator` #602, optional
+`dense_operator` #704, and `trace_profile` #603. The legacy `/1` stream omits
+the dense component entirely and remains byte-exact when dense is absent; a
+present dense record selects `/2` and is ordered between attention and trace.
+Both versions use explicit `absent` / `present:<value>` markers, so identity is
+setter-order independent and absence is never confusable with an empty value.
 
 **Capture plumbing, bounded.** Richer lanes are captured through the
 surfaces that already exist: the #599 `forward_capturing` discipline
@@ -1180,11 +1218,14 @@ cargo run --release -- evaluate-report \
   --report .uor-models/compiled/smollm2-135m-instruct/instruction-eval.json
 ```
 
-The report file stores an envelope with the held-out D3 metrics (top-1
-accuracy, teacher-argmax agreement, Witten–Bell bits/token vs the teacher
-floor), source/artifact/store/tokenizer/corpus CIDs, and
-`report_cid_of_report_bytes` for the inner metrics payload. Do not mark an
-artifact as passing merely to bypass the chat quality gate.
+Schema 4 stores an envelope with the held-out D3 metrics (top-1 accuracy,
+teacher-argmax agreement, Witten–Bell bits/token vs the teacher floor),
+source/artifact/store/tokenizer/corpus CIDs, the validated attention record,
+the optional dense record, CIDs of both sidecars when present, and
+`report_cid_of_report_bytes` for the inner metrics payload. Typed dense absence
+is persisted for Llama/historical evidence; arithmetic-dependent evaluation
+does not rely on rereading a mutable bundle directory. Do not mark an artifact
+as passing merely to bypass the chat quality gate.
 
 ### 6. Import the evaluated bundle
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -47,6 +47,16 @@ are shipped:
 - **The two-sided calibration gain** (#446), which is causally legitimate, sits
   at top-1 parity, and grows large at scale in bits.
 
+The offline source-teacher arithmetic migration is also measurement-gated.
+For GPT-2 dense execution (#704), the pre-declared whole-model 11-token gate
+passed: paired median candidate/conventional time was `0.694987183`, with an
+exact one-sided 95% bootstrap upper bound of `0.703876225` against the `≤ 3.0`
+rule, while timed output parity and the allocation/fallback census remained
+clean. That result adopts `gpt2-source-dense/2` for Conv1D, MLP, and tied
+`lm_head` source execution without changing the deployed table runtime. The
+run contract, hashes, negative canaries, and census are in
+[gpt2_dense_704.md](gpt2_dense_704.md).
+
 > **Reading the 0.8948 correctly.** It is a **cosine-ranked** figure. For a long
 > time it did not describe `get_top_resonances_native`, whose ordering is word
 > overlap — and #486 found the reason: that path compared a *routing* vector

--- a/docs/d2_canonical_compile.md
+++ b/docs/d2_canonical_compile.md
@@ -13,8 +13,9 @@ The mode is selected by `TLESS_CANONICAL_DETERMINISTIC=1` and currently does
 the following:
 
 - keeps Llama/shared teacher projections on the always-enabled pinned exact
-  `uor-matmul` owner; GPT-2's deliberately conventional dense sites are
-  outside this legacy D2 switch;
+  `uor-matmul` owner; GPT-2 attention/2 and dense/2 use their separately
+  versioned certified-native/exact-fallback owners outside this legacy D2
+  switch;
 - routes teacher `sqrt`, `exp`, `pow`, `sin`, and `cos` through the portable
   pure-Rust `libm` implementation;
 - routes transformerless compiler softmax, power-of-two packing, projection
@@ -22,8 +23,9 @@ the following:
   portable math family.
 
 `--exact-scalar` is a deprecated compatibility input. It no longer changes
-Llama/shared projection arithmetic and does not select a GPT-2 Conv1D or
-`lm_head` implementation.
+Llama/shared projection arithmetic and does not select or relabel GPT-2
+Conv1D/MLP/`lm_head` arithmetic; that dispatch follows the registered dense
+execution record.
 
 The mode is compiler-side only; the deployed runtime contract is unchanged.
 CI now runs a macOS/Linux differential compile of the pinned

--- a/docs/gpt2_dense_704.md
+++ b/docs/gpt2_dense_704.md
@@ -1,0 +1,147 @@
+# GPT-2 certified dense source execution (#704)
+
+- **Date:** 2026-08-15
+- **Role:** Empirical Criterion and implementation record
+- **Scope:** offline GPT-2 source-teacher execution only
+- **Issue:** [UOR-Foundation/uor-r4#704](https://github.com/UOR-Foundation/uor-r4/issues/704)
+
+This file is append-only evidence for the Choice-A dense migration. It does not
+change or weaken the deployed R4 inference operation contract: deployed graph
+inference remains allocation-free and multiplication-free. The floating-point
+work described here runs only while an offline teacher produces observations.
+
+## Decision history
+
+The first exact-owner prototype was about `220x` slower than conventional GPT-2
+and was not shipped. Immutable prepared weights did not rescue it: the real
+layer-0 `c_attn` consumer measured `1357.803945x`, and a later lookup/grade
+reachability study still left an optimistic `45.6–57x` gap. A first
+certified-native row design matched exact output bits but measured
+`16.903285271x` despite certifying 20,676 of 20,736 lanes. Those negatives rule
+out allocation cleanup, prepacking alone, and the original certified bound.
+
+The maintainer then selected **Choice A**: compiler arithmetic may use a native
+lane only when a mechanical witness establishes the declared binary32 result;
+uncertain lanes use the pinned exact owner. Output semantics remain exact and
+the deployed runtime remains unchanged.
+
+The replacement factorization passed its strict layer-0 cheap gate before any
+whole-model clock:
+
+| metric | result | rule |
+|---|---:|---:|
+| paired median, real layer-0 `c_attn` | `1.838843890x` | descriptive |
+| exact one-sided 95% bootstrap upper | `1.847055652x` | `<4.0x` |
+| lane census | 20,673 fast + 63 refined + 0 fallback | complete |
+| hot allocations | 0 | 0 |
+| pinned-exact output parity | bit-for-bit | required |
+
+That positive cheap gate activated, but did not prejudge, the whole-model run.
+
+## Pre-declared whole-model contract
+
+- **Metric:** paired candidate/conventional elapsed time for three independently
+  reset real GPT-2 stories, 11 recurrent steps total.
+- **Reachability instrument:** all 49 fixed matrices must be reached with
+  exactly 539 calls and 1,465,211 output lanes per suite; fast and refined arms
+  must both be nonzero and exact fallback must be zero before timing.
+- **Correctness:** production/default equals explicit conventional state;
+  candidate equals the stored pinned-exact recurrent state after every step;
+  every poisoned output is overwritten and every lane receives one verdict.
+- **Fairness:** one loaded immutable model, one prepared caller-owned workspace,
+  two complete warmup suites per arm, then nine adjacent pairs with alternating
+  first arm. Load, preparation, reset, parity, census, and allocation accounting
+  are outside timers.
+- **Estimator:** median of the nine paired ratios. The binding statistic is the
+  deterministic exact empirical-bootstrap one-sided 95% upper percentile; for
+  nine distinct samples it is the seventh ordered ratio.
+- **Exit rule:** every hard precondition passes and the upper bound is
+  `<=3.0x`.
+- **If positive:** implement current production dispatch plus a separate dense
+  execution record, preserve source κ and historical identities, then run the
+  repository gates and review.
+- **If negative:** ship no dispatch/provenance/pin/API and run no additional
+  dense clock.
+
+## Frozen measurement identity
+
+- Base: `6fbf718b4115859df6544545a5c43d7638a6ad0a`
+- Candidate `gpt2.rs` SHA-256:
+  `1a945487fb9ec350fd8f670b8c04dacaf6b66e2339ee96b6b3883082e4de4bf8`
+- Harness SHA-256:
+  `144fd32d35292a6fd3e949bc7040b7e14c58563bdc31924b66d38bc1db547d89`
+- Exact fallback owner: `uor-matmul`
+  `b13c98449948174f590e337c4dc25dfc394a07d0`
+- Source: `openai-community/gpt2@607a30d783dfa663caf39e06633721c8d4cfcd7e`
+- Model: 548,105,171 bytes,
+  `blake3:3bca1b7f6c327daecafc16e52d1319375299354e35413fb4e18d24e59b77ce06`
+- Config: 665 bytes,
+  `blake3:23e4471d412e06128072b559c031207de920b8a56d7108879d4b487c079a310c`
+- Host/toolchain: Apple M1, aarch64 macOS, rustc 1.97.1 / LLVM 22.1.6,
+  release build, no external codegen/profile overrides.
+
+The later production-integration compatibility repair changes opaque scratch
+equality but not model outputs or the frozen measurement. Its final reviewed
+`gpt2.rs` SHA-256 is
+`d29e209af69e2d79a7aee5ef027029a9d8921645779cd17b97e9dcaae536c384`.
+
+## Whole-model result
+
+Each time is the sum of only the 11 forward calls.
+
+| pair | first | candidate ns | conventional ns | paired ratio |
+|---:|---|---:|---:|---:|
+| 0 | candidate | 310,361,916 | 438,655,001 | 0.707530782 |
+| 1 | conventional | 305,372,418 | 439,392,877 | 0.694987183 |
+| 2 | candidate | 306,299,583 | 441,852,623 | 0.693216623 |
+| 3 | conventional | 303,427,415 | 439,566,250 | 0.690288244 |
+| 4 | candidate | 309,243,207 | 439,152,917 | 0.704181152 |
+| 5 | conventional | 302,627,915 | 439,511,791 | 0.688554713 |
+| 6 | candidate | 306,728,040 | 440,322,877 | 0.696598010 |
+| 7 | conventional | 303,182,542 | 439,220,832 | 0.690273593 |
+| 8 | candidate | 308,994,624 | 438,990,000 | 0.703876225 |
+
+- Paired median: **`0.694987183x`**.
+- Exact empirical-bootstrap one-sided 95% upper: **`0.703876225x`**.
+- Candidate median: `306,299,583 ns/suite` (`27,845,417 ns/token`).
+- Conventional median: `439,392,877 ns/suite` (`39,944,807 ns/token`).
+- Ratio of arm medians: `0.697097288x` (descriptive, not the gate).
+- Structural/preflight census per suite: 539 calls / 1,465,211 lanes;
+  1,450,907 fast + 14,304 refined + 0 fallback.
+- Timed census: 4,851 calls / 13,186,899 lanes; 13,058,163 fast +
+  128,736 refined + 0 fallback.
+- Prepared workspace: 157,203,831 bytes; preparation remained outside timing.
+- Every preflight/warmup/timed candidate state matched the pinned exact route;
+  every timed candidate and conventional call allocated zero bytes.
+
+**Verdict: PASS.** The binding upper `0.703876225x` is below `3.0x`, and every
+hard identity, parity, census, overwrite, fallback, and allocation precondition
+passed.
+
+## Adopted execution provenance
+
+`DenseOperatorSpec` is model-source execution provenance, not source-file
+provenance and not a runtime configuration knob. Current GPT-2 declares
+`gpt2-source-dense/2`; the historical sequential binary32 folds remain
+`gpt2-source-dense/1`. The final canonical declared digests are:
+
+- dense/1:
+  `blake3:b16a2a7f14828f854a7784d33cea9b49631136dbda77491899f2171cec011033`
+- dense/2:
+  `blake3:3a61d92e61b2a322e086162767173aca8439dffd1ddc7443f1d8b44ee1b1eaf6`
+
+Only learned-absolute attention/1+dense/1 and learned-absolute
+attention/2+dense/2 are registered explicit GPT-2 pairs. Dense absence remains
+valid for Llama and historical records. Observation identity bundle `/1` bytes
+are unchanged when dense is absent; a present dense record selects `/2` between
+the attention and trace components. Source and snapshot κs remain addresses of
+source bytes and do not move for this executor-only change. Observation,
+corpus, report, and artifact CIDs move only when their own bytes move.
+
+Production integration preserves serial, trace, and batched dispatch parity;
+validates the pair before mutation at observation, recorded-corpus, cover,
+evaluation, certification, API, completion/recovery, and serving boundaries;
+and places current dense/2 bundles only in the resolver-owned
+`<name>-attention-v2-dense-v2` root. This does not assert that a manifestless
+source-tree digest is a `source_manifest.json` κ; that pre-existing provenance
+type limitation is tracked separately from #704.

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -53,10 +53,10 @@ conventional arithmetic is a migration target for #655-B.
 The shared Llama teacher **weight matmuls** now call the pinned `uor-matmul`
 exact GEMM (`uor_matmul::slice::gemm_float`). The Accelerate `cblas_sgemv` /
 `cblas_sgemm` FFI and all hand-rolled SIMD dot helpers are removed. GPT-2's
-tied lm-head is a distinct hand-rolled fold and remains conventional below.
+separate dense sites are covered by their own certified-exact row below.
 The migrated Llama result is correctly-rounded exact and byte-identical across
 targets (no per-machine Accelerate variance) — a determinism improvement for
-teacher-side κ.
+teacher outputs and the derived corpus/artifact bytes that bind those outputs.
 
 | Site | Operation | Backend | Classification |
 |---|---|---|---|
@@ -67,50 +67,43 @@ No `cblas_*` symbol remains anywhere in the production chain; the CI guard now
 enforces zero library-BLAS use (only the two dependency-audit files, which list
 BLAS crate names as denylist data, are exempt).
 
-### certified-exact (migrated by #704 A2)
+### certified-exact (migrated by #704)
 
-Current-v2 source attention uses caller-owned output/scratch storage. For each
-Q·K row or weighted-value column it forms exact binary32 products in binary64,
-computes an outward roundoff enclosure, and accepts the native result only when
-the full enclosure lies strictly inside one binary32 rounding cell. The pinned
-`uor-matmul` exact GEMM is the control and fallback, so every accepted or
-fallback lane returns the same correctly-rounded f32 bit. This is host-side
-teacher arithmetic; it does not enter the deployed kernel.
+Current-v2 source attention and GPT-2 dense execution use caller-owned
+output/scratch storage. The certified-native path prepares a binary64 result,
+refines ambiguous lanes, and falls back to the pinned exact owner whenever its
+rounding certificate cannot establish the declared binary32 result. This is
+host-side teacher arithmetic; it does not enter the deployed kernel.
 
 | Site | Operation | Backend | Classification |
 |---|---|---|---|
 | `uor-r4-model-source/src/attention.rs` source-attention helpers | per-head Q·K and weighted-value column folds for standard, experimental, and GPT-2 learned-absolute v2 | certified-native f64 fold + mechanical cell witness; pinned `uor-matmul` exact fallback | certified-exact |
+| `uor-r4-model-source/src/gpt2.rs` `conv1d` / `conv1d_batched` | fixed-weight Conv1D `x@W` for `c_attn`, `c_proj`, and MLP projections | certified-native prepared/refined exact-real dot; pinned exact fallback | certified-exact |
+| `uor-r4-model-source/src/gpt2.rs` `finish_forward` / `forward_batch` | tied `lm_head` projection | certified-native prepared/refined exact-real dot; pinned exact fallback | certified-exact |
 
-### conventional-to-migrate (remaining — #655-B3)
+### conventional-to-migrate
 
-GPT-2 keeps conventional dense Conv1D arithmetic, a separate fixed-weight
-follow-up. Its current-v2 attention Q·K/value folds are certified-exact above:
-
-| Site | Operation | Backend today | Classification |
-|---|---|---|---|
-| `uor-r4-model-source/src/gpt2.rs` `conv1d` / `conv1d_batched` | fixed-weight Conv1D `x@W` for `c_attn`, `c_proj`, and MLP projections | hand-rolled f32 | conventional-to-migrate |
-| `uor-r4-model-source/src/gpt2.rs` `finish_forward` / `forward_batch` | tied `lm_head` projection | hand-rolled f32 | conventional-to-migrate |
-
-These are not library-BLAS (no `cblas_*`), so the mechanical guard does not flag
-them; they are tracked here for #655-B3.
+No matrix-like production-chain site remains in this class after #704. The
+historical GPT-2 binary32 left folds remain reproducible under
+`gpt2-source-dense/1`; they are provenance history, not a current dispatch.
 
 ## Teacher-arithmetic eras (#655-B2, #704 A2)
 
-Switching the teacher weight matmuls from Accelerate/hand-rolled f32 to the exact
-`uor-matmul` GEMM changes teacher output bytes, so compiled artifacts produced
-after B2 have different CIDs than pre-B2 ones. This is recorded by the teacher's
-own κ (blake3 over teacher output), which changes accordingly, and surfaced in
-the "teacher model ready" diagnostic (`matmul=uor-matmul exact GEMM`). No test
-pins a pre-B2 teacher-derived κ as a constant (verified across the full suite),
-so no fixture re-pin is required; post-B2 CIDs are a new teacher-arithmetic era
-and are never retroactively assigned to pre-B2 artifacts.
+Changing teacher arithmetic can change observation rows and derived artifact
+CIDs. It does **not** change the source-file/snapshot κ: those addresses cover
+source bytes, not teacher output, and there is no separate "teacher output κ"
+with that meaning. Arithmetic eras are recorded by the typed attention/dense
+records; downstream corpus, report, and artifact identities move when their
+actual bytes move. No source κ is re-pinned for an executor-only change.
 
-#704 A2 appends a second explicit era for source attention. The current
+#704 appends second explicit eras for source attention and GPT-2 dense
+execution. The current
 `standard-source-attention/2`, `experimental-r4-source-attention/2`, and
 `learned-absolute-source-attention/2` records use the certified-exact Q·K and
-weighted-value folds described above. The immutable `/1` records continue to
-identify the prior sequential/chunked f32 bytes; existing v1 bundles are never
-relabelled or resumed as v2.
+weighted-value folds described above. `gpt2-source-dense/2` names current
+Conv1D, MLP, and tied-lm-head semantics. The immutable attention/1 and dense/1
+records continue to identify prior bytes; existing bundles are never relabelled
+or resumed across eras.
 
 ## Out of census scope
 
@@ -134,11 +127,11 @@ the crate-dependency audits confirm it pulls in no BLAS/GPU crate.
   (#701). No behavior/CID change.
 - #655-B2: Llama teacher weight matmuls (`matmul`, `matmul_batched`) migrated
   to `uor_matmul::slice::gemm_float`; `cblas_*` FFI + SIMD dot helpers removed;
-  census guard tightened to zero library-BLAS. GPT-2's separate tied `lm_head`
-  fold did not migrate and remains in the conventional table above.
-  Teacher-arithmetic era change (see above); no fixture re-pin required.
+  census guard tightened to zero library-BLAS. Teacher-arithmetic era change
+  (see above); no source-κ re-pin required.
 - #704 A2 (2026-08-15): source-attention Q·K and weighted-value folds migrated to the
   certified-exact path for all current `/2` families; `/1` provenance remains
   immutable.
-- #655-B3 remaining: migrate GPT-2 fixed-weight `conv1d` / `conv1d_batched`
-  and tied `lm_head` folds.
+- #704 dense (2026-08-15): GPT-2 fixed-weight `conv1d` / `conv1d_batched`,
+  MLP, and tied `lm_head` folds migrated under `gpt2-source-dense/2`; dense/1
+  remains immutable history. #655-B3 is closed by this row.

--- a/docs/r4_graph_compiler_implementation_plan.md
+++ b/docs/r4_graph_compiler_implementation_plan.md
@@ -75,9 +75,10 @@ Recorded in the R4G1 RFC in Phase 0; implemented as a compiler mode in Phase 2.
 Implementation update (2026-08-15): #655-B2 removed the historical
 Accelerate/NEON/AVX2 split from Llama/shared teacher projections, which now use
 the pinned portable exact `uor-matmul` owner. GPT-2 Conv1D/MLP and tied
-`lm_head` remain conventional; current-v2 QK/value attention has its own
-certified-native/exact-fallback owner. Canonical mode continues to govern the
-remaining libm and ordered-reduction choices.
+`lm_head` now use the separately versioned dense/2 certified-native/exact-
+fallback owner; current-v2 QK/value attention retains its own execution record
+and owner. Canonical mode continues to govern the remaining libm and
+ordered-reduction choices.
 
 ### D3 — Evaluation distribution and corpora
 
@@ -242,9 +243,9 @@ only; it must never become a dependency of format/runtime/proof-model. Per-stage
 2. No naive parallel FP reductions: FP addition is non-associative, so all reductions are ordered
    (shard-ID order) with f64 or fixed-point accumulators.
 3. Llama/shared weight projections use pinned exact `uor-matmul`. Certificate-bearing compiles
-   additionally select the canonical libm and ordered-reduction family; GPT-2's conventional
-   dense sites and certified-exact current attention are recorded separately rather than being
-   relabeled by this historical D2 switch.
+   additionally select the canonical libm and ordered-reduction family; GPT-2's certified-exact
+   dense/2 and current attention/2 sites are recorded separately rather than being relabeled by
+   this historical D2 switch.
 4. Seeds pinned; any shuffling derives from a seeded PRNG over sample IDs, never iteration order.
 
 **Memory budget.** See [compiler_memory_budget.md](file:///Users/casey.allard/uor-r4/docs/compiler_memory_budget.md) (Issue #169) for the normative concurrency-aware memory budget and backpressure model. A `--memory-budget` flag derives shard sizes from

--- a/docs/scaling_law.md
+++ b/docs/scaling_law.md
@@ -174,8 +174,9 @@ promise.
   surfaced a latent bug: `compile-recorded --out $D` re-emits
   `corpus.meta`/`corpus.records` into `$D`, clobbering same-directory inputs.
   The harness now writes each sub-sample as a canonical pair under
-  `$D/input/`, uses `copy-recorded-attention` to preserve its
-  registry-validated source-attention binding, and uses the copied output pair
+  `$D/input/`, uses `copy-recorded-attention` to preserve its complete
+  registry-validated source-execution pair (attention plus optional dense), and
+  uses the copied output pair
   for cover/score. Keeping input and output roots distinct also prevents an
   unrelated same-directory filename pair from inheriting another corpus's
   provenance.

--- a/docs/scaling_law.md
+++ b/docs/scaling_law.md
@@ -193,3 +193,54 @@ promise.
   earlier 360M-only sweep (#516, below the knee at 360k) is superseded by this
   past-knee measurement. The law, the calculator, and the harness remain complete
   and mutually consistent; what remains is a resolution metric, not compute.
+
+## 2026-08-16 honesty correction and current runbook (#729)
+
+This section supersedes the interpretation and operational instructions above;
+the earlier text and tables remain as the dated record of what was run and what
+was believed at the time.
+
+The #531 rows were produced with the retired Python prefix writer. That helper
+ended a source prefix at a complete story-run boundary, then wrote the derived
+metadata's `stories` field as `max(kept story id) + 1`. Because the compiler's
+80/20 cutoff is calculated from that field, the cutoff moved with each derived
+corpus instead of retaining the finalized source's train/held partition. The
+rows are still descriptive records of those individual executions, but their
+size-to-size differences confound record count with partition membership.
+
+Consequently, #531 is **not** fixed-partition evidence for a 1.5M-record knee,
+does **not** empirically ground `N_REF = 2,000,000`, and supplies no β estimate.
+`N_REF` and the provisional `BETA = 0.5` remain estimator configuration, not
+parameters certified by that sweep. Issue #729 changes the derivation and
+workflow only; it does not spend another multi-hour run or replace the
+historical rows with new measurements.
+
+The current fixed-partition runbook is:
+
+```bash
+# Defaults: 50k/200k/800k when below the source, then the exact source N.
+scripts/scale_sweep.sh SOURCE/corpus.meta SOURCE/corpus.records 49152
+
+# Or predeclare every requested size explicitly (the exact source is allowed).
+scripts/scale_sweep.sh SOURCE/corpus.meta SOURCE/corpus.records 49152 \
+    50000 200000 800000 1995026
+```
+
+The script validates every requested size against finalized source metadata
+before creating `WORK`; any request above the source size terminates without a
+partial sweep. Every size, including the exact-source case, goes through
+`r4 transformerless subsample-recorded-corpus`. That Rust transaction preserves
+the source `stories`, RNG state, completion marker, execution identity, and
+fixed story partition while selecting deterministic complete story runs. A
+selection may undershoot its request rather than split a run, so the report
+shows both `requested` and `actual`.
+
+Each case has sibling `input/`, `compiled/`, `cover/`, and `score/` roots. The
+reported `actual` count comes from finalized `input/corpus.meta`; `train` and
+`held` come from `cover/cover_report.json`. The script requires
+`actual = train + held` and requires both Gate C's held-out population and the
+score distribution's held-out positions to equal `held` before it prints the
+row. Re-running the same command uses the same case paths and the underlying
+idempotent publication transactions. The historical
+`scripts/mc1_subsample_corpus.py` is now a non-writing tombstone that directs
+callers to the Rust command.

--- a/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
+++ b/docs/transformerless/INFERENCE_OPERATION_CONTRACT.md
@@ -72,16 +72,17 @@ Note (non-normative cross-reference, #602 and #704): the source attention
 operator specifications in `uor-r4-model-source::attention` are host-side
 provenance records of teacher execution — an activity this section already
 excludes.
-The registry contains immutable historical and current records for all three
-source families: `standard-source-attention/{1,2}`,
+The attention registry contains immutable historical and current records for
+all three source families: `standard-source-attention/{1,2}`,
 `experimental-r4-source-attention/{1,2}`, and GPT-2's
-`learned-absolute-source-attention/{1,2}`. Version 2 changes only source-teacher
-Q·K and weighted-value folds: native results are used only when a mechanical
-witness proves the exact pinned-`uor-matmul` f32 bit, with that exact kernel as
-the fallback. GPT-2's dense `c_attn`, `c_proj`, MLP, and `lm_head` remain
-conventional. These records are distinct from this deployed contract, describe
-floating-point source computation the deployed hot path never performs, and
-change none of the operation lists or obligations above.
+`learned-absolute-source-attention/{1,2}`. GPT-2 additionally declares
+`gpt2-source-dense/{1,2}` for its host-side Conv1D, MLP, and tied `lm_head`
+folds. Current `/2` records name certified-native preparation/refinement with
+the pinned exact owner as fallback; the versioned records state the returned
+source-teacher bits, not an allowed deployed operation. These records remain
+distinct from this contract, describe floating-point source computation the
+deployed hot path never performs, and change none of the operation lists or
+obligations above.
 
 Note (non-normative cross-reference, #604): `r4-route-attention/1`
 (`R4RouteAttentionV1`, documented in `docs/MODEL_LIFECYCLE.md`) is a

--- a/docs/transformerless/OBSERVATION_FIRST.md
+++ b/docs/transformerless/OBSERVATION_FIRST.md
@@ -10,18 +10,22 @@ There are two separate offline workflows:
    work and may use matrix operations internally.
 2. Compile recorded observations. The command's data inputs are
    `corpus.meta` and `corpus.records` plus an explicit vocabulary size; it also
-   validates their sibling attention-provenance record when present. It does
+   validates their sibling attention+dense execution records when present. It does
    not construct a teacher, load model weights, call the model-source forward
    path, or use GPU backends. The representation is a deterministic signed
    hash projection of the recorded top-k next-token distributions. Calibration
    and store construction use ordered worker reductions, so output bytes do
    not depend on worker count.
 
-`compile-recorded` resolves source-attention provenance from the recorded
-corpus directory: an explicit `attention_operator.json` and a sibling
-observation `manifest.json` are registry-validated, must agree when both are
-present, and are propagated into the compiled output. Genuine historical
-absence retains the implicit `standard-source-attention/1` interpretation.
+`compile-recorded` resolves one source-execution snapshot from the recorded
+corpus directory: explicit `attention_operator.json`, optional
+`dense_operator.json`, and the sibling observation `manifest.json` are
+registry-validated, must agree when multiple records are present, and are
+propagated into the compiled output. The resolver snapshots and rechecks the
+manifest plus both sidecars jointly so disappearance or cross-era mixing fails
+before output mutation. Genuine historical attention absence retains the
+implicit `standard-source-attention/1` interpretation; dense absence remains a
+typed compatibility state for Llama and pre-#704 corpora.
 The command still does not accept a runtime tokenizer as input, propagate a
 registered tokenizer identity, or emit `tokenizer.bin`. It must therefore not
 be treated as a self-contained text-serving bundle or used to infer/relabel the

--- a/scripts/mc1_subsample_corpus.py
+++ b/scripts/mc1_subsample_corpus.py
@@ -1,91 +1,33 @@
 #!/usr/bin/env python3
-"""M-C1 subsample control for the #399/#393 capacity-starvation hypothesis.
+"""Retired pre-#729 recorded-corpus prefix writer.
 
-Produces a record-count-matched control corpus from a larger v3 (88-byte
-record) observation corpus: the FIRST `--records` records of the source,
-truncated back to the last complete story-run boundary at or before the
-target, with a correctly rewritten 25-byte meta.
+This historical helper selected a prefix ending at a story-run boundary and
+rewrote ``stories`` as ``max(kept_story_id) + 1``. That changed the derived
+80/20 story cutoff instead of preserving the finalized source corpus's exact
+train/held partition, so outputs from different requested sizes were not the
+fixed-partition controls the scaling analysis assumed.
 
-Background: a merged observation corpus (e.g. /tmp/wiki10k-obs/merged.bin,
-the 16-shard wiki10k merge) is a concatenation of shards in which EVERY
-story contributes a slice of sparse probed positions to EACH shard, stories
-ascending within a shard. Story ids are therefore not globally monotonic
-and a story is not globally contiguous; the honest truncation point is a
-story-RUN boundary (the record where the story id changes), which is what
-the corpus loader treats as a story transition when rebuilding `input`.
+Use the registry-aware Rust transaction instead:
 
-The meta `stories` field is written as `max story id + 1`: consumers index
-`vec![true; c.stories]` by story id, so the field must exceed every id
-present, and the 80/20 `train_cut` stays on the same story-id split as the
-full corpus.
+    r4 transformerless subsample-recorded-corpus \
+        --src-meta SOURCE/corpus.meta --src-recs SOURCE/corpus.records \
+        --out-meta OUTPUT/corpus.meta --out-recs OUTPUT/corpus.records \
+        --records N
 
-Usage:
-  python3 scripts/mc1_subsample_corpus.py \
-      --src-meta /tmp/wiki10k-obs/state.bin \
-      --src-recs /tmp/wiki10k-obs/merged.bin \
-      --out-meta /tmp/mc1_meta.bin --out-recs /tmp/mc1_recs.bin \
-      --records 500000
+The tombstone intentionally exits before parsing arguments, reading an input,
+or touching an output path.
 """
 
-import argparse
-import struct
 import sys
-
-RECORD_SIZE = 88  # v3: story u32 | next u32 | top8 tokens | top8 weights | 4 anchors
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--src-meta", required=True)
-    parser.add_argument("--src-recs", required=True)
-    parser.add_argument("--out-meta", required=True)
-    parser.add_argument("--out-recs", required=True)
-    parser.add_argument("--records", type=int, default=500_000)
-    args = parser.parse_args()
-
-    meta = open(args.src_meta, "rb").read()
-    if len(meta) != 25 or meta[24] != 1:
-        print(f"source meta is not a finished 25-byte corpus meta: {args.src_meta}")
-        return 1
-    n_src, stories_src, rng = struct.unpack("<QQQ", meta[:24])
-
-    target = args.records
-    with open(args.src_recs, "rb") as f:
-        buf = f.read((target + 1) * RECORD_SIZE)
-    n_avail = len(buf) // RECORD_SIZE
-    if n_avail <= target:
-        print(f"source has only {n_avail} records; nothing to truncate")
-        return 1
-
-    def story(i: int) -> int:
-        return struct.unpack_from("<I", buf, i * RECORD_SIZE)[0]
-
-    # Truncate at the last complete story-run boundary at or before target.
-    cut = target
-    if story(target - 1) == story(target):
-        i = target - 1
-        while i >= 0 and story(i) == story(target - 1):
-            i -= 1
-        cut = i + 1
-    if cut == 0:
-        print("no story-run boundary at or before the target record count")
-        return 1
-
-    kept = {story(i) for i in range(cut)}
-    stories_field = max(kept) + 1
-
-    with open(args.out_recs, "wb") as g:
-        g.write(buf[: cut * RECORD_SIZE])
-    with open(args.out_meta, "wb") as g:
-        g.write(struct.pack("<QQQ", cut, stories_field, rng) + b"\x01")
-
     print(
-        f"M-C1 subsample: {cut} records (target {target}) of {n_src}; "
-        f"{len(kept)} distinct story ids, meta stories field {stories_field} "
-        f"(source {stories_src}); last kept story {story(cut - 1)}, "
-        f"first dropped story {story(cut)}"
+        "mc1_subsample_corpus.py is retired; use "
+        "`r4 transformerless subsample-recorded-corpus`",
+        file=sys.stderr,
     )
-    return 0
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/scale_sweep.sh
+++ b/scripts/scale_sweep.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
-# scale_sweep.sh --- the #514 saturation sweep.
+# scale_sweep.sh --- the #514 saturation sweep, corrected by #729.
 #
-# Sub-sample ONE observation corpus to several record counts and record where
-# held-out top-1 and EXCT-miss flatten. That knee is the teacher's needed scale;
-# fitting log(N_knee) against log(S) across teachers calibrates the `beta` in
-# `r4 transformerless recommend-scale` (docs/scaling_law.md). You observe once at
-# the top scale --- this reuses that one corpus, no re-observation.
+# Derive several fixed-partition corpora from ONE finalized recorded corpus and
+# run compile -> cover -> score in four sibling roots per requested size. The
+# Rust sampler preserves the source corpus's train/held story partition and
+# reports the number of rows it could select without splitting a story run.
 #
 # Usage:
 #   scripts/scale_sweep.sh <src-meta> <src-recs> <vocab-size> [record-sizes...]
-# Example (a 360M wiki observe at 2M records):
+# Example:
 #   scripts/scale_sweep.sh obs/state.bin obs/merged.bin 49152 \
-#       50000 200000 800000 2000000
+#       50000 200000 800000 1995026
 #
+# With no record sizes, the sweep uses each of 50k, 200k, and 800k that is
+# strictly below the finalized source size, followed by the exact source size.
 # R4 overrides the r4 binary path (default ./target/release/r4); WORK overrides
 # the scratch dir (default /tmp/scale-sweep).
 set -euo pipefail
@@ -24,70 +25,160 @@ if [ "$#" -lt 3 ]; then
     echo "usage: scripts/scale_sweep.sh <src-meta> <src-recs> <vocab-size> [sizes...]" >&2
     exit 2
 fi
-SRC_META="$1"; SRC_RECS="$2"; VOCAB="$3"; shift 3
-SIZES=("$@")
-if [ "${#SIZES[@]}" -eq 0 ]; then
-    SIZES=(50000 200000 800000 2000000)
-fi
+SRC_META="$1"
+SRC_RECS="$2"
+VOCAB="$3"
+shift 3
+
+# Resolve and validate EVERY requested target before creating WORK or a case.
+# This is deliberately one preflight: a late invalid target must not leave an
+# apparently usable prefix of a sweep behind.
+TARGET_WORDS="$(python3 - "$SRC_META" "$@" <<'PY'
+import struct
+import sys
+
+meta_path = sys.argv[1]
+try:
+    with open(meta_path, "rb") as source:
+        meta = source.read()
+except OSError as error:
+    raise SystemExit(f"cannot read source corpus metadata {meta_path}: {error}")
+if len(meta) != 25 or meta[24] != 1:
+    raise SystemExit(
+        f"source corpus metadata is not one finalized 25-byte record: {meta_path}"
+    )
+source_records = struct.unpack_from("<Q", meta)[0]
+if source_records == 0:
+    raise SystemExit("source corpus contains zero records")
+
+raw_targets = sys.argv[2:]
+if raw_targets:
+    targets = []
+    seen = set()
+    for raw in raw_targets:
+        if not raw.isascii() or not raw.isdecimal():
+            raise SystemExit(f"record target must be a positive decimal integer: {raw!r}")
+        target = int(raw)
+        if target == 0:
+            raise SystemExit("record target must be greater than zero")
+        if target > source_records:
+            raise SystemExit(
+                f"record target {target} exceeds finalized source size {source_records}"
+            )
+        if target not in seen:
+            targets.append(target)
+            seen.add(target)
+else:
+    targets = [n for n in (50_000, 200_000, 800_000) if n < source_records]
+    targets.append(source_records)
+
+print(" ".join(str(target) for target in targets))
+PY
+)"
+read -r -a SIZES <<< "$TARGET_WORDS"
 
 mkdir -p "$WORK"
-printf '%-12s %-10s %-12s %-12s\n' records held_out top1_rule12 exct_miss_%
+printf '%-12s %-12s %-12s %-12s %-12s %-12s\n' \
+    requested actual train held top1_rule12 exct_miss_%
 
-# Each sub-sample is a canonical corpus pair in its own input directory.
-# `compile-recorded` may then emit its canonical output pair in "$D" without
-# clobbering the input, while source-execution provenance remains
-# directory-scoped and cannot be inherited by an unrelated same-directory
-# filename pair.
 for N in "${SIZES[@]}"; do
-    D="$WORK/n-$N"
-    INPUT="$D/input"
-    mkdir -p "$INPUT"
+    CASE="$WORK/n-$N"
+    INPUT="$CASE/input"
+    COMPILED="$CASE/compiled"
+    COVER="$CASE/cover"
+    SCORE="$CASE/score"
+    mkdir -p "$CASE"
+
+    # Always use the certified Rust transaction, including for the exact-full
+    # case. That keeps execution provenance and dense/attention sidecars on
+    # the same publication path instead of special-casing a file copy.
     "$R4" transformerless subsample-recorded-corpus \
         --src-meta "$SRC_META" --src-recs "$SRC_RECS" \
         --out-meta "$INPUT/corpus.meta" --out-recs "$INPUT/corpus.records" \
         --records "$N" >/dev/null
-    ACTUAL_N="$(python3 - "$INPUT/corpus.meta" <<'PY'
-import struct, sys
-with open(sys.argv[1], "rb") as f:
-    meta = f.read()
-if len(meta) != 25 or meta[24] != 1:
-    raise SystemExit("subsample output is not one finalized 25-byte corpus metadata record")
-print(struct.unpack("<Q", meta[:8])[0])
-PY
-)"
 
     "$R4" transformerless compile-recorded \
         --corpus-meta "$INPUT/corpus.meta" --corpus-recs "$INPUT/corpus.records" \
-        --vocab-size "$VOCAB" --out "$D" >/dev/null 2>&1
-    ATTENTION_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$D/attention_operator.json")"
-    DENSE_OPERATOR_ARGS=()
-    if [ -f "$D/dense_operator.json" ]; then
-        DENSE_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$D/dense_operator.json")"
-        DENSE_OPERATOR_ARGS=(--dense-operator "$DENSE_OPERATOR")
+        --vocab-size "$VOCAB" --out "$COMPILED" >/dev/null
+
+    ATTENTION_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$COMPILED/attention_operator.json")"
+    OPERATOR_ARGS=(--attention-operator "$ATTENTION_OPERATOR")
+    if [ -f "$COMPILED/dense_operator.json" ]; then
+        DENSE_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$COMPILED/dense_operator.json")"
+        OPERATOR_ARGS+=(--dense-operator "$DENSE_OPERATOR")
     fi
+
     "$R4" transformerless cover \
-        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
-        --artifacts "$D/tless_artifacts.bin" \
-        --attention-operator "$ATTENTION_OPERATOR" \
-        "${DENSE_OPERATOR_ARGS[@]}" \
-        --out "$D/graph-cover" >/dev/null 2>&1
+        --corpus-meta "$COMPILED/corpus.meta" --corpus-recs "$COMPILED/corpus.records" \
+        --artifacts "$COMPILED/tless_artifacts.bin" \
+        "${OPERATOR_ARGS[@]}" \
+        --out "$COVER" >/dev/null
+
     "$R4" transformerless score \
-        --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
-        --artifacts "$D/tless_artifacts.bin" --cover "$D/graph-cover/cover.r4g1" \
-        --quality-profile relative_tla --out "$D/graph" >/dev/null 2>&1
-    python3 - "$D/graph/score_report.json" "$ACTUAL_N" <<'PY'
-import json, sys
-d = json.load(open(sys.argv[1]))
-n = sys.argv[2]
-gc = d["gate_c"]
-dist = d.get("distribution", {})
-ho = gc.get("held_out_population", 0)
-t1 = gc.get("rule12_precedence", {}).get("top1_agreement", 0.0)
-miss = dist.get("exct_miss_rate", float("nan"))
-print(f"{n:<12} {ho:<10} {t1 * 100:<12.2f} {miss * 100:<12.2f}")
+        --corpus-meta "$COMPILED/corpus.meta" --corpus-recs "$COMPILED/corpus.records" \
+        --artifacts "$COMPILED/tless_artifacts.bin" --cover "$COVER/cover.r4g1" \
+        --quality-profile relative_tla --out "$SCORE" >/dev/null
+
+    python3 - \
+        "$N" "$INPUT/corpus.meta" "$COVER/cover_report.json" \
+        "$SCORE/score_report.json" <<'PY'
+import json
+import math
+import struct
+import sys
+
+requested = int(sys.argv[1])
+with open(sys.argv[2], "rb") as source:
+    meta = source.read()
+if len(meta) != 25 or meta[24] != 1:
+    raise SystemExit("subsample output is not one finalized 25-byte corpus metadata record")
+actual = struct.unpack_from("<Q", meta)[0]
+
+with open(sys.argv[3], encoding="utf-8") as source:
+    cover = json.load(source)
+with open(sys.argv[4], encoding="utf-8") as source:
+    score = json.load(source)
+
+def count(value, label):
+    if type(value) is not int or value < 0:
+        raise SystemExit(f"{label} is not a nonnegative integer")
+    return value
+
+inputs = cover.get("inputs", {})
+train = count(inputs.get("train_observations"), "cover train_observations")
+held = count(inputs.get("held_out_observations"), "cover held_out_observations")
+if train + held != actual:
+    raise SystemExit(
+        f"cover partition mismatch: train {train} + held {held} != actual {actual}"
+    )
+
+gate = score.get("gate_c", {})
+distribution = score.get("distribution", {})
+score_held = count(gate.get("held_out_population"), "score held_out_population")
+distribution_held = count(
+    distribution.get("held_out_positions"), "score distribution held_out_positions"
+)
+if score_held != held or distribution_held != held:
+    raise SystemExit(
+        "score population mismatch: "
+        f"cover held {held}, Gate C held {score_held}, distribution held {distribution_held}"
+    )
+
+top1 = gate.get("rule12_precedence", {}).get("top1_agreement")
+miss = distribution.get("exct_miss_rate")
+for value, label in ((top1, "top1_agreement"), (miss, "exct_miss_rate")):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SystemExit(f"score {label} is not numeric")
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise SystemExit(f"score {label} is outside [0, 1]")
+
+print(
+    f"{requested:<12} {actual:<12} {train:<12} {held:<12} "
+    f"{top1 * 100:<12.2f} {miss * 100:<12.2f}"
+)
 PY
 done
 
 echo
-echo "The knee is the smallest N past which top1 and exct_miss stop moving."
-echo "Feed the (N_knee, teacher-S) points into the recommend-scale beta calibration (docs/scaling_law.md)."
+echo "Compare requested and actual before interpreting a curve; complete-story selection may undershoot."
+echo "The #729 fixed-partition harness produces evidence for a future scaling-law decision; it does not reuse the retired #531 calibration claim."

--- a/scripts/scale_sweep.sh
+++ b/scripts/scale_sweep.sh
@@ -35,39 +35,47 @@ printf '%-12s %-10s %-12s %-12s\n' records held_out top1_rule12 exct_miss_%
 
 # Each sub-sample is a canonical corpus pair in its own input directory.
 # `compile-recorded` may then emit its canonical output pair in "$D" without
-# clobbering the input, while attention provenance remains directory-scoped and
-# cannot be inherited by an unrelated same-directory filename pair.
+# clobbering the input, while source-execution provenance remains
+# directory-scoped and cannot be inherited by an unrelated same-directory
+# filename pair.
 for N in "${SIZES[@]}"; do
     D="$WORK/n-$N"
     INPUT="$D/input"
     mkdir -p "$INPUT"
-    python3 scripts/mc1_subsample_corpus.py \
+    "$R4" transformerless subsample-recorded-corpus \
         --src-meta "$SRC_META" --src-recs "$SRC_RECS" \
         --out-meta "$INPUT/corpus.meta" --out-recs "$INPUT/corpus.records" \
         --records "$N" >/dev/null
-
-    # Preserve the source corpus's exact attention era without copying a
-    # manifest whose record counts describe the unsampled corpus. The Rust
-    # boundary validates the complete source manifest, canonical corpus pair,
-    # registry record, and no-clobber destination before publishing anything.
-    "$R4" transformerless copy-recorded-attention \
-        --corpus-meta "$SRC_META" --corpus-recs "$SRC_RECS" \
-        --out "$INPUT/attention_operator.json" >/dev/null
+    ACTUAL_N="$(python3 - "$INPUT/corpus.meta" <<'PY'
+import struct, sys
+with open(sys.argv[1], "rb") as f:
+    meta = f.read()
+if len(meta) != 25 or meta[24] != 1:
+    raise SystemExit("subsample output is not one finalized 25-byte corpus metadata record")
+print(struct.unpack("<Q", meta[:8])[0])
+PY
+)"
 
     "$R4" transformerless compile-recorded \
         --corpus-meta "$INPUT/corpus.meta" --corpus-recs "$INPUT/corpus.records" \
         --vocab-size "$VOCAB" --out "$D" >/dev/null 2>&1
     ATTENTION_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$D/attention_operator.json")"
+    DENSE_OPERATOR_ARGS=()
+    if [ -f "$D/dense_operator.json" ]; then
+        DENSE_OPERATOR="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),separators=(",",":")))' "$D/dense_operator.json")"
+        DENSE_OPERATOR_ARGS=(--dense-operator "$DENSE_OPERATOR")
+    fi
     "$R4" transformerless cover \
         --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
         --artifacts "$D/tless_artifacts.bin" \
         --attention-operator "$ATTENTION_OPERATOR" \
+        "${DENSE_OPERATOR_ARGS[@]}" \
         --out "$D/graph-cover" >/dev/null 2>&1
     "$R4" transformerless score \
         --corpus-meta "$D/corpus.meta" --corpus-recs "$D/corpus.records" \
         --artifacts "$D/tless_artifacts.bin" --cover "$D/graph-cover/cover.r4g1" \
         --quality-profile relative_tla --out "$D/graph" >/dev/null 2>&1
-    python3 - "$D/graph/score_report.json" "$N" <<'PY'
+    python3 - "$D/graph/score_report.json" "$ACTUAL_N" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1]))
 n = sys.argv[2]

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -106,6 +106,16 @@ pub struct R4g1State {
     host_tokenizer: Option<TokenizerKind>,
 }
 
+/// One exact, already-captured standalone artifact generation. The server
+/// uses this for an explicit non-bundle `--r4g1-artifact` so no inferred
+/// ancestor lock or second pathname read can change the generation loaded.
+pub(crate) struct CapturedR4g1Bundle {
+    pub(crate) graph: Vec<u8>,
+    pub(crate) signature_artifact: Vec<u8>,
+    pub(crate) tokenizer: Option<Vec<u8>>,
+    pub(crate) score_report: Option<Vec<u8>>,
+}
+
 impl R4g1State {
     /// The manifest policy in force (D4 defaults or the score-report
     /// override).
@@ -218,7 +228,37 @@ impl R4g1State {
             .map(read_optional_tokenizer)
             .transpose()?
             .flatten();
-        let tokenizer = tokenizer_bytes
+        // Historical behavior: a score report that does not parse is
+        // ignored (D4 defaults), not an error — pre-validate before
+        // handing the bytes to the typed loader.
+        let score_report = graph_path
+            .parent()
+            .and_then(|parent| std::fs::read(parent.join("score_report.json")).ok())
+            .filter(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).is_ok());
+        Self::load_captured_with_source(
+            graph_path,
+            teacher_path,
+            &CapturedR4g1Bundle {
+                graph: graph_bytes,
+                signature_artifact: teacher_bytes,
+                tokenizer: tokenizer_bytes,
+                score_report,
+            },
+            source_dir,
+        )
+    }
+
+    pub(crate) fn load_captured_with_source(
+        graph_path: &Path,
+        teacher_path: &Path,
+        captured: &CapturedR4g1Bundle,
+        source_dir: Option<&Path>,
+    ) -> Result<Self, String> {
+        let tokenizer_path = teacher_path
+            .parent()
+            .map(|parent| parent.join("tokenizer.bin"));
+        let tokenizer = captured
+            .tokenizer
             .as_deref()
             .map(|bytes| {
                 Tokenizer::from_bytes(bytes).ok_or_else(|| {
@@ -232,20 +272,13 @@ impl R4g1State {
                 })
             })
             .transpose()?;
-        // Historical behavior: a score report that does not parse is
-        // ignored (D4 defaults), not an error — pre-validate before
-        // handing the bytes to the typed loader.
-        let score_report = graph_path
-            .parent()
-            .and_then(|parent| std::fs::read(parent.join("score_report.json")).ok())
-            .filter(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).is_ok());
         let engine = R4Engine::load(EngineParts {
-            graph: &graph_bytes,
-            signature_artifact: &teacher_bytes,
+            graph: &captured.graph,
+            signature_artifact: &captured.signature_artifact,
             // Supplying the exact bytes makes the graph header's independent
             // tokenizer.bin CID binding authoritative at this boundary.
-            tokenizer: tokenizer_bytes.as_deref(),
-            score_report: score_report.as_deref(),
+            tokenizer: captured.tokenizer.as_deref(),
+            score_report: captured.score_report.as_deref(),
         })
         .map_err(|error| {
             // The engine loader now returns a single sanctioned

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,7 @@ use uor_r4_core::transformerless::hf_bpe::{
 use uor_r4_core::transformerless::scenarios::RuntimeTokenizerIdentity;
 use uor_r4_graph_certify::ScoreStatus;
 use uor_r4_model_source::attention::AttentionOperatorSpec;
+use uor_r4_model_source::dense::DenseOperatorSpec;
 use uor_r4_model_source::{BehaviorSource, TeacherOracle};
 use uor_r4_router::fallback::{
     run_cascade, CascadeOutcome, EngineStatus, TierFn, TierOutcome, TierResult,
@@ -432,10 +433,42 @@ impl R4g1CompileStatus {
             "report": self.report,
             "model_name": active_canonical_model_name(serving),
             "physical_root": status_physical_root(serving.active_bundle.as_ref()),
+            "attention_operator": serving.active_bundle.as_ref().map(|bundle| &bundle.attention_operator),
+            "dense_operator": serving.active_bundle.as_ref().and_then(|bundle| bundle.dense_operator.as_ref()),
             "terminal_error": serving.terminal_load_error.as_deref(),
             "last_operation_error": serving.last_operation_error.as_deref(),
         })
     }
+}
+
+fn uor_status_json(installed: &ServingModelState) -> serde_json::Value {
+    let graph_loaded = installed.r4g1.is_some();
+    let graph_ready = graph_text_ready(installed);
+    let decode_only = graph_loaded && !graph_ready;
+    let teacher_ready = teacher_text_ready(installed);
+    let engine_active = graph_ready || teacher_ready;
+    let logical_name = installed_logical_model_name(installed);
+    let bundle_compiled = installed.active_bundle.is_some();
+
+    serde_json::json!({
+        "model_name": logical_name,
+        "physical_root": status_physical_root(installed.active_bundle.as_ref()),
+        "attention_operator": installed.active_bundle.as_ref().map(|bundle| &bundle.attention_operator),
+        "dense_operator": installed.active_bundle.as_ref().and_then(|bundle| bundle.dense_operator.as_ref()),
+        "r4g1_loaded": graph_loaded,
+        "r4g1_ready": graph_ready,
+        "decode_only": decode_only,
+        "teacher_ready": teacher_ready,
+        "engine_active": engine_active,
+        "terminal_error": installed.terminal_load_error.as_deref(),
+        "last_operation_error": installed.last_operation_error.as_deref(),
+        "stages": {
+            "stage_1_download": installed.active_teacher_source.is_some(),
+            "stage_2_compile": bundle_compiled,
+            "stage_3_graph_score": graph_loaded,
+            "stage_4_r4g1_active": graph_ready
+        }
+    })
 }
 
 /// Owns the single long-running R4G1 replacement slot while a reload is
@@ -1264,9 +1297,19 @@ enum CompiledRootState {
     /// stage A did not yet publish any corpus payload or attention binding.
     /// This is a resumable preflight state, not an implicit historical bundle.
     PreAttentionIdentity,
-    ImplicitV1(Box<AttentionOperatorSpec>),
-    BoundHistorical(Box<AttentionOperatorSpec>),
-    BoundCurrent(Box<AttentionOperatorSpec>),
+    /// A composite GPT-2 compile published its exact current attention record
+    /// but crashed before the matching dense record became stable. Only a
+    /// recognized identity-only prefix can enter this resumable state.
+    PreDenseIdentity(Box<AttentionOperatorSpec>),
+    ImplicitV1(Box<SourceExecutionIdentity>),
+    BoundHistorical(Box<SourceExecutionIdentity>),
+    BoundCurrent(Box<SourceExecutionIdentity>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SourceExecutionIdentity {
+    attention: AttentionOperatorSpec,
+    dense: Option<DenseOperatorSpec>,
 }
 
 impl CompiledRootState {
@@ -1274,8 +1317,31 @@ impl CompiledRootState {
         match self {
             Self::ImplicitV1(operator)
             | Self::BoundHistorical(operator)
-            | Self::BoundCurrent(operator) => Some(operator),
+            | Self::BoundCurrent(operator) => Some(&operator.attention),
+            Self::PreDenseIdentity(operator) => Some(operator),
             Self::Absent | Self::Empty | Self::PreAttentionIdentity => None,
+        }
+    }
+
+    fn dense_operator(&self) -> Option<&DenseOperatorSpec> {
+        match self {
+            Self::ImplicitV1(identity)
+            | Self::BoundHistorical(identity)
+            | Self::BoundCurrent(identity) => identity.dense.as_ref(),
+            Self::Absent | Self::Empty | Self::PreAttentionIdentity | Self::PreDenseIdentity(_) => {
+                None
+            }
+        }
+    }
+
+    fn identity(&self) -> Option<&SourceExecutionIdentity> {
+        match self {
+            Self::ImplicitV1(identity)
+            | Self::BoundHistorical(identity)
+            | Self::BoundCurrent(identity) => Some(identity),
+            Self::Absent | Self::Empty | Self::PreAttentionIdentity | Self::PreDenseIdentity(_) => {
+                None
+            }
         }
     }
 }
@@ -1287,6 +1353,8 @@ struct CompiledModelPair {
     conventional: CompiledRootState,
     current_root: PathBuf,
     current: CompiledRootState,
+    composite_root: PathBuf,
+    composite: CompiledRootState,
 }
 
 /// One logical source resolved to the exact physical bundle selected for
@@ -1299,6 +1367,7 @@ struct ResolvedCompiledBundle {
     graph: PathBuf,
     teacher: PathBuf,
     attention_operator: AttentionOperatorSpec,
+    dense_operator: Option<DenseOperatorSpec>,
     /// Exact source snapshot root recorded by the selected cover report.
     /// `None` is the historical pre-#597 state, not an inferred identity.
     source_manifest_kappa: Option<String>,
@@ -1344,8 +1413,16 @@ fn attention_era_suffix(current_version: u32) -> String {
     format!("-attention-v{current_version}")
 }
 
+fn composite_era_suffix(current_version: u32) -> String {
+    format!(
+        "-attention-v{current_version}-dense-v{}",
+        DenseOperatorSpec::GPT2_VERSION
+    )
+}
+
 fn validate_logical_model_name(name: &str, current_version: u32) -> Result<(), String> {
-    let suffix = attention_era_suffix(current_version);
+    let attention_suffix = attention_era_suffix(current_version);
+    let composite_suffix = composite_era_suffix(current_version);
     let path = Path::new(name);
     let one_normal_component = path.components().count() == 1
         && path.file_name().and_then(|part| part.to_str()) == Some(name)
@@ -1356,18 +1433,20 @@ fn validate_logical_model_name(name: &str, current_version: u32) -> Result<(), S
             "model name {name:?} is not one logical source basename"
         ));
     }
-    if name.ends_with(&suffix) {
+    if name.ends_with(&composite_suffix) || name.ends_with(&attention_suffix) {
         return Err(format!(
-            "model name {name:?} uses the resolver-owned suffix {suffix}; source basenames ending in that suffix are reserved"
+            "model name {name:?} uses a resolver-owned arithmetic suffix ({attention_suffix} or {composite_suffix}); source basenames ending in either suffix are reserved"
         ));
     }
     Ok(())
 }
 
 fn logical_model_name_for_request(requested: &str, current_version: u32) -> Result<String, String> {
-    let suffix = attention_era_suffix(current_version);
+    let composite_suffix = composite_era_suffix(current_version);
+    let attention_suffix = attention_era_suffix(current_version);
     let logical = requested
-        .strip_suffix(&suffix)
+        .strip_suffix(&composite_suffix)
+        .or_else(|| requested.strip_suffix(&attention_suffix))
         .filter(|base| !base.is_empty())
         .unwrap_or(requested);
     validate_logical_model_name(logical, current_version)?;
@@ -1378,6 +1457,7 @@ fn inspect_compiled_root(
     root: &Path,
     current_version: u32,
     resolver_owned_current_root: bool,
+    resolver_owned_dense_root: bool,
 ) -> Result<CompiledRootState, String> {
     let metadata = match fs::symlink_metadata(root) {
         Ok(metadata) => metadata,
@@ -1420,10 +1500,11 @@ fn inspect_compiled_root(
         return Ok(CompiledRootState::Empty);
     }
 
+    let dense_operator = source_compile_dense_binding(root)?;
     let binding = source_compile_attention_binding(root)?;
     let (operator, explicit_binding) = match binding {
         Some(operator) => (operator, true),
-        None if source_compile_pre_attention_prefix(root)? => {
+        None if dense_operator.is_none() && source_compile_pre_attention_prefix(root)? => {
             return Ok(CompiledRootState::PreAttentionIdentity);
         }
         None if resolver_owned_current_root => {
@@ -1459,13 +1540,55 @@ fn inspect_compiled_root(
             operator.version
         ));
     }
-    let operator = Box::new(operator);
+    if resolver_owned_dense_root
+        && dense_operator.is_none()
+        && source_compile_pre_attention_prefix(root)?
+    {
+        return Ok(CompiledRootState::PreDenseIdentity(Box::new(operator)));
+    }
+    uor_r4_model_source::dense::validate_source_execution_pair(
+        Some(&operator),
+        dense_operator.as_ref(),
+    )
+    .map_err(|error| format!("compiled model root {}: {error}", root.display()))?;
+    if resolver_owned_dense_root {
+        let dense = dense_operator.as_ref().ok_or_else(|| {
+            format!(
+                "deterministic composite bundle {} contains payload without {}; refusing fallback or relabeling",
+                root.display(),
+                uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+            )
+        })?;
+        if dense.version != DenseOperatorSpec::GPT2_VERSION {
+            return Err(format!(
+                "deterministic composite bundle {} is pinned to dense operator {}/{}; expected current version {}",
+                root.display(), dense.id, dense.version, DenseOperatorSpec::GPT2_VERSION
+            ));
+        }
+    } else if resolver_owned_current_root && dense_operator.is_some() {
+        return Err(format!(
+            "attention-only resolver root {} contains {}; current GPT-2 dense provenance belongs in the composite resolver root",
+            root.display(),
+            uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+        ));
+    } else if let Some(dense) = dense_operator.as_ref() {
+        if dense.version == DenseOperatorSpec::GPT2_VERSION {
+            return Err(format!(
+                "unsuffixed compiled root {} contains current dense operator {}/{}; current GPT-2 dense provenance belongs exclusively in the composite resolver root",
+                root.display(), dense.id, dense.version
+            ));
+        }
+    }
+    let identity = Box::new(SourceExecutionIdentity {
+        attention: operator,
+        dense: dense_operator,
+    });
     Ok(if !explicit_binding {
-        CompiledRootState::ImplicitV1(operator)
-    } else if operator.version == current_version {
-        CompiledRootState::BoundCurrent(operator)
+        CompiledRootState::ImplicitV1(identity)
+    } else if identity.attention.version == current_version {
+        CompiledRootState::BoundCurrent(identity)
     } else {
-        CompiledRootState::BoundHistorical(operator)
+        CompiledRootState::BoundHistorical(identity)
     })
 }
 
@@ -1482,39 +1605,69 @@ fn inspect_compiled_model_pair(
         "{logical_name}{}",
         attention_era_suffix(current_version)
     ));
-    let conventional = inspect_compiled_root(&conventional_root, current_version, false)?;
-    let current = inspect_compiled_root(&current_root, current_version, true)?;
+    let composite_root = compiled_root.join(format!(
+        "{logical_name}{}",
+        composite_era_suffix(current_version)
+    ));
+    let conventional = inspect_compiled_root(&conventional_root, current_version, false, false)?;
+    let current = inspect_compiled_root(&current_root, current_version, true, false)?;
+    let composite = inspect_compiled_root(&composite_root, current_version, true, true)?;
 
     if matches!(conventional, CompiledRootState::PreAttentionIdentity)
-        && current.operator().is_some()
+        && (current.operator().is_some() || composite.operator().is_some())
     {
         return Err(format!(
-            "conventional root {} contains an unfinished pre-attention identity while current root {} is already bound; refusing to hide or overwrite either initialization",
+            "conventional root {} contains an unfinished pre-attention identity while a preferred root ({}, {}) is already bound; refusing to hide or overwrite either initialization",
             conventional_root.display(),
-            current_root.display()
+            current_root.display(),
+            composite_root.display()
+        ));
+    }
+    if matches!(current, CompiledRootState::PreAttentionIdentity) && composite.operator().is_some()
+    {
+        return Err(format!(
+            "attention root {} contains an unfinished pre-attention identity while composite root {} is already bound; refusing to hide or overwrite either initialization",
+            current_root.display(),
+            composite_root.display()
         ));
     }
 
-    if let (Some(historical), Some(current_operator)) =
-        (conventional.operator(), current.operator())
-    {
-        if historical.id != current_operator.id {
-            return Err(format!(
-                "compiled roots {} and {} conflict across source-attention families ({}/{} versus {}/{})",
-                conventional_root.display(),
-                current_root.display(),
-                historical.id,
-                historical.version,
-                current_operator.id,
-                current_operator.version
-            ));
-        }
-        if historical.version == current_version {
-            return Err(format!(
-                "duplicate current source-attention bundles exist for logical model {logical_name}: {} and {}",
-                conventional_root.display(),
-                current_root.display()
-            ));
+    let roots = [
+        (&conventional_root, &conventional),
+        (&current_root, &current),
+        (&composite_root, &composite),
+    ];
+    for left in 0..roots.len() {
+        for right in (left + 1)..roots.len() {
+            let (Some(left_operator), Some(right_operator)) =
+                (roots[left].1.operator(), roots[right].1.operator())
+            else {
+                continue;
+            };
+            if left_operator.id != right_operator.id {
+                return Err(format!(
+                    "compiled roots {} and {} conflict across source-attention families ({}/{} versus {}/{})",
+                    roots[left].0.display(),
+                    roots[right].0.display(),
+                    left_operator.id,
+                    left_operator.version,
+                    right_operator.id,
+                    right_operator.version
+                ));
+            }
+            if roots[left].1.identity() == roots[right].1.identity() {
+                return Err(format!(
+                    "compiled roots {} and {} duplicate the same source-execution identity {}/{} with dense {:?}",
+                    roots[left].0.display(),
+                    roots[right].0.display(),
+                    left_operator.id,
+                    left_operator.version,
+                    roots[left]
+                        .1
+                        .dense_operator()
+                        .map(|operator| format!("{}/{}", operator.id, operator.version))
+                ));
+            }
         }
     }
 
@@ -1524,22 +1677,28 @@ fn inspect_compiled_model_pair(
         conventional,
         current_root,
         current,
+        composite_root,
+        composite,
     })
 }
 
-fn selected_compiled_root(pair: &CompiledModelPair) -> Option<(&Path, &AttentionOperatorSpec)> {
-    if let Some(operator) = pair.current.operator() {
-        Some((&pair.current_root, operator))
+fn selected_compiled_root(pair: &CompiledModelPair) -> Option<(&Path, &SourceExecutionIdentity)> {
+    if let Some(identity) = pair.composite.identity() {
+        Some((&pair.composite_root, identity))
+    } else if let Some(identity) = pair.current.identity() {
+        Some((&pair.current_root, identity))
     } else {
         pair.conventional
-            .operator()
-            .map(|operator| (pair.conventional_root.as_path(), operator))
+            .identity()
+            .map(|identity| (pair.conventional_root.as_path(), identity))
     }
 }
 
 struct CoverProvenanceProjection {
     attention_present: bool,
     operator: Option<AttentionOperatorSpec>,
+    dense_present: bool,
+    dense_operator: Option<DenseOperatorSpec>,
     source_manifest_kappa_present: bool,
     source_manifest_kappa: Option<String>,
 }
@@ -1564,6 +1723,8 @@ impl<'de> Deserialize<'de> for CoverProvenanceProjection {
             {
                 let mut attention_present = false;
                 let mut operator = None;
+                let mut dense_present = false;
+                let mut dense_operator = None;
                 let mut source_manifest_kappa_present = false;
                 let mut source_manifest_kappa = None;
                 while let Some(key) = map.next_key::<String>()? {
@@ -1576,6 +1737,13 @@ impl<'de> Deserialize<'de> for CoverProvenanceProjection {
                             }
                             attention_present = true;
                             operator = map.next_value()?;
+                        }
+                        "dense_operator" => {
+                            if dense_present {
+                                return Err(serde::de::Error::duplicate_field("dense_operator"));
+                            }
+                            dense_present = true;
+                            dense_operator = map.next_value()?;
                         }
                         "source_manifest_kappa" => {
                             if source_manifest_kappa_present {
@@ -1594,6 +1762,8 @@ impl<'de> Deserialize<'de> for CoverProvenanceProjection {
                 Ok(CoverProvenanceProjection {
                     attention_present,
                     operator,
+                    dense_present,
+                    dense_operator,
                     source_manifest_kappa_present,
                     source_manifest_kappa,
                 })
@@ -1613,11 +1783,16 @@ fn canonical_source_manifest_kappa(kappa: &str) -> bool {
     })
 }
 
-fn parse_cover_provenance(
-    report_path: &Path,
-) -> Result<(bool, Option<AttentionOperatorSpec>, Option<String>), String> {
+type CoverProvenance = (
+    bool,
+    Option<AttentionOperatorSpec>,
+    Option<DenseOperatorSpec>,
+    Option<String>,
+);
+
+fn parse_cover_provenance(report_path: &Path) -> Result<CoverProvenance, String> {
     let Some(bytes) = read_regular_file_nofollow(report_path, "cover report")? else {
-        return Ok((false, None, None));
+        return Ok((false, None, None, None));
     };
     let projection: CoverProvenanceProjection = serde_json::from_slice(&bytes)
         .map_err(|error| format!("{} is malformed JSON: {error}", report_path.display()))?;
@@ -1644,10 +1819,35 @@ fn parse_cover_provenance(
             }
         }
     }
+    if projection.dense_present {
+        if let Some(recorded) = projection.dense_operator.as_ref() {
+            let registered =
+                uor_r4_model_source::dense::operator_spec(&recorded.id, recorded.version)
+                    .map_err(|error| format!("{}: {error}", report_path.display()))?;
+            if &registered != recorded {
+                return Err(format!(
+                    "{} does not contain a registry-exact dense operator {}/{}",
+                    report_path.display(),
+                    recorded.id,
+                    recorded.version
+                ));
+            }
+        }
+    }
+    uor_r4_model_source::dense::validate_source_execution_pair(
+        projection.operator.as_ref(),
+        projection.dense_operator.as_ref(),
+    )
+    .map_err(|error| format!("{}: {error}", report_path.display()))?;
     // A JSON `null` is compatible with the historical unrecorded state; the
     // presence bit exists only so duplicate top-level controls are rejected.
     let _ = projection.source_manifest_kappa_present;
-    Ok((true, projection.operator, projection.source_manifest_kappa))
+    Ok((
+        true,
+        projection.operator,
+        projection.dense_operator,
+        projection.source_manifest_kappa,
+    ))
 }
 
 /// Reconcile every attention identity the server bundle records. Current-v2
@@ -1658,6 +1858,7 @@ fn parse_cover_provenance(
 fn validate_serving_attention_provenance(
     bundle: &Path,
     expected: &AttentionOperatorSpec,
+    expected_dense: Option<&DenseOperatorSpec>,
     current_version: u32,
 ) -> Result<Option<String>, String> {
     // New server-published generations carry a digest-complete transaction
@@ -1668,9 +1869,11 @@ fn validate_serving_attention_provenance(
     let records = bundle.join("corpus.records");
     let meta_present = regular_file_presence(&meta)?;
     let records_present = regular_file_presence(&records)?;
-    let recorded_corpus = match (meta_present, records_present) {
-        (true, true) => uor_r4_graph_cli::recorded_corpus_attention_operator(&meta, &records)
-            .map_err(|error| error.to_string())?,
+    let recorded_execution = match (meta_present, records_present) {
+        (true, true) => Some(
+            uor_r4_graph_cli::recorded_corpus_execution_identity(&meta, &records)
+                .map_err(|error| error.to_string())?,
+        ),
         (false, false) if expected.version < current_version => None,
         (false, false) => {
             return Err(format!(
@@ -1685,6 +1888,12 @@ fn validate_serving_attention_provenance(
             ))
         }
     };
+    let recorded_corpus = recorded_execution
+        .as_ref()
+        .and_then(|identity| identity.attention_operator.clone());
+    let recorded_dense = recorded_execution
+        .as_ref()
+        .and_then(|identity| identity.dense_operator.clone());
     if meta_present {
         let recorded = recorded_corpus.unwrap_or_else(AttentionOperatorSpec::standard_v1);
         if &recorded != expected {
@@ -1698,9 +1907,19 @@ fn validate_serving_attention_provenance(
             ));
         }
     }
+    if meta_present && recorded_dense.as_ref() != expected_dense {
+        return Err(format!(
+            "compiled bundle {} records dense operator {:?} in its corpus provenance but its selected root records {:?}",
+            bundle.display(),
+            recorded_dense
+                .as_ref()
+                .map(|operator| format!("{}/{}", operator.id, operator.version)),
+            expected_dense.map(|operator| format!("{}/{}", operator.id, operator.version)),
+        ));
+    }
 
     let report_path = bundle.join("graph-cover/cover_report.json");
-    let (report_present, report_operator, source_manifest_kappa) =
+    let (report_present, report_operator, report_dense, source_manifest_kappa) =
         parse_cover_provenance(&report_path)?;
     if expected.version == current_version && !report_present {
         return Err(format!(
@@ -1720,6 +1939,17 @@ fn validate_serving_attention_provenance(
                 bundle.display(),
                 expected.id,
                 expected.version
+            ));
+        }
+        if report_dense.as_ref() != expected_dense {
+            return Err(format!(
+                "{} records dense operator {:?} but selected bundle {} records {:?}",
+                report_path.display(),
+                report_dense
+                    .as_ref()
+                    .map(|operator| format!("{}/{}", operator.id, operator.version)),
+                bundle.display(),
+                expected_dense.map(|operator| format!("{}/{}", operator.id, operator.version)),
             ));
         }
     }
@@ -1769,15 +1999,27 @@ fn resolve_loadable_compiled_bundle(
     current_version: u32,
 ) -> Result<Option<ResolvedCompiledBundle>, String> {
     if matches!(
+        pair.composite,
+        CompiledRootState::Empty
+            | CompiledRootState::PreAttentionIdentity
+            | CompiledRootState::PreDenseIdentity(_)
+    ) {
+        return Err(format!(
+            "preferred composite source-execution root {} is present but incomplete; refusing attention-only or historical fallback",
+            pair.composite_root.display()
+        ));
+    }
+    if matches!(
         pair.current,
         CompiledRootState::Empty | CompiledRootState::PreAttentionIdentity
-    ) {
+    ) && matches!(pair.composite, CompiledRootState::Absent)
+    {
         return Err(format!(
             "preferred current source-attention root {} is present but incomplete; refusing historical fallback",
             pair.current_root.display()
         ));
     }
-    let Some((physical_root, operator)) = selected_compiled_root(pair) else {
+    let Some((physical_root, identity)) = selected_compiled_root(pair) else {
         return Ok(None);
     };
     let primary_graph = physical_root.join("graph/score.r4g1");
@@ -1802,14 +2044,19 @@ fn resolve_loadable_compiled_bundle(
             teacher.display()
         ));
     }
-    let source_manifest_kappa =
-        validate_serving_attention_provenance(physical_root, operator, current_version)?;
+    let source_manifest_kappa = validate_serving_attention_provenance(
+        physical_root,
+        &identity.attention,
+        identity.dense.as_ref(),
+        current_version,
+    )?;
     Ok(Some(ResolvedCompiledBundle {
         logical_name: pair.logical_name.clone(),
         physical_root: physical_root.to_path_buf(),
         graph,
         teacher,
-        attention_operator: operator.clone(),
+        attention_operator: identity.attention.clone(),
+        dense_operator: identity.dense.clone(),
         source_manifest_kappa,
     }))
 }
@@ -1838,8 +2085,11 @@ fn reject_requested_suffix_source_collision(
     models_root: &Path,
     current_version: u32,
 ) -> Result<(), String> {
-    let suffix = attention_era_suffix(current_version);
-    if requested.strip_suffix(&suffix).is_none() {
+    let attention_suffix = attention_era_suffix(current_version);
+    let composite_suffix = composite_era_suffix(current_version);
+    if requested.strip_suffix(&composite_suffix).is_none()
+        && requested.strip_suffix(&attention_suffix).is_none()
+    {
         return Ok(());
     }
     let ambiguous = models_root.join("sources").join(requested);
@@ -2006,11 +2256,19 @@ fn resolve_managed_teacher_bundle_in(
     let logical_name = logical_model_name_for_request(physical_name, current_version)?;
     let pair = inspect_compiled_model_pair(&compiled_root, &logical_name, current_version)?;
     if matches!(
-        pair.current,
-        CompiledRootState::Empty | CompiledRootState::PreAttentionIdentity
-    ) {
+        pair.composite,
+        CompiledRootState::Empty
+            | CompiledRootState::PreAttentionIdentity
+            | CompiledRootState::PreDenseIdentity(_)
+    ) || (matches!(pair.composite, CompiledRootState::Absent)
+        && matches!(
+            pair.current,
+            CompiledRootState::Empty | CompiledRootState::PreAttentionIdentity
+        ))
+    {
         return Ok(ConfiguredManagedBundle::Incomplete(format!(
-            "preferred current bundle {} exists but is incomplete; refusing historical adjacent-path fallback",
+            "preferred compiled bundle exists but is incomplete (composite {}, attention {}); refusing lower-precedence fallback",
+            pair.composite_root.display(),
             pair.current_root.display()
         )));
     }
@@ -2018,7 +2276,8 @@ fn resolve_managed_teacher_bundle_in(
         Some(bundle) => Ok(ConfiguredManagedBundle::Selected(Box::new(bundle))),
         None
             if matches!(pair.conventional, CompiledRootState::Absent)
-                && matches!(pair.current, CompiledRootState::Absent) =>
+                && matches!(pair.current, CompiledRootState::Absent)
+                && matches!(pair.composite, CompiledRootState::Absent) =>
         {
             Ok(ConfiguredManagedBundle::Absent)
         }
@@ -2045,17 +2304,26 @@ fn reject_reserved_suffix_source_collision(
     models_root: &Path,
     current_version: u32,
 ) -> Result<(), String> {
-    let expected_physical = format!(
+    let physical_name = bundle
+        .physical_root
+        .file_name()
+        .and_then(|name| name.to_str());
+    let attention_name = format!(
         "{}{}",
         bundle.logical_name,
         attention_era_suffix(current_version)
     );
-    if bundle
-        .physical_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        != Some(expected_physical.as_str())
-    {
+    let composite_name = format!(
+        "{}{}",
+        bundle.logical_name,
+        composite_era_suffix(current_version)
+    );
+    let expected_physical = match physical_name {
+        Some(name) if name == attention_name => attention_name,
+        Some(name) if name == composite_name => composite_name,
+        _ => return Ok(()),
+    };
+    if physical_name != Some(expected_physical.as_str()) {
         return Ok(());
     }
     let ambiguous = models_root.join("sources").join(&expected_physical);
@@ -2251,7 +2519,8 @@ fn discover_compiled_r4g1_candidates_in(
             ));
         }
     };
-    let suffix = attention_era_suffix(current_version);
+    let attention_suffix = attention_era_suffix(current_version);
+    let composite_suffix = composite_era_suffix(current_version);
     let mut logical_names = std::collections::BTreeSet::<String>::new();
 
     for entry in entries {
@@ -2284,7 +2553,8 @@ fn discover_compiled_r4g1_candidates_in(
             .into_string()
             .map_err(|_| format!("compiled bundle name is not UTF-8: {}", bundle.display()))?;
         let logical_name = name
-            .strip_suffix(&suffix)
+            .strip_suffix(&composite_suffix)
+            .or_else(|| name.strip_suffix(&attention_suffix))
             .filter(|base| !base.is_empty())
             .unwrap_or(&name)
             .to_owned();
@@ -2438,7 +2708,10 @@ fn source_for_compiled_teacher_in(
         )
     })?;
     let pair = inspect_compiled_model_pair(compiled_root, &logical_name, current_version)?;
-    if bundle != pair.conventional_root && bundle != pair.current_root {
+    if bundle != pair.conventional_root
+        && bundle != pair.current_root
+        && bundle != pair.composite_root
+    {
         return Err(format!(
             "compiled teacher {} is outside the resolved roots for logical model {}",
             teacher_path.display(),
@@ -2753,7 +3026,10 @@ fn reconcile_prepared_teacher_with_bundle(
     if let Some(mode) =
         teacher_mode_for_bundle_records(&default, experimental.as_ref(), &bundle.attention_operator)
     {
-        return Ok((mode, None));
+        let actual_dense = prepared_teacher.teacher.dense_operator_spec();
+        if actual_dense == bundle.dense_operator {
+            return Ok((mode, None));
+        }
     }
 
     let available = experimental
@@ -2765,11 +3041,19 @@ fn reconcile_prepared_teacher_with_bundle(
         })
         .unwrap_or_else(|| format!("{}/{}", default.id, default.version));
     let message = format!(
-        "teacher source {} provides {available}, but compiled bundle {} records {}/{}; keeping the valid graph and omitting its incompatible teacher fallback",
+        "teacher source {} provides attention {available} and dense {:?}, but compiled bundle {} records {}/{} and dense {:?}; keeping the valid graph and omitting its incompatible teacher fallback",
         prepared_teacher.source.display(),
+        prepared_teacher
+            .teacher
+            .dense_operator_spec()
+            .map(|operator| format!("{}/{}", operator.id, operator.version)),
         bundle.physical_root.display(),
         bundle.attention_operator.id,
-        bundle.attention_operator.version
+        bundle.attention_operator.version,
+        bundle
+            .dense_operator
+            .as_ref()
+            .map(|operator| format!("{}/{}", operator.id, operator.version))
     );
     *prepared = None;
     Ok((false, Some(message)))
@@ -3775,6 +4059,26 @@ fn validate_source_bundle_inventory(output: &Path) -> Result<(), String> {
             }
         }
     }
+    let attention = source_compile_attention_binding(output)?.ok_or_else(|| {
+        format!(
+            "transformerless bundle {} lost its source attention binding",
+            output.display()
+        )
+    })?;
+    let dense = source_compile_dense_binding(output)?;
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(&attention), dense.as_ref())
+        .map_err(|error| format!("transformerless bundle {}: {error}", output.display()))?;
+    if attention.id == AttentionOperatorSpec::LEARNED_ABSOLUTE_ID
+        && attention.version == AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION
+        && dense.is_none()
+    {
+        return Err(format!(
+            "transformerless GPT-2 bundle compilation is incomplete; missing {}",
+            output
+                .join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE)
+                .display()
+        ));
+    }
     Ok(())
 }
 
@@ -3890,6 +4194,23 @@ fn source_compile_attention_binding(
         file,
         &path,
         uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+    )?;
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))
+}
+
+/// Read an output directory's exact optional host-side dense binding through
+/// the same no-follow, duplicate-rejecting path as attention provenance.
+fn source_compile_dense_binding(output: &Path) -> Result<Option<DenseOperatorSpec>, String> {
+    let path = output.join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE);
+    let Some(file) = open_regular_file_nofollow(&path, "dense-operator binding")? else {
+        return Ok(None);
+    };
+    let value = validate_pre_attention_identity_handle(
+        file,
+        &path,
+        uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
     )?;
     serde_json::from_value(value)
         .map(Some)
@@ -4221,6 +4542,7 @@ fn source_compile_output_has_payload(output: &Path) -> Result<bool, String> {
         }
         if name == "tokenizer_adapter.json"
             || name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+            || name == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
         {
             validate_pre_attention_identity_file(&entry.path(), name)?;
             continue;
@@ -4246,6 +4568,7 @@ fn looks_like_atomic_identity_temporary(name: &str) -> bool {
         SOURCE_MANIFEST_KAPPA_BINDING_FILE,
         "tokenizer_adapter.json",
         uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
     ]
     .iter()
     .any(|sidecar| name.starts_with(&format!(".{sidecar}.")) && name.ends_with(".tmp"))
@@ -4257,6 +4580,7 @@ fn atomic_identity_temporary_kind(name: &str) -> Option<&'static str> {
         SOURCE_MANIFEST_KAPPA_BINDING_FILE,
         "tokenizer_adapter.json",
         uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
     ] {
         let prefix = format!(".{sidecar}.");
         let Some(sequence) = name
@@ -4287,6 +4611,7 @@ fn validate_source_compile_identity_temporaries(output: &Path) -> Result<(), Str
         SOURCE_MANIFEST_KAPPA_BINDING_FILE,
         "tokenizer_adapter.json",
         uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
     ] {
         let path = output.join(kind);
         if let Some(file) = open_regular_file_nofollow(&path, "pre-attention identity record")? {
@@ -4294,6 +4619,36 @@ fn validate_source_compile_identity_temporaries(output: &Path) -> Result<(), Str
             identities.insert(kind, value);
         }
     }
+    let stable_attention = identities
+        .get(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE)
+        .map(|value| serde_json::from_value::<AttentionOperatorSpec>(value.clone()))
+        .transpose()
+        .map_err(|error| {
+            format!(
+                "source compile output {} has an unreadable stable attention identity: {error}",
+                output.display()
+            )
+        })?;
+    let stable_dense = identities
+        .get(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE)
+        .map(|value| serde_json::from_value::<DenseOperatorSpec>(value.clone()))
+        .transpose()
+        .map_err(|error| {
+            format!(
+                "source compile output {} has an unreadable stable dense identity: {error}",
+                output.display()
+            )
+        })?;
+    uor_r4_model_source::dense::validate_source_execution_pair(
+        stable_attention.as_ref(),
+        stable_dense.as_ref(),
+    )
+    .map_err(|error| {
+        format!(
+            "source compile output {} has an invalid stable attention/dense identity: {error}",
+            output.display()
+        )
+    })?;
     let entries = fs::read_dir(output)
         .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
     for entry in entries {
@@ -4325,6 +4680,35 @@ fn validate_source_compile_identity_temporaries(output: &Path) -> Result<(), Str
             ));
         }
     }
+    let attention = identities
+        .get(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE)
+        .map(|value| {
+            serde_json::from_value::<AttentionOperatorSpec>(value.clone()).map_err(|error| {
+                format!(
+                    "source compile output {} has an unreadable effective attention identity: {error}",
+                    output.display()
+                )
+            })
+        })
+        .transpose()?;
+    let dense = identities
+        .get(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE)
+        .map(|value| {
+            serde_json::from_value::<DenseOperatorSpec>(value.clone()).map_err(|error| {
+                format!(
+                    "source compile output {} has an unreadable effective dense identity: {error}",
+                    output.display()
+                )
+            })
+        })
+        .transpose()?;
+    uor_r4_model_source::dense::validate_source_execution_pair(attention.as_ref(), dense.as_ref())
+        .map_err(|error| {
+            format!(
+            "source compile output {} has an invalid effective attention/dense identity: {error}",
+            output.display()
+        )
+        })?;
     Ok(())
 }
 
@@ -4345,6 +4729,11 @@ fn recover_source_compile_identity_temporaries(output: &Path) -> Result<(), Stri
             output.display()
         ));
     }
+    // Prove every stable and temporary identity record is canonical and that
+    // a temporary agrees with any stable peer before deleting one byte.
+    // Malformed, nonregular, or conflicting attention/dense residue remains
+    // terminal and byte-preserved for operator review.
+    validate_source_compile_identity_temporaries(output)?;
     let entries = fs::read_dir(output)
         .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
     for entry in entries {
@@ -4462,10 +4851,12 @@ fn validate_pre_attention_identity_handle(
     path: &Path,
     kind: &str,
 ) -> Result<serde_json::Value, String> {
-    let description = if kind == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE {
-        "attention-operator binding"
-    } else {
-        "pre-attention identity record"
+    let description = match kind {
+        kind if kind == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE => {
+            "attention-operator binding"
+        }
+        kind if kind == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE => "dense-operator binding",
+        _ => "pre-attention identity record",
     };
     let bytes = read_opened_regular_file_nofollow(file, path, description)?;
     reject_duplicate_json_fields(&bytes, path, description)?;
@@ -4569,6 +4960,25 @@ fn validate_pre_attention_identity_handle(
                 ));
             }
         }
+        kind if kind == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE => {
+            let operator: DenseOperatorSpec =
+                serde_json::from_value(value.clone()).map_err(|error| {
+                    format!("{} is not a dense operator record: {error}", path.display())
+                })?;
+            let registered =
+                uor_r4_model_source::dense::operator_spec(&operator.id, operator.version)
+                    .map_err(|error| format!("{}: {error}", path.display()))?;
+            if operator != registered
+                || value
+                    != serde_json::to_value(&registered)
+                        .map_err(|error| format!("{}: {error}", path.display()))?
+            {
+                return Err(format!(
+                    "{} is not the full registered dense operator record",
+                    path.display()
+                ));
+            }
+        }
         _ => {
             return Err(format!(
                 "{} is not a recognized pre-attention identity entry",
@@ -4615,7 +5025,10 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
             saw_identity = true;
             continue;
         }
-        if name == "tokenizer_adapter.json" {
+        if name == "tokenizer_adapter.json"
+            || name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+            || name == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+        {
             validate_pre_attention_identity_file(&entry.path(), name)?;
             saw_identity = true;
             continue;
@@ -6110,6 +6523,25 @@ fn publish_compiled_bundle_completion(root: &Path) -> Result<(), String> {
                 root.display()
             ));
         }
+    }
+    let attention = source_compile_attention_binding(root)?.ok_or_else(|| {
+        format!(
+            "compiled-bundle stage {} lost its attention binding before completion",
+            root.display()
+        )
+    })?;
+    let dense = source_compile_dense_binding(root)?;
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(&attention), dense.as_ref())
+        .map_err(|error| format!("compiled-bundle stage {}: {error}", root.display()))?;
+    if attention.id == AttentionOperatorSpec::LEARNED_ABSOLUTE_ID
+        && attention.version == current_source_attention_era_version()?
+        && dense.is_none()
+    {
+        return Err(format!(
+            "current GPT-2 compiled-bundle stage {} is missing required {}",
+            root.display(),
+            uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+        ));
     }
     // The completion record is the commit point. Every member and directory
     // entry it names must reach stable storage before that record can become
@@ -7922,7 +8354,7 @@ fn preflight_and_bind_source_snapshot_kappa(
         if let Some(requested) = requested.as_deref() {
             if source_compile_output_has_payload(output)? {
                 let report = output.join("graph-cover/cover_report.json");
-                let (present, _, cover_kappa) = parse_cover_provenance(&report)?;
+                let (present, _, _, cover_kappa) = parse_cover_provenance(&report)?;
                 if !present || cover_kappa.as_deref() != Some(requested) {
                     return Err(format!(
                         "populated source compile output {} has no immutable source-manifest kappa binding or exact cover provenance for {requested}; refusing to resume or relabel it",
@@ -8004,6 +8436,12 @@ fn source_compile_output_for_attention_era(
 }
 
 fn select_source_compile_output_from_pair(pair: CompiledModelPair) -> Result<PathBuf, String> {
+    if !matches!(pair.composite, CompiledRootState::Absent) {
+        return Err(format!(
+            "preferred composite root {} is present; attention-only output selection cannot bypass it",
+            pair.composite_root.display()
+        ));
+    }
     match (&pair.conventional, &pair.current) {
         (_, CompiledRootState::Empty) => Err(format!(
             "preferred current bundle {} exists but is empty; refusing compile mutation until the stale empty root is removed",
@@ -8013,24 +8451,37 @@ fn select_source_compile_output_from_pair(pair: CompiledModelPair) -> Result<Pat
             CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_),
             CompiledRootState::PreAttentionIdentity,
         ) => Ok(pair.current_root),
-        (_, CompiledRootState::PreAttentionIdentity) => Err(format!(
-            "preferred current bundle {} contains only a pre-attention identity prefix without a matching historical conventional bundle; refusing ambiguous compile mutation",
-            pair.current_root.display()
-        )),
-        (_, CompiledRootState::BoundCurrent(_)) => Ok(pair.current_root),
-        (CompiledRootState::BoundCurrent(_), CompiledRootState::Absent) => {
-            Ok(pair.conventional_root)
+        (CompiledRootState::BoundCurrent(_), CompiledRootState::PreAttentionIdentity) => {
+            Err(format!(
+                "unsuffixed current root {} is already bound while resolver root {} contains an unfinished duplicate-current identity; refusing resume before mutation",
+                pair.conventional_root.display(),
+                pair.current_root.display()
+            ))
         }
+        (_, CompiledRootState::PreAttentionIdentity) => Ok(pair.current_root),
+        (_, CompiledRootState::BoundCurrent(_)) => Ok(pair.current_root),
         (
             CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_),
             CompiledRootState::Absent,
         ) => Ok(pair.current_root),
         (
-            CompiledRootState::Absent
-                | CompiledRootState::Empty
-                | CompiledRootState::PreAttentionIdentity,
+            CompiledRootState::Absent | CompiledRootState::Empty,
             CompiledRootState::Absent,
         ) => Ok(pair.conventional_root),
+        (CompiledRootState::PreAttentionIdentity, CompiledRootState::Absent) => {
+            Ok(pair.conventional_root)
+        }
+        (CompiledRootState::BoundCurrent(_), CompiledRootState::Absent) => {
+            Ok(pair.conventional_root)
+        }
+        (CompiledRootState::BoundCurrent(_), _) => Err(format!(
+            "unsuffixed current root {} conflicts with the resolver-owned root {}",
+            pair.conventional_root.display(),
+            pair.current_root.display()
+        )),
+        (CompiledRootState::PreDenseIdentity(_), _) | (_, CompiledRootState::PreDenseIdentity(_)) => {
+            Err("internal placement error: a pre-dense identity was classified outside the composite resolver root".to_owned())
+        }
         (_, CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_)) => {
             Err(format!(
                 "resolver-owned current root {} was not classified as current",
@@ -8040,11 +8491,12 @@ fn select_source_compile_output_from_pair(pair: CompiledModelPair) -> Result<Pat
     }
 }
 
-fn source_compile_output_for_operator_era(
+fn source_compile_output_for_operator_era_with_dense(
     compiled_root: &Path,
     name: &str,
     current_version: u32,
     source_operator: &AttentionOperatorSpec,
+    source_dense: Option<&DenseOperatorSpec>,
 ) -> Result<PathBuf, String> {
     let registered =
         uor_r4_model_source::attention::operator_spec(&source_operator.id, source_operator.version)
@@ -8058,10 +8510,16 @@ fn source_compile_output_for_operator_era(
             source_operator.id, source_operator.version
         ));
     }
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(source_operator), source_dense)
+        .map_err(|error| format!("source teacher execution identity is invalid: {error}"))?;
     let pair = inspect_compiled_model_pair(compiled_root, name, current_version)?;
-    for recorded in [pair.conventional.operator(), pair.current.operator()]
-        .into_iter()
-        .flatten()
+    for recorded in [
+        pair.conventional.operator(),
+        pair.current.operator(),
+        pair.composite.operator(),
+    ]
+    .into_iter()
+    .flatten()
     {
         if recorded.id != source_operator.id {
             return Err(format!(
@@ -8074,7 +8532,81 @@ fn source_compile_output_for_operator_era(
             ));
         }
     }
+    if let Some(source_dense) = source_dense {
+        if matches!(pair.conventional, CompiledRootState::PreAttentionIdentity)
+            || matches!(pair.current, CompiledRootState::PreAttentionIdentity)
+        {
+            return Err(format!(
+                "cannot select composite root {} while a lower-precedence root ({}, {}) contains an unfinished pre-attention identity; refusing to hide or mutate any initialization",
+                pair.composite_root.display(),
+                pair.conventional_root.display(),
+                pair.current_root.display()
+            ));
+        }
+        return match &pair.composite {
+            CompiledRootState::Absent | CompiledRootState::PreAttentionIdentity => {
+                Ok(pair.composite_root)
+            }
+            CompiledRootState::PreDenseIdentity(operator) if **operator == *source_operator => {
+                Ok(pair.composite_root)
+            }
+            CompiledRootState::PreDenseIdentity(operator) => Err(format!(
+                "composite root {} has a resumable attention identity {}/{}, not requested {}/{}",
+                pair.composite_root.display(),
+                operator.id,
+                operator.version,
+                source_operator.id,
+                source_operator.version
+            )),
+            CompiledRootState::BoundCurrent(identity)
+                if identity.attention == *source_operator
+                    && identity.dense.as_ref() == Some(source_dense) =>
+            {
+                Ok(pair.composite_root)
+            }
+            CompiledRootState::BoundCurrent(identity) => Err(format!(
+                "composite root {} records {}/{} with dense {:?}, not requested {}/{} with {}/{}",
+                pair.composite_root.display(),
+                identity.attention.id,
+                identity.attention.version,
+                identity
+                    .dense
+                    .as_ref()
+                    .map(|operator| format!("{}/{}", operator.id, operator.version)),
+                source_operator.id,
+                source_operator.version,
+                source_dense.id,
+                source_dense.version
+            )),
+            CompiledRootState::Empty => Err(format!(
+                "preferred composite root {} exists but is empty; refusing compile mutation",
+                pair.composite_root.display()
+            )),
+            CompiledRootState::ImplicitV1(_) | CompiledRootState::BoundHistorical(_) => {
+                Err(format!(
+                    "resolver-owned composite root {} was not classified as current",
+                    pair.composite_root.display()
+                ))
+            }
+        };
+    }
     select_source_compile_output_from_pair(pair)
+}
+
+#[cfg(test)]
+fn source_compile_output_for_operator_era(
+    compiled_root: &Path,
+    name: &str,
+    current_version: u32,
+    source_operator: &AttentionOperatorSpec,
+) -> Result<PathBuf, String> {
+    source_compile_output_for_operator_era_with_dense(
+        compiled_root,
+        name,
+        current_version,
+        source_operator,
+        None,
+    )
 }
 
 struct CompiledSourceBundle {
@@ -8162,14 +8694,22 @@ fn compile_bundle_from_source(
     let source_operator = teacher
         .attention_operator_spec()
         .ok_or_else(|| "source teacher declares no attention operator".to_owned())?;
+    let source_dense = teacher.dense_operator_spec();
+    uor_r4_model_source::dense::validate_source_execution_pair(
+        Some(&source_operator),
+        source_dense.as_ref(),
+    )
+    .map_err(|error| format!("source teacher execution identity is invalid: {error}"))?;
     let compiled_root = Path::new(".uor-models/compiled");
     let current_version = current_source_attention_era_version()?;
     let conventional = compiled_root.join(name);
     let current = compiled_root.join(format!("{name}{}", attention_era_suffix(current_version)));
+    let composite = compiled_root.join(format!("{name}{}", composite_era_suffix(current_version)));
     let mut session_subjects = vec![
         compiled_root.to_path_buf(),
         conventional.clone(),
         current.clone(),
+        composite.clone(),
         source
             .parent()
             .unwrap_or_else(|| Path::new("."))
@@ -8191,21 +8731,24 @@ fn compile_bundle_from_source(
     )?;
     recover_source_compile_identity_temporaries(&conventional)?;
     recover_source_compile_identity_temporaries(&current)?;
-    let output = source_compile_output_for_operator_era(
+    recover_source_compile_identity_temporaries(&composite)?;
+    let output = source_compile_output_for_operator_era_with_dense(
         compiled_root,
         name,
         current_version,
         &source_operator,
+        source_dense.as_ref(),
     )?;
     // The process-local source-cache reservation is acquired by the HTTP
     // handler first. Both era siblings and any external score sink are now
     // exclusively owned before selection, preflight publication, or adoption.
     // The returned guards remain live through final serving installation.
-    let refreshed_output = source_compile_output_for_operator_era(
+    let refreshed_output = source_compile_output_for_operator_era_with_dense(
         compiled_root,
         name,
         current_version,
         &source_operator,
+        source_dense.as_ref(),
     )?;
     if refreshed_output != output {
         return Err(format!(
@@ -8319,6 +8862,7 @@ fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
 /// corpus. A genuinely operator-less caller corpus retains the historical
 /// implicit standard/1 interpretation; source-driven compiles must carry the
 /// explicit sidecar written by stage A.
+#[cfg(test)]
 fn append_recorded_attention_operator(
     cover_args: &mut Vec<String>,
     corpus_meta: &Path,
@@ -8343,6 +8887,56 @@ fn append_recorded_attention_operator(
         }
         None => Ok(()),
     }
+}
+
+/// Append both halves from one stable recorded-corpus snapshot. Source
+/// compilation uses this joint boundary so attention and dense can never be
+/// assembled from two filesystem generations.
+fn append_recorded_execution_identity(
+    cover_args: &mut Vec<String>,
+    corpus_meta: &Path,
+    corpus_recs: &Path,
+    require_explicit: bool,
+) -> Result<(), String> {
+    let identity = uor_r4_graph_cli::recorded_corpus_execution_identity(corpus_meta, corpus_recs)
+        .map_err(|error| error.to_string())?;
+    match identity.attention_operator.as_ref() {
+        Some(operator) => {
+            let json = serde_json::to_string(operator).map_err(|error| error.to_string())?;
+            cover_args.extend(["--attention-operator".to_owned(), json]);
+        }
+        None if require_explicit => {
+            let root = corpus_meta.parent().unwrap_or_else(|| Path::new("."));
+            return Err(format!(
+                "compiled source corpus is missing its attention-operator binding: {}",
+                root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE)
+                    .display()
+            ));
+        }
+        None => {}
+    }
+    if require_explicit
+        && identity
+            .attention_operator
+            .as_ref()
+            .is_some_and(|operator| {
+                operator.id == AttentionOperatorSpec::LEARNED_ABSOLUTE_ID
+                    && operator.version == AttentionOperatorSpec::LEARNED_ABSOLUTE_VERSION
+            })
+        && identity.dense_operator.is_none()
+    {
+        let root = corpus_meta.parent().unwrap_or_else(|| Path::new("."));
+        return Err(format!(
+            "current GPT-2 source corpus is missing its dense-operator binding: {}",
+            root.join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE)
+                .display()
+        ));
+    }
+    if let Some(operator) = identity.dense_operator.as_ref() {
+        let json = serde_json::to_string(operator).map_err(|error| error.to_string())?;
+        cover_args.extend(["--dense-operator".to_owned(), json]);
+    }
+    Ok(())
 }
 
 fn compile_r4g1_bundle(
@@ -8536,7 +9130,7 @@ fn compile_r4g1_bundle(
     // #602/#704: bind the identity stage A or the observation manifest
     // actually recorded. Reconstructing it as standard from the absent
     // experimental switch would mislabel GPT-2's learned-absolute operator.
-    append_recorded_attention_operator(
+    append_recorded_execution_identity(
         &mut cover_args,
         &corpus_meta,
         &corpus_recs,
@@ -8740,7 +9334,7 @@ fn compile_r4g1_bundle(
                     compiled.working_output.display()
                 )
             })?;
-            let (_, _, cover_kappa) = parse_cover_provenance(
+            let (_, _, _, cover_kappa) = parse_cover_provenance(
                 &compiled
                     .working_output
                     .join("graph-cover/cover_report.json"),
@@ -10619,32 +11213,7 @@ fn handle_connection(
         // alias (Deprecation header) so /v1 is OpenAI-only without losing this.
         let dep = deprecation_headers(clean_path);
         let installed = serving.lock().unwrap();
-        let graph_loaded = installed.r4g1.is_some();
-        let graph_ready = graph_text_ready(&installed);
-        let decode_only = graph_loaded && !graph_ready;
-        let teacher_ready = teacher_text_ready(&installed);
-        let engine_active = graph_ready || teacher_ready;
-        let logical_name = installed_logical_model_name(&installed);
-        let bundle_compiled = installed.active_bundle.is_some();
-
-        let body = serde_json::json!({
-            "model_name": logical_name,
-            "physical_root": status_physical_root(installed.active_bundle.as_ref()),
-            "attention_operator": installed.active_bundle.as_ref().map(|bundle| &bundle.attention_operator),
-            "r4g1_loaded": graph_loaded,
-            "r4g1_ready": graph_ready,
-            "decode_only": decode_only,
-            "teacher_ready": teacher_ready,
-            "engine_active": engine_active,
-            "terminal_error": installed.terminal_load_error.as_deref(),
-            "last_operation_error": installed.last_operation_error.as_deref(),
-            "stages": {
-                "stage_1_download": installed.active_teacher_source.is_some(),
-                "stage_2_compile": bundle_compiled,
-                "stage_3_graph_score": graph_loaded,
-                "stage_4_r4g1_active": graph_ready
-            }
-        });
+        let body = uor_status_json(&installed);
         send_json_response_ext(stream, 200, &body.to_string(), &dep);
         return;
     }
@@ -13752,6 +14321,21 @@ mod tests {
         bytes
     }
 
+    fn write_dense_binding(
+        root: &std::path::Path,
+        operator: &uor_r4_model_source::dense::DenseOperatorSpec,
+    ) -> Vec<u8> {
+        std::fs::create_dir_all(root).expect("create dense-bound compile root");
+        let mut bytes = serde_json::to_vec_pretty(operator).expect("serialize full dense operator");
+        bytes.push(b'\n');
+        std::fs::write(
+            root.join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE),
+            &bytes,
+        )
+        .expect("write dense binding");
+        bytes
+    }
+
     fn write_tokenizer_adapter_binding(root: &std::path::Path, marker: &str) -> Vec<u8> {
         let tokenizer_json = format!(
             r#"{{
@@ -13900,6 +14484,76 @@ mod tests {
     }
 
     #[test]
+    fn source_dense_cover_completion_and_resolver_share_one_exact_identity() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let root = attention_provenance_test_dir("dense-cover-completion-resolver");
+        let output = root.join("compiled/teacher-attention-v2-dense-v2");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        let source_kappa = format!("blake3:{}", "7".repeat(64));
+        super::publish_source_compile_preflight(&output, Some(&source_kappa))
+            .expect("source preflight identity");
+        super::publish_source_manifest_kappa_binding(&output, &source_kappa)
+            .expect("source snapshot binding");
+        write_attention_binding(&output, &attention);
+        write_dense_binding(&output, &dense);
+        let (meta, records) = attention_corpus_markers(&output);
+
+        let mut cover_args = Vec::new();
+        super::append_recorded_execution_identity(&mut cover_args, &meta, &records, true)
+            .expect("source compile forwards its recorded execution pair");
+        let argument = |flag: &str| {
+            cover_args
+                .windows(2)
+                .find(|pair| pair[0] == flag)
+                .map(|pair| pair[1].clone())
+                .unwrap_or_else(|| panic!("missing {flag} cover argument"))
+        };
+        let cover_attention: AttentionOperatorSpec =
+            serde_json::from_str(&argument("--attention-operator"))
+                .expect("cover attention record");
+        let cover_dense: DenseOperatorSpec =
+            serde_json::from_str(&argument("--dense-operator")).expect("cover dense record");
+        assert_eq!(cover_attention, attention);
+        assert_eq!(cover_dense, dense);
+
+        std::fs::create_dir_all(output.join("graph")).expect("graph directory");
+        std::fs::write(output.join("graph/score.r4g1"), b"graph").expect("graph marker");
+        std::fs::write(output.join("graph/score_report.json"), b"{}\n")
+            .expect("score report marker");
+        std::fs::write(output.join("tless_artifacts.bin"), b"teacher").expect("teacher marker");
+        std::fs::write(output.join("tokenizer.bin"), b"tokenizer").expect("tokenizer marker");
+        std::fs::write(output.join("tokenizer_adapter.json"), b"{}\n")
+            .expect("tokenizer adapter marker");
+        std::fs::create_dir_all(output.join("graph-cover")).expect("cover directory");
+        std::fs::write(output.join("graph-cover/cover.r4g1"), b"cover").expect("cover marker");
+        std::fs::write(
+            output.join("graph-cover/cover_report.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "attention_operator": cover_attention,
+                "dense_operator": cover_dense,
+                "source_manifest_kappa": source_kappa,
+            }))
+            .expect("cover report JSON"),
+        )
+        .expect("cover report");
+        super::publish_compiled_bundle_completion(&output).expect("publish exact completion");
+        super::validate_compiled_bundle_completion(&output)
+            .expect("completion validates")
+            .expect("completion exists");
+
+        let resolved = super::resolve_requested_compiled_bundle_in(&root, "teacher", 2)
+            .expect("resolver accepts completed source bundle")
+            .expect("completed source bundle is loadable");
+        assert_eq!(resolved.physical_root, output);
+        assert_eq!(resolved.attention_operator, attention);
+        assert_eq!(resolved.dense_operator, Some(dense));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn source_compile_routes_immutable_v1_bundles_to_a_fresh_v2_era() {
         use uor_r4_model_source::attention::AttentionOperatorSpec;
 
@@ -14040,6 +14694,174 @@ mod tests {
     }
 
     #[test]
+    fn current_gpt2_dense_identity_is_composite_root_only() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let root = attention_provenance_test_dir("dense-composite-only");
+        let compiled = root.join("compiled");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        assert_eq!(
+            super::source_compile_output_for_operator_era_with_dense(
+                &compiled,
+                "teacher",
+                2,
+                &attention,
+                Some(&dense),
+            )
+            .expect("fresh GPT-2 compile selects the composite root"),
+            composite
+        );
+        assert!(!compiled.exists(), "selection is read-only");
+
+        for misplaced in [
+            compiled.join("teacher"),
+            compiled.join("teacher-attention-v2"),
+        ] {
+            write_attention_binding(&misplaced, &attention);
+            write_dense_binding(&misplaced, &dense);
+            std::fs::write(
+                misplaced.join("corpus.records"),
+                b"immutable misplaced payload",
+            )
+            .expect("misplaced payload");
+            let before_attention =
+                std::fs::read(misplaced.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                    .expect("attention before");
+            let before_dense =
+                std::fs::read(misplaced.join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE))
+                    .expect("dense before");
+            let error = super::source_compile_output_for_operator_era_with_dense(
+                &compiled,
+                "teacher",
+                2,
+                &attention,
+                Some(&dense),
+            )
+            .expect_err("current dense provenance outside the composite root is terminal");
+            assert!(
+                error.contains("composite resolver root")
+                    || error.contains("composite resolver root")
+                    || error.contains("composite"),
+                "{error}"
+            );
+            assert_eq!(
+                std::fs::read(misplaced.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                    .expect("attention after"),
+                before_attention
+            );
+            assert_eq!(
+                std::fs::read(misplaced.join(uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE))
+                    .expect("dense after"),
+                before_dense
+            );
+            std::fs::remove_dir_all(&misplaced).expect("reset misplaced root");
+        }
+
+        write_attention_binding(&composite, &attention);
+        write_dense_binding(&composite, &dense);
+        std::fs::write(
+            composite.join("corpus.records"),
+            b"current composite payload",
+        )
+        .expect("composite payload");
+        assert_eq!(
+            super::source_compile_output_for_operator_era_with_dense(
+                &compiled,
+                "teacher",
+                2,
+                &attention,
+                Some(&dense),
+            )
+            .expect("matching composite resumes"),
+            composite
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn historical_dense_base_and_current_attention_only_can_coexist_with_composite() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let root = attention_provenance_test_dir("dense-era-coexistence");
+        let compiled = root.join("compiled");
+        let base = compiled.join("teacher");
+        write_attention_binding(&base, &AttentionOperatorSpec::learned_absolute_v1());
+        write_dense_binding(&base, &DenseOperatorSpec::gpt2_v1());
+        std::fs::write(base.join("corpus.records"), b"historical v1/v1")
+            .expect("historical payload");
+
+        let current = compiled.join("teacher-attention-v2");
+        write_attention_binding(&current, &AttentionOperatorSpec::learned_absolute_v2());
+        std::fs::write(current.join("corpus.records"), b"attention-only v2")
+            .expect("attention payload");
+
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_attention_binding(&composite, &AttentionOperatorSpec::learned_absolute_v2());
+        write_dense_binding(&composite, &DenseOperatorSpec::gpt2_v2());
+        std::fs::write(composite.join("corpus.records"), b"dense v2").expect("dense payload");
+
+        let pair = super::inspect_compiled_model_pair(&compiled, "teacher", 2)
+            .expect("three distinct valid execution identities coexist");
+        let (selected, identity) = super::selected_compiled_root(&pair).expect("selected root");
+        assert_eq!(selected, composite);
+        assert_eq!(identity.dense.as_ref(), Some(&DenseOperatorSpec::gpt2_v2()));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn dense_composite_selection_refuses_lower_unfinished_identities_before_mutation() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        for (label, lower_suffixes) in [
+            ("base", vec![""]),
+            ("attention", vec!["-attention-v2"]),
+            ("both", vec!["", "-attention-v2"]),
+        ] {
+            let root = attention_provenance_test_dir(&format!("dense-lower-prefix-{label}"));
+            let compiled = root.join("compiled");
+            let kappa = format!("blake3:{}", "a".repeat(64));
+            let mut snapshots = Vec::new();
+            for suffix in lower_suffixes {
+                let lower = compiled.join(format!("teacher{suffix}"));
+                super::publish_source_compile_preflight(&lower, Some(&kappa))
+                    .expect("publish lower preflight");
+                snapshots.push((
+                    lower.clone(),
+                    std::fs::read(lower.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                        .expect("preflight bytes"),
+                ));
+            }
+            let composite = compiled.join("teacher-attention-v2-dense-v2");
+            let error = super::source_compile_output_for_operator_era_with_dense(
+                &compiled,
+                "teacher",
+                2,
+                &AttentionOperatorSpec::learned_absolute_v2(),
+                Some(&DenseOperatorSpec::gpt2_v2()),
+            )
+            .expect_err("lower unfinished identity blocks composite selection");
+            assert!(error.contains("lower-precedence"), "{error}");
+            assert!(
+                !composite.exists(),
+                "selection cannot create composite output"
+            );
+            for (lower, before) in snapshots {
+                assert_eq!(
+                    std::fs::read(lower.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                        .expect("preflight after"),
+                    before
+                );
+            }
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
     fn source_compile_era_selection_fails_closed_on_invalid_provenance() {
         let root = attention_provenance_test_dir("era-invalid");
         let compiled = root.join("compiled");
@@ -14098,7 +14920,47 @@ mod tests {
             .expect("write suffix payload");
         let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
             .expect_err("two current roots are ambiguous");
-        assert!(error.contains("duplicate current"), "{error}");
+        assert!(
+            error.contains("duplicate the same source-execution identity"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn current_base_refuses_torn_attention_suffix_before_mutation() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = attention_provenance_test_dir("current-base-torn-suffix");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let binding = write_attention_binding(&conventional, &AttentionOperatorSpec::standard_v2());
+        let payload = conventional.join("corpus.records");
+        std::fs::write(&payload, b"current conventional payload").expect("payload");
+        let kappa = format!("blake3:{}", "4".repeat(64));
+        super::publish_source_compile_preflight(&current, Some(&kappa))
+            .expect("torn suffix preflight");
+        let prefix = std::fs::read(current.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+            .expect("prefix before");
+
+        let error = super::source_compile_output_for_attention_era(&compiled, "teacher", 2)
+            .expect_err("torn suffix cannot duplicate a bound-current base");
+        assert!(error.contains("duplicate-current"), "{error}");
+        assert_eq!(
+            std::fs::read(conventional.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE))
+                .expect("binding after"),
+            binding
+        );
+        assert_eq!(
+            std::fs::read(&payload).expect("payload after"),
+            b"current conventional payload"
+        );
+        assert_eq!(
+            std::fs::read(current.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("prefix after"),
+            prefix
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -14816,8 +15678,16 @@ mod tests {
             std::fs::write(&empty, b"").expect("zero-byte torn create");
             std::fs::write(&truncated, b"{\"prefix\":").expect("mid-write crash prefix");
         }
-        super::recover_source_compile_identity_temporaries(&output)
-            .expect("exclusive owner reclaims strict reserved temp names");
+        let before_recovery = std::fs::read_dir(&output)
+            .expect("enumerate torn identities")
+            .map(|entry| entry.expect("identity entry").file_name())
+            .collect::<Vec<_>>();
+        let error = super::recover_source_compile_identity_temporaries(&output)
+            .expect_err("malformed reserved identities remain terminal");
+        assert!(
+            error.contains("malformed") || error.contains("canonical"),
+            "{error}"
+        );
         assert_eq!(
             std::fs::read(output.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
                 .expect("stable P after recovery"),
@@ -14828,13 +15698,20 @@ mod tests {
                 .expect("stable K after recovery"),
             kappa_before
         );
-        assert!(std::fs::read_dir(&output)
-            .expect("enumerate recovered root")
-            .all(|entry| !entry
-                .expect("entry")
-                .file_name()
-                .to_string_lossy()
-                .ends_with(".tmp")));
+        let after_recovery = std::fs::read_dir(&output)
+            .expect("enumerate preserved torn identities")
+            .map(|entry| entry.expect("identity entry").file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(after_recovery.len(), before_recovery.len());
+        assert!(after_recovery
+            .iter()
+            .any(|name| name.to_string_lossy().ends_with(".tmp")));
+
+        for name in &before_recovery {
+            if name.to_string_lossy().ends_with(".tmp") {
+                std::fs::remove_file(output.join(name)).expect("remove malformed test residue");
+            }
+        }
 
         let unknown = output.join(".tokenizer_adapter.json.owner.tmp");
         std::fs::write(&unknown, b"").expect("unknown temp spelling");
@@ -14873,11 +15750,166 @@ mod tests {
             }
             let error = super::recover_source_compile_identity_temporaries(&output)
                 .expect_err("special entry is terminal and nonblocking");
-            assert!(error.contains("not a regular non-symlink file"), "{error}");
+            assert!(
+                error.contains("not a regular") || error.contains("cannot be opened"),
+                "{error}"
+            );
             assert!(std::fs::symlink_metadata(&temporary).is_ok());
             drop(session);
             let _ = std::fs::remove_dir_all(root);
         }
+    }
+
+    #[test]
+    fn identity_temp_recovery_rejects_cross_era_pairs_without_deleting_evidence() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        for scenario in [
+            "dense-temp-only",
+            "stable-attention-dense-temp",
+            "stable-dense-attention-temp",
+            "stable-mismatch",
+        ] {
+            let root = attention_provenance_test_dir(&format!("cross-era-temp-{scenario}"));
+            let output = root.join("compiled/teacher");
+            std::fs::create_dir_all(&output).expect("output root");
+            let dense_temp = output.join(".dense_operator.json.900.1.tmp");
+            let dense_v2 = {
+                let mut bytes = serde_json::to_vec_pretty(&DenseOperatorSpec::gpt2_v2())
+                    .expect("dense fixture");
+                bytes.push(b'\n');
+                bytes
+            };
+            match scenario {
+                "dense-temp-only" => {
+                    std::fs::write(&dense_temp, &dense_v2).expect("dense temp");
+                }
+                "stable-attention-dense-temp" => {
+                    write_attention_binding(&output, &AttentionOperatorSpec::learned_absolute_v1());
+                    std::fs::write(&dense_temp, &dense_v2).expect("dense temp");
+                }
+                "stable-dense-attention-temp" => {
+                    write_dense_binding(&output, &DenseOperatorSpec::gpt2_v2());
+                    let mut bytes =
+                        serde_json::to_vec_pretty(&AttentionOperatorSpec::learned_absolute_v2())
+                            .expect("attention fixture");
+                    bytes.push(b'\n');
+                    std::fs::write(output.join(".attention_operator.json.900.3.tmp"), bytes)
+                        .expect("attention temp");
+                }
+                "stable-mismatch" => {
+                    write_attention_binding(&output, &AttentionOperatorSpec::learned_absolute_v1());
+                    write_dense_binding(&output, &DenseOperatorSpec::gpt2_v2());
+                    let unrelated = output.join(".source_compile_preflight.json.900.2.tmp");
+                    std::fs::write(
+                        &unrelated,
+                        super::source_compile_preflight_bytes(None).expect("preflight fixture"),
+                    )
+                    .expect("unrelated temp");
+                }
+                _ => unreachable!(),
+            }
+            let before = std::fs::read_dir(&output)
+                .expect("enumerate before")
+                .map(|entry| {
+                    let entry = entry.expect("entry");
+                    (
+                        entry.file_name(),
+                        std::fs::read(entry.path()).expect("regular fixture bytes"),
+                    )
+                })
+                .collect::<std::collections::BTreeMap<_, _>>();
+            let error = super::recover_source_compile_identity_temporaries(&output)
+                .expect_err("invalid effective execution identity is terminal");
+            assert!(
+                error.contains("invalid effective attention/dense identity")
+                    || error.contains("invalid stable attention/dense identity"),
+                "{scenario}: {error}"
+            );
+            let after = std::fs::read_dir(&output)
+                .expect("enumerate after")
+                .map(|entry| {
+                    let entry = entry.expect("entry");
+                    (
+                        entry.file_name(),
+                        std::fs::read(entry.path()).expect("regular fixture bytes"),
+                    )
+                })
+                .collect::<std::collections::BTreeMap<_, _>>();
+            assert_eq!(after, before, "{scenario}: refusal is byte-preserving");
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn composite_attention_first_crashes_resume_but_payload_without_dense_is_terminal() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        for with_dense_temp in [false, true] {
+            let root = attention_provenance_test_dir(if with_dense_temp {
+                "pre-dense-temp"
+            } else {
+                "pre-dense-stable-attention"
+            });
+            let compiled = root.join("compiled");
+            let composite = compiled.join("teacher-attention-v2-dense-v2");
+            let attention = AttentionOperatorSpec::learned_absolute_v2();
+            let dense = DenseOperatorSpec::gpt2_v2();
+            write_attention_binding(&composite, &attention);
+            if with_dense_temp {
+                let mut bytes = serde_json::to_vec_pretty(&dense).expect("dense temp fixture");
+                bytes.push(b'\n');
+                let temporary = composite.join(".dense_operator.json.901.1.tmp");
+                std::fs::write(&temporary, bytes).expect("dense temp");
+                super::recover_source_compile_identity_temporaries(&composite)
+                    .expect("canonical matching temp is recoverable");
+                assert!(!temporary.exists(), "validated temp is reclaimed");
+            }
+            assert_eq!(
+                super::source_compile_output_for_operator_era_with_dense(
+                    &compiled,
+                    "teacher",
+                    2,
+                    &attention,
+                    Some(&dense),
+                )
+                .expect("pre-dense identity resumes exact composite"),
+                composite
+            );
+            write_dense_binding(&composite, &dense);
+            let pair = super::inspect_compiled_model_pair(&compiled, "teacher", 2)
+                .expect("completed composite is valid");
+            assert!(matches!(
+                pair.composite,
+                super::CompiledRootState::BoundCurrent(_)
+            ));
+            let _ = std::fs::remove_dir_all(root);
+        }
+
+        let root = attention_provenance_test_dir("pre-dense-with-payload");
+        let compiled = root.join("compiled");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        write_attention_binding(&composite, &attention);
+        let payload = composite.join("corpus.records");
+        std::fs::write(&payload, b"payload before dense binding").expect("payload fixture");
+        let before = std::fs::read(&payload).expect("payload before");
+        let error = super::source_compile_output_for_operator_era_with_dense(
+            &compiled,
+            "teacher",
+            2,
+            &attention,
+            Some(&DenseOperatorSpec::gpt2_v2()),
+        )
+        .expect_err("payload without dense is not a resumable prefix");
+        assert!(
+            error.contains("corpus.records") || error.contains("dense"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(&payload).expect("payload after"), before);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -14937,7 +15969,17 @@ mod tests {
             super::SOURCE_COMPILE_PREFLIGHT_FILE,
             super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
         ] {
-            std::fs::write(root.join(file), tag).expect("bundle fixture member");
+            let bytes = if file == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE {
+                let mut bytes = serde_json::to_vec_pretty(
+                    &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+                )
+                .expect("serialize fixture attention");
+                bytes.push(b'\n');
+                bytes
+            } else {
+                tag.to_vec()
+            };
+            std::fs::write(root.join(file), bytes).expect("bundle fixture member");
         }
         for file in [
             "graph-cover/cover.r4g1",
@@ -15106,7 +16148,11 @@ mod tests {
         symlink(root.join("missing"), &temporary).expect("dangling publisher temporary");
         let error = super::CompiledBundleStage::allocate(&output, &source_kappa)
             .expect_err("special publisher residue is terminal");
-        assert!(error.contains("not a regular non-symlink file"), "{error}");
+        assert!(
+            error.contains("not a regular non-symlink file")
+                || error.contains("cannot be opened as a regular non-symlink"),
+            "{error}"
+        );
         assert!(std::fs::symlink_metadata(&temporary).is_ok());
         let _ = std::fs::remove_dir_all(root);
     }
@@ -15893,6 +16939,7 @@ mod tests {
             teacher: output.join("tless_artifacts.bin"),
             attention_operator: uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(
             ),
+            dense_operator: None,
             source_manifest_kappa: Some(m1.content_kappa.clone()),
         };
         let error = super::validate_resolved_source_snapshot_binding(&resolved, Some(&m2), 2)
@@ -16089,7 +17136,10 @@ mod tests {
             2,
         )
         .expect_err("resolver-owned suffix is not an arbitrary source basename");
-        assert!(error.contains("resolver-owned suffix"), "{error}");
+        assert!(
+            error.contains("resolver-owned arithmetic suffix"),
+            "{error}"
+        );
         assert!(!compiled.exists(), "name rejection is read-only");
         let _ = std::fs::remove_dir_all(root);
     }
@@ -16291,6 +17341,62 @@ mod tests {
             .is_some());
         let error = super::resolve_reload_bundle_in(&root, "teacher-attention-v2", 2)
             .expect_err("exact suffix alias cannot consume a genuine source basename");
+        assert!(
+            error.contains("request the logical base explicitly"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn composite_suffix_is_reserved_and_stripped_as_one_longest_match() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        assert_eq!(
+            super::logical_model_name_for_request("teacher-attention-v2-dense-v2", 2)
+                .expect("exact composite alias resolves"),
+            "teacher"
+        );
+        assert_eq!(
+            super::logical_model_name_for_request("teacher-attention-v2", 2)
+                .expect("exact attention alias resolves"),
+            "teacher"
+        );
+        assert!(
+            super::logical_model_name_for_request("teacher-attention-v2-dense-v2-attention-v2", 2,)
+                .is_err(),
+            "stripping a shorter trailing suffix cannot expose a second reserved basename"
+        );
+
+        let root = attention_provenance_test_dir("reserved-composite-source-collision");
+        let composite = root.join("compiled/teacher-attention-v2-dense-v2");
+        write_loadable_graph_bundle(
+            &composite,
+            Some(&AttentionOperatorSpec::learned_absolute_v2()),
+        );
+        let dense = DenseOperatorSpec::gpt2_v2();
+        write_dense_binding(&composite, &dense);
+        let report_path = composite.join("graph-cover/cover_report.json");
+        let mut report: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(&report_path).expect("read cover report fixture"),
+        )
+        .expect("parse cover report fixture");
+        report["dense_operator"] =
+            serde_json::to_value(&dense).expect("serialize dense cover identity");
+        std::fs::write(
+            &report_path,
+            serde_json::to_vec_pretty(&report).expect("serialize dense cover report"),
+        )
+        .expect("write dense cover report");
+        std::fs::create_dir_all(root.join("sources/teacher-attention-v2-dense-v2"))
+            .expect("create genuine pre-upgrade composite-suffixed source");
+
+        let error = super::discover_compiled_r4g1_candidates_in(&root.join("compiled"), 2)
+            .expect_err("composite suffix collision cannot be reinterpreted as teacher");
+        assert!(error.contains("pre-existing source basename"), "{error}");
+        let error = super::resolve_reload_bundle_in(&root, "teacher-attention-v2-dense-v2", 2)
+            .expect_err("exact composite alias cannot consume a genuine source basename");
         assert!(
             error.contains("request the logical base explicitly"),
             "{error}"
@@ -16794,6 +17900,7 @@ mod tests {
                 graph: root.join("compiled/teacher/graph/score.r4g1"),
                 teacher: root.join("compiled/teacher/tless_artifacts.bin"),
                 attention_operator: AttentionOperatorSpec::standard_v1(),
+                dense_operator: None,
                 source_manifest_kappa: None,
             }),
             ..super::ServingModelState::default()
@@ -17000,6 +18107,7 @@ mod tests {
             graph: "/compiled/alpha-attention-v2/graph/score.r4g1".into(),
             teacher: "/compiled/alpha-attention-v2/tless_artifacts.bin".into(),
             attention_operator: AttentionOperatorSpec::standard_v2(),
+            dense_operator: None,
             source_manifest_kappa: None,
         };
         let serving = Arc::new(Mutex::new(super::ServingModelState {
@@ -17070,6 +18178,59 @@ mod tests {
             None,
             "a source path alone is not a text-ready engine"
         );
+    }
+
+    #[test]
+    fn both_status_surfaces_report_the_exact_optional_source_execution_pair() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+        use uor_r4_model_source::dense::DenseOperatorSpec;
+
+        let attention = AttentionOperatorSpec::learned_absolute_v2();
+        let dense = DenseOperatorSpec::gpt2_v2();
+        let serving = super::ServingModelState {
+            active_bundle: Some(super::ResolvedCompiledBundle {
+                logical_name: "teacher".to_owned(),
+                physical_root: "/compiled/teacher-attention-v2-dense-v2".into(),
+                graph: "/compiled/teacher-attention-v2-dense-v2/graph/score.r4g1".into(),
+                teacher: "/compiled/teacher-attention-v2-dense-v2/tless_artifacts.bin".into(),
+                attention_operator: attention.clone(),
+                dense_operator: Some(dense.clone()),
+                source_manifest_kappa: None,
+            }),
+            ..super::ServingModelState::default()
+        };
+        let compile = super::R4g1CompileStatus {
+            running: false,
+            ready: false,
+            progress: 0,
+            message: "idle".to_owned(),
+            report: None,
+        };
+
+        for (surface, status) in [
+            ("/uor/v1/status", super::uor_status_json(&serving)),
+            ("/api/r4g1/status", compile.json(&serving)),
+        ] {
+            assert_eq!(
+                status.get("attention_operator"),
+                Some(&serde_json::to_value(&attention).expect("serialize attention")),
+                "{surface} attention provenance"
+            );
+            assert_eq!(
+                status.get("dense_operator"),
+                Some(&serde_json::to_value(&dense).expect("serialize dense")),
+                "{surface} dense provenance"
+            );
+        }
+
+        let absent = super::ServingModelState::default();
+        for status in [super::uor_status_json(&absent), compile.json(&absent)] {
+            assert_eq!(
+                status.get("attention_operator"),
+                Some(&serde_json::Value::Null)
+            );
+            assert_eq!(status.get("dense_operator"), Some(&serde_json::Value::Null));
+        }
     }
 
     #[test]
@@ -18356,7 +19517,12 @@ mod tests {
             .expect_err("present-invalid attention sidecar fails closed");
         assert!(error.contains("not a regular file"), "{error}");
         std::fs::remove_dir(&attention).expect("remove invalid attention sidecar");
-        std::fs::write(&attention, b"{}").expect("regular attention sidecar");
+        let mut attention_bytes = serde_json::to_vec_pretty(
+            &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+        )
+        .expect("serialize attention sidecar");
+        attention_bytes.push(b'\n');
+        std::fs::write(&attention, attention_bytes).expect("regular attention sidecar");
         super::validate_source_bundle_inventory(&root).expect("complete regular inventory");
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -674,14 +674,11 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         cli.r4g1_artifact.as_deref(),
         Path::new(&cli.tless_artifacts),
     );
-    let configured_graph_subject = configured_graph
-        .as_deref()
-        .map(graph_output_session_subject);
-    let mut startup_session_subjects = configured_graph_subject.into_iter().collect::<Vec<_>>();
-    startup_session_subjects.push(PathBuf::from(".uor-models/sources"));
-    startup_session_subjects.push(graph_output_session_subject(Path::new(
-        &cli.tless_artifacts,
-    )));
+    let startup_session_subjects = startup_read_session_subjects(
+        configured_graph.as_deref(),
+        Path::new(&cli.tless_artifacts),
+        cli.r4g1_artifact.is_none(),
+    );
     let startup_sessions = if cli.r4g1_artifact.is_none() {
         try_lock_managed_inventory_write_sessions(
             Path::new(".uor-models/compiled"),
@@ -693,25 +690,44 @@ pub fn run_server(cli: Arc<ServerConfig>) {
             SourceCompileSessionMode::ExclusiveWriter,
         )
     };
+    let mut configured_graph_authority = None;
     let (startup_read_sessions, r4g1_discovery_allowed) = match startup_sessions {
         Ok(sessions) => {
-            let recovery = if cli.r4g1_artifact.is_none() {
+            let recovery: Result<(), String> = if cli.r4g1_artifact.is_none() {
                 // Managed roots are recovered one selected logical trio at a
                 // time under the lower common producer authority immediately
                 // before their reader pins are acquired. The inventory outer
                 // lock alone is not publication authority.
                 Ok(())
             } else {
-                configured_graph
-                    .as_deref()
-                    .and_then(Path::parent)
-                    .and_then(Path::parent)
-                    .map(recover_compiled_bundle_completion_temporaries)
-                    .transpose()
-                    .map(|_| ())
+                (|| -> Result<(), String> {
+                    match configured_graph.as_deref() {
+                        None => Ok(()),
+                        Some(graph) => match fs::symlink_metadata(graph) {
+                            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                            Err(error) => {
+                                Err(format!("{} cannot be inspected: {error}", graph.display()))
+                            }
+                            Ok(_) => {
+                                configured_graph_authority =
+                                    Some(capture_explicit_graph_startup_authority(
+                                        graph,
+                                        Path::new(&cli.tless_artifacts),
+                                    )?);
+                                Ok(())
+                            }
+                        },
+                    }
+                })()
             };
             match recovery {
                 Ok(()) => (Some(sessions), true),
+                Err(error) if source_compile_session_is_busy(&error) => {
+                    println!(
+                        "[-] Deferring R4G1 startup completion recovery while the bundle producer is busy: {error}"
+                    );
+                    (Some(sessions), false)
+                }
                 Err(error) => {
                     println!(
                         "[-] Refusing R4G1 startup completion recovery before discovery: {error}"
@@ -742,7 +758,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                     graph,
                     PathBuf::from(&cli.tless_artifacts),
                     None::<ResolvedCompiledBundle>,
-                    None::<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins>,
+                    configured_graph_authority.take(),
                 )]
             })
             .unwrap_or_default()
@@ -777,13 +793,13 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                     ) {
                         Ok(ManagedCompiledBundleRead {
                             resolved: Some(candidate),
-                            pins,
+                            authority,
                         }) => {
                             r4g1_candidates = vec![(
                                 candidate.graph.clone(),
                                 candidate.teacher.clone(),
                                 Some(candidate),
-                                Some(pins),
+                                Some(StartupGraphAuthority::Managed(authority)),
                             )];
                         }
                         Ok(ManagedCompiledBundleRead { resolved: None, .. }) => {
@@ -833,7 +849,11 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                 configured_managed_logical.as_deref(),
             ) {
                 Ok(reads) => {
-                    for ManagedCompiledBundleRead { resolved, pins } in reads {
+                    for ManagedCompiledBundleRead {
+                        resolved,
+                        authority,
+                    } in reads
+                    {
                         let Some(candidate) = resolved else {
                             continue;
                         };
@@ -841,7 +861,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                             candidate.graph.clone(),
                             candidate.teacher.clone(),
                             Some(candidate),
-                            Some(pins),
+                            Some(StartupGraphAuthority::Managed(authority)),
                         ));
                     }
                 }
@@ -866,8 +886,8 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         }
     }
     let mut loaded_r4g1 = false;
-    for (mut graph_path, mut teacher_path, mut resolved, mut managed_read_pins) in r4g1_candidates {
-        if managed_read_pins.is_none() {
+    for (mut graph_path, mut teacher_path, mut resolved, mut startup_authority) in r4g1_candidates {
+        if startup_authority.is_none() {
             if let Some(candidate) = resolved.as_ref() {
                 let Some(compiled_root) = candidate.physical_root.parent() else {
                     let error = format!(
@@ -904,7 +924,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                 };
                 let ManagedCompiledBundleRead {
                     resolved: refreshed,
-                    pins,
+                    authority,
                 } = read;
                 let Some(refreshed) = refreshed else {
                     let error = format!(
@@ -917,23 +937,33 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                 graph_path = refreshed.graph.clone();
                 teacher_path = refreshed.teacher.clone();
                 resolved = Some(refreshed);
-                managed_read_pins = Some(pins);
+                startup_authority = Some(StartupGraphAuthority::Managed(authority));
             }
         }
-        if let Err(error) = validate_legacy_graph_generation_for_serving(&graph_path) {
-            println!(
-                "[-] Refusing incomplete or changed legacy R4G1 generation {}: {error}",
-                graph_path.display()
-            );
-            set_r4g1_terminal_load_error(&serving, error);
-            break;
-        }
-        let inputs_present = match required_r4g1_inputs_present(&graph_path, &teacher_path) {
-            Ok(present) => present,
-            Err(error) => {
-                println!("[-] Refusing present-invalid R4G1 bundle: {error}");
+        let captured_snapshot = matches!(
+            startup_authority.as_ref(),
+            Some(StartupGraphAuthority::Standalone(_) | StartupGraphAuthority::Bundle { .. })
+        );
+        if !captured_snapshot {
+            if let Err(error) = validate_legacy_graph_generation_for_serving(&graph_path) {
+                println!(
+                    "[-] Refusing incomplete or changed legacy R4G1 generation {}: {error}",
+                    graph_path.display()
+                );
                 set_r4g1_terminal_load_error(&serving, error);
                 break;
+            }
+        }
+        let inputs_present = if captured_snapshot {
+            true
+        } else {
+            match required_r4g1_inputs_present(&graph_path, &teacher_path) {
+                Ok(present) => present,
+                Err(error) => {
+                    println!("[-] Refusing present-invalid R4G1 bundle: {error}");
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                }
             }
         };
         if !inputs_present {
@@ -1021,7 +1051,14 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                 break;
             }
         }
-        match R4g1State::load_with_source(&graph_path, &teacher_path, source) {
+        let loaded_state = match startup_authority.as_ref() {
+            Some(
+                StartupGraphAuthority::Standalone(captured)
+                | StartupGraphAuthority::Bundle { captured, .. },
+            ) => R4g1State::load_captured_with_source(&graph_path, &teacher_path, captured, source),
+            _ => R4g1State::load_with_source(&graph_path, &teacher_path, source),
+        };
+        match loaded_state {
             Ok(state) => {
                 let mut prepared_teacher = match prepare_optional_teacher_source_for_identity(
                     source,
@@ -1060,12 +1097,22 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                 let refreshed = match resolved.as_ref() {
                     Some(candidate) => {
                         match current_source_attention_era_version().and_then(|version| {
+                            let authority = match startup_authority.as_ref() {
+                                Some(StartupGraphAuthority::Managed(handoff)) => {
+                                    Some(RecordedCorpusReadAuthority::Producer(
+                                        recorded_handoff_guard_for_root(
+                                            handoff,
+                                            &candidate.physical_root,
+                                        )?,
+                                    ))
+                                }
+                                Some(StartupGraphAuthority::Bundle { _guard: guard, .. }) => {
+                                    Some(RecordedCorpusReadAuthority::Producer(guard))
+                                }
+                                Some(StartupGraphAuthority::Standalone(_)) | None => None,
+                            };
                             refresh_resolved_compiled_bundle_with_authority(
-                                candidate,
-                                version,
-                                managed_read_pins
-                                    .as_ref()
-                                    .map(RecordedCorpusReadAuthority::ReaderPins),
+                                candidate, version, authority,
                             )
                         }) {
                             Ok(refreshed) => Some(refreshed),
@@ -1140,9 +1187,17 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                         }
                     }
                 }
-                if let Some(pins) = managed_read_pins.as_ref() {
-                    if let Err(error) = pins.verify() {
-                        let error = error.to_string();
+                if let Some(authority) = startup_authority.as_ref() {
+                    let verified = match authority {
+                        StartupGraphAuthority::Managed(handoff) => {
+                            handoff.verify().map_err(|error| error.to_string())
+                        }
+                        StartupGraphAuthority::Bundle { _guard: guard, .. } => {
+                            guard.verify_owned_root().map_err(|error| error.to_string())
+                        }
+                        StartupGraphAuthority::Standalone(_) => Ok(()),
+                    };
+                    if let Err(error) = verified {
                         println!(
                             "[-] Refusing R4G1 graph {} after final managed-root re-check: {error}",
                             graph_path.display()
@@ -1961,7 +2016,6 @@ fn parse_cover_provenance(report_path: &Path) -> Result<CoverProvenance, String>
 #[derive(Clone, Copy)]
 enum RecordedCorpusReadAuthority<'a> {
     Producer(&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard),
-    ReaderPins(&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins),
 }
 
 fn validate_serving_attention_provenance_with_authority(
@@ -1984,12 +2038,6 @@ fn validate_serving_attention_provenance_with_authority(
             Some(RecordedCorpusReadAuthority::Producer(guard)) => {
                 uor_r4_graph_compiler::recorded_corpus::execution_identity_under_producer_guard(
                     guard, &meta, &records,
-                )
-                .map_err(|error| error.to_string())?
-            }
-            Some(RecordedCorpusReadAuthority::ReaderPins(pins)) => {
-                uor_r4_graph_compiler::recorded_corpus::execution_identity_under_reader_pins(
-                    pins, &meta, &records,
                 )
                 .map_err(|error| error.to_string())?
             }
@@ -4391,6 +4439,8 @@ const SOURCE_COMPILE_SESSION_LOCK_SUFFIX: &str = ".compile-session.lock";
 const COMPILED_BUNDLE_STAGE_TAG: &str = "bundle-stage";
 const COMPILED_BUNDLE_STAGE_MARKER_FILE: &str = ".compiled_bundle_stage.json";
 const COMPILED_BUNDLE_STAGE_SCHEMA: &str = "uor-r4-compiled-bundle-stage/2";
+const COMPILED_BUNDLE_STAGE_A_SEAL_FILE: &str = ".compiled_bundle_stage_a.json";
+const COMPILED_BUNDLE_STAGE_A_SEAL_SCHEMA: &str = "uor-r4-compiled-bundle-stage-a/1";
 const COMPILED_BUNDLE_COMPLETION_FILE: &str = "compiled_bundle_completion.json";
 const COMPILED_BUNDLE_COMPLETION_SCHEMA: &str = "uor-r4-compiled-bundle-completion/1";
 const COMPILED_BUNDLE_CONTROL_MAX_BYTES: u64 = 64 * 1024;
@@ -4398,6 +4448,7 @@ const COVER_REPORT_CONTROL_MAX_BYTES: u64 = 16 * 1024 * 1024;
 // Current managed score reports are below 25 KiB; one MiB leaves bounded
 // format-growth headroom without allowing an attacker-controlled allocation.
 const SCORE_REPORT_CONTROL_MAX_BYTES: u64 = 1024 * 1024;
+const COMPILE_REPORT_CONTROL_MAX_BYTES: u64 = 1024 * 1024;
 const COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT: usize = 64;
 const COMPILED_BUNDLE_STAGE_LIMIT: usize = 64;
 const LEGACY_GRAPH_GENERATION_SCHEMA: &str = "uor-r4-legacy-graph-generation/1";
@@ -4465,6 +4516,16 @@ struct CompiledBundleStageMarker {
     stage_path: String,
     source_snapshot_kappa: String,
     selection_base: Vec<CompiledBundleSelectionGeneration>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledBundleStageASeal {
+    schema: String,
+    stage_marker_cid: String,
+    source_snapshot_kappa: String,
+    recorded_corpus_binding_cid: String,
+    files: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -5490,6 +5551,7 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
         }
     }
     let mut saw_identity = preflight.is_some() || kappa.is_some();
+    let mut saw_attempt = false;
     let mut saw_attention = false;
     let mut unexpected = Vec::new();
     let entries = fs::read_dir(output)
@@ -5514,7 +5576,7 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
         }
         if name == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE {
             validate_recorded_corpus_compile_attempt_marker(&entry.path())?;
-            saw_identity = true;
+            saw_attempt = true;
             continue;
         }
         if name == "tokenizer_adapter.json" {
@@ -5549,6 +5611,12 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
     if saw_attention {
         return Ok(false);
     }
+    if saw_attempt && !saw_identity {
+        return Err(format!(
+            "source compile root {} contains a compile-attempt marker without a canonical P/K identity pair; coordination alone cannot authorize prefix adoption",
+            output.display()
+        ));
+    }
     if saw_identity && !unexpected.is_empty() {
         return Err(format!(
             "source compile root {} contains {} beside {} but has no {}; refusing to infer a historical era from an interrupted current-era compile",
@@ -5559,6 +5627,157 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
         ));
     }
     Ok(saw_identity)
+}
+
+/// Classify the only identity-only generation that a managed source refresh
+/// may resume before full corpus/bundle transaction recovery.  P and K are a
+/// required canonical pair for the exact requested source snapshot.  The
+/// lower compile-attempt marker is optional coordination and never supplies
+/// identity by itself.  Any corpus binding evidence beside an otherwise
+/// identity-only prefix is terminal: it must not be promoted merely to make
+/// the directory look resumable.
+fn exact_requested_source_identity_prefix(
+    root: &Path,
+    requested_source_snapshot_kappa: &str,
+) -> Result<bool, String> {
+    if !canonical_source_manifest_kappa(requested_source_snapshot_kappa) {
+        return Err(format!(
+            "requested source snapshot kappa {requested_source_snapshot_kappa:?} is not canonical"
+        ));
+    }
+    let metadata = match fs::symlink_metadata(root) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", root.display())),
+        Ok(metadata) => metadata,
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "source identity prefix {} is not a regular non-symlink directory",
+            root.display()
+        ));
+    }
+
+    let mut saw_preflight = false;
+    let mut saw_kappa = false;
+    let mut saw_attempt = false;
+    let mut saw_identity = false;
+    let mut saw_payload = false;
+    let mut saw_binding_evidence = false;
+    let binding_prefix = format!(
+        ".{}.",
+        uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+    );
+    let attempt_prefix = format!(
+        ".{}.",
+        uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE
+    );
+    for entry in fs::read_dir(root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "source identity prefix {} contains a non-UTF-8 entry",
+                root.display()
+            )
+        })?;
+        match name {
+            SOURCE_COMPILE_PREFLIGHT_FILE => {
+                saw_preflight = true;
+                saw_identity = true;
+            }
+            SOURCE_MANIFEST_KAPPA_BINDING_FILE => {
+                saw_kappa = true;
+                saw_identity = true;
+            }
+            "tokenizer_adapter.json" => {
+                validate_pre_attention_identity_file(&entry.path(), name)?;
+                saw_identity = true;
+            }
+            name if name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+                || name == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE =>
+            {
+                validate_pre_attention_identity_file(&entry.path(), name)?;
+                saw_identity = true;
+            }
+            COMPILED_BUNDLE_STAGE_MARKER_FILE => {
+                validate_source_prefix_stage_marker(root)?;
+            }
+            name if name
+                == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE =>
+            {
+                validate_recorded_corpus_compile_attempt_marker(&entry.path())?;
+                saw_attempt = true;
+            }
+            name if name
+                == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+                || name.starts_with(&binding_prefix) =>
+            {
+                saw_binding_evidence = true;
+            }
+            name if name.starts_with(&attempt_prefix) => {
+                return Err(format!(
+                    "source identity prefix {} contains non-stable compile-attempt residue {name}; refusing adoption",
+                    root.display()
+                ));
+            }
+            name if atomic_identity_temporary_kind(name).is_some()
+                || looks_like_atomic_identity_temporary(name) =>
+            {
+                return Err(format!(
+                    "source identity prefix {} contains non-stable identity residue {name}; refusing adoption",
+                    root.display()
+                ));
+            }
+            _ => saw_payload = true,
+        }
+    }
+    if saw_payload {
+        return Ok(false);
+    }
+    if saw_binding_evidence {
+        return Err(format!(
+            "identity-only source root {} contains recorded-corpus binding evidence; refusing prefix adoption before full transaction validation",
+            root.display()
+        ));
+    }
+    if !saw_preflight || !saw_kappa {
+        if saw_preflight || saw_kappa || saw_attempt || saw_identity {
+            return Err(format!(
+                "source identity prefix {} does not contain the exact requested canonical P/K pair; coordination or a partial identity cannot authorize adoption",
+                root.display()
+            ));
+        }
+        return Ok(false);
+    }
+    let preflight = read_optional_source_compile_preflight(root)?.ok_or_else(|| {
+        format!(
+            "source identity prefix {} lost its canonical P record",
+            root.display()
+        )
+    })?;
+    let kappa = read_optional_source_manifest_kappa_binding(root)?.ok_or_else(|| {
+        format!(
+            "source identity prefix {} lost its canonical K record",
+            root.display()
+        )
+    })?;
+    if preflight.source_manifest_kappa.as_deref() != Some(requested_source_snapshot_kappa)
+        || kappa != requested_source_snapshot_kappa
+    {
+        return Err(format!(
+            "source identity prefix {} does not bind exact requested P/K source snapshot {}",
+            root.display(),
+            requested_source_snapshot_kappa
+        ));
+    }
+    let attention = source_compile_attention_binding(root)?;
+    let dense = source_compile_dense_binding(root)?;
+    uor_r4_model_source::dense::validate_source_execution_pair(attention.as_ref(), dense.as_ref())
+        .map_err(|error| format!("source identity prefix {}: {error}", root.display()))?;
+    Ok(true)
 }
 
 fn publish_bytes_no_clobber(path: &Path, expected: &[u8], label: &str) -> Result<(), String> {
@@ -5859,6 +6078,299 @@ fn graph_output_session_subject(graph_path: &Path) -> PathBuf {
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."))
         .to_path_buf()
+}
+
+fn startup_read_session_subjects(
+    configured_graph: Option<&Path>,
+    teacher_path: &Path,
+    managed_discovery: bool,
+) -> Vec<PathBuf> {
+    let mut subjects = vec![PathBuf::from(".uor-models/sources")];
+    if managed_discovery {
+        if let Some(graph) = configured_graph {
+            subjects.push(graph_output_session_subject(graph));
+        }
+        subjects.push(graph_output_session_subject(teacher_path));
+    }
+    subjects
+}
+
+enum StartupGraphAuthority {
+    Managed(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff),
+    Bundle {
+        _guard: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+        captured: r4g1::CapturedR4g1Bundle,
+    },
+    Standalone(r4g1::CapturedR4g1Bundle),
+}
+
+/// Name-only pre-authority evidence probe. Publisher temporary bodies and
+/// metadata are mutable until the common bundle guard is held; this probe
+/// merely fixes the bundle-vs-standalone mode and leaves all validation,
+/// recovery, or refusal to the guarded path.
+fn compiled_bundle_completion_temporary_name_present(root: &Path) -> Result<bool, String> {
+    for entry in fs::read_dir(root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if looks_like_atomic_publisher_temporary(&name, COMPILED_BUNDLE_COMPLETION_FILE) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Recognize only a transaction-bearing canonical
+/// `<bundle>/graph/score.r4g1` layout. Completion, owner, seal, or completion-
+/// temporary evidence selects the bundle root solely so the exact common
+/// authority can classify it. The guarded classifier distinguishes a private
+/// stage from recoverable post-promotion owner-marker residue. Every other
+/// explicit artifact is the standalone exact-handle lane.
+fn canonical_explicit_graph_bundle_root(graph_path: &Path) -> Result<Option<PathBuf>, String> {
+    if graph_path.file_name() != Some(std::ffi::OsStr::new("score.r4g1"))
+        || graph_path.parent().and_then(Path::file_name) != Some(std::ffi::OsStr::new("graph"))
+    {
+        return Ok(None);
+    }
+    let Some(root) = graph_path.parent().and_then(Path::parent) else {
+        return Ok(None);
+    };
+    let root_metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", root.display())),
+    };
+    if !root_metadata.file_type().is_dir() {
+        return Err(format!(
+            "canonical graph bundle root {} is not a regular non-symlink directory",
+            root.display()
+        ));
+    }
+    let regular = |leaf: &str| -> Result<bool, String> {
+        let path = root.join(leaf);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+            Ok(_) => Err(format!(
+                "bundle evidence {} is not a regular non-symlink file",
+                path.display()
+            )),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(format!("{} cannot be inspected: {error}", path.display())),
+        }
+    };
+    let stage_marker = regular(COMPILED_BUNDLE_STAGE_MARKER_FILE)?;
+    let stage_a_seal = regular(COMPILED_BUNDLE_STAGE_A_SEAL_FILE)?;
+    let stable_completion = regular(COMPILED_BUNDLE_COMPLETION_FILE)?;
+    let completion_temporary = compiled_bundle_completion_temporary_name_present(root)?;
+    if !stage_marker && !stage_a_seal && !stable_completion && !completion_temporary {
+        return Ok(None);
+    }
+    let canonical_root = fs::canonicalize(root)
+        .map_err(|error| format!("{} cannot be canonicalized: {error}", root.display()))?;
+    let canonical_graph = fs::canonicalize(graph_path)
+        .map_err(|error| format!("{} cannot be canonicalized: {error}", graph_path.display()))?;
+    if canonical_graph != canonical_root.join("graph/score.r4g1") {
+        return Err(format!(
+            "explicit graph {} does not resolve to the exact canonical bundle member under {}",
+            graph_path.display(),
+            canonical_root.display()
+        ));
+    }
+    Ok(Some(canonical_root))
+}
+
+fn capture_completed_explicit_graph_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    graph_path: &Path,
+    teacher_path: &Path,
+) -> Result<r4g1::CapturedR4g1Bundle, String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect explicit bundle root {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    guard
+        .verify_owned_root()
+        .map_err(|error| error.to_string())?;
+    if read_optional_compiled_bundle_stage_a_seal(root)?.is_some() {
+        return Err(format!(
+            "explicit canonical graph root {} is an unpublished private compiled-bundle stage containing {}",
+            root.display(),
+            COMPILED_BUNDLE_STAGE_A_SEAL_FILE
+        ));
+    }
+    let published_marker = read_compiled_bundle_stage_marker(root)?;
+    if let Some(bytes) = published_marker.as_deref() {
+        validate_compiled_bundle_stage_marker_location(root, bytes)?;
+        let record: CompiledBundleStageMarker =
+            serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+        let actual = canonical_compile_session_subject(root)?;
+        let final_output = canonical_compile_session_subject(Path::new(&record.final_output))?;
+        let stage_path = canonical_compile_session_subject(Path::new(&record.stage_path))?;
+        if actual == stage_path {
+            return Err(format!(
+                "explicit canonical graph root {} is the marker's unpublished private compiled-bundle stage",
+                root.display()
+            ));
+        }
+        if actual != final_output {
+            return Err(format!(
+                "explicit canonical graph root {} is neither the marker's final output nor private stage",
+                root.display()
+            ));
+        }
+    }
+    guard
+        .verify_owned_root()
+        .map_err(|error| error.to_string())?;
+    recover_compiled_bundle_completion_temporaries(guard, root)?;
+    let before = validate_compiled_bundle_completion(root)?.ok_or_else(|| {
+        format!(
+            "explicit canonical graph root {} has no stable validated compiled-bundle completion",
+            root.display()
+        )
+    })?;
+    if published_marker.is_some() {
+        cleanup_published_compiled_bundle_stage_marker(guard, root)?;
+    }
+    let captured = capture_standalone_explicit_graph(graph_path, teacher_path)?;
+    let after = validate_compiled_bundle_completion(root)?.ok_or_else(|| {
+        format!(
+            "explicit canonical graph root {} lost its stable completion during capture",
+            root.display()
+        )
+    })?;
+    if after != before {
+        return Err(format!(
+            "explicit canonical graph root {} changed completion identity during capture",
+            root.display()
+        ));
+    }
+    guard
+        .verify_owned_root()
+        .map_err(|error| error.to_string())?;
+    Ok(captured)
+}
+
+fn capture_standalone_explicit_graph(
+    graph_path: &Path,
+    teacher_path: &Path,
+) -> Result<r4g1::CapturedR4g1Bundle, String> {
+    let graph = open_regular_file_nofollow(graph_path, "explicit R4G1 artifact")?
+        .ok_or_else(|| format!("explicit R4G1 artifact {} is absent", graph_path.display()))
+        .and_then(|file| {
+            read_opened_regular_file_nofollow(file, graph_path, "explicit R4G1 artifact")
+        })?;
+    let signature_artifact =
+        open_regular_file_nofollow(teacher_path, "explicit R4G1 signature artifact")?
+            .ok_or_else(|| {
+                format!(
+                    "explicit R4G1 signature artifact {} is absent",
+                    teacher_path.display()
+                )
+            })
+            .and_then(|file| {
+                read_opened_regular_file_nofollow(
+                    file,
+                    teacher_path,
+                    "explicit R4G1 signature artifact",
+                )
+            })?;
+    let tokenizer_path = teacher_path
+        .parent()
+        .map(|parent| parent.join("tokenizer.bin"));
+    let tokenizer = tokenizer_path
+        .as_deref()
+        .map(|path| {
+            open_regular_file_nofollow(path, "explicit R4G1 tokenizer")?
+                .map(|file| {
+                    read_opened_regular_file_nofollow(file, path, "explicit R4G1 tokenizer")
+                })
+                .transpose()
+        })
+        .transpose()?
+        .flatten();
+    let score_report_path = graph_path
+        .parent()
+        .map(|parent| parent.join("score_report.json"));
+    let score_report = score_report_path
+        .as_deref()
+        .map(|path| {
+            read_regular_file_nofollow_capped(
+                path,
+                "explicit R4G1 score report",
+                SCORE_REPORT_CONTROL_MAX_BYTES,
+            )
+        })
+        .transpose()?
+        .flatten();
+    let score_report = match score_report {
+        Some(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(_) => Some(bytes),
+            Err(_) => None,
+        },
+        None => None,
+    };
+    Ok(r4g1::CapturedR4g1Bundle {
+        graph,
+        signature_artifact,
+        tokenizer,
+        score_report,
+    })
+}
+
+fn capture_explicit_graph_startup_authority(
+    graph_path: &Path,
+    teacher_path: &Path,
+) -> Result<StartupGraphAuthority, String> {
+    capture_explicit_graph_startup_authority_with_after_classification(
+        graph_path,
+        teacher_path,
+        |_| Ok(()),
+    )
+}
+
+fn capture_explicit_graph_startup_authority_with_after_classification<F>(
+    graph_path: &Path,
+    teacher_path: &Path,
+    after_classification: F,
+) -> Result<StartupGraphAuthority, String>
+where
+    F: FnOnce(Option<&Path>) -> Result<(), String>,
+{
+    let root = canonical_explicit_graph_bundle_root(graph_path)?;
+    after_classification(root.as_deref())?;
+    match root {
+        Some(root) => {
+            let guard =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    &root,
+                )
+                .map_err(|error| error.to_string())?;
+            let captured = capture_completed_explicit_graph_under_guard(
+                &guard,
+                &root,
+                graph_path,
+                teacher_path,
+            )?;
+            Ok(StartupGraphAuthority::Bundle {
+                _guard: guard,
+                captured,
+            })
+        }
+        None => capture_standalone_explicit_graph(graph_path, teacher_path)
+            .map(StartupGraphAuthority::Standalone),
+    }
 }
 
 impl Drop for SourceCompileSessionLock {
@@ -6279,7 +6791,356 @@ fn validate_compiled_bundle_stage_marker(stage: &Path, expected: &[u8]) -> Resul
     Ok(read_compiled_bundle_stage_marker(stage)?.is_some_and(|bytes| bytes == expected))
 }
 
-fn cleanup_published_compiled_bundle_stage_marker(final_output: &Path) -> Result<(), String> {
+fn compiled_bundle_stage_a_seal_bytes(seal: &CompiledBundleStageASeal) -> Result<Vec<u8>, String> {
+    if seal.schema != COMPILED_BUNDLE_STAGE_A_SEAL_SCHEMA
+        || !canonical_blake3_cid(&seal.stage_marker_cid)
+        || !canonical_source_manifest_kappa(&seal.source_snapshot_kappa)
+        || !canonical_blake3_cid(&seal.recorded_corpus_binding_cid)
+        || seal.files.is_empty()
+        || seal
+            .files
+            .values()
+            .any(|digest| !canonical_blake3_cid(digest))
+    {
+        return Err("compiled-bundle Stage-A seal has a noncanonical identity field".to_owned());
+    }
+    let mut bytes = serde_json::to_vec_pretty(seal).map_err(|error| error.to_string())?;
+    bytes.push(b'\n');
+    if bytes.len() > COMPILED_BUNDLE_CONTROL_MAX_BYTES as usize {
+        return Err(format!(
+            "compiled-bundle Stage-A seal exceeds the fixed {COMPILED_BUNDLE_CONTROL_MAX_BYTES}-byte control limit"
+        ));
+    }
+    Ok(bytes)
+}
+
+fn read_optional_compiled_bundle_stage_a_seal(
+    root: &Path,
+) -> Result<Option<(CompiledBundleStageASeal, Vec<u8>)>, String> {
+    let path = root.join(COMPILED_BUNDLE_STAGE_A_SEAL_FILE);
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        &path,
+        "compiled-bundle Stage-A seal",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
+        return Ok(None);
+    };
+    reject_duplicate_json_fields(&bytes, &path, "compiled-bundle Stage-A seal")?;
+    let seal: CompiledBundleStageASeal = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    let canonical = compiled_bundle_stage_a_seal_bytes(&seal)?;
+    if bytes != canonical {
+        return Err(format!(
+            "{} is not a canonical compiled-bundle Stage-A seal",
+            path.display()
+        ));
+    }
+    Ok(Some((seal, bytes)))
+}
+
+fn compiled_bundle_stage_a_file_kappas(
+    root: &Path,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let mut ignored = [
+        root.join(COMPILED_BUNDLE_STAGE_A_SEAL_FILE),
+        root.join("graph"),
+        root.join("graph-cover"),
+        root.join("compiled.r4g1"),
+        root.join("compile_report.json"),
+        root.join("instruction-eval.json"),
+        root.join(COMPILED_BUNDLE_COMPLETION_FILE),
+    ]
+    .into_iter()
+    .collect::<std::collections::BTreeSet<_>>();
+    for temporary in compiled_bundle_stage_temporaries(root)? {
+        let Some(name) = temporary.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if is_atomic_publisher_temporary(name, COMPILED_BUNDLE_STAGE_A_SEAL_FILE) {
+            ignored.insert(temporary);
+        }
+    }
+    compiled_bundle_file_kappas_ignoring(root, &ignored)
+}
+
+fn expected_compiled_bundle_stage_a_seal(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    marker_bytes: &[u8],
+    source_snapshot_kappa: &str,
+) -> Result<CompiledBundleStageASeal, String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect Stage-A root {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    guard
+        .verify_owned_entry_bytes(
+            std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+            marker_bytes,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle owner marker for Stage-A seal",
+        )
+        .map_err(|error| error.to_string())?;
+    let preflight = read_optional_source_compile_preflight(root)?
+        .ok_or_else(|| format!("Stage-A root {} has no canonical P record", root.display()))?;
+    let kappa = read_optional_source_manifest_kappa_binding(root)?
+        .ok_or_else(|| format!("Stage-A root {} has no canonical K record", root.display()))?;
+    if preflight.source_manifest_kappa.as_deref() != Some(source_snapshot_kappa)
+        || kappa != source_snapshot_kappa
+    {
+        return Err(format!(
+            "Stage-A root {} does not bind exact requested P/K source snapshot {}",
+            root.display(),
+            source_snapshot_kappa
+        ));
+    }
+    validate_source_bundle_inventory(root)?;
+    let snapshot = uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(
+        guard,
+        &root.join("corpus.meta"),
+        &root.join("corpus.records"),
+    )
+    .map_err(|error| error.to_string())?;
+    let recorded_corpus_binding_cid = snapshot.binding_cid.clone().ok_or_else(|| {
+        format!(
+            "Stage-A root {} has no canonical recorded-corpus binding",
+            root.display()
+        )
+    })?;
+    snapshot
+        .verify_generation()
+        .map_err(|error| error.to_string())?;
+    let files = compiled_bundle_stage_a_file_kappas(root)?;
+    let seal = CompiledBundleStageASeal {
+        schema: COMPILED_BUNDLE_STAGE_A_SEAL_SCHEMA.to_owned(),
+        stage_marker_cid: format!("blake3:{}", blake3::hash(marker_bytes).to_hex()),
+        source_snapshot_kappa: source_snapshot_kappa.to_owned(),
+        recorded_corpus_binding_cid,
+        files,
+    };
+    let _ = compiled_bundle_stage_a_seal_bytes(&seal)?;
+    guard
+        .verify_owned_root()
+        .map_err(|error| error.to_string())?;
+    Ok(seal)
+}
+
+fn validate_compiled_bundle_stage_a_seal_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    marker_bytes: &[u8],
+    source_snapshot_kappa: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    let Some((recorded, bytes)) = read_optional_compiled_bundle_stage_a_seal(root)? else {
+        return Ok(None);
+    };
+    let expected =
+        expected_compiled_bundle_stage_a_seal(guard, root, marker_bytes, source_snapshot_kappa)?;
+    if recorded != expected {
+        return Err(format!(
+            "compiled-bundle Stage-A seal in {} does not match the exact current fixed-member generation",
+            root.display()
+        ));
+    }
+    guard
+        .verify_owned_entry_bytes(
+            std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_A_SEAL_FILE),
+            &bytes,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle Stage-A seal",
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(Some(bytes))
+}
+
+fn publish_compiled_bundle_stage_a_seal_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    marker_bytes: &[u8],
+    source_snapshot_kappa: &str,
+) -> Result<Vec<u8>, String> {
+    publish_compiled_bundle_stage_a_seal_under_guard_with_after_sync(
+        guard,
+        root,
+        marker_bytes,
+        source_snapshot_kappa,
+        |_| Ok(()),
+    )
+}
+
+fn publish_compiled_bundle_stage_a_seal_under_guard_with_after_sync<F>(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    marker_bytes: &[u8],
+    source_snapshot_kappa: &str,
+    after_sync: F,
+) -> Result<Vec<u8>, String>
+where
+    F: FnOnce(&Path) -> Result<(), String>,
+{
+    let seal =
+        expected_compiled_bundle_stage_a_seal(guard, root, marker_bytes, source_snapshot_kappa)?;
+    let bytes = compiled_bundle_stage_a_seal_bytes(&seal)?;
+    let stable = std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_A_SEAL_FILE);
+    let stable_present = guard
+        .verify_optional_owned_entry_bytes(
+            stable,
+            &bytes,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle Stage-A seal",
+        )
+        .map_err(|error| error.to_string())?;
+    let seal_temporaries = compiled_bundle_stage_temporaries(root)?
+        .into_iter()
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    is_atomic_publisher_temporary(name, COMPILED_BUNDLE_STAGE_A_SEAL_FILE)
+                })
+        })
+        .collect::<Vec<_>>();
+    for temporary in &seal_temporaries {
+        let actual = read_required_regular_file_nofollow_capped(
+            temporary,
+            "compiled-bundle Stage-A seal recovery temporary",
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+        )?;
+        if actual != bytes {
+            return Err(format!(
+                "compiled-bundle Stage-A seal temporary {} conflicts with the exact current Stage-A generation",
+                temporary.display()
+            ));
+        }
+    }
+    if !stable_present {
+        if let Some(temporary) = seal_temporaries.first() {
+            let name = temporary.file_name().ok_or_else(|| {
+                format!("Stage-A seal temporary {} has no name", temporary.display())
+            })?;
+            guard
+                .link_owned_entry(name, stable)
+                .map_err(|error| error.to_string())?;
+            guard.sync_owned_root().map_err(|error| error.to_string())?;
+        }
+    }
+    if stable_present || !seal_temporaries.is_empty() {
+        for temporary in seal_temporaries {
+            let name = temporary.file_name().ok_or_else(|| {
+                format!("Stage-A seal temporary {} has no name", temporary.display())
+            })?;
+            guard
+                .verify_owned_entry_bytes(
+                    name,
+                    &bytes,
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                    "compiled-bundle Stage-A seal recovery temporary",
+                )
+                .map_err(|error| error.to_string())?;
+            guard
+                .unlink_owned_entry(name)
+                .map_err(|error| error.to_string())?;
+        }
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        guard
+            .verify_owned_entry_bytes(
+                stable,
+                &bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "recovered compiled-bundle Stage-A seal",
+            )
+            .map_err(|error| error.to_string())?;
+        return Ok(bytes);
+    }
+    let mut after_sync = Some(after_sync);
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let temporary = std::ffi::OsString::from(format!(
+            ".{COMPILED_BUNDLE_STAGE_A_SEAL_FILE}.{}.{}.tmp",
+            std::process::id(),
+            id
+        ));
+        let mut file = match guard.create_new_owned_entry(&temporary) {
+            Ok(file) => file,
+            Err(error) if error.reason.contains("exists") => continue,
+            Err(error) => return Err(error.to_string()),
+        };
+        file.write_all(&bytes).map_err(|error| error.to_string())?;
+        file.sync_all().map_err(|error| error.to_string())?;
+        drop(file);
+        guard
+            .verify_owned_entry_bytes(
+                &temporary,
+                &bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "compiled-bundle Stage-A seal temporary",
+            )
+            .map_err(|error| error.to_string())?;
+        after_sync.take().expect("Stage-A seal sync hook runs once")(&root.join(&temporary))?;
+        if let Err(error) = guard.link_owned_entry(&temporary, stable) {
+            let _ = guard.unlink_owned_entry(&temporary);
+            return Err(error.to_string());
+        }
+        guard
+            .unlink_owned_entry(&temporary)
+            .map_err(|error| error.to_string())?;
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        guard
+            .verify_owned_entry_bytes(
+                stable,
+                &bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "published compiled-bundle Stage-A seal",
+            )
+            .map_err(|error| error.to_string())?;
+        return Ok(bytes);
+    }
+    Err(format!(
+        "could not reserve a compiled-bundle Stage-A seal temporary in {}",
+        root.display()
+    ))
+}
+
+fn remove_compiled_bundle_stage_a_seal_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    expected: &[u8],
+) -> Result<(), String> {
+    guard
+        .verify_owned_entry_bytes(
+            std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_A_SEAL_FILE),
+            expected,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle Stage-A seal before invalidation",
+        )
+        .map_err(|error| error.to_string())?;
+    guard
+        .unlink_owned_entry(std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_A_SEAL_FILE))
+        .map_err(|error| error.to_string())?;
+    guard.sync_owned_root().map_err(|error| error.to_string())?;
+    guard.verify_owned_root().map_err(|error| error.to_string())
+}
+
+fn cleanup_published_compiled_bundle_stage_marker(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    final_output: &Path,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(final_output)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect published-marker root {}",
+            guard.root().display(),
+            final_output.display()
+        ));
+    }
     let Some(bytes) = read_compiled_bundle_stage_marker(final_output)? else {
         return Ok(());
     };
@@ -6316,16 +7177,19 @@ fn cleanup_published_compiled_bundle_stage_marker(final_output: &Path) -> Result
             final_output.display()
         )
     })?;
-    let path = final_output.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
-    fs::remove_file(&path).map_err(|error| {
-        format!(
-            "published compiled-bundle marker {} cannot be reclaimed: {error}",
-            path.display()
+    guard
+        .verify_owned_entry_bytes(
+            std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+            &bytes,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "published compiled-bundle stage marker",
         )
-    })?;
-    fs::File::open(final_output)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| format!("{} cannot be synced: {error}", final_output.display()))
+        .map_err(|error| error.to_string())?;
+    guard
+        .unlink_owned_entry(std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE))
+        .map_err(|error| error.to_string())?;
+    guard.sync_owned_root().map_err(|error| error.to_string())?;
+    guard.verify_owned_root().map_err(|error| error.to_string())
 }
 
 fn is_atomic_publisher_temporary(name: &str, stable_name: &str) -> bool {
@@ -6366,12 +7230,14 @@ fn compiled_bundle_stage_temporaries(stage: &Path) -> Result<Vec<PathBuf>, Strin
         })?;
         let exact = [
             COMPILED_BUNDLE_STAGE_MARKER_FILE,
+            COMPILED_BUNDLE_STAGE_A_SEAL_FILE,
             COMPILED_BUNDLE_COMPLETION_FILE,
         ]
         .into_iter()
         .any(|stable| is_atomic_publisher_temporary(name, stable));
         let looks_reserved = [
             COMPILED_BUNDLE_STAGE_MARKER_FILE,
+            COMPILED_BUNDLE_STAGE_A_SEAL_FILE,
             COMPILED_BUNDLE_COMPLETION_FILE,
         ]
         .into_iter()
@@ -6393,6 +7259,34 @@ fn compiled_bundle_stage_temporaries(stage: &Path) -> Result<Vec<PathBuf>, Strin
                     entry.path().display()
                 ));
             }
+            if is_atomic_publisher_temporary(name, COMPILED_BUNDLE_STAGE_A_SEAL_FILE) {
+                let bytes = read_required_regular_file_nofollow_capped(
+                    &entry.path(),
+                    "compiled-bundle Stage-A seal temporary",
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                )?;
+                reject_duplicate_json_fields(
+                    &bytes,
+                    &entry.path(),
+                    "compiled-bundle Stage-A seal temporary",
+                )?;
+                let seal: CompiledBundleStageASeal = serde_json::from_slice(&bytes)
+                    .map_err(|error| format!("{} is malformed: {error}", entry.path().display()))?;
+                if compiled_bundle_stage_a_seal_bytes(&seal)? != bytes {
+                    return Err(format!(
+                        "{} is not a canonical compiled-bundle Stage-A seal temporary",
+                        entry.path().display()
+                    ));
+                }
+                if let Some((_, stable)) = read_optional_compiled_bundle_stage_a_seal(stage)? {
+                    if stable != bytes {
+                        return Err(format!(
+                            "compiled-bundle stage {} contains a Stage-A seal temporary conflicting with its stable seal",
+                            stage.display()
+                        ));
+                    }
+                }
+            }
             temporaries.push(entry.path());
         } else if looks_reserved {
             return Err(format!(
@@ -6401,6 +7295,10 @@ fn compiled_bundle_stage_temporaries(stage: &Path) -> Result<Vec<PathBuf>, Strin
             ));
         }
     }
+    // Stable seal syntax/canonicality is classified before any later lower-
+    // namespace recovery mutates the stage. A malformed seal is terminal
+    // evidence, never a reset authorization.
+    let _ = read_optional_compiled_bundle_stage_a_seal(stage)?;
     Ok(temporaries)
 }
 
@@ -6572,7 +7470,9 @@ fn reset_unbound_compiled_bundle_stage(
                 | "instruction-eval.json"
                 | SOURCE_COMPILE_PREFLIGHT_FILE
                 | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+                | COMPILED_BUNDLE_STAGE_A_SEAL_FILE
                 | COMPILED_BUNDLE_COMPLETION_FILE
+                | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
                 | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
                 | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
         );
@@ -6598,7 +7498,7 @@ fn reset_unbound_compiled_bundle_stage(
         .map_err(|error| format!("{} cannot be synced: {error}", stage.display()))
 }
 
-type RecoverableCompiledBundleStage = (PathBuf, Vec<u8>, Vec<PathBuf>);
+type RecoverableCompiledBundleStage = (PathBuf, Vec<u8>);
 
 fn recover_compiled_bundle_stages(
     output: &Path,
@@ -6649,7 +7549,10 @@ fn recover_compiled_bundle_stages(
                     entry.path().display()
                 ));
             }
-            let temporaries = compiled_bundle_stage_temporaries(&entry.path())?;
+            // Pre-lock classification rejects malformed publisher residue,
+            // but this path list is never trusted for mutation. Recovery
+            // recaptures it after acquiring the exact stage producer.
+            let _ = compiled_bundle_stage_temporaries(&entry.path())?;
             let expected_marker = compiled_bundle_stage_marker_bytes(
                 output,
                 &entry.path(),
@@ -6664,7 +7567,7 @@ fn recover_compiled_bundle_stages(
                         output.display()
                     ));
                 }
-                resumable = Some((entry.path(), expected_marker, temporaries));
+                resumable = Some((entry.path(), expected_marker));
             } else if recorded_marker.is_some() {
                 return Err(format!(
                     "{} does not bind this exact compiled output, stage path, source snapshot, and three-root base generation",
@@ -6860,6 +7763,10 @@ where
                 == std::ffi::OsStr::new(
                     uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
                 )
+            || name
+                == std::ffi::OsStr::new(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE,
+                )
         {
             continue;
         }
@@ -6909,6 +7816,137 @@ fn validate_copied_compiled_bundle_prefix(
     Ok(())
 }
 
+fn copied_prefix_kappas(
+    files: &std::collections::BTreeMap<String, String>,
+    include_binding: bool,
+) -> std::collections::BTreeMap<String, String> {
+    let mut copied = std::collections::BTreeMap::new();
+    for (relative, kappa) in files {
+        let copied_member = !relative.starts_with("graph/")
+            && !relative.starts_with("graph-cover/")
+            && relative.as_str() != "compiled.r4g1"
+            && relative.as_str() != "compile_report.json"
+            && relative.as_str() != "instruction-eval.json"
+            && (include_binding
+                || relative.as_str()
+                    != uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
+        if copied_member {
+            copied.insert(relative.clone(), kappa.clone());
+        }
+    }
+    copied
+}
+
+fn validate_copied_compiled_bundle_prefix_against_base(
+    destination: &Path,
+    base: &CompiledBundleBaseGeneration,
+    completion: Option<&CompiledBundleCompletion>,
+    include_binding: bool,
+) -> Result<(), String> {
+    let expected = match base {
+        CompiledBundleBaseGeneration::Absent => std::collections::BTreeMap::new(),
+        CompiledBundleBaseGeneration::Incomplete { files }
+        | CompiledBundleBaseGeneration::Legacy { files } => {
+            copied_prefix_kappas(files, include_binding)
+        }
+        CompiledBundleBaseGeneration::Complete { .. } => copied_prefix_kappas(
+            &completion
+                .ok_or_else(|| {
+                    "completed copied-prefix base has no validated completion record".to_owned()
+                })?
+                .files,
+            include_binding,
+        ),
+    };
+    let actual = compiled_bundle_file_kappas(destination)?;
+    if actual != expected {
+        return Err(format!(
+            "compiled-bundle prefix copied into {} does not exactly match its persisted typed base generation",
+            destination.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bound_compiled_stage_prefix_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    stage: &Path,
+    requested_source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(stage)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect bound stage {}",
+            guard.root().display(),
+            stage.display()
+        ));
+    }
+    let recoverable = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    if recoverable {
+        return Err(format!(
+            "bound compiled stage {} still contains recoverable binding evidence",
+            stage.display()
+        ));
+    }
+    guard
+        .preflight_planned_output_scope(&[])
+        .map_err(|error| error.to_string())?;
+    let meta = stage.join("corpus.meta");
+    let records = stage.join("corpus.records");
+    let snapshot =
+        uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(guard, &meta, &records)
+            .map_err(|error| error.to_string())?;
+    if snapshot.binding_cid.is_none() {
+        return Err(format!(
+            "bound compiled stage {} has no canonical recorded-corpus generation binding",
+            stage.display()
+        ));
+    }
+    let preflight = read_optional_source_compile_preflight(stage)?.ok_or_else(|| {
+        format!(
+            "bound compiled stage {} has no canonical P record",
+            stage.display()
+        )
+    })?;
+    let kappa = read_optional_source_manifest_kappa_binding(stage)?.ok_or_else(|| {
+        format!(
+            "bound compiled stage {} has no canonical K record",
+            stage.display()
+        )
+    })?;
+    if preflight.source_manifest_kappa.as_deref() != Some(requested_source_snapshot_kappa)
+        || kappa != requested_source_snapshot_kappa
+    {
+        return Err(format!(
+            "bound compiled stage {} does not carry exact requested P/K source snapshot {}",
+            stage.display(),
+            requested_source_snapshot_kappa
+        ));
+    }
+    let attention = source_compile_attention_binding(stage)?;
+    let dense = source_compile_dense_binding(stage)?;
+    if snapshot.execution.attention_operator.as_ref() != attention.as_ref()
+        || snapshot.execution.dense_operator.as_ref() != dense.as_ref()
+    {
+        return Err(format!(
+            "bound compiled stage {} has operator sidecars that differ from its committed corpus provenance",
+            stage.display()
+        ));
+    }
+    uor_r4_model_source::dense::validate_source_execution_pair(attention.as_ref(), dense.as_ref())
+        .map_err(|error| format!("bound compiled stage {}: {error}", stage.display()))?;
+    snapshot
+        .verify_generation()
+        .map_err(|error| error.to_string())?;
+    guard.verify_owned_root().map_err(|error| error.to_string())
+}
+
 #[derive(Debug)]
 struct CompiledBundleStage {
     path: PathBuf,
@@ -6918,14 +7956,16 @@ struct CompiledBundleStage {
 }
 
 impl CompiledBundleStage {
-    fn allocate_with_selection_transaction_with_after_first_copy<F>(
+    fn allocate_with_selection_transaction_with_hooks<F, G>(
         final_output: &Path,
         source_snapshot_kappa: &str,
         selection_base: &[CompiledBundleSelectionGeneration],
-        mut after_first_copy: F,
+        mut after_stage_scan: F,
+        mut after_first_copy: G,
     ) -> Result<(Self, uor_r4_graph_cli::SourceCorpusSession), String>
     where
         F: FnMut(&Path) -> Result<(), String>,
+        G: FnMut(&Path) -> Result<(), String>,
     {
         let final_output_canonical = canonical_compile_session_subject(final_output)?;
         let final_output_utf8 = final_output_canonical.to_str().ok_or_else(|| {
@@ -6975,23 +8015,86 @@ impl CompiledBundleStage {
                 ));
             }
         }
-        if let Some((path, marker_bytes, temporaries)) =
+        if let Some((path, marker_bytes)) =
             recover_compiled_bundle_stages(final_output, source_snapshot_kappa, selection_base)?
         {
+            after_stage_scan(&path)?;
             let session = uor_r4_graph_cli::acquire_source_corpus_session(&path)
                 .map_err(|error| error.to_string())?;
             let guard = session
                 .recorded_corpus_guard()
                 .map_err(|error| error.to_string())?;
             guard
-                .begin_compile_attempt()
+                .verify_owned_entry_bytes(
+                    std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                    &marker_bytes,
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                    "recovered compiled-bundle owner marker",
+                )
+                .map_err(|error| error.to_string())?;
+            let temporaries = compiled_bundle_stage_temporaries(&path)?;
+            guard
+                .verify_owned_entry_bytes(
+                    std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                    &marker_bytes,
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                    "recovered compiled-bundle owner marker after temporary recapture",
+                )
+                .map_err(|error| error.to_string())?;
+            guard
+                .verify_owned_root()
                 .map_err(|error| error.to_string())?;
             let binding =
                 path.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
-            if regular_file_presence(&binding)? {
+            let recover_binding = guard
+                .preflight_publication_namespace_for(
+                    uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+                )
+                .map_err(|error| error.to_string())?;
+            if recover_binding {
+                uor_r4_graph_compiler::recorded_corpus::publish_binding(
+                    guard,
+                    &path.join("corpus.meta"),
+                    &path.join("corpus.records"),
+                )
+                .map_err(|error| error.to_string())?;
+            } else {
+                guard
+                    .reclaim_uncommitted_binding_writings_for(
+                        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+                    )
+                    .map_err(|error| error.to_string())?;
+            }
+            let trusted_bound = if regular_file_presence(&binding)? {
+                validate_compiled_bundle_stage_a_seal_under_guard(
+                    guard,
+                    &path,
+                    &marker_bytes,
+                    source_snapshot_kappa,
+                )?
+                .is_some()
+            } else {
+                false
+            };
+            if trusted_bound {
+                validate_bound_compiled_stage_prefix_under_guard(
+                    guard,
+                    &path,
+                    source_snapshot_kappa,
+                )?;
+                guard
+                    .begin_compile_attempt()
+                    .map_err(|error| error.to_string())?;
                 reset_resumable_compiled_bundle_stage(&path, temporaries)?;
             } else {
+                // A binding without the exact Stage-A ancestry seal is not a
+                // resumable server generation. Reset the registered private
+                // namespace to its owner marker and rebuild from the still-
+                // CASed public base; never mint provenance from that binding.
                 reset_unbound_compiled_bundle_stage(&path, temporaries)?;
+                guard
+                    .begin_compile_attempt()
+                    .map_err(|error| error.to_string())?;
                 if !matches!(expected_base, CompiledBundleBaseGeneration::Absent) {
                     copy_compiled_bundle_prefix_with_after_first_copy(
                         final_output,
@@ -6999,6 +8102,18 @@ impl CompiledBundleStage {
                         &mut after_first_copy,
                     )?;
                 }
+                if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                    return Err(format!(
+                        "authoritative compiled-bundle base {} changed while a refresh stage prefix was recovered",
+                        final_output.display()
+                    ));
+                }
+                validate_copied_compiled_bundle_prefix_against_base(
+                    &path,
+                    expected_base,
+                    authoritative_completion.as_ref(),
+                    false,
+                )?;
                 if let Some(before) = authoritative_completion.as_ref() {
                     uor_r4_graph_compiler::recorded_corpus::publish_binding(
                         guard,
@@ -7020,6 +8135,12 @@ impl CompiledBundleStage {
                     }
                     validate_copied_compiled_bundle_prefix(&path, before)?;
                 }
+            }
+            if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                return Err(format!(
+                    "authoritative compiled-bundle base {} changed before recovered-stage reuse",
+                    final_output.display()
+                ));
             }
             if !validate_compiled_bundle_stage_marker(&path, &marker_bytes)? {
                 return Err(format!(
@@ -7109,6 +8230,18 @@ impl CompiledBundleStage {
                             &mut after_first_copy,
                         )?;
                     }
+                    if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                        return Err(format!(
+                            "authoritative compiled-bundle base {} changed while a refresh stage prefix was copied",
+                            final_output.display()
+                        ));
+                    }
+                    validate_copied_compiled_bundle_prefix_against_base(
+                        &path,
+                        expected_base,
+                        authoritative_completion.as_ref(),
+                        false,
+                    )?;
                     if let Some(before) = authoritative_completion.as_ref() {
                         uor_r4_graph_compiler::recorded_corpus::publish_binding(
                             guard,
@@ -7130,6 +8263,12 @@ impl CompiledBundleStage {
                             ));
                         }
                         validate_copied_compiled_bundle_prefix(&path, before)?;
+                    }
+                    if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                        return Err(format!(
+                            "authoritative compiled-bundle base {} changed before new-stage reuse",
+                            final_output.display()
+                        ));
                     }
                     guard
                         .verify_owned_root()
@@ -7159,15 +8298,35 @@ impl CompiledBundleStage {
         ))
     }
 
+    #[cfg(test)]
+    fn allocate_with_selection_transaction_with_after_first_copy<F>(
+        final_output: &Path,
+        source_snapshot_kappa: &str,
+        selection_base: &[CompiledBundleSelectionGeneration],
+        after_first_copy: F,
+    ) -> Result<(Self, uor_r4_graph_cli::SourceCorpusSession), String>
+    where
+        F: FnMut(&Path) -> Result<(), String>,
+    {
+        Self::allocate_with_selection_transaction_with_hooks(
+            final_output,
+            source_snapshot_kappa,
+            selection_base,
+            |_| Ok(()),
+            after_first_copy,
+        )
+    }
+
     fn allocate_with_selection_transaction(
         final_output: &Path,
         source_snapshot_kappa: &str,
         selection_base: &[CompiledBundleSelectionGeneration],
     ) -> Result<(Self, uor_r4_graph_cli::SourceCorpusSession), String> {
-        Self::allocate_with_selection_transaction_with_after_first_copy(
+        Self::allocate_with_selection_transaction_with_hooks(
             final_output,
             source_snapshot_kappa,
             selection_base,
+            |_| Ok(()),
             |_| Ok(()),
         )
     }
@@ -7346,6 +8505,7 @@ fn compiled_bundle_semantic_control_max_bytes(relative: &str) -> Option<u64> {
         | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
         | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
         | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE => Some(COMPILED_BUNDLE_CONTROL_MAX_BYTES),
+        "compile_report.json" => Some(COMPILE_REPORT_CONTROL_MAX_BYTES),
         "graph-cover/cover_report.json" => Some(COVER_REPORT_CONTROL_MAX_BYTES),
         "graph/score_report.json" => Some(SCORE_REPORT_CONTROL_MAX_BYTES),
         _ => None,
@@ -8361,7 +9521,7 @@ fn bytes_kappa(bytes: &[u8]) -> String {
 }
 
 fn regular_file_kappa(path: &Path, label: &str) -> Result<String, String> {
-    read_required_regular_file_nofollow(path, label).map(|bytes| bytes_kappa(&bytes))
+    regular_file_blake3_nofollow(path, label)
 }
 
 fn legacy_graph_controls_kappa(args: &[String]) -> Result<String, String> {
@@ -8499,7 +9659,12 @@ fn legacy_graph_completion_bytes(
 fn read_optional_legacy_graph_attempt(
     path: &Path,
 ) -> Result<Option<LegacyGraphGenerationAttempt>, String> {
-    let Some(bytes) = read_regular_file_nofollow(path, "legacy graph attempt")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        path,
+        "legacy graph attempt",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok(None);
     };
     reject_duplicate_json_fields(&bytes, path, "legacy graph attempt")?;
@@ -8519,7 +9684,12 @@ fn read_optional_legacy_graph_attempt(
 fn read_optional_legacy_graph_completion(
     path: &Path,
 ) -> Result<Option<LegacyGraphGenerationCompletion>, String> {
-    let Some(bytes) = read_regular_file_nofollow(path, "legacy graph completion")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        path,
+        "legacy graph completion",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok(None);
     };
     reject_duplicate_json_fields(&bytes, path, "legacy graph completion")?;
@@ -8742,11 +9912,21 @@ fn graph_output_file_kappas(
         ));
     }
     let mut files = std::collections::BTreeMap::new();
-    for name in [kind.files().0, kind.files().1] {
+    let (artifact_name, report_name) = kind.files();
+    for name in [artifact_name, report_name] {
         let path = output.join(name);
+        let kappa = if name == report_name {
+            let max_bytes = match kind {
+                GraphOutputKind::Cover => COVER_REPORT_CONTROL_MAX_BYTES,
+                GraphOutputKind::Score => SCORE_REPORT_CONTROL_MAX_BYTES,
+            };
+            regular_file_blake3_nofollow_capped(&path, "legacy graph output report", max_bytes)?
+        } else {
+            regular_file_blake3_nofollow(&path, "legacy graph output artifact")?
+        };
         files.insert(
             canonical_path_text(&path, "legacy graph output member")?,
-            regular_file_kappa(&path, "legacy graph output member")?,
+            kappa,
         );
     }
     Ok(files)
@@ -8921,29 +10101,28 @@ fn validate_graph_output_directory(output: &Path, kind: GraphOutputKind) -> Resu
         ));
     }
     let (artifact_name, report_name) = kind.files();
-    let mut inventory = fs::read_dir(output)
+    let mut inventory = Vec::new();
+    for entry in fs::read_dir(output)
         .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?
-        .map(|entry| {
-            let entry = entry
-                .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
-            let name = entry
-                .file_name()
-                .to_str()
-                .map(str::to_owned)
-                .ok_or_else(|| format!("{} contains a non-UTF-8 output entry", output.display()))?;
-            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
-                format!("{} cannot be inspected: {error}", entry.path().display())
-            })?;
-            if !metadata.file_type().is_file() {
-                return Err(format!(
-                    "{} output entry {} is not a regular non-symlink file",
-                    kind.label(),
-                    entry.path().display()
-                ));
-            }
-            Ok(name)
-        })
-        .collect::<Result<Vec<_>, String>>()?;
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
+        let name = entry
+            .file_name()
+            .to_str()
+            .map(str::to_owned)
+            .ok_or_else(|| format!("{} contains a non-UTF-8 output entry", output.display()))?;
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|error| format!("{} cannot be inspected: {error}", entry.path().display()))?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "{} output entry {} is not a regular non-symlink file",
+                kind.label(),
+                entry.path().display()
+            ));
+        }
+        inventory.push(name);
+    }
     inventory.sort();
     let mut expected = vec![artifact_name.to_owned(), report_name.to_owned()];
     expected.sort();
@@ -8958,7 +10137,12 @@ fn validate_graph_output_directory(output: &Path, kind: GraphOutputKind) -> Resu
     let artifact_path = output.join(artifact_name);
     let report_path = output.join(report_name);
     let artifact = read_regular_file_nofollow(&artifact_path, "R4G1 output artifact")?;
-    let report = read_regular_file_nofollow(&report_path, "R4G1 output report")?;
+    let report_max_bytes = match kind {
+        GraphOutputKind::Cover => COVER_REPORT_CONTROL_MAX_BYTES,
+        GraphOutputKind::Score => SCORE_REPORT_CONTROL_MAX_BYTES,
+    };
+    let report =
+        read_regular_file_nofollow_capped(&report_path, "R4G1 output report", report_max_bytes)?;
     let (Some(artifact), Some(report)) = (artifact, report) else {
         return Err(format!(
             "{} output {} exists without its complete {artifact_name}/{report_name} pair; refusing to adopt or mutate partial publication",
@@ -9602,7 +10786,23 @@ fn validate_compiled_bundle_completion_bytes(
 /// the temporary. Classification and full member validation precede the first
 /// removal; malformed, conflicting, symlinked, or special entries remain
 /// terminal and untouched.
-fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), String> {
+fn recover_compiled_bundle_completion_temporaries(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect completion-recovery root {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    guard
+        .verify_owned_root()
+        .map_err(|error| error.to_string())?;
     let temporaries = compiled_bundle_completion_temporaries(root)?;
     if temporaries.is_empty() {
         return Ok(());
@@ -9630,59 +10830,71 @@ fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), Str
         .map(|(path, _)| path.clone())
         .collect::<std::collections::BTreeSet<_>>();
     validate_compiled_bundle_completion_bytes(root, &stable, candidate, &ignored)?;
+    let stable_name = std::ffi::OsStr::new(COMPILED_BUNDLE_COMPLETION_FILE);
+    let stable_present = guard
+        .verify_optional_owned_entry_bytes(
+            stable_name,
+            candidate,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle completion before recovery",
+        )
+        .map_err(|error| error.to_string())?;
 
-    if stable_bytes.is_none() {
-        match fs::hard_link(&temporaries[0].0, &stable) {
-            Ok(()) => sync_parent_directory(&stable, "compiled-bundle completion recovery")?,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                let raced = read_required_regular_file_nofollow_capped(
-                    &stable,
-                    "concurrently recovered compiled-bundle completion",
-                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
-                )?;
-                if raced != candidate {
-                    return Err(format!(
-                        "{} concurrently recorded a different compiled-bundle completion",
-                        stable.display()
-                    ));
-                }
-            }
-            Err(error) => {
-                return Err(format!(
-                    "compiled-bundle completion recovery {} -> {} failed: {error}",
-                    temporaries[0].0.display(),
-                    stable.display()
-                ));
-            }
-        }
+    if stable_bytes.is_none() && !stable_present {
+        let temporary_name = temporaries[0].0.file_name().ok_or_else(|| {
+            format!(
+                "compiled-bundle completion temporary {} has no leaf name",
+                temporaries[0].0.display()
+            )
+        })?;
+        guard
+            .verify_owned_entry_bytes(
+                temporary_name,
+                candidate,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "compiled-bundle completion recovery source",
+            )
+            .map_err(|error| error.to_string())?;
+        guard
+            .link_owned_entry(temporary_name, stable_name)
+            .map_err(|error| error.to_string())?;
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        guard
+            .verify_owned_entry_bytes(
+                stable_name,
+                candidate,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "recovered compiled-bundle completion",
+            )
+            .map_err(|error| error.to_string())?;
     }
     for (temporary, expected) in temporaries {
-        let current = read_required_regular_file_nofollow_capped(
-            &temporary,
-            "compiled-bundle completion temporary before recovery",
-            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
-        )?;
-        if current != expected {
-            return Err(format!(
-                "compiled-bundle completion temporary {} changed before recovery",
-                temporary.display()
-            ));
-        }
-        fs::remove_file(&temporary).map_err(|error| {
+        let temporary_name = temporary.file_name().ok_or_else(|| {
             format!(
-                "recognized compiled-bundle completion temporary {} cannot be reclaimed: {error}",
+                "compiled-bundle completion temporary {} has no leaf name",
                 temporary.display()
             )
         })?;
+        guard
+            .verify_owned_entry_bytes(
+                temporary_name,
+                &expected,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "compiled-bundle completion temporary before recovery",
+            )
+            .map_err(|error| error.to_string())?;
+        guard
+            .unlink_owned_entry(temporary_name)
+            .map_err(|error| error.to_string())?;
     }
-    sync_parent_directory(&stable, "compiled-bundle completion recovery")?;
+    guard.sync_owned_root().map_err(|error| error.to_string())?;
     validate_compiled_bundle_completion(root)?.ok_or_else(|| {
         format!(
             "compiled bundle {} lost its recovered completion record",
             root.display()
         )
     })?;
-    Ok(())
+    guard.verify_owned_root().map_err(|error| error.to_string())
 }
 
 fn validate_compiled_bundle_completion(
@@ -9734,8 +10946,27 @@ fn recover_managed_compiled_bundle_completion_temporaries(
         })?;
         let metadata = fs::symlink_metadata(entry.path())
             .map_err(|error| format!("{} cannot be inspected: {error}", entry.path().display()))?;
+        if entry.file_name()
+            == std::ffi::OsStr::new(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+            || entry.file_name() == std::ffi::OsStr::new(SOURCE_COMPILE_STAGING_DIR)
+        {
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "reserved compiled-inventory namespace {} is not a regular non-symlink directory",
+                    entry.path().display()
+                ));
+            }
+            continue;
+        }
         if metadata.file_type().is_dir() {
-            recover_compiled_bundle_completion_temporaries(&entry.path())?;
+            let guard =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    entry.path(),
+                )
+                .map_err(|error| error.to_string())?;
+            recover_compiled_bundle_completion_temporaries(&guard, &entry.path())?;
         }
     }
     Ok(())
@@ -9883,7 +11114,7 @@ fn publish_source_compile_preflight(output: &Path, kappa: Option<&str>) -> Resul
                 ));
             }
             let exact_empty_stage = exact_empty_compiled_bundle_stage(output)?;
-            if !source_compile_pre_attention_prefix(output)? && !exact_empty_stage {
+            if !exact_empty_stage && !source_compile_pre_attention_prefix(output)? {
                 return Err(format!(
                     "source compile output {} exists without a stable source compile preflight; refusing to adopt or mutate it",
                     output.display()
@@ -10348,7 +11579,7 @@ struct CompiledSourceBundle {
     selection_generations:
         Vec<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration>,
     selection_base: Vec<CompiledBundleSelectionGeneration>,
-    stage_reader_pins: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins>,
+    stage_compile_authority: Option<uor_r4_graph_cli::SourceCorpusSession>,
     source_snapshot_kappa: String,
     logical_name: String,
     current_version: u32,
@@ -10414,9 +11645,9 @@ fn prepare_compiled_selection_sibling_under_guard(
             .finish_compile_attempt()
             .map_err(|error| error.to_string())?;
     }
-    recover_compiled_bundle_completion_temporaries(root)?;
+    recover_compiled_bundle_completion_temporaries(guard, root)?;
     if validate_compiled_bundle_completion(root)?.is_some() {
-        cleanup_published_compiled_bundle_stage_marker(root)?;
+        cleanup_published_compiled_bundle_stage_marker(guard, root)?;
     }
     Ok(())
 }
@@ -10427,6 +11658,42 @@ fn prepare_compiled_root_transaction_under_guard(
     source_snapshot_kappa: &str,
 ) -> Result<(), String> {
     if !guard.root_exists() {
+        return Ok(());
+    }
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect compiled root {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    let prefix_recoverable_binding = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    if !prefix_recoverable_binding {
+        // A partial `.writing` inode is explicitly non-authoritative. Reclaim
+        // it before prefix classification while the retained root guard makes
+        // cleanup race-free. A canonical `.tmp` remains visible and terminal
+        // for an otherwise identity-only prefix.
+        guard
+            .reclaim_uncommitted_binding_writings_for(
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+            )
+            .map_err(|error| error.to_string())?;
+    }
+    // An identity-only crash prefix is decided before any lower recovery can
+    // promote binding evidence or otherwise mutate it.  Only the exact
+    // requested P/K pair (with an optional canonical attempt marker) is a
+    // resumable pre-attention/pre-dense generation.
+    if exact_requested_source_identity_prefix(root, source_snapshot_kappa)? {
+        guard
+            .verify_owned_root()
+            .map_err(|error| error.to_string())?;
         return Ok(());
     }
     guard
@@ -10465,10 +11732,10 @@ fn prepare_compiled_root_transaction_under_guard(
             .finish_compile_attempt()
             .map_err(|error| error.to_string())?;
     }
-    recover_compiled_bundle_completion_temporaries(root)?;
+    recover_compiled_bundle_completion_temporaries(guard, root)?;
     match validate_compiled_bundle_completion(root)? {
         Some(_) => {
-            cleanup_published_compiled_bundle_stage_marker(root)?;
+            cleanup_published_compiled_bundle_stage_marker(guard, root)?;
             Ok(())
         }
         None if source_compile_pre_attention_prefix(root)? => Ok(()),
@@ -10546,7 +11813,7 @@ fn require_compiled_refresh_source_snapshot(
 
 struct ManagedCompiledBundleRead {
     resolved: Option<ResolvedCompiledBundle>,
-    pins: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins,
+    authority: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff,
 }
 
 fn managed_compiled_selection_roots(
@@ -10567,15 +11834,15 @@ fn managed_compiled_selection_roots(
     ]
 }
 
-/// Reconcile one managed logical selection under the common exclusive root
-/// protocol. This is a short migration/recovery transaction: it may finish an
-/// exact publication residue or bootstrap the durable completion record of a
-/// valid pre-#728 current bundle, but it never spans runtime loading.
-fn bootstrap_managed_compiled_bundle(
+/// Reconcile one managed logical selection under a single sorted producer
+/// set which remains live through resolution, runtime loading, and serving
+/// installation. There is deliberately no producer-to-reader lock conversion:
+/// standard file locking offers no portable atomic downgrade operation.
+fn acquire_managed_compiled_bundle_read(
     compiled_root: &Path,
     logical_name: &str,
     current_version: u32,
-) -> Result<(), String> {
+) -> Result<ManagedCompiledBundleRead, String> {
     let roots = managed_compiled_selection_roots(compiled_root, logical_name, current_version);
     let generations = roots
         .iter()
@@ -10612,46 +11879,26 @@ fn bootstrap_managed_compiled_bundle(
             // Historical roots may legitimately predate both the binding and
             // completion records. If a completion record exists, it remains
             // authoritative and must validate exactly.
-            recover_compiled_bundle_completion_temporaries(selected_root)?;
+            recover_compiled_bundle_completion_temporaries(selected_guard, selected_root)?;
             let _ = validate_compiled_bundle_completion(selected_root)?;
         }
         let refreshed = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
-        resolve_loadable_compiled_bundle_with_authority(
+        let resolved = resolve_loadable_compiled_bundle_with_authority(
             &refreshed,
             current_version,
             Some(RecordedCorpusReadAuthority::Producer(selected_guard)),
-        )?
-        .ok_or_else(|| {
-            format!("managed compiled model {logical_name} disappeared during completion bootstrap")
-        })?;
+        )?;
+        handoff.verify().map_err(|error| error.to_string())?;
+        return Ok(ManagedCompiledBundleRead {
+            resolved,
+            authority: handoff,
+        });
     }
-    handoff.verify().map_err(|error| error.to_string())
-}
-
-/// Bootstrap under short exclusive authority, then pin the full precedence
-/// trio shared through resolution, runtime loading, and installation. Managed
-/// pins seed permanent lock inodes for absent siblings, so a cooperating
-/// writer cannot create a newly preferred root in the installation window.
-fn acquire_managed_compiled_bundle_read(
-    compiled_root: &Path,
-    logical_name: &str,
-    current_version: u32,
-) -> Result<ManagedCompiledBundleRead, String> {
-    bootstrap_managed_compiled_bundle(compiled_root, logical_name, current_version)?;
-    let roots = managed_compiled_selection_roots(compiled_root, logical_name, current_version);
-    let pins =
-        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire_managed(
-            &roots,
-        )
-        .map_err(|error| error.to_string())?;
-    let pair = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
-    let resolved = resolve_loadable_compiled_bundle_with_authority(
-        &pair,
-        current_version,
-        Some(RecordedCorpusReadAuthority::ReaderPins(&pins)),
-    )?;
-    pins.verify().map_err(|error| error.to_string())?;
-    Ok(ManagedCompiledBundleRead { resolved, pins })
+    handoff.verify().map_err(|error| error.to_string())?;
+    Ok(ManagedCompiledBundleRead {
+        resolved: None,
+        authority: handoff,
+    })
 }
 
 fn discover_managed_compiled_reads_in(
@@ -10679,6 +11926,21 @@ fn discover_managed_compiled_reads_in(
 }
 
 impl CompiledSourceBundle {
+    fn stage_graph_guard(
+        &self,
+    ) -> Result<&uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard, String> {
+        self.stage_compile_authority
+            .as_ref()
+            .ok_or_else(|| {
+                format!(
+                    "compiled-bundle stage {} has no retained source/graph authority",
+                    self.working_output.display()
+                )
+            })?
+            .recorded_corpus_guard()
+            .map_err(|error| error.to_string())
+    }
+
     fn publish(
         &mut self,
     ) -> Result<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff, String> {
@@ -10705,52 +11967,49 @@ impl CompiledSourceBundle {
         F: FnOnce(&Path) -> Result<(), String>,
         G: FnOnce(&Path) -> Result<(), String>,
     {
-        // The shared stage pin protected the exact corpus generation while
-        // cover/score wrote only private derived outputs. Convert it to
-        // exclusive stage ownership before completion publication. Capture a
-        // full fixed-inventory content witness while the shared pins are still
-        // live, then require it immediately after exclusive acquisition so a
-        // supported writer cannot win the reader-to-producer transition and
-        // silently splice corpus B under graph A.
-        let stage_before_transition =
-            capture_compiled_bundle_base_generation(&self.working_output)?;
+        // Stage A, cover, and score share one retained producer interval. The
+        // durable seal proves that the corpus/artifact prefix still equals the
+        // exact server-verified Stage-A generation while graph-only members
+        // are added. It is removed only after the complete graph transaction
+        // validates and immediately before completion becomes the new commit.
+        let stage_compile_authority = self.stage_compile_authority.take().ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} has no retained graph-derivation authority",
+                self.working_output.display()
+            )
+        })?;
+        let stage_guard = stage_compile_authority
+            .recorded_corpus_guard()
+            .map_err(|error| error.to_string())?;
         if !validate_compiled_bundle_stage_marker(&self.working_output, &self.stage.marker_bytes)? {
             return Err(format!(
-                "compiled-bundle stage {} lost its exact owner/base marker before producer transition",
+                "compiled-bundle stage {} lost its exact owner/base marker before completion",
                 self.working_output.display()
             ));
         }
-        if let Some(pins) = self.stage_reader_pins.as_ref() {
-            pins.verify().map_err(|error| error.to_string())?;
-        }
-        drop(self.stage_reader_pins.take());
         before_stage_guard(&self.working_output)?;
-        let stage_guard =
-            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
-                &self.working_output,
-            )
-            .map_err(|error| error.to_string())?;
-        let stage_after_transition = capture_compiled_bundle_base_generation(&self.working_output)?;
-        if stage_after_transition != stage_before_transition
-            || !validate_compiled_bundle_stage_marker(
-                &self.working_output,
-                &self.stage.marker_bytes,
-            )?
-        {
-            return Err(format!(
-                "compiled-bundle stage {} changed generation while serving pins transitioned to exclusive publication authority",
-                self.working_output.display()
-            ));
-        }
         stage_guard
             .verify_owned_root()
             .map_err(|error| error.to_string())?;
+        let stage_a_seal = validate_compiled_bundle_stage_a_seal_under_guard(
+            stage_guard,
+            &self.working_output,
+            &self.stage.marker_bytes,
+            &self.source_snapshot_kappa,
+        )?
+        .ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} lost its durable Stage-A ancestry seal",
+                self.working_output.display()
+            )
+        })?;
         validate_compiled_stage_transaction_under_guard(
-            &stage_guard,
+            stage_guard,
             &self.working_output,
             &self.source_snapshot_kappa,
         )?;
-        publish_compiled_bundle_completion_under_guard(&stage_guard, &self.working_output)?;
+        remove_compiled_bundle_stage_a_seal_under_guard(stage_guard, &stage_a_seal)?;
+        publish_compiled_bundle_completion_under_guard(stage_guard, &self.working_output)?;
         validate_compiled_bundle_completion(&self.working_output)?.ok_or_else(|| {
             format!(
                 "compiled-bundle stage {} lost its completion record before publication",
@@ -10782,7 +12041,7 @@ impl CompiledSourceBundle {
         stage_generation
             .verify()
             .map_err(|error| error.to_string())?;
-        drop(stage_guard);
+        drop(stage_compile_authority);
         before_handoff(&self.working_output)?;
 
         let mut expected = std::mem::take(&mut self.selection_generations);
@@ -11069,6 +12328,25 @@ fn compile_bundle_from_source(
         &selection_base,
     )?;
     let working_output = stage.path.clone();
+    if let Some(seal) = validate_compiled_bundle_stage_a_seal_under_guard(
+        stage_compile_session
+            .recorded_corpus_guard()
+            .map_err(|error| error.to_string())?,
+        &working_output,
+        &stage.marker_bytes,
+        source_snapshot_kappa,
+    )? {
+        // The source compiler may advance the corpus target. Invalidate the
+        // exact Stage-A claim under the same retained guard before its first
+        // identity/corpus mutation; a crash can then only leave an unsealed
+        // generation, which recovery rebuilds instead of trusting.
+        remove_compiled_bundle_stage_a_seal_under_guard(
+            stage_compile_session
+                .recorded_corpus_guard()
+                .map_err(|error| error.to_string())?,
+            &seal,
+        )?;
+    }
     preflight_and_bind_source_snapshot_kappa(&working_output, Some(source_snapshot_kappa))?;
     let args = vec![
         "--source".to_owned(),
@@ -11115,7 +12393,7 @@ fn compile_bundle_from_source(
         set_r4g1_compile_progress(status, progress, &message);
         std::thread::sleep(Duration::from_millis(500));
     }
-    compiler
+    let stage_compile_authority = compiler
         .join()
         .map_err(|payload| {
             format!(
@@ -11124,11 +12402,38 @@ fn compile_bundle_from_source(
             )
         })?
         .map_err(|error| error.to_string())?;
-    let stage_reader_pins =
-        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire([
-            &working_output,
-        ])
+    // The compiler returns the exact same opaque source/common authority it
+    // consumed. No writer can enter between its final corpus publication and
+    // the Stage-A validation/seal below.
+    let stage_graph_guard = stage_compile_authority
+        .recorded_corpus_guard()
         .map_err(|error| error.to_string())?;
+    if !validate_compiled_bundle_stage_marker(&working_output, &stage.marker_bytes)? {
+        return Err(format!(
+            "compiled-bundle stage {} lost its exact owner/base marker after source compilation",
+            working_output.display()
+        ));
+    }
+    validate_bound_compiled_stage_prefix_under_guard(
+        stage_graph_guard,
+        &working_output,
+        source_snapshot_kappa,
+    )?;
+    if stage_graph_guard
+        .compile_attempt_active()
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "compiled-bundle stage {} still has an active source compile attempt after Stage A",
+            working_output.display()
+        ));
+    }
+    publish_compiled_bundle_stage_a_seal_under_guard(
+        stage_graph_guard,
+        &working_output,
+        &stage.marker_bytes,
+        source_snapshot_kappa,
+    )?;
     validate_source_bundle_inventory(&working_output)?;
     let meta = working_output.join("corpus.meta");
     let records = working_output.join("corpus.records");
@@ -11150,7 +12455,7 @@ fn compile_bundle_from_source(
         stage,
         selection_generations,
         selection_base,
-        stage_reader_pins: Some(stage_reader_pins),
+        stage_compile_authority: Some(stage_compile_authority),
         source_snapshot_kappa: source_snapshot_kappa.to_owned(),
         logical_name: name.to_owned(),
         current_version,
@@ -11209,9 +12514,17 @@ fn append_recorded_execution_identity(
     corpus_meta: &Path,
     corpus_recs: &Path,
     require_explicit: bool,
+    producer_guard: Option<&uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard>,
 ) -> Result<(), String> {
-    let identity = uor_r4_graph_cli::recorded_corpus_execution_identity(corpus_meta, corpus_recs)
-        .map_err(|error| error.to_string())?;
+    let identity = match producer_guard {
+        Some(guard) => uor_r4_graph_cli::recorded_corpus_execution_identity_under_producer_guard(
+            guard,
+            corpus_meta,
+            corpus_recs,
+        ),
+        None => uor_r4_graph_cli::recorded_corpus_execution_identity(corpus_meta, corpus_recs),
+    }
+    .map_err(|error| error.to_string())?;
     match identity.attention_operator.as_ref() {
         Some(operator) => {
             let json = serde_json::to_string(operator).map_err(|error| error.to_string())?;
@@ -11442,14 +12755,23 @@ fn compile_r4g1_bundle(
     // #602/#704: bind the identity stage A or the observation manifest
     // actually recorded. Reconstructing it as standard from the absent
     // experimental switch would mislabel GPT-2's learned-absolute operator.
+    let retained_graph_guard = compiled_source
+        .as_ref()
+        .map(CompiledSourceBundle::stage_graph_guard)
+        .transpose()?;
     append_recorded_execution_identity(
         &mut cover_args,
         &corpus_meta,
         &corpus_recs,
         compiled_from_source,
+        retained_graph_guard,
     )?;
     if compiled_from_source {
-        uor_r4_graph_cli::cover_command(&cover_args).map_err(|error| error.to_string())?;
+        let guard = retained_graph_guard.ok_or_else(|| {
+            "managed compiled source lost graph producer authority before cover".to_owned()
+        })?;
+        uor_r4_graph_cli::cover_command_under_producer_guard(&cover_args, guard)
+            .map_err(|error| error.to_string())?;
     }
 
     set_r4g1_compile_progress(status, 55, "Scoring graph transitions and emissions...");
@@ -11482,7 +12804,11 @@ fn compile_r4g1_bundle(
         downloaded_source.is_some(),
     )?;
     if compiled_from_source {
-        uor_r4_graph_cli::score_command(&score_args).map_err(|error| error.to_string())?;
+        let guard = retained_graph_guard.ok_or_else(|| {
+            "managed compiled source lost graph producer authority before score".to_owned()
+        })?;
+        uor_r4_graph_cli::score_command_under_producer_guard(&score_args, guard)
+            .map_err(|error| error.to_string())?;
     } else {
         let identity = capture_legacy_graph_generation_identity(LegacyGraphGenerationInputs {
             artifacts: &artifacts,
@@ -13749,7 +15075,7 @@ fn handle_connection(
         };
         let ManagedCompiledBundleRead {
             resolved,
-            pins: reload_bundle_pins,
+            authority: reload_bundle_authority,
         } = managed_read;
         let resolved = match resolved {
             Some(resolved) => resolved,
@@ -13881,7 +15207,24 @@ fn handle_connection(
         let refreshed = match refresh_resolved_compiled_bundle_with_authority(
             &resolved,
             current_version,
-            Some(RecordedCorpusReadAuthority::ReaderPins(&reload_bundle_pins)),
+            Some(RecordedCorpusReadAuthority::Producer(
+                match recorded_handoff_guard_for_root(
+                    &reload_bundle_authority,
+                    &resolved.physical_root,
+                ) {
+                    Ok(guard) => guard,
+                    Err(error) => {
+                        record_replacement_failure(&serving, error.clone());
+                        send_json_response_ext(
+                            stream,
+                            500,
+                            &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                            &dep,
+                        );
+                        return;
+                    }
+                },
+            )),
         ) {
             Ok(refreshed) => refreshed,
             Err(error) => {
@@ -13949,7 +15292,7 @@ fn handle_connection(
                 ),
                 None => (None, None, None),
             };
-        if let Err(error) = reload_bundle_pins.verify() {
+        if let Err(error) = reload_bundle_authority.verify() {
             let error = error.to_string();
             record_replacement_failure(&serving, error.clone());
             send_json_response_ext(
@@ -13993,7 +15336,7 @@ fn handle_connection(
             refreshed.logical_name
         );
         reload_reservation.disarm();
-        drop(reload_bundle_pins);
+        drop(reload_bundle_authority);
         drop(reload_read_sessions);
         let resp = serde_json::json!({
             "status": "success",
@@ -16923,7 +18266,7 @@ mod tests {
         commit_test_recorded_corpus_binding(&output);
 
         let mut cover_args = Vec::new();
-        super::append_recorded_execution_identity(&mut cover_args, &meta, &records, true)
+        super::append_recorded_execution_identity(&mut cover_args, &meta, &records, true, None)
             .expect("source compile forwards its recorded execution pair");
         let argument = |flag: &str| {
             cover_args
@@ -17535,6 +18878,151 @@ mod tests {
             std::fs::read(invalid.join("corpus.meta")).expect("payload after"),
             payload_before
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn managed_prepare_accepts_only_exact_requested_pk_prefix_and_reclaims_lower_writing() {
+        let root = attention_provenance_test_dir("exact-requested-pk-prefix");
+        let requested = format!("blake3:{}", "7".repeat(64));
+        let other = format!("blake3:{}", "8".repeat(64));
+
+        let exact = root.join("exact");
+        super::publish_source_compile_preflight(&exact, Some(&requested)).expect("exact P");
+        super::publish_source_manifest_kappa_binding(&exact, &requested).expect("exact K");
+        let writing = exact.join(format!(
+            ".{}.77.1.writing",
+            uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+        ));
+        std::fs::write(&writing, b"partial lower binding").expect("lower writing residue");
+        let exact_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &exact,
+            )
+            .expect("exact prefix guard");
+        exact_guard
+            .begin_compile_attempt()
+            .expect("optional canonical attempt");
+        super::prepare_compiled_root_transaction_under_guard(&exact_guard, &exact, &requested)
+            .expect("exact P/K plus canonical attempt resumes");
+        assert!(
+            !writing.exists(),
+            "non-authoritative lower writing reclaimed"
+        );
+        assert!(exact_guard
+            .compile_attempt_active()
+            .expect("attempt remains"));
+        drop(exact_guard);
+
+        let attempt_only = root.join("attempt-only");
+        std::fs::create_dir_all(&attempt_only).expect("attempt-only root");
+        let attempt_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &attempt_only,
+            )
+            .expect("attempt-only guard");
+        attempt_guard
+            .begin_compile_attempt()
+            .expect("attempt-only marker");
+        let attempt_bytes = std::fs::read(
+            attempt_only
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE),
+        )
+        .expect("attempt evidence");
+        let error = super::prepare_compiled_root_transaction_under_guard(
+            &attempt_guard,
+            &attempt_only,
+            &requested,
+        )
+        .expect_err("attempt alone never authorizes prefix adoption");
+        assert!(
+            error.contains("exact requested canonical P/K pair"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(attempt_only.join(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE,
+            ))
+            .expect("attempt evidence preserved"),
+            attempt_bytes
+        );
+        drop(attempt_guard);
+
+        let mismatch = root.join("mismatch");
+        super::publish_source_compile_preflight(&mismatch, Some(&other)).expect("mismatch P");
+        super::publish_source_manifest_kappa_binding(&mismatch, &other).expect("mismatch K");
+        let mismatch_before = std::fs::read(mismatch.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+            .expect("mismatch P before");
+        let mismatch_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &mismatch,
+            )
+            .expect("mismatch guard");
+        let error = super::prepare_compiled_root_transaction_under_guard(
+            &mismatch_guard,
+            &mismatch,
+            &requested,
+        )
+        .expect_err("another P/K generation is terminal");
+        assert!(error.contains("does not bind exact requested"), "{error}");
+        assert_eq!(
+            std::fs::read(mismatch.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("mismatch P after"),
+            mismatch_before
+        );
+        drop(mismatch_guard);
+
+        let payload = root.join("payload");
+        super::publish_source_compile_preflight(&payload, Some(&requested)).expect("payload P");
+        super::publish_source_manifest_kappa_binding(&payload, &requested).expect("payload K");
+        std::fs::write(payload.join("corpus.meta"), b"payload sentinel").expect("payload sentinel");
+        let payload_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &payload,
+            )
+            .expect("payload guard");
+        let error = super::prepare_compiled_root_transaction_under_guard(
+            &payload_guard,
+            &payload,
+            &requested,
+        )
+        .expect_err("identity plus payload cannot be adopted as a prefix");
+        assert!(
+            error.contains("corpus") || error.contains("payload"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(payload.join("corpus.meta")).expect("payload preserved"),
+            b"payload sentinel"
+        );
+
+        let copy_source = root.join("copy-source");
+        let copy_destination = root.join("copy-destination");
+        std::fs::create_dir_all(&copy_source).expect("copy source");
+        std::fs::create_dir_all(&copy_destination).expect("copy destination");
+        std::fs::write(copy_source.join("tless_artifacts.bin"), b"copied payload")
+            .expect("copy payload");
+        std::fs::write(
+            copy_source
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE),
+            uor_r4_graph_compiler::recorded_corpus::recorded_corpus_compile_attempt_bytes()
+                .expect("canonical attempt bytes"),
+        )
+        .expect("copy attempt");
+        super::copy_compiled_bundle_prefix_with_after_first_copy(
+            &copy_source,
+            &copy_destination,
+            |_| Ok(()),
+        )
+        .expect("copy deterministic prefix");
+        assert_eq!(
+            std::fs::read(copy_destination.join("tless_artifacts.bin")).expect("payload copied"),
+            b"copied payload"
+        );
+        assert!(!copy_destination
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+            .exists());
+        drop(payload_guard);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -18377,15 +19865,20 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    fn write_completion_fixture(root: &std::path::Path, tag: &[u8]) {
+    fn write_completion_fixture_under_guard(
+        root: &std::path::Path,
+        tag: &[u8],
+        producer: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+        attempt_already_active: bool,
+        publish_completion: bool,
+    ) {
         std::fs::create_dir_all(root.join("graph-cover")).expect("cover directory");
         std::fs::create_dir_all(root.join("graph")).expect("graph directory");
-        let producer =
-            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(root)
-                .expect("fixture producer guard");
-        producer
-            .begin_compile_attempt()
-            .expect("fixture compile attempt");
+        if !attempt_already_active {
+            producer
+                .begin_compile_attempt()
+                .expect("fixture compile attempt");
+        }
         let source_kappa = format!("blake3:{}", "0".repeat(64));
         let mut meta = [0u8; 25];
         meta[0..8].copy_from_slice(&1u64.to_le_bytes());
@@ -18444,7 +19937,7 @@ mod tests {
         std::fs::write(root.join("graph-cover/cover_report.json"), cover_report)
             .expect("fixture cover report");
         uor_r4_graph_compiler::recorded_corpus::publish_binding(
-            &producer,
+            producer,
             &root.join("corpus.meta"),
             &root.join("corpus.records"),
         )
@@ -18452,8 +19945,43 @@ mod tests {
         producer
             .finish_compile_attempt()
             .expect("finish fixture compile attempt");
-        super::publish_compiled_bundle_completion_under_guard(&producer, root)
-            .expect("fixture bundle completion");
+        if publish_completion {
+            super::publish_compiled_bundle_completion_under_guard(producer, root)
+                .expect("fixture bundle completion");
+        }
+    }
+
+    fn write_completion_fixture(root: &std::path::Path, tag: &[u8]) {
+        std::fs::create_dir_all(root).expect("fixture bundle root");
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("fixture producer guard");
+        write_completion_fixture_under_guard(root, tag, &producer, false, true);
+    }
+
+    fn fixture_stage_marker_bytes(
+        final_output: &std::path::Path,
+        stage_path: &std::path::Path,
+    ) -> Vec<u8> {
+        let parent = final_output.parent().expect("fixture final parent");
+        let name = final_output
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("fixture final name");
+        let roots = [
+            parent.join(format!(".{name}.fixture-a")),
+            final_output.to_path_buf(),
+            parent.join(format!(".{name}.fixture-z")),
+        ];
+        let selection = super::capture_compiled_bundle_selection_base(&roots, final_output)
+            .expect("fixture marker selection base");
+        super::compiled_bundle_stage_marker_bytes(
+            final_output,
+            stage_path,
+            &format!("blake3:{}", "0".repeat(64)),
+            &selection,
+        )
+        .expect("fixture stage marker")
     }
 
     fn make_completion_fixture_graph_outputs_valid(root: &std::path::Path, tag: &str) {
@@ -18500,24 +20028,47 @@ mod tests {
         let selection = super::capture_compiled_bundle_selection_base(&roots, &conventional)
             .expect("empty three-root selection");
         let source_kappa = format!("blake3:{}", "0".repeat(64));
-        let stage = super::CompiledBundleStage::allocate_with_selection(
-            &conventional,
-            &source_kappa,
-            &selection,
+        let (stage, stage_compile_authority) =
+            super::CompiledBundleStage::allocate_with_selection_transaction(
+                &conventional,
+                &source_kappa,
+                &selection,
+            )
+            .expect("private publication stage");
+        let stage_graph_guard = stage_compile_authority
+            .recorded_corpus_guard()
+            .expect("private Stage-A graph producer");
+        write_completion_fixture_under_guard(
+            &stage.path,
+            tag.as_bytes(),
+            stage_graph_guard,
+            true,
+            false,
+        );
+        for relative in ["graph-cover/cover.r4g1", "graph/score.r4g1"] {
+            std::fs::write(stage.path.join(relative), minimal_r4g1_bytes())
+                .expect("valid private Stage-A R4G1 bytes");
+        }
+        std::fs::write(
+            stage.path.join("graph/score_report.json"),
+            serde_json::to_vec(&serde_json::json!({ "tag": tag }))
+                .expect("private Stage-A score report"),
         )
-        .expect("private publication stage");
-        write_completion_fixture(&stage.path, tag.as_bytes());
-        make_completion_fixture_graph_outputs_valid(&stage.path, tag);
-        let stage_reader_pins =
-            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire([
-                &stage.path
-            ])
-            .expect("serving-stage reader pin");
-        let selection_generations = roots
-            .iter()
-            .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
-            .collect::<Result<Vec<_>, _>>()
-            .expect("selection root identities");
+        .expect("private Stage-A score report");
+        super::publish_compiled_bundle_stage_a_seal_under_guard(
+            stage_graph_guard,
+            &stage.path,
+            &stage.marker_bytes,
+            &source_kappa,
+        )
+        .expect("private Stage-A ancestry seal");
+        let mut selection_generations = Vec::with_capacity(roots.len());
+        for root in &roots {
+            selection_generations.push(
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture(root)
+                    .expect("selection root identity"),
+            );
+        }
         let sessions = super::try_lock_source_compile_sessions(
             [
                 compiled,
@@ -18535,7 +20086,7 @@ mod tests {
             stage,
             selection_generations,
             selection_base: selection,
-            stage_reader_pins: Some(stage_reader_pins),
+            stage_compile_authority: Some(stage_compile_authority),
             source_snapshot_kappa: source_kappa,
             logical_name: "teacher".to_owned(),
             current_version: 2,
@@ -18621,6 +20172,317 @@ mod tests {
             format!("blake3:{}", blake3::hash(&bytes).to_hex()),
             "blake3:ca8826c3b1b5661d61702178d92c76d9e5f92c6fd838f7acef36dd8a1241af80"
         );
+    }
+
+    #[test]
+    fn compiled_bundle_completion_v1_canonical_bytes_and_cid_are_pinned() {
+        let files = std::collections::BTreeMap::from([
+            ("a.bin".to_owned(), format!("blake3:{}", "1".repeat(64))),
+            ("z.bin".to_owned(), format!("blake3:{}", "2".repeat(64))),
+        ]);
+        let bytes =
+            super::compiled_bundle_completion_bytes(files).expect("canonical completion record");
+        let expected = format!(
+            concat!(
+                "{{\n",
+                "  \"schema\": \"uor-r4-compiled-bundle-completion/1\",\n",
+                "  \"files\": {{\n",
+                "    \"a.bin\": \"blake3:{}\",\n",
+                "    \"z.bin\": \"blake3:{}\"\n",
+                "  }}\n",
+                "}}\n"
+            ),
+            "1".repeat(64),
+            "2".repeat(64),
+        );
+        assert_eq!(bytes, expected.as_bytes());
+        assert_eq!(
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+            "blake3:2b88cbeee95fb5ff36862e68bbd5077911ae1cff36098b2027cda2c9c81fe216"
+        );
+    }
+
+    #[test]
+    fn compiled_bundle_stage_a_v1_canonical_bytes_and_cid_are_pinned() {
+        let seal = super::CompiledBundleStageASeal {
+            schema: super::COMPILED_BUNDLE_STAGE_A_SEAL_SCHEMA.to_owned(),
+            stage_marker_cid: format!("blake3:{}", "0".repeat(64)),
+            source_snapshot_kappa: format!("blake3:{}", "1".repeat(64)),
+            recorded_corpus_binding_cid: format!("blake3:{}", "2".repeat(64)),
+            files: std::collections::BTreeMap::from([
+                ("a.bin".to_owned(), format!("blake3:{}", "3".repeat(64))),
+                ("z.bin".to_owned(), format!("blake3:{}", "4".repeat(64))),
+            ]),
+        };
+        let bytes =
+            super::compiled_bundle_stage_a_seal_bytes(&seal).expect("canonical Stage-A seal");
+        let expected = format!(
+            concat!(
+                "{{\n",
+                "  \"schema\": \"uor-r4-compiled-bundle-stage-a/1\",\n",
+                "  \"stage_marker_cid\": \"blake3:{}\",\n",
+                "  \"source_snapshot_kappa\": \"blake3:{}\",\n",
+                "  \"recorded_corpus_binding_cid\": \"blake3:{}\",\n",
+                "  \"files\": {{\n",
+                "    \"a.bin\": \"blake3:{}\",\n",
+                "    \"z.bin\": \"blake3:{}\"\n",
+                "  }}\n",
+                "}}\n"
+            ),
+            "0".repeat(64),
+            "1".repeat(64),
+            "2".repeat(64),
+            "3".repeat(64),
+            "4".repeat(64),
+        );
+        assert_eq!(bytes, expected.as_bytes());
+        assert_eq!(
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+            "blake3:6edc7cf8066056dc19e05f3b5c42036cdf274b225fd53bc9a7549246c7b29917"
+        );
+    }
+
+    #[test]
+    fn compiled_bundle_stage_a_seal_publish_crash_retries_exact_temporary() {
+        let root = attention_provenance_test_dir("stage-a-seal-publish-crash");
+        let mut bundle = compiled_source_bundle_publish_fixture(&root, "seal-crash");
+        let authority = bundle
+            .stage_compile_authority
+            .take()
+            .expect("retained Stage-A producer");
+        let guard = authority
+            .recorded_corpus_guard()
+            .expect("retained Stage-A common guard");
+        let stable = bundle
+            .working_output
+            .join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE);
+        let expected = std::fs::read(&stable).expect("published fixture seal");
+        super::remove_compiled_bundle_stage_a_seal_under_guard(guard, &expected)
+            .expect("return fixture to pre-publication boundary");
+        let observed = std::sync::Mutex::new(None::<std::path::PathBuf>);
+        let error = super::publish_compiled_bundle_stage_a_seal_under_guard_with_after_sync(
+            guard,
+            &bundle.working_output,
+            &bundle.stage.marker_bytes,
+            &bundle.source_snapshot_kappa,
+            |temporary| {
+                *observed.lock().expect("seal temp observation") = Some(temporary.to_path_buf());
+                Err("injected Stage-A seal post-sync crash".to_owned())
+            },
+        )
+        .expect_err("post-sync crash precedes stable seal publication");
+        assert!(error.contains("post-sync crash"), "{error}");
+        let temporary = observed
+            .into_inner()
+            .expect("seal observation mutex")
+            .expect("seal temporary captured");
+        assert!(!stable.exists());
+        assert_eq!(
+            std::fs::read(&temporary).expect("durable seal temporary"),
+            expected
+        );
+        let recovered = super::publish_compiled_bundle_stage_a_seal_under_guard(
+            guard,
+            &bundle.working_output,
+            &bundle.stage.marker_bytes,
+            &bundle.source_snapshot_kappa,
+        )
+        .expect("exact retry promotes the durable seal temporary");
+        assert_eq!(recovered, expected);
+        assert!(!temporary.exists());
+        assert_eq!(
+            std::fs::read(&stable).expect("recovered stable seal"),
+            expected
+        );
+        drop(authority);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_source_publish_refuses_missing_malformed_or_stale_stage_a_seal() {
+        for scenario in ["missing", "malformed", "stale-member"] {
+            let root = attention_provenance_test_dir(&format!("stage-a-seal-{scenario}"));
+            let mut bundle = compiled_source_bundle_publish_fixture(&root, scenario);
+            let final_output = bundle.final_output.clone();
+            let stage = bundle.working_output.clone();
+            let seal = stage.join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE);
+            match scenario {
+                "missing" => std::fs::remove_file(&seal).expect("remove seal"),
+                "malformed" => std::fs::write(&seal, b"{}\n").expect("malformed seal"),
+                "stale-member" => {
+                    std::fs::write(stage.join("tless_artifacts.bin"), b"post-seal mutation")
+                        .expect("mutate sealed member");
+                }
+                _ => unreachable!(),
+            }
+            let error = bundle
+                .publish()
+                .expect_err("nonexact Stage-A seal cannot authorize completion");
+            assert!(
+                error.contains("Stage-A")
+                    || error.contains("canonical")
+                    || error.contains("malformed")
+                    || error.contains("changed"),
+                "{scenario}: {error}"
+            );
+            assert!(!final_output.exists(), "{scenario}: final remains absent");
+            assert!(stage.exists(), "{scenario}: stage evidence is preserved");
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn persisted_exact_stage_a_seal_recovers_only_derived_outputs() {
+        let root = attention_provenance_test_dir("stage-a-seal-exact-recovery");
+        let mut bundle = compiled_source_bundle_publish_fixture(&root, "sealed-stage-a");
+        let stage = bundle.working_output.clone();
+        let expected_seal = std::fs::read(stage.join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE))
+            .expect("persisted exact Stage-A seal");
+        let expected_binding = std::fs::read(
+            stage.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        )
+        .expect("persisted Stage-A binding");
+        drop(
+            bundle
+                .stage_compile_authority
+                .take()
+                .expect("release crashed Stage-A producer"),
+        );
+
+        let (recovered, authority) =
+            super::CompiledBundleStage::allocate_with_selection_transaction(
+                &bundle.final_output,
+                &bundle.source_snapshot_kappa,
+                &bundle.selection_base,
+            )
+            .expect("exact sealed Stage A is the only resumable generation");
+        assert_eq!(recovered.path, stage);
+        assert_eq!(
+            std::fs::read(stage.join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE))
+                .expect("recovered seal"),
+            expected_seal
+        );
+        assert_eq!(
+            std::fs::read(
+                stage.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+            )
+            .expect("recovered binding"),
+            expected_binding
+        );
+        assert!(stage.join("tless_artifacts.bin").is_file());
+        assert!(stage
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+            .is_file());
+        assert!(!stage.join("graph").exists());
+        assert!(!stage.join("graph-cover").exists());
+        let busy =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &stage,
+            )
+            .expect_err("recovered Stage-A authority remains exclusive");
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+            "{busy}"
+        );
+        drop(authority);
+        drop(bundle);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persisted_missing_stage_a_seal_resets_to_owner_marker_for_rebuild() {
+        let root = attention_provenance_test_dir("stage-a-seal-missing-recovery");
+        let mut bundle = compiled_source_bundle_publish_fixture(&root, "missing-seal");
+        let stage = bundle.working_output.clone();
+        drop(
+            bundle
+                .stage_compile_authority
+                .take()
+                .expect("release crashed Stage-A producer"),
+        );
+        std::fs::remove_file(stage.join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE))
+            .expect("simulate crash before durable Stage-A seal");
+
+        let (recovered, authority) =
+            super::CompiledBundleStage::allocate_with_selection_transaction(
+                &bundle.final_output,
+                &bundle.source_snapshot_kappa,
+                &bundle.selection_base,
+            )
+            .expect("missing seal resets the private namespace for a full rebuild");
+        assert_eq!(recovered.path, stage);
+        assert!(stage
+            .join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE)
+            .is_file());
+        assert!(stage
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE)
+            .is_file());
+        for removed in [
+            super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE,
+            uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
+            "tless_artifacts.bin",
+            "corpus.meta",
+            "corpus.records",
+            "graph",
+            "graph-cover",
+        ] {
+            assert!(
+                !stage.join(removed).exists(),
+                "missing-seal recovery must reclaim {removed}"
+            );
+        }
+        drop(authority);
+        drop(bundle);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persisted_malformed_or_stale_stage_a_seal_is_terminal_without_reset() {
+        for scenario in ["malformed", "stale"] {
+            let root = attention_provenance_test_dir(&format!(
+                "stage-a-seal-recovery-terminal-{scenario}"
+            ));
+            let mut bundle = compiled_source_bundle_publish_fixture(&root, scenario);
+            let stage = bundle.working_output.clone();
+            drop(
+                bundle
+                    .stage_compile_authority
+                    .take()
+                    .expect("release crashed Stage-A producer"),
+            );
+            let seal = stage.join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE);
+            match scenario {
+                "malformed" => std::fs::write(&seal, b"{}\n").expect("malformed seal"),
+                "stale" => std::fs::write(stage.join("tless_artifacts.bin"), b"generation-b")
+                    .expect("post-seal fixed-member mutation"),
+                _ => unreachable!(),
+            }
+            let seal_before = std::fs::read(&seal).expect("terminal seal evidence");
+            let artifact_before =
+                std::fs::read(stage.join("tless_artifacts.bin")).expect("artifact evidence");
+
+            let error = super::CompiledBundleStage::allocate_with_selection_transaction(
+                &bundle.final_output,
+                &bundle.source_snapshot_kappa,
+                &bundle.selection_base,
+            )
+            .expect_err("malformed or stale seals never authorize a reset");
+            assert!(
+                error.contains("Stage-A")
+                    || error.contains("malformed")
+                    || error.contains("canonical"),
+                "{scenario}: {error}"
+            );
+            assert_eq!(std::fs::read(&seal).expect("seal preserved"), seal_before);
+            assert_eq!(
+                std::fs::read(stage.join("tless_artifacts.bin")).expect("artifact preserved"),
+                artifact_before
+            );
+            assert!(stage.join("graph").is_dir());
+            assert!(stage.join("graph-cover").is_dir());
+            drop(bundle);
+            let _ = std::fs::remove_dir_all(root);
+        }
     }
 
     #[test]
@@ -18728,8 +20590,16 @@ mod tests {
             )
             .expect("completion temp");
         }
-        let error = super::recover_compiled_bundle_completion_temporaries(&completion_root)
-            .expect_err("65 completion temporaries exceed the fixed registry bound");
+        let completion_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &completion_root,
+            )
+            .expect("completion namespace guard");
+        let error = super::recover_compiled_bundle_completion_temporaries(
+            &completion_guard,
+            &completion_root,
+        )
+        .expect_err("65 completion temporaries exceed the fixed registry bound");
         assert!(error.contains("fixed 64-entry"), "{error}");
         assert_eq!(
             std::fs::read_dir(&completion_root)
@@ -18880,6 +20750,11 @@ mod tests {
                 super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
             ),
             (
+                "compile-report",
+                "compile_report.json",
+                super::COMPILE_REPORT_CONTROL_MAX_BYTES,
+            ),
+            (
                 "dense",
                 uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
                 super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
@@ -18917,6 +20792,12 @@ mod tests {
                 "attention" => super::validate_pre_attention_identity_file(
                     &path,
                     uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+                )
+                .map(|_| ()),
+                "compile-report" => super::compiled_bundle_member_kappa(
+                    "compile_report.json",
+                    &path,
+                    "compiled report",
                 )
                 .map(|_| ()),
                 "dense" => super::validate_pre_attention_identity_file(
@@ -18989,7 +20870,11 @@ mod tests {
             write_completion_fixture(&output, case.as_bytes());
             make_completion_fixture_graph_outputs_valid(&output, case);
             let control = output.join(relative);
-            std::fs::remove_file(&control).expect("remove completed semantic control");
+            match std::fs::remove_file(&control) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => panic!("remove completed semantic control: {error}"),
+            }
             let file = std::fs::File::create(&control).expect("sparse completed control");
             file.set_len(1_u64 << 40)
                 .expect("1 TiB sparse completed semantic control");
@@ -19001,6 +20886,71 @@ mod tests {
             assert_eq!(
                 std::fs::metadata(&control)
                     .expect("sparse completed semantic control preserved")
+                    .len(),
+                1_u64 << 40
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_graph_controls_and_reports_are_capped_without_mutation() {
+        let root = attention_provenance_test_dir("legacy-graph-control-caps");
+        for leaf in ["attempt.json", "completion.json"] {
+            let path = root.join(leaf);
+            let file = std::fs::File::create(&path).expect("sparse legacy control");
+            file.set_len(1_u64 << 40)
+                .expect("1 TiB sparse legacy control");
+            drop(file);
+            let error = if leaf == "attempt.json" {
+                super::read_optional_legacy_graph_attempt(&path)
+                    .map(|_| ())
+                    .expect_err("legacy attempt cap rejects before allocation")
+            } else {
+                super::read_optional_legacy_graph_completion(&path)
+                    .map(|_| ())
+                    .expect_err("legacy completion cap rejects before allocation")
+            };
+            assert!(
+                error.contains(&super::COMPILED_BUNDLE_CONTROL_MAX_BYTES.to_string()),
+                "{error}"
+            );
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("sparse legacy control preserved")
+                    .len(),
+                1_u64 << 40
+            );
+        }
+
+        for (name, kind, max_bytes) in [
+            (
+                "cover",
+                super::GraphOutputKind::Cover,
+                super::COVER_REPORT_CONTROL_MAX_BYTES,
+            ),
+            (
+                "score",
+                super::GraphOutputKind::Score,
+                super::SCORE_REPORT_CONTROL_MAX_BYTES,
+            ),
+        ] {
+            let output = root.join(name);
+            std::fs::create_dir(&output).expect("legacy graph output");
+            let (artifact_name, report_name) = kind.files();
+            std::fs::write(output.join(artifact_name), minimal_r4g1_bytes())
+                .expect("valid legacy graph artifact");
+            let report = output.join(report_name);
+            let file = std::fs::File::create(&report).expect("sparse legacy report");
+            file.set_len(1_u64 << 40)
+                .expect("1 TiB sparse legacy report");
+            drop(file);
+            let error = super::validate_graph_output_directory(&output, kind)
+                .expect_err("legacy graph report cap rejects before allocation");
+            assert!(error.contains(&max_bytes.to_string()), "{error}");
+            assert_eq!(
+                std::fs::metadata(&report)
+                    .expect("sparse legacy report preserved")
                     .len(),
                 1_u64 << 40
             );
@@ -19178,13 +21128,13 @@ mod tests {
             std::fs::write(failed.path.join("graph/score.r4g1"), b"partial")
                 .expect("partial score residue");
             std::fs::write(failed.path.join("corpus.records"), b"advanced")
-                .expect("resumable corpus progress");
+                .expect("unsealed corpus drift");
             let error = super::publish_compiled_bundle_completion(&failed.path)
                 .expect_err("missing report/cover cannot complete");
             assert!(error.contains("incomplete"), "{error}");
             failed.path.clone()
         };
-        assert!(failed_path.exists(), "incomplete stage remains resumable");
+        assert!(failed_path.exists(), "incomplete stage remains recoverable");
         assert_eq!(
             std::fs::read(output.join("graph/score.r4g1")).expect("old graph preserved"),
             old_graph
@@ -19197,9 +21147,15 @@ mod tests {
         let mut replacement = super::CompiledBundleStage::allocate(&output, &source_kappa)
             .expect("replacement stage");
         assert_eq!(replacement.path, failed_path, "retry adopts exact stage");
+        let recovered_corpus =
+            std::fs::read(replacement.path.join("corpus.records")).expect("reconstructed corpus");
         assert_eq!(
-            std::fs::read(replacement.path.join("corpus.records")).expect("resumed corpus"),
-            b"advanced"
+            recovered_corpus, old_corpus,
+            "unsealed corpus drift is discarded and the authoritative last-good prefix is reconstructed"
+        );
+        assert_ne!(
+            recovered_corpus, b"advanced",
+            "unsealed corpus drift is never adopted"
         );
         assert!(
             !replacement.path.join("graph").exists(),
@@ -19287,6 +21243,70 @@ mod tests {
             marker
         );
         drop(producer);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovered_stage_revalidates_owner_and_temporaries_after_guard_acquisition() {
+        let root = attention_provenance_test_dir("compiled-stage-post-scan-swap");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&current, b"generation-a");
+        make_completion_fixture_graph_outputs_valid(&current, "generation-a");
+        let roots = [conventional, current.clone(), composite];
+        let selection = super::capture_compiled_bundle_selection_base(&roots, &current)
+            .expect("capture generation A selection");
+        let source_kappa = format!("blake3:{}", "5".repeat(64));
+        let (stage, session) = super::CompiledBundleStage::allocate_with_selection_transaction(
+            &current,
+            &source_kappa,
+            &selection,
+        )
+        .expect("initial private stage");
+        let stage_path = stage.path.clone();
+        drop(session);
+        std::fs::write(stage_path.join("compiled.r4g1"), b"preserve-before-guard")
+            .expect("derived residue sentinel");
+        let old_temp = stage_path.join(format!(
+            ".{}.81.1.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        let new_temp = stage_path.join(format!(
+            ".{}.81.2.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&old_temp, b"old temporary").expect("pre-scan temporary");
+
+        let error = super::CompiledBundleStage::allocate_with_selection_transaction_with_hooks(
+            &current,
+            &source_kappa,
+            &selection,
+            |scanned_stage| {
+                assert_eq!(scanned_stage, stage_path);
+                std::fs::remove_file(&old_temp).expect("replace pre-lock temporary set");
+                std::fs::write(&new_temp, b"new temporary").expect("post-scan temporary set");
+                std::fs::write(
+                    scanned_stage.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                    b"foreign owner after scan\n",
+                )
+                .expect("replace owner marker before common guard");
+                Ok(())
+            },
+            |_| Ok(()),
+        )
+        .expect_err("post-scan foreign owner is refused before stage mutation");
+        assert!(error.contains("owner marker"), "{error}");
+        assert_eq!(
+            std::fs::read(stage_path.join("compiled.r4g1")).expect("derived residue preserved"),
+            b"preserve-before-guard"
+        );
+        assert_eq!(
+            std::fs::read(&new_temp).expect("post-scan temporary preserved"),
+            b"new temporary"
+        );
+        assert!(!old_temp.exists());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -19522,8 +21542,8 @@ mod tests {
     }
 
     #[test]
-    fn managed_bundle_bootstraps_legacy_completion_and_pins_absent_precedence_roots() {
-        let root = attention_provenance_test_dir("managed-bootstrap-reader-pins");
+    fn managed_bundle_bootstraps_legacy_completion_and_holds_absent_precedence_roots() {
+        let root = attention_provenance_test_dir("managed-bootstrap-producer-set");
         let compiled = root.join("compiled");
         let current = compiled.join("teacher-attention-v2");
         let composite = compiled.join("teacher-attention-v2-dense-v2");
@@ -19554,18 +21574,20 @@ mod tests {
             uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
                 &composite,
             )
-            .expect_err("absent preferred root stays BUSY while serving pins are live");
+            .expect_err("absent preferred root stays BUSY while serving authority is live");
         assert!(
             uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
             "{busy}"
         );
-        read.pins.verify().expect("managed pins remain exact");
+        read.authority
+            .verify()
+            .expect("managed producer set remains exact");
         drop(read);
         let contender =
             uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
                 &composite,
             )
-            .expect("preferred-root writer proceeds after serving install releases pins");
+            .expect("preferred-root writer proceeds after serving install releases authority");
         drop(contender);
         let _ = std::fs::remove_dir_all(root);
     }
@@ -19802,7 +21824,7 @@ mod tests {
     #[test]
     fn compiled_source_publish_refuses_stage_b_in_each_lock_transition_gap() {
         for scenario in [
-            "reader-to-producer",
+            "retained-producer-busy",
             "producer-to-handoff",
             "marker-to-handoff",
         ] {
@@ -19811,10 +21833,15 @@ mod tests {
             let final_output = bundle.final_output.clone();
             let stage_path = bundle.working_output.clone();
             let error = match scenario {
-                "reader-to-producer" => bundle.publish_with_transition_hooks(
+                "retained-producer-busy" => bundle.publish_with_transition_hooks(
                     |stage| {
-                        advance_private_stage_generation(stage, b"stage-b-before-producer");
-                        Ok(())
+                        let busy = uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(stage)
+                            .expect_err("retained Stage-A producer excludes a cooperating Stage-B writer");
+                        assert!(
+                            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+                            "{busy}"
+                        );
+                        Err(format!("injected retained producer BUSY: {busy}"))
                     },
                     |_| Ok(()),
                 ),
@@ -19845,7 +21872,10 @@ mod tests {
                 _ => unreachable!(),
             }
             .expect_err("stage B is never promoted as stage A");
-            assert!(error.contains("changed"), "{scenario}: {error}");
+            assert!(
+                error.contains("changed") || error.contains("BUSY"),
+                "{scenario}: {error}"
+            );
             assert!(
                 !final_output.exists(),
                 "{scenario}: absent final remains absent"
@@ -19924,6 +21954,12 @@ mod tests {
             super::validate_compiled_bundle_completion(&final_output)
                 .expect("promoted completion validates")
                 .expect("promoted completion remains present");
+            assert!(
+                !final_output
+                    .join(super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE)
+                    .exists(),
+                "the private Stage-A ancestry seal is never a final bundle member"
+            );
             if let Some(final_before) = final_before {
                 let displaced = std::fs::metadata(&stage_path).expect("old final displaced");
                 assert!(
@@ -19951,7 +21987,7 @@ mod tests {
     }
 
     #[test]
-    fn serving_stage_reader_pin_blocks_cli_and_observation_writers() {
+    fn serving_stage_producer_authority_blocks_cli_and_observation_writers() {
         let root = attention_provenance_test_dir("serving-stage-pin-contention");
         let bundle = compiled_source_bundle_publish_fixture(&root, "pinned-stage");
         let stage = bundle.working_output.clone();
@@ -19959,14 +21995,16 @@ mod tests {
             uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
                 &stage,
             )
-            .expect_err("CLI/common producer is BUSY while serving stage pins are live");
+            .expect_err("CLI/common producer is BUSY while serving stage authority is live");
         assert!(
             uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
             "{busy}"
         );
         let observation =
             match uor_r4_graph_compiler::observation::ObservationSession::acquire(&stage, 1) {
-                Ok(_) => panic!("observation writer is BUSY while serving stage pins are live"),
+                Ok(_) => {
+                    panic!("observation writer is BUSY while serving stage authority is live")
+                }
                 Err(error) => error,
             };
         assert!(
@@ -19978,7 +22016,7 @@ mod tests {
             uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
                 &stage,
             )
-            .expect("supported writer proceeds after serving pins are released");
+            .expect("supported writer proceeds after serving authority is released");
         drop(producer);
         let _ = std::fs::remove_dir_all(root);
     }
@@ -20045,6 +22083,27 @@ mod tests {
         write_completion_fixture(&output, b"stable");
         super::publish_compiled_bundle_completion(&output).expect("publish stable completion");
         let stable = output.join(super::COMPILED_BUNDLE_COMPLETION_FILE);
+        let temp_only = output.join(format!(
+            ".{}.90.6.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        let expected = std::fs::read(&stable).expect("stable completion before temp-only crash");
+        std::fs::rename(&stable, &temp_only)
+            .expect("simulate crash after durable temporary before stable hard link");
+        let temp_only_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("temp-only completion recovery guard");
+        super::recover_compiled_bundle_completion_temporaries(&temp_only_guard, &output)
+            .expect("temp-only completion is promoted under exact bundle authority");
+        assert_eq!(
+            std::fs::read(&stable).expect("promoted stable completion"),
+            expected
+        );
+        assert!(!temp_only.exists());
+        drop(temp_only_guard);
+
         let temporary = output.join(format!(
             ".{}.91.7.tmp",
             super::COMPILED_BUNDLE_COMPLETION_FILE
@@ -20068,7 +22127,12 @@ mod tests {
         ));
         std::fs::write(&tampered, b"not the committed completion")
             .expect("write conflicting exact-name residue");
-        let error = super::recover_compiled_bundle_completion_temporaries(&output)
+        let output_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("completion conflict guard");
+        let error = super::recover_compiled_bundle_completion_temporaries(&output_guard, &output)
             .expect_err("conflicting regular residue is terminal");
         assert!(error.contains("conflicting"), "{error}");
         assert_eq!(
@@ -20081,8 +22145,9 @@ mod tests {
             use std::os::unix::fs::symlink;
             std::fs::remove_file(&tampered).expect("remove regular conflict fixture");
             symlink(&stable, &tampered).expect("exact-byte symlink residue");
-            let error = super::recover_compiled_bundle_completion_temporaries(&output)
-                .expect_err("symlink residue is terminal without following");
+            let error =
+                super::recover_compiled_bundle_completion_temporaries(&output_guard, &output)
+                    .expect_err("symlink residue is terminal without following");
             assert!(error.contains("not a regular non-symlink"), "{error}");
             assert!(std::fs::symlink_metadata(&tampered).is_ok());
         }
@@ -21433,6 +23498,358 @@ mod tests {
         let error = super::required_r4g1_inputs_present(&graph, &teacher)
             .expect_err("present teacher with absent graph is terminal");
         assert!(error.contains("graph"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_custom_graph_capture_never_infers_or_seeds_a_broad_bundle_root() {
+        let root = attention_provenance_test_dir("explicit-custom-graph-authority");
+        std::fs::create_dir_all(root.join("container/custom")).expect("custom graph parent");
+        let teacher = root.join("teacher.bin");
+        std::fs::write(&teacher, b"standalone teacher").expect("standalone teacher bytes");
+
+        let shallow = root.join("score.r4g1");
+        std::fs::write(&shallow, b"shallow standalone graph")
+            .expect("shallow standalone graph bytes");
+        assert_eq!(
+            super::startup_read_session_subjects(Some(&shallow), &teacher, false),
+            vec![std::path::PathBuf::from(".uor-models/sources")],
+            "explicit artifact startup must not lock a graph or teacher ancestor"
+        );
+        assert_eq!(
+            super::canonical_explicit_graph_bundle_root(&shallow)
+                .expect("shallow explicit classification"),
+            None
+        );
+        let captured = super::capture_standalone_explicit_graph(&shallow, &teacher)
+            .expect("shallow explicit graph is captured from exact handles");
+        assert_eq!(captured.graph, b"shallow standalone graph");
+        assert_eq!(captured.signature_artifact, b"standalone teacher");
+
+        let custom = root.join("container/custom/score.r4g1");
+        std::fs::write(&custom, b"custom standalone graph").expect("custom standalone graph bytes");
+        assert_eq!(
+            super::canonical_explicit_graph_bundle_root(&custom)
+                .expect("custom explicit classification"),
+            None
+        );
+        let captured = super::capture_standalone_explicit_graph(&custom, &teacher)
+            .expect("custom explicit graph is captured from exact handles");
+        assert_eq!(captured.graph, b"custom standalone graph");
+        assert!(
+            !root
+                .join(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR
+                )
+                .exists(),
+            "standalone capture must not seed coordination for an inferred grandparent"
+        );
+
+        let bundle = root.join("bundle");
+        let canonical = bundle.join("graph/score.r4g1");
+        std::fs::create_dir_all(canonical.parent().expect("canonical graph parent"))
+            .expect("canonical graph directory");
+        std::fs::write(&canonical, b"canonical graph").expect("canonical graph bytes");
+        std::fs::write(bundle.join("tless_artifacts.bin"), b"bundle teacher")
+            .expect("canonical bundle teacher evidence");
+        std::fs::write(bundle.join("corpus.meta"), b"bundle corpus evidence")
+            .expect("canonical bundle corpus evidence");
+        assert_eq!(
+            super::canonical_explicit_graph_bundle_root(&canonical)
+                .expect("canonical explicit classification"),
+            None,
+            "legacy-looking canonical paths stay on the standalone exact-handle lane"
+        );
+        assert!(
+            !root
+                .join(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR
+                )
+                .exists(),
+            "read-only classification itself never mutates coordination"
+        );
+
+        write_completion_fixture(&bundle, b"completed-explicit");
+        make_completion_fixture_graph_outputs_valid(&bundle, "completed-explicit");
+        let canonical_root = std::fs::canonicalize(&bundle).expect("canonical bundle root");
+        assert_eq!(
+            super::canonical_explicit_graph_bundle_root(&canonical)
+                .expect("completed canonical explicit classification"),
+            Some(canonical_root.clone())
+        );
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &canonical_root,
+            )
+            .expect("completed explicit bundle authority");
+        let captured = super::capture_completed_explicit_graph_under_guard(
+            &guard,
+            &canonical_root,
+            &canonical,
+            &bundle.join("tless_artifacts.bin"),
+        )
+        .expect("stable completion validates before canonical capture");
+        assert_eq!(captured.graph, minimal_r4g1_bytes());
+        drop(guard);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_completion_temp_classification_is_name_only_and_inner_busy_is_transient() {
+        let root = attention_provenance_test_dir("explicit-completion-temp-barriers");
+        let bundle = root.join("bundle");
+        let graph = bundle.join("graph/score.r4g1");
+        std::fs::create_dir_all(graph.parent().expect("graph parent"))
+            .expect("canonical graph parent");
+        std::fs::write(&graph, b"temp-only graph").expect("temp-only graph bytes");
+        let teacher = bundle.join("tless_artifacts.bin");
+        std::fs::write(&teacher, b"temp-only teacher").expect("temp-only teacher bytes");
+        let temporary = bundle.join(format!(
+            ".{}.41.43.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&temporary, b"body must not be read before authority")
+            .expect("completion temporary");
+        let canonical_bundle = std::fs::canonicalize(&bundle).expect("canonical bundle");
+
+        let error = match super::capture_explicit_graph_startup_authority_with_after_classification(
+            &graph,
+            &teacher,
+            |classified| {
+                assert_eq!(classified, Some(canonical_bundle.as_path()));
+                std::fs::remove_file(&temporary)
+                    .expect("cooperating publisher removes temp after name classification");
+                Ok(())
+            },
+        ) {
+            Ok(_) => panic!("disappeared temp cannot silently fall back to standalone capture"),
+            Err(error) => error,
+        };
+        assert!(
+            error.contains("no stable validated compiled-bundle completion"),
+            "{error}"
+        );
+        assert_eq!(
+            std::fs::read(&graph).expect("graph preserved after disappearance"),
+            b"temp-only graph"
+        );
+
+        let reserved = bundle.join(format!(
+            ".{}.reserved.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::write(&reserved, b"reserved active publisher evidence")
+            .expect("reserved completion temporary");
+        let writer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &bundle,
+            )
+            .expect("active bundle publisher");
+        let error = match super::capture_explicit_graph_startup_authority(&graph, &teacher) {
+            Ok(_) => panic!("active common producer must defer explicit startup"),
+            Err(error) => error,
+        };
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert_eq!(
+            std::fs::read(&reserved).expect("active publisher evidence preserved"),
+            b"reserved active publisher evidence"
+        );
+        drop(writer);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_canonical_graph_refuses_private_owner_or_seal_without_mutation() {
+        let root = attention_provenance_test_dir("explicit-private-stage-owner");
+        let compiled = root.join("compiled");
+        let final_output = compiled.join("teacher");
+        let stage = compiled
+            .join(super::SOURCE_COMPILE_STAGING_DIR)
+            .join(".teacher.bundle-stage.17.19");
+        let graph = stage.join("graph/score.r4g1");
+        std::fs::create_dir_all(graph.parent().expect("private graph parent"))
+            .expect("private graph parent");
+        std::fs::write(&graph, b"unpublished graph").expect("private graph bytes");
+        let teacher = stage.join("tless_artifacts.bin");
+        std::fs::write(&teacher, b"unpublished teacher").expect("private teacher bytes");
+        let marker = fixture_stage_marker_bytes(&final_output, &stage);
+        std::fs::write(
+            stage.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE),
+            &marker,
+        )
+        .expect("canonical private owner marker");
+        let canonical_stage = super::canonical_explicit_graph_bundle_root(&graph)
+            .expect("private topology classification")
+            .expect("owner evidence selects exact guarded classification");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &canonical_stage,
+            )
+            .expect("private-stage authority");
+        let error = match super::capture_completed_explicit_graph_under_guard(
+            &guard,
+            &canonical_stage,
+            &graph,
+            &teacher,
+        ) {
+            Ok(_) => panic!("private stage cannot become an explicit public bundle"),
+            Err(error) => error,
+        };
+        assert!(error.contains("unpublished private"), "{error}");
+        assert_eq!(
+            std::fs::read(stage.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE))
+                .expect("private marker preserved"),
+            marker
+        );
+        drop(guard);
+        let _ = std::fs::remove_dir_all(root);
+
+        for owner_leaf in [
+            super::COMPILED_BUNDLE_STAGE_MARKER_FILE,
+            super::COMPILED_BUNDLE_STAGE_A_SEAL_FILE,
+        ] {
+            let root = attention_provenance_test_dir(&format!(
+                "explicit-final-owner-only-{}",
+                owner_leaf.replace('.', "-")
+            ));
+            let bundle = root.join("bundle");
+            let graph = bundle.join("graph/score.r4g1");
+            std::fs::create_dir_all(graph.parent().expect("graph parent"))
+                .expect("owner-only graph parent");
+            std::fs::write(&graph, b"owner-only graph").expect("owner-only graph bytes");
+            let teacher = bundle.join("tless_artifacts.bin");
+            std::fs::write(&teacher, b"owner-only teacher").expect("owner-only teacher bytes");
+            let owner = bundle.join(owner_leaf);
+            let bytes = if owner_leaf == super::COMPILED_BUNDLE_STAGE_MARKER_FILE {
+                fixture_stage_marker_bytes(
+                    &bundle,
+                    &root
+                        .join(super::SOURCE_COMPILE_STAGING_DIR)
+                        .join(".bundle.bundle-stage.23.29"),
+                )
+            } else {
+                b"malformed private Stage-A seal\n".to_vec()
+            };
+            std::fs::write(&owner, &bytes).expect("owner-only control record");
+            let canonical_root = super::canonical_explicit_graph_bundle_root(&graph)
+                .expect("owner-only topology classification")
+                .expect("owner evidence selects exact guarded classification");
+            let guard =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    &canonical_root,
+                )
+                .expect("owner-only bundle authority");
+            let error = match super::capture_completed_explicit_graph_under_guard(
+                &guard,
+                &canonical_root,
+                &graph,
+                &teacher,
+            ) {
+                Ok(_) => panic!("owner-only root cannot become an explicit completed bundle"),
+                Err(error) => error,
+            };
+            assert!(
+                error.contains("no stable validated compiled-bundle completion")
+                    || error.contains("malformed"),
+                "{error}"
+            );
+            assert_eq!(std::fs::read(&owner).expect("owner preserved"), bytes);
+            drop(guard);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn explicit_completed_graph_recovers_post_promotion_owner_marker_before_capture() {
+        let root = attention_provenance_test_dir("explicit-promoted-marker-restart");
+        let bundle = root.join("bundle");
+        write_completion_fixture(&bundle, b"completed-explicit-marker");
+        make_completion_fixture_graph_outputs_valid(&bundle, "completed-explicit-marker");
+        let graph = bundle.join("graph/score.r4g1");
+        let teacher = bundle.join("tless_artifacts.bin");
+        let stage_path = root
+            .join(super::SOURCE_COMPILE_STAGING_DIR)
+            .join(".bundle.bundle-stage.31.37");
+        let marker = fixture_stage_marker_bytes(&bundle, &stage_path);
+        std::fs::write(
+            bundle.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE),
+            &marker,
+        )
+        .expect("post-promotion marker crash residue");
+        let completion_before = std::fs::read(bundle.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("completion before restart");
+        let canonical_root = super::canonical_explicit_graph_bundle_root(&graph)
+            .expect("promoted residue classification")
+            .expect("completion/marker selects exact bundle authority");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &canonical_root,
+            )
+            .expect("restart bundle authority");
+        let captured = super::capture_completed_explicit_graph_under_guard(
+            &guard,
+            &canonical_root,
+            &graph,
+            &teacher,
+        )
+        .expect("completed promoted marker residue is cleaned before capture");
+        assert_eq!(captured.graph, minimal_r4g1_bytes());
+        assert!(
+            !bundle
+                .join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE)
+                .exists(),
+            "guarded restart removes only the exact published marker residue"
+        );
+        assert_eq!(
+            std::fs::read(bundle.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                .expect("completion after restart"),
+            completion_before
+        );
+        drop(guard);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_completed_graph_refuses_member_mismatch_before_capture_without_mutation() {
+        let root = attention_provenance_test_dir("explicit-completion-member-mismatch");
+        let bundle = root.join("bundle");
+        write_completion_fixture(&bundle, b"completed-explicit");
+        make_completion_fixture_graph_outputs_valid(&bundle, "completed-explicit");
+        let graph = bundle.join("graph/score.r4g1");
+        let teacher = bundle.join("tless_artifacts.bin");
+        std::fs::write(&graph, b"post-completion graph mutation")
+            .expect("mutate a completion-bound member");
+        let completion = bundle.join(super::COMPILED_BUNDLE_COMPLETION_FILE);
+        let completion_before = std::fs::read(&completion).expect("completion before refusal");
+        let graph_before = std::fs::read(&graph).expect("graph before refusal");
+        let canonical_root = super::canonical_explicit_graph_bundle_root(&graph)
+            .expect("canonical topology classification")
+            .expect("stable completion selects bundle authority");
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &canonical_root,
+            )
+            .expect("explicit bundle guard");
+
+        let error = match super::capture_completed_explicit_graph_under_guard(
+            &guard,
+            &canonical_root,
+            &graph,
+            &teacher,
+        ) {
+            Ok(_) => panic!("completion/member mismatch is terminal before capture/load"),
+            Err(error) => error,
+        };
+        assert!(error.contains("changed after"), "{error}");
+        assert_eq!(
+            std::fs::read(&completion).expect("completion preserved"),
+            completion_before
+        );
+        assert_eq!(
+            std::fs::read(&graph).expect("graph preserved"),
+            graph_before
+        );
+        drop(guard);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -696,9 +696,11 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     let (startup_read_sessions, r4g1_discovery_allowed) = match startup_sessions {
         Ok(sessions) => {
             let recovery = if cli.r4g1_artifact.is_none() {
-                recover_managed_compiled_bundle_completion_temporaries(Path::new(
-                    ".uor-models/compiled",
-                ))
+                // Managed roots are recovered one selected logical trio at a
+                // time under the lower common producer authority immediately
+                // before their reader pins are acquired. The inventory outer
+                // lock alone is not publication authority.
+                Ok(())
             } else {
                 configured_graph
                     .as_deref()
@@ -740,6 +742,7 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                     graph,
                     PathBuf::from(&cli.tless_artifacts),
                     None::<ResolvedCompiledBundle>,
+                    None::<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins>,
                 )]
             })
             .unwrap_or_default()
@@ -750,61 +753,103 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         let mut discovery_valid = true;
         let mut configured_external = false;
         let mut configured_managed_logical = None;
-        match current_source_attention_era_version().and_then(|version| {
-            resolve_managed_teacher_bundle_in(
+        let current_version = match current_source_attention_era_version() {
+            Ok(version) => version,
+            Err(error) => {
+                set_r4g1_terminal_load_error(&serving, error);
+                r4g1_candidates.clear();
+                discovery_valid = false;
+                0
+            }
+        };
+        if discovery_valid {
+            match classify_managed_teacher_logical_name_in(
                 Path::new(&cli.tless_artifacts),
                 Path::new(".uor-models"),
-                version,
-            )
-        }) {
-            Ok(ConfiguredManagedBundle::Selected(candidate)) => {
-                let candidate = *candidate;
-                configured_managed_logical = Some(candidate.logical_name.clone());
-                r4g1_candidates = vec![(
-                    candidate.graph.clone(),
-                    candidate.teacher.clone(),
-                    Some(candidate),
-                )];
-            }
-            Ok(external @ ConfiguredManagedBundle::External) => {
-                configured_external = true;
-                discovery_valid = external.permits_inventory_discovery();
-            }
-            Ok(ConfiguredManagedBundle::Absent) => {
-                // A configured managed path selects one logical model even
-                // when that model is absent. Do not silently boot an
-                // unrelated bundle discovered elsewhere in the inventory.
-                r4g1_candidates.clear();
-                discovery_valid = ConfiguredManagedBundle::Absent.permits_inventory_discovery();
-            }
-            Ok(ConfiguredManagedBundle::Incomplete(error)) => {
-                println!("[-] Refusing incomplete configured managed R4G1 bundle: {error}");
-                set_r4g1_terminal_load_error(&serving, error);
-                r4g1_candidates.clear();
-                discovery_valid = false;
-            }
-            Err(error) => {
-                println!("[-] Refusing configured managed R4G1 bundle: {error}");
-                set_r4g1_terminal_load_error(&serving, error);
-                r4g1_candidates.clear();
-                discovery_valid = false;
+                current_version,
+            ) {
+                Ok(Some(logical_name)) => {
+                    configured_managed_logical = Some(logical_name.clone());
+                    match acquire_managed_compiled_bundle_read(
+                        Path::new(".uor-models/compiled"),
+                        &logical_name,
+                        current_version,
+                    ) {
+                        Ok(ManagedCompiledBundleRead {
+                            resolved: Some(candidate),
+                            pins,
+                        }) => {
+                            r4g1_candidates = vec![(
+                                candidate.graph.clone(),
+                                candidate.teacher.clone(),
+                                Some(candidate),
+                                Some(pins),
+                            )];
+                        }
+                        Ok(ManagedCompiledBundleRead { resolved: None, .. }) => {
+                            // A configured managed path selects one logical model
+                            // even when absent. Never fall through to an unrelated
+                            // inventory candidate.
+                            r4g1_candidates.clear();
+                            discovery_valid = false;
+                        }
+                        Err(error) if source_compile_session_is_busy(&error) => {
+                            println!(
+                            "[-] Deferring configured managed R4G1 startup while common publication is busy: {error}"
+                        );
+                            r4g1_candidates.clear();
+                            discovery_valid = false;
+                        }
+                        Err(error) => {
+                            println!("[-] Refusing configured managed R4G1 bundle: {error}");
+                            set_r4g1_terminal_load_error(&serving, error);
+                            r4g1_candidates.clear();
+                            discovery_valid = false;
+                        }
+                    }
+                }
+                Ok(None) => {
+                    configured_external = true;
+                }
+                Err(error) if source_compile_session_is_busy(&error) => {
+                    println!(
+                    "[-] Deferring configured managed R4G1 startup while common publication is busy: {error}"
+                );
+                    r4g1_candidates.clear();
+                    discovery_valid = false;
+                }
+                Err(error) => {
+                    println!("[-] Refusing configured managed R4G1 bundle: {error}");
+                    set_r4g1_terminal_load_error(&serving, error);
+                    r4g1_candidates.clear();
+                    discovery_valid = false;
+                }
             }
         }
-        if discovery_valid {
-            match discover_compiled_r4g1_candidates() {
-                Ok(candidates) => {
-                    for candidate in candidates {
-                        if configured_managed_logical.as_deref()
-                            == Some(candidate.logical_name.as_str())
-                        {
+        if discovery_valid && !configured_external {
+            match discover_managed_compiled_reads_in(
+                Path::new(".uor-models/compiled"),
+                current_version,
+                configured_managed_logical.as_deref(),
+            ) {
+                Ok(reads) => {
+                    for ManagedCompiledBundleRead { resolved, pins } in reads {
+                        let Some(candidate) = resolved else {
                             continue;
-                        }
+                        };
                         r4g1_candidates.push((
                             candidate.graph.clone(),
                             candidate.teacher.clone(),
                             Some(candidate),
+                            Some(pins),
                         ));
                     }
+                }
+                Err(error) if source_compile_session_is_busy(&error) => {
+                    println!(
+                        "[-] Deferring compiled R4G1 discovery while common publication is busy: {error}"
+                    );
+                    r4g1_candidates.clear();
                 }
                 Err(error) => {
                     println!("[-] Refusing compiled R4G1 discovery: {error}");
@@ -821,7 +866,60 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         }
     }
     let mut loaded_r4g1 = false;
-    for (graph_path, teacher_path, resolved) in r4g1_candidates {
+    for (mut graph_path, mut teacher_path, mut resolved, mut managed_read_pins) in r4g1_candidates {
+        if managed_read_pins.is_none() {
+            if let Some(candidate) = resolved.as_ref() {
+                let Some(compiled_root) = candidate.physical_root.parent() else {
+                    let error = format!(
+                        "managed bundle {} has no compiled-model parent",
+                        candidate.physical_root.display()
+                    );
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                };
+                let managed_current_version = match current_source_attention_era_version() {
+                    Ok(version) => version,
+                    Err(error) => {
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
+                    }
+                };
+                let read = match acquire_managed_compiled_bundle_read(
+                    compiled_root,
+                    &candidate.logical_name,
+                    managed_current_version,
+                ) {
+                    Ok(read) => read,
+                    Err(error) if source_compile_session_is_busy(&error) => {
+                        println!(
+                        "[-] Deferring R4G1 startup while common bundle publication is busy: {error}"
+                    );
+                        break;
+                    }
+                    Err(error) => {
+                        println!("[-] Refusing managed R4G1 startup transaction: {error}");
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
+                    }
+                };
+                let ManagedCompiledBundleRead {
+                    resolved: refreshed,
+                    pins,
+                } = read;
+                let Some(refreshed) = refreshed else {
+                    let error = format!(
+                        "managed model {} disappeared before startup loading",
+                        candidate.logical_name
+                    );
+                    set_r4g1_terminal_load_error(&serving, error);
+                    break;
+                };
+                graph_path = refreshed.graph.clone();
+                teacher_path = refreshed.teacher.clone();
+                resolved = Some(refreshed);
+                managed_read_pins = Some(pins);
+            }
+        }
         if let Err(error) = validate_legacy_graph_generation_for_serving(&graph_path) {
             println!(
                 "[-] Refusing incomplete or changed legacy R4G1 generation {}: {error}",
@@ -840,25 +938,6 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         };
         if !inputs_present {
             continue;
-        }
-        if let Some(bundle) = resolved.as_ref() {
-            let current_version = match current_source_attention_era_version() {
-                Ok(version) => version,
-                Err(error) => {
-                    set_r4g1_terminal_load_error(&serving, error);
-                    break;
-                }
-            };
-            if let Err(error) =
-                ensure_compiled_bundle_completion_for_serving(bundle, current_version)
-            {
-                println!(
-                    "[-] Refusing R4G1 graph {} because its bundle completion is invalid: {error}",
-                    graph_path.display()
-                );
-                set_r4g1_terminal_load_error(&serving, error);
-                break;
-            }
         }
         let resolved_source = match resolved.as_ref() {
             Some(bundle) => match source_for_resolved_bundle_in(bundle, Path::new(".uor-models")) {
@@ -979,19 +1058,27 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                     println!("[-] {message}");
                 }
                 let refreshed = match resolved.as_ref() {
-                    Some(candidate) => match current_source_attention_era_version()
-                        .and_then(|version| refresh_resolved_compiled_bundle(candidate, version))
-                    {
-                        Ok(refreshed) => Some(refreshed),
-                        Err(error) => {
-                            println!(
-                                "[-] Refusing R4G1 graph {} after provenance re-check: {error}",
-                                graph_path.display()
-                            );
-                            set_r4g1_terminal_load_error(&serving, error);
-                            break;
+                    Some(candidate) => {
+                        match current_source_attention_era_version().and_then(|version| {
+                            refresh_resolved_compiled_bundle_with_authority(
+                                candidate,
+                                version,
+                                managed_read_pins
+                                    .as_ref()
+                                    .map(RecordedCorpusReadAuthority::ReaderPins),
+                            )
+                        }) {
+                            Ok(refreshed) => Some(refreshed),
+                            Err(error) => {
+                                println!(
+                                    "[-] Refusing R4G1 graph {} after provenance re-check: {error}",
+                                    graph_path.display()
+                                );
+                                set_r4g1_terminal_load_error(&serving, error);
+                                break;
+                            }
                         }
-                    },
+                    }
                     None => None,
                 };
                 println!(
@@ -1051,6 +1138,17 @@ pub fn run_server(cli: Arc<ServerConfig>) {
                             set_r4g1_terminal_load_error(&serving, error);
                             break;
                         }
+                    }
+                }
+                if let Some(pins) = managed_read_pins.as_ref() {
+                    if let Err(error) = pins.verify() {
+                        let error = error.to_string();
+                        println!(
+                            "[-] Refusing R4G1 graph {} after final managed-root re-check: {error}",
+                            graph_path.display()
+                        );
+                        set_r4g1_terminal_load_error(&serving, error);
+                        break;
                     }
                 }
                 let mut installed = serving.lock().unwrap();
@@ -1542,7 +1640,7 @@ fn inspect_compiled_root(
     }
     if resolver_owned_dense_root
         && dense_operator.is_none()
-        && source_compile_pre_attention_prefix(root)?
+        && !source_compile_output_has_payload(root)?
     {
         return Ok(CompiledRootState::PreDenseIdentity(Box::new(operator)));
     }
@@ -1791,7 +1889,12 @@ type CoverProvenance = (
 );
 
 fn parse_cover_provenance(report_path: &Path) -> Result<CoverProvenance, String> {
-    let Some(bytes) = read_regular_file_nofollow(report_path, "cover report")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        report_path,
+        "cover report",
+        COVER_REPORT_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok((false, None, None, None));
     };
     let projection: CoverProvenanceProjection = serde_json::from_slice(&bytes)
@@ -1855,11 +1958,18 @@ fn parse_cover_provenance(report_path: &Path) -> Result<CoverProvenance, String>
 /// v1 bundles remain readable when those supporting records are genuinely
 /// absent. R4G1 graph-byte provenance itself remains the separate #637 PROV
 /// contract, so this check deliberately makes no stronger claim.
-fn validate_serving_attention_provenance(
+#[derive(Clone, Copy)]
+enum RecordedCorpusReadAuthority<'a> {
+    Producer(&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard),
+    ReaderPins(&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins),
+}
+
+fn validate_serving_attention_provenance_with_authority(
     bundle: &Path,
     expected: &AttentionOperatorSpec,
     expected_dense: Option<&DenseOperatorSpec>,
     current_version: u32,
+    authority: Option<RecordedCorpusReadAuthority<'_>>,
 ) -> Result<Option<String>, String> {
     // New server-published generations carry a digest-complete transaction
     // record. Its presence is authoritative; no caller may silently fall
@@ -1870,10 +1980,22 @@ fn validate_serving_attention_provenance(
     let meta_present = regular_file_presence(&meta)?;
     let records_present = regular_file_presence(&records)?;
     let recorded_execution = match (meta_present, records_present) {
-        (true, true) => Some(
-            uor_r4_graph_cli::recorded_corpus_execution_identity(&meta, &records)
+        (true, true) => Some(match authority {
+            Some(RecordedCorpusReadAuthority::Producer(guard)) => {
+                uor_r4_graph_compiler::recorded_corpus::execution_identity_under_producer_guard(
+                    guard, &meta, &records,
+                )
+                .map_err(|error| error.to_string())?
+            }
+            Some(RecordedCorpusReadAuthority::ReaderPins(pins)) => {
+                uor_r4_graph_compiler::recorded_corpus::execution_identity_under_reader_pins(
+                    pins, &meta, &records,
+                )
+                .map_err(|error| error.to_string())?
+            }
+            None => uor_r4_graph_compiler::recorded_corpus::execution_identity(&meta, &records)
                 .map_err(|error| error.to_string())?,
-        ),
+        }),
         (false, false) if expected.version < current_version => None,
         (false, false) => {
             return Err(format!(
@@ -1994,9 +2116,10 @@ fn validate_resolved_source_snapshot_binding(
     Ok(())
 }
 
-fn resolve_loadable_compiled_bundle(
+fn resolve_loadable_compiled_bundle_with_authority(
     pair: &CompiledModelPair,
     current_version: u32,
+    authority: Option<RecordedCorpusReadAuthority<'_>>,
 ) -> Result<Option<ResolvedCompiledBundle>, String> {
     if matches!(
         pair.composite,
@@ -2044,11 +2167,12 @@ fn resolve_loadable_compiled_bundle(
             teacher.display()
         ));
     }
-    let source_manifest_kappa = validate_serving_attention_provenance(
+    let source_manifest_kappa = validate_serving_attention_provenance_with_authority(
         physical_root,
         &identity.attention,
         identity.dense.as_ref(),
         current_version,
+        authority,
     )?;
     Ok(Some(ResolvedCompiledBundle {
         logical_name: pair.logical_name.clone(),
@@ -2061,6 +2185,15 @@ fn resolve_loadable_compiled_bundle(
     }))
 }
 
+#[cfg(test)]
+fn resolve_loadable_compiled_bundle(
+    pair: &CompiledModelPair,
+    current_version: u32,
+) -> Result<Option<ResolvedCompiledBundle>, String> {
+    resolve_loadable_compiled_bundle_with_authority(pair, current_version, None)
+}
+
+#[cfg(test)]
 fn resolve_requested_compiled_bundle_in(
     models_root: &Path,
     requested: &str,
@@ -2103,6 +2236,7 @@ fn reject_requested_suffix_source_collision(
     }
 }
 
+#[cfg(test)]
 #[derive(Debug, PartialEq, Eq)]
 enum ConfiguredManagedBundle {
     External,
@@ -2111,6 +2245,7 @@ enum ConfiguredManagedBundle {
     Selected(Box<ResolvedCompiledBundle>),
 }
 
+#[cfg(test)]
 impl ConfiguredManagedBundle {
     fn permits_inventory_discovery(&self) -> bool {
         matches!(self, Self::External | Self::Selected(_))
@@ -2143,16 +2278,16 @@ fn normalized_absolute_path(path: &Path) -> Result<PathBuf, String> {
 /// are classified by their canonical target so a symlink alias cannot bypass
 /// the paired-era resolver. Lexical normalization is used only when the target
 /// is genuinely absent and therefore cannot be canonicalized.
-fn resolve_managed_teacher_bundle_in(
+fn classify_managed_teacher_logical_name_in(
     teacher_path: &Path,
     models_root: &Path,
     current_version: u32,
-) -> Result<ConfiguredManagedBundle, String> {
+) -> Result<Option<String>, String> {
     if teacher_path.file_name() != Some(std::ffi::OsStr::new("tless_artifacts.bin")) {
-        return Ok(ConfiguredManagedBundle::External);
+        return Ok(None);
     }
     let Some(physical_root) = teacher_path.parent() else {
-        return Ok(ConfiguredManagedBundle::External);
+        return Ok(None);
     };
     let compiled_root = models_root.join("compiled");
     let normalized_compiled_root = normalized_absolute_path(&compiled_root)?;
@@ -2191,7 +2326,7 @@ fn resolve_managed_teacher_bundle_in(
                     compiled_root.display()
                 ));
             }
-            return Ok(ConfiguredManagedBundle::External);
+            return Ok(None);
         }
         let canonical_compiled = fs::canonicalize(&compiled_root).map_err(|error| {
             format!(
@@ -2237,11 +2372,11 @@ fn resolve_managed_teacher_bundle_in(
                     compiled_root.display()
                 ));
             } else {
-                return Ok(ConfiguredManagedBundle::External);
+                return Ok(None);
             }
         }
     } else if !lexical_managed {
-        return Ok(ConfiguredManagedBundle::External);
+        return Ok(None);
     }
 
     let physical_name = classified_root
@@ -2254,6 +2389,21 @@ fn resolve_managed_teacher_bundle_in(
             )
         })?;
     let logical_name = logical_model_name_for_request(physical_name, current_version)?;
+    Ok(Some(logical_name))
+}
+
+#[cfg(test)]
+fn resolve_managed_teacher_bundle_in(
+    teacher_path: &Path,
+    models_root: &Path,
+    current_version: u32,
+) -> Result<ConfiguredManagedBundle, String> {
+    let Some(logical_name) =
+        classify_managed_teacher_logical_name_in(teacher_path, models_root, current_version)?
+    else {
+        return Ok(ConfiguredManagedBundle::External);
+    };
+    let compiled_root = models_root.join("compiled");
     let pair = inspect_compiled_model_pair(&compiled_root, &logical_name, current_version)?;
     if matches!(
         pair.composite,
@@ -2428,6 +2578,7 @@ fn active_models(state: &ServingModelState) -> Vec<(String, u64)> {
     vec![(name, created)]
 }
 
+#[cfg(test)]
 fn resolve_reload_bundle_in(
     models_root: &Path,
     requested: &str,
@@ -2442,9 +2593,10 @@ fn resolve_reload_bundle_in(
     Ok(Some((bundle, source)))
 }
 
-fn refresh_resolved_compiled_bundle(
+fn refresh_resolved_compiled_bundle_with_authority(
     resolved: &ResolvedCompiledBundle,
     current_version: u32,
+    authority: Option<RecordedCorpusReadAuthority<'_>>,
 ) -> Result<ResolvedCompiledBundle, String> {
     let compiled_root = resolved.physical_root.parent().ok_or_else(|| {
         format!(
@@ -2453,12 +2605,14 @@ fn refresh_resolved_compiled_bundle(
         )
     })?;
     let pair = inspect_compiled_model_pair(compiled_root, &resolved.logical_name, current_version)?;
-    let refreshed = resolve_loadable_compiled_bundle(&pair, current_version)?.ok_or_else(|| {
-        format!(
-            "resolved compiled bundle {} disappeared before installation",
-            resolved.physical_root.display()
-        )
-    })?;
+    let refreshed =
+        resolve_loadable_compiled_bundle_with_authority(&pair, current_version, authority)?
+            .ok_or_else(|| {
+                format!(
+                    "resolved compiled bundle {} disappeared before installation",
+                    resolved.physical_root.display()
+                )
+            })?;
     if &refreshed != resolved {
         return Err(format!(
             "compiled model {} changed between resolution and installation",
@@ -2472,13 +2626,6 @@ fn refresh_resolved_compiled_bundle(
 /// explicit `--r4g1-artifact`. Every immediate entry is part of a logical
 /// pair: non-directories/symlinks and invalid siblings are terminal, while a
 /// valid current-era root wins over its historical sibling deterministically.
-fn discover_compiled_r4g1_candidates() -> Result<Vec<ResolvedCompiledBundle>, String> {
-    discover_compiled_r4g1_candidates_in(
-        Path::new(".uor-models/compiled"),
-        current_source_attention_era_version()?,
-    )
-}
-
 #[allow(dead_code)] // retained for protocol tests and future non-mutating inventory clients
 fn try_lock_managed_inventory_read_sessions(
     compiled_root: &Path,
@@ -2505,10 +2652,7 @@ fn try_lock_managed_inventory_write_sessions(
     try_lock_source_compile_sessions(subjects, SourceCompileSessionMode::ExclusiveWriter)
 }
 
-fn discover_compiled_r4g1_candidates_in(
-    root: &Path,
-    current_version: u32,
-) -> Result<Vec<ResolvedCompiledBundle>, String> {
+fn compiled_logical_names_in(root: &Path, current_version: u32) -> Result<Vec<String>, String> {
     let entries = match fs::read_dir(root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -2542,6 +2686,19 @@ fn discover_compiled_r4g1_candidates_in(
             }
             continue;
         }
+        if entry.file_name()
+            == std::ffi::OsStr::new(
+                uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_PRODUCER_COORDINATION_DIR,
+            )
+        {
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "recorded-corpus coordination namespace {} is not a regular non-symlink directory",
+                    bundle.display()
+                ));
+            }
+            continue;
+        }
         if !metadata.file_type().is_dir() {
             return Err(format!(
                 "compiled model candidate {} is not a regular non-symlink directory",
@@ -2562,8 +2719,16 @@ fn discover_compiled_r4g1_candidates_in(
         logical_names.insert(logical_name);
     }
 
+    Ok(logical_names.into_iter().collect())
+}
+
+#[cfg(test)]
+fn discover_compiled_r4g1_candidates_in(
+    root: &Path,
+    current_version: u32,
+) -> Result<Vec<ResolvedCompiledBundle>, String> {
     let mut selected = Vec::new();
-    for logical_name in logical_names {
+    for logical_name in compiled_logical_names_in(root, current_version)? {
         let pair = inspect_compiled_model_pair(root, &logical_name, current_version)?;
         if let Some(candidate) = resolve_loadable_compiled_bundle(&pair, current_version)? {
             reject_reserved_suffix_source_collision(
@@ -4225,9 +4390,16 @@ const SOURCE_COMPILE_STAGING_DIR: &str = ".uor-r4-source-compile-staging";
 const SOURCE_COMPILE_SESSION_LOCK_SUFFIX: &str = ".compile-session.lock";
 const COMPILED_BUNDLE_STAGE_TAG: &str = "bundle-stage";
 const COMPILED_BUNDLE_STAGE_MARKER_FILE: &str = ".compiled_bundle_stage.json";
-const COMPILED_BUNDLE_STAGE_SCHEMA: &str = "uor-r4-compiled-bundle-stage/1";
+const COMPILED_BUNDLE_STAGE_SCHEMA: &str = "uor-r4-compiled-bundle-stage/2";
 const COMPILED_BUNDLE_COMPLETION_FILE: &str = "compiled_bundle_completion.json";
 const COMPILED_BUNDLE_COMPLETION_SCHEMA: &str = "uor-r4-compiled-bundle-completion/1";
+const COMPILED_BUNDLE_CONTROL_MAX_BYTES: u64 = 64 * 1024;
+const COVER_REPORT_CONTROL_MAX_BYTES: u64 = 16 * 1024 * 1024;
+// Current managed score reports are below 25 KiB; one MiB leaves bounded
+// format-growth headroom without allowing an attacker-controlled allocation.
+const SCORE_REPORT_CONTROL_MAX_BYTES: u64 = 1024 * 1024;
+const COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT: usize = 64;
+const COMPILED_BUNDLE_STAGE_LIMIT: usize = 64;
 const LEGACY_GRAPH_GENERATION_SCHEMA: &str = "uor-r4-legacy-graph-generation/1";
 const LEGACY_GRAPH_ATTEMPT_SCHEMA: &str = "uor-r4-legacy-graph-attempt/1";
 static NEXT_SOURCE_KAPPA_BINDING_ID: AtomicU64 = AtomicU64::new(0);
@@ -4253,6 +4425,38 @@ struct CompiledBundleCompletion {
     files: std::collections::BTreeMap<String, String>,
 }
 
+/// Durable compare-and-swap identity for the public root from which a private
+/// compiled-bundle stage was derived. The inode generation is pinned in
+/// memory by the lower handoff guard; this content descriptor survives a
+/// process death so an old resumable stage can never overwrite a newer direct
+/// writer's committed generation.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum CompiledBundleBaseGeneration {
+    Absent,
+    Incomplete {
+        files: std::collections::BTreeMap<String, String>,
+    },
+    /// Exact fixed-inventory witness for a readable pre-transaction sibling
+    /// (normally the immutable conventional v1 root). It is not promoted to a
+    /// new completion/binding generation; it exists only so long stage builds
+    /// can content-CAS the resolver's full three-root selection.
+    Legacy {
+        files: std::collections::BTreeMap<String, String>,
+    },
+    Complete {
+        completion_cid: String,
+        recorded_corpus_binding_cid: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledBundleSelectionGeneration {
+    root: String,
+    generation: CompiledBundleBaseGeneration,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct CompiledBundleStageMarker {
@@ -4260,6 +4464,7 @@ struct CompiledBundleStageMarker {
     final_output: String,
     stage_path: String,
     source_snapshot_kappa: String,
+    selection_base: Vec<CompiledBundleSelectionGeneration>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -4346,9 +4551,33 @@ fn read_opened_regular_file_nofollow(
             path.display()
         ));
     }
+    let length = usize::try_from(opened_metadata.len()).map_err(|_| {
+        format!(
+            "{} {label} length cannot be represented in memory",
+            path.display()
+        )
+    })?;
     let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)
+    bytes.try_reserve_exact(length).map_err(|error| {
+        format!(
+            "{} {label} cannot reserve its declared {length} bytes: {error}",
+            path.display()
+        )
+    })?;
+    bytes.resize(length, 0);
+    file.read_exact(&mut bytes)
         .map_err(|error| format!("{} cannot be read: {error}", path.display()))?;
+    let mut extra = [0u8; 1];
+    if file
+        .read(&mut extra)
+        .map_err(|error| format!("{} cannot be read: {error}", path.display()))?
+        != 0
+    {
+        return Err(format!(
+            "{} grew beyond its opened {label} length",
+            path.display()
+        ));
+    }
     let final_file_metadata = file.metadata().map_err(|error| {
         format!(
             "{} opened {label} handle cannot be reinspected: {error}",
@@ -4361,7 +4590,8 @@ fn read_opened_regular_file_nofollow(
         || !final_path_metadata.file_type().is_file()
         || !source_compile_lock_metadata_matches(&opened_metadata, &final_file_metadata)
         || !source_compile_lock_metadata_matches(&final_path_metadata, &final_file_metadata)
-        || final_file_metadata.len() != bytes.len() as u64
+        || final_file_metadata.len() != opened_metadata.len()
+        || final_path_metadata.len() != opened_metadata.len()
     {
         return Err(format!(
             "{} changed identity, type, or length while its {label} bytes were read",
@@ -4369,6 +4599,213 @@ fn read_opened_regular_file_nofollow(
         ));
     }
     Ok(bytes)
+}
+
+/// Read one control record at its exact opened length. The limit is checked
+/// before allocation and the one-byte EOF probe rejects a file that grows
+/// after metadata capture instead of following a moving EOF.
+fn read_opened_regular_file_nofollow_capped(
+    file: fs::File,
+    path: &Path,
+    label: &str,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    read_opened_regular_file_nofollow_capped_with_after_eof(file, path, label, max_bytes, || Ok(()))
+}
+
+fn read_opened_regular_file_nofollow_capped_with_after_eof<F>(
+    mut file: fs::File,
+    path: &Path,
+    label: &str,
+    max_bytes: u64,
+    after_eof: F,
+) -> Result<Vec<u8>, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let opened_metadata = file.metadata().map_err(|error| {
+        format!(
+            "{} opened {label} handle cannot be inspected: {error}",
+            path.display()
+        )
+    })?;
+    if !opened_metadata.file_type().is_file() || opened_metadata.len() > max_bytes {
+        return Err(format!(
+            "{} is not a regular {label} within the registered {max_bytes}-byte control-record limit",
+            path.display()
+        ));
+    }
+    let length = usize::try_from(opened_metadata.len()).map_err(|_| {
+        format!(
+            "{} {label} length cannot be represented in memory",
+            path.display()
+        )
+    })?;
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(length).map_err(|error| {
+        format!(
+            "{} {label} cannot reserve its declared {length} bytes: {error}",
+            path.display()
+        )
+    })?;
+    bytes.resize(length, 0);
+    file.read_exact(&mut bytes)
+        .map_err(|error| format!("{} cannot be read: {error}", path.display()))?;
+    let mut extra = [0u8; 1];
+    if file
+        .read(&mut extra)
+        .map_err(|error| format!("{} cannot be read: {error}", path.display()))?
+        != 0
+    {
+        return Err(format!(
+            "{} grew beyond its opened {label} length",
+            path.display()
+        ));
+    }
+    after_eof()?;
+    let final_file_metadata = file.metadata().map_err(|error| {
+        format!(
+            "{} opened {label} handle cannot be reinspected: {error}",
+            path.display()
+        )
+    })?;
+    let final_path_metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    if !final_file_metadata.file_type().is_file()
+        || !final_path_metadata.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&opened_metadata, &final_file_metadata)
+        || !source_compile_lock_metadata_matches(&final_path_metadata, &final_file_metadata)
+        || final_file_metadata.len() != opened_metadata.len()
+        || final_path_metadata.len() != opened_metadata.len()
+    {
+        return Err(format!(
+            "{} changed identity, type, or generation while its {label} bytes were read",
+            path.display()
+        ));
+    }
+    Ok(bytes)
+}
+
+fn read_regular_file_nofollow_capped(
+    path: &Path,
+    label: &str,
+    max_bytes: u64,
+) -> Result<Option<Vec<u8>>, String> {
+    open_regular_file_nofollow(path, label)?
+        .map(|file| read_opened_regular_file_nofollow_capped(file, path, label, max_bytes))
+        .transpose()
+}
+
+fn read_required_regular_file_nofollow_capped(
+    path: &Path,
+    label: &str,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    read_regular_file_nofollow_capped(path, label, max_bytes)?.ok_or_else(|| {
+        format!(
+            "{} disappeared before its {label} bytes could be read",
+            path.display()
+        )
+    })
+}
+
+/// Hash a large bundle member through one no-follow handle using its initial
+/// exact length. No body is retained, and an append/truncate/replacement is
+/// rejected before the digest can enter a completion record.
+fn regular_file_blake3_nofollow(path: &Path, label: &str) -> Result<String, String> {
+    regular_file_blake3_nofollow_with_limit_and_after_eof(path, label, None, || Ok(()))
+}
+
+fn regular_file_blake3_nofollow_capped(
+    path: &Path,
+    label: &str,
+    max_bytes: u64,
+) -> Result<String, String> {
+    regular_file_blake3_nofollow_with_limit_and_after_eof(path, label, Some(max_bytes), || Ok(()))
+}
+
+#[cfg(test)]
+fn regular_file_blake3_nofollow_with_after_eof<F>(
+    path: &Path,
+    label: &str,
+    after_eof: F,
+) -> Result<String, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    regular_file_blake3_nofollow_with_limit_and_after_eof(path, label, None, after_eof)
+}
+
+fn regular_file_blake3_nofollow_with_limit_and_after_eof<F>(
+    path: &Path,
+    label: &str,
+    max_bytes: Option<u64>,
+    after_eof: F,
+) -> Result<String, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let mut file = open_regular_file_nofollow(path, label)?
+        .ok_or_else(|| format!("{} disappeared before hashing", path.display()))?;
+    let opened = file
+        .metadata()
+        .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+    if let Some(max_bytes) = max_bytes {
+        if opened.len() > max_bytes {
+            return Err(format!(
+                "{} is not a regular {label} within the registered {max_bytes}-byte control-record limit",
+                path.display()
+            ));
+        }
+    }
+    let mut remaining = opened.len();
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|error| format!("{} length is unsupported: {error}", path.display()))?;
+        let read = file
+            .read(&mut buffer[..limit])
+            .map_err(|error| format!("{} cannot be hashed: {error}", path.display()))?;
+        if read == 0 {
+            return Err(format!(
+                "{} ended before its opened {label} length",
+                path.display()
+            ));
+        }
+        hasher.update(&buffer[..read]);
+        remaining -= read as u64;
+    }
+    let mut extra = [0u8; 1];
+    if file
+        .read(&mut extra)
+        .map_err(|error| format!("{} cannot be hashed: {error}", path.display()))?
+        != 0
+    {
+        return Err(format!(
+            "{} grew beyond its opened {label} length",
+            path.display()
+        ));
+    }
+    after_eof()?;
+    let final_handle = file
+        .metadata()
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    let final_path = fs::symlink_metadata(path)
+        .map_err(|error| format!("{} cannot be reinspected: {error}", path.display()))?;
+    if !final_handle.file_type().is_file()
+        || !final_path.file_type().is_file()
+        || !source_compile_lock_metadata_matches(&opened, &final_handle)
+        || !source_compile_lock_metadata_matches(&final_path, &final_handle)
+        || final_handle.len() != opened.len()
+        || final_path.len() != opened.len()
+    {
+        return Err(format!(
+            "{} changed identity, type, or generation while its {label} digest was computed",
+            path.display()
+        ));
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
 }
 
 fn read_regular_file_nofollow(path: &Path, label: &str) -> Result<Option<Vec<u8>>, String> {
@@ -4403,7 +4840,11 @@ fn source_compile_preflight_bytes(kappa: Option<&str>) -> Result<Vec<u8>, String
 }
 
 fn read_source_compile_preflight_path(path: &Path) -> Result<SourceCompilePreflight, String> {
-    let bytes = read_required_regular_file_nofollow(path, "source compile preflight")?;
+    let bytes = read_required_regular_file_nofollow_capped(
+        path,
+        "source compile preflight",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?;
     reject_duplicate_json_fields(&bytes, path, "source compile preflight")?;
     let record: SourceCompilePreflight = serde_json::from_slice(&bytes)
         .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
@@ -4449,7 +4890,12 @@ fn read_optional_source_compile_preflight(
     let path = output.join(SOURCE_COMPILE_PREFLIGHT_FILE);
     match open_regular_file_nofollow(&path, "source compile preflight")? {
         Some(file) => {
-            let bytes = read_opened_regular_file_nofollow(file, &path, "source compile preflight")?;
+            let bytes = read_opened_regular_file_nofollow_capped(
+                file,
+                &path,
+                "source compile preflight",
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            )?;
             reject_duplicate_json_fields(&bytes, &path, "source compile preflight")?;
             let record: SourceCompilePreflight = serde_json::from_slice(&bytes)
                 .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
@@ -4489,7 +4935,12 @@ fn source_manifest_kappa_binding_bytes(kappa: &str) -> Result<Vec<u8>, String> {
 
 fn read_optional_source_manifest_kappa_binding(output: &Path) -> Result<Option<String>, String> {
     let path = output.join(SOURCE_MANIFEST_KAPPA_BINDING_FILE);
-    let Some(bytes) = read_regular_file_nofollow(&path, "source-manifest kappa binding")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        &path,
+        "source-manifest kappa binding",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok(None);
     };
     reject_duplicate_json_fields(&bytes, &path, "source-manifest kappa binding")?;
@@ -4510,6 +4961,23 @@ fn read_optional_source_manifest_kappa_binding(output: &Path) -> Result<Option<S
         ));
     }
     Ok(Some(binding.source_manifest_kappa))
+}
+
+fn validate_recorded_corpus_compile_attempt_marker(path: &Path) -> Result<(), String> {
+    let bytes = read_required_regular_file_nofollow_capped(
+        path,
+        "recorded-corpus compile-attempt marker",
+        1024,
+    )?;
+    let expected = uor_r4_graph_compiler::recorded_corpus::recorded_corpus_compile_attempt_bytes()
+        .map_err(|error| error.to_string())?;
+    if bytes != expected {
+        return Err(format!(
+            "{} is not the exact canonical recorded-corpus compile-attempt marker",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 fn source_compile_output_has_payload(output: &Path) -> Result<bool, String> {
@@ -4538,6 +5006,14 @@ fn source_compile_output_has_payload(output: &Path) -> Result<bool, String> {
             )
         })?;
         if name == SOURCE_MANIFEST_KAPPA_BINDING_FILE || name == SOURCE_COMPILE_PREFLIGHT_FILE {
+            continue;
+        }
+        if name == COMPILED_BUNDLE_STAGE_MARKER_FILE {
+            validate_source_prefix_stage_marker(output)?;
+            continue;
+        }
+        if name == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE {
+            validate_recorded_corpus_compile_attempt_marker(&entry.path())?;
             continue;
         }
         if name == "tokenizer_adapter.json"
@@ -4858,7 +5334,12 @@ fn validate_pre_attention_identity_handle(
         kind if kind == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE => "dense-operator binding",
         _ => "pre-attention identity record",
     };
-    let bytes = read_opened_regular_file_nofollow(file, path, description)?;
+    let bytes = read_opened_regular_file_nofollow_capped(
+        file,
+        path,
+        description,
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?;
     reject_duplicate_json_fields(&bytes, path, description)?;
     let value: serde_json::Value = serde_json::from_slice(&bytes)
         .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
@@ -4993,6 +5474,7 @@ fn validate_pre_attention_identity_handle(
 /// publish before its attention sidecar. This makes a process-death retry
 /// resumable without treating arbitrary payload as an implicit v1 bundle.
 fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
+    validate_source_compile_identity_temporaries(output)?;
     let preflight = read_optional_source_compile_preflight(output)?;
     reject_legacy_source_compile_initialization(output)?;
     let kappa = read_optional_source_manifest_kappa_binding(output)?;
@@ -5008,6 +5490,7 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
         }
     }
     let mut saw_identity = preflight.is_some() || kappa.is_some();
+    let mut saw_attention = false;
     let mut unexpected = Vec::new();
     let entries = fs::read_dir(output)
         .map_err(|error| format!("{} cannot be enumerated: {error}", output.display()))?;
@@ -5025,10 +5508,27 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
             saw_identity = true;
             continue;
         }
-        if name == "tokenizer_adapter.json"
-            || name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
-            || name == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
-        {
+        if name == COMPILED_BUNDLE_STAGE_MARKER_FILE {
+            validate_source_prefix_stage_marker(output)?;
+            continue;
+        }
+        if name == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE {
+            validate_recorded_corpus_compile_attempt_marker(&entry.path())?;
+            saw_identity = true;
+            continue;
+        }
+        if name == "tokenizer_adapter.json" {
+            validate_pre_attention_identity_file(&entry.path(), name)?;
+            saw_identity = true;
+            continue;
+        }
+        if name == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE {
+            validate_pre_attention_identity_file(&entry.path(), name)?;
+            saw_identity = true;
+            saw_attention = true;
+            continue;
+        }
+        if name == uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE {
             validate_pre_attention_identity_file(&entry.path(), name)?;
             saw_identity = true;
             continue;
@@ -5046,6 +5546,9 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
         }
         unexpected.push(name.to_owned());
     }
+    if saw_attention {
+        return Ok(false);
+    }
     if saw_identity && !unexpected.is_empty() {
         return Err(format!(
             "source compile root {} contains {} beside {} but has no {}; refusing to infer a historical era from an interrupted current-era compile",
@@ -5059,7 +5562,13 @@ fn source_compile_pre_attention_prefix(output: &Path) -> Result<bool, String> {
 }
 
 fn publish_bytes_no_clobber(path: &Path, expected: &[u8], label: &str) -> Result<(), String> {
-    if let Some(existing) = read_regular_file_nofollow(path, label)? {
+    let expected_len = u64::try_from(expected.len()).map_err(|_| {
+        format!(
+            "{} expected {label} length cannot be represented",
+            path.display()
+        )
+    })?;
+    if let Some(existing) = read_regular_file_nofollow_capped(path, label, expected_len)? {
         return if existing == expected {
             sync_parent_directory(path, label)
         } else {
@@ -5109,12 +5618,13 @@ fn publish_bytes_no_clobber(path: &Path, expected: &[u8], label: &str) -> Result
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 let _ = fs::remove_file(&temporary);
-                let existing = read_regular_file_nofollow(path, label)?.ok_or_else(|| {
-                    format!(
-                        "{} concurrently appeared and disappeared while publishing {label}",
-                        path.display()
-                    )
-                })?;
+                let existing = read_regular_file_nofollow_capped(path, label, expected_len)?
+                    .ok_or_else(|| {
+                        format!(
+                            "{} concurrently appeared and disappeared while publishing {label}",
+                            path.display()
+                        )
+                    })?;
                 return if existing == expected {
                     sync_parent_directory(path, label)
                 } else {
@@ -5340,6 +5850,7 @@ impl SourceCompileSessionMode {
 
 fn source_compile_session_is_busy(error: &str) -> bool {
     error.contains(" is BUSY under an active cross-process compile session; refusing ")
+        || uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy_message(error)
 }
 
 fn graph_output_session_subject(graph_path: &Path) -> PathBuf {
@@ -5599,6 +6110,7 @@ fn compiled_bundle_stage_marker_bytes(
     final_output: &Path,
     stage_path: &Path,
     source_snapshot_kappa: &str,
+    selection_base: &[CompiledBundleSelectionGeneration],
 ) -> Result<Vec<u8>, String> {
     if !canonical_source_manifest_kappa(source_snapshot_kappa) {
         return Err(format!(
@@ -5624,6 +6136,7 @@ fn compiled_bundle_stage_marker_bytes(
         final_output: final_output.to_owned(),
         stage_path: stage_path.to_owned(),
         source_snapshot_kappa: source_snapshot_kappa.to_owned(),
+        selection_base: selection_base.to_vec(),
     })
     .map_err(|error| error.to_string())?;
     bytes.push(b'\n');
@@ -5632,7 +6145,12 @@ fn compiled_bundle_stage_marker_bytes(
 
 fn read_compiled_bundle_stage_marker(stage: &Path) -> Result<Option<Vec<u8>>, String> {
     let path = stage.join(COMPILED_BUNDLE_STAGE_MARKER_FILE);
-    let Some(bytes) = read_regular_file_nofollow(&path, "compiled-bundle stage marker")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        &path,
+        "compiled-bundle stage marker",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok(None);
     };
     reject_duplicate_json_fields(&bytes, &path, "compiled-bundle stage marker")?;
@@ -5646,6 +6164,7 @@ fn read_compiled_bundle_stage_marker(stage: &Path) -> Result<Option<Vec<u8>>, St
             path.display()
         ));
     }
+    validate_compiled_bundle_selection_base(&record.selection_base, &record.final_output)?;
     Ok(Some(bytes))
 }
 
@@ -5659,6 +6178,7 @@ fn validate_compiled_bundle_stage_marker_location(root: &Path, bytes: &[u8]) -> 
             record.source_snapshot_kappa
         ));
     }
+    validate_compiled_bundle_selection_base(&record.selection_base, &record.final_output)?;
     let final_output = canonical_compile_session_subject(Path::new(&record.final_output))?;
     let stage_path = canonical_compile_session_subject(Path::new(&record.stage_path))?;
     if final_output.to_str() != Some(record.final_output.as_str())
@@ -5701,26 +6221,93 @@ fn validate_compiled_bundle_stage_marker_location(root: &Path, bytes: &[u8]) -> 
     Ok(())
 }
 
+/// A private stage marker is coordination, not source payload. Only the exact
+/// canonical marker whose encoded public/staging locations include `root` is
+/// ignored by the source-identity prefix classifiers; malformed or copied
+/// markers remain terminal evidence.
+fn validate_source_prefix_stage_marker(root: &Path) -> Result<(), String> {
+    let bytes = read_compiled_bundle_stage_marker(root)?.ok_or_else(|| {
+        format!(
+            "compiled-bundle stage marker disappeared from {} during source-prefix validation",
+            root.display()
+        )
+    })?;
+    validate_compiled_bundle_stage_marker_location(root, &bytes)
+}
+
+/// A freshly allocated private stage contains only its exact durable owner
+/// marker. That marker authorizes the first P/K publication without making an
+/// arbitrary pre-existing directory adoptable as compiler output.
+fn exact_empty_compiled_bundle_stage(root: &Path) -> Result<bool, String> {
+    let Some(bytes) = read_compiled_bundle_stage_marker(root)? else {
+        return Ok(false);
+    };
+    validate_compiled_bundle_stage_marker_location(root, &bytes)?;
+    let mut saw_marker = false;
+    let mut saw_attempt = false;
+    for entry in fs::read_dir(root)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", root.display()))?;
+        if entry.file_name() == COMPILED_BUNDLE_STAGE_MARKER_FILE && !saw_marker {
+            saw_marker = true;
+        } else if entry.file_name()
+            == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE
+            && !saw_attempt
+        {
+            let actual = read_required_regular_file_nofollow_capped(
+                &entry.path(),
+                "recorded-corpus compile-attempt marker",
+                1024,
+            )?;
+            let expected =
+                uor_r4_graph_compiler::recorded_corpus::recorded_corpus_compile_attempt_bytes()
+                    .map_err(|error| error.to_string())?;
+            if actual != expected {
+                return Ok(false);
+            }
+            saw_attempt = true;
+        } else {
+            return Ok(false);
+        }
+    }
+    Ok(saw_marker)
+}
+
 fn validate_compiled_bundle_stage_marker(stage: &Path, expected: &[u8]) -> Result<bool, String> {
     Ok(read_compiled_bundle_stage_marker(stage)?.is_some_and(|bytes| bytes == expected))
 }
 
-fn cleanup_published_compiled_bundle_stage_marker(
-    final_output: &Path,
-    source_snapshot_kappa: &str,
-) -> Result<(), String> {
+fn cleanup_published_compiled_bundle_stage_marker(final_output: &Path) -> Result<(), String> {
     let Some(bytes) = read_compiled_bundle_stage_marker(final_output)? else {
         return Ok(());
     };
     validate_compiled_bundle_stage_marker_location(final_output, &bytes)?;
     let record: CompiledBundleStageMarker =
         serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
-    if record.source_snapshot_kappa != source_snapshot_kappa {
+    let bound = read_optional_source_manifest_kappa_binding(final_output)?.ok_or_else(|| {
+        format!(
+            "published compiled-bundle marker in {} has no canonical source snapshot binding",
+            final_output.display()
+        )
+    })?;
+    let preflight = read_optional_source_compile_preflight(final_output)?.ok_or_else(|| {
+        format!(
+            "published compiled-bundle marker in {} has no canonical source preflight",
+            final_output.display()
+        )
+    })?;
+    let report = final_output.join("graph-cover/cover_report.json");
+    let (_, _, _, report_kappa) = parse_cover_provenance(&report)?;
+    if bound != record.source_snapshot_kappa
+        || preflight.source_manifest_kappa.as_deref() != Some(record.source_snapshot_kappa.as_str())
+        || report_kappa.as_deref() != Some(record.source_snapshot_kappa.as_str())
+    {
         return Err(format!(
-            "published compiled-bundle marker in {} binds source snapshot {}, not {}",
+            "published compiled-bundle marker in {} does not match its completed generation's own P/K/cover source snapshot {}",
             final_output.display(),
-            record.source_snapshot_kappa,
-            source_snapshot_kappa
+            record.source_snapshot_kappa
         ));
     }
     validate_compiled_bundle_completion(final_output)?.ok_or_else(|| {
@@ -5790,6 +6377,13 @@ fn compiled_bundle_stage_temporaries(stage: &Path) -> Result<Vec<PathBuf>, Strin
         .into_iter()
         .any(|stable| looks_like_atomic_publisher_temporary(name, stable));
         if exact {
+            if temporaries.len() == COMPILED_BUNDLE_STAGE_LIMIT {
+                return Err(format!(
+                    "compiled-bundle stage {} exceeds the fixed {}-entry publisher-temporary limit",
+                    stage.display(),
+                    COMPILED_BUNDLE_STAGE_LIMIT
+                ));
+            }
             let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
                 format!("{} cannot be inspected: {error}", entry.path().display())
             })?;
@@ -5849,6 +6443,25 @@ fn reset_resumable_compiled_bundle_stage(
             }
         }
     }
+    let mut derived_files = Vec::new();
+    for name in [
+        "instruction-eval.json",
+        "compiled.r4g1",
+        "compile_report.json",
+    ] {
+        let path = stage.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => derived_files.push(path),
+            Ok(_) => {
+                return Err(format!(
+                    "resumable derived compiled-bundle output {} is not a regular non-symlink file",
+                    path.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("{} cannot be inspected: {error}", path.display())),
+        }
+    }
     if remove_completion {
         fs::remove_file(&completion)
             .map_err(|error| format!("{} cannot be reclaimed: {error}", completion.display()))?;
@@ -5858,6 +6471,14 @@ fn reset_resumable_compiled_bundle_stage(
             format!(
                 "recognized compiled-bundle publisher temporary {} cannot be reclaimed: {error}",
                 temporary.display()
+            )
+        })?;
+    }
+    for path in derived_files {
+        fs::remove_file(&path).map_err(|error| {
+            format!(
+                "derived compiled-bundle stage output {} cannot be reclaimed: {error}",
+                path.display()
             )
         })?;
     }
@@ -5874,10 +6495,116 @@ fn reset_resumable_compiled_bundle_stage(
         .map_err(|error| format!("{} cannot be synced: {error}", stage.display()))
 }
 
+/// A stage without a stable recorded-corpus binding has no committed payload
+/// generation. An honest death during prefix copy or compiler publication may
+/// therefore leave torn canonical members. Under the retained source/common
+/// transaction, classify the complete private-stage namespace first, then
+/// reclaim only registered compile members so the exact retry can reconstruct
+/// the prefix from its authoritative base.
+fn reset_unbound_compiled_bundle_stage(
+    stage: &Path,
+    temporaries: Vec<PathBuf>,
+) -> Result<(), String> {
+    let mut files = Vec::new();
+    let mut directories = Vec::new();
+    for entry in fs::read_dir(stage)
+        .map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("{} cannot be enumerated: {error}", stage.display()))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            format!(
+                "compiled-bundle stage {} contains a non-UTF-8 entry",
+                stage.display()
+            )
+        })?;
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+        if matches!(
+            name,
+            COMPILED_BUNDLE_STAGE_MARKER_FILE
+                | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE
+        ) {
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "private-stage coordination entry {} is not a regular non-symlink file",
+                    path.display()
+                ));
+            }
+            continue;
+        }
+        if temporaries.iter().any(|temporary| temporary == &path) {
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "private-stage publisher residue {} is not a regular non-symlink file",
+                    path.display()
+                ));
+            }
+            files.push(path);
+            continue;
+        }
+        if matches!(name, "graph" | "graph-cover") {
+            if !metadata.file_type().is_dir() {
+                return Err(format!(
+                    "private-stage derived output {} is not a regular non-symlink directory",
+                    path.display()
+                ));
+            }
+            directories.push(path);
+            continue;
+        }
+        let registered = matches!(
+            name,
+            "corpus.meta"
+                | "corpus.records"
+                | "corpus.records.hidden"
+                | "tless_artifacts.bin"
+                | "tless_store.bin"
+                | "tokenizer.bin"
+                | "tokenizer_adapter.json"
+                | "hamming_calibration.json"
+                | "hierarchical_codes.json"
+                | "space_manifest.json"
+                | "compiled.r4g1"
+                | "compile_report.json"
+                | "instruction-eval.json"
+                | SOURCE_COMPILE_PREFLIGHT_FILE
+                | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+                | COMPILED_BUNDLE_COMPLETION_FILE
+                | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+                | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+        );
+        if !registered || !metadata.file_type().is_file() {
+            return Err(format!(
+                "unbound private stage {} contains unsupported or nonregular entry {}",
+                stage.display(),
+                path.display()
+            ));
+        }
+        files.push(path);
+    }
+    for path in files {
+        fs::remove_file(&path)
+            .map_err(|error| format!("{} cannot be reclaimed: {error}", path.display()))?;
+    }
+    for path in directories {
+        fs::remove_dir_all(&path)
+            .map_err(|error| format!("{} cannot be reclaimed: {error}", path.display()))?;
+    }
+    fs::File::open(stage)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("{} cannot be synced: {error}", stage.display()))
+}
+
+type RecoverableCompiledBundleStage = (PathBuf, Vec<u8>, Vec<PathBuf>);
+
 fn recover_compiled_bundle_stages(
     output: &Path,
     source_snapshot_kappa: &str,
-) -> Result<Option<(PathBuf, Vec<u8>)>, String> {
+    selection_base: &[CompiledBundleSelectionGeneration],
+) -> Result<Option<RecoverableCompiledBundleStage>, String> {
     let parent = output.parent().ok_or_else(|| {
         format!(
             "source compile output {} has no staging parent",
@@ -5891,6 +6618,7 @@ fn recover_compiled_bundle_stages(
     let staging = ensure_source_compile_staging_root(parent)?;
     let mut resumable = None;
     let mut stale = Vec::new();
+    let mut recognized_stages = 0usize;
     for entry in fs::read_dir(&staging)
         .map_err(|error| format!("{} cannot be enumerated: {error}", staging.display()))?
     {
@@ -5904,6 +6632,14 @@ fn recover_compiled_bundle_stages(
             )
         })?;
         if is_compiled_bundle_stage_name(name, output_name) {
+            if recognized_stages == COMPILED_BUNDLE_STAGE_LIMIT {
+                return Err(format!(
+                    "source compile output {} exceeds the fixed {}-entry compiled-stage limit",
+                    output.display(),
+                    COMPILED_BUNDLE_STAGE_LIMIT
+                ));
+            }
+            recognized_stages += 1;
             let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
                 format!("{} cannot be inspected: {error}", entry.path().display())
             })?;
@@ -5914,8 +6650,12 @@ fn recover_compiled_bundle_stages(
                 ));
             }
             let temporaries = compiled_bundle_stage_temporaries(&entry.path())?;
-            let expected_marker =
-                compiled_bundle_stage_marker_bytes(output, &entry.path(), source_snapshot_kappa)?;
+            let expected_marker = compiled_bundle_stage_marker_bytes(
+                output,
+                &entry.path(),
+                source_snapshot_kappa,
+                selection_base,
+            )?;
             let recorded_marker = read_compiled_bundle_stage_marker(&entry.path())?;
             if recorded_marker.as_deref() == Some(expected_marker.as_slice()) {
                 if resumable.is_some() {
@@ -5925,11 +6665,9 @@ fn recover_compiled_bundle_stages(
                     ));
                 }
                 resumable = Some((entry.path(), expected_marker, temporaries));
-            } else if recorded_marker.is_some()
-                && validate_compiled_bundle_completion(&entry.path())?.is_none()
-            {
+            } else if recorded_marker.is_some() {
                 return Err(format!(
-                    "{} does not bind this exact compiled output, stage path, and source snapshot",
+                    "{} does not bind this exact compiled output, stage path, source snapshot, and three-root base generation",
                     entry
                         .path()
                         .join(COMPILED_BUNDLE_STAGE_MARKER_FILE)
@@ -5954,26 +6692,32 @@ fn recover_compiled_bundle_stages(
     // or duplicate candidate can therefore never leave earlier stage entries
     // partially reclaimed.
     for stage in stale {
+        let guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &stage,
+            )
+            .map_err(|error| error.to_string())?;
+        if !guard
+            .protects_directory(&stage)
+            .map_err(|error| error.to_string())?
+        {
+            return Err(format!(
+                "common producer guard does not protect stale compiled stage {}",
+                stage.display()
+            ));
+        }
         fs::remove_dir_all(&stage).map_err(|error| {
             format!(
                 "stale compiled-bundle stage {} cannot be reclaimed under exclusive session ownership: {error}",
                 stage.display()
             )
         })?;
-    }
-    if let Some((stage, expected_marker, temporaries)) = resumable.as_ref() {
-        reset_resumable_compiled_bundle_stage(stage, temporaries.clone())?;
-        if !validate_compiled_bundle_stage_marker(stage, expected_marker)? {
-            return Err(format!(
-                "resumable compiled-bundle stage {} lost its owner marker during recovery",
-                stage.display()
-            ));
-        }
+        drop(guard);
     }
     fs::File::open(&staging)
         .and_then(|directory| directory.sync_all())
         .map_err(|error| format!("{} cannot be synced: {error}", staging.display()))?;
-    Ok(resumable.map(|(path, marker, _)| (path, marker)))
+    Ok(resumable)
 }
 
 fn copy_regular_file_nofollow(source: &Path, destination: &Path) -> Result<(), String> {
@@ -5987,8 +6731,38 @@ fn copy_regular_file_nofollow(source: &Path, destination: &Path) -> Result<(), S
         .create_new(true)
         .open(destination)
         .map_err(|error| format!("{} cannot be created: {error}", destination.display()))?;
-    let copied = std::io::copy(&mut source_file, &mut destination_file)
-        .map_err(|error| format!("{} cannot be copied: {error}", source.display()))?;
+    let mut copied = 0u64;
+    let mut remaining = opened_metadata.len();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining != 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|error| format!("{} length is unsupported: {error}", source.display()))?;
+        let read = source_file
+            .read(&mut buffer[..limit])
+            .map_err(|error| format!("{} cannot be copied: {error}", source.display()))?;
+        if read == 0 {
+            return Err(format!(
+                "{} ended before its opened compiled-bundle source length",
+                source.display()
+            ));
+        }
+        destination_file
+            .write_all(&buffer[..read])
+            .map_err(|error| format!("{} cannot be written: {error}", destination.display()))?;
+        copied += read as u64;
+        remaining -= read as u64;
+    }
+    let mut extra = [0u8; 1];
+    if source_file
+        .read(&mut extra)
+        .map_err(|error| format!("{} cannot be copied: {error}", source.display()))?
+        != 0
+    {
+        return Err(format!(
+            "{} grew beyond its opened compiled-bundle source length",
+            source.display()
+        ));
+    }
     destination_file
         .sync_all()
         .map_err(|error| format!("{} cannot be synced: {error}", destination.display()))?;
@@ -6001,6 +6775,8 @@ fn copy_regular_file_nofollow(source: &Path, destination: &Path) -> Result<(), S
         || !final_path_metadata.file_type().is_file()
         || !source_compile_lock_metadata_matches(&opened_metadata, &final_source_metadata)
         || !source_compile_lock_metadata_matches(&final_path_metadata, &final_source_metadata)
+        || final_source_metadata.len() != opened_metadata.len()
+        || final_path_metadata.len() != opened_metadata.len()
         || copied != final_source_metadata.len()
     {
         return Err(format!(
@@ -6058,7 +6834,15 @@ fn validate_legacy_coordination_directory_for_prefix_copy(path: &Path) -> Result
     Ok(())
 }
 
-fn copy_compiled_bundle_prefix(source: &Path, destination: &Path) -> Result<(), String> {
+fn copy_compiled_bundle_prefix_with_after_first_copy<F>(
+    source: &Path,
+    destination: &Path,
+    mut after_first_copy: F,
+) -> Result<(), String>
+where
+    F: FnMut(&Path) -> Result<(), String>,
+{
+    let mut copied_any = false;
     for entry in fs::read_dir(source)
         .map_err(|error| format!("{} cannot be enumerated: {error}", source.display()))?
     {
@@ -6067,8 +6851,15 @@ fn copy_compiled_bundle_prefix(source: &Path, destination: &Path) -> Result<(), 
         let name = entry.file_name();
         if name == std::ffi::OsStr::new("graph")
             || name == std::ffi::OsStr::new("graph-cover")
+            || name == std::ffi::OsStr::new("compiled.r4g1")
+            || name == std::ffi::OsStr::new("compile_report.json")
+            || name == std::ffi::OsStr::new("instruction-eval.json")
             || name == std::ffi::OsStr::new(COMPILED_BUNDLE_COMPLETION_FILE)
             || name == std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE)
+            || name
+                == std::ffi::OsStr::new(
+                    uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
+                )
         {
             continue;
         }
@@ -6086,6 +6877,10 @@ fn copy_compiled_bundle_prefix(source: &Path, destination: &Path) -> Result<(), 
             ));
         }
         copy_regular_file_nofollow(&entry.path(), &destination.join(name))?;
+        if !copied_any {
+            copied_any = true;
+            after_first_copy(destination)?;
+        }
     }
     fs::File::open(destination)
         .and_then(|directory| directory.sync_all())
@@ -6117,28 +6912,133 @@ fn validate_copied_compiled_bundle_prefix(
 #[derive(Debug)]
 struct CompiledBundleStage {
     path: PathBuf,
+    #[cfg(test)]
     final_output: PathBuf,
     marker_bytes: Vec<u8>,
 }
 
 impl CompiledBundleStage {
-    fn allocate(final_output: &Path, source_snapshot_kappa: &str) -> Result<Self, String> {
+    fn allocate_with_selection_transaction_with_after_first_copy<F>(
+        final_output: &Path,
+        source_snapshot_kappa: &str,
+        selection_base: &[CompiledBundleSelectionGeneration],
+        mut after_first_copy: F,
+    ) -> Result<(Self, uor_r4_graph_cli::SourceCorpusSession), String>
+    where
+        F: FnMut(&Path) -> Result<(), String>,
+    {
+        let final_output_canonical = canonical_compile_session_subject(final_output)?;
+        let final_output_utf8 = final_output_canonical.to_str().ok_or_else(|| {
+            format!(
+                "compiled output is not UTF-8: {}",
+                final_output_canonical.display()
+            )
+        })?;
+        validate_compiled_bundle_selection_base(selection_base, final_output_utf8)?;
+        let expected_base = selection_base
+            .iter()
+            .find(|entry| entry.root == final_output_utf8)
+            .map(|entry| &entry.generation)
+            .ok_or_else(|| "compiled-bundle selection omitted its final root".to_owned())?;
         // A stable completion is authoritative. Validate every recorded
         // corpus/artifact member before copying a single byte into a resumable
         // refresh stage, and retain the exact record for a post-copy recheck.
         // This prevents a structurally parseable tamper from being copied and
         // freshly re-certified as a new generation.
-        recover_compiled_bundle_completion_temporaries(final_output)?;
         let authoritative_completion = validate_compiled_bundle_completion(final_output)?;
-        cleanup_published_compiled_bundle_stage_marker(final_output, source_snapshot_kappa)?;
-        if let Some((path, marker_bytes)) =
-            recover_compiled_bundle_stages(final_output, source_snapshot_kappa)?
+        match (expected_base, authoritative_completion.as_ref()) {
+            (CompiledBundleBaseGeneration::Absent, None) => {}
+            (
+                CompiledBundleBaseGeneration::Incomplete { .. }
+                | CompiledBundleBaseGeneration::Legacy { .. },
+                None,
+            ) => {
+                if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                    return Err(format!(
+                        "incomplete compiled-bundle base {} changed before stage allocation",
+                        final_output.display()
+                    ));
+                }
+            }
+            (CompiledBundleBaseGeneration::Complete { .. }, Some(_)) => {
+                if &capture_compiled_bundle_base_generation(final_output)? != expected_base {
+                    return Err(format!(
+                        "completed compiled-bundle base {} changed before stage allocation",
+                        final_output.display()
+                    ));
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "compiled-bundle base {} no longer matches its captured absence/completion state",
+                    final_output.display()
+                ));
+            }
+        }
+        if let Some((path, marker_bytes, temporaries)) =
+            recover_compiled_bundle_stages(final_output, source_snapshot_kappa, selection_base)?
         {
-            return Ok(Self {
-                path,
-                final_output: final_output.to_path_buf(),
-                marker_bytes,
-            });
+            let session = uor_r4_graph_cli::acquire_source_corpus_session(&path)
+                .map_err(|error| error.to_string())?;
+            let guard = session
+                .recorded_corpus_guard()
+                .map_err(|error| error.to_string())?;
+            guard
+                .begin_compile_attempt()
+                .map_err(|error| error.to_string())?;
+            let binding =
+                path.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
+            if regular_file_presence(&binding)? {
+                reset_resumable_compiled_bundle_stage(&path, temporaries)?;
+            } else {
+                reset_unbound_compiled_bundle_stage(&path, temporaries)?;
+                if !matches!(expected_base, CompiledBundleBaseGeneration::Absent) {
+                    copy_compiled_bundle_prefix_with_after_first_copy(
+                        final_output,
+                        &path,
+                        &mut after_first_copy,
+                    )?;
+                }
+                if let Some(before) = authoritative_completion.as_ref() {
+                    uor_r4_graph_compiler::recorded_corpus::publish_binding(
+                        guard,
+                        &path.join("corpus.meta"),
+                        &path.join("corpus.records"),
+                    )
+                    .map_err(|error| error.to_string())?;
+                    let after = validate_compiled_bundle_completion(final_output)?.ok_or_else(|| {
+                        format!(
+                            "authoritative compiled bundle {} lost its completion record while a refresh stage was recovered",
+                            final_output.display()
+                        )
+                    })?;
+                    if &after != before {
+                        return Err(format!(
+                            "authoritative compiled bundle {} changed completion identity while a refresh stage was recovered",
+                            final_output.display()
+                        ));
+                    }
+                    validate_copied_compiled_bundle_prefix(&path, before)?;
+                }
+            }
+            if !validate_compiled_bundle_stage_marker(&path, &marker_bytes)? {
+                return Err(format!(
+                    "resumable compiled-bundle stage {} lost its owner marker during recovery",
+                    path.display()
+                ));
+            }
+            guard
+                .verify_owned_root()
+                .map_err(|error| error.to_string())?;
+            return Ok((
+                Self {
+                    path,
+                    #[cfg(test)]
+                    final_output: final_output.to_path_buf(),
+                    marker_bytes,
+                },
+                session,
+            ));
         }
         let parent = final_output.parent().ok_or_else(|| {
             format!(
@@ -6169,6 +7069,7 @@ impl CompiledBundleStage {
                         final_output,
                         &path,
                         source_snapshot_kappa,
+                        selection_base,
                     ) {
                         Ok(bytes) => bytes,
                         Err(error) => {
@@ -6178,37 +7079,6 @@ impl CompiledBundleStage {
                             return Err(error);
                         }
                     };
-                    if let Err(error) = copy_compiled_bundle_prefix(final_output, &path) {
-                        let _ = fs::remove_dir_all(&path);
-                        return Err(error);
-                    }
-                    if let Some(before) = authoritative_completion.as_ref() {
-                        let after = match validate_compiled_bundle_completion(final_output) {
-                            Ok(Some(after)) => after,
-                            Ok(None) => {
-                                let _ = fs::remove_dir_all(&path);
-                                return Err(format!(
-                                    "authoritative compiled bundle {} lost its completion record while a refresh stage was copied",
-                                    final_output.display()
-                                ));
-                            }
-                            Err(error) => {
-                                let _ = fs::remove_dir_all(&path);
-                                return Err(error);
-                            }
-                        };
-                        if &after != before {
-                            let _ = fs::remove_dir_all(&path);
-                            return Err(format!(
-                                "authoritative compiled bundle {} changed completion identity while a refresh stage was copied",
-                                final_output.display()
-                            ));
-                        }
-                        if let Err(error) = validate_copied_compiled_bundle_prefix(&path, before) {
-                            let _ = fs::remove_dir_all(&path);
-                            return Err(error);
-                        }
-                    }
                     if let Err(error) = publish_bytes_no_clobber(
                         &path.join(COMPILED_BUNDLE_STAGE_MARKER_FILE),
                         &marker_bytes,
@@ -6224,11 +7094,55 @@ impl CompiledBundleStage {
                         let _ = fs::File::open(&staging).and_then(|directory| directory.sync_all());
                         return Err(format!("{} cannot be synced: {error}", staging.display()));
                     }
-                    return Ok(Self {
-                        path,
-                        final_output: final_output.to_path_buf(),
-                        marker_bytes,
-                    });
+                    let session = uor_r4_graph_cli::acquire_source_corpus_session(&path)
+                        .map_err(|error| error.to_string())?;
+                    let guard = session
+                        .recorded_corpus_guard()
+                        .map_err(|error| error.to_string())?;
+                    guard
+                        .begin_compile_attempt()
+                        .map_err(|error| error.to_string())?;
+                    if !matches!(expected_base, CompiledBundleBaseGeneration::Absent) {
+                        copy_compiled_bundle_prefix_with_after_first_copy(
+                            final_output,
+                            &path,
+                            &mut after_first_copy,
+                        )?;
+                    }
+                    if let Some(before) = authoritative_completion.as_ref() {
+                        uor_r4_graph_compiler::recorded_corpus::publish_binding(
+                            guard,
+                            &path.join("corpus.meta"),
+                            &path.join("corpus.records"),
+                        )
+                        .map_err(|error| error.to_string())?;
+                        let after = validate_compiled_bundle_completion(final_output)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "authoritative compiled bundle {} lost its completion record while a refresh stage was copied",
+                                    final_output.display()
+                                )
+                            })?;
+                        if &after != before {
+                            return Err(format!(
+                                "authoritative compiled bundle {} changed completion identity while a refresh stage was copied",
+                                final_output.display()
+                            ));
+                        }
+                        validate_copied_compiled_bundle_prefix(&path, before)?;
+                    }
+                    guard
+                        .verify_owned_root()
+                        .map_err(|error| error.to_string())?;
+                    return Ok((
+                        Self {
+                            path,
+                            #[cfg(test)]
+                            final_output: final_output.to_path_buf(),
+                            marker_bytes,
+                        },
+                        session,
+                    ));
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
                 Err(error) => {
@@ -6245,6 +7159,71 @@ impl CompiledBundleStage {
         ))
     }
 
+    fn allocate_with_selection_transaction(
+        final_output: &Path,
+        source_snapshot_kappa: &str,
+        selection_base: &[CompiledBundleSelectionGeneration],
+    ) -> Result<(Self, uor_r4_graph_cli::SourceCorpusSession), String> {
+        Self::allocate_with_selection_transaction_with_after_first_copy(
+            final_output,
+            source_snapshot_kappa,
+            selection_base,
+            |_| Ok(()),
+        )
+    }
+
+    #[cfg(test)]
+    fn allocate_with_selection(
+        final_output: &Path,
+        source_snapshot_kappa: &str,
+        selection_base: &[CompiledBundleSelectionGeneration],
+    ) -> Result<Self, String> {
+        let (stage, session) = Self::allocate_with_selection_transaction(
+            final_output,
+            source_snapshot_kappa,
+            selection_base,
+        )?;
+        drop(session);
+        Ok(stage)
+    }
+
+    #[cfg(test)]
+    fn allocate(final_output: &Path, source_snapshot_kappa: &str) -> Result<Self, String> {
+        let final_root = canonical_compile_session_subject(final_output)?;
+        let parent = final_root
+            .parent()
+            .ok_or_else(|| format!("{} has no parent", final_root.display()))?;
+        let name = final_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("{} is not UTF-8", final_root.display()))?;
+        let mut roots = vec![
+            parent.join(format!(".{name}.test-selection-a")),
+            final_root.clone(),
+            parent.join(format!(".{name}.test-selection-z")),
+        ];
+        roots.sort();
+        let selection = roots
+            .into_iter()
+            .map(|root| {
+                let generation = if root == final_root {
+                    capture_compiled_bundle_base_generation(&root)?
+                } else {
+                    CompiledBundleBaseGeneration::Absent
+                };
+                Ok(CompiledBundleSelectionGeneration {
+                    root: root
+                        .to_str()
+                        .ok_or_else(|| format!("{} is not UTF-8", root.display()))?
+                        .to_owned(),
+                    generation,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Self::allocate_with_selection(final_output, source_snapshot_kappa, &selection)
+    }
+
+    #[cfg(test)]
     fn sync_publication_parents(&self, label: &str) -> Result<(), String> {
         // The working generation lives in the hidden staging namespace while
         // the public generation lives directly below the compiled root. A
@@ -6260,6 +7239,7 @@ impl CompiledBundleStage {
         }
     }
 
+    #[cfg(test)]
     fn publish(&mut self) -> Result<(), String> {
         validate_compiled_bundle_completion(&self.path)?.ok_or_else(|| {
             format!(
@@ -6356,18 +7336,90 @@ impl CompiledBundleStage {
     }
 }
 
+fn compiled_bundle_semantic_control_max_bytes(relative: &str) -> Option<u64> {
+    match relative {
+        "corpus.meta"
+        | "tokenizer_adapter.json"
+        | "space_manifest.json"
+        | SOURCE_COMPILE_PREFLIGHT_FILE
+        | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+        | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+        | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+        | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE => Some(COMPILED_BUNDLE_CONTROL_MAX_BYTES),
+        "graph-cover/cover_report.json" => Some(COVER_REPORT_CONTROL_MAX_BYTES),
+        "graph/score_report.json" => Some(SCORE_REPORT_CONTROL_MAX_BYTES),
+        _ => None,
+    }
+}
+
+fn require_compiled_bundle_semantic_control_size(
+    relative: &str,
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> Result<(), String> {
+    if let Some(max_bytes) = compiled_bundle_semantic_control_max_bytes(relative) {
+        if metadata.len() > max_bytes {
+            return Err(format!(
+                "{} exceeds the registered {max_bytes}-byte compiled-bundle control-record limit for {relative}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn compiled_bundle_member_kappa(
+    relative: &str,
+    path: &Path,
+    label: &str,
+) -> Result<String, String> {
+    match compiled_bundle_semantic_control_max_bytes(relative) {
+        Some(max_bytes) => regular_file_blake3_nofollow_capped(path, label, max_bytes),
+        None => regular_file_blake3_nofollow(path, label),
+    }
+}
+
 fn collect_compiled_bundle_files(
     root: &Path,
     directory: &Path,
     files: &mut Vec<(String, PathBuf)>,
     ignored: &std::collections::BTreeSet<PathBuf>,
 ) -> Result<(), String> {
-    let mut entries = fs::read_dir(directory)
+    collect_compiled_bundle_files_with_legacy_fallbacks(root, directory, files, ignored, false)
+}
+
+fn collect_compiled_bundle_files_with_legacy_fallbacks(
+    root: &Path,
+    directory: &Path,
+    files: &mut Vec<(String, PathBuf)>,
+    ignored: &std::collections::BTreeSet<PathBuf>,
+    allow_legacy_fallbacks: bool,
+) -> Result<(), String> {
+    let relative_directory = directory.strip_prefix(root).map_err(|_| {
+        format!(
+            "compiled-bundle directory {} escaped root {}",
+            directory.display(),
+            root.display()
+        )
+    })?;
+    let relative_directory = relative_directory.to_str().ok_or_else(|| {
+        format!(
+            "compiled-bundle directory {} has a non-UTF-8 relative path",
+            directory.display()
+        )
+    })?;
+    if !matches!(relative_directory, "" | "graph" | "graph-cover") {
+        return Err(format!(
+            "compiled bundle {} contains unsupported directory {}",
+            root.display(),
+            directory.display()
+        ));
+    }
+    for entry in fs::read_dir(directory)
         .map_err(|error| format!("{} cannot be enumerated: {error}", directory.display()))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| format!("{} cannot be enumerated: {error}", directory.display()))?;
-    entries.sort_by_key(fs::DirEntry::file_name);
-    for entry in entries {
+    {
+        let entry = entry
+            .map_err(|error| format!("{} cannot be enumerated: {error}", directory.display()))?;
         let path = entry.path();
         if ignored.contains(&path) {
             continue;
@@ -6385,40 +7437,146 @@ fn collect_compiled_bundle_files(
                 path.display()
             )
         })?;
-        if relative_utf8 == COMPILED_BUNDLE_COMPLETION_FILE {
-            continue;
-        }
-        if relative_utf8 == COMPILED_BUNDLE_STAGE_MARKER_FILE {
-            let bytes = read_required_regular_file_nofollow(&path, "compiled-bundle stage marker")?;
-            reject_duplicate_json_fields(&bytes, &path, "compiled-bundle stage marker")?;
-            let record: CompiledBundleStageMarker = serde_json::from_slice(&bytes)
-                .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
-            let mut canonical =
-                serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
-            canonical.push(b'\n');
-            if record.schema != COMPILED_BUNDLE_STAGE_SCHEMA || bytes != canonical {
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
+        if relative_directory.is_empty() {
+            if relative_utf8 == COMPILED_BUNDLE_COMPLETION_FILE {
+                if !metadata.file_type().is_file() {
+                    return Err(format!(
+                        "compiled-bundle completion {} is not a regular non-symlink file",
+                        path.display()
+                    ));
+                }
+                continue;
+            }
+            if relative_utf8 == COMPILED_BUNDLE_STAGE_MARKER_FILE {
+                if !metadata.file_type().is_file() {
+                    return Err(format!(
+                        "compiled-bundle stage marker {} is not a regular non-symlink file",
+                        path.display()
+                    ));
+                }
+                let bytes = read_required_regular_file_nofollow_capped(
+                    &path,
+                    "compiled-bundle stage marker",
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                )?;
+                reject_duplicate_json_fields(&bytes, &path, "compiled-bundle stage marker")?;
+                let record: CompiledBundleStageMarker = serde_json::from_slice(&bytes)
+                    .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+                let mut canonical =
+                    serde_json::to_vec_pretty(&record).map_err(|error| error.to_string())?;
+                canonical.push(b'\n');
+                if record.schema != COMPILED_BUNDLE_STAGE_SCHEMA || bytes != canonical {
+                    return Err(format!(
+                        "{} is not a canonical supported compiled-bundle stage marker",
+                        path.display()
+                    ));
+                }
+                validate_compiled_bundle_stage_marker_location(root, &bytes)?;
+                continue;
+            }
+            if relative_utf8
+                == uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE
+            {
+                if !metadata.file_type().is_file() {
+                    return Err(format!(
+                        "recorded-corpus compile-attempt marker {} is not a regular non-symlink file",
+                        path.display()
+                    ));
+                }
+                let bytes = read_required_regular_file_nofollow_capped(
+                    &path,
+                    "recorded-corpus compile-attempt marker",
+                    1024,
+                )?;
+                let expected =
+                    uor_r4_graph_compiler::recorded_corpus::recorded_corpus_compile_attempt_bytes()
+                        .map_err(|error| error.to_string())?;
+                if bytes != expected {
+                    return Err(format!(
+                        "{} is not the exact canonical recorded-corpus compile-attempt marker",
+                        path.display()
+                    ));
+                }
+                // Coordination state spans a binding-last commit. It is not
+                // immutable bundle payload and therefore never enters the
+                // completion CID inventory.
+                continue;
+            }
+            if relative_utf8 == "instruction-eval.json" {
+                if !metadata.file_type().is_file() {
+                    return Err(format!(
+                        "derived evaluation report {} is not a regular non-symlink file",
+                        path.display()
+                    ));
+                }
+                // The evaluator publishes after the immutable compiled
+                // generation and defaults to this root. It is derived output,
+                // not a member of the completion CID transaction.
+                continue;
+            }
+            if matches!(relative_utf8, "graph" | "graph-cover") {
+                if !metadata.file_type().is_dir() {
+                    return Err(format!(
+                        "compiled-bundle output {} is not a regular non-symlink directory",
+                        path.display()
+                    ));
+                }
+                collect_compiled_bundle_files_with_legacy_fallbacks(
+                    root,
+                    &path,
+                    files,
+                    ignored,
+                    allow_legacy_fallbacks,
+                )?;
+                continue;
+            }
+            let allowed = matches!(
+                relative_utf8,
+                "corpus.meta"
+                    | "corpus.records"
+                    | "corpus.records.hidden"
+                    | "tless_artifacts.bin"
+                    | "tless_store.bin"
+                    | "tokenizer.bin"
+                    | "tokenizer_adapter.json"
+                    | "hamming_calibration.json"
+                    | "hierarchical_codes.json"
+                    | "space_manifest.json"
+                    | SOURCE_COMPILE_PREFLIGHT_FILE
+                    | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+                    | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+                    | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+                    | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+            ) || (allow_legacy_fallbacks
+                && matches!(relative_utf8, "compiled.r4g1" | "compile_report.json"));
+            if !allowed || !metadata.file_type().is_file() {
                 return Err(format!(
-                    "{} is not a canonical supported compiled-bundle stage marker",
+                    "compiled bundle {} contains unsupported entry {}",
+                    root.display(),
                     path.display()
                 ));
             }
-            validate_compiled_bundle_stage_marker_location(root, &bytes)?;
+            require_compiled_bundle_semantic_control_size(relative_utf8, &path, &metadata)?;
+            files.push((relative_utf8.to_owned(), path));
             continue;
         }
-        let metadata = fs::symlink_metadata(&path)
-            .map_err(|error| format!("{} cannot be inspected: {error}", path.display()))?;
-        if metadata.file_type().is_file() {
-            files.push((relative_utf8.to_owned(), path));
-        } else if metadata.file_type().is_dir() && matches!(relative_utf8, "graph" | "graph-cover")
-        {
-            collect_compiled_bundle_files(root, &path, files, ignored)?;
-        } else {
+
+        let allowed = matches!(
+            (relative_directory, entry.file_name().to_str()),
+            ("graph", Some("score.r4g1" | "score_report.json"))
+                | ("graph-cover", Some("cover.r4g1" | "cover_report.json"))
+        );
+        if !allowed || !metadata.file_type().is_file() {
             return Err(format!(
-                "compiled bundle {} contains unsupported nonregular entry {}",
+                "compiled bundle {} contains unsupported entry {}",
                 root.display(),
                 path.display()
             ));
         }
+        require_compiled_bundle_semantic_control_size(relative_utf8, &path, &metadata)?;
+        files.push((relative_utf8.to_owned(), path));
     }
     Ok(())
 }
@@ -6429,6 +7587,26 @@ fn compiled_bundle_file_kappas(
     compiled_bundle_file_kappas_ignoring(root, &std::collections::BTreeSet::new())
 }
 
+fn legacy_compiled_bundle_file_kappas(
+    root: &Path,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let mut files = Vec::new();
+    collect_compiled_bundle_files_with_legacy_fallbacks(
+        root,
+        root,
+        &mut files,
+        &std::collections::BTreeSet::new(),
+        true,
+    )?;
+    let mut kappas = std::collections::BTreeMap::new();
+    for (relative, path) in files {
+        let digest =
+            compiled_bundle_member_kappa(&relative, &path, "legacy compiled-bundle member")?;
+        kappas.insert(relative, digest);
+    }
+    Ok(kappas)
+}
+
 fn compiled_bundle_file_kappas_ignoring(
     root: &Path,
     ignored: &std::collections::BTreeSet<PathBuf>,
@@ -6437,11 +7615,8 @@ fn compiled_bundle_file_kappas_ignoring(
     collect_compiled_bundle_files(root, root, &mut files, ignored)?;
     let mut kappas = std::collections::BTreeMap::new();
     for (relative, path) in files {
-        let bytes = read_required_regular_file_nofollow(&path, "compiled-bundle member")?;
-        kappas.insert(
-            relative,
-            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
-        );
+        let digest = compiled_bundle_member_kappa(&relative, &path, "compiled-bundle member")?;
+        kappas.insert(relative, digest);
     }
     Ok(kappas)
 }
@@ -6502,6 +7677,236 @@ fn compiled_bundle_completion_bytes(
     Ok(bytes)
 }
 
+fn canonical_blake3_cid(value: &str) -> bool {
+    value.strip_prefix("blake3:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn validate_compiled_bundle_base_generation(
+    base: &CompiledBundleBaseGeneration,
+) -> Result<(), String> {
+    match base {
+        CompiledBundleBaseGeneration::Absent => Ok(()),
+        CompiledBundleBaseGeneration::Incomplete { files } => {
+            if files.is_empty()
+                || files.len() > 5
+                || files.iter().any(|(name, digest)| {
+                    !matches!(
+                        name.as_str(),
+                        SOURCE_COMPILE_PREFLIGHT_FILE
+                            | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+                            | "tokenizer_adapter.json"
+                            | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+                            | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+                    ) || !canonical_blake3_cid(digest)
+                })
+            {
+                return Err(
+                    "compiled-bundle base generation is not an exact bounded source-identity prefix"
+                        .to_owned(),
+                );
+            }
+            Ok(())
+        }
+        CompiledBundleBaseGeneration::Legacy { files } => {
+            if files.is_empty()
+                || files.len() > 21
+                || files.iter().any(|(name, digest)| {
+                    !matches!(
+                        name.as_str(),
+                        "corpus.meta"
+                            | "corpus.records"
+                            | "corpus.records.hidden"
+                            | "tless_artifacts.bin"
+                            | "tless_store.bin"
+                            | "tokenizer.bin"
+                            | "tokenizer_adapter.json"
+                            | "hamming_calibration.json"
+                            | "hierarchical_codes.json"
+                            | "space_manifest.json"
+                            | SOURCE_COMPILE_PREFLIGHT_FILE
+                            | SOURCE_MANIFEST_KAPPA_BINDING_FILE
+                            | uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE
+                            | uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE
+                            | uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE
+                            | "graph/score.r4g1"
+                            | "graph/score_report.json"
+                            | "graph-cover/cover.r4g1"
+                            | "graph-cover/cover_report.json"
+                            | "compiled.r4g1"
+                            | "compile_report.json"
+                    ) || !canonical_blake3_cid(digest)
+                })
+            {
+                return Err(
+                    "compiled-bundle legacy base is not an exact bounded fixed-inventory witness"
+                        .to_owned(),
+                );
+            }
+            Ok(())
+        }
+        CompiledBundleBaseGeneration::Complete {
+            completion_cid,
+            recorded_corpus_binding_cid,
+        } => {
+            if !canonical_blake3_cid(completion_cid)
+                || !canonical_blake3_cid(recorded_corpus_binding_cid)
+            {
+                return Err(
+                    "compiled-bundle complete base generation contains a noncanonical CID"
+                        .to_owned(),
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_compiled_bundle_selection_base(
+    selection: &[CompiledBundleSelectionGeneration],
+    final_output: &str,
+) -> Result<(), String> {
+    if selection.len() != 3 {
+        return Err(format!(
+            "compiled-bundle stage selection base must contain exactly three resolver roots, not {}",
+            selection.len()
+        ));
+    }
+    let mut previous: Option<&str> = None;
+    let mut contains_final = false;
+    for entry in selection {
+        let canonical = canonical_compile_session_subject(Path::new(&entry.root))?;
+        if canonical.to_str() != Some(entry.root.as_str()) {
+            return Err(format!(
+                "compiled-bundle stage selection root {:?} is not canonical UTF-8",
+                entry.root
+            ));
+        }
+        if previous.is_some_and(|previous| previous >= entry.root.as_str()) {
+            return Err(
+                "compiled-bundle stage selection roots are not strictly canonical-sorted"
+                    .to_owned(),
+            );
+        }
+        previous = Some(&entry.root);
+        contains_final |= entry.root == final_output;
+        validate_compiled_bundle_base_generation(&entry.generation)?;
+    }
+    if !contains_final {
+        return Err(
+            "compiled-bundle stage selection base does not include its final output root"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// Capture the content half of the public-root CAS identity. The caller holds
+/// one lower common reader/producer authority for `root` across this whole
+/// function; the lower root-generation witness supplies the inode/absence
+/// half used by the final handoff.
+fn capture_compiled_bundle_base_generation(
+    root: &Path,
+) -> Result<CompiledBundleBaseGeneration, String> {
+    match fs::symlink_metadata(root) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CompiledBundleBaseGeneration::Absent)
+        }
+        Err(error) => return Err(format!("{} cannot be inspected: {error}", root.display())),
+        Ok(metadata) if !metadata.file_type().is_dir() => {
+            return Err(format!(
+                "compiled bundle root {} is not a regular non-symlink directory",
+                root.display()
+            ))
+        }
+        Ok(_) => {}
+    }
+    if validate_compiled_bundle_completion(root)?.is_some() {
+        let completion = read_required_regular_file_nofollow_capped(
+            &root.join(COMPILED_BUNDLE_COMPLETION_FILE),
+            "compiled-bundle completion",
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+        )?;
+        let binding = read_required_regular_file_nofollow_capped(
+            &root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+            "recorded-corpus generation binding",
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+        )?;
+        return Ok(CompiledBundleBaseGeneration::Complete {
+            completion_cid: format!("blake3:{}", blake3::hash(&completion).to_hex()),
+            recorded_corpus_binding_cid: format!("blake3:{}", blake3::hash(&binding).to_hex()),
+        });
+    }
+    if source_compile_pre_attention_prefix(root)? && !source_compile_output_has_payload(root)? {
+        let files = compiled_bundle_file_kappas(root)?;
+        let base = CompiledBundleBaseGeneration::Incomplete { files };
+        validate_compiled_bundle_base_generation(&base)?;
+        return Ok(base);
+    }
+    let files = legacy_compiled_bundle_file_kappas(root)?;
+    let base = CompiledBundleBaseGeneration::Legacy { files };
+    validate_compiled_bundle_base_generation(&base)?;
+    Ok(base)
+}
+
+fn capture_compiled_bundle_selection_base(
+    roots: &[PathBuf; 3],
+    final_output: &Path,
+) -> Result<Vec<CompiledBundleSelectionGeneration>, String> {
+    let mut selection = roots
+        .iter()
+        .map(|root| {
+            let canonical = canonical_compile_session_subject(root)?;
+            let root_utf8 = canonical
+                .to_str()
+                .ok_or_else(|| format!("compiled root is not UTF-8: {}", canonical.display()))?;
+            Ok(CompiledBundleSelectionGeneration {
+                root: root_utf8.to_owned(),
+                generation: capture_compiled_bundle_base_generation(&canonical)?,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    selection.sort_by(|left, right| left.root.cmp(&right.root));
+    let final_output = canonical_compile_session_subject(final_output)?;
+    let final_output = final_output.to_str().ok_or_else(|| {
+        format!(
+            "compiled final output is not UTF-8: {}",
+            final_output.display()
+        )
+    })?;
+    validate_compiled_bundle_selection_base(&selection, final_output)?;
+    Ok(selection)
+}
+
+fn require_compiled_bundle_selection_base_unchanged(
+    expected: &[CompiledBundleSelectionGeneration],
+    final_output: &Path,
+) -> Result<(), String> {
+    if expected.len() != 3 {
+        return Err("compiled-bundle selection CAS witness has the wrong arity".to_owned());
+    }
+    let roots = expected
+        .iter()
+        .map(|entry| PathBuf::from(&entry.root))
+        .collect::<Vec<_>>();
+    let roots: [PathBuf; 3] = roots
+        .try_into()
+        .map_err(|_| "compiled-bundle selection CAS witness has the wrong arity".to_owned())?;
+    let current = capture_compiled_bundle_selection_base(&roots, final_output)?;
+    if current != expected {
+        return Err(format!(
+            "compiled-bundle resolver selection changed while its private stage was built; refusing stale publication into {}",
+            final_output.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
 fn publish_compiled_bundle_completion(root: &Path) -> Result<(), String> {
     for required in [
         "corpus.meta",
@@ -6510,6 +7915,7 @@ fn publish_compiled_bundle_completion(root: &Path) -> Result<(), String> {
         "tokenizer.bin",
         "tokenizer_adapter.json",
         uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
         SOURCE_COMPILE_PREFLIGHT_FILE,
         SOURCE_MANIFEST_KAPPA_BINDING_FILE,
         "graph-cover/cover.r4g1",
@@ -6557,6 +7963,317 @@ fn publish_compiled_bundle_completion(root: &Path) -> Result<(), String> {
     )
 }
 
+fn publish_compiled_bundle_completion_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect completion root {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    // Reuse the common validation/hash path, but commit the final control leaf
+    // through the retained root descriptor so a logical-root redirection
+    // cannot move the commit to a different inode.
+    for required in [
+        "corpus.meta",
+        "corpus.records",
+        "tless_artifacts.bin",
+        "tokenizer.bin",
+        "tokenizer_adapter.json",
+        uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+        uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
+        SOURCE_COMPILE_PREFLIGHT_FILE,
+        SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+        "graph-cover/cover.r4g1",
+        "graph-cover/cover_report.json",
+        "graph/score.r4g1",
+        "graph/score_report.json",
+    ] {
+        if !regular_file_presence(&root.join(required))? {
+            return Err(format!(
+                "compiled-bundle stage {} is incomplete; missing required {required}",
+                root.display()
+            ));
+        }
+    }
+    sync_compiled_bundle_members(root)?;
+    let files = compiled_bundle_file_kappas(root)?;
+    let bytes = compiled_bundle_completion_bytes(files)?;
+    let stable = std::ffi::OsStr::new(COMPILED_BUNDLE_COMPLETION_FILE);
+    if guard
+        .verify_optional_owned_entry_bytes(
+            stable,
+            &bytes,
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            "compiled-bundle completion",
+        )
+        .map_err(|error| error.to_string())?
+    {
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+    for _ in 0..128 {
+        let id = NEXT_SOURCE_KAPPA_BINDING_ID.fetch_add(1, Ordering::Relaxed);
+        let temporary = std::ffi::OsString::from(format!(
+            ".{COMPILED_BUNDLE_COMPLETION_FILE}.{}.{}.tmp",
+            std::process::id(),
+            id
+        ));
+        let mut file = match guard.create_new_owned_entry(&temporary) {
+            Ok(file) => file,
+            Err(error) if error.reason.contains("exists") => continue,
+            Err(error) => return Err(error.to_string()),
+        };
+        file.write_all(&bytes).map_err(|error| error.to_string())?;
+        file.sync_all().map_err(|error| error.to_string())?;
+        guard
+            .verify_owned_entry_bytes(
+                &temporary,
+                &bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "compiled-bundle completion temporary",
+            )
+            .map_err(|error| error.to_string())?;
+        if let Err(error) = guard.link_owned_entry(&temporary, stable) {
+            let _ = guard.unlink_owned_entry(&temporary);
+            return Err(error.to_string());
+        }
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        guard
+            .verify_owned_entry_bytes(
+                stable,
+                &bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "compiled-bundle completion",
+            )
+            .map_err(|error| error.to_string())?;
+        guard
+            .unlink_owned_entry(&temporary)
+            .map_err(|error| error.to_string())?;
+        guard.sync_owned_root().map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+    Err(format!(
+        "could not reserve a compiled-bundle completion temporary in {}",
+        root.display()
+    ))
+}
+
+fn validate_compiled_stage_transaction_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect compiled stage {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    let recoverable = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    if recoverable {
+        return Err(format!(
+            "compiled stage {} still contains a recoverable recorded-corpus binding temporary",
+            root.display()
+        ));
+    }
+    guard
+        .preflight_planned_output_scope(&[])
+        .map_err(|error| error.to_string())?;
+    if guard
+        .compile_attempt_active()
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "compiled stage {} still has an active recorded-corpus compile attempt",
+            root.display()
+        ));
+    }
+    validate_source_bundle_inventory(root)?;
+    validate_staged_graph_outputs(root)?;
+    let meta = root.join("corpus.meta");
+    let records = root.join("corpus.records");
+    let snapshot =
+        uor_r4_graph_compiler::recorded_corpus::open_stream_under_guard(guard, &meta, &records)
+            .map_err(|error| error.to_string())?;
+    let binding_cid = snapshot.binding_cid.as_deref().ok_or_else(|| {
+        format!(
+            "compiled stage {} has no canonical recorded-corpus generation binding",
+            root.display()
+        )
+    })?;
+    if !canonical_blake3_cid(binding_cid) {
+        return Err(format!(
+            "compiled stage {} reports a noncanonical recorded-corpus binding CID",
+            root.display()
+        ));
+    }
+    let attention = source_compile_attention_binding(root)?.ok_or_else(|| {
+        format!(
+            "compiled stage {} lost its source attention binding",
+            root.display()
+        )
+    })?;
+    let dense = source_compile_dense_binding(root)?;
+    if snapshot.execution.attention_operator.as_ref() != Some(&attention)
+        || snapshot.execution.dense_operator.as_ref() != dense.as_ref()
+    {
+        return Err(format!(
+            "compiled stage {} records a corpus execution identity that differs from its canonical operator sidecars",
+            root.display()
+        ));
+    }
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(&attention), dense.as_ref())
+        .map_err(|error| format!("compiled stage {}: {error}", root.display()))?;
+    let preflight = read_optional_source_compile_preflight(root)?.ok_or_else(|| {
+        format!(
+            "compiled stage {} lost its source compile preflight",
+            root.display()
+        )
+    })?;
+    let kappa = read_optional_source_manifest_kappa_binding(root)?.ok_or_else(|| {
+        format!(
+            "compiled stage {} lost its source snapshot binding",
+            root.display()
+        )
+    })?;
+    if preflight.source_manifest_kappa.as_deref() != Some(source_snapshot_kappa)
+        || kappa != source_snapshot_kappa
+    {
+        return Err(format!(
+            "compiled stage {} does not bind requested source snapshot {} consistently across P/K",
+            root.display(),
+            source_snapshot_kappa
+        ));
+    }
+    let report = root.join("graph-cover/cover_report.json");
+    let (present, report_attention, report_dense, report_kappa) = parse_cover_provenance(&report)?;
+    if !present
+        || report_attention.as_ref() != Some(&attention)
+        || report_dense.as_ref() != dense.as_ref()
+        || report_kappa.as_deref() != Some(source_snapshot_kappa)
+    {
+        return Err(format!(
+            "compiled stage {} does not reconcile its corpus/operator/source identity with {}",
+            root.display(),
+            report.display()
+        ));
+    }
+    snapshot
+        .verify_generation()
+        .map_err(|error| error.to_string())?;
+    guard.verify_owned_root().map_err(|error| error.to_string())
+}
+
+/// Validate a complete pre-transaction compiler generation before minting its
+/// first recorded-corpus binding. This is deliberately read-only: every
+/// server/operator/source/graph check and the lower streaming binding
+/// candidate check completes before `begin_compile_attempt` mutates the root.
+fn validate_unbound_compiled_stage_transaction_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    if !guard
+        .protects_directory(root)
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "recorded-corpus producer authority for {} does not protect unbound compiled stage {}",
+            guard.root().display(),
+            root.display()
+        ));
+    }
+    if regular_file_presence(
+        &root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+    )? {
+        return Err(format!(
+            "unbound compiled-stage preflight for {} found a stable recorded-corpus binding",
+            root.display()
+        ));
+    }
+    let recoverable = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    if recoverable {
+        return Err(format!(
+            "unbound compiled stage {} contains a recoverable binding temporary",
+            root.display()
+        ));
+    }
+    guard
+        .preflight_planned_output_scope(&[])
+        .map_err(|error| error.to_string())?;
+    validate_source_bundle_inventory(root)?;
+    validate_staged_graph_outputs(root)?;
+    let meta = root.join("corpus.meta");
+    let records = root.join("corpus.records");
+    uor_r4_graph_compiler::recorded_corpus::preflight_binding_evidence_matches_current(
+        guard, &meta, &records,
+    )
+    .map_err(|error| error.to_string())?;
+    let attention = source_compile_attention_binding(root)?.ok_or_else(|| {
+        format!(
+            "unbound compiled stage {} lost its source attention binding",
+            root.display()
+        )
+    })?;
+    let dense = source_compile_dense_binding(root)?;
+    uor_r4_model_source::dense::validate_source_execution_pair(Some(&attention), dense.as_ref())
+        .map_err(|error| format!("unbound compiled stage {}: {error}", root.display()))?;
+    let preflight = read_optional_source_compile_preflight(root)?.ok_or_else(|| {
+        format!(
+            "unbound compiled stage {} lost its source compile preflight",
+            root.display()
+        )
+    })?;
+    let kappa = read_optional_source_manifest_kappa_binding(root)?.ok_or_else(|| {
+        format!(
+            "unbound compiled stage {} lost its source snapshot binding",
+            root.display()
+        )
+    })?;
+    if preflight.source_manifest_kappa.as_deref() != Some(source_snapshot_kappa)
+        || kappa != source_snapshot_kappa
+    {
+        return Err(format!(
+            "unbound compiled stage {} does not bind requested source snapshot {} consistently across P/K",
+            root.display(),
+            source_snapshot_kappa
+        ));
+    }
+    let report = root.join("graph-cover/cover_report.json");
+    let (present, report_attention, report_dense, report_kappa) = parse_cover_provenance(&report)?;
+    if !present
+        || report_attention.as_ref() != Some(&attention)
+        || report_dense.as_ref() != dense.as_ref()
+        || report_kappa.as_deref() != Some(source_snapshot_kappa)
+    {
+        return Err(format!(
+            "unbound compiled stage {} does not reconcile its operator/source identity with {}",
+            root.display(),
+            report.display()
+        ));
+    }
+    guard.verify_owned_root().map_err(|error| error.to_string())
+}
+
 fn validate_staged_graph_outputs(root: &Path) -> Result<(), String> {
     for relative in ["graph-cover/cover.r4g1", "graph/score.r4g1"] {
         let path = root.join(relative);
@@ -6573,15 +8290,26 @@ fn validate_staged_graph_outputs(root: &Path) -> Result<(), String> {
             return Err(format!("{} has no R4G1 HEAD section", path.display()));
         }
     }
-    for relative in ["graph-cover/cover_report.json", "graph/score_report.json"] {
+    for (relative, max_bytes) in [
+        (
+            "graph-cover/cover_report.json",
+            COVER_REPORT_CONTROL_MAX_BYTES,
+        ),
+        ("graph/score_report.json", SCORE_REPORT_CONTROL_MAX_BYTES),
+    ] {
         let path = root.join(relative);
-        let bytes = read_required_regular_file_nofollow(&path, "staged graph report")?;
-        reject_duplicate_json_fields(&bytes, &path, "staged graph report")?;
-        let value: serde_json::Value = serde_json::from_slice(&bytes)
-            .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
-        if !value.is_object() {
-            return Err(format!("{} must contain a JSON object", path.display()));
-        }
+        validate_staged_graph_report(&path, max_bytes)?;
+    }
+    Ok(())
+}
+
+fn validate_staged_graph_report(path: &Path, max_bytes: u64) -> Result<(), String> {
+    let bytes = read_required_regular_file_nofollow_capped(path, "staged graph report", max_bytes)?;
+    reject_duplicate_json_fields(&bytes, path, "staged graph report")?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("{} is malformed: {error}", path.display()))?;
+    if !value.is_object() {
+        return Err(format!("{} must contain a JSON object", path.display()));
     }
     Ok(())
 }
@@ -7802,6 +9530,13 @@ fn compiled_bundle_completion_temporaries(root: &Path) -> Result<Vec<(PathBuf, V
             )
         })?;
         if is_atomic_publisher_temporary(name, COMPILED_BUNDLE_COMPLETION_FILE) {
+            if temporaries.len() == COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT {
+                return Err(format!(
+                    "compiled bundle {} exceeds the fixed {}-entry completion-temporary limit",
+                    root.display(),
+                    COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT
+                ));
+            }
             let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
                 format!("{} cannot be inspected: {error}", entry.path().display())
             })?;
@@ -7811,9 +9546,10 @@ fn compiled_bundle_completion_temporaries(root: &Path) -> Result<Vec<(PathBuf, V
                     entry.path().display()
                 ));
             }
-            let bytes = read_required_regular_file_nofollow(
+            let bytes = read_required_regular_file_nofollow_capped(
                 &entry.path(),
                 "compiled-bundle completion temporary",
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
             )?;
             temporaries.push((entry.path(), bytes));
         } else if looks_like_atomic_publisher_temporary(name, COMPILED_BUNDLE_COMPLETION_FILE) {
@@ -7872,7 +9608,11 @@ fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), Str
         return Ok(());
     }
     let stable = root.join(COMPILED_BUNDLE_COMPLETION_FILE);
-    let stable_bytes = read_regular_file_nofollow(&stable, "compiled-bundle completion")?;
+    let stable_bytes = read_regular_file_nofollow_capped(
+        &stable,
+        "compiled-bundle completion",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?;
     let candidate = stable_bytes
         .as_deref()
         .unwrap_or_else(|| temporaries[0].1.as_slice());
@@ -7895,9 +9635,10 @@ fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), Str
         match fs::hard_link(&temporaries[0].0, &stable) {
             Ok(()) => sync_parent_directory(&stable, "compiled-bundle completion recovery")?,
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                let raced = read_required_regular_file_nofollow(
+                let raced = read_required_regular_file_nofollow_capped(
                     &stable,
                     "concurrently recovered compiled-bundle completion",
+                    COMPILED_BUNDLE_CONTROL_MAX_BYTES,
                 )?;
                 if raced != candidate {
                     return Err(format!(
@@ -7916,9 +9657,10 @@ fn recover_compiled_bundle_completion_temporaries(root: &Path) -> Result<(), Str
         }
     }
     for (temporary, expected) in temporaries {
-        let current = read_required_regular_file_nofollow(
+        let current = read_required_regular_file_nofollow_capped(
             &temporary,
             "compiled-bundle completion temporary before recovery",
+            COMPILED_BUNDLE_CONTROL_MAX_BYTES,
         )?;
         if current != expected {
             return Err(format!(
@@ -7947,7 +9689,12 @@ fn validate_compiled_bundle_completion(
     root: &Path,
 ) -> Result<Option<CompiledBundleCompletion>, String> {
     let path = root.join(COMPILED_BUNDLE_COMPLETION_FILE);
-    let Some(bytes) = read_regular_file_nofollow(&path, "compiled-bundle completion")? else {
+    let Some(bytes) = read_regular_file_nofollow_capped(
+        &path,
+        "compiled-bundle completion",
+        COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+    )?
+    else {
         return Ok(None);
     };
     validate_compiled_bundle_completion_bytes(
@@ -7959,31 +9706,7 @@ fn validate_compiled_bundle_completion(
     .map(Some)
 }
 
-fn ensure_compiled_bundle_completion_for_serving(
-    bundle: &ResolvedCompiledBundle,
-    current_version: u32,
-) -> Result<(), String> {
-    recover_compiled_bundle_completion_temporaries(&bundle.physical_root)?;
-    if validate_compiled_bundle_completion(&bundle.physical_root)?.is_some() {
-        return Ok(());
-    }
-    if bundle.attention_operator.version < current_version {
-        // Historical completed v1 roots predate this server transaction
-        // record. Their existing provenance compatibility remains unchanged.
-        return Ok(());
-    }
-    validate_staged_graph_outputs(&bundle.physical_root)?;
-    publish_compiled_bundle_completion(&bundle.physical_root)?;
-    validate_compiled_bundle_completion(&bundle.physical_root)?
-        .ok_or_else(|| {
-            format!(
-                "current compiled bundle {} lost its bootstrapped completion record",
-                bundle.physical_root.display()
-            )
-        })
-        .map(|_| ())
-}
-
+#[cfg(test)]
 fn recover_managed_compiled_bundle_completion_temporaries(
     compiled_root: &Path,
 ) -> Result<(), String> {
@@ -8159,7 +9882,8 @@ fn publish_source_compile_preflight(output: &Path, kappa: Option<&str>) -> Resul
                     kappa
                 ));
             }
-            if !source_compile_pre_attention_prefix(output)? {
+            let exact_empty_stage = exact_empty_compiled_bundle_stage(output)?;
+            if !source_compile_pre_attention_prefix(output)? && !exact_empty_stage {
                 return Err(format!(
                     "source compile output {} exists without a stable source compile preflight; refusing to adopt or mutate it",
                     output.display()
@@ -8183,6 +9907,14 @@ fn publish_source_compile_preflight(output: &Path, kappa: Option<&str>) -> Resul
                 (None, None) => None,
             };
             let Some(recovered) = recovered else {
+                if exact_empty_stage {
+                    publish_bytes_no_clobber(
+                        &output.join(SOURCE_COMPILE_PREFLIGHT_FILE),
+                        &expected,
+                        "source compile preflight",
+                    )?;
+                    return Ok(());
+                }
                 return Err(format!(
                     "source compile output {} has identity sidecars but no recoverable source snapshot binding",
                     output.display()
@@ -8613,6 +10345,15 @@ struct CompiledSourceBundle {
     final_output: PathBuf,
     working_output: PathBuf,
     stage: CompiledBundleStage,
+    selection_generations:
+        Vec<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration>,
+    selection_base: Vec<CompiledBundleSelectionGeneration>,
+    stage_reader_pins: Option<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins>,
+    source_snapshot_kappa: String,
+    logical_name: String,
+    current_version: u32,
+    source_operator: AttentionOperatorSpec,
+    source_dense: Option<DenseOperatorSpec>,
     /// Held until the caller finishes cover/score validation and atomically
     /// installs the replacement serving state. This is intentionally not
     /// released when Stage A returns: every compiler write derived from the
@@ -8620,16 +10361,541 @@ struct CompiledSourceBundle {
     _sessions: SourceCompileSessionLocks,
 }
 
+fn recorded_handoff_guard_for_root<'a>(
+    handoff: &'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff,
+    root: &Path,
+) -> Result<&'a uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard, String> {
+    let canonical = canonical_compile_session_subject(root)?;
+    handoff
+        .guards()
+        .find(|guard| guard.root() == canonical)
+        .ok_or_else(|| {
+            format!(
+                "recorded-corpus handoff does not own selected root {}",
+                canonical.display()
+            )
+        })
+}
+
+fn prepare_compiled_selection_sibling_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+) -> Result<(), String> {
+    if !guard.root_exists() {
+        return Ok(());
+    }
+    guard
+        .preflight_planned_output_scope(&[])
+        .map_err(|error| error.to_string())?;
+    let recover_binding = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    let meta = root.join("corpus.meta");
+    let records = root.join("corpus.records");
+    if recover_binding {
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(guard, &meta, &records)
+            .map_err(|error| error.to_string())?;
+    }
+    if guard
+        .compile_attempt_active()
+        .map_err(|error| error.to_string())?
+    {
+        if !regular_file_presence(
+            &root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        )? {
+            return Err(format!(
+                "non-selected compiled sibling {} has an active uncommitted source update; only its original compiler may resume it",
+                root.display()
+            ));
+        }
+        guard
+            .finish_compile_attempt()
+            .map_err(|error| error.to_string())?;
+    }
+    recover_compiled_bundle_completion_temporaries(root)?;
+    if validate_compiled_bundle_completion(root)?.is_some() {
+        cleanup_published_compiled_bundle_stage_marker(root)?;
+    }
+    Ok(())
+}
+
+fn prepare_compiled_root_transaction_under_guard(
+    guard: &uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard,
+    root: &Path,
+    source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    if !guard.root_exists() {
+        return Ok(());
+    }
+    guard
+        .preflight_planned_output_scope(&[])
+        .map_err(|error| error.to_string())?;
+    let recover_binding = guard
+        .preflight_publication_namespace_for(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRole::Compile,
+        )
+        .map_err(|error| error.to_string())?;
+    let meta = root.join("corpus.meta");
+    let records = root.join("corpus.records");
+    let binding_path =
+        root.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
+    if recover_binding {
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(guard, &meta, &records)
+            .map_err(|error| error.to_string())?;
+    }
+    let attempt_active = guard
+        .compile_attempt_active()
+        .map_err(|error| error.to_string())?;
+    if attempt_active && !regular_file_presence(&binding_path)? {
+        // Crash before the binding temporary existed. Re-run every read-only
+        // semantic/streaming preflight before completing the exact old
+        // generation under the already-durable compile-attempt marker.
+        validate_unbound_compiled_stage_transaction_under_guard(
+            guard,
+            root,
+            source_snapshot_kappa,
+        )?;
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(guard, &meta, &records)
+            .map_err(|error| error.to_string())?;
+    }
+    if attempt_active {
+        guard
+            .finish_compile_attempt()
+            .map_err(|error| error.to_string())?;
+    }
+    recover_compiled_bundle_completion_temporaries(root)?;
+    match validate_compiled_bundle_completion(root)? {
+        Some(_) => {
+            cleanup_published_compiled_bundle_stage_marker(root)?;
+            Ok(())
+        }
+        None if source_compile_pre_attention_prefix(root)? => Ok(()),
+        None if source_compile_output_has_payload(root)? => {
+            // Pre-#728 current bundles are migrated exactly once under the
+            // common producer authority before the long private-stage build.
+            // All terminal identity/graph/corpus checks complete before the
+            // compile-attempt marker is published.
+            if !regular_file_presence(&binding_path)? {
+                validate_unbound_compiled_stage_transaction_under_guard(
+                    guard,
+                    root,
+                    source_snapshot_kappa,
+                )?;
+                guard
+                    .begin_compile_attempt()
+                    .map_err(|error| error.to_string())?;
+                uor_r4_graph_compiler::recorded_corpus::publish_binding(
+                    guard, &meta, &records,
+                )
+                .map_err(|error| error.to_string())?;
+                guard
+                    .finish_compile_attempt()
+                    .map_err(|error| error.to_string())?;
+            }
+            validate_compiled_stage_transaction_under_guard(
+                guard,
+                root,
+                source_snapshot_kappa,
+            )?;
+            publish_compiled_bundle_completion_under_guard(guard, root)?;
+            validate_compiled_bundle_completion(root)?.ok_or_else(|| {
+                format!(
+                    "compiled bundle {} lost its bootstrapped completion",
+                    root.display()
+                )
+            })?;
+            Ok(())
+        }
+        None => Err(format!(
+            "compiled root {} is neither absent, a resumable source-identity prefix, nor a complete bundle",
+            root.display()
+        )),
+    }
+}
+
+/// A completed source-derived root is an immutable snapshot lineage for
+/// refresh.  Reject a different requested source while the public selection
+/// is still exclusively pinned, before a durable private stage can be
+/// allocated or populated from the old generation.
+fn require_compiled_refresh_source_snapshot(
+    root: &Path,
+    requested_source_snapshot_kappa: &str,
+) -> Result<(), String> {
+    if let Some(preflight) = read_optional_source_compile_preflight(root)? {
+        if let Some(recorded) = preflight.source_manifest_kappa.as_deref() {
+            if recorded != requested_source_snapshot_kappa {
+                return Err(format!(
+                    "compiled root {} is preflight-bound to source snapshot {recorded}, not requested {requested_source_snapshot_kappa}; refusing cross-snapshot refresh before private-stage allocation",
+                    root.display()
+                ));
+            }
+        }
+    }
+    if let Some(recorded) = read_optional_source_manifest_kappa_binding(root)? {
+        if recorded != requested_source_snapshot_kappa {
+            return Err(format!(
+                "compiled root {} is bound to source snapshot {recorded}, not requested {requested_source_snapshot_kappa}; refusing cross-snapshot refresh before private-stage allocation",
+                root.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+struct ManagedCompiledBundleRead {
+    resolved: Option<ResolvedCompiledBundle>,
+    pins: uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins,
+}
+
+fn managed_compiled_selection_roots(
+    compiled_root: &Path,
+    logical_name: &str,
+    current_version: u32,
+) -> [PathBuf; 3] {
+    [
+        compiled_root.join(logical_name),
+        compiled_root.join(format!(
+            "{logical_name}{}",
+            attention_era_suffix(current_version)
+        )),
+        compiled_root.join(format!(
+            "{logical_name}{}",
+            composite_era_suffix(current_version)
+        )),
+    ]
+}
+
+/// Reconcile one managed logical selection under the common exclusive root
+/// protocol. This is a short migration/recovery transaction: it may finish an
+/// exact publication residue or bootstrap the durable completion record of a
+/// valid pre-#728 current bundle, but it never spans runtime loading.
+fn bootstrap_managed_compiled_bundle(
+    compiled_root: &Path,
+    logical_name: &str,
+    current_version: u32,
+) -> Result<(), String> {
+    let roots = managed_compiled_selection_roots(compiled_root, logical_name, current_version);
+    let generations = roots
+        .iter()
+        .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    // No promotion occurs in this short ownership set; the designated indices
+    // simply satisfy the handoff type while it provides sorted, failure-atomic
+    // exclusive authority over the complete resolver selection.
+    let handoff =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+            &generations,
+            0,
+            1,
+        )
+        .map_err(|error| error.to_string())?;
+    let pair = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
+    if let Some((selected_root, identity)) = selected_compiled_root(&pair) {
+        let selected_guard = recorded_handoff_guard_for_root(&handoff, selected_root)?;
+        if identity.attention.version == current_version {
+            let source_snapshot_kappa = read_optional_source_manifest_kappa_binding(selected_root)?
+                .ok_or_else(|| {
+                    format!(
+                        "current compiled bundle {} has no canonical source snapshot binding",
+                        selected_root.display()
+                    )
+                })?;
+            prepare_compiled_root_transaction_under_guard(
+                selected_guard,
+                selected_root,
+                &source_snapshot_kappa,
+            )?;
+        } else {
+            // Historical roots may legitimately predate both the binding and
+            // completion records. If a completion record exists, it remains
+            // authoritative and must validate exactly.
+            recover_compiled_bundle_completion_temporaries(selected_root)?;
+            let _ = validate_compiled_bundle_completion(selected_root)?;
+        }
+        let refreshed = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
+        resolve_loadable_compiled_bundle_with_authority(
+            &refreshed,
+            current_version,
+            Some(RecordedCorpusReadAuthority::Producer(selected_guard)),
+        )?
+        .ok_or_else(|| {
+            format!("managed compiled model {logical_name} disappeared during completion bootstrap")
+        })?;
+    }
+    handoff.verify().map_err(|error| error.to_string())
+}
+
+/// Bootstrap under short exclusive authority, then pin the full precedence
+/// trio shared through resolution, runtime loading, and installation. Managed
+/// pins seed permanent lock inodes for absent siblings, so a cooperating
+/// writer cannot create a newly preferred root in the installation window.
+fn acquire_managed_compiled_bundle_read(
+    compiled_root: &Path,
+    logical_name: &str,
+    current_version: u32,
+) -> Result<ManagedCompiledBundleRead, String> {
+    bootstrap_managed_compiled_bundle(compiled_root, logical_name, current_version)?;
+    let roots = managed_compiled_selection_roots(compiled_root, logical_name, current_version);
+    let pins =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire_managed(
+            &roots,
+        )
+        .map_err(|error| error.to_string())?;
+    let pair = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
+    let resolved = resolve_loadable_compiled_bundle_with_authority(
+        &pair,
+        current_version,
+        Some(RecordedCorpusReadAuthority::ReaderPins(&pins)),
+    )?;
+    pins.verify().map_err(|error| error.to_string())?;
+    Ok(ManagedCompiledBundleRead { resolved, pins })
+}
+
+fn discover_managed_compiled_reads_in(
+    compiled_root: &Path,
+    current_version: u32,
+    skip_logical_name: Option<&str>,
+) -> Result<Vec<ManagedCompiledBundleRead>, String> {
+    let mut reads = Vec::new();
+    for logical_name in compiled_logical_names_in(compiled_root, current_version)? {
+        if skip_logical_name == Some(logical_name.as_str()) {
+            continue;
+        }
+        let read =
+            acquire_managed_compiled_bundle_read(compiled_root, &logical_name, current_version)?;
+        if let Some(candidate) = read.resolved.as_ref() {
+            reject_reserved_suffix_source_collision(
+                candidate,
+                compiled_root.parent().unwrap_or_else(|| Path::new(".")),
+                current_version,
+            )?;
+            reads.push(read);
+        }
+    }
+    Ok(reads)
+}
+
 impl CompiledSourceBundle {
-    fn publish(&mut self) -> Result<(), String> {
-        publish_compiled_bundle_completion(&self.working_output)?;
+    fn publish(
+        &mut self,
+    ) -> Result<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff, String> {
+        self.publish_with_transition_hooks(|_| Ok(()), |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    fn publish_with_before_handoff<F>(
+        &mut self,
+        before_handoff: F,
+    ) -> Result<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff, String>
+    where
+        F: FnOnce(&Path) -> Result<(), String>,
+    {
+        self.publish_with_transition_hooks(|_| Ok(()), before_handoff)
+    }
+
+    fn publish_with_transition_hooks<F, G>(
+        &mut self,
+        before_stage_guard: F,
+        before_handoff: G,
+    ) -> Result<uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff, String>
+    where
+        F: FnOnce(&Path) -> Result<(), String>,
+        G: FnOnce(&Path) -> Result<(), String>,
+    {
+        // The shared stage pin protected the exact corpus generation while
+        // cover/score wrote only private derived outputs. Convert it to
+        // exclusive stage ownership before completion publication. Capture a
+        // full fixed-inventory content witness while the shared pins are still
+        // live, then require it immediately after exclusive acquisition so a
+        // supported writer cannot win the reader-to-producer transition and
+        // silently splice corpus B under graph A.
+        let stage_before_transition =
+            capture_compiled_bundle_base_generation(&self.working_output)?;
+        if !validate_compiled_bundle_stage_marker(&self.working_output, &self.stage.marker_bytes)? {
+            return Err(format!(
+                "compiled-bundle stage {} lost its exact owner/base marker before producer transition",
+                self.working_output.display()
+            ));
+        }
+        if let Some(pins) = self.stage_reader_pins.as_ref() {
+            pins.verify().map_err(|error| error.to_string())?;
+        }
+        drop(self.stage_reader_pins.take());
+        before_stage_guard(&self.working_output)?;
+        let stage_guard =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &self.working_output,
+            )
+            .map_err(|error| error.to_string())?;
+        let stage_after_transition = capture_compiled_bundle_base_generation(&self.working_output)?;
+        if stage_after_transition != stage_before_transition
+            || !validate_compiled_bundle_stage_marker(
+                &self.working_output,
+                &self.stage.marker_bytes,
+            )?
+        {
+            return Err(format!(
+                "compiled-bundle stage {} changed generation while serving pins transitioned to exclusive publication authority",
+                self.working_output.display()
+            ));
+        }
+        stage_guard
+            .verify_owned_root()
+            .map_err(|error| error.to_string())?;
+        validate_compiled_stage_transaction_under_guard(
+            &stage_guard,
+            &self.working_output,
+            &self.source_snapshot_kappa,
+        )?;
+        publish_compiled_bundle_completion_under_guard(&stage_guard, &self.working_output)?;
         validate_compiled_bundle_completion(&self.working_output)?.ok_or_else(|| {
             format!(
                 "compiled-bundle stage {} lost its completion record before publication",
                 self.working_output.display()
             )
         })?;
-        self.stage.publish()
+        if !validate_compiled_bundle_stage_marker(&self.working_output, &self.stage.marker_bytes)? {
+            return Err(format!(
+                "compiled-bundle stage {} lost its exact owner/base marker before publication",
+                self.working_output.display()
+            ));
+        }
+        let stage_content_generation =
+            capture_compiled_bundle_base_generation(&self.working_output)?;
+        if !matches!(
+            &stage_content_generation,
+            CompiledBundleBaseGeneration::Complete { .. }
+        ) {
+            return Err(format!(
+                "compiled-bundle stage {} did not yield a complete content generation before handoff",
+                self.working_output.display()
+            ));
+        }
+        let stage_generation =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture(
+                &self.working_output,
+            )
+            .map_err(|error| error.to_string())?;
+        stage_generation
+            .verify()
+            .map_err(|error| error.to_string())?;
+        drop(stage_guard);
+        before_handoff(&self.working_output)?;
+
+        let mut expected = std::mem::take(&mut self.selection_generations);
+        let final_canonical = canonical_compile_session_subject(&self.final_output)?;
+        let final_index = expected
+            .iter()
+            .position(|generation| generation.root() == final_canonical)
+            .ok_or_else(|| {
+                format!(
+                    "compiled-bundle selection lost final root {}",
+                    final_canonical.display()
+                )
+            })?;
+        let stage_index = expected.len();
+        expected.push(stage_generation);
+        let mut handoff =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+                &expected,
+                final_index,
+                stage_index,
+            )
+            .map_err(|error| error.to_string())?;
+
+        handoff
+            .promote_stage_if(|authority| {
+                let fail = |error: String| uor_r4_model_source::SourceUnavailable::new(error);
+                require_compiled_bundle_selection_base_unchanged(
+                    &self.selection_base,
+                    &self.final_output,
+                )
+                .map_err(fail)?;
+                let compiled_root = self.final_output.parent().ok_or_else(|| {
+                    fail(format!(
+                        "compiled output {} has no resolver parent",
+                        self.final_output.display()
+                    ))
+                })?;
+                let selected = source_compile_output_for_operator_era_with_dense(
+                    compiled_root,
+                    &self.logical_name,
+                    self.current_version,
+                    &self.source_operator,
+                    self.source_dense.as_ref(),
+                )
+                .map_err(fail)?;
+                if canonical_compile_session_subject(&selected).map_err(fail)? != final_canonical {
+                    return Err(fail(format!(
+                        "compiled-bundle resolver selection changed from {} to {} during private stage construction; preserving the newer generation",
+                        self.final_output.display(),
+                        selected.display()
+                    )));
+                }
+                let current_stage_generation =
+                    capture_compiled_bundle_base_generation(&self.working_output).map_err(fail)?;
+                if current_stage_generation != stage_content_generation {
+                    return Err(fail(format!(
+                        "compiled-bundle stage {} changed content generation between completion and final handoff; preserving the newer stage",
+                        self.working_output.display()
+                    )));
+                }
+                if !validate_compiled_bundle_stage_marker(
+                    &self.working_output,
+                    &self.stage.marker_bytes,
+                )
+                .map_err(fail)?
+                {
+                    return Err(fail(format!(
+                        "compiled-bundle stage {} changed its exact owner/base marker during final handoff",
+                        self.working_output.display()
+                    )));
+                }
+                validate_compiled_stage_transaction_under_guard(
+                    authority.stage_guard(),
+                    &self.working_output,
+                    &self.source_snapshot_kappa,
+                )
+                .map_err(fail)?;
+                validate_compiled_bundle_completion(&self.working_output)
+                    .map_err(fail)?
+                    .ok_or_else(|| {
+                        fail(format!(
+                            "compiled-bundle stage {} lost its durable completion during final CAS",
+                            self.working_output.display()
+                        ))
+                    })?;
+                Ok(())
+            })
+            .map_err(|error| error.to_string())?;
+        handoff.verify().map_err(|error| error.to_string())?;
+        validate_compiled_bundle_completion(&self.final_output)?.ok_or_else(|| {
+            format!(
+                "promoted compiled bundle {} lost its durable completion",
+                self.final_output.display()
+            )
+        })?;
+        handoff
+            .final_guard()
+            .verify_owned_entry_bytes(
+                std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                &self.stage.marker_bytes,
+                COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+                "promoted compiled-bundle stage marker",
+            )
+            .map_err(|error| error.to_string())?;
+        handoff
+            .final_guard()
+            .unlink_owned_entry(std::ffi::OsStr::new(COMPILED_BUNDLE_STAGE_MARKER_FILE))
+            .map_err(|error| error.to_string())?;
+        handoff
+            .final_guard()
+            .sync_owned_root()
+            .map_err(|error| error.to_string())?;
+        Ok(handoff)
     }
 }
 
@@ -8729,6 +10995,23 @@ fn compile_bundle_from_source(
         session_subjects,
         SourceCompileSessionMode::ExclusiveWriter,
     )?;
+    let selection_roots = [conventional.clone(), current.clone(), composite.clone()];
+    let selection_generations = selection_roots
+        .iter()
+        .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    // Short common ownership makes crash-residue recovery and legacy
+    // completion bootstrap one coherent base capture. It is released before
+    // the long private-stage build; the retained generation witnesses and
+    // persisted content descriptor are re-CASed by the final handoff.
+    let base_handoff =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+            &selection_generations,
+            0,
+            1,
+        )
+        .map_err(|error| error.to_string())?;
     recover_source_compile_identity_temporaries(&conventional)?;
     recover_source_compile_identity_temporaries(&current)?;
     recover_source_compile_identity_temporaries(&composite)?;
@@ -8739,6 +11022,15 @@ fn compile_bundle_from_source(
         &source_operator,
         source_dense.as_ref(),
     )?;
+    require_compiled_refresh_source_snapshot(&output, source_snapshot_kappa)?;
+    for root in &selection_roots {
+        let guard = recorded_handoff_guard_for_root(&base_handoff, root)?;
+        if root == &output {
+            prepare_compiled_root_transaction_under_guard(guard, root, source_snapshot_kappa)?;
+        } else {
+            prepare_compiled_selection_sibling_under_guard(guard, root)?;
+        }
+    }
     // The process-local source-cache reservation is acquired by the HTTP
     // handler first. Both era siblings and any external score sink are now
     // exclusively owned before selection, preflight publication, or adoption.
@@ -8757,6 +11049,9 @@ fn compile_bundle_from_source(
             refreshed_output.display()
         ));
     }
+    let selection_base = capture_compiled_bundle_selection_base(&selection_roots, &output)?;
+    base_handoff.verify().map_err(|error| error.to_string())?;
+    drop(base_handoff);
     let canonical_graph_path = output.join("graph/score.r4g1");
     if let Some(requested) = requested_graph_path {
         if normalized_absolute_path(requested)? != normalized_absolute_path(&canonical_graph_path)?
@@ -8768,9 +11063,13 @@ fn compile_bundle_from_source(
             ));
         }
     }
-    preflight_and_bind_source_snapshot_kappa(&output, Some(source_snapshot_kappa))?;
-    let stage = CompiledBundleStage::allocate(&output, source_snapshot_kappa)?;
+    let (stage, stage_compile_session) = CompiledBundleStage::allocate_with_selection_transaction(
+        &output,
+        source_snapshot_kappa,
+        &selection_base,
+    )?;
     let working_output = stage.path.clone();
+    preflight_and_bind_source_snapshot_kappa(&working_output, Some(source_snapshot_kappa))?;
     let args = vec![
         "--source".to_owned(),
         source.display().to_string(),
@@ -8798,7 +11097,7 @@ fn compile_bundle_from_source(
             6,
             "Loading teacher model and preparing corpus...",
         );
-        uor_r4_graph_cli::compile_hugging_face(&args)
+        uor_r4_graph_cli::compile_hugging_face_with_session(&args, stage_compile_session)
     });
     while !compiler.is_finished() {
         let observed = fs::read(&meta_path).ok().and_then(|bytes| {
@@ -8825,6 +11124,11 @@ fn compile_bundle_from_source(
             )
         })?
         .map_err(|error| error.to_string())?;
+    let stage_reader_pins =
+        uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire([
+            &working_output,
+        ])
+        .map_err(|error| error.to_string())?;
     validate_source_bundle_inventory(&working_output)?;
     let meta = working_output.join("corpus.meta");
     let records = working_output.join("corpus.records");
@@ -8844,6 +11148,14 @@ fn compile_bundle_from_source(
         final_output: output,
         working_output,
         stage,
+        selection_generations,
+        selection_base,
+        stage_reader_pins: Some(stage_reader_pins),
+        source_snapshot_kappa: source_snapshot_kappa.to_owned(),
+        logical_name: name.to_owned(),
+        current_version,
+        source_operator,
+        source_dense,
         _sessions: sessions,
     })
 }
@@ -9304,6 +11616,7 @@ fn compile_r4g1_bundle(
         _ => None,
     };
 
+    let mut publication_handoff = None;
     if let Some(compiled) = compiled_source.as_mut() {
         validate_staged_graph_outputs(&compiled.working_output)?;
         // Exercise the exact runtime/quality-policy loader against the staged
@@ -9349,7 +11662,7 @@ fn compile_r4g1_bundle(
                 ));
             }
         }
-        compiled.publish()?;
+        publication_handoff = Some(compiled.publish()?);
         let final_root = compiled.final_output.clone();
         artifacts = final_root.join("tless_artifacts.bin");
         graph_output = final_root.join("graph");
@@ -9376,13 +11689,17 @@ fn compile_r4g1_bundle(
                 )
             })?;
             let pair = inspect_compiled_model_pair(compiled_root, logical_name, current_version)?;
+            let authority = publication_handoff
+                .as_ref()
+                .map(|handoff| RecordedCorpusReadAuthority::Producer(handoff.final_guard()));
             let resolved =
-                resolve_loadable_compiled_bundle(&pair, current_version)?.ok_or_else(|| {
-                    format!(
-                        "compiled output {} did not resolve to a loadable graph bundle",
-                        root.display()
-                    )
-                })?;
+                resolve_loadable_compiled_bundle_with_authority(&pair, current_version, authority)?
+                    .ok_or_else(|| {
+                        format!(
+                            "compiled output {} did not resolve to a loadable graph bundle",
+                            root.display()
+                        )
+                    })?;
             if resolved.physical_root != *root
                 || resolved.graph != graph_path
                 || resolved.teacher != artifacts
@@ -9439,9 +11756,18 @@ fn compile_r4g1_bundle(
     )?;
     let (teacher_default_r4_attention, _teacher_mismatch) =
         reconcile_prepared_teacher_with_bundle(&mut replacement_teacher, resolved.as_ref())?;
+    let publication_authority = publication_handoff
+        .as_ref()
+        .map(|handoff| RecordedCorpusReadAuthority::Producer(handoff.final_guard()));
     let refreshed = resolved
         .as_ref()
-        .map(|resolved| refresh_resolved_compiled_bundle(resolved, current_version))
+        .map(|resolved| {
+            refresh_resolved_compiled_bundle_with_authority(
+                resolved,
+                current_version,
+                publication_authority,
+            )
+        })
         .transpose()?;
     if let (Some(source), Some(before)) = (source_for_host, source_snapshot_before_prepare.as_ref())
     {
@@ -11319,11 +13645,13 @@ fn handle_connection(
         };
         let compiled_root = Path::new(".uor-models/compiled");
         let suffix = attention_era_suffix(current_version);
+        let composite_suffix = composite_era_suffix(current_version);
         let reload_read_sessions = match try_lock_managed_inventory_write_sessions(
             compiled_root,
             [
                 compiled_root.join(&reload_logical),
                 compiled_root.join(format!("{reload_logical}{suffix}")),
+                compiled_root.join(format!("{reload_logical}{composite_suffix}")),
                 PathBuf::from(".uor-models/sources"),
             ],
         ) {
@@ -11365,32 +13693,47 @@ fn handle_connection(
                 return;
             }
         };
-        if let Err(error) = recover_managed_compiled_bundle_completion_temporaries(compiled_root) {
+        if let Err(error) = reject_requested_suffix_source_collision(
+            target_model,
+            Path::new(".uor-models"),
+            current_version,
+        ) {
             record_replacement_failure(&serving, error.clone());
             send_json_response_ext(
                 stream,
-                500,
+                400,
                 &serde_json::json!({ "status": "error", "message": error }).to_string(),
                 &dep,
             );
             return;
         }
-        let (resolved, source_for_reload) = match resolve_reload_bundle_in(
-            Path::new(".uor-models"),
-            target_model,
+        let managed_read = match acquire_managed_compiled_bundle_read(
+            compiled_root,
+            &reload_logical,
             current_version,
         ) {
-            Ok(Some(resolved)) => resolved,
-            Ok(None) => {
-                record_replacement_failure(
-                    &serving,
-                    format!("no compiled R4G1 graph artifact found for model '{target_model}'"),
+            Ok(read) => read,
+            Err(error) if source_compile_session_is_busy(&error) => {
+                reload_reservation.disarm();
+                let installed = serving.lock().unwrap();
+                let mut status = r4g1_compile.lock().unwrap();
+                status.running = false;
+                status.ready = graph_text_ready(&installed);
+                status.message =
+                    "R4G1 reload deferred while another process publishes the bundle".to_owned();
+                drop(status);
+                drop(installed);
+                send_json_response_ext(
+                    stream,
+                    409,
+                    &serde_json::json!({
+                        "status": "error",
+                        "running": true,
+                        "message": error,
+                    })
+                    .to_string(),
+                    &dep,
                 );
-                let resp = serde_json::json!({
-                    "status": "error",
-                    "message": format!("No compiled R4G1 graph artifact found for model '{}'. Please compile it first.", target_model)
-                });
-                send_json_response_ext(stream, 404, &resp.to_string(), &dep);
                 return;
             }
             Err(error) => {
@@ -11404,19 +13747,40 @@ fn handle_connection(
                 return;
             }
         };
+        let ManagedCompiledBundleRead {
+            resolved,
+            pins: reload_bundle_pins,
+        } = managed_read;
+        let resolved = match resolved {
+            Some(resolved) => resolved,
+            None => {
+                record_replacement_failure(
+                    &serving,
+                    format!("no compiled R4G1 graph artifact found for model '{target_model}'"),
+                );
+                let resp = serde_json::json!({
+                    "status": "error",
+                    "message": format!("No compiled R4G1 graph artifact found for model '{}'. Please compile it first.", target_model)
+                });
+                send_json_response_ext(stream, 404, &resp.to_string(), &dep);
+                return;
+            }
+        };
+        let source_for_reload =
+            match source_for_resolved_bundle_in(&resolved, Path::new(".uor-models")) {
+                Ok(source) => source,
+                Err(error) => {
+                    record_replacement_failure(&serving, error.clone());
+                    send_json_response_ext(
+                        stream,
+                        500,
+                        &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                        &dep,
+                    );
+                    return;
+                }
+            };
         if let Err(error) = validate_legacy_graph_generation_for_serving(&resolved.graph) {
-            record_replacement_failure(&serving, error.clone());
-            send_json_response_ext(
-                stream,
-                500,
-                &serde_json::json!({ "status": "error", "message": error }).to_string(),
-                &dep,
-            );
-            return;
-        }
-        if let Err(error) =
-            ensure_compiled_bundle_completion_for_serving(&resolved, current_version)
-        {
             record_replacement_failure(&serving, error.clone());
             send_json_response_ext(
                 stream,
@@ -11514,7 +13878,11 @@ fn handle_connection(
                     return;
                 }
             };
-        let refreshed = match refresh_resolved_compiled_bundle(&resolved, current_version) {
+        let refreshed = match refresh_resolved_compiled_bundle_with_authority(
+            &resolved,
+            current_version,
+            Some(RecordedCorpusReadAuthority::ReaderPins(&reload_bundle_pins)),
+        ) {
             Ok(refreshed) => refreshed,
             Err(error) => {
                 record_replacement_failure(&serving, error.clone());
@@ -11581,6 +13949,17 @@ fn handle_connection(
                 ),
                 None => (None, None, None),
             };
+        if let Err(error) = reload_bundle_pins.verify() {
+            let error = error.to_string();
+            record_replacement_failure(&serving, error.clone());
+            send_json_response_ext(
+                stream,
+                500,
+                &serde_json::json!({ "status": "error", "message": error }).to_string(),
+                &dep,
+            );
+            return;
+        }
         let mut installed = serving.lock().unwrap();
         if installed.epoch != base_epoch {
             let error =
@@ -11614,6 +13993,7 @@ fn handle_connection(
             refreshed.logical_name
         );
         reload_reservation.disarm();
+        drop(reload_bundle_pins);
         drop(reload_read_sessions);
         let resp = serde_json::json!({
             "status": "success",
@@ -14241,6 +16621,46 @@ mod tests {
         (meta, records)
     }
 
+    fn valid_attention_corpus_markers(
+        root: &std::path::Path,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let meta = root.join("corpus.meta");
+        let records = root.join("corpus.records");
+        let mut metadata = [0u8; 25];
+        metadata[0..8].copy_from_slice(&1u64.to_le_bytes());
+        metadata[8..16].copy_from_slice(&1u64.to_le_bytes());
+        metadata[16..24].copy_from_slice(&7u64.to_le_bytes());
+        metadata[24] = 1;
+        let mut record = [0u8; 48];
+        record[20..24].copy_from_slice(&34u32.to_le_bytes());
+        record[24..28].copy_from_slice(&33u32.to_le_bytes());
+        record[28..32].copy_from_slice(&33u32.to_le_bytes());
+        record[36..40].copy_from_slice(&1u32.to_le_bytes());
+        record[40..44].copy_from_slice(&u32::MAX.to_le_bytes());
+        record[44..48].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(&meta, metadata).expect("write valid corpus metadata");
+        std::fs::write(&records, record).expect("write valid corpus record");
+        (meta, records)
+    }
+
+    fn commit_test_recorded_corpus_binding(root: &std::path::Path) {
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("test recorded-corpus producer guard");
+        producer
+            .begin_compile_attempt()
+            .expect("test recorded-corpus compile attempt");
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            &producer,
+            &root.join("corpus.meta"),
+            &root.join("corpus.records"),
+        )
+        .expect("test recorded-corpus binding");
+        producer
+            .finish_compile_attempt()
+            .expect("finish test recorded-corpus attempt");
+    }
+
     fn write_test_source_manifest(
         source_dir: &std::path::Path,
         source: &crate::model::SourceDownload,
@@ -14499,7 +16919,8 @@ mod tests {
             .expect("source snapshot binding");
         write_attention_binding(&output, &attention);
         write_dense_binding(&output, &dense);
-        let (meta, records) = attention_corpus_markers(&output);
+        let (meta, records) = valid_attention_corpus_markers(&output);
+        commit_test_recorded_corpus_binding(&output);
 
         let mut cover_args = Vec::new();
         super::append_recorded_execution_identity(&mut cover_args, &meta, &records, true)
@@ -15959,35 +18380,784 @@ mod tests {
     fn write_completion_fixture(root: &std::path::Path, tag: &[u8]) {
         std::fs::create_dir_all(root.join("graph-cover")).expect("cover directory");
         std::fs::create_dir_all(root.join("graph")).expect("graph directory");
-        for file in [
-            "corpus.meta",
-            "corpus.records",
-            "tless_artifacts.bin",
-            "tokenizer.bin",
-            "tokenizer_adapter.json",
-            uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
-            super::SOURCE_COMPILE_PREFLIGHT_FILE,
-            super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
-        ] {
-            let bytes = if file == uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE {
-                let mut bytes = serde_json::to_vec_pretty(
-                    &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
-                )
-                .expect("serialize fixture attention");
-                bytes.push(b'\n');
-                bytes
-            } else {
-                tag.to_vec()
-            };
-            std::fs::write(root.join(file), bytes).expect("bundle fixture member");
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("fixture producer guard");
+        producer
+            .begin_compile_attempt()
+            .expect("fixture compile attempt");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let mut meta = [0u8; 25];
+        meta[0..8].copy_from_slice(&1u64.to_le_bytes());
+        meta[8..16].copy_from_slice(&1u64.to_le_bytes());
+        meta[16..24].copy_from_slice(&7u64.to_le_bytes());
+        meta[24] = 1;
+        let mut record = [0u8; 48];
+        record[4..8].copy_from_slice(&(tag.first().copied().unwrap_or(0) as u32).to_le_bytes());
+        record[20..24].copy_from_slice(&34u32.to_le_bytes());
+        record[24..28].copy_from_slice(&33u32.to_le_bytes());
+        record[28..32].copy_from_slice(&33u32.to_le_bytes());
+        record[36..40].copy_from_slice(&1u32.to_le_bytes());
+        record[40..44].copy_from_slice(&u32::MAX.to_le_bytes());
+        record[44..48].copy_from_slice(&u32::MAX.to_le_bytes());
+        for file in ["tless_artifacts.bin", "tless_store.bin", "tokenizer.bin"] {
+            std::fs::write(root.join(file), tag).expect("bundle fixture member");
         }
+        write_tokenizer_adapter_binding(root, "compiled-bundle-fixture");
+        std::fs::write(root.join("corpus.meta"), meta).expect("fixture corpus metadata");
+        std::fs::write(root.join("corpus.records"), record).expect("fixture corpus records");
+        let mut attention = serde_json::to_vec_pretty(
+            &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+        )
+        .expect("serialize fixture attention");
+        attention.push(b'\n');
+        std::fs::write(
+            root.join(uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE),
+            attention,
+        )
+        .expect("fixture attention binding");
+        std::fs::write(
+            root.join(super::SOURCE_COMPILE_PREFLIGHT_FILE),
+            super::source_compile_preflight_bytes(Some(&source_kappa))
+                .expect("fixture source preflight"),
+        )
+        .expect("fixture source preflight");
+        std::fs::write(
+            root.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE),
+            super::source_manifest_kappa_binding_bytes(&source_kappa)
+                .expect("fixture source binding"),
+        )
+        .expect("fixture source binding");
         for file in [
             "graph-cover/cover.r4g1",
-            "graph-cover/cover_report.json",
             "graph/score.r4g1",
             "graph/score_report.json",
         ] {
             std::fs::write(root.join(file), tag).expect("graph fixture member");
+        }
+        let cover_report = serde_json::to_vec_pretty(&serde_json::json!({
+            "attention_operator": uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+            "dense_operator": null,
+            "source_manifest_kappa": source_kappa,
+        }))
+        .expect("fixture cover report");
+        std::fs::write(root.join("graph-cover/cover_report.json"), cover_report)
+            .expect("fixture cover report");
+        uor_r4_graph_compiler::recorded_corpus::publish_binding(
+            &producer,
+            &root.join("corpus.meta"),
+            &root.join("corpus.records"),
+        )
+        .expect("fixture corpus binding");
+        producer
+            .finish_compile_attempt()
+            .expect("finish fixture compile attempt");
+        super::publish_compiled_bundle_completion_under_guard(&producer, root)
+            .expect("fixture bundle completion");
+    }
+
+    fn make_completion_fixture_graph_outputs_valid(root: &std::path::Path, tag: &str) {
+        std::fs::remove_file(root.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("remove fixture completion before graph replacement");
+        for relative in ["graph-cover/cover.r4g1", "graph/score.r4g1"] {
+            std::fs::write(root.join(relative), minimal_r4g1_bytes())
+                .expect("valid fixture R4G1 bytes");
+        }
+        std::fs::write(
+            root.join("graph/score_report.json"),
+            serde_json::to_vec(&serde_json::json!({ "tag": tag })).expect("fixture score report"),
+        )
+        .expect("fixture score report");
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(root)
+                .expect("valid-graph fixture producer guard");
+        super::publish_compiled_bundle_completion_under_guard(&producer, root)
+            .expect("valid-graph fixture completion");
+    }
+
+    fn compiled_source_bundle_publish_fixture(
+        root: &std::path::Path,
+        tag: &str,
+    ) -> super::CompiledSourceBundle {
+        compiled_source_bundle_publish_fixture_with_final(root, tag, None)
+    }
+
+    fn compiled_source_bundle_publish_fixture_with_final(
+        root: &std::path::Path,
+        tag: &str,
+        final_tag: Option<&str>,
+    ) -> super::CompiledSourceBundle {
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        std::fs::create_dir_all(&compiled).expect("compiled fixture root");
+        if let Some(final_tag) = final_tag {
+            write_completion_fixture(&conventional, final_tag.as_bytes());
+            make_completion_fixture_graph_outputs_valid(&conventional, final_tag);
+        }
+        let roots = [conventional.clone(), current.clone(), composite.clone()];
+        let selection = super::capture_compiled_bundle_selection_base(&roots, &conventional)
+            .expect("empty three-root selection");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let stage = super::CompiledBundleStage::allocate_with_selection(
+            &conventional,
+            &source_kappa,
+            &selection,
+        )
+        .expect("private publication stage");
+        write_completion_fixture(&stage.path, tag.as_bytes());
+        make_completion_fixture_graph_outputs_valid(&stage.path, tag);
+        let stage_reader_pins =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusReaderPins::try_acquire([
+                &stage.path
+            ])
+            .expect("serving-stage reader pin");
+        let selection_generations = roots
+            .iter()
+            .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("selection root identities");
+        let sessions = super::try_lock_source_compile_sessions(
+            [
+                compiled,
+                conventional.clone(),
+                current.clone(),
+                composite,
+                stage.path.clone(),
+            ],
+            super::SourceCompileSessionMode::ExclusiveWriter,
+        )
+        .expect("server source sessions");
+        super::CompiledSourceBundle {
+            final_output: conventional,
+            working_output: stage.path.clone(),
+            stage,
+            selection_generations,
+            selection_base: selection,
+            stage_reader_pins: Some(stage_reader_pins),
+            source_snapshot_kappa: source_kappa,
+            logical_name: "teacher".to_owned(),
+            current_version: 2,
+            source_operator: uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+            source_dense: None,
+            _sessions: sessions,
+        }
+    }
+
+    fn advance_private_stage_generation(stage: &std::path::Path, tag: &[u8]) {
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(stage)
+                .expect("stage-B producer");
+        producer
+            .begin_compile_attempt()
+            .expect("stage-B compile attempt");
+        std::fs::remove_file(stage.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("remove stage-A completion");
+        std::fs::write(stage.join("tless_artifacts.bin"), tag).expect("stage-B artifact commit");
+        super::publish_compiled_bundle_completion_under_guard(&producer, stage)
+            .expect("stage-B completion");
+        producer
+            .finish_compile_attempt()
+            .expect("finish stage-B attempt");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compiled_bundle_stage_v2_canonical_bytes_and_cid_are_pinned() {
+        let conventional = "/uor-r4-stage-pin";
+        let current = "/uor-r4-stage-pin-attention-v2";
+        let composite = "/uor-r4-stage-pin-attention-v2-dense-v2";
+        let stage =
+            "/.uor-r4-source-compile-staging/.uor-r4-stage-pin-attention-v2.bundle-stage.7.9";
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let selection = [conventional, current, composite]
+            .into_iter()
+            .map(|root| super::CompiledBundleSelectionGeneration {
+                root: root.to_owned(),
+                generation: super::CompiledBundleBaseGeneration::Absent,
+            })
+            .collect::<Vec<_>>();
+        let bytes = super::compiled_bundle_stage_marker_bytes(
+            std::path::Path::new(current),
+            std::path::Path::new(stage),
+            &source_kappa,
+            &selection,
+        )
+        .expect("canonical stage marker");
+        let expected = format!(
+            concat!(
+                "{{\n",
+                "  \"schema\": \"uor-r4-compiled-bundle-stage/2\",\n",
+                "  \"final_output\": \"/uor-r4-stage-pin-attention-v2\",\n",
+                "  \"stage_path\": \"/.uor-r4-source-compile-staging/.uor-r4-stage-pin-attention-v2.bundle-stage.7.9\",\n",
+                "  \"source_snapshot_kappa\": \"blake3:{}\",\n",
+                "  \"selection_base\": [\n",
+                "    {{\n",
+                "      \"root\": \"/uor-r4-stage-pin\",\n",
+                "      \"generation\": {{\n",
+                "        \"kind\": \"absent\"\n",
+                "      }}\n",
+                "    }},\n",
+                "    {{\n",
+                "      \"root\": \"/uor-r4-stage-pin-attention-v2\",\n",
+                "      \"generation\": {{\n",
+                "        \"kind\": \"absent\"\n",
+                "      }}\n",
+                "    }},\n",
+                "    {{\n",
+                "      \"root\": \"/uor-r4-stage-pin-attention-v2-dense-v2\",\n",
+                "      \"generation\": {{\n",
+                "        \"kind\": \"absent\"\n",
+                "      }}\n",
+                "    }}\n",
+                "  ]\n",
+                "}}\n"
+            ),
+            "0".repeat(64)
+        );
+        assert_eq!(bytes, expected.as_bytes());
+        assert_eq!(
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+            "blake3:ca8826c3b1b5661d61702178d92c76d9e5f92c6fd838f7acef36dd8a1241af80"
+        );
+    }
+
+    #[test]
+    fn private_stage_marker_is_ignored_only_when_exact_and_location_bound() {
+        for scenario in ["exact", "malformed", "wrong-stage"] {
+            let root = attention_provenance_test_dir(&format!("stage-prefix-{scenario}"));
+            let compiled = root.join("compiled");
+            let conventional = compiled.join("teacher");
+            let current = compiled.join("teacher-attention-v2");
+            let composite = compiled.join("teacher-attention-v2-dense-v2");
+            let selection_roots = [conventional, current.clone(), composite];
+            let selection =
+                super::capture_compiled_bundle_selection_base(&selection_roots, &current)
+                    .expect("absent selection");
+            std::fs::create_dir_all(&compiled).expect("compiled root");
+            let source_kappa = format!("blake3:{}", "0".repeat(64));
+            let stage = super::CompiledBundleStage::allocate_with_selection(
+                &current,
+                &source_kappa,
+                &selection,
+            )
+            .expect("private stage");
+            let marker = stage.path.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE);
+            let expected = std::fs::read(&marker).expect("stage marker");
+            match scenario {
+                "exact" => {}
+                "malformed" => std::fs::write(&marker, b"{}\n").expect("malformed marker"),
+                "wrong-stage" => {
+                    let wrong = stage.path.parent().expect("stage parent").join(
+                        super::compiled_bundle_stage_name("teacher-attention-v2", 999, 999),
+                    );
+                    let bytes = super::compiled_bundle_stage_marker_bytes(
+                        &current,
+                        &wrong,
+                        &source_kappa,
+                        &selection,
+                    )
+                    .expect("wrong-stage canonical marker");
+                    std::fs::write(&marker, bytes).expect("wrong-stage marker");
+                }
+                _ => unreachable!(),
+            }
+            let session = uor_r4_graph_cli::acquire_source_corpus_session(&stage.path)
+                .expect("private-stage source/common session");
+            session
+                .recorded_corpus_guard()
+                .expect("private-stage common guard")
+                .begin_compile_attempt()
+                .expect("compile-attempt marker precedes P/K");
+            let result =
+                super::preflight_and_bind_source_snapshot_kappa(&stage.path, Some(&source_kappa));
+            match scenario {
+                "exact" => {
+                    result.expect("exact stage marker is non-payload coordination");
+                    assert!(stage
+                        .path
+                        .join(super::SOURCE_COMPILE_PREFLIGHT_FILE)
+                        .is_file());
+                    assert!(stage
+                        .path
+                        .join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE)
+                        .is_file());
+                    assert_eq!(std::fs::read(&marker).expect("marker unchanged"), expected);
+                }
+                _ => {
+                    let error = result.expect_err("nonexact stage marker is terminal");
+                    assert!(
+                        error.contains("marker")
+                            || error.contains("canonical")
+                            || error.contains("malformed"),
+                        "{error}"
+                    );
+                    assert!(!stage
+                        .path
+                        .join(super::SOURCE_COMPILE_PREFLIGHT_FILE)
+                        .exists());
+                    assert!(!stage
+                        .path
+                        .join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE)
+                        .exists());
+                    assert_ne!(
+                        std::fs::read(&marker).expect("evidence preserved"),
+                        expected
+                    );
+                }
+            }
+            drop(session);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn compiled_bundle_namespaces_are_bounded_and_preserved_on_refusal() {
+        let root = attention_provenance_test_dir("compiled-bundle-bounded-namespaces");
+
+        let completion_root = root.join("completion-temps");
+        std::fs::create_dir_all(&completion_root).expect("completion root");
+        for id in 0..=super::COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT {
+            std::fs::write(
+                completion_root.join(format!(
+                    ".{}.1.{id}.tmp",
+                    super::COMPILED_BUNDLE_COMPLETION_FILE
+                )),
+                b"{}\n",
+            )
+            .expect("completion temp");
+        }
+        let error = super::recover_compiled_bundle_completion_temporaries(&completion_root)
+            .expect_err("65 completion temporaries exceed the fixed registry bound");
+        assert!(error.contains("fixed 64-entry"), "{error}");
+        assert_eq!(
+            std::fs::read_dir(&completion_root)
+                .expect("preserved completion temps")
+                .count(),
+            super::COMPILED_BUNDLE_COMPLETION_TEMP_LIMIT + 1
+        );
+
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("model");
+        let current = compiled.join("model-attention-v2");
+        let composite = compiled.join("model-attention-v2-dense-v2");
+        let selection_roots = [conventional, current.clone(), composite];
+        let selection = super::capture_compiled_bundle_selection_base(&selection_roots, &current)
+            .expect("absent three-root base");
+        std::fs::create_dir_all(&compiled).expect("compiled root");
+        let staging =
+            super::ensure_source_compile_staging_root(&compiled).expect("stage registry root");
+        for id in 0..=super::COMPILED_BUNDLE_STAGE_LIMIT {
+            std::fs::create_dir(staging.join(super::compiled_bundle_stage_name(
+                "model-attention-v2",
+                1,
+                id as u64,
+            )))
+            .expect("recognized stage");
+        }
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let error = super::recover_compiled_bundle_stages(&current, &source_kappa, &selection)
+            .expect_err("65 stages exceed the fixed registry bound");
+        assert!(error.contains("fixed 64-entry"), "{error}");
+        assert_eq!(
+            std::fs::read_dir(&staging)
+                .expect("preserved stages")
+                .count(),
+            super::COMPILED_BUNDLE_STAGE_LIMIT + 1
+        );
+
+        let oversized = root.join("oversized-control");
+        std::fs::create_dir_all(&oversized).expect("oversized root");
+        let completion = oversized.join(super::COMPILED_BUNDLE_COMPLETION_FILE);
+        let file = std::fs::File::create(&completion).expect("sparse control");
+        file.set_len(1_u64 << 40).expect("1 TiB sparse control");
+        drop(file);
+        let error = super::validate_compiled_bundle_completion(&oversized)
+            .expect_err("oversized control is rejected before its body is retained");
+        assert!(error.contains("65536-byte control-record limit"), "{error}");
+        assert_eq!(
+            std::fs::metadata(&completion)
+                .expect("sparse control preserved")
+                .len(),
+            1_u64 << 40
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bounded_server_reads_reject_growth_after_the_eof_probe() {
+        use std::io::Write as _;
+
+        let root = attention_provenance_test_dir("server-post-eof-growth");
+        let control = root.join("control.json");
+        std::fs::write(&control, b"{}\n").expect("control fixture");
+        let opened = super::open_regular_file_nofollow(&control, "test control")
+            .expect("open control")
+            .expect("control present");
+        let control_error = super::read_opened_regular_file_nofollow_capped_with_after_eof(
+            opened,
+            &control,
+            "test control",
+            1024,
+            || {
+                std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&control)
+                    .and_then(|mut file| file.write_all(b"x"))
+                    .map_err(|error| error.to_string())
+            },
+        )
+        .expect_err("post-EOF control growth is rejected");
+        assert!(control_error.contains("changed"), "{control_error}");
+
+        let member = root.join("member.bin");
+        std::fs::write(&member, b"member-a").expect("member fixture");
+        let member_error =
+            super::regular_file_blake3_nofollow_with_after_eof(&member, "test member", || {
+                std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&member)
+                    .and_then(|mut file| file.write_all(b"b"))
+                    .map_err(|error| error.to_string())
+            })
+            .expect_err("post-EOF streamed-member growth is rejected");
+        assert!(member_error.contains("changed"), "{member_error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn semantic_bundle_controls_are_capped_before_json_parsing() {
+        let root = attention_provenance_test_dir("semantic-control-caps");
+        let large_cover = root.join("large-cover-report.json");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let decisions = (0..128)
+            .map(|region| {
+                serde_json::json!({
+                    "region": region,
+                    "objective_components": vec![0.0_f64; 24],
+                    "explanation": "x".repeat(768),
+                })
+            })
+            .collect::<Vec<_>>();
+        let large_cover_bytes = serde_json::to_vec(&serde_json::json!({
+            "attention_operator": uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2(),
+            "dense_operator": null,
+            "source_manifest_kappa": source_kappa,
+            "region_decisions": decisions,
+        }))
+        .expect("large supported cover report");
+        assert!(large_cover_bytes.len() > super::COMPILED_BUNDLE_CONTROL_MAX_BYTES as usize);
+        assert!(large_cover_bytes.len() < super::COVER_REPORT_CONTROL_MAX_BYTES as usize);
+        std::fs::write(&large_cover, large_cover_bytes).expect("large cover report fixture");
+        let (present, attention, dense, recorded_kappa) =
+            super::parse_cover_provenance(&large_cover)
+                .expect("supported cover report may exceed the scalar-control cap");
+        assert!(present);
+        assert_eq!(
+            attention,
+            Some(uor_r4_model_source::attention::AttentionOperatorSpec::standard_v2())
+        );
+        assert_eq!(dense, None);
+        assert_eq!(recorded_kappa.as_deref(), Some(source_kappa.as_str()));
+        super::validate_staged_graph_report(&large_cover, super::COVER_REPORT_CONTROL_MAX_BYTES)
+            .expect("staged validator accepts a supported cover report above 64 KiB");
+
+        for (case, leaf, max_bytes) in [
+            (
+                "preflight",
+                super::SOURCE_COMPILE_PREFLIGHT_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "source-binding",
+                super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "attention",
+                uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "dense",
+                uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "cover",
+                "cover_report.json",
+                super::COVER_REPORT_CONTROL_MAX_BYTES,
+            ),
+            (
+                "staged-cover",
+                "cover_report.json",
+                super::COVER_REPORT_CONTROL_MAX_BYTES,
+            ),
+            (
+                "staged-score",
+                "score_report.json",
+                super::SCORE_REPORT_CONTROL_MAX_BYTES,
+            ),
+        ] {
+            let case_root = root.join(case);
+            std::fs::create_dir_all(&case_root).expect("semantic-control case root");
+            let path = case_root.join(leaf);
+            let file = std::fs::File::create(&path).expect("sparse semantic control");
+            file.set_len(1_u64 << 40)
+                .expect("1 TiB sparse semantic control");
+            drop(file);
+            let error = match case {
+                "preflight" => {
+                    super::read_optional_source_compile_preflight(&case_root).map(|_| ())
+                }
+                "source-binding" => {
+                    super::read_optional_source_manifest_kappa_binding(&case_root).map(|_| ())
+                }
+                "attention" => super::validate_pre_attention_identity_file(
+                    &path,
+                    uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+                )
+                .map(|_| ()),
+                "dense" => super::validate_pre_attention_identity_file(
+                    &path,
+                    uor_r4_graph_cli::DENSE_OPERATOR_BINDING_FILE,
+                )
+                .map(|_| ()),
+                "cover" => super::parse_cover_provenance(&path).map(|_| ()),
+                "staged-cover" | "staged-score" => {
+                    super::validate_staged_graph_report(&path, max_bytes)
+                }
+                _ => unreachable!(),
+            }
+            .expect_err("oversized semantic control is rejected before JSON parsing");
+            assert!(
+                error.contains(&format!("{max_bytes}-byte control-record limit")),
+                "{error}"
+            );
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("sparse semantic control preserved")
+                    .len(),
+                1_u64 << 40
+            );
+        }
+
+        let no_clobber = root.join("oversized-existing-control.json");
+        let file = std::fs::File::create(&no_clobber).expect("sparse no-clobber control");
+        file.set_len(1_u64 << 40)
+            .expect("1 TiB sparse no-clobber control");
+        drop(file);
+        let error = super::publish_bytes_no_clobber(&no_clobber, b"{}\n", "test control")
+            .expect_err("no-clobber comparison rejects oversized existing control");
+        assert!(error.contains("3-byte control-record limit"), "{error}");
+        assert_eq!(
+            std::fs::metadata(&no_clobber)
+                .expect("sparse no-clobber control preserved")
+                .len(),
+            1_u64 << 40
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn completed_bundle_validation_caps_semantic_controls_before_hashing() {
+        let root = attention_provenance_test_dir("completed-semantic-control-caps");
+        for (case, relative, max_bytes) in [
+            (
+                "source-binding",
+                super::SOURCE_MANIFEST_KAPPA_BINDING_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "attention",
+                uor_r4_graph_cli::ATTENTION_OPERATOR_BINDING_FILE,
+                super::COMPILED_BUNDLE_CONTROL_MAX_BYTES,
+            ),
+            (
+                "cover",
+                "graph-cover/cover_report.json",
+                super::COVER_REPORT_CONTROL_MAX_BYTES,
+            ),
+            (
+                "score",
+                "graph/score_report.json",
+                super::SCORE_REPORT_CONTROL_MAX_BYTES,
+            ),
+        ] {
+            let output = root.join(case);
+            write_completion_fixture(&output, case.as_bytes());
+            make_completion_fixture_graph_outputs_valid(&output, case);
+            let control = output.join(relative);
+            std::fs::remove_file(&control).expect("remove completed semantic control");
+            let file = std::fs::File::create(&control).expect("sparse completed control");
+            file.set_len(1_u64 << 40)
+                .expect("1 TiB sparse completed semantic control");
+            drop(file);
+            let error = super::validate_compiled_bundle_completion(&output)
+                .expect_err("completion validation caps semantic controls before hashing");
+            assert!(error.contains(&max_bytes.to_string()), "{case}: {error}");
+            assert!(error.contains(relative), "{case}: {error}");
+            assert_eq!(
+                std::fs::metadata(&control)
+                    .expect("sparse completed semantic control preserved")
+                    .len(),
+                1_u64 << 40
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_bundle_unknown_inventory_is_refused_without_commit() {
+        let root = attention_provenance_test_dir("compiled-bundle-unknown-inventory");
+        let output = root.join("compiled/model-attention-v2");
+        write_completion_fixture(&output, b"stable");
+        make_completion_fixture_graph_outputs_valid(&output, "stable");
+        std::fs::remove_file(output.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("remove completion");
+        let unknown = output.join("unknown-stable-claim.json");
+        std::fs::write(&unknown, b"do not delete").expect("unknown stable claim");
+        let error = super::publish_compiled_bundle_completion(&output)
+            .expect_err("unknown stable inventory is terminal");
+        assert!(error.contains("unsupported entry"), "{error}");
+        assert_eq!(
+            std::fs::read(&unknown).expect("unknown claim preserved"),
+            b"do not delete"
+        );
+        assert!(!output.join(super::COMPILED_BUNDLE_COMPLETION_FILE).exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn canonical_compile_attempt_is_coordination_not_completion_payload() {
+        let root = attention_provenance_test_dir("completion-excludes-attempt");
+        let output = root.join("compiled/model-attention-v2");
+        write_completion_fixture(&output, b"stable");
+        make_completion_fixture_graph_outputs_valid(&output, "stable");
+        let before = super::compiled_bundle_file_kappas(&output)
+            .expect("completed payload inventory before attempt");
+        std::fs::write(
+            output.join("instruction-eval.json"),
+            b"{\"derived\":true}\n",
+        )
+        .expect("post-compile evaluation report");
+        super::validate_compiled_bundle_completion(&output)
+            .expect("derived evaluation report does not invalidate completion")
+            .expect("completion remains present");
+        assert_eq!(
+            super::compiled_bundle_file_kappas(&output)
+                .expect("derived evaluation report is excluded"),
+            before
+        );
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("fixture producer");
+        producer
+            .begin_compile_attempt()
+            .expect("canonical lower attempt marker");
+        let after = super::compiled_bundle_file_kappas(&output)
+            .expect("attempt marker is recognized and excluded");
+        assert_eq!(after, before);
+        super::publish_compiled_bundle_completion_under_guard(&producer, &output)
+            .expect("idempotent completion remains valid while attempt is active");
+        producer
+            .finish_compile_attempt()
+            .expect("finish exact no-op attempt");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn malformed_legacy_bundle_is_not_bootstrapped_or_mutated() {
+        let root = attention_provenance_test_dir("malformed-legacy-bootstrap");
+        let compiled = root.join("compiled");
+        let current = compiled.join("teacher-attention-v2");
+        write_completion_fixture(&current, b"legacy-current");
+        make_completion_fixture_graph_outputs_valid(&current, "legacy-current");
+        std::fs::remove_file(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("simulate pre-#728 bundle");
+        let report = current.join("graph-cover/cover_report.json");
+        std::fs::write(&report, b"{}\n").expect("malformed identity report");
+        let before = std::fs::read(&report).expect("malformed report before");
+        let error = match super::acquire_managed_compiled_bundle_read(&compiled, "teacher", 2) {
+            Ok(_) => panic!("malformed legacy payload is never bootstrapped"),
+            Err(error) => error,
+        };
+        assert!(
+            error.contains("does not reconcile") || error.contains("missing"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(&report).expect("report preserved"), before);
+        assert!(!current
+            .join(super::COMPILED_BUNDLE_COMPLETION_FILE)
+            .exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn staged_binding_absence_or_conflict_never_mutates_last_good_final() {
+        for scenario in ["missing", "conflicting"] {
+            let root = attention_provenance_test_dir(&format!("stage-binding-{scenario}"));
+            let compiled = root.join("compiled");
+            let conventional = compiled.join("teacher");
+            let current = compiled.join("teacher-attention-v2");
+            let composite = compiled.join("teacher-attention-v2-dense-v2");
+            write_completion_fixture(&current, b"last-good");
+            make_completion_fixture_graph_outputs_valid(&current, "last-good");
+            let final_completion =
+                std::fs::read(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                    .expect("last-good completion");
+            let selection_roots = [conventional, current.clone(), composite];
+            let selection =
+                super::capture_compiled_bundle_selection_base(&selection_roots, &current)
+                    .expect("capture last-good selection");
+            let source_kappa = format!("blake3:{}", "0".repeat(64));
+            let stage = super::CompiledBundleStage::allocate_with_selection(
+                &current,
+                &source_kappa,
+                &selection,
+            )
+            .expect("private stage");
+            write_completion_fixture(&stage.path, b"candidate");
+            make_completion_fixture_graph_outputs_valid(&stage.path, "candidate");
+            std::fs::remove_file(stage.path.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                .expect("remove candidate completion");
+            let binding = stage
+                .path
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
+            match scenario {
+                "missing" => std::fs::remove_file(&binding).expect("remove binding"),
+                "conflicting" => std::fs::write(&binding, b"{}\n").expect("conflict binding"),
+                _ => unreachable!(),
+            }
+            let producer =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    &stage.path,
+                )
+                .expect("stage producer");
+            let error = super::validate_compiled_stage_transaction_under_guard(
+                &producer,
+                &stage.path,
+                &source_kappa,
+            )
+            .expect_err("binding failure is terminal before completion/publication");
+            assert!(
+                error.contains("binding") || error.contains("recorded"),
+                "{error}"
+            );
+            assert!(!stage
+                .path
+                .join(super::COMPILED_BUNDLE_COMPLETION_FILE)
+                .exists());
+            assert_eq!(
+                std::fs::read(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                    .expect("last-good completion preserved"),
+                final_completion
+            );
+            drop(producer);
+            let _ = std::fs::remove_dir_all(root);
         }
     }
 
@@ -16043,9 +19213,11 @@ mod tests {
             std::fs::read(output.join("graph/score.r4g1")).expect("new graph"),
             b"new"
         );
+        let new_records = std::fs::read(output.join("corpus.records")).expect("advanced corpus");
+        assert_ne!(new_records, old_corpus);
         assert_eq!(
-            std::fs::read(output.join("corpus.records")).expect("advanced corpus"),
-            b"new"
+            u32::from_le_bytes(new_records[4..8].try_into().expect("next-token field")),
+            u32::from(b'n')
         );
         super::validate_compiled_bundle_completion(&output)
             .expect("new completion validates")
@@ -16083,6 +19255,123 @@ mod tests {
     }
 
     #[test]
+    fn compiled_bundle_stage_recovery_is_busy_before_any_reset_mutation() {
+        let root = attention_provenance_test_dir("compiled-stage-common-busy");
+        let output = root.join("compiled/model");
+        write_completion_fixture(&output, b"old");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let stage =
+            super::CompiledBundleStage::allocate(&output, &source_kappa).expect("resumable stage");
+        std::fs::create_dir_all(stage.path.join("graph")).expect("partial graph directory");
+        let partial = stage.path.join("graph/score.r4g1");
+        std::fs::write(&partial, b"owned-partial").expect("partial graph evidence");
+        let marker = std::fs::read(stage.path.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE))
+            .expect("stage marker before contention");
+        let stage_path = stage.path.clone();
+        drop(stage);
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &stage_path,
+            )
+            .expect("supported stage writer owns common guard");
+        let error = super::CompiledBundleStage::allocate(&output, &source_kappa)
+            .expect_err("retry cannot reset a stage owned by another common writer");
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert_eq!(
+            std::fs::read(&partial).expect("partial bytes preserved"),
+            b"owned-partial"
+        );
+        assert_eq!(
+            std::fs::read(stage_path.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE))
+                .expect("marker preserved"),
+            marker
+        );
+        drop(producer);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn refresh_prefix_crash_has_marker_attempt_and_recovers_binding_last() {
+        let root = attention_provenance_test_dir("compiled-stage-prefix-crash");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&current, b"generation-a");
+        make_completion_fixture_graph_outputs_valid(&current, "generation-a");
+        std::fs::write(current.join("instruction-eval.json"), b"stale-evaluation\n")
+            .expect("derived report on generation A");
+        let roots = [conventional, current.clone(), composite];
+        let selection = super::capture_compiled_bundle_selection_base(&roots, &current)
+            .expect("capture generation A selection");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let observed_stage = std::sync::Mutex::new(None::<std::path::PathBuf>);
+        let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = super::CompiledBundleStage::allocate_with_selection_transaction_with_after_first_copy(
+                &current,
+                &source_kappa,
+                &selection,
+                |stage| {
+                    *observed_stage.lock().expect("stage observation lock") =
+                        Some(stage.to_path_buf());
+                    assert!(stage.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE).is_file());
+                    assert!(stage
+                        .join(
+                            uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_COMPILE_ATTEMPT_FILE,
+                        )
+                        .is_file());
+                    assert!(!stage
+                        .join(
+                            uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE,
+                        )
+                        .exists());
+                    let busy = uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(stage)
+                        .expect_err("retained prefix transaction excludes another supported writer");
+                    assert!(
+                        uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+                        "{busy}"
+                    );
+                    panic!("injected death after first prefix member");
+                },
+            );
+        }));
+        assert!(crashed.is_err(), "injected crash reached its boundary");
+        let stage_path = observed_stage
+            .into_inner()
+            .expect("stage observation mutex")
+            .expect("stage path captured before crash");
+        assert!(stage_path.exists(), "crash residue remains resumable");
+        assert!(!stage_path
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+            .exists());
+
+        let (stage, session) = super::CompiledBundleStage::allocate_with_selection_transaction(
+            &current,
+            &source_kappa,
+            &selection,
+        )
+        .expect("exact retry reconstructs the private prefix");
+        assert_eq!(stage.path, stage_path, "exact owner adopts the crash stage");
+        assert!(stage
+            .path
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+            .is_file());
+        assert!(
+            !stage.path.join("instruction-eval.json").exists(),
+            "generation-A derived evaluation is never copied into generation B"
+        );
+        super::validate_copied_compiled_bundle_prefix(
+            &stage.path,
+            &super::validate_compiled_bundle_completion(&current)
+                .expect("source completion validates")
+                .expect("source completion present"),
+        )
+        .expect("binding-last recovered prefix exactly matches generation A");
+        drop(session);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn compiled_bundle_stage_recovers_only_exact_regular_publisher_temporaries() {
         let root = attention_provenance_test_dir("compiled-stage-publisher-temporaries");
         let output = root.join("compiled/model");
@@ -16102,12 +19391,30 @@ mod tests {
         ));
         std::fs::write(&marker_temp, b"").expect("pre-write marker crash");
         std::fs::write(&completion_temp, b"{\n").expect("mid-write completion crash");
+        for name in [
+            "instruction-eval.json",
+            "compiled.r4g1",
+            "compile_report.json",
+        ] {
+            std::fs::write(stage_path.join(name), b"stale-derived")
+                .expect("stale derived stage leaf");
+        }
 
         let recovered = super::CompiledBundleStage::allocate(&output, &source_kappa)
             .expect("exact regular residue recovers");
         assert_eq!(recovered.path, stage_path);
         assert!(!marker_temp.exists());
         assert!(!completion_temp.exists());
+        for name in [
+            "instruction-eval.json",
+            "compiled.r4g1",
+            "compile_report.json",
+        ] {
+            assert!(
+                !stage_path.join(name).exists(),
+                "bound-stage recovery removes stale derived {name}"
+            );
+        }
         drop(recovered);
 
         let unknown = stage_path.join(format!(
@@ -16163,7 +19470,7 @@ mod tests {
         let output = root.join("compiled/model");
         write_completion_fixture(&output, b"old");
         super::publish_compiled_bundle_completion(&output).expect("old completion");
-        let source_kappa = format!("blake3:{}", "5".repeat(64));
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
         let stage = super::CompiledBundleStage::allocate(&output, &source_kappa)
             .expect("replacement stage");
         write_completion_fixture(&stage.path, b"new");
@@ -16182,17 +19489,551 @@ mod tests {
         super::validate_compiled_bundle_completion(&output)
             .expect("published completion validates")
             .expect("published completion present");
+        let new_records = std::fs::read(output.join("corpus.records")).expect("new corpus");
         assert_eq!(
-            std::fs::read(output.join("corpus.records")).expect("new corpus"),
-            b"new"
+            u32::from_le_bytes(new_records[4..8].try_into().expect("next-token field")),
+            u32::from(b'n')
         );
 
-        let retry = super::CompiledBundleStage::allocate(&output, &source_kappa)
-            .expect("next owner reclaims exchanged old generation");
+        let next_source_kappa = format!("blake3:{}", "6".repeat(64));
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &output,
+            )
+            .expect("next source owns completed root cleanup");
+        super::prepare_compiled_root_transaction_under_guard(
+            &producer,
+            &output,
+            &next_source_kappa,
+        )
+        .expect("old post-exchange marker is validated against generation A, not request B");
+        assert!(!output
+            .join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE)
+            .exists());
+        drop(producer);
+        let retry = super::CompiledBundleStage::allocate(&output, &next_source_kappa)
+            .expect("next source owner reclaims exchanged old generation");
         assert_ne!(retry.path, stage.path);
         assert_eq!(
             std::fs::read(output.join("corpus.records")).expect("published corpus unchanged"),
-            b"new"
+            new_records
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn managed_bundle_bootstraps_legacy_completion_and_pins_absent_precedence_roots() {
+        let root = attention_provenance_test_dir("managed-bootstrap-reader-pins");
+        let compiled = root.join("compiled");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&current, b"legacy-current");
+        make_completion_fixture_graph_outputs_valid(&current, "legacy-current");
+        std::fs::remove_file(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("simulate valid pre-#728 current bundle");
+        std::fs::remove_file(
+            current.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        )
+        .expect("simulate bundle predating the recorded-corpus binding");
+
+        let read = super::acquire_managed_compiled_bundle_read(&compiled, "teacher", 2)
+            .expect("legacy current bundle bootstraps under common authority");
+        let resolved = read.resolved.as_ref().expect("current bundle resolves");
+        assert_eq!(resolved.physical_root, current);
+        super::validate_compiled_bundle_completion(&current)
+            .expect("bootstrapped completion validates")
+            .expect("completion was published");
+        assert!(
+            current
+                .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+                .is_file(),
+            "guarded bootstrap migrates the exact old corpus before completion"
+        );
+
+        let busy =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &composite,
+            )
+            .expect_err("absent preferred root stays BUSY while serving pins are live");
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+            "{busy}"
+        );
+        read.pins.verify().expect("managed pins remain exact");
+        drop(read);
+        let contender =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &composite,
+            )
+            .expect("preferred-root writer proceeds after serving install releases pins");
+        drop(contender);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn managed_common_writer_busy_is_transient_before_legacy_bootstrap() {
+        let root = attention_provenance_test_dir("managed-bootstrap-common-busy");
+        let compiled = root.join("compiled");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&current, b"legacy-current");
+        make_completion_fixture_graph_outputs_valid(&current, "legacy-current");
+        std::fs::remove_file(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("simulate legacy completion absence");
+        std::fs::remove_file(
+            current.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE),
+        )
+        .expect("simulate legacy binding absence");
+        let writer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &composite,
+            )
+            .expect("direct preferred-root writer");
+        let error = match super::acquire_managed_compiled_bundle_read(&compiled, "teacher", 2) {
+            Ok(_) => panic!("startup/reload reader cannot inspect through a common writer"),
+            Err(error) => error,
+        };
+        assert!(super::source_compile_session_is_busy(&error), "{error}");
+        assert!(!current
+            .join(super::COMPILED_BUNDLE_COMPLETION_FILE)
+            .exists());
+        assert!(!current
+            .join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE)
+            .exists());
+        assert!(
+            std::fs::read_dir(&current)
+                .expect("legacy current inventory")
+                .all(|entry| !entry
+                    .expect("legacy entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(&format!(".{}.", super::COMPILED_BUNDLE_COMPLETION_FILE))),
+            "BUSY never publishes a completion temporary"
+        );
+        drop(writer);
+        let read = super::acquire_managed_compiled_bundle_read(&compiled, "teacher", 2)
+            .expect("quiescent exact retry bootstraps and pins");
+        assert!(read.resolved.is_some());
+        drop(read);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn historical_markerless_sibling_has_a_durable_bounded_selection_witness() {
+        let root = attention_provenance_test_dir("historical-selection-witness");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_attention_binding(
+            &conventional,
+            &uor_r4_model_source::attention::AttentionOperatorSpec::standard_v1(),
+        );
+        let mut meta = [0u8; 25];
+        meta[0..8].copy_from_slice(&1u64.to_le_bytes());
+        meta[8..16].copy_from_slice(&1u64.to_le_bytes());
+        meta[16..24].copy_from_slice(&7u64.to_le_bytes());
+        meta[24] = 1;
+        let mut record = [0u8; 48];
+        record[4..8].copy_from_slice(&1u32.to_le_bytes());
+        record[20..24].copy_from_slice(&34u32.to_le_bytes());
+        record[24..28].copy_from_slice(&33u32.to_le_bytes());
+        record[28..32].copy_from_slice(&33u32.to_le_bytes());
+        record[36..40].copy_from_slice(&1u32.to_le_bytes());
+        record[40..44].copy_from_slice(&u32::MAX.to_le_bytes());
+        record[44..48].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(conventional.join("corpus.meta"), meta).expect("historical metadata");
+        std::fs::write(conventional.join("corpus.records"), record).expect("historical corpus");
+        std::fs::write(
+            conventional.join("tless_artifacts.bin"),
+            b"historical-teacher",
+        )
+        .expect("historical teacher");
+        std::fs::write(conventional.join("compiled.r4g1"), minimal_r4g1_bytes())
+            .expect("historical root graph fallback");
+        std::fs::write(conventional.join("compile_report.json"), b"{}\n")
+            .expect("historical root compile report");
+        let strict_error = super::compiled_bundle_file_kappas(&conventional)
+            .expect_err("new completion inventory never admits legacy root graph outputs");
+        assert!(strict_error.contains("unsupported entry"), "{strict_error}");
+        let roots = [conventional.clone(), current.clone(), composite];
+        let base = super::capture_compiled_bundle_selection_base(&roots, &current)
+            .expect("markerless historical sibling has a fixed-inventory witness");
+        let legacy = base
+            .iter()
+            .find_map(|entry| match &entry.generation {
+                super::CompiledBundleBaseGeneration::Legacy { files } => Some(files),
+                _ => None,
+            })
+            .expect("historical root is captured as a Legacy witness");
+        assert!(legacy.contains_key("compiled.r4g1"));
+        assert!(legacy.contains_key("compile_report.json"));
+        let pair = super::inspect_compiled_model_pair(&compiled, "teacher", 2)
+            .expect("historical pair is structurally readable");
+        let resolved = super::resolve_loadable_compiled_bundle(&pair, 2)
+            .expect("historical fallback resolves")
+            .expect("historical fallback is loadable");
+        assert_eq!(resolved.graph, conventional.join("compiled.r4g1"));
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let stage =
+            super::CompiledBundleStage::allocate_with_selection(&current, &source_kappa, &base)
+                .expect("new current stage can coexist with historical conventional root");
+        record[4..8].copy_from_slice(&2u32.to_le_bytes());
+        std::fs::write(conventional.join("corpus.records"), record)
+            .expect("supported sibling advances in the same directory");
+        let error = super::require_compiled_bundle_selection_base_unchanged(&base, &current)
+            .expect_err("content CAS detects historical sibling drift");
+        assert!(error.contains("selection changed"), "{error}");
+        assert!(stage.path.exists(), "private stage remains preserved");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn three_root_base_reconciles_exact_nonselected_completion_residue() {
+        let root = attention_provenance_test_dir("selection-sibling-completion-residue");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&conventional, b"lower-sibling");
+        make_completion_fixture_graph_outputs_valid(&conventional, "lower-sibling");
+        let stable = conventional.join(super::COMPILED_BUNDLE_COMPLETION_FILE);
+        let temporary = conventional.join(format!(
+            ".{}.700.1.tmp",
+            super::COMPILED_BUNDLE_COMPLETION_FILE
+        ));
+        std::fs::hard_link(&stable, &temporary).expect("honest completion hard-link residue");
+        let roots = [conventional.clone(), current, composite];
+        let generations = roots
+            .iter()
+            .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("selection root generations");
+        let handoff =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+                &generations,
+                0,
+                1,
+            )
+            .expect("three-root base authority");
+        let guard = super::recorded_handoff_guard_for_root(&handoff, &conventional)
+            .expect("conventional sibling guard");
+        super::prepare_compiled_selection_sibling_under_guard(guard, &conventional)
+            .expect("exact sibling residue recovers before base capture");
+        assert!(!temporary.exists());
+        super::validate_compiled_bundle_completion(&conventional)
+            .expect("stable sibling remains valid")
+            .expect("stable sibling completion remains present");
+        handoff.verify().expect("selection identities remain held");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_handoff_refuses_same_directory_generation_b_before_promotion() {
+        let root = attention_provenance_test_dir("compiled-handoff-content-cas");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        let stage = compiled.join("private-stage");
+        write_completion_fixture(&current, b"generation-a");
+        std::fs::create_dir_all(&stage).expect("private stage");
+        std::fs::write(stage.join("stage-sentinel"), b"stage-a").expect("stage sentinel");
+        let selection_roots = [conventional.clone(), current.clone(), composite.clone()];
+        let base_a = super::capture_compiled_bundle_selection_base(&selection_roots, &current)
+            .expect("capture generation A");
+        let mut generations = selection_roots
+            .iter()
+            .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("capture selection directories");
+
+        // Commit generation B by atomically replacing its completion member
+        // after changing one stable payload, while preserving the directory
+        // inode captured above. Directory-only CAS must not miss this.
+        std::fs::write(current.join("tless_artifacts.bin"), b"generation-b")
+            .expect("generation B artifact");
+        let files = super::compiled_bundle_file_kappas(&current)
+            .expect("generation B completion inventory");
+        let completion =
+            super::compiled_bundle_completion_bytes(files).expect("generation B completion bytes");
+        let temporary = current.join(".completion-generation-b");
+        std::fs::write(&temporary, completion).expect("generation B completion temporary");
+        std::fs::rename(
+            &temporary,
+            current.join(super::COMPILED_BUNDLE_COMPLETION_FILE),
+        )
+        .expect("atomically commit generation B completion");
+        super::validate_compiled_bundle_completion(&current)
+            .expect("generation B validates")
+            .expect("generation B completion present");
+
+        let final_index = 1;
+        let stage_index = generations.len();
+        generations.push(
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture(&stage)
+                .expect("capture stage"),
+        );
+        let mut handoff =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+                &generations,
+                final_index,
+                stage_index,
+            )
+            .expect("directory identities still match");
+        let error = handoff
+            .promote_stage_if(|_| {
+                super::require_compiled_bundle_selection_base_unchanged(&base_a, &current)
+                    .map_err(uor_r4_model_source::SourceUnavailable::new)
+            })
+            .expect_err("content CAS refuses stale generation A promotion");
+        assert!(error.to_string().contains("selection changed"), "{error}");
+        assert_eq!(
+            std::fs::read(current.join("tless_artifacts.bin")).expect("generation B preserved"),
+            b"generation-b"
+        );
+        assert_eq!(
+            std::fs::read(stage.join("stage-sentinel")).expect("stage preserved"),
+            b"stage-a"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compiled_source_publish_refuses_stage_b_in_each_lock_transition_gap() {
+        for scenario in [
+            "reader-to-producer",
+            "producer-to-handoff",
+            "marker-to-handoff",
+        ] {
+            let root = attention_provenance_test_dir(&format!("stage-content-cas-{scenario}"));
+            let mut bundle = compiled_source_bundle_publish_fixture(&root, "stage-a");
+            let final_output = bundle.final_output.clone();
+            let stage_path = bundle.working_output.clone();
+            let error = match scenario {
+                "reader-to-producer" => bundle.publish_with_transition_hooks(
+                    |stage| {
+                        advance_private_stage_generation(stage, b"stage-b-before-producer");
+                        Ok(())
+                    },
+                    |_| Ok(()),
+                ),
+                "producer-to-handoff" => bundle.publish_with_before_handoff(|stage| {
+                    advance_private_stage_generation(stage, b"stage-b-before-handoff");
+                    Ok(())
+                }),
+                "marker-to-handoff" => {
+                    let replacement = super::compiled_bundle_stage_marker_bytes(
+                        &bundle.final_output,
+                        &bundle.working_output,
+                        &format!("blake3:{}", "9".repeat(64)),
+                        &bundle.selection_base,
+                    )
+                    .expect("alternate canonical marker");
+                    bundle.publish_with_before_handoff(|stage| {
+                        let temporary = stage.join(".replacement-stage-marker");
+                        std::fs::write(&temporary, &replacement)
+                            .expect("alternate marker temporary");
+                        std::fs::rename(
+                            &temporary,
+                            stage.join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE),
+                        )
+                        .expect("atomically replace marker");
+                        Ok(())
+                    })
+                }
+                _ => unreachable!(),
+            }
+            .expect_err("stage B is never promoted as stage A");
+            assert!(error.contains("changed"), "{scenario}: {error}");
+            assert!(
+                !final_output.exists(),
+                "{scenario}: absent final remains absent"
+            );
+            assert!(stage_path.exists(), "{scenario}: newer stage is preserved");
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn compiled_source_publish_refuses_missing_or_conflicting_stage_binding_before_final_mutation()
+    {
+        for scenario in ["missing", "conflicting"] {
+            let root = attention_provenance_test_dir(&format!("publish-stage-binding-{scenario}"));
+            let mut bundle = compiled_source_bundle_publish_fixture(&root, "binding-a");
+            let final_output = bundle.final_output.clone();
+            let stage = bundle.working_output.clone();
+            let binding =
+                stage.join(uor_r4_graph_compiler::recorded_corpus::RECORDED_CORPUS_BINDING_FILE);
+            match scenario {
+                "missing" => std::fs::remove_file(&binding).expect("remove stage binding"),
+                "conflicting" => {
+                    std::fs::write(&binding, b"{}\n").expect("conflicting stage binding")
+                }
+                _ => unreachable!(),
+            }
+            let error = bundle
+                .publish()
+                .expect_err("invalid stage binding is terminal before final handoff");
+            assert!(
+                error.contains("binding") || error.contains("changed after"),
+                "{scenario}: {error}"
+            );
+            assert!(
+                !final_output.exists(),
+                "{scenario}: final namespace remains absent"
+            );
+            assert!(stage.exists(), "{scenario}: private evidence is preserved");
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn compiled_source_publish_adopts_exact_stage_inode_for_fresh_and_refresh() {
+        for existing in [false, true] {
+            let root = attention_provenance_test_dir(if existing {
+                "production-handoff-refresh"
+            } else {
+                "production-handoff-fresh"
+            });
+            let mut bundle = compiled_source_bundle_publish_fixture_with_final(
+                &root,
+                "generation-b",
+                existing.then_some("generation-a"),
+            );
+            let final_output = bundle.final_output.clone();
+            let stage_path = bundle.working_output.clone();
+            let stage_before = std::fs::metadata(&stage_path).expect("stage inode before publish");
+            let final_before = existing
+                .then(|| std::fs::metadata(&final_output).expect("final-A inode before refresh"));
+            let handoff = bundle
+                .publish()
+                .expect("production handoff publishes stage B");
+            assert!(
+                handoff
+                    .final_guard()
+                    .protects_directory(&final_output)
+                    .expect("final guard identity"),
+                "returned authority owns the promoted final root"
+            );
+            let final_after = std::fs::metadata(&final_output).expect("promoted final inode");
+            assert!(
+                super::source_compile_lock_metadata_matches(&stage_before, &final_after),
+                "promoted final adopts the exact validated stage inode"
+            );
+            super::validate_compiled_bundle_completion(&final_output)
+                .expect("promoted completion validates")
+                .expect("promoted completion remains present");
+            if let Some(final_before) = final_before {
+                let displaced = std::fs::metadata(&stage_path).expect("old final displaced");
+                assert!(
+                    super::source_compile_lock_metadata_matches(&final_before, &displaced),
+                    "refresh exchange preserves the displaced last-good inode"
+                );
+            } else {
+                assert!(
+                    !stage_path.exists(),
+                    "fresh rename consumes the stage namespace"
+                );
+            }
+            let busy =
+                uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                    &final_output,
+                )
+                .expect_err("final remains exclusively owned through serving installation");
+            assert!(
+                uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+                "{busy}"
+            );
+            drop(handoff);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn serving_stage_reader_pin_blocks_cli_and_observation_writers() {
+        let root = attention_provenance_test_dir("serving-stage-pin-contention");
+        let bundle = compiled_source_bundle_publish_fixture(&root, "pinned-stage");
+        let stage = bundle.working_output.clone();
+        let busy =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &stage,
+            )
+            .expect_err("CLI/common producer is BUSY while serving stage pins are live");
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&busy),
+            "{busy}"
+        );
+        let observation =
+            match uor_r4_graph_compiler::observation::ObservationSession::acquire(&stage, 1) {
+                Ok(_) => panic!("observation writer is BUSY while serving stage pins are live"),
+                Err(error) => error,
+            };
+        assert!(
+            uor_r4_graph_compiler::recorded_corpus::is_recorded_corpus_busy(&observation),
+            "{observation}"
+        );
+        drop(bundle);
+        let producer =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &stage,
+            )
+            .expect("supported writer proceeds after serving pins are released");
+        drop(producer);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persisted_stage_a_base_never_adopts_after_final_b_commit() {
+        let root = attention_provenance_test_dir("persisted-stage-base-cas");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&current, b"final-a");
+        make_completion_fixture_graph_outputs_valid(&current, "final-a");
+        let roots = [conventional, current.clone(), composite];
+        let base_a = super::capture_compiled_bundle_selection_base(&roots, &current)
+            .expect("capture final A");
+        let source_kappa = format!("blake3:{}", "0".repeat(64));
+        let stage_a =
+            super::CompiledBundleStage::allocate_with_selection(&current, &source_kappa, &base_a)
+                .expect("persisted stage A");
+        let stage_path = stage_a.path.clone();
+        std::fs::write(stage_path.join("stage-a-sentinel"), b"preserve-stage-a")
+            .expect("stage A evidence");
+        drop(stage_a);
+
+        let final_b =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerGuard::try_acquire(
+                &current,
+            )
+            .expect("direct final-B writer");
+        final_b
+            .begin_compile_attempt()
+            .expect("final-B compile attempt");
+        std::fs::remove_file(current.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+            .expect("remove final-A completion");
+        std::fs::write(current.join("tless_artifacts.bin"), b"final-b").expect("final-B artifact");
+        super::publish_compiled_bundle_completion_under_guard(&final_b, &current)
+            .expect("final-B completion");
+        final_b
+            .finish_compile_attempt()
+            .expect("finish final-B attempt");
+        drop(final_b);
+        let base_b = super::capture_compiled_bundle_selection_base(&roots, &current)
+            .expect("capture final B");
+        let error =
+            super::CompiledBundleStage::allocate_with_selection(&current, &source_kappa, &base_b)
+                .expect_err("stage A marker cannot be adopted against base B");
+        assert!(error.contains("does not bind this exact"), "{error}");
+        assert_eq!(
+            std::fs::read(current.join("tless_artifacts.bin")).expect("final B preserved"),
+            b"final-b"
+        );
+        assert_eq!(
+            std::fs::read(stage_path.join("stage-a-sentinel")).expect("stage A preserved"),
+            b"preserve-stage-a"
         );
         let _ = std::fs::remove_dir_all(root);
     }
@@ -16213,7 +20054,7 @@ mod tests {
 
         let strict_error = super::validate_compiled_bundle_completion(&output)
             .expect_err("raw member hashing sees the unrecovered residue");
-        assert!(strict_error.contains("changed after"), "{strict_error}");
+        assert!(strict_error.contains("unsupported entry"), "{strict_error}");
         super::recover_managed_compiled_bundle_completion_temporaries(&root.join("compiled"))
             .expect("startup/reload inventory owner reclaims exact linked residue");
         assert!(!temporary.exists());
@@ -16950,6 +20791,85 @@ mod tests {
     }
 
     #[test]
+    fn cross_snapshot_refresh_refuses_before_private_stage_allocation() {
+        let root = attention_provenance_test_dir("cross-snapshot-refresh-stage-gate");
+        let compiled = root.join("compiled");
+        let conventional = compiled.join("teacher");
+        let current = compiled.join("teacher-attention-v2");
+        let composite = compiled.join("teacher-attention-v2-dense-v2");
+        write_completion_fixture(&conventional, b"generation-a");
+        make_completion_fixture_graph_outputs_valid(&conventional, "generation-a");
+        let source_a = super::read_optional_source_manifest_kappa_binding(&conventional)
+            .expect("read generation-A source binding")
+            .expect("generation-A source binding");
+        let source_b = format!("blake3:{}", "b".repeat(64));
+        assert_ne!(source_a, source_b);
+        let completion_before =
+            std::fs::read(conventional.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                .expect("generation-A completion before refusal");
+        let preflight_before =
+            std::fs::read(conventional.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("generation-A preflight before refusal");
+        let binding_before =
+            std::fs::read(conventional.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+                .expect("generation-A source binding before refusal");
+
+        let roots = [conventional.clone(), current, composite];
+        let generations = roots
+            .iter()
+            .map(uor_r4_graph_compiler::recorded_corpus::RecordedCorpusRootGeneration::capture)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("capture generation-A selection roots");
+        let handoff =
+            uor_r4_graph_compiler::recorded_corpus::RecordedCorpusProducerHandoff::try_acquire(
+                &generations,
+                0,
+                1,
+            )
+            .expect("pin generation-A selection roots");
+        let error = super::require_compiled_refresh_source_snapshot(&conventional, &source_b)
+            .expect_err("generation B cannot allocate a stage derived from generation A");
+        assert!(error.contains("before private-stage allocation"), "{error}");
+        assert!(
+            !super::source_compile_staging_root(&compiled).exists(),
+            "cross-snapshot refusal creates no private-stage namespace"
+        );
+        assert_eq!(
+            std::fs::read(conventional.join(super::COMPILED_BUNDLE_COMPLETION_FILE))
+                .expect("generation-A completion after refusal"),
+            completion_before
+        );
+        assert_eq!(
+            std::fs::read(conventional.join(super::SOURCE_COMPILE_PREFLIGHT_FILE))
+                .expect("generation-A preflight after refusal"),
+            preflight_before
+        );
+        assert_eq!(
+            std::fs::read(conventional.join(super::SOURCE_MANIFEST_KAPPA_BINDING_FILE))
+                .expect("generation-A source binding after refusal"),
+            binding_before
+        );
+
+        super::require_compiled_refresh_source_snapshot(&conventional, &source_a)
+            .expect("generation A remains retryable after generation-B refusal");
+        let selection = super::capture_compiled_bundle_selection_base(&roots, &conventional)
+            .expect("capture unchanged generation-A selection");
+        handoff.verify().expect("generation-A roots remain exact");
+        drop(handoff);
+        let stage = super::CompiledBundleStage::allocate_with_selection(
+            &conventional,
+            &source_a,
+            &selection,
+        )
+        .expect("generation A can still allocate its private refresh stage");
+        assert!(stage
+            .path
+            .join(super::COMPILED_BUNDLE_STAGE_MARKER_FILE)
+            .is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn manifestless_tree_kappa_rejects_hidden_shards_and_binds_visible_weights() {
         let root = attention_provenance_test_dir("manifestless-hidden-shards");
         let source = root.join("source");
@@ -17377,6 +21297,8 @@ mod tests {
         );
         let dense = DenseOperatorSpec::gpt2_v2();
         write_dense_binding(&composite, &dense);
+        valid_attention_corpus_markers(&composite);
+        commit_test_recorded_corpus_binding(&composite);
         let report_path = composite.join("graph-cover/cover_report.json");
         let mut report: serde_json::Value = serde_json::from_slice(
             &std::fs::read(&report_path).expect("read cover report fixture"),

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -141,6 +141,24 @@ fn find_result_type(line: &str) -> Option<usize> {
     None
 }
 
+/// Whether this is one of the exact `std::io` trait signatures whose error
+/// type is fixed by the external trait contract.
+///
+/// Keep this carve-out adjacent and fully qualified: an ordinary helper named
+/// `read` or `seek` must still be rejected, as must an implementation of a
+/// repository-local trait with the same method name.
+fn is_std_io_trait_result(previous: Option<&str>, line: &str, tail: &str) -> bool {
+    let Some(previous) = previous else {
+        return false;
+    };
+    (previous.starts_with("impl std::io::Read for ")
+        && line.starts_with("fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize>")
+        && tail.starts_with("Result<usize>"))
+        || (previous.starts_with("impl std::io::Seek for ")
+            && line.starts_with("fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64>")
+            && tail.starts_with("Result<u64>"))
+}
+
 /// R5: no arbitrary limitation. Every bound is a property of the caller's
 /// chosen instantiation, never of the code.
 ///
@@ -237,6 +255,18 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
             // imposes --- and neither signature can name a sanctioned type, so
             // they are carved out exactly like the serde associated types.
             if tail.contains("ShapeViolation") || tail.contains("PipelineFailure") {
+                continue;
+            }
+            // `std::io::Read` and `std::io::Seek` fix their method return types
+            // to `std::io::Result`, just as serde fixes its associated error
+            // types above. Require the fully-qualified trait implementation on
+            // the immediately preceding effective line so this exemption
+            // cannot conceal an inherent or repository-local helper.
+            let previous = idx
+                .checked_sub(1)
+                .and_then(|previous| lines.get(previous))
+                .map(|(_, line)| *line);
+            if is_std_io_trait_result(previous, line, tail) {
                 continue;
             }
             violations.push(format!("{}:{line_no}:{}", src.rel, line.trim()));
@@ -398,4 +428,37 @@ fn gather_all(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Fail> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_std_io_trait_result;
+
+    #[test]
+    fn std_io_result_carve_out_requires_adjacent_fully_qualified_trait_impl() {
+        let read = "fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {";
+        assert!(is_std_io_trait_result(
+            Some("impl std::io::Read for Member {"),
+            read,
+            "Result<usize> {"
+        ));
+        assert!(!is_std_io_trait_result(None, read, "Result<usize> {"));
+        assert!(!is_std_io_trait_result(
+            Some("impl Member {"),
+            read,
+            "Result<usize> {"
+        ));
+        assert!(!is_std_io_trait_result(
+            Some("impl Read for Member {"),
+            read,
+            "Result<usize> {"
+        ));
+
+        let seek = "fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {";
+        assert!(is_std_io_trait_result(
+            Some("impl std::io::Seek for Member {"),
+            seek,
+            "Result<u64> {"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

This PR completes the uor-r4 work tracked by #704, #728, and #729.

- Implements certified native GPT-2 dense v2 for all 48 Conv1D projections plus the tied output head, with exact serial, trace, and genuine row-reuse batch semantics against the pinned exact reference.
- Carries one inseparable attention+dense execution identity through observation, recorded corpora, compiler/CLI/API/certifier paths, managed server publication, evaluation, cover, score, status, and serving.
- Makes recorded-corpus publication transactional: bounded no-follow readers, sorted common authority, crash recovery, binding-last commits, fixed inventories, managed multi-root CAS promotion, and BUSY-safe startup/reload.
- Replaces the historical scale-prefix writer with a bounded streaming fixed-partition Rust derivation, supports all 12/32/48/88-byte record eras plus opaque aligned hidden rows, and repairs the four-root scale workflow.
- Deprecates the Python writer and appends the #531 scaling-law honesty correction without running a new long measurement.

## Dense evidence

- Whole GPT-2 gate: 539 calls / 1,465,211 lanes.
- Paired median ratio: 0.694987183x.
- One-sided upper bound: 0.703876225x.
- Zero accepted whole-model fallback and zero hot-path allocation in the pinned gate.
- Immutable dense v1/v2 registry records and joint attention+dense era validation.

## Verification

- `cargo test --workspace --offline`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all -- --check`
- graph-format no-default and alloc ladders
- claim-wording gate and R5 audit
- graph CLI 125/125, graph compiler 199/199, server 174/174, scale workflow 6/6
- Kani, PR fast gate, register conformance, all-features, cargo audit, wasm, Gate C stub, and fuzz stub on head `6f1f53ff`
- independent final reviews: P0/P1/P2 = 0

## Repository boundary

All implementation is in `uor-r4`. No Casey-authored `uor-matmul` PR exists or is required. `uor-matmul` remains the pinned exact fallback/reference only.

Closes #704.
Closes #728.
Closes #729.