### PR TITLE
S1-1 runner: real-arm route-fit subset loader, overlap gates, route-fit-real CLI (#804, #605)

### DIFF
--- a/crates/uor-r4-graph-certify/src/route_fit_report.rs
+++ b/crates/uor-r4-graph-certify/src/route_fit_report.rs
@@ -1513,3 +1513,336 @@ pub fn run_route_fit_ladder(
         },
     })
 }
+
+// ---------------------------------------------------------------------------
+// #605 amendment 2 (2026-08-19): the S1-1 real-arm overlap stage.
+// ---------------------------------------------------------------------------
+
+/// One head's overlap numbers in the S1-1 report.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RealArmOverlapHeadRecord {
+    /// Source layer index.
+    pub layer: u32,
+    /// Head index within the layer.
+    pub head: u32,
+    /// Mean fitted-vs-teacher support overlap over eligible steps.
+    pub fitted: f64,
+    /// Mean N1 (permuted-code null) overlap.
+    pub n1: f64,
+    /// Mean N2 (deranged-support null) overlap.
+    pub n2: f64,
+    /// Eligible steps (strictly more candidates than `top_m`).
+    pub eligible_steps: u64,
+}
+
+/// The S1-1 report: the teacher-agnostic half of the pre-registered
+/// real-teacher stage, per #605's declared amendment 2 — fit the packed
+/// route codes on a REAL trace corpus, drive the DEPLOYED kernel over
+/// them (witness replay, closed-form census, certify cross-check, epoch
+/// discipline, #653 cost), and judge the pre-registered overlap gates
+/// (fitted support overlap vs the N1/N2 nulls, anti-vacuity) at
+/// whole-artifact scope. The replaced-forward parity gates
+/// (teacher-forced top-1, bits ratio) require the real executor's
+/// restricted forward — S1-2, built only on a PASS here (the
+/// stop-at-first-fail ordering makes this stage the cheapest falsifier).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RealArmOverlapReport {
+    /// `uor-r4-real-arm-overlap/1`.
+    pub format: String,
+    /// Records evaluated (after any pre-declared subset rule).
+    pub corpus_records: usize,
+    /// Stories evaluated.
+    pub corpus_stories: usize,
+    /// Declared capture layers.
+    pub declared_layers: Vec<u32>,
+    /// Declared per-head support cap.
+    pub support_size: u32,
+    /// Corpus record identity (subset digest for a subset load).
+    pub records_kappa: String,
+    /// Corpus trace identity (subset digest for a subset load).
+    pub trace_kappa: String,
+    /// The parent observation manifest's identity-bundle digest.
+    pub identity_bundle_digest: String,
+    /// κ of the fitted parameters' canonical bytes.
+    pub fitted_params_kappa: String,
+    /// The declared selection width the kernel was driven with.
+    pub top_m: u32,
+    /// The pre-registered contract judged against (gates unchanged).
+    pub contract: RunContract,
+    /// Aggregated deployed-kernel runtime checks across every head.
+    pub runtime: RuntimeChecks,
+    /// Whole-artifact overlap record (every fitted head).
+    pub overlap: OverlapRecord,
+    /// Per-head overlap breakdown.
+    pub heads: Vec<RealArmOverlapHeadRecord>,
+    /// PASS / FAIL for this stage.
+    pub verdict: StageVerdict,
+    /// The gate that decided the verdict, with its numbers.
+    pub reason: String,
+}
+
+/// Run the S1-1 real-arm overlap stage. Deterministic: the same corpus
+/// and contract produce a byte-identical report. Gate values and order
+/// mirror the synthetic ladder exactly (vacuity → runtime → overlap
+/// bar); only the teacher-forced parity gates are absent, by the
+/// declared amendment.
+pub fn run_real_arm_overlap_gates(
+    corpus: &RouteTraceCorpus,
+    fitted: &FittedRouteCodes,
+    contract: &RunContract,
+) -> Result<RealArmOverlapReport, SourceUnavailable> {
+    for head in &fitted.heads {
+        if head.query_codes.len() != corpus.stories.len()
+            || head.key_codes.len() != corpus.stories.len()
+        {
+            return Err(SourceUnavailable::new(
+                "fitted code tables do not align with the corpus stories",
+            ));
+        }
+    }
+    let null_codes = null_n1_codes(fitted, contract.nulls.n1_seed);
+    let mut evidence: Vec<HeadEvidence> = Vec::with_capacity(fitted.heads.len());
+    let mut per_head: Vec<HeadOverlaps> = Vec::with_capacity(fitted.heads.len());
+    let mut head_records: Vec<RealArmOverlapHeadRecord> = Vec::with_capacity(fitted.heads.len());
+    for (head_index, head) in fitted.heads.iter().enumerate() {
+        let lane_index = corpus
+            .declared_layers
+            .iter()
+            .position(|&layer| layer == head.layer)
+            .ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "fitted layer {} is not a declared trace layer",
+                    head.layer
+                ))
+            })?;
+        let head_evidence = packed_selection_evidence(head, fitted.top_m, true)
+            .map_err(|error| SourceUnavailable::new(format!("selection evidence: {error}")))?;
+        let n1_evidence = packed_selection_evidence(&null_codes[head_index], fitted.top_m, false)
+            .map_err(|error| {
+            SourceUnavailable::new(format!("null selection evidence: {error}"))
+        })?;
+        let overlaps = head_overlaps(
+            corpus,
+            lane_index,
+            head.head,
+            &head_evidence.selected,
+            &n1_evidence.selected,
+            fitted.top_m,
+        );
+        let denominator = overlaps.eligible.max(1) as f64;
+        head_records.push(RealArmOverlapHeadRecord {
+            layer: head.layer,
+            head: head.head,
+            fitted: overlaps.fitted_sum / denominator,
+            n1: overlaps.n1_sum / denominator,
+            n2: overlaps.n2_sum / denominator,
+            eligible_steps: overlaps.eligible,
+        });
+        evidence.push(head_evidence);
+        per_head.push(overlaps);
+    }
+    let runtime = aggregate_runtime(&evidence.iter().collect::<Vec<_>>());
+    let overlap = overlap_record(&per_head, contract.gates.n2_vacuity_fraction);
+
+    let verdict;
+    let reason;
+    if overlap.vacuous {
+        verdict = StageVerdict::Fail;
+        reason = format!(
+            "instrument VACUOUS: N2 overlap {:.6} is not below {:.2} x fitted overlap {:.6}; \
+             a vacuous instrument fails the run regardless of other numbers",
+            overlap.n2, contract.gates.n2_vacuity_fraction, overlap.fitted
+        );
+    } else if !runtime.pass {
+        verdict = StageVerdict::Fail;
+        reason = format!(
+            "deployed-kernel runtime checks FAILED (witness replay {}, census {}, reference \
+             cross-check {}, state epoch {})",
+            runtime.witness_replay_pass,
+            runtime.census_closed_form_pass,
+            runtime.reference_crosscheck_pass,
+            runtime.state_epoch_pass
+        );
+    } else {
+        let overlap_bar = (contract.gates.overlap_null_factor * overlap.best_null)
+            .max(contract.gates.overlap_floor);
+        if overlap.fitted < overlap_bar {
+            verdict = StageVerdict::Fail;
+            reason = format!(
+                "fitted support overlap {:.6} is below the pre-registered bar \
+                 max({:.1} x best null {:.6}, {:.2}) = {:.6}",
+                overlap.fitted,
+                contract.gates.overlap_null_factor,
+                overlap.best_null,
+                contract.gates.overlap_floor,
+                overlap_bar
+            );
+        } else {
+            verdict = StageVerdict::Pass;
+            reason = format!(
+                "overlap gates held at whole-artifact scope (fitted {:.6}, nulls n1 {:.6} / \
+                 n2 {:.6}, bar {:.6}, eligible steps {}); the replaced-forward parity gates \
+                 await S1-2 per the declared amendment",
+                overlap.fitted, overlap.n1, overlap.n2, overlap_bar, overlap.eligible_steps
+            );
+        }
+    }
+
+    Ok(RealArmOverlapReport {
+        format: "uor-r4-real-arm-overlap/1".to_owned(),
+        corpus_records: corpus.records,
+        corpus_stories: corpus.stories.len(),
+        declared_layers: corpus.declared_layers.clone(),
+        support_size: corpus.support_size,
+        records_kappa: corpus.records_kappa.clone(),
+        trace_kappa: corpus.trace_kappa.clone(),
+        identity_bundle_digest: corpus.identity_bundle_digest.clone(),
+        fitted_params_kappa: fitted.kappa(),
+        top_m: fitted.top_m,
+        contract: contract.clone(),
+        runtime,
+        overlap,
+        heads: head_records,
+        verdict,
+        reason,
+    })
+}
+
+#[cfg(test)]
+mod real_arm_tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use uor_r4_graph_compiler::route_fit::{
+        fit_route_codes, generate_synthetic_route_trace, load_route_trace_corpus,
+        load_route_trace_corpus_subset, synthetic_capture_geometry, RouteTraceSubset,
+        SyntheticRouteTeacher,
+    };
+    use uor_r4_model_source::TeacherOracle as _;
+
+    fn synth_bos() -> u32 {
+        SyntheticRouteTeacher::new().bos_token() as u32
+    }
+
+    fn unique_dir(label: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("uor-r4-real-arm-{label}-{nanos}"))
+    }
+
+    /// The S1-1 stage machinery end to end on the synthetic trace corpus
+    /// (produced through the PRODUCTION #603 pipeline): the fit clears
+    /// the pre-registered overlap gates, and the same report FAILS by
+    /// name under a seeded impossible floor and a seeded zero vacuity
+    /// fraction (falsifiers) — the instrument can fail.
+    #[test]
+    fn real_arm_overlap_gates_pass_on_synthetic_and_fail_on_seeded_gates() {
+        let dir = unique_dir("gates");
+        generate_synthetic_route_trace(&dir).expect("synthetic trace corpus");
+        let corpus = load_route_trace_corpus(&dir, synthetic_capture_geometry(), synth_bos())
+            .expect("load synthetic corpus");
+        let fitted = fit_route_codes(&corpus).expect("fit");
+        let contract = preregistered_route_fit_contract();
+
+        let report = run_real_arm_overlap_gates(&corpus, &fitted, &contract).expect("stage runs");
+        assert_eq!(
+            report.verdict,
+            StageVerdict::Pass,
+            "synthetic overlap gates hold: {}",
+            report.reason
+        );
+        assert!(report.runtime.pass, "deployed-kernel checks hold");
+        assert_eq!(report.heads.len(), fitted.heads.len());
+        assert!(report.overlap.fitted > report.overlap.best_null);
+
+        // Determinism: a second run is identical field for field.
+        let again = run_real_arm_overlap_gates(&corpus, &fitted, &contract).expect("second run");
+        assert_eq!(report, again, "the report is deterministic");
+
+        // Falsifier 1: an impossible overlap floor fails by name.
+        let mut impossible = contract.clone();
+        impossible.gates.overlap_floor = 1.1;
+        let failed =
+            run_real_arm_overlap_gates(&corpus, &fitted, &impossible).expect("stage still runs");
+        assert_eq!(failed.verdict, StageVerdict::Fail);
+        assert!(
+            failed.reason.contains("below the pre-registered bar"),
+            "{}",
+            failed.reason
+        );
+
+        // Falsifier 2: a zero vacuity fraction declares the instrument
+        // vacuous and fails the run outright.
+        let mut vacuous = contract.clone();
+        vacuous.gates.n2_vacuity_fraction = 0.0;
+        let failed =
+            run_real_arm_overlap_gates(&corpus, &fitted, &vacuous).expect("stage still runs");
+        assert_eq!(failed.verdict, StageVerdict::Fail);
+        assert!(failed.reason.contains("VACUOUS"), "{}", failed.reason);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The subset loader agrees with the full loader when the subset
+    /// covers everything, truncates stories at the declared position
+    /// bound (the deployed `ROUTE_MAX_CANDIDATES` window), and carries
+    /// domain-tagged subset κs distinct from the full-corpus κs.
+    #[test]
+    fn subset_loader_matches_full_load_and_truncates_at_the_declared_bound() {
+        let dir = unique_dir("subset");
+        generate_synthetic_route_trace(&dir).expect("synthetic trace corpus");
+        let geometry = synthetic_capture_geometry();
+        let full = load_route_trace_corpus(&dir, geometry, synth_bos()).expect("full load");
+        let all = load_route_trace_corpus_subset(
+            &dir,
+            geometry,
+            synth_bos(),
+            RouteTraceSubset {
+                max_stories: u32::MAX,
+                max_positions: u32::MAX,
+            },
+        )
+        .expect("covering subset load");
+        assert_eq!(all.records, full.records);
+        assert_eq!(all.stories.len(), full.stories.len());
+        for (a, b) in all.stories.iter().zip(full.stories.iter()) {
+            assert_eq!(a.story, b.story);
+            assert_eq!(a.tokens, b.tokens);
+            assert_eq!(a.steps.len(), b.steps.len());
+        }
+        assert_ne!(
+            all.records_kappa, full.records_kappa,
+            "subset κs are domain-tagged, never confusable with full-corpus κs"
+        );
+        assert_eq!(all.identity_bundle_digest, full.identity_bundle_digest);
+
+        let truncated = load_route_trace_corpus_subset(
+            &dir,
+            geometry,
+            synth_bos(),
+            RouteTraceSubset {
+                max_stories: 2,
+                max_positions: 3,
+            },
+        )
+        .expect("truncating subset load");
+        assert_eq!(truncated.stories.len(), 2.min(full.stories.len()));
+        for story in &truncated.stories {
+            assert!(story.steps.len() <= 3, "positions truncate at the bound");
+            for (expected, step) in story.steps.iter().enumerate() {
+                assert_eq!(step.pos as usize, expected, "kept window stays contiguous");
+            }
+        }
+        // The truncated corpus still fits and judges.
+        let fitted = fit_route_codes(&truncated).expect("fit on the truncated subset");
+        assert_eq!(
+            fitted.heads.len(),
+            truncated.declared_layers.len() * geometry.heads
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -3967,6 +3967,144 @@ fn parse_observe_text_options(args: &[String]) -> Result<ObserveTextOptions, Sou
     Ok(options)
 }
 
+/// #605 amendment 2 (S1-1): fit packed route codes on a REAL traced
+/// corpus and judge the pre-registered overlap gates — the
+/// teacher-agnostic half of the real-teacher stage. Geometry and the BOS
+/// id come from the teacher source's `config.json`; the corpus loads
+/// through the pre-declared streamed subset rule (first `--stories`
+/// ordinals, first `--positions` positions each — the deployed
+/// operator's own candidate bound). Writes the typed
+/// `RealArmOverlapReport` JSON and prints the verdict; a FAIL verdict is
+/// a recorded outcome, not a command error.
+fn route_fit_real_command(args: &[String]) -> Result<(), SourceUnavailable> {
+    use uor_r4_graph_certify::route_fit_report::{
+        preregistered_route_fit_contract, run_real_arm_overlap_gates,
+    };
+    use uor_r4_graph_compiler::route_fit::{
+        RouteTraceSubset, fit_route_codes, load_route_trace_corpus_subset,
+    };
+    use uor_r4_model_source::TraceCaptureGeometry;
+
+    let mut corpus_dir: Option<PathBuf> = None;
+    let mut source_dir: Option<PathBuf> = None;
+    let mut max_stories: u32 = 1000;
+    let mut max_positions: u32 = 64;
+    let mut out: Option<PathBuf> = None;
+    let mut index = 0usize;
+    while index < args.len() {
+        let flag = &args[index];
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| SourceUnavailable::new(format!("missing value for {flag}")))?;
+        match flag.as_str() {
+            "--corpus" => corpus_dir = Some(PathBuf::from(value)),
+            "--source" => source_dir = Some(PathBuf::from(value)),
+            "--stories" => {
+                max_stories = value.parse().map_err(|_| {
+                    SourceUnavailable::new(format!("invalid --stories value: {value}"))
+                })?;
+            }
+            "--positions" => {
+                max_positions = value.parse().map_err(|_| {
+                    SourceUnavailable::new(format!("invalid --positions value: {value}"))
+                })?;
+            }
+            "--out" => out = Some(PathBuf::from(value)),
+            _ => {
+                return Err(SourceUnavailable::new(format!(
+                    "unknown route-fit-real option: {flag}"
+                )));
+            }
+        }
+        index += 2;
+    }
+    let corpus_dir = corpus_dir
+        .ok_or_else(|| SourceUnavailable::new("route-fit-real requires --corpus <DIR>"))?;
+    let source_dir = source_dir.ok_or_else(|| {
+        SourceUnavailable::new(
+            "route-fit-real requires --source <teacher dir> (geometry + BOS come from its \
+             config.json)",
+        )
+    })?;
+    let config_path = source_dir.join("config.json");
+    let config_bytes = std::fs::read(&config_path)
+        .map_err(|error| SourceUnavailable::new(format!("{}: {error}", config_path.display())))?;
+    let config: serde_json::Value = serde_json::from_slice(&config_bytes).map_err(|error| {
+        SourceUnavailable::new(format!("{}: invalid JSON: {error}", config_path.display()))
+    })?;
+    let field = |name: &str| -> Result<usize, SourceUnavailable> {
+        config
+            .get(name)
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value as usize)
+            .ok_or_else(|| {
+                SourceUnavailable::new(format!(
+                    "{} carries no numeric {name}; cannot derive the capture geometry",
+                    config_path.display()
+                ))
+            })
+    };
+    let geometry = TraceCaptureGeometry {
+        layers: field("num_hidden_layers")?,
+        heads: field("num_attention_heads")?,
+        kv_heads: field("num_key_value_heads")?,
+        residual_width: field("hidden_size")?,
+    };
+    let bos_token = config
+        .get("bos_token_id")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(1) as u32;
+
+    eprintln!(
+        "route-fit-real: loading subset (stories < {max_stories}, positions < {max_positions}) \
+         from {} under geometry {}L/{}H/{}KV/{}D, bos {bos_token}",
+        corpus_dir.display(),
+        geometry.layers,
+        geometry.heads,
+        geometry.kv_heads,
+        geometry.residual_width
+    );
+    let corpus = load_route_trace_corpus_subset(
+        &corpus_dir,
+        geometry,
+        bos_token,
+        RouteTraceSubset {
+            max_stories,
+            max_positions,
+        },
+    )?;
+    eprintln!(
+        "route-fit-real: {} records across {} stories loaded (records κ {}, trace κ {})",
+        corpus.records,
+        corpus.stories.len(),
+        corpus.records_kappa,
+        corpus.trace_kappa
+    );
+    eprintln!("route-fit-real: fitting packed route codes...");
+    let fitted = fit_route_codes(&corpus)?;
+    eprintln!(
+        "route-fit-real: fitted {} heads (top_m {}, params κ {}); judging the \
+         pre-registered overlap gates...",
+        fitted.heads.len(),
+        fitted.top_m,
+        fitted.kappa()
+    );
+    let contract = preregistered_route_fit_contract();
+    let report = run_real_arm_overlap_gates(&corpus, &fitted, &contract)?;
+    let out = out.unwrap_or_else(|| corpus_dir.join("route_fit_real_report.json"));
+    let mut bytes = serde_json::to_vec_pretty(&report)
+        .map_err(|error| SourceUnavailable::new(format!("serialize real-arm report: {error}")))?;
+    bytes.push(b'\n');
+    write_regular_file_synced(&out, &bytes, "real-arm overlap report")?;
+    println!(
+        "route-fit-real verdict: {:?}\n  {}\n  report: {}",
+        report.verdict,
+        report.reason,
+        out.display()
+    );
+    Ok(())
+}
+
 /// Resolve the parsed `--trace-*` flags against the immutable #603 profile
 /// registry: `(id, version)` plus the declared bounds map to the typed
 /// record, or a typed refusal for unknown pairs and out-of-bound
@@ -9865,6 +10003,7 @@ pub fn run(args: &[String]) -> Result<(), SourceUnavailable> {
             Err(_) => println!("source checkpoint not found; see `setup`"),
         },
         Some("convert-r4g1") => convert_r4g1::run(&args[1..])?,
+        Some("route-fit-real") => route_fit_real_command(&args[1..])?,
         Some("runtime-corpus") => runtime_corpus::run(&args[1..])?,
         Some("cover") => cover_command(&args[1..])?,
         Some("cover-sweep") => cover_sweep::cover_sweep_command(&args[1..])?,
@@ -9906,6 +10045,7 @@ fn transformerless_usage() -> &'static str {
                    --bundle-root explicitly declares one managed/canonical bundle authority; without it, --out is an exact standalone root fixed at transaction start\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\
                  text observations (D3): observe-text [--input PATH] [--out DIR] [--shards N] [--seconds N] [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN --tokenizer PATH] [--sequence-length N] [--trace-profile ID/V --trace-layers I,J,... [--trace-support S]]\n\
+                 route-attention real arm (#605 S1-1): route-fit-real --corpus DIR --source DIR [--stories N] [--positions N] [--out PATH]\n\
                  A-mode infill serving: graph infill --artifact <scored R4G1> --skeleton <token ids, _ for free> [--teacher <TLA container>]\n\
                  quantum operations: cd-compile | quantum-eval\n\
                  hf evaluation: evaluate-report [--source DIR] [--tokenizer-family FAMILY --tokenizer-version N] [--compiled DIR] [--report PATH] [--sequence-length N] [--bos] [--max-held-out-stories N]\n\

--- a/crates/uor-r4-graph-compiler/src/observation.rs
+++ b/crates/uor-r4-graph-compiler/src/observation.rs
@@ -3746,6 +3746,30 @@ pub fn reconcile_probability_pair(
     Ok(())
 }
 
+/// Decode one probability sidecar's raw bytes into its aligned metadata
+/// rows — the per-shard building block `merge_probability_metadata`
+/// applies corpus-wide, exposed for streamed (shard-at-a-time) readers
+/// like the #605 route-fit subset loader.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn decode_probability_metadata(
+    bytes: &[u8],
+) -> Result<Vec<ProbabilityMetadata>, SourceUnavailable> {
+    if !bytes.len().is_multiple_of(PROBABILITY_METADATA_SIZE) {
+        return Err(invalid_data(format!(
+            "probability sidecar bytes are torn ({} bytes; rows are {} bytes)",
+            bytes.len(),
+            PROBABILITY_METADATA_SIZE
+        )));
+    }
+    bytes
+        .chunks_exact(PROBABILITY_METADATA_SIZE)
+        .map(|row| {
+            ProbabilityMetadata::decode(row)
+                .ok_or_else(|| invalid_data("invalid probability metadata row".to_owned()))
+        })
+        .collect()
+}
+
 /// Merge aligned #603 trace-sidecar rows in the same deterministic shard
 /// order as [`merge_shards`]. The result depends only on shard contents,
 /// never on completion order; rows are returned as raw bytes (the lane

--- a/crates/uor-r4-graph-compiler/src/route_fit.rs
+++ b/crates/uor-r4-graph-compiler/src/route_fit.rs
@@ -1109,6 +1109,242 @@ pub fn load_route_trace_corpus(
     })
 }
 
+/// The pre-declared subset rule for a memory-bound real-corpus load
+/// (#605 amendment 2, 2026-08-19): keep the first `max_stories` story
+/// ordinals, truncated to the first `max_positions` positions each.
+/// `max_positions` exists because the deployed operator's own instance
+/// bound (`ROUTE_MAX_CANDIDATES`) caps the candidate table — a prefix
+/// window is exactly what the packed operator could ever serve, and
+/// supports are self-contained within a prefix.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RouteTraceSubset {
+    /// Keep stories with `story < max_stories`.
+    pub max_stories: u32,
+    /// Keep positions with `pos < max_positions` within each kept story.
+    pub max_positions: u32,
+}
+
+/// [`load_route_trace_corpus`] for corpora too large to merge in memory:
+/// streams shard-by-shard (one shard's record/probability/trace files
+/// resident at a time) and keeps only the pre-declared
+/// [`RouteTraceSubset`]. Kept stories must still be position-contiguous
+/// from 0 up to their (possibly truncated) length — a gap inside the
+/// kept window is refused exactly like the full loader refuses it.
+///
+/// Subset identity: the full-corpus κs cannot be quoted for a partial
+/// read, so `records_kappa`/`trace_kappa` carry a canonical SUBSET
+/// digest instead — blake3 over the kept records' (respectively kept
+/// trace rows') per-record blake3 hashes in ascending `(story, pos)`
+/// order under a domain tag naming the rule. Deterministic for the same
+/// corpus + subset; distinct from any full-corpus κ by construction
+/// (domain-tagged). The parent corpus stays identified by
+/// `identity_bundle_digest` (the observation manifest's own digest).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn load_route_trace_corpus_subset(
+    dir: &Path,
+    geometry: TraceCaptureGeometry,
+    bos_token: u32,
+    subset: RouteTraceSubset,
+) -> Result<RouteTraceCorpus, SourceUnavailable> {
+    if subset.max_stories == 0 || subset.max_positions == 0 {
+        return Err(SourceUnavailable::new(
+            "an empty subset rule loads nothing; declare at least one story and position",
+        ));
+    }
+    let manifest = ObservationManifest::load(dir)?.ok_or_else(|| {
+        SourceUnavailable::new(format!("no observation manifest in {}", dir.display()))
+    })?;
+    let profile = manifest.trace_profile.clone().ok_or_else(|| {
+        SourceUnavailable::new(format!(
+            "{} was captured under the minimal profile; the route fit needs \
+             the q/k and attention-support lanes",
+            dir.display()
+        ))
+    })?;
+    let qkv_lane = profile.qkv_lane.clone().ok_or_else(|| {
+        SourceUnavailable::new("trace profile declares no q/k lane; the route fit needs it")
+    })?;
+    let support_lane = profile.attention_support_lane.clone().ok_or_else(|| {
+        SourceUnavailable::new(
+            "trace profile declares no attention-support lane; the route fit needs it",
+        )
+    })?;
+    let declared_layers = qkv_lane.layer_indices.clone();
+    if support_lane.layer_indices != declared_layers {
+        return Err(SourceUnavailable::new(
+            "q/k and attention-support lanes declare different layer lists; \
+             the route fit reads one aligned layer list",
+        ));
+    }
+    let layout = crate::observation::TraceRowLayout::new(&profile, &geometry);
+    let row_bytes = layout.row_bytes;
+    if manifest.trace_row_bytes != Some(row_bytes as u64) {
+        return Err(SourceUnavailable::new(format!(
+            "trace row width mismatch: manifest pins {:?}, geometry + profile imply {row_bytes}",
+            manifest.trace_row_bytes
+        )));
+    }
+
+    struct KeptStep {
+        pos: u32,
+        step: StepTrace,
+        record_hash: [u8; 32],
+        trace_hash: [u8; 32],
+    }
+    let mut by_story: BTreeMap<u32, Vec<KeptStep>> = BTreeMap::new();
+    let mut records = 0usize;
+    for shard in 0..manifest.shard_count() {
+        let Some(entry) = manifest.completed.get(&shard) else {
+            continue;
+        };
+        if entry.records == 0 {
+            continue;
+        }
+        let record_path = dir.join(crate::observation::shard_file_name(
+            manifest.shard_bits,
+            shard,
+        ));
+        let record_bytes = std::fs::read(&record_path)?;
+        if record_bytes.len() % RECORD_SIZE != 0 {
+            return Err(SourceUnavailable::new(format!(
+                "shard file {} has a torn record ({} bytes)",
+                record_path.display(),
+                record_bytes.len()
+            )));
+        }
+        let shard_records = record_bytes.len() / RECORD_SIZE;
+        let prob_path = dir.join(format!(
+            "{}.prob",
+            crate::observation::shard_file_name(manifest.shard_bits, shard)
+        ));
+        let prob_bytes = std::fs::read(&prob_path)?;
+        let trace_path = dir.join(crate::observation::trace_sidecar_name(
+            manifest.shard_bits,
+            shard,
+        ));
+        let trace_bytes = std::fs::read(&trace_path)?;
+        if trace_bytes.len() != shard_records * row_bytes {
+            return Err(SourceUnavailable::new(format!(
+                "trace sidecar {} is not record-aligned ({} bytes for {} records of {} each)",
+                trace_path.display(),
+                trace_bytes.len(),
+                shard_records,
+                row_bytes
+            )));
+        }
+        let probabilities = crate::observation::decode_probability_metadata(&prob_bytes)
+            .map_err(|error| SourceUnavailable::new(format!("{}: {error}", prob_path.display())))?;
+        if probabilities.len() != shard_records {
+            return Err(SourceUnavailable::new(format!(
+                "probability sidecar {} is not record-aligned",
+                prob_path.display()
+            )));
+        }
+        for index in 0..shard_records {
+            let record = &record_bytes[index * RECORD_SIZE..(index + 1) * RECORD_SIZE];
+            let story = read_u32(record, 0);
+            let pos = read_u32(record, 72);
+            if story >= subset.max_stories || pos >= subset.max_positions {
+                continue;
+            }
+            records += 1;
+            let next = read_u32(record, 4);
+            let mut top_tokens = [0u32; 8];
+            for (slot, token) in top_tokens.iter_mut().enumerate() {
+                *token = read_u32(record, 8 + slot * 4);
+            }
+            let row = &trace_bytes[index * row_bytes..(index + 1) * row_bytes];
+            let decoded = layout.read_row(row)?;
+            let q_rows: Vec<Vec<f32>> = decoded.qkv.iter().map(|(q, _, _)| q.clone()).collect();
+            let k_rows: Vec<Vec<f32>> = decoded.qkv.iter().map(|(_, k, _)| k.clone()).collect();
+            by_story.entry(story).or_default().push(KeptStep {
+                pos,
+                step: StepTrace {
+                    pos,
+                    input_token: 0,
+                    next,
+                    top_tokens,
+                    target_logprob_nats: probabilities[index].target_logprob_nats,
+                    q_rows,
+                    k_rows,
+                    supports: decoded.support,
+                },
+                record_hash: *blake3::hash(record).as_bytes(),
+                trace_hash: *blake3::hash(row).as_bytes(),
+            });
+        }
+    }
+    if by_story.is_empty() {
+        return Err(SourceUnavailable::new(format!(
+            "the declared subset (stories < {}, positions < {}) matched no records in {}",
+            subset.max_stories,
+            subset.max_positions,
+            dir.display()
+        )));
+    }
+
+    let mut record_digest = blake3::Hasher::new();
+    record_digest.update(
+        format!(
+            "uor-r4-route-trace-subset/1 records stories<{} positions<{}\n",
+            subset.max_stories, subset.max_positions
+        )
+        .as_bytes(),
+    );
+    let mut trace_digest = blake3::Hasher::new();
+    trace_digest.update(
+        format!(
+            "uor-r4-route-trace-subset/1 trace stories<{} positions<{}\n",
+            subset.max_stories, subset.max_positions
+        )
+        .as_bytes(),
+    );
+    let mut stories = Vec::with_capacity(by_story.len());
+    for (story, mut kept) in by_story {
+        kept.sort_by_key(|step| step.pos);
+        for (expected, step) in kept.iter().enumerate() {
+            if step.pos as usize != expected {
+                return Err(SourceUnavailable::new(format!(
+                    "story {story} has non-contiguous positions inside the kept window \
+                     (expected {expected}, found {})",
+                    step.pos
+                )));
+            }
+        }
+        let mut steps = Vec::with_capacity(kept.len());
+        for step in kept {
+            record_digest.update(&step.record_hash);
+            trace_digest.update(&step.trace_hash);
+            steps.push(step.step);
+        }
+        let mut tokens = Vec::with_capacity(steps.len());
+        let mut fed = bos_token;
+        for step in steps.iter_mut() {
+            step.input_token = fed;
+            tokens.push(fed);
+            fed = step.next;
+        }
+        stories.push(StoryTrace {
+            story,
+            tokens,
+            steps,
+        });
+    }
+
+    Ok(RouteTraceCorpus {
+        geometry,
+        declared_layers,
+        support_size: support_lane.support_size,
+        trace_profile: profile,
+        stories,
+        records,
+        records_kappa: format!("blake3:{}", record_digest.finalize().to_hex()),
+        trace_kappa: format!("blake3:{}", trace_digest.finalize().to_hex()),
+        identity_bundle_digest: manifest.identity_bundle_digest(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // The fit itself.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lands the **S1-1 runner** for the #605 real-arm ladder (route-attention fit, #804), ahead of tonight's traced-corpus completion — per the amendment + auto-run decision declared on #605.

- **Subset loader** (`route_fit.rs`): `RouteTraceSubset` + `load_route_trace_corpus_subset` stream the traced corpus shard-by-shard and keep the declared window (first 1000 story ordinals × first 64 positions), with domain-tagged subset κs (`uor-r4-route-trace-subset/1`, blake3 over per-record hashes) and a per-story contiguity check inside the kept window.
- **Sidecar decoder** (`observation.rs`): `decode_probability_metadata` exposes the per-shard probability-row decoder the streamed reader needs.
- **Overlap gates** (`route_fit_report.rs`): `RealArmOverlapReport` (`uor-r4-real-arm-overlap/1`) + `run_real_arm_overlap_gates` — pre-registered gate order (vacuity → deployed-kernel runtime checks → overlap bar `max(null_factor × best_null, floor)`), N1 = permuted codes, N2 = deranged supports.
- **CLI** (`graph-cli`): `transformerless route-fit-real --corpus … --source … --stories 1000 --positions 64 --out …` — loads the subset, fits, runs the gates, writes the report JSON; a FAIL verdict is a recorded outcome, not a command error.

S1-2 (restricted-forward parity on the deployed kernel) stays gated on an S1-1 PASS, exactly as amended.

## Tests

- `real_arm_overlap_gates_pass_on_synthetic_and_fail_on_seeded_gates` — synthetic PASS, byte-determinism via `PartialEq`, and both falsifiers (overlap floor 1.1 → FAIL; N2 vacuity fraction 0.0 → FAIL vacuous).
- `subset_loader_matches_full_load_and_truncates_at_the_declared_bound` — subset loader ≡ full loader on an in-window corpus; truncation honors the declared bound.
- Workspace `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, compiler lib suite 203 passed, certify suite 41 passed.

## Refs

- #804 (S1 decision + amendments), #605 (ladder; amendment issuecomment-5335971782 + addendum issuecomment-5335988956)
- Measurement-only: no serving-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
