### PR TITLE
feat(#655-C1c): additive release-bundle sidecar verification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod model;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4g1;
 #[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod release_bundle_loader;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod telemetry;
 
 /// Native HTTP server and terminal chat application.

--- a/src/release_bundle_loader.rs
+++ b/src/release_bundle_loader.rs
@@ -1,0 +1,233 @@
+//! #655-C1c: an additive, best-effort verification layer for a resolved
+//! R4G1 bundle's optional `release-bundle.json` sidecar
+//! (`docs/serving_shared_loader_655_c1.md`, #655-C0/C1a/C1b).
+//!
+//! This module does the filesystem I/O and digesting that
+//! `uor_r4_api::release_bundle` deliberately does not (that crate is
+//! schema/validation only, no I/O). [`verify_release_bundle_sidecar`]
+//! never changes which bundle loads: a missing sidecar, a parse or
+//! structural-validation failure, or a digest mismatch against the
+//! bundle's actual files on disk all resolve to `None`, exactly as if no
+//! sidecar existed. Per the design doc's Q3, `None` is the common case
+//! today -- no shipped bundle produces a sidecar yet (#655-D is still
+//! open).
+//!
+//! Scope: this slice verifies exactly the two components the caller
+//! already has resolved file paths for -- `components.graph` against the
+//! bundle's graph file, and `components.signature_artifact` against its
+//! teacher-companion file. `score_report`, `compile_report`, and
+//! `tokenizer` are checked for structural well-formedness (digest shape)
+//! by [`ReleaseBundleManifest::validate`] but not re-hashed against bytes
+//! on disk here: this resolution has no established path convention for
+//! locating those files independently of a packaging step that doesn't
+//! exist yet. Closing that gap is future work (#655-C1d) once #655-D
+//! settles a real bundle directory layout.
+
+use std::path::Path;
+
+use uor_r4_api::ReleaseBundleManifest;
+
+/// Sidecar file name a packaged bundle directory may place next to its
+/// R4G1 artifacts. Nothing writes this file yet (#655-D is still open);
+/// reading it here is purely additive.
+pub(crate) const RELEASE_BUNDLE_SIDECAR_FILE_NAME: &str = "release-bundle.json";
+
+/// Look for, parse, and verify a `release-bundle.json` sidecar next to a
+/// resolved bundle's `physical_root`. Returns `Some` only when the
+/// sidecar exists, parses, passes [`ReleaseBundleManifest::validate`],
+/// and its declared `components.graph` / `components.signature_artifact`
+/// digests match the actual bytes at `graph_path` / `teacher_path`.
+/// Returns `None` for every other case, including an I/O error reading
+/// either file -- this check is advisory and must never turn into a load
+/// failure for a bundle that would otherwise serve today.
+pub(crate) fn verify_release_bundle_sidecar(
+    physical_root: &Path,
+    graph_path: &Path,
+    teacher_path: &Path,
+) -> Option<ReleaseBundleManifest> {
+    let sidecar_path = physical_root.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME);
+    let bytes = std::fs::read(sidecar_path).ok()?;
+    let manifest: ReleaseBundleManifest = serde_json::from_slice(&bytes).ok()?;
+    if manifest.validate().is_some() {
+        return None;
+    }
+    if !file_matches_digest(graph_path, &manifest.components.graph) {
+        return None;
+    }
+    if !file_matches_digest(teacher_path, &manifest.components.signature_artifact) {
+        return None;
+    }
+    Some(manifest)
+}
+
+fn file_matches_digest(path: &Path, declared: &str) -> bool {
+    let Ok(bytes) = std::fs::read(path) else {
+        return false;
+    };
+    format!("blake3:{}", blake3::hash(&bytes).to_hex()) == declared
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uor_r4_api::{
+        BundleAbi, BundleCapability, BundleComponentDigests, UorMatmulProvenance,
+        RELEASE_BUNDLE_MANIFEST_SCHEMA,
+    };
+    use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
+
+    const VALID_REV: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+    const PLACEHOLDER_DIGEST: &str =
+        "blake3:0000000000000000000000000000000000000000000000000000000000000001";
+
+    fn digest_of(bytes: &[u8]) -> String {
+        format!("blake3:{}", blake3::hash(bytes).to_hex())
+    }
+
+    fn write(dir: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).expect("write fixture file");
+        path
+    }
+
+    fn manifest_for(graph_digest: String, teacher_digest: String) -> ReleaseBundleManifest {
+        ReleaseBundleManifest {
+            schema: RELEASE_BUNDLE_MANIFEST_SCHEMA,
+            model_id: "r4".to_string(),
+            capability: BundleCapability::InstructionChat,
+            abi: BundleAbi {
+                format_major: 1,
+                format_minor: 0,
+                contract_major: 1,
+                contract_minor: 0,
+                contract_patch: 0,
+                api_crate_version: "0.1.0".to_string(),
+            },
+            uor_matmul: UorMatmulProvenance {
+                rev: VALID_REV.to_string(),
+                operation_profile: "exact-gemm-float".to_string(),
+                license: "MIT".to_string(),
+                source_digest: None,
+            },
+            components: BundleComponentDigests {
+                graph: graph_digest,
+                signature_artifact: teacher_digest,
+                tokenizer: None,
+                score_report: PLACEHOLDER_DIGEST.to_string(),
+                compile_report: PLACEHOLDER_DIGEST.to_string(),
+            },
+            tokenizer_adapter: TokenizerAdapter {
+                family: "hf-byte-bpe".to_string(),
+                ..Default::default()
+            },
+            provenance_note: None,
+        }
+    }
+
+    fn scratch_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "uor-r4-release-bundle-loader-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        dir
+    }
+
+    #[test]
+    fn absent_sidecar_is_none() {
+        let dir = scratch_dir("absent");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn matching_digests_verify() {
+        let dir = scratch_dir("match");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        let manifest = manifest_for(digest_of(b"graph bytes"), digest_of(b"teacher bytes"));
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar");
+        let verified = verify_release_bundle_sidecar(&dir, &graph, &teacher);
+        assert_eq!(verified, Some(manifest));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mismatched_graph_digest_is_none() {
+        let dir = scratch_dir("mismatch-graph");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        let manifest = manifest_for(digest_of(b"WRONG BYTES"), digest_of(b"teacher bytes"));
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mismatched_teacher_digest_is_none() {
+        let dir = scratch_dir("mismatch-teacher");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        let manifest = manifest_for(digest_of(b"graph bytes"), digest_of(b"WRONG BYTES"));
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn structurally_invalid_manifest_is_none() {
+        let dir = scratch_dir("invalid");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        let mut manifest = manifest_for(digest_of(b"graph bytes"), digest_of(b"teacher bytes"));
+        manifest.model_id = String::new();
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_json_is_none() {
+        let dir = scratch_dir("malformed");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = write(&dir, "teacher", b"teacher bytes");
+        std::fs::write(dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME), b"not json")
+            .expect("write sidecar");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_referenced_file_is_none() {
+        let dir = scratch_dir("missing-file");
+        let graph = write(&dir, "graph", b"graph bytes");
+        let teacher = dir.join("teacher-does-not-exist");
+        let manifest = manifest_for(digest_of(b"graph bytes"), digest_of(b"teacher bytes"));
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar");
+        assert!(verify_release_bundle_sidecar(&dir, &graph, &teacher).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use uor_foundation::pipeline::PrismModel;
 
+use uor_r4_api::ReleaseBundleManifest;
 use uor_r4_core::transformerless::hf_bpe::{
     adapter_constructor, resolve_source_tokenizer, TokenizerAdapter, TokenizerAdapterKey,
     TokenizerKind,
@@ -29,6 +30,8 @@ use uor_r4_model_source::{BehaviorSource, TeacherOracle};
 use uor_r4_router::fallback::{
     run_cascade, CascadeOutcome, EngineStatus, TierFn, TierOutcome, TierResult,
 };
+
+use crate::release_bundle_loader;
 
 // The browser-triggered build must have enough teacher evidence and graph
 // capacity to be a meaningful quality attempt. These are still bounded,
@@ -1558,7 +1561,7 @@ struct CompiledModelPair {
 /// One logical source resolved to the exact physical bundle selected for
 /// serving. Keeping all of these fields together prevents reload/status from
 /// reconstructing a source name from the resolver-owned era suffix.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 struct ResolvedCompiledBundle {
     logical_name: String,
     physical_root: PathBuf,
@@ -1569,6 +1572,11 @@ struct ResolvedCompiledBundle {
     /// Exact source snapshot root recorded by the selected cover report.
     /// `None` is the historical pre-#597 state, not an inferred identity.
     source_manifest_kappa: Option<String>,
+    /// #655-C1c: additive, best-effort verification against an optional
+    /// `release-bundle.json` sidecar next to `physical_root`. `None` is the
+    /// common case today (no packaging step writes this file yet, #655-D) --
+    /// it never changes which bundle loads. See `release_bundle_loader`.
+    release_bundle: Option<ReleaseBundleManifest>,
 }
 
 /// The complete serving identity committed by startup, reload, or background
@@ -2267,6 +2275,8 @@ fn resolve_loadable_compiled_bundle_with_authority(
         current_version,
         authority,
     )?;
+    let release_bundle =
+        release_bundle_loader::verify_release_bundle_sidecar(physical_root, &graph, &teacher);
     Ok(Some(ResolvedCompiledBundle {
         logical_name: pair.logical_name.clone(),
         physical_root: physical_root.to_path_buf(),
@@ -2275,6 +2285,7 @@ fn resolve_loadable_compiled_bundle_with_authority(
         attention_operator: identity.attention.clone(),
         dense_operator: identity.dense.clone(),
         source_manifest_kappa,
+        release_bundle,
     }))
 }
 
@@ -2330,7 +2341,7 @@ fn reject_requested_suffix_source_collision(
 }
 
 #[cfg(test)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 enum ConfiguredManagedBundle {
     External,
     Absent,
@@ -22911,6 +22922,7 @@ mod tests {
             ),
             dense_operator: None,
             source_manifest_kappa: Some(m1.content_kappa.clone()),
+            release_bundle: None,
         };
         let error = super::validate_resolved_source_snapshot_binding(&resolved, Some(&m2), 2)
             .expect_err("serving cannot attach M2 teacher bytes to M1 graph provenance");
@@ -24305,6 +24317,7 @@ mod tests {
                 attention_operator: AttentionOperatorSpec::standard_v1(),
                 dense_operator: None,
                 source_manifest_kappa: None,
+                release_bundle: None,
             }),
             ..super::ServingModelState::default()
         };
@@ -24512,6 +24525,7 @@ mod tests {
             attention_operator: AttentionOperatorSpec::standard_v2(),
             dense_operator: None,
             source_manifest_kappa: None,
+            release_bundle: None,
         };
         let serving = Arc::new(Mutex::new(super::ServingModelState {
             active_bundle: Some(active.clone()),
@@ -24599,6 +24613,7 @@ mod tests {
                 attention_operator: attention.clone(),
                 dense_operator: Some(dense.clone()),
                 source_manifest_kappa: None,
+                release_bundle: None,
             }),
             ..super::ServingModelState::default()
         };


### PR DESCRIPTION
## What

Implements **C1c** from `docs/serving_shared_loader_655_c1.md` (#655-C1b,
PR #772): a new `src/release_bundle_loader.rs` module that parses and
verifies an optional `release-bundle.json` sidecar next to a resolved R4G1
bundle directory, checking the sidecar's declared `components.graph` and
`components.signature_artifact` blake3 digests against the bundle's actual
graph/teacher files on disk.

Wired into `resolve_loadable_compiled_bundle_with_authority` via a new
`ResolvedCompiledBundle.release_bundle: Option<ReleaseBundleManifest>`
field.

## Why this is safe to merge now

Strictly additive, per the design doc's Q3. A missing sidecar, a
parse/structural-validation failure, or a digest mismatch all resolve to
`None` — exactly today's behavior for **every bundle that exists today**,
since nothing produces a sidecar yet (#655-D packaging is still open).
Which bundle loads, and whether it loads, is unchanged either way. Unit
tests exercise all of these paths against synthetic fixtures.

## Scope

Verifies exactly the two components this resolution already has file
paths for (`graph`, `teacher`/`signature_artifact`). `score_report`,
`compile_report`, and `tokenizer` digests are structurally validated by
`ReleaseBundleManifest::validate()` but not re-hashed against disk — there
is no established path convention for locating those files independently
of a packaging step that doesn't exist yet. Documented as a gap for a
future #655-D/C1d slice, not silently skipped.

## Incidental change

Dropped `Eq` from `ResolvedCompiledBundle`'s derive (kept `PartialEq`),
since `ReleaseBundleManifest` doesn't implement `Eq`. One test-only enum
(`ConfiguredManagedBundle`) held a `Box<ResolvedCompiledBundle>` and also
derived `Eq`; adjusted the same way. Confirmed nothing in the codebase
depends on `Eq` for either type.

## Verification

- `cargo build --workspace` — clean
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings` — clean
- `cargo test --workspace --offline` — all pass, 0 failures (7 new tests in
  `release_bundle_loader::tests`)
- `just vv-register` — not runnable in this environment (`just` not
  installed); no registry/model/deferral surface touched by this change,
  and CI's merge queue runs it regardless.
