### PR TITLE
feat(#655-C1e): ModelStore recognizes both bundle eras — recognize, don't migrate

### DIFF
--- a/docs/serving_shared_loader_655_c1.md
+++ b/docs/serving_shared_loader_655_c1.md
@@ -125,3 +125,34 @@ or block on #655-D landing first (C1c is independently testable). Does not
 migrate `ModelStore` (Q2/C1e). Does not make manifest presence mandatory
 for a bundle to load — a missing or invalid sidecar is exactly as loadable
 as it is today, never a new hard failure mode.
+
+## C1e decision record (2026-08-19) — Q2 resolved: recognize, don't migrate
+
+Q2 deferred the `ModelStore`/cascade reconciliation because migrating the
+store to `ReleaseBundleManifest` would break every existing local
+`.uor-models` compatibility contract. C1e resolves it the additive way:
+
+- **Recognition, not migration.** `is_compiled_bundle` now recognizes BOTH
+  bundle eras: the legacy plain-path triple (`tless_artifacts.bin` +
+  `tless_store.bin` + `tokenizer.bin`, unchanged) and the R4G1-era shape
+  (`tless_artifacts.bin` + `tokenizer.bin` + `graph/score.r4g1` or
+  `compiled.r4g1` — exactly the component set `release-bundle.json`
+  packages under #655-D, with the plain-path store optional). No existing
+  store changes behavior; R4G1-era directories stop being misdiagnosed as
+  `SourceNotCompiled`.
+- **The CLI local engine degrades honestly.** `build_local_compiled_engine`
+  treats `tless_store.bin` as optional when a compiled graph is present:
+  the plain fallback tier loads EMPTY (it declines instead of serving; the
+  #785-C3 decode witness still names whichever engine ran) and the
+  degradation is logged loudly. A store-less, graph-less directory keeps
+  the legacy required-file error — it serves nothing and must not build.
+  `tless_artifacts.bin` stays required in both eras (it is the packaged
+  signature artifact).
+- **One predicate, no drift.** The CLI's compiled-presence probe
+  (`chat.rs`) previously accepted any single bundle file — looser than the
+  store's own triple. Both now call the one crate-visible predicate, the
+  same consolidation discipline #787 applied to the source scanners.
+- **`ReleaseBundleManifest` stays optional metadata** (C1c semantics
+  unchanged): recognition is by component files, verification is by the
+  sidecar when present. Making the manifest mandatory remains a #741-era
+  product decision, not a loader default.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -277,9 +277,27 @@ fn build_local_compiled_engine(
     sample_seed: Option<u32>,
 ) -> Result<ChatEngine, ChatError> {
     let artifact_bytes = std::fs::read(directory.join("tless_artifacts.bin"))?;
-    let store_bytes = std::fs::read(directory.join("tless_store.bin"))?;
     let r4g1_bytes = read_preferred_chat_graph(directory)?;
     validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
+    // #655-C1e: the plain-path store is optional for an R4G1-era bundle —
+    // the release-packaged component set (#655-D) is graph + signature
+    // artifact + tokenizer. Absent store with a present graph leaves the
+    // plain fallback tier EMPTY (it declines honestly instead of serving;
+    // the decode witness still names whichever engine ran, #785-C3).
+    // Absent store with NO graph stays the required-file error it always
+    // was — that directory serves nothing.
+    let store_bytes = match std::fs::read(directory.join("tless_store.bin")) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && r4g1_bytes.is_some() => {
+            tracing::warn!(
+                directory = %directory.display(),
+                "R4G1-era bundle without a plain-path store (tless_store.bin); \
+                 the plain fallback tier is empty and will decline honestly (#655-C1e)"
+            );
+            None
+        }
+        Err(error) => return Err(error.into()),
+    };
     let tok_file = directory.join("tokenizer.bin");
     tracing::debug!(?tok_file, "resolved chat tokenizer path");
     let bundled_tokenizer = std::fs::read(&tok_file)?;
@@ -287,19 +305,25 @@ fn build_local_compiled_engine(
     let r4g1_bytes = bind_chat_r4g1(r4g1_bytes, &tokenizer_bytes)?;
     let artifacts =
         compiler::parse_artifacts(&artifact_bytes).ok_or(ChatError::InvalidArtifacts)?;
-    let store = runtime::parse_store(&store_bytes).ok_or(ChatError::InvalidStore)?;
+    let store = match store_bytes.as_deref() {
+        Some(bytes) => runtime::parse_store(bytes).ok_or(ChatError::InvalidStore)?,
+        None => (0..=compiler::STAGES).map(|_| Default::default()).collect(),
+    };
 
     // Content-address all local compiler outputs immediately. A manifest and
     // quality report remain optional metadata; integrity does not.
     let artifact_object = model_store.put(&artifact_bytes)?;
-    let store_object = model_store.put(&store_bytes)?;
+    let store_cid = match store_bytes.as_deref() {
+        Some(bytes) => model_store.put(bytes)?.cid,
+        None => "absent (R4G1-era bundle, #655-C1e)".to_owned(),
+    };
     let tokenizer_object = model_store.put(&tokenizer_bytes)?;
     let tokenizer = parse_chat_tokenizer(&tokenizer_bytes)?;
     tracing::warn!(
         model = reference,
         directory = %directory.display(),
         artifact_cid = %artifact_object.cid,
-        store_cid = %store_object.cid,
+        store_cid = %store_cid,
         tokenizer_cid = %tokenizer_object.cid,
         "using a locally compiled bundle without an instruction-quality attestation"
     );
@@ -1275,11 +1299,11 @@ fn check_model_artifact_status(model_id: &str) -> (bool, bool) {
         entries.filter_map(|e| e.ok()).any(|entry| {
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_lowercase();
-            path.is_dir()
-                && name.contains(target_key)
-                && (path.join("tless_artifacts.bin").is_file()
-                    || path.join("graph/score.r4g1").is_file()
-                    || path.join("compiled.r4g1").is_file())
+            // #655-C1e: one recognition predicate, shared with the model
+            // store — this probe's previous any-single-file check drifted
+            // from `ModelStore`'s triple (a dir with only
+            // `tless_artifacts.bin` counted here but served nothing).
+            name.contains(target_key) && crate::model::is_compiled_bundle(&path)
         })
     } else {
         false
@@ -3072,6 +3096,63 @@ mod tests {
         .expect("nonzero exact tagged binding")
         .is_some());
         let _ = std::fs::remove_file(path);
+    }
+
+    /// #655-C1e: an R4G1-era bundle (graph + signature artifact +
+    /// tokenizer, NO `tless_store.bin`) builds a working engine with the
+    /// graph preferred and an EMPTY plain-fallback store — while removing
+    /// the graph too restores the legacy required-file error (falsifier:
+    /// a store-less, graph-less directory serves nothing and must not
+    /// silently build).
+    #[test]
+    fn r4g1_era_bundle_without_plain_store_builds_and_prefers_the_graph() {
+        let root =
+            std::env::temp_dir().join(format!("uor-r4-c1e-modern-bundle-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let dir = root.join("bundle");
+        std::fs::create_dir_all(dir.join("graph")).unwrap();
+
+        let artifact_bytes = std::fs::read("crates/uor-r4-core/tests/fixtures/tless_artifacts.bin")
+            .expect("fixture artifacts");
+        std::fs::write(dir.join("tless_artifacts.bin"), &artifact_bytes).unwrap();
+
+        let mut tokenizer_bytes = Vec::new();
+        for piece in [
+            b"<unk>".as_slice(),
+            b"<s>".as_slice(),
+            b"</s>".as_slice(),
+            b"a".as_slice(),
+        ] {
+            tokenizer_bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+            tokenizer_bytes.extend_from_slice(piece);
+        }
+        std::fs::write(dir.join("tokenizer.bin"), &tokenizer_bytes).unwrap();
+
+        let graph = minimal_graph(*blake3::hash(&tokenizer_bytes).as_bytes());
+        std::fs::write(dir.join("graph").join("score.r4g1"), &graph).unwrap();
+
+        let model_store = crate::model::ModelStore::new(root.join("store-root"));
+        let engine = super::build_local_compiled_engine(&model_store, &dir, "c1e-modern", 8, None)
+            .expect("an R4G1-era bundle builds without tless_store.bin");
+        assert_eq!(
+            engine.r4g1_bytes.as_deref(),
+            Some(graph.as_slice()),
+            "the graph is preferred and bound"
+        );
+        assert!(
+            engine.store.iter().all(|stage| stage.is_empty()),
+            "the plain fallback store is empty, never fabricated"
+        );
+
+        // Falsifier: no store AND no graph — the directory serves nothing
+        // and the legacy required-file error returns.
+        std::fs::remove_file(dir.join("graph").join("score.r4g1")).unwrap();
+        assert!(
+            super::build_local_compiled_engine(&model_store, &dir, "c1e-modern", 8, None).is_err(),
+            "a store-less, graph-less directory must not build"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -675,11 +675,28 @@ impl uor_r4_core::transformerless::region_store::RegionResolver for ModelStore {
     }
 }
 
-fn is_compiled_bundle(path: &Path) -> bool {
-    path.is_dir()
-        && ["tless_artifacts.bin", "tless_store.bin", "tokenizer.bin"]
-            .iter()
-            .all(|name| path.join(name).is_file())
+/// One predicate for "this directory is a locally compiled bundle",
+/// recognizing BOTH bundle eras (#655-C1e decision record in
+/// `docs/serving_shared_loader_655_c1.md`):
+///
+/// - the legacy plain-path shape: `tless_artifacts.bin` +
+///   `tless_store.bin` + `tokenizer.bin` (unchanged);
+/// - the R4G1-era shape: `tless_artifacts.bin` + `tokenizer.bin` + a
+///   compiled graph (`graph/score.r4g1` or `compiled.r4g1`) — exactly
+///   the component set `release-bundle.json` packages (#655-D), with
+///   the plain-path store optional.
+///
+/// Crate-visible so the CLI's compiled-presence probe uses the same
+/// recognition instead of its own drifted copy (the pre-C1e state).
+pub(crate) fn is_compiled_bundle(path: &Path) -> bool {
+    if !path.is_dir() {
+        return false;
+    }
+    let has = |name: &str| path.join(name).is_file();
+    if !(has("tless_artifacts.bin") && has("tokenizer.bin")) {
+        return false;
+    }
+    has("tless_store.bin") || path.join("graph/score.r4g1").is_file() || has("compiled.r4g1")
 }
 
 fn address_container(bytes: &[u8]) -> String {
@@ -1905,6 +1922,62 @@ mod tests {
             .read_manifest("compiled-model")
             .unwrap_err();
         assert!(matches!(error, ModelError::CompiledNotImported(path) if path == compiled));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// #655-C1e: bundle recognition covers BOTH eras — the legacy triple
+    /// and the R4G1-era release-component shape (graph + signature
+    /// artifact + tokenizer, store optional) — while partial directories
+    /// stay unrecognized (falsifiers), and an R4G1-era compiled directory
+    /// gets the correct `CompiledNotImported` diagnosis instead of the
+    /// misleading `SourceNotCompiled`/`ManifestNotFound`.
+    #[test]
+    fn compiled_bundle_recognition_covers_both_eras() {
+        let root = std::env::temp_dir().join(format!("uor-r4-c1e-shapes-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+
+        let legacy = root.join("compiled").join("legacy-era");
+        std::fs::create_dir_all(&legacy).unwrap();
+        for name in ["tless_artifacts.bin", "tless_store.bin", "tokenizer.bin"] {
+            std::fs::write(legacy.join(name), []).unwrap();
+        }
+        assert!(super::is_compiled_bundle(&legacy), "legacy triple");
+
+        let modern = root.join("compiled").join("r4g1-era");
+        std::fs::create_dir_all(modern.join("graph")).unwrap();
+        std::fs::write(modern.join("tless_artifacts.bin"), []).unwrap();
+        std::fs::write(modern.join("tokenizer.bin"), []).unwrap();
+        std::fs::write(modern.join("graph").join("score.r4g1"), []).unwrap();
+        assert!(
+            super::is_compiled_bundle(&modern),
+            "R4G1-era shape without a plain-path store"
+        );
+        let error = ModelStore::new(&root)
+            .read_manifest("r4g1-era")
+            .unwrap_err();
+        assert!(
+            matches!(error, ModelError::CompiledNotImported(ref path) if *path == modern),
+            "an R4G1-era bundle is diagnosed as compiled-not-imported: {error:?}"
+        );
+
+        // Falsifiers: a graph without a tokenizer, a lone signature
+        // artifact, and a lone store are NOT bundles.
+        let no_tokenizer = root.join("compiled").join("no-tokenizer");
+        std::fs::create_dir_all(no_tokenizer.join("graph")).unwrap();
+        std::fs::write(no_tokenizer.join("tless_artifacts.bin"), []).unwrap();
+        std::fs::write(no_tokenizer.join("graph").join("score.r4g1"), []).unwrap();
+        assert!(!super::is_compiled_bundle(&no_tokenizer));
+
+        let partial = root.join("compiled").join("partial");
+        std::fs::create_dir_all(&partial).unwrap();
+        std::fs::write(partial.join("tless_artifacts.bin"), []).unwrap();
+        assert!(!super::is_compiled_bundle(&partial));
+
+        let store_only = root.join("compiled").join("store-only");
+        std::fs::create_dir_all(&store_only).unwrap();
+        std::fs::write(store_only.join("tless_store.bin"), []).unwrap();
+        assert!(!super::is_compiled_bundle(&store_only));
+
         std::fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
References #655 (C1e, the last unstarted C slice; Q2 of the C1 design record, resolved additively — decision record included in `docs/serving_shared_loader_655_c1.md`).

- **Recognition, not migration**: `is_compiled_bundle` accepts the legacy plain-path triple (unchanged) AND the R4G1-era release-component shape (graph + signature artifact + tokenizer; `tless_store.bin` optional — the exact #655-D packaged set). R4G1-era directories get the correct `CompiledNotImported` diagnosis instead of `SourceNotCompiled`. No existing local store changes behavior.
- **Honest degradation**: `build_local_compiled_engine` builds store-less R4G1-era bundles with an EMPTY plain fallback tier (declines instead of serving; #785-C3 witness still names the engine; degradation logged loudly). Store-less + graph-less keeps the legacy required-file error.
- **One predicate**: the CLI compiled-presence probe drops its drifted any-single-file check for the shared crate-visible predicate (#787-style consolidation).

Tests: both-era recognition, three partial-directory falsifiers, R4G1-era `CompiledNotImported` diagnosis, store-less build with graph preferred + empty store, store-less graph-less falsifier.

Gates: fmt; clippy -D warnings (workspace, all targets); lib 255 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW