### PR TITLE
format(#836): complete PSTATE descriptor + compiler-packing round-trip (increment 2)

### DIFF
--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -137,7 +137,7 @@ pub use prov::{
     PROV_VERSION,
 };
 #[cfg(feature = "alloc")]
-pub use pstate::build_segment_lane;
+pub use pstate::{build_segment_lane, SegmentLaneDescriptor};
 pub use pstate::{
     PstateEntries, PstateEntry, PstateRow, PstateRows, PstateTable, LANE_SEGMENT, PSTATE_ENTRY_LEN,
     PSTATE_HEADER_LEN, PSTATE_MAGIC, PSTATE_ROW_LEN, PSTATE_VERSION,

--- a/crates/uor-r4-graph-format/src/pstate.rs
+++ b/crates/uor-r4-graph-format/src/pstate.rs
@@ -1,38 +1,46 @@
-//! Borrowed packed persistent-prompt-state rows — the optional `PSTATE`
+//! Borrowed packed persistent-prompt-state descriptor — the optional `PSTATE`
 //! section (#836, lowering the #835 segment lane).
 //!
-//! `PSTATE` carries the compiler-learned **segment lane**: for a quantized
-//! whole-prompt content key, a bounded, canonical row of signed `ScoreQ`
-//! candidate-support contributions. Rows and entries are canonical (sorted,
-//! contiguous, exact-coverage), so lookup is deterministic and allocation-free
-//! — the same discipline as [`crate::ngram`]. The section is **optional**
-//! ([`crate::types::SectionId::OPTIONAL_BIT`]): an artifact without it, or a
-//! reader that does not consume it, behaves exactly as before (absent-section
-//! identity), so this section is additive and does not change serving on its
-//! own. The deployed scorer consumes it in a later #836 increment; this module
-//! is the format foundation and its two-stage validation.
+//! The #835 **segment lane** is *prompt-derived*: at fold time each prompt
+//! content token is recorded into a bounded, halving-decay ring (fixed
+//! capacity, saturating `ScoreQ` accumulation), and at score time a candidate
+//! present in the ring receives a signed `ScoreQ` boost. There is no learned
+//! per-token table to ship; what the compiler packs is the lane **descriptor**
+//! — the fixed-capacity, decay, and score constants that let the deployed
+//! R4Engine reconstruct the lane deterministically with caller-owned state.
 //!
-//! Field order follows `docs/prompt_state_spec_835.md` §8: schema version,
-//! per-lane capacity and decay shift, key-quantization identity, then the
-//! quantized residual-weight table (all integer). No multiply/divide/float is
-//! used to read it.
+//! `PSTATE` therefore carries, in fixed field order (per
+//! `docs/prompt_state_spec_835.md` §8): a schema version, the lane kind, the
+//! per-lane capacity and decay shift, the score constants (`base_w`, `boost`),
+//! the key-quantization identity, and an **optional** residual-weight table for
+//! future table-bearing lanes (empty for the pure segment lane). All integer;
+//! no multiply/divide/float is used to read it.
+//!
+//! The section is **optional** ([`crate::types::SectionId::OPTIONAL_BIT`]): an
+//! artifact without it, or a reader that does not consume it, behaves exactly
+//! as before (absent-section identity). It is additive and does not change
+//! serving on its own — the deployed scorer consumes it in a later #836
+//! increment. This module is the format foundation and its two-stage
+//! validation.
 
 use crate::error::FormatError;
 use crate::types::ScoreQ;
 
 pub const PSTATE_MAGIC: [u8; 4] = *b"PST1";
 pub const PSTATE_VERSION: u16 = 1;
-pub const PSTATE_HEADER_LEN: usize = 24;
+/// Descriptor header length (bytes). See the module docs for the field order.
+pub const PSTATE_HEADER_LEN: usize = 40;
 pub const PSTATE_ROW_LEN: usize = 16;
 pub const PSTATE_ENTRY_LEN: usize = 8;
 
-/// The lane kind a `PSTATE` section encodes. #836 increment 1 lowers the
-/// segment lane; the enum reserves the remaining #835 lanes for later
-/// increments without a format break.
+/// The lane kind a `PSTATE` section encodes. #836 lowers the segment lane; the
+/// enum reserves the remaining #835 lanes for later increments without a format
+/// break.
 pub const LANE_SEGMENT: u8 = 0;
 
 /// One residual-table row: a quantized content key and its bounded, canonical
-/// list of candidate-support contributions.
+/// list of candidate-support contributions (used by table-bearing lanes; the
+/// pure segment lane ships zero rows).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PstateRow<'a> {
     bytes: &'a [u8],
@@ -84,7 +92,7 @@ impl Iterator for PstateEntries<'_> {
     }
 }
 
-/// A borrowed, validated `PSTATE` table over an artifact's section bytes.
+/// A borrowed, validated `PSTATE` descriptor over an artifact's section bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PstateTable<'a> {
     bytes: &'a [u8],
@@ -93,6 +101,9 @@ pub struct PstateTable<'a> {
     decay_shift: u8,
     max_entries: u16,
     key_quant_id: u32,
+    ring_capacity: u32,
+    base_w: i32,
+    boost: i32,
 }
 
 pub struct PstateRows<'a> {
@@ -101,10 +112,11 @@ pub struct PstateRows<'a> {
 }
 
 impl<'a> PstateTable<'a> {
-    /// Two-stage validation: a header check, then a per-row structural check
-    /// (bounded entry counts, contiguous canonical layout, sorted keys and
-    /// tokens, exact byte coverage). Never allocates; never panics on a
-    /// recoverable input.
+    /// Two-stage validation: a header/descriptor check (magic, version,
+    /// reserved zero, lane kind, capacity/decay ranges), then a per-row
+    /// structural check (bounded entry counts, contiguous canonical layout,
+    /// sorted keys and tokens, exact byte coverage). Never allocates; never
+    /// panics on a recoverable input.
     pub fn parse(bytes: &'a [u8]) -> Result<Self, crate::NotAProduct> {
         if bytes.len() < PSTATE_HEADER_LEN {
             return Err((FormatError::PstateTooShort).into());
@@ -115,8 +127,11 @@ impl<'a> PstateTable<'a> {
         if read_u16(&bytes[4..6]) != PSTATE_VERSION {
             return Err((FormatError::PstateUnsupportedVersion).into());
         }
-        // reserved fields must be zero (bytes 6..8, byte 19 half, 18..20)
-        if bytes[6..8].iter().any(|&b| b != 0) || bytes[18..20].iter().any(|&b| b != 0) {
+        // reserved fields must be zero.
+        if bytes[6..8].iter().any(|&b| b != 0)
+            || bytes[18..20].iter().any(|&b| b != 0)
+            || bytes[36..40].iter().any(|&b| b != 0)
+        {
             return Err((FormatError::PstateNonZeroReserved).into());
         }
         let row_count = read_u32(&bytes[8..12]);
@@ -125,7 +140,18 @@ impl<'a> PstateTable<'a> {
         let lane_kind = bytes[15];
         let _schema_version = read_u16(&bytes[16..18]);
         let key_quant_id = read_u32(&bytes[20..24]);
+        let ring_capacity = read_u32(&bytes[24..28]);
+        let base_w = i32::from_le_bytes([bytes[28], bytes[29], bytes[30], bytes[31]]);
+        let boost = i32::from_le_bytes([bytes[32], bytes[33], bytes[34], bytes[35]]);
+
+        // Semantic descriptor checks.
         if lane_kind != LANE_SEGMENT {
+            return Err((FormatError::PstateInvalidRow).into());
+        }
+        // A lane must have positive fixed capacity, and decay may not exceed
+        // the ScoreQ width (a shift of >=32 would zero every weight, which is
+        // never a meaningful descriptor).
+        if ring_capacity == 0 || decay_shift >= 32 {
             return Err((FormatError::PstateInvalidRow).into());
         }
 
@@ -192,6 +218,9 @@ impl<'a> PstateTable<'a> {
             decay_shift,
             max_entries,
             key_quant_id,
+            ring_capacity,
+            base_w,
+            boost,
         })
     }
 
@@ -209,6 +238,18 @@ impl<'a> PstateTable<'a> {
     }
     pub fn key_quant_id(&self) -> u32 {
         self.key_quant_id
+    }
+    /// Fixed ring capacity for the lane's caller-owned bounded state.
+    pub fn ring_capacity(&self) -> u32 {
+        self.ring_capacity
+    }
+    /// `ScoreQ` folded (saturating) per prompt-token occurrence.
+    pub fn base_w(&self) -> ScoreQ {
+        ScoreQ::from_raw(self.base_w)
+    }
+    /// `ScoreQ` contribution added (saturating) per candidate support.
+    pub fn boost(&self) -> ScoreQ {
+        ScoreQ::from_raw(self.boost)
     }
 
     pub fn rows(&self) -> PstateRows<'a> {
@@ -272,19 +313,40 @@ fn read_u16(bytes: &[u8]) -> u16 {
     u16::from(bytes[0]) | (u16::from(bytes[1]) << 8)
 }
 
-/// Build a canonical `PSTATE` segment-lane section (compiler side, `alloc`).
+/// The segment-lane descriptor a compiler packs into a `PSTATE` section.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SegmentLaneDescriptor {
+    /// Fixed ring capacity (bounded caller-owned state). Must be >= 1.
+    pub ring_capacity: u32,
+    /// Halving decay shift applied per transition. Must be < 32.
+    pub decay_shift: u8,
+    /// `ScoreQ` raw folded per prompt-token occurrence.
+    pub base_w: i32,
+    /// `ScoreQ` raw contribution per candidate support.
+    pub boost: i32,
+    /// Key-quantization table identity (0 = raw token id).
+    pub key_quant_id: u32,
+}
+
+/// Build a canonical segment-lane `PSTATE` section (compiler side, `alloc`).
 ///
-/// `rows` is `(key, entries)`; entries are `(token, raw ScoreQ)`. Keys and
-/// tokens are sorted here; duplicate keys or tokens, or an empty entry list,
-/// are rejected with a typed error so a producer cannot emit a non-canonical
-/// section. The bytes it returns parse back byte-for-byte (round-trip).
+/// `rows` is the optional residual table as `(key, entries)`; entries are
+/// `(token, raw ScoreQ)`. For the pure segment lane `rows` is empty. Keys and
+/// tokens are sorted here; duplicate keys or tokens, an empty entry list, a
+/// zero `ring_capacity`, or a `decay_shift >= 32` are rejected with a typed
+/// error so a producer cannot emit a non-canonical or invalid section. The
+/// bytes it returns parse back byte-for-byte (round-trip).
 #[cfg(feature = "alloc")]
 pub fn build_segment_lane(
-    decay_shift: u8,
-    key_quant_id: u32,
+    descriptor: &SegmentLaneDescriptor,
     rows: &[(u32, alloc::vec::Vec<(u32, i32)>)],
 ) -> Result<alloc::vec::Vec<u8>, crate::NotAProduct> {
     use alloc::vec::Vec;
+
+    if descriptor.ring_capacity == 0 || descriptor.decay_shift >= 32 {
+        return Err((FormatError::PstateInvalidRow).into());
+    }
 
     let mut sorted: Vec<(u32, Vec<(u32, i32)>)> = rows.to_vec();
     sorted.sort_by_key(|(k, _)| *k);
@@ -313,14 +375,19 @@ pub fn build_segment_lane(
     let mut out = Vec::new();
     out.extend_from_slice(&PSTATE_MAGIC);
     out.extend_from_slice(&PSTATE_VERSION.to_le_bytes());
-    out.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    out.extend_from_slice(&0u16.to_le_bytes()); // reserved [6..8]
     out.extend_from_slice(&row_count.to_le_bytes());
     out.extend_from_slice(&(max_entries as u16).to_le_bytes());
-    out.push(decay_shift);
+    out.push(descriptor.decay_shift);
     out.push(LANE_SEGMENT);
     out.extend_from_slice(&PSTATE_VERSION.to_le_bytes()); // schema_version
-    out.extend_from_slice(&0u16.to_le_bytes()); // reserved
-    out.extend_from_slice(&key_quant_id.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes()); // reserved [18..20]
+    out.extend_from_slice(&descriptor.key_quant_id.to_le_bytes());
+    out.extend_from_slice(&descriptor.ring_capacity.to_le_bytes());
+    out.extend_from_slice(&descriptor.base_w.to_le_bytes());
+    out.extend_from_slice(&descriptor.boost.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // reserved [36..40]
+    debug_assert_eq!(out.len(), PSTATE_HEADER_LEN);
 
     // rows, with contiguous entry offsets
     let mut entry_cursor = PSTATE_HEADER_LEN + sorted.len() * PSTATE_ROW_LEN;
@@ -346,10 +413,19 @@ mod tests {
     use super::*;
     use alloc::vec;
 
+    fn descriptor() -> SegmentLaneDescriptor {
+        SegmentLaneDescriptor {
+            ring_capacity: 64,
+            decay_shift: 1,
+            base_w: 1 << 12,
+            boost: 1 << 20,
+            key_quant_id: 0,
+        }
+    }
+
     fn sample() -> alloc::vec::Vec<u8> {
         build_segment_lane(
-            1,
-            0,
+            &descriptor(),
             &[
                 (10, vec![(3, 100), (7, -50)]),
                 (5, vec![(1, 200)]),
@@ -360,12 +436,15 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_and_lookup() {
+    fn round_trip_descriptor_and_lookup() {
         let bytes = sample();
         let table = PstateTable::parse(&bytes).expect("parse");
         assert_eq!(table.row_count(), 3);
         assert_eq!(table.lane_kind(), LANE_SEGMENT);
         assert_eq!(table.decay_shift(), 1);
+        assert_eq!(table.ring_capacity(), 64);
+        assert_eq!(table.base_w().raw(), 1 << 12);
+        assert_eq!(table.boost().raw(), 1 << 20);
         assert_eq!(table.max_entries(), 3);
         // sorted by key: 5, 10, 20
         let keys: alloc::vec::Vec<u32> = table.rows().map(|r| r.key()).collect();
@@ -376,10 +455,9 @@ mod tests {
             row.entries().map(|e| (e.token, e.score_q.raw())).collect();
         assert_eq!(entries, vec![(3, 100), (7, -50)]);
         assert!(table.find(11).is_none());
-        // re-serialize is byte-identical (determinism)
+        // re-serialize is byte-identical (determinism, order-independent)
         let again = build_segment_lane(
-            1,
-            0,
+            &descriptor(),
             &[
                 (20, vec![(9, 30), (2, 10), (4, 20)]),
                 (10, vec![(7, -50), (3, 100)]),
@@ -401,9 +479,9 @@ mod tests {
         let mut b = good.clone();
         b[4] = 9;
         assert!(PstateTable::parse(&b).is_err());
-        // non-zero reserved
+        // non-zero reserved (tail)
         let mut b = good.clone();
-        b[6] = 1;
+        b[36] = 1;
         assert!(PstateTable::parse(&b).is_err());
         // truncated (drops last entry) → bounds / coverage
         let mut b = good.clone();
@@ -417,18 +495,47 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_descriptor() {
+        // zero capacity
+        assert!(build_segment_lane(
+            &SegmentLaneDescriptor {
+                ring_capacity: 0,
+                ..descriptor()
+            },
+            &[]
+        )
+        .is_err());
+        // decay too wide
+        assert!(build_segment_lane(
+            &SegmentLaneDescriptor {
+                decay_shift: 32,
+                ..descriptor()
+            },
+            &[]
+        )
+        .is_err());
+        // a hand-built section with zero capacity fails parse (semantic teeth)
+        let mut b = build_segment_lane(&descriptor(), &[]).unwrap();
+        b[24..28].copy_from_slice(&0u32.to_le_bytes());
+        assert!(PstateTable::parse(&b).is_err());
+    }
+
+    #[test]
     fn builder_rejects_noncanonical() {
-        assert!(build_segment_lane(0, 0, &[(1, vec![])]).is_err()); // empty entries
-        assert!(build_segment_lane(0, 0, &[(1, vec![(2, 1)]), (1, vec![(3, 1)])]).is_err()); // dup key
-        assert!(build_segment_lane(0, 0, &[(1, vec![(2, 1), (2, 5)])]).is_err());
+        assert!(build_segment_lane(&descriptor(), &[(1, vec![])]).is_err()); // empty entries
+        assert!(
+            build_segment_lane(&descriptor(), &[(1, vec![(2, 1)]), (1, vec![(3, 1)])]).is_err()
+        ); // dup key
+        assert!(build_segment_lane(&descriptor(), &[(1, vec![(2, 1), (2, 5)])]).is_err());
         // dup token
     }
 
     #[test]
     fn header_only_is_valid_empty() {
-        let bytes = build_segment_lane(0, 0, &[]).unwrap();
+        let bytes = build_segment_lane(&descriptor(), &[]).unwrap();
         let table = PstateTable::parse(&bytes).expect("empty parses");
         assert_eq!(table.row_count(), 0);
+        assert_eq!(table.ring_capacity(), 64);
         assert_eq!(bytes.len(), PSTATE_HEADER_LEN);
     }
 }

--- a/crates/uor-r4-graph-format/tests/stage1.rs
+++ b/crates/uor-r4-graph-format/tests/stage1.rs
@@ -452,3 +452,114 @@ fn newtype_smoke() {
 
     assert!(!FormatError::BadMagic.to_string().is_empty());
 }
+
+// ── PSTATE packing round-trip (#836) ──────────────────────────────────
+
+/// A segment-lane descriptor packs into a `PSTATE` section, survives a full
+/// R4G1 artifact round-trip through the canonical serializer, and is read back
+/// bit-for-bit via the borrowed `GraphView::pstate_table` view. Also pins
+/// absent-section identity: dropping the optional section leaves every other
+/// section byte-identical and `pstate_table` returns `None`.
+#[test]
+fn pstate_section_round_trips_through_artifact() {
+    use uor_r4_graph_format::{build_segment_lane, SegmentLaneDescriptor, LANE_SEGMENT};
+
+    // Absent-section identity: the canonical sample carries no PSTATE.
+    let base = build_sample();
+    let base_view = GraphView::parse(&base).expect("base validates");
+    assert!(base_view.pstate_table().expect("no error").is_none());
+
+    // Pack a segment-lane descriptor + a small residual table into PSTATE.
+    let desc = SegmentLaneDescriptor {
+        ring_capacity: 128,
+        decay_shift: 0,
+        base_w: 1 << 12,
+        boost: 1 << 20,
+        key_quant_id: 0,
+    };
+    let pstate = build_segment_lane(&desc, &[(3, vec![(3, 1 << 20)]), (7, vec![(7, 1 << 20)])])
+        .expect("valid pstate");
+
+    let mut b = ArtifactBuilder::new(3);
+    b.add_section(SectionId::NODE, 7, &sample_node());
+    b.add_section(SectionId::HEAD, 0, &sample_head());
+    b.add_section(SectionId::ROUT, 0, &[0u8; 64]);
+    b.add_section(SectionId::EMIT, 0, &storage_section(1, 0, 0, &[]));
+    b.add_section(SectionId::PSTATE, 0, &pstate);
+    let bytes = b.build().expect("artifact with PSTATE builds");
+
+    let view = GraphView::parse(&bytes).expect("PSTATE artifact validates");
+    // Raw section bytes preserved exactly.
+    assert_eq!(view.section(SectionId::PSTATE), Some(&pstate[..]));
+    // Borrowed descriptor round-trips (reference-to-packed equivalence).
+    let table = view
+        .pstate_table()
+        .expect("no error")
+        .expect("PSTATE present");
+    assert_eq!(table.lane_kind(), LANE_SEGMENT);
+    assert_eq!(table.ring_capacity(), 128);
+    assert_eq!(table.decay_shift(), 0);
+    assert_eq!(table.base_w().raw(), 1 << 12);
+    assert_eq!(table.boost().raw(), 1 << 20);
+    assert_eq!(table.row_count(), 2);
+    let row = table.find(7).expect("key 7 present");
+    let entries: Vec<(u32, i32)> = row.entries().map(|e| (e.token, e.score_q.raw())).collect();
+    assert_eq!(entries, vec![(7, 1 << 20)]);
+
+    // Absent-section identity: dropping PSTATE leaves the other sections
+    // byte-identical and the accessor returns None.
+    let mut b2 = ArtifactBuilder::new(3);
+    b2.add_section(SectionId::NODE, 7, &sample_node());
+    b2.add_section(SectionId::HEAD, 0, &sample_head());
+    b2.add_section(SectionId::ROUT, 0, &[0u8; 64]);
+    b2.add_section(SectionId::EMIT, 0, &storage_section(1, 0, 0, &[]));
+    let without = b2.build().expect("artifact without PSTATE builds");
+    let wview = GraphView::parse(&without).expect("validates");
+    assert!(wview.pstate_table().expect("no error").is_none());
+    for id in [
+        SectionId::HEAD,
+        SectionId::NODE,
+        SectionId::ROUT,
+        SectionId::EMIT,
+    ] {
+        assert_eq!(
+            view.section(id),
+            wview.section(id),
+            "section {id:?} identity"
+        );
+    }
+}
+
+/// A malformed PSTATE section fails closed with a focused typed error at
+/// `GraphView::pstate_table` time — the artifact container still parses (the
+/// section is optional and structurally opaque to the container), but the
+/// borrowed view rejects the corrupt descriptor rather than returning garbage.
+#[test]
+fn pstate_malformed_section_fails_closed() {
+    use uor_r4_graph_format::{build_segment_lane, SegmentLaneDescriptor};
+
+    let desc = SegmentLaneDescriptor {
+        ring_capacity: 64,
+        decay_shift: 1,
+        base_w: 1 << 12,
+        boost: 1 << 20,
+        key_quant_id: 0,
+    };
+    let mut pstate = build_segment_lane(&desc, &[]).expect("valid");
+    // Corrupt the ring_capacity to zero (bytes [24..28]) — a semantic teeth.
+    pstate[24..28].copy_from_slice(&0u32.to_le_bytes());
+
+    let mut b = ArtifactBuilder::new(3);
+    b.add_section(SectionId::NODE, 7, &sample_node());
+    b.add_section(SectionId::HEAD, 0, &sample_head());
+    b.add_section(SectionId::ROUT, 0, &[0u8; 64]);
+    b.add_section(SectionId::EMIT, 0, &storage_section(1, 0, 0, &[]));
+    b.add_section(SectionId::PSTATE, 0, &pstate);
+    let bytes = b.build().expect("container builds around opaque section");
+
+    let view = GraphView::parse(&bytes).expect("container parses");
+    assert!(
+        view.pstate_table().is_err(),
+        "malformed PSTATE descriptor must fail closed"
+    );
+}


### PR DESCRIPTION
## Problem and outcome

Increment 2 of #836. #876 landed the optional `PSTATE` R4G1 section; two things follow here:

1. **Complete the descriptor.** The #835 segment lane is *prompt-derived* (fold prompt content into a bounded decaying ring; boost present candidates), so what a compiler packs is the lane **descriptor**, not a learned table. This extends the PSTATE header (24 → 40 bytes) with the fields the deployed R4Engine needs to reconstruct the lane with caller-owned fixed-capacity state — `ring_capacity`, `base_w`, `boost` — plus semantic validation for them (`capacity >= 1`, `decay_shift < 32`) with planted zero-capacity parse teeth. This is safe format completion: **no shipped artifact writes PSTATE yet** (the section merged minutes earlier and nothing produces it), so finishing the never-yet-written format before first use is a no-op for every existing bundle.

2. **Prove compiler packing end-to-end.** The "compiler packing and a borrowed/zero-copy view" scope item, exercised on the real artifact container: a `SegmentLaneDescriptor` packs into a PSTATE section, survives a full `ArtifactBuilder` → `GraphView` round-trip, and reads back bit-for-bit through `GraphView::pstate_table`.

## Scope

- `crates/uor-r4-graph-format/src/pstate.rs` — 40-byte descriptor header; `SegmentLaneDescriptor` builder input; `ring_capacity()` / `base_w()` / `boost()` accessors; semantic descriptor validation.
- `crates/uor-r4-graph-format/tests/stage1.rs` — two artifact-level tests (below).

## Tests and verification (all green)

- `pstate_section_round_trips_through_artifact` — pack descriptor + residual table, attach via `add_section`, `GraphView::parse`, assert the descriptor (capacity, decay, base_w, boost, lane_kind) and rows round-trip; assert **absent-section identity** (dropping PSTATE leaves HEAD/NODE/ROUT/EMIT byte-identical and `pstate_table` returns `None`).
- `pstate_malformed_section_fails_closed` — a corrupt (zero-capacity) descriptor **fails closed** at `pstate_table()` with a typed error while the optional-section container still parses.
- Plus the module's 5 descriptor tests (round-trip/determinism, corrupt magic/version/reserved/offset, invalid-descriptor teeth, non-canonical builder rejection, empty-section validity).
- `cargo test -p uor-r4-graph-format`, no_std ladder (`--no-default-features` +`--features alloc`), `clippy -D warnings`, `fmt --check`, `cargo check --workspace`, wasm target check, `xtask validate` (every gate passed; CONFORMANCE unchanged). `forbid(unsafe_code)` preserved.

## Non-goals (this increment)

- The deployed scorer still does **not** consume PSTATE (the hot-path transition + contributions + witnesses are the next increment, where the serving capability + its `model/ids.toml` row → Gherkin → CONFORMANCE land).
- No quality claim. No serving-behavior change.

## Compatibility and migration

Purely additive and **non-serving**. Absent-section identity is re-proven at the artifact level. The header extension touches a format nothing yet writes, so no historical bundle is affected; `PSTATE_VERSION` stays 1.

## Conformance / claim boundary

No capability added; `CONFORMANCE.md` unchanged. Binds existing RF-21/22. No claim change.

## Closure

**References #836** — increment 2 (complete descriptor + compiler-packing round-trip). Next: the normative R4Engine hot-path scorer + witnesses (P-4/no_std/allocation), then the causal-gate re-run on the packed path with the PROMOTE/REVISE/RETIRE verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
