### PR TITLE
feat(#804): measurement-only Accelerate exception for observation passes — opt-in, pinned, loud

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,16 @@ crate-type = ["cdylib", "rlib"]
 name = "r4"
 path = "src/main.rs"
 
+[features]
+# #804 measurement-only exception passthrough (maintainer-approved
+# 2026-08-18) — see uor-r4-model-source's feature of the same name.
+# Never a default; observation builds opt in explicitly:
+#   cargo build --release --features observation-blas-exception
+observation-blas-exception = [
+    "uor-r4-model-source/observation-blas-exception",
+    "uor-r4-graph-cli/observation-blas-exception",
+]
+
 [dependencies]
 uor-r4-core = { version = "0.1.0", path = "crates/uor-r4-core" }
 uor-r4-graph-format = { version = "0.1.0", path = "crates/uor-r4-graph-format" }

--- a/crates/uor-r4-graph-cli/Cargo.toml
+++ b/crates/uor-r4-graph-cli/Cargo.toml
@@ -4,6 +4,11 @@ license = "MIT"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+# #804 measurement-only exception passthrough — see uor-r4-model-source's
+# feature of the same name. Never a default.
+observation-blas-exception = ["uor-r4-model-source/observation-blas-exception"]
+
 [dependencies]
 uor-r4-core = { version = "0.1.0", path = "../uor-r4-core" }
 uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler" }

--- a/crates/uor-r4-model-source/Cargo.toml
+++ b/crates/uor-r4-model-source/Cargo.toml
@@ -4,6 +4,14 @@ license = "MIT"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# #804 measurement-only exception (maintainer-approved 2026-08-18): route
+# the TEACHER weight matmuls through Apple Accelerate for observation
+# passes. Never a default; the matrix_operation_census gate pins the
+# exception file, its feature gating, and its single dispatch site. The
+# deployed serving runtime is unaffected by construction (P-4 contract).
+observation-blas-exception = []
+
 [dependencies]
 safetensors = { version = "0.6", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -13,6 +13,10 @@ pub mod dense;
 pub mod geometry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gpt2;
+/// #804 measurement-only BLAS exception — opt-in feature, macOS only,
+/// pinned by the `matrix_operation_census` gate. See the module docs.
+#[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+mod observation_blas_exception;
 pub mod progress;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod teacher;
@@ -198,12 +202,23 @@ pub(crate) fn softmax_with_mode(x: &mut [f32], canonical: bool) {
 /// `fast` (Accelerate BLAS `sgemv`) / hand-rolled canonical paths are gone;
 /// `_fast` is retained in the signature only so callers need not change.
 fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, _fast: bool) {
-    // xout[d] = W[d, n] · x[n]  ==>  C[d, 1] = A[d, n] · B[n, 1].
-    let d = xout.len();
-    let mut pa = vec![uor_matmul::PackedCode::default(); n];
-    let mut pb = vec![uor_matmul::PackedCode::default(); n];
-    uor_matmul::slice::gemm_float(d, n, 1, w, x, xout, &mut pa, &mut pb)
-        .expect("teacher matrix-vector product is total over finite f32 operands");
+    // #804 measurement-only exception (maintainer-approved 2026-08-18):
+    // under the opt-in feature, observation builds route through Apple
+    // Accelerate — see `observation_blas_exception`'s module docs. Every
+    // default build takes the owned exact GEMM below.
+    #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+    {
+        observation_blas_exception::matmul(xout, x, w, n);
+    }
+    #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
+    {
+        // xout[d] = W[d, n] · x[n]  ==>  C[d, 1] = A[d, n] · B[n, 1].
+        let d = xout.len();
+        let mut pa = vec![uor_matmul::PackedCode::default(); n];
+        let mut pb = vec![uor_matmul::PackedCode::default(); n];
+        uor_matmul::slice::gemm_float(d, n, 1, w, x, xout, &mut pa, &mut pb)
+            .expect("teacher matrix-vector product is total over finite f32 operands");
+    }
 }
 
 /// Batched matmul: `batch` input vectors of length `n` through weight
@@ -219,18 +234,27 @@ fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize
     let rows = xout.len() / batch;
     debug_assert!(w.len() >= rows * n);
     debug_assert_eq!(x.len(), batch * n);
-    // gemm_float is C = A·B (no transpose), so transpose W[rows, n] → Wt[n, rows]
-    // and compute X[batch, n] · Wt[n, rows] into the sequence-major `xout`.
-    let mut wt = vec![0f32; n * rows];
-    for r in 0..rows {
-        for j in 0..n {
-            wt[j * rows + r] = w[r * n + j];
-        }
+    // #804 measurement-only exception — see `matmul` above and the
+    // `observation_blas_exception` module docs.
+    #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+    {
+        observation_blas_exception::matmul_batched(xout, x, w, n, batch);
     }
-    let mut pa = vec![uor_matmul::PackedCode::default(); n];
-    let mut pb = vec![uor_matmul::PackedCode::default(); n * rows];
-    uor_matmul::slice::gemm_float(batch, n, rows, x, &wt, xout, &mut pa, &mut pb)
-        .expect("batched teacher product is total over finite f32 operands");
+    #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
+    {
+        // gemm_float is C = A·B (no transpose), so transpose W[rows, n] → Wt[n, rows]
+        // and compute X[batch, n] · Wt[n, rows] into the sequence-major `xout`.
+        let mut wt = vec![0f32; n * rows];
+        for r in 0..rows {
+            for j in 0..n {
+                wt[j * rows + r] = w[r * n + j];
+            }
+        }
+        let mut pa = vec![uor_matmul::PackedCode::default(); n];
+        let mut pb = vec![uor_matmul::PackedCode::default(); n * rows];
+        uor_matmul::slice::gemm_float(batch, n, rows, x, &wt, xout, &mut pa, &mut pb)
+            .expect("batched teacher product is total over finite f32 operands");
+    }
 }
 
 /// The teacher's matrix-operation backend, for the "teacher model ready"
@@ -238,7 +262,16 @@ fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize
 /// pinned portable `uor-matmul` exact GEMM — no per-machine SIMD/Accelerate
 /// path. GPT-2 owns its separate declared dense implementation.
 fn fast_matmul_backend() -> &'static str {
-    "uor-matmul exact GEMM"
+    #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+    {
+        // Loud per-run provenance: every "teacher model ready" line names
+        // the exception so no corpus can be produced under it silently.
+        "Accelerate cblas (observation-only exception #804)"
+    }
+    #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
+    {
+        "uor-matmul exact GEMM"
+    }
 }
 
 impl Llama {

--- a/crates/uor-r4-model-source/src/observation_blas_exception.rs
+++ b/crates/uor-r4-model-source/src/observation_blas_exception.rs
@@ -1,0 +1,180 @@
+//! #804 measurement-only BLAS exception — maintainer-approved 2026-08-18.
+//!
+//! Routes the TEACHER weight matmuls through Apple Accelerate
+//! (`cblas_sgemv`/`cblas_sgemm`) for **observation passes only**, restoring
+//! the pre-#655-B2 throughput (~50–100× over the owned exact GEMM on this
+//! class of machine) so corpus-scale teacher-forced observation remains
+//! feasible on the pinned measurement Mac. This is an explicit, pinned
+//! exception to the #655-B2 arithmetic-ownership migration, NOT a rollback:
+//!
+//! - **Never a default.** This module only compiles under
+//!   `--features observation-blas-exception` on macOS; every default build
+//!   keeps the pinned `uor-matmul` exact GEMM everywhere. The
+//!   `matrix_operation_census` gate pins the file, its feature gating, and
+//!   its single dispatch site.
+//! - **Teacher data only.** Only the teacher forward used by
+//!   observation/compize passes dispatches here; the deployed
+//!   transformerless serving runtime carries no dependency on this crate's
+//!   matmuls at all (P-4 contract, `INFERENCE_OPERATION_CONTRACT.md`).
+//! - **Provenance is loud.** `fast_matmul_backend()` reports the exception
+//!   by name in every "teacher model ready" line, so any corpus produced
+//!   under it carries the backend in its run log; the #605/#643 contract
+//!   amendments record it for the S1 corpus explicitly.
+//! - **Numerics caveat, stated not hidden.** Accelerate accumulation order
+//!   is machine-tuned; logits differ from the exact GEMM in low-order bits,
+//!   so top-k near-ties can differ from an owned-GEMM pass. The S1 gates
+//!   compare fitted structures against traces produced under the SAME
+//!   backend, and the parity test below bounds the divergence on fixtures.
+
+/// W (d,n) @ x (n,) -> xout (d,) via Accelerate `cblas_sgemv`.
+pub(crate) fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize) {
+    const CBLAS_ROW_MAJOR: i32 = 101;
+    const CBLAS_NO_TRANSPOSE: i32 = 111;
+    debug_assert!(w.len() >= xout.len() * n);
+    debug_assert_eq!(x.len(), n);
+    // SAFETY: all pointers refer to initialized, non-overlapping f32 slices;
+    // their dimensions and strides describe W[xout.len(), n] and x[n].
+    unsafe {
+        cblas_sgemv(
+            CBLAS_ROW_MAJOR,
+            CBLAS_NO_TRANSPOSE,
+            i32::try_from(xout.len()).expect("teacher output dimension exceeds CBLAS i32"),
+            i32::try_from(n).expect("teacher input dimension exceeds CBLAS i32"),
+            1.0,
+            w.as_ptr(),
+            i32::try_from(n).expect("teacher stride exceeds CBLAS i32"),
+            x.as_ptr(),
+            1,
+            0.0,
+            xout.as_mut_ptr(),
+            1,
+        );
+    }
+}
+
+/// `C[batch, rows] = X[batch, n] · W[rows, n]ᵀ` via Accelerate `cblas_sgemm`,
+/// sequence-major exactly like the owned batched path it substitutes.
+pub(crate) fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
+    debug_assert!(batch > 0);
+    debug_assert_eq!(xout.len() % batch, 0);
+    let rows = xout.len() / batch;
+    debug_assert!(w.len() >= rows * n);
+    debug_assert_eq!(x.len(), batch * n);
+    const CBLAS_ROW_MAJOR: i32 = 101;
+    const CBLAS_NO_TRANSPOSE: i32 = 111;
+    const CBLAS_TRANSPOSE: i32 = 112;
+    // SAFETY: all pointers refer to initialized, non-overlapping f32 slices
+    // whose dimensions/strides describe X[batch, n], W[rows, n], C[batch, rows].
+    unsafe {
+        cblas_sgemm(
+            CBLAS_ROW_MAJOR,
+            CBLAS_NO_TRANSPOSE,
+            CBLAS_TRANSPOSE,
+            i32::try_from(batch).expect("teacher batch exceeds CBLAS i32"),
+            i32::try_from(rows).expect("teacher output dimension exceeds CBLAS i32"),
+            i32::try_from(n).expect("teacher input dimension exceeds CBLAS i32"),
+            1.0,
+            x.as_ptr(),
+            i32::try_from(n).expect("teacher input stride exceeds CBLAS i32"),
+            w.as_ptr(),
+            i32::try_from(n).expect("teacher weight stride exceeds CBLAS i32"),
+            0.0,
+            xout.as_mut_ptr(),
+            i32::try_from(rows).expect("teacher output stride exceeds CBLAS i32"),
+        );
+    }
+}
+
+#[link(name = "Accelerate", kind = "framework")]
+unsafe extern "C" {
+    fn cblas_sgemv(
+        order: i32,
+        transpose: i32,
+        rows: i32,
+        columns: i32,
+        alpha: f32,
+        matrix: *const f32,
+        leading_dimension: i32,
+        vector: *const f32,
+        vector_stride: i32,
+        beta: f32,
+        output: *mut f32,
+        output_stride: i32,
+    );
+
+    fn cblas_sgemm(
+        order: i32,
+        transpose_a: i32,
+        transpose_b: i32,
+        m: i32,
+        n: i32,
+        k: i32,
+        alpha: f32,
+        a: *const f32,
+        lda: i32,
+        b: *const f32,
+        ldb: i32,
+        beta: f32,
+        c: *mut f32,
+        ldc: i32,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    /// The exception's correctness witness: Accelerate sgemv/sgemm agree
+    /// with the owned exact GEMM within f32 tolerance on a deterministic
+    /// fixture — the divergence is low-order accumulation bits, not
+    /// structure.
+    #[test]
+    fn accelerate_matches_the_owned_exact_gemm_within_tolerance() {
+        let d = 7usize;
+        let n = 13usize;
+        let batch = 3usize;
+        let w: Vec<f32> = (0..d * n)
+            .map(|i| ((i * 37 % 19) as f32 - 9.0) * 0.125)
+            .collect();
+        let x: Vec<f32> = (0..batch * n)
+            .map(|i| ((i * 23 % 17) as f32 - 8.0) * 0.25)
+            .collect();
+
+        // Serial: one vector at a time against the owned exact GEMM.
+        for b in 0..batch {
+            let xb = &x[b * n..(b + 1) * n];
+            let mut exact = vec![0f32; d];
+            let mut pa = vec![uor_matmul::PackedCode::default(); n];
+            let mut pb = vec![uor_matmul::PackedCode::default(); n];
+            uor_matmul::slice::gemm_float(d, n, 1, &w, xb, &mut exact, &mut pa, &mut pb)
+                .expect("exact reference");
+            let mut fast = vec![0f32; d];
+            super::matmul(&mut fast, xb, &w, n);
+            for (row, (a, e)) in fast.iter().zip(exact.iter()).enumerate() {
+                assert!(
+                    (a - e).abs() <= 1e-4 * (1.0 + e.abs()),
+                    "sgemv row {row} diverges: accelerate={a}, exact={e}"
+                );
+            }
+        }
+
+        // Batched: sgemm against per-vector sgemv (self-consistency) and
+        // against the exact reference.
+        let mut batched = vec![0f32; batch * d];
+        super::matmul_batched(&mut batched, &x, &w, n, batch);
+        for b in 0..batch {
+            let xb = &x[b * n..(b + 1) * n];
+            let mut exact = vec![0f32; d];
+            let mut pa = vec![uor_matmul::PackedCode::default(); n];
+            let mut pb = vec![uor_matmul::PackedCode::default(); n];
+            uor_matmul::slice::gemm_float(d, n, 1, &w, xb, &mut exact, &mut pa, &mut pb)
+                .expect("exact reference");
+            for row in 0..d {
+                let a = batched[b * d + row];
+                let e = exact[row];
+                assert!(
+                    (a - e).abs() <= 1e-4 * (1.0 + e.abs()),
+                    "sgemm b={b} row={row} diverges: accelerate={a}, exact={e}"
+                );
+            }
+        }
+    }
+}

--- a/crates/uor-r4-model-source/tests/matrix_operation_census.rs
+++ b/crates/uor-r4-model-source/tests/matrix_operation_census.rs
@@ -39,6 +39,15 @@ const BLAS_MATRIX_MARKERS: &[&str] =
 const SANCTIONED_SUFFIXES: &[&str] = &[
     "uor-r4-graph-compiler/src/dependency_audit.rs",
     "uor-r4-proof-model/src/inference_audit.rs",
+    // #804 measurement-only BLAS exception (maintainer-approved
+    // 2026-08-18): the ONE sanctioned library-BLAS use site, compiled
+    // only under the opt-in `observation-blas-exception` feature on
+    // macOS, for teacher-forced observation passes. Its gating and its
+    // single dispatch site are pinned by
+    // `observation_blas_exception_is_opt_in_and_never_default` below —
+    // adding this suffix does NOT exempt default builds from anything,
+    // because the pin test fails if the cfg gates ever loosen.
+    "uor-r4-model-source/src/observation_blas_exception.rs",
 ];
 
 /// Workspace root: `CARGO_MANIFEST_DIR` = `<root>/crates/uor-r4-model-source`.
@@ -155,4 +164,88 @@ fn teacher_site_owns_no_blas_matrix_ffi() {
          uor-matmul-owned (#655-B2)",
         lib.display()
     );
+}
+
+/// #804: the measurement-only BLAS exception stays exactly what the
+/// maintainer approved — an opt-in, macOS-only, observation-side escape
+/// hatch — and can never silently widen:
+///
+/// - the exception module and every dispatch to it in `lib.rs` sit behind
+///   `cfg(all(feature = "observation-blas-exception", target_os = "macos"))`
+///   (pinned by exact gate-string counting against the dispatch count);
+/// - no Cargo manifest in the workspace enables the feature by default
+///   (`default = [...]` never names it, and no dependency edge turns it
+///   on unconditionally);
+/// - the `cblas_` FFI itself lives ONLY in the sanctioned exception file.
+#[test]
+fn observation_blas_exception_is_opt_in_and_never_default() {
+    let root = workspace_root();
+    const GATE: &str =
+        r#"#[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]"#;
+    const ANTI_GATE: &str =
+        r#"#[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]"#;
+
+    let lib = root.join("crates/uor-r4-model-source/src/lib.rs");
+    let lib_text = std::fs::read_to_string(&lib).expect("read the teacher executor source");
+    let dispatches = lib_text.matches("observation_blas_exception::").count();
+    assert_eq!(
+        dispatches, 2,
+        "the exception has exactly two dispatch sites (matmul, matmul_batched); \
+         a new one needs its own maintainer sign-off and this pin updated"
+    );
+    let gates = lib_text.matches(GATE).count();
+    let anti_gates = lib_text.matches(ANTI_GATE).count();
+    assert_eq!(
+        gates, 4,
+        "lib.rs carries exactly four exception gates (module decl, two \
+         dispatches, backend label); found {gates}"
+    );
+    assert_eq!(
+        anti_gates, 3,
+        "every gated dispatch keeps its default-path twin (two matmuls + \
+         backend label); found {anti_gates}"
+    );
+
+    let exception = root.join("crates/uor-r4-model-source/src/observation_blas_exception.rs");
+    let exception_text =
+        std::fs::read_to_string(&exception).expect("read the exception module source");
+    assert!(
+        exception_text.contains("#[link(name = \"Accelerate\", kind = \"framework\")]"),
+        "the exception file is where the Accelerate FFI lives"
+    );
+
+    // No manifest may default-enable the feature: a `default = [...]` list
+    // naming it, or a plain dependency edge activating it outside the
+    // named passthrough features, would make the exception silent.
+    let mut manifests = vec![root.join("Cargo.toml")];
+    if let Ok(entries) = std::fs::read_dir(root.join("crates")) {
+        for entry in entries.flatten() {
+            let manifest = entry.path().join("Cargo.toml");
+            if manifest.is_file() {
+                manifests.push(manifest);
+            }
+        }
+    }
+    for manifest in manifests {
+        let Ok(text) = std::fs::read_to_string(&manifest) else {
+            continue;
+        };
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("default") && trimmed.contains("observation-blas-exception") {
+                panic!(
+                    "{} default-enables the #804 exception feature — it must stay opt-in",
+                    manifest.display()
+                );
+            }
+            // A dependency edge like `features = ["observation-blas-exception"]`
+            // outside a `[features]` passthrough would hard-enable it.
+            if trimmed.contains("path = ") && trimmed.contains("observation-blas-exception") {
+                panic!(
+                    "{} hard-enables the #804 exception feature on a dependency edge",
+                    manifest.display()
+                );
+            }
+        }
+    }
 }

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -63,9 +63,29 @@ teacher outputs and the derived corpus/artifact bytes that bind those outputs.
 | `uor-r4-model-source/src/lib.rs` `matmul` | matrix–vector (`W·x`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
 | `uor-r4-model-source/src/lib.rs` `matmul_batched` | matrix–matrix (`X·Wᵀ`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
 
-No `cblas_*` symbol remains anywhere in the production chain; the CI guard now
-enforces zero library-BLAS use (only the two dependency-audit files, which list
-BLAS crate names as denylist data, are exempt).
+No `cblas_*` symbol remains anywhere in the default production chain; the CI
+guard now enforces zero library-BLAS use (only the two dependency-audit files,
+which list BLAS crate names as denylist data, are exempt).
+
+### #804 measurement-only BLAS exception (maintainer-approved 2026-08-18)
+
+One additional, **opt-in** sanctioned site exists:
+`uor-r4-model-source/src/observation_blas_exception.rs` routes the teacher
+weight matmuls through Apple Accelerate (`cblas_sgemv`/`cblas_sgemm`) — but
+ONLY when a build explicitly passes `--features observation-blas-exception`
+on macOS, for corpus-scale teacher-forced **observation** passes whose
+wall-clock is infeasible under the exact GEMM (~50–100× slower on the pinned
+measurement Mac). Every default build keeps the uor-matmul owner everywhere;
+the census gate (`observation_blas_exception_is_opt_in_and_never_default`)
+pins the file, its cfg gating, its exact two dispatch sites, and that no
+manifest default-enables the feature. Runtime provenance is loud: the
+"teacher model ready" line reports
+`Accelerate cblas (observation-only exception #804)` for every run built with
+the feature, and any corpus produced under it must record the backend in its
+run log / contract amendment (see #804/#605). Accelerate accumulation order
+is machine-tuned, so logits differ from the exact GEMM in low-order bits —
+corpora produced under the exception are compared against traces from the
+SAME backend, never mixed silently with exact-GEMM corpora.
 
 ### certified-exact (migrated by #704)
 


### PR DESCRIPTION
References #804 — implements the maintainer's measurement-only BLAS exception decision (2026-08-18), unblocking the S1 overnight corpus pass.

**Why.** The S1 smoke run measured the current exact-GEMM teacher (#655-B2) at >18 minutes for ONE 128-position traced article on the pinned M1 — ~150× slower than needed; the full 360,924-position `smollm2-360m-broad` traced pass would be 100+ hours. Under this exception the same article observes in **7 s** (~18.3 pos/s), putting the full corpus at ≈ 5.5 h single-stream.

**What.** A feature-gated (`observation-blas-exception`, macOS-only) Accelerate `cblas_sgemv`/`cblas_sgemm` path for the teacher weight matmuls, in one new sanctioned file (`observation_blas_exception.rs`), dispatched from exactly two sites in `matmul`/`matmul_batched`. Passthrough features on `uor-r4-graph-cli` and the root crate so observation builds opt in with one flag.

**Why this is an exception, not a rollback of #655-B2:**

- **Never a default** — every default build keeps the pinned `uor-matmul` exact GEMM byte-identically. The census gate gains `observation_blas_exception_is_opt_in_and_never_default`, pinning the exact cfg-gate count, the two dispatch sites, the FFI living only in the sanctioned file, and that no workspace manifest default-enables the feature.
- **Loud provenance** — every exception build's teacher-ready line reports `matmul=Accelerate cblas (observation-only exception #804)`; the S1 contract amendments record the backend for the produced corpus.
- **Correctness witness** — a feature-gated parity test bounds Accelerate vs the owned exact GEMM on fixtures (divergence is low-order accumulation bits; the caveat is stated in the census doc: exception corpora are compared against traces from the same backend, never mixed silently with exact-GEMM corpora).
- **Serving unaffected by construction** — the deployed transformerless runtime carries no dependency on these teacher matmuls (P-4 contract).

Gates: fmt; clippy `-D warnings` default (workspace, all targets) AND under the feature; model-source default suites incl. the census (3/3) green; feature-build census green; the parity witness green; smoke-verified end to end on the real 360M teacher with the trace pipeline from #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
