### PR TITLE
format/#637-1: freeze PROV/1 provenance-roots section

### DIFF
--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -220,6 +220,29 @@ pub enum FormatError {
     FwdaEntriesNotSorted,
     /// FWDA row metadata is invalid.
     FwdaInvalidRow,
+    /// PROV has no complete fixed header (#637 PROV/1).
+    ProvTooShort,
+    /// PROV magic is not `PRV1`.
+    ProvBadMagic,
+    /// PROV version is not supported.
+    ProvUnsupportedVersion,
+    /// PROV reserved byte or unused presence bits are non-zero.
+    ProvNonZeroReserved,
+    /// A PROV presence bit is clear but its digest slot is non-zero, or
+    /// set but the slot is all-zero — the declared presence and the slot
+    /// contents disagree.
+    ProvPresenceMismatch,
+    /// PROV license/evidence-root offset or length arithmetic is invalid,
+    /// out of bounds, or leaves trailing bytes unaccounted for.
+    ProvBounds,
+    /// PROV license length is non-zero while the license presence bit is
+    /// clear, or zero while it is set.
+    ProvInvalidLicenseLength,
+    /// PROV license bytes are not valid ASCII.
+    ProvLicenseNotAscii,
+    /// PROV evidence roots are not strictly ascending (canonical order;
+    /// duplicates rejected by the same check).
+    ProvEvidenceRootsNotSorted,
     /// A packed-node range field does not resolve within its target
     /// section under checked arithmetic (RFC §6 item 4). For
     /// `Prototype`/`Mask` the full W-word extent from the word start
@@ -645,6 +668,27 @@ impl fmt::Display for FormatError {
                 write!(f, "FWDA entries are not canonically sorted")
             }
             FormatError::FwdaInvalidRow => write!(f, "FWDA row metadata is invalid"),
+            FormatError::ProvTooShort => write!(f, "PROV section is shorter than its header"),
+            FormatError::ProvBadMagic => write!(f, "PROV magic is not PRV1"),
+            FormatError::ProvUnsupportedVersion => write!(f, "PROV version is unsupported"),
+            FormatError::ProvNonZeroReserved => {
+                write!(f, "PROV reserved byte or unused presence bits are non-zero")
+            }
+            FormatError::ProvPresenceMismatch => write!(
+                f,
+                "PROV presence bit and digest-slot contents disagree"
+            ),
+            FormatError::ProvBounds => {
+                write!(f, "PROV license or evidence-root range is out of bounds")
+            }
+            FormatError::ProvInvalidLicenseLength => write!(
+                f,
+                "PROV license length is inconsistent with the license presence bit"
+            ),
+            FormatError::ProvLicenseNotAscii => write!(f, "PROV license bytes are not ASCII"),
+            FormatError::ProvEvidenceRootsNotSorted => {
+                write!(f, "PROV evidence roots are not canonically sorted")
+            }
             FormatError::RangeOutOfBounds { node, field } => write!(
                 f,
                 "node {node}: {field} range does not resolve within its target section"

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -73,6 +73,7 @@ mod header;
 pub mod inference_contract;
 pub mod invariant_ownership;
 mod ngram;
+mod prov;
 #[cfg(feature = "alloc")]
 pub mod r4g1;
 pub mod records;
@@ -119,6 +120,9 @@ pub use ngram::{
     NgramEntries, NgramEntry, NgramRow, NgramRows, NgramTable, NGRAM_ENTRY_LEN, NGRAM_HEADER_LEN,
     NGRAM_MAGIC, NGRAM_ROW_LEN, NGRAM_VERSION,
 };
+#[cfg(feature = "alloc")]
+pub use prov::{build as build_prov, ProvComponents};
+pub use prov::{EvidenceRoots, Prov, PROV_DIGEST_LEN, PROV_HEADER_LEN, PROV_MAGIC, PROV_VERSION};
 pub use records::{
     EdgeKind, PackedEdge, PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, PACKED_EDGE_LEN,
     PACKED_NODE_LEN, STORAGE_DESCRIPTOR_LEN,

--- a/crates/uor-r4-graph-format/src/prov.rs
+++ b/crates/uor-r4-graph-format/src/prov.rs
@@ -1,0 +1,347 @@
+//! Borrowed PROV section view (#637 PROV/1) — provenance roots binding
+//! the source/geometry/tokenizer/attention/dense identity digests
+//! (#597/#600/#601/#602/#704), an SPDX license expression, and a
+//! canonically-ordered list of evidence-root κ for deletion support
+//! (RFC §3 row 0x08, RFC §5 "PROV" bullet).
+//!
+//! Format-only freeze (#637 phase 1): this module parses and canonically
+//! builds PROV/1 bytes. It does **not** wire PROV into
+//! `stage2::validate`'s mandatory-section completeness pass or the
+//! compiler's write path — those are #637 phases 2 and 3.
+//!
+//! Wire layout mirrors FWDA's (`fwda.rs`, issue #399) MAGIC+VERSION+
+//! checked-bounds+canonically-sorted-list convention for the variable
+//! evidence-root tail, and HEAD's fixed 32-byte digest-slot convention
+//! for the identity fields:
+//!
+//! ```text
+//! offset  size   field
+//! 0       4B     magic = "PRV1"
+//! 4       2B     version u16 (=1)
+//! 6       1B     presence bitmap: bit0=source_manifest_kappa(#597)
+//!                bit1=geometry(#600) bit2=tokenizer_adapter(#601)
+//!                bit3=attention_operator(#602) bit4=dense_operator(#704)
+//!                bit5=license bits6-7=reserved(0)
+//! 7       1B     reserved (0)
+//! 8       4B     evidence_root_count u32
+//! 12      4B     license_len u32 (0 when presence bit5 clear)
+//! 16      32B    source_manifest_kappa digest (zero-filled when absent)
+//! 48      32B    geometry_digest (zero-filled when absent)
+//! 80      32B    tokenizer_adapter_digest (zero-filled when absent)
+//! 112     32B    attention_operator_digest (zero-filled when absent)
+//! 144     32B    dense_operator_digest (zero-filled when absent)
+//! 176     ...    license bytes (ASCII SPDX expression, license_len bytes)
+//!         ...    evidence roots: evidence_root_count × 32B κ, strictly
+//!                ascending, no duplicates
+//! ```
+//!
+//! A presence bit governs whether its digest slot means anything: a
+//! clear bit requires an all-zero slot (structural consistency between
+//! the flag and the bytes — `parse` rejects a mismatch as tamper, not as
+//! a silently-ignored stray value). Digests are opaque 32-byte values
+//! here — this section carries identity, not content; the
+//! sidecars/manifests that own each component's canonical bytes are
+//! unchanged by this freeze.
+
+use crate::error::FormatError;
+use crate::sanctioned::NotAProduct;
+
+/// PROV/1 magic bytes.
+pub const PROV_MAGIC: [u8; 4] = *b"PRV1";
+/// PROV format version this module reads and writes.
+pub const PROV_VERSION: u16 = 1;
+/// Fixed prefix length before the variable license/evidence-root tail.
+pub const PROV_HEADER_LEN: usize = 176;
+/// Width of one digest slot / evidence-root entry.
+pub const PROV_DIGEST_LEN: usize = 32;
+
+const PRESENCE_SOURCE_MANIFEST_KAPPA: u8 = 1 << 0;
+const PRESENCE_GEOMETRY: u8 = 1 << 1;
+const PRESENCE_TOKENIZER_ADAPTER: u8 = 1 << 2;
+const PRESENCE_ATTENTION_OPERATOR: u8 = 1 << 3;
+const PRESENCE_DENSE_OPERATOR: u8 = 1 << 4;
+const PRESENCE_LICENSE: u8 = 1 << 5;
+const PRESENCE_KNOWN_BITS: u8 = PRESENCE_SOURCE_MANIFEST_KAPPA
+    | PRESENCE_GEOMETRY
+    | PRESENCE_TOKENIZER_ADAPTER
+    | PRESENCE_ATTENTION_OPERATOR
+    | PRESENCE_DENSE_OPERATOR
+    | PRESENCE_LICENSE;
+
+const SLOT_SOURCE_MANIFEST_KAPPA: usize = 16;
+const SLOT_GEOMETRY: usize = 48;
+const SLOT_TOKENIZER_ADAPTER: usize = 80;
+const SLOT_ATTENTION_OPERATOR: usize = 112;
+const SLOT_DENSE_OPERATOR: usize = 144;
+
+/// One digest slot's presence bit and byte offset, in wire order.
+const SLOTS: [(u8, usize); 5] = [
+    (PRESENCE_SOURCE_MANIFEST_KAPPA, SLOT_SOURCE_MANIFEST_KAPPA),
+    (PRESENCE_GEOMETRY, SLOT_GEOMETRY),
+    (PRESENCE_TOKENIZER_ADAPTER, SLOT_TOKENIZER_ADAPTER),
+    (PRESENCE_ATTENTION_OPERATOR, SLOT_ATTENTION_OPERATOR),
+    (PRESENCE_DENSE_OPERATOR, SLOT_DENSE_OPERATOR),
+];
+
+/// Borrowed, validated view of one PROV/1 section's bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Prov<'a> {
+    bytes: &'a [u8],
+    presence: u8,
+    evidence_root_count: u32,
+    evidence_roots_start: usize,
+}
+
+impl<'a> Prov<'a> {
+    /// Parse and structurally validate one PROV/1 section's bytes.
+    ///
+    /// Checks (in order): minimum length, magic, version, reserved
+    /// byte/bits zero, every presence bit agrees with its digest slot's
+    /// zero/non-zero contents, the license length agrees with its
+    /// presence bit and is ASCII, the license and evidence-root ranges
+    /// resolve under checked arithmetic with no trailing bytes, and the
+    /// evidence roots are strictly ascending (which also rejects
+    /// duplicates — an equal successor fails the same `>=` check as an
+    /// out-of-order one).
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, NotAProduct> {
+        if bytes.len() < PROV_HEADER_LEN {
+            return Err(FormatError::ProvTooShort.into());
+        }
+        if bytes[0..4] != PROV_MAGIC {
+            return Err(FormatError::ProvBadMagic.into());
+        }
+        if read_u16(&bytes[4..6]) != PROV_VERSION {
+            return Err(FormatError::ProvUnsupportedVersion.into());
+        }
+        let presence = bytes[6];
+        if bytes[7] != 0 || presence & !PRESENCE_KNOWN_BITS != 0 {
+            return Err(FormatError::ProvNonZeroReserved.into());
+        }
+        let evidence_root_count = read_u32(&bytes[8..12]);
+        let license_len = read_u32(&bytes[12..16]);
+
+        for (bit, slot_start) in SLOTS {
+            let slot = &bytes[slot_start..slot_start + PROV_DIGEST_LEN];
+            let all_zero = slot.iter().all(|&byte| byte == 0);
+            if (presence & bit != 0) == all_zero {
+                return Err(FormatError::ProvPresenceMismatch.into());
+            }
+        }
+
+        if (presence & PRESENCE_LICENSE != 0) == (license_len == 0) {
+            return Err(FormatError::ProvInvalidLicenseLength.into());
+        }
+
+        let license_start = PROV_HEADER_LEN;
+        let license_end = license_start
+            .checked_add(license_len as usize)
+            .ok_or(FormatError::ProvBounds)?;
+        if license_end > bytes.len() {
+            return Err(FormatError::ProvBounds.into());
+        }
+        if !bytes[license_start..license_end].is_ascii() {
+            return Err(FormatError::ProvLicenseNotAscii.into());
+        }
+
+        let evidence_roots_start = license_end;
+        let evidence_bytes_len = (evidence_root_count as usize)
+            .checked_mul(PROV_DIGEST_LEN)
+            .ok_or(FormatError::ProvBounds)?;
+        let evidence_roots_end = evidence_roots_start
+            .checked_add(evidence_bytes_len)
+            .ok_or(FormatError::ProvBounds)?;
+        if evidence_roots_end != bytes.len() {
+            return Err(FormatError::ProvBounds.into());
+        }
+
+        let mut previous: Option<&[u8]> = None;
+        for chunk in bytes[evidence_roots_start..evidence_roots_end].chunks_exact(PROV_DIGEST_LEN) {
+            if previous.is_some_and(|last| last >= chunk) {
+                return Err(FormatError::ProvEvidenceRootsNotSorted.into());
+            }
+            previous = Some(chunk);
+        }
+
+        Ok(Self {
+            bytes,
+            presence,
+            evidence_root_count,
+            evidence_roots_start,
+        })
+    }
+
+    fn slot(&self, bit: u8, start: usize) -> Option<[u8; PROV_DIGEST_LEN]> {
+        if self.presence & bit == 0 {
+            return None;
+        }
+        let mut out = [0u8; PROV_DIGEST_LEN];
+        out.copy_from_slice(&self.bytes[start..start + PROV_DIGEST_LEN]);
+        Some(out)
+    }
+
+    /// #597 source-snapshot manifest root κ digest, when bound.
+    pub fn source_manifest_kappa(&self) -> Option<[u8; PROV_DIGEST_LEN]> {
+        self.slot(PRESENCE_SOURCE_MANIFEST_KAPPA, SLOT_SOURCE_MANIFEST_KAPPA)
+    }
+
+    /// #600 geometry-projection identity digest, when bound.
+    pub fn geometry_digest(&self) -> Option<[u8; PROV_DIGEST_LEN]> {
+        self.slot(PRESENCE_GEOMETRY, SLOT_GEOMETRY)
+    }
+
+    /// #601 tokenizer-adapter identity digest
+    /// (`TokenizerAdapter::adapter_digest`), when bound.
+    pub fn tokenizer_adapter_digest(&self) -> Option<[u8; PROV_DIGEST_LEN]> {
+        self.slot(PRESENCE_TOKENIZER_ADAPTER, SLOT_TOKENIZER_ADAPTER)
+    }
+
+    /// #602 source-attention-operator identity digest, when bound.
+    pub fn attention_operator_digest(&self) -> Option<[u8; PROV_DIGEST_LEN]> {
+        self.slot(PRESENCE_ATTENTION_OPERATOR, SLOT_ATTENTION_OPERATOR)
+    }
+
+    /// #704 dense-operator identity digest, when bound.
+    pub fn dense_operator_digest(&self) -> Option<[u8; PROV_DIGEST_LEN]> {
+        self.slot(PRESENCE_DENSE_OPERATOR, SLOT_DENSE_OPERATOR)
+    }
+
+    /// SPDX license expression, when declared. Validated ASCII at parse
+    /// time, so this is a plain `&str` with no further checking needed.
+    pub fn license(&self) -> Option<&'a str> {
+        if self.presence & PRESENCE_LICENSE == 0 {
+            return None;
+        }
+        let bytes = &self.bytes[PROV_HEADER_LEN..self.evidence_roots_start];
+        // ASCII was checked in `parse`; ASCII is always valid UTF-8.
+        Some(core::str::from_utf8(bytes).unwrap_or(""))
+    }
+
+    /// Number of evidence-root entries.
+    pub fn evidence_root_count(&self) -> u32 {
+        self.evidence_root_count
+    }
+
+    /// Evidence-root κ entries, strictly ascending (RFC "deletion
+    /// support" roots).
+    pub fn evidence_roots(&self) -> EvidenceRoots<'a> {
+        EvidenceRoots {
+            bytes: &self.bytes[self.evidence_roots_start..],
+            remaining: self.evidence_root_count,
+        }
+    }
+}
+
+/// Iterator over one PROV section's evidence-root κ entries.
+pub struct EvidenceRoots<'a> {
+    bytes: &'a [u8],
+    remaining: u32,
+}
+
+impl<'a> Iterator for EvidenceRoots<'a> {
+    type Item = &'a [u8; PROV_DIGEST_LEN];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let (chunk, rest) = self.bytes.split_at(PROV_DIGEST_LEN);
+        self.bytes = rest;
+        self.remaining -= 1;
+        chunk.try_into().ok()
+    }
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    u16::from(bytes[0]) | (u16::from(bytes[1]) << 8)
+}
+
+fn read_u32(bytes: &[u8]) -> u32 {
+    u32::from(bytes[0])
+        | (u32::from(bytes[1]) << 8)
+        | (u32::from(bytes[2]) << 16)
+        | (u32::from(bytes[3]) << 24)
+}
+
+/// Input to [`build`]: the optional identity digests, optional SPDX
+/// license expression, and evidence-root κ set for one PROV/1 section.
+/// Plain data — no wire-format knowledge required of callers.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProvComponents<'a> {
+    pub source_manifest_kappa: Option<[u8; PROV_DIGEST_LEN]>,
+    pub geometry_digest: Option<[u8; PROV_DIGEST_LEN]>,
+    pub tokenizer_adapter_digest: Option<[u8; PROV_DIGEST_LEN]>,
+    pub attention_operator_digest: Option<[u8; PROV_DIGEST_LEN]>,
+    pub dense_operator_digest: Option<[u8; PROV_DIGEST_LEN]>,
+    pub license: Option<&'a str>,
+    /// Evidence-root κ entries. Order does not matter — [`build`] sorts
+    /// them into canonical (ascending) order; an exact duplicate is
+    /// rejected rather than silently collapsed, since a repeated root is
+    /// more likely a caller bug than an intentional weight.
+    pub evidence_roots: &'a [[u8; PROV_DIGEST_LEN]],
+}
+
+/// Canonically build one PROV/1 section's bytes from `components`.
+///
+/// Sorts `evidence_roots` into ascending order and rejects an exact
+/// duplicate ([`FormatError::ProvEvidenceRootsNotSorted`]); rejects a
+/// non-ASCII `license`. The result always round-trips through
+/// [`Prov::parse`] to an equivalent view — asserted by this module's
+/// tests.
+#[cfg(feature = "alloc")]
+pub fn build(components: &ProvComponents<'_>) -> Result<alloc::vec::Vec<u8>, NotAProduct> {
+    use alloc::vec::Vec;
+
+    if !components.license.is_none_or(|license| license.is_ascii()) {
+        return Err(FormatError::ProvLicenseNotAscii.into());
+    }
+    let mut roots: Vec<[u8; PROV_DIGEST_LEN]> = components.evidence_roots.to_vec();
+    roots.sort_unstable();
+    if roots.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(FormatError::ProvEvidenceRootsNotSorted.into());
+    }
+
+    let mut presence = 0u8;
+    let digests: [(u8, Option<[u8; PROV_DIGEST_LEN]>); 5] = [
+        (
+            PRESENCE_SOURCE_MANIFEST_KAPPA,
+            components.source_manifest_kappa,
+        ),
+        (PRESENCE_GEOMETRY, components.geometry_digest),
+        (
+            PRESENCE_TOKENIZER_ADAPTER,
+            components.tokenizer_adapter_digest,
+        ),
+        (
+            PRESENCE_ATTENTION_OPERATOR,
+            components.attention_operator_digest,
+        ),
+        (PRESENCE_DENSE_OPERATOR, components.dense_operator_digest),
+    ];
+    for (bit, value) in digests {
+        if value.is_some() {
+            presence |= bit;
+        }
+    }
+    let license_bytes = components.license.unwrap_or("").as_bytes();
+    if components.license.is_some() {
+        presence |= PRESENCE_LICENSE;
+    }
+
+    let mut out =
+        Vec::with_capacity(PROV_HEADER_LEN + license_bytes.len() + roots.len() * PROV_DIGEST_LEN);
+    out.extend_from_slice(&PROV_MAGIC);
+    out.extend_from_slice(&PROV_VERSION.to_le_bytes());
+    out.push(presence);
+    out.push(0); // reserved
+    out.extend_from_slice(&(roots.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(license_bytes.len() as u32).to_le_bytes());
+    for (_, value) in digests {
+        out.extend_from_slice(&value.unwrap_or([0u8; PROV_DIGEST_LEN]));
+    }
+    out.extend_from_slice(license_bytes);
+    for root in &roots {
+        out.extend_from_slice(root);
+    }
+    Ok(out)
+}

--- a/crates/uor-r4-graph-format/tests/prov_637.rs
+++ b/crates/uor-r4-graph-format/tests/prov_637.rs
@@ -1,0 +1,228 @@
+//! PROV/1 format-freeze tests (#637 phase 1): round-trip, bounds, order,
+//! duplicate, and tamper coverage for `uor_r4_graph_format::Prov` /
+//! `build_prov`. Format-only — no `stage2`/compiler wiring is exercised
+//! here (that is #637 phases 2/3).
+
+use uor_r4_graph_format::{build_prov, NotAProduct, Prov, ProvComponents, PROV_HEADER_LEN};
+
+const fn digest(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+const ASCENDING_ROOTS: [[u8; 32]; 3] = [digest(0x10), digest(0x20), digest(0x30)];
+const UNSORTED_ROOTS: [[u8; 32]; 3] = [digest(0x30), digest(0x10), digest(0x20)];
+const DUPLICATE_ROOTS: [[u8; 32]; 3] = [digest(0x10), digest(0x20), digest(0x10)];
+
+fn full_components() -> ProvComponents<'static> {
+    ProvComponents {
+        source_manifest_kappa: Some(digest(0x01)),
+        geometry_digest: Some(digest(0x02)),
+        tokenizer_adapter_digest: Some(digest(0x03)),
+        attention_operator_digest: Some(digest(0x04)),
+        dense_operator_digest: Some(digest(0x05)),
+        license: Some("MIT"),
+        evidence_roots: &ASCENDING_ROOTS,
+    }
+}
+
+#[test]
+fn round_trips_all_components_present() {
+    let bytes = build_prov(&full_components()).expect("build");
+    let prov = Prov::parse(&bytes).expect("parse");
+    assert_eq!(prov.source_manifest_kappa(), Some(digest(0x01)));
+    assert_eq!(prov.geometry_digest(), Some(digest(0x02)));
+    assert_eq!(prov.tokenizer_adapter_digest(), Some(digest(0x03)));
+    assert_eq!(prov.attention_operator_digest(), Some(digest(0x04)));
+    assert_eq!(prov.dense_operator_digest(), Some(digest(0x05)));
+    assert_eq!(prov.license(), Some("MIT"));
+    assert_eq!(prov.evidence_root_count(), 3);
+    let roots: Vec<_> = prov.evidence_roots().copied().collect();
+    assert_eq!(roots, vec![digest(0x10), digest(0x20), digest(0x30)]);
+}
+
+#[test]
+fn round_trips_all_components_absent() {
+    let components = ProvComponents::default();
+    let bytes = build_prov(&components).expect("build empty");
+    assert_eq!(bytes.len(), PROV_HEADER_LEN);
+    let prov = Prov::parse(&bytes).expect("parse empty");
+    assert_eq!(prov.source_manifest_kappa(), None);
+    assert_eq!(prov.geometry_digest(), None);
+    assert_eq!(prov.tokenizer_adapter_digest(), None);
+    assert_eq!(prov.attention_operator_digest(), None);
+    assert_eq!(prov.dense_operator_digest(), None);
+    assert_eq!(prov.license(), None);
+    assert_eq!(prov.evidence_root_count(), 0);
+    assert!(prov.evidence_roots().next().is_none());
+}
+
+#[test]
+fn builder_sorts_evidence_roots_and_output_round_trips_ascending() {
+    let components = ProvComponents {
+        evidence_roots: &UNSORTED_ROOTS,
+        ..full_components()
+    };
+    let bytes = build_prov(&components).expect("build unsorted input");
+    let prov = Prov::parse(&bytes).expect("parse");
+    let roots: Vec<_> = prov.evidence_roots().copied().collect();
+    assert_eq!(roots, vec![digest(0x10), digest(0x20), digest(0x30)]);
+}
+
+#[test]
+fn builder_rejects_duplicate_evidence_roots() {
+    let components = ProvComponents {
+        evidence_roots: &DUPLICATE_ROOTS,
+        ..full_components()
+    };
+    assert!(build_prov(&components).is_err());
+}
+
+#[test]
+fn builder_rejects_non_ascii_license() {
+    let components = ProvComponents {
+        license: Some("MIT\u{2764}"), // non-ASCII heart
+        ..full_components()
+    };
+    assert!(build_prov(&components).is_err());
+}
+
+// --- bounds ---
+
+#[test]
+fn parse_rejects_too_short_header() {
+    let bytes = vec![0u8; PROV_HEADER_LEN - 1];
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "shorter than its header"));
+}
+
+#[test]
+fn parse_rejects_license_length_past_end_of_section() {
+    let mut bytes = build_prov(&ProvComponents {
+        license: Some("MIT"),
+        ..ProvComponents::default()
+    })
+    .expect("build");
+    // Header declares license_len at offset 12..16; inflate it past the
+    // actual remaining bytes without extending the buffer.
+    let inflated = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) + 1_000_000;
+    bytes[12..16].copy_from_slice(&inflated.to_le_bytes());
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "out of bounds"));
+}
+
+#[test]
+fn parse_rejects_evidence_root_count_past_end_of_section() {
+    let mut bytes = build_prov(&full_components()).expect("build");
+    let len = bytes.len();
+    // Truncate one byte off the last evidence root so the declared count
+    // no longer matches the available bytes exactly.
+    bytes.truncate(len - 1);
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "out of bounds"));
+}
+
+// --- order / duplicate (hand-built bytes: the builder always emits
+// canonical order, so exercising the reader's own check requires
+// constructing bytes directly rather than going through `build_prov`) ---
+
+/// Build a minimal valid PROV/1 header (all components absent) followed
+/// by the given raw evidence-root bytes, with `evidence_root_count` set
+/// to `count`. Lets a test hand-craft an out-of-order or duplicate tail
+/// that the builder itself would never produce.
+fn header_with_raw_roots(count: u32, root_bytes: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0u8; PROV_HEADER_LEN];
+    bytes[0..4].copy_from_slice(b"PRV1");
+    bytes[4..6].copy_from_slice(&1u16.to_le_bytes());
+    // presence = 0, reserved = 0, license_len = 0 (all already zeroed).
+    bytes[8..12].copy_from_slice(&count.to_le_bytes());
+    bytes.extend_from_slice(root_bytes);
+    bytes
+}
+
+fn is_reason(err: &NotAProduct, needle: &str) -> bool {
+    std::format!("{err}").contains(needle)
+}
+
+#[test]
+fn parse_rejects_out_of_order_evidence_roots() {
+    let mut roots = Vec::new();
+    roots.extend_from_slice(&digest(0x20));
+    roots.extend_from_slice(&digest(0x10)); // descending: out of order
+    let bytes = header_with_raw_roots(2, &roots);
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "canonically sorted"));
+}
+
+#[test]
+fn parse_rejects_duplicate_evidence_roots() {
+    let mut roots = Vec::new();
+    roots.extend_from_slice(&digest(0x10));
+    roots.extend_from_slice(&digest(0x10)); // exact duplicate
+    let bytes = header_with_raw_roots(2, &roots);
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "canonically sorted"));
+}
+
+// --- tamper ---
+
+#[test]
+fn parse_rejects_bad_magic() {
+    let mut bytes = build_prov(&ProvComponents::default()).expect("build");
+    bytes[0] = b'X';
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "magic"));
+}
+
+#[test]
+fn parse_rejects_unsupported_version() {
+    let mut bytes = build_prov(&ProvComponents::default()).expect("build");
+    bytes[4..6].copy_from_slice(&2u16.to_le_bytes());
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "version"));
+}
+
+#[test]
+fn parse_rejects_nonzero_reserved_byte() {
+    let mut bytes = build_prov(&ProvComponents::default()).expect("build");
+    bytes[7] = 0x01;
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "reserved"));
+}
+
+#[test]
+fn parse_rejects_nonzero_unused_presence_bits() {
+    let mut bytes = build_prov(&ProvComponents::default()).expect("build");
+    bytes[6] = 0b1100_0000; // bits 6-7 are reserved
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "reserved"));
+}
+
+#[test]
+fn parse_rejects_presence_bit_set_with_zeroed_slot() {
+    let mut bytes = build_prov(&ProvComponents::default()).expect("build");
+    bytes[6] = 0b0000_0001; // claim source_manifest_kappa present
+                            // ...but leave its digest slot (offset 16..48) all-zero.
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "presence"));
+}
+
+#[test]
+fn parse_rejects_presence_bit_clear_with_nonzero_slot() {
+    let mut bytes = build_prov(&full_components()).expect("build");
+    bytes[6] &= !0b0000_0001; // clear the source_manifest_kappa presence bit
+                              // ...but its digest slot (offset 16..48) is still non-zero.
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "presence"));
+}
+
+#[test]
+fn parse_rejects_non_ascii_license_bytes() {
+    let mut bytes = header_with_raw_roots(0, &[]);
+    // Declare a 1-byte license and set the presence bit, then splice in
+    // a non-ASCII byte directly (bypassing the builder's own check).
+    bytes[6] = 0b0010_0000;
+    bytes[12..16].copy_from_slice(&1u32.to_le_bytes());
+    bytes.insert(PROV_HEADER_LEN, 0xFF);
+    let err = Prov::parse(&bytes).unwrap_err();
+    assert!(is_reason(&err, "ASCII"));
+}

--- a/docs/transformerless/R4G1.md
+++ b/docs/transformerless/R4G1.md
@@ -67,7 +67,7 @@ reject any pre-freeze artifact that claims `major >= 1`.
 | 0x05 | ROUT | yes | decision programs (DAG bytecode), prototypes, masks, shortlist tables |
 | 0x06 | EMIT | yes | root token priors B(v), emission residuals ΔE, transition residuals ΔT |
 | 0x07 | EXCT | opt. | exact-context residual evidence (successor of TLS1 store) |
-| 0x08 | PROV | yes | provenance roots: source model κ, corpus CIDs, license refs, evidence roots |
+| 0x08 | PROV | yes | provenance roots (PROV/1, #637 phase 1): source-manifest/geometry/tokenizer/attention/dense identity digests, SPDX license expression, evidence roots for deletion support |
 | 0x09 | CERT | opt. | certification metadata: certificate CID(s), thresholds, metric refs |
 | 0x0A | PTCH | opt. | patch-epoch header when the artifact is a patch layer (Phase 9) |
 | 0x0B | SECT | opt. | per-section hash table — **reserved, future exploration** (§9.2) |
@@ -217,8 +217,19 @@ unassigned in v0 (PTCH-era, Phase 9); the draft line carries only the fixed pref
   reference scorer quantizes at probe time inside one delimited compiler-side float block
   (never reached by the deployed RX1 path). A reader distinguishes forms by attempting the RX1
   parse first (magic + exact consumption), then the TLS1 parsers.
-- **PROV**: source/corpus/observation CIDs, evidence roots for deletion support, license
-  identifiers (SPDX) for redistributable corpora (D3).
+- **PROV** (PROV/1, frozen by #637 phase 1; `crates/uor-r4-graph-format/src/prov.rs`): a fixed
+  176-byte prefix — `magic "PRV1"` \| `version u16` \| `presence bitmap u8` \| `reserved u8` \|
+  `evidence_root_count u32` \| `license_len u32` \| five 32-byte identity-digest slots for
+  `source_manifest_kappa` (#597), `geometry` (#600), `tokenizer_adapter` (#601),
+  `attention_operator` (#602), and `dense_operator` (#704), each zero-filled and its presence
+  bit clear when absent — followed by a variable ASCII SPDX license expression
+  (`license_len` bytes) and `evidence_root_count` × 32-byte evidence-root κ entries, strictly
+  ascending with duplicates rejected (mirrors FWDA's canonical-order discipline, #399). PROV
+  stores identity digests, not payloads: the sidecars/manifests that own each component's
+  canonical bytes (e.g. `TokenizerAdapter::adapter_digest`) are unchanged by this section.
+  Phase 1 freezes the format (reader `Prov::parse` + canonical builder `build_prov`) only;
+  producer propagation (emit/preserve through cover/score/converter) and consumer/era adoption
+  are phases 2 and 3.
 - **CERT**: certificate CID(s) + metric/threshold summary; the certificate document itself lives
   in the object store, not inline.
 


### PR DESCRIPTION
## References #637

**Not** Closes — this is phase 1 of the 3-phase decomposition Casey approved on #637 (format-only freeze; producer propagation and consumer/era adoption are separate follow-up PRs).

### Background

#637's own format audit found R4G1 PROV (section 0x08) already a known mandatory section — readers accept it and preserve its bytes — but its payload schema, semantic validation, and writer emission were never specified beyond a one-line RFC summary ("provenance roots: source model κ, corpus CIDs, license refs, evidence roots"). Casey approved proceeding on the recommended direction (use the existing PROV section, no new TLA8 era) without waiting on @afflom/@auser sign-off; [design comment posted on #637](https://github.com/UOR-Foundation/uor-r4/issues/637#issuecomment-5307879665) before implementation, inviting their review even though it's no longer blocking.

### PROV/1 wire layout

Grounded in existing precedent rather than invented from scratch: mirrors FWDA's (#399, `fwda.rs`) MAGIC+VERSION+checked-bounds+canonically-sorted-list convention for the variable evidence-root tail, and HEAD's fixed 32-byte digest-slot convention for the identity fields.

```
offset  size   field
0       4B     magic = "PRV1"
4       2B     version u16 (=1)
6       1B     presence bitmap: bit0=source_manifest_kappa(#597) bit1=geometry(#600)
               bit2=tokenizer_adapter(#601) bit3=attention_operator(#602)
               bit4=dense_operator(#704) bit5=license bits6-7=reserved(0)
7       1B     reserved (0)
8       4B     evidence_root_count u32
12      4B     license_len u32 (0 when presence bit5 clear)
16      32B    source_manifest_kappa digest (zero-filled when absent)
48      32B    geometry_digest (zero-filled when absent)
80      32B    tokenizer_adapter_digest (zero-filled when absent)
112     32B    attention_operator_digest (zero-filled when absent)
144     32B    dense_operator_digest (zero-filled when absent)
176     ...    license bytes (ASCII SPDX expression, license_len bytes)
        ...    evidence roots: evidence_root_count × 32B κ, strictly ascending, no duplicates
```

PROV stores identity **digests**, not payloads — the sidecars/manifests that already own each component's canonical bytes (e.g. `TokenizerAdapter::adapter_digest`) are unchanged by this freeze.

### Scope

- `uor_r4_graph_format::Prov<'a>` — borrowed, no_std (core-only) parser with full structural validation.
- `uor_r4_graph_format::build_prov` — canonical builder, `alloc`-gated (mirrors `ArtifactBuilder`/`build_route_attention_instance`'s existing gating convention).
- New `FormatError::Prov*` variants + `NotAProduct` conversion (R5-sanctioned error surface).
- `docs/transformerless/R4G1.md` — §3 table row and §5 bullet updated with the frozen layout.
- 17 new tests (`crates/uor-r4-graph-format/tests/prov_637.rs`): round-trip, builder canonicalization (sorts unsorted input, rejects duplicates, rejects non-ASCII license), and parser negatives for every check (bounds, order, duplicate, tamper).

### Non-goals (this PR)

- No wiring into `stage2::validate`'s mandatory-section completeness pass (phase 2).
- No producer propagation — nothing in the compiler calls `build_prov` yet (phase 2).
- No consumer/era adoption, bundle/API agreement, or legacy-unbound compatibility handling (phase 3).
- **No compiler write-path change and no artifact/CID/κ re-pin** — this PR cannot move any existing artifact's bytes since nothing reads or writes an actual PROV section yet. The TLA7 κ fixture is untouched.

### Tests and gates run locally

- `cargo build/test --workspace --offline` — pass, 0 failed.
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo check -p uor-r4-graph-format --no-default-features` / `--features alloc` — clean (parser is core-only; builder is alloc-gated).
- `cargo run -q -p xtask -- audit-limits` (R5) — pass.
- `python3 scripts/check_claim_wording.py` — pass.
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib` — pass.

### Known deferrals

- Phase 2: emit/preserve the full identity record through cover, score, converter, and cached-cover paths; prove same-input byte-stability and changed-geometry-changes-CID.
- Phase 3: bundle/API/evaluation fail-closed agreement, explicit legacy-unbound compatibility for pre-PROV artifacts, affected R4G1 identity updates.
