### PR TITLE
serving: r4 is the canonical served model identity (#655-F flip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ responses carry permissive CORS.
 **OpenAI-compatible (`/v1`)** — this is what `r4 client` and `r4 chat --remote`
 speak; `/v1` is kept a pure OpenAI surface (see `profiles/openai/`):
 
+The canonical served model id is **`r4`** (#655-F): requests may omit
+`model`, send `r4`, or send the deprecated pre-flip alias `uor-r4`
+(accepted for a compatibility window); responses, `/v1/models`, and wire
+ids (`chatcmpl-r4-…`, `system_fingerprint: r4-…`) always report `r4`.
+Per-bundle physical names remain visible as metadata on `/uor/v1/status`.
+
 | Endpoint | Purpose |
 |---|---|
 | `POST /v1/chat/completions` | Chat completion (non-streaming and SSE streaming) |

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1223,6 +1223,27 @@ impl R4Engine {
     /// signatures. EXCT is not enabled because its reference
     /// implementation performs probe-time floating-point quantization.
     pub fn load(parts: EngineParts<'_>) -> Result<Self, SourceUnavailable> {
+        Self::load_with_quality_gate(parts, true)
+    }
+
+    /// [`Self::load`] minus the serving-admission quality gate: the
+    /// bundle's recorded quality verdict (`validate_quality_report`)
+    /// does not change what the D4 policy resolves, and a caller that
+    /// has already decided — with its own recorded warning — to decode
+    /// a below-baseline bundle (the CLI's local-bundle path, #655-C1e)
+    /// still needs the deployed policy engine over it for the ask-path
+    /// abstention gate (#811). Everything else — CID verification,
+    /// tokenizer binding, teacher pairing, scorer rebuild, the
+    /// status-policy/report parsing — is identical to [`Self::load`].
+    /// Serving admission continues to use [`Self::load`] unchanged.
+    pub fn load_accepting_quality(parts: EngineParts<'_>) -> Result<Self, SourceUnavailable> {
+        Self::load_with_quality_gate(parts, false)
+    }
+
+    fn load_with_quality_gate(
+        parts: EngineParts<'_>,
+        enforce_quality: bool,
+    ) -> Result<Self, SourceUnavailable> {
         // Fail fast with the format crate's focused reason before any scorer
         // state is built (the scorer re-validates internally). Every part is
         // an external byte source; a malformed part is reported as a
@@ -1334,9 +1355,11 @@ impl R4Engine {
             exct_top_x,
         )
         .expect("engine load: scorer rebuild from the parsed, CID-verified, and teacher-paired graph bytes");
-        if let Some(report) = score_report.as_ref() {
-            if let Some(message) = validate_quality_report(report) {
-                return Err(SourceUnavailable::new(message));
+        if enforce_quality {
+            if let Some(report) = score_report.as_ref() {
+                if let Some(message) = validate_quality_report(report) {
+                    return Err(SourceUnavailable::new(message));
+                }
             }
         }
         let tokenizer = parts

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -162,6 +162,19 @@ All follow the override contract above.
 | `UOR_R4_RELEASE_BUNDLE_PATH` | — | `release_bundle_packager` real-local-bundle test (`#[ignore]`d; mirrors the `UOR_R4_API_E2E_SOURCE` convention) |
 | `PORT` | 8000 | `./uor-r4-cli` orchestrator only (shell script; the `r4` binary itself reads `UOR_R4_PORT`) |
 
+## Served model identity (#655-F)
+
+The canonical served model id on every serving surface (OpenAI `/v1`
+routes, native `/api/chat`, WS, WASM) is **`r4`**. Requests may omit
+`model`, send `r4`, or send the deprecated pre-flip alias `uor-r4`
+(accepted for a compatibility window); responses and `/v1/models`
+always report `r4`, and OpenAI wire ids are `r4`-prefixed
+(`chatcmpl-r4-…`, `resp-r4-…`, `msg-r4-…`, `system_fingerprint:
+r4-{mode}`). The CLI `client` subcommand's `--model` default is `r4`.
+Per-bundle logical/physical names are metadata (`/uor/v1/status`), not
+the served identity. Engine/tier names (`r4g1`, …) are unrelated to the
+model id and unchanged.
+
 ## Runtime state files
 
 Written under `.uor-models/` (or `UOR_MODEL_STORE`):

--- a/docs/serving_default_flip_655_f.md
+++ b/docs/serving_default_flip_655_f.md
@@ -232,3 +232,39 @@ Does not change `run_serving_cascade`, `resolve_pinned_tier`, or any
 `EngineProfile` mechanics landed in E — F operates one layer up, on
 canonical identity, not tier reachability, and E's own work already
 stands on its own regardless of F's timeline.
+
+## Addendum 2026-08-19 — the flip executed
+
+Both preconditions cleared and the maintainer gave the fresh explicit
+approval this document required, so the flip shipped:
+
+- **Precondition 1 (distributed bundle): met.** Release v0.1 is
+  published with the packaged `smollm2-360m-broad` bundle and attested
+  manifest as GitHub Release assets; `r4 install-release --tag v0.1` is
+  the explicit hard-verified fetch, proven end to end against the live
+  release (#741 closed; `docs/RELEASE_PIPELINE.md`).
+- **Precondition 2 (baseline-quality canary): met.** The sampled decode
+  became the serving/CLI default (#813/#814) and the default path is
+  byte-identical to the measured 15/15-valid canary arm; the F-p2
+  acceptance probes now pass through the same deployed D4 policy on the
+  CLI as on the server (#811/PR #816). Distinctness remains open as
+  #784 and is disclosed on the release.
+- **Authorization**: maintainer decisions of 2026-08-19 (~01:50Z,
+  recorded #655 issuecomment-5336515423) — flip authorized, sequenced
+  after the release publish and #811; both held before this change.
+
+What shipped (per `docs/serving_rename_inventory_655_f.md`, section by
+section): `CANONICAL_MODEL_ID = "r4"` served on every surface with
+`uor-r4` retained as the deprecated request alias;
+`active_canonical_model_name` reports the canonical id (physical names
+stay metadata); OpenAI wire ids and `system_fingerprint` are
+`r4`-prefixed; CLI `client --model` defaults to `r4` and the remote
+client parses both fingerprint prefixes for the deprecation window;
+README/CONFIGURATION carry the identity contract. Deliberate
+exclusions, unchanged from the inventory: crate names, schema strings,
+staging dirs, the `uor-r4-cli` orchestrator script file name, and the
+four source-verification logical-name fallbacks (infrastructure
+identifiers, not served identity). **The threat-model doc F's list
+names does not exist in this repository**; creating one remains a
+separate product decision, recorded here rather than improvised at
+flip time.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2016,7 +2016,7 @@ pub fn remote_interactive_chat(
 
     loop {
         let prompt_lbl = format!(
-            "\x1b[1;36muor-r4\x1b[0m \x1b[33m[model: {} | engine: {}]\x1b[0m \x1b[1;32m>\x1b[0m ",
+            "\x1b[1;36mr4\x1b[0m \x1b[33m[model: {} | engine: {}]\x1b[0m \x1b[1;32m>\x1b[0m ",
             current_active_model, current_active_engine
         );
         let line_opt = match read_line_with_history(&prompt_lbl, &mut history, input, output) {
@@ -2925,11 +2925,14 @@ fn send_vendor_chat_completion(
         .as_u64()
         .unwrap_or_else(|| content.split_whitespace().count() as u64)
         as usize;
-    let mode = parsed["system_fingerprint"]
-        .as_str()
-        .unwrap_or("uor-r4")
-        .strip_prefix("uor-r4-")
-        .unwrap_or_else(|| parsed["system_fingerprint"].as_str().unwrap_or("uor-r4"))
+    // #655-F: fingerprints are `r4-{mode}` post-flip; the pre-flip
+    // `uor-r4-{mode}` prefix stays parseable for the deprecation window
+    // (an old server behind a new client).
+    let fingerprint = parsed["system_fingerprint"].as_str().unwrap_or("r4");
+    let mode = fingerprint
+        .strip_prefix("r4-")
+        .or_else(|| fingerprint.strip_prefix("uor-r4-"))
+        .unwrap_or(fingerprint)
         .to_string();
 
     let uor_audit: Option<crate::server::UorAuditTrace> = parsed

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -57,6 +57,24 @@ pub struct ChatAnswer {
     /// #785 C3: which decode surface served this turn and how the
     /// context resolved — the observability the #759 scoping asked for.
     pub witness: DecodeWitness,
+    /// #811: `Some` when this turn ended in a typed D4 abstention
+    /// instead of served text — `text` is empty, no token is served,
+    /// and any partially generated tokens were dropped (the server
+    /// tier's exact contract). `None` on every served answer.
+    pub abstention: Option<ChatAbstention>,
+}
+
+/// #811: the CLI's typed honest abstention — the same D4 outcome the
+/// server's R4G1 tier surfaces (issue #78 decision D4), produced by the
+/// same deployed policy engine. No token is guessed; the status names
+/// how the context resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatAbstention {
+    /// The abstaining resolution status label (`"novel"`,
+    /// `"contradictory"`, …) from the deployed policy.
+    pub status: String,
+    /// Whether the policy widened once before abstaining.
+    pub widened: bool,
 }
 
 /// #785 C3: the depth/fallback-tier witness for one chat turn.
@@ -265,6 +283,12 @@ impl ChatEngineBuilder {
             max_tokens = self.max_tokens,
             "transformerless chat engine loaded"
         );
+        let policy_engine = load_chat_policy_engine(
+            r4g1_bytes.as_deref(),
+            &artifact_bytes,
+            &tokenizer_bytes,
+            read_chat_score_report(&model_dir).as_deref(),
+        );
         Ok(ChatEngine {
             artifacts,
             store,
@@ -274,7 +298,80 @@ impl ChatEngineBuilder {
             history_len: 0,
             max_tokens: self.max_tokens,
             sample_rng: self.sample_seed.map(SampleRng::new),
+            policy_engine,
         })
+    }
+}
+
+/// #811: the optional D4 policy override beside the graph
+/// (`graph/score_report.json`), pre-validated as JSON exactly like the
+/// server-side loader (`src/r4g1.rs`): an unparseable report is ignored
+/// (D4 defaults apply), never an error.
+fn read_chat_score_report(model_dir: &std::path::Path) -> Option<Vec<u8>> {
+    let bytes = std::fs::read(model_dir.join("graph").join("score_report.json")).ok()?;
+    serde_json::from_slice::<serde_json::Value>(&bytes).ok()?;
+    Some(bytes)
+}
+
+/// #811: build the deployed D4 policy engine over the same bundle bytes
+/// the CLI graph walk decodes from, so `ask`/`chat` share the server
+/// tier's exact abstention policy — one implementation (`R4Engine`'s
+/// serve / widen-once / abstain path, novel-seen FIFO included), never
+/// a re-derivation. `None` (with a loud warn) when the engine cannot
+/// load these bytes: the walk then runs ungated, exactly the pre-#811
+/// behavior — and since the serving tier would refuse the same bundle,
+/// the warn names a real bundle divergence rather than silencing one.
+fn load_chat_policy_engine(
+    r4g1_bytes: Option<&[u8]>,
+    artifact_bytes: &[u8],
+    tokenizer_bytes: &[u8],
+    score_report: Option<&[u8]>,
+) -> Option<uor_r4_api::engine::R4Engine> {
+    let graph = r4g1_bytes?;
+    // The deployed scorer itself must accept these bytes first: the
+    // engine's own load treats a scorer-rebuild refusal on CID-verified
+    // bytes as a self-produced-defect panic (R5, #510) — correct for the
+    // pipeline's own artifacts, but the chat walk also serves
+    // converter-era/legacy graphs the deployed engine has no scorer for
+    // (#655-C1e recognize-don't-migrate). Probe first so those bundles
+    // get the documented gate-absent warn instead of that panic.
+    if uor_r4_graph_certify::GraphScorer::from_artifact(
+        graph,
+        Some(artifact_bytes),
+        uor_r4_graph_certify::DEFAULT_ROOT_TOP_B,
+        uor_r4_graph_certify::DEFAULT_EXCT_TOP_X,
+    )
+    .is_none()
+    {
+        tracing::warn!(
+            "the deployed scorer does not rebuild from this graph (legacy/converter-era \
+             bundle); the ask-path D4 abstention gate (#811) is ABSENT this session and \
+             the graph walk runs ungated"
+        );
+        return None;
+    }
+    // `load_accepting_quality`, not `load`: the bundle's recorded
+    // quality verdict is a SERVING-admission concern — this chat path
+    // has already decided (with its own recorded warning) to decode the
+    // bundle, and the D4 policy is well-defined regardless of that
+    // verdict. The report still supplies the status-policy override and
+    // scorer widths exactly as it does for serving.
+    match uor_r4_api::engine::R4Engine::load_accepting_quality(uor_r4_api::engine::EngineParts {
+        graph,
+        signature_artifact: artifact_bytes,
+        tokenizer: Some(tokenizer_bytes),
+        score_report,
+    }) {
+        Ok(engine) => Some(engine),
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "deployed policy engine could not load this bundle; the ask-path \
+                 D4 abstention gate (#811) is ABSENT this session and the graph \
+                 walk runs ungated (the serving tier would refuse this bundle)"
+            );
+            None
+        }
     }
 }
 
@@ -336,6 +433,12 @@ fn build_local_compiled_engine(
         tokenizer_cid = %tokenizer_object.cid,
         "using a locally compiled bundle without an instruction-quality attestation"
     );
+    let policy_engine = load_chat_policy_engine(
+        r4g1_bytes.as_deref(),
+        &artifact_bytes,
+        &tokenizer_bytes,
+        read_chat_score_report(directory).as_deref(),
+    );
     Ok(ChatEngine {
         artifacts,
         store,
@@ -345,6 +448,7 @@ fn build_local_compiled_engine(
         history_len: 0,
         max_tokens,
         sample_rng: sample_seed.map(SampleRng::new),
+        policy_engine,
     })
 }
 
@@ -364,6 +468,12 @@ pub struct ChatEngine {
     /// end from its initial seed. `None` (the default) leaves both
     /// deterministic paths completely untouched.
     sample_rng: Option<SampleRng>,
+    /// #811: the deployed D4 policy engine over this same bundle — the
+    /// ask-path abstention gate. Stateful across turns (widen-once
+    /// bookkeeping, novel-seen FIFO), like the server tier's own engine.
+    /// `None` only when the bundle has no graph or the engine refused
+    /// the bytes (loudly warned at build).
+    policy_engine: Option<uor_r4_api::engine::R4Engine>,
 }
 
 impl ChatEngine {
@@ -387,7 +497,67 @@ impl ChatEngine {
             question,
             self.max_tokens,
             self.sample_rng.as_mut(),
+            self.policy_engine.as_mut(),
         )
+    }
+}
+
+/// #811: one D4 gate decision for the window about to be decoded. The
+/// deployed policy engine decides serve / widen-once / abstain exactly
+/// as the server tier does; the walk's own candidate selection is
+/// untouched on Serve, so served output stays byte-identical to the
+/// ungated walk. An out-of-vocabulary window (a bounds edge the walk
+/// itself tolerates) serves ungated with a warn rather than turning a
+/// previously-answerable prompt into an error.
+fn d4_gate(
+    policy_engine: &mut Option<&mut uor_r4_api::engine::R4Engine>,
+    window: &[u32],
+) -> Option<ChatAbstention> {
+    use uor_r4_api::engine::{PolicyStatus, PredictDecision};
+    let engine = policy_engine.as_deref_mut()?;
+    match engine.predict_decision(window) {
+        Ok(PredictDecision::Serve(_)) => None,
+        Ok(PredictDecision::Abstain(outcome)) => Some(ChatAbstention {
+            status: PolicyStatus::from(outcome.status).label().to_owned(),
+            widened: outcome.widened,
+        }),
+        Err(bound) => {
+            tracing::warn!(
+                %bound,
+                "D4 gate skipped an out-of-vocabulary window (#811); this step serves ungated"
+            );
+            None
+        }
+    }
+}
+
+/// #811: the typed abstention answer — empty text, zero tokens served,
+/// partial generation dropped (the server tier's exact contract), the
+/// decode witness naming which surface the gate fired on.
+fn abstention_answer(
+    engine: &'static str,
+    non_node_queries: usize,
+    node_path_queries: usize,
+    abstention: ChatAbstention,
+) -> ChatAnswer {
+    let witness = DecodeWitness {
+        engine,
+        non_node_queries,
+        node_path_queries,
+        plain_depths: Vec::new(),
+    };
+    tracing::info!(
+        engine = witness.engine,
+        status = %abstention.status,
+        widened = abstention.widened,
+        "D4 abstention on the ask path (#811): no token served"
+    );
+    ChatAnswer {
+        text: String::new(),
+        generated_tokens: 0,
+        repeated_token_rate: 0.0,
+        witness,
+        abstention: Some(abstention),
     }
 }
 
@@ -402,6 +572,7 @@ fn hologram_answer(
     question: &str,
     max_tokens: usize,
     mut sample_rng: Option<&mut SampleRng>,
+    mut policy_engine: Option<&mut uor_r4_api::engine::R4Engine>,
 ) -> Result<ChatAnswer, ChatError> {
     ensure_chat_prompt_encoder(tokenizer)?;
     let mut question_tokens = [0u32; MAX_CHAT_HISTORY];
@@ -458,6 +629,18 @@ fn hologram_answer(
                         context.extend_from_slice(&generated);
                         let len = core::cmp::min(context.len(), compiler::WINDOW);
                         let window = &context[context.len() - len..];
+                        // #811: the same per-step D4 decision the server
+                        // tier makes, BEFORE this step's candidate query.
+                        // On an abstention the tokens generated so far are
+                        // dropped, never served (the server contract).
+                        if let Some(abstention) = d4_gate(&mut policy_engine, window) {
+                            return Ok(abstention_answer(
+                                "r4g1-sampled",
+                                non_node_queries,
+                                node_path_queries,
+                                abstention,
+                            ));
+                        }
                         let bundle = runtime::bundle_window_plain(artifacts, &rot, window);
                         let sig = runtime::sig_plain(artifacts, &bundle);
                         let mut cands = [(0u32, ScoreQ::ZERO); 8];
@@ -542,7 +725,21 @@ fn hologram_answer(
                             generated.len(),
                         ),
                         witness,
+                        abstention: None,
                     });
+                }
+
+                // #811: the greedy beam gets the D4 gate at the question
+                // boundary — its per-hypothesis windows are speculative
+                // and would pollute the policy's widen-once bookkeeping,
+                // so per-step gating belongs to the single-trajectory
+                // default (sampled) path above. An abstaining question
+                // context never reaches the beam. Recorded limitation:
+                // mid-generation windows of the opt-in beam are ungated.
+                let question_len = core::cmp::min(*history_len, compiler::WINDOW);
+                let question_window = history[*history_len - question_len..*history_len].to_vec();
+                if let Some(abstention) = d4_gate(&mut policy_engine, &question_window) {
+                    return Ok(abstention_answer("r4g1-beam", 0, 0, abstention));
                 }
 
                 struct BeamHypothesis {
@@ -698,6 +895,7 @@ fn hologram_answer(
                     generated_tokens: generated.len(),
                     repeated_token_rate: recent_window_repetition_rate(generated, generated.len()),
                     witness,
+                    abstention: None,
                 });
             }
         }
@@ -779,6 +977,7 @@ fn hologram_answer(
         generated_tokens: generated.len(),
         repeated_token_rate: recent_window_repetition_rate(generated, generated.len()),
         witness,
+        abstention: None,
     })
 }
 
@@ -1055,6 +1254,12 @@ pub fn engine_from_bytes_with_r4g1(
         // The live quality gate (#750) must stay fully deterministic --
         // this constructor has no seed input, so sampling is never on.
         sample_rng: None,
+        // #811: deliberately ungated. This constructor exists for the
+        // #750 live quality gate, which measures the raw decode; wiring
+        // the D4 abstention gate here would silently change what that
+        // gate measures. The product ask/chat surfaces (builder +
+        // local-compiled paths) are the gated ones.
+        policy_engine: None,
     })
 }
 
@@ -3494,5 +3699,310 @@ mod tests {
             session_signature_from_tokens(&first_history),
             session_signature_from_tokens(&second_history)
         );
+    }
+
+    /// #811: end-to-end ask-path D4 abstention over a real scored
+    /// two-region bundle (the `tests/status_policy_common` fixture
+    /// shape, rebuilt in-module because integration fixtures cannot be
+    /// imported here). Questions go through the real chat tokenizer
+    /// (whose encoder prepends BOS + a leading space), so the gated
+    /// windows are exactly what `ask` derives: a Novel question
+    /// abstains with a typed outcome on both decode paths, a covered
+    /// question serves byte-identically to the ungated engine, and an
+    /// engine without a policy engine keeps the pre-#811 behavior.
+    mod d4_gate_tests {
+        use crate::chat::{ChatEngine, SampleRng, MAX_CHAT_HISTORY};
+        use uor_r4_core::transformerless::compiler::{self, D, K, SIG_BYTES, STAGES};
+        use uor_r4_core::transformerless::runtime;
+        use uor_r4_core::transformerless::scenarios::Tokenizer;
+        use uor_r4_graph_certify::{
+            self as score, ContextRow, EmissionTables, RegionParams, Smoothing, StructuralEdge,
+        };
+        use uor_r4_graph_format::ScoreQ;
+
+        fn xorshift(state: &mut u64) -> u64 {
+            let mut x = *state;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            *state = x;
+            x
+        }
+
+        /// A minimal deterministic `Compiled` (mirrors
+        /// `tests/status_policy_common::synthetic_compiled`).
+        fn synthetic_compiled() -> compiler::Compiled {
+            let vocab = 64usize;
+            let mut rng = 0xC0DE42u64;
+            let mut rand_bytes = |n: usize| -> Vec<u8> {
+                (0..n).map(|_| (xorshift(&mut rng) & 0xff) as u8).collect()
+            };
+            compiler::Compiled {
+                token_codes: rand_bytes(vocab * STAGES),
+                stage_books: (0..STAGES)
+                    .map(|_| rand_bytes(K * D).iter().map(|&b| b as i8).collect())
+                    .collect(),
+                stage_shifts: vec![0; STAGES],
+                thresholds: vec![0; D],
+                class_sigs: (0..STAGES).map(|_| rand_bytes(K * SIG_BYTES)).collect(),
+                ctx_cb: Vec::new(),
+                token_stage_kappas: Vec::new(),
+                dot_cb: Vec::new(),
+                resid_cb: Vec::new(),
+                resid_scale_shifts: Vec::new(),
+                norm_fold_const: 0,
+            }
+        }
+
+        /// The 64-piece chat tokenizer: `<unk>`/`<s>`/`</s>`, a space
+        /// piece (the encoder prepends BOS + one space), then 60 unique
+        /// single characters at ids 4..=63.
+        fn fixture_tokenizer_bytes() -> Vec<u8> {
+            let alphabet: Vec<u8> = (b'A'..=b'Z')
+                .chain(b'a'..=b'z')
+                .chain(b'0'..=b'7')
+                .collect();
+            assert_eq!(alphabet.len(), 60);
+            let mut bytes = Vec::new();
+            for piece in [
+                b"<unk>".as_slice(),
+                b"<s>".as_slice(),
+                b"</s>".as_slice(),
+                b" ".as_slice(),
+            ] {
+                bytes.extend_from_slice(&(piece.len() as i32).to_le_bytes());
+                bytes.extend_from_slice(piece);
+            }
+            for &ch in &alphabet {
+                bytes.extend_from_slice(&1i32.to_le_bytes());
+                bytes.push(ch);
+            }
+            bytes
+        }
+
+        /// Encode a question exactly as the chat path will (BOS + space
+        /// prepended by the encoder itself).
+        fn encode_question(tokenizer: &Tokenizer, question: &str) -> Vec<u32> {
+            let mut buffer = [0u32; 16];
+            let count = tokenizer
+                .encode_into(question, &mut buffer)
+                .expect("fixture question encodes");
+            buffer[..count].to_vec()
+        }
+
+        fn policy_engine(graph: &[u8], teacher: &[u8]) -> uor_r4_api::engine::R4Engine {
+            uor_r4_api::engine::R4Engine::load(uor_r4_api::engine::EngineParts {
+                graph,
+                signature_artifact: teacher,
+                tokenizer: None,
+                score_report: None,
+            })
+            .expect("the deployed policy engine loads the scored fixture")
+        }
+
+        /// The complete fixture: a scored graph whose region 0 is
+        /// anchored at the derived signature of the COVERED question's
+        /// real encoded window, a bigram context row so the packed
+        /// walk has candidates to serve on that window, and a scanned
+        /// NOVEL question whose encoded window the deployed policy
+        /// abstains on. Returns
+        /// `(graph, teacher, covered question, novel question)`.
+        fn fixture() -> (Vec<u8>, Vec<u8>, String, String) {
+            let artifacts = synthetic_compiled();
+            let teacher = compiler::artifact_bytes(&artifacts);
+            let tokenizer =
+                Tokenizer::from_bytes(&fixture_tokenizer_bytes()).expect("fixture tokenizer");
+            let covered_question = "C".to_owned();
+            let covered_window = encode_question(&tokenizer, &covered_question);
+            let covered_last = *covered_window.last().expect("nonempty window");
+            let rotations = compiler::derive_rotations();
+            let window_tail =
+                &covered_window[covered_window.len().saturating_sub(compiler::WINDOW)..];
+            let bundle = runtime::bundle_window_plain(&artifacts, &rotations, window_tail);
+            let covered_sig = runtime::sig_plain(&artifacts, &bundle);
+
+            let emissions = EmissionTables {
+                root_prior: [(10u32, 100i32), (20, 200), (30, 300), (40, 50)]
+                    .into_iter()
+                    .map(|(token, raw)| (token, ScoreQ::from_raw(raw)))
+                    .collect(),
+                root_floor: ScoreQ::from_raw(-7000),
+                root_total: 1000,
+                region_lists: vec![
+                    vec![(10, ScoreQ::from_raw(1000)), (20, ScoreQ::from_raw(-500))],
+                    vec![(20, ScoreQ::from_raw(2000)), (30, ScoreQ::from_raw(100))],
+                ],
+                smoothing: Smoothing::AddOne,
+                root_prior_quantization: score::QuantizationErrorStats::default(),
+                emission_quantization: score::QuantizationErrorStats::default(),
+                selection_stats: score::EmissionSelectionStats::default(),
+            };
+            let regions = [
+                RegionParams {
+                    node: 1,
+                    depth: 1,
+                    radius: 4,
+                    sig: covered_sig,
+                    parent: None,
+                },
+                RegionParams {
+                    node: 2,
+                    depth: 1,
+                    radius: 4,
+                    sig: [0xFF; SIG_BYTES],
+                    parent: None,
+                },
+            ];
+            // The packed walk on a scored graph serves candidates from
+            // context rows (the canary's own witness: non-node queries);
+            // one bigram row keyed on the covered question's last token
+            // gives the walk something real to emit.
+            let context_rows = [ContextRow {
+                context_len: 1,
+                key0: covered_last,
+                key1: 0,
+                entries: vec![(10, ScoreQ::from_raw(900)), (20, ScoreQ::from_raw(400))],
+            }];
+            let store: runtime::Store = (0..=STAGES).map(|_| Default::default()).collect();
+            let tls1 = runtime::store_bytes(&store);
+            let (graph, _) = score::emit_scored_r4g1(
+                &teacher,
+                (b"chat-d4-meta", b"chat-d4-recs"),
+                64,
+                &score::ScoredGraphSections {
+                    regions: &regions,
+                    structural: &[
+                        StructuralEdge {
+                            src: 0,
+                            kind: 0,
+                            dst: 1,
+                            score_q: ScoreQ::ZERO,
+                        },
+                        StructuralEdge {
+                            src: 0,
+                            kind: 0,
+                            dst: 2,
+                            score_q: ScoreQ::ZERO,
+                        },
+                    ],
+                    transitions: &[],
+                    transition_quantization: score::QuantizationErrorStats::default(),
+                    emissions: &emissions,
+                    context_rows: &context_rows,
+                    fwd_rows: &[],
+                    exct_tls1: &tls1,
+                    exct_top_x: score::ScoreConfig::default().exct_top_x,
+                },
+            );
+            uor_r4_graph_runtime::R4G1Runtime::parse(&graph)
+                .expect("the packed runtime parses the scored fixture");
+
+            // Sanity + scan with a throwaway policy engine (probing
+            // pollutes widen-once bookkeeping; test engines are fresh).
+            use uor_r4_api::engine::PredictDecision;
+            let mut scan = policy_engine(&graph, &teacher);
+            assert!(
+                matches!(
+                    scan.predict_decision(&covered_window),
+                    Ok(PredictDecision::Serve(_))
+                ),
+                "the covered question's own window must resolve Serve"
+            );
+            let alphabet: Vec<u8> = (b'A'..=b'Z')
+                .chain(b'a'..=b'z')
+                .chain(b'0'..=b'7')
+                .collect();
+            let novel_question = alphabet
+                .iter()
+                .map(|&ch| (ch as char).to_string())
+                .filter(|question| question != &covered_question)
+                .find(|question| {
+                    let window = encode_question(&tokenizer, question);
+                    matches!(
+                        scan.predict_decision(&window),
+                        Ok(PredictDecision::Abstain(_))
+                    )
+                })
+                .expect("some single-character question resolves Novel");
+            (graph, teacher, covered_question, novel_question)
+        }
+
+        fn chat_engine(
+            graph: &[u8],
+            teacher: &[u8],
+            gated: bool,
+            seed: Option<u32>,
+            max_tokens: usize,
+        ) -> ChatEngine {
+            ChatEngine {
+                artifacts: compiler::parse_artifacts(teacher).expect("fixture artifacts parse"),
+                store: (0..=STAGES).map(|_| Default::default()).collect(),
+                r4g1_bytes: Some(graph.to_vec()),
+                tokenizer: Tokenizer::from_bytes(&fixture_tokenizer_bytes())
+                    .expect("fixture tokenizer parses"),
+                history: [0; MAX_CHAT_HISTORY],
+                history_len: 0,
+                max_tokens,
+                sample_rng: seed.map(SampleRng::new),
+                policy_engine: gated.then(|| policy_engine(graph, teacher)),
+            }
+        }
+
+        #[test]
+        fn novel_question_abstains_on_both_decode_paths_and_serves_ungated() {
+            let (graph, teacher, _, novel_question) = fixture();
+
+            // Default (sampled) path: typed abstention, no token served.
+            let mut sampled = chat_engine(&graph, &teacher, true, Some(42), 8);
+            let answer = sampled
+                .ask(&novel_question)
+                .expect("abstention is an answer, not an error");
+            let abstention = answer.abstention.expect("novel question abstains");
+            assert_eq!(abstention.status, "novel");
+            assert!(answer.text.is_empty(), "no text on abstention");
+            assert_eq!(answer.generated_tokens, 0, "no token served");
+            assert_eq!(answer.witness.engine, "r4g1-sampled");
+
+            // Greedy beam opt-out: the question-boundary gate fires too.
+            let mut beam = chat_engine(&graph, &teacher, true, None, 8);
+            let answer = beam.ask(&novel_question).expect("abstention is an answer");
+            assert!(answer.abstention.is_some(), "beam question gate fires");
+            assert_eq!(answer.witness.engine, "r4g1-beam");
+
+            // No policy engine (pre-#811 shape): the same question runs
+            // ungated — whatever the walk did before, it still does.
+            let mut ungated = chat_engine(&graph, &teacher, false, Some(42), 8);
+            if let Ok(answer) = ungated.ask(&novel_question) {
+                assert!(
+                    answer.abstention.is_none(),
+                    "no gate without a policy engine"
+                );
+            }
+        }
+
+        #[test]
+        fn covered_question_serves_byte_identically_to_the_ungated_walk() {
+            let (graph, teacher, covered_question, _) = fixture();
+
+            // One served step (max_tokens 1): the gate decides Serve and
+            // the walk's own selection is untouched — gated and ungated
+            // engines produce the identical answer under the same seed.
+            let mut gated = chat_engine(&graph, &teacher, true, Some(42), 1);
+            let mut ungated = chat_engine(&graph, &teacher, false, Some(42), 1);
+            let gated_answer = gated
+                .ask(&covered_question)
+                .expect("covered question serves");
+            let ungated_answer = ungated
+                .ask(&covered_question)
+                .expect("covered question serves ungated");
+            assert!(gated_answer.abstention.is_none());
+            assert_eq!(gated_answer.text, ungated_answer.text);
+            assert_eq!(
+                gated_answer.generated_tokens,
+                ungated_answer.generated_tokens
+            );
+            assert_eq!(gated_answer.witness, ungated_answer.witness);
+            assert!(!gated_answer.text.is_empty(), "a real token was served");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ enum Command {
     Ask(AskArgs),
     /// Start an interactive, stateful local chat.
     Chat(ChatArgs),
-    /// Connect to a local uor-r4 server endpoint as a remote interactive client.
+    /// Connect to a local r4 server endpoint as a remote interactive client.
     Client(ClientArgs),
     /// View or export UOR Q&A audit traces and geometry metrics.
     Audit(AuditArgs),
@@ -216,7 +216,7 @@ struct ClientArgs {
     #[arg(long, default_value = "http://127.0.0.1:8000/v1")]
     remote: String,
     /// Model name to send in chat completions payload.
-    #[arg(long, default_value = "uor-r4")]
+    #[arg(long, default_value = "r4")]
     model: String,
 }
 
@@ -948,7 +948,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             if let Some(remote) = &args.remote {
                 uor_r4_wasm_router::chat::remote_interactive_chat(
                     remote,
-                    args.model.as_deref().unwrap_or("uor-r4"),
+                    args.model.as_deref().unwrap_or("r4"),
                     &mut io::stdin().lock(),
                     &mut io::stdout().lock(),
                 )?;
@@ -1163,9 +1163,7 @@ fn audit_command(log_file: &PathBuf) -> Result<(), RunError> {
             "\x1b[33m[!] No audit log file found at {}\x1b[0m",
             log_file.display()
         );
-        println!(
-            "    Run the interactive client ('./uor-r4-cli' or 'r4 client') and ask questions first.\n"
-        );
+        println!("    Run the interactive client ('r4 client') and ask questions first.\n");
         return Ok(());
     }
     let content = std::fs::read_to_string(log_file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,12 +516,32 @@ impl From<io::Error> for RunError {
     }
 }
 
+/// #811: render one turn honestly — served text as before, and a typed
+/// D4 abstention as an explicit line instead of empty output or a
+/// confidently served guess.
+fn rendered_answer(answer: &ChatAnswer) -> String {
+    match &answer.abstention {
+        None => answer.text.clone(),
+        Some(abstention) => format!(
+            "[abstained: {} context{}] no answer served — the model's D4 policy \
+             declined this prompt as outside its certified context.",
+            abstention.status,
+            if abstention.widened {
+                ", widened once"
+            } else {
+                ""
+            }
+        ),
+    }
+}
+
 fn answer_once(
     chat: &mut impl Chat,
     question: &str,
     output: &mut impl Write,
 ) -> Result<(), RunError> {
-    writeln!(output, "{}", chat.ask(question)?.text)?;
+    let answer = chat.ask(question)?;
+    writeln!(output, "{}", rendered_answer(&answer))?;
     Ok(())
 }
 
@@ -547,7 +567,7 @@ fn interactive_chat(
             continue;
         }
         match chat.ask(question) {
-            Ok(answer) => writeln!(output, "r4> {}\n", answer.text)?,
+            Ok(answer) => writeln!(output, "r4> {}\n", rendered_answer(&answer))?,
             Err(error) => tracing::error!(%error, "chat response failed"),
         }
     }
@@ -1246,6 +1266,7 @@ mod tests {
                 generated_tokens: 1,
                 repeated_token_rate: 0.0,
                 witness: Default::default(),
+                abstention: None,
             })
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -547,6 +547,9 @@ fn uor_status_json(installed: &ServingModelState, profile: EngineProfile) -> ser
 
     serde_json::json!({
         "profile": profile.label(),
+        // #655-F: the served identity is the canonical id; `model_name`
+        // below remains the PHYSICAL installed name (metadata).
+        "canonical_model": CANONICAL_MODEL_ID,
         "model_name": logical_name,
         "physical_root": status_physical_root(installed.active_bundle.as_ref()),
         "attention_operator": installed.active_bundle.as_ref().map(|bundle| &bundle.attention_operator),
@@ -2669,6 +2672,22 @@ fn teacher_text_ready(state: &ServingModelState) -> bool {
         && state.active_teacher_source.is_some()
 }
 
+/// #655-F (maintainer-approved flip, 2026-08-19): the canonical served
+/// model identity across every serving surface — a product name, not a
+/// directory name. Per-bundle logical/physical names remain visible as
+/// metadata (`/uor/v1/status` `physical_root`, bundle fields,
+/// [`installed_logical_model_name`]), never as the served identity.
+const CANONICAL_MODEL_ID: &str = "r4";
+
+/// The pre-flip identity, retained as a deprecated request-side alias
+/// for a compatibility window (#655-F). Responses always report
+/// [`CANONICAL_MODEL_ID`], never this alias.
+const DEPRECATED_MODEL_ALIAS: &str = "uor-r4";
+
+/// The *physical* installed name — bundle logical name or teacher-source
+/// basename — used for metadata and provenance surfaces. Since #655-F
+/// this is no longer the served identity ([`CANONICAL_MODEL_ID`] is);
+/// its own final fallback follows the canonical name.
 fn installed_logical_model_name(state: &ServingModelState) -> String {
     state
         .active_bundle
@@ -2682,7 +2701,7 @@ fn installed_logical_model_name(state: &ServingModelState) -> String {
                 .and_then(|name| name.to_str())
                 .map(str::to_owned)
         })
-        .unwrap_or_else(|| "uor-r4".to_owned())
+        .unwrap_or_else(|| CANONICAL_MODEL_ID.to_owned())
 }
 
 /// #789-G2: discovery agrees with serving. Under `Production` only a
@@ -2690,6 +2709,8 @@ fn installed_logical_model_name(state: &ServingModelState) -> String {
 /// must not advertise a model the Production cascade can never serve
 /// (every completion would 503 `declined_by_all`). Under `Experimental`
 /// the teacher lane still counts toward activity, exactly as before.
+/// #655-F: when a model IS active, its served identity is the canonical
+/// [`CANONICAL_MODEL_ID`] — the physical name stays metadata.
 fn active_canonical_model_name(
     state: &ServingModelState,
     profile: EngineProfile,
@@ -2702,12 +2723,13 @@ fn active_canonical_model_name(
     if !servable {
         return None;
     }
-    Some(installed_logical_model_name(state))
+    Some(CANONICAL_MODEL_ID.to_owned())
 }
 
 /// Resolve the OpenAI request model before any routing or generation side
-/// effects. `uor-r4` is the one intentional compatibility alias; responses
-/// always report the canonical active identity rather than echoing the alias.
+/// effects. #655-F: `r4` is the canonical identity; `uor-r4` is the
+/// deprecated pre-flip alias, accepted for a compatibility window.
+/// Responses always report the canonical identity, never an alias.
 fn resolve_active_request_model(
     state: &ServingModelState,
     profile: EngineProfile,
@@ -2723,7 +2745,7 @@ fn resolve_request_model_name(
 ) -> Result<String, String> {
     let active = active.ok_or_else(|| "no text-ready serving model is active".to_owned())?;
     match requested.map(str::trim).filter(|name| !name.is_empty()) {
-        None | Some("uor-r4") => Ok(active.to_owned()),
+        None | Some(CANONICAL_MODEL_ID) | Some(DEPRECATED_MODEL_ALIAS) => Ok(active.to_owned()),
         Some(name) if name == active => Ok(active.to_owned()),
         Some(name) => Err(format!(
             "The model '{name}' is not active; the active model is '{active}'."
@@ -15984,8 +16006,8 @@ fn handle_connection(
         };
 
         // Values shared by the single-JSON and the streaming surfaces.
-        let response_id = format!("chatcmpl-uor-r4-{}", gen.created_ts);
-        let system_fingerprint = format!("uor-r4-{}", gen.generation_mode);
+        let response_id = format!("chatcmpl-r4-{}", gen.created_ts);
+        let system_fingerprint = format!("r4-{}", gen.generation_mode);
         // #654 phase C: `length` when the served completion reached the
         // effective token budget, otherwise `stop`.
         let finish_reason = completion_finish_reason(gen.completion_tokens, max_tokens).to_string();
@@ -16135,7 +16157,7 @@ fn handle_connection(
         // the Responses typed-event sequence (created → … → response.completed;
         // no `[DONE]` sentinel). The wire format is streaming, not the generation.
         if req.stream == Some(true) {
-            let response_id = format!("resp-uor-r4-{}", gen.created_ts);
+            let response_id = format!("resp-r4-{}", gen.created_ts);
             let created_at = gen.created_ts;
             let content = gen.text.clone();
             let completed = build_responses_body(gen, &model_name, max_tokens);
@@ -17933,14 +17955,14 @@ fn build_responses_body(
     };
     let audit = serde_json::to_value(&gen.uor_audit).unwrap_or(serde_json::Value::Null);
     let mut body = serde_json::json!({
-        "id": format!("resp-uor-r4-{}", gen.created_ts),
+        "id": format!("resp-r4-{}", gen.created_ts),
         "object": "response",
         "created_at": gen.created_ts,
         "model": model,
         "status": status,
         "output": [{
             "type": "message",
-            "id": format!("msg-uor-r4-{}", gen.created_ts),
+            "id": format!("msg-r4-{}", gen.created_ts),
             "status": "completed",
             "role": "assistant",
             "content": [{
@@ -17987,7 +18009,7 @@ fn build_responses_stream_frames(
     content: &str,
     completed: serde_json::Value,
 ) -> Vec<String> {
-    let item_id = format!("msg-uor-r4-{created_at}");
+    let item_id = format!("msg-r4-{created_at}");
     let in_progress = serde_json::json!({
         "id": id,
         "object": "response",
@@ -24847,9 +24869,15 @@ mod tests {
         assert_eq!(
             super::active_canonical_model_name(&serving, super::EngineProfile::Production)
                 .as_deref(),
-            Some("teacher"),
+            Some(super::CANONICAL_MODEL_ID),
             "a host-encoded historical graph remains advertised (it IS the \
-             servable R4G1 artifact, so Production counts it, #789-G2)"
+             servable R4G1 artifact, so Production counts it, #789-G2) — \
+             under the canonical identity, not the physical name (#655-F)"
+        );
+        assert_eq!(
+            super::installed_logical_model_name(&serving),
+            "teacher",
+            "the physical name stays visible as metadata (#655-F)"
         );
         assert_eq!(
             super::resolve_active_request_model(
@@ -24857,8 +24885,17 @@ mod tests {
                 super::EngineProfile::Production,
                 Some("uor-r4")
             )
-            .expect("legacy alias resolves to the graph"),
-            "teacher"
+            .expect("the deprecated alias resolves to the canonical identity"),
+            super::CANONICAL_MODEL_ID
+        );
+        assert_eq!(
+            super::resolve_active_request_model(
+                &serving,
+                super::EngineProfile::Production,
+                Some("r4")
+            )
+            .expect("the canonical identity resolves to itself"),
+            super::CANONICAL_MODEL_ID
         );
         let _ = std::fs::remove_dir_all(root);
     }
@@ -27383,11 +27420,43 @@ mod tests {
         );
     }
 
+    /// #655-F: the native status surface (which `/api/chat`'s shared
+    /// serving state also reports through) carries the canonical served
+    /// identity alongside the physical name as metadata — the B-item
+    /// verify of the rename inventory.
+    #[test]
+    fn status_reports_the_canonical_identity_with_the_physical_name_as_metadata() {
+        let state = super::ServingModelState {
+            active_bundle: Some(sample_resolved_compiled_bundle(None)),
+            ..super::ServingModelState::default()
+        };
+        for profile in [
+            super::EngineProfile::Production,
+            super::EngineProfile::Experimental,
+        ] {
+            let status = super::uor_status_json(&state, profile);
+            assert_eq!(status["canonical_model"], super::CANONICAL_MODEL_ID);
+            assert_eq!(
+                status["model_name"],
+                super::installed_logical_model_name(&state),
+                "the physical name stays visible as metadata"
+            );
+        }
+    }
+
     #[test]
     fn openai_model_alias_and_wire_surfaces_report_only_the_active_canonical_id() {
+        // #655-F deprecation window: both the canonical `r4` and the
+        // pre-flip `uor-r4` alias resolve to the active canonical id;
+        // an unknown name still declines; no active model still errors.
         let canonical = super::resolve_request_model_name(Some("alpha"), Some("uor-r4"))
-            .expect("legacy alias intentionally maps to active");
+            .expect("deprecated alias intentionally maps to active");
         assert_eq!(canonical, "alpha");
+        assert_eq!(
+            super::resolve_request_model_name(Some("alpha"), Some("r4")).unwrap(),
+            "alpha",
+            "the canonical id is accepted regardless of the active string (#655-F)"
+        );
         assert_eq!(
             super::resolve_request_model_name(Some("alpha"), None).unwrap(),
             "alpha"
@@ -27398,6 +27467,7 @@ mod tests {
         );
         assert!(super::resolve_request_model_name(Some("alpha"), Some("beta")).is_err());
         assert!(super::resolve_request_model_name(None, Some("uor-r4")).is_err());
+        assert!(super::resolve_request_model_name(None, Some("r4")).is_err());
 
         let listed = super::models_list_body(&[(canonical.clone(), 7, false)]);
         assert_eq!(listed["data"].as_array().unwrap().len(), 1);
@@ -27687,7 +27757,7 @@ mod tests {
     #[test]
     fn stream_frames_have_role_first_content_then_terminal_done() {
         let frames = super::build_chat_stream_frames(
-            "chatcmpl-uor-r4-1",
+            "chatcmpl-r4-1",
             1,
             "uor-r4",
             "uor-r4-r4g1",
@@ -27705,7 +27775,7 @@ mod tests {
         // Every chunk is a chat.completion.chunk carrying the shared id.
         for chunk in &chunks {
             assert_eq!(chunk["object"], "chat.completion.chunk");
-            assert_eq!(chunk["id"], "chatcmpl-uor-r4-1");
+            assert_eq!(chunk["id"], "chatcmpl-r4-1");
         }
         // First chunk carries the assistant role and no finish_reason.
         assert_eq!(chunks[0]["choices"][0]["delta"]["role"], "assistant");
@@ -27739,7 +27809,7 @@ mod tests {
             total_tokens: 5,
         };
         let frames = super::build_chat_stream_frames(
-            "chatcmpl-uor-r4-2",
+            "chatcmpl-r4-2",
             2,
             "uor-r4",
             "uor-r4-r4g1",
@@ -27955,7 +28025,7 @@ mod tests {
         // The SDK reads choices[0].message.{role,content}, choices[0].
         // finish_reason, usage.{prompt,completion,total}_tokens, and id/object.
         let resp = super::VendorChatCompletionsResponse {
-            id: "chatcmpl-uor-r4-1".to_string(),
+            id: "chatcmpl-r4-1".to_string(),
             object: "chat.completion".to_string(),
             created: 1,
             model: "uor-r4".to_string(),
@@ -28077,7 +28147,7 @@ mod tests {
         let completed =
             super::build_responses_body(dummy_generation("hello world", 2, 7), "uor-r4", 64);
         let frames = super::build_responses_stream_frames(
-            "resp-uor-r4-7",
+            "resp-r4-7",
             7,
             "uor-r4",
             "hello world",


### PR DESCRIPTION
## Summary

Executes the maintainer-authorized **#655-F flip** (fresh explicit approval 2026-08-19, #655 issuecomment-5336515423, sequenced after the v0.1 release publish and #811 — both held): **`r4` is the canonical served model identity** on every serving surface, with `uor-r4` retained as the deprecated request-side alias for a compatibility window. The change list is exactly the PR #810 inventory; the execution record is the new addendum in `docs/serving_default_flip_655_f.md`. Stacked on #816 (the #811 abstention gate); the last commit is this PR's.

- `CANONICAL_MODEL_ID = "r4"`; `resolve_request_model_name` accepts omitted / `r4` / `uor-r4`, responses always report the canonical id.
- `active_canonical_model_name` reports `r4`; the physical installed name narrows to metadata (`/uor/v1/status` gains `canonical_model` alongside the unchanged physical `model_name` + `physical_root`).
- OpenAI wire ids `r4`-prefixed (`chatcmpl-r4-…`, `resp-r4-…`, `msg-r4-…`, `system_fingerprint: r4-{mode}`).
- CLI `client --model` defaults to `r4`; the remote client parses both fingerprint prefixes during the deprecation window.
- Docs: README + CONFIGURATION carry the identity contract; the F0 doc records execution, including the **recorded absence of a THREAT_MODEL.md** (creating one stays a separate product decision).
- Deliberate non-sites, unchanged per the inventory: crate names, schema strings, staging dirs, the `uor-r4-cli` orchestrator script file name, the four source-verification logical-name fallbacks, and every engine/tier name (`r4g1` is a tier, not the model).

## Preconditions at flip time (per F's own activation contract)

1. **Distributed bundle**: v0.1 published with the attested bundle; `r4 install-release --tag v0.1` proven end to end (#741 closed).
2. **Baseline-quality canary**: the default decode is the measured 15/15-valid path (#814, byte-proven); probes run through the same deployed D4 policy on CLI and server (#816). #784 distinctness stays open and disclosed.

## Evidence

Post-flip in-domain ask output byte-identical to the archived decode canary (0 diffs) — identity is a serving-surface rename, not a decode change. Deprecation-window resolve tests (omitted/`r4`/`uor-r4` all resolve; unknown declines; inactive errors); canonical-id + physical-metadata status test on both profiles; #789-G2 discovery test updated to the canonical identity. Server 197 · chat 14 · openai_profile_pin 3 · bin 7 · workspace clippy `-D warnings` clean · fmt clean.

#655's close record follows on the issue once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
