### PR TITLE
docs: repo-wide accuracy review + README makeover with process diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,87 @@
 # R⁴ — Local Transformerless AI
 
 [![CI](https://github.com/UOR-Foundation/uor-r4/actions/workflows/ci.yml/badge.svg)](https://github.com/UOR-Foundation/uor-r4/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/UOR-Foundation/uor-r4)](https://github.com/UOR-Foundation/uor-r4/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Rust 1.97.1](https://img.shields.io/badge/rust-1.97.1-orange.svg)](rust-toolchain.toml)
 
-R⁴ cross-compiles a pinned Hugging Face model into a **table-native artifact that
-runs inference with no multiplication, no floating point, and no allocation in
-the hot path** — on a CPU, locally, with a content-addressed witness for every
-prediction. It also contains a geometric text router and a browser dashboard.
+## What is this?
 
-No Ollama, llama.cpp, OpenAI, or Anthropic at runtime. Nothing leaves the
-machine.
+Modern AI models answer questions by doing billions of floating-point
+multiplications per word, which is why they want GPUs, datacenters, and a
+power budget. **R⁴ asks whether the expensive math can be paid once, ahead
+of time, instead of on every single question.**
 
-R⁴ is aligned with the
+It takes an ordinary open language model (the *teacher*), watches how it
+behaves on a corpus, and **compiles** that behavior into integer lookup
+structures — packed tables and a scored graph. Answering then needs only
+bit operations, integer adds, compares, and table reads: **no
+multiplication, no floating point, no GPU, no allocation in the hot path**,
+on an ordinary CPU. Every answer carries a content-addressed witness — a
+verifiable receipt of exactly which evidence produced it — and when the
+engine doesn't have grounded evidence for a prompt, it says so with a typed
+abstention instead of guessing confidently.
+
+Everything runs locally. No Ollama, llama.cpp, OpenAI, or Anthropic at
+runtime; nothing leaves the machine, and nothing downloads unless you
+explicitly ask it to.
+
+**Who this is for.** Researchers and engineers curious whether serving-time
+AI can shed the GPU/energy footprint — and anyone who wants to watch a
+measurement-driven research programme happen in the open. It is **not** a
+ChatGPT replacement: output quality is research-grade and honestly
+disclosed ([What actually works](#what-actually-works)). If you are
+completely new, the [ELI5](docs/explainers/ELI5.md) and
+[undergraduate](docs/explainers/UNDERGRADUATE.md) explainers are written
+for you.
+
+R⁴ is part of the [UOR Foundation](https://github.com/UOR-Foundation)'s
+work, aligned with the
 [Universal Object Reference Framework](https://github.com/UOR-Foundation/UOR-Framework),
 [Prism](https://github.com/UOR-Foundation/prism) and
 [uor-addr](https://github.com/UOR-Foundation/uor-addr).
 
-> **Status: research project, v0.1.0.** The compiler, runtime, artifact format
-> and measurement harnesses work and are exercised by CI. Generation quality is
-> *not* competitive with the teacher models it compiles — see
-> [What actually works](#what-actually-works) for honest numbers. This repository
-> is run as a measured research programme; [docs/RESEARCH.md](docs/RESEARCH.md)
-> records what has been established and what has been refuted.
+## The idea in one picture
+
+```mermaid
+flowchart LR
+    subgraph offline["OFFLINE — paid once, hours on a CPU"]
+        direction LR
+        Teacher["Open teacher model<br/>(e.g. SmolLM2)"] -->|"teacher-forced<br/>observation"| Corpus["Deterministic<br/>corpus"]
+        Corpus -->|"compile +<br/>score"| Bundle["Integer bundle<br/>tables + scored graph<br/>(content-addressed)"]
+    end
+    subgraph online["ONLINE — every question, milliseconds on a CPU"]
+        direction LR
+        Q["Your question"] --> Kernel["Integer kernel<br/>XOR · popcount · add ·<br/>compare · table reads"]
+        Kernel --> A["Answer + verifiable witness<br/>(or an honest typed abstention)"]
+    end
+    Bundle ==>|"ships as a verified<br/>release asset"| Kernel
+```
+
+The heavy math (the teacher's matrix multiplications) happens only in the
+offline compile — and even there it runs through the project's own pinned
+exact-arithmetic library, not platform BLAS. The deployed answer path is
+enforced multiplication-free by a machine-checked source scan and an
+operation census, not by convention.
+
+> **Status: research project.** [Release v0.1](https://github.com/UOR-Foundation/uor-r4/releases/tag/v0.1)
+> ships working binaries and a compiled model bundle you can install and
+> query in one verified command. The compiler, runtime, artifact format and
+> measurement harnesses are exercised by CI. Generation quality is *not*
+> competitive with the teacher models it compiles — answers are valid
+> English with weak prompt-conditioning and research-grade factuality; see
+> [What actually works](#what-actually-works) for honest numbers. This
+> repository is run as a measured research programme;
+> [docs/RESEARCH.md](docs/RESEARCH.md) records what has been established
+> and what has been refuted.
 
 ---
 
 ## Contents
 
 - [Quick start](#quick-start) · [Requirements](#requirements) · [What actually works](#what-actually-works)
-- [Project layout](#project-layout) · [Architecture](#architecture)
+- [Project layout](#project-layout) · [Architecture](#architecture) · [How a request is served](#how-a-request-is-served)
+- [Releases and verified install](#releases-and-verified-install)
 - [CLI reference](#cli-reference) · [HTTP API](#http-api) · [Configuration](#configuration)
 - [Testing and quality gates](#testing-and-quality-gates) · [Troubleshooting](#troubleshooting)
 - [Documentation map](#documentation-map) · [Contributing](#contributing) · [License](#license)
@@ -50,6 +102,26 @@ Open <http://127.0.0.1:8000>. The geometric router, the 96-vertex W(3,3)
 phase-field canvas and the semantic map all work with no model, no download and
 no compile. This is the fastest way to confirm the repository builds and runs on
 your machine.
+
+### 2 minutes — install the released model and ask it something
+
+Skip the multi-hour compile entirely: [release v0.1](https://github.com/UOR-Foundation/uor-r4/releases/tag/v0.1)
+ships a compiled bundle as an attested asset.
+
+```bash
+cargo build --release
+./target/release/r4 install-release --tag v0.1   # explicit, digest-verified fetch (~16 MB)
+./target/release/r4 ask --model r4 "Tell me a fact about the ocean."
+```
+
+`install-release` verifies every component's blake3 digest against the
+release's attested manifest before anything lands on disk, and refuses
+archives containing anything unattested. The answer will be valid English
+of research-grade quality — read the honest release notes and
+[What actually works](#what-actually-works) before judging it as a
+chatbot. Decode defaults to seeded sampling with a pinned seed, so the
+same question reproduces the same answer; `--greedy` opts into the
+deterministic beam.
 
 ### 5 minutes — run the measurement pipeline on the committed fixtures
 
@@ -90,6 +162,7 @@ client at the end:
 | **Rust** | Pinned to **1.97.1** by `rust-toolchain.toml`. rustup resolves it automatically. |
 | **Python 3** | For `scripts/*.py` — two of them are CI gates. |
 | **`hf`** (Hugging Face CLI) | Only for downloading teacher models. |
+| **`curl` + `tar`** | Only for `r4 install-release` (fetching released bundle assets). Present by default on macOS and most Linux. |
 | **`wasm-pack`** | Only to rebuild the browser WASM bundle. |
 | **`cargo-nextest`** | Only to mirror CI's test runner locally. |
 | **Nightly Rust** | Only for `cargo fuzz`. |
@@ -129,31 +202,47 @@ whole method is measurement.
 - **UOR attestation**: content-addressed model objects and manifests, witnessed
   prediction, and a `POST /api/uor/verify` validation endpoint.
 - The **geometric router**, browser dashboard and OpenAI-compatible server.
+- **Honest serving semantics, by construction.** The default `production`
+  profile admits only the audited r4g1 tier; a request nothing can serve gets
+  a typed `declined_by_all`, never a silent fallback; out-of-distribution
+  resolution triggers the D4 policy (serve / widen-once / abstain) on both
+  the HTTP and CLI surfaces, and an abstention serves *no* tokens rather
+  than a guess. Decode defaults to seeded sampling with a pinned seed —
+  identical requests reproduce identical completions.
+- **A shipped, verifiable release.** `v*` tags build both frontends and bind
+  code SHA + inference-contract version; the model bundle ships as an
+  attested asset, and `r4 install-release` refuses anything whose digests
+  don't match the manifest ([docs/RELEASE_PIPELINE.md](docs/RELEASE_PIPELINE.md)).
 - A **measurement apparatus**: 34 harnesses with pre-declared exit rules, null
   baselines and falsifiers, plus a Gate C trend alarm that fails CI on
   regression.
 
 **Real limitations, stated plainly:**
 
-- **Generation quality is weak, and on the best locally compiled bundle it is
-  currently incoherent.** On out-of-distribution prompts the compiled runtimes
-  score around 1% top-1 against the teacher. On in-distribution corpus replay
-  Gate C measures ~36% top-1 on the 500k fixture, and a broader teacher (P3,
-  #509) lifts broad-text held-out top-1 to 10.2–29.0% causal — real,
-  replicated, goal-aligned signal. That signal has **not yet composed into
-  coherent multi-token output**: asked real questions through `r4 ask`, this
-  repository's largest local bundle answers in non-grammatical word-salad, and
-  smaller bundles answer with nothing (#745 — closed 2026-08-17: the root cause
-  was found and fixed in the compiler (#755, corpus record ordering), but the
-  canonical local bundles have not yet been recompiled with the fix, so
-  baseline output is unchanged as of 2026-08-18). See
+- **Generation quality is the central open research question.** The offline
+  per-position signal is real: on in-distribution corpus replay Gate C
+  measures ~36% top-1 on the 500k fixture, and a broader teacher (P3, #509)
+  lifts broad-text held-out top-1 to 10.2–29.0% causal — replicated,
+  goal-aligned, entirely inside the integer kernel. End-to-end answers have
+  improved in *kind* but remain research-grade: the #755 corpus-ordering fix
+  turned word-salad into real English, and the 2026-08-19 decode-default
+  change (seeded sampling replacing greedy) took the declared 15-prompt
+  in-domain canary from **0/15 valid completions to 15/15** — but
+  **prompt-conditioning is still weak**: distinct prompts converge onto
+  similar completions (5/15 distinct, tracked as #784), factual content
+  wanders, and the canonical local bundles still predate the #755 recompile.
+  Semantically unanswerable prompts ("what did I eat for breakfast?") are
+  served rather than abstained, because they do not present as
+  signature-space novelty to the D4 policy — a measured substrate property
+  (#811), same family as #784. See
   [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer)
-  for the full picture — this is the project's central open question, not a
-  footnote. This is a research engine, not a chat model.
-- **Instruction following is gated, not solved.** `r4 ask` accepts only an
-  imported `instruction-chat` manifest carrying a CID-addressed passing
-  evaluation report, precisely so a fast continuation artifact cannot be
-  presented as a question-answering model.
+  for the full picture. This is a research engine, not a chat model.
+- **Instruction following is gated, not solved.** An *imported* manifest is
+  accepted by `r4 ask` only with a CID-addressed passing evaluation report,
+  precisely so a fast continuation artifact cannot be presented as a
+  question-answering model; a locally compiled (or release-installed) bundle
+  is served directly but logs a loud
+  "without an instruction-quality attestation" warning every time.
 - **Standalone two-pass generation is refuted**, twice, and is not coming back.
 - **The geometric router's retrieval was measured broken, and is now fixed and
   shipping.** #486 found `retrieve_geometric_resonance` compared a *routing*
@@ -251,6 +340,58 @@ legacy u16 stores are readable but want a recompile.
 
 ---
 
+## How a request is served
+
+Serving is built so that every outcome is a *typed, honest* one — served
+text with a witness, a typed decline, or a typed abstention. Nothing falls
+back silently and nothing is guessed:
+
+```mermaid
+flowchart TD
+    Req["Request<br/>(model: r4 · optional engine, temperature, seed)"] --> Profile{"Engine profile<br/>(.uor-models/engine_profile.txt)"}
+    Profile -->|"production (default):<br/>r4g1 only"| Tier["r4g1 tier<br/>validated scored graph"]
+    Profile -->|"explicit non-r4g1 engine<br/>under production"| Decline["Typed decline<br/>(echoes the requested engine)"]
+    Profile -->|"experimental:<br/>full cascade, r4g1 first"| Tier
+    Tier --> D4{"D4 policy, per step<br/>(resolution status)"}
+    D4 -->|"exact-context / graph"| Decode["Decode<br/>default: seeded sampling, pinned seed<br/>(temperature: 0 → greedy)"]
+    D4 -->|"novel → widen once<br/>→ still novel"| Abstain["Typed abstention<br/>no tokens served,<br/>partial output dropped"]
+    Decode --> Resp["Response as model 'r4'<br/>+ decode witness"]
+    Tier -->|"nothing can serve"| DBA["Typed declined_by_all"]
+```
+
+The same D4 policy runs on the HTTP server and the CLI `ask`/`chat` paths —
+one implementation, not two approximations of each other. The `uor-r4`
+request alias from before the identity flip is still accepted for a
+deprecation window; responses always report `r4`.
+
+---
+
+## Releases and verified install
+
+A version tag `vX.Y` binds three identities in one place: the **code** (the
+tag's commit SHA), the **contract** (the inference-contract version), and
+the **model bundle** (blake3 digests of every component, declared in the
+attested `release-bundle.json`). CI builds and attaches both frontends;
+the bundle is packaged and attached by the maintainer; nothing publishes
+without an explicit tag cut. Full convention:
+[docs/RELEASE_PIPELINE.md](docs/RELEASE_PIPELINE.md).
+
+```mermaid
+flowchart LR
+    Tag["git tag vX.Y"] --> CI["CI: draft release<br/>CLI (linux x86_64, macOS arm64)<br/>+ wasm frontend + sha256s"]
+    CI --> Rel["Published GitHub Release<br/>+ attested bundle manifest"]
+    Rel --> Fetch["r4 install-release --tag vX.Y<br/>(explicit — nothing auto-downloads)"]
+    Fetch --> Verify{"every component digest<br/>== attested manifest?<br/>nothing unattested?"}
+    Verify -->|yes| Install["Atomic install under<br/>.uor-models/compiled/<br/>manifest kept beside bundle"]
+    Verify -->|no| Refuse["Refuse — nothing<br/>touches the store"]
+```
+
+The install never overwrites an existing bundle, refuses archives carrying
+unattested files or symlinks, and leaves the manifest beside the bundle so
+serving-time verification sees the same attestation.
+
+---
+
 ## CLI reference
 
 Everything below supports `--help`. Global flags (`--host`, `--port`,
@@ -262,15 +403,23 @@ no subcommand is `r4 serve`.
 
 ```bash
 r4 serve                                    # HTTP server + dashboard
-r4 ask [--model NAME|CID] <question...>     # one-shot; prints only the answer
-r4 chat [--model NAME|CID] [--remote URL]   # REPL, local or against a remote /v1
-r4 client [--remote http://127.0.0.1:8000/v1]
+r4 ask [--model NAME|CID] [--greedy | --sample SEED] <question...>
+r4 chat [--model NAME|CID] [--remote URL] [--greedy | --sample SEED]
+r4 client [--remote http://127.0.0.1:8000/v1]   # --model defaults to r4
 r4 audit [--log-file .uor-models/audit_log.json]
 ```
+
+`ask`/`chat` decode with seeded sampling by default (pinned seed —
+reproducible); `--sample SEED` overrides the seed, `--greedy` opts into the
+deterministic beam. A typed D4 abstention prints as an explicit
+`[abstained: …]` line, never as empty output.
 
 **Model lifecycle** — full guide in [docs/MODEL_LIFECYCLE.md](docs/MODEL_LIFECYCLE.md)
 
 ```bash
+r4 install-release --tag vX.Y [--repo OWNER/REPO] [--name NAME]   # verified fetch of a released bundle
+r4 package-release-bundle --compiled DIR --model-id r4 --capability instruction-chat \
+                          --source DIR --tokenizer-family FAMILY --tokenizer-version N
 r4 download --repository OWNER/REPO --revision <40-char SHA> --name NAME
 r4 compile --source DIR [--tokenizer-family FAMILY --tokenizer-version N] \
            [--output DIR] [--seconds N] [--target N] [--sequence-length N]
@@ -378,6 +527,9 @@ The canonical served model id is **`r4`** (#655-F): requests may omit
 (accepted for a compatibility window); responses, `/v1/models`, and wire
 ids (`chatcmpl-r4-…`, `system_fingerprint: r4-…`) always report `r4`.
 Per-bundle physical names remain visible as metadata on `/uor/v1/status`.
+Decode is seeded sampling by default: `temperature: 0` opts a request into
+the deterministic greedy decode, and an optional integer `seed` overrides
+the pinned default so identical requests stay reproducible either way.
 
 | Endpoint | Purpose |
 |---|---|
@@ -534,7 +686,8 @@ harness inventory is in [docs/RESEARCH.md](docs/RESEARCH.md).
 | κ tests pass suspiciously fast | `/tmp/ref/out/model.bin` is missing, so they **skip silently and report vacuous green**. `/tmp` cleanup deletes it. Re-fetch (below) and confirm the file exists before trusting a pass. |
 | fmt/clippy disagree with CI | A non-rustup Rust earlier in `PATH` ignores the toolchain pin. Check `which cargo`. |
 | clippy passes locally, fails in CI | You omitted `--all-features`. Use the exact invocation above. |
-| `r4 ask` refuses to run | The bundle has no CID-addressed passing evaluation report. Run `r4 evaluate-report`, then `r4 import`. |
+| `r4 ask` refuses to run | An *imported* manifest needs a CID-addressed passing evaluation report — run `r4 evaluate-report`, then `r4 import`. Locally compiled or release-installed bundles serve directly (with an attestation warning). |
+| `install-release` refuses | That's it working: a digest mismatch, an unattested archive entry, or an existing install at the target name all refuse with nothing written. The error names the exact cause. |
 | Port 8000 already in use | Use `--port` / `UOR_R4_PORT`, or `PORT=9000 ./uor-r4-cli`. |
 | Compiled bundle behaves oddly after an upgrade | The on-disk store in `.uor-models/` may predate the u32 token migration. A full recompile refreshes it. |
 | `--revision` rejected | It must be a full 40-character commit hash; the server refuses unpinned revisions. |
@@ -554,12 +707,14 @@ cd /tmp && unzip -o run.com out/model.bin tokenizer.bin -d ref
 
 **Start here**
 
+- [docs/explainers/ELI5.md](docs/explainers/ELI5.md) · [docs/explainers/UNDERGRADUATE.md](docs/explainers/UNDERGRADUATE.md) — if you're new, start with these.
 - [docs/RESEARCH.md](docs/RESEARCH.md) — what is measured, what is closed, what is open, and
   [which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).
-- [docs/MODEL_LIFECYCLE.md](docs/MODEL_LIFECYCLE.md) — download → compile → cover → score → evaluate → import → serve.
+- [docs/MODEL_LIFECYCLE.md](docs/MODEL_LIFECYCLE.md) — install a released bundle, or download → compile → cover → score → evaluate → import → serve.
+- [docs/RELEASE_PIPELINE.md](docs/RELEASE_PIPELINE.md) — the vX.Y convention, cutting a release, and the verified install.
 - [AGENTS.md](AGENTS.md) — contributor manual: gates, normative invariants, κ re-pin, long-run discipline.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to open a PR here.
-- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — every environment knob.
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — every environment knob, and the served-identity contract.
 
 **Explainers** — [ELI5](docs/explainers/ELI5.md) ·
 [Undergraduate](docs/explainers/UNDERGRADUATE.md) ·

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,32 +6,40 @@ programme — what has been measured, refuted and left open — lives in
 purpose. Research direction is set by measurement and changes faster than this
 list does.
 
-_Last reviewed: 2026-08-18 (baseline audit; issue states reconciled to GitHub)._
+_Last reviewed: 2026-08-19 (post-#655 close; issue states reconciled to GitHub)._
 
 ## Next up (recommended sequencing)
 
-Open issues are now exactly **#655** (serving epic; A–E and F0 complete, the
-F flip blocked on #741 + a fresh quality read) and **#741** (distribution,
-maintainer-deferred). The previously listed items #744, #745, #740, and #653
-have all **closed** — see `docs/RESEARCH.md` and
-`docs/project_baseline_audit_2026_08_18.md`. Recommended order now:
+The serving epic is **done**: **#655 closed 2026-08-19** (A–F complete; `r4`
+is the canonical served identity, seeded sampling is the decode default, the
+ask path applies the deployed D4 policy) along with **#741** (release **v0.1
+is published**, with the tag-triggered pipeline and the verified
+`r4 install-release` fetch — `docs/RELEASE_PIPELINE.md`) and **#811**. The
+only open issue repo-wide is **#804** (the route-attention decision; its S1
+real-teacher evidence run is executing under the amended #605 contract).
+Recommended order now:
 
-1. **Recompile the canonical local bundles with the #755 fix and take a fresh
-   quality read** (no open issue yet — the audit's E-1 run contract). The
-   compiler fix is merged and regression-tested, but every canonical bundle
-   still predates it and remains degenerate at baseline (reproduced
-   2026-08-18). This is the cheapest action that can move #655-F
-   precondition 2, and it decides whether the #460-lineage codebook-collision
-   work needs its own new issue.
-2. **[#655](https://github.com/UOR-Foundation/uor-r4/issues/655)** — the
-   remaining epic itself: C1e (loader reconciliation) and the F identity flip
-   stay blocked per `docs/serving_default_flip_655_f.md`.
-3. **[#741](https://github.com/UOR-Foundation/uor-r4/issues/741)** —
-   explicitly deferred until the model-quality work lands; unchanged.
-4. **Untracked remnants worth new issues when picked up:** the #653 phase-2
+1. **[#804](https://github.com/UOR-Foundation/uor-r4/issues/804)** — land the
+   S1 verdict (fit + pre-registered overlap gates on the traced broad
+   corpus). PASS → S1-2 restricted-forward parity, then the #643 A/B; FAIL →
+   negative record, operator retained. Either way the verdict decides the
+   next step for the **#784 family** (output distinctness; the D4
+   semantic-OOD finding recorded on #811) per the standing maintainer
+   decision.
+2. **Recompile the canonical local bundles with the #755 fix and take a fresh
+   quality read** (no open issue yet — the audit's E-1 run contract). Every
+   canonical bundle still predates the fix; the decode-default change made
+   baseline output *valid* (15/15 on the declared canary) but distinctness
+   and factual quality remain research-grade, and the v0.1 bundle's own
+   score report keeps it below the serving-admission quality bar (CLI-served
+   today, refused by the server's r4g1 tier). A post-#755 recompile that
+   clears its own bar is the path to a **server-admissible release bundle**,
+   and it decides whether the #460-lineage codebook-collision work needs its
+   own new issue.
+3. **Untracked remnants worth new issues when picked up:** the #653 phase-2
    "defer-open" items (GNAF cost/witness seam, xtask proof-integrity ports,
-   Lean CI policy) and the #759→#460 codebook-collision root cause, both of
-   whose parent issues are closed.
+   Lean CI policy), the #759→#460 codebook-collision root cause, and the
+   eventual `uor-r4` alias-removal cleanup (deprecation window, #655-F).
 
 ## Landed
 
@@ -58,16 +66,34 @@ have all **closed** — see `docs/RESEARCH.md` and
   is cost-optimal, unrelated to text generation; source and provenance only
   — not wired into any pipeline, not in the deployed dependency graph. Phase
   2 (integration matrix, PR #765) landed and #653 closed 2026-08-17; its
-  "defer-open" items are currently untracked (see Next up item 4).
+  "defer-open" items are currently untracked (see Next up item 3).
+- [x] **Ready-by-default serving epic (#655, closed 2026-08-19)** — A–F
+  complete: uor-matmul-owned compile arithmetic; shared bundle loader +
+  sidecar manifest/verifier; Production/Experimental engine profiles
+  (Production default, r4g1-only admission, typed declines); **`r4` as the
+  canonical served identity** on every surface (`uor-r4` a deprecated request
+  alias); **seeded sampling as the decode default** (pinned seed, greedy
+  opt-out; 15/15 valid on the declared in-domain canary vs 0/15 greedy); the
+  CLI ask path applying the **same deployed D4 abstention policy** as the
+  server tier (#811). Execution records:
+  `docs/serving_default_flip_655_f.md` + the #655 close comment.
+- [x] **Release v0.1 + pipeline (#741, closed 2026-08-19)** — tag-triggered
+  workflow (draft release binding code SHA + contract version; native CLI for
+  linux x86_64 + macOS arm64; wasm frontend), the packaged model bundle as an
+  attested GitHub Release asset, and the explicit hard-verified
+  `r4 install-release --tag v0.1` fetch, proven end to end against the live
+  release. `docs/RELEASE_PIPELINE.md`.
 
 ## Capabilities
 
-- [~] Text-based AI — compiles and serves; **coherent end-to-end generation
-  remains the central research problem** (#745 closed 2026-08-17 with the root
-  cause fixed in the compiler, #755; the canonical local bundles still predate
-  the fix and answer real questions in non-grammatical word-salad at baseline,
-  reproduced 2026-08-18, even though offline per-position metrics show real
-  signal). See
+- [~] Text-based AI — compiles, serves, and ships as a verified release;
+  **output quality remains the central research problem**. The #755 corpus-
+  ordering fix plus the seeded-sampling decode default moved baseline answers
+  from word-salad/digit-attractors to valid English sentences (15/15 on the
+  declared canary, 2026-08-19), but distinctness is weak (#784: distinct
+  prompts converge onto similar completions) and factual quality is
+  research-grade; the canonical local bundles still predate the #755
+  recompile. See
   [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).
 - [ ] Image
 - [ ] Audio

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -8,6 +8,22 @@ For a zero-setup path that needs none of this, see the
 [Quick start](../README.md#quick-start) in the README: the router and dashboard
 run with no model at all, and the Gate C harness runs on committed fixtures.
 
+**Skipping the pipeline entirely: install a released bundle.** Since v0.1
+(#741, `docs/RELEASE_PIPELINE.md`) a compiled bundle ships as an attested
+GitHub Release asset, and
+
+```bash
+r4 install-release --tag v0.1
+```
+
+downloads it, hard-verifies every component digest against the release's
+attested manifest, and installs it under the model store — no teacher
+download, no compile, no silent network access on any serving path. The
+install is explicit-only and never overwrites an existing bundle. Released
+bundles are research-grade (the release notes disclose measured quality);
+compiling your own via the stages below remains the path to a current-fix
+bundle.
+
 The single-command orchestrator (`./uor-r4-cli`) runs stages 1-3 and then serves,
 if you would rather not drive them individually.
 
@@ -1330,10 +1346,13 @@ model-discovery path — it does not use `ModelStore` at all, instead running
 its own per-engine "#248 cascade" (`r4g1 → transformerless → teacher-oracle
 → geometric`) with its own file-discovery conventions. See
 [`SERVING_MODEL_DISCOVERY.md`](SERVING_MODEL_DISCOVERY.md) for the full map
-of that cascade, `.uor-models/last_engine.txt`'s semantics, and how (or
-whether) it currently relates to `ModelStore` and to the #655-C0
-`ReleaseBundleManifest` schema — tracked under #655 ("ship a ready-by-default
-R4 model"), still open as of this writing.
+of that cascade, `.uor-models/last_engine.txt`'s semantics, and how it
+relates to `ModelStore` and the #655-C0 `ReleaseBundleManifest` schema.
+The #655 epic ("ship a ready-by-default R4 model") **closed 2026-08-19**:
+the server's canonical served identity is `r4` (with `uor-r4` a deprecated
+request alias), the default engine profile is `production` (r4g1-only
+admission), and seeded sampling is the decode default on both the HTTP and
+CLI surfaces.
 
 
 ## Legacy benchmark and certification workflow

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -278,6 +278,27 @@ and #755's decisive fix-and-retest (detailed above) substantially advanced
 that answer — real, grammatical English where the same corpus previously
 produced garbage or a hang — though the residual prompt-insensitivity means
 it is not fully settled.
+
+**Continuation (2026-08-19, the #655 close-out measurements).** The
+prompt-insensitivity question got sharper and partially decomposed. The F-p2
+canary (#655, 20 declared prompts × 2 passes on `smollm2-360m-broad`)
+separated *validity* from *distinctness*: under greedy decode, **0/15**
+in-domain prompts produced valid completions (every one collapsed into a
+digit-attractor); under seeded weighted sampling, **15/15** were valid
+English sentences — so the validity failure was decode-policy-bound, and
+seeded sampling (pinned seed, reproducible) is now the serving/CLI default
+(#813/#814, byte-identical to the measured arm). *Distinctness* did not
+move: 5/15 distinct outputs with an 8-identical group, and the convergence
+sits upstream of decode in the context-code path — tracked as **#784**, the
+current sharpest statement of the prompt-conditioning question. Relatedly,
+wiring the deployed D4 policy into the CLI ask path (#811) measured that
+none of the five out-of-distribution probes resolves Novel — semantic OOD
+does not present as signature-space novelty on a broad corpus, so honest
+"I don't know" behavior for such prompts is also gated on the same
+substrate question, not on serving wiring. The #784 next step is
+deliberately held for the **#604/#605 S1 verdict** (the route-attention
+real-teacher fit, running under the amended contract as of this note),
+per the standing maintainer decision.
 The **geometric router** is a validated, real component (content-query
 retrieval MRR 0.88+, #486/#490/#502) but it is a retrieval/routing mechanism,
 not itself a generative model, and it runs on `f64` outside the P-4 kernel by
@@ -290,8 +311,12 @@ P-4-legal integer attention analog (masked-XOR/popcount distance plus bounded
 top-M selection) that is constructible today but wired into **no serving
 path** — registered dormant (`r4-route-attention-dormant`) in
 `model/ledger.toml`. It is the closest thing in this repository to a
-transformer-*shaped* mechanism that is also genuinely goal-aligned, and it has
-not yet been evaluated as a lever for #745's generation-quality question. The
+transformer-*shaped* mechanism that is also genuinely goal-aligned, and its
+first real-teacher evaluation is now **in progress**: #804/#605's S1 fits
+route codes against a traced SmolLM2-360M teacher on a broad corpus under a
+pre-registered overlap-gate contract (amendments on #605), with the verdict
+deciding whether the operator advances (S1-2 restricted-forward parity,
+then the #643 A/B) or retires with a negative record. The
 **`attention`/`r4-attention`** engine modes and **GNAF** (#653) are out of
 scope for this question by the project's own stated goal: the former run the
 teacher's real matmul/float attention purely as a comparison baseline, never

--- a/docs/serving_default_flip_655_f.md
+++ b/docs/serving_default_flip_655_f.md
@@ -264,7 +264,13 @@ README/CONFIGURATION carry the identity contract. Deliberate
 exclusions, unchanged from the inventory: crate names, schema strings,
 staging dirs, the `uor-r4-cli` orchestrator script file name, and the
 four source-verification logical-name fallbacks (infrastructure
-identifiers, not served identity). **The threat-model doc F's list
-names does not exist in this repository**; creating one remains a
-separate product decision, recorded here rather than improvised at
-flip time.
+identifiers, not served identity).
+
+**Correction (2026-08-19, docs review):** the addendum above and the
+inventory originally recorded "no THREAT_MODEL.md exists" — that was
+wrong. The threat model lives at
+`docs/transformerless/THREAT_MODEL.md` (README-linked); the inventory's
+grep only covered `docs/` root. F's threat-model doc obligation was
+satisfied in the same docs-review pass by adding the release-asset
+supply-chain row (the surface the flip's distribution channel
+introduced); no identity mentions existed there to rename.

--- a/docs/serving_rename_inventory_655_f.md
+++ b/docs/serving_rename_inventory_655_f.md
@@ -74,7 +74,7 @@ effect. F does not touch them.
 | `docs/RESEARCH.md` | 9 | historical mentions stay (records); forward-looking identity lines change |
 | `docs/MODEL_LIFECYCLE.md` | 45 | the big one: lifecycle examples all use `uor-r4` |
 | `docs/CONFIGURATION.md` | 2 | alias + default rows |
-| threat-model | **no `THREAT_MODEL.md` exists in `docs/`** | F's list references a doc this repo does not have; the flip PR either creates it (product decision) or records the absence — flag for the maintainer at flip time |
+| threat-model | **CORRECTED 2026-08-19**: this row originally said no `THREAT_MODEL.md` exists — wrong; it lives at `docs/transformerless/THREAT_MODEL.md` (this table's grep only covered `docs/` root) | Updated in the post-flip docs review: a release-asset supply-chain row was added for the distribution surface the flip introduced; the doc had no identity mentions to rename |
 | `docs/SERVING_MODEL_DISCOVERY.md` (not on F's list) | 3 | update anyway — it documents the alias |
 
 ## Execution shape (when authorized)

--- a/docs/transformerless/THREAT_MODEL.md
+++ b/docs/transformerless/THREAT_MODEL.md
@@ -35,6 +35,7 @@ from untrusted storage or networks.
 | Bias amplification / rare-group erasure | compression strengthens source-model failures or drops rare behavior | amplification/erasure metrics, worst-group slices in certificates, provenance at membership-edge granularity enabling deletion (PDF §14) |
 | Patch-chain abuse | forks, unbounded layers, replayed old layers | immutable ordered layers, newest-valid precedence, bounded lookup, chain validation, canonical compaction (Theorem 11) |
 | Witness forgery | fabricated prediction witnesses | independent replay verifier recomputes every step from validated bytes; CID inclusion checks (Theorem 6) |
+| Release-asset tampering (supply chain) | swapped or modified bundle assets on the distribution channel; archives smuggling unattested files or symlinks | `r4 install-release` (#741, since v0.1) verifies **every** component's blake3 digest against the release's attested `release-bundle.json` before anything is installed; archives containing any unattested entry or any symlink are refused outright; existing installs are never overwritten; the fetch is explicit-only — no serving path or first request ever downloads (`docs/RELEASE_PIPELINE.md`). The manifest binds the bundle to the release tag, which binds the code SHA and contract version |
 
 ## 4. Explicit non-defenses (documented limits)
 

--- a/src/release_bundle_loader.rs
+++ b/src/release_bundle_loader.rs
@@ -8,9 +8,11 @@
 //! never changes which bundle loads: a missing sidecar, a parse or
 //! structural-validation failure, or a digest mismatch against the
 //! bundle's actual files on disk all resolve to `None`, exactly as if no
-//! sidecar existed. Per the design doc's Q3, `None` is the common case
-//! today -- no shipped bundle produces a sidecar yet (#655-D is still
-//! open).
+//! sidecar existed. Sidecars now exist in the wild: `r4
+//! package-release-bundle` (#655-D2) writes one, and `r4 install-release`
+//! (#741) installs a hard-verified copy beside every released bundle --
+//! locally compiled bundles that never ran packaging still have none,
+//! and remain the `None` case.
 //!
 //! Scope: this slice verifies exactly the two components the caller
 //! already has resolved file paths for -- `components.graph` against the


### PR DESCRIPTION
## Summary

Maintainer-requested repo-wide documentation review after the #655/#741/#811 closes and the v0.1 release, plus the README makeover: canonicalized accurate information, written so someone with no idea what this repo is understands it before the reference material starts, with **four Mermaid process diagrams** that render natively on GitHub (text-maintained, no image assets to drift).

### README makeover

- **Plain-language opening** — the pay-the-math-once framing, what "compiling a teacher" means, the witness/abstention honesty model, who it's for, explainers linked up front.
- **Diagrams**: "The idea in one picture" (offline compile vs online integer serving) · architecture (kept) · "How a request is served" (profile gate → D4 policy → decode, every outcome typed) · "Releases and verified install" (tag → CI → published release → hard-verified install). All four render-validated.
- Quick start gains the **2-minute path**: `install-release --tag v0.1` + `ask`.
- "What actually works" refreshed to the measured state: honest-serving and shipped-release bullets; the quality limitation rewritten around the 0/15 → 15/15 decode canary, #784 distinctness, and the D4 semantic-OOD finding. Stale ask-gating claim corrected.
- CLI/HTTP reference, docs map, requirements, troubleshooting updated.

### Accuracy fixes

- **ROADMAP**: post-close "Next up" (#804 the only open issue; S1 verdict → recompile/quality read toward a server-admissible bundle); Landed gains the #655 epic + v0.1; Capabilities row updated.
- **MODEL_LIFECYCLE**: install-release as the skip-the-pipeline entry point; "#655 still open" note replaced with the closed end-state.
- **RESEARCH**: dated continuation of the load-bearing "which track" section (validity/distinctness decomposition, decode default, D4 finding, #784 gated on S1); route-attention paragraph updated to S1-in-progress.
- **THREAT_MODEL**: release-asset supply-chain row for the new distribution surface.
- **Record correction**: the F0 addendum + rename inventory claimed no THREAT_MODEL.md exists — wrong (it lives at `docs/transformerless/THREAT_MODEL.md`; the grep only covered `docs/` root). Corrected in both docs and on the closed #655 thread (issuecomment-5337018357).
- `src/release_bundle_loader.rs`: stale "no shipped bundle produces a sidecar yet" module doc updated (comment-only).

## Gates

Claim-wording gate clean · fmt clean · lib compiles (one comment-only code change) · all README anchors resolve · all four Mermaid diagrams render-validated to SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X39CfJSLCU4KhjNP2XXTW
