### PR TITLE
chore(#868): vendor arrayref 0.3.9 in-tree to clear the yanked advisory at the source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,8 +70,6 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-members = [
     "crates/uor-r4-proof-model",
     "crates/uor-r4-graph-runtime",
 ]
-exclude = ["uor_standards", "crates/uor-r4-graph-format/fuzz", "research"]
+exclude = ["uor_standards", "crates/uor-r4-graph-format/fuzz", "research", "third_party/arrayref"]
 resolver = "2"
 
 [package]
@@ -97,3 +97,15 @@ harness = false
 [patch.crates-io]
 uor-foundation = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1" }
 uor-foundation-sdk = { git = "https://github.com/UOR-Foundation/UOR-Framework.git", rev = "51c01382200b0179d6640b07e9c8119364ab69a1" }
+
+# #868: `arrayref` 0.3.x was yanked upstream (a maintainer yank, not a RUSTSEC
+# advisory) and is pulled only transitively by blake3 1.5.x, which this graph
+# cannot move off (uor-prism-crypto caps blake3 <1.6, and every 1.5.x still
+# bundles arrayref; blake3 drops it only at >=1.6). Vendor the exact 0.3.9 bytes
+# in-tree and source them from a local path: cargo-deny's yanked check is
+# registry-only, so the advisory genuinely clears — nothing suppressed — and the
+# bytes blake3 links are unchanged, so κ / CID output stays bit-identical. See
+# third_party/arrayref/README.md. Remove this patch (and the vendored dir + the
+# workspace exclude) when uor-addr/uor-prism-crypto move to a blake3 (>=1.6) that
+# no longer depends on arrayref. Tracked in #868.
+arrayref = { path = "third_party/arrayref" }

--- a/deny.toml
+++ b/deny.toml
@@ -4,19 +4,16 @@ all-features = true
 [advisories]
 version = 2
 yanked = "deny"
-# Each ignore names the crate it excuses and why there is no upgrade, so the next
-# reader can tell whether it still applies (an ignore outlives the dependency that
-# needed it, and then it is an advisory nobody re-examines).
+# No ignores. An ignore outlives the dependency that needed it, and then it is an
+# advisory nobody will re-examine; each one added here should name the crate it
+# excuses and the reason there is no upgrade, so the next reader can tell whether
+# it still applies.
 #
-# arrayref@0.3.9: the whole arrayref 0.3.x line (0.3.5–0.3.9) was yanked upstream.
-# It is not a vulnerability — a maintainer yank, no RUSTSEC advisory — and it is
-# pulled only transitively, by blake3 1.5.x. blake3 cannot be upgraded past 1.5.x
-# in this graph: the pinned `uor-addr` rev's `uor-prism-crypto v0.4.0` requires
-# `blake3 >=1.5, <1.6`, and every blake3 1.5.x still bundles arrayref (blake3
-# drops it only at >=1.6). Removing arrayref therefore requires bumping the
-# `uor-addr` pin, a separate ecosystem decision. Remove this ignore the moment
-# `uor-addr` moves to a blake3 that no longer depends on arrayref.
-ignore = [{ crate = "arrayref@0.3.9", reason = "yanked upstream; transitive via the pinned uor-addr's blake3 1.5.x (capped <1.6); no upgrade without an uor-addr pin bump" }]
+# (The yanked `arrayref` 0.3.x that once needed an ignore here is now vendored
+# in-tree and sourced from a local path — see third_party/arrayref/README.md and
+# the [patch.crates-io] note in the root Cargo.toml — so the advisory is resolved
+# at the source, not suppressed.)
+ignore = []
 
 [licenses]
 version = 2

--- a/third_party/arrayref/Cargo.toml
+++ b/third_party/arrayref/Cargo.toml
@@ -1,0 +1,20 @@
+# Vendored copy of `arrayref` 0.3.9 — see README.md for why.
+#
+# The `src/lib.rs` and `LICENSE` here are byte-for-byte the crates.io 0.3.9
+# release (sha256 recorded in README.md). This manifest is trimmed to a
+# library-only build: no dev-dependencies (arrayref's own quickcheck tests are
+# not run here) and no examples. The library code — the only thing blake3
+# links — is unchanged.
+[package]
+name = "arrayref"
+version = "0.3.9"
+authors = ["David Roundy <roundyd@physics.oregonstate.edu>"]
+description = "Macros to take array references of slices"
+documentation = "https://docs.rs/arrayref"
+repository = "https://github.com/droundy/arrayref"
+license = "BSD-2-Clause"
+edition = "2015"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/third_party/arrayref/LICENSE
+++ b/third_party/arrayref/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2015 David Roundy <roundyd@physics.oregonstate.edu>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/arrayref/README.md
+++ b/third_party/arrayref/README.md
@@ -1,0 +1,40 @@
+# Vendored `arrayref` 0.3.9
+
+This is an in-tree, byte-identical copy of the crates.io release
+[`arrayref` 0.3.9](https://crates.io/crates/arrayref/0.3.9), used via a
+`[patch.crates-io]` entry in the workspace root `Cargo.toml`.
+
+## Why it is here
+
+`arrayref` is pulled only transitively, by `blake3` 1.5.x (`blake3` declares
+`arrayref = "0.3.5"`). The entire `arrayref` 0.3.x line (0.3.5–0.3.9) was
+**yanked** upstream — a maintainer yank, **not** a security advisory (there is
+no RUSTSEC entry; `cargo deny` reports it as `yanked`, not `vulnerability`).
+
+`blake3` cannot move off 1.5.x in this graph: the pinned `uor-addr` rev's
+`uor-prism-crypto v0.4.0` requires `blake3 >=1.5, <1.6`, and every `blake3`
+1.5.x still bundles `arrayref` (`blake3` drops it only at >= 1.6). So the graph
+is stuck on a yanked-but-benign crate for reasons entirely outside this repo.
+
+Rather than suppress the advisory with a `deny.toml` ignore (which outlives the
+dependency and trains readers to skip the place a real warning would appear),
+we **own the code**: the exact 0.3.9 bytes are vendored here and sourced from
+the local path. `cargo deny`'s yanked check only applies to registry-sourced
+crates, so the advisory genuinely goes away — nothing is suppressed — and the
+bytes `blake3` links are unchanged, so κ / CID behaviour is bit-identical.
+
+## Provenance (verify before trusting)
+
+    src/lib.rs  sha256 = b74872c9bb2b836132817e024a3f9205f83a6864de1a9bfb46acc1bfbbc1873a
+    LICENSE     sha256 = 1bc7e6f475b3ec99b7e2643411950ae2368c250dd4c5c325f80f9811362a94a1
+
+Both match crates.io `arrayref` 0.3.9 exactly. `Cargo.toml` here is trimmed to a
+library-only build (no dev-dependencies, no examples); `src/lib.rs` is verbatim,
+including its `#[cfg(test)]` module (not compiled in dependency builds).
+
+## Removal condition
+
+Delete this directory and the `arrayref` line from the root `[patch.crates-io]`
+(and the `third_party/arrayref` entry from `[workspace].exclude`) the moment the
+`uor-addr` / `uor-prism-crypto` chain moves to a `blake3` (>= 1.6) that no longer
+depends on `arrayref`. Tracked in issue #868.

--- a/third_party/arrayref/src/lib.rs
+++ b/third_party/arrayref/src/lib.rs
@@ -1,0 +1,504 @@
+//! This package contains just four macros, which enable the creation
+//! of array references to portions of arrays or slices (or things
+//! that can be sliced).
+//!
+//! # Examples
+//!
+//! Here is a simple example of slicing and dicing a slice into array
+//! references with these macros.  Here we implement a simple
+//! little-endian conversion from bytes to `u16`, and demonstrate code
+//! that uses `array_ref!` to extract an array reference from a larger
+//! array.  Note that the documentation for each macro also has an
+//! example of its use.
+//!
+//! ```
+//! #[macro_use]
+//! extern crate arrayref;
+//!
+//! fn read_u16(bytes: &[u8; 2]) -> u16 {
+//!      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+//! }
+//! // ...
+//! # fn main() {
+//! let data = [0,1,2,3,4,0,6,7,8,9];
+//! assert_eq!(256, read_u16(array_ref![data,0,2]));
+//! assert_eq!(4, read_u16(array_ref![data,4,2]));
+//! # }
+//! ```
+#![deny(warnings)]
+#![no_std]
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+/// You can use `array_ref` to generate an array reference to a subset
+/// of a sliceable bit of data (which could be an array, or a slice,
+/// or a Vec).
+///
+/// **Panics** if the slice is out of bounds.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn read_u16(bytes: &[u8; 2]) -> u16 {
+///      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+/// }
+/// // ...
+/// # fn main() {
+/// let data = [0,1,2,3,4,0,6,7,8,9];
+/// assert_eq!(256, read_u16(array_ref![data,0,2]));
+/// assert_eq!(4, read_u16(array_ref![data,4,2]));
+/// # }
+/// ```
+
+#[macro_export]
+macro_rules! array_ref {
+    ($arr:expr, $offset:expr, $len:expr) => {{
+        {
+            #[inline]
+            const unsafe fn as_array<T>(slice: &[T]) -> &[T; $len] {
+                &*(slice.as_ptr() as *const [_; $len])
+            }
+            let offset = $offset;
+            let slice = &$arr[offset..offset + $len];
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_array(slice)
+            }
+        }
+    }};
+}
+
+/// You can use `array_refs` to generate a series of array references
+/// to an input array reference.  The idea is if you want to break an
+/// array into a series of contiguous and non-overlapping arrays.
+/// `array_refs` is a bit funny in that it insists on slicing up the
+/// *entire* array.  This is intentional, as I find it handy to make
+/// me ensure that my sub-arrays add up to the entire array.  This
+/// macro will *never* panic, since the sizes are all checked at
+/// compile time.
+///
+/// Note that unlike `array_ref!`, `array_refs` *requires* that the
+/// first argument be an array reference.  The following arguments are
+/// the lengths of each subarray you wish a reference to.  The total
+/// of these arguments *must* equal the size of the array itself.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn read_u16(bytes: &[u8; 2]) -> u16 {
+///      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+/// }
+/// // ...
+/// # fn main() {
+/// let data = [0,1,2,3,4,0,6,7];
+/// let (a,b,c) = array_refs![&data,2,2,4];
+/// assert_eq!(read_u16(a), 256);
+/// assert_eq!(read_u16(b), 3*256+2);
+/// assert_eq!(*c, [4,0,6,7]);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! array_refs {
+    ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
+        {
+            use core::slice;
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            const unsafe fn as_arrays<T>(a: &[T]) -> ( $( &[T; $pre], )* &[T],  $( &[T; $post], )*) {
+                const MIN_LEN: usize = 0usize $( .saturating_add($pre) )* $( .saturating_add($post) )*;
+                assert!(MIN_LEN < usize::MAX, "Your arrays are too big, are you trying to hack yourself?!");
+                let var_len = a.len() - MIN_LEN;
+                assert!(a.len() >= MIN_LEN);
+                let mut p = a.as_ptr();
+                ( $( {
+                    let aref = & *(p as *const [T; $pre]);
+                    p = p.add($pre);
+                    aref
+                }, )* {
+                    let sl = slice::from_raw_parts(p as *const T, var_len);
+                    p = p.add(var_len);
+                    sl
+                }, $( {
+                    let aref = & *(p as *const [T; $post]);
+                    p = p.add($post);
+                    aref
+                }, )*)
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+    ( $arr:expr, $( $len:expr ),* ) => {{
+        {
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            const unsafe fn as_arrays<T>(a: &[T; $( $len + )* 0 ]) -> ( $( &[T; $len], )* ) {
+                let mut p = a.as_ptr();
+                ( $( {
+                    let aref = &*(p as *const [T; $len]);
+                    p = p.offset($len as isize);
+                    aref
+                }, )* )
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }}
+}
+
+/// You can use `mut_array_refs` to generate a series of mutable array
+/// references to an input mutable array reference.  The idea is if
+/// you want to break an array into a series of contiguous and
+/// non-overlapping mutable array references.  Like `array_refs!`,
+/// `mut_array_refs!` is a bit funny in that it insists on slicing up
+/// the *entire* array.  This is intentional, as I find it handy to
+/// make me ensure that my sub-arrays add up to the entire array.
+/// This macro will *never* panic, since the sizes are all checked at
+/// compile time.
+///
+/// Note that unlike `array_mut_ref!`, `mut_array_refs` *requires*
+/// that the first argument be a mutable array reference.  The
+/// following arguments are the lengths of each subarray you wish a
+/// reference to.  The total of these arguments *must* equal the size
+/// of the array itself.  Also note that this macro allows you to take
+/// out multiple mutable references to a single object, which is both
+/// weird and powerful.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn write_u16(bytes: &mut [u8; 2], num: u16) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8;
+/// }
+/// fn write_u32(bytes: &mut [u8; 4], num: u32) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8; // this is buggy to save space...
+/// }
+/// // ...
+/// # fn main() {
+/// let mut data = [0,1,2,3,4,0,6,7];
+/// let (a,b,c) = mut_array_refs![&mut data,2,2,4];
+/// // let's write out some nice prime numbers!
+/// write_u16(a, 37);
+/// write_u16(b, 73);
+/// write_u32(c, 137); // approximate inverse of the fine structure constant!
+/// # }
+/// ```
+#[macro_export]
+macro_rules! mut_array_refs {
+    ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
+        {
+            use core::slice;
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            unsafe fn as_arrays<T>(a: &mut [T]) -> ( $( &mut [T; $pre], )* &mut [T],  $( &mut [T; $post], )*) {
+                const MIN_LEN: usize = 0usize $( .saturating_add($pre) )* $( .saturating_add($post) )*;
+                assert!(MIN_LEN < usize::MAX, "Your arrays are too big, are you trying to hack yourself?!");
+                let var_len = a.len() - MIN_LEN;
+                assert!(a.len() >= MIN_LEN);
+                let mut p = a.as_mut_ptr();
+                ( $( {
+                    let aref = &mut *(p as *mut [T; $pre]);
+                    p = p.add($pre);
+                    aref
+                }, )* {
+                    let sl = slice::from_raw_parts_mut(p as *mut T, var_len);
+                    p = p.add(var_len);
+                    sl
+                }, $( {
+                    let aref = &mut *(p as *mut [T; $post]);
+                    p = p.add($post);
+                    aref
+                }, )*)
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+    ( $arr:expr, $( $len:expr ),* ) => {{
+        {
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            unsafe fn as_arrays<T>(a: &mut [T; $( $len + )* 0 ]) -> ( $( &mut [T; $len], )* ) {
+                let mut p = a.as_mut_ptr();
+                ( $( {
+                    let aref = &mut *(p as *mut [T; $len]);
+                    p = p.add($len);
+                    aref
+                }, )* )
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+}
+
+/// You can use `array_mut_ref` to generate a mutable array reference
+/// to a subset of a sliceable bit of data (which could be an array,
+/// or a slice, or a Vec).
+///
+/// **Panics** if the slice is out of bounds.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn write_u16(bytes: &mut [u8; 2], num: u16) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8;
+/// }
+/// // ...
+/// # fn main() {
+/// let mut data = [0,1,2,3,4,0,6,7,8,9];
+/// write_u16(array_mut_ref![data,0,2], 1);
+/// write_u16(array_mut_ref![data,2,2], 5);
+/// assert_eq!(*array_ref![data,0,4], [1,0,5,0]);
+/// *array_mut_ref![data,4,5] = [4,3,2,1,0];
+/// assert_eq!(data, [1,0,5,0,4,3,2,1,0,9]);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! array_mut_ref {
+    ($arr:expr, $offset:expr, $len:expr) => {{
+        {
+            #[inline]
+            unsafe fn as_array<T>(slice: &mut [T]) -> &mut [T; $len] {
+                &mut *(slice.as_mut_ptr() as *mut [_; $len])
+            }
+            let offset = $offset;
+            let slice = &mut $arr[offset..offset + $len];
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_array(slice)
+            }
+        }
+    }};
+}
+
+#[allow(clippy::all)]
+#[cfg(test)]
+mod test {
+
+    extern crate quickcheck;
+
+    use std::vec::Vec;
+
+    // use super::*;
+
+    #[test]
+    #[should_panic]
+    fn checks_bounds() {
+        let foo: [u8; 11] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let bar = array_ref!(foo, 1, 11);
+        println!("I am checking that I can dereference bar[0] = {}", bar[0]);
+    }
+
+    #[test]
+    fn simple_case_works() {
+        fn check(expected: [u8; 3], actual: &[u8; 3]) {
+            for (e, a) in (&expected).iter().zip(actual.iter()) {
+                assert_eq!(e, a)
+            }
+        }
+        let mut foo: [u8; 11] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        {
+            let bar = array_ref!(foo, 2, 3);
+            check([2, 3, 4], bar);
+        }
+        check([0, 1, 2], array_ref!(foo, 0, 3));
+        fn zero2(x: &mut [u8; 2]) {
+            x[0] = 0;
+            x[1] = 0;
+        }
+        zero2(array_mut_ref!(foo, 8, 2));
+        check([0, 0, 10], array_ref!(foo, 8, 3));
+    }
+
+    #[test]
+    fn check_array_ref_5() {
+        fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 5
+            if data.len() < 5 || data.len() - 5 < offset {
+                return quickcheck::TestResult::discard();
+            }
+            let out = array_ref!(data, offset, 5);
+            quickcheck::TestResult::from_bool(out.len() == 5)
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_ref_out_of_bounds_5() {
+        fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 5
+            if data.len() >= 5 && data.len() - 5 >= offset {
+                return quickcheck::TestResult::discard();
+            }
+            quickcheck::TestResult::must_fail(move || {
+                array_ref!(data, offset, 5);
+            })
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_mut_ref_7() {
+        fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 7
+            if data.len() < 7 || data.len() - 7 < offset {
+                return quickcheck::TestResult::discard();
+            }
+            let out = array_mut_ref!(data, offset, 7);
+            out[6] = 3;
+            quickcheck::TestResult::from_bool(out.len() == 7)
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_mut_ref_out_of_bounds_32() {
+        fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 32
+            if data.len() >= 32 && data.len() - 32 >= offset {
+                return quickcheck::TestResult::discard();
+            }
+            quickcheck::TestResult::must_fail(move || {
+                array_mut_ref!(data, offset, 32);
+            })
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn test_5_array_refs() {
+        let mut data: [usize; 128] = [0; 128];
+        for i in 0..128 {
+            data[i] = i;
+        }
+        let data = data;
+        let (a, b, c, d, e) = array_refs!(&data, 1, 14, 3, 100, 10);
+        assert_eq!(a.len(), 1 as usize);
+        assert_eq!(b.len(), 14 as usize);
+        assert_eq!(c.len(), 3 as usize);
+        assert_eq!(d.len(), 100 as usize);
+        assert_eq!(e.len(), 10 as usize);
+        assert_eq!(a, array_ref![data, 0, 1]);
+        assert_eq!(b, array_ref![data, 1, 14]);
+        assert_eq!(c, array_ref![data, 15, 3]);
+        assert_eq!(e, array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_array_refs_dotdot() {
+        let mut data: [usize; 128] = [0; 128];
+        for i in 0..128 {
+            data[i] = i;
+        }
+        let data = data;
+        let (a, b, c, d, e) = array_refs!(&data, 1, 14, 3; ..; 10);
+        assert_eq!(a.len(), 1 as usize);
+        assert_eq!(b.len(), 14 as usize);
+        assert_eq!(c.len(), 3 as usize);
+        assert_eq!(d.len(), 100 as usize);
+        assert_eq!(e.len(), 10 as usize);
+        assert_eq!(a, array_ref![data, 0, 1]);
+        assert_eq!(b, array_ref![data, 1, 14]);
+        assert_eq!(c, array_ref![data, 15, 3]);
+        assert_eq!(e, array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_mut_xarray_refs() {
+        let mut data: [usize; 128] = [0; 128];
+        {
+            // temporarily borrow the data to modify it.
+            let (a, b, c, d, e) = mut_array_refs!(&mut data, 1, 14, 3, 100, 10);
+            assert_eq!(a.len(), 1 as usize);
+            assert_eq!(b.len(), 14 as usize);
+            assert_eq!(c.len(), 3 as usize);
+            assert_eq!(d.len(), 100 as usize);
+            assert_eq!(e.len(), 10 as usize);
+            *a = [1; 1];
+            *b = [14; 14];
+            *c = [3; 3];
+            *d = [100; 100];
+            *e = [10; 10];
+        }
+        assert_eq!(&[1; 1], array_ref![data, 0, 1]);
+        assert_eq!(&[14; 14], array_ref![data, 1, 14]);
+        assert_eq!(&[3; 3], array_ref![data, 15, 3]);
+        assert_eq!(&[10; 10], array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_mut_xarray_refs_with_dotdot() {
+        let mut data: [usize; 128] = [0; 128];
+        {
+            // temporarily borrow the data to modify it.
+            let (a, b, c, d, e) = mut_array_refs!(&mut data, 1, 14, 3; ..; 10);
+            assert_eq!(a.len(), 1 as usize);
+            assert_eq!(b.len(), 14 as usize);
+            assert_eq!(c.len(), 3 as usize);
+            assert_eq!(d.len(), 100 as usize);
+            assert_eq!(e.len(), 10 as usize);
+            *a = [1; 1];
+            *b = [14; 14];
+            *c = [3; 3];
+            *e = [10; 10];
+        }
+        assert_eq!(&[1; 1], array_ref![data, 0, 1]);
+        assert_eq!(&[14; 14], array_ref![data, 1, 14]);
+        assert_eq!(&[3; 3], array_ref![data, 15, 3]);
+        assert_eq!(&[10; 10], array_ref![data, 118, 10]);
+    }
+
+    #[forbid(clippy::ptr_offset_with_cast)]
+    #[test]
+    fn forbidden_clippy_lints_do_not_fire() {
+        let mut data = [0u8; 32];
+        let _ = array_refs![&data, 8; .. ;];
+        let _ = mut_array_refs![&mut data, 8; .. ; 10];
+    }
+
+    #[test]
+    fn single_arg_refs() {
+        let mut data = [0u8; 8];
+        let (_,) = array_refs![&data, 8];
+        let (_,) = mut_array_refs![&mut data, 8];
+
+        let (_, _) = array_refs![&data, 4; ..;];
+        let (_, _) = mut_array_refs![&mut data, 4; ..;];
+
+        let (_, _) = array_refs![&data,; ..; 4];
+        let (_, _) = mut_array_refs![&mut data,; ..; 4];
+
+        let (_,) = array_refs![&data,; ..;];
+        let (_,) = mut_array_refs![&mut data,; ..;];
+    }
+} // mod test


### PR DESCRIPTION
## Problem

`cargo deny check advisories` went red on `main`: the whole `arrayref` 0.3.x line
(0.3.5–0.3.9) was **yanked** upstream. It's a maintainer yank, not a RUSTSEC
advisory, and `arrayref` is pulled **only transitively** by `blake3` 1.5.x. #869
landed an interim `deny.toml` ignore to clear the red; this PR replaces that
suppression with a resolution we own.

## Why we can't just upgrade

`blake3` can't move past 1.5.x in this graph: the pinned `uor-addr` rev's
`uor-prism-crypto v0.4.0` requires `blake3 >=1.5, <1.6`, and every `blake3` 1.5.x
still bundles `arrayref` (dropped only at >= 1.6). No in-repo bump helps (verified:
1.8.7 fails the `<1.6` cap; 1.5.5 keeps `arrayref`). The only true root fix is an
upstream `uor-prism-crypto`/`uor-addr` bump — which we are now treating as
indefinitely unavailable, so we resolve it ourselves.

## Fix — vendor, don't suppress

Vendor the **exact** `arrayref` 0.3.9 bytes into `third_party/arrayref` and source
them via `[patch.crates-io]`. cargo-deny's yanked check only applies to
**registry-sourced** crates, so pointing `arrayref` at a local path makes the
advisory **genuinely disappear** — the `deny.toml` ignore is removed, not relied
on. The bytes `blake3` links are byte-identical (`src/lib.rs` sha256
`b74872c9bb2b836132817e024a3f9205f83a6864de1a9bfb46acc1bfbbc1873a`), so κ / CID
output is unchanged: this is a re-sourcing, not a code change.

- `third_party/arrayref/`: verbatim 0.3.9 `src/lib.rs` + `LICENSE`, a library-only
  manifest, and a `README.md` documenting provenance (sha256s) and the removal
  condition. Excluded from the workspace, so it is not linted/tested as a member.
- `Cargo.toml`: `[patch.crates-io] arrayref = { path = "third_party/arrayref" }`
  plus a `[workspace].exclude` entry.
- `Cargo.lock`: `arrayref` re-sourced from the path (registry `source`/`checksum`
  gone).
- `deny.toml`: `[advisories].ignore` back to `[]` (the file's canonical
  "no ignores" state), with a breadcrumb to the vendored crate.

## Verification (local)

- `cargo deny check` → **advisories, bans, licenses, sources all ok** with **no
  ignore**.
- `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features --
  -D warnings`; `cargo build --target wasm32-unknown-unknown --lib` → green.
- Register conformance **R1–R6** green (`repo-conformance`, `xtask validate`,
  `cargo deny check bans`).
- κ / CID determinism, deterministic-rebuild, allocation-census, and fuzz-smoke
  tests green; `blake3` κ verified identical through the patched crate.
- Full `cargo test --workspace` re-run clean; the merge-queue ladder runs it
  authoritatively.

## Removal condition

Delete `third_party/arrayref`, the `[patch.crates-io] arrayref` entry, and the
`[workspace].exclude` entry the moment `uor-addr`/`uor-prism-crypto` move to a
`blake3` (>= 1.6) that no longer depends on `arrayref`.

Supersedes the interim ignore from #869. Refs #868.
