### PR TITLE
api: fix the 404-body bug and accept OpenAI content-parts messages (#740)

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -86,7 +86,52 @@ fn startup_source_candidates(last_model_name: &str) -> Vec<PathBuf> {
 #[derive(Debug, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
+    #[serde(deserialize_with = "deserialize_chat_content")]
     pub content: String,
+}
+
+/// `content` accepts either a plain string (the original supported shape)
+/// or an OpenAI content-parts array (`[{"type":"text","text":"..."}]`) --
+/// increasingly a default some SDKs send even for plain-text-only messages
+/// (#740). Text parts are concatenated in order; a part of any other
+/// `type` (`image_url`, `input_audio`, ...) fails closed with a clear
+/// `invalid_request_error` rather than silently dropping content this
+/// server has no way to actually see, consistent with this file's existing
+/// "support is never implied by omission" convention.
+fn deserialize_chat_content<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ContentValue {
+        Text(String),
+        Parts(Vec<ContentPart>),
+    }
+    #[derive(Deserialize)]
+    struct ContentPart {
+        #[serde(rename = "type")]
+        kind: String,
+        #[serde(default)]
+        text: Option<String>,
+    }
+
+    match ContentValue::deserialize(deserializer)? {
+        ContentValue::Text(text) => Ok(text),
+        ContentValue::Parts(parts) => {
+            let mut combined = String::new();
+            for part in parts {
+                if part.kind != "text" {
+                    return Err(serde::de::Error::custom(format!(
+                        "unsupported message content part type '{}': only 'text' parts are supported",
+                        part.kind
+                    )));
+                }
+                combined.push_str(part.text.as_deref().unwrap_or_default());
+            }
+            Ok(combined)
+        }
+    }
 }
 
 /// The supported subset of the OpenAI Chat Completions request. `#654`
@@ -17086,6 +17131,25 @@ fn handle_connection(
         return;
     }
 
+    // #740: an unmatched `/v1/*` path is an API call to a route that
+    // doesn't exist (legacy `/v1/completions`, `/v1/embeddings`, a typo,
+    // etc.), not a missing dashboard asset -- it must fail with the same
+    // OpenAI error envelope every other API error on this server uses, not
+    // fall through to the static-file 404 below (empty body, no
+    // `Content-Type: application/json`), which breaks any client that
+    // tries to JSON-parse the 404 response.
+    if clean_path.starts_with("/v1/") {
+        send_openai_error(
+            stream,
+            404,
+            "invalid_request_error",
+            &format!("Unknown request URL: {method} {clean_path}."),
+            None,
+            Some("unknown_url"),
+        );
+        return;
+    }
+
     // Serve static files fallback
     let mut relative_path = clean_path.trim_start_matches('/');
     if relative_path.is_empty() {
@@ -26451,6 +26515,41 @@ mod tests {
         assert!(
             denied.is_err(),
             "unsupported parameter top_p is rejected, not ignored"
+        );
+    }
+
+    // ---- #740: OpenAI-compatible surface gaps ----
+
+    #[test]
+    fn chat_message_content_still_accepts_a_plain_string() {
+        let req: super::VendorChatCompletionsRequest =
+            serde_json::from_str(r#"{"messages":[{"role":"user","content":"hi"}]}"#)
+                .expect("plain string content must still parse");
+        assert_eq!(req.messages[0].content, "hi");
+    }
+
+    #[test]
+    fn chat_message_content_accepts_the_openai_content_parts_array_shape() {
+        // Several SDKs default every message to this shape, even for
+        // plain text — rejecting it broke real, otherwise-compliant
+        // clients for no capability reason (#740).
+        let req: super::VendorChatCompletionsRequest = serde_json::from_str(
+            r#"{"messages":[{"role":"user","content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]}]}"#,
+        )
+        .expect("content-parts array must parse");
+        assert_eq!(req.messages[0].content, "hello world");
+    }
+
+    #[test]
+    fn chat_message_content_rejects_non_text_parts_instead_of_dropping_them() {
+        let req: Result<super::VendorChatCompletionsRequest, _> = serde_json::from_str(
+            r#"{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/x.png"}}]}]}"#,
+        );
+        assert!(
+            req.is_err(),
+            "a non-text content part must fail closed, not be silently dropped -- \
+             this server cannot see images, so pretending to accept one and then \
+             answering as if it weren't there would be worse than refusing"
         );
     }
 


### PR DESCRIPTION
api: fix the 404-body bug and accept OpenAI content-parts messages (#740)

#740 audited the `/v1/*` OpenAI-compatible surface and asked for a
deliberate per-gap decision, not a default-implement-everything pass.
This closes it by fixing the two genuine correctness/interop bugs it
found and recording an explicit decision on everything else, so the
issue doesn't stay open against work nobody decided to do.

Fixed (real bugs, not scope questions):
- The catch-all for an unmatched route returned a bare
  `HTTP/1.1 404 NOT FOUND` with an empty body and no `Content-Type`,
  falling through to the dashboard's static-file-serving path. Any
  `/v1/*` request to a route that doesn't exist (a typo, the legacy
  `/v1/completions`, `/v1/embeddings`) now gets the same
  `{"error":{...}}` envelope every other API error on this server
  uses, with `Content-Type: application/json` -- a client that tries
  to JSON-parse the error no longer gets a parse failure instead of a
  readable one. Non-`/v1/` paths are unaffected: the dashboard's own
  static assets and its existing empty-body 404 behavior are
  untouched (verified live, not just by the new unit tests -- see
  below).
- `messages[].content` accepted a plain string only; the
  content-parts array shape (`[{"type":"text","text":"..."}]`) --
  increasingly a default some SDKs send even for plain-text-only
  messages -- failed to deserialize, breaking otherwise-compliant
  clients for no capability reason. Text parts are now concatenated
  in order; a part of any other `type` (`image_url`, `input_audio`,
  ...) still fails closed with a clear `invalid_request_error`
  instead of being silently dropped, consistent with this file's
  existing "support is never implied by omission" convention
  (`deny_unknown_fields` on the outer request types).

Decided (per-gap, not implemented -- recorded so this isn't silent):
- `top_p`, `n`, `stop`, `presence_penalty`, `frequency_penalty`,
  `logit_bias`, `logprobs`/`top_logprobs`, `seed`: continue to reject
  with 400 (already the existing `deny_unknown_fields` behavior,
  unchanged). Implementing any of these for real is a generation-
  engine change, not an HTTP-surface one -- #740's own non-goals
  section already draws that line ("any change to sampling/generation
  semantics... is the #653/generation-coherence track"), and #762
  (issue-#759 follow-up, merging as #763) is the concrete evidence:
  it added a real seeded-sampling primitive, but scoped deliberately
  to the CLI/chat-engine surface, not this server's per-request
  handling, for exactly this reason.
- `tools`/`tool_choice` (function calling), `response_format` (JSON
  mode): not implemented. Both are substantial standalone engine
  capabilities (a tool-call protocol; constrained/structured decoding)
  disproportionate to an HTTP-surface issue; tracked as an explicit
  non-goal here rather than reopened piecemeal.
- `user`: not implemented -- there is no per-user state on this server
  to attach it to.
- `/v1/completions` (legacy) and `/v1/embeddings`: explicit non-goals,
  not silence. `/v1/completions` would duplicate `/v1/chat/completions`
  semantics under a different wire shape with no concrete client
  demand; a table-native transformerless graph has no embedding-model
  shape to serve `/v1/embeddings` from today.
- Multi-model routing: already an explicit non-goal in #740 itself
  (tracked under #655 if ever).

Verification:
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo run -p xtask -- audit-limits
- cargo test --workspace --offline (full suite, no failures)
- Live verification against the real server binary (`r4 serve`), not
  just unit tests: `curl` against an unmatched `/v1/*` route confirms
  the JSON envelope + `Content-Type: application/json`; a non-`/v1/`
  unmatched path confirms the old empty-body static-file 404 is
  unchanged; a content-parts-array chat request reaches the model
  layer (503 model-not-ready in this environment, not a 400 parse
  error); a non-text content part correctly 400s.

New tests (src/server.rs):
- chat_message_content_still_accepts_a_plain_string
- chat_message_content_accepts_the_openai_content_parts_array_shape
- chat_message_content_rejects_non_text_parts_instead_of_dropping_them

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
