### PR TITLE
chore(#868): ignore the yanked arrayref advisory in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,11 +4,19 @@ all-features = true
 [advisories]
 version = 2
 yanked = "deny"
-# No ignores. An ignore outlives the dependency that needed it, and then it is an
-# advisory nobody will re-examine; each one added here should name the crate it
-# excuses and the reason there is no upgrade, so the next reader can tell whether
-# it still applies.
-ignore = []
+# Each ignore names the crate it excuses and why there is no upgrade, so the next
+# reader can tell whether it still applies (an ignore outlives the dependency that
+# needed it, and then it is an advisory nobody re-examines).
+#
+# arrayref@0.3.9: the whole arrayref 0.3.x line (0.3.5–0.3.9) was yanked upstream.
+# It is not a vulnerability — a maintainer yank, no RUSTSEC advisory — and it is
+# pulled only transitively, by blake3 1.5.x. blake3 cannot be upgraded past 1.5.x
+# in this graph: the pinned `uor-addr` rev's `uor-prism-crypto v0.4.0` requires
+# `blake3 >=1.5, <1.6`, and every blake3 1.5.x still bundles arrayref (blake3
+# drops it only at >=1.6). Removing arrayref therefore requires bumping the
+# `uor-addr` pin, a separate ecosystem decision. Remove this ignore the moment
+# `uor-addr` moves to a blake3 that no longer depends on arrayref.
+ignore = [{ crate = "arrayref@0.3.9", reason = "yanked upstream; transitive via the pinned uor-addr's blake3 1.5.x (capped <1.6); no upgrade without an uor-addr pin bump" }]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Problem

`cargo deny check advisories` is red on `main` (surfaced in the merge-queue
`register conformance` job as `advisories FAILED, bans ok`): the entire `arrayref`
0.3.x line was **yanked** upstream. Non-blocking (register-conformance isn't a
required check) but red on every PR.

## Why not just upgrade

`arrayref` is pulled only transitively by `blake3` 1.5.x, and blake3 can't move past
1.5.x here: the pinned `uor-addr` rev's `uor-prism-crypto v0.4.0` requires
`blake3 >=1.5, <1.6`, and every blake3 1.5.x still bundles `arrayref` (dropped only
at >= 1.6). I verified this — a workspace blake3 bump to 1.8.7 fails resolution
against the `<1.6` cap, and 1.5.5 (the max allowed) keeps `arrayref`. The only root
fix is a **`uor-addr` pin bump**, which is a separate ecosystem decision (tracked in
#868), so I did not make it here.

## Fix

A single targeted `deny.toml` `[advisories].ignore` for `arrayref@0.3.9`, naming the
crate and the reason there is no upgrade (per the file's own convention). It's a
maintainer yank, not a vulnerability (no RUSTSEC advisory). `bans` and `licenses`
are unaffected.

## Verification

- `cargo deny check advisories` → **advisories ok** (locally, cargo-deny 0.20.2).
- `cargo deny check bans` → **bans ok**.
- One-file change (`deny.toml`); no dependency, code, or lockfile change.

## Removal condition

Delete the ignore the moment `uor-addr` moves to a blake3 (>= 1.6) that drops
`arrayref` — tracked in #868.

Closes #868
