### PR TITLE
fix(#790-4): remove the dead FallbackRouter pipeline and the legacy engine resolver

### DIFF
--- a/crates/uor-r4-router/src/fallback.rs
+++ b/crates/uor-r4-router/src/fallback.rs
@@ -1,16 +1,22 @@
-//! Dynamic Fallback Engine Pipeline (`FallbackRouter`).
+//! The N-tier serving cascade (issue #248).
 //!
-//! Formalizes dynamic engine fallback: when primary `R4G1` graph inference
-//! encounters an unmapped region, pathological loop, or `Novel`/`Contradictory`
-//! state status, `FallbackRouter` seamlessly cascades to secondary `transformerless`
-//! (TLA5/TLS1) engine generation, returning a valid response without dropping HTTP/WS payloads.
+//! [`run_cascade`] walks an ordered list of named tier closures, serves
+//! the first [`EngineStatus::Success`] with non-empty text, and records
+//! every attempted tier's typed outcome in a [`CascadeOutcome::trail`].
+//! A declared abstention is a recorded event the cascade continues past
+//! (PR #223 semantics: recording, not refusing), and a run where no tier
+//! serves ends with an honest empty outcome the caller types as
+//! `declined_by_all`.
 //!
-//! Issue #248 adds the generalized N-tier serving cascade: [`run_cascade`]
-//! walks an ordered list of named tier closures, serves the first
-//! [`EngineStatus::Success`], records every attempted tier's typed outcome
-//! in a [`CascadeOutcome::trail`], and — under the central
-//! [`SERVING_ABSTAIN_POLICY`] — treats a declared abstention as a recorded
-//! event the cascade continues past, not a refusal to try later tiers.
+//! #790 item 4 (2026-08-18 audit finding): the original
+//! `FallbackRouter` two-engine pipeline that founded this module — plus
+//! its `EngineResponse`/`FallbackResult` types, the never-selected
+//! `AbstainPolicy::Terminal` parameterization, the never-constructed
+//! `UnmappedRegion` status, and the `r4g1-graph`/`transformerless-tla5`
+//! engine names — had zero callers outside its own tests while the docs
+//! presented it as the live serving path. It was removed rather than
+//! kept as dead weight; `run_cascade` and its typed outcome records are
+//! the one serving surface.
 
 use serde::{Deserialize, Serialize};
 
@@ -19,8 +25,6 @@ use serde::{Deserialize, Serialize};
 pub enum EngineStatus {
     /// Successful inference generation.
     Success,
-    /// Primary engine encountered an unmapped region or novel context.
-    UnmappedRegion,
     /// Primary engine encountered a pathological loop or cycle.
     Pathological,
     /// Unrecoverable engine failure.
@@ -35,7 +39,6 @@ impl std::fmt::Display for EngineStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EngineStatus::Success => write!(f, "success"),
-            EngineStatus::UnmappedRegion => write!(f, "unmapped_region"),
             EngineStatus::Pathological => write!(f, "pathological"),
             EngineStatus::Failed => write!(f, "failed"),
             EngineStatus::Abstained => write!(f, "abstained"),
@@ -109,40 +112,19 @@ pub struct CascadeOutcome {
     pub trail: Vec<TierOutcome>,
 }
 
-/// Whether a declared tier abstention ends the cascade or is recorded
-/// while later tiers still get to attempt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AbstainPolicy {
-    /// Record the abstention in the trail and continue to the next tier
-    /// (PR #223 semantics: recording, not refusing).
-    Cascade,
-    /// Record the abstention and end the cascade with no text.
-    Terminal,
-}
-
-/// The centralized serving policy for abstentions (issue #248). Both HTTP
-/// serving endpoints route through this one constant, so flipping the
-/// abstention semantics later is a one-line change.
-pub const SERVING_ABSTAIN_POLICY: AbstainPolicy = AbstainPolicy::Cascade;
-
 /// A named cascade tier's generation closure.
 pub type TierFn<'a> = Box<dyn FnMut() -> TierResult + 'a>;
 
-/// Run an ordered serving cascade under [`SERVING_ABSTAIN_POLICY`].
+/// Run an ordered serving cascade.
 ///
 /// The first tier returning [`EngineStatus::Success`] with non-empty text
-/// serves; every attempted tier's outcome is recorded in the trail. A
-/// `Success` without text is downgraded to a recorded `Failed` so a
-/// contradictory tier cannot serve emptiness.
+/// serves; every attempted tier's outcome is recorded in the trail, and a
+/// declared abstention is recorded while later tiers still attempt (the
+/// PR #223 record-and-continue semantics — previously a
+/// policy parameter whose alternative was never selected, inlined by
+/// #790 item 4). A `Success` without text is downgraded to a recorded
+/// `Failed` so a contradictory tier cannot serve emptiness.
 pub fn run_cascade(tiers: Vec<(&'static str, TierFn<'_>)>) -> CascadeOutcome {
-    run_cascade_with_policy(tiers, SERVING_ABSTAIN_POLICY)
-}
-
-/// [`run_cascade`] with an explicit abstention policy.
-pub fn run_cascade_with_policy(
-    tiers: Vec<(&'static str, TierFn<'_>)>,
-    policy: AbstainPolicy,
-) -> CascadeOutcome {
     let mut trail = Vec::with_capacity(tiers.len());
     for (tier, mut run) in tiers {
         let mut result = run();
@@ -177,16 +159,11 @@ pub fn run_cascade_with_policy(
             detail = result.detail.as_deref().unwrap_or(""),
             "Cascade tier declined"
         );
-        let terminal =
-            result.status == EngineStatus::Abstained && policy == AbstainPolicy::Terminal;
         trail.push(TierOutcome {
             tier,
             status: result.status,
             detail: result.detail,
         });
-        if terminal {
-            break;
-        }
     }
     CascadeOutcome {
         text: None,
@@ -195,180 +172,9 @@ pub fn run_cascade_with_policy(
     }
 }
 
-/// Response returned by an individual engine step/generation call.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EngineResponse {
-    pub text: String,
-    pub status: EngineStatus,
-    pub engine: String,
-    pub tokens_generated: usize,
-}
-
-/// Consolidated result from `FallbackRouter::execute`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FallbackResult {
-    pub text: String,
-    pub primary_status: EngineStatus,
-    pub fallback_triggered: bool,
-    pub active_engine: String,
-    pub tokens_generated: usize,
-}
-
-/// A dynamic fallback router managing primary (R4G1) and secondary (TLA5) inference engines.
-#[derive(Debug, Clone)]
-pub struct FallbackRouter {
-    primary_name: String,
-    secondary_name: String,
-}
-
-impl Default for FallbackRouter {
-    fn default() -> Self {
-        Self {
-            primary_name: "r4g1-graph".to_string(),
-            secondary_name: "transformerless-tla5".to_string(),
-        }
-    }
-}
-
-impl FallbackRouter {
-    /// Create a new `FallbackRouter` with custom engine identifiers.
-    pub fn new(primary_name: impl Into<String>, secondary_name: impl Into<String>) -> Self {
-        Self {
-            primary_name: primary_name.into(),
-            secondary_name: secondary_name.into(),
-        }
-    }
-
-    /// Primary engine name.
-    pub fn primary_name(&self) -> &str {
-        &self.primary_name
-    }
-
-    /// Secondary engine name.
-    pub fn secondary_name(&self) -> &str {
-        &self.secondary_name
-    }
-
-    /// Execute inference generation with automatic fallback cascading.
-    ///
-    /// Evaluates `primary_fn`. If it returns [`EngineStatus::Success`], returns
-    /// that result directly. For any other status (`UnmappedRegion`,
-    /// `Pathological`, `Failed`, `Abstained`) it logs a `tracing::info!`
-    /// fallback event and invokes `secondary_fn`, returning a clean
-    /// [`FallbackResult`].
-    ///
-    /// Each engine closure returns an [`EngineResponse`] directly: the outcome
-    /// — success or otherwise — is carried in the response's own
-    /// [`EngineStatus`], not a separate error channel. A failed engine reports
-    /// `EngineStatus::Failed` with its explanatory text, so there is no bound
-    /// on how an engine may report (R5 — the closures are total).
-    pub fn execute<FPrimary, FSecondary>(
-        &self,
-        mut primary_fn: FPrimary,
-        mut secondary_fn: FSecondary,
-    ) -> FallbackResult
-    where
-        FPrimary: FnMut() -> EngineResponse,
-        FSecondary: FnMut() -> EngineResponse,
-    {
-        let primary_res = primary_fn();
-        if primary_res.status == EngineStatus::Success {
-            return FallbackResult {
-                text: primary_res.text,
-                primary_status: EngineStatus::Success,
-                fallback_triggered: false,
-                active_engine: primary_res.engine,
-                tokens_generated: primary_res.tokens_generated,
-            };
-        }
-        tracing::info!(
-            target: "uor_r4_router::fallback",
-            primary = %self.primary_name,
-            secondary = %self.secondary_name,
-            primary_status = %primary_res.status,
-            "Primary engine status requiring fallback; cascading to secondary engine"
-        );
-        let sec_res = secondary_fn();
-        FallbackResult {
-            text: sec_res.text,
-            primary_status: primary_res.status,
-            fallback_triggered: true,
-            active_engine: sec_res.engine,
-            tokens_generated: sec_res.tokens_generated,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_fallback_router_primary_success() {
-        let router = FallbackRouter::default();
-        let res = router.execute(
-            || EngineResponse {
-                text: "Primary clean output".to_string(),
-                status: EngineStatus::Success,
-                engine: "r4g1-graph".to_string(),
-                tokens_generated: 10,
-            },
-            || panic!("secondary should not be called"),
-        );
-
-        assert!(!res.fallback_triggered);
-        assert_eq!(res.primary_status, EngineStatus::Success);
-        assert_eq!(res.active_engine, "r4g1-graph");
-        assert_eq!(res.text, "Primary clean output");
-    }
-
-    #[test]
-    fn test_fallback_router_unmapped_region_triggers_fallback() {
-        let router = FallbackRouter::default();
-        let res = router.execute(
-            || EngineResponse {
-                text: "".to_string(),
-                status: EngineStatus::UnmappedRegion,
-                engine: "r4g1-graph".to_string(),
-                tokens_generated: 0,
-            },
-            || EngineResponse {
-                text: "Secondary fallback output".to_string(),
-                status: EngineStatus::Success,
-                engine: "transformerless-tla5".to_string(),
-                tokens_generated: 8,
-            },
-        );
-
-        assert!(res.fallback_triggered);
-        assert_eq!(res.primary_status, EngineStatus::UnmappedRegion);
-        assert_eq!(res.active_engine, "transformerless-tla5");
-        assert_eq!(res.text, "Secondary fallback output");
-    }
-
-    #[test]
-    fn test_fallback_router_pathological_loop_triggers_fallback() {
-        let router = FallbackRouter::default();
-        let res = router.execute(
-            || EngineResponse {
-                text: "Loop detected".to_string(),
-                status: EngineStatus::Pathological,
-                engine: "r4g1-graph".to_string(),
-                tokens_generated: 2,
-            },
-            || EngineResponse {
-                text: "Secondary fallback recovery".to_string(),
-                status: EngineStatus::Success,
-                engine: "transformerless-tla5".to_string(),
-                tokens_generated: 12,
-            },
-        );
-
-        assert!(res.fallback_triggered);
-        assert_eq!(res.primary_status, EngineStatus::Pathological);
-        assert_eq!(res.active_engine, "transformerless-tla5");
-        assert_eq!(res.text, "Secondary fallback recovery");
-    }
 
     #[test]
     fn test_run_cascade_first_success_wins() {
@@ -407,7 +213,7 @@ mod tests {
                 Box::new(|| TierResult::success("served after abstention".to_owned())),
             ),
         ];
-        let outcome = run_cascade_with_policy(tiers, AbstainPolicy::Cascade);
+        let outcome = run_cascade(tiers);
         assert_eq!(outcome.text.as_deref(), Some("served after abstention"));
         assert_eq!(outcome.served_by, Some("transformerless"));
         assert_eq!(outcome.trail.len(), 2);
@@ -417,27 +223,6 @@ mod tests {
             Some("R4G1 policy abstained (status: novel)")
         );
         assert_eq!(outcome.trail[1].status, EngineStatus::Success);
-    }
-
-    #[test]
-    fn test_run_cascade_terminal_policy_stops_at_abstention() {
-        let mut later_tier_called = false;
-        let tiers: Vec<(&'static str, TierFn<'_>)> = vec![
-            ("r4g1", Box::new(|| TierResult::abstained("novel input"))),
-            (
-                "transformerless",
-                Box::new(|| {
-                    later_tier_called = true;
-                    TierResult::success("never attempted".to_owned())
-                }),
-            ),
-        ];
-        let outcome = run_cascade_with_policy(tiers, AbstainPolicy::Terminal);
-        assert!(outcome.text.is_none());
-        assert!(outcome.served_by.is_none());
-        assert_eq!(outcome.trail.len(), 1);
-        assert_eq!(outcome.trail[0].status, EngineStatus::Abstained);
-        assert!(!later_tier_called);
     }
 
     #[test]

--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -20,11 +20,9 @@ pub use session_signature::{
     from_tokens as session_signature_from_tokens, MULTI_TURN_FIXTURE,
 };
 
-pub use fallback::{
-    run_cascade, run_cascade_with_policy, AbstainPolicy, CascadeOutcome, EngineResponse,
-    EngineStatus, FallbackResult, FallbackRouter, TierFn, TierOutcome, TierResult,
-    SERVING_ABSTAIN_POLICY,
-};
+// #790 item 4: only the live cascade surface is exported — the dead
+// FallbackRouter pipeline and its satellite types were removed.
+pub use fallback::{run_cascade, CascadeOutcome, EngineStatus, TierFn, TierOutcome, TierResult};
 
 /// A content-addressed identifier derived via the 3/8 Resonance Hashing Law.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -3683,18 +3683,18 @@ pub fn validate_r4g1_corpus_inputs(meta: &Path, records: &Path) -> Result<(), St
     Ok(())
 }
 
-/// Resolve the synthesis engine. R4G1 is the active default; legacy and
-/// geometric paths are reachable only through explicit engine values.
-pub fn select_synthesis_engine(requested: Option<&str>) -> &'static str {
-    match requested {
-        Some("r4g1") => "r4g1",
-        Some("geometric") => "geometric",
-        Some("attention") => "attention",
-        Some("r4-attention") => "r4-attention",
-        Some("transformerless-legacy") => "transformerless-legacy",
-        Some("auto" | "ollama" | "transformerless") | None => "r4g1",
-        Some(_) => "r4g1",
-    }
+/// #790 item 4: the live single-value engine resolution the BDD
+/// scenarios pin — an explicit KNOWN engine name resolves to its cascade
+/// tier constant (via `tier_for_engine_name`, the same mapping serving
+/// uses), and everything else (none, "auto", "r4g1", unknown) resolves
+/// to the cascade default, whose first tier is r4g1. Replaces the
+/// removed legacy `select_synthesis_engine`, which disagreed with
+/// serving on "transformerless" (it collapsed the tier to "r4g1" while
+/// the live cascade pins the transformerless tier).
+pub fn default_resolved_tier(requested: Option<&str>) -> &'static str {
+    requested
+        .and_then(tier_for_engine_name)
+        .unwrap_or(TIER_R4G1)
 }
 
 /// The explicit failure contract for an unavailable R4G1 runtime. Keeping
@@ -3725,8 +3725,9 @@ fn r4g1_unavailable_response_with_reason(reason: Option<&str>) -> (u16, serde_js
 
 // ---------------------------------------------------------------------------
 // The single serving cascade (issue #248). Both HTTP chat endpoints route
-// through `run_serving_cascade`; the abstention policy is centralized in
-// `uor_r4_router::fallback::SERVING_ABSTAIN_POLICY`.
+// through `run_serving_cascade`; abstentions are recorded in the trail
+// while later tiers still attempt (PR #223 record-and-continue, the one
+// policy `run_cascade` implements — #790 item 4).
 // ---------------------------------------------------------------------------
 
 /// Serving-cascade tier identifiers, in full-cascade order.
@@ -3842,8 +3843,8 @@ fn engine_profile_preference() -> Option<String> {
 /// full cascade's order, so the choice loses nothing by cascading.
 /// Explicit non-default selections (attention, geometric, transformerless,
 /// r4-attention) pin. "auto"/empty/unknown and the legacy "ollama" alias
-/// run the full cascade. `select_synthesis_engine` remains the legacy
-/// single-value resolver for existing consumers.
+/// run the full cascade. `default_resolved_tier` is the single-value
+/// view of the same mapping (#790 item 4).
 fn resolve_pinned_tier(requested: Option<&str>) -> Option<&'static str> {
     let requested = match requested.map(str::trim) {
         Some(value) if !value.is_empty() => Some(value.to_owned()),
@@ -16043,7 +16044,8 @@ fn handle_connection(
         // 5. Decode response through the single serving cascade (issue
         // #248). A D4 abstention no longer refuses fallback outright: it is
         // RECORDED in the per-tier trail while later tiers still attempt
-        // (PR #223 semantics, centralized in `SERVING_ABSTAIN_POLICY`).
+        // (PR #223 record-and-continue semantics, implemented directly by
+        // `run_cascade` — #790 item 4).
         let t_gen = Instant::now();
         let mut cascade = run_serving_cascade(
             &mut router_guard,

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -22,7 +22,7 @@ use uor_r4_graph_format::INFERENCE_OPERATION_CONTRACT_VERSION;
 use uor_r4_wasm_router::cd_space_fold;
 use uor_r4_wasm_router::r4g1::validate_quality_report;
 use uor_r4_wasm_router::server::{
-    is_usable_generated_text, r4g1_unavailable_response, select_synthesis_engine,
+    default_resolved_tier, is_usable_generated_text, r4g1_unavailable_response,
     validate_r4g1_corpus_inputs,
 };
 
@@ -236,7 +236,12 @@ fn no_saved_engine(_w: &mut R4g1World) {}
 
 #[when("the server resolves the synthesis engine")]
 fn resolve_engine(w: &mut R4g1World) {
-    w.selected_engine = Some(select_synthesis_engine(w.requested_engine));
+    // #790 item 4: repointed at the live resolver (the same
+    // tier_for_engine_name mapping serving uses, with the cascade
+    // r4g1-first default) instead of the removed legacy
+    // select_synthesis_engine, which disagreed with serving on
+    // "transformerless".
+    w.selected_engine = Some(default_resolved_tier(w.requested_engine));
 }
 
 #[then("the selected engine is R4G1")]
@@ -251,7 +256,10 @@ fn explicit_legacy(w: &mut R4g1World) {
 
 #[then("the selected engine is Legacy TLA/TLS")]
 fn selected_engine_is_legacy(w: &mut R4g1World) {
-    assert_eq!(w.selected_engine, Some("transformerless-legacy"));
+    // The live cascade pins the transformerless TIER for the legacy
+    // alias — the tier constant, not the requested alias string (the
+    // request-echo question is #789-G3.2, about decline messages).
+    assert_eq!(w.selected_engine, Some("transformerless"));
 }
 
 #[then("the browser UI selects R4G1 and does not offer automatic fallback")]


### PR DESCRIPTION
References #790 (item 4, individual PR per the convention). Removes the audit-confirmed dead serving code (FallbackRouter pipeline + satellite types + never-selected policy/status variants + the legacy resolver) and repoints the BDD scenarios at the live resolver semantics. Live cascade behavior byte-identical; router 18+2 tests green, workspace clippy -D warnings, wasm32 lib, bdd builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW