### PR TITLE
Sampled decode machinery: step candidate lists + engine generate_sampled_into (#655)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -112,8 +112,8 @@ pub struct InferenceResponse {
 }
 use uor_r4_core::transformerless::scenarios::{RuntimeTokenizerIdentity, Tokenizer};
 use uor_r4_graph_certify::{
-    GraphScorer, ScoreStatus, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B, TOP_M,
-    WIDENED_TOP_M,
+    GraphScorer, ScoreStatus, StepCandidates, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B,
+    TOP_M, WIDENED_TOP_M,
 };
 use uor_r4_graph_format::{
     ContractVersion, FormatError, GraphView, ObservedBound, FORMAT_VERSION_MAJOR,
@@ -579,18 +579,43 @@ impl R4Engine {
     /// with legacy TLS1 exact-context evidence stay on the reference
     /// scorer (the deployed step requires residualized RX1 evidence);
     /// that path ignores the width — widening is unavailable there.
-    fn score_sig(
+    /// A supplied sink additionally receives the step's bounded top-K
+    /// candidate list. Selection and status are identical either way;
+    /// on the legacy reference path the list is rebuilt from the
+    /// reference outcome's own candidate vector under the same
+    /// canonical order.
+    fn score_sig_with_candidates(
         &mut self,
         sig: &[u8; SIG_BYTES],
         input_code: Option<&[u8; compiler::STAGES]>,
         top_m: usize,
         recent_tokens: &[u32],
+        candidates: Option<&mut StepCandidates>,
     ) -> ScoredProbe {
         if self.step_supported {
-            let outcome = self
-                .scorer
-                .score_step_coded_with_recent(sig, input_code, top_m, &mut self.step, recent_tokens)
-                .expect("serving: scorer produced no candidates for a validated sig");
+            let outcome = match candidates {
+                Some(list) => self
+                    .scorer
+                    .score_step_candidates_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                        list,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+                None => self
+                    .scorer
+                    .score_step_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+            };
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.status,
@@ -602,6 +627,12 @@ impl R4Engine {
                 .scorer
                 .score_candidates_coded(sig, input_code, recent_tokens)
                 .expect("serving: scorer produced no candidates for a validated sig");
+            if let Some(list) = candidates {
+                list.len = 0;
+                for &(token, score) in &outcome.candidates {
+                    list.push_ranked(token, score);
+                }
+            }
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.witness.status,
@@ -645,8 +676,29 @@ impl R4Engine {
         input_code: Option<&[u8; compiler::STAGES]>,
         recent_tokens: &[u32],
     ) -> PredictDecision {
+        self.predict_signature_status_with_recent_candidates(sig, input_code, recent_tokens, None)
+    }
+
+    /// The same policy path with an optional candidate sink: when the
+    /// decision serves, the sink holds the bounded top-K list of the
+    /// exact probe that served (the widened probe when widening served).
+    /// Policy bookkeeping — counters, widen-once, the novel-seen FIFO —
+    /// is this one implementation either way.
+    fn predict_signature_status_with_recent_candidates(
+        &mut self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> PredictDecision {
         self.counters.predicts += 1;
-        let first = self.score_sig(sig, input_code, TOP_M, recent_tokens);
+        let first = self.score_sig_with_candidates(
+            sig,
+            input_code,
+            TOP_M,
+            recent_tokens,
+            candidates.as_deref_mut(),
+        );
         match self.policy.action(first.status.into()) {
             StatusAction::Serve => {
                 self.counters.serves += 1;
@@ -686,7 +738,13 @@ impl R4Engine {
                     });
                 }
                 self.counters.widen_attempts += 1;
-                let second = self.score_sig(sig, input_code, WIDENED_TOP_M, recent_tokens);
+                let second = self.score_sig_with_candidates(
+                    sig,
+                    input_code,
+                    WIDENED_TOP_M,
+                    recent_tokens,
+                    candidates,
+                );
                 if second.status == ScoreStatus::Novel {
                     self.novel_seen.insert(sig);
                 }
@@ -853,6 +911,145 @@ impl R4Engine {
                     last_status = Some(outcome.status);
                     widened = widened || outcome.widened;
                     *token = next;
+                    if next == 1 || next == 2 {
+                        return Ok(GenerateStatus {
+                            count: generated,
+                            status: last_status,
+                            widened,
+                            abstained: false,
+                        });
+                    }
+                    if window_len < WINDOW {
+                        window[window_len] = next;
+                        window_len += 1;
+                    } else {
+                        window.copy_within(1.., 0);
+                        window[WINDOW - 1] = next;
+                    }
+                }
+                PredictDecision::Abstain(outcome) => {
+                    return Ok(GenerateStatus {
+                        count: generated,
+                        status: Some(outcome.status),
+                        widened: widened || outcome.widened,
+                        abstained: true,
+                    });
+                }
+            }
+        }
+        Ok(GenerateStatus {
+            count: out.len(),
+            status: last_status,
+            widened,
+            abstained: false,
+        })
+    }
+
+    /// The status-aware decision for one token window, additionally
+    /// filling `candidates` with the bounded top-K list of the exact
+    /// probe that decided (the widened probe when widening served).
+    fn predict_decision_candidates(
+        &mut self,
+        window: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Result<PredictDecision, ObservedBound> {
+        self.check_window(window)?;
+        let (sig, code) = self.derive_sig_code(window);
+        Ok(self.predict_signature_status_with_recent_candidates(
+            &sig,
+            Some(&code),
+            window,
+            Some(candidates),
+        ))
+    }
+
+    /// One #762-scheme draw over a served step's ranked candidates:
+    /// order-preserving shift to positive weights, the soft
+    /// ~1000-per-occurrence penalty over tokens already emitted this
+    /// generation with floor 1 (a penalized candidate stays reachable,
+    /// never excluded), and the shared division-free
+    /// [`runtime::SampleRng::draw`]. `served` is returned when the list
+    /// is degenerate so the policy's served selection is never
+    /// overridden by an unweighable list.
+    fn sample_step_candidate(
+        candidates: &StepCandidates,
+        emitted: &[u32],
+        served: u32,
+        rng: &mut runtime::SampleRng,
+    ) -> u32 {
+        let ranked = candidates.ranked();
+        if ranked.is_empty() {
+            return served;
+        }
+        let min_raw = ranked
+            .iter()
+            .map(|&(_, score)| i64::from(score.raw()))
+            .min()
+            .unwrap_or(0);
+        let mut weights = [0u32; uor_r4_graph_certify::STEP_TOP_CANDIDATES];
+        let mut total = 0u32;
+        for (index, &(token, score)) in ranked.iter().enumerate() {
+            let occurrences = emitted.iter().filter(|&&t| t == token).count() as i64;
+            let mut weight = i64::from(score.raw()) - min_raw + 1;
+            weight -= (occurrences << 10) - (occurrences << 4) - (occurrences << 3);
+            weights[index] = weight.clamp(1, i64::from(u32::MAX)) as u32;
+            total = total.saturating_add(weights[index]);
+        }
+        if total == 0 {
+            return served;
+        }
+        let draw = rng.draw(total);
+        let mut accumulated = 0u32;
+        for (index, &(token, _)) in ranked.iter().enumerate() {
+            accumulated = accumulated.saturating_add(weights[index]);
+            if draw < accumulated {
+                return token;
+            }
+        }
+        served
+    }
+
+    /// Seeded weighted sampling over the deployed step scorer's own
+    /// top-K candidates, through the same D4 policy path as
+    /// [`Self::generate_into`] (#655 decode-default decision 2026-08-19;
+    /// #785-C2/#762 scheme parity).
+    ///
+    /// Per step the policy decision — Serve / WidenOnce / Abstain, the
+    /// novel-seen FIFO, every counter — is computed exactly as the
+    /// greedy path computes it; sampling only replaces WHICH served
+    /// candidate is emitted, weighting the serving probe's own candidate
+    /// scores (deployed recent-window repetition penalty included).
+    /// Abstention semantics are identical by construction: a step that
+    /// abstains under greedy abstains here with the same status, and no
+    /// token is guessed. A `(seed tokens, rng seed)` pair is
+    /// reproducible end to end.
+    pub fn generate_sampled_into(
+        &mut self,
+        seed: &[u32],
+        out: &mut [u32],
+        rng: &mut runtime::SampleRng,
+    ) -> Result<GenerateStatus, ObservedBound> {
+        self.check_window(seed)?;
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+
+        let mut candidates = StepCandidates::default();
+        let mut last_status = None;
+        let mut widened = false;
+        for generated in 0..out.len() {
+            match self.predict_decision_candidates(&window[..window_len], &mut candidates)? {
+                PredictDecision::Serve(outcome) => {
+                    last_status = Some(outcome.status);
+                    widened = widened || outcome.widened;
+                    let next = Self::sample_step_candidate(
+                        &candidates,
+                        &out[..generated],
+                        outcome.token,
+                        rng,
+                    );
+                    out[generated] = next;
                     if next == 1 || next == 2 {
                         return Ok(GenerateStatus {
                             count: generated,

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -1891,6 +1891,73 @@ pub struct StepOutcome {
     pub exact_context_source: Option<ExactContextSource>,
 }
 
+/// Capacity of the bounded per-step candidate list
+/// ([`GraphScorer::score_step_candidates_coded_with_recent`]): the same
+/// eight-wide bound the R4G1 packed runtime's candidate surface and the
+/// #785-C2 CLI sampled decode already use.
+pub const STEP_TOP_CANDIDATES: usize = 8;
+
+/// The bounded top-K candidate list of one deployed scoring step,
+/// ordered by the canonical selection rule (score descending, then
+/// token id ascending) so `ranked()[0]` is exactly the step's greedy
+/// selection. Fixed capacity; assembling it performs no allocation.
+/// List assembly is selection bookkeeping outside the op census — the
+/// same convention the reference scorer applies to its ranking sort.
+#[derive(Debug, Clone)]
+pub struct StepCandidates {
+    /// The ranked `(token, score)` entries; only `..len` are valid.
+    pub entries: [(u32, ScoreQ); STEP_TOP_CANDIDATES],
+    /// Number of valid entries.
+    pub len: usize,
+}
+
+impl Default for StepCandidates {
+    fn default() -> Self {
+        Self {
+            entries: [(0, ScoreQ::ZERO); STEP_TOP_CANDIDATES],
+            len: 0,
+        }
+    }
+}
+
+impl StepCandidates {
+    /// The valid ranked entries.
+    pub fn ranked(&self) -> &[(u32, ScoreQ)] {
+        &self.entries[..self.len]
+    }
+
+    /// Bounded rank insertion under the canonical selection rule (score
+    /// descending, then token id ascending); entries past capacity fall
+    /// off the tail. Shift/compare only — no allocation, no division.
+    /// Public so engine-layer assemblers (the legacy reference path)
+    /// can rebuild the same ranked list from reference candidates.
+    pub fn push_ranked(&mut self, token: u32, score: ScoreQ) {
+        let mut pos = self.len;
+        while pos > 0 {
+            let (held_token, held_score) = self.entries[pos - 1];
+            if score.raw() > held_score.raw()
+                || (score.raw() == held_score.raw() && token < held_token)
+            {
+                pos -= 1;
+            } else {
+                break;
+            }
+        }
+        if pos >= STEP_TOP_CANDIDATES {
+            return;
+        }
+        let mut slot = self.len.min(STEP_TOP_CANDIDATES - 1);
+        while slot > pos {
+            self.entries[slot] = self.entries[slot - 1];
+            slot -= 1;
+        }
+        self.entries[pos] = (token, score);
+        if self.len < STEP_TOP_CANDIDATES {
+            self.len += 1;
+        }
+    }
+}
+
 /// Advance the step state's epoch, re-zeroing the stamp buffers on the
 /// (practically unreachable) u64 wrap so a stale stamp can never alias
 /// the fresh epoch.
@@ -2190,6 +2257,45 @@ impl GraphScorer {
         state: &mut StepState,
         recent_tokens: &[u32],
     ) -> Option<StepOutcome> {
+        self.score_step_impl(sig, input_code, top_m, state, recent_tokens, None)
+    }
+
+    /// [`GraphScorer::score_step_coded_with_recent`] that additionally
+    /// assembles the bounded top-K candidate list of the same step.
+    /// Selection, status, census, and candidate count are byte-identical
+    /// to the plain step — `candidates.ranked()[0]` IS the selection —
+    /// so a caller sampling among candidates (the #655 sampled decode)
+    /// shares the exact deployed scoring path the greedy step serves
+    /// from, including the bounded recent-window repetition penalty.
+    pub fn score_step_candidates_coded_with_recent(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Option<StepOutcome> {
+        candidates.len = 0;
+        self.score_step_impl(
+            sig,
+            input_code,
+            top_m,
+            state,
+            recent_tokens,
+            Some(candidates),
+        )
+    }
+
+    fn score_step_impl(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> Option<StepOutcome> {
         if top_m == 0 || top_m > state.max_top_m {
             return None;
         }
@@ -2209,6 +2315,12 @@ impl GraphScorer {
         }
         if let Some(entries) = self.context_row(recent_tokens) {
             let (selected, selected_score) = Self::context_row_argmax(entries);
+            if let Some(list) = candidates.as_deref_mut() {
+                list.len = 0;
+                for &(token, score) in entries {
+                    list.push_ranked(token, score);
+                }
+            }
             let census = OpKernel {
                 table_reads: 1,
                 ..Default::default()
@@ -2379,6 +2491,10 @@ impl GraphScorer {
             best_score = best_score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
             k.adds += 1;
         }
+        if let Some(list) = candidates.as_deref_mut() {
+            list.len = 0;
+            list.push_ranked(best, best_score);
+        }
         for &token in state.touched.iter().skip(1) {
             k.candidate_scans += 1;
             k.compares += 1;
@@ -2389,6 +2505,9 @@ impl GraphScorer {
             if recent_tokens.contains(&token) {
                 score = score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
                 k.adds += 1;
+            }
+            if let Some(list) = candidates.as_deref_mut() {
+                list.push_ranked(token, score);
             }
             if score > best_score || (score == best_score && token < best) {
                 best = token;

--- a/tests/status_policy.rs
+++ b/tests/status_policy.rs
@@ -22,11 +22,14 @@ mod status_policy_common;
 
 use status_policy_common as fixture;
 
-use uor_r4_api::engine::WitnessVerificationError;
-use uor_r4_graph_certify::{ScoreStatus, TOP_M, WIDENED_TOP_M};
+use uor_r4_api::engine::{EngineParts, R4Engine, WitnessVerificationError};
+use uor_r4_graph_certify::{
+    ScoreStatus, StepCandidates, STEP_TOP_CANDIDATES, TOP_M, WIDENED_TOP_M,
+};
 use uor_r4_wasm_router::r4g1::{
     AbstainOutcome, PolicyStatus, PredictDecision, PredictOutcome, StatusAction, StatusPolicy,
 };
+use uor_r4_wasm_router::transformerless::runtime::SampleRng;
 
 // ------------------------------------------------------- (a) OOD probe --
 
@@ -309,6 +312,135 @@ fn generation_stops_at_the_first_abstain() {
         .expect("legacy generate");
     assert_eq!(legacy_count, outcome.count);
     assert_eq!(legacy_out[..legacy_count], out[..outcome.count]);
+}
+
+// ---------------------------------------------- sampled decode (#655) --
+
+/// The candidates-reporting step is the plain deployed step: selection,
+/// score, status, and candidate count are identical on every probe
+/// signature at both membership widths, with and without the deployed
+/// recent-window penalty; the ranked list leads with the selection,
+/// is strictly ordered under the canonical rule (score descending,
+/// token ascending), and is bounded by the candidate count.
+#[test]
+fn step_candidates_match_the_plain_step_and_rank_the_selection_first() {
+    let fixture = fixture::signature_fixture(None);
+    let scorer = fixture.reference_scorer();
+    let mut step_state = scorer.step_state(WIDENED_TOP_M).expect("step state");
+    let mut candidates = StepCandidates::default();
+    for sig in [fixture.covered_sig, fixture.graph_sig, fixture.ood_sig] {
+        for top_m in [TOP_M, WIDENED_TOP_M] {
+            for recent in [&[][..], &[10u32][..]] {
+                let plain = scorer
+                    .score_step_with_recent(&sig, top_m, &mut step_state, recent)
+                    .expect("plain step");
+                let listed = scorer
+                    .score_step_candidates_coded_with_recent(
+                        &sig,
+                        None,
+                        top_m,
+                        &mut step_state,
+                        recent,
+                        &mut candidates,
+                    )
+                    .expect("candidates step");
+                assert_eq!(listed.selected, plain.selected);
+                assert_eq!(listed.selected_score, plain.selected_score);
+                assert_eq!(listed.status, plain.status);
+                assert_eq!(listed.candidate_count, plain.candidate_count);
+                let ranked = candidates.ranked();
+                assert_eq!(
+                    ranked.len(),
+                    (plain.candidate_count as usize).min(STEP_TOP_CANDIDATES)
+                );
+                assert_eq!(ranked[0], (plain.selected, plain.selected_score));
+                for pair in ranked.windows(2) {
+                    let (prev_token, prev_score) = pair[0];
+                    let (next_token, next_score) = pair[1];
+                    assert!(
+                        prev_score.raw() > next_score.raw()
+                            || (prev_score.raw() == next_score.raw() && prev_token < next_token),
+                        "ranked list must be strictly ordered under the canonical rule"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The #655 sampled decode (`R4Engine::generate_sampled_into`) shares
+/// the greedy path's D4 policy decisions by construction: an OOD seed
+/// abstains with the same typed outcome (no token guessed under
+/// sampling either), a served run is byte-reproducible from its rng
+/// seed, every emitted token stays inside the fixture's declared
+/// emission universe, and the policy counters show each emitted token
+/// paid one served policy decision.
+#[test]
+fn sampled_decode_is_seeded_and_abstains_exactly_like_greedy() {
+    let fixture = fixture::window_fixture();
+    let load_engine = || {
+        R4Engine::load(EngineParts {
+            graph: &fixture.bytes,
+            signature_artifact: &fixture.teacher,
+            tokenizer: None,
+            score_report: None,
+        })
+        .expect("fixture engine loads")
+    };
+    let ood_window = fixture::find_window_by_status(&fixture, ScoreStatus::Novel);
+
+    // OOD seed: identical abstention under greedy and sampled decode.
+    let mut greedy_engine = load_engine();
+    let greedy = greedy_engine
+        .generate_into(&ood_window, &mut [0u32; 8])
+        .expect("greedy generate");
+    let mut sampled_engine = load_engine();
+    let mut rng = SampleRng::new(42);
+    let mut sampled_out = [0u32; 8];
+    let sampled = sampled_engine
+        .generate_sampled_into(&ood_window, &mut sampled_out, &mut rng)
+        .expect("sampled generate");
+    assert!(greedy.abstained, "fixture OOD seed abstains under greedy");
+    assert!(sampled.abstained, "the sampled path preserves abstention");
+    assert_eq!(sampled.count, 0, "no token guessed under sampling");
+    assert_eq!(sampled.status, greedy.status);
+
+    // Served seed: same rng seed → identical run, end to end.
+    let run = |seed: u32| {
+        let mut engine = load_engine();
+        let mut rng = SampleRng::new(seed);
+        let mut out = [0u32; 8];
+        let outcome = engine
+            .generate_sampled_into(&fixture.covered_window, &mut out, &mut rng)
+            .expect("sampled generate");
+        let counters = engine.policy_counters();
+        (
+            outcome.count,
+            outcome.status,
+            outcome.abstained,
+            out,
+            counters.serves,
+        )
+    };
+    let (count, status, abstained, tokens, serves) = run(41);
+    assert_eq!(
+        (count, status, abstained, tokens, serves),
+        run(41),
+        "same seed reproduces the run end to end"
+    );
+    assert!(count >= 1, "the covered seed serves at least one token");
+    // Every emitted token draws from a serving probe's own candidate
+    // list; the fixture's whole emission universe (root prior + region
+    // lists) is {10, 20, 30, 40}.
+    for &token in &tokens[..count] {
+        assert!(
+            matches!(token, 10 | 20 | 30 | 40),
+            "sampled token {token} escaped the fixture's emission universe"
+        );
+    }
+    // No EOS ids exist in that universe, so every emitted token paid
+    // exactly one served policy decision.
+    assert_eq!(serves as usize, count, "one serve per emitted token");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Slice 1 of the maintainer decision on #655 (2026-08-19): **sampled decode becomes the default everywhere, pinned seed, greedy opt-in**. This slice is purely additive machinery — no serving surface calls it yet; slice 2 wires the CLI + server defaults and docs.

- **`StepCandidates`** (certify): the bounded top-8 `(token, score)` list of one deployed scoring step, ranked under the canonical selection rule (score desc, token asc) so `ranked()[0]` **is** the greedy selection. `score_step_candidates_coded_with_recent` assembles it alongside the byte-identical plain step — one shared `score_step_impl`, list assembly outside the op census (the reference scorer's own sort convention).
- **`R4Engine::generate_sampled_into`** (api): seeded weighted sampling over the serving probe's own candidate list, through the **same D4 policy path** as `generate_into` — one shared policy implementation (counters, widen-once, novel-seen FIFO). Abstention is identical by construction: sampling only replaces *which served candidate* is emitted. Weights are the #762/#785-C2 scheme (order-preserving positive shift, soft ~1000-per-occurrence emitted-token penalty with floor 1, shared division-free `SampleRng::draw`).
- All new engine code sits inside the delimited integer-only status-policy block and passes its source scan (no float, no `*`/`/`/`%` value arithmetic, no `unsafe`).

## Tests

- `step_candidates_match_the_plain_step_and_rank_the_selection_first` — parity vs the plain step on every probe signature × both membership widths × penalty on/off; selection-first, strict canonical order, count bound.
- `sampled_decode_is_seeded_and_abstains_exactly_like_greedy` — OOD probe abstains with the same typed outcome (no guessed token under sampling); served run byte-reproducible from its rng seed; every emitted token stays in the fixture's emission universe; policy counters show one serve per emitted token.
- Full gates: workspace clippy `-D warnings` clean, fmt clean, status_policy 14 passed (incl. the integer-only source scan), census suite pass, api 27+19, certify 41.

## Refs

#655 (decode-default decision, 2026-08-19) · #762 / #785-C2 (sampling scheme provenance) · #784 (the attractor-basin substrate issue this mitigates at serving time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
