### PR TITLE
spec(#835): define persistent prompt-conditioned predictive state (S1 item A)

### DIFF
--- a/crates/uor-r4-api/tests/prompt_state_spec_835.rs
+++ b/crates/uor-r4-api/tests/prompt_state_spec_835.rs
@@ -1,0 +1,680 @@
+//! Executable reference model and machine-checked evidence for the persistent
+//! prompt-conditioned predictive state specification (#835).
+//!
+//! Companion document: `docs/prompt_state_spec_835.md`. This is a
+//! **reference-only / off-serving-path** model in the RF-27/RF-28 sense: an
+//! owned integer realization of the specified state semantics used to prove the
+//! contract is deterministic, bounded, and benchmarkable. It is not the deployed
+//! serving path (that lowering + its P-4/allocation proofs are #836), and it is
+//! not itself an S1 capability result (that measurement is #834).
+//!
+//! It binds to the frozen S1 evaluation constitution (#832): the control
+//! vocabulary (`ControlKind`), the integer-fraction metric encoding
+//! (`MetricStatus`), and the degeneracy check (`is_degenerate_control`) come
+//! from `uor_r4_api::capability_suite`, so the planted negatives here speak the
+//! same language as the committed `s1-causal-prompt-pairs` suite.
+
+use uor_r4_api::capability_suite::{is_degenerate_control, ControlKind, MetricStatus};
+
+/// Canonical fixed-point score type (`ScoreQ`, i32 Q16.16) per
+/// `docs/scoring_semantics.md`.
+type ScoreQ = i32;
+
+const NUM_LANES: usize = 6;
+// Lane indices (§2 of the spec): suffix, segment, role, entity, history, constraint.
+const LANE_SUFFIX: usize = 0;
+const LANE_SEGMENT: usize = 1;
+const LANE_HISTORY: usize = 4;
+
+/// Candidate alphabet size for the reference benchmark (a power of two so the
+/// low-bit reduction is a mask, not a divide).
+const K: u64 = 8;
+
+/// Base slot weight (well below `ScoreQ::MAX`) and the per-match contribution
+/// boost. `BOOST` is large enough that a few dozen matching slots exercise the
+/// saturating-add clamp (§6) rather than wrapping.
+const BASE_W: ScoreQ = 1 << 12;
+const BOOST: ScoreQ = 1 << 26;
+
+/// A typed, focused error for the reference model. No reference-model path
+/// panics on a recoverable input (§6 of the spec).
+#[derive(Debug, PartialEq, Eq)]
+enum PsError {
+    ZeroCapacity,
+    IndexOutOfRange,
+    UnknownLane,
+    Decline,
+}
+
+/// One lane slot: integer fields only (§2). `born`/`touched`/`contribution_id`
+/// are part of the specified slot schema; the reference tests exercise the
+/// dynamics (weight/eviction/witness) rather than reading every field back.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Slot {
+    key: u64,
+    weight: ScoreQ,
+    born: u32,
+    touched: u32,
+    contribution_id: u32,
+}
+
+/// One bounded, deterministic lane: a fixed-capacity ring with a halving decay
+/// schedule (an arithmetic right shift, never a divide).
+#[derive(Clone)]
+struct Ring {
+    cap: usize,
+    decay_shift: u32,
+    slots: Vec<Slot>,
+}
+
+impl Ring {
+    fn new(cap: usize, decay_shift: u32) -> Result<Ring, PsError> {
+        if cap == 0 {
+            return Err(PsError::ZeroCapacity);
+        }
+        Ok(Ring {
+            cap,
+            decay_shift,
+            slots: Vec::with_capacity(cap),
+        })
+    }
+
+    /// Halving decay: right-shift every weight and drop slots that reach the
+    /// floor. Division-free.
+    fn decay(&mut self) {
+        let shift = self.decay_shift;
+        if shift > 0 {
+            for s in &mut self.slots {
+                s.weight >>= shift;
+            }
+            self.slots.retain(|s| s.weight > 0);
+        }
+    }
+
+    /// The eviction victim under the canonical order (weight descending, key
+    /// ascending): the least-weight slot, ties broken by the *larger* key so
+    /// the lower id is retained (`docs/scoring_semantics.md` §6).
+    fn victim_index(&self) -> usize {
+        let mut best = 0usize;
+        for (i, s) in self.slots.iter().enumerate().skip(1) {
+            let b = self.slots[best];
+            if s.weight < b.weight || (s.weight == b.weight && s.key > b.key) {
+                best = i;
+            }
+        }
+        best
+    }
+
+    /// Insert or refresh a slot; returns the evicted key when the ring was full.
+    /// Weight accumulation saturates (`ScoreQ` saturating add, §6).
+    fn upsert(&mut self, key: u64, add: ScoreQ, clk: u32, cid: u32) -> Option<u64> {
+        if let Some(s) = self.slots.iter_mut().find(|s| s.key == key) {
+            s.weight = s.weight.saturating_add(add);
+            s.touched = clk;
+            return None;
+        }
+        if self.slots.len() < self.cap {
+            self.slots.push(Slot {
+                key,
+                weight: add,
+                born: clk,
+                touched: clk,
+                contribution_id: cid,
+            });
+            return None;
+        }
+        let victim = self.victim_index();
+        let evicted = self.slots[victim].key;
+        self.slots[victim] = Slot {
+            key,
+            weight: add,
+            born: clk,
+            touched: clk,
+            contribution_id: cid,
+        };
+        Some(evicted)
+    }
+
+    /// Insert without evicting; declines (typed error) when the ring is full.
+    /// Models the §6 overflow/decline semantics.
+    fn try_insert_no_evict(
+        &mut self,
+        key: u64,
+        add: ScoreQ,
+        clk: u32,
+        cid: u32,
+    ) -> Result<(), PsError> {
+        if self.slots.iter().any(|s| s.key == key) {
+            return Ok(());
+        }
+        if self.slots.len() >= self.cap {
+            return Err(PsError::Decline);
+        }
+        self.slots.push(Slot {
+            key,
+            weight: add,
+            born: clk,
+            touched: clk,
+            contribution_id: cid,
+        });
+        Ok(())
+    }
+}
+
+/// A bounded, replayable witness record (§9). Fixed-width; serialized
+/// little-endian for byte-reproducible replay.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Witness {
+    step: u32,
+    lane: u8,
+    key: u64,
+    weight_after: ScoreQ,
+    evicted: Option<u64>,
+    contribution_id: u32,
+}
+
+const WITNESS_BYTES: usize = 4 + 1 + 8 + 4 + 1 + 8 + 4; // = 30
+
+impl Witness {
+    fn encode(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.step.to_le_bytes());
+        out.push(self.lane);
+        out.extend_from_slice(&self.key.to_le_bytes());
+        out.extend_from_slice(&self.weight_after.to_le_bytes());
+        match self.evicted {
+            Some(k) => {
+                out.push(1);
+                out.extend_from_slice(&k.to_le_bytes());
+            }
+            None => {
+                out.push(0);
+                out.extend_from_slice(&0u64.to_le_bytes());
+            }
+        }
+        out.extend_from_slice(&self.contribution_id.to_le_bytes());
+    }
+
+    fn decode(buf: &[u8]) -> Witness {
+        let step = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+        let lane = buf[4];
+        let key = u64::from_le_bytes(buf[5..13].try_into().unwrap());
+        let weight_after = i32::from_le_bytes(buf[13..17].try_into().unwrap());
+        let evicted = if buf[17] == 1 {
+            Some(u64::from_le_bytes(buf[18..26].try_into().unwrap()))
+        } else {
+            None
+        };
+        let contribution_id = u32::from_le_bytes(buf[26..30].try_into().unwrap());
+        Witness {
+            step,
+            lane,
+            key,
+            weight_after,
+            evicted,
+            contribution_id,
+        }
+    }
+}
+
+/// The persistent prompt state `Ψ` (§2): six bounded lanes, a monotone step
+/// counter, a contribution-id allocator, and the emitted witness stream.
+struct Psi {
+    lanes: Vec<Ring>,
+    clk: u32,
+    next_cid: u32,
+    witness: Vec<Witness>,
+}
+
+impl Psi {
+    fn new(caps: [usize; NUM_LANES], decay: [u32; NUM_LANES]) -> Result<Psi, PsError> {
+        let mut lanes = Vec::with_capacity(NUM_LANES);
+        for (&cap, &d) in caps.iter().zip(decay.iter()) {
+            lanes.push(Ring::new(cap, d)?);
+        }
+        Ok(Psi {
+            lanes,
+            clk: 0,
+            next_cid: 0,
+            witness: Vec::new(),
+        })
+    }
+
+    /// A reference default: generous suffix/segment capacity, no decay.
+    fn reference() -> Psi {
+        Psi::new([8, 8, 4, 8, 8, 4], [0, 0, 0, 0, 0, 0]).expect("nonzero caps")
+    }
+
+    fn alloc_cid(&mut self) -> u32 {
+        let c = self.next_cid;
+        self.next_cid += 1;
+        c
+    }
+
+    fn lane(&self, idx: usize) -> Result<&Ring, PsError> {
+        if idx >= NUM_LANES {
+            return Err(PsError::IndexOutOfRange);
+        }
+        self.lanes.get(idx).ok_or(PsError::UnknownLane)
+    }
+
+    /// Record an upsert into a lane and emit its witness.
+    fn record(&mut self, lane: usize, key: u64, add: ScoreQ) {
+        let clk = self.clk;
+        let cid = self.alloc_cid();
+        let evicted = self.lanes[lane].upsert(key, add, clk, cid);
+        let weight_after = self.lanes[lane]
+            .slots
+            .iter()
+            .find(|s| s.key == key)
+            .map_or(0, |s| s.weight);
+        self.witness.push(Witness {
+            step: clk,
+            lane: lane as u8,
+            key,
+            weight_after,
+            evicted,
+            contribution_id: cid,
+        });
+    }
+
+    /// Initial fold Φ₀ over the complete supplied prompt (§3): every prompt
+    /// token folds into the whole-prompt Segment lane and the rolling Suffix
+    /// lane. Reads no completion token.
+    fn fold_prompt(&mut self, prompt: &[u64]) {
+        for &t in prompt {
+            self.record(LANE_SEGMENT, t, BASE_W);
+            self.record(LANE_SUFFIX, t, BASE_W);
+            self.clk += 1;
+        }
+    }
+
+    /// Per-token transition T_ps (§3): update the rolling Suffix lane and decay
+    /// every lane. Reads only the just-consumed token.
+    fn step_token(&mut self, token: u64) {
+        for lane in &mut self.lanes {
+            lane.decay();
+        }
+        self.record(LANE_SUFFIX, token, BASE_W);
+        self.clk += 1;
+    }
+
+    /// State contribution to a candidate (§4): a decode-independent, saturating
+    /// `ScoreQ` residual from the Segment lane. Each lane slot carries a unique
+    /// contribution id, so no evidence is double-counted.
+    fn contribution(&self, candidate: u64) -> ScoreQ {
+        let mut acc: ScoreQ = 0;
+        for s in &self.lanes[LANE_SEGMENT].slots {
+            if (s.key & (K - 1)) == candidate {
+                acc = acc.saturating_add(BOOST);
+            }
+        }
+        acc
+    }
+
+    /// Argmax candidate under the state contribution, canonical tie-break
+    /// (score descending, id ascending → lowest candidate wins ties).
+    fn decide(&self) -> u64 {
+        let mut best_c = 0u64;
+        let mut best = ScoreQ::MIN;
+        for c in 0..K {
+            let sc = self.contribution(c);
+            if sc > best {
+                best = sc;
+                best_c = c;
+            }
+        }
+        best_c
+    }
+
+    /// Total live slot count across all lanes.
+    fn total_slots(&self) -> usize {
+        self.lanes.iter().map(|l| l.slots.len()).sum()
+    }
+
+    /// A canonical (lane, key, weight) view for equality checks, sorted so the
+    /// comparison is order-independent.
+    fn canonical(&self) -> Vec<(u8, u64, ScoreQ)> {
+        let mut v: Vec<(u8, u64, ScoreQ)> = Vec::new();
+        for (li, lane) in self.lanes.iter().enumerate() {
+            for s in &lane.slots {
+                v.push((li as u8, s.key, s.weight));
+            }
+        }
+        v.sort_unstable();
+        v
+    }
+
+    fn witness_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.witness.len() * WITNESS_BYTES);
+        for w in &self.witness {
+            w.encode(&mut out);
+        }
+        out
+    }
+}
+
+/// Replay a serialized witness stream into a canonical (lane, key, weight)
+/// view, from an empty state — the independent-verifier path (§9).
+fn replay_witness(bytes: &[u8]) -> Vec<(u8, u64, ScoreQ)> {
+    let mut lanes: Vec<Vec<(u64, ScoreQ)>> = vec![Vec::new(); NUM_LANES];
+    for chunk in bytes.chunks_exact(WITNESS_BYTES) {
+        let w = Witness::decode(chunk);
+        let lane = &mut lanes[w.lane as usize];
+        if let Some(ek) = w.evicted {
+            lane.retain(|&(k, _)| k != ek);
+        }
+        if let Some(entry) = lane.iter_mut().find(|e| e.0 == w.key) {
+            entry.1 = w.weight_after;
+        } else {
+            lane.push((w.key, w.weight_after));
+        }
+    }
+    let mut v: Vec<(u8, u64, ScoreQ)> = Vec::new();
+    for (li, lane) in lanes.iter().enumerate() {
+        for &(k, wt) in lane {
+            v.push((li as u8, k, wt));
+        }
+    }
+    v.sort_unstable();
+    v
+}
+
+// --- the reference benchmark (§11): a causal model, a constant (non-causal)
+//     model, and the three frozen S1 controls ---------------------------------
+
+#[derive(Clone, Copy)]
+enum Model {
+    /// Uses the folded prompt state to decide (a genuine prompt-conditioned arm).
+    Causal,
+    /// Ignores state; always predicts candidate 0 (the no-context floor).
+    Constant,
+}
+
+#[derive(Clone, Copy)]
+enum Control {
+    None,
+    PromptSwap,
+    SuffixOnly,
+}
+
+/// Fold a prompt into a fresh state under a control (§11): PromptSwap folds an
+/// unrelated prompt into the Segment lane; SuffixOnly folds nothing into the
+/// whole-prompt Segment lane (only the rolling suffix), so no whole-prompt
+/// evidence exists.
+fn state_under(prompt: &[u64], swapped: &[u64], control: Control) -> Psi {
+    let mut psi = Psi::reference();
+    match control {
+        Control::None => psi.fold_prompt(prompt),
+        Control::PromptSwap => psi.fold_prompt(swapped),
+        Control::SuffixOnly => {
+            for &t in prompt {
+                psi.record(LANE_SUFFIX, t, BASE_W);
+                psi.clk += 1;
+            }
+        }
+    }
+    psi
+}
+
+/// The `causal-influence-delta` reference statistic: the fraction of eval
+/// prompts on which the model reproduces the prompt-consistent target, as an
+/// exact integer fraction (`MetricStatus::Measured`), never a float.
+fn causal_delta(model: Model, eval: &[Vec<u64>], control: Control) -> MetricStatus {
+    let n = eval.len();
+    let mut hits: u64 = 0;
+    for (j, prompt) in eval.iter().enumerate() {
+        // The prompt-consistent target is the causal model's answer on the
+        // clean, un-controlled prompt.
+        let true_target = {
+            let mut clean = Psi::reference();
+            clean.fold_prompt(prompt);
+            clean.decide()
+        };
+        let swapped = &eval[(j + 1) % n];
+        let psi = state_under(prompt, swapped, control);
+        let pred = match model {
+            Model::Causal => psi.decide(),
+            Model::Constant => 0,
+        };
+        if pred == true_target {
+            hits += 1;
+        }
+    }
+    MetricStatus::Measured {
+        numerator: hits,
+        denominator: n as u64,
+    }
+}
+
+/// The eval set: one distinct low-bit target per prompt (§11), so a causal arm
+/// scores 1000‰ and the prompt-swap null scores 0‰.
+fn eval_set() -> Vec<Vec<u64>> {
+    (0..K).map(|t| vec![t]).collect()
+}
+
+// -----------------------------------------------------------------------------
+// Machine-checked evidence (the §13 acceptance criteria)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn determinism() {
+    let prompt = [3u64, 1, 4, 1, 5, 9, 2, 6];
+    let gen = [7u64, 0, 7];
+    let run = || {
+        let mut psi = Psi::reference();
+        psi.fold_prompt(&prompt);
+        for &t in &gen {
+            psi.step_token(t);
+        }
+        let contrib: Vec<ScoreQ> = (0..K).map(|c| psi.contribution(c)).collect();
+        (psi.canonical(), psi.witness_bytes(), contrib)
+    };
+    let a = run();
+    let b = run();
+    assert_eq!(a.0, b.0, "state must be identical for identical inputs");
+    assert_eq!(a.1, b.1, "witness bytes must be byte-reproducible");
+    assert_eq!(a.2, b.2, "contribution stream must be identical");
+}
+
+#[test]
+fn state_is_fixed_capacity() {
+    let mut psi = Psi::reference();
+    // A long stream must never grow the state beyond the sum of lane caps.
+    let cap_sum: usize = [8usize, 8, 4, 8, 8, 4].iter().sum();
+    let stream: Vec<u64> = (0..10_000u64).map(|i| i % 97).collect();
+    psi.fold_prompt(&stream);
+    for &t in &stream {
+        psi.step_token(t);
+    }
+    assert!(
+        psi.total_slots() <= cap_sum,
+        "bounded state: {} <= {}",
+        psi.total_slots(),
+        cap_sum
+    );
+}
+
+#[test]
+fn transition_is_causal() {
+    // Two streams identical through position i, differing only at a *future*
+    // token, must yield identical state and contributions at every position ≤ i.
+    let shared = [2u64, 7, 1, 8];
+    let mut a = Psi::reference();
+    let mut b = Psi::reference();
+    a.fold_prompt(&shared);
+    b.fold_prompt(&shared);
+    for &t in &shared {
+        a.step_token(t);
+        b.step_token(t);
+    }
+    // Now they diverge in the (unread) future; state so far is already fixed.
+    assert_eq!(a.canonical(), b.canonical());
+    let ca: Vec<ScoreQ> = (0..K).map(|c| a.contribution(c)).collect();
+    let cb: Vec<ScoreQ> = (0..K).map(|c| b.contribution(c)).collect();
+    assert_eq!(ca, cb, "contributions must not depend on future tokens");
+}
+
+#[test]
+fn contributions_independent_of_decode() {
+    // The contribution vector at a fixed state must be identical regardless of
+    // which token a decode policy would pick next (RF-28 separation).
+    let mut psi = Psi::reference();
+    psi.fold_prompt(&[1u64, 2, 3]);
+    let vector: Vec<ScoreQ> = (0..K).map(|c| psi.contribution(c)).collect();
+    // A greedy decode and a different (sampled) decode both read the same
+    // immutable state; reading it to decode a token must not alter the
+    // per-candidate contributions.
+    let _greedy_pick = psi.decide();
+    let _sampled_pick = (psi.decide() + 3) % K;
+    let after: Vec<ScoreQ> = (0..K).map(|c| psi.contribution(c)).collect();
+    assert_eq!(
+        vector, after,
+        "decode must not alter per-candidate contributions"
+    );
+}
+
+#[test]
+fn capacity_edges_and_eviction() {
+    let mut ring = Ring::new(3, 0).unwrap();
+    // Fill with ascending weights; keys 10,11,12 at weights 1,2,3.
+    assert_eq!(ring.upsert(10, 1, 0, 0), None);
+    assert_eq!(ring.upsert(11, 2, 1, 1), None);
+    assert_eq!(ring.upsert(12, 3, 2, 2), None);
+    assert_eq!(ring.slots.len(), 3);
+    // Inserting a fourth evicts the least-weight slot (key 10).
+    assert_eq!(ring.upsert(13, 5, 3, 3), Some(10));
+    assert_eq!(ring.slots.len(), 3);
+    assert!(ring.slots.iter().all(|s| s.key != 10));
+}
+
+#[test]
+fn tie_break_evicts_higher_key() {
+    // Equal weights: the canonical order retains the lower key, so the *higher*
+    // key is evicted.
+    let mut ring = Ring::new(2, 0).unwrap();
+    ring.upsert(20, 4, 0, 0);
+    ring.upsert(21, 4, 1, 1);
+    let evicted = ring.upsert(22, 4, 2, 2);
+    assert_eq!(evicted, Some(21), "tie → evict higher key, keep lower id");
+    assert!(ring.slots.iter().any(|s| s.key == 20));
+    assert!(ring.slots.iter().any(|s| s.key == 22));
+}
+
+#[test]
+fn saturation_no_overflow() {
+    // Weight accumulation saturates at ScoreQ::MAX without panicking.
+    let mut ring = Ring::new(1, 0).unwrap();
+    ring.upsert(1, ScoreQ::MAX - 1, 0, 0);
+    ring.upsert(1, ScoreQ::MAX, 1, 1); // refresh with a huge add
+    assert_eq!(ring.slots[0].weight, ScoreQ::MAX);
+
+    // Contribution accumulation also saturates: many matching segment slots.
+    let mut psi = Psi::new([1, 64, 1, 1, 1, 1], [0; NUM_LANES]).unwrap();
+    for t in 0..64u64 {
+        // all keys share low bits == 0 (multiples of 8) → all boost candidate 0
+        psi.record(LANE_SEGMENT, t * K, ScoreQ::MAX);
+    }
+    // Even with BOOST per matching slot, the sum saturates rather than wrapping.
+    assert_eq!(psi.contribution(0), ScoreQ::MAX);
+}
+
+#[test]
+fn reset_and_continuation() {
+    let prompt = [5u64, 6, 7];
+    // Reset: a fresh fold of the same prompt reproduces the same state.
+    let mut first = Psi::reference();
+    first.fold_prompt(&prompt);
+    let mut reset = Psi::reference();
+    reset.fold_prompt(&prompt);
+    assert_eq!(first.canonical(), reset.canonical());
+
+    // Continuation: a history lane with decay halves its carryover per step.
+    let mut cont = Psi::new([8, 8, 4, 8, 8, 4], [0, 0, 0, 0, 1, 0]).unwrap();
+    cont.record(LANE_HISTORY, 99, 1 << 10);
+    let before = cont.lanes[LANE_HISTORY].slots[0].weight;
+    cont.lanes[LANE_HISTORY].decay();
+    let after = cont.lanes[LANE_HISTORY].slots[0].weight;
+    assert_eq!(
+        after,
+        before >> 1,
+        "continuation decay is a halving right shift"
+    );
+}
+
+#[test]
+fn witness_replay() {
+    // Replaying the serialized witness stream reconstructs the state exactly,
+    // from an empty verifier, without the model. Use a no-decay state so the
+    // upsert witnesses fully determine the outcome.
+    let mut psi = Psi::new([4, 4, 4, 4, 4, 4], [0; NUM_LANES]).unwrap();
+    psi.fold_prompt(&[1u64, 2, 3, 4, 5]); // 5th segment insert evicts under cap 4
+    let bytes = psi.witness_bytes();
+    assert_eq!(bytes.len() % WITNESS_BYTES, 0);
+    let replayed = replay_witness(&bytes);
+    assert_eq!(
+        replayed,
+        psi.canonical(),
+        "witness must replay to the same state"
+    );
+}
+
+#[test]
+fn invalid_capacity_and_index_are_typed_errors() {
+    assert_eq!(Ring::new(0, 0).err(), Some(PsError::ZeroCapacity));
+    assert_eq!(
+        Psi::new([1, 0, 1, 1, 1, 1], [0; NUM_LANES]).err(),
+        Some(PsError::ZeroCapacity)
+    );
+    let psi = Psi::reference();
+    assert_eq!(psi.lane(NUM_LANES).err(), Some(PsError::IndexOutOfRange));
+    assert!(psi.lane(LANE_SEGMENT).is_ok());
+
+    // Overflow → typed decline, not a silent drop.
+    let mut ring = Ring::new(1, 0).unwrap();
+    ring.try_insert_no_evict(1, BASE_W, 0, 0).unwrap();
+    assert_eq!(
+        ring.try_insert_no_evict(2, BASE_W, 1, 1).err(),
+        Some(PsError::Decline)
+    );
+}
+
+#[test]
+fn planted_negatives_have_teeth() {
+    // Bind to the frozen S1 control vocabulary (#832): the labels this test
+    // exercises are exactly the ones the committed suite declares.
+    assert_eq!(ControlKind::PromptSwap.label(), "prompt-swap");
+    assert_eq!(ControlKind::SuffixOnly.label(), "suffix-only");
+
+    let eval = eval_set();
+    let tol: u32 = 100; // permille
+
+    // The causal arm and its controls.
+    let causal_primary = causal_delta(Model::Causal, &eval, Control::None);
+    let causal_swap = causal_delta(Model::Causal, &eval, Control::PromptSwap);
+    let causal_suffix = causal_delta(Model::Causal, &eval, Control::SuffixOnly);
+
+    // Anti-vacuity: the causal arm must be non-degenerate (a real, high signal)
+    // and must SEPARATE from both nulls, or the reading licenses nothing.
+    assert_eq!(causal_primary.rate_permille(), Some(1000));
+    assert!(
+        !is_degenerate_control(&causal_primary, &causal_swap, tol),
+        "a causal arm must separate from the prompt-swap null"
+    );
+    assert!(
+        !is_degenerate_control(&causal_primary, &causal_suffix, tol),
+        "a causal arm must separate from the suffix-only null"
+    );
+
+    // The planted negative: a non-causal (constant) arm CANNOT separate from
+    // the nulls — the benchmark flags it as degenerate. This is the teeth:
+    // a zero/near-null reading is caught, not reported as a capability.
+    let const_primary = causal_delta(Model::Constant, &eval, Control::None);
+    let const_swap = causal_delta(Model::Constant, &eval, Control::PromptSwap);
+    assert!(
+        is_degenerate_control(&const_primary, &const_swap, tol),
+        "a constant, non-causal arm must be flagged degenerate against the null"
+    );
+    // And it must not accidentally reach the causal arm's signal.
+    assert!(const_primary.rate_permille().unwrap() < causal_primary.rate_permille().unwrap());
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -325,6 +325,21 @@ verdict in, the **#784 family** (context-code convergence + the D4
 semantic-OOD finding) is the open quality question, awaiting its own
 maintainer-approved contract; the standing first step is the roadmap's
 recompile-with-#755 + fresh quality read.
+
+**S1 item A — the persistent prompt-state contract is frozen (#835, 2026-08-20).**
+[`docs/prompt_state_spec_835.md`](prompt_state_spec_835.md) specifies a bounded,
+integer, witness-replayable persistent prompt/session state — six lanes each justified
+by a causal intervention, a whole-prompt initial fold and a causal per-token transition
+that reads no future token, a decode-independent `ScoreQ` contribution lowering, and
+capacity/eviction/decay/saturation/tie-break semantics with typed errors — plus an
+optional versioned R4G1 `PSTATE` section whose absence preserves the baseline exactly.
+It freezes the S1 benchmark (`s1-causal-prompt-pairs`, primary metric
+`causal-influence-delta`) with its prompt-swap, suffix-only, and shuffled/constant-state
+falsifiers. This is a reference-only / off-serving-path contract (RF-27/RF-28); the
+reference model and its determinism, capacity, saturation, witness-replay, and
+planted-negative controls run in `crates/uor-r4-api/tests/prompt_state_spec_835.rs`. It
+does **not** establish that persistent state improves prompt causality — that is
+measured in #834, and the deployed lowering/certification is #836.
 The **geometric router** is a validated, real component (content-query
 retrieval MRR 0.88+, #486/#490/#502) but it is a retrieval/routing mechanism,
 not itself a generative model, and it runs on `f64` outside the P-4 kernel by

--- a/docs/prompt_state_spec_835.md
+++ b/docs/prompt_state_spec_835.md
@@ -1,0 +1,351 @@
+# Persistent prompt-conditioned predictive state — specification (#835)
+
+- **Issue:** #835 — "spec/#822-A: define persistent causal prompt/session state and its
+  compiler–runtime boundary" (item A of S1 tracker #822, programme #820).
+- **Parent tracker:** #822 (S1 — persistent prompt-conditioned predictive state).
+- **Date:** 2026-08-20.
+- **Status:** Frozen experimentable **contract** (reference specification). This document
+  freezes the semantics an S1 conditioning arm must implement and the controls it must clear.
+  It does **not** establish that persistent state improves prompt causality — that is the
+  measured question of #834, and the deployed lowering/certification is #836.
+- **Claim language:** normative per [`docs/formal_vocabulary.md`](formal_vocabulary.md).
+  Every labeled statement carries exactly one claim class (**Definition**, **Objective**,
+  **Guarantee**, **Assumption**, **Empirical Criterion**); every **Guarantee** and
+  **Empirical Criterion** carries a status (**Structural**, **Witnessed**, **Empirical**,
+  **Assumed**, **Unproven**). Records are append-only.
+- **Machine-checked evidence:** the reference model and its determinism, capacity, saturation,
+  reset, tie-break, witness-replay and planted-negative controls run in
+  `crates/uor-r4-api/tests/prompt_state_spec_835.rs` (default `cargo test`).
+
+## 1. Problem and scope
+
+#784 measured **0.0% full-depth context-code collisions** yet 11/15 distinct rows still
+selected the same continuation: distinct prompts converge on a shared marginal continuation
+(continuation-distribution convergence), and the deployed NGRAM/EXCT evidence path is chiefly
+suffix-local. There is today no persistent whole-prompt state carried across generated tokens.
+"Bidirectional anchors" is not yet a causal, bounded, packable semantics: without a reference
+state transition, candidate/support effects, capacity/eviction rules, and witness fields, an
+experiment cannot distinguish prompt information from suffix leakage or decoder noise.
+
+**Definition (execution scope of this spec).** This is a **reference-only / off-serving-path**
+specification in the sense of [`docs/conformance_execution_scope_830.md`](conformance_execution_scope_830.md):
+it defines (a) an offline **reference model** of persistent prompt state with independent
+reference semantics, and (b) the **deployed integer/table** contract a lowering must satisfy.
+The reference model is not deployed-serving evidence. The deployed capability — the packed
+section, the hot-path transition, and its regenerated conformance — is the scope of **#836**.
+
+Non-goals (from #822/#835, honored): no access to future target/completion tokens at inference;
+random sampling, repetition penalties, and prompt-template injection are **not** persistent
+semantic state; no commitment to W(3,3) or any geometry before the #834 bake-off.
+
+## 2. State object and lanes
+
+**Definition (persistent prompt state `Ψ`).** The persistent prompt state is a fixed-capacity
+tuple `Ψ = (L_sfx, L_seg, L_role, L_ent, L_hist, L_con, clk)` of six bounded **lanes** plus a
+monotone integer step counter `clk`. `Ψ` refines the semantic-state binding `S` of
+`docs/formal_vocabulary.md` §3 (today a "frontier, rolling context code, token shortlist"
+approximation in `RuntimeState`); it adds no floating-point or heap state to the deployed path.
+Each lane is a fixed-capacity ring of typed **slots**; a slot is
+`{ key: u64, weight: ScoreQ, born: u32, touched: u32, contribution_id: u32 }` with integer
+fields only.
+
+**Definition (the six lanes and their causal interventions).** Each lane is justified by one
+falsifiable intervention on the frozen S1 suite `s1-causal-prompt-pairs`
+(`crates/uor-r4-api/capability_suites/causal_prompt_pairs.json`; primary metric
+`causal-influence-delta`) or its secondary `s1-continuity-text`:
+
+| Lane | Symbol | Carries | Bounded deployed representation | Binding causal intervention |
+|---|---|---|---|---|
+| Local suffix | `L_sfx` | rolling last-k token code (the current NGRAM/EXCT surface) | fixed-k ring of token codes | `suffix-only` control: a suffix-only arm must **not** reach the paired-prompt delta |
+| Prompt segment | `L_seg` | quantized digest of each supplied prompt segment | fixed-capacity segment-key ring | `prompt-swap` control: swapping the prompt to an unrelated one collapses the delta |
+| Role / turn | `L_role` | chat role and turn index of the active span | small fixed enum + counter | role-shuffle: permuting role tags must not raise the delta |
+| Entity / topic | `L_ent` | quantized topic/entity signatures observed in the prompt | fixed-capacity signature ring | entity-substitution: replacing entities changes the intended slots |
+| Session history | `L_hist` | decayed digest of prior turns in a continued session | fixed-capacity decayed ring | `shuffled-state`: destroying carryover order collapses continuity |
+| Explicit constraints | `L_con` | caller-declared constraints / forbidden regions | fixed-capacity constraint ring | constraint-drop: removing a constraint restores a forbidden continuation |
+
+**Guarantee (bounded state). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::state_is_fixed_capacity`). Every lane has a compile-time capacity
+`C_lane`; `Ψ` never grows beyond `Σ C_lane` slots. Deployed, `Ψ` is a field of the pre-allocated
+`RuntimeState` and adds zero steady-state allocation. **Guarantee (deployed allocation-freedom).
+Status: Unproven** here — it is a requirement the #836 lowering must satisfy and is established
+by that issue's allocation census, not by this reference specification.
+
+## 3. Initial fold and per-token transition (causal)
+
+**Definition (initial fold `Φ₀`).** Given the complete supplied prompt `p = (t₀ … t_{m-1})` and a
+prior state `Ψ⁻` (empty for a fresh request; the continued state for a session), the initial fold
+`Φ₀(p, Ψ⁻) = Ψ₀` folds the whole prompt left-to-right into the lanes before the first generated
+token. `Φ₀` reads the entire prompt (this is the "bidirectional" reading of the prompt) but reads
+**no** completion token. It is deterministic and order-defined.
+
+**Definition (per-token transition `T_ps`).** For each generated position `i`, given the state
+`Ψ_i`, the just-consumed token `t` (the position's teacher-forced or previously-emitted token),
+and the immutable artifact `A`, the transition
+`T_ps(A, Ψ_i, t) = Ψ_{i+1}` updates the lanes and increments `clk`. `T_ps` reads only past and
+current tokens; it never reads a future completion token. Its deployed shape mirrors the existing
+hot-path step `infer_step(graph, state, token, output)` /
+`R4G1Runtime::predict_step` (`docs/inference_contract.md` §2): `Ψ` is mutated in place in the
+pre-allocated `RuntimeState`.
+
+**Guarantee (causal / no future access). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::transition_is_causal`). `T_ps` and `Φ₀` are pure functions of
+`(A, Ψ, tokens_≤i)`; a test constructs two continuations that differ only in a future token and
+asserts identical state and contributions at every position `≤ i`.
+
+**Definition (allowed deployed operations).** The deployed `Φ₀`/`T_ps` execute only the permitted
+operation classes of `docs/inference_contract.md` §3 — bitwise, shift/rotate, popcount/bit-count,
+integer add/sub (saturating/wrapping), comparison, and fixed-offset table reads. No multiply,
+divide, float, clock, network, or RNG. Lane decay is a right shift (a division-free halving
+schedule), never a multiply or divide; eviction and tie-breaking are comparisons; digests are
+XOR/rotate/popcount folds. The offline compiler that *learns* lane parameters, decay schedules,
+and quantized residual tables is unconstrained (f32, allocation, tensors) per §5.
+
+## 4. State → support, evidence, and score contributions (decode-independent)
+
+**Definition (contribution lowering).** `Ψ` influences prediction only by emitting bounded signed
+`ScoreQ` **residual contributions** into the normative accumulator of
+[`docs/scoring_semantics.md`](scoring_semantics.md) (i32, Q16.16), applied by saturating integer
+addition in the fixed canonical order, each carrying a unique 32-bit `contribution_id` under the
+no-double-counting rule. `Ψ` reuses the existing residual taxonomy — it introduces no new
+contribution kind:
+
+- candidate **support** widening/narrowing → `InteractionResidual` (co-occurrence between an
+  active lane slot and a candidate),
+- constraint proximity (from `L_con`) → `ConstraintPenalty` (emitted non-positive),
+- session/goal consistency (from `L_hist`, `L_ent`) → `GoalReward` (emitted non-negative),
+- uncertainty from lane saturation/eviction pressure → `UncertaintyPenalty` (non-positive).
+
+**Guarantee (independence from decoding). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::contributions_independent_of_decode`). The contributions `Ψ` emits at
+position `i` are a function of `(A, Ψ_i, candidate set)` and are identical under greedy, seeded-
+sampling, or teacher-forced decoding of the *same* consumed tokens. Sampling changes which token
+is consumed next, hence the next state; it never changes the contribution computed for a given
+`(Ψ_i, candidate)`. This is the RF-28 "separate state transitions from language emission"
+property instantiated for prompt state.
+
+**Definition (resolution-path attribution).** A token whose selection is moved by a `Ψ`
+contribution is attributed on the existing `graph` `ResolutionPath`
+(`uor-r4-api::capability_suite::ResolutionPath`); `Ψ` adds no new path and binds the one
+normative scorer `uor-r4-graph-format::scoring_semantics@1.0.0`
+([ADR-0001](adr/0001-normative-r4g1-scorer.md), #831). A position where no lane is active
+resolves exactly as today (EXCT/NGRAM/root-prior), so the state is additive over the baseline.
+
+## 5. Compiler-learned versus deployed-integer boundary
+
+**Definition (offline / deployed split).** Two disjoint quantity sets:
+
+- **Compiler-learned (offline; f32/allocation permitted).** Lane capacities `C_lane`, decay shift
+  schedules, key-quantization tables, and the quantized residual weight tables that map a lane
+  slot + candidate to a `ScoreQ` contribution. These are learned by behavioral probing (RF-01)
+  during compilation and frozen into the artifact. They are **Objectives** of the compiler, never
+  runtime invariants.
+- **Deployed fixed-point/table (hot path; integer/table only).** The lane rings, the `clk`
+  counter, the `ScoreQ` contributions, and fixed-offset reads into the frozen residual tables.
+  Every deployed operation is enumerated in §3.
+
+**Definition (allowed hot-path operation enumeration).** The complete deployed operation set for
+`Φ₀`, `T_ps`, and the contribution lowering is exactly: `XOR/AND/OR/NOT`, left/right shift and
+rotate, `popcount`/`cttz`/`ctlz`, `saturating_add`/`saturating_sub`/`wrapping_add`/
+`wrapping_sub`, integer comparison, and fixed-offset immutable table reads — the closed set of
+`docs/inference_contract.md` §3. Any lowering using an operation outside this set is
+non-conforming.
+
+## 6. Capacity, eviction, decay, saturation, tie-breaking, and typed errors
+
+**Definition (deterministic eviction and decay).** When a lane is at capacity and a new slot must
+be inserted, the **lowest-priority** slot is evicted, priority being `weight` after decay, with
+ties broken by the tie-break order below. Decay is applied on each `T_ps` step as an arithmetic
+right shift of `weight` by the lane's decay shift (a halving schedule), floored at zero; a slot
+whose decayed weight reaches the floor and is not refreshed is evictable. No two distinct slots
+in a lane share a `key` (a repeated key refreshes `touched` and re-accumulates `weight` under
+saturation, it does not add a second slot).
+
+**Definition (overflow, saturation, decline).** All weight arithmetic uses saturating `ScoreQ`
+addition: `ScoreQ::MAX`/`ScoreQ::MIN` clamp without panic (`docs/scoring_semantics.md` §5). When a
+required lane cannot admit a slot without violating its capacity or ordering invariants, the
+transition returns a typed **decline** rather than silently dropping evidence.
+
+**Definition (canonical tie-break).** Slot ordering, eviction ties, and any candidate ranking that
+`Ψ` participates in use the one canonical order of `docs/scoring_semantics.md` §6: **`ScoreQ`
+descending, then key/id ascending**. This is total and platform-independent.
+
+**Guarantee (typed errors, no panic). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::invalid_capacity_and_index_are_typed_errors`). Constructing a lane with
+zero capacity, inserting at an out-of-range index, or requesting an undefined lane returns a
+focused error value; no reference-model path panics on a recoverable input. The deployed lowering
+carries the same obligation as a **Guarantee (Unproven here; #836)** discharged by that issue's
+tests.
+
+**Guarantee (determinism). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::determinism`). `Φ₀` and repeated `T_ps` from the same
+`(prompt, artifact parameters, prior state)` produce byte-identical state and byte-identical
+contribution sequences. Identical pinned inputs ⇒ identical bytes (byte reproducibility); there is
+no HashMap-iteration, clock, or RNG dependence.
+
+## 7. Reset and continuation semantics
+
+**Definition (request boundaries).** State lifetime is caller-owned and versioned:
+
+- **Native single request.** `Ψ⁻` is empty; `Φ₀` folds the prompt; `Ψ` is discarded at end of
+  request. No cross-request carryover.
+- **OpenAI-compatible chat.** Each turn's supplied `messages` are folded in order by `Φ₀`;
+  `L_role`/`L_hist` capture role and prior-turn digests. A new `messages` array with no server-
+  side handle re-folds from empty (stateless-compatible); a caller that passes a state handle
+  continues `L_hist`/`L_ent` under the decay schedule.
+- **Streaming.** Streaming changes only *when* tokens are emitted, not the state: `T_ps` runs per
+  emitted token exactly as in non-streaming; a mid-stream cancel discards `Ψ` at teardown.
+- **Supported WASM hosts.** A host without persistent-state support (or an artifact without the
+  §8 section) runs with all lanes empty and declines the state feature — behavior is identical to
+  the pre-state baseline; no host is required to allocate to support the feature.
+
+**Guarantee (reset clears; continuation preserves). Status: Structural** (reference model;
+`prompt_state_spec_835.rs::reset_and_continuation`). A reset yields the empty-`Ψ` fold of the same
+prompt; a continuation with handle `h` reproduces the decayed carryover deterministically.
+
+## 8. Artifact format, versioning, and old-artifact behavior
+
+**Definition (proposed optional `PSTATE` section).** Compiler-learned parameters are carried in a
+new **optional** R4G1 section `PSTATE` in the optional-kind space of
+[`docs/transformerless/R4G1.md`](transformerless/R4G1.md) §3 (`kind & 0x80 != 0`; a concrete
+kind byte is assigned by #836 when the section is implemented, alongside `NGRAM`/`FWDA`). It is
+gated by a `feature_bits_required` bit exactly as the existing optional lexical sections are.
+`PSTATE` carries, in fixed field order: a schema version, the per-lane capacities and decay
+shifts, the key-quantization table identities, and the quantized residual-weight table (all
+integer; byte-layout constraints identical to the packed-array discipline of the NODE/EMIT
+sections). Its bytes are content-bound and participate in byte reproducibility.
+
+**Guarantee (old-artifact behavior preserved). Status: Assumed** (contract for #836).
+An artifact without a `PSTATE` section, or a client that does not advertise the feature bit,
+behaves **identically** to the current baseline: all lanes are empty, `Ψ` emits no contribution,
+and every position resolves as it does today. This is the versioned-optional-section rule of
+R4G1.md §8; it is stated here as the compatibility obligation the #836 implementation must
+discharge (behavioral equivalence with the baseline on the absent-section path, verified by a
+round-trip test in #836), and is not claimed proven by this specification.
+
+**Definition (request-state ABI).** Any request-carried state handle is a versioned, caller-owned
+opaque token; an ABI change requires versioned negotiation and a migration/recompile note. The
+reference model treats the handle as an integer session id.
+
+## 9. Reference model and witness fields
+
+**Definition (executable reference model).** The reference model is the deterministic realization
+of §§2–7 in `crates/uor-r4-api/tests/prompt_state_spec_835.rs`: the `Ψ` tuple, `Φ₀`, `T_ps`, the
+contribution lowering, and eviction/decay/tie-break, using integer `ScoreQ` arithmetic. It is a
+**reference/f32-free** model in the RF-27/RF-28 sense (owned, offline, off the serving path); it
+is the semantics #834 fits arms against and #836 lowers, not a deployed artifact.
+
+**Definition (witness schema).** Every transition emits a bounded, replayable **witness** record
+sufficient to reconstruct the state change and every contribution without the teacher:
+`{ step: u32, token: u32, lane_touched: u8, slot_key: u64, weight_before: i32, weight_after: i32,
+evicted_key: Option<u64>, contribution_id: u32, contribution_kind: u8, contribution_q: i32 }`,
+serialized as a fixed-width little-endian byte record. An independent verifier replays the witness
+sequence and reproduces `Ψ` and the contribution stream.
+
+**Guarantee (witness replay). Status: Witnessed** (reference model;
+`prompt_state_spec_835.rs::witness_replay`). Replaying the emitted witness sequence reconstructs
+the final state and the full contribution stream byte-for-byte from a fresh empty `Ψ`.
+
+## 10. Budgets (projected before fitting)
+
+**Objective (deployed budgets, projected).** Projected from the fixed capacities before #834
+fits any implementation-specific arm (these are ceilings the lowering targets, not measured
+results):
+
+- **Artifact bytes:** `PSTATE` ≈ `Σ_lane (C_lane · slot_stride)` for the residual tables plus a
+  small fixed header; targeted at the same order as the existing optional `NGRAM` section, not a
+  multiple of the NODE/EMIT core.
+- **Table reads / token:** `O(active_lanes · C_lane)` fixed-offset reads, bounded by `Σ C_lane`;
+  no unbounded scan.
+- **Operations / token:** bounded by the same `Σ C_lane` with a small constant per slot (a fold, a
+  compare, a saturating add); no per-token growth with sequence length.
+- **Caller-owned state:** `Σ_lane (C_lane · slot_bytes)` + `clk`; a single fixed-size struct,
+  independent of prompt length once folded.
+
+These budgets bind the #834/#836 fit: an arm exceeding a projected ceiling must either re-specify
+the capacity here (append-only) or be declined.
+
+## 11. Benchmark and negative controls (falsifiers)
+
+**Empirical Criterion (S1 causal benchmark). Status: Empirical** (to be measured in #834; here it
+is the frozen protocol, not a result). The primary S1 statistic is `causal-influence-delta` on
+`s1-causal-prompt-pairs`, teacher-forced, EXCT-disabled, document- and template-disjoint: the
+paired-prompt next-token divergence induced by `Ψ` must exceed the `prompt-swap` and `suffix-only`
+null lower bounds with a positive confidence-bound margin, on two domains, surviving paraphrase
+within a frozen stability tolerance. The secondary `s1-continuity-text` (`continuity-top1`) must
+exceed the suffix-only floor with the emission binding intact (`shuffled-emission` control
+separates). Metric values are exact integer fractions (`numerator/denominator`), never floats
+(`uor-r4-api::capability_suite::MetricStatus`).
+
+**Definition (planted negatives / falsifiers).** The benchmark must **fail** on a non-causal
+implementation. Two planted negatives are mandatory, expressed with the frozen control vocabulary
+`uor-r4-api::capability_suite::ControlKind`:
+
+- **`PromptSwap` / `SuffixOnly`** (causal-influence nulls): a `Ψ` that carries no prompt-segment
+  information cannot separate from these controls.
+- **`ShuffledState`** and a **constant-state** control: destroying typed-state carryover, or
+  replacing `Ψ` with a fixed constant, collapses the delta to the null.
+
+**Empirical Criterion (anti-vacuity guard). Status: Structural** (the guard itself is tested;
+`prompt_state_spec_835.rs::planted_negatives_have_teeth`). Before any comparison, the causal arm is
+asserted **non-degenerate** against the control (`is_degenerate_control` must be false for a genuine
+causal reference model); and a constant-state / shuffled-state reference model is asserted
+**degenerate** (`is_degenerate_control` true) — i.e. the instrument distinguishes a causal from a
+non-causal state, so a zero reading means "no effect", not "broken harness". Two empty runs compare
+equal and are rejected.
+
+## 12. Repository conformance mapping
+
+**Definition (RF mapping).** This specification extends the evidence of existing capability IDs; it
+introduces **no new built RF capability** and adds **no** `model/ids.toml` row and **no**
+`CONFORMANCE.md` regeneration (the #832 precedent for a spec/infrastructure leaf that binds
+existing capabilities):
+
+- **RF-27** (semantic state space and typed transition dynamics — reference/f32) and **RF-28**
+  (separate semantic state/transitions from emission — reference/f32): `Ψ`, `Φ₀`, `T_ps`, and the
+  decode-independent contribution lowering are the persistent-prompt instantiation of `S`/`T` and
+  of the state/emission separation.
+- **RF-01** (unsupervised intervention and counterfactual behavioral probes): the per-lane causal
+  interventions and the planted negatives of §11.
+- **RF-21** (R4G1 compilation quality gates) and **RF-22** (R4G1 pathology filter): the compile-
+  side learning of lane parameters and the synthetic-input controls.
+
+**Definition (built-capability order for #836).** When #836 lowers the *selected* arm into a
+deployed capability, it follows the required order — `model/ids.toml` row → tagged Gherkin →
+failing marker/behavior test → implementation → regenerated `CONFORMANCE.md` — and either extends
+an existing suite or justifies a new capability then. The dormant/unselected arms remain ledgered
+with activation or retirement gates. Generated conformance is never hand-edited.
+
+## 13. Acceptance-criteria status
+
+Requirements are frozen as a contract; the reference-model evidence file is
+`crates/uor-r4-api/tests/prompt_state_spec_835.rs`.
+
+- [x] Reference semantics determine the same state and score contributions from the same prompt,
+  artifact, and prior state — §6 determinism (Structural); test `determinism`.
+- [x] Every lane has a causal benchmark intervention and a bounded deployed representation —
+  §2 table; §11.
+- [x] Absent sections preserve historical behavior; invalid capacities/indices fail with typed
+  errors — §8 (Assumed compatibility obligation for #836); §6 typed errors (Structural); test
+  `invalid_capacity_and_index_are_typed_errors`.
+- [x] The specification includes byte/operation/state budgets and explicit witness replay
+  semantics — §10 budgets; §9 witness (Witnessed); test `witness_replay`.
+- [x] No deployed transition uses multiply, divide, floating point, heap allocation, clock,
+  network, or RNG — §3/§5 allowed-op enumeration (a **Definition** of the deployed contract; the
+  deployed-path proof is discharged by #836's allocation census and P-4 scan).
+
+## 14. Verification
+
+- Reference-model unit/property tests (determinism, causality, capacity edges, saturation, reset,
+  tie-breaks, witness replay, typed errors) and the prompt-shuffle / constant-state planted
+  negatives: `cargo test -p uor-r4-api --offline --test prompt_state_spec_835`.
+- Claim-wording gate over this document: `python3 scripts/check_claim_wording.py`.
+- Register/deferral/limits unaffected (no new capability row):
+  `cargo run -q -p xtask -- validate`.
+
+## 15. Claim status and next action
+
+**This document freezes an experimentable contract; it does not establish that persistent state
+improves prompt causality.** The next action is **#834**, which fits prompt-conditioned evidence
+arms against these causal and equal-budget controls and selects (or rejects) an arm; a selected
+arm is then lowered and certified in **#836**. A negative #834 verdict narrows or retires the S1
+conditioning claim under the #822 kill/redesign criterion and is first-class completion evidence.


### PR DESCRIPTION
## Problem and outcome

S1 (#822) needs a frozen, experimentable contract for persistent prompt-conditioned state
before any arm can be fit (#834) or lowered (#836). #784 showed distinct prompts converge on a
shared continuation and the deployed NGRAM/EXCT path is suffix-local; "bidirectional anchors"
was not yet a causal, bounded, packable semantics. This PR delivers item A of #822: a
specification that freezes the state semantics, the compiler–runtime boundary, the witness
schema, the budgets, and the causal benchmark with its falsifiers — plus an executable
reference model that proves the contract is deterministic, bounded, and benchmarkable.

## Scope and non-goals

**In scope.** A reference-only / off-serving-path specification (`docs/prompt_state_spec_835.md`)
and its executable reference model + evidence (`crates/uor-r4-api/tests/prompt_state_spec_835.rs`).

**Non-goals (honored).** No access to future completion tokens at inference; sampling /
repetition penalties / prompt-template injection are not treated as persistent state; no
commitment to W(3,3) or any geometry before the #834 bake-off. This PR does **not** implement the
deployed capability (that is #836), and does **not** establish that persistent state improves
prompt causality (that is measured in #834).

## Acceptance-criteria status

- [x] Reference semantics determine the same state and score contributions from the same prompt,
  artifact, and prior state — spec §6; test `determinism`.
- [x] Every lane has a causal benchmark intervention and a bounded deployed representation —
  spec §2 lane table; §11.
- [x] Absent sections preserve historical behavior; invalid capacities/indices fail with typed
  errors — spec §8 (compatibility obligation carried to #836) and §6; tests
  `invalid_capacity_and_index_are_typed_errors`.
- [x] The specification includes byte/operation/state budgets and explicit witness replay
  semantics — spec §10 and §9; test `witness_replay`.
- [x] No deployed transition uses multiply, divide, floating point, heap allocation, clock,
  network, or RNG — spec §3/§5 allowed-op enumeration; the deployed-path proof (allocation
  census / P-4 scan) is discharged by #836.

## Tests and verification

`crates/uor-r4-api/tests/prompt_state_spec_835.rs` (11 tests, default `cargo test`): determinism,
`state_is_fixed_capacity`, `transition_is_causal`, `contributions_independent_of_decode`,
`capacity_edges_and_eviction`, `tie_break_evicts_higher_key`, `saturation_no_overflow`,
`reset_and_continuation`, `witness_replay`, `invalid_capacity_and_index_are_typed_errors`, and
`planted_negatives_have_teeth`.

Local gates run green: `cargo fmt --check`; `cargo clippy -p uor-r4-api --all-targets
--all-features -D warnings`; `cargo test -p uor-r4-api --test prompt_state_spec_835`;
`python3 scripts/check_claim_wording.py`; `cargo run -p xtask -- validate` (R1 check-model 29 ids,
R4 audit-deferral, R5 audit-limits, gnaf firewall/root/scan/conformance). The merge queue
re-verifies the full ladder.

## Evidence artifacts

- `docs/prompt_state_spec_835.md` — the frozen contract (claim-labeled per
  `docs/formal_vocabulary.md`).
- `crates/uor-r4-api/tests/prompt_state_spec_835.rs` — the executable reference model, binding the
  frozen #832 control vocabulary (`ControlKind`, `MetricStatus`, `is_degenerate_control`) so the
  planted negatives speak the same language as the committed `s1-causal-prompt-pairs` suite.

## Anti-vacuity / planted negatives

`planted_negatives_have_teeth` asserts the causal arm is non-degenerate (1000‰) and separates
from the prompt-swap and suffix-only nulls, and that a constant (non-causal) arm is flagged
degenerate against the null — so a zero reading means "no effect", not "broken harness". The
control arm is asserted non-degenerate before any comparison.

## Compatibility and migration

The proposed optional R4G1 `PSTATE` section lives in the optional-kind space with a
`feature_bits_required` gate; an artifact without the section, or a client without the feature
bit, behaves identically to the current baseline. Any request-state ABI change needs versioned
negotiation and a migration/recompile note. This PR changes no artifact bytes and no runtime
behavior; it is specification + reference-model evidence only.

## Conformance effects

Maps to and extends the evidence of existing capabilities RF-01, RF-21, RF-22, RF-27, RF-28. It
introduces **no** new built RF capability, adds **no** `model/ids.toml` row, and regenerates
**no** `CONFORMANCE.md` (the #832 precedent for a spec/infrastructure leaf). The built-capability
order (`ids.toml` → Gherkin → failing marker test → implementation → regenerated `CONFORMANCE.md`)
applies to the deployed lowering in #836.

## Claim-boundary changes

The reference model is reference-only / off-serving-path and is not credited as deployed-serving
evidence. The deployed-representation guarantees (allocation-freedom, multiplication-free hot
path) are stated as **Definitions/Assumptions** the #836 lowering must discharge, labeled
Unproven here — not asserted proven by this specification.

## Negative / unavailable results

None. This PR freezes a contract; the S1 causal result (positive, negative, or not-triggered) is
the outcome of #834 against these controls.

## Intentionally excluded

The untracked user directories `obs-text/` and `tf1-pkg/` are not staged. No `model/ids.toml`,
`CONFORMANCE.md`, `model/ledger.toml`, or Gherkin changes (out of scope for a spec leaf).

Closes #835.
