### PR TITLE
compiler(#836): emit the PSTATE segment-lane section (gated) — the lane goes live

### DIFF
--- a/crates/uor-r4-api/tests/pstate_engine_836.rs
+++ b/crates/uor-r4-api/tests/pstate_engine_836.rs
@@ -14,14 +14,14 @@ use uor_r4_api::{EngineParts, PredictDecision, R4Engine};
 use uor_r4_core::transformerless::compiler::STAGES;
 use uor_r4_core::transformerless::{convert_r4g1, runtime};
 use uor_r4_graph_certify::StepCandidates;
-use uor_r4_graph_format::ScoreQ;
+use uor_r4_graph_format::{GraphView, ScoreQ, SectionId, SegmentLaneDescriptor, LANE_SEGMENT};
 use uor_r4_graph_runtime::runtime_state::{SegmentSession, SEGMENT_STATE_CAPACITY};
 
 /// A small self-contained R4G1 bundle the engine can load (the synthetic store
 /// recipe the scorer unit tests use). Returns `(r4g1_bytes, teacher_bytes)`.
 /// The bundle carries no PSTATE section, so it exercises absent-section
 /// identity directly.
-fn synthetic_bundle() -> (Vec<u8>, Vec<u8>) {
+fn synthetic_bundle_opt(lane: Option<&SegmentLaneDescriptor>) -> (Vec<u8>, Vec<u8>) {
     use uor_r4_core::transformerless::compiler;
     let dir = env!("CARGO_MANIFEST_DIR");
     let art_bytes = std::fs::read(format!(
@@ -43,10 +43,37 @@ fn synthetic_bundle() -> (Vec<u8>, Vec<u8>) {
         runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
     }
     let store_bytes = runtime::store_bytes(&store);
-    let r4g1 = convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None)
-        .expect("convert to R4G1")
-        .0;
+    let r4g1 = match lane {
+        Some(descriptor) => convert_r4g1::convert_with_segment_lane(
+            &art_bytes,
+            &artifacts,
+            &store,
+            &store_bytes,
+            None,
+            descriptor,
+        ),
+        None => convert_r4g1::convert(&art_bytes, &artifacts, &store, &store_bytes, None),
+    }
+    .expect("convert to R4G1")
+    .0;
     (r4g1, art_bytes)
+}
+
+/// `synthetic_bundle` without a segment lane (no PSTATE section).
+fn synthetic_bundle() -> (Vec<u8>, Vec<u8>) {
+    synthetic_bundle_opt(None)
+}
+
+/// A representative selected segment-lane descriptor (the reference arm's
+/// constants; the final values are pinned by the causal re-run / verdict).
+fn selected_descriptor() -> SegmentLaneDescriptor {
+    SegmentLaneDescriptor {
+        ring_capacity: SEGMENT_STATE_CAPACITY as u32,
+        decay_shift: 0,
+        base_w: 1 << 12,
+        boost: 1 << 20,
+        key_quant_id: 0,
+    }
 }
 
 fn load_engine(graph: &[u8], teacher: &[u8]) -> R4Engine {
@@ -144,5 +171,71 @@ fn active_session_runs_and_preserves_invariants_on_real_engine() {
                 panic!("the segment lane must not turn a served decision into an abstention")
             }
         }
+    }
+}
+
+// --- compiler emission (increment 4a): the lane becomes non-inert ----------
+
+#[test]
+fn compiler_emits_pstate_and_engine_activates_the_lane() {
+    let descriptor = selected_descriptor();
+    let (graph, teacher) = synthetic_bundle_opt(Some(&descriptor));
+
+    // The produced bundle carries a PSTATE section that round-trips the
+    // descriptor the compiler was given.
+    let view = GraphView::parse(&graph).expect("compiled bundle parses");
+    let table = view
+        .pstate_table()
+        .expect("pstate section valid")
+        .expect("compiled bundle carries a PSTATE section");
+    assert_eq!(table.lane_kind(), LANE_SEGMENT);
+    assert_eq!(table.ring_capacity(), descriptor.ring_capacity);
+    assert_eq!(table.decay_shift(), descriptor.decay_shift);
+    assert_eq!(table.base_w().raw(), descriptor.base_w);
+    assert_eq!(table.boost().raw(), descriptor.boost);
+
+    // And the deployed engine activates the segment lane from it — the lane is
+    // no longer inert on a real compiled bundle.
+    let engine = load_engine(&graph, &teacher);
+    assert!(
+        engine.segment_session().is_active(),
+        "a compiled PSTATE bundle must activate the deployed segment lane"
+    );
+}
+
+#[test]
+fn segment_lane_emission_is_deterministic_and_section_preserving() {
+    let descriptor = selected_descriptor();
+    let (with_lane, _) = synthetic_bundle_opt(Some(&descriptor));
+    let (with_lane_again, _) = synthetic_bundle_opt(Some(&descriptor));
+    let (without_lane, _) = synthetic_bundle_opt(None);
+
+    // Deterministic bytes: identical inputs → identical container.
+    assert_eq!(
+        with_lane, with_lane_again,
+        "PSTATE emission must be deterministic"
+    );
+
+    // Absent-section identity at the source: emitting PSTATE leaves every other
+    // section byte-identical, and the no-lane bundle carries no PSTATE.
+    let vw = GraphView::parse(&with_lane).expect("with-lane parses");
+    let vo = GraphView::parse(&without_lane).expect("no-lane parses");
+    assert!(
+        vo.pstate_table().expect("valid").is_none(),
+        "the no-lane bundle must carry no PSTATE section"
+    );
+    for id in [
+        SectionId::HEAD,
+        SectionId::NODE,
+        SectionId::EDGE,
+        SectionId::ROUT,
+        SectionId::EMIT,
+        SectionId::EXCT,
+    ] {
+        assert_eq!(
+            vw.section(id),
+            vo.section(id),
+            "PSTATE emission must not change section {id:?}"
+        );
     }
 }

--- a/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
+++ b/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
@@ -110,7 +110,7 @@
 
 use std::collections::BTreeSet;
 
-use uor_r4_graph_format::{ArtifactBuilder, SectionId};
+use uor_r4_graph_format::{build_segment_lane, ArtifactBuilder, SectionId, SegmentLaneDescriptor};
 
 use super::compiler::{Compiled, HammingCalibrationReport, D, K, SIG_BYTES, SIG_WORDS, STAGES};
 use super::runtime::Store;
@@ -183,6 +183,48 @@ pub fn convert(
     store: &Store,
     store_container: &[u8],
     calibration: Option<&HammingCalibrationReport>,
+) -> Option<(Vec<u8>, ConversionReport)> {
+    convert_inner(
+        artifact_container,
+        artifacts,
+        store,
+        store_container,
+        calibration,
+        None,
+    )
+}
+
+/// Like [`convert`], but additionally emits the optional #835 segment-lane
+/// `PSTATE` section (#836) carrying `descriptor`. The bytes stay deterministic
+/// and every other section is unchanged, so a reader that ignores PSTATE sees
+/// exactly the [`convert`] output (absent-section identity). Emitting the
+/// descriptor is what makes the deployed segment lane non-inert on the produced
+/// bundle.
+pub fn convert_with_segment_lane(
+    artifact_container: &[u8],
+    artifacts: &Compiled,
+    store: &Store,
+    store_container: &[u8],
+    calibration: Option<&HammingCalibrationReport>,
+    descriptor: &SegmentLaneDescriptor,
+) -> Option<(Vec<u8>, ConversionReport)> {
+    convert_inner(
+        artifact_container,
+        artifacts,
+        store,
+        store_container,
+        calibration,
+        Some(descriptor),
+    )
+}
+
+fn convert_inner(
+    artifact_container: &[u8],
+    artifacts: &Compiled,
+    store: &Store,
+    store_container: &[u8],
+    calibration: Option<&HammingCalibrationReport>,
+    segment_lane: Option<&SegmentLaneDescriptor>,
 ) -> Option<(Vec<u8>, ConversionReport)> {
     // Input shape honesty: the artifact must carry the 4 × 256 × 36-byte
     // class signature books the ROUT section is built from.
@@ -396,6 +438,15 @@ pub fn convert(
     builder.add_section(SectionId::ROUT, 0, &rout);
     builder.add_section(SectionId::EMIT, 0, &emit);
     builder.add_section(SectionId::EXCT, 0, &exct);
+    // #836: optional segment-lane PSTATE section. The prompt-derived segment
+    // lane ships a config-only descriptor (empty residual table), so this adds
+    // the lane's capacity/decay/score constants without any learned table.
+    // Emitted only when a descriptor is supplied; otherwise the container is
+    // byte-identical to `convert` (absent-section identity).
+    if let Some(descriptor) = segment_lane {
+        let pstate = build_segment_lane(descriptor, &[]).ok()?;
+        builder.add_section(SectionId::PSTATE, 0, &pstate);
+    }
     let bytes = builder.build().ok()?;
 
     let report = ConversionReport {


### PR DESCRIPTION
## Problem and outcome

Increment 4a of #836 — the enabler that makes the deployed segment lane **non-inert**. #880 wired the lane into `R4Engine`, but nothing produced a PSTATE-bearing bundle, so no real request was ever re-ranked. This teaches the compiler to emit the section.

## What changed

- **`convert_r4g1::convert_with_segment_lane(...)`** — like `convert()`, plus an optional `PSTATE` section built from a `SegmentLaneDescriptor`. The prompt-derived segment lane ships a **config-only** descriptor (capacity / decay / score constants; empty residual table — there is no learned table). `convert()` is unchanged and delegates to a shared inner fn with no lane, so **every existing call site and every no-lane bundle is byte-identical** (absent-section identity), and bytes stay deterministic.

## Verification (all green)

Real compile → load path, in `uor-r4-api/tests/pstate_engine_836.rs`:

- **`compiler_emits_pstate_and_engine_activates_the_lane`** — a bundle compiled with a descriptor carries a round-tripping PSTATE section **and** `R4Engine::segment_session()` is **active** on it. The milestone: the lane is no longer inert on a real compiled bundle.
- **`segment_lane_emission_is_deterministic_and_section_preserving`** — identical inputs → identical bytes; emitting PSTATE leaves `HEAD/NODE/EDGE/ROUT/EMIT/EXCT` byte-identical, and the no-lane bundle carries no PSTATE.
- `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -D warnings`; `cargo run -p xtask -- validate` — every gate incl. the **P-4 forbidden-construct scan** and register/conformance; `CONFORMANCE.md` unchanged. `forbid(unsafe_code)` preserved.

## Non-goals

- **No quality claim / no `model/ids.toml` capability row yet.** The descriptor emitted here is *representative*; the **final selected descriptor** and the **PROMOTE / REVISE / RETIRE** verdict come from the causal re-run on the packed production path (increment 4c). No CLI flag yet — the causal harness calls `convert_with_segment_lane` directly.

## Closure

**References #836** — the compiler now emits the lane. Next: witness attribution for the segment-promoted token (4b), then the frozen causal benchmark on the packed path + the verdict, capability row, and CONFORMANCE regen (4c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
