### PR TITLE
compiler(#836): fit and emit the learned segment table (4c-ii)

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1163,6 +1163,16 @@ impl R4Engine {
         }
     }
 
+    /// The number of learned content→candidate rows the deployed segment lane
+    /// carries (#836 4c): `Some(n)` when the loaded PSTATE section packed a
+    /// residual table the engine consumes (`n >= 1`), `None` for a config-only
+    /// descriptor (the recurrence lane) or no PSTATE section at all. An
+    /// observability seam: it lets a caller confirm a compiled bundle's fitted
+    /// table reached the engine intact, without exposing the table itself.
+    pub fn segment_learned_rows(&self) -> Option<usize> {
+        self.segment_table.as_ref().map(Vec::len)
+    }
+
     /// Status-aware decision for one window, re-selecting the served token
     /// under the #835 segment lane (#836).
     ///

--- a/crates/uor-r4-api/tests/pstate_engine_836.rs
+++ b/crates/uor-r4-api/tests/pstate_engine_836.rs
@@ -11,9 +11,10 @@
 use std::collections::BTreeMap;
 
 use uor_r4_api::{EngineParts, PredictDecision, R4Engine};
-use uor_r4_core::transformerless::compiler::STAGES;
+use uor_r4_core::transformerless::compiler::{Corpus, STAGES};
 use uor_r4_core::transformerless::{convert_r4g1, runtime};
 use uor_r4_graph_certify::StepCandidates;
+use uor_r4_graph_compiler::segment_fit;
 use uor_r4_graph_format::{GraphView, ScoreQ, SectionId, SegmentLaneDescriptor, LANE_SEGMENT};
 use uor_r4_graph_runtime::runtime_state::{SegmentSession, SEGMENT_STATE_CAPACITY};
 
@@ -266,6 +267,214 @@ fn segment_lane_emission_is_deterministic_and_section_preserving() {
             vw.section(id),
             vo.section(id),
             "PSTATE emission must not change section {id:?}"
+        );
+    }
+}
+
+// --- learned table: fit → emit → load (increment 4c-ii) --------------------
+
+/// A small self-contained R4G1 bundle carrying the fitted learned segment
+/// `rows` in its PSTATE section (the 4c-ii path). Same synthetic store recipe
+/// as [`synthetic_bundle_opt`], but through
+/// [`convert_r4g1::convert_with_segment_table`]. Returns `(r4g1, teacher)`.
+fn synthetic_bundle_with_table(
+    descriptor: &SegmentLaneDescriptor,
+    rows: &[(u32, Vec<(u32, i32)>)],
+) -> (Vec<u8>, Vec<u8>) {
+    use uor_r4_core::transformerless::compiler;
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let art_bytes = std::fs::read(format!(
+        "{dir}/../uor-r4-core/tests/fixtures/tless_artifacts.bin"
+    ))
+    .expect("fixture artifacts present");
+    let artifacts = compiler::parse_artifacts(&art_bytes).expect("artifacts parse");
+
+    let mut store: runtime::Store = (0..=STAGES).map(|_| BTreeMap::new()).collect();
+    let codes: [[u8; 4]; 6] = [
+        [3, 1, 4, 1],
+        [3, 1, 4, 2],
+        [3, 5, 9, 2],
+        [7, 5, 9, 2],
+        [7, 5, 8, 2],
+        [11, 5, 8, 7],
+    ];
+    for (i, code) in codes.iter().enumerate() {
+        runtime::add_evidence(&mut store, code, (i + 1) as u32, 1);
+    }
+    let store_bytes = runtime::store_bytes(&store);
+    let r4g1 = convert_r4g1::convert_with_segment_table(
+        &art_bytes,
+        &artifacts,
+        &store,
+        &store_bytes,
+        None,
+        descriptor,
+        rows,
+    )
+    .expect("convert to R4G1 with segment table")
+    .0;
+    (r4g1, art_bytes)
+}
+
+/// A multi-story corpus in which content token 100 is, on every TRAIN
+/// position it is live for, associated with a teacher-argmax of candidate 9 —
+/// a clean content→candidate association the fitter must recover. Four TRAIN
+/// stories plus one held-out story satisfy the 80/20 story cut.
+fn content_corpus() -> Corpus {
+    let unit_input = [100u32, 500];
+    let unit_argmax = [9u32, 9];
+    let stories = 5usize;
+    let mut story = Vec::new();
+    let mut input = Vec::new();
+    let mut next = Vec::new();
+    let mut t_argmax = Vec::new();
+    for sid in 0..stories {
+        for (j, (&tok, &tg)) in unit_input.iter().zip(&unit_argmax).enumerate() {
+            story.push(sid as u32);
+            input.push(tok);
+            next.push(if j + 1 < unit_input.len() {
+                unit_input[j + 1]
+            } else {
+                0
+            });
+            t_argmax.push(tg);
+        }
+    }
+    let n = input.len();
+    Corpus {
+        n,
+        stories: stories as u64,
+        story,
+        input,
+        next,
+        t_argmax,
+        top_tokens: vec![[0u32; 8]; n],
+        top_weights: vec![[0u32; 8]; n],
+        span_start: (0..n).map(|i| i as u32).collect(),
+        span_end: (0..n).map(|i| i as u32 + 1).collect(),
+        byte_start: vec![u32::MAX; n],
+        byte_end: vec![u32::MAX; n],
+        hidden: None,
+    }
+}
+
+#[test]
+fn fitted_table_round_trips_through_convert_and_reaches_the_engine() {
+    // Fit a real learned table from a corpus, emit it into a compiled bundle,
+    // and prove (a) the emitted PSTATE rows are byte-faithful to the fitted
+    // table and (b) the deployed engine ingests exactly those rows.
+    let corpus = content_corpus();
+    let rows = segment_fit::fit_segment_table(&corpus, segment_fit::DEFAULT_TOP_K, 64);
+    assert!(
+        !rows.is_empty(),
+        "the fit must learn at least one content key"
+    );
+    assert!(
+        rows.iter()
+            .any(|(k, entries)| *k == 100 && entries.iter().any(|(c, w)| *c == 9 && *w > 0)),
+        "the fitted table must carry the 100→9 association with positive weight"
+    );
+
+    let descriptor = selected_descriptor();
+    let (graph, teacher) = synthetic_bundle_with_table(&descriptor, &rows);
+
+    // (a) The PSTATE section round-trips the fitted rows exactly.
+    let view = GraphView::parse(&graph).expect("compiled bundle parses");
+    let table = view
+        .pstate_table()
+        .expect("pstate section valid")
+        .expect("bundle carries a PSTATE section");
+    assert_eq!(table.lane_kind(), LANE_SEGMENT);
+    let emitted: Vec<(u32, Vec<(u32, i32)>)> = table
+        .rows()
+        .map(|row| {
+            (
+                row.key(),
+                row.entries().map(|e| (e.token, e.score_q.raw())).collect(),
+            )
+        })
+        .collect();
+    // Canonicalize the fitted rows the same way `build_segment_lane` does
+    // (keys ascending, candidates ascending) before comparing.
+    let mut expected = rows.clone();
+    expected.sort_by_key(|(k, _)| *k);
+    for (_, entries) in expected.iter_mut() {
+        entries.sort_by_key(|(t, _)| *t);
+    }
+    assert_eq!(
+        emitted, expected,
+        "emitted PSTATE rows must be byte-faithful to the fitted table"
+    );
+
+    // (b) The deployed engine ingests exactly those learned rows.
+    let engine = load_engine(&graph, &teacher);
+    assert!(
+        engine.segment_session().is_active(),
+        "a learned-table bundle activates the segment lane"
+    );
+    assert_eq!(
+        engine.segment_learned_rows(),
+        Some(expected.len()),
+        "the engine consumes the learned table (one row per fitted content key)"
+    );
+}
+
+#[test]
+fn config_only_and_no_lane_bundles_carry_no_learned_table() {
+    // A config-only descriptor (empty rows) is the recurrence lane: active, but
+    // no learned rows reach the engine. A no-PSTATE bundle carries neither.
+    let descriptor = selected_descriptor();
+    let (recurrence, teacher) = synthetic_bundle_with_table(&descriptor, &[]);
+    let engine = load_engine(&recurrence, &teacher);
+    assert!(
+        engine.segment_session().is_active(),
+        "a config-only descriptor still activates the lane"
+    );
+    assert_eq!(
+        engine.segment_learned_rows(),
+        None,
+        "an empty table leaves the engine on the recurrence lane (no learned rows)"
+    );
+
+    let (no_lane, teacher2) = synthetic_bundle();
+    let plain = load_engine(&no_lane, &teacher2);
+    assert_eq!(
+        plain.segment_learned_rows(),
+        None,
+        "a no-PSTATE bundle carries no learned table"
+    );
+}
+
+#[test]
+fn learned_table_emission_is_section_preserving_and_deterministic() {
+    // Emitting the learned table changes only the PSTATE section (absent-section
+    // identity at the source) and is deterministic.
+    let corpus = content_corpus();
+    let rows = segment_fit::fit_segment_table(&corpus, segment_fit::DEFAULT_TOP_K, 64);
+    let descriptor = selected_descriptor();
+
+    let (with_table, _) = synthetic_bundle_with_table(&descriptor, &rows);
+    let (with_table_again, _) = synthetic_bundle_with_table(&descriptor, &rows);
+    assert_eq!(
+        with_table, with_table_again,
+        "learned-table emission must be deterministic"
+    );
+
+    let (without_lane, _) = synthetic_bundle();
+    let vt = GraphView::parse(&with_table).expect("with-table parses");
+    let vo = GraphView::parse(&without_lane).expect("no-lane parses");
+    for id in [
+        SectionId::HEAD,
+        SectionId::NODE,
+        SectionId::EDGE,
+        SectionId::ROUT,
+        SectionId::EMIT,
+        SectionId::EXCT,
+    ] {
+        assert_eq!(
+            vt.section(id),
+            vo.section(id),
+            "learned-table emission must not change section {id:?}"
         );
     }
 }

--- a/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
+++ b/crates/uor-r4-core/src/transformerless/convert_r4g1.rs
@@ -214,7 +214,41 @@ pub fn convert_with_segment_lane(
         store,
         store_container,
         calibration,
-        Some(descriptor),
+        Some((descriptor, &[])),
+    )
+}
+
+/// One fitted residual row of the #836 learned segment table: a content key
+/// mapped to its `(candidate, raw ScoreQ)` entries. Produced by
+/// `uor_r4_graph_compiler::segment_fit::fit_segment_table` (the faithful
+/// compiler-side lowering of the #834 §6.2 Ψ segment arm).
+pub type SegmentTableRow = (u32, Vec<(u32, i32)>);
+
+/// Like [`convert_with_segment_lane`], but the emitted `PSTATE` section also
+/// carries the learned content→candidate residual `rows` (#836 4c-ii). The
+/// deployed engine consumes the table (its 4c-i lowering) instead of the pure
+/// recurrence lane. Passing empty `rows` is byte-identical to
+/// [`convert_with_segment_lane`] (a config-only descriptor). Every other
+/// section is unchanged, so a reader that ignores PSTATE still sees exactly the
+/// [`convert`] output (absent-section identity). The rows are canonicalized by
+/// [`build_segment_lane`] (keys and candidates sorted, duplicates rejected), so
+/// the produced bytes are deterministic and round-trip.
+pub fn convert_with_segment_table(
+    artifact_container: &[u8],
+    artifacts: &Compiled,
+    store: &Store,
+    store_container: &[u8],
+    calibration: Option<&HammingCalibrationReport>,
+    descriptor: &SegmentLaneDescriptor,
+    rows: &[SegmentTableRow],
+) -> Option<(Vec<u8>, ConversionReport)> {
+    convert_inner(
+        artifact_container,
+        artifacts,
+        store,
+        store_container,
+        calibration,
+        Some((descriptor, rows)),
     )
 }
 
@@ -224,7 +258,7 @@ fn convert_inner(
     store: &Store,
     store_container: &[u8],
     calibration: Option<&HammingCalibrationReport>,
-    segment_lane: Option<&SegmentLaneDescriptor>,
+    segment_lane: Option<(&SegmentLaneDescriptor, &[SegmentTableRow])>,
 ) -> Option<(Vec<u8>, ConversionReport)> {
     // Input shape honesty: the artifact must carry the 4 × 256 × 36-byte
     // class signature books the ROUT section is built from.
@@ -438,13 +472,14 @@ fn convert_inner(
     builder.add_section(SectionId::ROUT, 0, &rout);
     builder.add_section(SectionId::EMIT, 0, &emit);
     builder.add_section(SectionId::EXCT, 0, &exct);
-    // #836: optional segment-lane PSTATE section. The prompt-derived segment
-    // lane ships a config-only descriptor (empty residual table), so this adds
-    // the lane's capacity/decay/score constants without any learned table.
-    // Emitted only when a descriptor is supplied; otherwise the container is
-    // byte-identical to `convert` (absent-section identity).
-    if let Some(descriptor) = segment_lane {
-        let pstate = build_segment_lane(descriptor, &[]).ok()?;
+    // #836: optional segment-lane PSTATE section. A config-only descriptor
+    // (empty `rows`) adds the lane's capacity/decay/score constants without a
+    // learned table (recurrence lane); non-empty `rows` additionally pack the
+    // fitted content→candidate residual table (4c-ii), which the deployed
+    // engine consumes. Emitted only when a descriptor is supplied; otherwise
+    // the container is byte-identical to `convert` (absent-section identity).
+    if let Some((descriptor, rows)) = segment_lane {
+        let pstate = build_segment_lane(descriptor, rows).ok()?;
         builder.add_section(SectionId::PSTATE, 0, &pstate);
     }
     let bytes = builder.build().ok()?;

--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -28,6 +28,8 @@ pub mod reproducibility;
 pub mod residual;
 pub mod route_fit;
 pub mod routing;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod segment_fit;
 pub mod semantic_emission_decoupling;
 pub mod semantic_state;
 pub mod stage_dag;

--- a/crates/uor-r4-graph-compiler/src/segment_fit.rs
+++ b/crates/uor-r4-graph-compiler/src/segment_fit.rs
@@ -1,0 +1,255 @@
+//! #836 4c-ii — fit the learned content-token→teacher-argmax segment table
+//! from a recorded corpus. This is the compiler-side counterpart of the
+//! deployed segment lane (`uor-r4-api` engine, #836 4c-i): the same
+//! content→argmax co-occurrence tally as the #834 §6.2 Ψ segment reference
+//! arm, capped to top-`K` per key, but **quantized to the integer ScoreQ
+//! weights the P-4 serving path consumes**.
+//!
+//! Faithfulness of the lowering. The reference arm scored a candidate `c` by
+//! `content_rate(c) = Σ_{t live} (count_t(c) / total_t) / ncontent`, a float
+//! sum the normative hot path cannot compute (no divide, no float). Two of
+//! those operations are **argmax-invariant** and are therefore discharged here,
+//! at fit time, where floats are allowed:
+//!
+//!   * the per-key normalization `count_t(c) / total_t` becomes a fixed
+//!     per-`(t, c)` integer weight `round((count/total) · 2^RATE_SCALE_SHIFT)`;
+//!   * the per-prompt `/ ncontent` is a single positive scalar shared by every
+//!     candidate of a given prompt, so dropping it never changes which
+//!     candidate is the argmax.
+//!
+//! What remains at serve time is exactly `Σ_{t live} weight(t, c)` — a bounded
+//! saturating integer sum (`table_contribution` in the engine) — so the served
+//! argmax matches the reference arm's up to the fixed rescaling between the
+//! base scorer's ScoreQ units and the reference's suffix-rate floats. The
+//! per-prompt content weight λ of the reference is a global scalar folded into
+//! `RATE_SCALE_SHIFT` (it multiplies every content contribution equally).
+
+use std::collections::HashMap;
+
+use uor_r4_core::transformerless::compiler::Corpus;
+
+use crate::induction;
+
+/// Default per-key cap on retained teacher-argmax candidates (top-`K`),
+/// matching the #834 §6.2 reference arm's `CAP = 64`.
+pub const DEFAULT_TOP_K: usize = 64;
+
+/// Fixed-point scale applied to the normalized co-occurrence rate
+/// `count(key→cand) / total(key) ∈ [0, 1]` to produce the integer ScoreQ
+/// weight the serving lane sums. A rate of `1.0` (a content token whose
+/// teacher-argmax is always the same candidate) maps to `1 << RATE_SCALE_SHIFT`
+/// — deliberately the same magnitude as the recurrence lane's `boost`
+/// (`1 << 20` in the selected descriptor), so a fully-predictive content token
+/// carries one boost worth of evidence.
+pub const RATE_SCALE_SHIFT: u32 = 20;
+
+/// Fit the learned segment table from `corpus` over its TRAIN positions
+/// (the `induction::split_positions` 80/20 story cut — held-out positions are
+/// never fitted, exactly as the reference arm builds its tables from TRAIN
+/// only).
+///
+/// Returns rows `(content_key, [(candidate, weight_raw_scoreq)])`:
+///   * at most `max_keys` content keys, retained by descending total evidence
+///     (ties broken by the smaller token id) so a bounded table keeps the
+///     highest-signal content tokens;
+///   * each key capped to its top-`top_k` teacher-argmax candidates by count
+///     (ties broken by the smaller candidate id), matching the reference cap;
+///   * every retained weight is `round((count / total) · 2^RATE_SCALE_SHIFT)`
+///     computed in pure integer arithmetic and clamped to `[1, i32::MAX]`, so
+///     no retained `(key, candidate)` pair is silently dropped to a zero
+///     contribution.
+///
+/// The rows are canonicalized (keys and candidates sorted, duplicates
+/// rejected) by [`uor_r4_graph_format::build_segment_lane`] when emitted, so
+/// the caller need not pre-sort. Deterministic: the same corpus and bounds
+/// produce byte-identical rows.
+pub fn fit_segment_table(
+    corpus: &Corpus,
+    top_k: usize,
+    max_keys: usize,
+) -> Vec<(u32, Vec<(u32, i32)>)> {
+    if top_k == 0 || max_keys == 0 {
+        return Vec::new();
+    }
+    let (train, _held_out) = induction::split_positions(corpus);
+
+    // content token -> (teacher-argmax candidate -> co-occurrence count).
+    // One bump per *distinct* content token in the whole-prompt window, exactly
+    // the reference arm's `seen.sort/dedup` step.
+    let mut content_next: HashMap<u32, HashMap<u32, u32>> = HashMap::new();
+    for &i in &train {
+        let target = corpus.t_argmax[i];
+        let mut seen = induction::context_window(corpus, i);
+        seen.sort_unstable();
+        seen.dedup();
+        for t in seen {
+            *content_next
+                .entry(t)
+                .or_default()
+                .entry(target)
+                .or_insert(0) += 1;
+        }
+    }
+
+    // Retain the highest-evidence content keys (bounded table).
+    let mut keyed: Vec<(u32, HashMap<u32, u32>)> = content_next.into_iter().collect();
+    keyed.sort_unstable_by(|a, b| {
+        let ta: u64 = a.1.values().map(|&c| u64::from(c)).sum();
+        let tb: u64 = b.1.values().map(|&c| u64::from(c)).sum();
+        tb.cmp(&ta).then(a.0.cmp(&b.0))
+    });
+    keyed.truncate(max_keys);
+
+    let mut rows: Vec<(u32, Vec<(u32, i32)>)> = Vec::with_capacity(keyed.len());
+    for (key, counts) in keyed {
+        let total: u64 = counts.values().map(|&c| u64::from(c)).sum();
+        if total == 0 {
+            continue;
+        }
+        // top-K candidates by count, canonical tie-break (count desc, id asc).
+        let mut cand: Vec<(u32, u32)> = counts.into_iter().collect();
+        cand.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        cand.truncate(top_k);
+
+        let mut entries: Vec<(u32, i32)> = Vec::with_capacity(cand.len());
+        for (candidate, count) in cand {
+            entries.push((candidate, quantize_rate(u64::from(count), total)));
+        }
+        if !entries.is_empty() {
+            rows.push((key, entries));
+        }
+    }
+    rows
+}
+
+/// Quantize a normalized rate `count / total ∈ [0, 1]` to an integer ScoreQ
+/// weight `round((count / total) · 2^RATE_SCALE_SHIFT)`, in pure integer
+/// arithmetic (round-half-up via `+ total/2`), clamped to `[1, i32::MAX]`.
+///
+/// The clamp floor of `1` keeps every retained pair a non-zero contribution:
+/// a pair that survived the top-`K` cut carries evidence, and rounding it to a
+/// zero weight would silently drop it from the served sum. `count <= total`, so
+/// the pre-clamp value never exceeds `2^RATE_SCALE_SHIFT` and cannot overflow.
+fn quantize_rate(count: u64, total: u64) -> i32 {
+    debug_assert!(count <= total && total > 0);
+    let numer = count << RATE_SCALE_SHIFT;
+    let scaled = (numer + total / 2) / total;
+    scaled.clamp(1, i32::MAX as u64) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a multi-story `Corpus` from per-story `(input, t_argmax)` token
+    /// runs, laid out contiguously with matching `story` ids so
+    /// `split_positions` and `context_window` see real story boundaries.
+    fn corpus_from_stories(stories: &[(Vec<u32>, Vec<u32>)]) -> Corpus {
+        let mut story = Vec::new();
+        let mut input = Vec::new();
+        let mut next = Vec::new();
+        let mut t_argmax = Vec::new();
+        for (sid, (toks, targ)) in stories.iter().enumerate() {
+            assert_eq!(toks.len(), targ.len(), "input/argmax length match");
+            for (j, (&tok, &tg)) in toks.iter().zip(targ).enumerate() {
+                story.push(sid as u32);
+                input.push(tok);
+                next.push(if j + 1 < toks.len() { toks[j + 1] } else { 0 });
+                t_argmax.push(tg);
+            }
+        }
+        let n = input.len();
+        Corpus {
+            n,
+            stories: stories.len() as u64,
+            story,
+            input,
+            next,
+            t_argmax,
+            top_tokens: vec![[0u32; 8]; n],
+            top_weights: vec![[0u32; 8]; n],
+            span_start: (0..n).map(|i| i as u32).collect(),
+            span_end: (0..n).map(|i| i as u32 + 1).collect(),
+            byte_start: vec![u32::MAX; n],
+            byte_end: vec![u32::MAX; n],
+            hidden: None,
+        }
+    }
+
+    #[test]
+    fn quantize_maps_a_certain_rate_to_one_boost() {
+        // A content token whose teacher-argmax is always the same candidate
+        // (rate 1.0) earns exactly `1 << RATE_SCALE_SHIFT` — one boost.
+        assert_eq!(quantize_rate(7, 7), 1 << RATE_SCALE_SHIFT);
+        // Half the mass → half a boost (round-half-up).
+        assert_eq!(quantize_rate(1, 2), 1 << (RATE_SCALE_SHIFT - 1));
+        // A rare pair never rounds to a silent zero — the floor keeps it at 1.
+        assert_eq!(quantize_rate(1, 5_000_000), 1);
+    }
+
+    #[test]
+    fn fit_learns_the_dominant_content_to_argmax_association() {
+        // Four TRAIN stories where every position that content token 100 is
+        // live for has teacher-argmax 9 (the whole-prompt window carries 100
+        // into both positions), plus one held-out story. The fitted row for key
+        // 100 must rank candidate 9 first with the top weight.
+        let train_story = (vec![100u32, 500], vec![9u32, 9]);
+        let stories = vec![
+            train_story.clone(),
+            train_story.clone(),
+            train_story.clone(),
+            train_story.clone(),
+            (vec![100u32, 500], vec![9u32, 9]), // held-out (story 4, >= cut)
+        ];
+        let corpus = corpus_from_stories(&stories);
+
+        let rows = fit_segment_table(&corpus, DEFAULT_TOP_K, 64);
+        let row = rows
+            .iter()
+            .find(|(k, _)| *k == 100)
+            .expect("content key 100 is fitted");
+        // Candidate 9 is present and carries a positive weight.
+        let w9 = row
+            .1
+            .iter()
+            .find(|(c, _)| *c == 9)
+            .map(|(_, w)| *w)
+            .expect("candidate 9 present for key 100");
+        assert!(w9 > 0, "the learned association carries positive weight");
+        // 9 is the top-weighted candidate for key 100.
+        let top = row
+            .1
+            .iter()
+            .max_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)))
+            .map(|(c, _)| *c)
+            .expect("non-empty row");
+        assert_eq!(top, 9, "candidate 9 dominates key 100's fitted row");
+    }
+
+    #[test]
+    fn fit_respects_the_key_and_candidate_bounds() {
+        // Two content tokens with different evidence mass; max_keys=1 keeps only
+        // the higher-evidence key.
+        let stories = vec![
+            (vec![1u32, 2, 3], vec![7u32, 7, 0]),
+            (vec![1u32, 2, 3], vec![7u32, 7, 0]),
+            (vec![1u32, 2, 3], vec![7u32, 7, 0]),
+            (vec![4u32, 5], vec![8u32, 0]),
+            (vec![9u32, 9], vec![1u32, 0]), // held-out
+        ];
+        let corpus = corpus_from_stories(&stories);
+
+        let one = fit_segment_table(&corpus, DEFAULT_TOP_K, 1);
+        assert_eq!(one.len(), 1, "max_keys=1 retains exactly one key");
+
+        // top_k=1 keeps a single candidate per key.
+        let capped = fit_segment_table(&corpus, 1, 64);
+        for (_, entries) in &capped {
+            assert_eq!(entries.len(), 1, "top_k=1 keeps one candidate per key");
+        }
+
+        // Degenerate bounds yield an empty table (nothing to fit).
+        assert!(fit_segment_table(&corpus, 0, 64).is_empty());
+        assert!(fit_segment_table(&corpus, 64, 0).is_empty());
+    }
+}


### PR DESCRIPTION
## #836 4c-ii — fit and emit the learned segment table

Item C of #822, continuing the #836 lowering. 4c-i wired the deployed
`R4Engine` to **consume** a learned content→candidate residual table when a
PSTATE section carries one. This increment **produces** that table, closing the
fit → emit → load → consume chain end-to-end.

### What lands

- **`uor_r4_graph_compiler::segment_fit::fit_segment_table`** — the
  compiler-side lowering of the #834 §6.2 Ψ segment arm. It runs the *same*
  content→teacher-argmax co-occurrence tally over the whole-prompt window
  (`induction::context_window`) restricted to TRAIN positions, caps to top-`K`
  per key, then **quantizes to the integer ScoreQ weights the P-4 serving path
  sums**. Two float operations of the reference arm are argmax-invariant and are
  discharged here at fit time (where floats are allowed):
  - per-key normalization `count/total` → a fixed per-`(key,candidate)` weight
    `round((count/total)·2²⁰)` in pure integer arithmetic;
  - the per-prompt `/ncontent` is a single positive scalar shared by every
    candidate of a prompt, so dropping it never changes the argmax.

  A fully-predictive content token earns exactly one `boost` worth of weight
  (`1<<20`, matching the recurrence lane's boost magnitude).

- **`convert_r4g1::convert_with_segment_table`** — emits the fitted rows into
  the PSTATE section. Empty rows are byte-identical to
  `convert_with_segment_lane` (config-only descriptor → recurrence lane); every
  other section is unchanged (absent-section identity). `convert_inner` now
  threads `(descriptor, rows)`.

- **`R4Engine::segment_learned_rows`** — observability seam reporting how many
  learned rows the loaded lane carries (`None` on the recurrence lane or no
  PSTATE), so a caller can confirm a compiled bundle's table reached the engine
  without exposing the table itself.

### Verification

- `segment_fit` unit tests: the fit recovers the dominant content→argmax
  association and respects the key/candidate bounds; quantization maps a certain
  rate to one boost and never rounds a retained pair to a silent zero.
- `pstate_engine_836` integration tests: the fitted table round-trips through
  `convert_with_segment_table` byte-faithfully and the engine ingests exactly
  those rows; a config-only / no-PSTATE bundle carries no learned table;
  emission is section-preserving and deterministic.
- The engine's re-rank arithmetic over the learned table is already pinned by
  the inline `table_*` unit tests (4c-i).

### Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo run -p xtask -- validate` (check-model, audit-limits/deferral,
gnaf firewall/root/scan/conformance all green), and the
`uor-r4-{api,core,graph-format,graph-runtime}` suites (482 passed, 0 failed).

The lane stays **dormant** — no serving row in `model/ids.toml`, CONFORMANCE
unchanged. The causal-utility verdict is recorded separately in 4c-iii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNGVP646hV5uuCZGMKfxTk
