### PR TITLE
api/#655-C0: release-bundle manifest schema

### DIFF
--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -17,12 +17,18 @@
 //! - [`serving_eval`]: held-out evaluation of the serving surface —
 //!   the certify C row (issue #280) — measuring [`engine::R4Engine`]
 //!   with the D4 policy on a compiled bundle's own held-out split.
+//! - [`release_bundle`]: versioned release-bundle manifest schema
+//!   (#655-C0) — the declared identity a packaged serving bundle carries
+//!   (ABI/contract version, pinned `uor-matmul` provenance, component
+//!   digests, tokenizer identity). Schema and structural validation only;
+//!   no discovery/loading/serving wiring yet (that is #655-C1/D).
 //!
 //! Claim language follows `docs/formal_vocabulary.md`; nothing here
 //! strengthens or weakens the guarantees of the underlying crates.
 
 pub mod compile;
 pub mod engine;
+pub mod release_bundle;
 pub mod serving_eval;
 
 pub use compile::{
@@ -35,6 +41,10 @@ pub use engine::{
     InferenceRequest, InferenceResponse, InferenceWitness, PolicyCounters, PolicyStatus,
     PredictDecision, PredictOutcome, PredictOutput, R4Engine, ResolutionStatus, StatusAction,
     StatusPolicy, WitnessVerificationError,
+};
+pub use release_bundle::{
+    BundleAbi, BundleCapability, BundleComponentDigests, ReleaseBundleManifest,
+    UorMatmulProvenance, RELEASE_BUNDLE_MANIFEST_SCHEMA,
 };
 
 // The bytes-based tokenizer the engine's text helpers use

--- a/crates/uor-r4-api/src/release_bundle.rs
+++ b/crates/uor-r4-api/src/release_bundle.rs
@@ -1,0 +1,368 @@
+//! Versioned release-bundle manifest schema (#655-C0).
+//!
+//! Schema and structural validation ONLY. This module defines
+//! [`ReleaseBundleManifest`] — the versioned record a packaged serving
+//! bundle declares: schema version, public model id, instruction-chat
+//! capability, ABI/contract version, pinned `uor-matmul` provenance
+//! (#655-B), component digests, and tokenizer identity.
+//!
+//! It does **not** discover, load, or serve a bundle (that is #655-C1, the
+//! shared startup loader), does not produce bundle contents (#655-D), and
+//! does not change any default engine selection (#655-E/F). No existing
+//! `src/server.rs`, `src/chat.rs`, or CLI code reads or writes this
+//! manifest yet — landing the schema first, consumed by a loader in a
+//! later focused PR, mirrors the issue's own proposed implementation
+//! shape.
+//!
+//! Field shapes mirror existing manifest conventions in this workspace
+//! (`uor_r4_graph_compiler::observation::ObservationManifest`): a
+//! `schema: u32` version, `#[serde(deny_unknown_fields)]` so an unknown
+//! field is a hard parse error rather than silently ignored, and
+//! `Option<T>` with `#[serde(default, skip_serializing_if =
+//! "Option::is_none")]` for fields a future schema revision may add.
+
+use serde::{Deserialize, Serialize};
+
+use crate::compile::TokenizerAdapter;
+use crate::engine::AbiVersion;
+
+/// Current schema version this crate writes and accepts. A field change
+/// that is not additive-with-default bumps this and documents the
+/// migration here, mirroring `ObservationManifest::schema`.
+pub const RELEASE_BUNDLE_MANIFEST_SCHEMA: u32 = 1;
+
+/// Declared serving capability of the bundle's compiled model. Mirrors
+/// (without reusing — this crate does not depend on the `r4` binary
+/// crate) the two capability tiers `src/model.rs`'s `ModelCapability`
+/// enforces at the request boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BundleCapability {
+    Continuation,
+    InstructionChat,
+}
+
+/// Pinned `uor-matmul` provenance the bundle's compile-time arithmetic ran
+/// against (#655-B). Field values mirror
+/// `docs/matrix_operation_census.md`'s pinned rev/codec description.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UorMatmulProvenance {
+    /// Git revision of the pinned `uor-matmul`/`uor-matmul-core`
+    /// dependency (40-hex-char commit; matches the `rev` pinned in the
+    /// workspace `Cargo.toml`s).
+    pub rev: String,
+    /// Name of the operation/codec profile the bundle's compile-time
+    /// arithmetic used, e.g. `"exact-gemm-float"` or
+    /// `"certified-exact-fold"` (see `docs/matrix_operation_census.md`).
+    pub operation_profile: String,
+    /// SPDX license identifier of the pinned dependency source.
+    pub license: String,
+    /// Content digest of the pinned dependency source tree, when the
+    /// producing pipeline computed one. Absent until a future loader/CI
+    /// step wires a digest computation; a manifest without it is still
+    /// schema-valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_digest: Option<String>,
+}
+
+/// blake3 digests of the bundle's runtime-required components. Field-for-
+/// field mirror of `uor_r4_api::compile::ComponentDigests` (that type does
+/// not derive `Serialize`/`Deserialize`, so this is an owned, persistable
+/// value copy, not a re-export) so a future loader (#655-C1) converts
+/// between them without a semantic gap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleComponentDigests {
+    pub graph: String,
+    pub signature_artifact: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokenizer: Option<String>,
+    pub score_report: String,
+    pub compile_report: String,
+}
+
+/// The ABI/format surface the bundle declares. Owned, serializable copy of
+/// `uor_r4_api::engine::AbiVersion` (`format_major`/`format_minor`) and
+/// `uor_r4_graph_format::inference_contract::ContractVersion`
+/// (`contract_*`) — both source types carry a non-serializable shape
+/// (`AbiVersion::api_crate_version` is `&'static str`), so this manifest
+/// stores the same values as owned fields instead of embedding them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleAbi {
+    pub format_major: u8,
+    pub format_minor: u8,
+    pub contract_major: u16,
+    pub contract_minor: u16,
+    pub contract_patch: u16,
+    pub api_crate_version: String,
+}
+
+impl From<AbiVersion> for BundleAbi {
+    fn from(abi: AbiVersion) -> Self {
+        let (contract_major, contract_minor, contract_patch) = abi.contract.as_tuple();
+        Self {
+            format_major: abi.format_major,
+            format_minor: abi.format_minor,
+            contract_major,
+            contract_minor,
+            contract_patch,
+            api_crate_version: abi.api_crate_version.to_string(),
+        }
+    }
+}
+
+/// Versioned manifest binding one packaged serving bundle's declared
+/// identity: schema version, public model id, capability, ABI/contract
+/// version, pinned `uor-matmul` provenance, component digests, and
+/// tokenizer identity.
+///
+/// Schema and structural validation only (#655-C0) — see the module docs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseBundleManifest {
+    pub schema: u32,
+    /// The public model identity this bundle serves (e.g. `"r4"`), plus
+    /// any versioned/legacy alias the bundle declares. Binding this to an
+    /// actual default engine selection is #655-E/F, not this schema.
+    pub model_id: String,
+    pub capability: BundleCapability,
+    pub abi: BundleAbi,
+    pub uor_matmul: UorMatmulProvenance,
+    pub components: BundleComponentDigests,
+    pub tokenizer_adapter: TokenizerAdapter,
+    /// Free-text pointer to a fuller provenance record (e.g. a corpus
+    /// manifest κ or an issue/PR reference), when the producing pipeline
+    /// has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_note: Option<String>,
+}
+
+fn is_blake3_digest(value: &str) -> bool {
+    value
+        .strip_prefix("blake3:")
+        .is_some_and(|hex| hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+fn is_git_rev(value: &str) -> bool {
+    value.len() == 40 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+impl ReleaseBundleManifest {
+    /// Structural validation: schema support, non-empty identity fields,
+    /// well-formed component digests, and a plausible pinned `uor-matmul`
+    /// revision. Returns the first violation found as a human-readable
+    /// reason, or `None` if the manifest is structurally valid.
+    ///
+    /// Returns `Option<String>` rather than `Result<(), E>` — mirroring
+    /// `engine::validate_quality_report` in this same crate — so this
+    /// shipped function names no custom error type (R5: a shipped crate's
+    /// `Result` may only name the sanctioned graph-substrate/host-source
+    /// error surface, which a bundle-manifest schema check is not).
+    ///
+    /// Structural validity does not certify that the referenced bytes
+    /// exist, parse, or match these digests — that is the loader's job
+    /// (#655-C1).
+    pub fn validate(&self) -> Option<String> {
+        if self.schema != RELEASE_BUNDLE_MANIFEST_SCHEMA {
+            return Some(format!(
+                "unsupported release-bundle manifest schema {} (this build reads schema {RELEASE_BUNDLE_MANIFEST_SCHEMA})",
+                self.schema
+            ));
+        }
+        if self.model_id.trim().is_empty() {
+            return Some("model_id is empty".to_string());
+        }
+        if !is_git_rev(&self.uor_matmul.rev) {
+            return Some(format!(
+                "uor_matmul.rev {:?} is not a 40-character hex git revision",
+                self.uor_matmul.rev
+            ));
+        }
+        if self.uor_matmul.operation_profile.trim().is_empty() {
+            return Some("uor_matmul.operation_profile is empty".to_string());
+        }
+        if self.uor_matmul.license.trim().is_empty() {
+            return Some("uor_matmul.license is empty".to_string());
+        }
+        self.validate_component_digests()
+    }
+
+    fn validate_component_digests(&self) -> Option<String> {
+        let required = [
+            ("components.graph", self.components.graph.as_str()),
+            (
+                "components.signature_artifact",
+                self.components.signature_artifact.as_str(),
+            ),
+            (
+                "components.score_report",
+                self.components.score_report.as_str(),
+            ),
+            (
+                "components.compile_report",
+                self.components.compile_report.as_str(),
+            ),
+        ];
+        for (name, digest) in required {
+            if !is_blake3_digest(digest) {
+                return Some(format!("{name} {digest:?} is not a blake3:<hex> digest"));
+            }
+        }
+        if let Some(digest) = self.components.tokenizer.as_deref() {
+            if !is_blake3_digest(digest) {
+                return Some(format!(
+                    "components.tokenizer {digest:?} is not a blake3:<hex> digest"
+                ));
+            }
+        }
+        if self.capability == BundleCapability::InstructionChat
+            && self.tokenizer_adapter.family.trim().is_empty()
+        {
+            return Some(
+                "capability is instruction-chat but tokenizer_adapter.family is empty".to_string(),
+            );
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_REV: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+    const VALID_DIGEST: &str =
+        "blake3:0000000000000000000000000000000000000000000000000000000000000001";
+
+    fn valid_manifest() -> ReleaseBundleManifest {
+        ReleaseBundleManifest {
+            schema: RELEASE_BUNDLE_MANIFEST_SCHEMA,
+            model_id: "r4".to_string(),
+            capability: BundleCapability::InstructionChat,
+            abi: BundleAbi {
+                format_major: 1,
+                format_minor: 0,
+                contract_major: 1,
+                contract_minor: 0,
+                contract_patch: 0,
+                api_crate_version: "0.1.0".to_string(),
+            },
+            uor_matmul: UorMatmulProvenance {
+                rev: VALID_REV.to_string(),
+                operation_profile: "exact-gemm-float".to_string(),
+                license: "MIT".to_string(),
+                source_digest: None,
+            },
+            components: BundleComponentDigests {
+                graph: VALID_DIGEST.to_string(),
+                signature_artifact: VALID_DIGEST.to_string(),
+                tokenizer: Some(VALID_DIGEST.to_string()),
+                score_report: VALID_DIGEST.to_string(),
+                compile_report: VALID_DIGEST.to_string(),
+            },
+            tokenizer_adapter: TokenizerAdapter {
+                family: "hf-byte-bpe".to_string(),
+                ..Default::default()
+            },
+            provenance_note: None,
+        }
+    }
+
+    #[test]
+    fn valid_manifest_passes_validation() {
+        assert_eq!(valid_manifest().validate(), None);
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let manifest = valid_manifest();
+        let bytes = serde_json::to_vec(&manifest).expect("serialize valid manifest");
+        let parsed: ReleaseBundleManifest =
+            serde_json::from_slice(&bytes).expect("deserialize round trip");
+        assert_eq!(manifest, parsed);
+    }
+
+    #[test]
+    fn unknown_field_is_a_hard_parse_error() {
+        let mut value = serde_json::to_value(valid_manifest()).expect("to_value");
+        value
+            .as_object_mut()
+            .expect("object")
+            .insert("unexpected_field".to_string(), serde_json::json!(true));
+        let result: Result<ReleaseBundleManifest, _> = serde_json::from_value(value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_schema() {
+        let mut manifest = valid_manifest();
+        manifest.schema = RELEASE_BUNDLE_MANIFEST_SCHEMA + 1;
+        let reason = manifest.validate().expect("schema mismatch rejected");
+        assert!(reason.contains("schema"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn rejects_empty_model_id() {
+        let mut manifest = valid_manifest();
+        manifest.model_id = String::new();
+        assert!(manifest.validate().is_some());
+    }
+
+    #[test]
+    fn rejects_malformed_uor_matmul_rev() {
+        let mut manifest = valid_manifest();
+        manifest.uor_matmul.rev = "not-a-rev".to_string();
+        let reason = manifest.validate().expect("malformed rev rejected");
+        assert!(reason.contains("uor_matmul.rev"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn rejects_malformed_component_digest() {
+        let mut manifest = valid_manifest();
+        manifest.components.graph = "not-a-digest".to_string();
+        let reason = manifest.validate().expect("malformed digest rejected");
+        assert!(reason.contains("components.graph"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn rejects_malformed_optional_tokenizer_digest() {
+        let mut manifest = valid_manifest();
+        manifest.components.tokenizer = Some("not-a-digest".to_string());
+        let reason = manifest
+            .validate()
+            .expect("malformed tokenizer digest rejected");
+        assert!(
+            reason.contains("components.tokenizer"),
+            "reason was: {reason}"
+        );
+    }
+
+    #[test]
+    fn instruction_chat_requires_tokenizer_family() {
+        let mut manifest = valid_manifest();
+        manifest.tokenizer_adapter.family = String::new();
+        let reason = manifest
+            .validate()
+            .expect("missing tokenizer family rejected");
+        assert!(
+            reason.contains("tokenizer_adapter.family"),
+            "reason was: {reason}"
+        );
+    }
+
+    #[test]
+    fn continuation_capability_does_not_require_tokenizer_family() {
+        let mut manifest = valid_manifest();
+        manifest.capability = BundleCapability::Continuation;
+        manifest.tokenizer_adapter.family = String::new();
+        assert_eq!(manifest.validate(), None);
+    }
+
+    #[test]
+    fn abi_conversion_preserves_current_build_version() {
+        let bundle_abi = BundleAbi::from(AbiVersion::current());
+        assert_eq!(bundle_abi.api_crate_version, env!("CARGO_PKG_VERSION"));
+    }
+}


### PR DESCRIPTION
## References #655

**Not** Closes — this is one focused slice of the A–F decomposition on #655.

### Gap audit (posted on #655)

Re-checked the decomposition against current main before proposing this:

- **A (matrix-operation census + CI guard)** — already done (#699).
- **B (uor-matmul production arithmetic ownership)** — already done and taken further than originally scoped (#701/#703, plus #704/#727/#730 for the GPT-2 certified-exact path). Zero `cblas_*` call sites remain anywhere in the tree.
- **C (release-bundle manifest + shared startup loader)**, **D (packaged bundle)**, **E (Production/Experimental profiles)** — unstarted before this PR.
- **F (default flip)** — blocked on explicit Casey sign-off, not touched here.

### Scope

Adds `uor_r4_api::release_bundle::ReleaseBundleManifest` — schema + structural validation only:

- Schema version (`RELEASE_BUNDLE_MANIFEST_SCHEMA = 1`), public model id, `BundleCapability` (continuation / instruction-chat).
- `BundleAbi` — owned/serializable copy of the ABI/contract version surface (`AbiVersion`/`ContractVersion` carry a `&'static str` field and are intentionally not `Serialize`/`Deserialize`).
- `UorMatmulProvenance` — pinned rev, operation/codec profile, license, optional source digest (#655-B).
- `BundleComponentDigests` — blake3 digests of graph/signature-artifact/tokenizer/score-report/compile-report, field-for-field mirroring `compile::ComponentDigests`.
- `TokenizerAdapter` reused directly (already `Serialize`/`Deserialize` in `uor-r4-core`).
- `ReleaseBundleManifest::validate(&self) -> Option<String>` — first-violation structural check (schema support, non-empty identity, well-formed digests/rev, instruction-chat requires a tokenizer family). Returns `Option<String>`, not `Result<_, E>`, mirroring `engine::validate_quality_report` in the same crate — so this shipped function names no custom error type, satisfying R5 (`cargo run -q -p xtask -- audit-limits` passes).

### Non-goals

- No discovery/loading wiring into `src/server.rs` / `src/chat.rs` (#655-C1, follow-up).
- No bundle production (#655-D).
- No Production/Experimental engine-profile split or `.uor-models/last_engine.txt` migration (#655-E).
- No default-model change (#655-F, requires explicit Casey approval).
- Zero behavior change anywhere in the tree; the only existing file touched is `crates/uor-r4-api/src/lib.rs` (module declaration + re-exports).

### Compatibility / era implications

None. This is a new, unread, unwritten type — no artifact, CID, κ, or era is affected.

### Tests and gates run locally

- `cargo test --workspace --offline` — pass, 0 failed (full suite, including the new module's 11 unit tests: round-trip, `deny_unknown_fields`, and one negative case per validated field).
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo check -p uor-r4-graph-format --no-default-features` / `--features alloc` — clean.
- `python3 scripts/check_claim_wording.py` — pass.
- `cargo run -q -p xtask -- audit-limits` (R5) — pass.

### Known deferrals

- `#655-C1`: shared startup loader that discovers/validates/loads a manifest + bundle, wired into server/CLI/client/WS/WASM.
- `#655-D`: produce and package an actual pinned instruction-chat bundle.
- `UorMatmulProvenance::source_digest` is `Option` and unpopulated until a future step wires a content-digest computation over the pinned dependency source.
