### PR TITLE
format/graph-compiler/graph-cli/#637-2a: opt-in PROV/1 producer propagation

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -4221,6 +4221,13 @@ struct CoverOptions {
     /// Typed host-side dense-execution record. Absence is retained for
     /// historical corpora and Llama; present records are registry exact.
     dense_operator: Option<DenseOperatorSpec>,
+    /// #637 phase 2a: bind whichever of `source_manifest_kappa`/
+    /// `geometry`/`attention_operator`/`dense_operator` the caller
+    /// passed into a PROV/1 section on the emitted artifact
+    /// (`--emit-provenance`). Default off: the artifact bytes and κ of
+    /// every existing pinned fixture are unaffected unless a caller
+    /// opts in explicitly.
+    emit_provenance: bool,
 }
 
 fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailable> {
@@ -4243,10 +4250,16 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         geometry: None,
         attention_operator: None,
         dense_operator: None,
+        emit_provenance: false,
     };
     let mut index = 0usize;
     while index < args.len() {
         let flag = &args[index];
+        if flag == "--emit-provenance" {
+            options.emit_provenance = true;
+            index += 1;
+            continue;
+        }
         let value = args
             .get(index + 1)
             .ok_or_else(|| SourceUnavailable::new(format!("missing value for {flag}")))?;
@@ -4564,16 +4577,91 @@ fn cover_command_with_authority(
     let prior = cover::root_prior(&train);
     let vocab = u32::try_from(artifacts.token_codes.len() / compiler::STAGES)
         .expect("vocabulary exceeds u32 token ids");
-    let (artifact_bytes, info) = cover::emit_r4g1_with_tokenizer_cid(
-        &artifact_container,
-        (&meta_bytes, &recs_bytes),
-        vocab,
-        &induced.cover,
-        &edges,
-        &prior,
-        &train,
-        tokenizer_cid,
-    )
+    // #637 phase 2a: `--emit-provenance` binds whichever identity records
+    // the caller already passed (`--source-manifest-kappa`,
+    // `--geometry-projection`, `--attention-operator`, `--dense-operator`)
+    // into a PROV/1 section on the artifact itself, not just the JSON
+    // report. Digest strings that fail to parse as a canonical
+    // `blake3:<hex>`/bare-hex κ are refused before any output mutation,
+    // matching this parser's existing fail-closed CLI-argument pattern.
+    // Off by default: no existing pinned fixture's bytes or κ move.
+    let (artifact_bytes, info) = if options.emit_provenance {
+        let parse_digest = |label: &str, value: &str| {
+            uor_r4_graph_format::parse_digest_hex(value).ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "--emit-provenance: {label} is not a blake3:<hex> or bare-hex digest: {value}"
+                ))
+            })
+        };
+        let provenance = uor_r4_graph_format::ProvComponents {
+            source_manifest_kappa: options
+                .source_manifest_kappa
+                .as_deref()
+                .map(|value| parse_digest("source-manifest-kappa", value))
+                .transpose()?,
+            geometry_digest: options
+                .geometry
+                .as_ref()
+                .map(|record| {
+                    parse_digest(
+                        "geometry implementation_digest",
+                        &record.implementation_digest,
+                    )
+                })
+                .transpose()?,
+            // #601 tokenizer-adapter digest is not yet threaded to this
+            // call site (the typed record lives in this crate, one layer
+            // above the graph-compiler emitter) -- deferred to a #637
+            // follow-up rather than expanded here.
+            tokenizer_adapter_digest: None,
+            attention_operator_digest: options
+                .attention_operator
+                .as_ref()
+                .map(|record| {
+                    parse_digest(
+                        "attention-operator implementation_digest",
+                        &record.implementation_digest,
+                    )
+                })
+                .transpose()?,
+            dense_operator_digest: options
+                .dense_operator
+                .as_ref()
+                .map(|record| {
+                    parse_digest(
+                        "dense-operator implementation_digest",
+                        &record.implementation_digest,
+                    )
+                })
+                .transpose()?,
+            // No CLI surface for a license or evidence-root set yet
+            // (#637 follow-up); this slice binds identity digests only.
+            license: None,
+            evidence_roots: &[],
+        };
+        cover::emit_r4g1_with_provenance(
+            &artifact_container,
+            (&meta_bytes, &recs_bytes),
+            vocab,
+            &induced.cover,
+            &edges,
+            &prior,
+            &train,
+            tokenizer_cid,
+            &provenance,
+        )
+    } else {
+        cover::emit_r4g1_with_tokenizer_cid(
+            &artifact_container,
+            (&meta_bytes, &recs_bytes),
+            vocab,
+            &induced.cover,
+            &edges,
+            &prior,
+            &train,
+            tokenizer_cid,
+        )
+    }
     .map_err(|bound| {
         SourceUnavailable::new(format!(
             "a token or count exceeded the i32 R4G1 wire bound: {bound}"
@@ -11378,6 +11466,27 @@ mod tests {
         );
         let defaults = parse_cover_options(&[]).expect("default cover options");
         assert_eq!(defaults.source_manifest_kappa, None);
+    }
+
+    /// #637 phase 2a: `--emit-provenance` is a no-value toggle (like
+    /// `--r4-attention` on the compile stage), off by default so no
+    /// existing pinned fixture's bytes move without an explicit opt-in.
+    #[test]
+    fn cover_options_carry_the_emit_provenance_toggle() {
+        let defaults = parse_cover_options(&[]).expect("default cover options");
+        assert!(!defaults.emit_provenance);
+        let kappa = format!("blake3:{}", "7".repeat(64));
+        let args = [
+            "--emit-provenance".to_owned(),
+            "--source-manifest-kappa".to_owned(),
+            kappa.clone(),
+        ];
+        let options = parse_cover_options(&args).expect("valid cover options");
+        assert!(options.emit_provenance);
+        assert_eq!(
+            options.source_manifest_kappa.as_deref(),
+            Some(kappa.as_str())
+        );
     }
 
     /// #600 plumbing seam: the cover stage accepts the typed

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -2277,6 +2277,82 @@ pub fn emit_r4g1_with_tokenizer_cid(
     observations: &[Observation],
     tokenizer_cid: [u8; 32],
 ) -> Result<(Vec<u8>, CoverArtifactInfo), uor_r4_graph_format::ObservedBound> {
+    emit_r4g1_inner(
+        artifact_container,
+        corpus_cid_material,
+        vocab_size,
+        cover,
+        edges,
+        prior,
+        observations,
+        tokenizer_cid,
+        None,
+    )
+}
+
+/// Emit the induced cover bound to a #637 PROV/1 provenance-roots section
+/// carrying the identity components the caller's pipeline knows
+/// (#597 source-manifest κ, #600 geometry projection, #601 tokenizer
+/// adapter, #602 attention operator, #704 dense operator, an SPDX license,
+/// and/or evidence-root κ).
+///
+/// Always adds a PROV section, even when every field of `provenance` is
+/// `None`/empty — call [`emit_r4g1_with_tokenizer_cid`] instead when the
+/// artifact should carry no PROV section at all (its bytes stay
+/// unchanged for identical other arguments; no pinned κ fixture is
+/// affected by this function's addition). A present-but-empty PROV
+/// section is a deliberate, valid PROV/1 record (round-trips through
+/// [`Prov::parse`][parse]), not a legacy omission.
+///
+/// A `provenance.license` that is not ASCII, or a duplicate entry in
+/// `provenance.evidence_roots`, panics rather than returning an error
+/// (see the fail-closed note at this function's PROV-building call
+/// site) — validate those two caller-supplied fields before calling this
+/// function if they come from an untrusted source.
+///
+/// [parse]: uor_r4_graph_format::Prov::parse
+#[allow(clippy::too_many_arguments)]
+pub fn emit_r4g1_with_provenance(
+    artifact_container: &[u8],
+    corpus_cid_material: (&[u8], &[u8]),
+    vocab_size: u32,
+    cover: &Cover,
+    edges: &[CoverEdge],
+    prior: &BTreeMap<u32, u32>,
+    observations: &[Observation],
+    tokenizer_cid: [u8; 32],
+    provenance: &uor_r4_graph_format::ProvComponents<'_>,
+) -> Result<(Vec<u8>, CoverArtifactInfo), uor_r4_graph_format::ObservedBound> {
+    emit_r4g1_inner(
+        artifact_container,
+        corpus_cid_material,
+        vocab_size,
+        cover,
+        edges,
+        prior,
+        observations,
+        tokenizer_cid,
+        Some(provenance),
+    )
+}
+
+/// Shared body of [`emit_r4g1_with_tokenizer_cid`] and
+/// [`emit_r4g1_with_provenance`]. `provenance` is `None` for the former
+/// (no PROV section, byte-identical to every pre-#637 caller) and
+/// `Some(components)` for the latter (builds and appends one PROV/1
+/// section from `components`).
+#[allow(clippy::too_many_arguments)]
+fn emit_r4g1_inner(
+    artifact_container: &[u8],
+    corpus_cid_material: (&[u8], &[u8]),
+    vocab_size: u32,
+    cover: &Cover,
+    edges: &[CoverEdge],
+    prior: &BTreeMap<u32, u32>,
+    observations: &[Observation],
+    tokenizer_cid: [u8; 32],
+    provenance: Option<&uor_r4_graph_format::ProvComponents<'_>>,
+) -> Result<(Vec<u8>, CoverArtifactInfo), uor_r4_graph_format::ObservedBound> {
     let node_count = 1 + cover.regions.len() as u32;
     let depth_count = (cover.max_depth + 1) as u8;
     let edge_count = edges.len() as u32;
@@ -2512,6 +2588,27 @@ pub fn emit_r4g1_with_tokenizer_cid(
     builder.add_section(uor_r4_graph_format::SectionId::EDGE, 0, &edge_section);
     builder.add_section(uor_r4_graph_format::SectionId::ROUT, 0, &rout);
     builder.add_section(uor_r4_graph_format::SectionId::EMIT, 0, &emit);
+    // #637 phase 2: a caller-supplied provenance-roots record becomes one
+    // PROV section, built with the same fail-closed convention as the
+    // rest of this constructor: `build_prov` can only reject a
+    // non-ASCII license or duplicate evidence roots
+    // (`uor_r4_graph_format::NotAProduct`), and this crate's own current
+    // producers (graph-cli's cover command, #637 phase 2a) never
+    // populate those two fields, so a rejection here means a future
+    // caller passed a malformed `ProvComponents` -- a caller-input
+    // defect this emitter reports by panicking, exactly like the
+    // `builder.build()`/`GraphView::parse`/`verify_cids` invariants
+    // below. A caller that needs a typed error instead of a panic for a
+    // free-form license/evidence-root set is a real but distinct need;
+    // validate `components` before calling this function until then.
+    let prov_section = provenance.map(|components| {
+        uor_r4_graph_format::build_prov(components).unwrap_or_else(|error| {
+            panic!("the caller's ProvComponents failed to encode as PROV/1: {error}")
+        })
+    });
+    if let Some(prov_bytes) = &prov_section {
+        builder.add_section(uor_r4_graph_format::SectionId::PROV, 0, prov_bytes);
+    }
     // These bytes were just serialized from the compiler's own cover; a
     // serialization or re-validation failure is a defect in this emitter or the
     // format layer, never a property of the caller's input, so it is an

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -940,6 +940,143 @@ fn r4g1_artifact_validates_and_reproduces() {
     assert!(view.section(SectionId::EXCT).is_none());
 }
 
+/// #637 phase 2: `emit_r4g1_with_provenance` is additive-only. Its `None`
+/// sibling ([`cover::emit_r4g1_with_tokenizer_cid`]) stays byte-identical
+/// (no PROV section, no pinned κ fixture affected); a caller that opts in
+/// gets a real PROV/1 section whose digests round-trip and whose presence
+/// changes the artifact bytes deterministically -- same components, same
+/// bytes; a changed component, different bytes.
+#[test]
+fn emit_r4g1_with_provenance_binds_a_prov_section_without_disturbing_the_unbound_path() {
+    let (observations, _) = synthetic_observations();
+    let induced = induce_synthetic(&observations, &synthetic_config());
+    let cover = &induced.cover;
+    let reference = cover::ReferenceClassifier::freeze(cover);
+    let edges = cover::build_edges(cover, &reference, &observations, &vec![0; 10000]);
+    let prior = cover::root_prior(&observations);
+
+    let (unbound_bytes, _) = cover::emit_r4g1_with_tokenizer_cid(
+        b"synthetic-artifact-container",
+        (b"synthetic-meta", b"synthetic-recs"),
+        64,
+        cover,
+        &edges,
+        &prior,
+        &[],
+        [0; 32],
+    )
+    .expect("unbound emit succeeds");
+
+    let empty_components = uor_r4_graph_format::ProvComponents::default();
+    let (empty_prov_bytes, _) = cover::emit_r4g1_with_provenance(
+        b"synthetic-artifact-container",
+        (b"synthetic-meta", b"synthetic-recs"),
+        64,
+        cover,
+        &edges,
+        &prior,
+        &[],
+        [0; 32],
+        &empty_components,
+    )
+    .expect("empty-provenance emit succeeds");
+
+    assert_ne!(
+        unbound_bytes.len(),
+        empty_prov_bytes.len(),
+        "a present-but-empty PROV section still adds bytes over no PROV section at all"
+    );
+    let empty_view = GraphView::parse(&empty_prov_bytes).expect("stage-1+2 validation");
+    empty_view.verify_cids().expect("integrity CIDs");
+    assert_eq!(
+        empty_view.head().expect("HEAD present").node_count(),
+        GraphView::parse(&unbound_bytes)
+            .expect("unbound view")
+            .head()
+            .expect("unbound HEAD")
+            .node_count(),
+        "HEAD content is unaffected by the PROV section"
+    );
+    let empty_prov_section = empty_view
+        .section(SectionId::PROV)
+        .expect("PROV section present when provenance is Some(..)");
+    let empty_prov = uor_r4_graph_format::Prov::parse(empty_prov_section).expect("PROV/1 parses");
+    assert_eq!(empty_prov.source_manifest_kappa(), None);
+    assert_eq!(empty_prov.geometry_digest(), None);
+    assert_eq!(empty_prov.attention_operator_digest(), None);
+    assert_eq!(empty_prov.dense_operator_digest(), None);
+    assert_eq!(empty_prov.evidence_root_count(), 0);
+
+    // Determinism: same components, same bytes.
+    let (empty_prov_bytes2, _) = cover::emit_r4g1_with_provenance(
+        b"synthetic-artifact-container",
+        (b"synthetic-meta", b"synthetic-recs"),
+        64,
+        cover,
+        &edges,
+        &prior,
+        &[],
+        [0; 32],
+        &empty_components,
+    )
+    .expect("repeat empty-provenance emit succeeds");
+    assert_eq!(
+        empty_prov_bytes, empty_prov_bytes2,
+        "identical provenance components reproduce identical bytes"
+    );
+
+    // A populated component set round-trips and, because it changes the
+    // PROV section body, changes the artifact bytes and artifact_cid --
+    // but not head_cid, since HEAD's own bytes are untouched.
+    let geometry_digest = *blake3::hash(b"#600 geometry projection fixture").as_bytes();
+    let source_manifest_kappa = *blake3::hash(b"#597 source manifest fixture").as_bytes();
+    let populated_components = uor_r4_graph_format::ProvComponents {
+        source_manifest_kappa: Some(source_manifest_kappa),
+        geometry_digest: Some(geometry_digest),
+        tokenizer_adapter_digest: None,
+        attention_operator_digest: None,
+        dense_operator_digest: None,
+        license: None,
+        evidence_roots: &[],
+    };
+    let (populated_bytes, _) = cover::emit_r4g1_with_provenance(
+        b"synthetic-artifact-container",
+        (b"synthetic-meta", b"synthetic-recs"),
+        64,
+        cover,
+        &edges,
+        &prior,
+        &[],
+        [0; 32],
+        &populated_components,
+    )
+    .expect("populated-provenance emit succeeds");
+    assert_ne!(
+        populated_bytes, empty_prov_bytes,
+        "a changed provenance component changes the emitted artifact bytes"
+    );
+    let populated_view = GraphView::parse(&populated_bytes).expect("stage-1+2 validation");
+    populated_view.verify_cids().expect("integrity CIDs");
+    assert_eq!(
+        populated_view.header().head_cid,
+        empty_view.header().head_cid,
+        "head_cid is unaffected by which components PROV carries"
+    );
+    let populated_prov = uor_r4_graph_format::Prov::parse(
+        populated_view
+            .section(SectionId::PROV)
+            .expect("PROV section present"),
+    )
+    .expect("PROV/1 parses");
+    assert_eq!(
+        populated_prov.source_manifest_kappa(),
+        Some(source_manifest_kappa)
+    );
+    assert_eq!(populated_prov.geometry_digest(), Some(geometry_digest));
+    assert_eq!(populated_prov.attention_operator_digest(), None);
+    assert_eq!(populated_prov.dense_operator_digest(), None);
+}
+
 // ------------------------------------------------------------ primitives --
 
 #[test]

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -122,7 +122,10 @@ pub use ngram::{
 };
 #[cfg(feature = "alloc")]
 pub use prov::{build as build_prov, ProvComponents};
-pub use prov::{EvidenceRoots, Prov, PROV_DIGEST_LEN, PROV_HEADER_LEN, PROV_MAGIC, PROV_VERSION};
+pub use prov::{
+    parse_digest_hex, EvidenceRoots, Prov, PROV_DIGEST_LEN, PROV_HEADER_LEN, PROV_MAGIC,
+    PROV_VERSION,
+};
 pub use records::{
     EdgeKind, PackedEdge, PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, PACKED_EDGE_LEN,
     PACKED_NODE_LEN, STORAGE_DESCRIPTOR_LEN,

--- a/crates/uor-r4-graph-format/src/prov.rs
+++ b/crates/uor-r4-graph-format/src/prov.rs
@@ -83,6 +83,30 @@ const SLOTS: [(u8, usize); 5] = [
     (PRESENCE_DENSE_OPERATOR, SLOT_DENSE_OPERATOR),
 ];
 
+/// Parse a canonical digest string into its raw 32 bytes.
+///
+/// Accepts the `blake3:<64 lowercase hex>` form this workspace's typed
+/// identity records declare via their `implementation_digest` field
+/// (#600 geometry projection, #602 attention operator, #704 dense
+/// operator) or `adapter_digest` field (#601 tokenizer adapter), and a
+/// bare 64-hex-char form for producers that carry a raw κ without the
+/// scheme prefix (e.g. #597's `--source-manifest-kappa`). Hex digits may
+/// be upper or lower case. Returns `None` for anything else — a producer
+/// deciding whether an unparseable digest is a hard error is a caller
+/// concern, not this parser's.
+pub fn parse_digest_hex(value: &str) -> Option<[u8; PROV_DIGEST_LEN]> {
+    let hex = value.strip_prefix("blake3:").unwrap_or(value);
+    if hex.len() != PROV_DIGEST_LEN * 2 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; PROV_DIGEST_LEN];
+    for (index, slot) in out.iter_mut().enumerate() {
+        let byte_hex = &hex[index * 2..index * 2 + 2];
+        *slot = u8::from_str_radix(byte_hex, 16).ok()?;
+    }
+    Some(out)
+}
+
 /// Borrowed, validated view of one PROV/1 section's bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Prov<'a> {
@@ -344,4 +368,64 @@ pub fn build(components: &ProvComponents<'_>) -> Result<alloc::vec::Vec<u8>, Not
         out.extend_from_slice(root);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod digest_hex_tests {
+    use super::parse_digest_hex;
+
+    // 32 bytes, values 0x01..=0x20, no alloc needed: every case below is a
+    // literal so this module compiles regardless of the `alloc` feature.
+    const HEX_LOWER: &str = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+    const HEX_UPPER: &str = "0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20";
+    const PREFIXED_LOWER: &str =
+        "blake3:0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+    const PREFIXED_UPPER: &str =
+        "blake3:0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20";
+
+    fn expected() -> [u8; 32] {
+        let mut out = [0u8; 32];
+        for (index, slot) in out.iter_mut().enumerate() {
+            *slot = (index + 1) as u8;
+        }
+        out
+    }
+
+    #[test]
+    fn parses_blake3_prefixed_form() {
+        assert_eq!(parse_digest_hex(PREFIXED_LOWER), Some(expected()));
+    }
+
+    #[test]
+    fn parses_bare_hex_form() {
+        assert_eq!(parse_digest_hex(HEX_LOWER), Some(expected()));
+    }
+
+    #[test]
+    fn parses_uppercase_hex() {
+        assert_eq!(parse_digest_hex(PREFIXED_UPPER), Some(expected()));
+        assert_eq!(parse_digest_hex(HEX_UPPER), Some(expected()));
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert_eq!(parse_digest_hex("blake3:ab"), None);
+        assert_eq!(parse_digest_hex(""), None);
+    }
+
+    #[test]
+    fn rejects_non_hex_characters() {
+        const NOT_HEX: &str =
+            "blake3:gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg";
+        assert_eq!(parse_digest_hex(NOT_HEX), None);
+    }
+
+    #[test]
+    fn rejects_odd_scheme_prefix() {
+        // A different scheme prefix is not stripped, so the remaining
+        // string is too long to be 64 hex chars and parsing fails closed.
+        const SHA256_PREFIXED: &str =
+            "sha256:0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        assert_eq!(parse_digest_hex(SHA256_PREFIXED), None);
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2a of #637: wires the frozen PROV/1 section (phase 1, #732) into the real R4G1 producer path, additively and opt-in.

- `uor-r4-graph-format`: `parse_digest_hex` parses a canonical `blake3:<hex>` or bare-hex digest string into PROV's 32-byte wire form (core-only, no_std-safe; 6 unit tests).
- `uor-r4-graph-compiler`: `induction::emit_r4g1_with_provenance` builds and appends one PROV/1 section from a caller-supplied `ProvComponents`. `emit_r4g1`/`emit_r4g1_with_tokenizer_cid` now delegate to a shared private inner emitter with `provenance: None`, so their output stays byte-identical — **no pinned κ fixture moves**. New determinism/round-trip test: same components → same bytes; a changed geometry digest changes the artifact bytes/`artifact_cid` but not `head_cid`.
- `uor-r4-graph-cli`: `cover` gains an opt-in `--emit-provenance` toggle (off by default) that binds whichever of `--source-manifest-kappa` (#597) / `--geometry-projection` (#600) / `--attention-operator` (#602) / `--dense-operator` (#704) the caller already passes into a real PROV section on the artifact, not just the JSON report. Malformed digest strings are refused before any output mutation.

## Non-goals (deferred, tracked on #637)

- #601 tokenizer-adapter digest (the typed record lives one layer above this call site).
- A license / evidence-root CLI surface.
- The score / converter / cached-cover producer paths.
- Flipping `cover`'s *default* output to always carry PROV — that changes every future artifact's κ and needs an explicit maintainer-supervised re-pin per AGENTS.md, not bundled into an additive slice.

## Test plan

- [x] `cargo fmt --check` (uor-r4-graph-format, uor-r4-graph-compiler, uor-r4-graph-cli)
- [x] `cargo clippy --all-targets -- -D warnings` (same three crates)
- [x] `cargo test` — 439 tests, 0 failed, across the three crates
- [x] `cargo run -p xtask -- audit-limits` (R5: no unsanctioned error type)
- [x] `cargo build -p uor-r4-graph-format --no-default-features` (no_std build)
- [x] New test: `emit_r4g1_with_provenance_binds_a_prov_section_without_disturbing_the_unbound_path` (round-trip, determinism, CID-change-on-component-change)
- [x] New test: `cover_options_carry_the_emit_provenance_toggle`

References #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfUSQi4hgpvVFTgwVrQ3U8
