### PR TITLE
docs: fold in #743/#742, fix stale #490 claim, add track-viability answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,32 @@ whole method is measurement.
 
 **Real limitations, stated plainly:**
 
-- **Generation quality is weak.** On out-of-distribution prompts the compiled
-  runtimes score around 1% top-1 against the teacher. On in-distribution corpus
-  replay Gate C measures ~36% top-1 on the 500k fixture. This is a research
-  engine, not a chat model.
+- **Generation quality is weak, and on the best locally compiled bundle it is
+  currently incoherent.** On out-of-distribution prompts the compiled runtimes
+  score around 1% top-1 against the teacher. On in-distribution corpus replay
+  Gate C measures ~36% top-1 on the 500k fixture, and a broader teacher (P3,
+  #509) lifts broad-text held-out top-1 to 10.2–29.0% causal — real,
+  replicated, goal-aligned signal. That signal has **not yet composed into
+  coherent multi-token output**: asked real questions through `r4 ask`, this
+  repository's largest local bundle answers in non-grammatical word-salad, and
+  smaller bundles answer with nothing (#745, open). See
+  [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer)
+  for the full picture — this is the project's central open question, not a
+  footnote. This is a research engine, not a chat model.
 - **Instruction following is gated, not solved.** `r4 ask` accepts only an
   imported `instruction-chat` manifest carrying a CID-addressed passing
   evaluation report, precisely so a fast continuation artifact cannot be
   presented as a question-answering model.
 - **Standalone two-pass generation is refuted**, twice, and is not coming back.
-- **The geometric router's retrieval was measured broken**, and the fix sits
-  behind a default-off knob. Until issue #490 clears its gate, the deployed
-  retrieval ranking is word overlap, not geometry.
+- **The geometric router's retrieval was measured broken, and is now fixed and
+  shipping.** #486 found `retrieve_geometric_resonance` compared a *routing*
+  query vector against the stored *content* vector — a category error that put
+  the cosine at chance. #490 (closed 2026-08-08) fixed the query to use the
+  same content-vector construction as storage, landing 0.8542 MRR; #502
+  (closed) then dropped the now-meaningful lexical term to reach the current
+  deployed default of 0.8763 MRR / 0.99 recall. Both are the shipped default
+  today — see [docs/RESEARCH.md](docs/RESEARCH.md#what-works-and-is-load-bearing)
+  for the full record.
 
 Every claim above traces to a merged measurement — see
 [docs/RESEARCH.md](docs/RESEARCH.md).
@@ -165,12 +179,19 @@ crates/
   uor-r4-model-source    teacher forward-pass port + pinned Safetensors adapter
   uor-r4-proof-model     executable proof obligations + proof-status matrix
   uor-r4-api             typed compile + engine library facade for downstream consumers
+  uor-r4-naf             UOR-NAF v1 interchange slice + GNAF claim/status vocabulary (#623)
+  repo-model             typed registries parsed from `model/*.toml`; generates CONFORMANCE.md (R1)
+  repo-conformance       BDD runner + honesty meta-gate cross-checking scenarios/IDs/tests (R2/R3)
+xtask/                   repository gates (`cargo xtask <task>`); enforces the rules in AGENTS.md
 src/                     root package: the `r4` binary, HTTP server, chat, WASM facade
 docs/                    research records, design docs, explainers, formal material
 features/                Cucumber BDD suites (teacher parity, FMM)
 scripts/                 CI gates and corpus tooling
 research/                exploratory notes (290-fmm, 395-e8)
 models/                  pinned model descriptors
+proofs/wasm-gemm-gnaf/   vendored WASM-GEMM-GNAF (#653/#742) — Lean4 proof that a WASM GEMM
+                         kernel is cost-optimal; formal reference material, NOT in the deployed
+                         dependency graph and NOT an LLM engine (see docs/gnaf_import_provenance.md)
 tests/                   root-package integration tests and BDD steps
 index.html, index.css    browser dashboard
 r4_worker.js             dashboard WASM worker
@@ -508,7 +529,8 @@ cd /tmp && unzip -o run.com out/model.bin tokenizer.bin -d ref
 
 **Start here**
 
-- [docs/RESEARCH.md](docs/RESEARCH.md) — what is measured, what is closed, what is open.
+- [docs/RESEARCH.md](docs/RESEARCH.md) — what is measured, what is closed, what is open, and
+  [which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).
 - [docs/MODEL_LIFECYCLE.md](docs/MODEL_LIFECYCLE.md) — download → compile → cover → score → evaluate → import → serve.
 - [AGENTS.md](AGENTS.md) — contributor manual: gates, normative invariants, κ re-pin, long-run discipline.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to open a PR here.
@@ -529,6 +551,8 @@ cd /tmp && unzip -o run.com out/model.bin tokenizer.bin -d ref
 [Formal vocabulary](docs/formal_vocabulary.md) (normative for claim wording) ·
 [Reproducibility](docs/reproducibility.md) ·
 [Performance comparison](docs/transformerless/COMPARISON.md) ·
+[GNAF import provenance](docs/gnaf_import_provenance.md) (vendored formal-verification
+reference material, not an LLM engine — #653) ·
 [Matrix-operation census](docs/matrix_operation_census.md) ·
 [Serving-time model discovery](docs/SERVING_MODEL_DISCOVERY.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,38 @@ programme — what has been measured, refuted and left open — lives in
 purpose. Research direction is set by measurement and changes faster than this
 list does.
 
-_Last reviewed: 2026-08-08._
+_Last reviewed: 2026-08-16._
+
+## Next up (recommended sequencing)
+
+Order for the currently open backlog, based on what actually unblocks
+progress toward a working transformerless LLM — not effort or familiarity:
+
+1. **[#744](https://github.com/UOR-Foundation/uor-r4/issues/744)** —
+   reconcile the `instruction_eval_passed` quality gate with real generation
+   quality (two manifests over identical compiled bytes currently report
+   opposite numbers and both pass). Cheap and bounded, and everything
+   downstream — bundle selection, knowing whether a #745 fix actually helped,
+   trusting future compiles — depends on this gate being honest.
+2. **[#745](https://github.com/UOR-Foundation/uor-r4/issues/745)** —
+   root-cause the degenerate word-salad / empty-output generation on the
+   best-available compiled bundle. This is the single open question that
+   decides whether the transformerless/R4G1 track can produce coherent text
+   at all — see
+   [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).
+   Worth evaluating the dormant `#604` route-attention kernel
+   (`R4RouteAttentionV1`, P-4-legal, already built and differentially tested
+   but unused at serving time) as one candidate lever.
+3. **[#653](https://github.com/UOR-Foundation/uor-r4/issues/653) phase 2**
+   (GNAF adapter wiring) — lower priority; strengthens honesty/certification
+   infrastructure but does not itself move generation quality. Phase 1
+   (vendoring, #742) is landed.
+4. **[#740](https://github.com/UOR-Foundation/uor-r4/issues/740)**
+   (OpenAI-compatible API surface gaps) /
+   **[#741](https://github.com/UOR-Foundation/uor-r4/issues/741)**
+   (shipping/distribution) — explicitly deferred until #744/#745 land, per
+   the maintainer's own prior redirect on #655. Shipping a product that does
+   not yet generate coherent text is premature; revisit once it does.
 
 ## Landed
 
@@ -26,11 +57,21 @@ _Last reviewed: 2026-08-08._
 - [x] **Attestable / audit logging / provenance** — UOR attestation envelopes
   (`uor_address`, `artifact_cid`, `store_cid`, `attestation_cid`),
   `POST /api/uor/verify`, per-turn audit log rendered by `r4 audit`.
+- [x] **GNAF vendored (#653 phase 1, PR #742)** — the pinned
+  `WASM-GEMM-GNAF` Lean4 proof project is vendored at
+  `proofs/wasm-gemm-gnaf/` with full provenance
+  (`docs/gnaf_import_provenance.md`). It is a proof that a WASM GEMM kernel
+  is cost-optimal, unrelated to text generation; source and provenance only
+  — not wired into any pipeline, not in the deployed dependency graph. Phase
+  2 (adapter wiring) is open, see Next up above.
 
 ## Capabilities
 
-- [~] Text-based AI — compiles and serves; **generation quality is the open
-  research problem**, see [docs/RESEARCH.md](docs/RESEARCH.md)
+- [~] Text-based AI — compiles and serves; **coherent end-to-end generation is
+  the open research problem** (#745), not just "quality is weak" — the best
+  locally compiled bundle currently answers real questions in non-grammatical
+  word-salad, even though offline per-position metrics show real signal. See
+  [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).
 - [ ] Image
 - [ ] Audio
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -198,9 +198,74 @@ top-1 by 5.0pp. Not a counterexample — the resolution levers that failed all
 subdivided structures already resolved enough to be predictive. **Resolution pays
 up to the point where a structure predicts at all, and not past it.**
 
+## Which track can actually produce coherent text — the honest current answer
+
+This project's goal is a serving-time LLM with zero multiply/divide/float in
+the deployed kernel (P-4) — not merely a research artifact that scores well on
+per-position offline metrics. The #655 coherence sweep (2026-08-16, diagnostic
+only, no code changed; findings tracked as #743/#744/#745) is the most direct
+evidence yet on whether that goal is reachable, and it needs both halves
+stated together, because reading either alone is misleading.
+
+**The offline per-position signal is real and P-4-clean.** #509/#320's P3
+result — swapping only the teacher for SmolLM2-360M on a broad Simple-Wiki
+partition — moved held-out top-1 from the narrow-teacher ~0.1% off-distribution
+floor to 10.2% (Rule 1+2) / 29.0% (latent-mix, causal), a ~100–290× lift,
+entirely inside the transformerless/R4G1 table-native kernel. Deployed
+inference is machine-checked matmul-free
+(`p4_contract_owned_graph_runtime_source_scan`,
+[matrix_operation_census.md](matrix_operation_census.md)); only the *offline
+teacher-compile* step performs matrix multiplication, and even that now runs
+through the project's own `uor-matmul` exact GEMM rather than platform BLAS.
+That is genuine, replicated, goal-aligned signal, and it is why the
+broad-corpus programme is licensed rather than abandoned.
+
+**That signal has not yet composed into coherent multi-token generation.** The
+#655 sweep asked the actual best-available locally compiled bundle
+(`smollm2-1-7b-chat`, 34.7% top-1 per its own eval) real questions through
+`r4 ask`. The output was non-grammatical word-salad cycling a small set of
+tokens (`tetra`, `gru`, `gulick`, `chall`, `caption`…) — not "weak English,"
+not close. Smaller bundles produced empty output. **#745** is chartered to
+root-cause this specifically; it is an open, unresolved question whether the
+cause is a fixable defect (bad bundle selection, a broken quality gate per
+**#744**, a decoding bug) or a genuine ceiling of the current cover/store
+design at multi-step generation time — see #745's own text for both
+hypotheses. Separately, **#743** found (and fixed, PR #746) that the serving
+loader panicked instead of failing closed on a stale/mismatched bundle — a
+robustness gap, not itself an explanation for the word-salad output on the
+bundle that *does* load.
+
+**So: which track could work?** Of the tracks that are actually goal-aligned
+(no transformer, no matmul, no float in the deployed kernel), the
+transformerless TLA runtime and the R4G1 graph scorer — the same underlying
+compiled representation viewed through two runtimes — are the only ones with
+any positive, replicated empirical signal at all. Neither is proven to work
+end-to-end yet; #745 is the open question that would settle it either way.
+The **geometric router** is a validated, real component (content-query
+retrieval MRR 0.88+, #486/#490/#502) but it is a retrieval/routing mechanism,
+not itself a generative model, and it runs on `f64` outside the P-4 kernel by
+design (see the project-layout table in [README.md](../README.md)) — it
+strengthens the product, it is not a candidate to *be* the product. The
+**dormant #604 route-attention kernel**
+(`R4RouteAttentionV1`, `crates/uor-r4-graph-runtime/src/route_attention.rs`)
+is worth calling out separately: a fully implemented, differentially-tested,
+P-4-legal integer attention analog (masked-XOR/popcount distance plus bounded
+top-M selection) that is constructible today but wired into **no serving
+path** — registered dormant (`r4-route-attention-dormant`) in
+`model/ledger.toml`. It is the closest thing in this repository to a
+transformer-*shaped* mechanism that is also genuinely goal-aligned, and it has
+not yet been evaluated as a lever for #745's generation-quality question. The
+**`attention`/`r4-attention`** engine modes and **GNAF** (#653) are out of
+scope for this question by the project's own stated goal: the former run the
+teacher's real matmul/float attention purely as a comparison baseline, never
+as the shipped product; GNAF is a Lean4 proof that a WASM GEMM kernel is cost-
+optimal — formal-verification infrastructure unrelated to text generation,
+whose only legitimate integration point is an honesty/claim-vocabulary bridge
+(`uor-r4-naf::claims`, #623), not a generation mechanism.
+
 ## Open, with defined work
 
-*Recently landed and closed (GitHub is the source of truth; this table tracks what is still open): **#502** — dropped the lexical weight (W=0) on the deployed content-query path (+0.022 MRR / +0.032 top-1, a simplification); the #421 rows are invariant under the weight, so the gate was moot the same way #490's was (below). **#488** — phase-timing instrument (DoD met); the at-scale run is now **#503**. **#457** — IPF Arm B landed NEGATIVE, consistency operator reaches only the unigram floor (below). **#486/#490** — the serving path compared a routing vector to a content vector; the content-vector query is now the deployed default (+0.1363 MRR), with the serde-default and blast-radius findings recorded on #490. **#487** — corrected #434's Spectral record (lexical, not geometry). **#493** — the VSA switch made honest; its `0.0000` is a scoring category error, not a wiring gap (below). **#458/#459** — interaction information and the estimation ladder, both landed NEGATIVE/count-limited. **#456** — reconstructability certificate + null arm (below).*
+*Recently landed and closed (GitHub is the source of truth; this table tracks what is still open): **#743** — `R4Engine::load` failed closed with a typed `SourceUnavailable` decline on a teacher_cid pairing mismatch instead of panicking (PR #746); the root cause was data-pairing drift between two independently-sourced bundle files, not format/era drift as first hypothesized. **#502** — dropped the lexical weight (W=0) on the deployed content-query path (+0.022 MRR / +0.032 top-1, a simplification); the #421 rows are invariant under the weight, so the gate was moot the same way #490's was (below). **#488** — phase-timing instrument (DoD met); the at-scale run is now **#503**. **#457** — IPF Arm B landed NEGATIVE, consistency operator reaches only the unigram floor (below). **#486/#490** — the serving path compared a routing vector to a content vector; the content-vector query is now the deployed default (+0.1363 MRR), with the serde-default and blast-radius findings recorded on #490. **#487** — corrected #434's Spectral record (lexical, not geometry). **#493** — the VSA switch made honest; its `0.0000` is a scoring category error, not a wiring gap (below). **#458/#459** — interaction information and the estimation ladder, both landed NEGATIVE/count-limited. **#456** — reconstructability certificate + null arm (below).*
 
 | Issue | Question | State |
 |---|---|---|
@@ -213,6 +278,8 @@ up to the point where a structure predicts at all, and not past it.**
 | #320 | Teacher upgrade (SmolLM2) | P1/P2 rehearsal recorded; **P3 decided POSITIVE** (#509, this record). Repeatedly named the **binding constraint on absolute accuracy** — the stories15M argmax is near-degenerate on broad text (6.4% next==argmax on wiki10k vs 70.2% on its home corpus). P3 tested the prediction directly: swap only the teacher (SmolLM2-360M) on the same Simple-Wiki D3 partition and broad-text held-out top-1 moves from the recorded ~0.1% off-distribution floor to **10.2% (Rule 1+2) / 29.0% (latent-mix #446 M2)**, both causal. Teacher breadth was the constraint; the broad-corpus program is warranted. The baseline re-pin stays a maintainer step per AGENTS.md. [smollm2_teacher_baseline_320.md](smollm2_teacher_baseline_320.md#p3--broad-corpus-program-509-smollm2-360m-observed-on-simple-wiki) |
 | #509 | Broad-corpus decider (P3 for #320) | **Landed POSITIVE & closed** (this record). One end-to-end broad-text pass — observe SmolLM2-360M on Simple-Wiki (3,000 articles → 21,235 records) → recorded compile → cover (46 regions) → score `relative_tla` → Gate C on 4,358 held-out D3 positions. Rule 1+2 **10.2%** / 12.72 bits, latent-mix (#446 M2, causal) **29.0%** / 11.71 bits, vs the narrow-teacher ~0.1% off-distribution floor — a ~100–290× lift on the causal rows, clearing the unigram null and shuffled-class control. Absolute accuracy is still compiler-/data-bound, far below the teacher floor, so this licenses the program, not substrate parity. All native, no GPU. [smollm2_teacher_baseline_320.md](smollm2_teacher_baseline_320.md#p3--broad-corpus-program-509-smollm2-360m-observed-on-simple-wiki) |
 | #273 | Template rebase / claim register | **Landed & closed** (PR #511). Adopted the UOR-Foundation/template register machinery (`repo-model`, `repo-conformance`, `xtask`, `model/`) and brought uor-r4's real BDD under it: 29 feature suites / 101 scenarios tagged `@RF-NN @build`, registered in `model/ids.toml` with explicit marker tests, cucumber unbroken. R1–R3 gates wired and advisory in CI; R4/R5/R6 spun out as **#510**. The r4 scenarios supersede the template's empty scaffolding — the goal was to beef up the BDD, not replace it |
+| #744 | `instruction_eval_passed` quality gate self-consistency | **Open.** The #655 sweep found two manifests over byte-identical compiled artifacts (`smollm2-135m-instruct` vs `smollm2-135m-chat`, and the 360M/1.7B pair) report opposite quality — `grounded_answer_rate`/`repetition_rate` of 0.0/1.0 on one manifest and 0.85/0.01 on the other for the *same bytes* — and both pass the gate. Either the "-instruct" vs "-chat" eval methodology differs substantially, or the gate does not discriminate real output from total failure; `instruction_eval_passed` is the thing `r4 ask` relies on to accept a bundle at all, so a gate that cannot tell the two apart is a live risk of serving a broken bundle as passing |
+| #745 | Root-cause the degenerate small-vocabulary generation on the best-available compiled bundle | **Open.** The #655 sweep asked real questions of every reachable local bundle through `r4 ask`. `smollm2-135m-instruct`/`-chat` (recorded 0.0/1.0 and 0.85/0.01 respectively) both returned empty output. `smollm2-1-7b-chat` — this repo's largest/best-looking local bundle, 34.7% top-1 per its own eval — produced non-grammatical word-salad cycling a small set of nonsense tokens, not degraded-but-recognizable English. Open hypotheses: a specific fixable defect (bundle selection, decoding, the #744 gate feeding a bad "best" choice) vs. a genuine ceiling of the current cover/store design at multi-step generation time. See [Which track can actually produce coherent text](#which-track-can-actually-produce-coherent-text--the-honest-current-answer) above — this is the single open question that would settle it |
 
 ## Measurement infrastructure
 


### PR DESCRIPTION
## Summary

Deep audit of README.md, ROADMAP.md, docs/RESEARCH.md against current main
and the live code (per the maintainer's request following the #655
coherence sweep). Findings:

- **Found and fixed a real drift.** README's geometric-router limitation
  bullet said retrieval stays word-overlap "until issue #490 clears its
  gate" -- but #490 (and follow-up #502) closed 2026-08-08, over a week
  before this audit, and the content-vector query is the current deployed
  default (0.8763 MRR / 0.99 recall per docs/RESEARCH.md). Corrected.
- **Found an incomplete project-layout table.** `uor-r4-naf`, `repo-model`,
  `repo-conformance`, and `xtask/` are real workspace members with no entry
  in README's crate table; `proofs/wasm-gemm-gnaf/` (vendored by #742) had
  no mention anywhere in the layout. Added all four with descriptions
  pulled from their own doc comments.
- **Added the track-viability answer** the maintainer asked for:
  `docs/RESEARCH.md#which-track-can-actually-produce-coherent-text` states,
  with citations, both halves of the current evidence -- the offline
  per-position signal from the broad-teacher programme (#509/#320) is real
  and P-4-clean, but has not yet composed into coherent end-to-end
  generation on the best locally compiled bundle (#745, open) -- and
  classifies engine tracks as goal-aligned (transformerless/R4G1),
  comparison-only (attention/r4-attention), or out of scope for text
  generation entirely (GNAF -- a WASM-GEMM optimality proof, not a language
  mechanism). Flags the dormant, P-4-legal `#604` route-attention kernel
  (built, differentially tested, wired into no serving path) as an
  unexplored lever worth evaluating against #745.
- Added #743/#744/#745 to RESEARCH.md's "Open, with defined work" table.
- Sharpened the generation-quality bullets in README/ROADMAP to cite the
  #655 sweep's concrete evidence (empty output / word-salad) rather than
  only the older aggregate percentages.
- ROADMAP.md: refreshed the review date, added a "Next up" section with
  the recommended backlog sequencing (#744 -> #745 -> #653 phase 2 ->
  #740/#741, with rationale), and a Landed entry for GNAF phase 1 (#742).

No goals, existing measurement conclusions, or evidence were changed --
this is additions and corrections to drifted/missing narrative text only.

## Verification

- `scripts/check_claim_wording.py` -- clean
- `cargo fmt --check` -- clean (no code touched)
- Markdown-only diff (README.md, ROADMAP.md, docs/RESEARCH.md), so CI's
  docs-only fast path applies

Closes #747

🤖 Generated with Claude (Cowork)