### PR TITLE
runtime(#836): segment-lane witness attribution (4b)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -90,6 +90,27 @@ pub struct InferenceWitness {
     pub token: u32,
     /// Whether the policy had to use its widened membership pass.
     pub widened: bool,
+    /// #836 segment-lane attribution: present only when the deployed segment
+    /// lane changed the served token. Absent (skipped in JSON) for every
+    /// artifact without a PSTATE section, so the witness is unchanged — the
+    /// witness-level absent-section identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_lane: Option<SegmentLaneWitness>,
+}
+
+/// #836 segment-lane witness attribution: which candidate the deployed segment
+/// lane promoted to served, the base-scorer token it displaced, and the raw
+/// `ScoreQ` boost that promoted it — enough for a verifier to reproduce the
+/// re-rank over the decided candidate list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SegmentLaneWitness {
+    /// The candidate the segment lane promoted to the served token.
+    pub promoted_token: u32,
+    /// The base-scorer token the promotion displaced (what would have served
+    /// without the lane).
+    pub base_token: u32,
+    /// The raw `ScoreQ` boost the lane added to the promoted candidate.
+    pub boost: i32,
 }
 
 /// Unified inference response payload across HTTP REST, WebSocket, and WASM interfaces.
@@ -536,6 +557,29 @@ fn segment_adjusted_token<const CAP: usize>(
     best_token
 }
 
+/// The #836 segment-lane witness attribution over a decided candidate list:
+/// `Some` only when the lane is active AND promotes a different token than the
+/// base winner; `None` otherwise (inactive lane, or no change → no attribution,
+/// preserving witness identity). Pure.
+fn segment_lane_attribution<const CAP: usize>(
+    ranked: &[(u32, ScoreQ)],
+    session: &SegmentSession<CAP>,
+    base_token: u32,
+) -> Option<SegmentLaneWitness> {
+    if !session.is_active() {
+        return None;
+    }
+    let promoted = segment_adjusted_token(ranked, session, base_token);
+    if promoted == base_token {
+        return None;
+    }
+    Some(SegmentLaneWitness {
+        promoted_token: promoted,
+        base_token,
+        boost: session.contribution(promoted).raw(),
+    })
+}
+
 impl R4Engine {
     /// The manifest policy in force (D4 defaults or the score-report
     /// override).
@@ -601,6 +645,9 @@ impl R4Engine {
             engine: "r4g1".to_owned(),
             token: witness.selected,
             widened,
+            // The base reference witness carries no segment attribution; the
+            // deployed segment-witness path fills it when the lane promotes.
+            segment_lane: None,
         }
     }
 
@@ -1054,6 +1101,34 @@ impl R4Engine {
                 Ok(PredictDecision::Serve(outcome))
             }
             PredictDecision::Abstain(_) => Ok(decision),
+        }
+    }
+
+    /// Like [`Self::predict_decision_candidates_with_segment`], but also returns
+    /// the #836 segment-lane **witness attribution**: `Some` when the lane
+    /// promoted a different served token (carrying the promoted/base tokens and
+    /// the `ScoreQ` boost that promoted it), `None` otherwise — inactive lane,
+    /// abstention, or a lane that left the winner unchanged. The returned
+    /// decision's served token and the attribution's `promoted_token` agree by
+    /// construction. Absent PSTATE → `None` → the served result is byte-identical
+    /// to the base decision, and callers attach nothing to the witness.
+    pub fn predict_decision_candidates_with_segment_witness(
+        &mut self,
+        window: &[u32],
+        candidates: &mut StepCandidates,
+        session: &SegmentSession<SEGMENT_STATE_CAPACITY>,
+    ) -> Result<(PredictDecision, Option<SegmentLaneWitness>), ObservedBound> {
+        let decision = self.predict_decision_candidates(window, candidates)?;
+        match decision {
+            PredictDecision::Serve(mut outcome) => {
+                let attribution =
+                    segment_lane_attribution(candidates.ranked(), session, outcome.token);
+                if let Some(attr) = &attribution {
+                    outcome.token = attr.promoted_token;
+                }
+                Ok((PredictDecision::Serve(outcome), attribution))
+            }
+            PredictDecision::Abstain(_) => Ok((decision, None)),
         }
     }
 
@@ -1687,5 +1762,53 @@ mod tests {
         let ranked = [(9u32, ScoreQ::from_raw(50)), (4, ScoreQ::from_raw(50))];
         // Equal adjusted score → canonical tie-break keeps the lower id.
         assert_eq!(segment_adjusted_token(&ranked, &session, 9), 4);
+    }
+
+    #[test]
+    fn segment_lane_attribution_records_only_real_promotions() {
+        let ranked = [(5u32, ScoreQ::from_raw(100)), (9, ScoreQ::from_raw(80))];
+        // Inactive lane → no attribution.
+        assert!(segment_lane_attribution(
+            &ranked,
+            &SegmentSession::<SEGMENT_STATE_CAPACITY>::inactive(),
+            5
+        )
+        .is_none());
+        // Active but the winner is unchanged (base winner folded) → no attribution.
+        let mut unchanged = active_session();
+        unchanged.fold_prompt(&[5]);
+        assert!(segment_lane_attribution(&ranked, &unchanged, 5).is_none());
+        // Active promotion → attribution records promoted/base tokens + boost.
+        let mut promo = active_session();
+        promo.fold_prompt(&[9]);
+        let attr = segment_lane_attribution(&ranked, &promo, 5).expect("promotion attributed");
+        assert_eq!(attr.promoted_token, 9);
+        assert_eq!(attr.base_token, 5);
+        assert_eq!(attr.boost, 1 << 20);
+    }
+
+    #[test]
+    fn inference_witness_segment_lane_serde_is_backward_compatible() {
+        let witness = InferenceWitness {
+            region_kappa: None,
+            region_id: None,
+            depth: 0,
+            resolution_status: "novel".to_owned(),
+            engine: "r4g1".to_owned(),
+            token: 9,
+            widened: false,
+            segment_lane: Some(SegmentLaneWitness {
+                promoted_token: 9,
+                base_token: 5,
+                boost: 1 << 20,
+            }),
+        };
+        let json = serde_json::to_string(&witness).expect("serialize");
+        let back: InferenceWitness = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(witness, back);
+        // A pre-#836 witness (no segment_lane) still deserializes → None.
+        let legacy = r#"{"region_kappa":null,"region_id":null,"depth":0,"resolution_status":"novel","engine":"r4g1","token":7,"widened":false}"#;
+        let parsed: InferenceWitness = serde_json::from_str(legacy).expect("legacy deserialize");
+        assert!(parsed.segment_lane.is_none());
     }
 }

--- a/crates/uor-r4-api/src/lib.rs
+++ b/crates/uor-r4-api/src/lib.rs
@@ -57,8 +57,8 @@ pub use compile::{
 pub use engine::{
     validate_quality_report, AbiVersion, AbstainOutcome, EngineParts, GenerateStatus,
     InferenceRequest, InferenceResponse, InferenceWitness, PolicyCounters, PolicyStatus,
-    PredictDecision, PredictOutcome, PredictOutput, R4Engine, ResolutionStatus, StatusAction,
-    StatusPolicy, WitnessVerificationError,
+    PredictDecision, PredictOutcome, PredictOutput, R4Engine, ResolutionStatus, SegmentLaneWitness,
+    StatusAction, StatusPolicy, WitnessVerificationError,
 };
 pub use release_bundle::{
     BundleAbi, BundleCapability, BundleComponentDigests, ReleaseBundleManifest,

--- a/crates/uor-r4-api/tests/pstate_engine_836.rs
+++ b/crates/uor-r4-api/tests/pstate_engine_836.rs
@@ -146,3 +146,33 @@ fn active_session_runs_and_preserves_invariants_on_real_engine() {
         }
     }
 }
+
+// --- witness attribution (increment 4b) ------------------------------------
+
+#[test]
+fn segment_witness_method_is_identity_when_inactive() {
+    // The witness-bearing segment method returns the base decision and a `None`
+    // attribution whenever the lane is inactive — the witness-level absent-
+    // section identity, on the real engine.
+    let (graph, teacher) = synthetic_bundle();
+    let mut engine = load_engine(&graph, &teacher);
+    let inactive = SegmentSession::<SEGMENT_STATE_CAPACITY>::inactive();
+
+    for window in WINDOWS {
+        let mut base_c = StepCandidates::default();
+        let base = engine
+            .predict_decision_candidates_with_segment(window, &mut base_c, &inactive)
+            .expect("base decision");
+
+        let mut wit_c = StepCandidates::default();
+        let (decision, attribution) = engine
+            .predict_decision_candidates_with_segment_witness(window, &mut wit_c, &inactive)
+            .expect("witness path");
+
+        assert_eq!(base, decision, "inactive witness path decision == base");
+        assert!(
+            attribution.is_none(),
+            "an inactive lane never attributes a promotion"
+        );
+    }
+}


### PR DESCRIPTION
## Problem and outcome

Increment 4b of #836 — witness attribution, so a segment-promoted served token is **provable**. Extends the deployed witness data model and the deployed segment path; no quality claim (the verdict is 4c).

## What changed

- **`InferenceWitness`** gains `segment_lane: Option<SegmentLaneWitness>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Absent for every artifact without a PSTATE section, so **pre-#836 witnesses serialize/deserialize unchanged** — the witness-level absent-section identity. `SegmentLaneWitness` records the **promoted token**, the **base-scorer token** it displaced, and the raw **`ScoreQ` boost**.
- **`R4Engine::predict_decision_candidates_with_segment_witness(...)`** — the deployed segment path, additionally returning `Some(attribution)` **exactly when** the lane promoted a different served token; `None` otherwise (inactive lane, abstention, or no change). The served token and the attribution's `promoted_token` agree by construction.
- **`segment_lane_attribution()`** — pure helper (reuses `segment_adjusted_token`).

## Verification (all green)

- `segment_lane_attribution_records_only_real_promotions` — inactive lane / unchanged winner → `None`; a real promotion → attribution with the right promoted/base tokens and boost.
- `inference_witness_segment_lane_serde_is_backward_compatible` — a witness carrying `segment_lane` round-trips, **and a pre-#836 witness JSON (no `segment_lane`) still deserializes → `None`**.
- `segment_witness_method_is_identity_when_inactive` — on the real engine, the witness method returns the base decision and `None` attribution when inactive.
- `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -D warnings`; `cargo run -p xtask -- validate` (every gate incl. the **P-4 scan** + register/conformance; `CONFORMANCE.md` unchanged). `forbid(unsafe_code)` preserved.

## Closure

**References #836** — witnesses now attribute the segment promotion. Next (4c, the finale): compile a real teacher-grounded bundle with the lane, run the frozen causal benchmark on the packed path, and record the **PROMOTE / REVISE / RETIRE** verdict + `model/ids.toml` capability row → Gherkin → CONFORMANCE regen. A run contract precedes that hours-long run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
