### PR TITLE
docs: freshen GLOSSARY and README doc-map (routine maintenance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,8 @@ cd /tmp && unzip -o run.com out/model.bin tokenizer.bin -d ref
 [Scoring semantics](docs/scoring_semantics.md) ·
 [Formal vocabulary](docs/formal_vocabulary.md) (normative for claim wording) ·
 [Reproducibility](docs/reproducibility.md) ·
-[Performance comparison](docs/transformerless/COMPARISON.md)
+[Performance comparison](docs/transformerless/COMPARISON.md) ·
+[Matrix-operation census](docs/matrix_operation_census.md)
 
 **Plan** — [R⁴ graph compiler implementation plan](docs/r4_graph_compiler_implementation_plan.md) ·
 [ROADMAP.md](ROADMAP.md) · [Minimal client](docs/minimal_client.md)

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -144,6 +144,46 @@ graph term is normative for new work. See the terminology bridge in the plan (§
   P2/P3 era notes and `baseline_kappa.json`. Gate C compares the graph against this baseline
   before replacement.
 
+## Target operators and dormant lanes (Epic #602)
+
+- **TARGET operator** — a versioned, registered `(id, version)` selection/attention mechanism
+  candidate for the deployed R4G1 runtime, following the two-stage template established by #604
+  and reused by #643: compiler/certify-side reference semantics + a replayable operation-count
+  witness land first, a P-4-scanned packed R4G1 lowering (table read / integer compare /
+  saturating add only, no runtime multiply/divide/modulo/float) lands second. Registered in
+  `uor-r4-model-source::attention::operator_spec`.
+- **Dormant lane (#515 "preserve-and-gate")** — an operator implementation that is
+  constructible, differentially tested (reference vs. packed kernel agree bit-for-bit), and
+  registered as an `open`-level claim in `model/ledger.toml`, but referenced by no serving path.
+  Each claim's `statement` names an explicit activation gate (e.g. a pre-registered A/B exit
+  rule) that must clear before the operator can be wired into serving.
+- **`r4-route-attention/1`** (#604) — masked XOR+popcount route-code distance, bounded top-M
+  selection, saturating `ScoreQ` aggregation. Dormant (`r4-route-attention-dormant`); an offline
+  `route-fit/1` method (#605, `uor-r4-graph-compiler::route_fit`) fits route codes from teacher
+  query/key vectors via the `bucket-average/1` projection for evaluation on a synthetic held-out
+  corpus.
+- **`msa-structured-selector/1`** (#643) — Modular Structural Arithmetic role-class + cascade-orbit
+  selection: candidates classify by `candidate_id mod 11` into a paper-proven 3-anchor role table
+  (MSA7's "11-Theorem") plus this project's own cascade-position-mod-3 extension for the
+  remaining residues; selection and aggregation are plug-compatible with `r4-route-attention/1`
+  (same top-M/tie-break/`ScoreQ`-fold shape) for a shared A/B harness. Classification is
+  position-only (no fitting step). Measured NEGATIVE against `r4-route-attention/1` on the #605
+  synthetic corpus (`msa-structured-selector-dormant`, `uor-r4-graph-certify::msa_ab_harness`):
+  clears the unigram floor by a wide margin but falls well short of the fitted, content-aware
+  route-attention arm.
+- **PROV/1** (#637 phase 1, `crates/uor-r4-graph-format/src/prov.rs`) — the canonical bounded
+  provenance-identity envelope for R4G1's PROV section: a presence-bitmapped set of digest slots
+  (source-manifest κ, geometry, tokenizer-adapter, attention-operator, dense-operator, license)
+  plus a strictly-ascending evidence-root list. Frozen as a format (parser + builder + RFC row);
+  wired into the real producer path as an additive, opt-in `cover --emit-provenance` flag (phase
+  2a, #733) — no existing artifact's bytes or κ moved. Not yet the default; the default-flip and
+  consumer/era adoption are phases 2b/3, open pending format-governance review.
+- **Release-bundle manifest** (#655-C0, `crates/uor-r4-api/src/release_bundle.rs`) — the versioned
+  `ReleaseBundleManifest` schema a packaged serving bundle declares: schema version, public model
+  id, instruction-chat capability, ABI/contract version, pinned `uor-matmul` provenance,
+  component digests, tokenizer identity. Schema and structural validation only as of #655-C0; no
+  discovery/loading/serving code reads it yet (that is #655-C1).
+
 ## Recent Architecture & Engine Additions (Epic #201)
 
 - **`tokenizer_cid`** — BLAKE3 hash of the loaded `tokenizer.bin` checked against `R4G1Header::tokenizer_cid` in `uor-r4-graph-format` (`verify_tokenizer_cid`), guaranteeing that loaded tokenizers match compiled graph artifacts and preventing silent index shifts.


### PR DESCRIPTION
No specific issue -- routine documentation maintenance, per standing request to keep docs current as the repo grows.

## What this fixes

While working #643/#655/#637 this session, found `docs/transformerless/GLOSSARY.md`'s "Recent Architecture" section hadn't been touched since Epic #201, and the glossary had no entries at all for the TARGET-operator framework (#602/#604/#643), the #515 dormant-lane convention, PROV/1 (#637), or the #655-C0 release-bundle manifest -- despite these being some of the largest recent additions to the project.

- Adds a "Target operators and dormant lanes (Epic #602)" glossary section: TARGET operator template, dormant-lane convention, `r4-route-attention/1`, `msa-structured-selector/1` (including its just-closed #643 A/B result), PROV/1, release-bundle manifest.
- Links `docs/matrix_operation_census.md` from README's documentation map -- it exists and is actively maintained (#655-A/B1/B2/#704) but wasn't indexed anywhere.

No code change, no behavior change.

## Verification

- Prose-only diff to two markdown files; confirmed all referenced paths/issue numbers exist (`docs/matrix_operation_census.md`, `crates/uor-r4-graph-format/src/prov.rs`, `crates/uor-r4-api/src/release_bundle.rs`, `crates/uor-r4-graph-certify/src/msa_ab_harness.rs`).
- No `.rs` files touched; no test/gate depends on `GLOSSARY.md`'s content.
