### PR TITLE
architecture: designate one normative R4G1 scorer (#831)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -173,7 +173,7 @@ The `build` level is *harness-built* (structural). It is a separate axis from an
 
 | ID | Level | Execution scope | Serving reachability | Evidence | Statement |
 | --- | --- | --- | --- | --- | --- |
-| `RF-23` | `build` | `normative-runtime` | `deployed-serving` | src/tless_uor.rs, src/chat.rs (R4G1Runtime selection/fallback on the served path) | R4G1 runtime selection and fallback policy |
+| `RF-23` | `build` | `normative-runtime` | `deployed-serving` | src/tless_uor.rs, src/chat.rs (R4G1Runtime selection/fallback on the served path); docs/adr/0001-normative-r4g1-scorer.md designates the R4G1Runtime scoring path as the one normative scorer (#831) | R4G1 runtime selection and fallback policy |
 
 ## rate_distortion_compression
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "uor-r4-graph-cli",
  "uor-r4-graph-compiler",
  "uor-r4-graph-format",
+ "uor-r4-graph-runtime",
  "uor-r4-model-source",
 ]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,10 @@ gate (**#811**), and the route-attention decision (**#804**, S1 verdict:
 FAIL — instrument vacuous; operator retained dormant with the record on
 **#605**). The open, sequenced successor work is now the **R4 Intelligence
 programme (#820)**, beginning with stage **S0** (#821); the completion plan
-holds the full hierarchy. The maintainer-decision items below remain valid
+holds the full hierarchy. Within S0, the single normative R4G1 scorer for
+deployed inference — the R4G1Runtime scoring path — is designated by
+[ADR-0001](docs/adr/0001-normative-r4g1-scorer.md) (#831), with the
+reference/certifier scorers explicitly scoped and divergence made fail-closed. The maintainer-decision items below remain valid
 inputs to that programme, each needing its own contract when picked up:
 
 1. **Recompile the canonical local bundles with the #755 fix and take a

--- a/crates/uor-r4-api/Cargo.toml
+++ b/crates/uor-r4-api/Cargo.toml
@@ -17,3 +17,8 @@ serde_json = "1.0"
 # Pinned to the workspace-wide blake3 version.
 blake3 = "=1.5.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+# #831 normative-scorer differential: the deployed runtime accumulator/selector
+# and R4G1Runtime are compared against the normative scoring spec in a test.
+uor-r4-graph-runtime = { version = "0.1.0", path = "../uor-r4-graph-runtime" }

--- a/crates/uor-r4-api/tests/normative_scorer_831.rs
+++ b/crates/uor-r4-api/tests/normative_scorer_831.rs
@@ -1,0 +1,317 @@
+//! #831 — normative R4G1 scorer designation: machine-checked evidence.
+//!
+//! Decision record: `docs/adr/0001-normative-r4g1-scorer.md`; evidence record:
+//! `docs/normative_scorer_831.md`.
+//!
+//! These tests are the fail-closed teeth behind ADR-0001. They exercise real
+//! production code from three crates and prove a planted divergence from the
+//! normative scoring semantics is detected:
+//!   * normative specification — `uor-r4-graph-format::scoring_semantics`,
+//!   * deployed runtime accumulator/selector — `uor-r4-graph-runtime::scoring`,
+//!   * reference/certifier scorer — `uor-r4-graph-certify::GraphScorer`.
+
+use std::cmp::Ordering;
+
+use uor_r4_graph_certify::{GraphScorer, DEFAULT_EXCT_TOP_X, DEFAULT_ROOT_TOP_B};
+use uor_r4_graph_format::scoring_semantics::{
+    ResidualContribution, ResidualContributionKind, ScoreAccumulator, ScoringSemanticsVerifier,
+    ScoringSemanticsVersion,
+};
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_runtime::scoring::{
+    accumulate_reference, select_best, OrderedScore, ResidualKind, TypedContribution,
+};
+use uor_r4_graph_runtime::R4G1Runtime;
+
+// --- normative oracle vs deployed runtime: accumulation ----------------------
+
+/// Oracle total for a duplicate-free residual set: the normative
+/// `scoring_semantics` accumulator (graph-format crate).
+fn oracle_total(items: &[(u32, i32)]) -> i32 {
+    let mut acc = ScoreAccumulator::<32>::new();
+    for &(id, raw) in items {
+        acc.accumulate(&ResidualContribution {
+            kind: ResidualContributionKind::TokenEmission,
+            contribution_id: id,
+            raw_value: raw,
+        })
+        .expect("within evidence capacity");
+    }
+    acc.score()
+}
+
+/// Deployed runtime total for the same set: `accumulate_reference`
+/// (graph-runtime crate). `None` when the set repeats an evidence id.
+fn runtime_total(items: &[(u32, i32)]) -> Option<ScoreQ> {
+    let contributions: Vec<TypedContribution> = items
+        .iter()
+        .map(|&(id, raw)| TypedContribution {
+            evidence_id: id,
+            kind: ResidualKind::Emission,
+            value: ScoreQ::from_raw(raw),
+        })
+        .collect();
+    accumulate_reference(ScoreQ::ZERO, &contributions)
+}
+
+const ACC_CASES: &[&[(u32, i32)]] = &[
+    &[(1, 100), (2, -25), (3, -10)],
+    &[(1, 0)],
+    &[(5, i32::MAX - 5), (6, 10)],  // positive saturation
+    &[(7, i32::MIN + 5), (8, -10)], // negative saturation
+    &[(9, 250), (10, -250), (11, 1)],
+    &[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)],
+];
+
+#[test]
+fn spec_and_runtime_accumulators_agree_on_disjoint_sets() {
+    for &case in ACC_CASES {
+        let oracle = oracle_total(case);
+        let runtime = runtime_total(case).expect("duplicate-free set accumulates");
+        assert_eq!(
+            runtime.raw(),
+            oracle,
+            "normative spec and deployed runtime accumulator diverged on {case:?}"
+        );
+    }
+}
+
+// --- normative oracle vs deployed runtime: selection -------------------------
+
+/// Normative winner via the spec `compare_candidates` (score desc, id asc).
+fn oracle_winner(cands: &[(u32, i32)]) -> u32 {
+    let mut best = cands[0];
+    for &c in &cands[1..] {
+        if ScoreAccumulator::<4>::compare_candidates(c.1, c.0, best.1, best.0) == Ordering::Less {
+            best = c;
+        }
+    }
+    best.0
+}
+
+/// Deployed runtime winner via `select_best` (graph-runtime crate).
+fn runtime_winner(cands: &[(u32, i32)]) -> u32 {
+    let ordered: Vec<(u32, OrderedScore)> = cands
+        .iter()
+        .map(|&(id, raw)| (id, OrderedScore::Real(ScoreQ::from_raw(raw))))
+        .collect();
+    select_best(&ordered).expect("non-empty candidate set").0
+}
+
+const SELECT_CASES: &[&[(u32, i32)]] = &[
+    &[(10, 500), (20, 500)],         // tie -> lowest id (10)
+    &[(3, 900), (1, 100), (2, 900)], // tie at top -> lowest id (2)
+    &[(7, -5), (8, -5), (9, -6)],    // negative scores, tie -> lowest id (7)
+    &[(2, i32::MAX), (1, i32::MAX)], // saturated tie -> lowest id (1)
+];
+
+#[test]
+fn spec_and_runtime_selectors_agree() {
+    for &case in SELECT_CASES {
+        assert_eq!(
+            runtime_winner(case),
+            oracle_winner(case),
+            "normative spec and deployed runtime selector diverged on {case:?}"
+        );
+    }
+}
+
+// --- no-double-counting, honored by both (in each one's documented way) ------
+
+#[test]
+fn no_double_counting_enforced_by_both() {
+    // Spec accumulator: a repeated contribution id is ignored; score unchanged.
+    let mut acc = ScoreAccumulator::<8>::new();
+    let item = ResidualContribution {
+        kind: ResidualContributionKind::InteractionResidual,
+        contribution_id: 42,
+        raw_value: 250,
+    };
+    assert!(acc.accumulate(&item).expect("within capacity"));
+    assert!(
+        !acc.accumulate(&item).expect("within capacity"),
+        "spec must ignore a repeated contribution id"
+    );
+    assert_eq!(acc.score(), 250);
+    assert_eq!(acc.evidence_count(), 1);
+
+    // Runtime accumulator: a set carrying a duplicated evidence id is rejected.
+    let dup = [
+        TypedContribution {
+            evidence_id: 42,
+            kind: ResidualKind::Emission,
+            value: ScoreQ::from_raw(250),
+        },
+        TypedContribution {
+            evidence_id: 42,
+            kind: ResidualKind::Emission,
+            value: ScoreQ::from_raw(250),
+        },
+    ];
+    assert!(
+        accumulate_reference(ScoreQ::ZERO, &dup).is_none(),
+        "runtime accumulate_reference must reject a duplicated evidence id"
+    );
+}
+
+// --- planted negative: the differential has teeth ----------------------------
+
+/// Planted-negative selector: higher-id-wins on ties (violates id-ascending).
+fn divergent_winner(cands: &[(u32, i32)]) -> u32 {
+    let mut best = cands[0];
+    for &c in &cands[1..] {
+        if c.1 > best.1 || (c.1 == best.1 && c.0 > best.0) {
+            best = c;
+        }
+    }
+    best.0
+}
+
+/// Planted-negative accumulator: wrapping add (violates saturation).
+fn wrapping_total(items: &[(u32, i32)]) -> i32 {
+    let mut total: i32 = 0;
+    for &(_, raw) in items {
+        total = total.wrapping_add(raw);
+    }
+    total
+}
+
+#[test]
+fn planted_divergence_is_detected() {
+    // Tie case: normative winner is the lower id; the planted higher-id-wins
+    // selector must disagree — proving the differential would catch a real
+    // scorer that violated the normative tie-break.
+    let tie: &[(u32, i32)] = &[(10, 500), (20, 500)];
+    assert_eq!(oracle_winner(tie), 10);
+    assert_eq!(runtime_winner(tie), 10);
+    assert_ne!(
+        divergent_winner(tie),
+        oracle_winner(tie),
+        "planted higher-id-wins selector must diverge from the normative tie-break"
+    );
+
+    // Saturation case: normative total clamps; the planted wrapping accumulator
+    // must diverge.
+    let sat: &[(u32, i32)] = &[(1, i32::MAX - 5), (2, 10)];
+    assert_eq!(oracle_total(sat), i32::MAX, "spec saturates high");
+    assert_eq!(
+        runtime_total(sat).unwrap().raw(),
+        i32::MAX,
+        "runtime saturates high"
+    );
+    assert_ne!(
+        wrapping_total(sat),
+        oracle_total(sat),
+        "planted wrapping accumulator must diverge from the normative saturation"
+    );
+}
+
+// --- single-source scorer status space + spec pin ----------------------------
+
+#[test]
+fn scorer_status_is_single_source_and_spec_pinned() {
+    // Compiles only if `uor-r4-api::ResolutionStatus` is the *same type* as the
+    // certifier scorer's `ScoreStatus` — the single-source scorer status space.
+    let coerce: fn(uor_r4_api::ResolutionStatus) -> uor_r4_graph_certify::ScoreStatus = |s| s;
+    let _ = coerce;
+
+    assert_eq!(
+        ScoringSemanticsVerifier::version(),
+        ScoringSemanticsVersion::V1_0_0
+    );
+    assert!(
+        ScoringSemanticsVerifier::audit_scoring_compliance().is_none(),
+        "normative scoring-semantics self-audit must report no violation"
+    );
+}
+
+// --- reachability + fail-closed boundary -------------------------------------
+
+/// A small, self-contained R4G1 bundle both scorers can read (the synthetic
+/// store recipe used by the runtime unit tests). Returns `(r4g1_bytes,
+/// teacher_bytes)`; the teacher container carries the pinned `teacher_cid`
+/// that the reference scorer's EXCT path verifies fail-closed.
+fn synthetic_bundle() -> (Vec<u8>, Vec<u8>) {
+    use std::collections::BTreeMap;
+    use uor_r4_core::transformerless::compiler::{self, STAGES};
+    use uor_r4_core::transformerless::{convert_r4g1, runtime};
+
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let art_bytes = std::fs::read(format!(
+        "{dir}/../uor-r4-core/tests/fixtures/tless_artifacts.bin"
+    ))
+    .expect("fixture artifacts present");
+    let artifacts = compiler::parse_artifacts(&art_bytes).expect("artifacts parse");
+
+    let mut store: runtime::Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    let codes: [[u8; 4]; 6] = [
+        [3, 1, 4, 1],
+        [3, 1, 4, 2],
+        [3, 5, 9, 2],
+        [7, 5, 9, 2],
+        [7, 5, 8, 2],
+        [11, 5, 8, 7],
+    ];
+    for (i, code) in codes.iter().enumerate() {
+        runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
+    }
+    let store_bytes = runtime::store_bytes(&store);
+    let r4g1 = convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None)
+        .expect("convert to R4G1")
+        .0;
+    (r4g1, art_bytes)
+}
+
+#[test]
+fn reference_and_normative_reachable_from_same_artifact() {
+    let (bytes, teacher) = synthetic_bundle();
+
+    // Deployed normative scorer is reachable and deterministic.
+    let runtime = R4G1Runtime::parse(&bytes).expect("normative deployed scorer parses");
+    assert!(runtime.node_count() > 0);
+    let mut ns1 = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let mut ns2 = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let a = runtime.predict_distribution(&[1, 2, 3], None, &mut ns1);
+    let b = runtime.predict_distribution(&[1, 2, 3], None, &mut ns2);
+    assert_eq!(
+        a, b,
+        "normative scorer must be deterministic on identical input"
+    );
+
+    // Reference/certifier scorer is reachable from the *same* artifact bytes
+    // (with the pinned teacher container its EXCT path verifies fail-closed).
+    let scorer = GraphScorer::from_artifact(
+        &bytes,
+        Some(&teacher),
+        DEFAULT_ROOT_TOP_B,
+        DEFAULT_EXCT_TOP_X,
+    );
+    assert!(
+        scorer.is_some(),
+        "reference scorer must construct from the same normative artifact bytes"
+    );
+}
+
+#[test]
+fn incompatible_artifacts_fail_closed() {
+    let garbage = [0u8; 32];
+
+    // Both the normative and the reference scorer reject non-artifact bytes.
+    assert!(
+        R4G1Runtime::parse(&garbage).is_err(),
+        "normative scorer must reject non-artifact bytes"
+    );
+    assert!(
+        GraphScorer::from_artifact(&garbage, None, DEFAULT_ROOT_TOP_B, DEFAULT_EXCT_TOP_X)
+            .is_none(),
+        "reference scorer must reject non-artifact bytes"
+    );
+
+    // Patch owner: an incompatible patch is rejected (fail closed).
+    let (bytes, _teacher) = synthetic_bundle();
+    let mut runtime = R4G1Runtime::parse(&bytes).expect("parse normative artifact");
+    assert!(
+        runtime.try_push_patch(&garbage).is_some(),
+        "incompatible patch bytes must fail closed with a rejection reason"
+    );
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -289,7 +289,12 @@ end-to-end yet; #745 is the open question that would settle it either way,
 and #755's decisive fix-and-retest (detailed above) substantially advanced
 that answer — real, grammatical English where the same corpus previously
 produced garbage or a hang — though the residual prompt-insensitivity means
-it is not fully settled.
+it is not fully settled. (As of #831, the one normative scorer for deployed
+inference — the R4G1Runtime scoring path — is designated in
+[ADR-0001](adr/0001-normative-r4g1-scorer.md), and the reference/certifier
+scorers are explicitly scoped; a certifier measurement is no longer read as a
+served-path result, and scorer divergence fails closed rather than serving a
+drifted token.)
 
 **Continuation (2026-08-19, the #655 close-out measurements).** The
 prompt-insensitivity question got sharper and partially decomposed. The F-p2

--- a/docs/adr/0001-normative-r4g1-scorer.md
+++ b/docs/adr/0001-normative-r4g1-scorer.md
@@ -1,0 +1,182 @@
+# ADR-0001: One normative R4G1 scorer for serving, certification, patches, and proofs
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Issue:** #831 (item C of S0 tracker #821, programme #820)
+- **Scope of this decision:** Normative **deployed R4Engine/R4G1 serving path**; alternate
+  scorers only as explicitly named reference / certifier scopes. Evidence outside this scope
+  is not credited as a deployed-serving result.
+- **Relation to prior records:** Extends `docs/inference_contract.md` (RF-10) and
+  `docs/scoring_semantics.md`; does not retract them. Claim language follows
+  `docs/formal_vocabulary.md` (normative). This is a **Definition/Guarantee-scope** design
+  record, not an empirical claim.
+
+## Context
+
+The repository carries several scoring surfaces that were each motivated separately and whose
+production-versus-reference roles were **not expressed as one unambiguous normative production
+semantics** (the #831 problem statement):
+
+- `uor-r4-graph-runtime` — the `no_std`, allocation-free deployed runtime
+  (`R4G1Runtime::step` / `predict_distribution*` / `predict_candidates*`), plus its
+  `scoring` (fixed-point accumulator, `OrderedScore` ordering, canonical selection),
+  `patch_chain`, and witness surfaces. This is what selects the **served token** on the
+  deployed path (`src/chat.rs`, `src/tless_uor.rs`, `src/server.rs`).
+- `uor-r4-graph-format::scoring_semantics` (v1.0.0) — the machine-readable **normative
+  specification** of the fixed-point scoring semantics: `ScoreQ` (Q16.16), the seven typed
+  residual contribution kinds, saturating accumulation, the no-double-counting rule, and the
+  deterministic tie-break. It is a specification, not a second serving implementation.
+- `uor-r4-graph-certify::score_runtime::GraphScorer` (the "Phase-4 reference scorer") — a
+  witness-replayable, integer-accumulation reference/certifier scorer (Rule 2 exact-context
+  precedence, Rule 1 chain-telescoped graph residuals). It is also loaded on the served path
+  **as the D4 abstention-policy resolver** through `uor-r4-api::R4Engine`.
+- `uor-r4-graph-certify::score` — the offline Gate C measurement harness.
+- `GraphScorer::score_candidates_legacy` — the retired Σ-over-cloud formula (confirmed double
+  counting; kept only for the Gate C side-by-side).
+- `uor-r4-router` — the exploratory `f64` geometric retrieval router, off the P-4 kernel and
+  off the serving-selection path by design.
+
+**The concrete drift this ADR removes.** On the deployed path the served token is chosen by
+`R4G1Runtime`, while whether to serve or abstain is chosen by `R4Engine`/`GraphScorer`
+resolving the *same* position. These are two implementations, and they are **not exactly
+equivalent**: for example the Cayley–Dickson `syntactic_morphism_score` term runs only in the
+`R4G1Runtime` multi-candidate generation slice (recorded in `crates/uor-r4-graph-certify/tests/r4g1_cd_ab.rs`).
+Quality measured on one surface (Gate C over `GraphScorer`) was therefore discussed as though
+it applied to what the other surface serves. Without a single named owner, such divergence is
+silent and would invalidate every downstream S1–S7 gate that cites "the scorer".
+
+## Decision
+
+**1. The one normative scorer for deployed inference is the deployed R4G1 runtime scoring
+path** — `uor-r4-graph-runtime` (`R4G1Runtime::step` / `predict_distribution*` /
+`predict_candidates*` and its `scoring` module). Its step, state, tie-break, saturation,
+and no-double-counting rules are **specified normatively** by
+`uor-r4-graph-format::scoring_semantics` (v1.0.0) and constrained by the operation contract in
+`docs/inference_contract.md`. The served token is, by definition, the token this path selects.
+
+The normative semantics are fixed as follows (all already realized in code; this ADR names
+them as the single owner):
+
+- **Score domain (Definition):** `ScoreQ` = signed Q16.16 integer. `ScoreQ::MIN`/`MAX` are the
+  saturated-low/high sentinels.
+- **Accumulation (Definition):** pre-quantized, already-signed residuals combined with
+  **saturating** integer add (`i32::saturating_add`); positive/negative overflow clamps to
+  `MAX`/`MIN`. No float, no multiply, no divide, no runtime rescaling on the hot path.
+- **No-double-counting (Guarantee, Structural):** each canonical evidence id contributes at
+  most once per candidate evaluation.
+- **Deterministic tie-break (Guarantee, Structural):** primary key `ScoreQ` descending,
+  secondary key candidate id (token/node) ascending — a total order across x86_64, aarch64,
+  and portable scalar targets.
+- **Resolution status / decline (Definition):** the single **scorer resolution-status**
+  space is `ScoreStatus` (`uor-r4-api::ResolutionStatus` is a type alias of it — there is no
+  second definition of the *scorer* status space). This is distinct from, and must not be
+  conflated with, `uor-r4-graph-runtime::status::ResolutionStatus`, which classifies ROUT
+  routing margin (Supported / Boundary / BackedOff / Novel / Contradictory) and is a routing
+  concern, not the scorer's resolution class. The deployed D4 `StatusPolicy`
+  (`serve` / `widen_once` / `abstain`) is the decline policy; abstention is a typed outcome,
+  never a guessed token.
+- **Patch precedence (owner):** `uor-r4-graph-runtime::patch_chain`
+  (`R4G1Runtime::try_push_patch`) is the single normative owner of patch/delta interpretation.
+  Bytes that are not a valid, compatible R4G1 artifact **fail closed** (a rejection reason is
+  returned; no partial patch is applied).
+- **Witness (owner):** the R4G1 witness / replay surface is the single normative owner of
+  witness semantics; a witness whose token, region, depth, length, or contribution ids do not
+  reproduce the artifact replay **fails closed** (typed `ReplayError` / witness-rejection
+  reason), and no unverified witness is credited.
+
+**2. The other scorers are explicitly scoped (distinct identities, distinct claim
+boundaries).** Convergence of the implementations is a non-goal; clear scoping is sufficient
+(#831 non-goals). No scorer other than the one above may be cited as deployed-serving
+evidence.
+
+| Surface | Crate / symbol | Role | Execution scope |
+|---|---|---|---|
+| **Normative deployed scorer** | `uor-r4-graph-runtime` `R4G1Runtime` + `scoring` | Selects the served token; owns patch + witness | `normative-runtime` (served) |
+| Normative specification | `uor-r4-graph-format::scoring_semantics` v1.0.0 | The rules the deployed scorer realizes | `normative-runtime` (spec) |
+| Reference / certifier scorer | `uor-r4-graph-certify::score_runtime::GraphScorer` | Witness-replayable reference; **and** the deployed D4 abstention-policy resolver via `R4Engine` | `certifier-instrument` (+ policy-only on the served path) |
+| Gate C harness | `uor-r4-graph-certify::score` | Offline held-out measurement | `certifier-instrument` |
+| Legacy scorer | `GraphScorer::score_candidates_legacy` | Retired Σ-over-cloud formula (double counting) | `reference-only` (retired) |
+| Geometric router | `uor-r4-router` | Exploratory `f64` retrieval | off-serving (out of scope) |
+
+**3. Bounded, named non-equivalence.** `R4G1Runtime` (served token) and `GraphScorer`
+(reference / abstention policy) are **not asserted exactly equivalent** — they are distinct
+implementations with distinct identities. They **share** the normative tie-break, saturating
+accumulation, no-double-counting rule, and the single `ScoreStatus` status space. Their known
+divergence is bounded to the `R4G1Runtime` multi-candidate generation slice (the CD term). The
+decline rule that keeps this fail-closed: on the served path, a position whose reference
+resolution status and normative served status disagree is resolved **conservatively** — the
+D4 policy already routes anything not resolved `ExactContext`/`Graph` through `WidenOnce` and
+then abstains, so a drifted position abstains rather than silently serving a divergent token.
+
+**4. Per-token attribution.** The normative scorer already carries per-token **resolution
+attribution** through `ScoreStatus` (ExactContext / Graph / Novel …), the typed residual
+contribution kinds (RootPrior / ChildCorrection / InteractionResidual / GoalReward /
+ConstraintPenalty / UncertaintyPenalty / TokenEmission), and the witness (region, depth,
+edges, contribution ids). This ADR names that surface as the attribution owner. Committing the
+**CID-bound per-token attribution capability suites** on top of it is the explicitly scoped
+deliverable of sibling item **#832** (documented exception, not omitted).
+
+## Reachability (production entry points → normative semantics)
+
+Every production entry point that selects a served token reaches the normative deployed
+scorer; the reference scorer is reachable only in its scoped roles.
+
+| Entry point | Path | Reaches |
+|---|---|---|
+| Local chat / generation | `src/chat.rs` → `R4G1Runtime::predict_candidates_with_signature_lanes` | Normative deployed scorer |
+| Transformerless serve | `src/tless_uor.rs` → `R4G1Runtime::parse` + `predict_candidates_with_signature_lanes` | Normative deployed scorer |
+| HTTP / WS / WASM server | `src/server.rs` → the chat surface above | Normative deployed scorer |
+| Library façade | `uor-r4-api::R4Engine` | Reference `GraphScorer` **as D4 policy resolver only**; token selection stays with `R4G1Runtime` |
+| Certification (Gate C, replay) | `uor-r4-graph-certify` `score` / `score_runtime` / `verify_witness_replay` | Reference / certifier scope |
+| Proof obligations | `uor-r4-proof-model` (`ExecutableSpec`, Kani surface) | Structural obligations over the runtime + format |
+
+Machine-checked reachability and the fail-closed boundary are asserted by
+`crates/uor-r4-graph-certify/tests/normative_scorer_831.rs`.
+
+## Consequences
+
+- Downstream reports (S1–S7) must name the normative scorer identity when citing scorer
+  quality, and must not transfer a reference/certifier measurement to the served path without
+  the reachability shown here.
+- Adding a third production scoring implementation is prohibited by this ADR; extend the
+  normative path or add an explicitly scoped reference with its own claim boundary.
+- The `scoring_semantics` module remains the single normative spec: a change to tie-break,
+  saturation, accumulation order, or the no-double-counting rule is an ADR-superseding change
+  and versions the spec (§`ScoringSemanticsVersion`).
+- No format or ABI bytes change in this ADR (convergence is a non-goal). If a future change
+  alters bytes or semantics, version the relevant section/operator and publish a migration
+  decision.
+
+## Conformance mapping
+
+Reuses/extends existing capability rows (no new RF id required):
+
+- **RF-23** `r4g1_runtime` (`normative-runtime`, `deployed-serving`) — R4G1Runtime selection
+  and fallback: the normative deployed scorer designated here; evidence extended to cite this
+  ADR.
+- **RF-10** `inference_contract` (`normative-runtime`, `deployed-serving`) — the operation
+  contract the normative path obeys.
+- **RF-09** `graph_invariant_ownership` (`normative-runtime`, `deployed-serving`) — loader
+  validation that makes incompatible artifacts fail closed.
+- **RF-22** `r4g1_quality` (`certifier-instrument`, `off-serving-path`) — the certifier
+  instrument scope kept distinct from the served scorer.
+- **RF-15** / **RF-21** (`offline-compiler`, `off-serving-path`) — compile-time quality /
+  reproducibility, distinct from serving.
+
+`CONFORMANCE.md` is regenerated (never edited directly) after the RF-23 evidence extension.
+
+## Verification
+
+- `crates/uor-r4-graph-certify/tests/normative_scorer_831.rs` — differential of the normative
+  specification (`scoring_semantics`) against the deployed runtime `scoring` accumulator and
+  selector; a **planted-negative** divergent scorer that the differential detects; the
+  single-source status-space check; reachability of both the deployed and reference scorers
+  from the same artifact bytes; and the incompatible-artifact fail-closed boundary.
+- The four local gates + register conformance (R1–R6) + wasm-router lib build.
+
+## Claim status
+
+This record establishes **semantic ownership and reachability**, not model quality. It makes
+divergence between the deployed scorer and the reference scorer fail closed rather than
+silent. It does not claim the two scorers are exactly equivalent, and it does not establish
+any generation-quality result.

--- a/docs/normative_scorer_831.md
+++ b/docs/normative_scorer_831.md
@@ -1,0 +1,74 @@
+# Normative R4G1 scorer designation — evidence record (#831)
+
+- **Issue:** #831 — "architecture: designate one normative R4G1 scorer for serving,
+  certification, patches, and proofs" (item C of S0 tracker #821, programme #820).
+- **Decision record:** [`docs/adr/0001-normative-r4g1-scorer.md`](adr/0001-normative-r4g1-scorer.md).
+- **Date:** 2026-08-20.
+- **Claim status:** Establishes semantic ownership + reachability + fail-closed divergence.
+  Not a quality claim; the two scorers are **not** asserted exactly equivalent.
+
+This record is append-only. It captures the inventory, the differential/reachability
+evidence, and the acceptance-criteria status behind ADR-0001.
+
+## Scorer inventory (as found)
+
+| Surface | Symbol | Role | Scope |
+|---|---|---|---|
+| Deployed runtime scorer | `uor-r4-graph-runtime::R4G1Runtime` (+ `scoring`) | selects the served token; owns patch + witness | normative-runtime (served) |
+| Normative spec | `uor-r4-graph-format::scoring_semantics` v1.0.0 | the rules the runtime realizes | normative-runtime (spec) |
+| Reference / certifier | `uor-r4-graph-certify::score_runtime::GraphScorer` | witness-replayable reference; D4 policy resolver via `R4Engine` | certifier-instrument |
+| Gate C harness | `uor-r4-graph-certify::score` | offline measurement | certifier-instrument |
+| Legacy | `GraphScorer::score_candidates_legacy` | retired Σ-over-cloud formula | reference-only (retired) |
+| Geometric router | `uor-r4-router` | exploratory f64 retrieval | off-serving |
+
+The drift ADR-0001 removes: on the served path the token is chosen by `R4G1Runtime` while the
+serve/abstain decision is chosen by `R4Engine`/`GraphScorer` on the same position — two
+implementations, not exactly equivalent (the Cayley–Dickson `syntactic_morphism_score` term
+runs only in the `R4G1Runtime` multi-candidate slice; see
+`crates/uor-r4-graph-certify/tests/r4g1_cd_ab.rs`).
+
+## Machine-checked evidence
+
+`crates/uor-r4-graph-certify/tests/normative_scorer_831.rs` (default `cargo test` suite):
+
+1. **Differential — spec vs deployed accumulator.** For duplicate-free residual sets
+   (including saturation cases), the normative spec `ScoreAccumulator::accumulate`
+   (graph-format) and the deployed runtime `scoring::accumulate_reference` (graph-runtime)
+   produce identical totals. Two independent implementations in two crates agree on the
+   normative accumulation semantics.
+2. **Differential — spec vs deployed selector.** The runtime `scoring::select_best` winner
+   matches the normative `ScoreAccumulator::compare_candidates` order (ScoreQ descending,
+   id ascending), including exact ties.
+3. **No-double-counting, per implementation.** The spec accumulator ignores a repeated
+   contribution id (score unchanged); the runtime `accumulate_reference` rejects a set with a
+   repeated evidence id (`None`). Both honor count-once.
+4. **Planted negative (has teeth).** A divergent selector (higher-id-wins) and a
+   non-saturating (wrapping) accumulator each **disagree** with the normative spec on a
+   constructed case — proving the differential would catch a real scorer that violated the
+   semantics.
+5. **Single-source status space.** `uor-r4-api::ResolutionStatus` is the same type as
+   `ScoreStatus`; `ScoringSemanticsVerifier::version() == 1.0.0` and
+   `audit_scoring_compliance()` reports no violation.
+6. **Reachability + fail-closed.** Both the deployed `R4G1Runtime::parse` and the reference
+   `GraphScorer::from_artifact` are reachable from the same synthetic R4G1 bytes; both reject
+   non-artifact bytes, and `R4G1Runtime::try_push_patch` rejects incompatible patch bytes
+   (fail closed).
+
+## Acceptance-criteria status
+
+- [x] Exactly one implementation/specification named normative for deployed inference — the
+  deployed `R4G1Runtime` scoring path, specified by `scoring_semantics` v1.0.0 (ADR §Decision.1).
+- [x] All production entry points and certificates demonstrate reachability to that semantics
+  — ADR §Reachability; test items 6.
+- [x] Reference/certifier-only implementations explicitly scoped and differentially tested —
+  ADR §Decision.2 table; test items 1–4.
+- [x] Patch and witness semantics have one normative owner and incompatible artifacts fail
+  closed — ADR §Decision.1 (patch/witness owner); test item 6.
+- [x] A planted semantic divergence fails the relevant test — test item 4.
+
+## Conformance / documentation reconciliation
+
+- `model/ids.toml` RF-23 evidence extended to cite ADR-0001; `CONFORMANCE.md` regenerated
+  (generated file, not hand-edited).
+- `docs/RESEARCH.md` and `ROADMAP.md` note the S0 normative-scorer designation and link the ADR.
+- Per-token CID-bound attribution **suites** remain scoped to #832 (documented exception).

--- a/model/ids.toml
+++ b/model/ids.toml
@@ -225,7 +225,7 @@ suite = "r4g1_runtime"
 statement = "R4G1 runtime selection and fallback policy"
 scope = "normative-runtime"
 reachability = "deployed-serving"
-evidence = "src/tless_uor.rs, src/chat.rs (R4G1Runtime selection/fallback on the served path)"
+evidence = "src/tless_uor.rs, src/chat.rs (R4G1Runtime selection/fallback on the served path); docs/adr/0001-normative-r4g1-scorer.md designates the R4G1Runtime scoring path as the one normative scorer (#831)"
 
 [[id]]
 id = "RF-24"


### PR DESCRIPTION
## Problem and outcome

The repo carried several scoring surfaces whose production-vs-reference roles were not
expressed as one normative production semantics (the #831 problem). On the deployed path the
served token is chosen by `R4G1Runtime` while the serve/abstain decision is chosen by
`R4Engine`/`GraphScorer` on the *same* position — two implementations that are **not** exactly
equivalent (the Cayley–Dickson term runs only in the `R4G1Runtime` generation slice; see
`crates/uor-r4-graph-certify/tests/r4g1_cd_ab.rs`). A certifier (Gate C) measurement was
therefore discussed as though it applied to what the deployed path serves — silent drift that
would invalidate downstream S1–S7 gates.

**Outcome:** one normative scorer is designated and documented; the reference/certifier
scorers are given distinct identities and claim boundaries; divergence is made fail-closed;
and a differential with a planted negative proves the boundary has teeth. Closes #831.

## Scope and non-goals

**In scope:** an ADR designating the normative scorer; a reachability inventory; explicit
scoping of the reference/certifier/legacy/router surfaces; a differential + planted-negative +
reachability + fail-closed test; conformance-register and doc reconciliation.

**Non-goals (per the issue):** improving model quality or changing the decode policy; removing
reference implementations where scoping suffices; calling bit-different scorers equivalent.
No format/ABI bytes change (convergence is a non-goal; distinct-identity scoping is used).

## Decision (ADR-0001)

The one normative scorer for deployed inference is the **deployed R4G1 runtime scoring path**
(`uor-r4-graph-runtime` `R4G1Runtime` + `scoring`), specified by
`uor-r4-graph-format::scoring_semantics` v1.0.0 and constrained by `docs/inference_contract.md`.
Tie-break (ScoreQ desc, id asc), saturating accumulation, no-double-counting, the single
`ScoreStatus` scorer-status space, patch owner (`try_push_patch`, fail-closed), and witness
owner (replay mismatch fail-closed) are named. `GraphScorer` (reference/certifier + D4 policy
resolver), the Gate C harness, the retired `score_candidates_legacy`, and the `uor-r4-router`
are explicitly scoped out of the served-selection role.

## Acceptance-criteria status

- [x] Exactly one implementation/specification named normative for deployed inference — ADR §Decision.1.
- [x] All production entry points and certificates demonstrate reachability — ADR §Reachability + test `reference_and_normative_reachable_from_same_artifact`.
- [x] Reference/certifier-only implementations explicitly scoped and differentially tested — ADR §Decision.2 + `spec_and_runtime_accumulators_agree*` / `spec_and_runtime_selectors_agree`.
- [x] Patch and witness semantics have one normative owner and incompatible artifacts fail closed — ADR §Decision.1 + `incompatible_artifacts_fail_closed`.
- [x] A planted semantic divergence fails the relevant test — `planted_divergence_is_detected`.

## Tests and verification

New: `crates/uor-r4-api/tests/normative_scorer_831.rs` (7 tests, default suite) — spec-vs-runtime
accumulator/selector differential across three crates, planted negatives (higher-id-wins
selector + wrapping accumulator) detected, no-double-counting per implementation, single-source
scorer status space, reachability of both scorers from one artifact, and the incompatible-artifact
fail-closed boundary.

Gates run locally (real Mac, pinned toolchain), all green:
`cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
`cargo check -p uor-r4-graph-format --no-default-features (+ --features alloc)`;
`python3 scripts/check_claim_wording.py`; register conformance R1 (`check-model`), R4
(`audit-deferral`), R5 (`audit-limits`), R2/R3 (`repo-conformance`), R6 (`cargo deny check bans`);
`cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`; and the full
`cargo test --workspace --no-fail-fast` (every suite green; the live-teacher parity BDD is the
documented slow mode and its graph scenarios skip on the pre-existing quality gate, unrelated
to this change).

## Evidence artifacts

`docs/adr/0001-normative-r4g1-scorer.md` (decision record) and `docs/normative_scorer_831.md`
(per-issue evidence record + acceptance map).

## Compatibility and migration

No format/ABI/bytes change. `scoring_semantics` v1.0.0 unchanged; the ADR names it as the
single spec owner and records that any future change to tie-break/saturation/accumulation
versions the spec and supersedes the ADR.

## Conformance effects

`model/ids.toml` RF-23 (`r4g1_runtime`, `normative-runtime`/`deployed-serving`) evidence
extended to cite the ADR; `CONFORMANCE.md` regenerated via `xtask check-model --write` (generated
file, not hand-edited). No new RF id (reuse/extend, per the issue). ADR maps RF-09/10/22/15/21
to their scopes.

## Claim-boundary changes

Establishes semantic ownership + reachability; makes reference↔normative divergence fail closed
rather than silent. Does **not** claim the two scorers are exactly equivalent and does **not**
establish any generation-quality result.

## Negative / unavailable results

None asserted as PASS. The reference scorer's EXCT path correctly fails closed without the
pinned teacher container (used to construct the reachability fixture).

## Intentionally excluded

Per-token **CID-bound attribution suites** are the deliverable of sibling item #832 (the ADR
names the attribution owner; the suites are out of scope here). No runtime convergence/refactor
(non-goal). `obs-text/` and `tf1-pkg/` untracked user artifacts were deliberately not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code
