### PR TITLE
test(#655-D3): golden round-trip proving D2's packager output verifies

### DIFF
--- a/src/release_bundle_packager.rs
+++ b/src/release_bundle_packager.rs
@@ -32,6 +32,13 @@
 //! and writes this function's returned manifest to
 //! `release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME` next to
 //! `physical_root`.
+//!
+//! #655-D3 (this module's own test suite, see
+//! `packaged_bundle_is_accepted_by_the_loaders_sidecar_verifier`) closes
+//! the loop: a golden test that packages a bundle, writes the sidecar
+//! exactly as #655-D2's CLI command does, and asserts
+//! `release_bundle_loader::verify_release_bundle_sidecar` accepts it --
+//! proving the two independently-tested halves actually compose.
 
 use std::path::{Path, PathBuf};
 
@@ -353,7 +360,83 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// #655-D1/D3 preview: confirms `package_release_bundle` works
+    /// #655-D3: closes the loop from "D1/D2 can produce a sidecar" to
+    /// "C1c's verifier actually accepts what D2 produces" -- the two
+    /// halves are each independently well-tested (this module's own
+    /// tests above; `release_bundle_loader`'s synthetic-fixture tests)
+    /// but neither proves they compose against the exact bytes/paths
+    /// the other side expects. This test writes a real
+    /// `release-bundle.json` the same way #655-D2's CLI command does
+    /// (`serde_json::to_vec_pretty` to
+    /// `release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME` next to
+    /// `physical_root`) and asserts
+    /// `release_bundle_loader::verify_release_bundle_sidecar` returns
+    /// `Some` of that exact manifest, unblocking #655-C1d.
+    #[test]
+    fn packaged_bundle_is_accepted_by_the_loaders_sidecar_verifier() {
+        use crate::release_bundle_loader::{
+            verify_release_bundle_sidecar, RELEASE_BUNDLE_SIDECAR_FILE_NAME,
+        };
+
+        let dir = scratch_dir("d3-golden-round-trip");
+        write_full_bundle(&dir);
+        let manifest = package_release_bundle(&dir, valid_inputs()).expect("full bundle packages");
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar, mirroring main.rs's package_release_bundle_command");
+
+        let graph_path = dir.join(GRAPH_RELATIVE_PATH);
+        let teacher_path = dir.join(SIGNATURE_ARTIFACT_RELATIVE_PATH);
+        let verified = verify_release_bundle_sidecar(&dir, &graph_path, &teacher_path);
+        assert_eq!(
+            verified,
+            Some(manifest),
+            "the loader must accept exactly what the packager just wrote"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #655-D3 companion: the same round trip, but for an
+    /// `InstructionChat` bundle carrying a real (non-default)
+    /// `tokenizer_adapter`, mirroring #655-D2's `--source` +
+    /// `--tokenizer-family`/`--tokenizer-version` path rather than only
+    /// the simpler `Continuation` default-adapter case above.
+    #[test]
+    fn instruction_chat_bundle_with_real_tokenizer_adapter_round_trips_through_the_loader() {
+        use crate::release_bundle_loader::{
+            verify_release_bundle_sidecar, RELEASE_BUNDLE_SIDECAR_FILE_NAME,
+        };
+
+        let dir = scratch_dir("d3-golden-instruction-chat");
+        write_full_bundle(&dir);
+        let mut inputs = valid_inputs();
+        inputs.capability = BundleCapability::InstructionChat;
+        inputs.tokenizer_adapter = TokenizerAdapter {
+            family: "hf-byte-bpe".to_string(),
+            ..Default::default()
+        };
+        let manifest =
+            package_release_bundle(&dir, inputs).expect("instruction-chat bundle packages");
+        std::fs::write(
+            dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+            serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        )
+        .expect("write sidecar, mirroring main.rs's package_release_bundle_command");
+
+        let graph_path = dir.join(GRAPH_RELATIVE_PATH);
+        let teacher_path = dir.join(SIGNATURE_ARTIFACT_RELATIVE_PATH);
+        let verified = verify_release_bundle_sidecar(&dir, &graph_path, &teacher_path);
+        assert_eq!(
+            verified,
+            Some(manifest),
+            "the loader must accept an InstructionChat sidecar with a real tokenizer_adapter too"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #655-D1 preview: confirms `package_release_bundle` works
     /// end-to-end against a real local compiled bundle directory, not
     /// just a synthetic fixture. `#[ignore]`d by default and
     /// environment-gated (mirrors `crates/uor-r4-api/tests/api.rs`'s own


### PR DESCRIPTION
## What

Closes the loop that #655-D0/D1/D2 and #655-C1c left open: `package_release_bundle`
(D1) and `verify_release_bundle_sidecar` (C1c) were each independently
well-tested against synthetic fixtures, but nothing proved the two halves
actually compose against the exact bytes and sidecar path #655-D2's CLI
command produces. This PR adds exactly that -- a golden round-trip test,
no production code changes.

## Tests added (`src/release_bundle_packager.rs`)

- `packaged_bundle_is_accepted_by_the_loaders_sidecar_verifier` --
  packages a `Continuation` bundle, writes `release-bundle.json` the same
  way `package_release_bundle_command` (`src/main.rs`) does
  (`serde_json::to_vec_pretty` to
  `release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME`), and asserts
  `verify_release_bundle_sidecar` returns `Some` of that exact manifest.
- `instruction_chat_bundle_with_real_tokenizer_adapter_round_trips_through_the_loader`
  -- same round trip for an `InstructionChat` bundle carrying a real
  (non-default) `tokenizer_adapter`, mirroring D2's `--source` +
  `--tokenizer-family`/`--tokenizer-version` path rather than only the
  simpler default-adapter case.

## Why these tests live here, not in `tests/`

`verify_release_bundle_sidecar` is `pub(crate)` (D2 only elevated the
sidecar file-name constant and the packaging path to `pub` -- main.rs
writes a sidecar, it never reads one back). An integration test under
`tests/` compiles as a separate crate and can only see `pub` items, so
it cannot call the verifier. These tests live inside
`release_bundle_packager.rs`'s own `#[cfg(test)]` module instead, which
also gives them access to that module's private relative-path constants
(`GRAPH_RELATIVE_PATH` etc.) as the single source of truth for the
on-disk layout, rather than re-hardcoding paths that could drift.

## Verification ladder (all green, run locally on this branch)

- `cargo fmt --check`
- `cargo clippy -p uor-r4-wasm-router --all-targets --all-features -- -D warnings`
- `cargo test -p uor-r4-wasm-router --lib release_bundle_packager::` -- 10/10 passed, 1 ignored (env-gated)
- `UOR_R4_RELEASE_BUNDLE_PATH=.../smollm2-135m-instruct cargo test ... -- --ignored packages_the_real_local_bundle` -- passed
- `cargo build -p uor-r4-wasm-router --lib --target wasm32-unknown-unknown` -- clean
- `cargo test --workspace` -- 154 suites, 0 failures
- Register conformance gate (R1-R6): `check-model`, `repo-conformance`, `audit-deferral`, `audit-limits`, `cargo deny check` -- all passed

## Next

With D0-D3 done, #655-D (packaging) is complete. The next natural slice
is **#655-C1d**: surface `verified` on `/v1/models` and
`/uor/v1/status`, now that there's a proven, tested path from a real
compiled bundle to a sidecar the server-side loader actually accepts.
No default-engine change here or in C1d -- #655-F still requires
Casey's explicit sign-off per the issue's standing decisions.
