### PR TITLE
fix(#787): honest instruments — Witnessed status, engine-scope audit, full P-4 scan coverage, one canonical scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,11 @@ jobs:
       - name: Claim-wording gate (docs/formal_vocabulary.md §2.1, issue #123)
         run: python3 scripts/check_claim_wording.py
 
-      - name: Inference contract machine-code & dependency audit (issue #160)
+      # #787: honest name — this exercises the audit ENGINE against
+      # reference fixtures; the real #160 disassembly/dependency audit of
+      # the release binary has not landed, and the operation-set guarantee
+      # rests on the P-4 source-scan witnesses until it does.
+      - name: Inference audit engine self-test (source-witness level; #160 disassembly audit pending)
         run: cargo test -p uor-r4-proof-model --lib inference_audit
 
       - name: cargo fmt --check

--- a/crates/uor-r4-core/src/transformerless/bott_fock.rs
+++ b/crates/uor-r4-core/src/transformerless/bott_fock.rs
@@ -190,55 +190,23 @@ mod tests {
     }
 
     /// P-4-style self scan: the update path uses no multiplication,
-    /// division, or modulo operator on values. Doc/comment lines are
-    /// stripped; dereference `*x` (star not preceded by an operand) is
-    /// not an arithmetic operator and does not match.
+    /// division, or modulo operator on values. #787 E-c: delegates to the
+    /// shared `source_scan` implementation instead of carrying its own
+    /// weaker copy (the old inline scanner lacked string-aware comment
+    /// stripping and the method-form needles).
     #[test]
     fn p4_update_source_scan() {
         let src = include_str!("bott_fock.rs");
-        let mut offenders = Vec::new();
-        for (ln, line) in src.lines().enumerate() {
-            let code = line.trim_start();
-            if code.starts_with("//") {
-                continue;
-            }
-            let b = code.as_bytes();
-            for (i, &ch) in b.iter().enumerate() {
-                if ch != b'*' && ch != b'/' && ch != b'%' {
-                    continue;
-                }
-                if ch == b'/'
-                    && ((i + 1 < b.len() && b[i + 1] == b'/') || (i >= 1 && b[i - 1] == b'/'))
-                {
-                    continue; // comment slashes
-                }
-                let prev = if i >= 2 && b[i - 1] == b' ' {
-                    b[i - 2]
-                } else if i >= 1 {
-                    b[i - 1]
-                } else {
-                    b' '
-                };
-                let next = if i + 2 < b.len() && b[i + 1] == b' ' {
-                    b[i + 2]
-                } else if i + 1 < b.len() {
-                    b[i + 1]
-                } else {
-                    b' '
-                };
-                let operand_l =
-                    |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b')' || c == b']';
-                let operand_r = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'(';
-                if operand_l(prev) && operand_r(next) {
-                    offenders.push(format!("line {}: {}", ln + 1, code));
-                    break;
-                }
-            }
-        }
+        let outcome = crate::transformerless::source_scan::scan_for_forbidden_arith(src);
         assert!(
-            offenders.is_empty(),
+            outcome.offenders.is_empty(),
             "arithmetic operators in the update path:\n{}",
-            offenders.join("\n")
+            outcome.offenders.join("\n")
+        );
+        assert!(
+            outcome.allowed.is_empty(),
+            "bott_fock has no sanctioned allowances:\n{}",
+            outcome.allowed.join("\n")
         );
     }
 }

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -40,139 +40,11 @@ pub use uor_r4_graph_runtime::runtime_state::{
 mod witnesses {
     use super::runtime::{derive_popcount_table, hamming, sign_signature, OpKernel};
 
-    fn scan_for_forbidden_arith(src: &str) -> Vec<String> {
-        fn strip_line_comment(line: &str) -> &str {
-            let bytes = line.as_bytes();
-            let mut i = 0usize;
-            let mut in_string = false;
-            let mut in_char = false;
-            let mut escaped = false;
-
-            while i + 1 < bytes.len() {
-                let ch = bytes[i];
-                if escaped {
-                    escaped = false;
-                    i += 1;
-                    continue;
-                }
-                if (in_string || in_char) && ch == b'\\' {
-                    escaped = true;
-                    i += 1;
-                    continue;
-                }
-                if !in_char && ch == b'"' {
-                    in_string = !in_string;
-                    i += 1;
-                    continue;
-                }
-                if !in_string && ch == b'\'' {
-                    in_char = !in_char;
-                    i += 1;
-                    continue;
-                }
-                if !in_string && !in_char && ch == b'/' && bytes[i + 1] == b'/' {
-                    return &line[..i];
-                }
-                i += 1;
-            }
-            line
-        }
-
-        fn prev_ident(code: &str, idx: usize) -> Option<&str> {
-            let bytes = code.as_bytes();
-            if idx == 0 {
-                return None;
-            }
-            let mut j = idx;
-            while j > 0 && bytes[j - 1] == b' ' {
-                j -= 1;
-            }
-            let end = j;
-            while j > 0 && (bytes[j - 1].is_ascii_alphanumeric() || bytes[j - 1] == b'_') {
-                j -= 1;
-            }
-            if j == end {
-                None
-            } else {
-                code.get(j..end)
-            }
-        }
-
-        let mut offenders = Vec::new();
-        for (ln, line) in src.lines().enumerate() {
-            let code = strip_line_comment(line).trim_start();
-            if code.is_empty() {
-                continue;
-            }
-            let b = code.as_bytes();
-            for (i, &ch) in b.iter().enumerate() {
-                if ch != b'*' && ch != b'/' && ch != b'%' {
-                    continue;
-                }
-                if ch == b'/'
-                    && ((i + 1 < b.len() && b[i + 1] == b'/') || (i >= 1 && b[i - 1] == b'/'))
-                {
-                    continue; // comment slashes
-                }
-                let prev = if i >= 2 && b[i - 1] == b' ' {
-                    b[i - 2]
-                } else if i >= 1 {
-                    b[i - 1]
-                } else {
-                    b' '
-                };
-                let next = if i + 2 < b.len() && b[i + 1] == b' ' {
-                    b[i + 2]
-                } else if i + 1 < b.len() {
-                    b[i + 1]
-                } else {
-                    b' '
-                };
-                let operand_l =
-                    |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b')' || c == b']';
-                let operand_r = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'(';
-                if ch == b'*'
-                    && operand_r(next)
-                    && matches!(
-                        prev_ident(code, i),
-                        None | Some("if")
-                            | Some("while")
-                            | Some("for")
-                            | Some("loop")
-                            | Some("match")
-                            | Some("return")
-                            | Some("let")
-                    )
-                {
-                    continue; // pointer deref
-                }
-                if operand_l(prev) && operand_r(next) {
-                    offenders.push(format!("line {}: {}", ln + 1, code));
-                    break;
-                }
-            }
-            for needle in [
-                "wrapping_mul(",
-                "saturating_mul(",
-                "checked_mul(",
-                ".mul(",
-                "wrapping_div(",
-                "saturating_div(",
-                "checked_div(",
-                ".div(",
-                "wrapping_rem(",
-                "saturating_rem(",
-                "checked_rem(",
-                ".rem(",
-            ] {
-                if code.contains(needle) {
-                    offenders.push(format!("line {}: {}", ln + 1, code));
-                    break;
-                }
-            }
-        }
-        offenders
-    }
+    // #787 E-c: the scanner implementation moved to the shared
+    // `super::source_scan` module (one canonical copy, with falsifiers
+    // and the explicit allowance mechanism); these witnesses now consume
+    // it instead of carrying their own copy.
+    use super::source_scan::scan_for_forbidden_arith;
 
     /// P-1: the popcount table matches its definition on all 256 bytes and
     /// carries the stratum partition sizes C(8,k).
@@ -220,17 +92,52 @@ mod witnesses {
     #[test]
     fn p4_runtime_source_scan() {
         let src = include_str!("runtime.rs");
-        let offenders = scan_for_forbidden_arith(src);
+        let outcome = scan_for_forbidden_arith(src);
         assert!(
-            offenders.is_empty(),
+            outcome.offenders.is_empty(),
             "value arithmetic in runtime.rs:\n{}",
-            offenders.join("\n")
+            outcome.offenders.join("\n")
+        );
+        assert!(
+            outcome.allowed.is_empty(),
+            "runtime.rs is deployed hot path — no allowances:\n{}",
+            outcome.allowed.join("\n")
         );
     }
 
-    /// P-4 extension: all contract-owned graph-runtime modules are scanned
-    /// with the same arithmetic restrictions until machine-code audit (issue
-    /// #160) supersedes source-level witnessing.
+    /// #787 E-b: `runtime.rs` delegates its SIMD dispatch to `simd.rs`,
+    /// which is deliberately NOT arithmetic-scanned — it holds the
+    /// vectorized kernels whose intrinsics necessarily encode multiply
+    /// semantics. Its exclusion is sanctioned by per-kernel
+    /// scalar-equivalence witnesses instead: `test_simd_hamming_equivalence`
+    /// and `simd_dot_argmax_matches_scalar_reference` pin every dispatcher
+    /// to the scalar reference the P-4 scan DOES cover. This test pins the
+    /// exclusion itself: the set of runtime→simd delegation points must
+    /// not grow without this witness being revisited.
+    #[test]
+    fn p4_simd_exclusion_is_pinned_to_its_equivalence_witnesses() {
+        let src = include_str!("runtime.rs");
+        let delegations = src.matches("simd::").count();
+        assert!(
+            delegations > 0,
+            "runtime.rs no longer delegates to simd.rs — remove this pin"
+        );
+        assert_eq!(
+            delegations, 11,
+            "the runtime.rs simd:: reference count changed ({delegations} vs 11); \
+             add or revisit the scalar-equivalence witnesses for the affected \
+             kernels, then re-pin this count deliberately"
+        );
+    }
+
+    /// P-4 extension: ALL graph-runtime modules are scanned with the same
+    /// arithmetic restrictions until machine-code audit (issue #160)
+    /// supersedes source-level witnessing. #787 E-b closed the gap the
+    /// 2026-08-18 audit found: `lib.rs`, `packed_kernels.rs`,
+    /// `patch_chain.rs`, `scoring.rs`, and `vp_tree.rs` were previously
+    /// unscanned. Load-time construction code inside scanned modules may
+    /// carry an explicit `p4-allow(load-time)` marker; the exact allowance
+    /// list is pinned below so it can never grow silently.
     #[test]
     fn p4_contract_owned_graph_runtime_source_scan() {
         let modules = [
@@ -239,12 +146,24 @@ mod witnesses {
                 include_str!("../../../uor-r4-graph-runtime/src/engine.rs"),
             ),
             (
-                "route_attention.rs",
-                include_str!("../../../uor-r4-graph-runtime/src/route_attention.rs"),
+                "lib.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/lib.rs"),
             ),
             (
                 "msa_selector.rs",
                 include_str!("../../../uor-r4-graph-runtime/src/msa_selector.rs"),
+            ),
+            (
+                "packed_kernels.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/packed_kernels.rs"),
+            ),
+            (
+                "patch_chain.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/patch_chain.rs"),
+            ),
+            (
+                "route_attention.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/route_attention.rs"),
             ),
             (
                 "routing.rs",
@@ -255,20 +174,61 @@ mod witnesses {
                 include_str!("../../../uor-r4-graph-runtime/src/runtime_state.rs"),
             ),
             (
+                "scoring.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/scoring.rs"),
+            ),
+            (
                 "status.rs",
                 include_str!("../../../uor-r4-graph-runtime/src/status.rs"),
             ),
+            (
+                "vp_tree.rs",
+                include_str!("../../../uor-r4-graph-runtime/src/vp_tree.rs"),
+            ),
+            // #787 E-b: the two ACTIVITY_OWNERS modules the audit found
+            // unscanned — the active-frontier owner in this crate and the
+            // wasm-router decode-support owner.
+            ("reference_state.rs", include_str!("reference_state.rs")),
+            (
+                "wasm-router/r4g1.rs",
+                include_str!("../../../../src/r4g1.rs"),
+            ),
         ];
-        let mut all = Vec::new();
+        let mut offenders = Vec::new();
+        let mut allowed = Vec::new();
         for (name, src) in modules {
-            for offender in scan_for_forbidden_arith(src) {
-                all.push(format!("{name}: {offender}"));
+            let outcome = scan_for_forbidden_arith(src);
+            for offender in outcome.offenders {
+                offenders.push(format!("{name}: {offender}"));
+            }
+            for allowance in outcome.allowed {
+                allowed.push(format!("{name}: {allowance}"));
             }
         }
         assert!(
-            all.is_empty(),
+            offenders.is_empty(),
             "value arithmetic in contract modules:\n{}",
-            all.join("\n")
+            offenders.join("\n")
+        );
+        // The complete, reviewed allowance set. Adding a `p4-allow` marker
+        // anywhere in these modules fails this witness until the new line
+        // is justified here. All three sites are VP-tree CONSTRUCTION code
+        // that runs at graph load, before the steady-state boundary: two
+        // overflow-checked word-to-byte conversions (the query path uses
+        // shifts for the same conversion) and the median split. The query
+        // path is division- and multiplication-free.
+        let expected_allowed = vec![
+            "vp_tree.rs: line 59: let proto_start = \
+             (node.prototype_word_start as usize).checked_mul(8)?; "
+                .to_string(),
+            "vp_tree.rs: line 60: let mask_start = \
+             (node.mask_word_start as usize).checked_mul(8)?; "
+                .to_string(),
+            "vp_tree.rs: line 142: let split = distances.len() / 2; ".to_string(),
+        ];
+        assert_eq!(
+            allowed, expected_allowed,
+            "the p4-allow allowance set changed — review and re-pin it"
         );
     }
 
@@ -302,6 +262,7 @@ pub mod resolution_status;
 pub mod runtime;
 pub mod scenarios;
 pub mod score_q;
+pub mod source_scan;
 // Host/compile-side tokenizer source adapter: parses `spiece.model` and
 // reports refusals on the `SourceUnavailable` surface, which is itself
 // gated off wasm32 (the deployed wasm runtime uses the exported tokenizer,

--- a/crates/uor-r4-core/src/transformerless/simd.rs
+++ b/crates/uor-r4-core/src/transformerless/simd.rs
@@ -272,7 +272,7 @@ impl DotTables {
     }
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))] // #787: scalar-reference helper, all targets
 #[inline]
 fn dot_term_scalar_decoded(work: i64, shift: i64, negative: i64) -> i64 {
     if shift == 64 {
@@ -290,7 +290,7 @@ fn dot_term_scalar_decoded(work: i64, shift: i64, negative: i64) -> i64 {
     }
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))] // #787: scalar-reference helper, all targets
 #[inline]
 fn dot_term_scalar(work: i64, term: &DotTermVector, lane: usize) -> i64 {
     if term.active[lane] == 0 {
@@ -299,7 +299,13 @@ fn dot_term_scalar(work: i64, term: &DotTermVector, lane: usize) -> i64 {
     dot_term_scalar_decoded(work, term.shifts[lane], term.negative[lane])
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+// #787 E-b: compiled on EVERY target — this is the normative scalar
+// reference the per-kernel equivalence witnesses compare the SIMD
+// dispatchers against (`simd_dot_argmax_matches_scalar_reference`).
+// It was previously cfg'd off aarch64, which is exactly why no scalar
+// witness for the NEON dot path could exist. On aarch64 the dispatcher
+// itself never calls it outside tests, hence the allow.
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
 pub(crate) fn dot_argmax_scalar(stage: &DotStage, work: &[i64; D]) -> u8 {
     let mut scores = [0i64; K];
     match &stage.data {
@@ -692,6 +698,46 @@ mod tests {
             prop_assert_eq!(
                 dot_argmax(&compact.stages[0], &work),
                 dot_argmax(&legacy.stages[0], &work)
+            );
+        }
+
+        /// #787 E-b: the missing scalar witness for the `dot_argmax`
+        /// dispatcher. The layouts test above compares two layouts through
+        /// the SAME dispatcher — on an AVX2/NEON host neither side is
+        /// scalar, so it cannot catch a vectorized-kernel divergence. This
+        /// pins the dispatcher (whatever backend it selects on the running
+        /// host) to `dot_argmax_scalar`, the P-4-scanned reference — the
+        /// same shape as `test_simd_hamming_equivalence`, completing the
+        /// per-kernel equivalence set that sanctions `simd.rs`'s exclusion
+        /// from the arithmetic source scan.
+        #[test]
+        fn simd_dot_argmax_matches_scalar_reference(
+            weights in proptest::collection::vec(-1.0f32..1.0, K),
+            work_seed in proptest::collection::vec(-4096i64..4096, D),
+        ) {
+            let mut table = vec![0u16; D * K];
+            for class in 0..K {
+                for dimension in 0..D {
+                    table[class * D + dimension] =
+                        compiler::pack_dot_entry(weights[class] * ((dimension % 5) as f32 - 2.0));
+                }
+            }
+            let packed = vec![table];
+
+            let compact = DotTables::from_packed(&packed).expect("valid dot table");
+            let legacy =
+                DotTables::from_packed_forced_two_term(&packed).expect("valid dot table");
+
+            let mut work = [0i64; D];
+            work.copy_from_slice(&work_seed);
+
+            prop_assert_eq!(
+                dot_argmax(&compact.stages[0], &work),
+                dot_argmax_scalar(&compact.stages[0], &work)
+            );
+            prop_assert_eq!(
+                dot_argmax(&legacy.stages[0], &work),
+                dot_argmax_scalar(&legacy.stages[0], &work)
             );
         }
 

--- a/crates/uor-r4-core/src/transformerless/source_scan.rs
+++ b/crates/uor-r4-core/src/transformerless/source_scan.rs
@@ -1,0 +1,325 @@
+//! The one source-scanner implementation behind every P-4-style source
+//! witness in the workspace (#787 E-c).
+//!
+//! Four divergent copies previously existed (`transformerless::mod`'s
+//! witnesses, `bott_fock`'s self-scan, graph-certify's `msa_selector_643`
+//! scan, and graph-runtime's n-gram kernel scan), each with slightly
+//! different comment handling and operator coverage — which meant four
+//! places for a scanner bug to hide and no single falsifier suite. This
+//! module is the canonical implementation: string-aware line-comment
+//! stripping, value-operator detection for `*` `/` `%` (dereference-`*`
+//! excluded), the method-form needles (`wrapping_mul(` and friends), an
+//! optional float-token check, and an explicit, enumerable allowance
+//! mechanism.
+//!
+//! ## Allowances
+//!
+//! A line whose comment carries `p4-allow(<scope>): <justification>` is
+//! reported in [`ArithScanOutcome::allowed`] instead of `offenders`. Scans
+//! that accept allowances must assert the exact expected `allowed` list,
+//! so a new allowance can never ride in silently — it has to be added to
+//! the witness's expectation, where review sees it. The marker is for
+//! load-time/setup code inside otherwise-scanned modules (e.g. a
+//! construction-phase `/ 2` that the steady-state boundary permits);
+//! deployed hot-path code gets no allowances.
+
+/// Strip a line comment, respecting string and char literals.
+pub fn strip_line_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut i = 0usize;
+    let mut in_string = false;
+    let mut in_char = false;
+    let mut escaped = false;
+
+    while i + 1 < bytes.len() {
+        let ch = bytes[i];
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if (in_string || in_char) && ch == b'\\' {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+        if !in_char && ch == b'"' {
+            in_string = !in_string;
+            i += 1;
+            continue;
+        }
+        if !in_string && ch == b'\'' {
+            in_char = !in_char;
+            i += 1;
+            continue;
+        }
+        if !in_string && !in_char && ch == b'/' && bytes[i + 1] == b'/' {
+            return &line[..i];
+        }
+        i += 1;
+    }
+    line
+}
+
+/// Outcome of a forbidden-arithmetic scan.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArithScanOutcome {
+    /// Lines carrying forbidden value arithmetic (or float tokens, when
+    /// requested) with no allowance marker. Any entry fails the witness.
+    pub offenders: Vec<String>,
+    /// Lines that WOULD have been offenders but carry an explicit
+    /// `p4-allow(...)` marker. Witnesses must pin this list exactly.
+    pub allowed: Vec<String>,
+}
+
+/// Marker that moves a flagged line from `offenders` to `allowed`.
+pub const ALLOW_MARKER: &str = "p4-allow(";
+
+/// Scan `src` for value `*` `/` `%` operators and the method forms
+/// (`wrapping_mul(` etc.). Dereference `*x` and comment slashes are
+/// excluded; comments are stripped string-aware before matching.
+pub fn scan_for_forbidden_arith(src: &str) -> ArithScanOutcome {
+    scan(src, false)
+}
+
+/// [`scan_for_forbidden_arith`] plus a float-token check (`f32`/`f64` in
+/// stripped code) for witnesses that also assert float-freedom.
+pub fn scan_for_forbidden_arith_and_floats(src: &str) -> ArithScanOutcome {
+    scan(src, true)
+}
+
+fn prev_ident(code: &str, idx: usize) -> Option<&str> {
+    let bytes = code.as_bytes();
+    if idx == 0 {
+        return None;
+    }
+    let mut j = idx;
+    while j > 0 && bytes[j - 1] == b' ' {
+        j -= 1;
+    }
+    let end = j;
+    while j > 0 && (bytes[j - 1].is_ascii_alphanumeric() || bytes[j - 1] == b'_') {
+        j -= 1;
+    }
+    if j == end {
+        None
+    } else {
+        code.get(j..end)
+    }
+}
+
+fn line_is_flagged(code: &str, check_floats: bool) -> bool {
+    let b = code.as_bytes();
+    for (i, &ch) in b.iter().enumerate() {
+        if ch != b'*' && ch != b'/' && ch != b'%' {
+            continue;
+        }
+        if ch == b'/' && ((i + 1 < b.len() && b[i + 1] == b'/') || (i >= 1 && b[i - 1] == b'/')) {
+            continue; // comment slashes surviving inside string literals
+        }
+        let prev = if i >= 2 && b[i - 1] == b' ' {
+            b[i - 2]
+        } else if i >= 1 {
+            b[i - 1]
+        } else {
+            b' '
+        };
+        let next = if i + 2 < b.len() && b[i + 1] == b' ' {
+            b[i + 2]
+        } else if i + 1 < b.len() {
+            b[i + 1]
+        } else {
+            b' '
+        };
+        let operand_l = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b')' || c == b']';
+        let operand_r = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'(';
+        if ch == b'*'
+            && operand_r(next)
+            && matches!(
+                prev_ident(code, i),
+                None | Some("if")
+                    | Some("while")
+                    | Some("for")
+                    | Some("loop")
+                    | Some("match")
+                    | Some("return")
+                    | Some("let")
+            )
+        {
+            continue; // pointer dereference
+        }
+        if operand_l(prev) && operand_r(next) {
+            return true;
+        }
+    }
+    for needle in [
+        "wrapping_mul(",
+        "saturating_mul(",
+        "checked_mul(",
+        ".mul(",
+        "wrapping_div(",
+        "saturating_div(",
+        "checked_div(",
+        ".div(",
+        "wrapping_rem(",
+        "saturating_rem(",
+        "checked_rem(",
+        ".rem(",
+    ] {
+        if code.contains(needle) {
+            return true;
+        }
+    }
+    if check_floats && (code.contains("f32") || code.contains("f64")) {
+        return true;
+    }
+    false
+}
+
+/// Blank out string- and char-literal CONTENTS so literal text (paths
+/// with `/`, prose mentioning `f32`) cannot flag the operator scan —
+/// code inside a literal never executes. Lifetime ticks (`'a`) are NOT
+/// treated as char-literal openers (a one-sided toggle would mask the
+/// rest of the line and could hide a real operator), so a `'` only opens
+/// a char literal when it closes like one (`'x'` or a short escape).
+fn mask_literals(code: &str) -> String {
+    let bytes = code.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    while i < bytes.len() {
+        let ch = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+                out.push(b' ');
+            } else if ch == b'\\' {
+                escaped = true;
+                out.push(b' ');
+            } else if ch == b'"' {
+                in_string = false;
+                out.push(b'"');
+            } else {
+                out.push(b' ');
+            }
+            i += 1;
+            continue;
+        }
+        if ch == b'"' {
+            in_string = true;
+            out.push(b'"');
+            i += 1;
+            continue;
+        }
+        if ch == b'\'' {
+            // Char literal only if it closes like one within a short
+            // window; otherwise it is a lifetime tick and stays code.
+            let close = bytes[i + 1..]
+                .iter()
+                .take(8)
+                .position(|&c| c == b'\'')
+                .map(|offset| i + 1 + offset);
+            let is_char_literal = match close {
+                Some(end) => end == i + 2 || bytes.get(i + 1) == Some(&b'\\'),
+                None => false,
+            };
+            if let (true, Some(end)) = (is_char_literal, close) {
+                out.push(b'\'');
+                out.extend(core::iter::repeat_n(b' ', end - (i + 1)));
+                out.push(b'\'');
+                i = end + 1;
+                continue;
+            }
+        }
+        out.push(ch);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_default()
+}
+
+fn scan(src: &str, check_floats: bool) -> ArithScanOutcome {
+    let mut outcome = ArithScanOutcome::default();
+    for (ln, line) in src.lines().enumerate() {
+        let code = strip_line_comment(line).trim_start();
+        if code.is_empty() {
+            continue;
+        }
+        let masked = mask_literals(code);
+        if line_is_flagged(&masked, check_floats) {
+            let entry = format!("line {}: {}", ln + 1, code);
+            if line.contains(ALLOW_MARKER) {
+                outcome.allowed.push(entry);
+            } else {
+                outcome.offenders.push(entry);
+            }
+        }
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #787 falsifiers: the scanner must fire on each seeded violation
+    /// class and stay quiet on the legal look-alikes.
+    #[test]
+    fn seeded_violations_are_caught_and_lookalikes_pass() {
+        let mul = "let x = a * b;";
+        assert_eq!(scan_for_forbidden_arith(mul).offenders.len(), 1);
+        let div = "let x = a / 2;";
+        assert_eq!(scan_for_forbidden_arith(div).offenders.len(), 1);
+        let rem = "let x = a % m;";
+        assert_eq!(scan_for_forbidden_arith(rem).offenders.len(), 1);
+        let method = "let x = a.wrapping_mul(b);";
+        assert_eq!(scan_for_forbidden_arith(method).offenders.len(), 1);
+        let float = "let x: f32 = 0.0;";
+        assert!(scan_for_forbidden_arith(float).offenders.is_empty());
+        assert_eq!(
+            scan_for_forbidden_arith_and_floats(float).offenders.len(),
+            1
+        );
+
+        let deref = "let x = *pointer;";
+        assert!(scan_for_forbidden_arith(deref).offenders.is_empty());
+        let comment = "// a * b in prose is fine";
+        assert!(scan_for_forbidden_arith(comment).offenders.is_empty());
+        let string_slash = "let path = \"a/b\";";
+        assert!(scan_for_forbidden_arith(string_slash).offenders.is_empty());
+        let string_float = "let label = \"f32 lanes\";";
+        assert!(scan_for_forbidden_arith_and_floats(string_float)
+            .offenders
+            .is_empty());
+        // A lifetime tick must NOT open a literal mask — masking the rest
+        // of the line would hide the real multiply here.
+        let lifetime_mul = "fn f<'a>(x: &'a i64, y: i64) -> i64 { x * y }";
+        assert_eq!(scan_for_forbidden_arith(lifetime_mul).offenders.len(), 1);
+        let char_slash = "let c = '/'; let ok = a ^ b;";
+        assert!(scan_for_forbidden_arith(char_slash).offenders.is_empty());
+    }
+
+    /// The allowance mechanism is explicit and enumerable: a marked line
+    /// moves to `allowed` (never silently passes), an unmarked one stays
+    /// an offender.
+    #[test]
+    fn allow_marker_moves_lines_to_the_allowed_list() {
+        let src = "let half = n / 2; // p4-allow(load-time): construction split\nlet bad = n / 2;";
+        let outcome = scan_for_forbidden_arith(src);
+        assert_eq!(outcome.allowed.len(), 1, "{outcome:?}");
+        assert_eq!(outcome.offenders.len(), 1, "{outcome:?}");
+        assert!(outcome.allowed[0].contains("line 1"));
+        assert!(outcome.offenders[0].contains("line 2"));
+    }
+
+    /// String-aware comment stripping: `//` inside a string literal is not
+    /// a comment, and code after a real comment is gone.
+    #[test]
+    fn comment_stripping_respects_string_literals() {
+        assert_eq!(strip_line_comment("let a = 1; // b * c"), "let a = 1; ");
+        assert_eq!(
+            strip_line_comment("let url = \"http://x\"; let y = 2;"),
+            "let url = \"http://x\"; let y = 2;"
+        );
+    }
+}

--- a/crates/uor-r4-graph-certify/src/target_operator_certificate.rs
+++ b/crates/uor-r4-graph-certify/src/target_operator_certificate.rs
@@ -478,7 +478,9 @@ pub fn route_attention_obligation_links() -> Vec<ObligationLink> {
         link(
             "Plan §6 / PDF §17",
             "Operation-Set Conformance",
-            "Verified",
+            // #787: mirrors the proof matrix's honest Witnessed status —
+            // source-scan evidence until the #160 disassembly audit lands.
+            "Witnessed",
             "the multiplication-free operation contract the packed lowering runs under \
              (P-4 source scan; XOR/popcount/add/compare/table-read)",
         ),

--- a/crates/uor-r4-graph-certify/tests/msa_selector_643.rs
+++ b/crates/uor-r4-graph-certify/tests/msa_selector_643.rs
@@ -575,95 +575,21 @@ fn property_caps_refuse_with_sanctioned_errors() {
 
 // -------------------------------------------------------- source scans --
 
-/// Comment- and string-stripped source scan for value `*` `/` `%`
-/// operators and float types on the packed lowering — the by-
-/// construction zero-float/zero-multiply/zero-divide/zero-modulo claim,
-/// machine-checked on every test run. This mirrors
-/// `route_attention_604.rs`'s equivalent scan and the P-4 extension in
-/// `uor-r4-core::transformerless::mod.rs` (which also covers this file
-/// as a contract-owned graph-runtime module).
+/// Source scan for value `*` `/` `%` operators and float types on the
+/// packed lowering — the by-construction zero-float/zero-multiply/
+/// zero-divide/zero-modulo claim, machine-checked on every test run.
+/// #787 E-c: delegates to the shared canonical scanner
+/// (`uor_r4_core::transformerless::source_scan`) instead of carrying its
+/// own divergent copy; this scan sanctions no allowances.
 fn scan_source_for_forbidden_ops(source: &str) -> Vec<String> {
-    let mut offenders = Vec::new();
-    for (line_number, raw_line) in source.lines().enumerate() {
-        let mut stripped = String::with_capacity(raw_line.len());
-        let mut in_string = false;
-        let mut escaped = false;
-        for ch in raw_line.chars() {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-            if in_string {
-                if ch == '\\' {
-                    escaped = true;
-                } else if ch == '"' {
-                    in_string = false;
-                }
-                continue;
-            }
-            if ch == '"' {
-                in_string = true;
-                continue;
-            }
-            stripped.push(ch);
-        }
-        let code = match stripped.find("//") {
-            Some(comment_start) => &stripped[..comment_start],
-            None => stripped.as_str(),
-        };
-        if code.trim().is_empty() {
-            continue;
-        }
-        if code.contains("f32") || code.contains("f64") {
-            offenders.push(format!("line {}: float type: {}", line_number + 1, code));
-            continue;
-        }
-        for needle in [
-            "wrapping_mul(",
-            "saturating_mul(",
-            "checked_mul(",
-            ".mul(",
-            "wrapping_div(",
-            "saturating_div(",
-            "checked_div(",
-            ".div(",
-            "wrapping_rem(",
-            "saturating_rem(",
-            "checked_rem(",
-            ".rem(",
-        ] {
-            if code.contains(needle) {
-                offenders.push(format!("line {}: {}", line_number + 1, code));
-            }
-        }
-        let bytes = code.as_bytes();
-        for (index, &byte) in bytes.iter().enumerate() {
-            if byte != b'*' && byte != b'/' && byte != b'%' {
-                continue;
-            }
-            let operand = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b')' || c == b']';
-            let operand_right = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'(';
-            let prev = if index >= 2 && bytes[index - 1] == b' ' {
-                bytes[index - 2]
-            } else if index >= 1 {
-                bytes[index - 1]
-            } else {
-                b' '
-            };
-            let next = if index + 2 < bytes.len() && bytes[index + 1] == b' ' {
-                bytes[index + 2]
-            } else if index + 1 < bytes.len() {
-                bytes[index + 1]
-            } else {
-                b' '
-            };
-            if operand(prev) && operand_right(next) {
-                offenders.push(format!("line {}: {}", line_number + 1, code));
-                break;
-            }
-        }
-    }
-    offenders
+    let outcome =
+        uor_r4_core::transformerless::source_scan::scan_for_forbidden_arith_and_floats(source);
+    assert!(
+        outcome.allowed.is_empty(),
+        "no p4-allow markers are sanctioned in the #643 scans:\n{}",
+        outcome.allowed.join("\n")
+    );
+    outcome.offenders
 }
 
 /// The packed lowering carries no float type and no value

--- a/crates/uor-r4-graph-format/src/inference_contract.rs
+++ b/crates/uor-r4-graph-format/src/inference_contract.rs
@@ -181,10 +181,15 @@ pub struct InferenceContractVersion {
 }
 
 impl InferenceContractVersion {
-    pub const V1_0_0: Self = Self {
-        major: 1,
-        minor: 0,
-        patch: 0,
+    /// #787 (AUD-INV-002): derived from the one canonical contract
+    /// version, so the two version types can never drift again — the
+    /// audit found this constant at 1.0.0 while the normative document
+    /// and [`INFERENCE_OPERATION_CONTRACT_VERSION`] both said 0.1.0
+    /// (the §7 synchronization obligation covered only the latter).
+    pub const CURRENT: Self = Self {
+        major: INFERENCE_OPERATION_CONTRACT_VERSION.major,
+        minor: INFERENCE_OPERATION_CONTRACT_VERSION.minor,
+        patch: INFERENCE_OPERATION_CONTRACT_VERSION.patch,
     };
 }
 
@@ -209,7 +214,7 @@ pub struct InferenceContractVerifier;
 
 impl InferenceContractVerifier {
     pub const fn version() -> InferenceContractVersion {
-        InferenceContractVersion::V1_0_0
+        InferenceContractVersion::CURRENT
     }
 
     pub fn audit_operation(
@@ -375,6 +380,35 @@ mod tests {
         InferenceContractVerifier, OperationClass, ACTIVITY_OWNERS, BOUNDARY_ACTIVITIES,
         INFERENCE_OPERATION_CONTRACT_VERSION,
     };
+
+    /// #787 (AUD-INV-002): the three version statements — the normative
+    /// document, the canonical machine constant, and the audit-report
+    /// version type — must all agree; §7 demands the sync and this test
+    /// enforces it for all three at once. Falsifier: bump any one of them
+    /// alone and this fails.
+    #[test]
+    fn contract_versions_agree_across_document_constant_and_report_type() {
+        let doc = include_str!("../../../docs/transformerless/INFERENCE_OPERATION_CONTRACT.md");
+        let doc_version = doc
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("- **Version:** "))
+            .expect("the normative document declares its version")
+            .trim();
+        let canonical = INFERENCE_OPERATION_CONTRACT_VERSION;
+        assert_eq!(
+            doc_version,
+            format!(
+                "{}.{}.{}",
+                canonical.major, canonical.minor, canonical.patch
+            ),
+            "document vs canonical constant"
+        );
+        assert_eq!(
+            InferenceContractVerifier::version().to_string(),
+            doc_version,
+            "audit-report version type vs document"
+        );
+    }
 
     #[test]
     fn every_boundary_activity_has_owner_mapping() {

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -56,8 +56,8 @@ impl VpTree {
             if node_id == 0 {
                 continue;
             }
-            let proto_start = (node.prototype_word_start as usize).checked_mul(8)?;
-            let mask_start = (node.mask_word_start as usize).checked_mul(8)?;
+            let proto_start = (node.prototype_word_start as usize).checked_mul(8)?; // p4-allow(load-time): overflow-checked word-to-byte conversion during VP-tree construction; the query path uses shifts
+            let mask_start = (node.mask_word_start as usize).checked_mul(8)?; // p4-allow(load-time): same load-time conversion as above
             let proto_end = proto_start.checked_add(signature_bytes)?;
             let mask_end = mask_start.checked_add(signature_bytes)?;
             let prototype = rout.get(proto_start..proto_end)?;
@@ -139,7 +139,7 @@ impl VpTree {
                 .then_with(|| points[*left_id].node_id.cmp(&points[*right_id].node_id))
         });
 
-        let split = distances.len() / 2;
+        let split = distances.len() / 2; // p4-allow(load-time): VP-tree construction split; query path is division-free
         let threshold = distances[split].1;
         for (slot, &(candidate, _)) in distances.iter().enumerate() {
             indices[slot + 1] = candidate;

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -267,22 +267,23 @@ fn ngram_lookup_kernel_is_integer_only_by_source_scan() {
     let end = source
         .find("impl<'a> R4G1Runtime")
         .expect("runtime implementation follows lookup helpers");
-    // Strip line comments before scanning so the kernel functions can carry
-    // doc comments (which necessarily contain '/') without weakening the
-    // check on the code itself. No string literal in this region contains
-    // "//", so the naive split is exact here (#785; scanner consolidation
-    // tracked by #787).
-    let kernel = source[start..end]
-        .lines()
-        .map(|line| line.split("//").next().unwrap_or(""))
-        .collect::<Vec<_>>()
-        .join("\n");
-    for forbidden in ["*", "/", "f32", "f64"] {
-        assert!(
-            !kernel.contains(forbidden),
-            "NGRAM lookup kernel contains forbidden operation/type {forbidden:?}"
-        );
-    }
+    // #787 E-c: the naive per-file scan this test carried was consolidated
+    // onto the shared canonical scanner (comment- and literal-aware value
+    // `*` `/` `%` detection, method-form needles, float tokens). The
+    // kernel region sanctions no allowances.
+    let outcome = uor_r4_core::transformerless::source_scan::scan_for_forbidden_arith_and_floats(
+        &source[start..end],
+    );
+    assert!(
+        outcome.offenders.is_empty(),
+        "NGRAM lookup kernel contains forbidden operations/types:\n{}",
+        outcome.offenders.join("\n")
+    );
+    assert!(
+        outcome.allowed.is_empty(),
+        "no p4-allow markers are sanctioned in the NGRAM kernel:\n{}",
+        outcome.allowed.join("\n")
+    );
 }
 
 #[test]

--- a/crates/uor-r4-proof-model/src/inference_audit.rs
+++ b/crates/uor-r4-proof-model/src/inference_audit.rs
@@ -1,14 +1,21 @@
-//! Machine-Code, Allocator, and Dependency Audit Engine
+//! Machine-Code and Dependency Audit ENGINE — reference fixtures only.
 //!
 //! Specification & Source: `docs/inference_contract.md`; `docs/scoring_semantics.md`;
 //! `docs/hologram_formal_analysis_direction.md` PDF §13; GitHub Issue #160.
 //!
-//! This module provides a machine-code disassembly auditor, a dependency graph auditor,
-//! and a counting allocator verification harness for the production inference runtime:
-//! - Disassembly Audit: Inspects instruction mnemonics to verify zero floating point, zero multiplication,
-//!   zero division, and zero heap allocation on the hot path.
-//! - Dependency Audit: Asserts that no GPU, accelerator, tensor, or BLAS dependencies exist in the manifest.
-//! - Allocator Audit: Asserts zero heap allocations and deallocations during hot-path execution.
+//! **What this module IS (#787, honest scope):** the audit *engine* — a
+//! mnemonic scanner over disassembly text and a denylist scanner over
+//! dependency-name lists — exercised against reference fixtures so the
+//! engine itself is tested and its falsifiers demonstrably fire.
+//!
+//! **What this module is NOT:** the #160 machine-code audit. Nothing here
+//! disassembles the release binary, walks the real `cargo metadata`
+//! graph, or hooks an allocator; until #160 lands, the deployed
+//! operation-set guarantee rests on the P-4 source-scan witnesses
+//! (`INFERENCE_OPERATION_CONTRACT.md` §6/§8 — **Witnessed**, not
+//! Structural, mirrored by the proof matrix's `Witnessed` row). The real
+//! allocation census lives in the runtime crates' counting-allocator
+//! tests, not here.
 
 use core::fmt;
 
@@ -21,8 +28,6 @@ pub enum AuditVerdict {
     ForbiddenInstructionDetected,
     /// Forbidden GPU/tensor/BLAS dependency detected in manifest.
     ForbiddenDependencyDetected,
-    /// Unexpected heap allocation detected during steady-state execution.
-    UnexpectedAllocationDetected,
 }
 
 impl fmt::Display for AuditVerdict {
@@ -31,22 +36,27 @@ impl fmt::Display for AuditVerdict {
             Self::Compliant => write!(f, "Compliant"),
             Self::ForbiddenInstructionDetected => write!(f, "Forbidden Instruction Detected"),
             Self::ForbiddenDependencyDetected => write!(f, "Forbidden Dependency Detected"),
-            Self::UnexpectedAllocationDetected => write!(f, "Unexpected Allocation Detected"),
         }
     }
 }
 
-/// Audit Report produced by `InferenceAuditVerifier`.
+/// Report produced by [`InferenceAuditVerifier::audit_reference_fixtures`].
+///
+/// #787: this reports on the ENGINE's reference fixtures only — it
+/// carries no allocation figure (nothing here measures allocations; the
+/// old `steady_state_allocations: 0` literal was removed as an
+/// overclaim) and `fixtures_clean` certifies the fixtures, never the
+/// release binary (#160's job).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InferenceAuditReport {
     pub verdict: AuditVerdict,
     pub instructions_scanned: usize,
     pub dependencies_scanned: usize,
-    pub steady_state_allocations: usize,
-    pub is_certified: bool,
+    pub fixtures_clean: bool,
 }
 
-/// Machine-Code, Dependency, and Allocator Auditor Engine.
+/// Machine-code and dependency audit ENGINE (fixture-level; see the
+/// module doc — the #160 release-binary audit has not landed).
 pub struct InferenceAuditVerifier;
 
 impl InferenceAuditVerifier {
@@ -127,30 +137,35 @@ impl InferenceAuditVerifier {
         Some(count)
     }
 
-    /// Execute complete machine-code, dependency, and allocator audit. Total:
-    /// always produces an [`InferenceAuditReport`]; its `verdict` and
-    /// `is_certified` carry whether every sub-audit held (R5 — the audit reports
-    /// its finding, it never raises).
-    pub fn audit_all() -> InferenceAuditReport {
-        let sample_disassembly = "mov eax, [rsp+8]\nadd eax, ebx\nxor ecx, ecx\nret";
-        let Some(instructions_scanned) = Self::audit_disassembly(sample_disassembly) else {
+    /// Exercise the audit ENGINE against its reference fixtures. Total:
+    /// always produces an [`InferenceAuditReport`]; `verdict` and
+    /// `fixtures_clean` carry whether the fixture scans held (R5 — the
+    /// audit reports its finding, it never raises).
+    ///
+    /// #787: this is an engine self-test, not the #160 machine-code
+    /// audit — the fixtures are a hand-written disassembly snippet and a
+    /// hand-written dependency list, named as such. When #160 lands, the
+    /// real inputs (release-binary disassembly of the contract-owned
+    /// functions, the actual `cargo metadata` graph) replace these
+    /// fixtures and this doc contract changes with them.
+    pub fn audit_reference_fixtures() -> InferenceAuditReport {
+        let fixture_disassembly = "mov eax, [rsp+8]\nadd eax, ebx\nxor ecx, ecx\nret";
+        let Some(instructions_scanned) = Self::audit_disassembly(fixture_disassembly) else {
             return InferenceAuditReport {
                 verdict: AuditVerdict::ForbiddenInstructionDetected,
                 instructions_scanned: 0,
                 dependencies_scanned: 0,
-                steady_state_allocations: 0,
-                is_certified: false,
+                fixtures_clean: false,
             };
         };
 
-        let sample_dependencies = &["uor-r4-graph-format", "uor-r4-graph-runtime", "core"];
-        let Some(dependencies_scanned) = Self::audit_dependencies(sample_dependencies) else {
+        let fixture_dependencies = &["uor-r4-graph-format", "uor-r4-graph-runtime", "core"];
+        let Some(dependencies_scanned) = Self::audit_dependencies(fixture_dependencies) else {
             return InferenceAuditReport {
                 verdict: AuditVerdict::ForbiddenDependencyDetected,
                 instructions_scanned,
                 dependencies_scanned: 0,
-                steady_state_allocations: 0,
-                is_certified: false,
+                fixtures_clean: false,
             };
         };
 
@@ -158,8 +173,7 @@ impl InferenceAuditVerifier {
             verdict: AuditVerdict::Compliant,
             instructions_scanned,
             dependencies_scanned,
-            steady_state_allocations: 0,
-            is_certified: true,
+            fixtures_clean: true,
         }
     }
 }

--- a/crates/uor-r4-proof-model/src/proof_matrix.rs
+++ b/crates/uor-r4-proof-model/src/proof_matrix.rs
@@ -7,6 +7,13 @@ pub enum ProofStatus {
     Verified,
     ExecutableSpec,
     DifferentialPass,
+    /// #787 (AUD-INV-001): the honest tier between `Verified` and
+    /// `Unverified` — the property is enforced by source-scan witnesses
+    /// (Witnessed evidence per `INFERENCE_OPERATION_CONTRACT.md` §6/§8),
+    /// not yet by the #160 machine-code audit. A `Witnessed` row passes
+    /// `verify_all` but is visibly not `Verified`, so the matrix can no
+    /// longer overclaim structural evidence it does not have.
+    Witnessed,
     Unverified,
 }
 
@@ -38,7 +45,10 @@ impl Default for ProofStatusMatrix {
                 TheoremEntry {
                     name: "Operation-Set Conformance".to_string(),
                     theorem_id: "Plan §6 / PDF §17".to_string(),
-                    status: ProofStatus::Verified,
+                    // #787: the description was always accurate; the status
+                    // overclaimed. Witnessed until the #160 disassembly
+                    // audit lands.
+                    status: ProofStatus::Witnessed,
                     description:
                         "Witnessed source scans enforce the multiplication-free inference operation contract until disassembly audit lands".to_string(),
                 },
@@ -112,6 +122,40 @@ mod tests {
     #[test]
     fn test_proof_matrix_all_verified() {
         let matrix = ProofStatusMatrix::new();
+        assert!(matrix.verify_all().is_none());
+    }
+
+    /// #787 falsifier: the matrix instrument must be able to fail — a
+    /// seeded `Unverified` entry makes `verify_all` report it. Before this
+    /// issue the default matrix hardcoded 8/8 `Verified` and no code path
+    /// ever constructed the failing status, making the instrument
+    /// indistinguishable from one that always passes.
+    #[test]
+    fn verify_all_fails_on_a_seeded_unverified_entry() {
+        let mut matrix = ProofStatusMatrix::new();
+        matrix.entries.push(TheoremEntry {
+            name: "Seeded violation".to_string(),
+            theorem_id: "TEST-787".to_string(),
+            status: ProofStatus::Unverified,
+            description: "instrument falsifier".to_string(),
+        });
+        let reason = matrix.verify_all().expect("seeded violation must fail");
+        assert!(reason.contains("TEST-787"));
+    }
+
+    /// #787: the honest tier is visible — Operation-Set Conformance is
+    /// `Witnessed` (source-scan evidence), not `Verified`, until the #160
+    /// disassembly audit lands; `verify_all` accepts it without erasing
+    /// the distinction.
+    #[test]
+    fn operation_set_conformance_is_witnessed_not_verified() {
+        let matrix = ProofStatusMatrix::new();
+        let row = matrix
+            .entries
+            .iter()
+            .find(|entry| entry.name == "Operation-Set Conformance")
+            .expect("row present");
+        assert_eq!(row.status, ProofStatus::Witnessed);
         assert!(matrix.verify_all().is_none());
     }
 }

--- a/crates/uor-r4-proof-model/src/structural_guarantees.rs
+++ b/crates/uor-r4-proof-model/src/structural_guarantees.rs
@@ -368,15 +368,17 @@ impl StructuralGuaranteeVerifier {
                     .to_string(),
         }
     }
-    /// Verify machine-code, allocator, and dependency CI audit compliance (#160).
+    /// Verify the inference audit ENGINE's fixture self-test (#787: this is
+    /// not the #160 machine-code audit — until that lands, the report is
+    /// honestly `Witnessed`-tier engine evidence, never `Verified`).
     pub fn verify_inference_audit_compliance(obligation_id: &str) -> ProofVerificationReport {
         use crate::inference_audit::InferenceAuditVerifier;
-        // `audit_all` is total: it always produces a report whose verdict/
-        // is_certified carry the finding (R5).
-        let report = InferenceAuditVerifier::audit_all();
+        // `audit_reference_fixtures` is total: it always produces a report
+        // whose verdict/fixtures_clean carry the finding (R5).
+        let report = InferenceAuditVerifier::audit_reference_fixtures();
 
-        let status = if report.is_certified {
-            ProofStatus::Verified
+        let status = if report.fixtures_clean {
+            ProofStatus::Witnessed
         } else {
             ProofStatus::Unverified
         };
@@ -385,9 +387,9 @@ impl StructuralGuaranteeVerifier {
             obligation_id: obligation_id.to_string(),
             kind: StructuralObligationKind::BoundedResource,
             status,
-            verified: report.is_certified,
+            verified: report.fixtures_clean,
             details: format!(
-                "Inference audit verified (verdict: {}, scanned_inst: {}, scanned_deps: {})",
+                "Inference audit engine self-test (fixture-level; #160 pending) — verdict: {}, scanned_inst: {}, scanned_deps: {}",
                 report.verdict, report.instructions_scanned, report.dependencies_scanned
             ),
         }

--- a/crates/uor-r4-proof-model/tests/proof_matrix_audit.rs
+++ b/crates/uor-r4-proof-model/tests/proof_matrix_audit.rs
@@ -40,10 +40,12 @@ fn test_ci_audit_proof_matrix_entries() {
     );
     assert!(report_rev.verified);
 
+    // #787: Operation-Set Conformance is honestly Witnessed (source-scan
+    // evidence) until the #160 disassembly audit lands.
     let report_ops = StructuralGuaranteeVerifier::audit_proof_matrix_entry(
         &matrix,
         "Operation-Set Conformance",
-        ProofStatus::Verified,
+        ProofStatus::Witnessed,
     );
     assert!(report_ops.verified);
 }
@@ -63,6 +65,7 @@ fn test_606_certificate_obligation_links_mirror_the_matrix() {
             ProofStatus::Verified => "Verified",
             ProofStatus::ExecutableSpec => "ExecutableSpec",
             ProofStatus::DifferentialPass => "DifferentialPass",
+            ProofStatus::Witnessed => "Witnessed",
             ProofStatus::Unverified => "Unverified",
         }
     }

--- a/features/suites/inference_contract.feature
+++ b/features/suites/inference_contract.feature
@@ -6,7 +6,7 @@ Feature: Normative CPU-only, multiplication-free, zero-allocation inference cont
   Scenario: Validate inference contract document and module parity
     Given the normative inference contract specification
     When audited by the inference contract verifier
-    Then contract version "1.0.0" is verified with 0 steady-state allocations
+    Then the reported contract version matches the canonical constant
     And the contract audit certification status is verified
 
   @RF-10 @build

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -1902,10 +1902,21 @@ fn bdd_contract_audit_when(w: &mut R4g1World) {
     w.contract_report = Some(rep);
 }
 
-#[then("contract version \"1.0.0\" is verified with 0 steady-state allocations")]
+#[then("the reported contract version matches the canonical constant")]
 fn bdd_contract_ver_check(w: &mut R4g1World) {
     let rep = w.contract_report.as_ref().expect("contract report");
-    assert_eq!(rep.contract_version.to_string(), "1.0.0");
+    // #787: no hardcoded version literal — the audit found the report
+    // type at 1.0.0 while the normative document said 0.1.0; both now
+    // derive from INFERENCE_OPERATION_CONTRACT_VERSION and this step
+    // pins the report to that single source of truth.
+    let canonical = uor_r4_graph_format::INFERENCE_OPERATION_CONTRACT_VERSION;
+    assert_eq!(
+        rep.contract_version.to_string(),
+        format!(
+            "{}.{}.{}",
+            canonical.major, canonical.minor, canonical.patch
+        )
+    );
     assert!(rep.is_zero_allocation_guaranteed);
 }
 


### PR DESCRIPTION
References #787 (E-a per the maintainer's make-it-honest decision; E-b and E-c complete).

- **E-a**: the machine-code audit is honestly scoped as an engine self-test everywhere it is named (CI step, module, API, report fields); proof matrix gains the Witnessed tier and Operation-Set Conformance uses it; verify_all has a working falsifier for the first time; the certify obligation mirror follows.
- **E-b**: dot_argmax scalar differential (the scalar reference now compiles on aarch64, where its absence was the gap); delegation-count pin; ALL 11 graph-runtime modules + both previously-unscanned ACTIVITY_OWNERS modules under the P-4 scan with an exactly-pinned 3-entry load-time allowance list (vp_tree construction); contract versions reconciled with a 3-way doc/constant/report sync test; the audit's phantom-generate_into finding corrected on verification (the function exists).
- **E-c**: four divergent source-scanner copies consolidated onto one canonical, literal-aware implementation with its own falsifier suite (per the issue's decision rule, every instrument here demonstrably fails on a seeded violation: scanner falsifiers, the matrix falsifier, and the allowance-list pin all fire red when seeded).

Gates: fmt, clippy -D warnings (workspace), core 58 / graph-runtime 11 / certify-msa 26 / graph-format 7 / proof-model suites green, registered 29/29, R1/R4/R5, wasm32 lib, bdd binary builds (the changed contract scenario runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW