### PR TITLE
Release pipeline: tag-triggered dual-frontend builds + verified install-release (#741)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: release
+
+# #741 release pipeline (maintainer decision 2026-08-19, recorded on
+# #741/#655): a pushed `v*` tag builds BOTH frontends — the native `r4`
+# CLI (linux x86_64 + macOS arm64) and the wasm frontend — and attaches
+# them to a DRAFT GitHub Release whose notes bind the tag to the exact
+# code SHA and inference-contract version. Nothing is published by this
+# workflow: the maintainer attaches the packaged model bundle
+# (`release-bundle.tar.gz` + `release-bundle.json`, produced locally by
+# `r4 package-release-bundle` — CI cannot compile the model) and then
+# publishes the draft by hand. Consumers fetch with the explicit
+# verified command: `r4 install-release --tag <tag>`.
+# See docs/RELEASE_PIPELINE.md for the full convention.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the draft release (idempotent)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "release $TAG already exists; leaving it as-is"
+            exit 0
+          fi
+          CONTRACT=$(grep -m1 '^\*\*Version:\*\*' docs/inference_contract.md | sed 's/[^0-9.]//g' || echo unknown)
+          gh release create "$TAG" --draft --verify-tag \
+            --title "uor-r4 $TAG" \
+            --notes "$(printf 'code: %s\ninference contract: %s\n\nAssets: r4 CLI (linux x86_64, macos arm64), wasm frontend.\nThe model bundle (release-bundle.tar.gz + release-bundle.json) is attached by the maintainer from a locally packaged compiled bundle before publishing; its manifest binds the bundle component digests to this tag.\n\nVerified install: r4 install-release --tag %s\n' "$GITHUB_SHA" "$CONTRACT" "$TAG")"
+
+  cli:
+    needs: draft-release
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build the r4 CLI
+        run: cargo build --release --locked
+      - name: Package and attach
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          NAME="r4-${TAG}-${{ matrix.target }}"
+          mkdir -p "dist/$NAME"
+          cp target/release/r4 "dist/$NAME/"
+          cp LICENSE* "dist/$NAME/" 2>/dev/null || true
+          tar -C dist -czf "dist/$NAME.tar.gz" "$NAME"
+          shasum -a 256 "dist/$NAME.tar.gz" | awk '{print $1}' > "dist/$NAME.tar.gz.sha256"
+          gh release upload "$TAG" "dist/$NAME.tar.gz" "dist/$NAME.tar.gz.sha256" --clobber
+
+  wasm:
+    needs: draft-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build the wasm frontend
+        run: wasm-pack build --target web
+      - name: Package and attach
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          NAME="r4-wasm-${TAG}"
+          mkdir -p dist
+          tar -czf "dist/$NAME.tar.gz" pkg
+          shasum -a 256 "dist/$NAME.tar.gz" | awk '{print $1}' > "dist/$NAME.tar.gz.sha256"
+          gh release upload "$TAG" "dist/$NAME.tar.gz" "dist/$NAME.tar.gz.sha256" --clobber

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -112,8 +112,8 @@ pub struct InferenceResponse {
 }
 use uor_r4_core::transformerless::scenarios::{RuntimeTokenizerIdentity, Tokenizer};
 use uor_r4_graph_certify::{
-    GraphScorer, ScoreStatus, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B, TOP_M,
-    WIDENED_TOP_M,
+    GraphScorer, ScoreStatus, StepCandidates, StepState, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B,
+    TOP_M, WIDENED_TOP_M,
 };
 use uor_r4_graph_format::{
     ContractVersion, FormatError, GraphView, ObservedBound, FORMAT_VERSION_MAJOR,
@@ -579,18 +579,43 @@ impl R4Engine {
     /// with legacy TLS1 exact-context evidence stay on the reference
     /// scorer (the deployed step requires residualized RX1 evidence);
     /// that path ignores the width — widening is unavailable there.
-    fn score_sig(
+    /// A supplied sink additionally receives the step's bounded top-K
+    /// candidate list. Selection and status are identical either way;
+    /// on the legacy reference path the list is rebuilt from the
+    /// reference outcome's own candidate vector under the same
+    /// canonical order.
+    fn score_sig_with_candidates(
         &mut self,
         sig: &[u8; SIG_BYTES],
         input_code: Option<&[u8; compiler::STAGES]>,
         top_m: usize,
         recent_tokens: &[u32],
+        candidates: Option<&mut StepCandidates>,
     ) -> ScoredProbe {
         if self.step_supported {
-            let outcome = self
-                .scorer
-                .score_step_coded_with_recent(sig, input_code, top_m, &mut self.step, recent_tokens)
-                .expect("serving: scorer produced no candidates for a validated sig");
+            let outcome = match candidates {
+                Some(list) => self
+                    .scorer
+                    .score_step_candidates_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                        list,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+                None => self
+                    .scorer
+                    .score_step_coded_with_recent(
+                        sig,
+                        input_code,
+                        top_m,
+                        &mut self.step,
+                        recent_tokens,
+                    )
+                    .expect("serving: scorer produced no candidates for a validated sig"),
+            };
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.status,
@@ -602,6 +627,12 @@ impl R4Engine {
                 .scorer
                 .score_candidates_coded(sig, input_code, recent_tokens)
                 .expect("serving: scorer produced no candidates for a validated sig");
+            if let Some(list) = candidates {
+                list.len = 0;
+                for &(token, score) in &outcome.candidates {
+                    list.push_ranked(token, score);
+                }
+            }
             ScoredProbe {
                 token: outcome.selected,
                 status: outcome.witness.status,
@@ -645,8 +676,29 @@ impl R4Engine {
         input_code: Option<&[u8; compiler::STAGES]>,
         recent_tokens: &[u32],
     ) -> PredictDecision {
+        self.predict_signature_status_with_recent_candidates(sig, input_code, recent_tokens, None)
+    }
+
+    /// The same policy path with an optional candidate sink: when the
+    /// decision serves, the sink holds the bounded top-K list of the
+    /// exact probe that served (the widened probe when widening served).
+    /// Policy bookkeeping — counters, widen-once, the novel-seen FIFO —
+    /// is this one implementation either way.
+    fn predict_signature_status_with_recent_candidates(
+        &mut self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; compiler::STAGES]>,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> PredictDecision {
         self.counters.predicts += 1;
-        let first = self.score_sig(sig, input_code, TOP_M, recent_tokens);
+        let first = self.score_sig_with_candidates(
+            sig,
+            input_code,
+            TOP_M,
+            recent_tokens,
+            candidates.as_deref_mut(),
+        );
         match self.policy.action(first.status.into()) {
             StatusAction::Serve => {
                 self.counters.serves += 1;
@@ -686,7 +738,13 @@ impl R4Engine {
                     });
                 }
                 self.counters.widen_attempts += 1;
-                let second = self.score_sig(sig, input_code, WIDENED_TOP_M, recent_tokens);
+                let second = self.score_sig_with_candidates(
+                    sig,
+                    input_code,
+                    WIDENED_TOP_M,
+                    recent_tokens,
+                    candidates,
+                );
                 if second.status == ScoreStatus::Novel {
                     self.novel_seen.insert(sig);
                 }
@@ -853,6 +911,145 @@ impl R4Engine {
                     last_status = Some(outcome.status);
                     widened = widened || outcome.widened;
                     *token = next;
+                    if next == 1 || next == 2 {
+                        return Ok(GenerateStatus {
+                            count: generated,
+                            status: last_status,
+                            widened,
+                            abstained: false,
+                        });
+                    }
+                    if window_len < WINDOW {
+                        window[window_len] = next;
+                        window_len += 1;
+                    } else {
+                        window.copy_within(1.., 0);
+                        window[WINDOW - 1] = next;
+                    }
+                }
+                PredictDecision::Abstain(outcome) => {
+                    return Ok(GenerateStatus {
+                        count: generated,
+                        status: Some(outcome.status),
+                        widened: widened || outcome.widened,
+                        abstained: true,
+                    });
+                }
+            }
+        }
+        Ok(GenerateStatus {
+            count: out.len(),
+            status: last_status,
+            widened,
+            abstained: false,
+        })
+    }
+
+    /// The status-aware decision for one token window, additionally
+    /// filling `candidates` with the bounded top-K list of the exact
+    /// probe that decided (the widened probe when widening served).
+    fn predict_decision_candidates(
+        &mut self,
+        window: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Result<PredictDecision, ObservedBound> {
+        self.check_window(window)?;
+        let (sig, code) = self.derive_sig_code(window);
+        Ok(self.predict_signature_status_with_recent_candidates(
+            &sig,
+            Some(&code),
+            window,
+            Some(candidates),
+        ))
+    }
+
+    /// One #762-scheme draw over a served step's ranked candidates:
+    /// order-preserving shift to positive weights, the soft
+    /// ~1000-per-occurrence penalty over tokens already emitted this
+    /// generation with floor 1 (a penalized candidate stays reachable,
+    /// never excluded), and the shared division-free
+    /// [`runtime::SampleRng::draw`]. `served` is returned when the list
+    /// is degenerate so the policy's served selection is never
+    /// overridden by an unweighable list.
+    fn sample_step_candidate(
+        candidates: &StepCandidates,
+        emitted: &[u32],
+        served: u32,
+        rng: &mut runtime::SampleRng,
+    ) -> u32 {
+        let ranked = candidates.ranked();
+        if ranked.is_empty() {
+            return served;
+        }
+        let min_raw = ranked
+            .iter()
+            .map(|&(_, score)| i64::from(score.raw()))
+            .min()
+            .unwrap_or(0);
+        let mut weights = [0u32; uor_r4_graph_certify::STEP_TOP_CANDIDATES];
+        let mut total = 0u32;
+        for (index, &(token, score)) in ranked.iter().enumerate() {
+            let occurrences = emitted.iter().filter(|&&t| t == token).count() as i64;
+            let mut weight = i64::from(score.raw()) - min_raw + 1;
+            weight -= (occurrences << 10) - (occurrences << 4) - (occurrences << 3);
+            weights[index] = weight.clamp(1, i64::from(u32::MAX)) as u32;
+            total = total.saturating_add(weights[index]);
+        }
+        if total == 0 {
+            return served;
+        }
+        let draw = rng.draw(total);
+        let mut accumulated = 0u32;
+        for (index, &(token, _)) in ranked.iter().enumerate() {
+            accumulated = accumulated.saturating_add(weights[index]);
+            if draw < accumulated {
+                return token;
+            }
+        }
+        served
+    }
+
+    /// Seeded weighted sampling over the deployed step scorer's own
+    /// top-K candidates, through the same D4 policy path as
+    /// [`Self::generate_into`] (#655 decode-default decision 2026-08-19;
+    /// #785-C2/#762 scheme parity).
+    ///
+    /// Per step the policy decision — Serve / WidenOnce / Abstain, the
+    /// novel-seen FIFO, every counter — is computed exactly as the
+    /// greedy path computes it; sampling only replaces WHICH served
+    /// candidate is emitted, weighting the serving probe's own candidate
+    /// scores (deployed recent-window repetition penalty included).
+    /// Abstention semantics are identical by construction: a step that
+    /// abstains under greedy abstains here with the same status, and no
+    /// token is guessed. A `(seed tokens, rng seed)` pair is
+    /// reproducible end to end.
+    pub fn generate_sampled_into(
+        &mut self,
+        seed: &[u32],
+        out: &mut [u32],
+        rng: &mut runtime::SampleRng,
+    ) -> Result<GenerateStatus, ObservedBound> {
+        self.check_window(seed)?;
+        let mut window = [0u32; WINDOW];
+        let seed = &seed[seed.len().saturating_sub(WINDOW)..];
+        let mut window_len = seed.len();
+        window[..window_len].copy_from_slice(seed);
+
+        let mut candidates = StepCandidates::default();
+        let mut last_status = None;
+        let mut widened = false;
+        for generated in 0..out.len() {
+            match self.predict_decision_candidates(&window[..window_len], &mut candidates)? {
+                PredictDecision::Serve(outcome) => {
+                    last_status = Some(outcome.status);
+                    widened = widened || outcome.widened;
+                    let next = Self::sample_step_candidate(
+                        &candidates,
+                        &out[..generated],
+                        outcome.token,
+                        rng,
+                    );
+                    out[generated] = next;
                     if next == 1 || next == 2 {
                         return Ok(GenerateStatus {
                             count: generated,

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -51,8 +51,15 @@ pub struct InferenceRequest {
     pub engine: Option<String>,
     /// Maximum continuation tokens to generate.
     pub max_tokens: Option<usize>,
-    /// Temperature for geometric sampling.
+    /// Temperature for geometric sampling; `0` additionally opts the
+    /// R4G1 tier into deterministic greedy decode (#655 decode-default
+    /// decision, 2026-08-19 — sampled decode is otherwise the default).
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode; absent requests use the pinned default seed so default
+    /// serving stays reproducible. Ignored under `temperature: 0`.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// Ask a serving endpoint to include a replayable proof summary.
     /// Witness assembly is opt-in and remains outside the default hot path.
     #[serde(default)]
@@ -1484,6 +1491,7 @@ mod tests {
             engine: Some("r4g1".to_string()),
             max_tokens: Some(32),
             temperature: Some(0.7),
+            seed: None,
             include_witness: false,
         };
         let json = serde_json::to_string(&req).expect("serialize InferenceRequest");

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -1891,6 +1891,73 @@ pub struct StepOutcome {
     pub exact_context_source: Option<ExactContextSource>,
 }
 
+/// Capacity of the bounded per-step candidate list
+/// ([`GraphScorer::score_step_candidates_coded_with_recent`]): the same
+/// eight-wide bound the R4G1 packed runtime's candidate surface and the
+/// #785-C2 CLI sampled decode already use.
+pub const STEP_TOP_CANDIDATES: usize = 8;
+
+/// The bounded top-K candidate list of one deployed scoring step,
+/// ordered by the canonical selection rule (score descending, then
+/// token id ascending) so `ranked()[0]` is exactly the step's greedy
+/// selection. Fixed capacity; assembling it performs no allocation.
+/// List assembly is selection bookkeeping outside the op census — the
+/// same convention the reference scorer applies to its ranking sort.
+#[derive(Debug, Clone)]
+pub struct StepCandidates {
+    /// The ranked `(token, score)` entries; only `..len` are valid.
+    pub entries: [(u32, ScoreQ); STEP_TOP_CANDIDATES],
+    /// Number of valid entries.
+    pub len: usize,
+}
+
+impl Default for StepCandidates {
+    fn default() -> Self {
+        Self {
+            entries: [(0, ScoreQ::ZERO); STEP_TOP_CANDIDATES],
+            len: 0,
+        }
+    }
+}
+
+impl StepCandidates {
+    /// The valid ranked entries.
+    pub fn ranked(&self) -> &[(u32, ScoreQ)] {
+        &self.entries[..self.len]
+    }
+
+    /// Bounded rank insertion under the canonical selection rule (score
+    /// descending, then token id ascending); entries past capacity fall
+    /// off the tail. Shift/compare only — no allocation, no division.
+    /// Public so engine-layer assemblers (the legacy reference path)
+    /// can rebuild the same ranked list from reference candidates.
+    pub fn push_ranked(&mut self, token: u32, score: ScoreQ) {
+        let mut pos = self.len;
+        while pos > 0 {
+            let (held_token, held_score) = self.entries[pos - 1];
+            if score.raw() > held_score.raw()
+                || (score.raw() == held_score.raw() && token < held_token)
+            {
+                pos -= 1;
+            } else {
+                break;
+            }
+        }
+        if pos >= STEP_TOP_CANDIDATES {
+            return;
+        }
+        let mut slot = self.len.min(STEP_TOP_CANDIDATES - 1);
+        while slot > pos {
+            self.entries[slot] = self.entries[slot - 1];
+            slot -= 1;
+        }
+        self.entries[pos] = (token, score);
+        if self.len < STEP_TOP_CANDIDATES {
+            self.len += 1;
+        }
+    }
+}
+
 /// Advance the step state's epoch, re-zeroing the stamp buffers on the
 /// (practically unreachable) u64 wrap so a stale stamp can never alias
 /// the fresh epoch.
@@ -2190,6 +2257,45 @@ impl GraphScorer {
         state: &mut StepState,
         recent_tokens: &[u32],
     ) -> Option<StepOutcome> {
+        self.score_step_impl(sig, input_code, top_m, state, recent_tokens, None)
+    }
+
+    /// [`GraphScorer::score_step_coded_with_recent`] that additionally
+    /// assembles the bounded top-K candidate list of the same step.
+    /// Selection, status, census, and candidate count are byte-identical
+    /// to the plain step — `candidates.ranked()[0]` IS the selection —
+    /// so a caller sampling among candidates (the #655 sampled decode)
+    /// shares the exact deployed scoring path the greedy step serves
+    /// from, including the bounded recent-window repetition penalty.
+    pub fn score_step_candidates_coded_with_recent(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        candidates: &mut StepCandidates,
+    ) -> Option<StepOutcome> {
+        candidates.len = 0;
+        self.score_step_impl(
+            sig,
+            input_code,
+            top_m,
+            state,
+            recent_tokens,
+            Some(candidates),
+        )
+    }
+
+    fn score_step_impl(
+        &self,
+        sig: &[u8; SIG_BYTES],
+        input_code: Option<&[u8; STAGES]>,
+        top_m: usize,
+        state: &mut StepState,
+        recent_tokens: &[u32],
+        mut candidates: Option<&mut StepCandidates>,
+    ) -> Option<StepOutcome> {
         if top_m == 0 || top_m > state.max_top_m {
             return None;
         }
@@ -2209,6 +2315,12 @@ impl GraphScorer {
         }
         if let Some(entries) = self.context_row(recent_tokens) {
             let (selected, selected_score) = Self::context_row_argmax(entries);
+            if let Some(list) = candidates.as_deref_mut() {
+                list.len = 0;
+                for &(token, score) in entries {
+                    list.push_ranked(token, score);
+                }
+            }
             let census = OpKernel {
                 table_reads: 1,
                 ..Default::default()
@@ -2379,6 +2491,10 @@ impl GraphScorer {
             best_score = best_score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
             k.adds += 1;
         }
+        if let Some(list) = candidates.as_deref_mut() {
+            list.len = 0;
+            list.push_ranked(best, best_score);
+        }
         for &token in state.touched.iter().skip(1) {
             k.candidate_scans += 1;
             k.compares += 1;
@@ -2389,6 +2505,9 @@ impl GraphScorer {
             if recent_tokens.contains(&token) {
                 score = score.saturating_add(ScoreQ::from_raw(self.repetition_penalty_raw));
                 k.adds += 1;
+            }
+            if let Some(list) = candidates.as_deref_mut() {
+                list.push_ranked(token, score);
             }
             if score > best_score || (score == best_score && token < best) {
                 best = token;

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -1,0 +1,99 @@
+# Release pipeline (#741)
+
+Adopted by maintainer decision on 2026-08-19 (recorded on #741/#655):
+the "package + build release pipeline now" option — both frontends, a
+GitHub Release as the distribution artifact, an explicit verified fetch
+command, and a versioning convention that binds each tag to its exact
+code and bundle identity. **This pipeline publishes nothing by itself**:
+every piece below is inert until the maintainer pushes a `v*` tag, and
+even then the release starts as a draft that only the maintainer
+publishes.
+
+## Versioning convention
+
+A release tag `vX.Y` binds, in one auditable place:
+
+- **code identity** — the tag's commit SHA (in the release notes and on
+  the tag itself);
+- **contract identity** — the inference-contract version from
+  `docs/inference_contract.md` (in the release notes);
+- **bundle identity** — the blake3 component digests (graph, signature
+  artifact, tokenizer, score/compile reports) declared by the attached
+  `release-bundle.json`, the #655-D sidecar manifest produced by
+  `r4 package-release-bundle`.
+
+A tag with no bundle assets attached is a code-only release; the
+verified fetch command simply reports the missing asset.
+
+## What the tag triggers (`.github/workflows/release.yml`)
+
+Pushing `vX.Y` creates a **draft** release and attaches both frontends:
+
+- `r4-vX.Y-x86_64-unknown-linux-gnu.tar.gz` — native CLI, linux;
+- `r4-vX.Y-aarch64-apple-darwin.tar.gz` — native CLI, macOS arm64;
+- `r4-wasm-vX.Y.tar.gz` — the wasm frontend (`wasm-pack build`, the
+  same build the Pages deploy runs);
+- a `.sha256` beside each.
+
+CI cannot compile the model (hours of teacher-bound compute against a
+pinned snapshot), so the model bundle is attached by the maintainer:
+
+## Maintainer steps to cut a release
+
+1. Pick the bundle (current candidate per the decision record:
+   the `smollm2-360m-broad` compile) and package its sidecar:
+
+   ```sh
+   r4 package-release-bundle \
+     --compiled .uor-models/compiled/<name> \
+     --model-id r4 --capability instruction-chat \
+     --source .uor-models/sources/<source> \
+     --tokenizer-family hf-byte-bpe --tokenizer-version 1
+   ```
+
+2. Archive exactly the attested component files (the packaged layout —
+   nothing else; `r4 install-release` refuses archives carrying any
+   unattested entry):
+
+   ```sh
+   cd .uor-models/compiled/<name>
+   tar -czf /tmp/release-bundle.tar.gz \
+     graph/score.r4g1 tless_artifacts.bin tokenizer.bin \
+     graph/score_report.json graph-cover/cover_report.json
+   ```
+
+3. Tag and push: `git tag vX.Y && git push origin vX.Y` — the workflow
+   drafts the release and attaches the frontend builds.
+
+4. Attach the bundle and publish:
+
+   ```sh
+   gh release upload vX.Y /tmp/release-bundle.tar.gz \
+     .uor-models/compiled/<name>/release-bundle.json
+   gh release edit vX.Y --draft=false
+   ```
+
+## The explicit verified fetch
+
+```sh
+r4 install-release --tag vX.Y            # from UOR-Foundation/uor-r4
+r4 install-release --tag vX.Y --repo owner/name --name custom-install
+```
+
+`install-release` (`src/release_install.rs`) downloads the two bundle
+assets, hard-verifies **every** declared component digest against the
+extracted bytes, refuses archives containing anything unattested (or
+any symlink), never overwrites an existing install, and only then moves
+the bundle into `.uor-models/compiled/<name>` with its sidecar beside
+it (so serving-time advisory verification, #655-C1c, sees the same
+manifest). A failure at any step installs nothing. The fetch is always
+explicit: no serving path, first request, or setup step triggers it —
+exactly #655's "first request must not silently download" scope line.
+
+## What this pipeline deliberately does not do
+
+- It does not flip any serving default or canonical model identity —
+  that is #655-F, separately gated on its own preconditions and a fresh
+  maintainer sign-off.
+- It does not auto-publish: drafts require the maintainer.
+- It does not compile models in CI.

--- a/docs/SERVING_MODEL_DISCOVERY.md
+++ b/docs/SERVING_MODEL_DISCOVERY.md
@@ -54,6 +54,19 @@ functionally the cascade's terminal "always something" tier).
   present or the whole bundle is refused (`2200-2213`).
 - State type: `r4g1::R4g1State`, held in `ServingModelState.r4g1`.
 - Availability: `installed.r4g1.is_some()` after startup load succeeds.
+- Decode (#655 decode-default decision, 2026-08-19): **seeded weighted
+  sampling is the default** on every serving surface (native `/api/chat`,
+  OpenAI chat-completions and responses, and the CLI `ask`/`chat`),
+  weighting the deployed step scorer's own top-K candidates through the
+  identical D4 policy path — abstention behavior is decode-mode
+  independent by construction, and the seed is pinned
+  (`chat::DEFAULT_SAMPLE_SEED`) so identical requests reproduce
+  identical completions. `temperature: 0` on the wire (or `--greedy` on
+  the CLI) is the deterministic opt-out; a request `seed` field
+  overrides the pinned seed; the opt-in witness envelope decodes greedy
+  (witness claims bind the greedy selection). See
+  `r4g1_decode_from_request` (`src/server.rs`) and
+  `R4Engine::generate_sampled_into` (`crates/uor-r4-api/src/engine.rs`).
 
 ### Tier 2 — `transformerless`
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -14,6 +14,15 @@ const MAX_CHAT_TOKENS: usize = 256;
 const MAX_CHAT_HISTORY: usize = 4096;
 const MAX_ANSWER_BYTES: usize = 16 * 1024;
 
+/// The pinned default sampling seed (#655 decode-default decision,
+/// 2026-08-19): sampled decode is the CLI/serving default everywhere,
+/// seeded with this constant so default behavior stays reproducible run
+/// to run; greedy decode is the explicit opt-in (`--greedy` on the CLI,
+/// `temperature: 0` on the wire). 42 is the seed the #655 F-p2 canary
+/// measured 15/15 valid completions with (vs 0/15 greedy,
+/// issuecomment-5335796517).
+pub const DEFAULT_SAMPLE_SEED: u32 = 42;
+
 /// A completed local chat turn.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChatAnswer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ pub mod release_bundle_loader;
 /// [`release_bundle_packager::package_release_bundle`].
 #[cfg(not(target_arch = "wasm32"))]
 pub mod release_bundle_packager;
+/// #741: the explicit, verified release-bundle fetch (`r4
+/// install-release`) — downloads a published GitHub Release's bundle
+/// assets and installs them only after every declared component digest
+/// matches (`docs/RELEASE_PIPELINE.md`).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod release_install;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod telemetry;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use uor_r4_api::{BundleCapability, TokenizerAdapter, UorMatmulProvenance};
 use uor_r4_core::transformerless::hf_bpe::{resolve_source_tokenizer, TokenizerAdapterKey};
 use uor_r4_graph_cli as transformerless_command;
-use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError};
+use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError, DEFAULT_SAMPLE_SEED};
 use uor_r4_wasm_router::model::{
     default_model_reference, download_source, evaluate_live_quality, ModelCapability, ModelError,
     ModelManifest, ModelStore, QualityAttestation, SourceDownload,
@@ -164,13 +164,19 @@ struct AskArgs {
     /// CID manifest name/CID, or a locally compiled bundle name.
     #[arg(long, env = "TLESS_MODEL")]
     model: Option<String>,
-    /// Opt into seeded weighted sampling instead of the default
-    /// deterministic decode, on both generation paths: issue #762 lever 2
-    /// on the plain path, and the same weighting over the R4G1 candidate
-    /// walk (#785-C2 parity). Reproducible from the seed (see
-    /// `chat::ChatEngineBuilder::sample_seed`).
-    #[arg(long, value_name = "SEED")]
+    /// Override the pinned default sampling seed (#655 decode-default
+    /// decision, 2026-08-19: seeded weighted sampling IS the default on
+    /// both generation paths — issue #762 lever 2 on the plain path, the
+    /// same weighting over the R4G1 candidate walk per #785-C2). Absent,
+    /// the pinned `chat::DEFAULT_SAMPLE_SEED` keeps default runs
+    /// reproducible. Reproducible from the seed either way.
+    #[arg(long, value_name = "SEED", conflicts_with = "greedy")]
     sample: Option<u32>,
+    /// Opt into the deterministic decode (greedy beam on the R4G1 path,
+    /// greedy argmax on the plain path) instead of the default seeded
+    /// sampling.
+    #[arg(long, conflicts_with = "sample")]
+    greedy: bool,
     /// Question to ask. Multiple unquoted words are accepted.
     #[arg(required = true, num_args = 1..)]
     question: Vec<String>,
@@ -184,13 +190,17 @@ struct ChatArgs {
     /// Remote HTTP server URL (e.g. http://127.0.0.1:8000/v1) for client mode.
     #[arg(long)]
     remote: Option<String>,
-    /// Opt into seeded weighted sampling instead of the default
-    /// deterministic decode, on both generation paths (#762 lever 2 on
-    /// the plain path, #785-C2 parity on the R4G1 candidate walk); the
-    /// seed advances turn to turn so the whole session is reproducible
-    /// from it. Has no effect in `--remote` client mode.
-    #[arg(long, value_name = "SEED")]
+    /// Override the pinned default sampling seed (#655: seeded weighted
+    /// sampling IS the default on both generation paths — #762 lever 2
+    /// plain, #785-C2 R4G1); the seed advances turn to turn so the whole
+    /// session is reproducible from it. Has no effect in `--remote`
+    /// client mode.
+    #[arg(long, value_name = "SEED", conflicts_with = "greedy")]
     sample: Option<u32>,
+    /// Opt into the deterministic decode instead of the default seeded
+    /// sampling. Has no effect in `--remote` client mode.
+    #[arg(long, conflicts_with = "sample")]
+    greedy: bool,
 }
 
 #[derive(Args, Debug)]
@@ -523,11 +533,21 @@ fn interactive_chat(
     Ok(())
 }
 
-fn build_chat_engine(model: Option<&str>, sample: Option<u32>) -> Result<ChatEngine, ChatError> {
+/// Build the local chat engine under the #655 decode default
+/// (2026-08-19): seeded weighted sampling unless `--greedy` opts out,
+/// with `--sample <SEED>` overriding the pinned default seed. The
+/// library builder itself stays explicit (`sample_seed` opt-in); the
+/// default is applied here, at the product surface, exactly like the
+/// server's request mapping.
+fn build_chat_engine(
+    model: Option<&str>,
+    sample: Option<u32>,
+    greedy: bool,
+) -> Result<ChatEngine, ChatError> {
     let mut builder =
         ChatEngine::builder().model(model.map_or_else(default_model_reference, ToOwned::to_owned));
-    if let Some(seed) = sample {
-        builder = builder.sample_seed(seed);
+    if !greedy {
+        builder = builder.sample_seed(sample.unwrap_or(DEFAULT_SAMPLE_SEED));
     }
     builder.build()
 }
@@ -838,7 +858,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
     cli.configure_tless();
     match cli.command.as_ref() {
         Some(Command::Ask(args)) => {
-            let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
+            let mut chat = build_chat_engine(args.model.as_deref(), args.sample, args.greedy)?;
             answer_once(
                 &mut chat,
                 &args.question.join(" "),
@@ -855,7 +875,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
                 )?;
                 Ok(())
             } else {
-                let mut chat = build_chat_engine(args.model.as_deref(), args.sample)?;
+                let mut chat = build_chat_engine(args.model.as_deref(), args.sample, args.greedy)?;
                 interactive_chat(&mut chat, &mut io::stdin().lock(), &mut io::stdout().lock())?;
                 Ok(())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,13 @@ enum Command {
     /// sidecar, giving `release_bundle_loader::verify_release_bundle_sidecar`
     /// (#655-C1c) a real manifest to verify.
     PackageReleaseBundle(PackageReleaseBundleArgs),
+    /// #741: explicitly fetch a published release's packaged bundle from
+    /// its GitHub Release and install it — only after every component
+    /// digest matches the release's attested `release-bundle.json`
+    /// manifest. Never runs implicitly; a digest mismatch, an unattested
+    /// archive entry, or an existing install refuses with nothing
+    /// written.
+    InstallRelease(InstallReleaseArgs),
     /// Evaluate an HF-compiled bundle and emit an instruction-quality report.
     EvaluateReport(EvaluateReportArgs),
     /// Print legacy proof-workflow prerequisites.
@@ -398,6 +405,20 @@ struct PackageReleaseBundleArgs {
     /// `<compiled>/release-bundle.json`.
     #[arg(long)]
     output: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct InstallReleaseArgs {
+    /// Release tag to install (e.g. v0.1).
+    #[arg(long)]
+    tag: String,
+    /// GitHub repository the release lives in.
+    #[arg(long, default_value = "UOR-Foundation/uor-r4")]
+    repo: String,
+    /// Install name under the model store's compiled/ inventory
+    /// [default: the release manifest's own model_id].
+    #[arg(long)]
+    name: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -794,6 +815,44 @@ fn package_release_bundle_command(args: &PackageReleaseBundleArgs) -> Result<(),
     Ok(())
 }
 
+/// #741: the explicit verified fetch. All verification lives in
+/// `release_install::install_release`; this handler supplies the real
+/// curl fetcher and the model-store root, then reports the installed
+/// identity so the user can bind what they fetched to the release tag.
+fn install_release_command(args: &InstallReleaseArgs) -> Result<(), RunError> {
+    let store_root = uor_r4_wasm_router::model::model_store_root();
+    let request = uor_r4_wasm_router::release_install::InstallReleaseRequest {
+        repo: args.repo.clone(),
+        tag: args.tag.clone(),
+        name: args.name.clone(),
+    };
+    let installed = uor_r4_wasm_router::release_install::install_release(
+        &store_root,
+        &request,
+        &mut uor_r4_wasm_router::release_install::CurlFetcher,
+    )
+    .map_err(RunError::Command)?;
+    println!("installed: {}", installed.destination.display());
+    println!("release: {} @ {}", args.repo, args.tag);
+    println!(
+        "model_id: {} ({:?})",
+        installed.manifest.model_id, installed.manifest.capability
+    );
+    println!("graph: {}", installed.manifest.components.graph);
+    println!(
+        "signature_artifact: {}",
+        installed.manifest.components.signature_artifact
+    );
+    if let Some(tokenizer) = installed.manifest.components.tokenizer.as_deref() {
+        println!("tokenizer: {tokenizer}");
+    }
+    println!(
+        "every component digest verified against the release's attested manifest; \
+         the sidecar is installed beside the bundle for serving-time verification"
+    );
+    Ok(())
+}
+
 fn evaluate_report(args: &EvaluateReportArgs) -> Result<(), RunError> {
     if args.sequence_length == 0 {
         return Err(RunError::Command(
@@ -893,6 +952,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         Some(Command::Download(args)) => download(args),
         Some(Command::Import(args)) => import(args),
         Some(Command::PackageReleaseBundle(args)) => package_release_bundle_command(args),
+        Some(Command::InstallRelease(args)) => install_release_command(args),
         Some(Command::EvaluateReport(args)) => evaluate_report(args),
         Some(Command::Setup) => run_core("setup", &[]),
         Some(Command::Gen { seconds, target }) => {

--- a/src/r4g1.rs
+++ b/src/r4g1.rs
@@ -169,6 +169,26 @@ impl R4g1State {
             .map_err(|error| error.to_string())
     }
 
+    /// #655 decode-default decision (2026-08-19): seeded weighted
+    /// sampling over the deployed step scorer's own candidates, through
+    /// the same D4 policy path as [`Self::generate_into_status`] —
+    /// abstention semantics identical by construction (see
+    /// `R4Engine::generate_sampled_into`). This is the server tier's
+    /// default decode; greedy remains the `temperature: 0` opt-in and
+    /// the witness path's decode (witness claims bind the greedy
+    /// selection).
+    pub fn generate_sampled_into_status(
+        &self,
+        seed: &[u32],
+        out: &mut [u32],
+        rng: &mut uor_r4_core::transformerless::runtime::SampleRng,
+    ) -> Result<GenerateStatus, String> {
+        self.engine
+            .borrow_mut()
+            .generate_sampled_into(seed, out, rng)
+            .map_err(|error| error.to_string())
+    }
+
     /// Witness-enabled generation for the opt-in proof-carrying response
     /// envelope. The ordinary generation method remains allocation-free.
     pub fn generate_into_status_with_witness(

--- a/src/release_install.rs
+++ b/src/release_install.rs
@@ -1,0 +1,596 @@
+//! #741: the explicit, verified release-bundle fetch — the install half
+//! of the release pipeline (`docs/RELEASE_PIPELINE.md`).
+//!
+//! `r4 install-release --tag vX.Y` downloads the two release assets a
+//! published GitHub Release carries — `release-bundle.json` (the #655-D
+//! sidecar manifest) and `release-bundle.tar.gz` (the packaged compiled
+//! bundle) — and installs the bundle under the model store ONLY after
+//! every declared component digest matches the extracted bytes. This is
+//! deliberately stricter than serving-time sidecar verification
+//! (`release_bundle_loader`, advisory by design): at install time a
+//! mismatch is a hard failure and nothing is installed. The fetch is
+//! explicit — no serving path, first request, or setup step ever
+//! triggers it (#655's own scope: "first request must not silently
+//! download").
+//!
+//! Fail-closed inventory: the archive must contain EXACTLY the
+//! attested component files (the five `docs/serving_release_packaging_655_d.md`
+//! relative paths, tokenizer present iff the manifest declares it) — an
+//! archive smuggling any other file is refused outright, so nothing
+//! unattested ever lands on disk.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use uor_r4_api::ReleaseBundleManifest;
+
+use crate::release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME;
+
+/// Release asset name of the packaged bundle archive.
+pub const RELEASE_BUNDLE_ARCHIVE_ASSET: &str = "release-bundle.tar.gz";
+
+/// The component relative paths inside a packaged bundle —
+/// `docs/serving_release_packaging_655_d.md`'s field-to-file mapping,
+/// mirrored from `release_bundle_packager`.
+const GRAPH_RELATIVE_PATH: &str = "graph/score.r4g1";
+const SIGNATURE_ARTIFACT_RELATIVE_PATH: &str = "tless_artifacts.bin";
+const TOKENIZER_RELATIVE_PATH: &str = "tokenizer.bin";
+const SCORE_REPORT_RELATIVE_PATH: &str = "graph/score_report.json";
+const COMPILE_REPORT_RELATIVE_PATH: &str = "graph-cover/cover_report.json";
+
+/// One verified-install request.
+pub struct InstallReleaseRequest {
+    /// GitHub repository the release lives in (`owner/name`).
+    pub repo: String,
+    /// Release tag (e.g. `v0.1`).
+    pub tag: String,
+    /// Install name under the model store's `compiled/` inventory;
+    /// `None` uses the manifest's own `model_id`.
+    pub name: Option<String>,
+}
+
+/// A completed verified install.
+#[derive(Debug)]
+pub struct InstalledRelease {
+    /// Where the verified bundle now lives.
+    pub destination: PathBuf,
+    /// The verified manifest (also written beside the bundle as its
+    /// serving-time sidecar).
+    pub manifest: ReleaseBundleManifest,
+}
+
+/// Fetch one URL to a destination file. The production fetcher shells
+/// out to `curl` (the same external-tool convention `download_source`
+/// uses for `hf`); tests substitute a local fixture writer.
+pub trait AssetFetcher {
+    fn fetch(&mut self, url: &str, destination: &Path) -> Result<(), String>;
+}
+
+/// `curl -fsSL --retry 3` — fail on HTTP errors, follow the release
+/// asset redirect, no progress noise, bounded retries.
+pub struct CurlFetcher;
+
+impl AssetFetcher for CurlFetcher {
+    fn fetch(&mut self, url: &str, destination: &Path) -> Result<(), String> {
+        let status = Command::new("curl")
+            .args(["-fsSL", "--retry", "3", "-o"])
+            .arg(destination)
+            .arg(url)
+            .status()
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    "curl is required for install-release but was not found on PATH".to_owned()
+                } else {
+                    format!("could not run curl: {error}")
+                }
+            })?;
+        if !status.success() {
+            return Err(format!(
+                "download failed ({url}): curl exited with {status}; the release/tag/asset may not exist"
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_repo(repo: &str) -> Result<(), String> {
+    let mut parts = repo.split('/');
+    let (Some(owner), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
+        return Err(format!("--repo must be owner/name, got {repo:?}"));
+    };
+    let ok = |s: &str| {
+        !s.is_empty()
+            && s.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+    };
+    if ok(owner) && ok(name) {
+        Ok(())
+    } else {
+        Err(format!("--repo must be owner/name, got {repo:?}"))
+    }
+}
+
+fn validate_tag(tag: &str) -> Result<(), String> {
+    if !tag.is_empty()
+        && tag
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "--tag must be a plain release tag (alphanumeric/._-), got {tag:?}"
+        ))
+    }
+}
+
+fn asset_url(repo: &str, tag: &str, asset: &str) -> String {
+    format!("https://github.com/{repo}/releases/download/{tag}/{asset}")
+}
+
+fn digest_matches(path: &Path, declared: &str, label: &str) -> Result<(), String> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        format!(
+            "{label}: could not read extracted {}: {error}",
+            path.display()
+        )
+    })?;
+    let actual = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    if actual == declared {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label}: digest mismatch — manifest declares {declared}, archive bytes are {actual}; refusing to install"
+        ))
+    }
+}
+
+/// Every regular file under `root`, as `/`-joined paths relative to it.
+fn inventory(root: &Path) -> Result<Vec<String>, String> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|error| format!("could not list {}: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| format!("could not list archive entry: {error}"))?;
+            let path = entry.path();
+            let kind = entry
+                .file_type()
+                .map_err(|error| format!("could not stat {}: {error}", path.display()))?;
+            if kind.is_symlink() {
+                return Err(format!(
+                    "archive contains a symlink ({}); refusing to install",
+                    path.display()
+                ));
+            }
+            if kind.is_dir() {
+                stack.push(path);
+            } else {
+                let relative = path
+                    .strip_prefix(root)
+                    .map_err(|_| "archive entry escaped the extraction root".to_owned())?;
+                let mut joined = String::new();
+                for component in relative.components() {
+                    if !joined.is_empty() {
+                        joined.push('/');
+                    }
+                    joined.push_str(&component.as_os_str().to_string_lossy());
+                }
+                found.push(joined);
+            }
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+/// Download, verify, and install one published release bundle. See the
+/// module docs for the contract; every failure leaves the model store
+/// untouched (all work happens in a staging directory that is removed
+/// on the way out).
+pub fn install_release(
+    store_root: &Path,
+    request: &InstallReleaseRequest,
+    fetcher: &mut dyn AssetFetcher,
+) -> Result<InstalledRelease, String> {
+    validate_repo(&request.repo)?;
+    validate_tag(&request.tag)?;
+    if let Some(name) = request.name.as_deref() {
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+        {
+            return Err(format!(
+                "--name must be a plain directory name (alphanumeric/._-), got {name:?}"
+            ));
+        }
+    }
+
+    let staging = store_root.join("staging").join(format!(
+        "install-release-{}-{}",
+        request.tag,
+        std::process::id()
+    ));
+    let result = install_into_staging(store_root, &staging, request, fetcher);
+    let _ = std::fs::remove_dir_all(&staging);
+    result
+}
+
+fn install_into_staging(
+    store_root: &Path,
+    staging: &Path,
+    request: &InstallReleaseRequest,
+    fetcher: &mut dyn AssetFetcher,
+) -> Result<InstalledRelease, String> {
+    std::fs::create_dir_all(staging)
+        .map_err(|error| format!("could not create staging {}: {error}", staging.display()))?;
+
+    // 1. The sidecar manifest first: small, and it names what the
+    //    archive must contain before the archive is even fetched.
+    let sidecar_path = staging.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME);
+    fetcher.fetch(
+        &asset_url(
+            &request.repo,
+            &request.tag,
+            RELEASE_BUNDLE_SIDECAR_FILE_NAME,
+        ),
+        &sidecar_path,
+    )?;
+    let sidecar_bytes = std::fs::read(&sidecar_path)
+        .map_err(|error| format!("could not read downloaded sidecar: {error}"))?;
+    let manifest: ReleaseBundleManifest = serde_json::from_slice(&sidecar_bytes)
+        .map_err(|error| format!("release-bundle.json does not parse: {error}"))?;
+    if let Some(reason) = manifest.validate() {
+        return Err(format!("release-bundle.json failed validation: {reason}"));
+    }
+
+    // 2. The archive, extracted into an empty staging subdirectory.
+    let archive_path = staging.join(RELEASE_BUNDLE_ARCHIVE_ASSET);
+    fetcher.fetch(
+        &asset_url(&request.repo, &request.tag, RELEASE_BUNDLE_ARCHIVE_ASSET),
+        &archive_path,
+    )?;
+    let bundle_dir = staging.join("bundle");
+    std::fs::create_dir_all(&bundle_dir)
+        .map_err(|error| format!("could not create {}: {error}", bundle_dir.display()))?;
+    let status = Command::new("tar")
+        .arg("-xzf")
+        .arg(&archive_path)
+        .arg("-C")
+        .arg(&bundle_dir)
+        .status()
+        .map_err(|error| format!("could not run tar: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "archive extraction failed: tar exited with {status}"
+        ));
+    }
+
+    // 3. Fail-closed inventory: exactly the attested files, nothing else.
+    let mut expected: Vec<String> = vec![
+        GRAPH_RELATIVE_PATH.to_owned(),
+        SIGNATURE_ARTIFACT_RELATIVE_PATH.to_owned(),
+        SCORE_REPORT_RELATIVE_PATH.to_owned(),
+        COMPILE_REPORT_RELATIVE_PATH.to_owned(),
+    ];
+    if manifest.components.tokenizer.is_some() {
+        expected.push(TOKENIZER_RELATIVE_PATH.to_owned());
+    }
+    expected.sort();
+    let found = inventory(&bundle_dir)?;
+    if found != expected {
+        return Err(format!(
+            "archive contents do not match the manifest's attested component set; expected exactly {expected:?}, found {found:?}; refusing to install"
+        ));
+    }
+
+    // 4. Every declared digest must match the extracted bytes.
+    digest_matches(
+        &bundle_dir.join(GRAPH_RELATIVE_PATH),
+        &manifest.components.graph,
+        "components.graph",
+    )?;
+    digest_matches(
+        &bundle_dir.join(SIGNATURE_ARTIFACT_RELATIVE_PATH),
+        &manifest.components.signature_artifact,
+        "components.signature_artifact",
+    )?;
+    digest_matches(
+        &bundle_dir.join(SCORE_REPORT_RELATIVE_PATH),
+        &manifest.components.score_report,
+        "components.score_report",
+    )?;
+    digest_matches(
+        &bundle_dir.join(COMPILE_REPORT_RELATIVE_PATH),
+        &manifest.components.compile_report,
+        "components.compile_report",
+    )?;
+    if let Some(declared) = manifest.components.tokenizer.as_deref() {
+        digest_matches(
+            &bundle_dir.join(TOKENIZER_RELATIVE_PATH),
+            declared,
+            "components.tokenizer",
+        )?;
+    }
+
+    // 5. Keep the verified sidecar beside the bundle so serving-time
+    //    advisory verification (#655-C1c) finds it.
+    std::fs::write(
+        bundle_dir.join(RELEASE_BUNDLE_SIDECAR_FILE_NAME),
+        &sidecar_bytes,
+    )
+    .map_err(|error| format!("could not write bundle sidecar: {error}"))?;
+
+    // 6. Atomic move into the store; never overwrite an existing install.
+    let install_name = request
+        .name
+        .clone()
+        .unwrap_or_else(|| manifest.model_id.clone());
+    let destination = store_root.join("compiled").join(&install_name);
+    if destination.exists() {
+        return Err(format!(
+            "{} already exists; remove it first if you intend to replace it (install-release never overwrites)",
+            destination.display()
+        ));
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    std::fs::rename(&bundle_dir, &destination).map_err(|error| {
+        format!(
+            "could not move verified bundle into {}: {error}",
+            destination.display()
+        )
+    })?;
+
+    Ok(InstalledRelease {
+        destination,
+        manifest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::release_bundle_packager::{package_release_bundle, PackageInputs};
+    use uor_r4_api::{BundleCapability, UorMatmulProvenance};
+    use uor_r4_core::transformerless::hf_bpe::TokenizerAdapter;
+
+    /// Serves the two release assets from local fixture files, recording
+    /// requested URLs — the network never runs in tests.
+    struct FixtureFetcher {
+        sidecar: Vec<u8>,
+        archive: Vec<u8>,
+        urls: Vec<String>,
+    }
+
+    impl AssetFetcher for FixtureFetcher {
+        fn fetch(&mut self, url: &str, destination: &Path) -> Result<(), String> {
+            self.urls.push(url.to_owned());
+            let bytes = if url.ends_with(RELEASE_BUNDLE_SIDECAR_FILE_NAME) {
+                &self.sidecar
+            } else if url.ends_with(RELEASE_BUNDLE_ARCHIVE_ASSET) {
+                &self.archive
+            } else {
+                return Err(format!("unexpected fixture URL {url}"));
+            };
+            std::fs::write(destination, bytes).map_err(|error| error.to_string())
+        }
+    }
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "uor-r4-release-install-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        dir
+    }
+
+    fn write(dir: &Path, relative: &str, bytes: &[u8]) {
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&path, bytes).expect("write fixture file");
+    }
+
+    /// A complete packaged bundle directory + its honestly-derived
+    /// manifest, mirroring the packager's own layout.
+    fn packaged_fixture(root: &Path) -> (PathBuf, ReleaseBundleManifest) {
+        let bundle = root.join("packaged");
+        write(&bundle, "graph/score.r4g1", b"graph bytes");
+        write(&bundle, "tless_artifacts.bin", b"signature bytes");
+        write(&bundle, "tokenizer.bin", b"tokenizer bytes");
+        write(&bundle, "graph/score_report.json", b"{\"score\":true}");
+        write(
+            &bundle,
+            "graph-cover/cover_report.json",
+            b"{\"cover\":true}",
+        );
+        let manifest = package_release_bundle(
+            &bundle,
+            PackageInputs {
+                model_id: "r4".to_owned(),
+                capability: BundleCapability::InstructionChat,
+                uor_matmul: UorMatmulProvenance {
+                    rev: "b13c98449948174f590e337c4dc25dfc394a07d0".to_owned(),
+                    operation_profile: "exact-gemm-float".to_owned(),
+                    license: "MIT".to_owned(),
+                    source_digest: None,
+                },
+                tokenizer_adapter: TokenizerAdapter {
+                    family: "hf-byte-bpe".to_owned(),
+                    ..Default::default()
+                },
+                provenance_note: None,
+            },
+        )
+        .expect("fixture packages");
+        (bundle, manifest)
+    }
+
+    fn tar_gz(dir: &Path, out: &Path) -> Vec<u8> {
+        let status = Command::new("tar")
+            .arg("-czf")
+            .arg(out)
+            .arg("-C")
+            .arg(dir)
+            .arg(".")
+            .status()
+            .expect("tar runs");
+        assert!(status.success(), "fixture archive builds");
+        std::fs::read(out).expect("read fixture archive")
+    }
+
+    fn fetcher_for(root: &Path) -> (FixtureFetcher, ReleaseBundleManifest) {
+        let (bundle, manifest) = packaged_fixture(root);
+        let archive = tar_gz(&bundle, &root.join("release-bundle.tar.gz"));
+        (
+            FixtureFetcher {
+                sidecar: serde_json::to_vec(&manifest).expect("serialize manifest"),
+                archive,
+                urls: Vec::new(),
+            },
+            manifest,
+        )
+    }
+
+    fn request() -> InstallReleaseRequest {
+        InstallReleaseRequest {
+            repo: "UOR-Foundation/uor-r4".to_owned(),
+            tag: "v0.1".to_owned(),
+            name: None,
+        }
+    }
+
+    #[test]
+    fn verified_release_installs_with_its_sidecar_and_exact_urls() {
+        let root = scratch_dir("happy");
+        let store = root.join("store");
+        let (mut fetcher, manifest) = fetcher_for(&root);
+        let installed =
+            install_release(&store, &request(), &mut fetcher).expect("verified install");
+        assert_eq!(installed.destination, store.join("compiled").join("r4"));
+        assert_eq!(installed.manifest, manifest);
+        // The attested components and the sidecar are in place; the
+        // serving loader's advisory verification would now find them.
+        for file in [
+            "graph/score.r4g1",
+            "tless_artifacts.bin",
+            "tokenizer.bin",
+            "graph/score_report.json",
+            "graph-cover/cover_report.json",
+            RELEASE_BUNDLE_SIDECAR_FILE_NAME,
+        ] {
+            assert!(
+                installed.destination.join(file).is_file(),
+                "{file} installed"
+            );
+        }
+        assert_eq!(
+            fetcher.urls,
+            vec![
+                "https://github.com/UOR-Foundation/uor-r4/releases/download/v0.1/release-bundle.json".to_owned(),
+                "https://github.com/UOR-Foundation/uor-r4/releases/download/v0.1/release-bundle.tar.gz".to_owned(),
+            ],
+            "explicit fetch hits exactly the two declared release assets"
+        );
+        // Staging is cleaned up on success.
+        assert!(
+            !store.join("staging").exists()
+                || std::fs::read_dir(store.join("staging"))
+                    .map(|mut d| d.next().is_none())
+                    .unwrap_or(true)
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn tampered_component_bytes_refuse_to_install() {
+        let root = scratch_dir("tampered");
+        let store = root.join("store");
+        let (bundle, manifest) = packaged_fixture(&root);
+        // Tamper AFTER the manifest was derived.
+        write(&bundle, "graph/score.r4g1", b"TAMPERED graph bytes");
+        let archive = tar_gz(&bundle, &root.join("release-bundle.tar.gz"));
+        let mut fetcher = FixtureFetcher {
+            sidecar: serde_json::to_vec(&manifest).expect("serialize manifest"),
+            archive,
+            urls: Vec::new(),
+        };
+        let error = install_release(&store, &request(), &mut fetcher)
+            .expect_err("tampered bytes must refuse");
+        assert!(error.contains("components.graph"), "{error}");
+        assert!(error.contains("digest mismatch"), "{error}");
+        assert!(
+            !store.join("compiled").join("r4").exists(),
+            "nothing installed"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn smuggled_extra_file_refuses_to_install() {
+        let root = scratch_dir("smuggled");
+        let store = root.join("store");
+        let (bundle, manifest) = packaged_fixture(&root);
+        write(&bundle, "extra/unattested.bin", b"not in the manifest");
+        let archive = tar_gz(&bundle, &root.join("release-bundle.tar.gz"));
+        let mut fetcher = FixtureFetcher {
+            sidecar: serde_json::to_vec(&manifest).expect("serialize manifest"),
+            archive,
+            urls: Vec::new(),
+        };
+        let error = install_release(&store, &request(), &mut fetcher)
+            .expect_err("unattested file must refuse");
+        assert!(error.contains("attested component set"), "{error}");
+        assert!(
+            !store.join("compiled").join("r4").exists(),
+            "nothing installed"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn existing_install_is_never_overwritten() {
+        let root = scratch_dir("existing");
+        let store = root.join("store");
+        std::fs::create_dir_all(store.join("compiled").join("r4")).expect("pre-existing install");
+        let (mut fetcher, _) = fetcher_for(&root);
+        let error = install_release(&store, &request(), &mut fetcher)
+            .expect_err("existing destination must refuse");
+        assert!(error.contains("never overwrites"), "{error}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invalid_repo_tag_and_name_shapes_are_rejected_before_any_fetch() {
+        let root = scratch_dir("shapes");
+        let store = root.join("store");
+        let (mut fetcher, _) = fetcher_for(&root);
+        for (repo, tag, name) in [
+            ("not-a-repo", "v0.1", None),
+            ("owner/name/extra", "v0.1", None),
+            ("UOR-Foundation/uor-r4", "v0.1/../evil", None),
+            ("UOR-Foundation/uor-r4", "", None),
+            ("UOR-Foundation/uor-r4", "v0.1", Some("../evil")),
+        ] {
+            let bad = InstallReleaseRequest {
+                repo: repo.to_owned(),
+                tag: tag.to_owned(),
+                name: name.map(str::to_owned),
+            };
+            assert!(
+                install_release(&store, &bad, &mut fetcher).is_err(),
+                "shape {repo:?} {tag:?} {name:?} must be rejected"
+            );
+        }
+        assert!(fetcher.urls.is_empty(), "no fetch before validation");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -150,8 +150,16 @@ pub struct VendorChatCompletionsRequest {
     pub messages: Vec<ChatMessage>,
     #[serde(default)]
     pub max_tokens: Option<usize>,
+    /// `temperature: 0` opts the R4G1 tier into deterministic greedy
+    /// decode (#655 decode-default decision, 2026-08-19); any other
+    /// value (or absence) keeps the default seeded sampled decode.
     #[serde(default)]
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode (OpenAI `seed` compatibility); absent requests use the
+    /// pinned default seed, so identical requests stay reproducible.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// Optional engine pin ("r4g1", "transformerless", "attention",
     /// "r4-attention", "geometric"); absent/"auto" runs the full cascade,
     /// falling back to the persisted `/engine` selection (issue #248).
@@ -192,8 +200,15 @@ pub struct VendorResponsesRequest {
     pub instructions: Option<String>,
     #[serde(default)]
     pub max_output_tokens: Option<usize>,
+    /// `temperature: 0` opts the R4G1 tier into deterministic greedy
+    /// decode (#655); any other value or absence keeps the default
+    /// seeded sampled decode.
     #[serde(default)]
     pub temperature: Option<f64>,
+    /// Sampling seed override for the R4G1 tier's default sampled
+    /// decode; absent requests use the pinned default seed.
+    #[serde(default)]
+    pub seed: Option<u32>,
     /// When `true`, the completion is delivered as the Responses
     /// `text/event-stream` event sequence terminating on `response.completed`.
     #[serde(default)]
@@ -3116,11 +3131,14 @@ struct R4g1Text {
 
 /// Generate directly from the validated R4G1 graph runtime. Tokenization and
 /// decoding intentionally use the same tokenizer as the compiled teacher
-/// artifact; R4G1 stores token ids, not user-facing text.
+/// artifact; R4G1 stores token ids, not user-facing text. `decode` selects
+/// the #655 decode mode: sampled (the default, pinned seed) or the
+/// `temperature: 0` greedy opt-in — the D4 policy path is identical.
 fn generate_r4g1_text(
     state: Option<&R4g1State>,
     prompt: &str,
     max_tokens: usize,
+    decode: R4g1Decode,
 ) -> Result<Option<R4g1Text>, String> {
     const MAX_SERVER_TOKENS: usize = 256;
     const MAX_SERVER_TEXT_BYTES: usize = 16 * 1024;
@@ -3148,12 +3166,24 @@ fn generate_r4g1_text(
         if seed_len == 0 {
             return Err("R4G1 tokenizer produced an empty prompt".to_owned());
         }
-        let outcome = state
-            .generate_into_status(
-                &seed[..seed_len],
-                &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
-            )
-            .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?;
+        let outcome = match decode {
+            R4g1Decode::Greedy => state
+                .generate_into_status(
+                    &seed[..seed_len],
+                    &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
+                )
+                .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?,
+            R4g1Decode::Sampled { seed: rng_seed } => {
+                let mut rng = uor_r4_core::transformerless::runtime::SampleRng::new(rng_seed);
+                state
+                    .generate_sampled_into_status(
+                        &seed[..seed_len],
+                        &mut generated[..max_tokens.min(MAX_SERVER_TOKENS)],
+                        &mut rng,
+                    )
+                    .map_err(|error| format!("R4G1 graph scoring failed: {error}"))?
+            }
+        };
         // On an abstention no text is produced: the tokens generated before
         // the abstaining step are dropped rather than served, so an
         // out-of-distribution prompt never surfaces partial output.
@@ -3768,6 +3798,39 @@ const TIER_R4_ATTENTION: &str = "r4-attention";
 /// abstention (issue #248) — never served as if it were generated prose.
 const SPARSE_RESONANCE_MESSAGE: &str = "Manifold resonance too sparse for synthesis.";
 
+/// #655 decode-default decision (2026-08-19): how the R4G1 tier decodes
+/// one request. `Sampled` with the pinned default seed is the default on
+/// every serving surface; `Greedy` is the explicit `temperature: 0`
+/// opt-in. Both run the identical D4 policy path — sampling only
+/// replaces which served candidate is emitted (never whether a step
+/// serves or abstains), so Novel/OOD abstention behavior is decode-mode
+/// independent by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum R4g1Decode {
+    /// Deterministic beam/argmax walk (opt-in via `temperature: 0`;
+    /// also what the opt-in witness envelope decodes with, since
+    /// witness claims bind the greedy selection).
+    Greedy,
+    /// Seeded weighted sampling over the serving probe's own candidate
+    /// list — the default. The seed is pinned per request so default
+    /// serving stays reproducible: identical requests produce identical
+    /// completions.
+    Sampled { seed: u32 },
+}
+
+/// Map one request's raw decode-relevant fields to the tier decode mode:
+/// an explicit `temperature` of zero (or below) opts into greedy; every
+/// other request samples, seeded by the request's `seed` override or
+/// the pinned [`crate::chat::DEFAULT_SAMPLE_SEED`].
+fn r4g1_decode_from_request(temperature: Option<f64>, seed: Option<u32>) -> R4g1Decode {
+    match temperature {
+        Some(value) if value <= 0.0 => R4g1Decode::Greedy,
+        _ => R4g1Decode::Sampled {
+            seed: seed.unwrap_or(crate::chat::DEFAULT_SAMPLE_SEED),
+        },
+    }
+}
+
 /// R4G1 policy metadata surfaced alongside the cascade outcome so the
 /// legacy `r4g1` response block keeps its exact shape.
 #[derive(Debug, Default)]
@@ -4035,6 +4098,7 @@ fn tless_bypass_profile_decline() -> Option<(u16, serde_json::Value)> {
 /// the central policy (recording, not refusing; PR #223 semantics).
 /// Unusable text is `Pathological` with the reason; an unavailable runtime
 /// or scoring error is `Failed`.
+#[allow(clippy::too_many_arguments)]
 fn r4g1_tier(
     state: Option<&R4g1State>,
     prompt: &str,
@@ -4042,8 +4106,9 @@ fn r4g1_tier(
     signal: &mut R4g1Signal,
     load_error: Option<&str>,
     usage: &Cell<Option<ServingUsage>>,
+    decode: R4g1Decode,
 ) -> TierResult {
-    match generate_r4g1_text(state, prompt, max_tokens.max(32)) {
+    match generate_r4g1_text(state, prompt, max_tokens.max(32), decode) {
         Ok(Some(gen)) if gen.abstained => {
             signal.status = gen.status.map(r4g1::PolicyStatus::from).map(|s| s.label());
             signal.widened = gen.widened;
@@ -4198,6 +4263,7 @@ fn run_serving_cascade(
     session_signature: Option<&[u8]>,
     pinned: Option<&'static str>,
     profile: EngineProfile,
+    r4g1_decode: R4g1Decode,
 ) -> ServingCascade {
     let ServingModelState {
         r4g1,
@@ -4237,6 +4303,7 @@ fn run_serving_cascade(
                         signal_ref,
                         load_error.as_deref(),
                         usage_ref,
+                        r4g1_decode,
                     )
                 }),
             ));
@@ -14912,8 +14979,12 @@ fn generate_serving_completion(
     engine: Option<&str>,
     max_tokens: usize,
     temperature_override: Option<f64>,
+    seed: Option<u32>,
 ) -> GenerationOutcome {
     let identity = "tenant-alpha".to_string();
+    // #655 decode default: derived from the RAW request fields (an
+    // autotuned nonzero temperature must never read as a greedy opt-in).
+    let r4g1_decode = r4g1_decode_from_request(temperature_override, seed);
 
     // #789-G3.4: every engine-name decline is judged BEFORE any lock or
     // router/brain mutation — this path previously evolved brain state and
@@ -15035,6 +15106,7 @@ fn generate_serving_completion(
         Some(&session_signature),
         pinned,
         profile,
+        r4g1_decode,
     );
     let generation_mode = derive_generation_mode(&cascade, pinned);
     let Some(final_response_text) = cascade.outcome.text.clone() else {
@@ -15902,6 +15974,7 @@ fn handle_connection(
             req.engine.as_deref(),
             max_tokens,
             req.temperature,
+            req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
                 send_json_response(stream, status, &body.to_string());
@@ -16049,6 +16122,7 @@ fn handle_connection(
             req.engine.as_deref(),
             max_tokens,
             req.temperature,
+            req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
                 send_json_response(stream, status, &body.to_string());
@@ -16213,6 +16287,10 @@ fn handle_connection(
         // (PR #223 record-and-continue semantics, implemented directly by
         // `run_cascade` — #790 item 4).
         let t_gen = Instant::now();
+        // #655 decode default: derived from the RAW request fields — the
+        // autotuned geometric temperature above must never read as a
+        // greedy opt-in.
+        let r4g1_decode = r4g1_decode_from_request(payload.temperature, payload.seed);
         let mut cascade = run_serving_cascade(
             &mut router_guard,
             &mut installed,
@@ -16225,6 +16303,7 @@ fn handle_connection(
             Some(&session_signature),
             pinned,
             profile,
+            r4g1_decode,
         );
 
         // Legacy response fields, derived from the trail so consumers keep
@@ -18520,6 +18599,50 @@ mod tests {
             path: path.to_path_buf(),
             identity,
         }
+    }
+
+    /// #655 decode-default decision (2026-08-19): the request-field →
+    /// decode-mode mapping. Sampled with the pinned default seed is the
+    /// default; `temperature: 0` (or below) is the greedy opt-in; a
+    /// request `seed` overrides the pinned default; and a greedy opt-in
+    /// wins over a supplied seed (the seed only parameterizes sampling).
+    #[test]
+    fn r4g1_decode_defaults_to_pinned_seed_sampling_with_greedy_opt_in() {
+        use super::R4g1Decode;
+        assert_eq!(
+            super::r4g1_decode_from_request(None, None),
+            R4g1Decode::Sampled {
+                seed: crate::chat::DEFAULT_SAMPLE_SEED
+            },
+            "an ordinary request samples with the pinned default seed"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.7), None),
+            R4g1Decode::Sampled {
+                seed: crate::chat::DEFAULT_SAMPLE_SEED
+            },
+            "a nonzero temperature keeps the default sampled decode"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(None, Some(7)),
+            R4g1Decode::Sampled { seed: 7 },
+            "a request seed overrides the pinned default"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.0), None),
+            R4g1Decode::Greedy,
+            "temperature zero is the greedy opt-in"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(-1.0), None),
+            R4g1Decode::Greedy,
+            "a negative temperature never samples"
+        );
+        assert_eq!(
+            super::r4g1_decode_from_request(Some(0.0), Some(7)),
+            R4g1Decode::Greedy,
+            "the greedy opt-in wins over a supplied seed"
+        );
     }
 
     #[test]

--- a/tests/status_policy.rs
+++ b/tests/status_policy.rs
@@ -22,11 +22,14 @@ mod status_policy_common;
 
 use status_policy_common as fixture;
 
-use uor_r4_api::engine::WitnessVerificationError;
-use uor_r4_graph_certify::{ScoreStatus, TOP_M, WIDENED_TOP_M};
+use uor_r4_api::engine::{EngineParts, R4Engine, WitnessVerificationError};
+use uor_r4_graph_certify::{
+    ScoreStatus, StepCandidates, STEP_TOP_CANDIDATES, TOP_M, WIDENED_TOP_M,
+};
 use uor_r4_wasm_router::r4g1::{
     AbstainOutcome, PolicyStatus, PredictDecision, PredictOutcome, StatusAction, StatusPolicy,
 };
+use uor_r4_wasm_router::transformerless::runtime::SampleRng;
 
 // ------------------------------------------------------- (a) OOD probe --
 
@@ -309,6 +312,135 @@ fn generation_stops_at_the_first_abstain() {
         .expect("legacy generate");
     assert_eq!(legacy_count, outcome.count);
     assert_eq!(legacy_out[..legacy_count], out[..outcome.count]);
+}
+
+// ---------------------------------------------- sampled decode (#655) --
+
+/// The candidates-reporting step is the plain deployed step: selection,
+/// score, status, and candidate count are identical on every probe
+/// signature at both membership widths, with and without the deployed
+/// recent-window penalty; the ranked list leads with the selection,
+/// is strictly ordered under the canonical rule (score descending,
+/// token ascending), and is bounded by the candidate count.
+#[test]
+fn step_candidates_match_the_plain_step_and_rank_the_selection_first() {
+    let fixture = fixture::signature_fixture(None);
+    let scorer = fixture.reference_scorer();
+    let mut step_state = scorer.step_state(WIDENED_TOP_M).expect("step state");
+    let mut candidates = StepCandidates::default();
+    for sig in [fixture.covered_sig, fixture.graph_sig, fixture.ood_sig] {
+        for top_m in [TOP_M, WIDENED_TOP_M] {
+            for recent in [&[][..], &[10u32][..]] {
+                let plain = scorer
+                    .score_step_with_recent(&sig, top_m, &mut step_state, recent)
+                    .expect("plain step");
+                let listed = scorer
+                    .score_step_candidates_coded_with_recent(
+                        &sig,
+                        None,
+                        top_m,
+                        &mut step_state,
+                        recent,
+                        &mut candidates,
+                    )
+                    .expect("candidates step");
+                assert_eq!(listed.selected, plain.selected);
+                assert_eq!(listed.selected_score, plain.selected_score);
+                assert_eq!(listed.status, plain.status);
+                assert_eq!(listed.candidate_count, plain.candidate_count);
+                let ranked = candidates.ranked();
+                assert_eq!(
+                    ranked.len(),
+                    (plain.candidate_count as usize).min(STEP_TOP_CANDIDATES)
+                );
+                assert_eq!(ranked[0], (plain.selected, plain.selected_score));
+                for pair in ranked.windows(2) {
+                    let (prev_token, prev_score) = pair[0];
+                    let (next_token, next_score) = pair[1];
+                    assert!(
+                        prev_score.raw() > next_score.raw()
+                            || (prev_score.raw() == next_score.raw() && prev_token < next_token),
+                        "ranked list must be strictly ordered under the canonical rule"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The #655 sampled decode (`R4Engine::generate_sampled_into`) shares
+/// the greedy path's D4 policy decisions by construction: an OOD seed
+/// abstains with the same typed outcome (no token guessed under
+/// sampling either), a served run is byte-reproducible from its rng
+/// seed, every emitted token stays inside the fixture's declared
+/// emission universe, and the policy counters show each emitted token
+/// paid one served policy decision.
+#[test]
+fn sampled_decode_is_seeded_and_abstains_exactly_like_greedy() {
+    let fixture = fixture::window_fixture();
+    let load_engine = || {
+        R4Engine::load(EngineParts {
+            graph: &fixture.bytes,
+            signature_artifact: &fixture.teacher,
+            tokenizer: None,
+            score_report: None,
+        })
+        .expect("fixture engine loads")
+    };
+    let ood_window = fixture::find_window_by_status(&fixture, ScoreStatus::Novel);
+
+    // OOD seed: identical abstention under greedy and sampled decode.
+    let mut greedy_engine = load_engine();
+    let greedy = greedy_engine
+        .generate_into(&ood_window, &mut [0u32; 8])
+        .expect("greedy generate");
+    let mut sampled_engine = load_engine();
+    let mut rng = SampleRng::new(42);
+    let mut sampled_out = [0u32; 8];
+    let sampled = sampled_engine
+        .generate_sampled_into(&ood_window, &mut sampled_out, &mut rng)
+        .expect("sampled generate");
+    assert!(greedy.abstained, "fixture OOD seed abstains under greedy");
+    assert!(sampled.abstained, "the sampled path preserves abstention");
+    assert_eq!(sampled.count, 0, "no token guessed under sampling");
+    assert_eq!(sampled.status, greedy.status);
+
+    // Served seed: same rng seed → identical run, end to end.
+    let run = |seed: u32| {
+        let mut engine = load_engine();
+        let mut rng = SampleRng::new(seed);
+        let mut out = [0u32; 8];
+        let outcome = engine
+            .generate_sampled_into(&fixture.covered_window, &mut out, &mut rng)
+            .expect("sampled generate");
+        let counters = engine.policy_counters();
+        (
+            outcome.count,
+            outcome.status,
+            outcome.abstained,
+            out,
+            counters.serves,
+        )
+    };
+    let (count, status, abstained, tokens, serves) = run(41);
+    assert_eq!(
+        (count, status, abstained, tokens, serves),
+        run(41),
+        "same seed reproduces the run end to end"
+    );
+    assert!(count >= 1, "the covered seed serves at least one token");
+    // Every emitted token draws from a serving probe's own candidate
+    // list; the fixture's whole emission universe (root prior + region
+    // lists) is {10, 20, 30, 40}.
+    for &token in &tokens[..count] {
+        assert!(
+            matches!(token, 10 | 20 | 30 | 40),
+            "sampled token {token} escaped the fixture's emission universe"
+        );
+    }
+    // No EOS ids exist in that universe, so every emitted token paid
+    // exactly one served policy decision.
+    assert_eq!(serves as usize, count, "one serve per emitted token");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the #741 maintainer decision (2026-08-19): **adopt the #655-D package as the release artifact and build the pipeline now** — both frontends, GitHub Release distribution, explicit verified fetch, and `vX.Y` tags binding code SHA + bundle component digests + contract version. **Publishes nothing until a tag is cut**, and even then the release is a draft until the maintainer publishes. Stacked on #814 (decode flip) → #813 (decode machinery); the last commit is this PR's.

- **`.github/workflows/release.yml`** — on `v*` tag push: draft release (notes bind tag → commit SHA + inference-contract version), native CLI builds for linux x86_64 + macOS arm64, the wasm frontend (same `wasm-pack` build the Pages deploy runs), `.sha256` beside each. The model bundle is attached by the maintainer from a locally packaged compile — CI cannot compile the model.
- **`r4 install-release --tag vX.Y`** (`src/release_install.rs`) — downloads `release-bundle.json` + `release-bundle.tar.gz`, **hard-verifies every declared component digest** against extracted bytes (deliberately stricter than the advisory serving-time check), refuses archives with any unattested entry or symlink, never overwrites an existing install, installs atomically with the sidecar beside the bundle so #655-C1c serving verification sees the same manifest. Fetch is explicit-only — per #655's "first request must not silently download" scope line. Fetcher is a trait: `curl` in production, fixtures in tests (the network never runs in tests).
- **`docs/RELEASE_PIPELINE.md`** — the versioning convention, exact maintainer release steps (bundle candidate per the decision record: the `smollm2-360m-broad` compile), and the verified-fetch contract.

## Tests

Verified-install happy path (exact asset URLs, sidecar installed beside the bundle, staging cleaned) · tampered component bytes refused · smuggled unattested file refused · existing install never overwritten · repo/tag/name shape validation rejects before any fetch. Workspace clippy `-D warnings` clean, fmt clean, bin + lib suites pass.

## What this does NOT do

No serving default or canonical identity change (that is #655-F, separately gated); no auto-publish; no CI model compilation.

## Refs

#741 (decision brief issuecomment-5335803275, adoption issuecomment-5335968482) · #655-D (packager/sidecar this pipeline distributes) · #655 precondition 1 (a fresh clone can now reach a real bundle via one explicit verified command once a release exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
