### PR TITLE
Decode-default flip: sampled decode default on CLI + all serving surfaces (#655)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -112,8 +112,8 @@ pub struct InferenceResponse {
 }
 use uor_r4_core::transformerless::scenarios::{RuntimeTokenizerIdentity, Tokenizer};
 use uor_r4_graph_certify::{
-    GraphScorer, ScoreStatus, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B, TOP_M,
-    WIDENED_TOP_M,
+    GraphScorer, ScoreStatus, StepCandidates, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B,
+    TOP_M, WIDENED_TOP_M,
 };
 use uor_r4_graph_format::{
     ContractVersion, FormatError, GraphView, ObservedBound, FORMAT_VERSION_MAJOR,
@@ -579,18 +579,43 @@ impl R4Engine {
     /// with legacy TLS1 exact-context evidence stay on the reference
     /// scorer (the deployed step requires residualized RX1 evidence);
     /// that path ignores the width — widening is unavailable there.
-    fn score_sig(
+    /// A supplied sink additionally receives the step's bounded top-K
+    /// candidate list. Selection and status are identical either way;
+    /// on the legacy reference path the list is rebuilt from the
+    /// reference outcome's own candidate vector under the same
+    /// canonical order.
+    fn score_sig_with_candidates(
         &mut self,
         sig: &[u8; SIG_BYTES],
         input_code: Option<&[u8; compiler::STAGES]>,
         top_m: usize,
         recent_tokens: &[u32],
+        candidates: Option<&mut StepCandidates>,
     ) -> ScoredProbe {
         if self.step_supported {
-            let outcome = self
-                .scorer
-                .score_step_coded_with_recent(sig, input_code, top_m, &mut self.step, recent_tokens)
-                .expect("serving: scorer produced no candidates for a validated sig");
+            let outcome = match candidates {
+                Some(list) => self
+                    .scorer
+                    .score_step_candidates_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                        list,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+                None => self
+                    .scorer
+                    .score_step_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+            };
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.status,
@@ -602,6 +627,12 @@ impl R4Engine {
                 .scorer
                 .score_candidates_coded(sig, input_code, recent_tokens)
                 .expect("serving: scorer produced no candidates for a validated sig");
+            if let Some(list) = candidates {
+                list.len = 0;
+                for &(token, score) in &outcome.candidates {
+                    list.push_ranked(token, score);
+                }
+            }
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.witness.status,
@@ -645,8 +676,29 @@ impl R4Engine {
         input_code: Option<&[u8; compiler::STAGES]>,
         recent_tokens: &[u32],
     ) -> PredictDecision {
+        self.predict_signature_status_with_recent_candidates(sig, input_code, recent_tokens, None)
+    }
+
+    /// The same policy path with an optional candidate sink: when the
+    /// decision serves, the sink holds the bounded top-K list of the
+    /// exact probe that served (the widened probe when widening served).
+    /// Policy bookkeeping — counters, widen-once, the novel-seen FIFO —
+    /// is this one implementation either way.
+    fn predict_signature_status_with_recent_candidates(
+        &mut self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> PredictDecision {
         self.counters.predicts += 1;
-        let first = self.score_sig(sig, input_code, TOP_M, recent_tokens);
+        let first = self.score_sig_with_candidates(
+            sig,
+            input_code,
+            TOP_M,
+            recent_tokens,
+            candidates.as_deref_mut(),
+        );
         match self.policy.action(first.status.into()) {
             StatusAction::Serve => {
                 self.counters.serves += 1;
@@ -686,7 +738,13 @@ impl R4Engine {
                     });
                 }
                 self.counters.widen_attempts += 1;
-                let second = self.score_sig(sig, input_code, WIDENED_TOP_M, recent_tokens);
+                let second = self.score_sig_with_candidates(
+                    sig,
+                    input_code,
+                    WIDENED_TOP_M,
+                    recent_tokens,
+                    candidates,
+                );
                 if second.status == ScoreStatus::Novel {
                     self.novel_seen.insert(sig);
                 }
@@ -853,6 +911,145 @@ impl R4Engine {
                     last_status = Some(outcome.status);
                     widened = widened || outcome.widened;
                     *token = next;
+                    if next == 1 || next == 2 {
+                        return Ok(GenerateStatus {
+                            count: generated,
+                            status: last_status,
+                            widened,
+                            abstained: false,
+                        });
+                    }
+                    if window_len < WINDOW {
+                        window[window_len] = next;
+                        window_len += 1;
+                    } else {
+                        window.copy_within(1.., 0);
+                        window[WINDOW - 1] = next;
+                    }
+                }
+                PredictDecision::Abstain(outcome) => {
+                    return Ok(GenerateStatus {
+                        count: generated,
+                        status: Some(outcome.status),
+                        widened: widened || outcome.widened,
+                        abstained: true,
+                    });
+                }
+            }
+        }
+        Ok(GenerateStatus {
+            count: out.len(),
+            status: last_status,
+            widened,
+            abstained: false,
+        })
+    }
+
+    /// The status-aware decision for one token window, additionally
+    /// filling `candidates` with the bounded top-K list of the exact
+    /// probe that decided (the widened probe when widening served).
+    fn predict_decision_candidates(
+        &mut self,
+        window: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Result<PredictDecision, ObservedBound> {
+        self.check_window(window)?;
+        let (sig, code) = self.derive_sig_code(window);
+        Ok(self.predict_signature_status_with_recent_candidates(
+            &sig,
+            Some(&code),
+            window,
+            Some(candidates),
+        ))
+    }
+
+    /// One #762-scheme draw over a served step's ranked candidates:
+    /// order-preserving shift to positive weights, the soft
+    /// ~1000-per-occurrence penalty over tokens already emitted this
+    /// generation with floor 1 (a penalized candidate stays reachable,
+    /// never excluded), and the shared division-free
+    /// [`runtime::SampleRng::draw`]. `served` is returned when the list
+    /// is degenerate so the policy's served selection is never
+    /// overridden by an unweighable list.
+    fn sample_step_candidate(
+        candidates: &StepCandidates,
+        emitted: &[u32],
+        served: u32,
+        rng: &mut runtime::SampleRng,
+    ) -> u32 {
+        let ranked = candidates.ranked();
+        if ranked.is_empty() {
+            return served;
+        }
+        let min_raw = ranked
+            .iter()
+            .map(|&(_, score)| i64::from(score.raw()))
+            .min()
+            .unwrap_or(0);
+        let mut weights = [0u32; uor_r4_graph_certify::STEP_TOP_CANDIDATES];
+        let mut total = 0u32;
+        for (index, &(token, score)) in ranked.iter().enumerate() {
+            let occurrences = emitted.iter().filter(|&&t| t == token).count() as i64;
+            let mut weight = i64::from(score.raw()) - min_raw + 1;
+            weight -= (occurrences << 10) - (occurrences << 4) - (occurrences << 3);
+            weights[index] = weight.clamp(1, i64::from(u32::MAX)) as u32;
+            total = total.saturating_add(weights[index]);
+        }
+        if total == 0 {
+            return served;
+        }
+        let draw = rng.draw(total);
+        let mut accumulated = 0u32;
+        for (index, &(token, _)) in ranked.iter().enumerate() {
+            accumulated = accumulated.saturating_add(weights[index]);
+            if draw < accumulated {
+                return token;
+            }
+        }
+        served
+    }
+
+    /// Seeded weighted sampling over the deployed step scorer's own
+    /// top-K candidates, through the same D4 policy path as
+    /// [`Self::generate_into`] (#655 decode-default decision 2026-08-19;
+    /// #785-C2/#762 scheme parity).
+    ///
+    /// Per step the policy decision — Serve / WidenOnce / Abstain, the
+    /// novel-seen FIFO, every counter — is computed exactly as the
+    /// greedy path computes it; sampling only replaces WHICH served
+    /// candidate is emitted, weighting the serving probe's own candidate
+    /// scores (deployed recent-window repetition penalty included).
+    /// Abstention semantics are identical by construction: a step that
+    /// abstains under greedy abstains here with the same status, and no
+    /// token is guessed. A `(seed tokens, rng seed)` pair is
+    /// reproducible end to end.
+    pub fn generate_sampled_into(
+        &mut self,
+        seed: &[u32],
+        out: &mut [u32],
+        rng: &mut runtime::SampleRng,
+    ) -> Result<GenerateStatus, ObservedBound> {
+        self.check_window(seed)?;
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+
+        let mut candidates = StepCandidates::default();
+        let mut last_status = None;
+        let mut widened = false;
+        for generated in 0..out.len() {
+            match self.predict_decision_candidates(&window[..window_len], &mut candidates)? {
+                PredictDecision::Serve(outcome) => {
+                    last_status = Some(outcome.status);
+                    widened = widened || outcome.widened;
+                    let next = Self::sample_step_candidate(
+                        &candidates,
+                        &out[..generated],
+                        outcome.token,
+                        rng,
+                    );
+                    out[generated] = next;
                     if next == 1 || next == 2 {
                         return Ok(GenerateStatus {
                             count: generated,

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -51,8 +51,15 @@ pub struct InferenceRequest {
     pub engine: Option<String>,
     /// Maximum continuation tokens to generate.
     pub max_tokens: Option<usize>,
-    /// Temperature for geometric sampling.
+    /// Temperature for geometric sampling; `0` additionally opts the
+    /// R4G1 tier into deterministic greedy decode (#655 decode-default
+    /// decision, 2026-08-19 — sampled decode is otherwise the default).
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode; absent requests use the pinned default seed so default
+    /// serving stays reproducible. Ignored under `temperature: 0`.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// Ask a serving endpoint to include a replayable proof summary.
     /// Witness assembly is opt-in and remains outside the default hot path.
     #[serde(default)]
@@ -1484,6 +1491,7 @@ mod tests {
             engine: Some("r4g1".to_string()),
             max_tokens: Some(32),
             temperature: Some(0.7),
+            seed: None,
             include_witness: false,
         };
         let json = serde_json::to_string(&req).expect("serialize InferenceRequest");

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -1891,6 +1891,73 @@ pub struct StepOutcome {
     pub exact_context_source: Option<ExactContextSource>,
 }
 
+/// Capacity of the bounded per-step candidate list
+/// ([`GraphScorer::score_step_candidates_coded_with_recent`]): the same
+/// eight-wide bound the R4G1 packed runtime's candidate surface and the
+/// #785-C2 CLI sampled decode already use.
+pub const STEP_TOP_CANDIDATES: usize = 8;
+
+/// The bounded top-K candidate list of one deployed scoring step,
+/// ordered by the canonical selection rule (score descending, then
+/// token id ascending) so `ranked()[0]` is exactly the step's greedy
+/// selection. Fixed capacity; assembling it performs no allocation.
+/// List assembly is selection bookkeeping outside the op census — the
+/// same convention the reference scorer applies to its ranking sort.
+#[derive(Debug, Clone)]
+pub struct StepCandidates {
+    /// The ranked `(token, score)` entries; only `..len` are valid.
+    pub entries: [(u32, ScoreQ); STEP_TOP_CANDIDATES],
+    /// Number of valid entries.
+    pub len: usize,
+}
+
+impl Default for StepCandidates {
+    fn default() -> Self {
+        Self {
+            entries: [(0, ScoreQ::ZERO); STEP_TOP_CANDIDATES],
+            len: 0,
+        }
+    }
+}
+
+impl StepCandidates {
+    /// The valid ranked entries.
+    pub fn ranked(&self) -> &[(u32, ScoreQ)] {
+        &self.entries[..self.len]
+    }
+
+    /// Bounded rank insertion under the canonical selection rule (score
+    /// descending, then token id ascending); entries past capacity fall
+    /// off the tail. Shift/compare only — no allocation, no division.
+    /// Public so engine-layer assemblers (the legacy reference path)
+    /// can rebuild the same ranked list from reference candidates.
+    pub fn push_ranked(&mut self, token: u32, score: ScoreQ) {
+        let mut pos = self.len;
+        while pos > 0 {
+            let (held_token, held_score) = self.entries[pos - 1];
+            if score.raw() > held_score.raw()
+                || (score.raw() == held_score.raw() && token < held_token)
+            {
+                pos -= 1;
+            } else {
+                break;
+            }
+        }
+        if pos >= STEP_TOP_CANDIDATES {
+            return;
+        }
+        let mut slot = self.len.min(STEP_TOP_CANDIDATES - 1);
+        while slot > pos {
+            self.entries[slot] = self.entries[slot - 1];
+            slot -= 1;
+        }
+        self.entries[pos] = (token, score);
+        if self.len < STEP_TOP_CANDIDATES {
+            self.len += 1;
+        }
+    }
+}
+
 /// Advance the step state's epoch, re-zeroing the stamp buffers on the
 /// (practically unreachable) u64 wrap so a stale stamp can never alias
 /// the fresh epoch.
@@ -2190,6 +2257,45 @@ impl GraphScorer {
         state: &mut StepState,
         recent_tokens: &[u32],
     ) -> Option<StepOutcome> {
+        self.score_step_impl(sig, input_code, top_m, state, recent_tokens, None)
+    }
+
+    /// [`GraphScorer::score_step_coded_with_recent`] that additionally
+    /// assembles the bounded top-K candidate list of the same step.
+    /// Selection, status, census, and candidate count are byte-identical
+    /// to the plain step — `candidates.ranked()[0]` IS the selection —
+    /// so a caller sampling among candidates (the #655 sampled decode)
+    /// shares the exact deployed scoring path the greedy step serves
+    /// from, including the bounded recent-window repetition penalty.
+    pub fn score_step_candidates_coded_with_recent(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Option<StepOutcome> {
+        candidates.len = 0;
+        self.score_step_impl(
+            sig,
+            input_code,
+            top_m,
+            state,
+            recent_tokens,
+            Some(candidates),
+        )
+    }
+
+    fn score_step_impl(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> Option<StepOutcome> {
         if top_m == 0 || top_m > state.max_top_m {
             return None;
         }
@@ -2209,6 +2315,12 @@ impl GraphScorer {
         }
         if let Some(entries) = self.context_row(recent_tokens) {
             let (selected, selected_score) = Self::context_row_argmax(entries);
+            if let Some(list) = candidates.as_deref_mut() {
+                list.len = 0;
+                for &(token, score) in entries {
+                    list.push_ranked(token, score);
+                }
+            }
             let census = OpKernel {
                 table_reads: 1,
                 ..Default::default()
@@ -2379,6 +2491,10 @@ impl GraphScorer {
             best_score = best_score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
             k.adds += 1;
         }
+        if let Some(list) = candidates.as_deref_mut() {
+            list.len = 0;
+            list.push_ranked(best, best_score);
+        }
         for &token in state.touched.iter().skip(1) {
             k.candidate_scans += 1;
             k.compares += 1;
@@ -2389,6 +2505,9 @@ impl GraphScorer {
             if recent_tokens.contains(&token) {
                 score = score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
                 k.adds += 1;
+            }
+            if let Some(list) = candidates.as_deref_mut() {
+                list.push_ranked(token, score);
             }
             if score > best_score || (score == best_score && token < best) {
                 best = token;

--- a/docs/SERVING_MODEL_DISCOVERY.md
+++ b/docs/SERVING_MODEL_DISCOVERY.md
@@ -54,6 +54,19 @@ functionally the cascade's terminal "always something" tier).
   present or the whole bundle is refused (`2200-2213`).
 - State type: `r4g1::R4g1State`, held in `ServingModelState.r4g1`.
 - Availability: `installed.r4g1.is_some()` after startup load succeeds.
+- Decode (#655 decode-default decision, 2026-08-19): **seeded weighted
+  sampling is the default** on every serving surface (native `/api/chat`,
+  OpenAI chat-completions and responses, and the CLI `ask`/`chat`),
+  weighting the deployed step scorer's own top-K candidates through the
+  identical D4 policy path — abstention behavior is decode-mode
+  independent by construction, and the seed is pinned
+  (`chat::DEFAULT_SAMPLE_SEED`) so identical requests reproduce
+  identical completions. `temperature: 0` on the wire (or `--greedy` on
+  the CLI) is the deterministic opt-out; a request `seed` field
+  overrides the pinned seed; the opt-in witness envelope decodes greedy
+  (witness claims bind the greedy selection). See
+  `r4g1_decode_from_request` (`src/server.rs`) and
+  `R4Engine::generate_sampled_into` (`crates/uor-r4-api/src/engine.rs`).
 
 ### Tier 2 — `transformerless`
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -14,6 +14,15 @@ const MAX_CHAT_TOKENS: usize = 256;
 const MAX_CHAT_HISTORY: usize = 4096;
 const MAX_ANSWER_BYTES: usize = 16 * 1024;
 
+/// The pinned default sampling seed (#655 decode-default decision,
+/// 2026-08-19): sampled decode is the CLI/serving default everywhere,
+/// seeded with this constant so default behavior stays reproducible run
+/// to run; greedy decode is the explicit opt-in (`--greedy` on the CLI,
+/// `temperature: 0` on the wire). 42 is the seed the #655 F-p2 canary
+/// measured 15/15 valid completions with (vs 0/15 greedy,
+/// issuecomment-5335796517).
+pub const DEFAULT_SAMPLE_SEED: u32 = 42;
+
 /// A completed local chat turn.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChatAnswer {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use uor_r4_api::{BundleCapability, TokenizerAdapter, UorMatmulProvenance};
 use uor_r4_core::transformerless::hf_bpe::{resolve_source_tokenizer, TokenizerAdapterKey};
 use uor_r4_graph_cli as transformerless_command;
-use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError};
+use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError, DEFAULT_SAMPLE_SEED};
 use uor_r4_wasm_router::model::{
     default_model_reference, download_source, evaluate_live_quality, ModelCapability, ModelError,
     ModelManifest, ModelStore, QualityAttestation, SourceDownload,
@@ -164,13 +164,19 @@ struct AskArgs {
     /// CID manifest name/CID, or a locally compiled bundle name.
     #[arg(long, env = "TLESS_MODEL")]
     model: Option<String>,
-    /// Opt into seeded weighted sampling instead of the default
-    /// deterministic decode, on both generation paths: issue #762 lever 2
-    /// on the plain path, and the same weighting over the R4G1 candidate
-    /// walk (#785-C2 parity). Reproducible from the seed (see
-    /// `chat::ChatEngineBuilder::sample_seed`).
-    #[arg(long, value_name = "SEED")]
+    /// Override the pinned default sampling seed (#655 decode-default
+    /// decision, 2026-08-19: seeded weighted sampling IS the default on
+    /// both generation paths — issue #762 lever 2 on the plain path, the
+    /// same weighting over the R4G1 candidate walk per #785-C2). Absent,
+    /// the pinned `chat::DEFAULT_SAMPLE_SEED` keeps default runs
+    /// reproducible. Reproducible from the seed either way.
+    #[arg(long, value_name = "SEED", conflicts_with = "greedy")]
     sample: Option<u32>,
+    /// Opt into the deterministic decode (greedy beam on the R4G1 path,
+    /// greedy argmax on the plain path) instead of the default seeded
+    /// sampling.
+    #[arg(long, conflicts_with = "sample")]
+    greedy: bool,
     /// Question to ask. Multiple unquoted words are accepted.
     #[arg(required = true, num_args = 1..)]
     question: Vec<String>,
@@ -184,13 +190,17 @@ struct ChatArgs {
     /// Remote HTTP server URL (e.g. http://127.0.0.1:8000/v1) for client mode.
     #[arg(long)]
     remote: Option<String>,
-    /// Opt into seeded weighted sampling instead of the default
-    /// deterministic decode, on both generation paths (#762 lever 2 on
-    /// the plain path, #785-C2 parity on the R4G1 candidate walk); the
-    /// seed advances turn to turn so the whole session is reproducible
-    /// from it. Has no effect in `--remote` client mode.
-    #[arg(long, value_name = "SEED")]
+    /// Override the pinned default sampling seed (#655: seeded weighted
+    /// sampling IS the default on both generation paths — #762 lever 2
+    /// plain, #785-C2 R4G1); the seed advances turn to turn so the whole
+    /// session is reproducible from it. Has no effect in `--remote`
+    /// client mode.
+    #[arg(long, value_name = "SEED", conflicts_with = "greedy")]
     sample: Option<u32>,
+    /// Opt into the deterministic decode instead of the default seeded
+    /// sampling. Has no effect in `--remote` client mode.
+    #[arg(long, conflicts_with = "sample")]
+    greedy: bool,
 }
 
 #[derive(Args, Debug)]
@@ -523,11 +533,21 @@ fn interactive_chat(
     Ok(())
 }
 
-fn build_chat_engine(model: Option<&str>, sample: Option<u32>) -> Result<ChatEngine, ChatError> {
+/// Build the local chat engine under the #655 decode default
+/// (2026-08-19): seeded weighted sampling unless `--greedy` opts out,
+/// with `--sample <SEED>` overriding the pinned default seed. The
+/// library builder itself stays explicit (`sample_seed` opt-in); the
+/// default is applied here, at the product surface, exactly like the
+/// server's request mapping.
+fn build_chat_engine(
+    model: Option<&str>,
+    sample: Option<u32>,
+    greedy: bool,
+) -> Result<ChatEngine, ChatError> {
     let mut builder =
         ChatEngine::builder().model(model.map_or_else(default_model_reference, ToOwned::to_owned));
-    if let Some(seed) = sample {
-        builder = builder.sample_seed(seed);
+    if !greedy {
+        builder = builder.sample_seed(sample.unwrap_or(DEFAULT_SAMPLE_SEED));
     }
     builder.build()
 }
@@ -838,7 +858,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
     cli.configure_tless();
     match cli.command.as_ref() {
         Some(Command::Ask(args)) => {
-            let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
+            let mut chat = build_chat_engine(args.model.as_deref(), args.sample, args.greedy)?;
             answer_once(
                 &mut chat,
                 &args.question.join(" "),
@@ -855,7 +875,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
                 )?;
                 Ok(())
             } else {
-                let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
+                let mut chat = build_chat_engine(args.model.as_deref(), args.sample, args.greedy)?;
                 interactive_chat(&mut chat, &mut io::stdin().lock(), &mut io::stdout().lock())?;
                 Ok(())
             }

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -169,6 +169,26 @@ impl R4g1State {
             .map_err(|error| error.to_string())
     }
 
+    /// #655 decode-default decision (2026-08-19): seeded weighted
+    /// sampling over the deployed step scorer's own candidates, through
+    /// the same D4 policy path as [`Self::generate_into_status`] —
+    /// abstention semantics identical by construction (see
+    /// `R4Engine::generate_sampled_into`). This is the server tier's
+    /// default decode; greedy remains the `temperature: 0` opt-in and
+    /// the witness path's decode (witness claims bind the greedy
+    /// selection).
+    pub fn generate_sampled_into_status(
+        &self,
+        seed: &[u32],
+        out: &mut [u32],
+        rng: &mut uor_r4_core::transformerless::runtime::SampleRng,
+    ) -> Result<GenerateStatus, String> {
+        self.engine
+            .borrow_mut()
+            .generate_sampled_into(seed, out, rng)
+            .map_err(|error| error.to_string())
+    }
+
     /// Witness-enabled generation for the opt-in proof-carrying response
     /// envelope. The ordinary generation method remains allocation-free.
     pub fn generate_into_status_with_witness(

--- a/src/server.rs
+++ b/src/server.rs
@@ -150,8 +150,16 @@ pub struct VendorChatCompletionsRequest {
     pub messages: Vec<ChatMessage>,
     #[serde(default)]
     pub max_tokens: Option<usize>,
+    /// `temperature: 0` opts the R4G1 tier into deterministic greedy
+    /// decode (#655 decode-default decision, 2026-08-19); any other
+    /// value (or absence) keeps the default seeded sampled decode.
     #[serde(default)]
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode (OpenAI `seed` compatibility); absent requests use the
+    /// pinned default seed, so identical requests stay reproducible.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// Optional engine pin ("r4g1", "transformerless", "attention",
     /// "r4-attention", "geometric"); absent/"auto" runs the full cascade,
     /// falling back to the persisted `/engine` selection (issue #248).
@@ -192,8 +200,15 @@ pub struct VendorResponsesRequest {
     pub instructions: Option<String>,
     #[serde(default)]
     pub max_output_tokens: Option<usize>,
+    /// `temperature: 0` opts the R4G1 tier into deterministic greedy
+    /// decode (#655); any other value or absence keeps the default
+    /// seeded sampled decode.
     #[serde(default)]
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode; absent requests use the pinned default seed.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// When `true`, the completion is delivered as the Responses
     /// `text/event-stream` event sequence terminating on `response.completed`.
     #[serde(default)]
@@ -3116,11 +3131,14 @@ struct R4g1Text {
 
 /// Generate directly from the validated R4G1 graph runtime. Tokenization and
 /// decoding intentionally use the same tokenizer as the compiled teacher
-/// artifact; R4G1 stores token ids, not user-facing text.
+/// artifact; R4G1 stores token ids, not user-facing text. `decode` selects
+/// the #655 decode mode: sampled (the default, pinned seed) or the
+/// `temperature: 0` greedy opt-in — the D4 policy path is identical.
 fn generate_r4g1_text(
     state: Option<&R4g1State>,
     prompt: &str,
     max_tokens: usize,
+    decode: R4g1Decode,
 ) -> Result<Option<R4g1Text>, String> {
     const MAX_SERVER_TOKENS: usize = 256;
     const MAX_SERVER_TEXT_BYTES: usize = 16 * 1024;
@@ -3148,12 +3166,24 @@ fn generate_r4g1_text(
         if seed_len == 0 {
             return Err("R4G1 tokenizer produced an empty prompt".to_owned());
         }
-        let outcome = state
-            .generate_into_status(
-                &seed[..seed_len],
-                &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
-            )
-            .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?;
+        let outcome = match decode {
+            R4g1Decode::Greedy => state
+                .generate_into_status(
+                    &seed[..seed_len],
+                    &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
+                )
+                .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?,
+            R4g1Decode::Sampled { seed: rng_seed } => {
+                let mut rng = uor_r4_core::transformerless::runtime::SampleRng::new(rng_seed);
+                state
+                    .generate_sampled_into_status(
+                        &seed[..seed_len],
+                        &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
+                        &mut rng,
+                    )
+                    .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?
+            }
+        };
         // On an abstention no text is produced: the tokens generated before
         // the abstaining step are dropped rather than served, so an
         // out-of-distribution prompt never surfaces partial output.
@@ -3768,6 +3798,39 @@ const TIER_R4_ATTENTION: &str = "r4-attention";
 /// abstention (issue #248) — never served as if it were generated prose.
 const SPARSE_RESONANCE_MESSAGE: &str = "Manifold resonance too sparse for synthesis.";
 
+/// #655 decode-default decision (2026-08-19): how the R4G1 tier decodes
+/// one request. `Sampled` with the pinned default seed is the default on
+/// every serving surface; `Greedy` is the explicit `temperature: 0`
+/// opt-in. Both run the identical D4 policy path — sampling only
+/// replaces which served candidate is emitted (never whether a step
+/// serves or abstains), so Novel/OOD abstention behavior is decode-mode
+/// independent by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum R4g1Decode {
+    /// Deterministic beam/argmax walk (opt-in via `temperature: 0`;
+    /// also what the opt-in witness envelope decodes with, since
+    /// witness claims bind the greedy selection).
+    Greedy,
+    /// Seeded weighted sampling over the serving probe's own candidate
+    /// list — the default. The seed is pinned per request so default
+    /// serving stays reproducible: identical requests produce identical
+    /// completions.
+    Sampled { seed: u32 },
+}
+
+/// Map one request's raw decode-relevant fields to the tier decode mode:
+/// an explicit `temperature` of zero (or below) opts into greedy; every
+/// other request samples, seeded by the request's `seed` override or
+/// the pinned [`crate::chat::DEFAULT_SAMPLE_SEED`].
+fn r4g1_decode_from_request(temperature: Option<f64>, seed: Option<u32>) -> R4g1Decode {
+    match temperature {
+        Some(value) if value <= 0.0 => R4g1Decode::Greedy,
+        _ => R4g1Decode::Sampled {
+            seed: seed.unwrap_or(crate::chat::DEFAULT_SAMPLE_SEED),
+        },
+    }
+}
+
 /// R4G1 policy metadata surfaced alongside the cascade outcome so the
 /// legacy `r4g1` response block keeps its exact shape.
 #[derive(Debug, Default)]
@@ -4035,6 +4098,7 @@ fn tless_bypass_profile_decline() -> Option<(u16, serde_json::Value)> {
 /// the central policy (recording, not refusing; PR #223 semantics).
 /// Unusable text is `Pathological` with the reason; an unavailable runtime
 /// or scoring error is `Failed`.
+#[allow(clippy::too_many_arguments)]
 fn r4g1_tier(
     state: Option<&R4g1State>,
     prompt: &str,
@@ -4042,8 +4106,9 @@ fn r4g1_tier(
     signal: &mut R4g1Signal,
     load_error: Option<&str>,
     usage: &Cell<Option<ServingUsage>>,
+    decode: R4g1Decode,
 ) -> TierResult {
-    match generate_r4g1_text(state, prompt, max_tokens.max(32)) {
+    match generate_r4g1_text(state, prompt, max_tokens.max(32), decode) {
         Ok(Some(gen)) if gen.abstained => {
             signal.status = gen.status.map(r4g1::PolicyStatus::from).map(|s| s.label());
             signal.widened = gen.widened;
@@ -4198,6 +4263,7 @@ fn run_serving_cascade(
     session_signature: Option<&[u8]>,
     pinned: Option<&'static str>,
     profile: EngineProfile,
+    r4g1_decode: R4g1Decode,
 ) -> ServingCascade {
     let ServingModelState {
         r4g1,
@@ -4237,6 +4303,7 @@ fn run_serving_cascade(
                         signal_ref,
                         load_error.as_deref(),
                         usage_ref,
+                        r4g1_decode,
                     )
                 }),
             ));
@@ -14912,8 +14979,12 @@ fn generate_serving_completion(
     engine: Option<&str>,
     max_tokens: usize,
     temperature_override: Option<f64>,
+    seed: Option<u32>,
 ) -> GenerationOutcome {
     let identity = "tenant-alpha".to_string();
+    // #655 decode default: derived from the RAW request fields (an
+    // autotuned nonzero temperature must never read as a greedy opt-in).
+    let r4g1_decode = r4g1_decode_from_request(temperature_override, seed);
 
     // #789-G3.4: every engine-name decline is judged BEFORE any lock or
     // router/brain mutation — this path previously evolved brain state and
@@ -15035,6 +15106,7 @@ fn generate_serving_completion(
         Some(&session_signature),
         pinned,
         profile,
+        r4g1_decode,
     );
     let generation_mode = derive_generation_mode(&cascade, pinned);
     let Some(final_response_text) = cascade.outcome.text.clone() else {
@@ -15902,6 +15974,7 @@ fn handle_connection(
             req.engine.as_deref(),
             max_tokens,
             req.temperature,
+            req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
                 send_json_response(stream, status, &body.to_string());
@@ -16049,6 +16122,7 @@ fn handle_connection(
             req.engine.as_deref(),
             max_tokens,
             req.temperature,
+            req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
                 send_json_response(stream, status, &body.to_string());
@@ -16213,6 +16287,10 @@ fn handle_connection(
         // (PR #223 record-and-continue semantics, implemented directly by
         // `run_cascade` — #790 item 4).
         let t_gen = Instant::now();
+        // #655 decode default: derived from the RAW request fields — the
+        // autotuned geometric temperature above must never read as a
+        // greedy opt-in.
+        let r4g1_decode = r4g1_decode_from_request(payload.temperature, payload.seed);
         let mut cascade = run_serving_cascade(
             &mut router_guard,
             &mut installed,
@@ -16225,6 +16303,7 @@ fn handle_connection(
             Some(&session_signature),
             pinned,
             profile,
+            r4g1_decode,
         );
 
         // Legacy response fields, derived from the trail so consumers keep
@@ -18520,6 +18599,50 @@ mod tests {
             path: path.to_path_buf(),
             identity,
         }
+    }
+
+    /// #655 decode-default decision (2026-08-19): the request-field →
+    /// decode-mode mapping. Sampled with the pinned default seed is the
+    /// default; `temperature: 0` (or below) is the greedy opt-in; a
+    /// request `seed` overrides the pinned default; and a greedy opt-in
+    /// wins over a supplied seed (the seed only parameterizes sampling).
+    #[test]
+    fn r4g1_decode_defaults_to_pinned_seed_sampling_with_greedy_opt_in() {
+        use super::R4g1Decode;
+        assert_eq!(
+            super::r4g1_decode_from_request(None, None),
+            R4g1Decode::Sampled {
+                seed: crate::chat::DEFAULT_SAMPLE_SEED
+            },
+            "an ordinary request samples with the pinned default seed"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.7), None),
+            R4g1Decode::Sampled {
+                seed: crate::chat::DEFAULT_SAMPLE_SEED
+            },
+            "a nonzero temperature keeps the default sampled decode"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(None, Some(7)),
+            R4g1Decode::Sampled { seed: 7 },
+            "a request seed overrides the pinned default"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.0), None),
+            R4g1Decode::Greedy,
+            "temperature zero is the greedy opt-in"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(-1.0), None),
+            R4g1Decode::Greedy,
+            "a negative temperature never samples"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.0), Some(7)),
+            R4g1Decode::Greedy,
+            "the greedy opt-in wins over a supplied seed"
+        );
     }
 
     #[test]

--- a/tests/status_policy.rs
+++ b/tests/status_policy.rs
@@ -22,11 +22,14 @@ mod status_policy_common;
 
 use status_policy_common as fixture;
 
-use uor_r4_api::engine::WitnessVerificationError;
-use uor_r4_graph_certify::{ScoreStatus, TOP_M, WIDENED_TOP_M};
+use uor_r4_api::engine::{EngineParts, R4Engine, WitnessVerificationError};
+use uor_r4_graph_certify::{
+    ScoreStatus, StepCandidates, STEP_TOP_CANDIDATES, TOP_M, WIDENED_TOP_M,
+};
 use uor_r4_wasm_router::r4g1::{
     AbstainOutcome, PolicyStatus, PredictDecision, PredictOutcome, StatusAction, StatusPolicy,
 };
+use uor_r4_wasm_router::transformerless::runtime::SampleRng;
 
 // ------------------------------------------------------- (a) OOD probe --
 
@@ -309,6 +312,135 @@ fn generation_stops_at_the_first_abstain() {
         .expect("legacy generate");
     assert_eq!(legacy_count, outcome.count);
     assert_eq!(legacy_out[..legacy_count], out[..outcome.count]);
+}
+
+// ---------------------------------------------- sampled decode (#655) --
+
+/// The candidates-reporting step is the plain deployed step: selection,
+/// score, status, and candidate count are identical on every probe
+/// signature at both membership widths, with and without the deployed
+/// recent-window penalty; the ranked list leads with the selection,
+/// is strictly ordered under the canonical rule (score descending,
+/// token ascending), and is bounded by the candidate count.
+#[test]
+fn step_candidates_match_the_plain_step_and_rank_the_selection_first() {
+    let fixture = fixture::signature_fixture(None);
+    let scorer = fixture.reference_scorer();
+    let mut step_state = scorer.step_state(WIDENED_TOP_M).expect("step state");
+    let mut candidates = StepCandidates::default();
+    for sig in [fixture.covered_sig, fixture.graph_sig, fixture.ood_sig] {
+        for top_m in [TOP_M, WIDENED_TOP_M] {
+            for recent in [&[][..], &[10u32][..]] {
+                let plain = scorer
+                    .score_step_with_recent(&sig, top_m, &mut step_state, recent)
+                    .expect("plain step");
+                let listed = scorer
+                    .score_step_candidates_coded_with_recent(
+                        &sig,
+                        None,
+                        top_m,
+                        &mut step_state,
+                        recent,
+                        &mut candidates,
+                    )
+                    .expect("candidates step");
+                assert_eq!(listed.selected, plain.selected);
+                assert_eq!(listed.selected_score, plain.selected_score);
+                assert_eq!(listed.status, plain.status);
+                assert_eq!(listed.candidate_count, plain.candidate_count);
+                let ranked = candidates.ranked();
+                assert_eq!(
+                    ranked.len(),
+                    (plain.candidate_count as usize).min(STEP_TOP_CANDIDATES)
+                );
+                assert_eq!(ranked[0], (plain.selected, plain.selected_score));
+                for pair in ranked.windows(2) {
+                    let (prev_token, prev_score) = pair[0];
+                    let (next_token, next_score) = pair[1];
+                    assert!(
+                        prev_score.raw() > next_score.raw()
+                            || (prev_score.raw() == next_score.raw() && prev_token < next_token),
+                        "ranked list must be strictly ordered under the canonical rule"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The #655 sampled decode (`R4Engine::generate_sampled_into`) shares
+/// the greedy path's D4 policy decisions by construction: an OOD seed
+/// abstains with the same typed outcome (no token guessed under
+/// sampling either), a served run is byte-reproducible from its rng
+/// seed, every emitted token stays inside the fixture's declared
+/// emission universe, and the policy counters show each emitted token
+/// paid one served policy decision.
+#[test]
+fn sampled_decode_is_seeded_and_abstains_exactly_like_greedy() {
+    let fixture = fixture::window_fixture();
+    let load_engine = || {
+        R4Engine::load(EngineParts {
+            graph: &fixture.bytes,
+            signature_artifact: &fixture.teacher,
+            tokenizer: None,
+            score_report: None,
+        })
+        .expect("fixture engine loads")
+    };
+    let ood_window = fixture::find_window_by_status(&fixture, ScoreStatus::Novel);
+
+    // OOD seed: identical abstention under greedy and sampled decode.
+    let mut greedy_engine = load_engine();
+    let greedy = greedy_engine
+        .generate_into(&ood_window, &mut [0u32; 8])
+        .expect("greedy generate");
+    let mut sampled_engine = load_engine();
+    let mut rng = SampleRng::new(42);
+    let mut sampled_out = [0u32; 8];
+    let sampled = sampled_engine
+        .generate_sampled_into(&ood_window, &mut sampled_out, &mut rng)
+        .expect("sampled generate");
+    assert!(greedy.abstained, "fixture OOD seed abstains under greedy");
+    assert!(sampled.abstained, "the sampled path preserves abstention");
+    assert_eq!(sampled.count, 0, "no token guessed under sampling");
+    assert_eq!(sampled.status, greedy.status);
+
+    // Served seed: same rng seed → identical run, end to end.
+    let run = |seed: u32| {
+        let mut engine = load_engine();
+        let mut rng = SampleRng::new(seed);
+        let mut out = [0u32; 8];
+        let outcome = engine
+            .generate_sampled_into(&fixture.covered_window, &mut out, &mut rng)
+            .expect("sampled generate");
+        let counters = engine.policy_counters();
+        (
+            outcome.count,
+            outcome.status,
+            outcome.abstained,
+            out,
+            counters.serves,
+        )
+    };
+    let (count, status, abstained, tokens, serves) = run(41);
+    assert_eq!(
+        (count, status, abstained, tokens, serves),
+        run(41),
+        "same seed reproduces the run end to end"
+    );
+    assert!(count >= 1, "the covered seed serves at least one token");
+    // Every emitted token draws from a serving probe's own candidate
+    // list; the fixture's whole emission universe (root prior + region
+    // lists) is {10, 20, 30, 40}.
+    for &token in &tokens[..count] {
+        assert!(
+            matches!(token, 10 | 20 | 30 | 40),
+            "sampled token {token} escaped the fixture's emission universe"
+        );
+    }
+    // No EOS ids exist in that universe, so every emitted token paid
+    // exactly one served policy decision.
+    assert_eq!(serves as usize, count, "one serve per emitted token");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Slice 2 of the #655 decode-default decision (2026-08-19, maintainer sign-off issuecomment-5335968364): **seeded weighted sampling is now the default decode on every product surface**; greedy is the explicit opt-out. Stacked on #813 (the machinery slice) — the first commit here is #813's.

- **CLI**: `ask`/`chat` default to sampled decode with the pinned `chat::DEFAULT_SAMPLE_SEED` (42 — the F-p2 canary's 15/15-valid seed). `--greedy` opts out; `--sample <SEED>` overrides the pinned seed.
- **Server**: `R4g1Decode` + `r4g1_decode_from_request`, derived from the RAW request fields on all three chat surfaces (native `/api/chat`, OpenAI chat-completions, OpenAI responses): `temperature <= 0` → greedy opt-in; otherwise sampled with the request `seed` override or the pinned default — identical requests reproduce identical completions. The autotuned geometric temperature is never read as a greedy opt-in.
- **Wire**: `seed` added to `VendorChatCompletionsRequest` / `VendorResponsesRequest` (previously failed closed under `deny_unknown_fields`) and the shared `InferenceRequest` (REST/WS/WASM).
- The opt-in witness envelope keeps greedy decode (witness claims bind the greedy selection). D4 abstention is decode-mode independent by construction (#813's engine tests pin it).
- `docs/SERVING_MODEL_DISCOVERY.md` Tier 1 gains the decode-default record.

## Canary evidence (this branch's binary, smollm2-360m-broad, the 20 declared F-p2 prompts × 2 passes)

| comparison | result |
|---|---|
| new default arm vs archived F-p2 `--sample 42` arm | **byte-identical, 0/40 diffs** — the default IS the measured 15/15-valid decode |
| new `--greedy` arm vs archived F-p2 greedy (old default) | **byte-identical, 0/40 diffs** — the opt-out is exactly the old behavior |
| default pass 1 vs pass 2 | **0 diffs** — pinned-seed default is deterministic |
| witnesses | default = `r4g1-sampled` 20/20; greedy = `r4g1-beam` |

The flip changes exactly the default binding and nothing else.

## Tests

`r4g1_decode_defaults_to_pinned_seed_sampling_with_greedy_opt_in` (mapping: default sampling + pinned seed, nonzero temperature stays sampled, request seed override, temperature-zero/negative greedy, greedy wins over seed) · workspace clippy `-D warnings` clean · fmt clean · api suites pass.

## Refs

#655 (decision + F-p2 canary packet issuecomment-5335796517) · #784 (attractor substrate) · #813 (machinery slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
