### PR TITLE
feat(#804-S1-0): traced teacher-forced text observation — #603 capture reaches observe-text

### DIFF
--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -4140,6 +4140,17 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         attention_operator.as_ref(),
         dense_operator.as_ref(),
     )?;
+    // #603/#605 S1: the trace profile pins into the session manifest
+    // BEFORE the tokenizer export below — the payload-presence preflight
+    // counts `tokenizer.bin` as era evidence, so pinning after the export
+    // would misread a fresh traced session as a minimal-era one.
+    if let Some(profile) = trace_profile.as_ref() {
+        observe_text::pin_text_observation_trace_profile_in_session(
+            &session,
+            pool[0].as_ref(),
+            profile,
+        )?;
+    }
     if let Some(runtime_table) = runtime_table.as_ref() {
         token_byte_lengths = export_observation_tokenizer_in_session(&session, runtime_table)?;
     }

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -3778,6 +3778,15 @@ struct ObserveTextOptions {
     workers: usize,
     batch: usize,
     tokenizer_adapter: Option<TokenizerAdapterKey>,
+    /// #603/#605 S1: a registered non-minimal trace profile as
+    /// `<id>/<version>` (e.g. `full/1`), captured into per-shard
+    /// `.trace` sidecars through the teacher's exact-executor taps.
+    trace_profile: Option<(String, u32)>,
+    /// Declared capture layer indices for the trace profile's lanes.
+    trace_layers: Vec<u32>,
+    /// Per-head attention-support cap (defaults to the registry's
+    /// `PRIMARY_TOP_K` when omitted).
+    trace_support: Option<u32>,
 }
 
 fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, SourceUnavailable> {
@@ -3794,6 +3803,9 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
         workers: 1,
         batch: 1,
         tokenizer_adapter: None,
+        trace_profile: None,
+        trace_layers: Vec::new(),
+        trace_support: None,
     };
     let mut index = 0usize;
     while index < args.len() {
@@ -3856,6 +3868,53 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
                     return Err(SourceUnavailable::new("--batch must be greater than zero"));
                 }
             }
+            "--trace-profile" => {
+                // #603/#605 S1: `<id>/<version>` against the immutable
+                // profile registry (e.g. `full/1`). Unknown pairs are
+                // refused by the registry, never approximated.
+                let (id, version) = value.split_once('/').ok_or_else(|| {
+                    SourceUnavailable::new(format!(
+                        "invalid --trace-profile value: {value} (expected <id>/<version>, e.g. full/1)"
+                    ))
+                })?;
+                let version: u32 = version.parse().map_err(|_| {
+                    SourceUnavailable::new(format!(
+                        "invalid --trace-profile version in {value}: expected an integer"
+                    ))
+                })?;
+                options.trace_profile = Some((id.to_owned(), version));
+            }
+            "--trace-layers" => {
+                let mut layers = Vec::new();
+                for part in value.split(',') {
+                    let part = part.trim();
+                    if part.is_empty() {
+                        continue;
+                    }
+                    layers.push(part.parse::<u32>().map_err(|_| {
+                        SourceUnavailable::new(format!(
+                            "invalid --trace-layers entry: {part} (expected comma-separated layer indices)"
+                        ))
+                    })?);
+                }
+                if layers.is_empty() {
+                    return Err(SourceUnavailable::new(
+                        "--trace-layers must name at least one layer index",
+                    ));
+                }
+                options.trace_layers = layers;
+            }
+            "--trace-support" => {
+                let support: u32 = value.parse().map_err(|_| {
+                    SourceUnavailable::new(format!("invalid --trace-support value: {value}"))
+                })?;
+                if support == 0 {
+                    return Err(SourceUnavailable::new(
+                        "--trace-support must be greater than zero",
+                    ));
+                }
+                options.trace_support = Some(support);
+            }
             flag if tokenizer_adapter.parse(flag, value)? => {}
             _ => {
                 return Err(SourceUnavailable::new(format!(
@@ -3876,7 +3935,55 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
             "--tokenizer is the legacy llama2.c tokenizer and requires --checkpoint",
         ));
     }
+    // #603/#605 S1 trace-flag coherence: the capture surface is the
+    // single-stream Hugging Face exact executor, so traced passes refuse
+    // the batched driver and the legacy checkpoint path with typed
+    // errors instead of failing later mid-load; bounds flags without a
+    // profile are a mistake worth naming.
+    if options.trace_profile.is_some() {
+        if options.batch > 1 {
+            return Err(SourceUnavailable::new(
+                "--trace-profile capture is single-stream (per-oracle exact-executor taps); \
+                 it cannot run under --batch — use --workers for parallelism",
+            ));
+        }
+        if options.checkpoint.is_some() {
+            return Err(SourceUnavailable::new(
+                "--trace-profile requires the Hugging Face teacher path; the legacy \
+                 --checkpoint oracle declares no capture surface",
+            ));
+        }
+        if options.trace_layers.is_empty() {
+            return Err(SourceUnavailable::new(
+                "--trace-profile requires --trace-layers naming the declared capture layers",
+            ));
+        }
+    } else if !options.trace_layers.is_empty() || options.trace_support.is_some() {
+        return Err(SourceUnavailable::new(
+            "--trace-layers/--trace-support declare capture bounds for --trace-profile; \
+             pass a profile or drop them",
+        ));
+    }
     Ok(options)
+}
+
+/// Resolve the parsed `--trace-*` flags against the immutable #603 profile
+/// registry: `(id, version)` plus the declared bounds map to the typed
+/// record, or a typed refusal for unknown pairs and out-of-bound
+/// declarations.
+fn resolve_observe_text_trace_profile(
+    options: &ObserveTextOptions,
+) -> Result<Option<uor_r4_graph_compiler::trace_profile::TraceProfile>, SourceUnavailable> {
+    let Some((id, version)) = options.trace_profile.as_ref() else {
+        return Ok(None);
+    };
+    let bounds = uor_r4_graph_compiler::trace_profile::TraceCaptureBounds {
+        layer_indices: options.trace_layers.clone(),
+        support_size: options
+            .trace_support
+            .unwrap_or(uor_r4_graph_compiler::trace_profile::PRIMARY_TOP_K),
+    };
+    uor_r4_graph_compiler::trace_profile::profile_spec(id, *version, &bounds).map(Some)
 }
 
 fn resolve_registered_observation_tokenizer(
@@ -3916,6 +4023,10 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
         "warning: debug builds make teacher generation much slower; use `cargo run --release -- observe-text ...`"
     );
     let options = parse_observe_text_options(args)?;
+    // Resolve the trace profile against the registry BEFORE loading an
+    // expensive teacher or touching resumable output — same discipline as
+    // the tokenizer resolution below.
+    let trace_profile = resolve_observe_text_trace_profile(&options)?;
     // Batched teacher path: one shared weight copy, B articles per forward. This
     // is the throughput lever (measured ~15× at batch 32) and supersedes
     // --workers for the Hugging Face teacher.
@@ -4035,16 +4146,40 @@ pub fn observe_text_command(args: &[String]) -> Result<(), SourceUnavailable> {
     if options.workers > 1 {
         eprintln!("observing with {} teacher workers", options.workers);
     }
-    let report = observe_text::observe_text_corpus_in_session(
-        &session,
-        &mut pool,
-        options.seconds,
-        &tokenizer,
-        token_byte_lengths.as_deref(),
-        &options.input,
-        true,
-    )
-    .map_err(SourceUnavailable::new)?;
+    let report = match trace_profile.as_ref() {
+        Some(profile) => {
+            eprintln!(
+                "observing under trace profile {}/{} ({} declared layers, support cap {})",
+                profile.id,
+                profile.version,
+                options.trace_layers.len(),
+                options
+                    .trace_support
+                    .unwrap_or(uor_r4_graph_compiler::trace_profile::PRIMARY_TOP_K)
+            );
+            observe_text::observe_text_corpus_traced_in_session(
+                &session,
+                &mut pool,
+                options.seconds,
+                &tokenizer,
+                token_byte_lengths.as_deref(),
+                &options.input,
+                true,
+                profile,
+            )
+            .map_err(SourceUnavailable::new)?
+        }
+        None => observe_text::observe_text_corpus_in_session(
+            &session,
+            &mut pool,
+            options.seconds,
+            &tokenizer,
+            token_byte_lengths.as_deref(),
+            &options.input,
+            true,
+        )
+        .map_err(SourceUnavailable::new)?,
+    };
     let result = finish_observe_text_report(&report, &session);
     drop(session);
     result
@@ -9770,7 +9905,7 @@ fn transformerless_usage() -> &'static str {
                  graph score: score --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
                    --bundle-root explicitly declares one managed/canonical bundle authority; without it, --out is an exact standalone root fixed at transaction start\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
-                 text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N]\n\
+                 text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N] [--trace-profile ID/V --trace-layers I,J,... [--trace-support S]]\n\
                  A-mode infill serving: graph infill --artifact <scored R4G1> --skeleton <token ids, _ for free> [--teacher <TLA container>]\n\
                  quantum operations: cd-compile | quantum-eval\n\
                  hf evaluation: evaluate-report [--source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--compiled DIR] [--report PATH] [--sequence-length N] [--bos] [--max-held-out-stories N]\n\
@@ -14979,6 +15114,77 @@ mod tests {
         }
         let missing = ["--out"].map(str::to_owned);
         assert!(parse_observe_text_options(&missing).is_err());
+    }
+
+    /// #603/#605 S1: the traced observe-text flags parse, resolve against
+    /// the immutable registry, and refuse incoherent combinations with
+    /// typed errors (batch, legacy checkpoint, missing layers, orphan
+    /// bounds, unknown profile).
+    #[test]
+    fn observe_text_trace_flags_parse_and_refuse_incoherent_combinations() {
+        let traced = [
+            "--trace-profile",
+            "full/1",
+            "--trace-layers",
+            "0,4,9,13,18,22,27,31",
+            "--trace-support",
+            "8",
+        ]
+        .map(str::to_owned);
+        let options = parse_observe_text_options(&traced).expect("traced flags parse");
+        assert_eq!(options.trace_profile, Some(("full".to_owned(), 1)));
+        assert_eq!(options.trace_layers, vec![0, 4, 9, 13, 18, 22, 27, 31]);
+        assert_eq!(options.trace_support, Some(8));
+        let profile = resolve_observe_text_trace_profile(&options)
+            .expect("full/1 resolves against the registry")
+            .expect("a profile is produced");
+        assert_eq!(profile.id, "full");
+        assert_eq!(profile.version, 1);
+
+        let unknown = parse_observe_text_options(
+            &["--trace-profile", "imagined/9", "--trace-layers", "0"].map(str::to_owned),
+        )
+        .expect("shape parses");
+        assert!(
+            resolve_observe_text_trace_profile(&unknown).is_err(),
+            "unknown registry pairs are refused, never approximated"
+        );
+
+        for args in [
+            // batched capture is refused (single-stream taps)
+            vec![
+                "--trace-profile",
+                "full/1",
+                "--trace-layers",
+                "0",
+                "--batch",
+                "8",
+            ],
+            // legacy checkpoint oracle has no capture surface
+            vec![
+                "--trace-profile",
+                "full/1",
+                "--trace-layers",
+                "0",
+                "--checkpoint",
+                "/tmp/model.bin",
+            ],
+            // a profile without declared layers is refused
+            vec!["--trace-profile", "full/1"],
+            // bounds without a profile are a named mistake
+            vec!["--trace-layers", "0,1"],
+            vec!["--trace-support", "8"],
+            // malformed values
+            vec!["--trace-profile", "full"],
+            vec!["--trace-layers", "a,b"],
+            vec!["--trace-support", "0"],
+        ] {
+            let args: Vec<String> = args.iter().map(|arg| (*arg).to_owned()).collect();
+            assert!(
+                parse_observe_text_options(&args).is_err(),
+                "{args:?} rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -3415,6 +3415,28 @@ impl ObservationShardWriter {
         Ok(written)
     }
 
+    /// Partition-counting variant of
+    /// [`ObservationShardWriter::write_record_with_probability_and_trace`]
+    /// — one append carrying the record, its probability metadata, its
+    /// #603 trace-sidecar row, AND the D3 partition count, for the
+    /// teacher-forced text pipeline's traced passes (#605 S1).
+    pub fn write_record_with_probability_and_trace_in_partition(
+        &mut self,
+        record: &[u8; RECORD_SIZE],
+        probability: ProbabilityMetadata,
+        trace_row: &[u8],
+        shard: u32,
+        partition: RecordPartition,
+    ) -> Result<bool, SourceUnavailable> {
+        let written =
+            self.write_record_with_probability_and_trace(record, probability, trace_row, shard)?;
+        if written {
+            self.partition_counts[shard as usize].add(partition);
+            self.partitions_active = true;
+        }
+        Ok(written)
+    }
+
     /// Flush every open shard handle. Called at whole-story checkpoints so
     /// the on-disk shard bytes always cover exactly the completed stories
     /// of the deterministic stream.
@@ -4134,16 +4156,16 @@ impl TraceRowLayout {
 /// f32/u32 bytes; the row width is a pure function of (profile,
 /// geometry), pinned into the manifest at the first write.
 #[cfg(not(target_arch = "wasm32"))]
-struct TraceCapture {
-    profile: TraceProfile,
+pub(crate) struct TraceCapture {
+    pub(crate) profile: TraceProfile,
     residual_layers: Vec<usize>,
     qkv_layers: Vec<usize>,
     attention_layers: Vec<usize>,
     support: usize,
     final_hidden: bool,
     residual_width: usize,
-    row_bytes: usize,
-    row: Vec<u8>,
+    pub(crate) row_bytes: usize,
+    pub(crate) row: Vec<u8>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -4152,7 +4174,10 @@ impl TraceCapture {
     /// Refused — never zero-filled — when the oracle exposes no capture
     /// surface, no hidden state for a declared final-hidden lane, or a
     /// declared layer index outside its layer range.
-    fn new(profile: &TraceProfile, oracle: &dyn TeacherOracle) -> Result<Self, SourceUnavailable> {
+    pub(crate) fn new(
+        profile: &TraceProfile,
+        oracle: &dyn TeacherOracle,
+    ) -> Result<Self, SourceUnavailable> {
         validate_registered_trace_profile(profile)?;
         let geometry = oracle.trace_capture_geometry().ok_or_else(|| {
             invalid_input(format!(
@@ -4222,7 +4247,7 @@ impl TraceCapture {
     /// oracle's exact-executor capture path and assemble this position's
     /// trace-sidecar row into `self.row`. Deterministic: the row is a
     /// pure function of (oracle state, token, pos, profile).
-    fn step(
+    pub(crate) fn step(
         &mut self,
         oracle: &mut dyn TeacherOracle,
         token: usize,
@@ -4326,6 +4351,62 @@ impl TraceCapture {
         }
         Ok(())
     }
+}
+
+/// #603 profile pinning, read-only half: a corpus is captured under ONE
+/// profile. A recorded profile must match the requested one (minimal
+/// requests refuse traced corpora and vice versa once bytes exist); a
+/// fresh traced pass returns the profile to record before any record is
+/// written. Shared by the generation driver and the teacher-forced text
+/// driver so the two cannot drift.
+#[cfg(not(target_arch = "wasm32"))]
+fn preflight_trace_profile_pin(
+    writer: &ObservationShardWriter,
+    trace: Option<&TraceCapture>,
+    out: &Path,
+) -> Result<Option<TraceProfile>, SourceUnavailable> {
+    writer.preflight_trace_profile(trace.map(|trace| &trace.profile))?;
+    writer.preflight_trace_row_bytes(trace.map(|trace| trace.row_bytes as u64))?;
+    let recorded = writer.manifest().trace_profile.clone();
+    match (&recorded, trace) {
+        (None, None) => Ok(None),
+        (Some(recorded), Some(trace)) if *recorded == trace.profile => Ok(None),
+        (None, Some(trace)) => Ok(Some(trace.profile.clone())),
+        (Some(recorded), Some(trace)) => Err(invalid_input(format!(
+            "{} is pinned to trace profile {}/{}; requested {}/{}",
+            out.display(),
+            recorded.id,
+            recorded.version,
+            trace.profile.id,
+            trace.profile.version
+        ))),
+        (Some(recorded), None) => Err(invalid_input(format!(
+            "{} is pinned to trace profile {}/{}; pass the same profile to resume",
+            out.display(),
+            recorded.id,
+            recorded.version
+        ))),
+    }
+}
+
+/// [`preflight_trace_profile_pin`] plus the write half — record the
+/// profile and pin the row width — in one call, for drivers (the
+/// teacher-forced text pipeline) whose other identity records are
+/// published elsewhere.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn pin_writer_trace_profile(
+    writer: &mut ObservationShardWriter,
+    trace: Option<&TraceCapture>,
+    out: &Path,
+) -> Result<(), SourceUnavailable> {
+    let to_set = preflight_trace_profile_pin(writer, trace, out)?;
+    if let Some(profile) = to_set.as_ref() {
+        writer.set_trace_profile(profile)?;
+    }
+    if let Some(trace) = trace {
+        writer.set_trace_row_bytes(trace.row_bytes as u64)?;
+    }
+    Ok(())
 }
 
 /// Run the teacher generation of `compile_hugging_face`'s corpus step,
@@ -4504,36 +4585,11 @@ fn observe_sharded_inner(
             out.display()
         )));
     }
-    // #603 profile pinning: a corpus is captured under ONE profile. A
-    // recorded profile must match the requested one (minimal requests
-    // refuse traced corpora and vice versa once bytes exist); a fresh
-    // traced pass records its profile before any record is written.
-    writer.preflight_trace_profile(trace.as_ref().map(|trace| &trace.profile))?;
-    writer.preflight_trace_row_bytes(trace.as_ref().map(|trace| trace.row_bytes as u64))?;
-    let recorded = writer.manifest().trace_profile.clone();
-    let trace_profile_to_set = match (&recorded, trace.as_ref()) {
-        (None, None) => None,
-        (Some(recorded), Some(trace)) if *recorded == trace.profile => None,
-        (None, Some(trace)) => Some(trace.profile.clone()),
-        (Some(recorded), Some(trace)) => {
-            return Err(invalid_input(format!(
-                "{} is pinned to trace profile {}/{}; requested {}/{}",
-                out.display(),
-                recorded.id,
-                recorded.version,
-                trace.profile.id,
-                trace.profile.version
-            )));
-        }
-        (Some(recorded), None) => {
-            return Err(invalid_input(format!(
-                "{} is pinned to trace profile {}/{}; pass the same profile to resume",
-                out.display(),
-                recorded.id,
-                recorded.version
-            )));
-        }
-    };
+    // #603 profile pinning (shared with the teacher-forced text driver via
+    // `preflight_trace_profile_pin`, so the two drivers cannot drift): a
+    // corpus is captured under ONE profile; mismatches refuse before any
+    // stateful operation.
+    let trace_profile_to_set = preflight_trace_profile_pin(&writer, trace.as_ref(), out)?;
     // Every identity check above is read-only. Only after all of them agree do
     // we publish either missing record.
     if let Some(geometry) = geometry.as_ref() {

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -1586,6 +1586,23 @@ pub fn observe_text_corpus_in_session(
     )
 }
 
+/// Pin the #603 trace profile (and its resolved row width) into a
+/// session's manifest during identity pinning — BEFORE any tokenizer
+/// export or other payload write — so a traced session is never mistaken
+/// for a minimal-era one by the payload-presence preflight
+/// (`observation_payload_present` counts the exported `tokenizer.bin` as
+/// era evidence). Idempotent for the same profile: the traced corpus
+/// driver re-pins as a no-op, and every mismatch refuses.
+pub fn pin_text_observation_trace_profile_in_session(
+    session: &observe::ObservationSession,
+    oracle: &dyn TeacherOracle,
+    profile: &TraceProfile,
+) -> Result<(), SourceUnavailable> {
+    let capture = observe::TraceCapture::new(profile, oracle)?;
+    let mut writer = session.writer()?;
+    observe::pin_writer_trace_profile(&mut writer, Some(&capture), session.dir())
+}
+
 /// [`observe_text_corpus`] under a non-minimal #603 trace profile — the
 /// session-less twin of [`observe_text_corpus_traced_in_session`], with
 /// identical semantics.
@@ -3858,6 +3875,52 @@ mod tests {
                 .expect("same-profile resume pins cleanly");
         }
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The CLI ordering contract behind
+    /// `pin_text_observation_trace_profile_in_session`: the profile must
+    /// pin BEFORE any payload (e.g. the exported `tokenizer.bin`) lands in
+    /// the session dir — pin-first survives later payload and same-profile
+    /// re-pins, while payload-first is refused as a minimal-era relabel
+    /// (the falsifier half, which is exactly the defect the S1 smoke run
+    /// caught).
+    #[test]
+    fn trace_pin_before_payload_export_survives_the_payload_preflight() {
+        let profile = traced_profile();
+        let oracle = TracedFakeOracle::default();
+
+        let dir = unique_path("trace-pin-order");
+        fs::create_dir_all(&dir).expect("pin dir");
+        {
+            let mut writer = ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer opens");
+            let capture = observe::TraceCapture::new(&profile, &oracle).expect("capture");
+            observe::pin_writer_trace_profile(&mut writer, Some(&capture), &dir)
+                .expect("pin before payload");
+        }
+        fs::write(dir.join("tokenizer.bin"), b"exported-table").expect("tokenizer export");
+        {
+            let mut writer =
+                ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer reopens");
+            let capture = observe::TraceCapture::new(&profile, &oracle).expect("capture");
+            observe::pin_writer_trace_profile(&mut writer, Some(&capture), &dir)
+                .expect("same-profile re-pin passes over exported payload");
+        }
+        let _ = fs::remove_dir_all(&dir);
+
+        let late = unique_path("trace-pin-order-late");
+        fs::create_dir_all(&late).expect("late dir");
+        fs::write(late.join("tokenizer.bin"), b"exported-table").expect("tokenizer export");
+        {
+            let mut writer = ObservationShardWriter::open(&late, SHARD_BITS).expect("writer opens");
+            let capture = observe::TraceCapture::new(&profile, &oracle).expect("capture");
+            let error = observe::pin_writer_trace_profile(&mut writer, Some(&capture), &late)
+                .expect_err("payload-first pin refuses the relabel");
+            assert!(
+                error.to_string().contains("refusing to relabel"),
+                "unexpected error: {error}"
+            );
+        }
+        let _ = fs::remove_dir_all(&late);
     }
 
     /// The resume-side sidecar alignment: uncommitted (or torn) tail rows

--- a/crates/uor-r4-graph-compiler/src/observation_text.rs
+++ b/crates/uor-r4-graph-compiler/src/observation_text.rs
@@ -46,6 +46,7 @@ use super::compiler;
 use crate::observation::{
     self as observe, ObservationShardWriter, PartitionCounts, RECORD_SIZE, RecordPartition,
 };
+use crate::trace_profile::TraceProfile;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
@@ -782,6 +783,10 @@ fn build_report(
 struct ArticleProduced {
     ordinal: u64,
     records: Vec<(u32, [u8; RECORD_SIZE], observe::ProbabilityMetadata)>,
+    /// #603 trace-sidecar rows aligned index-for-index with `records`
+    /// when the pass runs under a non-minimal trace profile; empty for
+    /// minimal (untraced) passes. Absence is absence — never zero rows.
+    trace_rows: Vec<Vec<u8>>,
     story_entry: StoryEntry,
     truncated: bool,
     replaced: u64,
@@ -876,6 +881,7 @@ fn produce_article_records(
     token_byte_lengths: Option<&[u32]>,
     shard_bits: u8,
     rng: &mut u64,
+    mut trace: Option<&mut observe::TraceCapture>,
 ) -> Result<ArticleProduced, SourceUnavailable> {
     let story = u32::try_from(ordinal)
         .map_err(|_| SourceUnavailable::new("article ordinal exceeds the u32 story field"))?;
@@ -887,11 +893,23 @@ fn produce_article_records(
     let mut logits = vec![0f32; oracle.vocab()];
     let mut window: Vec<u32> = Vec::with_capacity(compiler::WINDOW);
     let mut records = Vec::with_capacity(positions);
+    let mut trace_rows: Vec<Vec<u8>> =
+        Vec::with_capacity(if trace.is_some() { positions } else { 0 });
     let mut story_byte_offset = 0u32;
     oracle.reset();
     for pos in 0..positions {
         let token = tokens[pos];
-        oracle.step(token as usize, pos, &mut logits);
+        // #603/#605 S1: a traced pass steps through the capture assembler
+        // (the oracle's exact-executor taps) so the recorded logits and
+        // the sidecar row come from the same forward; an untraced pass is
+        // byte-for-byte the original plain step.
+        match trace.as_deref_mut() {
+            None => oracle.step(token as usize, pos, &mut logits),
+            Some(capture) => {
+                capture.step(oracle, token as usize, pos, &mut logits)?;
+                trace_rows.push(capture.row.clone());
+            }
+        }
         let next = tokens[pos + 1];
         let (encoded, advanced) = encode_position(
             &mut logits,
@@ -911,6 +929,7 @@ fn produce_article_records(
     Ok(ArticleProduced {
         ordinal,
         records,
+        trace_rows,
         story_entry: StoryEntry {
             story,
             id: article.id.clone(),
@@ -921,6 +940,56 @@ fn produce_article_records(
         truncated,
         replaced,
     })
+}
+
+/// #603/#605 S1: align every trace sidecar to the checkpoint-committed
+/// record count after the shard/probability preflights truncated the
+/// primary files. Truncate-only — record files are owned by the
+/// checkpoint. A sidecar SHORTER than its committed records is a typed
+/// error rather than a healable crash artifact: `commit_article` flushes
+/// trace bytes before the checkpoint advances, so a shortfall means the
+/// sidecar was externally modified or lost.
+fn trim_trace_sidecars_to_checkpoint(
+    out_dir: &Path,
+    shard_bits: u8,
+    checkpoint: &Checkpoint,
+    trace_row_bytes: u64,
+) -> Result<(), SourceUnavailable> {
+    for (shard, state) in checkpoint.shards.iter().enumerate() {
+        let records = state.bytes / RECORD_SIZE as u64;
+        let path = out_dir.join(observe::trace_sidecar_name(shard_bits, shard as u32));
+        let metadata = match fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if records > 0 {
+                    return Err(SourceUnavailable::new(format!(
+                        "shard {shard} has {records} committed records but no trace \
+                         sidecar; the trace profile cannot change mid-corpus"
+                    )));
+                }
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let want = records
+            .checked_mul(trace_row_bytes)
+            .ok_or_else(|| SourceUnavailable::new("trace sidecar size overflows u64"))?;
+        if metadata.len() < want {
+            return Err(SourceUnavailable::new(format!(
+                "trace sidecar {} holds {} bytes but the checkpoint commits {want}; \
+                 refusing a sidecar shorter than its committed records",
+                path.display(),
+                metadata.len()
+            )));
+        }
+        if metadata.len() > want {
+            fs::OpenOptions::new()
+                .write(true)
+                .open(&path)?
+                .set_len(want)?;
+        }
+    }
+    Ok(())
 }
 
 /// Commit one produced article's records in order: append them to their
@@ -944,17 +1013,38 @@ fn commit_article(
         *truncated += 1;
     }
     *replaced += produced.replaced;
+    let traced = !produced.trace_rows.is_empty();
+    if traced && produced.trace_rows.len() != produced.records.len() {
+        return Err(SourceUnavailable::new(format!(
+            "article {} produced {} records but {} trace rows; refusing a \
+             misaligned sidecar",
+            produced.ordinal,
+            produced.records.len(),
+            produced.trace_rows.len()
+        )));
+    }
     checkpoint.n += produced.records.len() as u64;
     // Per-article checkpoint: shard bytes first (flush), then the story
     // mapping line, then the atomic committed checkpoint and its state.bin
     // mirror.
-    for (shard, record, probability) in &produced.records {
-        if writer.write_record_with_probability_in_partition(
-            record,
-            *probability,
-            *shard,
-            produced.story_entry.partition,
-        )? {
+    for (index, (shard, record, probability)) in produced.records.iter().enumerate() {
+        let wrote = if traced {
+            writer.write_record_with_probability_and_trace_in_partition(
+                record,
+                *probability,
+                &produced.trace_rows[index],
+                *shard,
+                produced.story_entry.partition,
+            )?
+        } else {
+            writer.write_record_with_probability_in_partition(
+                record,
+                *probability,
+                *shard,
+                produced.story_entry.partition,
+            )?
+        };
+        if wrote {
             *written += 1;
             checkpoint.shards[*shard as usize].bytes += RECORD_SIZE as u64;
         }
@@ -1466,6 +1556,7 @@ pub fn observe_text_corpus(
         out_dir,
         shard_bits,
         resume,
+        None,
     )
 }
 
@@ -1491,6 +1582,82 @@ pub fn observe_text_corpus_in_session(
         session.dir(),
         session.shard_bits(),
         resume,
+        None,
+    )
+}
+
+/// [`observe_text_corpus`] under a non-minimal #603 trace profile — the
+/// session-less twin of [`observe_text_corpus_traced_in_session`], with
+/// identical semantics.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus_traced(
+    oracles: &mut [Box<dyn TeacherOracle + Send>],
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    out_dir: &Path,
+    shard_bits: u8,
+    resume: bool,
+    profile: &TraceProfile,
+) -> Result<ObservationReport, SourceUnavailable> {
+    if profile.is_minimal() {
+        return Err(SourceUnavailable::new(
+            "the minimal profile captures no richer lanes; use \
+             observe_text_corpus for untraced passes",
+        ));
+    }
+    observe_text_corpus_inner(
+        None,
+        oracles,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        out_dir,
+        shard_bits,
+        resume,
+        Some(profile),
+    )
+}
+
+/// [`observe_text_corpus_in_session`] under a non-minimal #603 trace
+/// profile (#605 S1): every teacher-forced position additionally captures
+/// the profile's declared lanes through the oracle's exact-executor taps
+/// into per-shard `.trace` sidecars, with the profile and row width
+/// pinned in the manifest before any record is written. Resume follows
+/// the text pipeline's whole-article checkpoint: sidecars are trimmed to
+/// the committed record count on open, and a minimal resume of a traced
+/// corpus (or a profile change mid-corpus) is a typed refusal. Passing a
+/// minimal profile is refused — call the untraced entry instead.
+#[allow(clippy::too_many_arguments)]
+pub fn observe_text_corpus_traced_in_session(
+    session: &observe::ObservationSession,
+    oracles: &mut [Box<dyn TeacherOracle + Send>],
+    budget_s: u64,
+    tokenizer: &TokenizerKind,
+    token_byte_lengths: Option<&[u32]>,
+    articles_path: &Path,
+    resume: bool,
+    profile: &TraceProfile,
+) -> Result<ObservationReport, SourceUnavailable> {
+    if profile.is_minimal() {
+        return Err(SourceUnavailable::new(
+            "the minimal profile captures no richer lanes; use \
+             observe_text_corpus_in_session for untraced passes",
+        ));
+    }
+    observe_text_corpus_inner(
+        Some(session),
+        oracles,
+        budget_s,
+        tokenizer,
+        token_byte_lengths,
+        articles_path,
+        session.dir(),
+        session.shard_bits(),
+        resume,
+        Some(profile),
     )
 }
 
@@ -1505,6 +1672,7 @@ fn observe_text_corpus_inner(
     out_dir: &Path,
     shard_bits: u8,
     resume: bool,
+    trace_profile: Option<&TraceProfile>,
 ) -> Result<ObservationReport, SourceUnavailable> {
     assert!(
         !oracles.is_empty(),
@@ -1582,6 +1750,31 @@ fn observe_text_corpus_inner(
         } => (writer, checkpoint, articles_total, stories_path),
     };
 
+    // #603/#605 S1: traced text observation. One capture assembler per
+    // worker oracle (each validates the profile against its own declared
+    // geometry — a mixed pool already refused above); the profile and row
+    // width pin into the manifest through the same shared helper the
+    // generation driver uses, so a minimal resume of a traced corpus (or
+    // any profile change) refuses before a single record is appended; and
+    // every sidecar is trimmed to the checkpoint-committed record count,
+    // matching the whole-article truncation `prepare_text_observation`
+    // just applied to the primary shards.
+    let mut captures: Vec<observe::TraceCapture> = Vec::new();
+    if let Some(profile) = trace_profile {
+        for oracle in oracles.iter() {
+            captures.push(observe::TraceCapture::new(profile, oracle.as_ref())?);
+        }
+    }
+    observe::pin_writer_trace_profile(&mut writer, captures.first(), out_dir)?;
+    if let Some(capture) = captures.first() {
+        trim_trace_sidecars_to_checkpoint(
+            out_dir,
+            shard_bits,
+            &checkpoint,
+            capture.row_bytes as u64,
+        )?;
+    }
+
     let workers = oracles.len();
     let seq_len = oracles[0].seq_len();
     let mut progress = Progress::new("text observations", articles_total as usize);
@@ -1649,11 +1842,17 @@ fn observe_text_corpus_inner(
                     token_byte_lengths,
                     shard_bits,
                     &mut checkpoint.rng,
+                    captures.get_mut(0),
                 )?]
             } else {
+                // A traced pool pairs each worker oracle with its own
+                // capture assembler; `captures` is either empty (untraced
+                // — every worker gets `None`) or exactly oracle-aligned.
+                let mut capture_iter = captures.iter_mut();
                 std::thread::scope(|scope| -> Result<Vec<ArticleProduced>, SourceUnavailable> {
                     let mut handles = Vec::with_capacity(batch.len());
                     for ((ord, article), oracle) in batch.iter().zip(oracles.iter_mut()) {
+                        let capture = capture_iter.next();
                         handles.push(scope.spawn(move || {
                             let mut rng = RNG_SEED;
                             produce_article_records(
@@ -1665,6 +1864,7 @@ fn observe_text_corpus_inner(
                                 token_byte_lengths,
                                 shard_bits,
                                 &mut rng,
+                                capture,
                             )
                         }));
                     }
@@ -1999,6 +2199,10 @@ fn observe_text_corpus_batched_inner<T: BatchedTeacher>(
             let produced = ArticleProduced {
                 ordinal: slot.ordinal,
                 records: slot.records.clone(),
+                // The batched driver has no trace-capture surface
+                // (BatchedTeacher exposes no per-head taps); traced
+                // passes run the serial driver.
+                trace_rows: Vec::new(),
                 story_entry: StoryEntry {
                     story,
                     id: slot.article.id.clone(),
@@ -3331,6 +3535,441 @@ mod tests {
         let _ = fs::remove_dir_all(&dir1);
         let _ = fs::remove_dir_all(&dir3);
         let _ = fs::remove_file(&input);
+    }
+
+    /// Deterministic capture-capable oracle for #603 traced text passes:
+    /// logits identical to `FakeOracle`'s formula; every capture lane is
+    /// a pure function of (token, pos, layer, head), so sidecar bytes
+    /// are content-stable across restarts and worker counts. The hidden
+    /// buffer starts allocated (the capture constructor requires a
+    /// retained hidden state for the declared final-hidden lane) and is
+    /// overwritten deterministically on every traced step before capture.
+    struct TracedFakeOracle {
+        hidden: Vec<f32>,
+    }
+
+    impl Default for TracedFakeOracle {
+        fn default() -> Self {
+            Self {
+                hidden: vec![0.0; 4],
+            }
+        }
+    }
+
+    impl RepresentationSource for TracedFakeOracle {
+        fn vocab_size(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn source_dimension(&self) -> usize {
+            4
+        }
+        fn tokenizer_address(&self) -> &str {
+            "fake-tokenizer"
+        }
+        fn read_embedding_rows(
+            &self,
+            _range: std::ops::Range<usize>,
+            output: &mut [f32],
+        ) -> Option<()> {
+            output.fill(0.0);
+            Some(())
+        }
+    }
+
+    impl BehaviorSource for TracedFakeOracle {
+        fn reset(&mut self) {}
+        fn step(&mut self, token: usize, pos: usize, logits: &mut [f32]) {
+            for (index, logit) in logits.iter_mut().enumerate() {
+                let value = (token as u64 * 31 + pos as u64 * 7 + index as u64 * 13) % 29;
+                *logit = value as f32 * 0.25 - 3.0;
+            }
+        }
+    }
+
+    impl TeacherOracle for TracedFakeOracle {
+        fn vocab(&self) -> usize {
+            FAKE_VOCAB
+        }
+        fn dim(&self) -> usize {
+            4
+        }
+        fn seq_len(&self) -> usize {
+            FAKE_SEQ_LEN
+        }
+        fn kappa(&self) -> String {
+            "blake3:fake-traced".to_owned()
+        }
+        fn source_bytes(&self) -> usize {
+            0
+        }
+        fn embedding(&self, _token: usize, out: &mut [f32]) {
+            out.fill(0.0);
+        }
+        fn hidden_state(&self) -> Option<&[f32]> {
+            Some(&self.hidden)
+        }
+        fn trace_capture_geometry(&self) -> Option<uor_r4_model_source::TraceCaptureGeometry> {
+            Some(uor_r4_model_source::TraceCaptureGeometry {
+                layers: 2,
+                heads: 2,
+                kv_heads: 1,
+                residual_width: 4,
+            })
+        }
+        fn step_with_trace_capture(
+            &mut self,
+            token: usize,
+            pos: usize,
+            logits: &mut [f32],
+            request: &uor_r4_model_source::TraceCaptureRequest<'_>,
+            sinks: &mut uor_r4_model_source::TraceCaptureSinks<'_, '_>,
+        ) -> bool {
+            self.step(token, pos, logits);
+            for &layer in request.residual_layers {
+                let x: Vec<f32> = (0..4)
+                    .map(|i| (token * 3 + pos * 5 + layer * 7 + i) as f32)
+                    .collect();
+                (sinks.residual)(layer, &x);
+            }
+            for &layer in request.qkv_layers {
+                let q: Vec<f32> = (0..4)
+                    .map(|i| (token + pos * 2 + layer * 11 + i) as f32)
+                    .collect();
+                let k: Vec<f32> = (0..2)
+                    .map(|i| (token * 2 + pos + layer * 13 + i) as f32)
+                    .collect();
+                let v: Vec<f32> = (0..2)
+                    .map(|i| (token * 5 + pos * 3 + layer * 17 + i) as f32)
+                    .collect();
+                (sinks.qkv)(layer, &q, &k, &v);
+            }
+            for &layer in request.attention_layers {
+                for head in 0..2usize {
+                    let weights: Vec<f32> = (0..=pos)
+                        .map(|p| 1.0 / (1.0 + (pos - p) as f32 + head as f32 + layer as f32))
+                        .collect();
+                    (sinks.attention)(layer, head, &weights);
+                }
+            }
+            self.hidden = (0..4).map(|i| (token * 7 + pos + i) as f32).collect();
+            true
+        }
+    }
+
+    /// The `full/1` fixture profile: both layers declared on every lane,
+    /// per-head support cap 2. Row width for the fixture geometry
+    /// (residual 4, heads 2, kv 1 → kv width 2):
+    /// residuals (2+1)·4·4 = 48 + q/k/v 2·(4+2+2)·4 = 64 + support
+    /// 2·2·2·8 = 64 → 176 bytes.
+    fn traced_profile() -> TraceProfile {
+        crate::trace_profile::profile_spec(
+            crate::trace_profile::FULL_PROFILE,
+            1,
+            &crate::trace_profile::TraceCaptureBounds {
+                layer_indices: vec![0, 1],
+                support_size: 2,
+            },
+        )
+        .expect("registered full/1 fixture profile")
+    }
+
+    const TRACED_ROW_BYTES: u64 = 176;
+
+    fn traced_pool() -> Vec<Box<dyn TeacherOracle + Send>> {
+        vec![Box::new(TracedFakeOracle::default())]
+    }
+
+    fn shard_trace_lengths(dir: &Path) -> Vec<(u64, u64)> {
+        (0..SHARD_COUNT)
+            .map(|shard| {
+                let base = dir
+                    .join(shard_file_name(SHARD_BITS, shard))
+                    .metadata()
+                    .map(|meta| meta.len())
+                    .unwrap_or(0);
+                let trace = dir
+                    .join(observe::trace_sidecar_name(SHARD_BITS, shard))
+                    .metadata()
+                    .map(|meta| meta.len())
+                    .unwrap_or(0);
+                (base, trace)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn traced_text_observation_pins_the_profile_and_aligns_every_sidecar() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let articles = test_articles();
+        let article_refs: Vec<(&str, &str)> = articles
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect();
+        let input = unique_path("traced-articles.jsonl");
+        write_articles(&input, &article_refs);
+        let profile = traced_profile();
+
+        let dir_a = unique_path("traced-a");
+        observe_text_corpus_traced(
+            &mut traced_pool(),
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_a,
+            SHARD_BITS,
+            false,
+            &profile,
+        )
+        .expect("traced pass completes");
+
+        let manifest = ObservationManifest::load(&dir_a)
+            .expect("manifest readable")
+            .expect("manifest present");
+        assert_eq!(
+            manifest.trace_profile.as_ref(),
+            Some(&profile),
+            "the profile is pinned in the manifest"
+        );
+        assert_eq!(manifest.trace_row_bytes, Some(TRACED_ROW_BYTES));
+        let mut nonempty = 0;
+        for (base, trace) in shard_trace_lengths(&dir_a) {
+            let records = base / RECORD_SIZE as u64;
+            assert_eq!(
+                trace,
+                records * TRACED_ROW_BYTES,
+                "every shard's sidecar is record-aligned"
+            );
+            if records > 0 {
+                nonempty += 1;
+            }
+        }
+        assert!(nonempty > 0, "the fixture corpus produced records");
+
+        // Determinism: a second fresh traced pass produces byte-identical
+        // sidecars.
+        let dir_b = unique_path("traced-b");
+        observe_text_corpus_traced(
+            &mut traced_pool(),
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_b,
+            SHARD_BITS,
+            false,
+            &profile,
+        )
+        .expect("second traced pass completes");
+        for shard in 0..SHARD_COUNT {
+            let name = observe::trace_sidecar_name(SHARD_BITS, shard);
+            let a = fs::read(dir_a.join(&name)).unwrap_or_default();
+            let b = fs::read(dir_b.join(&name)).unwrap_or_default();
+            assert_eq!(a, b, "sidecar {name} is content-stable");
+        }
+
+        // Multi-worker parity: two capture-paired workers, same bytes.
+        let dir_c = unique_path("traced-c");
+        let mut pool: Vec<Box<dyn TeacherOracle + Send>> = vec![
+            Box::new(TracedFakeOracle::default()),
+            Box::new(TracedFakeOracle::default()),
+        ];
+        observe_text_corpus_traced(
+            &mut pool,
+            60,
+            &tokenizer,
+            Some(&lengths),
+            &input,
+            &dir_c,
+            SHARD_BITS,
+            false,
+            &profile,
+        )
+        .expect("two-worker traced pass completes");
+        for shard in 0..SHARD_COUNT {
+            let name = observe::trace_sidecar_name(SHARD_BITS, shard);
+            let a = fs::read(dir_a.join(&name)).unwrap_or_default();
+            let c = fs::read(dir_c.join(&name)).unwrap_or_default();
+            assert_eq!(a, c, "worker count does not change sidecar {name}");
+        }
+
+        let _ = fs::remove_file(&input);
+        for dir in [&dir_a, &dir_b, &dir_c] {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    /// #603 profile pinning on the text path, via the shared helper: a
+    /// traced corpus refuses a minimal resume AND any profile change
+    /// (including a bounds-only change) with the same typed errors the
+    /// generation driver produces, while a same-profile reopen pins
+    /// cleanly.
+    #[test]
+    fn trace_profile_pin_refuses_minimal_resume_and_profile_changes() {
+        let dir = unique_path("trace-pin");
+        fs::create_dir_all(&dir).expect("pin dir");
+        let profile = traced_profile();
+        let oracle = TracedFakeOracle::default();
+        let capture = observe::TraceCapture::new(&profile, &oracle).expect("capture resolves");
+        {
+            let mut writer = ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer opens");
+            observe::pin_writer_trace_profile(&mut writer, Some(&capture), &dir)
+                .expect("fresh traced pin records the profile");
+        }
+        {
+            let mut writer =
+                ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer reopens");
+            let error = observe::pin_writer_trace_profile(&mut writer, None, &dir)
+                .expect_err("a traced corpus refuses a minimal resume");
+            assert!(
+                error
+                    .to_string()
+                    .contains("requested the minimal/absent profile"),
+                "unexpected error: {error}"
+            );
+        }
+        {
+            let other = crate::trace_profile::profile_spec(
+                crate::trace_profile::FULL_PROFILE,
+                1,
+                &crate::trace_profile::TraceCaptureBounds {
+                    layer_indices: vec![0],
+                    support_size: 2,
+                },
+            )
+            .expect("registered narrower variant");
+            let other_capture =
+                observe::TraceCapture::new(&other, &oracle).expect("capture resolves");
+            let mut writer =
+                ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer reopens");
+            let error = observe::pin_writer_trace_profile(&mut writer, Some(&other_capture), &dir)
+                .expect_err("a bounds change is a profile change");
+            assert!(
+                error.to_string().contains("is pinned to trace profile"),
+                "unexpected error: {error}"
+            );
+        }
+        {
+            let same = observe::TraceCapture::new(&profile, &oracle).expect("capture resolves");
+            let mut writer =
+                ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer reopens");
+            observe::pin_writer_trace_profile(&mut writer, Some(&same), &dir)
+                .expect("same-profile resume pins cleanly");
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The resume-side sidecar alignment: uncommitted (or torn) tail rows
+    /// beyond the committed checkpoint are trimmed exactly; a sidecar
+    /// shorter than its committed records, or absent while records exist,
+    /// is a typed refusal — never healed silently.
+    #[test]
+    fn sidecar_trim_matches_the_committed_checkpoint_and_names_shortfalls() {
+        let dir = unique_path("trace-trim");
+        fs::create_dir_all(&dir).expect("trim dir");
+        let mut checkpoint = Checkpoint::fresh(SHARD_COUNT, [0u8; INPUT_KAPPA_SIZE]);
+        checkpoint.shards[0].bytes = 2 * RECORD_SIZE as u64;
+
+        let sidecar = dir.join(observe::trace_sidecar_name(SHARD_BITS, 0));
+        fs::write(&sidecar, vec![0x5A; 3 * TRACED_ROW_BYTES as usize + 1])
+            .expect("write long sidecar with a torn tail byte");
+        trim_trace_sidecars_to_checkpoint(&dir, SHARD_BITS, &checkpoint, TRACED_ROW_BYTES)
+            .expect("trim succeeds");
+        assert_eq!(
+            fs::metadata(&sidecar).expect("sidecar").len(),
+            2 * TRACED_ROW_BYTES,
+            "the tail (including the torn byte) trims to the committed rows"
+        );
+
+        fs::write(&sidecar, vec![0x5A; TRACED_ROW_BYTES as usize]).expect("write short sidecar");
+        let error =
+            trim_trace_sidecars_to_checkpoint(&dir, SHARD_BITS, &checkpoint, TRACED_ROW_BYTES)
+                .expect_err("a shortfall refuses");
+        assert!(
+            error
+                .to_string()
+                .contains("shorter than its committed records"),
+            "unexpected error: {error}"
+        );
+
+        let _ = fs::remove_file(&sidecar);
+        let error =
+            trim_trace_sidecars_to_checkpoint(&dir, SHARD_BITS, &checkpoint, TRACED_ROW_BYTES)
+                .expect_err("a missing sidecar with committed records refuses");
+        assert!(
+            error.to_string().contains("no trace sidecar"),
+            "unexpected error: {error}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn commit_refuses_a_misaligned_trace_sidecar_batch() {
+        let tokenizer = fixture_tokenizer();
+        let lengths = fixture_token_byte_lengths();
+        let profile = traced_profile();
+        let mut oracle = TracedFakeOracle::default();
+        let mut capture = observe::TraceCapture::new(&profile, &oracle).expect("capture resolves");
+        let article = Article {
+            id: "1".to_owned(),
+            url: "https://example.test/1".to_owned(),
+            title: "Title 1".to_owned(),
+            text: "abcd".to_owned(),
+        };
+        let mut rng = RNG_SEED;
+        let mut produced = produce_article_records(
+            &mut oracle,
+            0,
+            &article,
+            FAKE_SEQ_LEN,
+            &tokenizer,
+            Some(&lengths),
+            SHARD_BITS,
+            &mut rng,
+            Some(&mut capture),
+        )
+        .expect("traced article produces");
+        assert_eq!(
+            produced.trace_rows.len(),
+            produced.records.len(),
+            "a traced article is row-aligned by construction"
+        );
+        assert!(
+            produced
+                .trace_rows
+                .iter()
+                .all(|row| row.len() as u64 == TRACED_ROW_BYTES),
+            "every row carries the layout width"
+        );
+
+        // Falsifier: drop one row and the commit refuses before writing.
+        produced.trace_rows.pop();
+        let dir = unique_path("misaligned-commit");
+        fs::create_dir_all(&dir).expect("commit dir");
+        let mut writer = ObservationShardWriter::open(&dir, SHARD_BITS).expect("writer opens");
+        let mut checkpoint = Checkpoint::fresh(SHARD_COUNT, [0u8; INPUT_KAPPA_SIZE]);
+        let stories_path = dir.join(STORIES_FILE);
+        let mut written = 0u64;
+        let mut truncated = 0u64;
+        let mut replaced = 0u64;
+        let error = commit_article(
+            &mut writer,
+            &mut checkpoint,
+            &dir,
+            &stories_path,
+            &produced,
+            1,
+            &mut written,
+            &mut truncated,
+            &mut replaced,
+        )
+        .expect_err("misaligned sidecar batch refuses");
+        assert!(
+            error.to_string().contains("misaligned sidecar"),
+            "unexpected error: {error}"
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 
     /// A batched teacher whose per-position logits match `FakeOracle::step`


### PR DESCRIPTION
References #804 (S1-0, per the decided plan and profile: `full/1`, declared layers `[0,4,9,13,18,22,27,31]`, S=8, on the `smollm2-360m-broad` corpus) and #605 (whose real-corpus arm consumes the output through `load_route_trace_corpus`).

The #603 trace stack was complete at library level for the **generation** driver (`observe_sharded_traced`, the oracle's exact-executor taps, the sidecar writer, the route-fit loader) — but the **teacher-forced text** pipeline, which is how the broad corpus is actually observed, had no trace plumbing, and `observe-text` exposed no flag. This PR wires it end to end:

- **`observation.rs`** — the #603 profile-pinning block is factored into one shared preflight helper (`preflight_trace_profile_pin` / `pin_writer_trace_profile`) used by both drivers, so they cannot drift; `ObservationShardWriter` gains the record+probability+trace+partition combined append; `TraceCapture` becomes crate-visible for the sibling driver.
- **`observation_text.rs`** — `observe_text_corpus_traced[_in_session]`: one capture assembler per worker oracle (multi-worker traced passes stay byte-deterministic), produce/commit thread sidecar rows index-aligned with records (misalignment refuses before writing), resume trims sidecars to the committed whole-article checkpoint (truncate-only; a shortfall or missing sidecar under committed records refuses by name), and minimal resumes / profile changes of a traced corpus refuse via the shared pin. The batched driver has no per-head taps and is refused for traced passes.
- **`graph-cli`** — `observe-text --trace-profile <id>/<version> --trace-layers i,j,... [--trace-support S]`, resolved against the immutable registry before any teacher load; incoherent combinations (`--batch`, legacy `--checkpoint`, orphan bounds flags) refuse at parse with typed errors. Help text updated.

Tests (all falsifier-verified red where a refusal is claimed): traced sidecar alignment + manifest pinning; fresh-pass and worker-count byte-determinism; pin refusals (minimal resume, bounds-only profile change); trim exactness incl. torn-tail bytes + shortfall/missing refusals; commit misalignment falsifier; the CLI flag matrix.

Gates: fmt; clippy `-D warnings` (workspace, all targets); graph-compiler lib 203 pass; graph-cli lib 129 pass; wasm32 graph-compiler check (the 1 pre-existing warning is unchanged on main, verified by stash A/B).

Next (on #804's thread, per the posted plan): the 1-article smoke run for measured capture-rate numbers, the contract amendments on #605/#643, then the overnight corpus pass on the maintainer's confirmed window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
