### PR TITLE
fix(#865): deterministic hierarchical_codes + re-pin 360M source-of-record (#833)

### DIFF
--- a/crates/uor-r4-core/src/transformerless/compiler.rs
+++ b/crates/uor-r4-core/src/transformerless/compiler.rs
@@ -2328,7 +2328,12 @@ pub fn induce_hierarchical_codes(
         .filter(|(_, count)| *count >= 5)
         .collect();
 
-    frequent_paths.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    // Total order: count descending, then path bytes ascending. Count alone is
+    // not a total order, so tied paths would otherwise retain HashMap iteration
+    // order (`RandomState` is seeded per process) and `take(100)` would select a
+    // run-dependent subset — the #865 non-determinism. The tie-break makes the
+    // selection a pure function of the input multiset (byte reproducibility).
+    frequent_paths.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     let relational_prefixes = frequent_paths
         .into_iter()
@@ -2339,6 +2344,59 @@ pub fn induce_hierarchical_codes(
     HierarchicalCodes {
         token_type_prefixes,
         relational_prefixes,
+    }
+}
+
+#[cfg(test)]
+mod hierarchical_codes_determinism_865 {
+    use super::{induce_hierarchical_codes, Corpus, STAGES};
+
+    // #865: `relational_prefixes` must be a pure function of the corpus, with a
+    // total tie-break (count descending, then path bytes ascending). Before the
+    // fix, tied paths kept HashMap iteration order and `take(100)` selected a
+    // run-dependent subset, so `hierarchical_codes.json` was not byte-reproducible.
+    #[test]
+    fn relational_prefixes_are_deterministically_ordered() {
+        // One story; next = [1,2,3] repeated 6 times (n = 18).
+        let mut next = Vec::new();
+        for _ in 0..6 {
+            next.extend_from_slice(&[1u32, 2, 3]);
+        }
+        let n = next.len();
+        let corpus = Corpus {
+            n,
+            stories: 1,
+            story: vec![0u32; n],
+            input: vec![0u32; n],
+            next,
+            t_argmax: Vec::new(),
+            top_tokens: Vec::new(),
+            top_weights: Vec::new(),
+            span_start: Vec::new(),
+            span_end: Vec::new(),
+            byte_start: Vec::new(),
+            byte_end: Vec::new(),
+            hidden: None,
+        };
+        let vocab = 4usize;
+        let token_codes = vec![0u8; vocab * STAGES];
+
+        // Transition counts: [1,2]=6 [2,3]=6 [1,2,3]=6 | [3,1]=5 [2,3,1]=5
+        // [3,1,2]=5. Sorted by count descending, then path ascending
+        // (lexicographic Vec<u32> order, shorter-prefix first):
+        let expected: Vec<Vec<u32>> = vec![
+            vec![1, 2],
+            vec![1, 2, 3],
+            vec![2, 3],
+            vec![2, 3, 1],
+            vec![3, 1],
+            vec![3, 1, 2],
+        ];
+
+        let first = induce_hierarchical_codes(&token_codes, vocab, &corpus);
+        let second = induce_hierarchical_codes(&token_codes, vocab, &corpus);
+        assert_eq!(first.relational_prefixes, expected);
+        assert_eq!(first.relational_prefixes, second.relational_prefixes);
     }
 }
 

--- a/docs/attested_broad_baseline_833.md
+++ b/docs/attested_broad_baseline_833.md
@@ -149,3 +149,45 @@ This record is a **preflight and a hold verdict**, not evidence of a new baselin
 of general capability. It changes no promoted claim. The canonical broad-text
 baseline remains the #516 pin (retained) until a source-complete, #755-native,
 byte-reproducible, admitted rebuild replaces it and re-ratifies the M.V.G. gates.
+
+## Update 2026-08-20 — preconditions (1) and (2) resolved; (3) reduced
+
+Two of the three HELD preconditions are now cleared, and the third is materially
+reduced.
+
+1. **Determinism — FIXED (#865).** The `hierarchical_codes.json` non-determinism was
+   a tie-break in `induce_hierarchical_codes`
+   (`crates/uor-r4-core/src/transformerless/compiler.rs`): `frequent_paths` was
+   sorted by transition count alone, so tied paths kept `HashMap` iteration order and
+   `take(100)` selected a run-dependent subset. Fixed with a total tie-break (count
+   descending, then path bytes ascending); regression test
+   `hierarchical_codes_determinism_865`. Two fresh `compile-recorded` runs now produce
+   a byte-identical `hierarchical_codes.json` (verified).
+
+2. **Source provenance — RE-PINNED.** `models/smollm2-360m-instruct.json` now records
+   the local snapshot as the content-addressed source-of-record: `source_kappa`
+   `blake3:eb23c3e8…` (loader-emitted, scope `model.safetensors`), `source_bytes`
+   `723674912`, and `revision` `a10cc1512eabd3dde888204e902eca88bddb4951` (the
+   byte-identical, previously-fetchable release the local weights match; the earlier
+   pinned `2366112999…` was rewritten upstream). Reconstruction no longer depends on
+   the dead HF revision — the pinned κ verifies against the local bytes.
+
+3. **Re-observe — largely AVOIDABLE (the ~6 h teacher pass is reusable).** The raw
+   teacher observation is already on disk: `.uor-models/obs-wiki-360m/` — 256
+   content-addressed shards, 361,693 records, `input_cid` `blake3:194db0ee…`, plus a
+   merged `merged.bin` (31,761,312 B = the #516 corpus size). A #755-clean rebuild
+   re-merges/finalizes these shards under the post-#755 corpus reconstruction (by
+   `(story, span_start)`) rather than re-running the teacher. Remaining chain — all but
+   one stage teacher-free: re-merge shards → `compile-recorded` (~2 min measured) →
+   cover → score → `evaluate-report` (the one teacher-bound stage: teacher-forced
+   replay of the 72,864 held-out positions) → package → admit, plus a second
+   deterministic build for byte reproducibility. Estimated wall clock **~2–3 h** (vs.
+   ~8–10 h with a fresh observe), dominated by `score` plus the single
+   `evaluate-report` teacher replay. One validation remains before launch: confirm the
+   post-#755 re-merge of the existing shards yields a corpus that passes the strict
+   `subsample-recorded-corpus` guard (no dangling story id); if the defect is intrinsic
+   to the raw shards, only the affected stories re-observe.
+
+**Remaining gate for #833:** a ~2–3 h compute window (maintainer resource
+authorization) for the teacher-forced `evaluate-report` replay under the
+measurement-only Accelerate exception. Determinism and provenance are resolved.

--- a/models/smollm2-360m-instruct.json
+++ b/models/smollm2-360m-instruct.json
@@ -1,6 +1,9 @@
 {
   "repository": "HuggingFaceTB/SmolLM2-360M-Instruct",
-  "revision": "2366112999e525164f9f74a3fbf50ec19b48b940",
+  "revision": "a10cc1512eabd3dde888204e902eca88bddb4951",
+  "source_kappa": "blake3:eb23c3e8527110b83c091f8660aba676ec4993c9212a9e147503878d6087191f",
+  "source_bytes": 723674912,
+  "source_kappa_scope": "model.safetensors",
   "license": "Apache-2.0",
   "architecture": "LlamaForCausalLM",
   "weight_format": "safetensors",


### PR DESCRIPTION
## Problem and outcome

Clears the first two HELD preconditions of the #833 attested broad-bundle rebuild,
and reduces the third.

**(1) Determinism defect (#865).** `induce_hierarchical_codes`
(`crates/uor-r4-core/src/transformerless/compiler.rs`) sorted `frequent_paths` by
transition count alone. Count is not a total order, so tied paths kept `HashMap`
iteration order (`RandomState` is seeded per process) and `take(100)` selected a
run-dependent subset — a byte-reproducibility violation isolated to
`hierarchical_codes.json` (the #833 preflight measured it). Fixed with a total
tie-break: count descending, then path bytes ascending.

**(2) Source re-pin (#833).** `models/smollm2-360m-instruct.json` now records the
local snapshot as the content-addressed source-of-record so reconstruction no longer
depends on a dead HF revision.

## Scope and non-goals

- **Scope:** one compiler sort + a regression test; one descriptor file; the #833
  record update.
- **Non-goals:** the flagship rebuild itself; any numeric/quality change (the *set*
  of frequent paths is unchanged — only the previously-ambiguous order among ties
  becomes fixed).

## Acceptance-criteria status

- Determinism — **met**. Two fresh sequential `compile-recorded` runs (isolated
  caches) now produce a byte-identical `hierarchical_codes.json` (previously
  differed); `tless_artifacts.bin` (κ `blake3:0b85c43d…`), `tless_store.bin`,
  `hamming_calibration.json` were already byte-identical and remain so.
- Re-pin — **met**. `source_kappa blake3:eb23c3e8…` (loader-emitted, verified
  against the local `model.safetensors`), `source_bytes 723674912`,
  `source_kappa_scope model.safetensors`, `revision a10cc1512…` (byte-identical,
  previously-fetchable release; the old `2366112999…` 404s upstream).

## Tests and verification

- New unit test `hierarchical_codes_determinism_865` (pins the total tie-break) — pass.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D
  warnings`, `cargo build --target wasm32-unknown-unknown --lib`,
  `cargo run -p xtask -- validate` (check-model / audit-limits / audit-deferral /
  gnaf), `python3 scripts/check_claim_wording.py` — all pass.
- End-to-end determinism re-verified with the rebuilt release binary (two sequential
  `compile-recorded` runs, `cmp` byte-identical).

## Evidence artifacts, compatibility, conformance, claim boundary

`docs/attested_broad_baseline_833.md` updated (append) with the resolution. No
format/ABI change; no numeric change; no conformance-row change (R1 unaffected — the
descriptor is `models/*.json`, not `model/*.toml`); no claim-boundary change.

## Negative / unavailable results

None regressed. The re-pin's `source_kappa` is the loader-emitted value, verified by
loading the local weights (it differs from a differently-labeled hash in the P3
record; the verified loader value is authoritative).

## Intentionally excluded

The flagship rebuild remains #833's own work — reduced to a ~2–3 h compute window
because the raw teacher observation (`.uor-models/obs-wiki-360m`, 256 shards) is
reusable, so the ~6 h re-observe is largely avoidable.

Closes #865
References #833
