### PR TITLE
fix(#788): resolve the repo root at runtime; audit walks refuse an empty scan set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,3 +271,14 @@ never sit between two pieces of code work.
 - The on-disk compiled store in `.uor-models/` predates the u32 token
   migration (TLS1-u16); `runtime::parse_store_legacy_u16` reads it, and a full
   recompile is needed to refresh it.
+- After deleting a git worktree, cached rlibs in the shared `target/` can
+  carry the dead worktree's baked paths and poison the local register gates
+  (#788, AUD-VER-001). `repo_root()` now resolves at runtime, but any other
+  compile-time `env!("CARGO_MANIFEST_DIR")` user (fixture-loading tests) has
+  the same hazard — `cargo clean -p repo-model -p repo-conformance -p xtask`
+  clears the register gates; when in doubt, clean the crate whose test reads
+  a repo path.
+- `cargo test` is fail-fast at the test-binary level: one poisoned binary
+  hides every suite after it. Use `cargo test --workspace --no-fail-fast`
+  for local gate runs so a single bad binary cannot mask the rest
+  (AUD-VER-002).

--- a/crates/repo-conformance/tests/bdd.rs
+++ b/crates/repo-conformance/tests/bdd.rs
@@ -12,11 +12,10 @@ use repo_conformance::{check_honesty, scenarios_in};
 use repo_model::{Level, Model};
 
 fn root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("crates/conformance is two below the root")
-        .to_path_buf()
+    // #788: runtime resolution, never compile-time env!() — see
+    // registered.rs; a cached test binary with a baked worktree path made
+    // this suite read a nonexistent tree (AUD-VER-001).
+    repo_model::repo_root()
 }
 
 /// Every `#[test]` function name in the workspace.

--- a/crates/repo-conformance/tests/registered.rs
+++ b/crates/repo-conformance/tests/registered.rs
@@ -10,11 +10,13 @@ use repo_conformance::scenarios_in;
 use std::path::PathBuf;
 
 fn root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("crates/repo-conformance is two below the root")
-        .to_path_buf()
+    // #788: runtime resolution, never compile-time env!() — a cached test
+    // binary carries the baked path of whatever checkout built it, which
+    // made all 29 markers fail (`features/suites` NotFound) after a
+    // sibling worktree was deleted (AUD-VER-001). repo_model::repo_root
+    // walks up from the runtime CARGO_MANIFEST_DIR (cwd fallback) to the
+    // ancestor holding model/ledger.toml.
+    repo_model::repo_root()
 }
 
 fn check(id: &str, suite: &str) {

--- a/crates/repo-model/src/lib.rs
+++ b/crates/repo-model/src/lib.rs
@@ -159,13 +159,35 @@ fn read<T: serde::de::DeserializeOwned>(dir: &Path, name: &str) -> Result<T, Mod
     toml::from_str(&text).map_err(|e| ModelError::Parse(path, e))
 }
 
-/// The repository root, resolved from this crate's manifest directory.
+/// The repository root, resolved at **runtime**.
+///
+/// #788: this must not use compile-time `env!("CARGO_MANIFEST_DIR")` —
+/// a cached rlib carries the path of whatever checkout (or since-deleted
+/// worktree) built it, which poisoned the R1/R2/R3/R4 register gates and
+/// let R5 pass vacuously against a nonexistent root (AUD-VER-001).
+/// Runtime resolution order:
+/// 1. `CARGO_MANIFEST_DIR` from the process environment (cargo sets it
+///    for `cargo run`/`cargo test`), walking up to the workspace root;
+/// 2. otherwise walk up from the current directory to the first ancestor
+///    containing `model/ledger.toml` (direct binary invocation).
 pub fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("crates/model is two levels below the repository root")
-        .to_path_buf()
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        for ancestor in Path::new(&manifest_dir).ancestors() {
+            if ancestor.join("model/ledger.toml").is_file() {
+                return ancestor.to_path_buf();
+            }
+        }
+    }
+    let cwd = std::env::current_dir().expect("current directory is readable");
+    for ancestor in cwd.ancestors() {
+        if ancestor.join("model/ledger.toml").is_file() {
+            return ancestor.to_path_buf();
+        }
+    }
+    panic!(
+        "repository root not found: no ancestor of CARGO_MANIFEST_DIR or the \
+         current directory contains model/ledger.toml"
+    );
 }
 
 #[cfg(test)]

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -55,6 +55,20 @@ fn shipped_sources(root: &Path) -> Result<Vec<Source>, Fail> {
         }
         collect(&dir, root, &mut out)?;
     }
+    // #788: an empty scan set must fail, never vacuously pass. A stale or
+    // wrong repository root (e.g. a path baked into a cached build from a
+    // since-deleted worktree, AUD-VER-001) previously made the R4/R5
+    // audits report success while checking nothing — "no violations" and
+    // "no files" must not share a representation.
+    if out.is_empty() {
+        return Err(format!(
+            "audit walk found zero shipped source files under {} — refusing \
+             the vacuous pass (#788): the repository root is wrong or the \
+             shipped-crate set is unreadable",
+            root.display()
+        )
+        .into());
+    }
     Ok(out)
 }
 
@@ -347,6 +361,16 @@ pub fn audit_deferral(root: &Path) -> Result<(), Fail> {
             files.push(p);
         }
     }
+    // #788: same empty-walk refusal as `shipped_sources` — a wrong root
+    // that happens to exist must not scan nothing and report success.
+    if files.is_empty() {
+        return Err(format!(
+            "deferral walk found zero files under {} — refusing the vacuous \
+             pass (#788): the repository root is wrong",
+            root.display()
+        )
+        .into());
+    }
 
     for path in files {
         let Ok(text) = std::fs::read_to_string(&path) else {
@@ -460,5 +484,40 @@ mod tests {
             seek,
             "Result<u64> {"
         ));
+    }
+}
+
+#[cfg(test)]
+mod empty_walk_tests {
+    use super::*;
+
+    // #788 falsifiers: both audit walkers must refuse an empty scan set.
+    // Each fixture root exists and is readable — the pre-#788 behavior on
+    // such a root was a 0-second vacuous PASS (AUD-VER-001).
+
+    #[test]
+    fn audit_limits_refuses_an_empty_walk() {
+        let dir = std::env::temp_dir().join("xtask-788-empty-walk-limits");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("crates")).expect("fixture root");
+        let err = audit_limits(&dir).expect_err("an empty walk must fail, not pass");
+        assert!(
+            err.to_string().contains("zero shipped source files"),
+            "refusal must name the empty walk, got: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn audit_deferral_refuses_an_empty_walk() {
+        let dir = std::env::temp_dir().join("xtask-788-empty-walk-deferral");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("crates")).expect("fixture root");
+        let err = audit_deferral(&dir).expect_err("an empty walk must fail, not pass");
+        assert!(
+            err.to_string().contains("zero files"),
+            "refusal must name the empty walk, got: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
References #788. Closes the AUD-VER-001/-002 gate-integrity findings: runtime repo-root resolution (env-var walk + cwd fallback + loud failure), empty-walk refusal in both audit walkers with seeded falsifier tests (the pre-fix behavior on the same fixture was a vacuous 0-second pass), and the AGENTS.md operational notes (stale-worktree rlib hazard, --no-fail-fast). Verified: all register gates green from the live tree via cargo AND via direct binary invocation from the repo root; direct invocation from an unrelated directory fails loudly instead of walking a wrong tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW