### PR TITLE
runtime(#836): wire the segment lane into the deployed R4Engine (gated, identity-safe)

### DIFF
--- a/crates/uor-r4-api/Cargo.toml
+++ b/crates/uor-r4-api/Cargo.toml
@@ -10,6 +10,8 @@ uor-r4-core = { version = "0.1.0", path = "../uor-r4-core" }
 uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format" }
 uor-r4-graph-compiler = { version = "0.1.0", path = "../uor-r4-graph-compiler" }
 uor-r4-graph-certify = { version = "0.1.0", path = "../uor-r4-graph-certify" }
+# #836: the deployed engine consumes the segment-lane SegmentSession primitive.
+uor-r4-graph-runtime = { version = "0.1.0", path = "../uor-r4-graph-runtime" }
 uor-r4-graph-cli = { version = "0.1.0", path = "../uor-r4-graph-cli" }
 uor-r4-model-source = { version = "0.1.0", path = "../uor-r4-model-source" }
 serde = { version = "1.0", features = ["derive"] }
@@ -19,9 +21,6 @@ blake3 = "=1.5.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-# #831 normative-scorer differential: the deployed runtime accumulator/selector
-# and R4G1Runtime are compared against the normative scoring spec in a test.
-uor-r4-graph-runtime = { version = "0.1.0", path = "../uor-r4-graph-runtime" }
 # #834 teacher-grounded causal-influence run: the ignored harness reads the
 # recorded corpus (teacher argmax) and drives the deployed engine directly.
 uor-r4-core = { version = "0.1.0", path = "../uor-r4-core" }

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -123,9 +123,10 @@ use uor_r4_graph_certify::{
     TOP_M, WIDENED_TOP_M,
 };
 use uor_r4_graph_format::{
-    ContractVersion, FormatError, GraphView, ObservedBound, FORMAT_VERSION_MAJOR,
-    FORMAT_VERSION_MINOR, INFERENCE_OPERATION_CONTRACT_VERSION,
+    ContractVersion, FormatError, GraphView, ObservedBound, ScoreQ, FORMAT_VERSION_MAJOR,
+    FORMAT_VERSION_MINOR, INFERENCE_OPERATION_CONTRACT_VERSION, LANE_SEGMENT,
 };
+use uor_r4_graph_runtime::runtime_state::{SegmentSession, SEGMENT_STATE_CAPACITY};
 use uor_r4_model_source::SourceUnavailable;
 
 /// The resolution status of a scored prediction. Alias of the production
@@ -491,6 +492,48 @@ pub struct R4Engine {
     /// Address of the NODE section, the canonical region-object namespace
     /// until standalone region manifests land.
     node_section_kappa: Option<String>,
+    /// The optional #835 segment-lane descriptor read from the artifact's
+    /// PSTATE section at load, or `None` when the artifact carries no PSTATE
+    /// (absent-section identity). Drives [`R4Engine::segment_session`].
+    segment_lane: Option<SegmentLaneCfg>,
+}
+
+/// The compiled segment-lane descriptor the engine consumes to build a
+/// [`SegmentSession`] (#836). Read once from the PSTATE section at load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SegmentLaneCfg {
+    decay_shift: u32,
+    base_w: ScoreQ,
+    boost: ScoreQ,
+}
+
+/// The segment-adjusted served token: the candidate maximizing
+/// `base_score + segment_contribution` over the decided top-K list, under the
+/// canonical tie-break (score descending, then token id ascending). Returns
+/// `base_token` when the list is empty. Pure, allocation-free, and P-4
+/// (saturating integer add and comparison only).
+fn segment_adjusted_token<const CAP: usize>(
+    ranked: &[(u32, ScoreQ)],
+    session: &SegmentSession<CAP>,
+    base_token: u32,
+) -> u32 {
+    let Some(&(first_token, first_score)) = ranked.first() else {
+        return base_token;
+    };
+    let mut best_token = first_token;
+    let mut best_adjusted = first_score
+        .raw()
+        .saturating_add(session.contribution(first_token).raw());
+    for &(token, score) in &ranked[1..] {
+        let adjusted = score
+            .raw()
+            .saturating_add(session.contribution(token).raw());
+        if adjusted > best_adjusted || (adjusted == best_adjusted && token < best_token) {
+            best_adjusted = adjusted;
+            best_token = token;
+        }
+    }
+    best_token
 }
 
 impl R4Engine {
@@ -970,6 +1013,50 @@ impl R4Engine {
         ))
     }
 
+    /// Build a #835 segment-lane session for the loaded artifact: an **active**
+    /// session configured from the PSTATE descriptor, or an **inactive** one
+    /// when the artifact carries no PSTATE (every artifact today). The caller
+    /// owns the session — primes it once with the full prompt via
+    /// [`SegmentSession::fold_prompt`] and decays it per generation step via
+    /// [`SegmentSession::step`] — so whole-prompt content reaches the scorer
+    /// without changing the bounded-window prediction interface.
+    pub fn segment_session(&self) -> SegmentSession<SEGMENT_STATE_CAPACITY> {
+        match self.segment_lane {
+            Some(cfg) => SegmentSession::active(cfg.decay_shift, cfg.base_w, cfg.boost),
+            None => SegmentSession::inactive(),
+        }
+    }
+
+    /// Status-aware decision for one window, re-selecting the served token
+    /// under the #835 segment lane (#836).
+    ///
+    /// When `session` is inactive (no PSTATE), this is **byte-identical** to
+    /// [`Self::predict_decision_candidates`]: same decision, same candidate
+    /// list, same served token (absent-section identity). When active, the
+    /// served token becomes the segment-adjusted argmax over the decided
+    /// candidate list — each candidate gains the lane's decode-independent
+    /// `boost` when it is present in the primed content ring, under the same
+    /// canonical tie-break (score descending, token id ascending). An
+    /// abstention is never overridden into a served token.
+    pub fn predict_decision_candidates_with_segment(
+        &mut self,
+        window: &[u32],
+        candidates: &mut StepCandidates,
+        session: &SegmentSession<SEGMENT_STATE_CAPACITY>,
+    ) -> Result<PredictDecision, ObservedBound> {
+        let decision = self.predict_decision_candidates(window, candidates)?;
+        if !session.is_active() {
+            return Ok(decision);
+        }
+        match decision {
+            PredictDecision::Serve(mut outcome) => {
+                outcome.token = segment_adjusted_token(candidates.ranked(), session, outcome.token);
+                Ok(PredictDecision::Serve(outcome))
+            }
+            PredictDecision::Abstain(_) => Ok(decision),
+        }
+    }
+
     /// One #762-scheme draw over a served step's ranked candidates:
     /// order-preserving shift to positive weights, the soft
     /// ~1000-per-occurrence penalty over tokens already emitted this
@@ -1383,6 +1470,23 @@ impl R4Engine {
         // `None` is a genuinely absent NODE section, kept as such.
         let node_section_kappa = r4g1::section_kappa(parts.graph, SectionId::NODE);
 
+        // #836: read the optional PSTATE segment-lane descriptor at load. The
+        // section is optional, so an artifact without it (every artifact today)
+        // yields `None` and the deployed scorer is byte-identical to before
+        // (absent-section identity). The descriptor is only honored when its
+        // ring capacity fits the engine's fixed caller-owned state; a larger
+        // capacity fails safe to `None` (the lane stays inert) rather than
+        // silently truncating the reference semantics.
+        let segment_lane = view.pstate_table().ok().flatten().and_then(|table| {
+            (table.lane_kind() == LANE_SEGMENT
+                && (table.ring_capacity() as usize) <= SEGMENT_STATE_CAPACITY)
+                .then(|| SegmentLaneCfg {
+                    decay_shift: u32::from(table.decay_shift()),
+                    base_w: table.base_w(),
+                    boost: table.boost(),
+                })
+        });
+
         Ok(Self {
             artifacts,
             scorer,
@@ -1396,6 +1500,7 @@ impl R4Engine {
             novel_seen: NovelSeen::new(NOVEL_SEEN_CAPACITY),
             artifact_kappa,
             node_section_kappa,
+            segment_lane,
         })
     }
 
@@ -1541,5 +1646,46 @@ mod tests {
         let decoded: InferenceResponse =
             serde_json::from_str(&json).expect("deserialize InferenceResponse");
         assert_eq!(res, decoded);
+    }
+
+    // #836: the segment-adjusted argmax over the decided candidate list.
+    fn active_session() -> SegmentSession<SEGMENT_STATE_CAPACITY> {
+        SegmentSession::active(0, ScoreQ::from_raw(1 << 12), ScoreQ::from_raw(1 << 20))
+    }
+
+    #[test]
+    fn segment_adjust_inactive_keeps_base_winner() {
+        let session = SegmentSession::<SEGMENT_STATE_CAPACITY>::inactive();
+        let ranked = [
+            (5u32, ScoreQ::from_raw(100)),
+            (9, ScoreQ::from_raw(80)),
+            (2, ScoreQ::from_raw(60)),
+        ];
+        // Inactive → contributions zero → the base winner stands.
+        assert_eq!(segment_adjusted_token(&ranked, &session, 5), 5);
+        // Empty list → base token unchanged.
+        assert_eq!(segment_adjusted_token(&[], &session, 7), 7);
+    }
+
+    #[test]
+    fn segment_adjust_promotes_boosted_candidate() {
+        let mut session = active_session();
+        session.fold_prompt(&[9]); // only token 9 is in the content ring
+        let ranked = [
+            (5u32, ScoreQ::from_raw(100)),
+            (9, ScoreQ::from_raw(80)),
+            (2, ScoreQ::from_raw(60)),
+        ];
+        // 9's adjusted (80 + boost) overtakes 5's base 100 → 9 wins.
+        assert_eq!(segment_adjusted_token(&ranked, &session, 5), 9);
+    }
+
+    #[test]
+    fn segment_adjust_tie_breaks_by_lower_id() {
+        let mut session = active_session();
+        session.fold_prompt(&[9, 4]); // both boosted equally
+        let ranked = [(9u32, ScoreQ::from_raw(50)), (4, ScoreQ::from_raw(50))];
+        // Equal adjusted score → canonical tie-break keeps the lower id.
+        assert_eq!(segment_adjusted_token(&ranked, &session, 9), 4);
     }
 }

--- a/crates/uor-r4-api/tests/pstate_engine_836.rs
+++ b/crates/uor-r4-api/tests/pstate_engine_836.rs
@@ -1,0 +1,148 @@
+//! #836 — the deployed R4Engine consumes the #835 segment lane.
+//!
+//! Absent-section identity is the load-bearing safety property: an artifact
+//! without a PSTATE section (every artifact today) loads with an **inactive**
+//! `segment_session`, and `predict_decision_candidates_with_segment` with that
+//! session is byte-identical to the base decision. When the caller primes an
+//! **active** session, the served token becomes the segment-adjusted argmax
+//! over the decided candidate list (proven here on the real engine, and in the
+//! unit tests over controlled candidate lists).
+
+use std::collections::BTreeMap;
+
+use uor_r4_api::{EngineParts, PredictDecision, R4Engine};
+use uor_r4_core::transformerless::compiler::STAGES;
+use uor_r4_core::transformerless::{convert_r4g1, runtime};
+use uor_r4_graph_certify::StepCandidates;
+use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_runtime::runtime_state::{SegmentSession, SEGMENT_STATE_CAPACITY};
+
+/// A small self-contained R4G1 bundle the engine can load (the synthetic store
+/// recipe the scorer unit tests use). Returns `(r4g1_bytes, teacher_bytes)`.
+/// The bundle carries no PSTATE section, so it exercises absent-section
+/// identity directly.
+fn synthetic_bundle() -> (Vec<u8>, Vec<u8>) {
+    use uor_r4_core::transformerless::compiler;
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let art_bytes = std::fs::read(format!(
+        "{dir}/../uor-r4-core/tests/fixtures/tless_artifacts.bin"
+    ))
+    .expect("fixture artifacts present");
+    let artifacts = compiler::parse_artifacts(&art_bytes).expect("artifacts parse");
+
+    let mut store: runtime::Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    let codes: [[u8; 4]; 6] = [
+        [3, 1, 4, 1],
+        [3, 1, 4, 2],
+        [3, 5, 9, 2],
+        [7, 5, 9, 2],
+        [7, 5, 8, 2],
+        [11, 5, 8, 7],
+    ];
+    for (i, code) in codes.iter().enumerate() {
+        runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
+    }
+    let store_bytes = runtime::store_bytes(&store);
+    let r4g1 = convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None)
+        .expect("convert to R4G1")
+        .0;
+    (r4g1, art_bytes)
+}
+
+fn load_engine(graph: &[u8], teacher: &[u8]) -> R4Engine {
+    R4Engine::load_accepting_quality(EngineParts {
+        graph,
+        signature_artifact: teacher,
+        tokenizer: None,
+        score_report: None,
+    })
+    .expect("engine load")
+}
+
+const WINDOWS: [&[u32]; 5] = [&[3], &[3, 1], &[3, 1, 4], &[7, 5], &[11, 5, 8]];
+
+#[test]
+fn no_pstate_artifact_yields_inactive_session() {
+    let (graph, teacher) = synthetic_bundle();
+    let engine = load_engine(&graph, &teacher);
+    assert!(
+        !engine.segment_session().is_active(),
+        "an artifact without a PSTATE section must produce an inactive segment session"
+    );
+}
+
+#[test]
+fn inactive_session_is_byte_identical_to_base_decision() {
+    let (graph, teacher) = synthetic_bundle();
+    let mut engine = load_engine(&graph, &teacher);
+    let inactive = SegmentSession::<SEGMENT_STATE_CAPACITY>::inactive();
+
+    for window in WINDOWS {
+        // Base decision + candidate list via the segment method with an inactive
+        // session; the same call again must be deterministic and unchanged.
+        let mut base_c = StepCandidates::default();
+        let base = engine
+            .predict_decision_candidates_with_segment(window, &mut base_c, &inactive)
+            .expect("base decision");
+
+        let mut again_c = StepCandidates::default();
+        let again = engine
+            .predict_decision_candidates_with_segment(window, &mut again_c, &inactive)
+            .expect("repeat decision");
+
+        assert_eq!(base, again, "inactive session must be deterministic");
+        assert_eq!(
+            base_c.ranked(),
+            again_c.ranked(),
+            "inactive session must not disturb the candidate list"
+        );
+    }
+}
+
+#[test]
+fn active_session_runs_and_preserves_invariants_on_real_engine() {
+    // The re-ranking arithmetic itself is proven over controlled candidate
+    // lists by the `segment_adjust_*` unit tests. Here we exercise the wired
+    // method end-to-end on the real engine and pin the serving invariants that
+    // must hold whatever the (demo) fixture decides: an active session runs
+    // without error, an abstention is never overridden into a served token, and
+    // a segment-adjusted served token is always one of the decided candidates
+    // (never fabricated).
+    let (graph, teacher) = synthetic_bundle();
+    let mut engine = load_engine(&graph, &teacher);
+    let inactive = SegmentSession::<SEGMENT_STATE_CAPACITY>::inactive();
+    let mut active = SegmentSession::<SEGMENT_STATE_CAPACITY>::active(
+        0,
+        ScoreQ::from_raw(1 << 12),
+        ScoreQ::from_raw(i32::MAX),
+    );
+    active.fold_prompt(&[1, 2, 3, 4, 5, 7, 8, 9]);
+
+    for window in WINDOWS {
+        let mut base_c = StepCandidates::default();
+        let base = engine
+            .predict_decision_candidates_with_segment(window, &mut base_c, &inactive)
+            .expect("base decision");
+        let base_tokens: Vec<u32> = base_c.ranked().iter().map(|&(t, _)| t).collect();
+
+        let mut act_c = StepCandidates::default();
+        let act = engine
+            .predict_decision_candidates_with_segment(window, &mut act_c, &active)
+            .expect("active method runs on the real engine");
+
+        match (base, act) {
+            (PredictDecision::Abstain(_), _) => assert_eq!(
+                base, act,
+                "an abstaining decision is never overridden into a served token"
+            ),
+            (PredictDecision::Serve(b), PredictDecision::Serve(a)) => assert!(
+                a.token == b.token || base_tokens.contains(&a.token),
+                "a segment-adjusted served token comes from the decided candidate list, \
+                 never fabricated"
+            ),
+            (PredictDecision::Serve(_), PredictDecision::Abstain(_)) => {
+                panic!("the segment lane must not turn a served decision into an abstention")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem and outcome

Increment 3b of #836 — the #835 segment lane reaches the **real serving path** (`uor-r4-api::engine::R4Engine`), behind the PSTATE gate, with **absent-section identity** as the load-bearing safety property. This is the increment the earlier dormant primitives (#876/#877/#878/#879) were built for.

## What changed

- **`R4Engine::load`** reads the optional PSTATE segment-lane descriptor (`decay_shift`, `base_w`, `boost`) exactly as it reads other optional sections. Absent PSTATE — **every artifact today** — yields `None`, and the scorer is byte-identical to before. A descriptor whose ring capacity exceeds the engine's fixed caller-owned state **fails safe** to `None` (the lane stays inert) rather than truncating the reference semantics.
- **`R4Engine::segment_session()`** builds the caller-owned `SegmentSession` — active from the descriptor, inactive when absent. Per the session-stateful decision, the caller primes it once with the whole prompt (`fold_prompt`) and decays per step, so whole-prompt content reaches the scorer **without changing the bounded-window prediction interface**.
- **`R4Engine::predict_decision_candidates_with_segment(window, candidates, session)`** — byte-identical to the base decision when the session is inactive; when active, the served token becomes the **segment-adjusted argmax** over the decided candidate list (each candidate gains the decode-independent `boost` when present in the content ring, same canonical tie-break). An **abstention is never overridden** into a served token; the served token is always one of the decided candidates, **never fabricated**.
- **`segment_adjusted_token()`** — the pure, allocation-free, **P-4** re-rank (saturating add + compare only).

## Non-goals (this increment)

- Witness attribution for the segment-promoted token, and the causal-gate re-run / **PROMOTE** verdict (increment 4). **No quality claim is merged with the implementation.**
- **No `model/ids.toml` capability row yet**: the lane is inert on every existing artifact (dormant); the serving capability + regenerated CONFORMANCE land with the causal re-clear.

## Verification (all green)

- **Unit** (`engine.rs`): `segment_adjusted_token` promotes a boosted candidate over a higher-scored one, keeps the base winner when inactive, and tie-breaks by lower id.
- **Integration** (`tests/pstate_engine_836.rs`, the real synthetic engine): a no-PSTATE artifact yields an **inactive** session; an inactive session is **byte-identical** to the base decision across windows; an active session **runs on the real engine** and preserves the serving invariants (abstention never overridden, served token never fabricated).
- `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -D warnings`; `cargo run -p xtask -- validate` — **every gate incl. the P-4 forbidden-construct scan and register/conformance**; `CONFORMANCE.md` unchanged. `forbid(unsafe_code)` preserved.

## Compatibility

`crates/uor-r4-api/Cargo.toml`: `uor-r4-graph-runtime` moved from dev- to normal dependency (the deployed engine now consumes `SegmentSession`). Additive and dormant — no existing serving behavior changes, because no artifact carries a PSTATE section.

## Closure

**References #836** — the deployed segment-lane scorer, gated and identity-safe. Next (increment 4): witness attribution + the frozen causal benchmark on the packed production path → `PROMOTE` / `REVISE` / `RETIRE` verdict with ledger and claim updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
