### PR TITLE
release_bundle: add from_compiled_model bridge; map the serving cascade (#655)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,8 @@ cd /tmp && unzip -o run.com out/model.bin tokenizer.bin -d ref
 [Formal vocabulary](docs/formal_vocabulary.md) (normative for claim wording) ·
 [Reproducibility](docs/reproducibility.md) ·
 [Performance comparison](docs/transformerless/COMPARISON.md) ·
-[Matrix-operation census](docs/matrix_operation_census.md)
+[Matrix-operation census](docs/matrix_operation_census.md) ·
+[Serving-time model discovery](docs/SERVING_MODEL_DISCOVERY.md)
 
 **Plan** — [R⁴ graph compiler implementation plan](docs/r4_graph_compiler_implementation_plan.md) ·
 [ROADMAP.md](ROADMAP.md) · [Minimal client](docs/minimal_client.md)

--- a/crates/uor-r4-api/src/release_bundle.rs
+++ b/crates/uor-r4-api/src/release_bundle.rs
@@ -7,12 +7,20 @@
 //! (#655-B), component digests, and tokenizer identity.
 //!
 //! It does **not** discover, load, or serve a bundle (that is #655-C1, the
-//! shared startup loader), does not produce bundle contents (#655-D), and
-//! does not change any default engine selection (#655-E/F). No existing
-//! `src/server.rs`, `src/chat.rs`, or CLI code reads or writes this
-//! manifest yet — landing the schema first, consumed by a loader in a
-//! later focused PR, mirrors the issue's own proposed implementation
-//! shape.
+//! shared startup loader), does not package bundle contents to a
+//! directory or on-disk layout (#655-D), and does not change any default
+//! engine selection (#655-E/F). No existing `src/server.rs`, `src/chat.rs`,
+//! or CLI code reads or writes this manifest yet — landing the schema
+//! first, consumed by a loader in a later focused PR, mirrors the issue's
+//! own proposed implementation shape.
+//!
+//! [`ReleaseBundleManifest::from_compiled_model`] is the one bridge this
+//! slice adds: a pure, in-memory constructor from `crate::compile`'s
+//! already-computed [`CompiledModel`] output, so a future #655-D
+//! packaging step (or this crate's own tests) has a checked way to turn a
+//! real compile's digests/provenance into this schema instead of
+//! hand-assembling one field by field. It performs no filesystem I/O and
+//! discovers nothing.
 //!
 //! Field shapes mirror existing manifest conventions in this workspace
 //! (`uor_r4_graph_compiler::observation::ObservationManifest`): a
@@ -23,7 +31,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::compile::TokenizerAdapter;
+use crate::compile::{CompiledModel, TokenizerAdapter};
 use crate::engine::AbiVersion;
 
 /// Current schema version this crate writes and accepts. A field change
@@ -150,6 +158,63 @@ fn is_git_rev(value: &str) -> bool {
 }
 
 impl ReleaseBundleManifest {
+    /// Build a release-bundle manifest for one completed compile's output
+    /// components (the #655-C0 → #655-D bridge). Pure, in-memory
+    /// construction: copies `compiled`'s already-computed digests and ABI
+    /// provenance field-for-field into this schema. Touches no
+    /// filesystem, discovers no bundle directory, and validates nothing
+    /// against bytes on disk — packaging bundle contents to a directory
+    /// is #655-D; loading one back is #655-C1.
+    ///
+    /// `model_id`, `capability`, `uor_matmul`, and `provenance_note` are
+    /// caller-supplied because [`CompiledModel`] carries none of them: a
+    /// public model identity and a serving-capability policy are
+    /// application decisions this schema crate does not make on a
+    /// caller's behalf, and `uor-matmul` provenance is not yet computed
+    /// anywhere in the compile pipeline (see [`UorMatmulProvenance`]'s
+    /// `source_digest` field doc) — the caller supplies whatever it
+    /// already has pinned (e.g. from `docs/matrix_operation_census.md`)
+    /// until a future slice wires an automatic digest.
+    ///
+    /// The result is a field copy, not a validating constructor: an
+    /// empty `model_id` or a malformed `uor_matmul.rev` the caller passed
+    /// in still round-trips into the output unchanged. Callers that need
+    /// a checked manifest call [`Self::validate`] on the result.
+    pub fn from_compiled_model(
+        model_id: impl Into<String>,
+        capability: BundleCapability,
+        compiled: &CompiledModel,
+        uor_matmul: UorMatmulProvenance,
+        provenance_note: Option<String>,
+    ) -> Self {
+        let provenance = &compiled.provenance;
+        let (contract_major, contract_minor, contract_patch) =
+            provenance.contract_version.as_tuple();
+        Self {
+            schema: RELEASE_BUNDLE_MANIFEST_SCHEMA,
+            model_id: model_id.into(),
+            capability,
+            abi: BundleAbi {
+                format_major: provenance.format_version.0,
+                format_minor: provenance.format_version.1,
+                contract_major,
+                contract_minor,
+                contract_patch,
+                api_crate_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            uor_matmul,
+            components: BundleComponentDigests {
+                graph: provenance.digests.graph.clone(),
+                signature_artifact: provenance.digests.signature_artifact.clone(),
+                tokenizer: provenance.digests.tokenizer.clone(),
+                score_report: provenance.digests.score_report.clone(),
+                compile_report: provenance.digests.compile_report.clone(),
+            },
+            tokenizer_adapter: provenance.tokenizer_adapter.clone(),
+            provenance_note,
+        }
+    }
+
     /// Structural validation: schema support, non-empty identity fields,
     /// well-formed component digests, and a plausible pinned `uor-matmul`
     /// revision. Returns the first violation found as a human-readable
@@ -268,6 +333,124 @@ mod tests {
             },
             provenance_note: None,
         }
+    }
+
+    /// A minimal but fully-provenanced [`CompiledModel`] fixture, mirroring
+    /// `crate::compile`'s own private `compiled_model_with_report` test
+    /// helper (that one is not `pub(crate)`, so this module builds its own
+    /// rather than reaching into a sibling module's test internals).
+    fn compiled_model_fixture() -> CompiledModel {
+        use crate::compile::{CompileOptions, CompileProvenance, ComponentDigests};
+        use uor_r4_graph_format::{
+            FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR, INFERENCE_OPERATION_CONTRACT_VERSION,
+        };
+        CompiledModel {
+            graph: b"graph bytes".to_vec(),
+            signature_artifact: b"signature bytes".to_vec(),
+            tokenizer: Some(b"tokenizer bytes".to_vec()),
+            score_report: b"{}".to_vec(),
+            compile_report: b"{}".to_vec(),
+            provenance: CompileProvenance {
+                options: CompileOptions::default(),
+                tokenizer_adapter: TokenizerAdapter {
+                    family: "hf-byte-bpe".to_string(),
+                    ..Default::default()
+                },
+                format_version: (FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR),
+                contract_version: INFERENCE_OPERATION_CONTRACT_VERSION,
+                digests: ComponentDigests {
+                    graph: VALID_DIGEST.to_string(),
+                    signature_artifact: VALID_DIGEST.to_string(),
+                    tokenizer: Some(VALID_DIGEST.to_string()),
+                    score_report: VALID_DIGEST.to_string(),
+                    compile_report: VALID_DIGEST.to_string(),
+                },
+            },
+        }
+    }
+
+    fn valid_uor_matmul_provenance() -> UorMatmulProvenance {
+        UorMatmulProvenance {
+            rev: VALID_REV.to_string(),
+            operation_profile: "exact-gemm-float".to_string(),
+            license: "MIT".to_string(),
+            source_digest: None,
+        }
+    }
+
+    #[test]
+    fn from_compiled_model_copies_digests_and_abi_and_passes_validation() {
+        let compiled = compiled_model_fixture();
+        let manifest = ReleaseBundleManifest::from_compiled_model(
+            "r4",
+            BundleCapability::InstructionChat,
+            &compiled,
+            valid_uor_matmul_provenance(),
+            Some("built from a fixture compile".to_string()),
+        );
+        assert_eq!(manifest.model_id, "r4");
+        assert_eq!(manifest.components.graph, compiled.provenance.digests.graph);
+        assert_eq!(
+            manifest.components.signature_artifact,
+            compiled.provenance.digests.signature_artifact
+        );
+        assert_eq!(
+            manifest.components.tokenizer,
+            compiled.provenance.digests.tokenizer
+        );
+        assert_eq!(
+            manifest.components.score_report,
+            compiled.provenance.digests.score_report
+        );
+        assert_eq!(
+            manifest.components.compile_report,
+            compiled.provenance.digests.compile_report
+        );
+        assert_eq!(
+            manifest.tokenizer_adapter,
+            compiled.provenance.tokenizer_adapter
+        );
+        let (major, minor, patch) = compiled.provenance.contract_version.as_tuple();
+        assert_eq!(
+            manifest.abi.format_major,
+            compiled.provenance.format_version.0
+        );
+        assert_eq!(
+            manifest.abi.format_minor,
+            compiled.provenance.format_version.1
+        );
+        assert_eq!(manifest.abi.contract_major, major);
+        assert_eq!(manifest.abi.contract_minor, minor);
+        assert_eq!(manifest.abi.contract_patch, patch);
+        assert_eq!(manifest.abi.api_crate_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            manifest.provenance_note.as_deref(),
+            Some("built from a fixture compile")
+        );
+        assert_eq!(manifest.validate(), None, "fixture builds a valid manifest");
+    }
+
+    #[test]
+    fn from_compiled_model_does_not_validate_a_caller_supplied_bad_field() {
+        // The constructor is a field copy, not a validating constructor:
+        // a malformed caller-supplied `uor_matmul.rev` still round-trips
+        // into the output unchanged, and `.validate()` (called
+        // separately) is what catches it.
+        let compiled = compiled_model_fixture();
+        let mut bad_provenance = valid_uor_matmul_provenance();
+        bad_provenance.rev = "not-a-rev".to_string();
+        let manifest = ReleaseBundleManifest::from_compiled_model(
+            "r4",
+            BundleCapability::InstructionChat,
+            &compiled,
+            bad_provenance,
+            None,
+        );
+        assert_eq!(manifest.uor_matmul.rev, "not-a-rev");
+        let reason = manifest
+            .validate()
+            .expect("the malformed rev is still caught by validate()");
+        assert!(reason.contains("uor_matmul.rev"), "reason was: {reason}");
     }
 
     #[test]

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -1286,6 +1286,19 @@ println!("{}", answer.text);
 Chat is an application of transformerless R⁴, not a separate crate or
 inference layer.
 
+### 8. Serve over HTTP
+
+`ask`/`chat` above go through `ModelStore`, the mechanism this page
+documents. The HTTP server (`src/server.rs`) is a **separate, independent**
+model-discovery path — it does not use `ModelStore` at all, instead running
+its own per-engine "#248 cascade" (`r4g1 → transformerless → teacher-oracle
+→ geometric`) with its own file-discovery conventions. See
+[`SERVING_MODEL_DISCOVERY.md`](SERVING_MODEL_DISCOVERY.md) for the full map
+of that cascade, `.uor-models/last_engine.txt`'s semantics, and how (or
+whether) it currently relates to `ModelStore` and to the #655-C0
+`ReleaseBundleManifest` schema — tracked under #655 ("ship a ready-by-default
+R4 model"), still open as of this writing.
+
 
 ## Legacy benchmark and certification workflow
 

--- a/docs/SERVING_MODEL_DISCOVERY.md
+++ b/docs/SERVING_MODEL_DISCOVERY.md
@@ -1,0 +1,228 @@
+# Serving-time model discovery (#655)
+
+This document maps how a running process decides *which* model/engine to
+load and serve, as of `origin/main` at `146a976e` (2026-08-16). It exists
+because this area had no documentation at all before now — `docs/MODEL_LIFECYCLE.md`
+covers download/compile/`ask` thoroughly through its own "7. Ask or chat with
+an imported manifest" section, but stops before the HTTP server's own,
+separate discovery path. This gap is exactly what #655 ("ship a
+ready-by-default R4 model") needs closed before a shared startup loader
+(#655-C1) or a default-engine flip (#655-F) can be attempted safely.
+
+**Headline finding: there are three independent, currently-disconnected
+model-loading systems in this codebase.** A change to one does not, by
+itself, change what the others do. Anyone editing "how the model loads"
+needs to know which of the three they are actually touching.
+
+1. `src/model.rs`'s `ModelStore`/`ModelManifest` — used by the CLI
+   `ask`/`chat` commands.
+2. `src/server.rs`'s ~27,000-line HTTP server — its own ad hoc per-engine
+   "#248 cascade", used by every HTTP-serving code path.
+3. `crates/uor-r4-api::release_bundle::ReleaseBundleManifest` (#655-C0,
+   PR #731) — a schema-only type, not yet read or written by either of
+   the above.
+
+## 1. The `#248` cascade in `src/server.rs`
+
+`run_serving_cascade` (`src/server.rs:3872-4007`) builds an ordered list of
+tiers and calls `uor_r4_router::fallback::run_cascade(tiers)`:
+
+```rust
+const TIER_R4G1: &str = "r4g1";
+const TIER_TRANSFORMERLESS: &str = "transformerless";
+const TIER_TEACHER_ORACLE: &str = "teacher-oracle";
+const TIER_GEOMETRIC: &str = "geometric";
+```
+
+Each tier is attempted in order; a `Failed`/`Pathological`/`Abstained`
+outcome falls through to the next. The four tiers, briefly (full detail
+below): **r4g1** (the packed-graph, table-native production candidate),
+**transformerless** (an older, separately-pathed artifact+store+tokenizer
+trio), **teacher-oracle** (the raw HF teacher model, used as a fallback
+oracle), and **geometric** (an always-degrades-gracefully manifold router,
+functionally the cascade's terminal "always something" tier).
+
+### Tier 1 — `r4g1`
+
+- Entry points: `run_server`'s startup load loop (`src/server.rs:888-1249`),
+  `resolve_loadable_compiled_bundle_with_authority` (`2166-2227`); per-request
+  `r4g1_tier` (`3729-3768`) → `generate_r4g1_text` (`3014-3086`).
+- Discovery: explicit `--r4g1-artifact` flag, else
+  `.uor-models/compiled/<logical_name>/graph/score.r4g1` (fallback
+  `compiled.r4g1`) **plus** a required sibling `tless_artifacts.bin` in the
+  same directory — the graph and its teacher-companion artifact must both be
+  present or the whole bundle is refused (`2200-2213`).
+- State type: `r4g1::R4g1State`, held in `ServingModelState.r4g1`.
+- Availability: `installed.r4g1.is_some()` after startup load succeeds.
+
+### Tier 2 — `transformerless`
+
+- Entry point: `with_tless_server_state` (`1430-1443`) →
+  `tless_uor::load_tless_state()` (`src/tless_uor.rs`).
+- Discovery (`src/tless_uor.rs:424-467`): `TLESS_ARTIFACTS` env var / CLI flag,
+  default `/tmp/tless_artifacts.bin`; `TLESS_STORE`/CLI, default
+  `/tmp/tless_store.bin`; tokenizer via `TLESS_TOKENIZER`/CLI, else a
+  hardcoded probe of
+  `.uor-models/compiled/{smollm2-135m,smollm2-360m}-instruct/tokenizer.bin`,
+  else `/tmp/ref/tokenizer.bin`.
+- **Naming collision to be aware of:** the *filename* `tless_artifacts.bin`
+  is reused by both Tier 1 (as the R4G1 bundle's required teacher-companion
+  file, under `.uor-models/compiled/<name>/`) and Tier 2 (as its own primary
+  artifact, default location `/tmp/`) — same basename, different directory,
+  different role. Do not assume one `tless_artifacts.bin` on disk implies
+  the other tier is also satisfied.
+- State type: `tless_uor::TlessState { art, store, artifact_kappa,
+  artifact_address, store_kappa }`.
+
+### Tier 3 — `teacher-oracle`
+
+- Entry points: standalone startup resolution of `startup_source_candidates`
+  (`547-627`) → `prepare_optional_teacher_source_for_identity` (`3149-3197`)
+  → `Teacher::load(source)`; or riding along with a successful Tier-1 load
+  via the same bundle's `.uor-models/sources/<logical_name>` directory.
+  Per-request: `attention_tier` (`3799-3822`) → `generate_attention_text`.
+- Discovery: `.uor-models/sources/<last_model_name.txt content>`, else
+  hardcoded fallbacks for the three pinned SmolLM2 sizes; expects an
+  HF-style weights directory (safetensors, optionally sharded).
+- State type: `uor_r4_model_source::Teacher`, held in
+  `ServingModelState.oracle`.
+- Availability: `oracle.as_mut().is_some()`; only attempted when the R4G1
+  host encoder wasn't tagged-but-missing (`3934-3946`).
+
+### Tier 4 — `geometric`
+
+- Entry point: `geometric_tier` (`3830-3852`) →
+  `router.generate_geometric_response_native(...)`.
+- The router (`UorR4Router`) is constructed unconditionally at startup
+  (`let router = Arc::new(Mutex::new(UorR4Router::new(0.85)))`, `559`) and
+  optionally hydrated from `cli.manifold_cache` if that file exists — a
+  missing cache file just means an empty-but-constructed router, never a
+  hard "unavailable" state.
+- This tier has **no file-presence gate** the way Tiers 1-3 do; it always
+  runs, degrading to a typed `Abstained` outcome on sparse resonance rather
+  than failing outright. It functions as the cascade's terminal
+  "always-something" fallback, which is presumably why it is last.
+
+## 2. `.uor-models/last_engine.txt`
+
+Read in `src/server.rs` only as a fallback when an HTTP request carries no
+`engine` field (`persisted_engine_preference`, `3686-3695`; consulted inside
+`resolve_pinned_tier`, `3700-3721`). It stores a **plain tier-name string**
+(`"r4g1"`, `"attention"`, `"geometric"`, `"transformerless-legacy"`, ...),
+never a path.
+
+Written and read primarily by `src/chat.rs` (the CLI/terminal client): read
+at startup to restore the last active engine (`chat.rs:1265`, default
+`"r4g1"`), written on `/engine` menu selection (`chat.rs:1550`) and
+remediation-flow switches (`1208-1217`, `1900-1908`). `chat.rs` always sends
+`engine` explicitly in every request body (`2168`), so for the CLI client
+itself the server-side file read is redundant — it is a genuine fallback
+only for other HTTP clients that omit `engine`.
+
+**Deliberate design decision** (`src/server.rs:3699-3708`): a persisted (or
+request-supplied) preference of anything other than `"r4g1"`/`"auto"`/unknown
+**pins the cascade to that single tier, no fallback**. `"r4g1"` (or its
+absence) never pins — it is the full cascade's own first tier, so pinning it
+would lose nothing while silently disabling every fallback tier for the
+common default-install case.
+
+## 3. `ModelStore`/`ModelManifest` (`src/model.rs`) vs. the cascade
+
+`ModelStore::from_env()` roots at the same `.uor-models` directory (env var
+`UOR_MODEL_STORE`) and even shares Tier 1's `compiled/<name>/` subdirectory
+naming convention — but its required-file set is a third, incompatible
+contract:
+
+```rust
+// src/model.rs:430-434
+fn is_compiled_bundle(path: &Path) -> bool {
+    path.is_dir()
+        && ["tless_artifacts.bin", "tless_store.bin", "tokenizer.bin"]
+            .iter()
+            .all(|name| path.join(name).is_file())
+}
+```
+
+This requires `tless_artifacts.bin` + `tless_store.bin` + `tokenizer.bin`
+together — the pre-R4G1 bundle shape. It never checks for
+`compiled.r4g1`/`graph/score.r4g1` (Tier 1's required file), so a directory
+satisfying Tier 1 does not satisfy `ModelStore`, and vice versa. `ask`/`chat`
+go through `ModelStore` exclusively (`chat.rs:133-146`) and never touch
+`ServingModelState`, `R4g1State`, `TlessState`, or `Teacher` directly.
+
+## 4. `ReleaseBundleManifest` (#655-C0) fit against the four tiers
+
+`crates/uor-r4-api/src/release_bundle.rs` models **one bundle serving one
+engine kind** (`schema`, `model_id`, `capability`, `abi`, `uor_matmul`
+provenance, one `components` block of `{graph, signature_artifact,
+tokenizer, score_report, compile_report}` digests, `tokenizer_adapter`) — not
+"a release that offers up to four alternative engines with cascade
+fallback." Per tier:
+
+| Tier | Fit today |
+|---|---|
+| **r4g1** | Closest fit. `components.graph` ↔ `score.r4g1`/`compiled.r4g1`; `components.signature_artifact` plausibly ↔ the teacher-companion `tless_artifacts.bin`; `score_report`/`compile_report` ↔ the R4G1 compile pipeline's own outputs. This is, not coincidentally, exactly what `crate::compile::CompiledModel` (the in-process compile pipeline's output type) produces — see §5. |
+| **transformerless** | Ambiguous. No distinct field for `tless_store.bin` (the graded-code store); the schema's single graph+signature_artifact pair doesn't obviously map onto this tier's artifact+store+tokenizer trio. |
+| **teacher-oracle** | Not represented. No field for an HF-style multi-file weights directory. |
+| **geometric** | Not represented, and arguably shouldn't need to be — this tier is always-available and degrades gracefully rather than being an "artifact" in the same sense as the other three. |
+
+**Conclusion carried forward from #655-C1's own prior research comment,
+confirmed by this pass:** `ReleaseBundleManifest` should **not** be
+generalized into a multi-tier/multi-engine schema. #655-D's own text asks
+for "one minimal ... instruction-chat bundle," not a description of the
+whole four-tier cascade. The schema's current one-bundle-one-engine shape is
+the right shape for what D actually wants to produce and ship (almost
+certainly the R4G1 tier, since that is the table-native, non-neural-hot-path
+candidate this project's whole mission is built around). `ModelStore` should
+not be replaced wholesale either — it is a live, working system with a
+distinct purpose (content-addressed store + `QualityAttestation` gate for
+`ask`/`chat`) serving a real, different bundle shape. Reconciling
+`ModelStore` and `ReleaseBundleManifest` into one loader remains an open
+question explicitly deferred to #655-C1/E/F, not resolved by this document.
+
+## 5. This slice: `ReleaseBundleManifest::from_compiled_model`
+
+`crate::compile::CompiledModel` — the in-process compile pipeline's own
+output type (`crates/uor-r4-api/src/compile.rs`) — already carries exactly
+the digest and ABI/contract shape `ReleaseBundleManifest.components`/`.abi`
+need for the R4G1 tier: `graph`, `signature_artifact`, `tokenizer`,
+`score_report`, `compile_report` digests plus `format_version`/
+`contract_version`/`tokenizer_adapter`. `ReleaseBundleManifest::
+from_compiled_model` is a small, pure, in-memory constructor added in this
+slice that copies those fields across, so a future #655-D packaging step (or
+this crate's own tests) has a checked bridge from "a completed compile" to
+"a release-bundle manifest describing it," instead of hand-assembling one
+field by field each time. `model_id`, `capability`, and `uor_matmul`
+provenance stay caller-supplied, since `CompiledModel` carries none of them
+and this schema crate should not invent application policy.
+
+This function performs no filesystem I/O, discovers no bundle directory, and
+is not wired into any server/CLI/client code path — it is additive and
+dormant, per #515's convention, exactly like #655-C0 itself.
+
+## 6. Other discovery/readiness consumers (flagged, not deep-dived)
+
+- `/v1/models`, `/uor/v1/status` — reflect only Tier 1's installed state.
+- `/api/tags`, `/api/sysinfo` — compute their own independent readiness
+  booleans from Tier 1 + Tier 2 file presence, a third readiness
+  computation distinct from the cascade's own tier-by-tier attempt/fallback.
+- `/api/r4g1/*` and `/api/tless/*` — parallel per-tier HTTP surfaces that
+  bypass the OpenAI-compatible cascade entirely.
+- `select_synthesis_engine` (`3605-3616`) — a legacy single-value resolver,
+  apparently superseded by `resolve_pinned_tier` but still present; worth
+  checking whether anything still calls it before #655-E/F touches routing.
+
+## Next open questions for #655-C1
+
+1. Does the shared startup loader read `ReleaseBundleManifest` for the R4G1
+   tier only, leaving Tiers 2-4 on their current ad hoc discovery? (This
+   document's answer leans yes, given §4's conclusion.)
+2. Does `ask`/`chat`'s `ModelStore` get pointed at the same manifest-and-
+   digest-described bundle `ReleaseBundleManifest` names, or does it stay a
+   fully separate mechanism? A migration path for existing `.uor-models`
+   stores is required either way per #655's own compatibility requirement.
+3. `#655-D` (packaging) needs to actually write a bundle directory somewhere
+   before a real loader can be tested end to end — that dependency should
+   probably be sequenced before the loader's file-discovery half is built,
+   even though the loader's manifest-parsing half (this slice feeds that)
+   can be developed and tested independently now.


### PR DESCRIPTION
References #655

## Summary

Scoping + a small grounded code slice toward #655-C1 (shared startup loader), which prior research on this issue found needed dedicated scoping rather than a quick continuation, since the codebase has three independent, disconnected model-loading systems (`ModelStore`, `src/server.rs`'s `#248` cascade, and the #655-C0 `ReleaseBundleManifest` schema).

- **New:** `docs/SERVING_MODEL_DISCOVERY.md` — a code-cited map of the `#248` cascade's four tiers (r4g1, transformerless, teacher-oracle, geometric), their exact discovery/file conventions, `.uor-models/last_engine.txt`'s pin/no-pin semantics, and `ModelStore`'s divergent required-file contract. Concludes `ReleaseBundleManifest` should stay scoped to one bundle/one engine (matching #655-D's own "one minimal bundle" framing) rather than becoming a multi-tier schema. Linked from README's doc map and a new `MODEL_LIFECYCLE.md` "8. Serve over HTTP" section.
- **Code:** `ReleaseBundleManifest::from_compiled_model` — a pure, in-memory constructor bridging `crate::compile::CompiledModel`'s real compile output into this schema, proving the field fit empirically. No filesystem I/O, no bundle-directory discovery, not wired into any server/CLI/client path — additive and dormant per #515's convention.

## Verification

- `cargo fmt --check`
- `cargo clippy -p uor-r4-api --all-targets -- -D warnings`
- `cargo test -p uor-r4-api` (27 tests, including 2 new)
- `cargo run -q -p xtask -- audit-limits` (R5)
- `cargo run -q -p xtask -- check-model` (CM-01)
- `python3 scripts/check_claim_wording.py`

All green.

Files: `crates/uor-r4-api/src/release_bundle.rs`, `docs/SERVING_MODEL_DISCOVERY.md` (new), `docs/MODEL_LIFECYCLE.md`, `README.md`.