### PR TITLE
Probe the R4G1 graph path in the live quality gate (#750)

### DIFF
--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -1237,7 +1237,8 @@ cargo run -- import \
   --artifacts .uor-models/compiled/smollm2-135m-instruct/tless_artifacts.bin \
   --store .uor-models/compiled/smollm2-135m-instruct/tless_store.bin \
   --tokenizer .uor-models/compiled/smollm2-135m-instruct/tokenizer.bin \
-  --evaluation-report /path/to/instruction-eval.json
+  --evaluation-report /path/to/instruction-eval.json \
+  --r4g1 .uor-models/compiled/smollm2-135m-instruct/compiled.r4g1  # optional, see #750 below
 ```
 
 `instruction_eval_passed`, `grounded_answer_rate`, and `repetition_rate` are
@@ -1254,19 +1255,28 @@ pass/fail decision — only the live probe run decides that. This closes the
 gap (#744) where two manifests over byte-identical compiled bytes could
 carry hand-typed, disagreeing quality numbers and both pass.
 
-Known limitation: the live probe run always exercises the plain TLA/TLS1
-generation path, the same one `engine_from_bytes` builds. It does not load
-or probe an R4G1 graph (`compiled.r4g1`), even though `ask`/`chat` will
-transparently prefer an R4G1 graph over the plain path at serving time if
-one exists at the manifest-name-keyed convention path
-(`.uor-models/compiled/<manifest name>/compiled.r4g1`). The two paths can
-disagree sharply — on at least one real local bundle the R4G1 beam-search
-path produced single-token degenerate repetition ("cut cut cut ...") where
-the plain path produced word-salad, i.e. both paths were bad but not
-identically bad. A manifest that passes today's gate is only guaranteed
-non-degenerate on the plain path; if that same bundle also has a
-same-name-keyed `compiled.r4g1` file, `ask` may still serve degenerate
-output despite the gate having passed. Tracked as a follow-up.
+The live probe run always exercises the plain TLA/TLS1 generation path, the
+same one `engine_from_bytes` builds — that's the baseline every bundle must
+clear regardless of which runtime ultimately serves it. When the bundle also
+has a compiled R4G1 graph, pass `--r4g1 <path/to/compiled.r4g1>` (`#750`): the
+probe set is then run a second time through the R4G1 beam-search path, and
+`instruction_eval_passed` requires **both** paths to independently clear the
+pass bar. This matters because `ask`/`chat` transparently prefer an R4G1
+graph over the plain path at serving time whenever one exists at the
+manifest-name-keyed convention path
+(`.uor-models/compiled/<manifest name>/compiled.r4g1`) — and the two paths
+have been observed to diverge sharply on the same underlying bytes: on at
+least one real local bundle the R4G1 beam-search path produced single-token
+degenerate repetition ("cut cut cut ...") where the plain path produced
+word-salad, i.e. both paths were bad but not identically bad. Before `#750`,
+a manifest could pass this gate on the strength of the plain path alone even
+when its same-name-keyed `compiled.r4g1` file was degenerate; `import` now
+catches that case whenever `--r4g1` is supplied. `--r4g1` is optional — a
+bundle imported without a compiled R4G1 graph (or without passing one to
+`import`) is still gated on the plain path only, and its manifest's
+`r4g1_grounded_answer_rate`/`r4g1_repetition_rate` fields stay `None` rather
+than a probed-and-degenerate `Some(0.0)`, so "not probed" stays
+distinguishable from "probed and failed."
 
 The model store defaults to `.uor-models`; set `UOR_MODEL_STORE` to relocate
 it. Objects are stored once under `objects/blake3/<digest>`. Reads verify both

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -694,19 +694,50 @@ fn recent_window_repetition_rate(tokens: &[u32], window: usize) -> f64 {
 /// clear regardless of which runtime ultimately serves it, and the one
 /// whose repetition guard (`repeated_suffix`) is weaker, making it the
 /// conservative choice for a pass/fail gate.
+///
+/// Thin wrapper over [`engine_from_bytes_with_r4g1`] with `r4g1_bytes:
+/// None` — kept as its own function so existing callers that only ever
+/// want the plain path (and any external callers of this crate) are
+/// unaffected by #750's addition of R4G1-path probing.
 pub fn engine_from_bytes(
     artifact_bytes: &[u8],
     store_bytes: &[u8],
     tokenizer_bytes: &[u8],
     max_tokens: usize,
 ) -> Result<ChatEngine, ChatError> {
+    engine_from_bytes_with_r4g1(
+        artifact_bytes,
+        store_bytes,
+        tokenizer_bytes,
+        None,
+        max_tokens,
+    )
+}
+
+/// Same as [`engine_from_bytes`], but accepts an optional R4G1 graph
+/// (`compiled.r4g1` bytes) so a caller — currently only
+/// `model::evaluate_live_quality` (#750) — can construct an engine that
+/// exercises the R4G1 beam-search path (`hologram_answer`'s `r4g1_bytes:
+/// Some(...)` branch) instead of the plain TLA/TLS1 path, the same
+/// validation and CID-binding `ChatEngineBuilder::build()` and
+/// `build_local_compiled_engine` apply to a discovered
+/// `compiled.r4g1` file.
+pub fn engine_from_bytes_with_r4g1(
+    artifact_bytes: &[u8],
+    store_bytes: &[u8],
+    tokenizer_bytes: &[u8],
+    r4g1_bytes: Option<&[u8]>,
+    max_tokens: usize,
+) -> Result<ChatEngine, ChatError> {
     let artifacts = compiler::parse_artifacts(artifact_bytes).ok_or(ChatError::InvalidArtifacts)?;
     let store = runtime::parse_store(store_bytes).ok_or(ChatError::InvalidStore)?;
+    validate_chat_r4g1_structure(r4g1_bytes)?;
+    let r4g1_bytes = bind_chat_r4g1(r4g1_bytes.map(<[u8]>::to_vec), tokenizer_bytes)?;
     let tokenizer = parse_chat_tokenizer(tokenizer_bytes)?;
     Ok(ChatEngine {
         artifacts,
         store,
-        r4g1_bytes: None,
+        r4g1_bytes,
         tokenizer,
         history: [0; MAX_CHAT_HISTORY],
         history_len: 0,
@@ -2579,7 +2610,7 @@ fn render_audit_trace_record(
 #[cfg(test)]
 mod tests {
     use super::{
-        bind_chat_r4g1, ensure_chat_prompt_encoder, parse_remote_url,
+        bind_chat_r4g1, engine_from_bytes_with_r4g1, ensure_chat_prompt_encoder, parse_remote_url,
         recent_window_repetition_rate, repeated_suffix, select_chat_tokenizer_bytes, ChatError,
     };
     use uor_r4_core::transformerless::scenarios::{
@@ -2750,6 +2781,67 @@ mod tests {
                 .as_deref(),
             Some(legacy.as_slice())
         );
+    }
+
+    /// #750 falsifier: `engine_from_bytes_with_r4g1` must actually thread
+    /// the supplied graph bytes into the resulting `ChatEngine` (bound and
+    /// validated the same way `ChatEngineBuilder::build()` does), not
+    /// silently drop them the way `engine_from_bytes` always has. A
+    /// plumbing bug here would defeat #750's entire point: the quality
+    /// gate could believe it probed the R4G1 path while actually still
+    /// only exercising the plain path.
+    #[test]
+    fn engine_from_bytes_with_r4g1_actually_threads_the_graph_bytes_through() {
+        use uor_r4_core::transformerless::{compiler, runtime};
+
+        let art_bytes = std::fs::read("crates/uor-r4-core/tests/fixtures/tless_artifacts.bin")
+            .expect("fixture artifacts present");
+        let mut store: runtime::Store =
+            (0..=compiler::STAGES).map(|_| Default::default()).collect();
+        runtime::add_evidence(&mut store, &[3, 1, 4, 1], 7, 5);
+        let store_bytes = runtime::store_bytes(&store);
+
+        let mut tokenizer_bytes = Vec::new();
+        for piece in [b"<unk>".as_slice(), b"a".as_slice(), b"b".as_slice()] {
+            tokenizer_bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+            tokenizer_bytes.extend_from_slice(piece);
+        }
+
+        // No graph supplied: behaves exactly like the original
+        // `engine_from_bytes` (r4g1_bytes stays None).
+        let plain_only =
+            engine_from_bytes_with_r4g1(&art_bytes, &store_bytes, &tokenizer_bytes, None, 8)
+                .expect("plain engine builds");
+        assert!(plain_only.r4g1_bytes.is_none());
+
+        // A graph is supplied: it must survive validation/binding and end
+        // up populated on the engine, so `ask()` actually takes the R4G1
+        // branch of `hologram_answer` rather than silently falling back.
+        let graph = minimal_graph([0; 32]);
+        let with_graph = engine_from_bytes_with_r4g1(
+            &art_bytes,
+            &store_bytes,
+            &tokenizer_bytes,
+            Some(&graph),
+            8,
+        )
+        .expect("engine with graph builds");
+        assert_eq!(with_graph.r4g1_bytes.as_deref(), Some(graph.as_slice()));
+
+        // A structurally invalid graph is rejected up front rather than
+        // silently ignored (mirrors `ChatEngineBuilder::build()`'s own
+        // `validate_chat_r4g1_structure` gate).
+        let result = engine_from_bytes_with_r4g1(
+            &art_bytes,
+            &store_bytes,
+            &tokenizer_bytes,
+            Some(&[0u8; 4]),
+            8,
+        );
+        match result {
+            Err(error) => assert!(matches!(error, ChatError::Io(_))),
+            Ok(_) => panic!("truncated graph bytes must be rejected"),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,13 @@ struct ImportArgs {
     store: PathBuf,
     #[arg(long)]
     tokenizer: PathBuf,
+    /// Optional compiled R4G1 graph (`compiled.r4g1`). When present, the
+    /// live quality gate (#750) probes this path in addition to the plain
+    /// TLA path and requires both to pass, since `r4 ask`/`r4 chat` will
+    /// transparently prefer this graph over the plain path at serving time
+    /// if one exists at the manifest-name-keyed convention path.
+    #[arg(long)]
+    r4g1: Option<PathBuf>,
     /// Offline held-out evaluation report from `r4 evaluate-report`.
     /// Required for `--capability instruction-chat`: not consulted for
     /// the pass/fail decision (that's `evaluate_live_quality`, run
@@ -557,6 +564,7 @@ fn import(args: &ImportArgs) -> Result<(), RunError> {
     let artifact_bytes = std::fs::read(&args.artifacts)?;
     let store_bytes = std::fs::read(&args.store)?;
     let tokenizer_bytes = std::fs::read(&args.tokenizer)?;
+    let r4g1_bytes = args.r4g1.as_ref().map(std::fs::read).transpose()?;
     // Quality is DERIVED, not accepted as operator input (#744): a
     // manually-typed `--grounded-answer-rate`/`--repetition-rate` could
     // (and did) disagree with the actual compiled bytes and with itself
@@ -564,15 +572,22 @@ fn import(args: &ImportArgs) -> Result<(), RunError> {
     // bundles are never chat-gated (`validate_for_chat` below), so there
     // is nothing honest to compute for them; they get a fixed
     // not-evaluated attestation instead of running probes that would
-    // never be consulted.
+    // never be consulted. When `--r4g1` is supplied, #750 requires that
+    // path to independently pass too, since `ask`/`chat` will prefer it
+    // over the plain path at serving time.
     let quality = match args.capability {
-        Capability::InstructionChat => {
-            evaluate_live_quality(&artifact_bytes, &store_bytes, &tokenizer_bytes)?
-        }
+        Capability::InstructionChat => evaluate_live_quality(
+            &artifact_bytes,
+            &store_bytes,
+            &tokenizer_bytes,
+            r4g1_bytes.as_deref(),
+        )?,
         Capability::Continuation => QualityAttestation {
             instruction_eval_passed: false,
             grounded_answer_rate: 0.0,
             repetition_rate: 1.0,
+            r4g1_grounded_answer_rate: None,
+            r4g1_repetition_rate: None,
         },
     };
     let artifacts = model_store.put(&artifact_bytes)?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -69,11 +69,28 @@ pub struct ModelObject {
 /// stays at or below [`LIVE_QUALITY_REPETITION_BAR`] — i.e. the answer is
 /// not empty and not dominated by recently-repeated tokens, the failure
 /// mode observed in `#745`'s word-salad transcripts.
+///
+/// `grounded_answer_rate`/`repetition_rate` are always the **plain
+/// TLA/TLS1 path**'s results, the baseline every bundle must clear
+/// regardless of which runtime ultimately serves it. `#750`: when the
+/// import also supplies an R4G1 graph (`--r4g1`), that path is probed
+/// too and its results land in `r4g1_grounded_answer_rate`/
+/// `r4g1_repetition_rate` — `None` when no R4G1 graph was supplied,
+/// distinct from a probed-and-degenerate `Some(0.0)`.
+/// `instruction_eval_passed` requires **both** paths to independently
+/// clear the bar when both were probed (see `combine_path_quality`) —
+/// `ask`/`chat` will actually serve whichever path is available at
+/// runtime for a given manifest name, so a pass on one path cannot
+/// paper over a fail on the other.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualityAttestation {
     pub instruction_eval_passed: bool,
     pub grounded_answer_rate: f32,
     pub repetition_rate: f32,
+    #[serde(default)]
+    pub r4g1_grounded_answer_rate: Option<f32>,
+    #[serde(default)]
+    pub r4g1_repetition_rate: Option<f32>,
 }
 
 /// Fixed probe set for [`evaluate_live_quality`] (`#744`): ordinary
@@ -136,7 +153,20 @@ enum ProbeOutcome {
     Failed,
 }
 
-fn aggregate_probe_outcomes(outcomes: &[ProbeOutcome]) -> QualityAttestation {
+/// One code path's reduced probe results, before combination across
+/// paths (`#750`). Kept separate from the final [`QualityAttestation`]
+/// so [`combine_path_quality`] — the actual cross-path pass/fail policy
+/// — can be exercised by a fast, deterministic unit test without
+/// loading a real compiled bundle, the same discipline
+/// `aggregate_probe_outcomes`'s `#744` falsifier already established.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PathQuality {
+    passed: bool,
+    grounded_answer_rate: f32,
+    repetition_rate: f32,
+}
+
+fn aggregate_probe_outcomes(outcomes: &[ProbeOutcome]) -> PathQuality {
     debug_assert!(!outcomes.is_empty(), "probe set must be non-empty");
     let mut non_degenerate = 0usize;
     let mut repetition_sum = 0.0f64;
@@ -159,43 +189,65 @@ fn aggregate_probe_outcomes(outcomes: &[ProbeOutcome]) -> QualityAttestation {
     let probe_count = outcomes.len().max(1);
     let grounded_answer_rate = non_degenerate as f32 / probe_count as f32;
     let repetition_rate = (repetition_sum / probe_count as f64) as f32;
-    QualityAttestation {
-        instruction_eval_passed: grounded_answer_rate >= LIVE_QUALITY_PASS_BAR,
+    PathQuality {
+        passed: grounded_answer_rate >= LIVE_QUALITY_PASS_BAR,
         grounded_answer_rate,
         repetition_rate,
     }
 }
 
-/// Run [`LIVE_QUALITY_PROBES`] against the exact bytes being imported and
-/// derive a [`QualityAttestation`] from the results (`#744`). Fails fast
-/// with a real error if the bytes cannot even be loaded, rather than
-/// scoring repeated identical load failures into the metrics below — an
-/// unloadable bundle is a defect in the import inputs, not a
-/// generation-quality signal for this gate to describe.
+/// Combine the plain-path and (when a bundle carries a `compiled.r4g1`
+/// graph) R4G1-path probe results into the manifest's final
+/// [`QualityAttestation`] (`#750`). `ask`/`chat` will actually serve
+/// whichever path is available at runtime for a given manifest name, so
+/// silently averaging the two paths, or taking whichever is better,
+/// would let a bundle that is degenerate under one of them still pass —
+/// both paths must independently clear the bar when both were probed.
+fn combine_path_quality(plain: PathQuality, r4g1: Option<PathQuality>) -> QualityAttestation {
+    QualityAttestation {
+        instruction_eval_passed: plain.passed && r4g1.is_none_or(|path| path.passed),
+        grounded_answer_rate: plain.grounded_answer_rate,
+        repetition_rate: plain.repetition_rate,
+        r4g1_grounded_answer_rate: r4g1.map(|path| path.grounded_answer_rate),
+        r4g1_repetition_rate: r4g1.map(|path| path.repetition_rate),
+    }
+}
+
+/// Run [`LIVE_QUALITY_PROBES`] against the exact bytes being imported,
+/// through the plain TLA/TLS1 path (`r4g1_bytes: None`) or through the
+/// R4G1 beam-search path when `r4g1_bytes` is supplied, and reduce the
+/// results to a [`PathQuality`] (`#744`, path parameter added `#750`).
+/// Fails fast with a real error if the bytes cannot even be loaded,
+/// rather than scoring repeated identical load failures into the
+/// metrics below — an unloadable bundle is a defect in the import
+/// inputs, not a generation-quality signal for this gate to describe.
 ///
 /// A fresh engine is built per probe: the probes are independent
 /// ordinary questions, not turns of one conversation, so no chat history
 /// should carry between them.
-pub fn evaluate_live_quality(
+fn run_live_quality_probe_set(
     artifact_bytes: &[u8],
     store_bytes: &[u8],
     tokenizer_bytes: &[u8],
-) -> Result<QualityAttestation, ModelError> {
+    r4g1_bytes: Option<&[u8]>,
+) -> Result<PathQuality, ModelError> {
     const PROBE_MAX_TOKENS: usize = 64;
-    crate::chat::engine_from_bytes(
+    crate::chat::engine_from_bytes_with_r4g1(
         artifact_bytes,
         store_bytes,
         tokenizer_bytes,
+        r4g1_bytes,
         PROBE_MAX_TOKENS,
     )
     .map_err(|error| ModelError::Io(std::io::Error::other(error.to_string())))?;
 
     let mut outcomes = Vec::with_capacity(LIVE_QUALITY_PROBES.len());
     for probe in LIVE_QUALITY_PROBES {
-        let mut engine = crate::chat::engine_from_bytes(
+        let mut engine = crate::chat::engine_from_bytes_with_r4g1(
             artifact_bytes,
             store_bytes,
             tokenizer_bytes,
+            r4g1_bytes,
             PROBE_MAX_TOKENS,
         )
         .map_err(|error| ModelError::Io(std::io::Error::other(error.to_string())))?;
@@ -208,6 +260,35 @@ pub fn evaluate_live_quality(
         });
     }
     Ok(aggregate_probe_outcomes(&outcomes))
+}
+
+/// Derive a [`QualityAttestation`] for the exact bytes being imported
+/// (`#744`). When `r4g1_bytes` is supplied (`#750`, `r4 import --r4g1
+/// <path>`), the probe set is run a second time through the R4G1
+/// beam-search path and both paths must independently pass — see
+/// [`combine_path_quality`] — since `ask`/`chat` will transparently
+/// prefer an R4G1 graph over the plain path at serving time when one
+/// exists at the manifest-name-keyed convention path, and the two paths
+/// have been observed to diverge sharply on the same underlying bytes
+/// (one bundle: `"cut cut cut ..."` under R4G1 vs. word-salad on the
+/// plain path).
+pub fn evaluate_live_quality(
+    artifact_bytes: &[u8],
+    store_bytes: &[u8],
+    tokenizer_bytes: &[u8],
+    r4g1_bytes: Option<&[u8]>,
+) -> Result<QualityAttestation, ModelError> {
+    let plain = run_live_quality_probe_set(artifact_bytes, store_bytes, tokenizer_bytes, None)?;
+    let r4g1 = match r4g1_bytes {
+        Some(bytes) => Some(run_live_quality_probe_set(
+            artifact_bytes,
+            store_bytes,
+            tokenizer_bytes,
+            Some(bytes),
+        )?),
+        None => None,
+    };
+    Ok(combine_path_quality(plain, r4g1))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -241,6 +322,16 @@ impl ModelManifest {
             || !(0.0..=1.0).contains(&self.quality.repetition_rate)
         {
             return Err(ModelError::InvalidQualityMetrics);
+        }
+        if let Some(rate) = self.quality.r4g1_grounded_answer_rate {
+            if !(0.0..=1.0).contains(&rate) {
+                return Err(ModelError::InvalidQualityMetrics);
+            }
+        }
+        if let Some(rate) = self.quality.r4g1_repetition_rate {
+            if !(0.0..=1.0).contains(&rate) {
+                return Err(ModelError::InvalidQualityMetrics);
+            }
         }
         Ok(())
     }
@@ -1470,7 +1561,7 @@ mod tests {
         // observed empty `<|im_end|>` output in the #655 sweep.
         let all_failed = vec![ProbeOutcome::Failed; probe_count];
         let quality = aggregate_probe_outcomes(&all_failed);
-        assert!(!quality.instruction_eval_passed);
+        assert!(!quality.passed);
         assert_eq!(quality.grounded_answer_rate, 0.0);
         assert_eq!(quality.repetition_rate, 1.0);
 
@@ -1484,7 +1575,7 @@ mod tests {
             probe_count
         ];
         let quality = aggregate_probe_outcomes(&all_degenerate);
-        assert!(!quality.instruction_eval_passed);
+        assert!(!quality.passed);
         assert_eq!(quality.grounded_answer_rate, 0.0);
         assert!((quality.repetition_rate - 0.9).abs() < 1e-6);
 
@@ -1497,7 +1588,7 @@ mod tests {
             probe_count
         ];
         let quality = aggregate_probe_outcomes(&all_healthy);
-        assert!(quality.instruction_eval_passed);
+        assert!(quality.passed);
         assert_eq!(quality.grounded_answer_rate, 1.0);
 
         // Confirm the documented 0.5 pass bar is exactly where it's
@@ -1520,14 +1611,67 @@ mod tests {
         let half = probe_count / 2;
         let at_bar = aggregate_probe_outcomes(&outcomes_with_healthy_count(half));
         assert!(
-            at_bar.instruction_eval_passed,
+            at_bar.passed,
             "exactly half non-degenerate should clear the >= 0.5 bar"
         );
         let below_bar = aggregate_probe_outcomes(&outcomes_with_healthy_count(half - 1));
         assert!(
-            !below_bar.instruction_eval_passed,
+            !below_bar.passed,
             "one fewer non-degenerate probe should miss the 0.5 bar"
         );
+    }
+
+    /// Falsifier for `#750`'s cross-path combination policy: a bundle
+    /// that is healthy on the plain path but degenerate on R4G1 (the
+    /// exact divergence observed on a real local bundle -- "cut cut
+    /// cut ..." under R4G1 vs. word-salad on plain, both bad but not
+    /// identically bad) must NOT pass overall, since `ask`/`chat` will
+    /// serve the R4G1 path whenever one is present. Exercises
+    /// `combine_path_quality` directly, without loading a real compiled
+    /// bundle, following the same discipline as `#744`'s falsifier
+    /// above.
+    #[test]
+    fn combine_path_quality_requires_both_probed_paths_to_pass() {
+        let healthy = PathQuality {
+            passed: true,
+            grounded_answer_rate: 0.9,
+            repetition_rate: 0.05,
+        };
+        let degenerate = PathQuality {
+            passed: false,
+            grounded_answer_rate: 0.0,
+            repetition_rate: 0.95,
+        };
+
+        // No R4G1 graph supplied: only the plain path's verdict matters,
+        // and the r4g1_* fields stay None (not a probed-and-degenerate
+        // Some(0.0)) so a manifest without a graph is distinguishable
+        // from one that was probed and found wanting.
+        let plain_only = combine_path_quality(healthy, None);
+        assert!(plain_only.instruction_eval_passed);
+        assert_eq!(plain_only.r4g1_grounded_answer_rate, None);
+        assert_eq!(plain_only.r4g1_repetition_rate, None);
+
+        // Plain healthy, R4G1 degenerate: must fail overall -- this is
+        // the exact scenario #750 exists to catch, since #744's gate
+        // alone would have looked only at the plain path and passed it.
+        let plain_healthy_r4g1_degenerate = combine_path_quality(healthy, Some(degenerate));
+        assert!(!plain_healthy_r4g1_degenerate.instruction_eval_passed);
+        assert_eq!(
+            plain_healthy_r4g1_degenerate.r4g1_grounded_answer_rate,
+            Some(0.0)
+        );
+
+        // Both paths healthy: passes.
+        let both_healthy = combine_path_quality(healthy, Some(healthy));
+        assert!(both_healthy.instruction_eval_passed);
+
+        // Plain degenerate, R4G1 healthy: still fails -- a healthy R4G1
+        // graph cannot paper over a degenerate plain path either, since
+        // a manifest without an R4G1 graph present at serving time (or
+        // one that's later removed) falls back to the plain path.
+        let plain_degenerate_r4g1_healthy = combine_path_quality(degenerate, Some(healthy));
+        assert!(!plain_degenerate_r4g1_healthy.instruction_eval_passed);
     }
 
     fn manifest(capability: ModelCapability, passed: bool) -> ModelManifest {
@@ -1555,6 +1699,8 @@ mod tests {
                 instruction_eval_passed: passed,
                 grounded_answer_rate: 0.8,
                 repetition_rate: 0.01,
+                r4g1_grounded_answer_rate: None,
+                r4g1_repetition_rate: None,
             },
         }
     }


### PR DESCRIPTION
## Summary

Closes the gap #750 named: `evaluate_live_quality` (the `#744` live quality
gate) always built its probe engine with `r4g1_bytes: None`, so `r4 import`
only ever exercised the plain TLA/TLS1 generation path -- even though
`ask`/`chat` transparently prefer a manifest-name-keyed `compiled.r4g1`
graph over the plain path at serving time whenever one exists. The two
paths have been observed to diverge sharply on the same underlying bytes
(one bundle: single-token degenerate repetition under R4G1 vs. word-salad
on plain, both bad but not identically bad), so a manifest could pass the
gate on the strength of one path while still serving degenerate output
through the other.

## Changes

- `chat::engine_from_bytes_with_r4g1(artifact_bytes, store_bytes,
  tokenizer_bytes, r4g1_bytes: Option<&[u8]>, max_tokens)` splits out of
  `engine_from_bytes` (now a thin wrapper), so the gate can build an
  engine bound to either path on demand.
- `model::evaluate_live_quality` gains an `r4g1_bytes: Option<&[u8]>`
  parameter. When supplied, the fixed 8-question probe set runs a second
  time through the R4G1 path via a new `run_live_quality_probe_set`
  helper, and a new `combine_path_quality(plain, r4g1)` function requires
  **both** probed paths to independently pass before
  `instruction_eval_passed` is true -- silently averaging or taking the
  better path would let a bundle degenerate on one path still pass.
- `QualityAttestation` gains `r4g1_grounded_answer_rate` /
  `r4g1_repetition_rate: Option<f32>` fields, `#[serde(default)]` so
  existing manifests deserialize unchanged (no `MANIFEST_SCHEMA` bump
  needed). `None` means "not probed" (no R4G1 graph supplied at import
  time), distinct from a probed-and-degenerate `Some(0.0)`.
- `r4 import` gains an optional `--r4g1 <path/to/compiled.r4g1>` flag
  threading the graph bytes through to the gate. `validate_for_chat` now
  also range-checks the new fields when present.
- `docs/MODEL_LIFECYCLE.md`'s step-6 "Known limitation" paragraph rewritten
  to describe the fix instead of the gap, and its `import` example updated
  to show `--r4g1`.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo run -p xtask -- audit-limits`
- `cargo test --workspace --offline` -- full suite, no failures
- Real-bundle check against `smollm2-1-7b-instruct` (a real local bundle
  carrying a `compiled.r4g1`, using a scratch `UOR_MODEL_STORE` so nothing
  touched the checkout): `r4 import --r4g1 <path>` and a plain-only
  `r4 import` of the identical bytes both correctly reject the bundle via
  `ModelError::QualityGateFailed` -- confirms the gate now catches a
  known-divergent bundle regardless of which path is probed. (This
  particular bundle turned out to already fail on the plain path too, per
  `#745`'s prior word-salad finding, so it doesn't showcase the
  plain-passes/R4G1-fails split specifically -- that exact scenario is
  what the new synthetic falsifier test below covers directly.)

New tests:
- `chat::tests::engine_from_bytes_with_r4g1_actually_threads_the_graph_bytes_through`
  -- confirms the new function actually binds/validates supplied graph
  bytes into the resulting `ChatEngine`, and rejects structurally invalid
  ones.
- `model::tests::combine_path_quality_requires_both_probed_paths_to_pass`
  -- the falsifier this issue's acceptance criteria calls for: a synthetic
  plain-healthy + R4G1-degenerate case must not pass overall; plain-only
  (no R4G1 supplied) passes on the plain verdict alone; both-healthy
  passes; plain-degenerate + R4G1-healthy still fails.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)
