### PR TITLE
feat(#790-5): wire the wasm r4g1 export — module global assigned, bundle installer exported, static-mode install

### DIFF
--- a/index.html
+++ b/index.html
@@ -1528,12 +1528,40 @@ function runWorkerGeneration(payload) {
     });
 }
 
+// #790 item 5: same static-mode bundle install as r4_worker.js — scored
+// graph preferred, converter carryover fallback; missing files keep the
+// honest geometric fallback, and a typed installer refusal is logged.
+async function tryInstallStaticR4g1Bundle(scope, wasmModule) {
+    if (typeof wasmModule.set_r4g1_bundle !== 'function') return;
+    try {
+        for (const graphPath of ['./graph/score.r4g1', './compiled.r4g1']) {
+            const graphRes = await fetch(graphPath);
+            if (!graphRes.ok) continue;
+            const tokRes = await fetch('./tokenizer.bin');
+            if (!tokRes.ok) break;
+            const graph = new Uint8Array(await graphRes.arrayBuffer());
+            const tokenizer = new Uint8Array(await tokRes.arrayBuffer());
+            wasmModule.set_r4g1_bundle(graph, tokenizer);
+            console.log(`[${scope}] R4G1 bundle installed from ${graphPath}`);
+            return;
+        }
+        console.log(`[${scope}] no static R4G1 bundle found; geometric fallback stays active`);
+    } catch (err) {
+        console.warn(`[${scope}] R4G1 bundle install refused:`, err);
+    }
+}
+
 async function tryInitLocalWasm() {
     initR4Worker();
     if (wasmInitialized) return true;
     try {
-        const { default: init, UorR4Router } = await import('./pkg/uor_r4_wasm_router.js');
+        const wasmModule = await import('./pkg/uor_r4_wasm_router.js');
+        const { default: init, UorR4Router } = wasmModule;
         await init();
+        // #790 item 5: previously never assigned, so the main-thread
+        // r4g1/transformerless generation branch could never run.
+        window.wasm_module = wasmModule;
+        await tryInstallStaticR4g1Bundle('dashboard', wasmModule);
         router = new UorR4Router(1.2);
         wasmInitialized = true;
         console.log("Local WebAssembly Router Initialized Successfully!");

--- a/r4_worker.js
+++ b/r4_worker.js
@@ -4,14 +4,44 @@
 let router = null;
 let wasmInitialized = false;
 
+// #790 item 5: try to install a static-mode R4G1 bundle (scored graph
+// preferred, converter carryover fallback — the same preference order the
+// CLI and server use) so r4g1/transformerless selections can actually
+// serve through generate_r4g1_response. Missing files keep the honest
+// geometric fallback; a typed installer refusal is logged, never hidden.
+async function tryInstallStaticR4g1Bundle(scope, wasmModule) {
+    if (typeof wasmModule.set_r4g1_bundle !== 'function') return;
+    try {
+        for (const graphPath of ['./graph/score.r4g1', './compiled.r4g1']) {
+            const graphRes = await fetch(graphPath);
+            if (!graphRes.ok) continue;
+            const tokRes = await fetch('./tokenizer.bin');
+            if (!tokRes.ok) break;
+            const graph = new Uint8Array(await graphRes.arrayBuffer());
+            const tokenizer = new Uint8Array(await tokRes.arrayBuffer());
+            wasmModule.set_r4g1_bundle(graph, tokenizer);
+            console.log(`[${scope}] R4G1 bundle installed from ${graphPath}`);
+            return;
+        }
+        console.log(`[${scope}] no static R4G1 bundle found; geometric fallback stays active`);
+    } catch (err) {
+        console.warn(`[${scope}] R4G1 bundle install refused:`, err);
+    }
+}
+
 self.onmessage = async function (e) {
     const { type, id, payload } = e.data || {};
     
     switch (type) {
         case 'INIT_ENGINE': {
             try {
-                const { default: init, UorR4Router } = await import('./pkg/uor_r4_wasm_router.js');
+                const wasmModule = await import('./pkg/uor_r4_wasm_router.js');
+                const { default: init, UorR4Router } = wasmModule;
                 await init();
+                // #790 item 5: this global was never assigned before, so
+                // the r4g1/transformerless branches below could never run.
+                self.wasm_module = wasmModule;
+                await tryInstallStaticR4g1Bundle('r4_worker', wasmModule);
                 router = new UorR4Router(1.2);
                 wasmInitialized = true;
                 if (router.get_vocab_size() === 0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,20 @@ pub fn generate_r4g1_response(prompt: &str, max_tokens: usize) -> Option<String>
     tless_uor::generate_r4g1_response(prompt, max_tokens)
 }
 
+/// #790 item 5: install a graph and its exact tokenizer into the wasm
+/// runtime so the dashboard's r4g1/transformerless selections can
+/// actually serve through [`generate_r4g1_response`] in static mode.
+/// Previously that export was unreachable — no installer was exported
+/// and neither frontend assigned the `wasm_module` global it is gated
+/// on, so those selections silently took the geometric fallback. Throws
+/// the installer's typed refusal (CID mismatch, malformed bytes) without
+/// replacing a previously active bundle.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn set_r4g1_bundle(graph: Vec<u8>, tokenizer: Vec<u8>) -> Result<(), JsValue> {
+    tless_uor::set_r4g1_bundle(graph, tokenizer).map_err(|error| JsValue::from_str(&error))
+}
+
 /// The one-import surface for library users.
 pub mod prelude {
     pub use crate::tless_uor;


### PR DESCRIPTION
References #790 (item 5, per the maintainer's wire-it decision). Exports the atomic bundle installer to wasm (verified in wasm-pack bindings), assigns the module global both frontends gate on, and installs a static-mode bundle when one is served alongside the dashboard (score.r4g1 preferred, honest geometric fallback when absent). Gates: fmt, clippy -D warnings, wasm32 lib, wasm-pack build green, node --check on the worker, bdd builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW