### PR TITLE
fix(#785-C1): publish node scores from the R4G1 distribution pass so the candidate walk is real

### DIFF
--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -461,14 +461,9 @@ impl<'a> R4G1Runtime<'a> {
         &self,
         context_tokens: &[u32],
         signature: Option<&[u8]>,
-        _node_scores: &mut [ScoreQ],
+        node_scores: &mut [ScoreQ],
     ) -> (u32, ScoreQ) {
-        self.predict_distribution_with_signature_lanes(
-            context_tokens,
-            signature,
-            None,
-            _node_scores,
-        )
+        self.predict_distribution_with_signature_lanes(context_tokens, signature, None, node_scores)
     }
 
     /// Predict with separate context and session signatures.
@@ -481,12 +476,23 @@ impl<'a> R4G1Runtime<'a> {
     /// probe admits nothing within any calibrated radius. The session
     /// signature also participates in the emission affinity bonus below,
     /// unchanged.
+    ///
+    /// `node_scores` (#785 C1): the caller provides a buffer it has reset to
+    /// `ScoreQ::MIN`; when the node-emission path executes, every target
+    /// node whose emissions were scored receives its best final score
+    /// (bounds-checked, so a short buffer simply records fewer nodes). An
+    /// n-gram context-row hit returns before any node is consulted and
+    /// leaves the buffer untouched — absence of node evidence stays
+    /// visible, never fabricated. `predict_candidates_with_signature_lanes`
+    /// reads exactly these entries to expand beyond the single distribution
+    /// winner; before this contract existed the buffer was never written and
+    /// the candidate walk could not return more than one token.
     pub fn predict_distribution_with_signature_lanes(
         &self,
         context_tokens: &[u32],
         context_signature: Option<&[u8]>,
         session_signature: Option<&[u8]>,
-        _node_scores: &mut [ScoreQ],
+        node_scores: &mut [ScoreQ],
     ) -> (u32, ScoreQ) {
         let num_nodes = self.node_count();
         if num_nodes == 0 || context_tokens.is_empty() {
@@ -766,6 +772,16 @@ impl<'a> R4G1Runtime<'a> {
                             .saturating_add(sig_bonus)
                             .saturating_sub(penalty);
                         emit_score = ScoreQ::from_raw(final_score);
+
+                        // #785 C1: publish this node's best final score so
+                        // the top-k candidate walk can expand genuinely
+                        // active nodes instead of gating on a never-written
+                        // buffer.
+                        if let Some(slot) = node_scores.get_mut(target_id as usize)
+                            && emit_score.raw() > slot.raw()
+                        {
+                            *slot = emit_score;
+                        }
 
                         if emit_score.raw() > best_score.raw()
                             || (best_token != 0

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -280,3 +280,60 @@ fn ngram_lookup_kernel_is_integer_only_by_source_scan() {
 fn ngram_artifact_bytes_are_deterministic() {
     assert_eq!(artifact_with_ngram(true), artifact_with_ngram(true));
 }
+
+#[test]
+fn node_path_prediction_publishes_node_scores_for_candidate_expansion() {
+    // #785 C1: the distribution pass writes each scored target node's best
+    // final emission score into the caller's node_scores buffer, so the
+    // top-k candidate walk can expand genuinely active nodes. Before this
+    // contract the buffer was never written and predict_candidates could
+    // never return more than the single distribution winner.
+    let (art_bytes, artifacts) = fixture_artifacts();
+    let store = synthetic_store();
+    let store_bytes = runtime::store_bytes(&store);
+    let (r4g1_bytes, _) =
+        convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None).unwrap();
+    let rt = R4G1Runtime::parse(&r4g1_bytes).unwrap();
+
+    let mut node_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let (best_token, best_score) = rt.predict_distribution(&[1, 2, 3], None, &mut node_scores);
+    assert!(best_token != 0);
+    assert!(best_score > ScoreQ::MIN);
+    let written = node_scores
+        .iter()
+        .filter(|s| s.raw() != ScoreQ::MIN.raw())
+        .count();
+    assert!(
+        written > 0,
+        "node-path prediction must publish at least one node score"
+    );
+
+    // A zero-length buffer reproduces the pre-fix gate: nothing can be
+    // published, so only the distribution winner survives.
+    let mut no_scores: [ScoreQ; 0] = [];
+    let mut gated = [(0u32, ScoreQ::ZERO); 8];
+    let gated_count = rt.predict_candidates(&[1, 2, 3], None, &mut no_scores, &mut gated);
+    assert!(gated_count <= 1);
+
+    let mut full_scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let mut cands = [(0u32, ScoreQ::ZERO); 8];
+    let count = rt.predict_candidates(&[1, 2, 3], None, &mut full_scores, &mut cands);
+    assert!(count >= 1);
+    assert!(
+        count >= gated_count,
+        "published node scores must never shrink the candidate set"
+    );
+}
+
+#[test]
+fn ngram_hit_leaves_node_scores_untouched() {
+    // A context-row hit returns before any node is consulted; the buffer
+    // stays all-MIN and the candidate walk stays single-winner. Absence of
+    // node evidence is left visible, never fabricated.
+    let trigram_bytes = artifact_with_ngram(true);
+    let rt = R4G1Runtime::parse(&trigram_bytes).unwrap();
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let prediction = rt.predict_distribution(&[1, 10, 20], None, &mut scores);
+    assert_eq!(prediction, (8, ScoreQ::from_raw(200)));
+    assert!(scores.iter().all(|s| s.raw() == ScoreQ::MIN.raw()));
+}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -390,6 +390,13 @@ fn hologram_answer(
                     let bundle = runtime::bundle_window_plain(artifacts, &rot, window);
                     let sig = runtime::sig_plain(artifacts, &bundle);
 
+                    // #785 C1: reset the per-step node-score buffer so one
+                    // beam's active-node evidence never leaks into another
+                    // beam or a later step (the engine only ever raises
+                    // entries within a single call).
+                    for slot in node_scores.iter_mut() {
+                        *slot = uor_r4_core::transformerless::score_q::ScoreQ::MIN;
+                    }
                     let mut cands =
                         [(0u32, uor_r4_core::transformerless::score_q::ScoreQ::ZERO); 8];
                     let num_cands = r4g1.predict_candidates_with_signature_lanes(


### PR DESCRIPTION
## What

#785 C1 (the populate arm): make the R4G1 ask-path candidate machinery real. The engine's distribution pass now publishes each scored target node's best final emission score into the caller's `node_scores` buffer (bounds-checked; n-gram hits leave it untouched so absence stays visible), `chat.rs` resets the buffer per beam step, and two contract tests pin the behavior. Before this, the buffer was never written anywhere, `predict_candidates_with_signature_lanes` skipped every node, each beam expanded to exactly one child, and the repeat penalty + `truncate(4)` downstream were dead code — the audited "beam search" was width-1 greedy (baseline audit AUD-QUAL-001; `docs/project_baseline_audit_2026_08_18.md` §14).

## Why now

#783's bundle refresh isolated the failure cleanly: the refreshed `smollm2-135m-instruct` produces grammatical English on the plain path but a prompt-invariant `regarding regarding …` loop through the R4G1 path (5/5 probes byte-identical) — the path `r4 ask` prefers. With candidates real, beam diversity exists at node-path steps and the existing repeat penalty can actually steer; the decisive live re-probe on the refreshed bundle happens on #783 right after this merges, and the C4 decode-policy experiment stays pre-declared there.

## Honesty notes

- This changes generated output on the R4G1 ask path (width-1 → genuine beam-4 at node-path steps). Current output on that path is the degenerate loop above; the live before/after lands on #783 either way.
- Candidates beyond the distribution winner carry raw emission scores (pre-existing asymmetry, deliberately not expanded here).
- No serving default, tier, profile, or artifact-byte changes; P-4 surface unchanged; zero-alloc kernels unchanged (writes into a caller-owned slice).

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets --all-features -- -D warnings` · `cargo test -p uor-r4-graph-runtime` (incl. the two new contract tests) · `cargo test -p uor-r4-core --test allocation_census` · root `--lib` tests · `cargo build --target wasm32-unknown-unknown --lib` · `cargo run -p xtask -- audit-limits` — all green locally; the merge queue re-runs the full ladder as the binding verdict.

References #785 #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
