### PR TITLE
model-source/graph-certify/#643: MSA-structured selector (reference + witness)

### DIFF
--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -14,6 +14,7 @@ pub mod frame_consistency;
 #[cfg(feature = "holographic-encoding")]
 pub mod holographic_encoding;
 pub mod long_context;
+pub mod msa_selector;
 pub mod octeract;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod octeract_trace_screen;

--- a/crates/uor-r4-graph-certify/src/msa_selector.rs
+++ b/crates/uor-r4-graph-certify/src/msa_selector.rs
@@ -1,0 +1,589 @@
+//! `MsaStructuredSelectorV1` reference semantics and witness (#643): the
+//! second TARGET operator, alongside `r4-route-attention/1` (#604),
+//! registered for a pre-registered A/B evaluation against it. Certifier
+//! -side code, next to `route_attention.rs` where the first target
+//! operator's reference semantics live — same layering, deliberately
+//! smaller: this operator has no per-byte relation to compute, so its
+//! reference and witness are proportionally shorter.
+//!
+//! # Grounding (Modular Structural Arithmetic, Casey-approved publication
+//! 2026-08-16)
+//!
+//! Two THEOREMS of the paper are reused directly as fixed tables, no
+//! runtime derivation:
+//!
+//! - **MSA7, "The 11-Theorem":** `DP(11)` holds with role anchors
+//!   `mod_11(γ) = 2` (Gen), `mod_11(μ) = 4` (Med), `mod_11(ε) = 8`
+//!   (Man) — the only three residues mod 11 the paper actually assigns
+//!   a role.
+//! - **Theorem M4, "The 11-Cascade Theorem":** the doubling cascade
+//!   `(2, 4, 8, 5, 10, 9, 7, 3, 6, 1)` has maximal period 10 = p−1 in
+//!   ℤ/11ℤ (Lagrange, via Theorem M3).
+//!
+//! # Role extension beyond the paper (explicit, confirmed choice)
+//!
+//! The paper never assigns a role to the other 8 nonzero-or-zero
+//! residues (0, 1, 3, 5, 6, 7, 9, 10) — that depends on the base
+//! Structural Arithmetic theory's `Gen`/`Med`/`Man` predicates for
+//! values other than γ/μ/ε, which is not in this paper. This module
+//! extends role coverage to every residue by the anchors' own cascade
+//! POSITIONS: γ=2 sits at orbit position 0, μ=4 at position 1, ε=8 at
+//! position 2, so every residue's role is `orbit_position(residue) mod
+//! 3`. Residue 0 is outside the multiplicative group entirely (it has
+//! no orbit under doubling) and gets its own fourth "zero" class. This
+//! extension was proposed and confirmed by Casey (2026-08-16, in
+//! response to an explicit question) — it is this operator's design
+//! choice, not a proven MSA theorem, and every doc comment that states
+//! it says so.
+//!
+//! # Reference specification (version 1)
+//!
+//! An operator INSTANCE is `N` declared candidate ids (`u32`, arbitrary
+//! — typically route/token ids) with one declared `ScoreQ` contribution
+//! each, and a declared selection width `M` under `1 <= M <= N`. No
+//! query enters the classification at all — unlike
+//! `r4-route-attention/1`, this operator's per-step "query" parameter
+//! exists only for interface parity (the same fixture can drive either
+//! operator through the same harness for the A/B); it does not affect
+//! the outcome, and every step over the same instance is identical.
+//!
+//! One STEP:
+//!
+//! 1. **Classification** (table lookup): for every candidate `i` in
+//!    index order, `residue = candidate_id[i] mod 11`, then
+//!    `role_rank = cascade_position(residue) mod 3` (or the sentinel
+//!    zero-class `3` when `residue == 0`), `cascade_position =
+//!    cascade_position(residue)` (or the sentinel `10`, one past the
+//!    max valid orbit index, when `residue == 0`). Table reads only —
+//!    the reference computes `mod 11` directly with an integer `%`
+//!    (certifier-side; not the P-4-scanned deployed surface), but the
+//!    result is exactly what a precomputed per-vocabulary table would
+//!    return, which is what a future packed lowering must actually use
+//!    (`permitted_operation_class` on the registry record already
+//!    names this: no runtime modulo in the deployed path).
+//! 2. **Selection** (bounded top-M): the `M` smallest candidates under
+//!    the strict lexicographic order `(role_rank, cascade_position,
+//!    index)`. Deterministic tie rule: on equal role and cascade
+//!    position, the LOWEST candidate INDEX wins — the same
+//!    tie-breaking shape as `r4-route-attention/1`.
+//! 3. **Aggregation** (integer/table): the selected contributions fold
+//!    from `ScoreQ::ZERO` in selection order with SATURATING i32
+//!    adds — identical convention to `r4-route-attention/1`, so the two
+//!    operators are plug-compatible for the A/B harness.
+//!
+//! # Non-goals of this slice
+//!
+//! No packed R4G1 lowering exists yet (mirrors #604's own two-stage
+//! plan: reference semantics first). No A/B run has happened — the
+//! exit rule is pre-registered on #643 before any run, per the #626
+//! convention. No wire-format/artifact carriage exists (same dormant
+//! posture as `r4-route-attention/1`).
+//!
+//! # Census (per step, closed form)
+//!
+//! ```text
+//! table_reads         = N + M   (one classification read per candidate,
+//!                                one contribution read per selected slot)
+//! compares             = M*N
+//! adds                 = M
+//! candidates_examined  = N
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use uor_r4_graph_format::ScoreQ;
+
+/// Format tag of the witness record.
+pub const MSA_SELECTOR_WITNESS_FORMAT: &str = "uor-r4-msa-selector-witness/1";
+/// Domain-separation prefix of the inputs digest.
+pub const MSA_SELECTOR_INPUTS_DOMAIN: &str = "uor-r4-msa-selector-inputs/1";
+/// Domain-separation prefix of the instance bytes.
+const MSA_SELECTOR_INSTANCE_TAG: &[u8] = b"uor-r4-msa-selector-instance/1\n";
+
+/// Theorem M4 ("The 11-Cascade Theorem"): the doubling cascade starting
+/// at 2 in `(ℤ/11ℤ)*`, in orbit order. Position 0 = γ's residue (2,
+/// Gen), position 1 = μ's residue (4, Med), position 2 = ε's residue
+/// (8, Man) — MSA7, "The 11-Theorem". Positions 3..9 are this module's
+/// own mod-3 role extension (see module docs), not a paper theorem.
+const CASCADE_ORBIT_11: [u8; 10] = [2, 4, 8, 5, 10, 9, 7, 3, 6, 1];
+/// The modulus this operator is pinned to (MSA7/M4 are both stated for
+/// p = 11 specifically).
+const CASCADE_MODULUS: u32 = 11;
+/// Residue 0 is outside `(ℤ/11ℤ)*` and has no orbit position; this
+/// sentinel sorts after every real position (0..=9).
+const CASCADE_SENTINEL_POSITION: u8 = 10;
+
+/// Role rank of the γ anchor (`mod_11(γ) = 2`, cascade position 0) —
+/// MSA7.
+pub const ROLE_GEN: u8 = 0;
+/// Role rank of the μ anchor (`mod_11(μ) = 4`, cascade position 1) —
+/// MSA7.
+pub const ROLE_MED: u8 = 1;
+/// Role rank of the ε anchor (`mod_11(ε) = 8`, cascade position 2) —
+/// MSA7.
+pub const ROLE_MAN: u8 = 2;
+/// Role rank of residue 0 — outside the multiplicative group, so
+/// outside every role MSA7 assigns; sentinel class, sorts last.
+pub const ROLE_ZERO: u8 = 3;
+
+/// This residue's position in [`CASCADE_ORBIT_11`], or `None` for
+/// residue 0 (not in the multiplicative group `(ℤ/11ℤ)*`).
+fn cascade_position(residue: u8) -> Option<u8> {
+    CASCADE_ORBIT_11
+        .iter()
+        .position(|&candidate| candidate == residue)
+        .map(|position| position as u8)
+}
+
+/// This residue's role rank: the proven MSA7 anchors sit at cascade
+/// positions 0/1/2 (Gen/Med/Man); every other nonzero residue's role is
+/// its cascade position mod 3 (this module's extension, see module
+/// docs); residue 0 is [`ROLE_ZERO`].
+fn role_rank(residue: u8) -> u8 {
+    match cascade_position(residue) {
+        Some(position) => position % 3,
+        None => ROLE_ZERO,
+    }
+}
+
+/// One candidate id's classification: its role rank and cascade
+/// position under modulus 11.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MsaClassification {
+    /// [`ROLE_GEN`]/[`ROLE_MED`]/[`ROLE_MAN`]/[`ROLE_ZERO`].
+    pub role_rank: u8,
+    /// Position in [`CASCADE_ORBIT_11`] (0..=9), or
+    /// [`CASCADE_SENTINEL_POSITION`] for residue 0.
+    pub cascade_position: u8,
+}
+
+/// Classify a candidate id: `residue = candidate_id mod 11`, then table
+/// lookup for role and cascade position. Total — every `u32` classifies
+/// to something, by construction (`role_rank` and `cascade_position`
+/// each have an explicit branch for residue 0).
+pub fn classify(candidate_id: u32) -> MsaClassification {
+    let residue = (candidate_id % CASCADE_MODULUS) as u8;
+    MsaClassification {
+        role_rank: role_rank(residue),
+        cascade_position: cascade_position(residue).unwrap_or(CASCADE_SENTINEL_POSITION),
+    }
+}
+
+/// The op census (witness): every field a closed form of `(N, M,
+/// steps)` (module docs table), deliberately data-independent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsaSelectorOpCensus {
+    /// Table reads: one classification per candidate, one contribution
+    /// per selected slot.
+    #[serde(default)]
+    pub table_reads: u64,
+    /// Ordered slot comparisons during top-M insertion.
+    #[serde(default)]
+    pub compares: u64,
+    /// Saturating adds during the aggregate fold.
+    #[serde(default)]
+    pub adds: u64,
+    /// Candidates classified.
+    #[serde(default)]
+    pub candidates_examined: u64,
+}
+
+/// The census closed form for `steps` steps over an instance with
+/// `candidate_count` candidates selecting `top_m` (module docs table).
+pub fn expected_msa_selector_census(
+    candidate_count: u32,
+    top_m: u16,
+    steps: usize,
+) -> MsaSelectorOpCensus {
+    let mut census = MsaSelectorOpCensus::default();
+    let mut step = 0usize;
+    while step < steps {
+        let mut candidate = 0u32;
+        while candidate < candidate_count {
+            census.candidates_examined += 1;
+            census.table_reads += 1;
+            census.compares += u64::from(top_m);
+            candidate += 1;
+        }
+        let mut slot = 0u16;
+        while slot < top_m {
+            census.table_reads += 1;
+            census.adds += 1;
+            slot += 1;
+        }
+        step += 1;
+    }
+    census
+}
+
+/// One selected candidate of one step, in selection order.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsaSelection {
+    /// Candidate INDEX into the instance's declared id/contribution
+    /// tables (the same "index, not id" convention `RouteSelection`
+    /// uses) — the tie-break winner on equal classification.
+    #[serde(default)]
+    pub candidate: u32,
+    /// The declared candidate id at that index (`instance
+    /// candidate_ids[candidate]`), carried for readability.
+    #[serde(default)]
+    pub candidate_id: u32,
+    /// [`MsaClassification::role_rank`] of that candidate.
+    #[serde(default)]
+    pub role_rank: u8,
+    /// [`MsaClassification::cascade_position`] of that candidate.
+    #[serde(default)]
+    pub cascade_position: u8,
+}
+
+/// One step of the witness: the selected candidates (selection order)
+/// and the aggregate they fold to.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsaSelectorWitnessStep {
+    /// Selected candidates, selection order.
+    #[serde(default)]
+    pub selected: Vec<MsaSelection>,
+    /// Raw ScoreQ of the selection-order saturating fold.
+    #[serde(default)]
+    pub aggregate_raw: i32,
+}
+
+/// The bounded, replayable record of one run: identity, input binding,
+/// per-step selections, and the op census. All fields serde-defaulted,
+/// same era discipline as [`uor_r4_graph_format`]'s peer records.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsaSelectorWitness {
+    /// [`MSA_SELECTOR_WITNESS_FORMAT`].
+    #[serde(default)]
+    pub format: String,
+    /// Operator registry id (`msa-structured-selector`).
+    #[serde(default)]
+    pub operator_id: String,
+    /// Operator registry version (1).
+    #[serde(default)]
+    pub operator_version: u32,
+    /// `blake3:<hex>` of the canonical instance bytes.
+    #[serde(default)]
+    pub instance_digest: String,
+    /// `blake3:<hex>` binding the instance digest and the step count.
+    #[serde(default)]
+    pub inputs_digest: String,
+    /// Per-step selections and aggregates.
+    #[serde(default)]
+    pub steps: Vec<MsaSelectorWitnessStep>,
+    /// Op census of the whole run.
+    #[serde(default)]
+    pub census: MsaSelectorOpCensus,
+}
+
+/// One step's outcome as returned to callers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MsaSelectorStepRecord {
+    /// Selected candidates, selection order.
+    pub selected: Vec<MsaSelection>,
+    /// The selection-order saturating ScoreQ fold.
+    pub aggregate: ScoreQ,
+}
+
+/// `blake3:<hex>` presentation of a raw digest.
+pub fn digest_string(digest: &[u8; 32]) -> String {
+    format!("blake3:{}", blake3::Hash::from_bytes(*digest).to_hex())
+}
+
+/// Canonical instance bytes: format tag, candidate count, `top_m`, then
+/// every `(candidate_id, contribution)` pair in declared order. Fixed
+/// line/field layout, not derived from any serializer, so the digest
+/// over these bytes is reproducible everywhere — same convention as
+/// `AttentionOperatorSpec::canonical_bytes`.
+pub fn msa_instance_bytes(candidate_ids: &[u32], contributions: &[ScoreQ], top_m: u16) -> Vec<u8> {
+    let mut bytes =
+        Vec::with_capacity(MSA_SELECTOR_INSTANCE_TAG.len() + 8 + candidate_ids.len() * 8);
+    bytes.extend_from_slice(MSA_SELECTOR_INSTANCE_TAG);
+    bytes.extend_from_slice(&(candidate_ids.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(&top_m.to_le_bytes());
+    for (&candidate_id, &contribution) in candidate_ids.iter().zip(contributions.iter()) {
+        bytes.extend_from_slice(&candidate_id.to_le_bytes());
+        bytes.extend_from_slice(&contribution.raw().to_le_bytes());
+    }
+    bytes
+}
+
+/// The inputs digest: blake3 over the domain tag, the instance digest,
+/// and the step count (u32 LE). Binds the witness to exactly one
+/// (instance, step-count) pair — there is no query sequence to bind
+/// (query-independent classification, module docs).
+pub fn msa_inputs_digest(instance_digest: &[u8; 32], steps: usize) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(MSA_SELECTOR_INPUTS_DOMAIN.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(instance_digest);
+    hasher.update(&(steps as u32).to_le_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// The scalar reference implementation: owned declared candidate ids
+/// and contributions, plus the canonical instance bytes for identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MsaSelectorReference {
+    candidate_ids: Vec<u32>,
+    contributions: Vec<ScoreQ>,
+    top_m: usize,
+    instance_bytes: Vec<u8>,
+}
+
+impl MsaSelectorReference {
+    /// Build the reference from declared candidate ids and their
+    /// contributions. `None` when the instance is malformed: empty,
+    /// mismatched lengths, or `top_m` outside `1..=candidate_ids.len()`
+    /// — the same fail-closed posture as
+    /// `RouteAttentionReference::from_instance_bytes`, expressed as
+    /// `Option` here since there is no wire format to name a
+    /// `NotAProduct` violation against yet (module docs: no artifact
+    /// carriage in this slice).
+    pub fn new(candidate_ids: Vec<u32>, contributions: Vec<ScoreQ>, top_m: usize) -> Option<Self> {
+        if candidate_ids.is_empty() || candidate_ids.len() != contributions.len() {
+            return None;
+        }
+        if top_m == 0 || top_m > candidate_ids.len() {
+            return None;
+        }
+        let instance_bytes = msa_instance_bytes(&candidate_ids, &contributions, top_m as u16);
+        Some(Self {
+            candidate_ids,
+            contributions,
+            top_m,
+            instance_bytes,
+        })
+    }
+
+    /// The canonical instance bytes this reference was built from.
+    pub fn instance_bytes(&self) -> &[u8] {
+        &self.instance_bytes
+    }
+
+    /// Declared candidate count `N`.
+    pub fn candidate_count(&self) -> u32 {
+        self.candidate_ids.len() as u32
+    }
+
+    /// Declared selection width `M`.
+    pub fn top_m(&self) -> u16 {
+        self.top_m as u16
+    }
+
+    /// One reference step (module-docs semantics; query-independent, so
+    /// every call returns the same result), counting into `census` with
+    /// exactly the declared operation schedule.
+    pub fn reference_step(&self, census: &mut MsaSelectorOpCensus) -> MsaSelectorStepRecord {
+        // Selection slots, ascending (role_rank, cascade_position,
+        // index); sentinel triples order after every real candidate.
+        let mut slots: Vec<(u8, u8, u32)> = Vec::with_capacity(self.top_m);
+        slots.resize(self.top_m, (u8::MAX, u8::MAX, u32::MAX));
+        for (index, &candidate_id) in self.candidate_ids.iter().enumerate() {
+            let index = index as u32;
+            census.candidates_examined += 1;
+            census.table_reads += 1;
+            let classification = classify(candidate_id);
+            let key = (
+                classification.role_rank,
+                classification.cascade_position,
+                index,
+            );
+            // Exactly M ordered slot comparisons; the first slot this
+            // candidate beats is its insertion point — same shape as
+            // `RouteAttentionReference::reference_step`.
+            let mut insert_at = None;
+            for (slot, &slot_key) in slots.iter().enumerate() {
+                census.compares += 1;
+                if key < slot_key && insert_at.is_none() {
+                    insert_at = Some(slot);
+                }
+            }
+            if let Some(position) = insert_at {
+                slots.insert(position, key);
+                slots.truncate(self.top_m);
+            }
+        }
+        // Selection-order saturating fold of the selected contributions.
+        let mut aggregate = ScoreQ::ZERO;
+        let mut selected = Vec::with_capacity(self.top_m);
+        for &(role_rank, cascade_position, index) in &slots {
+            let contribution = self.contributions[index as usize];
+            census.table_reads += 1;
+            aggregate = aggregate.saturating_add(contribution);
+            census.adds += 1;
+            selected.push(MsaSelection {
+                candidate: index,
+                candidate_id: self.candidate_ids[index as usize],
+                role_rank,
+                cascade_position,
+            });
+        }
+        MsaSelectorStepRecord {
+            selected,
+            aggregate,
+        }
+    }
+
+    /// Run the reference for `steps` steps, producing the step records
+    /// and the replayable witness. Every step is identical
+    /// (query-independent classification, module docs) — `steps` exists
+    /// for interface parity with the per-query `run` shape
+    /// `r4-route-attention/1` uses, so the same A/B harness can drive
+    /// either operator.
+    pub fn run(&self, steps: usize) -> (Vec<MsaSelectorStepRecord>, MsaSelectorWitness) {
+        let mut census = MsaSelectorOpCensus::default();
+        let mut records = Vec::with_capacity(steps);
+        let mut witness_steps = Vec::with_capacity(steps);
+        for _ in 0..steps {
+            let record = self.reference_step(&mut census);
+            witness_steps.push(MsaSelectorWitnessStep {
+                selected: record.selected.clone(),
+                aggregate_raw: record.aggregate.raw(),
+            });
+            records.push(record);
+        }
+        let instance_digest = *blake3::hash(&self.instance_bytes).as_bytes();
+        let witness = MsaSelectorWitness {
+            format: MSA_SELECTOR_WITNESS_FORMAT.to_owned(),
+            operator_id: uor_r4_model_source::attention::AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_ID
+                .to_owned(),
+            operator_version:
+                uor_r4_model_source::attention::AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_VERSION,
+            instance_digest: digest_string(&instance_digest),
+            inputs_digest: digest_string(&msa_inputs_digest(&instance_digest, steps)),
+            steps: witness_steps,
+            census,
+        };
+        (records, witness)
+    }
+}
+
+/// Independent witness replay: verify `witness` against the fixture
+/// (`candidate_ids`, `contributions`, `top_m`, `steps`) WITHOUT running
+/// the operator. Returns `None` when the witness verifies, or
+/// `Some(reason)` naming the first observed mismatch — the
+/// `Option<String>` shape `ReleaseBundleManifest::validate` and
+/// `engine::validate_quality_report` use (R5: this shipped crate names
+/// no custom error type for a check that is not itself the operator).
+pub fn replay_msa_selector_witness(
+    candidate_ids: &[u32],
+    contributions: &[ScoreQ],
+    top_m: u16,
+    steps: usize,
+    witness: &MsaSelectorWitness,
+) -> Option<String> {
+    if witness.format != MSA_SELECTOR_WITNESS_FORMAT {
+        return Some(format!("witness format tag mismatch: {}", witness.format));
+    }
+    if witness.operator_id
+        != uor_r4_model_source::attention::AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_ID
+        || witness.operator_version
+            != uor_r4_model_source::attention::AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_VERSION
+    {
+        return Some("witness names a different operator id or version".to_owned());
+    }
+    if candidate_ids.len() != contributions.len() {
+        return Some("candidate_ids and contributions lengths differ".to_owned());
+    }
+    let instance_bytes = msa_instance_bytes(candidate_ids, contributions, top_m);
+    let instance_digest = *blake3::hash(&instance_bytes).as_bytes();
+    if witness.instance_digest != digest_string(&instance_digest) {
+        return Some("recorded instance digest does not match the fixture".to_owned());
+    }
+    if witness.inputs_digest != digest_string(&msa_inputs_digest(&instance_digest, steps)) {
+        return Some("recorded inputs digest does not bind this step count".to_owned());
+    }
+    if witness.steps.len() != steps {
+        return Some(format!(
+            "step count mismatch: witness {}, requested {steps}",
+            witness.steps.len()
+        ));
+    }
+
+    let candidate_count = candidate_ids.len() as u32;
+    for (step_index, record) in witness.steps.iter().enumerate() {
+        if record.selected.len() != top_m as usize {
+            return Some(format!("step {step_index}: selection is not top_m wide"));
+        }
+        let mut previous: Option<(u8, u8, u32)> = None;
+        for (slot, selection) in record.selected.iter().enumerate() {
+            if selection.candidate >= candidate_count {
+                return Some(format!(
+                    "step {step_index} slot {slot}: candidate index out of range"
+                ));
+            }
+            if selection.candidate_id != candidate_ids[selection.candidate as usize] {
+                return Some(format!(
+                    "step {step_index} slot {slot}: recorded candidate_id does not match the fixture"
+                ));
+            }
+            let recomputed = classify(selection.candidate_id);
+            if recomputed.role_rank != selection.role_rank
+                || recomputed.cascade_position != selection.cascade_position
+            {
+                return Some(format!(
+                    "step {step_index} slot {slot}: classification does not recompute"
+                ));
+            }
+            let key = (
+                selection.role_rank,
+                selection.cascade_position,
+                selection.candidate,
+            );
+            if let Some(previous_key) = previous {
+                if key <= previous_key {
+                    return Some(format!(
+                        "step {step_index} slot {slot}: selection order violated"
+                    ));
+                }
+            }
+            previous = Some(key);
+        }
+        // Completeness by optimality: no unselected candidate may beat
+        // the worst selected slot under (role_rank, cascade_position,
+        // index).
+        let Some(worst) = record.selected.last().map(|selection| {
+            (
+                selection.role_rank,
+                selection.cascade_position,
+                selection.candidate,
+            )
+        }) else {
+            return Some(format!("step {step_index}: empty selection"));
+        };
+        for (index, &candidate_id) in candidate_ids.iter().enumerate() {
+            let index = index as u32;
+            let is_selected = record
+                .selected
+                .iter()
+                .any(|selection| selection.candidate == index);
+            if !is_selected {
+                let classification = classify(candidate_id);
+                let key = (
+                    classification.role_rank,
+                    classification.cascade_position,
+                    index,
+                );
+                if key < worst {
+                    return Some(format!(
+                        "step {step_index}: unselected candidate index {index} beats the selection"
+                    ));
+                }
+            }
+        }
+        // Aggregate refold over the RECORDED selection, selection order.
+        let mut aggregate = ScoreQ::ZERO;
+        for selection in &record.selected {
+            aggregate = aggregate.saturating_add(contributions[selection.candidate as usize]);
+        }
+        if aggregate.raw() != record.aggregate_raw {
+            return Some(format!("step {step_index}: aggregate does not refold"));
+        }
+    }
+
+    if witness.census != expected_msa_selector_census(candidate_count, top_m, steps) {
+        return Some("census does not equal its closed form".to_owned());
+    }
+    None
+}

--- a/crates/uor-r4-graph-certify/tests/msa_selector_643.rs
+++ b/crates/uor-r4-graph-certify/tests/msa_selector_643.rs
@@ -1,0 +1,326 @@
+//! `MsaStructuredSelectorV1` grounding, reference, and witness tests
+//! (#643).
+//!
+//! The operator under test is DORMANT: these tests construct it
+//! directly through `uor-r4-graph-certify::msa_selector`; no serving
+//! path is exercised or changed, and no packed R4G1 lowering exists yet
+//! (#604's own two-stage plan: reference semantics land first).
+//!
+//! # Pre-registered exit rule (issue #643 — binding)
+//!
+//! This operator is a candidate to REPLACE or supplement
+//! `r4-route-attention/1` as the target selection mechanism. The two
+//! are plug-compatible by construction (identical `value_aggregation`
+//! and `tie_breaking` shape, module docs of both operators) precisely
+//! so a fair A/B is possible once a shared evaluation harness exists.
+//!
+//! POSITIVE iff, on the SAME held-out evaluation corpus and candidate
+//! set `r4-route-attention/1` is measured against, `msa-structured-
+//! selector/1` achieves top-1 next-token accuracy >= r4-route-
+//! attention/1's top-1 accuracy + 0.02 absolute, AND does not increase
+//! bits-per-token versus r4-route-attention/1, AND beats the #457
+//! unigram floor. NEGATIVE (including "no measurable difference") ⇒
+//! close #643 with the comparison table and register a
+//! `msa-structured-selector-dormant` lane in `model/ledger.toml`, the
+//! same disposition `r4-route-attention/1` itself would receive on a
+//! negative result.
+//!
+//! This criterion is posted before any run, per the #626 convention.
+//! Running it requires wiring `msa-structured-selector/1` into the same
+//! held-out evaluation loop `r4-route-attention/1` uses (a packed
+//! lowering, or at minimum a harness adapter) — that wiring is
+//! explicitly OUT OF SCOPE for this slice (see #643's pinned scope
+//! comment) and is the next concrete action once this reference lands.
+
+use uor_r4_graph_certify::msa_selector::{
+    classify, expected_msa_selector_census, replay_msa_selector_witness, MsaClassification,
+    MsaSelectorReference, ROLE_GEN, ROLE_MAN, ROLE_MED, ROLE_ZERO,
+};
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_model_source::attention::{operator_spec, AttentionOperatorSpec};
+
+// ------------------------------------------------------- grounding tests --
+
+/// MSA7 ("The 11-Theorem") + Theorem M4 ("The 11-Cascade Theorem"),
+/// transcribed literally: `mod_11(γ)=2` at cascade position 0 (Gen),
+/// `mod_11(μ)=4` at position 1 (Med), `mod_11(ε)=8` at position 2
+/// (Man). These three (residue, role, position) triples are the ONLY
+/// ones the paper proves; everything else this module derives is an
+/// explicit extension (module docs).
+#[test]
+fn role_anchors_match_msa7_and_the_11_theorem() {
+    assert_eq!(
+        classify(2),
+        MsaClassification {
+            role_rank: ROLE_GEN,
+            cascade_position: 0
+        },
+        "mod_11(gamma) = 2 is the Gen anchor at cascade position 0"
+    );
+    assert_eq!(
+        classify(4),
+        MsaClassification {
+            role_rank: ROLE_MED,
+            cascade_position: 1
+        },
+        "mod_11(mu) = 4 is the Med anchor at cascade position 1"
+    );
+    assert_eq!(
+        classify(8),
+        MsaClassification {
+            role_rank: ROLE_MAN,
+            cascade_position: 2
+        },
+        "mod_11(epsilon) = 8 is the Man anchor at cascade position 2"
+    );
+}
+
+/// Theorem M4's literal cascade `(2, 4, 8, 5, 10, 9, 7, 3, 6, 1)`,
+/// transcribed as the full residue -> cascade_position table. This is
+/// the paper's own worked proof (module docs of `route_attention.rs`'s
+/// counterpart theorem citations follow the same "transcribe, then
+/// test" discipline).
+#[test]
+fn cascade_orbit_matches_theorem_m4_exactly() {
+    let expected_positions = [
+        (2u32, 0u8),
+        (4, 1),
+        (8, 2),
+        (5, 3),
+        (10, 4),
+        (9, 5),
+        (7, 6),
+        (3, 7),
+        (6, 8),
+        (1, 9),
+    ];
+    for (residue, position) in expected_positions {
+        assert_eq!(
+            classify(residue).cascade_position,
+            position,
+            "residue {residue} should sit at cascade position {position}"
+        );
+    }
+}
+
+/// Positions 0..9 mod 3, the mod-3 role extension confirmed by Casey
+/// (2026-08-16) for the 7 residues MSA7 does not itself assign a role
+/// to.
+#[test]
+fn role_extension_is_cascade_position_mod_3() {
+    let expected_roles = [
+        (5u32, ROLE_GEN), // position 3, 3 % 3 == 0
+        (10, ROLE_MED),   // position 4, 4 % 3 == 1
+        (9, ROLE_MAN),    // position 5, 5 % 3 == 2
+        (7, ROLE_GEN),    // position 6, 6 % 3 == 0
+        (3, ROLE_MED),    // position 7, 7 % 3 == 1
+        (6, ROLE_MAN),    // position 8, 8 % 3 == 2
+        (1, ROLE_GEN),    // position 9, 9 % 3 == 0
+    ];
+    for (residue, role) in expected_roles {
+        assert_eq!(
+            classify(residue).role_rank,
+            role,
+            "residue {residue}'s extended role should be {role}"
+        );
+    }
+}
+
+/// Residue 0 is outside `(Z/11Z)*` (Lagrange's theorem, which the
+/// cascade-periodicity theorem invokes, only covers the multiplicative
+/// group) and gets its own sentinel class, not silently folded into one
+/// of the three proven anchors.
+#[test]
+fn residue_zero_is_its_own_sentinel_class() {
+    for candidate in [0u32, 11, 22, 110] {
+        let classification = classify(candidate);
+        assert_eq!(classification.role_rank, ROLE_ZERO);
+        assert_eq!(classification.cascade_position, 10);
+    }
+}
+
+/// Classification depends only on the residue mod 11 — periodic by
+/// construction.
+#[test]
+fn classification_is_periodic_mod_11() {
+    for base in 0u32..11 {
+        let a = classify(base);
+        let b = classify(base + 11);
+        let c = classify(base + 110);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+}
+
+/// Every nonzero residue gets a real orbit position (< the residue-0
+/// sentinel of 10) — the classification is total and the orbit is a
+/// complete permutation of the 10 nonzero residues (Theorem M4:
+/// maximal period 10 means every nonzero residue appears exactly once).
+#[test]
+fn every_nonzero_residue_gets_a_real_cascade_position() {
+    for residue in 1u32..11 {
+        assert!(
+            classify(residue).cascade_position < 10,
+            "residue {residue} should have a real (non-sentinel) cascade position"
+        );
+    }
+}
+
+// ------------------------------------------------------- registry tests --
+
+/// The `msa-structured-selector/1` record is reachable through the
+/// #602 registry by (id, version), exactly like `r4-route-attention/1`.
+#[test]
+fn registry_resolves_msa_structured_selector_v1() {
+    let record = operator_spec(
+        AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_ID,
+        AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_VERSION,
+    )
+    .expect("registered MSA-structured-selector target operator");
+    assert_eq!(record, AttentionOperatorSpec::msa_structured_selector_v1());
+    assert_eq!(record.id, "msa-structured-selector");
+    assert_eq!(record.version, 1);
+}
+
+/// The declared identity digest is a real blake3 digest and is stable
+/// across repeated construction (canonical_bytes is deterministic).
+#[test]
+fn registry_digest_is_stable() {
+    let a = AttentionOperatorSpec::msa_structured_selector_v1();
+    let b = AttentionOperatorSpec::msa_structured_selector_v1();
+    assert_eq!(a.implementation_digest, b.implementation_digest);
+    assert!(a.implementation_digest.starts_with("blake3:"));
+}
+
+// ------------------------------------------------------- reference/witness --
+
+/// Deterministic synthetic fixture: ramp candidate ids and contributions
+/// (no RNG), spanning multiple residue classes.
+fn synthetic_fixture(candidate_count: u32, top_m: usize) -> (Vec<u32>, Vec<ScoreQ>) {
+    let candidate_ids: Vec<u32> = (0..candidate_count).map(|i| i * 7 + 3).collect();
+    let contributions: Vec<ScoreQ> = (0..candidate_count)
+        .map(|i| ScoreQ::from_raw((i as i32) * 100 - 500))
+        .collect();
+    let _ = top_m;
+    (candidate_ids, contributions)
+}
+
+#[test]
+fn reference_run_is_deterministic_across_repeats() {
+    let (candidate_ids, contributions) = synthetic_fixture(20, 4);
+    let reference =
+        MsaSelectorReference::new(candidate_ids, contributions, 4).expect("valid instance");
+    let (records_a, witness_a) = reference.run(3);
+    let (records_b, witness_b) = reference.run(3);
+    assert_eq!(records_a, records_b);
+    assert_eq!(witness_a, witness_b);
+    // Query-independence: every step within one run is identical too.
+    assert_eq!(witness_a.steps[0], witness_a.steps[1]);
+    assert_eq!(witness_a.steps[1], witness_a.steps[2]);
+}
+
+#[test]
+fn reference_selection_is_top_m_wide_and_sorted() {
+    let (candidate_ids, contributions) = synthetic_fixture(15, 5);
+    let reference =
+        MsaSelectorReference::new(candidate_ids, contributions, 5).expect("valid instance");
+    let (records, _witness) = reference.run(1);
+    let record = &records[0];
+    assert_eq!(record.selected.len(), 5);
+    let mut previous: Option<(u8, u8, u32)> = None;
+    for selection in &record.selected {
+        let key = (
+            selection.role_rank,
+            selection.cascade_position,
+            selection.candidate,
+        );
+        if let Some(previous_key) = previous {
+            assert!(previous_key < key, "selection must be strictly ordered");
+        }
+        previous = Some(key);
+    }
+}
+
+#[test]
+fn witness_census_matches_closed_form() {
+    let (candidate_ids, contributions) = synthetic_fixture(30, 6);
+    let candidate_count = candidate_ids.len() as u32;
+    let reference =
+        MsaSelectorReference::new(candidate_ids, contributions, 6).expect("valid instance");
+    let (_records, witness) = reference.run(4);
+    assert_eq!(
+        witness.census,
+        expected_msa_selector_census(candidate_count, 6, 4)
+    );
+}
+
+#[test]
+fn witness_replays_successfully() {
+    let (candidate_ids, contributions) = synthetic_fixture(25, 4);
+    let reference = MsaSelectorReference::new(candidate_ids.clone(), contributions.clone(), 4)
+        .expect("valid instance");
+    let (_records, witness) = reference.run(2);
+    let outcome = replay_msa_selector_witness(&candidate_ids, &contributions, 4, 2, &witness);
+    assert_eq!(
+        outcome, None,
+        "a genuine witness must replay clean: {outcome:?}"
+    );
+}
+
+#[test]
+fn replay_rejects_a_tampered_aggregate() {
+    let (candidate_ids, contributions) = synthetic_fixture(12, 3);
+    let reference = MsaSelectorReference::new(candidate_ids.clone(), contributions.clone(), 3)
+        .expect("valid instance");
+    let (_records, mut witness) = reference.run(1);
+    witness.steps[0].aggregate_raw = witness.steps[0].aggregate_raw.wrapping_add(1);
+    let outcome = replay_msa_selector_witness(&candidate_ids, &contributions, 3, 1, &witness);
+    assert!(outcome.is_some(), "a tampered aggregate must fail replay");
+}
+
+#[test]
+fn replay_rejects_a_wrong_operator_version() {
+    let (candidate_ids, contributions) = synthetic_fixture(12, 3);
+    let reference = MsaSelectorReference::new(candidate_ids.clone(), contributions.clone(), 3)
+        .expect("valid instance");
+    let (_records, mut witness) = reference.run(1);
+    witness.operator_version = 99;
+    let outcome = replay_msa_selector_witness(&candidate_ids, &contributions, 3, 1, &witness);
+    assert!(
+        outcome.is_some(),
+        "a wrong operator version must fail replay"
+    );
+}
+
+#[test]
+fn replay_rejects_a_reordered_selection() {
+    let (candidate_ids, contributions) = synthetic_fixture(12, 3);
+    let reference = MsaSelectorReference::new(candidate_ids.clone(), contributions.clone(), 3)
+        .expect("valid instance");
+    let (_records, mut witness) = reference.run(1);
+    witness.steps[0].selected.swap(0, 1);
+    let outcome = replay_msa_selector_witness(&candidate_ids, &contributions, 3, 1, &witness);
+    assert!(
+        outcome.is_some(),
+        "an out-of-order selection must fail replay"
+    );
+}
+
+/// `top_m == candidate_count` (select everything) is a legal boundary.
+#[test]
+fn top_m_equal_to_candidate_count_selects_every_candidate() {
+    let (candidate_ids, contributions) = synthetic_fixture(6, 6);
+    let reference =
+        MsaSelectorReference::new(candidate_ids, contributions, 6).expect("valid instance");
+    let (records, _witness) = reference.run(1);
+    assert_eq!(records[0].selected.len(), 6);
+}
+
+/// Malformed instances are refused before any reference construction.
+#[test]
+fn malformed_instances_are_refused() {
+    assert!(MsaSelectorReference::new(vec![], vec![], 1).is_none());
+    assert!(MsaSelectorReference::new(vec![1, 2], vec![ScoreQ::ZERO], 1).is_none());
+    assert!(MsaSelectorReference::new(vec![1, 2], vec![ScoreQ::ZERO, ScoreQ::ZERO], 0).is_none());
+    assert!(MsaSelectorReference::new(vec![1, 2], vec![ScoreQ::ZERO, ScoreQ::ZERO], 3).is_none());
+}

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -246,6 +246,21 @@ impl AttentionOperatorParams {
         }
     }
 
+    /// The declared parameters of `msa-structured-selector/1` (#643): no
+    /// query/key score is computed at all — candidates rank by a fixed
+    /// modular classification of their own declared id, independent of
+    /// any query.
+    pub fn msa_structured_selector() -> Self {
+        Self {
+            head_selection: "single-selector-lane".to_owned(),
+            score_scale: "none-ordinal-classification-key-not-a-scalar-score".to_owned(),
+            score_width_policy: "candidate-id-residue-mod-11-only".to_owned(),
+            remainder_policy: "none-no-remainder-every-candidate-id-classified".to_owned(),
+            score_accumulation: "role-rank-then-cascade-position-then-candidate-id-sort-key"
+                .to_owned(),
+        }
+    }
+
     /// The declared parameters of current
     /// `learned-absolute-source-attention/2`.
     pub fn learned_absolute() -> Self {
@@ -398,6 +413,17 @@ impl AttentionOperatorSpec {
     pub const LEARNED_ABSOLUTE_V2_VERSION: u32 = 2;
     /// Current learned-absolute registry version.
     pub const LEARNED_ABSOLUTE_VERSION: u32 = Self::LEARNED_ABSOLUTE_V2_VERSION;
+    /// Registry id of the `MsaStructuredSelectorV1` TARGET operator
+    /// (#643) — a second, independent target operator alongside
+    /// `r4-route-attention/1`, pre-registered for an A/B evaluation
+    /// under the same #626-style exit-rule convention. Reference
+    /// semantics live in `uor-r4-graph-certify::msa_selector`, the
+    /// same layering `r4-route-attention/1` uses.
+    pub const MSA_STRUCTURED_SELECTOR_ID: &'static str = "msa-structured-selector";
+    /// Registry version of the target operator implemented by
+    /// `uor-r4-graph-certify::msa_selector` (reference only in this
+    /// slice; no packed lowering exists yet).
+    pub const MSA_STRUCTURED_SELECTOR_VERSION: u32 = 1;
 
     /// The current `standard-source-attention/2` record.
     pub fn standard() -> Self {
@@ -549,6 +575,61 @@ impl AttentionOperatorSpec {
             permitted_operation_class: "deployed-integer-xor-popcount-add-compare-table-read"
                 .to_owned(),
             params: AttentionOperatorParams::r4_route_attention(),
+            implementation_digest: String::new(),
+        };
+        record.implementation_digest = record.declared_digest();
+        record
+    }
+
+    /// The `msa-structured-selector/1` record (#643): `MsaStructuredSelectorV1`,
+    /// a second TARGET operator alongside `r4-route-attention/1` —
+    /// deployed integer class, dormant, pre-registered for an A/B
+    /// evaluation against it. Grounded in two proven theorems of the
+    /// (now-published, per Casey's 2026-08-16 direction) "Modular
+    /// Structural Arithmetic" paper: the 11-Theorem (`DP(11)` with role
+    /// anchors `mod_11(γ)=2, mod_11(μ)=4, mod_11(ε)=8`) and the maximal
+    /// doubling-cascade period in ℤ/11ℤ. Truthful inventory of what
+    /// `uor-r4-graph-certify::msa_selector` computes:
+    ///
+    /// - no projections and no positional action: a candidate's
+    ///   classification depends only on its own declared id, never on a
+    ///   query or a learned weight;
+    /// - compatibility relation `modular-role-then-cascade-position`:
+    ///   `residue = candidate_id mod 11`; `role_rank` is the residue's
+    ///   position in the doubling-cascade orbit `(2,4,8,5,10,9,7,3,6,1)`
+    ///   taken mod 3 (residue 0 — outside the multiplicative group — is
+    ///   its own fourth "zero" class). **Only the three anchor residues
+    ///   {2,4,8} → {Gen,Med,Man} are a theorem of the paper (the
+    ///   11-Theorem); the mod-3 extension covering the other 7 nonzero
+    ///   residues is this operator's own design choice, confirmed by
+    ///   Casey (2026-08-16), not itself a proven MSA result**;
+    /// - selector: NONE — no softmax; a bounded top-M selection by
+    ///   ascending `(role_rank, cascade_position, candidate_index)`;
+    /// - tie-breaking: lowest candidate index (into the declared id/
+    ///   contribution tables) on equal role and cascade position,
+    ///   deterministic by construction, same shape as
+    ///   `r4-route-attention/1`;
+    /// - value aggregation: the selected ScoreQ contributions fold in
+    ///   selection order with saturating integer adds — identical
+    ///   convention to `r4-route-attention/1`, so the two operators are
+    ///   plug-compatible for the pre-registered A/B;
+    /// - runtime state: none — the classification is query-independent,
+    ///   so nothing carries across steps.
+    pub fn msa_structured_selector_v1() -> Self {
+        let mut record = Self {
+            id: Self::MSA_STRUCTURED_SELECTOR_ID.to_owned(),
+            version: Self::MSA_STRUCTURED_SELECTOR_VERSION,
+            projections: "none-declared-candidate-id-table-no-qkv-reuse".to_owned(),
+            positional_action: "none-classification-carries-no-positional-action".to_owned(),
+            compatibility_relation: "modular-role-then-cascade-position".to_owned(),
+            selector_normalization: "none-bounded-top-m-selection".to_owned(),
+            value_aggregation: "selection-order-saturating-scoreq-add".to_owned(),
+            output_projection: "none-aggregate-scoreq-only".to_owned(),
+            runtime_state: "none-query-independent-classification".to_owned(),
+            tie_breaking: "lowest-candidate-index-on-equal-role-and-cascade-position".to_owned(),
+            permitted_operation_class: "deployed-integer-table-read-compare-add-no-runtime-modulo"
+                .to_owned(),
+            params: AttentionOperatorParams::msa_structured_selector(),
             implementation_digest: String::new(),
         };
         record.implementation_digest = record.declared_digest();
@@ -738,6 +819,10 @@ pub fn operator_spec(
         (AttentionOperatorSpec::R4_ROUTE_ID, AttentionOperatorSpec::R4_ROUTE_VERSION) => {
             Ok(AttentionOperatorSpec::r4_route_attention_v1())
         }
+        (
+            AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_ID,
+            AttentionOperatorSpec::MSA_STRUCTURED_SELECTOR_VERSION,
+        ) => Ok(AttentionOperatorSpec::msa_structured_selector_v1()),
         (
             AttentionOperatorSpec::LEARNED_ABSOLUTE_ID,
             AttentionOperatorSpec::LEARNED_ABSOLUTE_V1_VERSION,


### PR DESCRIPTION
## Summary

Slice 1 of #643: registers a new attention-operator identity, `msa-structured-selector/1`, in the #602/#604 operator-identity registry, grounded in the Modular Structural Arithmetic (MSA) paper (private paper, cleared for publication by Casey 2026-08-16).

- MSA7's **11-Theorem**: role anchors for residues 2, 4, 8 mod 11 → Gen/Med/Man.
- Theorem M4's **11-Cascade Theorem**: the doubling-cascade orbit `(2,4,8,5,10,9,7,3,6,1)` has maximal period 10 in ℤ/11ℤ (Lagrange's theorem).

**Role-extension gap, resolved explicitly by Casey:** the MSA paper only proves role classification for 3 of the 11 residues mod 11 (2, 4, 8). Rather than silently inventing a rule for the remaining 8 nonzero residues, I raised this as a genuine open design question via `AskUserQuestion`. Casey selected **cascade-position mod 3** (2026-08-16): each nonzero residue's role rank is derived from its position in the doubling-cascade orbit, taken mod 3. This is documented in `msa_selector.rs`'s module doc and in the `role_extension_is_cascade_position_mod_3` test as **this operator's own design choice, explicitly not a proven MSA/paper theorem**.

## What's new

`crates/uor-r4-graph-certify/src/msa_selector.rs` (593 lines):
- `classify(candidate_id) -> MsaClassification`: query-independent `role_rank` (0=Gen, 1=Med, 2=Man, 3=Zero-sentinel) + `cascade_position`, both via integer-only table read/compare — no runtime modulo, P-4-legal.
- `MsaSelectorReference`: top-M selection sorted by `(role_rank, cascade_position, index)`, reusing `route_attention`'s (#604) exact saturating-scoreq-aggregation and lowest-index tie-break conventions — deliberately plug-compatible with a future shared A/B harness against `r4-route-attention/1`.
- `MsaSelectorWitness` + `replay_msa_selector_witness`: independent replay verification of a run's recorded selections/aggregate/census without re-running the operator. Returns `Option<String>` (R5 audit-limits sanctioned shape), matching the existing `ReleaseBundleManifest::validate` convention.

`crates/uor-r4-graph-certify/tests/msa_selector_643.rs` (17 tests, all passing): role-anchor/cascade-orbit fidelity to MSA7/Theorem M4, the mod-3 extension's own behavior, registry resolution and digest stability, reference-run determinism and top-M correctness, witness census/replay (tamper/reorder/version-mismatch rejection), and a malformed-instance refusal case. Carries a "Pre-registered exit rule (issue #643 — binding)" module doc per the #626 convention.

`crates/uor-r4-model-source/src/attention.rs`: new `MSA_STRUCTURED_SELECTOR_ID`/`_VERSION` constants, `msa_structured_selector_v1()` builder, and the corresponding `operator_spec()` registry match arm.

## Scope / deferred

This is slice 1: compiler-side reference semantics and a replayable witness only. NOT yet done — tracked as follow-ups on #643:
- Packed R4G1 lowering in `uor-r4-graph-runtime` (the #604 TARGET-operator template's second half).
- The actual A/B evaluation run against `r4-route-attention/1`.

## Test plan

- [x] `cargo fmt --check -p uor-r4-model-source -p uor-r4-graph-certify`
- [x] `cargo clippy -p uor-r4-model-source -p uor-r4-graph-certify --all-targets -- -D warnings`
- [x] `cargo test -p uor-r4-model-source -p uor-r4-graph-certify` — zero regressions across both crates' full existing suites, plus 17/17 new tests passing
- [x] `cargo run -p xtask -- audit-limits` (R5 gate) — clean

References #643.
