### PR TITLE
fix(#790): CLI batch — pin the 1.7B revision, loud unknown subcommands, real default-model discovery (items 1-3)

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -15218,7 +15218,10 @@ mod transformerless_dispatch_790 {
         let unknown = super::run(&["definitely-not-a-subcommand".to_string()]);
         assert!(unknown.is_err(), "unknown subcommand must fail loudly");
         assert!(
-            unknown.unwrap_err().to_string().contains("definitely-not-a-subcommand"),
+            unknown
+                .unwrap_err()
+                .to_string()
+                .contains("definitely-not-a-subcommand"),
             "the error must name the unknown subcommand"
         );
         assert!(super::run(&["help".to_string()]).is_ok());
@@ -15232,8 +15235,17 @@ mod transformerless_dispatch_790 {
             !usage.contains("compare"),
             "compare/compare-report are top-level r4 commands, not transformerless subcommands"
         );
-        for advertised in ["setup", "store", "scenarios", "teacher-kappa", "convert-r4g1"] {
-            assert!(usage.contains(advertised), "banner must keep `{advertised}`");
+        for advertised in [
+            "setup",
+            "store",
+            "scenarios",
+            "teacher-kappa",
+            "convert-r4g1",
+        ] {
+            assert!(
+                usage.contains(advertised),
+                "banner must keep `{advertised}`"
+            );
         }
     }
 }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -9738,10 +9738,30 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
         Some("graph") => graph_command(&args[1..])?,
         Some("cd-compile") => cd_compile_command(&args[1..]),
         Some("quantum-eval") => quantum_eval_command(&args[1..]),
+        // #790 item 2: `help`/no-args prints usage and succeeds; an
+        // UNKNOWN subcommand prints usage and fails — previously any typo
+        // (or the removed `compare`/`compare-report`, which are top-level
+        // `r4` commands, not transformerless subcommands) exited 0 as a
+        // silent no-op, so a broken pipeline stage reported success.
+        Some(unknown) if unknown != "help" => {
+            println!("{}", transformerless_usage());
+            return Err(SourceUnavailable::new(format!(
+                "unknown transformerless subcommand `{unknown}`"
+            )));
+        }
         _ => {
-            println!(
-                "R4 transformerless — compile a mul-free table artifact\n\
-                 commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | compare | compare-report | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
+            println!("{}", transformerless_usage());
+        }
+    }
+    Ok(())
+}
+
+/// Usage banner for the `transformerless` command family. Lists exactly
+/// the subcommands `run` dispatches (#790: it previously advertised
+/// `compare`/`compare-report`, which live on the top-level `r4` CLI).
+fn transformerless_usage() -> &'static str {
+    "R4 transformerless — compile a mul-free table artifact\n\
+                 commands: setup | gen [secs] [target] | compile [--model REPO --revision SHA | --source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--output DIR] [--seconds N] [--target N] [--sequence-length N] | store | scenarios | teacher-kappa | convert-r4g1 --artifacts <TLA> --store <TLS1> [--calibration <hamming_calibration.json>] --out <R4G1>\n\
                  recorded compile (no transformer): compile-recorded --corpus-meta <META> --corpus-recs <RECS> --vocab-size <N> --out <DIR>\n\
                  markerless legacy attention copy (dense-present derivations are refused): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
                  guarded streaming corpus derivation (N <= source; complete runs may undershoot): subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
@@ -9756,10 +9776,6 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
                  hf evaluation: evaluate-report [--source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--compiled DIR] [--report PATH] [--sequence-length N] [--bos] [--max-held-out-stories N]\n\
                  scale sizing (#514): recommend-scale (--config <hf dir> | --d-model N --n-layers N --vocab N) [--corpus wiki|stories] [--beta B]\n\
                  docs: docs/transformerless/TRANSFORMERLESS.md (extrapolation), docs/transformerless/PROOF.md (proof + certificate)"
-            );
-        }
-    }
-    Ok(())
 }
 
 pub fn cd_compile_command(args: &[String]) {
@@ -15188,5 +15204,36 @@ mod tests {
         assert_eq!(parse("none"), score::EmissionShrinkage::None);
         assert_eq!(parse("witten-bell"), score::EmissionShrinkage::WittenBell);
         assert!(parse_score_options(&["--emission-shrinkage", "bad"].map(str::to_owned)).is_err());
+    }
+}
+
+#[cfg(test)]
+mod transformerless_dispatch_790 {
+    // #790 item 2 falsifier: an unknown subcommand must be a nonzero-exit
+    // error, never a banner-printing silent success; `help`/no-args stays
+    // a successful usage print; the banner only advertises subcommands
+    // this dispatcher actually handles.
+    #[test]
+    fn unknown_subcommand_is_an_error_and_help_is_not() {
+        let unknown = super::run(&["definitely-not-a-subcommand".to_string()]);
+        assert!(unknown.is_err(), "unknown subcommand must fail loudly");
+        assert!(
+            unknown.unwrap_err().to_string().contains("definitely-not-a-subcommand"),
+            "the error must name the unknown subcommand"
+        );
+        assert!(super::run(&["help".to_string()]).is_ok());
+        assert!(super::run(&[]).is_ok());
+    }
+
+    #[test]
+    fn usage_banner_lists_only_dispatched_subcommands() {
+        let usage = super::transformerless_usage();
+        assert!(
+            !usage.contains("compare"),
+            "compare/compare-report are top-level r4 commands, not transformerless subcommands"
+        );
+        for advertised in ["setup", "store", "scenarios", "teacher-kappa", "convert-r4g1"] {
+            assert!(usage.contains(advertised), "banner must keep `{advertised}`");
+        }
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1084,7 +1084,13 @@ fn trigger_in_client_compilation<W: Write>(
             "HuggingFaceTB/SmolLM2-360M-Instruct",
             "9d9ff7299a9a3b6d289ff100d0246a48d88c0326",
         ),
-        "smollm2-1-7b-instruct" => ("HuggingFaceTB/SmolLM2-1.7B-Instruct", "main"),
+        // #790: pinned 40-hex revision — the download path refuses branch
+        // names by design, so "main" made this arm unreachable on a fresh
+        // machine. Resolved from the repo's main on 2026-08-18.
+        "smollm2-1-7b-instruct" => (
+            "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+            "31b70e2e869a7173562077fd711b654946d38674",
+        ),
         _ => (
             "HuggingFaceTB/SmolLM2-135M-Instruct",
             "7e27bd9f95328f0f3b08261d1252705110c806f8",

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,10 +24,14 @@ pub const SOURCE_EXECUTION_MODE_OFFLINE_COMPILER_INPUT: &str = "offline-compiler
 /// Default CID-manifest name selected when neither CLI nor environment chooses one.
 pub const DEFAULT_CHAT_MODEL: &str = "smollm2-135m-instruct";
 
-/// Select the most recently modified model descriptor in `models/`.
+/// Select the default chat model from the descriptors in `models/`.
 ///
-/// `TLESS_MODEL` always wins. The static default is used when discovery is
-/// unavailable, such as when a binary runs outside the repository checkout.
+/// `TLESS_MODEL` always wins. Discovery considers only chat-capable
+/// descriptors (declaring `architecture` + `weight_format`; tokenizer-only
+/// pins are skipped), prefers one whose compiled bundle exists locally,
+/// then newest, then name (#790). The static default is used when
+/// discovery is unavailable, such as when a binary runs outside the
+/// repository checkout.
 pub fn default_model_reference() -> String {
     std::env::var("TLESS_MODEL")
         .ok()
@@ -725,6 +729,14 @@ fn safe_name(name: &str) -> String {
 }
 
 fn latest_descriptor_name(directory: &Path) -> Option<String> {
+    // #790 item 3: only chat-capable model descriptors participate in
+    // default-model discovery. The mtime-newest-json rule used to pick the
+    // tokenizer-only `t5-base-tokenizer.json`, breaking bare `r4 ask` with
+    // "compiled model manifest 't5-base-tokenizer' was not found". A
+    // descriptor is chat-capable when it declares both `architecture` and
+    // `weight_format`; tokenizer pins declare neither. Newest still wins,
+    // with the name as a deterministic tiebreak (a fresh clone gives every
+    // descriptor the same mtime, which made the old pick arbitrary).
     std::fs::read_dir(directory)
         .ok()?
         .filter_map(Result::ok)
@@ -735,12 +747,28 @@ fn latest_descriptor_name(directory: &Path) -> Option<String> {
                 .is_some_and(|extension| extension == "json")
         })
         .filter_map(|entry| {
+            let path = entry.path();
+            let descriptor: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).ok()?).ok()?;
+            if descriptor.get("architecture").is_none() || descriptor.get("weight_format").is_none()
+            {
+                return None;
+            }
             let modified = entry.metadata().ok()?.modified().ok()?;
-            let name = entry.path().file_stem()?.to_str()?.to_owned();
-            Some((modified, name))
+            let name = path.file_stem()?.to_str()?.to_owned();
+            // A descriptor whose bundle is actually compiled locally beats
+            // any uncompiled one: bare `r4 ask` should reach a servable
+            // model when one exists rather than erroring on the newest pin.
+            let compiled = ModelStore::from_env()
+                .root
+                .join("compiled")
+                .join(safe_name(&name))
+                .join("tless_artifacts.bin")
+                .is_file();
+            Some((compiled, modified, name))
         })
-        .max_by_key(|(modified, _)| *modified)
-        .map(|(_, name)| name)
+        .max()
+        .map(|(_, _, name)| name)
 }
 
 /// A pinned open-weight model source used only by offline compilation.
@@ -1545,6 +1573,36 @@ pub fn write_source_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #790 item 3 falsifier: a tokenizer-only descriptor must never win
+    /// default-model discovery, even when it is the mtime-newest json —
+    /// the pre-fix rule picked `t5-base-tokenizer` and broke bare
+    /// `r4 ask` ("compiled model manifest 't5-base-tokenizer' was not
+    /// found", verified live in the 2026-08-18 audit).
+    #[test]
+    fn default_model_discovery_skips_tokenizer_only_descriptors() {
+        let dir = std::env::temp_dir().join("uor-r4-790-descriptor-pick");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("fixture dir");
+        std::fs::write(
+            dir.join("aaa-chat-model.json"),
+            r#"{"architecture":"LlamaForCausalLM","weight_format":"safetensors"}"#,
+        )
+        .expect("chat descriptor");
+        // Written second, so it is at least as new as the chat descriptor.
+        std::fs::write(
+            dir.join("zzz-tokenizer-only.json"),
+            r#"{"tokenizer_family":"sentencepiece-unigram"}"#,
+        )
+        .expect("tokenizer descriptor");
+        assert_eq!(
+            latest_descriptor_name(&dir).as_deref(),
+            Some("aaa-chat-model")
+        );
+        // Deterministic across repeated calls.
+        assert_eq!(latest_descriptor_name(&dir), latest_descriptor_name(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// Falsifier for `#744`'s live quality gate: demonstrates
     /// `aggregate_probe_outcomes` correctly rejects the two known-bad

--- a/uor-r4-cli
+++ b/uor-r4-cli
@@ -96,7 +96,9 @@ case "$MODEL_CHOICE" in
     3)
         MODEL_NAME="smollm2-1-7b-instruct"
         HF_REPO="HuggingFaceTB/SmolLM2-1.7B-Instruct"
-        HF_REV="main"
+        # #790: pinned 40-hex revision (the downloader refuses branch names
+        # by design). Resolved from the repo's main on 2026-08-18.
+        HF_REV="31b70e2e869a7173562077fd711b654946d38674"
         TARGET_TOKENS="1768000"
         COMPILE_SECS="1200"
         ;;


### PR DESCRIPTION
References #790 (items 1-3; the batch the issue's next-action names — pure CLI/orchestrator, no serving semantics; items 4-8 stay individual).

- **Item 1**: `uor-r4-cli` menu 3 and the in-client 1.7B compile trigger pinned to `31b70e2e869a7173562077fd711b654946d38674` (resolved from HuggingFaceTB/SmolLM2-1.7B-Instruct main, 2026-08-18) — `HF_REV=main` was refused by the 40-hex rule by design, breaking Stage 1 on fresh machines.
- **Item 2**: unknown `transformerless` subcommands now exit nonzero naming the subcommand (`help`/no-args keeps the successful usage print); the banner no longer advertises `compare`/`compare-report`, which this dispatcher never handled. Verified live: `r4 transformerless compare` exit 1 (was 0), `help` exit 0. Falsifier tests included.
- **Item 3**: bare `r4 ask` default-model discovery skips tokenizer-only descriptors (architecture+weight_format required), prefers a locally compiled bundle, and orders (compiled, mtime, name) deterministically. Was: picks mtime-newest json → t5-base-tokenizer → hard error (audit-verified). Now: bare `r4 ask` serves smollm2-135m-instruct on this machine, exit 0. Falsifier test seeds a newest tokenizer-only descriptor and asserts it cannot win.

One commit per item per the batch-flow convention. Gates: fmt, clippy -D warnings (touched crates), wasm-router lib 241 green, graph-cli lib 128 green, xtask/register gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW