### PR TITLE
fix(#510): bring just vv-register back in sync with CI's R5 gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,12 +6,18 @@ bdd:
     cargo test --test bdd
 
 # --- #273 template adoption: the register conformance gate ---
-# R1/R2/R3 landed in Phase 1. #510 wires R4 (deferral) and R6 (cargo-deny):
-# R4's `audit-deferral` now honours the carve-out --- a marker is a violation
-# only when its line does not cite an `open` claim in model/ledger.toml --- and
-# R6's deny.toml allow-lists uor-r4's pinned git sources. R5 (`audit-limits`) is
-# still an incremental migration (352 unsanctioned `Result` returns as of #510)
-# and is NOT yet in the gate.
+# R1/R2/R3 landed in Phase 1. #510 wires R4 (deferral), R5 (audit-limits) and
+# R6 (cargo-deny): R4's `audit-deferral` honours the carve-out --- a marker is
+# a violation only when its line does not cite an `open` claim in
+# model/ledger.toml --- and R6's deny.toml allow-lists uor-r4's pinned git
+# sources. R5's incremental migration is COMPLETE (graph-cli hit 0 in #587):
+# every shipped crate's `Result` error surface now names only the four
+# sanctioned types (see `xtask/src/audit.rs`), and CI's `register-conformance`
+# job (.github/workflows/ci.yml) has enforced it since #588. This recipe was
+# left listing only R1/R2/R3/R4/R6 after that landed, which meant `just
+# vv-register` could pass locally on an R5 violation that CI would then catch
+# --- silently, since nothing here said R5 was even expected to run. Brought
+# back in sync with CI: R5 joins below.
 
 # R1: model/*.toml is the single source; CONFORMANCE.md is generated from it.
 check-model:
@@ -30,12 +36,18 @@ register-bdd:
 audit-deferral:
     cargo run -q -p xtask -- audit-deferral
 
+# R5: every shipped crate's Result names only a sanctioned error type
+# (NotAProduct / ObservedBound / KappaError / SourceUnavailable) --- no
+# arbitrary limitation. Migration complete since #587/#588.
+audit-limits:
+    cargo run -q -p xtask -- audit-limits
+
 # R6: supply-chain hygiene over the real graph --- advisories, licences, bans,
 # and sources (the pinned git deps are allow-listed in deny.toml).
 deny:
     cargo deny check
 
 # The register acceptance gate --- the wired slice of the template's `just vv`
-# (R1/R2/R3 + R4 + R6). R5 joins when the audit-limits migration completes.
-vv-register: check-model register-bdd audit-deferral deny
-    @echo "vv-register: the register conformance gate passed (R1/R2/R3/R4/R6)"
+# (R1/R2/R3 + R4/R5/R6), matching CI's `register-conformance` job exactly.
+vv-register: check-model register-bdd audit-deferral audit-limits deny
+    @echo "vv-register: the register conformance gate passed (R1/R2/R3/R4/R5/R6)"


### PR DESCRIPTION
## Summary

R5 (\`audit-limits\`) has been CI-enforced since #587/#588, but the local
\`just vv-register\` recipe still claimed it wasn't ready and never invoked
\`audit-limits\`. This let a contributor's local \`just vv-register\` pass
while the same change would fail R5 in CI.

- Add an \`audit-limits\` recipe to the Justfile.
- Wire it into \`vv-register\`: \`check-model register-bdd audit-deferral audit-limits deny\`.
- Rewrite the stale header comment that described the old (pre-R5) gate list.

## Test plan

- [x] \`just vv-register\` runs \`audit-limits\` locally and passes.
- [x] No change to CI itself -- this only brings the local recipe back in
      sync with what CI has already been enforcing since #587/#588.

🤖 Generated with local engineering work performed during a GitHub outage,
now being synced back now that GitHub is reachable again.