### PR TITLE
engine: fail closed with SourceUnavailable on teacher_cid pairing mismatch (#743)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1059,6 +1059,39 @@ impl R4Engine {
                 "tokenizer binding unavailable: a tagged tokenizer requires a nonzero R4G1 header tokenizer CID",
             ));
         }
+        // `parts.graph` and `parts.signature_artifact` are two
+        // independently-sourced inputs when loading a persisted bundle
+        // from disk (as opposed to freshly self-compiled, same-process
+        // bytes) — they can legitimately drift out of pairing (for
+        // example, a bundle directory reused across multiple compile runs,
+        // so `score.r4g1` and its accompanying teacher file no longer
+        // belong to the same generation). Check that explicitly, before
+        // spending effort parsing `signature_artifact` as a TLA artifact,
+        // and report a typed `SourceUnavailable` decline — rather than
+        // let `from_artifact`'s internal self-produced-defect panic fire
+        // further down on a condition that is not actually a code defect
+        // (#743). `from_artifact` only consults `HEAD.teacher_cid` when
+        // the graph carries an EXCT section
+        // (uor-r4-graph-certify/src/score_runtime.rs); no EXCT section
+        // means no pairing is required here either.
+        if view.section(SectionId::EXCT).is_some() {
+            let expected_teacher_cid = view
+                .head()
+                .ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "invalid R4G1 graph: {}",
+                        FormatError::MissingHead
+                    ))
+                })?
+                .teacher_cid();
+            let actual_teacher_cid = blake3::hash(parts.signature_artifact);
+            if expected_teacher_cid.0 != *actual_teacher_cid.as_bytes() {
+                return Err(SourceUnavailable::new(format!(
+                    "teacher artifact mismatch: R4G1 header requires teacher blake3:{}, loaded teacher hashes to blake3:{actual_teacher_cid}",
+                    blake3::Hash::from(expected_teacher_cid.0).to_hex()
+                )));
+            }
+        }
         let artifacts = compiler::parse_artifacts(parts.signature_artifact)
             .ok_or_else(|| SourceUnavailable::new("not a TLA3/TLA4/TLA5 teacher artifact"))?;
         let score_report = parts
@@ -1086,13 +1119,17 @@ impl R4Engine {
         // The compiled RX1 EXCT table contains integer residuals. Supplying
         // the teacher artifact here is only for integer class-code lookup;
         // no probe-time log quantization occurs in the deployed path.
+        // Pairing was already checked above (#743); anything else that
+        // makes `from_artifact` decline here is an unanticipated defect
+        // in the already-CID-verified, now teacher-paired graph bytes,
+        // and remains the original self-produced-defect panic (R5, #510).
         let scorer = GraphScorer::from_artifact(
             parts.graph,
             Some(parts.signature_artifact),
             root_top_b,
             exct_top_x,
         )
-        .expect("engine load: scorer rebuild from the parsed and CID-verified graph bytes");
+        .expect("engine load: scorer rebuild from the parsed, CID-verified, and teacher-paired graph bytes");
         if let Some(report) = score_report.as_ref() {
             if let Some(message) = validate_quality_report(report) {
                 return Err(SourceUnavailable::new(message));

--- a/crates/uor-r4-api/tests/api.rs
+++ b/crates/uor-r4-api/tests/api.rs
@@ -310,6 +310,101 @@ fn engine_load_rejects_a_tagged_tokenizer_when_the_head_cid_is_zero() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+fn minimal_graph_with_teacher_cid_and_exct(teacher_cid: [u8; 32]) -> Vec<u8> {
+    let mut head = Vec::with_capacity(224);
+    head.extend_from_slice(&teacher_cid); // teacher CID
+    head.extend_from_slice(&[0; 32]); // tokenizer CID: zero, no binding required
+    head.extend_from_slice(&[0x33; 32]); // corpus-construction CID
+    head.extend_from_slice(&[0x44; 32]); // corpus-certification CID
+    head.extend_from_slice(b"0123456789abcdef0123"); // HF revision
+    head.extend_from_slice(&[0x55; 32]); // compiler-version CID
+    head.extend_from_slice(&32u16.to_le_bytes()); // max frontier width
+    head.extend_from_slice(&16u16.to_le_bytes()); // max candidates
+    head.extend_from_slice(&8u16.to_le_bytes()); // signature words
+    head.extend_from_slice(&8u16.to_le_bytes()); // shortlist size
+    head.extend_from_slice(&64u32.to_le_bytes()); // max emission entries
+    head.extend_from_slice(&64u32.to_le_bytes()); // max program steps
+    head.extend_from_slice(&0u32.to_le_bytes()); // node count
+    head.extend_from_slice(&0u32.to_le_bytes()); // edge count
+    head.push(1); // depth count
+    head.extend_from_slice(&[0; 5]); // fallback policies
+    head.extend_from_slice(&[0; 2]); // reserved
+    head.extend_from_slice(&64u16.to_le_bytes()); // signature bytes
+    head.extend_from_slice(&1u16.to_le_bytes()); // minimum runtime major
+    head.extend_from_slice(&0u16.to_le_bytes()); // minimum runtime minor
+    head.extend_from_slice(&0u16.to_le_bytes()); // required feature bits
+    head.extend_from_slice(&100u32.to_le_bytes()); // vocabulary size
+    assert_eq!(head.len(), 224);
+
+    let mut builder = ArtifactBuilder::new(3);
+    builder.add_section(SectionId::HEAD, 0, &head);
+    // Any EXCT section triggers the teacher-pairing requirement; its
+    // internal content is irrelevant to `check_teacher_pairing`, which
+    // checks section presence and HEAD.teacher_cid only, matching
+    // `from_artifact`'s own condition for consulting `teacher_cid`
+    // (crates/uor-r4-graph-certify/src/score_runtime.rs).
+    builder.add_section(SectionId::EXCT, 0, &[2, 0, 0, 0]);
+    builder.build().expect("minimal graph with EXCT")
+}
+
+// #743: `R4Engine::load` used to `.expect()`-panic when the graph and
+// teacher/signature artifact were parsed and CID-verified individually but
+// did not pair (mismatched `teacher_cid`) -- reproduced against a real
+// locally compiled bundle whose `tless_artifacts.bin` no longer matched its
+// `score.r4g1` (see the #743 issue body for the full repro). `load` now
+// checks pairing explicitly via `GraphScorer::check_teacher_pairing` and
+// reports a typed decline instead.
+#[test]
+fn engine_load_declines_instead_of_panicking_on_a_teacher_cid_mismatch() {
+    let expected_teacher = *blake3::hash(b"the real paired teacher bytes").as_bytes();
+    let graph = minimal_graph_with_teacher_cid_and_exct(expected_teacher);
+    let result = R4Engine::load(EngineParts {
+        graph: &graph,
+        signature_artifact: b"a completely different teacher artifact",
+        tokenizer: None,
+        score_report: None,
+    });
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("a mismatched teacher_cid must not load"),
+    };
+    assert!(
+        error.reason.contains("teacher artifact mismatch"),
+        "{error}"
+    );
+    assert!(
+        error
+            .reason
+            .contains(&blake3::Hash::from(expected_teacher).to_hex().to_string()),
+        "expected digest must be named in the decline: {error}"
+    );
+    assert_eq!(error.reason.matches("blake3:").count(), 2, "{error}");
+}
+
+#[test]
+fn engine_load_accepts_a_correctly_paired_teacher_cid_past_the_exct_gate() {
+    let teacher = b"the real paired teacher bytes";
+    let graph = minimal_graph_with_teacher_cid_and_exct(*blake3::hash(teacher).as_bytes());
+    let result = R4Engine::load(EngineParts {
+        graph: &graph,
+        signature_artifact: teacher,
+        tokenizer: None,
+        score_report: None,
+    });
+    // The correctly-paired teacher clears the #743 pairing gate; this
+    // minimal fixture's EXCT body is not a real residual/TLS1 table, so
+    // `from_artifact` itself still declines further in — that failure is
+    // out of scope for this test (it is not a panic, and not the pairing
+    // check this test exists to cover).
+    match result {
+        Ok(_) => {}
+        Err(error) => assert!(
+            !error.reason.contains("teacher artifact mismatch"),
+            "a correctly paired teacher must clear the #743 gate: {error}"
+        ),
+    }
+}
+
 #[test]
 fn engine_errors_implement_std_error() {
     let parts = EngineParts {


### PR DESCRIPTION
## Summary

`R4Engine::load` panicked instead of failing closed when a persisted
bundle's graph (`score.r4g1`) and teacher/signature artifact were no
longer paired -- e.g. a bundle directory reused across multiple compile
runs, so the two files no longer belong to the same generation.
`GraphScorer::from_artifact` is documented as total for self-produced,
same-process bytes and panics on the premise that any failure there is
a code defect (R5, #510); that premise doesn't hold once bytes are
reloaded from disk on the serving path.

**Root cause correction:** I originally hypothesized format/era drift
(#732/#733/#735). Empirical instrumentation showed that's not it --
`format_version` has stayed at 0.0 throughout and all three PRs were
verified non-breaking. The actual cause is a genuine data-pairing
mismatch: the graph's `HEAD.teacher_cid` doesn't match
`blake3(signature_artifact)` for the `smollm2-135m-instruct` bundle on
disk. This PR targets that empirically-confirmed cause, in the same
narrow-gate spirit already discussed on the issue (leave other panic
conditions alone; add an explicit gate for the specific detectable,
non-defect condition).

## Fix

In `R4Engine::load`, when the parsed graph carries an `EXCT` section
(the only case `from_artifact` consults `HEAD.teacher_cid`), check the
teacher_cid pairing explicitly before parsing `signature_artifact`, and
return a typed `SourceUnavailable` decline on mismatch. No new error
type: an earlier attempt added a `TeacherPairingError` enum in
`uor-r4-graph-certify`, but `cargo run -p xtask -- audit-limits` (R5)
correctly rejected it -- only `NotAProduct`, `ObservedBound`,
`KappaError`, and `SourceUnavailable` may appear in a `Result`
signature anywhere in a shipped crate. The check is inlined in
`engine.rs` instead, reusing `SourceUnavailable`.

Other panic conditions inside `from_artifact` are untouched and remain
intentional per the R5/#510 "self-produced defect" design -- this PR
closes the gap for the one condition that's provably not a code defect
(pairing drift between two independently-sourced files on disk), which
is also the exact condition #743 reported and reproduced.

## Verification

- `cargo fmt --check`
- `cargo run -p xtask -- audit-limits` -- no shipped crate returns an unsanctioned error (R5)
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p uor-r4-api --test api` -- 19 passed (2 new tests covering mismatch-declines and matched-pairing-clears-the-gate)
- `cargo test -p uor-r4-graph-certify -p uor-r4-api` -- full suite, all green
- `cargo run -q -p xtask -- check-model` -- CM-01 conformance holds
- `scripts/check_claim_wording.py` -- claim-wording gate passes
- Direct re-run of the original repro against the real bundle:
  ```
  R4_CERTIFY_C_ONLY=1 R4_CERTIFY_SERVING_BUNDLE=.../smollm2-135m-instruct ./target/debug/r4 certify
  ```
  now produces a clean typed decline (`teacher artifact mismatch: ...`)
  instead of a panic.

Closes #743

🤖 Generated with Claude (Cowork)