### PR TITLE
fix(#785): make the R4G1 CLI ask path decode from real evidence

### DIFF
--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -37,32 +37,8 @@ fn signature_affinity_bonus(prototype: &[u8], mask: &[u8], signature: &[u8]) -> 
 /// The first non-empty row wins: trigram, then bigram, then the EMIT
 /// unigram path (represented by `None`).
 fn context_backoff(view: &GraphView<'_>, context_tokens: &[u32]) -> Option<(u32, ScoreQ)> {
-    let table = view.ngram_table().ok().flatten()?;
-    let tokens = if context_tokens.first().is_some_and(|&token| token <= 1) {
-        &context_tokens[1..]
-    } else {
-        context_tokens
-    };
-    let mut best = None;
-    if tokens.len() >= 2
-        && let Some(row) = table.find(2, tokens[tokens.len() - 2], tokens[tokens.len() - 1])
-    {
-        best = best_context_entry(row.entries());
-    }
-    if best.is_none()
-        && let Some(&previous) = tokens.last()
-        && let Some(row) = table.find(1, previous, 0)
-    {
-        best = best_context_entry(row.entries());
-    }
-    best
-}
-
-fn best_context_entry(
-    entries: impl Iterator<Item = uor_r4_graph_format::NgramEntry>,
-) -> Option<(u32, ScoreQ)> {
-    let mut best = None;
-    for entry in entries {
+    let mut best: Option<(u32, ScoreQ)> = None;
+    with_context_row_entries(view, context_tokens, |entry| {
         let candidate = (entry.token, entry.score_q);
         if best.is_none_or(|(token, score): (u32, ScoreQ)| {
             candidate.1.raw() > score.raw()
@@ -70,8 +46,51 @@ fn best_context_entry(
         }) {
             best = Some(candidate);
         }
-    }
+    });
     best
+}
+
+/// Visit every entry of the winning explicit context row for
+/// `context_tokens` — the identical trigram-then-bigram resolution and
+/// leading-BOS skip `context_backoff` applies — so single-winner backoff
+/// and the top-k candidate walk read the same row instead of drifting.
+/// Returns true when a non-empty row was found.
+fn with_context_row_entries<F: FnMut(uor_r4_graph_format::NgramEntry)>(
+    view: &GraphView<'_>,
+    context_tokens: &[u32],
+    mut visit: F,
+) -> bool {
+    let Some(table) = view.ngram_table().ok().flatten() else {
+        return false;
+    };
+    let tokens = if context_tokens.first().is_some_and(|&token| token <= 1) {
+        &context_tokens[1..]
+    } else {
+        context_tokens
+    };
+    if tokens.len() >= 2
+        && let Some(row) = table.find(2, tokens[tokens.len() - 2], tokens[tokens.len() - 1])
+    {
+        let mut any = false;
+        for entry in row.entries() {
+            any = true;
+            visit(entry);
+        }
+        if any {
+            return true;
+        }
+    }
+    if let Some(&previous) = tokens.last()
+        && let Some(row) = table.find(1, previous, 0)
+    {
+        let mut any = false;
+        for entry in row.entries() {
+            any = true;
+            visit(entry);
+        }
+        return any;
+    }
+    false
 }
 
 impl<'a> R4G1Runtime<'a> {
@@ -287,12 +306,32 @@ impl<'a> R4G1Runtime<'a> {
     }
 }
 
+/// Whether any node in `base_graph` carries a per-node emission list.
+///
+/// The two graph writers differ here: the certify score writer wires
+/// per-node `emission_start`/`emission_len` ranges over the EMIT
+/// remainder, while the converter carryover writes every node with an
+/// empty range and stores a single global root-prior (token, count)
+/// table as the whole EMIT remainder. The fallback readers below must
+/// know which flavor they are looking at before treating a section
+/// remainder as a pair list (#785).
+fn has_per_node_emissions(base_graph: &GraphView<'_>) -> bool {
+    let count = base_graph.node_count().unwrap_or(0);
+    for n in 0..count {
+        if let Some(node) = base_graph.node(n)
+            && node.emission_len > 0
+        {
+            return true;
+        }
+    }
+    false
+}
+
 fn check_node_emits(
     base_graph: &uor_r4_graph_format::GraphView,
     node_id: u32,
     target_token: u32,
     emit_remainder: Option<&[u8]>,
-    exct_remainder: Option<&[u8]>,
 ) -> (bool, ScoreQ) {
     let mut stack = [0u32; 128];
     let mut visited = [0u32; 128];
@@ -362,34 +401,12 @@ fn check_node_emits(
         }
     }
 
-    if let Some(exct_bytes) = exct_remainder {
-        for i in 0..(exct_bytes.len() >> 3) {
-            let offset = i << 3;
-            let cand = u32::from_le_bytes([
-                exct_bytes[offset],
-                exct_bytes[offset + 1],
-                exct_bytes[offset + 2],
-                exct_bytes[offset + 3],
-            ]);
-            if cand == target_token {
-                let raw = i32::from_le_bytes([
-                    exct_bytes[offset + 4],
-                    exct_bytes[offset + 5],
-                    exct_bytes[offset + 6],
-                    exct_bytes[offset + 7],
-                ]);
-                return (
-                    true,
-                    if raw > 0 {
-                        ScoreQ::from_raw(raw)
-                    } else {
-                        ScoreQ::from_raw(1)
-                    },
-                );
-            }
-        }
-    }
-
+    // #785 C1c: no EXCT fallback here. EXCT is a storage descriptor
+    // followed by a raw store container (TLS1 carryover from the
+    // converter, RX1 residual tables from the score writer), never a
+    // (token, score_q) pair list — scanning it as pairs manufactured
+    // garbage matches at garbage scores and paid a multi-megabyte
+    // linear walk per query doing it.
     (false, ScoreQ::ZERO)
 }
 
@@ -507,9 +524,13 @@ impl<'a> R4G1Runtime<'a> {
         let emit_remainder = base_graph
             .section(SectionId::EMIT)
             .and_then(|b| if b.len() >= 4 { Some(&b[4..]) } else { None });
-        let exct_remainder = base_graph
-            .section(SectionId::EXCT)
-            .and_then(|b| if b.len() >= 12 { Some(&b[4..]) } else { None });
+        // #785 C1c: EXCT is deliberately not read anywhere in this
+        // engine. Both writers emit it as a storage descriptor followed
+        // by a raw store container (TLS1 carryover / RX1 residual
+        // tables); no artifact carries a pair-list EXCT, so the old
+        // pair-scan fallbacks over it only ever produced near-saturated
+        // garbage scores that drowned every real tier.
+        let per_node_emissions = has_per_node_emissions(base_graph);
 
         let mut active_nodes = [0u32; 64];
         let mut active_len = 0usize;
@@ -531,8 +552,7 @@ impl<'a> R4G1Runtime<'a> {
             let mut current = [0u32; 64];
             let mut current_len = 0usize;
             for n in 0..num_nodes {
-                if check_node_emits(base_graph, n, suffix[0], emit_remainder, exct_remainder).0
-                    && current_len < 64
+                if check_node_emits(base_graph, n, suffix[0], emit_remainder).0 && current_len < 64
                 {
                     current[current_len] = n;
                     current_len += 1;
@@ -559,14 +579,8 @@ impl<'a> R4G1Runtime<'a> {
                                     } // EDGE_KIND_TRANSITION
 
                                     let dst = edge.dst.0;
-                                    if check_node_emits(
-                                        base_graph,
-                                        dst,
-                                        t,
-                                        emit_remainder,
-                                        exct_remainder,
-                                    )
-                                    .0 && !next_current[..next_len].contains(&dst)
+                                    if check_node_emits(base_graph, dst, t, emit_remainder).0
+                                        && !next_current[..next_len].contains(&dst)
                                         && next_len < 64
                                     {
                                         next_current[next_len] = dst;
@@ -686,8 +700,14 @@ impl<'a> R4G1Runtime<'a> {
                     };
 
                     let sl = if target_node.emission_len == 0 {
-                        if target_id == 0 {
-                            exct_remainder.or(emit_remainder).unwrap_or(&[])
+                        if target_id == 0 && !per_node_emissions {
+                            // Converter-flavor graph: the whole EMIT
+                            // remainder is the root prior (token, count)
+                            // table, served as node 0's list. On a scored
+                            // graph the remainder is a root-prior block
+                            // plus per-region lists and must only be read
+                            // through per-node ranges (#785 C1c).
+                            emit_remainder.unwrap_or(&[])
                         } else {
                             &[][..]
                         }
@@ -796,8 +816,12 @@ impl<'a> R4G1Runtime<'a> {
             }
         }
 
-        if best_token == 0 {
-            // If best_token is still 0, emit the first non-zero token from Node 0's emission list
+        if best_token == 0 && !per_node_emissions {
+            // Converter-flavor last resort: emit the first usable token
+            // from the global root-prior table. A scored graph's EMIT
+            // remainder starts with the root-prior block header, which is
+            // not a pair list — an unmatched scored-graph query returns
+            // (0, ...) honestly instead (#785 C1c).
             if let Some(remainder) = emit_remainder {
                 for i in 0..(remainder.len() >> 3) {
                     let offset = i << 3;
@@ -857,6 +881,23 @@ impl<'a> R4G1Runtime<'a> {
             out_candidates[0] = (top_tok, top_score);
             count = 1;
         }
+
+        // #785 C1: a context-row hit resolves before any node is consulted,
+        // so `node_scores` stays empty on those steps — but the winning row
+        // itself carries the alternative continuations. Surface them here so
+        // the candidate walk is real on the n-gram tier too, not only the
+        // node path. Same reserved-token guard and dedup as the node walk.
+        with_context_row_entries(self.chain.base_graph(), context_tokens, |entry| {
+            if count >= 8 {
+                return;
+            }
+            let cand = entry.token;
+            if cand > 2 && cand < 49152 && !out_candidates[..count].iter().any(|(c, _)| *c == cand)
+            {
+                out_candidates[count] = (cand, entry.score_q);
+                count += 1;
+            }
+        });
 
         // Iterate over the top active nodes in node_scores to collect candidate tokens
         let emit_remainder = self.view().section(SectionId::EMIT);

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -267,7 +267,16 @@ fn ngram_lookup_kernel_is_integer_only_by_source_scan() {
     let end = source
         .find("impl<'a> R4G1Runtime")
         .expect("runtime implementation follows lookup helpers");
-    let kernel = &source[start..end];
+    // Strip line comments before scanning so the kernel functions can carry
+    // doc comments (which necessarily contain '/') without weakening the
+    // check on the code itself. No string literal in this region contains
+    // "//", so the naive split is exact here (#785; scanner consolidation
+    // tracked by #787).
+    let kernel = source[start..end]
+        .lines()
+        .map(|line| line.split("//").next().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
     for forbidden in ["*", "/", "f32", "f64"] {
         assert!(
             !kernel.contains(forbidden),
@@ -336,4 +345,134 @@ fn ngram_hit_leaves_node_scores_untouched() {
     let prediction = rt.predict_distribution(&[1, 10, 20], None, &mut scores);
     assert_eq!(prediction, (8, ScoreQ::from_raw(200)));
     assert!(scores.iter().all(|s| s.raw() == ScoreQ::MIN.raw()));
+}
+
+#[test]
+fn ngram_hit_surfaces_row_alternatives_as_candidates() {
+    // #785 C1: on a context-row hit the winning row's alternative entries
+    // become candidates, so multi-candidate decoding exists on the n-gram
+    // tier too. The fixture trigram row holds (8, 200) and (9, 200); the
+    // single-winner distribution keeps 8 (tie broken by lower token), and
+    // the candidate walk must now surface 9 as well.
+    let trigram_bytes = artifact_with_ngram(true);
+    let rt = R4G1Runtime::parse(&trigram_bytes).unwrap();
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let mut cands = [(0u32, ScoreQ::ZERO); 8];
+    let count = rt.predict_candidates(&[1, 10, 20], None, &mut scores, &mut cands);
+    assert!(count >= 2, "row alternatives must be surfaced, got {count}");
+    assert_eq!(cands[0], (8, ScoreQ::from_raw(200)));
+    assert!(
+        cands[..count].iter().any(|&(token, _)| token == 9),
+        "the row's alternative continuation must appear"
+    );
+    // The buffer contract is unchanged: a row hit still consults no nodes.
+    assert!(scores.iter().all(|s| s.raw() == ScoreQ::MIN.raw()));
+}
+
+/// Rebuild the base converter artifact with selected section payloads
+/// replaced, preserving section order and alignment.
+fn artifact_with_replaced_sections(replacements: &[(SectionId, Vec<u8>)]) -> Vec<u8> {
+    let base = base_r4g1_artifact();
+    let view = GraphView::parse(&base).expect("base artifact parses");
+    let mut builder = ArtifactBuilder::new(view.header().alignment_log2);
+    for section in view.sections() {
+        match replacements.iter().find(|(id, _)| *id == section.id) {
+            Some((_, payload)) => {
+                builder.add_section(section.id, section.flags, payload);
+            }
+            None => {
+                builder.add_section(section.id, section.flags, section.payload);
+            }
+        }
+    }
+    builder.build().expect("rebuilt artifact builds")
+}
+
+#[test]
+fn exct_container_bytes_are_never_scored_as_emission_pairs() {
+    // #785 C1c seeded violation: EXCT is a storage descriptor plus a raw
+    // store container, never a (token, score_q) pair list. The old
+    // node-0 fallback preferred EXCT and pair-scanned it, so a byte
+    // pattern that happens to decode as a valid token id with a
+    // near-saturated score would win every step — exactly the failure
+    // observed live on converter bundles carrying a multi-megabyte TLS1
+    // container. Seed one such pattern and prove it can never surface.
+    let mut poisoned_exct = vec![2u8, 0, 0, 0];
+    poisoned_exct.extend_from_slice(&4242u32.to_le_bytes());
+    poisoned_exct.extend_from_slice(&(i32::MAX - 1).to_le_bytes());
+    let bytes = artifact_with_replaced_sections(&[(SectionId::EXCT, poisoned_exct)]);
+    let rt = R4G1Runtime::parse(&bytes).expect("poisoned-EXCT artifact parses");
+
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let (token, score) = rt.predict_distribution(&[1, 2, 3], None, &mut scores);
+    assert_ne!(token, 4242, "EXCT container bytes must never be emitted");
+    assert!(
+        score.raw() < 1_000_000,
+        "no near-saturated garbage score may survive, got {}",
+        score.raw()
+    );
+
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let mut cands = [(0u32, ScoreQ::ZERO); 8];
+    let count = rt.predict_candidates(&[1, 2, 3], None, &mut scores, &mut cands);
+    assert!(
+        cands[..count].iter().all(|&(t, _)| t != 4242),
+        "EXCT container bytes must never enter the candidate walk"
+    );
+}
+
+#[test]
+fn scored_flavor_reads_only_per_node_emission_ranges() {
+    // #785 C1c seeded violation, scored flavor: when any node carries a
+    // per-node emission range, the EMIT remainder is a root-prior block
+    // plus per-region lists — whole-remainder reads (old node-0 and
+    // last-resort fallbacks) would score arbitrary header bytes. Craft a
+    // remainder whose first pseudo-pair is a valid-looking token at a
+    // near-saturated score, wire node 1's range past it, and prove only
+    // the ranged entry is ever read.
+    let base = base_r4g1_artifact();
+    let base_view = GraphView::parse(&base).expect("base artifact parses");
+    let mut node_payload = base_view
+        .section(SectionId::NODE)
+        .expect("NODE section present")
+        .to_vec();
+    // Node 1's record starts at PACKED_NODE_LEN; emission_start is at
+    // record offset 12 (u32), emission_len at 16 (u16).
+    let record = uor_r4_graph_format::PACKED_NODE_LEN;
+    node_payload[record + 12..record + 16].copy_from_slice(&8u32.to_le_bytes());
+    node_payload[record + 16..record + 18].copy_from_slice(&8u16.to_le_bytes());
+
+    let mut emit = vec![2u8, 0, 0, 0];
+    emit.extend_from_slice(&49000u32.to_le_bytes()); // poison pseudo-pair
+    emit.extend_from_slice(&(i32::MAX - 1).to_le_bytes());
+    emit.extend_from_slice(&7u32.to_le_bytes()); // node 1's real entry
+    emit.extend_from_slice(&500i32.to_le_bytes());
+
+    let mut poisoned_exct = vec![2u8, 0, 0, 0];
+    poisoned_exct.extend_from_slice(&49000u32.to_le_bytes());
+    poisoned_exct.extend_from_slice(&(i32::MAX - 1).to_le_bytes());
+
+    let bytes = artifact_with_replaced_sections(&[
+        (SectionId::NODE, node_payload),
+        (SectionId::EMIT, emit),
+        (SectionId::EXCT, poisoned_exct),
+    ]);
+    let rt = R4G1Runtime::parse(&bytes).expect("scored-flavor artifact parses");
+
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let (token, score) = rt.predict_distribution(&[1, 2, 3], None, &mut scores);
+    assert_ne!(token, 49000, "whole-remainder reads must be gated off");
+    assert!(
+        score.raw() < 1_000_000,
+        "no near-saturated garbage score may survive, got {}",
+        score.raw()
+    );
+
+    let mut scores = vec![ScoreQ::MIN; rt.node_count() as usize];
+    let mut cands = [(0u32, ScoreQ::ZERO); 8];
+    let count = rt.predict_candidates(&[1, 2, 3], None, &mut scores, &mut cands);
+    assert!(
+        cands[..count].iter().all(|&(t, _)| t != 49000),
+        "poison pseudo-pair must never enter the candidate walk"
+    );
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -195,11 +195,8 @@ impl ChatEngineBuilder {
             compiler::parse_artifacts(&artifact_bytes).ok_or(ChatError::InvalidArtifacts)?;
         let store_bytes = model_store.get(&manifest.store)?;
         let store = runtime::parse_store(&store_bytes).ok_or(ChatError::InvalidStore)?;
-        let r4g1_path = std::path::PathBuf::from(format!(
-            ".uor-models/compiled/{}/compiled.r4g1",
-            manifest.name
-        ));
-        let r4g1_bytes = read_optional_chat_file(&r4g1_path)?;
+        let model_dir = std::path::PathBuf::from(format!(".uor-models/compiled/{}", manifest.name));
+        let r4g1_bytes = read_preferred_chat_graph(&model_dir)?;
         validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
         let bundled_tokenizer = match model_store.get(&manifest.tokenizer) {
             Ok(bytes) => bytes,
@@ -243,7 +240,7 @@ fn build_local_compiled_engine(
 ) -> Result<ChatEngine, ChatError> {
     let artifact_bytes = std::fs::read(directory.join("tless_artifacts.bin"))?;
     let store_bytes = std::fs::read(directory.join("tless_store.bin"))?;
-    let r4g1_bytes = read_optional_chat_file(&directory.join("compiled.r4g1"))?;
+    let r4g1_bytes = read_preferred_chat_graph(directory)?;
     validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
     let tok_file = directory.join("tokenizer.bin");
     tracing::debug!(?tok_file, "resolved chat tokenizer path");
@@ -554,6 +551,22 @@ fn invalid_chat_data(message: impl Into<String>) -> ChatError {
         std::io::ErrorKind::InvalidData,
         message.into(),
     ))
+}
+
+/// Resolve the model directory's servable R4G1 graph, preferring the
+/// scored artifact over the converter carryover.
+///
+/// `graph/score.r4g1` is the graph the HTTP server (`primary_graph`) and
+/// the release-bundle packager (`GRAPH_RELATIVE_PATH`) already treat as
+/// the servable one: it carries per-node emissions, context rows, and
+/// residual EXCT tables. `compiled.r4g1` is the converter carryover
+/// (empty per-node emissions, raw TLS1 EXCT) and stays as the fallback
+/// for bundles that never ran score (#785 C1c).
+fn read_preferred_chat_graph(directory: &std::path::Path) -> Result<Option<Vec<u8>>, ChatError> {
+    if let Some(bytes) = read_optional_chat_file(&directory.join("graph/score.r4g1"))? {
+        return Ok(Some(bytes));
+    }
+    read_optional_chat_file(&directory.join("compiled.r4g1"))
 }
 
 fn read_optional_chat_file(path: &std::path::Path) -> Result<Option<Vec<u8>>, ChatError> {


### PR DESCRIPTION
References #785 (C1b + C1c). References #783 (feeds the A4 quality read).

## What was wrong

`r4 ask --model smollm2-135m-instruct` produced byte-identical
degenerate output (`regarding regarding ...`) even on the freshly
recompiled post-#755 bundle (#783-A1), while the same bundle's plain
transformerless path produced grammatical English. Instrumenting the
beam showed one candidate per step carrying a near-saturated score
(~2,147,356,480 raw ~= i32::MAX), decaying by exactly the 350x recency
step. Dumping the artifact explained it:

- `compiled.r4g1` (converter carryover) has **zero per-node emission
  entries** across all 1,025 nodes, and its EXCT section is the raw
  TLS1 store container (31 MB, magic `TLS1` at the descriptor
  boundary) -- by design ("EXCT: descriptor + the raw TLS1
  carryover", `convert_r4g1.rs`).
- The engine's node-0 fallback preferred EXCT and read those container
  bytes as (token, score_q) pairs; ~20% of 3.9M pseudo-pairs pass the
  token filter, several at near-i32::MAX raw. The suffix-DFA's
  emission oracle (`check_node_emits`) did the same whole-section scan
  per query. Garbage drowned every real tier and cost ~35 s per ask.
- The scored graph `graph/score.r4g1` (36/37 nodes with real
  emissions, real context rows, RX1 residual EXCT) sat next to it,
  already preferred by the HTTP server (`server.rs` `primary_graph`)
  and the release packager (`GRAPH_RELATIVE_PATH`) -- but the CLI
  loader never looked at it.

## The change

- **C1c (loader)**: `read_preferred_chat_graph` -- both CLI chat
  loaders (manifested + local-compiled) now prefer
  `graph/score.r4g1`, falling back to `compiled.r4g1`. This aligns
  the CLI with the server/packager artifact preference; it does not
  build #655-C1e's shared loader stack.
- **C1c (engine)**: EXCT is no longer read anywhere in the runtime
  engine -- both writers emit a storage descriptor + store container
  there, never a pair list. The whole-EMIT-remainder fallbacks
  (node-0 source, last-resort emit) are gated to the converter flavor
  (`has_per_node_emissions == false`), where the remainder really is
  the global root-prior table. On a scored graph an unmatched query
  now returns an honest miss instead of scored header bytes.
- **C1b (engine)**: a context-row hit surfaces the winning row's
  alternative entries into the candidate walk, so beam search is real
  on the n-gram tier (previously: single winner, greedy in effect).

## Evidence

- Seeded-violation tests (`exct_container_bytes_are_never_scored_as_
  emission_pairs`, `scored_flavor_reads_only_per_node_emission_
  ranges`) poison EXCT/EMIT with valid-looking near-MAX pseudo-pairs;
  against the previous engine both fail by emitting the poison
  (4242 / 49000); with this change the poison cannot surface.
  `ngram_hit_surfaces_row_alternatives_as_candidates` pins C1b (also
  fails pre-change: `got 1` candidate).
- 15-prompt protocol (#758 set), canonical refreshed 135m bundle,
  default R4G1 ask path, deterministic double pass (30/30
  byte-identical):
  - pre-fix: 15/15 prompts -> one byte-identical `regarding`
    repetition, ~35 s per ask;
  - post-fix: 5/15 distinct outputs with grammatical, prompt-form
    openers ("What is the capital of France?" -> "It is the capital
    of the 19...", "hello" -> "What is known as the 19...",
    "Once upon a time, there was a little" -> "more than 2000..."),
    ~1 s per ask; 11/15 converge to "The word comes from the 19..."
    and every trajectory ends in a "19"-digit/comma attractor.
- The remaining attractor is the #759-corrected collapse on real
  evidence (year/number n-grams dominating continuations); it is
  #784's instrument target and #785-C4's decode-policy experiment,
  deliberately not patched ad hoc here. The beam's consecutive-only
  repeat penalty never fires on the digit/comma cycle -- same evasion
  class as the earlier whitespace alternation; that observation is
  recorded for C4.

Gates run locally: fmt, clippy --workspace --all-targets
--all-features -D warnings, workspace tests (--no-fail-fast), wasm32
lib build, R-register conformance. Latency on the canonical ask path:
~35 s -> ~1 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
