### PR TITLE
runtime(#836): P-4 hot-path segment ring, reference-equivalent (increment 3a, dormant)

### DIFF
--- a/crates/uor-r4-graph-runtime/src/runtime_state.rs
+++ b/crates/uor-r4-graph-runtime/src/runtime_state.rs
@@ -185,6 +185,156 @@ impl<const CAP: usize> ReservedState<CAP> {
     }
 }
 
+/// One segment-lane ring slot: a quantized content key and its saturating
+/// `ScoreQ` weight. Integer fields only (no_std, P-4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SegmentSlot {
+    pub key: u32,
+    pub weight: ScoreQ,
+}
+
+/// The #835 segment lane, lowered to the hot path (#836): a fixed-capacity,
+/// bounded ring with halving (arithmetic-right-shift) decay and saturating
+/// `ScoreQ` accumulation. Caller-owned fixed-capacity state; **no allocation,
+/// no multiply/divide/float** (P-4). Bit-equivalent to the #835 reference ring
+/// semantics (`docs/prompt_state_spec_835.md` §6 / `docs/scoring_semantics.md`
+/// §6): saturating upsert, canonical eviction victim (least weight, ties broken
+/// by the larger key so the lower id is retained), division-free decay, and a
+/// decode-independent candidate contribution.
+///
+/// This is a **dormant** runtime primitive: it is not yet wired into the
+/// deployed R4Engine scoring path, so serving behavior is unchanged. The
+/// descriptor it consumes (`ring_capacity`, `decay_shift`, `boost`) rides in
+/// the optional PSTATE section; a later #836 increment activates it on the
+/// request path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentRing<const CAP: usize> {
+    len: usize,
+    slots: [SegmentSlot; CAP],
+    decay_shift: u32,
+}
+
+impl<const CAP: usize> Default for SegmentRing<CAP> {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            slots: [SegmentSlot::default(); CAP],
+            decay_shift: 0,
+        }
+    }
+}
+
+impl<const CAP: usize> SegmentRing<CAP> {
+    /// A ring with the given halving decay shift; capacity is `CAP`.
+    pub fn with_decay(decay_shift: u32) -> Self {
+        Self {
+            decay_shift,
+            ..Self::default()
+        }
+    }
+
+    pub const fn capacity(&self) -> usize {
+        CAP
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn as_slice(&self) -> &[SegmentSlot] {
+        &self.slots[..self.len]
+    }
+
+    pub fn clear(&mut self) {
+        for slot in &mut self.slots[..self.len] {
+            *slot = SegmentSlot::default();
+        }
+        self.len = 0;
+    }
+
+    /// Halving decay: arithmetic right-shift every weight, then drop slots that
+    /// reached the floor (`weight <= 0`). Division-free; compaction is in place.
+    pub fn decay(&mut self) {
+        if self.decay_shift == 0 {
+            return;
+        }
+        let shift = self.decay_shift;
+        let mut write = 0usize;
+        for read in 0..self.len {
+            let decayed = self.slots[read].weight.raw() >> shift;
+            if decayed > 0 {
+                self.slots[write] = SegmentSlot {
+                    key: self.slots[read].key,
+                    weight: ScoreQ::from_raw(decayed),
+                };
+                write += 1;
+            }
+        }
+        for slot in &mut self.slots[write..self.len] {
+            *slot = SegmentSlot::default();
+        }
+        self.len = write;
+    }
+
+    /// The eviction victim under the canonical order: least weight, ties broken
+    /// by the *larger* key (so the lower id is retained).
+    fn victim_index(&self) -> usize {
+        let mut best = 0usize;
+        let mut i = 1usize;
+        while i < self.len {
+            let s = self.slots[i];
+            let b = self.slots[best];
+            if s.weight.raw() < b.weight.raw()
+                || (s.weight.raw() == b.weight.raw() && s.key > b.key)
+            {
+                best = i;
+            }
+            i += 1;
+        }
+        best
+    }
+
+    /// Insert or refresh a slot with a saturating `ScoreQ` add; returns the
+    /// evicted key when the ring was full and the new key displaced a victim.
+    pub fn upsert(&mut self, key: u32, add: ScoreQ) -> Option<u32> {
+        if CAP == 0 {
+            return None;
+        }
+        for i in 0..self.len {
+            if self.slots[i].key == key {
+                let weight = self.slots[i].weight.raw().saturating_add(add.raw());
+                self.slots[i].weight = ScoreQ::from_raw(weight);
+                return None;
+            }
+        }
+        if self.len < CAP {
+            self.slots[self.len] = SegmentSlot { key, weight: add };
+            self.len += 1;
+            return None;
+        }
+        let victim = self.victim_index();
+        let evicted = self.slots[victim].key;
+        self.slots[victim] = SegmentSlot { key, weight: add };
+        Some(evicted)
+    }
+
+    /// The decode-independent `ScoreQ` contribution to a candidate: the
+    /// saturating sum of `boost` over live slots keyed by the candidate.
+    pub fn contribution(&self, candidate: u32, boost: ScoreQ) -> ScoreQ {
+        let mut acc: i32 = 0;
+        for i in 0..self.len {
+            if self.slots[i].key == candidate {
+                acc = acc.saturating_add(boost.raw());
+            }
+        }
+        ScoreQ::from_raw(acc)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeStateLevel {
     Local,
@@ -283,8 +433,10 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::{
-        ReservedStateUpdate, RuntimeState, RuntimeStateLevel, SemanticStateSlot, TokenState,
+        ReservedStateUpdate, RuntimeState, RuntimeStateLevel, SegmentRing, SemanticStateSlot,
+        TokenState,
     };
+    use alloc::vec::Vec;
     use uor_r4_graph_format::ScoreQ;
 
     #[test]
@@ -347,5 +499,142 @@ mod tests {
         assert_eq!(state.local().as_slice(), &[local.slot]);
         assert_eq!(state.segment().as_slice(), &[segment.slot]);
         assert_eq!(state.session().as_slice(), &[session.slot]);
+    }
+
+    /// Oracle mirroring the #835 reference segment-lane ring semantics
+    /// (`docs/prompt_state_spec_835.md` §6): a `Vec`-backed ring with identical
+    /// decay / eviction / upsert / contribution rules. The hot-path
+    /// `SegmentRing` must match it bit-for-bit (reference-to-packed teeth).
+    #[derive(Clone)]
+    struct Oracle {
+        cap: usize,
+        decay_shift: u32,
+        slots: Vec<(u32, i32)>,
+    }
+
+    impl Oracle {
+        fn new(cap: usize, decay_shift: u32) -> Self {
+            Self {
+                cap,
+                decay_shift,
+                slots: Vec::new(),
+            }
+        }
+        fn decay(&mut self) {
+            if self.decay_shift > 0 {
+                for s in &mut self.slots {
+                    s.1 >>= self.decay_shift;
+                }
+                self.slots.retain(|s| s.1 > 0);
+            }
+        }
+        fn victim(&self) -> usize {
+            let mut best = 0usize;
+            for i in 1..self.slots.len() {
+                let s = self.slots[i];
+                let b = self.slots[best];
+                if s.1 < b.1 || (s.1 == b.1 && s.0 > b.0) {
+                    best = i;
+                }
+            }
+            best
+        }
+        fn upsert(&mut self, key: u32, add: i32) -> Option<u32> {
+            if let Some(s) = self.slots.iter_mut().find(|s| s.0 == key) {
+                s.1 = s.1.saturating_add(add);
+                return None;
+            }
+            if self.slots.len() < self.cap {
+                self.slots.push((key, add));
+                return None;
+            }
+            let v = self.victim();
+            let evicted = self.slots[v].0;
+            self.slots[v] = (key, add);
+            Some(evicted)
+        }
+        fn contribution(&self, candidate: u32, boost: i32) -> i32 {
+            let mut acc = 0i32;
+            for s in &self.slots {
+                if s.0 == candidate {
+                    acc = acc.saturating_add(boost);
+                }
+            }
+            acc
+        }
+        fn sorted(&self) -> Vec<(u32, i32)> {
+            let mut v = self.slots.clone();
+            v.sort_unstable();
+            v
+        }
+    }
+
+    fn ring_sorted<const CAP: usize>(ring: &SegmentRing<CAP>) -> Vec<(u32, i32)> {
+        let mut v: Vec<(u32, i32)> = ring
+            .as_slice()
+            .iter()
+            .map(|s| (s.key, s.weight.raw()))
+            .collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// The hot-path `SegmentRing` reproduces the reference ring bit-for-bit
+    /// across a long deterministic fold/decay stream: identical contents,
+    /// eviction returns, length, and per-candidate contributions at every step,
+    /// for a range of decay shifts. Key space (16) < capacity is exceeded so
+    /// eviction and collisions are exercised.
+    #[test]
+    fn segment_ring_matches_reference_semantics() {
+        const CAP: usize = 8;
+        const KEYS: u32 = 16; // power of two so we mask instead of dividing
+        let base_w: i32 = 1 << 12;
+        let boost: i32 = 1 << 20;
+
+        for &decay_shift in &[0u32, 1, 2] {
+            let mut ring = SegmentRing::<CAP>::with_decay(decay_shift);
+            let mut oracle = Oracle::new(CAP, decay_shift);
+            // deterministic xorshift key stream (shifts + xor, no mul/div)
+            let mut rng: u32 = 0x9E37_79B9 ^ decay_shift.wrapping_add(1);
+
+            for step in 0..4000u32 {
+                if (step & 7) == 7 {
+                    ring.decay();
+                    oracle.decay();
+                } else {
+                    rng ^= rng << 13;
+                    rng ^= rng >> 17;
+                    rng ^= rng << 5;
+                    let key = rng & (KEYS - 1);
+                    let ev_ring = ring.upsert(key, ScoreQ::from_raw(base_w));
+                    let ev_oracle = oracle.upsert(key, base_w);
+                    assert_eq!(ev_ring, ev_oracle, "eviction differs at step {step}");
+                }
+                assert_eq!(ring.len(), oracle.slots.len(), "len differs at step {step}");
+                assert_eq!(
+                    ring_sorted(&ring),
+                    oracle.sorted(),
+                    "contents differ at step {step}"
+                );
+                for candidate in 0..KEYS {
+                    assert_eq!(
+                        ring.contribution(candidate, ScoreQ::from_raw(boost)).raw(),
+                        oracle.contribution(candidate, boost),
+                        "contribution differs for candidate {candidate} at step {step}"
+                    );
+                }
+            }
+            // capacity is honored throughout
+            assert!(ring.len() <= CAP);
+        }
+    }
+
+    #[test]
+    fn segment_ring_zero_capacity_declines_without_panic() {
+        let mut ring = SegmentRing::<0>::with_decay(1);
+        assert_eq!(ring.upsert(5, ScoreQ::from_raw(1)), None);
+        assert_eq!(ring.len(), 0);
+        ring.decay();
+        assert_eq!(ring.contribution(5, ScoreQ::from_raw(1 << 20)).raw(), 0);
     }
 }


### PR DESCRIPTION
## Problem and outcome

Increment 3a of #836. Lowers the #835 **segment lane** to a hot-path primitive: `SegmentRing<CAP>` in `uor-r4-graph-runtime::runtime_state` — the fixed-capacity, caller-owned, **no_std, allocation-free, P-4 (no multiply/divide/float)** realization of the reference ring. It sits alongside the crate's existing `TokenState`/`ReservedState` fixed-capacity state, filling the reserved "Phase 8 segment update" hook.

Semantics are bit-equivalent to the #835 reference ring (`docs/prompt_state_spec_835.md` §6 / `docs/scoring_semantics.md` §6): halving arithmetic-right-shift decay (division-free), saturating `ScoreQ` accumulation, canonical eviction victim (least weight, ties broken by the larger key so the lower id is retained), and a decode-independent candidate contribution.

## Scope

- `crates/uor-r4-graph-runtime/src/runtime_state.rs` — `SegmentSlot`, `SegmentRing<CAP>` (`with_decay`, `upsert`, `decay`, `contribution`, `capacity`/`len`/`as_slice`/`clear`), and two tests.

## Dormant — no serving change

`SegmentRing` is **not yet wired into the deployed R4Engine scoring path**, so serving behavior is unchanged (no request path reads it). The descriptor it will consume — `ring_capacity`, `decay_shift`, `boost` — rides in the optional PSTATE section (#876 landed the section; #877 completes the descriptor). A later increment activates it on the request path (CLI/API/server/WASM) with witness attribution and the causal-gate re-run.

## Verification (all green)

- `segment_ring_matches_reference_semantics` — **differential** vs a `Vec` oracle mirroring the #835 reference ring: identical contents, eviction returns, length, and per-candidate contributions **at every step** over a 4,000-step deterministic fold/decay stream, for decay shifts {0,1,2}, with key space (16) exceeding capacity (8) so eviction and collisions are exercised (~12k assertion points per shift).
- `segment_ring_zero_capacity_declines_without_panic` — `CAP=0` declines without panic (typed/`None`).
- `cargo test -p uor-r4-graph-runtime`, `clippy -D warnings` clean; `cargo run -p xtask -- validate` — **every gate passed incl. the gnaf forbidden-construct (P-4) scan** (97 modules); wasm target check; workspace check. `forbid(unsafe_code)` preserved.

## Compatibility / conformance

Additive, dormant. `CONFORMANCE.md` unchanged — no serving capability is claimed here (the capability + its `model/ids.toml` row → Gherkin → CONFORMANCE land when the scorer is wired onto the request path). No `no_std`/allocation/P-4 obligation is weakened.

## Closure

**References #836** — increment 3a (hot-path ring primitive). Next: wire it into the normative R4Engine scoring path behind the PSTATE descriptor with witness attribution, then the causal-gate re-run → PROMOTE/REVISE/RETIRE verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
