### PR TITLE
fix(model): compute instruction_eval_passed from live probes, not CLI flags

### DIFF
--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -1237,11 +1237,36 @@ cargo run -- import \
   --artifacts .uor-models/compiled/smollm2-135m-instruct/tless_artifacts.bin \
   --store .uor-models/compiled/smollm2-135m-instruct/tless_store.bin \
   --tokenizer .uor-models/compiled/smollm2-135m-instruct/tokenizer.bin \
-  --evaluation-report /path/to/instruction-eval.json \
-  --instruction-eval-passed \
-  --grounded-answer-rate 0.80 \
-  --repetition-rate 0.01
+  --evaluation-report /path/to/instruction-eval.json
 ```
+
+`instruction_eval_passed`, `grounded_answer_rate`, and `repetition_rate` are
+**not** CLI flags and cannot be supplied by the operator. For
+`--capability instruction-chat`, `import` derives them itself by loading the
+exact `--artifacts`/`--store`/`--tokenizer` bytes being imported and running
+them through a fixed probe set of ordinary questions on the live `ask` code
+path, then scoring each answer's repetition rate the same way Gate C does
+(`crates/uor-r4-graph-certify`'s greedy-repetition metric, applied over the
+full generated span). `--evaluation-report` is still accepted and stored
+content-addressed as provenance of the offline D3 top-1/agreement/bits
+measurement from step 5, but it is not read back or trusted for the
+pass/fail decision — only the live probe run decides that. This closes the
+gap (#744) where two manifests over byte-identical compiled bytes could
+carry hand-typed, disagreeing quality numbers and both pass.
+
+Known limitation: the live probe run always exercises the plain TLA/TLS1
+generation path, the same one `engine_from_bytes` builds. It does not load
+or probe an R4G1 graph (`compiled.r4g1`), even though `ask`/`chat` will
+transparently prefer an R4G1 graph over the plain path at serving time if
+one exists at the manifest-name-keyed convention path
+(`.uor-models/compiled/<manifest name>/compiled.r4g1`). The two paths can
+disagree sharply — on at least one real local bundle the R4G1 beam-search
+path produced single-token degenerate repetition ("cut cut cut ...") where
+the plain path produced word-salad, i.e. both paths were bad but not
+identically bad. A manifest that passes today's gate is only guaranteed
+non-degenerate on the plain path; if that same bundle also has a
+same-name-keyed `compiled.r4g1` file, `ask` may still serve degenerate
+output despite the gate having passed. Tracked as a follow-up.
 
 The model store defaults to `.uor-models`; set `UOR_MODEL_STORE` to relocate
 it. Objects are stored once under `objects/blake3/<digest>`. Reads verify both

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -15,12 +15,36 @@ const MAX_CHAT_HISTORY: usize = 4096;
 const MAX_ANSWER_BYTES: usize = 16 * 1024;
 
 /// A completed local chat turn.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChatAnswer {
     /// Generated assistant text.
     pub text: String,
     /// Number of tokens generated for this turn.
     pub generated_tokens: usize,
+    /// Fraction of generated tokens that already appeared earlier in
+    /// this same generation (see [`recent_window_repetition_rate`],
+    /// called with the full generated length as its window — a bounded
+    /// chat turn is short enough that "recent" can mean "the whole
+    /// answer so far"). A fixed 32-token window, the convention Gate C's
+    /// `generate_greedy_repetition_rate` uses for its much longer
+    /// generations, empirically under-detects real degenerate output
+    /// here: `#744`'s own verification against the actual `#745`
+    /// word-salad bundle measured only 0.10-0.25 at window 32, because
+    /// the small pool of recurring fragments (`tetra`/`gru`/`caption`/…)
+    /// mixes with enough distinct short filler subword pieces that few
+    /// *exact same-token* recurrences land inside any single 32-token
+    /// slice, even though the visible vocabulary is obviously collapsed
+    /// to a human reader. Widening the window to the full answer raised
+    /// the same transcripts to 0.31-0.41, which is why
+    /// [`crate::model::evaluate_live_quality`]'s repetition bar was
+    /// recalibrated down from 0.5 to 0.25 alongside this change — see
+    /// that function's bar constant for the honest caveat on how that
+    /// number was chosen. Unlike
+    /// [`repeated_suffix`]'s exact-block detector (this module's other
+    /// repetition guard), this also catches small-vocabulary cycling
+    /// through several distinct tokens in varying order, which never
+    /// forms an identical repeated block.
+    pub repeated_token_rate: f64,
 }
 
 /// Failure to load or run the local transformerless chat engine.
@@ -416,6 +440,7 @@ fn hologram_answer(
             return Ok(ChatAnswer {
                 text,
                 generated_tokens: generated.len(),
+                repeated_token_rate: recent_window_repetition_rate(generated, generated.len()),
             });
         }
     }
@@ -459,6 +484,7 @@ fn hologram_answer(
     Ok(ChatAnswer {
         text,
         generated_tokens: generated.len(),
+        repeated_token_rate: recent_window_repetition_rate(generated, generated.len()),
     })
 }
 
@@ -626,6 +652,66 @@ fn repeated_suffix(tokens: &[u32], width: usize) -> bool {
     tokens[..tokens.len() - width]
         .windows(width)
         .any(|window| window == suffix)
+}
+
+/// Fraction of `tokens` that already appeared among the preceding
+/// `window` tokens of the same generation — the same recent-window
+/// repetition definition Gate C's `generate_greedy_repetition_rate` uses
+/// (`uor-r4-graph-certify::score`), reimplemented here for the live
+/// serving path (`chat`'s `Compiled`/`Store` types are private to
+/// `uor-r4-core::transformerless`, a different crate boundary than
+/// graph-certify's `GraphScorer`, so the definition is duplicated rather
+/// than shared code — see `#744`). Empty input is defined as
+/// non-repetitive (`0.0`), matching the natural reading of "no
+/// repetition observed" rather than the alternative "undefined".
+fn recent_window_repetition_rate(tokens: &[u32], window: usize) -> f64 {
+    if tokens.is_empty() {
+        return 0.0;
+    }
+    let mut recent: std::collections::VecDeque<u32> =
+        std::collections::VecDeque::with_capacity(window);
+    let mut duplicate_count = 0usize;
+    for &token in tokens {
+        if recent.contains(&token) {
+            duplicate_count += 1;
+        }
+        if recent.len() == window {
+            recent.pop_front();
+        }
+        recent.push_back(token);
+    }
+    duplicate_count as f64 / tokens.len() as f64
+}
+
+/// Build a chat engine directly from raw artifact/store/tokenizer bytes,
+/// bypassing manifest lookup and the on-disk compiled-bundle directory
+/// convention (`build_local_compiled_engine`'s fixed file names). Used by
+/// `model::evaluate_live_quality` (`#744`) to measure generation quality
+/// against the exact bytes being imported, before any manifest or
+/// `.uor-models/compiled/<name>` directory exists for them. No R4G1
+/// graph is attempted (`r4g1_bytes: None`) — this always exercises the
+/// plain TLA/TLS1 runtime path, the common baseline every bundle must
+/// clear regardless of which runtime ultimately serves it, and the one
+/// whose repetition guard (`repeated_suffix`) is weaker, making it the
+/// conservative choice for a pass/fail gate.
+pub fn engine_from_bytes(
+    artifact_bytes: &[u8],
+    store_bytes: &[u8],
+    tokenizer_bytes: &[u8],
+    max_tokens: usize,
+) -> Result<ChatEngine, ChatError> {
+    let artifacts = compiler::parse_artifacts(artifact_bytes).ok_or(ChatError::InvalidArtifacts)?;
+    let store = runtime::parse_store(store_bytes).ok_or(ChatError::InvalidStore)?;
+    let tokenizer = parse_chat_tokenizer(tokenizer_bytes)?;
+    Ok(ChatEngine {
+        artifacts,
+        store,
+        r4g1_bytes: None,
+        tokenizer,
+        history: [0; MAX_CHAT_HISTORY],
+        history_len: 0,
+        max_tokens: max_tokens.clamp(1, MAX_CHAT_TOKENS),
+    })
 }
 
 fn parse_chat_tokenizer(bytes: &[u8]) -> Result<Tokenizer, ChatError> {
@@ -2493,8 +2579,8 @@ fn render_audit_trace_record(
 #[cfg(test)]
 mod tests {
     use super::{
-        bind_chat_r4g1, ensure_chat_prompt_encoder, parse_remote_url, repeated_suffix,
-        select_chat_tokenizer_bytes, ChatError,
+        bind_chat_r4g1, ensure_chat_prompt_encoder, parse_remote_url,
+        recent_window_repetition_rate, repeated_suffix, select_chat_tokenizer_bytes, ChatError,
     };
     use uor_r4_core::transformerless::scenarios::{
         export_runtime_tokenizer_table, RuntimeTokenizerDecodePolicy, RuntimeTokenizerDecodeTable,
@@ -2538,6 +2624,37 @@ mod tests {
     fn repetition_guard_detects_repeated_token_windows() {
         assert!(repeated_suffix(&[1, 2, 3, 4, 1, 2, 3, 4], 4));
         assert!(!repeated_suffix(&[1, 2, 3, 4, 1, 2, 3, 5], 4));
+    }
+
+    /// `repeated_suffix`'s exact-block detector is blind to the #745
+    /// failure mode: cycling through a handful of distinct tokens in
+    /// varying (non-block-repeating) order. `recent_window_repetition_rate`
+    /// (#744) is built specifically to catch it.
+    #[test]
+    fn recent_window_repetition_rate_catches_small_vocabulary_cycling_that_repeated_suffix_misses()
+    {
+        let cycling = [1u32, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
+        assert!(
+            !repeated_suffix(&cycling, 8),
+            "too short for the exact 8-token block detector to see anything"
+        );
+        assert!(
+            recent_window_repetition_rate(&cycling, 8) > 0.5,
+            "but a small-vocabulary cycle is mostly recently-seen tokens"
+        );
+
+        let varied: Vec<u32> = (0..40).collect();
+        assert_eq!(
+            recent_window_repetition_rate(&varied, 8),
+            0.0,
+            "monotonically novel tokens carry no repetition"
+        );
+
+        assert_eq!(
+            recent_window_repetition_rate(&[], 8),
+            0.0,
+            "empty generation is defined as non-repetitive, not undefined"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use uor_r4_graph_cli as transformerless_command;
 use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError};
 use uor_r4_wasm_router::model::{
-    default_model_reference, download_source, ModelCapability, ModelError, ModelManifest,
-    ModelStore, QualityAttestation, SourceDownload,
+    default_model_reference, download_source, evaluate_live_quality, ModelCapability, ModelError,
+    ModelManifest, ModelStore, QualityAttestation, SourceDownload,
 };
 use uor_r4_wasm_router::server::{self, ServerConfig};
 use uor_r4_wasm_router::tless_uor;
@@ -295,14 +295,13 @@ struct ImportArgs {
     store: PathBuf,
     #[arg(long)]
     tokenizer: PathBuf,
+    /// Offline held-out evaluation report from `r4 evaluate-report`.
+    /// Required for `--capability instruction-chat`: not consulted for
+    /// the pass/fail decision (that's `evaluate_live_quality`, run
+    /// against the exact bytes below), but retained as CID-addressed
+    /// provenance of the offline top-1/agreement/bits measurement.
     #[arg(long)]
     evaluation_report: Option<PathBuf>,
-    #[arg(long, default_value_t = false)]
-    instruction_eval_passed: bool,
-    #[arg(long, default_value_t = 0.0)]
-    grounded_answer_rate: f32,
-    #[arg(long, default_value_t = 1.0)]
-    repetition_rate: f32,
 }
 
 #[derive(Args, Debug)]
@@ -555,9 +554,30 @@ fn descriptor_license(name: &str, repository: &str, revision: &str) -> Option<St
 
 fn import(args: &ImportArgs) -> Result<(), RunError> {
     let model_store = ModelStore::from_env();
-    let artifacts = model_store.put(&std::fs::read(&args.artifacts)?)?;
-    let store = model_store.put(&std::fs::read(&args.store)?)?;
-    let tokenizer = model_store.put(&std::fs::read(&args.tokenizer)?)?;
+    let artifact_bytes = std::fs::read(&args.artifacts)?;
+    let store_bytes = std::fs::read(&args.store)?;
+    let tokenizer_bytes = std::fs::read(&args.tokenizer)?;
+    // Quality is DERIVED, not accepted as operator input (#744): a
+    // manually-typed `--grounded-answer-rate`/`--repetition-rate` could
+    // (and did) disagree with the actual compiled bytes and with itself
+    // across re-imports of the same artifact. Continuation-capability
+    // bundles are never chat-gated (`validate_for_chat` below), so there
+    // is nothing honest to compute for them; they get a fixed
+    // not-evaluated attestation instead of running probes that would
+    // never be consulted.
+    let quality = match args.capability {
+        Capability::InstructionChat => {
+            evaluate_live_quality(&artifact_bytes, &store_bytes, &tokenizer_bytes)?
+        }
+        Capability::Continuation => QualityAttestation {
+            instruction_eval_passed: false,
+            grounded_answer_rate: 0.0,
+            repetition_rate: 1.0,
+        },
+    };
+    let artifacts = model_store.put(&artifact_bytes)?;
+    let store = model_store.put(&store_bytes)?;
+    let tokenizer = model_store.put(&tokenizer_bytes)?;
     let evaluation_report = args
         .evaluation_report
         .as_ref()
@@ -574,11 +594,7 @@ fn import(args: &ImportArgs) -> Result<(), RunError> {
         store,
         tokenizer,
         evaluation_report,
-        quality: QualityAttestation {
-            instruction_eval_passed: args.instruction_eval_passed,
-            grounded_answer_rate: args.grounded_answer_rate,
-            repetition_rate: args.repetition_rate,
-        },
+        quality,
     };
     manifest.validate_for_chat().or_else(|error| {
         (manifest.capability == ModelCapability::Continuation)
@@ -978,6 +994,7 @@ mod tests {
             Ok(ChatAnswer {
                 text: self.answers.pop_front().unwrap_or_default(),
                 generated_tokens: 1,
+                repeated_token_rate: 0.0,
             })
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -48,11 +48,166 @@ pub struct ModelObject {
     pub bytes: u64,
 }
 
+/// Whether an imported bundle may serve `r4 ask`, and how it earned that.
+///
+/// Before `#744`, these three fields were plain CLI floats on `r4 import`
+/// (`--instruction-eval-passed`, `--grounded-answer-rate`,
+/// `--repetition-rate`) — an operator-typed attestation with no
+/// connection to any computation. Two manifests over byte-identical
+/// compiled artifacts could (and did) carry opposite numbers, both
+/// "passing". [`evaluate_live_quality`] replaces that: for
+/// instruction-chat imports, these fields are now derived from actually
+/// running the exact bytes being imported against a fixed probe set
+/// through the same generation path `r4 ask` uses (see
+/// `chat::engine_from_bytes`), not accepted as operator input.
+///
+/// `grounded_answer_rate` measures **non-degeneracy**, not semantic fact-
+/// checking — this codebase has no mechanism to verify an answer's
+/// factual content, so the honest thing is not to claim it does. A probe
+/// counts toward `grounded_answer_rate` when it produces a non-empty
+/// answer whose [`repeated_token_rate`](crate::chat::ChatAnswer::repeated_token_rate)
+/// stays at or below [`LIVE_QUALITY_REPETITION_BAR`] — i.e. the answer is
+/// not empty and not dominated by recently-repeated tokens, the failure
+/// mode observed in `#745`'s word-salad transcripts.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityAttestation {
     pub instruction_eval_passed: bool,
     pub grounded_answer_rate: f32,
     pub repetition_rate: f32,
+}
+
+/// Fixed probe set for [`evaluate_live_quality`] (`#744`): ordinary
+/// questions with no single expected answer string, used only to check
+/// that generation is non-degenerate — not to verify factual
+/// correctness, which nothing in this codebase currently checks. Kept
+/// small and fixed so the gate stays fast and its verdict reproducible
+/// run to run on the same bytes.
+const LIVE_QUALITY_PROBES: &[&str] = &[
+    "What is the capital of France?",
+    "Why is the sky blue?",
+    "What is two plus two?",
+    "Name a primary color.",
+    "What day comes after Monday?",
+    "What is water made of?",
+    "How many legs does a dog have?",
+    "What is the opposite of hot?",
+];
+
+/// A probe answer counts as non-degenerate when its full-generation
+/// repetition rate ([`chat::ChatAnswer::repeated_token_rate`]) stays at
+/// or below this bar.
+///
+/// Calibrated empirically against the real `#745` bundle
+/// (`smollm2-1-7b-instruct`, artifact `blake3:fca5bdfb…` — the same
+/// bytes the `#655` sweep found producing word-salad): its actual probe
+/// answers measured 0.31-0.41 on this metric, well above ordinary
+/// short-answer word reuse. `0.25` catches that entire observed range
+/// with margin.
+///
+/// Honest limitation, stated plainly: this bar is calibrated only
+/// against known-*bad* evidence. No genuinely coherent local bundle
+/// exists yet to confirm it does not also reject good output — that
+/// positive calibration point does not exist until `#745` produces one.
+/// Revisit this constant against real positive evidence once it does,
+/// rather than treating `0.25` as load-bearing precision.
+const LIVE_QUALITY_REPETITION_BAR: f64 = 0.25;
+
+/// An imported bundle passes when at least this fraction of the probe
+/// set produces a non-degenerate answer. A bar below `1.0` tolerates an
+/// occasional empty/degenerate probe without failing an otherwise-working
+/// bundle outright; `0.5` requires a majority.
+const LIVE_QUALITY_PASS_BAR: f32 = 0.5;
+
+/// One probe's live-generation outcome, reduced to just what the gate
+/// needs. Kept separate from `chat::ChatAnswer`/`ChatError` so
+/// [`aggregate_probe_outcomes`] — the actual pass/fail policy — can be
+/// exercised by a fast, deterministic unit test (`#744`'s falsifier)
+/// without loading a real compiled bundle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ProbeOutcome {
+    /// Generation produced some text.
+    Answered {
+        non_empty: bool,
+        repeated_token_rate: f64,
+    },
+    /// `ask` returned an error (empty/repetitive generation, or a load
+    /// failure) — scored as the worst case (maximal repetition) so it
+    /// cannot be diluted by averaging with healthier probes.
+    Failed,
+}
+
+fn aggregate_probe_outcomes(outcomes: &[ProbeOutcome]) -> QualityAttestation {
+    debug_assert!(!outcomes.is_empty(), "probe set must be non-empty");
+    let mut non_degenerate = 0usize;
+    let mut repetition_sum = 0.0f64;
+    for outcome in outcomes {
+        match outcome {
+            ProbeOutcome::Answered {
+                non_empty: true,
+                repeated_token_rate,
+            } if *repeated_token_rate <= LIVE_QUALITY_REPETITION_BAR => {
+                non_degenerate += 1;
+                repetition_sum += repeated_token_rate;
+            }
+            ProbeOutcome::Answered {
+                repeated_token_rate,
+                ..
+            } => repetition_sum += repeated_token_rate,
+            ProbeOutcome::Failed => repetition_sum += 1.0,
+        }
+    }
+    let probe_count = outcomes.len().max(1);
+    let grounded_answer_rate = non_degenerate as f32 / probe_count as f32;
+    let repetition_rate = (repetition_sum / probe_count as f64) as f32;
+    QualityAttestation {
+        instruction_eval_passed: grounded_answer_rate >= LIVE_QUALITY_PASS_BAR,
+        grounded_answer_rate,
+        repetition_rate,
+    }
+}
+
+/// Run [`LIVE_QUALITY_PROBES`] against the exact bytes being imported and
+/// derive a [`QualityAttestation`] from the results (`#744`). Fails fast
+/// with a real error if the bytes cannot even be loaded, rather than
+/// scoring repeated identical load failures into the metrics below — an
+/// unloadable bundle is a defect in the import inputs, not a
+/// generation-quality signal for this gate to describe.
+///
+/// A fresh engine is built per probe: the probes are independent
+/// ordinary questions, not turns of one conversation, so no chat history
+/// should carry between them.
+pub fn evaluate_live_quality(
+    artifact_bytes: &[u8],
+    store_bytes: &[u8],
+    tokenizer_bytes: &[u8],
+) -> Result<QualityAttestation, ModelError> {
+    const PROBE_MAX_TOKENS: usize = 64;
+    crate::chat::engine_from_bytes(
+        artifact_bytes,
+        store_bytes,
+        tokenizer_bytes,
+        PROBE_MAX_TOKENS,
+    )
+    .map_err(|error| ModelError::Io(std::io::Error::other(error.to_string())))?;
+
+    let mut outcomes = Vec::with_capacity(LIVE_QUALITY_PROBES.len());
+    for probe in LIVE_QUALITY_PROBES {
+        let mut engine = crate::chat::engine_from_bytes(
+            artifact_bytes,
+            store_bytes,
+            tokenizer_bytes,
+            PROBE_MAX_TOKENS,
+        )
+        .map_err(|error| ModelError::Io(std::io::Error::other(error.to_string())))?;
+        outcomes.push(match engine.ask(probe) {
+            Ok(answer) => ProbeOutcome::Answered {
+                non_empty: !answer.text.trim().is_empty(),
+                repeated_token_rate: answer.repeated_token_rate,
+            },
+            Err(_) => ProbeOutcome::Failed,
+        });
+    }
+    Ok(aggregate_probe_outcomes(&outcomes))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1299,6 +1454,81 @@ pub fn write_source_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Falsifier for `#744`'s live quality gate: demonstrates
+    /// `aggregate_probe_outcomes` correctly rejects the two known-bad
+    /// cases the `#655` coherence sweep actually observed (all-empty
+    /// output, and small-vocabulary word-salad), and accepts a
+    /// genuinely healthy probe set. Exercises the pass/fail policy
+    /// directly, without loading a real compiled bundle, so it stays
+    /// fast and deterministic in CI.
+    #[test]
+    fn live_quality_gate_rejects_known_bad_probe_sets_and_accepts_a_healthy_one() {
+        let probe_count = LIVE_QUALITY_PROBES.len();
+
+        // Every probe fails outright -- mirrors `smollm2-135m-instruct`'s
+        // observed empty `<|im_end|>` output in the #655 sweep.
+        let all_failed = vec![ProbeOutcome::Failed; probe_count];
+        let quality = aggregate_probe_outcomes(&all_failed);
+        assert!(!quality.instruction_eval_passed);
+        assert_eq!(quality.grounded_answer_rate, 0.0);
+        assert_eq!(quality.repetition_rate, 1.0);
+
+        // Every probe "answers" but collapses into a small repeated-token
+        // cycle -- mirrors the #745 word-salad transcripts.
+        let all_degenerate = vec![
+            ProbeOutcome::Answered {
+                non_empty: true,
+                repeated_token_rate: 0.9,
+            };
+            probe_count
+        ];
+        let quality = aggregate_probe_outcomes(&all_degenerate);
+        assert!(!quality.instruction_eval_passed);
+        assert_eq!(quality.grounded_answer_rate, 0.0);
+        assert!((quality.repetition_rate - 0.9).abs() < 1e-6);
+
+        // A genuinely healthy probe set passes.
+        let all_healthy = vec![
+            ProbeOutcome::Answered {
+                non_empty: true,
+                repeated_token_rate: 0.1,
+            };
+            probe_count
+        ];
+        let quality = aggregate_probe_outcomes(&all_healthy);
+        assert!(quality.instruction_eval_passed);
+        assert_eq!(quality.grounded_answer_rate, 1.0);
+
+        // Confirm the documented 0.5 pass bar is exactly where it's
+        // declared to be: exactly half non-degenerate passes (`>=`), one
+        // probe fewer does not.
+        let outcomes_with_healthy_count = |healthy: usize| -> Vec<ProbeOutcome> {
+            (0..probe_count)
+                .map(|i| {
+                    if i < healthy {
+                        ProbeOutcome::Answered {
+                            non_empty: true,
+                            repeated_token_rate: 0.1,
+                        }
+                    } else {
+                        ProbeOutcome::Failed
+                    }
+                })
+                .collect()
+        };
+        let half = probe_count / 2;
+        let at_bar = aggregate_probe_outcomes(&outcomes_with_healthy_count(half));
+        assert!(
+            at_bar.instruction_eval_passed,
+            "exactly half non-degenerate should clear the >= 0.5 bar"
+        );
+        let below_bar = aggregate_probe_outcomes(&outcomes_with_healthy_count(half - 1));
+        assert!(
+            !below_bar.instruction_eval_passed,
+            "one fewer non-degenerate probe should miss the 0.5 bar"
+        );
+    }
 
     fn manifest(capability: ModelCapability, passed: bool) -> ModelManifest {
         let object = ModelObject {


### PR DESCRIPTION
## Summary

`instruction_eval_passed`, `grounded_answer_rate`, and `repetition_rate` were never computed by any code path. `r4 import`'s CLI accepted them as manually-typed `--instruction-eval-passed`/`--grounded-answer-rate`/`--repetition-rate` flags, copied verbatim into the manifest. That's why two manifests over byte-identical compiled artifacts could carry opposite recorded quality and both still pass the gate meant to keep unevaluated or known-bad bundles from being served (#744).

## Fix

For `--capability instruction-chat`, `import` now derives the quality attestation itself:

- Loads the exact `--artifacts`/`--store`/`--tokenizer` bytes being imported (new `chat::engine_from_bytes`).
- Runs them through a fixed probe set of ordinary questions on the real `ask` code path.
- Scores each answer's repetition with a new `recent_window_repetition_rate`, reusing Gate C's greedy-repetition-rate precedent (`uor-r4-graph-certify`'s `generate_greedy_repetition_rate`), but over a window equal to the *full generated length* rather than a fixed 32 tokens.
- `--evaluation-report` is still accepted and stored content-addressed as provenance of the offline D3 evaluation from `evaluate-report`, but is no longer consulted for the pass/fail decision — only the live probe run decides that now.

## A false positive caught during verification

The first working version (32-token window, 0.5 repetition bar) reported the exact #745 bundle (`smollm2-1-7b-instruct`, byte-identical to the `smollm2-1-7b-chat` bundle from the original #655 sweep) as **passing**. I didn't take that at face value — I cross-checked against real `r4 ask` output on the identical bytes via both live code paths:

- Directory-fallback + R4G1 beam-search path: `"cut cut cut cut cut ..."` (single-token degenerate repetition).
- Imported-manifest plain-path: the original #745 word-salad transcript.

Both confirmed the bundle is genuinely broken. Root cause: a 32-token window measured only 0.10–0.25 repetition on this transcript (too locally-scoped — a small pool of recurring fragments diluted by many one-off filler subword tokens). Widening to the full generation raised it to 0.31–0.41 — still under the original 0.5 bar. Fixed by widening the window and lowering `LIVE_QUALITY_REPETITION_BAR` to 0.25, with a code comment stating plainly that this bar is calibrated only against known-*bad* evidence — there's no known-good local bundle yet to confirm it doesn't also reject good output.

Verified end-to-end after the fix: both `smollm2-1-7b-instruct` and `smollm2-135m-instruct` are now correctly rejected by the real `import` CLI (`error=model has not passed its instruction/grounding evaluation gate`).

## Known limitation (not fixed here, filed as a follow-up)

The live probe run only exercises the plain TLA/TLS1 generation path — it never loads or probes a bundle's R4G1 graph, even though `ask`/`chat` prefer R4G1 over the plain path at serving time when a `compiled.r4g1` file exists at the manifest-name-keyed convention path. The two paths can disagree sharply, as shown above (word-salad vs. single-token "cut cut cut" repetition, on the exact same underlying bytes). A manifest that passes today's gate is only guaranteed non-degenerate on the plain path. Documented in `src/chat.rs`, `docs/MODEL_LIFECYCLE.md`, and filed as a separate follow-up issue rather than expanding this PR's scope — see linked issue.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` — clean
- `cargo run -p xtask -- audit-limits` — clean (R5: no unsanctioned error types)
- `cargo test --workspace --offline` — full suite green, including two new tests (`recent_window_repetition_rate_catches_small_vocabulary_cycling_that_repeated_suffix_misses`, `live_quality_gate_rejects_known_bad_probe_sets_and_accepts_a_healthy_one`)
- Manual end-to-end re-verification against both known-bad local bundles via the real `r4 import` CLI, post-fix

References #744 — leaving open rather than closing, since the R4G1-path gap means acceptance criterion 3 ("gate correlates with live `ask` output quality") is only fully satisfied for the plain-path bundles tested so far, not for bundles that would be served via R4G1 at runtime. See PR description above and the follow-up issue for the remaining scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)