### PR TITLE
Add opt-in weighted sampling to break the #759 attractor-basin collapse (#762)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/runtime.rs
+++ b/crates/uor-r4-core/src/transformerless/runtime.rs
@@ -929,6 +929,77 @@ fn fallback_prediction(store: &Store) -> Prediction {
     Prediction::default()
 }
 
+/// Division-free xorshift32 PRNG (issue #762 lever 2 prototype): the same
+/// bit-mixing shape already used as a test-only fixture elsewhere in this
+/// crate (`p2_hamming_exact` in `mod.rs`), reused here as a real runtime
+/// primitive. Shift and xor only — no multiply/divide/modulo — so it stays
+/// inside this file's P-4 scan (`p4_runtime_source_scan` in `mod.rs`).
+#[derive(Debug, Clone, Copy)]
+pub struct SampleRng(u32);
+
+impl SampleRng {
+    /// A zero seed would make xorshift32 output zero forever; substitute a
+    /// fixed nonzero constant so every caller-supplied seed (including 0)
+    /// still produces a real sequence.
+    pub fn new(seed: u32) -> Self {
+        SampleRng(if seed == 0 { 0xACE1_u32 } else { seed })
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.0 = x;
+        x
+    }
+}
+
+/// Reduce `value` into `[0, bound)` using shift/compare/subtract only —
+/// the classic restoring binary long-division remainder algorithm, spelled
+/// out by hand because this file's P-4 contract forbids the native `/`,
+/// `%`, and `*` operators (see `p4_runtime_source_scan` in `mod.rs`, which
+/// scans this whole file including its own test code). `bound == 0`
+/// returns 0 rather than panicking; callers are not expected to sample
+/// against an empty candidate set (mirrors `predict_witness`'s own
+/// empty-`dist` handling). Exhaustively checked against the real `%`
+/// operator in `crates/uor-r4-core/tests/sampling_reduction_762.rs` —
+/// that verification lives outside this file for the same reason
+/// `dot_assignment_tests` lives in `mod.rs` rather than here. `pub` (not
+/// `pub(crate)`) because that external test file is compiled as a
+/// separate crate and can only see this crate's public API.
+pub fn reduce_into_range(mut value: u32, bound: u32) -> u32 {
+    if bound == 0 {
+        return 0;
+    }
+    if value < bound {
+        return value;
+    }
+    // Align: find the largest `shift` such that `bound << shift` does not
+    // overflow past 32 bits and is still <= value.
+    let mut shift = 0u32;
+    while bound.leading_zeros() > shift {
+        let candidate = bound << (shift + 1);
+        if candidate > value {
+            break;
+        }
+        shift += 1;
+    }
+    // Restoring division: subtract the aligned divisor at each bit
+    // position from high to low.
+    loop {
+        let divisor = bound << shift;
+        if divisor <= value {
+            value -= divisor;
+        }
+        if shift == 0 {
+            break;
+        }
+        shift -= 1;
+    }
+    value
+}
+
 /// Plain-form prediction with witness: deepest populated class argmax with
 /// backoff; canonical rule — highest count, ties to smallest token id
 /// (first in B-tree order) — identical to the kernel path.
@@ -1326,6 +1397,71 @@ impl<'a> Runtime<'a> {
         fallback
     }
 
+    /// Sampling sibling of `predict_witness` (issue #762 lever 2
+    /// prototype): draws one candidate from the resolved depth's full
+    /// distribution with probability proportional to its
+    /// repetition-penalized score, instead of always taking the argmax.
+    /// Strictly additive and opt-in — `predict_witness` and every existing
+    /// caller (`generate_greedy_into`, `r4 ask`/`r4 chat`'s default path)
+    /// are completely unchanged; nothing reaches this function unless a
+    /// caller explicitly calls it or `generate_sampled_into` below. Uses
+    /// `SampleRng`/`reduce_into_range` (below `fallback_prediction`) so no
+    /// `/`, `%`, or `*` operator appears anywhere in the selection path,
+    /// keeping this file's P-4 contract intact for the new code too — see
+    /// `p4_runtime_source_scan` in `mod.rs`, which covers this whole file.
+    pub fn predict_witness_sampled(
+        &mut self,
+        store: &Store,
+        code: &[u8; STAGES],
+        rng: &mut SampleRng,
+    ) -> Prediction {
+        for d in (0..=STAGES).rev() {
+            if let Some(dist) = store[d].get(&code[..d]) {
+                if dist.is_empty() {
+                    continue;
+                }
+                let mut total_weight = 0u32;
+                let mut candidates: Vec<(u32, u32, u32)> = Vec::with_capacity(dist.len());
+                for (&t, &cnt) in dist {
+                    self.kernel.candidate_scan();
+                    let mut score = cnt as i64;
+                    let occurrences = self.state.token_occurrences(t);
+                    if occurrences > 0 {
+                        let val = occurrences as i64;
+                        score -= (val << 10) - (val << 4) - (val << 3);
+                    }
+                    // Every candidate keeps at least weight 1 so a
+                    // heavily repetition-penalized token remains reachable
+                    // (small chance) rather than being excluded outright —
+                    // a soft version of today's deterministic policy, not
+                    // a different one.
+                    let weight = if score > 0 { score as u32 } else { 1 };
+                    total_weight = total_weight.saturating_add(weight);
+                    candidates.push((t, weight, cnt));
+                }
+                let draw = reduce_into_range(rng.next_u32(), total_weight);
+                let mut acc = 0u32;
+                let mut chosen = candidates[0];
+                for &(t, w, cnt) in &candidates {
+                    acc = acc.saturating_add(w);
+                    if draw < acc {
+                        chosen = (t, w, cnt);
+                        break;
+                    }
+                }
+                self.state.record_token(chosen.0);
+                return Prediction {
+                    token: chosen.0,
+                    depth: d as u8,
+                    count: chosen.2,
+                };
+            }
+        }
+        let fallback = fallback_prediction(store);
+        self.state.record_token(fallback.token);
+        fallback
+    }
+
     /// Kernel-counted beam prediction (issue #281): deepest level where
     /// any membership prefix has evidence; merged-distribution argmax with
     /// the same repetition-penalty state as `predict_witness`. Merging is
@@ -1493,6 +1629,38 @@ impl<'a> Runtime<'a> {
         for slot in out.iter_mut() {
             let code = self.assign_window(&window[..window_len]);
             let p = self.predict_witness(store, &code);
+            if window_len < WINDOW {
+                window[window_len] = p.token;
+                window_len += 1;
+            } else {
+                window.copy_within(1.., 0);
+                window[WINDOW - 1] = p.token;
+            }
+            *slot = p;
+        }
+        out.len()
+    }
+
+    /// Sampling sibling of `generate_greedy_into` (issue #762 lever 2
+    /// prototype): identical rolling-window mechanics, but selects each
+    /// step's token via `predict_witness_sampled` instead of
+    /// `predict_witness`. Strictly opt-in — nothing in the default
+    /// `r4 ask`/`r4 chat` path calls this; a caller must explicitly choose
+    /// it (and a seed) to get sampled generation.
+    pub fn generate_sampled_into(
+        &mut self,
+        store: &Store,
+        seed: &[u32],
+        rng: &mut SampleRng,
+        out: &mut [Prediction],
+    ) -> usize {
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+        for slot in out.iter_mut() {
+            let code = self.assign_window(&window[..window_len]);
+            let p = self.predict_witness_sampled(store, &code, rng);
             if window_len < WINDOW {
                 window[window_len] = p.token;
                 window_len += 1;

--- a/crates/uor-r4-core/tests/sampling_prediction_762.rs
+++ b/crates/uor-r4-core/tests/sampling_prediction_762.rs
@@ -1,0 +1,182 @@
+//! Regression tests for issue #762 lever 2 (`predict_witness_sampled`,
+//! `generate_sampled_into`): proves the new opt-in sampling path is
+//! genuinely probabilistic (varies with seed) yet reproducible (fixed seed
+//! -> fixed output), stays within the evidence set, and does not change
+//! `predict_witness`'s or `generate_greedy_into`'s existing deterministic
+//! behavior at all.
+
+use std::collections::BTreeSet;
+
+use uor_r4_core::transformerless::compiler::{self, Compiled, STAGES};
+use uor_r4_core::transformerless::runtime::{self, Prediction, Runtime, SampleRng, Store};
+
+fn fixture_artifacts() -> Compiled {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(format!("{dir}/tests/fixtures/tless_artifacts.bin"))
+        .expect("fixture artifacts.bin present");
+    compiler::parse_artifacts(&bytes).expect("fixture artifacts parse")
+}
+
+/// A store with a rich, contested distribution: several tokens with
+/// meaningfully different counts under one code, so argmax always picks
+/// the same winner (10, the highest count) but weighted sampling has real
+/// spread to work with. `add_evidence` always also writes the depth-0
+/// (empty-key, universal) row, so this evidence is reachable via
+/// `assign_window` fallback regardless of what code an arbitrary window
+/// resolves to — see `add_evidence_multi` in runtime.rs.
+fn rich_store() -> Store {
+    let mut store: Store = (0..=STAGES).map(|_| Default::default()).collect();
+    let code = [0u8; STAGES];
+    runtime::add_evidence(&mut store, &code, 10, 50);
+    runtime::add_evidence(&mut store, &code, 20, 30);
+    runtime::add_evidence(&mut store, &code, 30, 15);
+    runtime::add_evidence(&mut store, &code, 40, 5);
+    store
+}
+
+#[test]
+fn predict_witness_sampled_is_deterministic_for_a_fixed_seed() {
+    let art = fixture_artifacts();
+    let store = rich_store();
+    let code = [0u8; STAGES];
+
+    let mut rt_a = Runtime::new(&art);
+    let mut rng_a = SampleRng::new(42);
+    let a = rt_a.predict_witness_sampled(&store, &code, &mut rng_a);
+
+    let mut rt_b = Runtime::new(&art);
+    let mut rng_b = SampleRng::new(42);
+    let b = rt_b.predict_witness_sampled(&store, &code, &mut rng_b);
+
+    assert_eq!(a, b, "same seed must reproduce the same sampled prediction");
+}
+
+#[test]
+fn predict_witness_sampled_varies_across_seeds_on_a_contested_distribution() {
+    let art = fixture_artifacts();
+    let store = rich_store();
+    let code = [0u8; STAGES];
+
+    let mut seen = BTreeSet::new();
+    for seed in 0u32..64 {
+        let mut rt = Runtime::new(&art);
+        let mut rng = SampleRng::new(seed);
+        let p = rt.predict_witness_sampled(&store, &code, &mut rng);
+        seen.insert(p.token);
+    }
+    assert!(
+        seen.len() > 1,
+        "sampling across 64 seeds on a 4-candidate contested distribution \
+         picked only one distinct token — sampling is not actually varying \
+         the outcome"
+    );
+}
+
+#[test]
+fn predict_witness_sampled_never_returns_a_token_outside_the_evidence_set() {
+    let art = fixture_artifacts();
+    let store = rich_store();
+    let code = [0u8; STAGES];
+    let valid: BTreeSet<u32> = [10, 20, 30, 40].into_iter().collect();
+
+    for seed in 0u32..200 {
+        let mut rt = Runtime::new(&art);
+        let mut rng = SampleRng::new(seed);
+        let p = rt.predict_witness_sampled(&store, &code, &mut rng);
+        assert!(
+            valid.contains(&p.token),
+            "seed {seed} produced token {} outside the evidence set",
+            p.token
+        );
+    }
+}
+
+#[test]
+fn predict_witness_default_path_is_unchanged_by_the_sampling_addition() {
+    let art = fixture_artifacts();
+    let store = rich_store();
+    let code = [0u8; STAGES];
+
+    let mut rt = Runtime::new(&art);
+    let p = rt.predict_witness(&store, &code);
+    // The highest-count candidate (10, count 50) must still win under
+    // plain argmax, unaffected by predict_witness_sampled existing in the
+    // same impl block.
+    assert_eq!(p.token, 10);
+    assert_eq!(p.count, 50);
+}
+
+#[test]
+fn generate_sampled_into_varies_across_seeds_and_generate_greedy_into_is_unaffected() {
+    let art = fixture_artifacts();
+    let store = rich_store();
+    let seed_tokens = [1u32, 2, 3];
+
+    // generate_greedy_into: deterministic, resolved every step via the
+    // depth-0 fallback row (this store has no evidence at any code an
+    // arbitrary [1, 2, 3] window resolves to, so `predict_witness` always
+    // falls through to the universal empty-key row -- same distribution,
+    // {10: 50, 20: 30, 30: 15, 40: 5}, at each of the 4 steps).
+    //
+    // The naive expectation is "always token 10" (the argmax winner), but
+    // `predict_witness`'s existing, pre-#762 repetition penalty
+    // (`self.state.token_occurrences(t)`, scored via
+    // `score -= (val << 10) - (val << 4) - (val << 3)`) already fires as
+    // soon as a token has been emitted once in this `Runtime`'s state, not
+    // just on an immediate repeat. So each step's winner is knocked out of
+    // contention for every later step, and the 4 steps walk the
+    // distribution in count order: 10 (score 50, first pick) -> 20 (10 is
+    // now penalized to -950, 20's 30 wins) -> 30 (10 and 20 penalized, 30's
+    // 15 wins) -> 40 (10/20/30 penalized, 40's 5 wins by default). This is
+    // existing `predict_witness` behavior, unrelated to and unaffected by
+    // the #762 sampling addition -- asserting the exact sequence here (not
+    // "always 10") is what actually proves the default path is unchanged.
+    let mut rt = Runtime::new(&art);
+    let mut out = [Prediction::default(); 4];
+    rt.generate_greedy_into(&store, &seed_tokens, &mut out);
+    let tokens: Vec<u32> = out.iter().map(|p| p.token).collect();
+    assert_eq!(
+        tokens,
+        vec![10, 20, 30, 40],
+        "generate_greedy_into's default (unsampled) path must still walk \
+         the repetition-penalized distribution in this exact, established \
+         order -- any change here means the sampling addition perturbed \
+         the existing deterministic path"
+    );
+
+    // generate_sampled_into: collect the first generated token across many
+    // seeds and confirm it isn't always 10.
+    let mut seen = BTreeSet::new();
+    for seed in 0u32..64 {
+        let mut rt = Runtime::new(&art);
+        let mut rng = SampleRng::new(seed);
+        let mut out = [Prediction::default(); 1];
+        rt.generate_sampled_into(&store, &seed_tokens, &mut rng, &mut out);
+        seen.insert(out[0].token);
+    }
+    assert!(
+        seen.len() > 1,
+        "generate_sampled_into across 64 seeds picked only one distinct \
+         first token"
+    );
+}
+
+#[test]
+fn sample_rng_zero_seed_does_not_produce_a_stuck_zero_sequence() {
+    let mut rng = SampleRng::new(0);
+    let mut seen = BTreeSet::new();
+    for _ in 0..8 {
+        // next_u32 is private; exercise it indirectly through a sampling
+        // call instead of reaching in directly.
+        seen.insert(format!("{rng:?}"));
+        let art = fixture_artifacts();
+        let store = rich_store();
+        let code = [0u8; STAGES];
+        let mut rt = Runtime::new(&art);
+        let _ = rt.predict_witness_sampled(&store, &code, &mut rng);
+    }
+    assert!(
+        seen.len() > 1,
+        "SampleRng::new(0) must not produce a degenerate stuck sequence"
+    );
+}

--- a/crates/uor-r4-core/tests/sampling_reduction_762.rs
+++ b/crates/uor-r4-core/tests/sampling_reduction_762.rs
@@ -1,0 +1,116 @@
+//! Exhaustive/randomized verification of `reduce_into_range` (issue #762
+//! lever 2 prototype) against the real `%` operator.
+//!
+//! This lives in an external `tests/` file rather than inside
+//! `runtime.rs` itself (or even inside `mod.rs`'s inline test modules)
+//! because `p4_runtime_source_scan` scans all of `runtime.rs` including
+//! its own test code for forbidden `/`, `%`, `*` tokens — the same reason
+//! `dot_assignment_tests` lives in `mod.rs` rather than in `runtime.rs`.
+//! An external integration test crate only sees `uor_r4_core`'s public
+//! API, which is why `reduce_into_range` is `pub` rather than
+//! `pub(crate)`.
+
+use uor_r4_core::transformerless::runtime::reduce_into_range;
+
+#[test]
+fn reduce_into_range_matches_modulo_exhaustively_for_small_values() {
+    for bound in 1u32..300 {
+        for value in 0u32..600 {
+            let want = value % bound;
+            let got = reduce_into_range(value, bound);
+            assert_eq!(
+                got, want,
+                "reduce_into_range({value}, {bound}) = {got}, want {want}"
+            );
+        }
+    }
+}
+
+#[test]
+fn reduce_into_range_zero_bound_returns_zero() {
+    assert_eq!(reduce_into_range(0, 0), 0);
+    assert_eq!(reduce_into_range(12345, 0), 0);
+    assert_eq!(reduce_into_range(u32::MAX, 0), 0);
+}
+
+#[test]
+fn reduce_into_range_value_less_than_bound_is_identity() {
+    assert_eq!(reduce_into_range(0, 1), 0);
+    assert_eq!(reduce_into_range(5, 10), 5);
+    assert_eq!(reduce_into_range(u32::MAX - 1, u32::MAX), u32::MAX - 1);
+}
+
+#[test]
+fn reduce_into_range_edge_cases_against_modulo() {
+    let cases: &[(u32, u32)] = &[
+        (0, 1),
+        (1, 1),
+        (u32::MAX, 1),
+        (u32::MAX, u32::MAX),
+        (u32::MAX, u32::MAX - 1),
+        (u32::MAX / 2, 3),
+        (u32::MAX, 2),
+        (u32::MAX, 3),
+        (u32::MAX, 7),
+        (0x8000_0000, 0x8000_0000),
+        (0x8000_0000, 3),
+        (0xFFFF_FFFE, 0x7FFF_FFFF),
+        (1 << 31, 1 << 30),
+        (1 << 31, (1 << 30) + 1),
+        (7, 7),
+        (14, 7),
+        (13, 7),
+        (100, 100),
+        (100, 99),
+        (100, 3),
+    ];
+    for &(value, bound) in cases {
+        let want = value % bound;
+        let got = reduce_into_range(value, bound);
+        assert_eq!(
+            got, want,
+            "reduce_into_range({value}, {bound}) = {got}, want {want}"
+        );
+    }
+}
+
+#[test]
+fn reduce_into_range_matches_modulo_on_a_large_random_sweep() {
+    // Deterministic xorshift32, fine to use `%` here since this file is
+    // outside runtime.rs's P-4 scan.
+    let mut state = 0x00C0_FFEEu32;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        state
+    };
+    for _ in 0..200_000 {
+        let value = next();
+        let mut bound = next();
+        if bound == 0 {
+            bound = 1;
+        }
+        let want = value % bound;
+        let got = reduce_into_range(value, bound);
+        assert_eq!(
+            got, want,
+            "reduce_into_range({value}, {bound}) = {got}, want {want}"
+        );
+    }
+}
+
+#[test]
+fn reduce_into_range_powers_of_two_bounds() {
+    for shift in 0u32..32 {
+        let bound = 1u32 << shift;
+        for value in [0u32, 1, bound - 1, bound, bound + 1, u32::MAX, u32::MAX - 1] {
+            let want = value % bound;
+            let got = reduce_into_range(value, bound);
+            assert_eq!(
+                got, want,
+                "reduce_into_range({value}, {bound}) = {got}, want {want}"
+            );
+        }
+    }
+}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, Read, Write};
 
 use crate::model::{default_model_reference, ModelError, ModelObject, ModelStore};
 use uor_r4_core::transformerless::compiler::{self, Compiled};
-use uor_r4_core::transformerless::runtime::{self, Runtime, Store};
+use uor_r4_core::transformerless::runtime::{self, Runtime, SampleRng, Store};
 use uor_r4_core::transformerless::scenarios::Tokenizer;
 
 const MAX_CHAT_TOKENS: usize = 256;
@@ -125,6 +125,7 @@ impl From<ModelError> for ChatError {
 pub struct ChatEngineBuilder {
     max_tokens: usize,
     model: Option<String>,
+    sample_seed: Option<u32>,
 }
 
 impl Default for ChatEngineBuilder {
@@ -132,6 +133,7 @@ impl Default for ChatEngineBuilder {
         Self {
             max_tokens: 96,
             model: Some(default_model_reference()),
+            sample_seed: None,
         }
     }
 }
@@ -141,6 +143,22 @@ impl ChatEngineBuilder {
     #[must_use]
     pub fn max_tokens(mut self, max_tokens: usize) -> Self {
         self.max_tokens = max_tokens.clamp(1, MAX_CHAT_TOKENS);
+        self
+    }
+
+    /// Opt into issue #762 lever-2 weighted sampling on the legacy
+    /// (non-R4G1) generation path, seeded for reproducibility. Strictly
+    /// additive: omitting this call (the default) keeps every turn on the
+    /// existing deterministic `generate_greedy_into` path, byte-for-byte
+    /// unchanged. When set, the R4G1 beam-search path (used automatically
+    /// whenever a manifest carries a `compiled.r4g1` graph) is NOT
+    /// affected -- lever 2 only reaches the legacy plain-TLA path, since
+    /// that's what issue #762 measured and scoped. The seeded RNG persists
+    /// and advances across turns within one `ChatEngine`, so a fixed seed
+    /// reproduces an entire session's sampled output, not just one turn.
+    #[must_use]
+    pub fn sample_seed(mut self, seed: u32) -> Self {
+        self.sample_seed = Some(seed);
         self
     }
 
@@ -163,6 +181,7 @@ impl ChatEngineBuilder {
                     &path,
                     reference,
                     self.max_tokens,
+                    self.sample_seed,
                 );
             }
             Err(error) => return Err(error.into()),
@@ -210,6 +229,7 @@ impl ChatEngineBuilder {
             history: [0; MAX_CHAT_HISTORY],
             history_len: 0,
             max_tokens: self.max_tokens,
+            sample_rng: self.sample_seed.map(SampleRng::new),
         })
     }
 }
@@ -219,6 +239,7 @@ fn build_local_compiled_engine(
     directory: &std::path::Path,
     reference: &str,
     max_tokens: usize,
+    sample_seed: Option<u32>,
 ) -> Result<ChatEngine, ChatError> {
     let artifact_bytes = std::fs::read(directory.join("tless_artifacts.bin"))?;
     let store_bytes = std::fs::read(directory.join("tless_store.bin"))?;
@@ -255,6 +276,7 @@ fn build_local_compiled_engine(
         history: [0; MAX_CHAT_HISTORY],
         history_len: 0,
         max_tokens,
+        sample_rng: sample_seed.map(SampleRng::new),
     })
 }
 
@@ -267,6 +289,12 @@ pub struct ChatEngine {
     history: [u32; MAX_CHAT_HISTORY],
     history_len: usize,
     max_tokens: usize,
+    /// Issue #762 lever 2: `Some` opts every turn's legacy-path generation
+    /// into weighted sampling (see `ChatEngineBuilder::sample_seed`); the
+    /// RNG advances turn to turn so a session is reproducible end to end
+    /// from its initial seed. `None` (the default) leaves the existing
+    /// deterministic `generate_greedy_into` path completely untouched.
+    sample_rng: Option<SampleRng>,
 }
 
 impl ChatEngine {
@@ -289,6 +317,7 @@ impl ChatEngine {
             &mut self.history_len,
             question,
             self.max_tokens,
+            self.sample_rng.as_mut(),
         )
     }
 }
@@ -303,6 +332,7 @@ fn hologram_answer(
     history_len: &mut usize,
     question: &str,
     max_tokens: usize,
+    sample_rng: Option<&mut SampleRng>,
 ) -> Result<ChatAnswer, ChatError> {
     ensure_chat_prompt_encoder(tokenizer)?;
     let mut question_tokens = [0u32; MAX_CHAT_HISTORY];
@@ -447,11 +477,23 @@ fn hologram_answer(
 
     let mut runtime = Runtime::new(artifacts);
     let mut predictions = [runtime::Prediction::default(); MAX_CHAT_TOKENS];
-    let prediction_count = runtime.generate_greedy_into(
-        store,
-        &history[..*history_len],
-        &mut predictions[..max_tokens.min(MAX_CHAT_TOKENS)],
-    );
+    let prediction_count = match sample_rng {
+        // Issue #762 lever 2: opt-in weighted sampling on this legacy
+        // path only -- the R4G1 beam-search path above returns before
+        // this point whenever a graph is present, so `sample_rng` never
+        // applies there (out of scope; see the builder doc comment).
+        Some(rng) => runtime.generate_sampled_into(
+            store,
+            &history[..*history_len],
+            rng,
+            &mut predictions[..max_tokens.min(MAX_CHAT_TOKENS)],
+        ),
+        None => runtime.generate_greedy_into(
+            store,
+            &history[..*history_len],
+            &mut predictions[..max_tokens.min(MAX_CHAT_TOKENS)],
+        ),
+    };
     let mut generated = [0u32; MAX_CHAT_TOKENS];
     let mut generated_count = 0usize;
     for prediction in &predictions[..prediction_count] {
@@ -742,6 +784,9 @@ pub fn engine_from_bytes_with_r4g1(
         history: [0; MAX_CHAT_HISTORY],
         history_len: 0,
         max_tokens: max_tokens.clamp(1, MAX_CHAT_TOKENS),
+        // The live quality gate (#750) must stay fully deterministic --
+        // this constructor has no seed input, so sampling is never on.
+        sample_rng: None,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,14 @@ struct AskArgs {
     /// CID manifest name/CID, or a locally compiled bundle name.
     #[arg(long, env = "TLESS_MODEL")]
     model: Option<String>,
+    /// Opt into issue #762 lever-2 weighted sampling (instead of the
+    /// default greedy argmax) on the legacy, non-R4G1 generation path,
+    /// seeded for reproducibility. Has no effect when the resolved model
+    /// carries a `compiled.r4g1` graph, since that beam-search path is
+    /// unaffected by this flag (out of #762's scope; see
+    /// `chat::ChatEngineBuilder::sample_seed`).
+    #[arg(long, value_name = "SEED")]
+    sample: Option<u32>,
     /// Question to ask. Multiple unquoted words are accepted.
     #[arg(required = true, num_args = 1..)]
     question: Vec<String>,
@@ -169,6 +177,14 @@ struct ChatArgs {
     /// Remote HTTP server URL (e.g. http://127.0.0.1:8000/v1) for client mode.
     #[arg(long)]
     remote: Option<String>,
+    /// Opt into issue #762 lever-2 weighted sampling (instead of the
+    /// default greedy argmax) on the legacy, non-R4G1 generation path,
+    /// seeded for reproducibility; the seed advances turn to turn so the
+    /// whole session is reproducible from it. Has no effect in `--remote`
+    /// client mode or when the resolved model carries a `compiled.r4g1`
+    /// graph (out of #762's scope).
+    #[arg(long, value_name = "SEED")]
+    sample: Option<u32>,
 }
 
 #[derive(Args, Debug)]
@@ -444,10 +460,13 @@ fn interactive_chat(
     Ok(())
 }
 
-fn build_chat_engine(model: Option<&str>) -> Result<ChatEngine, ChatError> {
-    ChatEngine::builder()
-        .model(model.map_or_else(default_model_reference, ToOwned::to_owned))
-        .build()
+fn build_chat_engine(model: Option<&str>, sample: Option<u32>) -> Result<ChatEngine, ChatError> {
+    let mut builder =
+        ChatEngine::builder().model(model.map_or_else(default_model_reference, ToOwned::to_owned));
+    if let Some(seed) = sample {
+        builder = builder.sample_seed(seed);
+    }
+    builder.build()
 }
 
 fn compile(args: &CompileArgs) -> Result<(), RunError> {
@@ -684,7 +703,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
     cli.configure_tless();
     match cli.command.as_ref() {
         Some(Command::Ask(args)) => {
-            let mut chat = build_chat_engine(args.model.as_deref())?;
+            let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
             answer_once(
                 &mut chat,
                 &args.question.join(" "),
@@ -701,7 +720,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
                 )?;
                 Ok(())
             } else {
-                let mut chat = build_chat_engine(args.model.as_deref())?;
+                let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
                 interactive_chat(&mut chat, &mut io::stdin().lock(), &mut io::stdout().lock())?;
                 Ok(())
             }


### PR DESCRIPTION
Add opt-in weighted sampling to break the #759 attractor-basin collapse (#762)

#759 found that greedy argmax decoding on the legacy plain-TLA path
locks onto the single highest-count continuation whenever multiple
prompts' trailing-token windows quantize to the same (or a
sufficiently similar) compiled code -- not a fallback-tier bug, but a
genuine argmax "attractor basin" effect (#460's already-open
codebook-fit thread is the deeper root; this is the decoding-side
lever). This lands lever 2 from that issue: weighted sampling over the
stored count distribution, as an opt-in alternative to always taking
the argmax winner.

- `SampleRng` (xorshift32) and `reduce_into_range` (restoring binary
  long division) in runtime.rs give a division-free, P-4-clean
  selection primitive -- zero `*`/`/`/`%` tokens, verified against the
  real `%` operator by an external 200k-iteration random sweep plus
  exhaustive small-value and edge-case tests (outside the P-4 scan
  file, so they're free to use real modulo as the oracle).
- `Runtime::predict_witness_sampled`/`generate_sampled_into` are
  additive siblings of `predict_witness`/`generate_greedy_into`:
  same repetition-penalized scoring, but draw proportionally from the
  resolved depth's full candidate distribution instead of always
  taking the max. Every existing caller is untouched -- nothing reaches
  the new functions unless a caller explicitly opts in.
- `ChatEngineBuilder::sample_seed`/`r4 ask --sample <SEED>`/
  `r4 chat --sample <SEED>` thread an opt-in, reproducible seed into
  the legacy generation path only. The R4G1 beam-search path (used
  automatically whenever a manifest carries `compiled.r4g1`) is
  unaffected -- out of this issue's scope, noted explicitly rather than
  silently expanded.

Measured effect (the decisive test, following #758's own
methodology): 15-prompt comparison (12 real questions + 3 edge cases)
against `smollm2-135m-instruct-tla6` (no `compiled.r4g1`, so this
exercises the legacy path end to end). Deterministic baseline: 15
prompts collapse to 13 distinct outputs (one group of 3 byte-identical
answers). With `--sample 42`: 15 prompts produce 15 distinct outputs --
zero exact-match collisions. Sampling does not fix the underlying
codebook-quantization root cause (#460's open thread), and doesn't
improve grammaticality on this already-degenerate bundle, but it does
eliminate the exact-repeat collapse #758/#759 measured, which is what
this lever set out to do.

Verification:
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo run -p xtask -- audit-limits
- cargo test --workspace --offline (full suite, no failures)
- allocation_census.rs re-verified passing: the new sampling functions
  use Vec/heap allocation but are never called from within the
  default (measured) generate_greedy_into path, so the allocation-free
  guarantee on the default path is untouched
- p4_runtime_source_scan / p4_contract_owned_graph_runtime_source_scan
  both pass with the new code in place
- Real 15-prompt before/after collapse-rate measurement against a live
  local bundle (see above)

New tests:
- crates/uor-r4-core/tests/sampling_reduction_762.rs (6 tests):
  reduce_into_range exhaustively verified against real `%`
- crates/uor-r4-core/tests/sampling_prediction_762.rs (6 tests):
  predict_witness_sampled/generate_sampled_into determinism-per-seed,
  variation-across-seeds, evidence-set containment, and non-effect on
  the existing default path

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
