### PR TITLE
feat(#655-D2): r4 package-release-bundle CLI command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,17 @@ pub mod chat;
 pub mod model;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4g1;
+/// #655-D2: `release-bundle.json`'s shared filename constant is `pub`
+/// (rather than `pub(crate)`) because the CLI packaging command in the
+/// `r4` binary crate (`src/main.rs`) needs to write to the exact path
+/// this module's own loader reads from.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) mod release_bundle_loader;
+pub mod release_bundle_loader;
+/// #655-D2: `pub` (rather than `pub(crate)`) so the `r4` binary crate's
+/// `package-release-bundle` CLI command can call
+/// [`release_bundle_packager::package_release_bundle`].
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) mod release_bundle_packager;
+pub mod release_bundle_packager;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod telemetry;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,16 @@ use std::fmt;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use uor_r4_api::{BundleCapability, TokenizerAdapter, UorMatmulProvenance};
+use uor_r4_core::transformerless::hf_bpe::{resolve_source_tokenizer, TokenizerAdapterKey};
 use uor_r4_graph_cli as transformerless_command;
 use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError};
 use uor_r4_wasm_router::model::{
     default_model_reference, download_source, evaluate_live_quality, ModelCapability, ModelError,
     ModelManifest, ModelStore, QualityAttestation, SourceDownload,
 };
+use uor_r4_wasm_router::release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME;
+use uor_r4_wasm_router::release_bundle_packager::{self, PackageInputs};
 use uor_r4_wasm_router::server::{self, ServerConfig};
 use uor_r4_wasm_router::tless_uor;
 
@@ -99,6 +103,10 @@ enum Command {
     Download(DownloadArgs),
     /// Import an evaluated compiled bundle into the UOR CID store.
     Import(ImportArgs),
+    /// #655-D2: package a compiled R4G1 bundle's release-bundle.json
+    /// sidecar, giving `release_bundle_loader::verify_release_bundle_sidecar`
+    /// (#655-C1c) a real manifest to verify.
+    PackageReleaseBundle(PackageReleaseBundleArgs),
     /// Evaluate an HF-compiled bundle and emit an instruction-quality report.
     EvaluateReport(EvaluateReportArgs),
     /// Print legacy proof-workflow prerequisites.
@@ -325,6 +333,63 @@ struct ImportArgs {
     /// provenance of the offline top-1/agreement/bits measurement.
     #[arg(long)]
     evaluation_report: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct PackageReleaseBundleArgs {
+    /// Compiled bundle directory to package (its physical_root, e.g.
+    /// .uor-models/compiled/<name>).
+    #[arg(long)]
+    compiled: PathBuf,
+    /// Public model identity this bundle serves.
+    #[arg(long, default_value = "r4")]
+    model_id: String,
+    /// Declared serving capability.
+    #[arg(long, value_enum)]
+    capability: Capability,
+    /// Original Hugging Face source snapshot this bundle was compiled
+    /// from. Required for `--capability instruction-chat`: physical_root
+    /// alone cannot supply a real tokenizer_adapter (see the
+    /// release_bundle_packager module docs -- tokenizer.bin is a
+    /// different format from the tokenizer.json/spiece.model a
+    /// TokenizerAdapter is derived from). Ignored for `--capability
+    /// continuation`, which packages with an empty tokenizer_adapter
+    /// (valid: `ReleaseBundleManifest::validate` only requires a real
+    /// adapter family for instruction-chat bundles).
+    #[arg(long)]
+    source: Option<PathBuf>,
+    /// Registered source-tokenizer family. Required together with
+    /// --tokenizer-version whenever --source is given: this project
+    /// never infers tokenizer identity (#718), the same policy `r4
+    /// compile`'s own --tokenizer-family/--tokenizer-version pair
+    /// enforces.
+    #[arg(long, requires = "tokenizer_version")]
+    tokenizer_family: Option<String>,
+    /// Registered source-tokenizer adapter version. Must be supplied
+    /// atomically with --tokenizer-family.
+    #[arg(long, requires = "tokenizer_family")]
+    tokenizer_version: Option<u32>,
+    /// uor-matmul git revision the bundle's compile-time arithmetic ran
+    /// against [default: the project's standing #655 pin].
+    #[arg(long, default_value = "b13c98449948174f590e337c4dc25dfc394a07d0")]
+    uor_matmul_rev: String,
+    /// uor-matmul operation/codec profile name.
+    #[arg(long, default_value = "exact-gemm-float")]
+    uor_matmul_operation_profile: String,
+    /// SPDX license identifier of the pinned uor-matmul source. NOTE: as
+    /// of the standing pin, upstream's own Cargo.toml declares
+    /// "Apache-2.0" while its checked-in LICENSE file text is an MIT
+    /// license -- this default matches the LICENSE file; override once
+    /// that upstream inconsistency is resolved.
+    #[arg(long, default_value = "MIT")]
+    uor_matmul_license: String,
+    /// Free-text provenance pointer (e.g. an issue/PR reference).
+    #[arg(long)]
+    provenance_note: Option<String>,
+    /// Write the manifest JSON here instead of
+    /// `<compiled>/release-bundle.json`.
+    #[arg(long)]
+    output: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -639,6 +704,78 @@ fn import(args: &ImportArgs) -> Result<(), RunError> {
     Ok(())
 }
 
+/// #655-D2: resolve a real `tokenizer_adapter` (for `--capability
+/// instruction-chat`, from `--source`) or an empty one (for `--capability
+/// continuation`, valid since `ReleaseBundleManifest::validate` only
+/// requires a real adapter family for instruction-chat bundles), then
+/// call `release_bundle_packager::package_release_bundle` and write its
+/// result to `--output` (default `<compiled>/release-bundle.json`).
+fn package_release_bundle_command(args: &PackageReleaseBundleArgs) -> Result<(), RunError> {
+    let capability = match args.capability {
+        Capability::Continuation => BundleCapability::Continuation,
+        Capability::InstructionChat => BundleCapability::InstructionChat,
+    };
+    let tokenizer_adapter = match &args.source {
+        Some(source) => {
+            let key = match (&args.tokenizer_family, args.tokenizer_version) {
+                (Some(family), Some(version)) => TokenizerAdapterKey::new(family.clone(), version),
+                _ => {
+                    return Err(RunError::Command(
+                        "--tokenizer-family and --tokenizer-version are required together with \
+                         --source (this project never infers tokenizer identity, #718)"
+                            .to_owned(),
+                    ));
+                }
+            };
+            let resolved = resolve_source_tokenizer(source, Some(&key))
+                .map_err(|error| RunError::Command(format!("--source: {}", error.reason)))?;
+            resolved.adapter().ok_or_else(|| {
+                RunError::Command(format!(
+                    "{} resolved to an adapterless tokenizer for {}/{}",
+                    source.display(),
+                    key.family,
+                    key.version
+                ))
+            })?
+        }
+        None if capability == BundleCapability::InstructionChat => {
+            return Err(RunError::Command(
+                "--source is required for --capability instruction-chat: physical_root alone \
+                 cannot supply a real tokenizer_adapter"
+                    .to_owned(),
+            ));
+        }
+        None => TokenizerAdapter::default(),
+    };
+
+    let inputs = PackageInputs {
+        model_id: args.model_id.clone(),
+        capability,
+        uor_matmul: UorMatmulProvenance {
+            rev: args.uor_matmul_rev.clone(),
+            operation_profile: args.uor_matmul_operation_profile.clone(),
+            license: args.uor_matmul_license.clone(),
+            source_digest: None,
+        },
+        tokenizer_adapter,
+        provenance_note: args.provenance_note.clone(),
+    };
+
+    let manifest = release_bundle_packager::package_release_bundle(&args.compiled, inputs)
+        .map_err(|error| RunError::Command(error.to_string()))?;
+
+    let output_path = args
+        .output
+        .clone()
+        .unwrap_or_else(|| args.compiled.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME));
+    let json = serde_json::to_vec_pretty(&manifest).map_err(|error| {
+        RunError::Command(format!("serialize release-bundle manifest: {error}"))
+    })?;
+    std::fs::write(&output_path, json)?;
+    println!("{}", output_path.display());
+    Ok(())
+}
+
 fn evaluate_report(args: &EvaluateReportArgs) -> Result<(), RunError> {
     if args.sequence_length == 0 {
         return Err(RunError::Command(
@@ -737,6 +874,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         Some(Command::Compile(args)) => compile(args),
         Some(Command::Download(args)) => download(args),
         Some(Command::Import(args)) => import(args),
+        Some(Command::PackageReleaseBundle(args)) => package_release_bundle_command(args),
         Some(Command::EvaluateReport(args)) => evaluate_report(args),
         Some(Command::Setup) => run_core("setup", &[]),
         Some(Command::Gen { seconds, target }) => {

--- a/src/release_bundle_loader.rs
+++ b/src/release_bundle_loader.rs
@@ -28,9 +28,10 @@ use std::path::Path;
 use uor_r4_api::ReleaseBundleManifest;
 
 /// Sidecar file name a packaged bundle directory may place next to its
-/// R4G1 artifacts. Nothing writes this file yet (#655-D is still open);
-/// reading it here is purely additive.
-pub(crate) const RELEASE_BUNDLE_SIDECAR_FILE_NAME: &str = "release-bundle.json";
+/// R4G1 artifacts. `pub` (not `pub(crate)`) since #655-D2's
+/// `r4 package-release-bundle` CLI command (`src/main.rs`) writes to
+/// this exact path.
+pub const RELEASE_BUNDLE_SIDECAR_FILE_NAME: &str = "release-bundle.json";
 
 /// Look for, parse, and verify a `release-bundle.json` sidecar next to a
 /// resolved bundle's `physical_root`. Returns `Some` only when the

--- a/src/release_bundle_packager.rs
+++ b/src/release_bundle_packager.rs
@@ -24,14 +24,14 @@
 //! requires the original Hugging Face source snapshot, which does not
 //! live in a compiled bundle's `physical_root`.
 //!
-//! Nothing calls [`package_release_bundle`] outside this module's own
-//! tests yet -- #655-D2 is the CLI subcommand that will. Until then this
-//! whole module is unreachable from any live root in a non-test build,
-//! so it is allowed dead code rather than split across a dozen per-item
-//! annotations; this mirrors landing `release_bundle.rs` (#655-C0) and
-//! `release_bundle_loader.rs` (#655-C1c) each before their own consumer
-//! existed.
-#![allow(dead_code)]
+//! #655-D2 (`src/main.rs`'s `r4 package-release-bundle` command) is the
+//! caller: it resolves a real `tokenizer_adapter` from an explicit
+//! `--source` HF snapshot for `InstructionChat` bundles (using
+//! `uor_r4_core::transformerless::hf_bpe::resolve_source_tokenizer`,
+//! outside this module's own responsibility), builds [`PackageInputs`],
+//! and writes this function's returned manifest to
+//! `release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME` next to
+//! `physical_root`.
 
 use std::path::{Path, PathBuf};
 
@@ -43,7 +43,7 @@ use uor_r4_api::{
 /// Standing #655 `uor-matmul` pin (`serving_655.md` project memory,
 /// mirroring `docs/matrix_operation_census.md`). Bump only via the
 /// project's κ/artifact-era re-pin process.
-pub(crate) const UOR_MATMUL_REVISION: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+pub const UOR_MATMUL_REVISION: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
 
 /// Relative paths within a resolved R4G1 bundle's `physical_root`, per
 /// `docs/serving_release_packaging_655_d.md`'s field-to-file mapping.
@@ -59,7 +59,7 @@ const COMPILE_REPORT_RELATIVE_PATH: &str = "graph-cover/cover_report.json";
 /// Caller-supplied policy `package_release_bundle` does not derive from
 /// `physical_root` -- see the module docs for why each field has no
 /// on-disk producer today.
-pub(crate) struct PackageInputs {
+pub struct PackageInputs {
     pub model_id: String,
     pub capability: BundleCapability,
     pub uor_matmul: UorMatmulProvenance,
@@ -69,7 +69,7 @@ pub(crate) struct PackageInputs {
 
 /// Why [`package_release_bundle`] could not build a manifest.
 #[derive(Debug)]
-pub(crate) enum PackageBundleError {
+pub enum PackageBundleError {
     /// A required component file could not be read (missing, permission
     /// denied, not a regular file, etc). The tokenizer is the one
     /// optional component (`BundleComponentDigests::tokenizer`) -- its
@@ -109,7 +109,7 @@ impl std::error::Error for PackageBundleError {}
 /// (#655-D2) and runs no compile/cover/score stage. The returned
 /// manifest has already passed [`ReleaseBundleManifest::validate`] --
 /// `Ok` never carries a structurally invalid manifest.
-pub(crate) fn package_release_bundle(
+pub fn package_release_bundle(
     physical_root: &Path,
     inputs: PackageInputs,
 ) -> Result<ReleaseBundleManifest, PackageBundleError> {


### PR DESCRIPTION
## What

Implements #655-D2 per `docs/serving_release_packaging_655_d.md`: a new
`r4 package-release-bundle` CLI command that calls D1's
`package_release_bundle` (PR #775) and writes its result to
`<compiled>/release-bundle.json` -- the first thing that actually
produces the sidecar C1c's `verify_release_bundle_sidecar` (PR #773)
already knows how to verify.

## Why

D1 built the pure digesting helper but nothing called it. D2 makes it
reachable from a real CLI surface, closing the loop that C1c opened.

## What it does

```
r4 package-release-bundle --compiled <dir> --capability continuation
r4 package-release-bundle --compiled <dir> --capability instruction-chat \
    --source <hf-snapshot-dir> --tokenizer-family hf-byte-bpe --tokenizer-version 1
```

`--capability continuation` packages with an empty `tokenizer_adapter`
(valid -- `ReleaseBundleManifest::validate` only requires a real adapter
family for instruction-chat bundles). `--capability instruction-chat`
requires `--source` (the original HF snapshot dir) plus
`--tokenizer-family`/`--tokenizer-version`, and resolves a *real*
`TokenizerAdapter` via `uor_r4_core::transformerless::hf_bpe`'s
`resolve_source_tokenizer` -- confirmed this session that
`physical_root` alone cannot supply one (a bundle's `tokenizer.bin` is a
different format from the `tokenizer.json`/`spiece.model` a
`TokenizerAdapter` is derived from). Tokenizer identity is required, not
inferred, matching #718's existing policy (the same one `r4 compile`'s
own `--tokenizer-family`/`--tokenizer-version` pair enforces).

`uor-matmul` rev/operation-profile/license are CLI flags defaulting to
the project's standing #655 pin and the `exact-gemm-float`/`MIT`
placeholder values already used throughout this codebase's test
fixtures -- kept overridable rather than hardcoded, since neither has a
real producer yet (D0's finding) and upstream `uor-matmul`'s own
`Cargo.toml` (`Apache-2.0`) and `LICENSE` file (MIT license text)
currently disagree with each other.

## Visibility changes

`release_bundle_loader`/`release_bundle_packager` go from `pub(crate)`
to `pub` in `lib.rs`, since `main.rs` (a separate crate from the library)
now needs to call into `release_bundle_packager::package_release_bundle`
and reference `release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME`
(elevated too, so the writer here and C1c's reader share one filename
constant instead of two copies that could drift). Removed D1's
`#![allow(dead_code)]` from `release_bundle_packager.rs` -- confirmed via
clippy that a `pub` item's dead-code lint is satisfied by potential
external use regardless of whether `main.rs`'s own crate target calls it
(unlike the `pub(crate)` case, where clippy flagged all 12 items
individually with no caller).

## Verification

Full ladder green: `cargo fmt --all -- --check`, `cargo clippy
--workspace --all-targets --all-features -- -D warnings`, `cargo build
--target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`, `cargo test
--workspace` (all passed, zero failures; D1's own 8 unit tests
unaffected by the visibility change).

Manually smoke-tested the built binary against the real local
`smollm2-135m-instruct` bundle: both `--capability continuation` and
`--capability instruction-chat` (`--source` pointed at the matching
`.uor-models/sources/smollm2-135m-instruct` snapshot) produced
structurally valid manifests -- the instruction-chat run's
`tokenizer_adapter` carried a real, non-empty `family`/`tokenizer_cid`,
not a placeholder. Also confirmed both guard-rail error paths (missing
`--source` for instruction-chat; `--source` given without the tokenizer
flags) fail with clear messages and a non-zero exit.

`just vv-register` was not runnable in this environment (`just` not
installed) -- same documented gap as PR #773/#775; CI's own register
conformance job covers it.

## Next

D3: a golden test confirming C1c's `verify_release_bundle_sidecar`
returns `Some(..)` against a bundle this command actually wrote (not
just a hand-built fixture), closing out the loop back to the blocked
C1d.
