### PR TITLE
fix(#790-6): one store root for every artifact and state path; sanitized compiled-bundle names

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -229,7 +229,11 @@ impl ChatEngineBuilder {
             compiler::parse_artifacts(&artifact_bytes).ok_or(ChatError::InvalidArtifacts)?;
         let store_bytes = model_store.get(&manifest.store)?;
         let store = runtime::parse_store(&store_bytes).ok_or(ChatError::InvalidStore)?;
-        let model_dir = std::path::PathBuf::from(format!(".uor-models/compiled/{}", manifest.name));
+        // #790 item 6: resolve against the store root with the same name
+        // sanitization the manifest read applied — the raw name was
+        // previously interpolated into a hardcoded `.uor-models` path, so
+        // it could disagree with an env-relocated store or escape it.
+        let model_dir = crate::model::compiled_model_dir(&manifest.name);
         let r4g1_bytes = read_preferred_chat_graph(&model_dir)?;
         validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
         let bundled_tokenizer = match model_store.get(&manifest.tokenizer) {
@@ -1528,7 +1532,7 @@ fn handle_model_switch_with_remediation<W: Write>(
             if res["status"] == "success" {
                 *current_active_model = target_model.to_string();
                 if let Err(error) = persist_state_file(
-                    std::path::Path::new(".uor-models/last_model_name.txt"),
+                    &crate::model::store_state_file("last_model_name.txt"),
                     current_active_model.as_str(),
                 ) {
                     writeln!(
@@ -1605,12 +1609,12 @@ fn handle_model_switch_with_remediation<W: Write>(
                                 *current_active_model = target_model.to_string();
                                 *current_active_engine = "r4g1".to_string();
                                 if let Err(error) = persist_state_file(
-                                    std::path::Path::new(".uor-models/last_model_name.txt"),
+                                    &crate::model::store_state_file("last_model_name.txt"),
                                     current_active_model.as_str(),
                                 )
                                 .and_then(|()| {
                                     persist_state_file(
-                                        std::path::Path::new(".uor-models/last_engine.txt"),
+                                        &crate::model::store_state_file("last_engine.txt"),
                                         current_active_engine.as_str(),
                                     )
                                 }) {
@@ -1624,7 +1628,7 @@ fn handle_model_switch_with_remediation<W: Write>(
                         1 => {
                             *current_active_engine = "attention".to_string();
                             if let Err(error) = persist_state_file(
-                                std::path::Path::new(".uor-models/last_engine.txt"),
+                                &crate::model::store_state_file("last_engine.txt"),
                                 current_active_engine.as_str(),
                             ) {
                                 writeln!(
@@ -1694,20 +1698,21 @@ pub fn remote_interactive_chat(
     let (host, port, path) = parse_remote_url(remote_url);
 
     // Read initial active model and engine from disk if present
-    let mut current_active_model =
-        if let Ok(m) = std::fs::read_to_string(".uor-models/last_model_name.txt") {
-            let trimmed = m.trim().to_string();
-            if !trimmed.is_empty() {
-                trimmed
-            } else {
-                model.to_string()
-            }
+    let mut current_active_model = if let Ok(m) =
+        std::fs::read_to_string(crate::model::store_state_file("last_model_name.txt"))
+    {
+        let trimmed = m.trim().to_string();
+        if !trimmed.is_empty() {
+            trimmed
         } else {
             model.to_string()
-        };
+        }
+    } else {
+        model.to_string()
+    };
 
     let mut current_active_engine =
-        if let Ok(e) = std::fs::read_to_string(".uor-models/last_engine.txt") {
+        if let Ok(e) = std::fs::read_to_string(crate::model::store_state_file("last_engine.txt")) {
             let trimmed = e.trim().to_string();
             if !trimmed.is_empty() {
                 trimmed
@@ -1993,7 +1998,7 @@ pub fn remote_interactive_chat(
 
                     current_active_engine = target_engine.clone();
                     if let Err(error) = persist_state_file(
-                        std::path::Path::new(".uor-models/last_engine.txt"),
+                        &crate::model::store_state_file("last_engine.txt"),
                         &current_active_engine,
                     ) {
                         writeln!(
@@ -2336,12 +2341,12 @@ pub fn remote_interactive_chat(
                             current_active_model = target_model.to_string();
                             current_active_engine = "r4g1".to_string();
                             if let Err(error) = persist_state_file(
-                                std::path::Path::new(".uor-models/last_model_name.txt"),
+                                &crate::model::store_state_file("last_model_name.txt"),
                                 &current_active_model,
                             )
                             .and_then(|()| {
                                 persist_state_file(
-                                    std::path::Path::new(".uor-models/last_engine.txt"),
+                                    &crate::model::store_state_file("last_engine.txt"),
                                     &current_active_engine,
                                 )
                             }) {

--- a/src/model.rs
+++ b/src/model.rs
@@ -481,9 +481,7 @@ impl ModelStore {
     }
 
     pub fn from_env() -> Self {
-        let root = std::env::var_os("UOR_MODEL_STORE")
-            .map_or_else(|| PathBuf::from(".uor-models"), PathBuf::from);
-        Self::new(root)
+        Self::new(model_store_root())
     }
 
     pub fn put(&self, bytes: &[u8]) -> Result<ModelObject, ModelError> {
@@ -714,6 +712,30 @@ fn cbor_byte_string_header(length: usize, out: &mut [u8; 9]) -> usize {
         out[1..9].copy_from_slice(&(length as u64).to_be_bytes());
         9
     }
+}
+
+/// The model-store root every artifact and state path resolves against
+/// (#790 item 6): `UOR_MODEL_STORE` when set, `.uor-models` otherwise.
+/// Previously the manifest store honored the env var while artifact
+/// preferences and the persisted engine/model state files hardcoded the
+/// default — a split root whenever the operator relocated the store.
+pub fn model_store_root() -> PathBuf {
+    std::env::var_os("UOR_MODEL_STORE").map_or_else(|| PathBuf::from(".uor-models"), PathBuf::from)
+}
+
+/// A small persisted state file (`last_engine.txt`,
+/// `last_model_name.txt`, `engine_profile.txt`) under the store root —
+/// the single path rule for every reader and writer (#790 item 6).
+pub fn store_state_file(name: &str) -> PathBuf {
+    model_store_root().join(name)
+}
+
+/// A compiled-bundle directory under the store root, with the same name
+/// sanitization the manifest reads apply (#790 item 6: raw manifest
+/// names were previously interpolated into the path unsanitized, so a
+/// name with separators could escape the store).
+pub fn compiled_model_dir(name: &str) -> PathBuf {
+    model_store_root().join("compiled").join(safe_name(name))
 }
 
 fn safe_name(name: &str) -> String {
@@ -1573,6 +1595,36 @@ pub fn write_source_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #790 item 6: every store path resolves against the one store root,
+    /// and compiled-bundle names are sanitized the same way manifest reads
+    /// are — a name carrying separators cannot escape the store (the old
+    /// interpolation `format!(".uor-models/compiled/{name}")` could).
+    /// Default-root behavior only: the env override is exercised by
+    /// `ModelStore::from_env` callers and is process-global, so mutating it
+    /// here would race parallel tests.
+    #[test]
+    fn store_paths_share_one_root_and_sanitize_names() {
+        if std::env::var_os("UOR_MODEL_STORE").is_none() {
+            assert_eq!(model_store_root(), PathBuf::from(".uor-models"));
+            assert_eq!(
+                store_state_file("last_engine.txt"),
+                PathBuf::from(".uor-models/last_engine.txt")
+            );
+            assert_eq!(
+                compiled_model_dir("smollm2-135m-instruct"),
+                PathBuf::from(".uor-models/compiled/smollm2-135m-instruct")
+            );
+        }
+        let escaped = compiled_model_dir("../evil/../../name");
+        assert!(escaped.starts_with(model_store_root().join("compiled")));
+        assert!(
+            !escaped
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir)),
+            "sanitized names must not traverse upward: {escaped:?}"
+        );
+    }
 
     /// #790 item 3 falsifier: a tokenizer-only descriptor must never win
     /// default-model discovery, even when it is the mtime-newest json —

--- a/src/server.rs
+++ b/src/server.rs
@@ -632,7 +632,8 @@ pub fn run_server(cli: Arc<ServerConfig>) {
     let tless: Arc<Mutex<Option<tless_uor::TlessState>>> = Arc::new(Mutex::new(None));
     let serving: SharedServingModel = Arc::new(Mutex::new(ServingModelState::default()));
 
-    let last_model = std::fs::read_to_string(".uor-models/last_model_name.txt").unwrap_or_default();
+    let last_model = std::fs::read_to_string(crate::model::store_state_file("last_model_name.txt"))
+        .unwrap_or_default();
     let last_model_name = last_model.trim();
 
     let candidates = startup_source_candidates(last_model_name);
@@ -3767,7 +3768,7 @@ struct ServingCascade {
 /// The persisted `/engine` selection written by the terminal chat client
 /// (`.uor-models/last_engine.txt`), if any.
 fn persisted_engine_preference() -> Option<String> {
-    let raw = fs::read_to_string(".uor-models/last_engine.txt").ok()?;
+    let raw = fs::read_to_string(crate::model::store_state_file("last_engine.txt")).ok()?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         None
@@ -3824,7 +3825,7 @@ impl EngineProfile {
 /// [`EngineProfile::from_persisted`], which already treats `None` the
 /// same as any other non-`"experimental"` value.
 fn engine_profile_preference() -> Option<String> {
-    let raw = fs::read_to_string(".uor-models/engine_profile.txt").ok()?;
+    let raw = fs::read_to_string(crate::model::store_state_file("engine_profile.txt")).ok()?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         None


### PR DESCRIPTION
References #790 (item 6, individual PR). Single store-root resolution (env-aware) for the ask-path artifact preference and all three persisted state files, readers and writers together; compiled-bundle paths sanitize names like manifest reads do. Default behavior byte-identical (verified live: bare ask unchanged). Gates: fmt, clippy -D warnings, wasm-router lib 250 green, wasm32 lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW