### PR TITLE
spec(#838): typed selective prediction and the answerability benchmark constitution (S2 item A)

### DIFF
--- a/crates/uor-r4-api/tests/selective_prediction_spec_838.rs
+++ b/crates/uor-r4-api/tests/selective_prediction_spec_838.rs
@@ -1,0 +1,1594 @@
+//! Executable reference model and machine-checked evidence for the typed
+//! selective-prediction contract and answerability benchmark constitution
+//! (#838, item A of S2 tracker #823).
+//!
+//! Companion document: `docs/selective_prediction_spec_838.md`. This is a
+//! **reference-only / off-serving-path** model in the #830 sense: an owned,
+//! integer realization of the specified status space, decision table, surface
+//! encodings, fail-closed calibration semantics, benchmark categories,
+//! baseline confusion signatures, and power/operating-point constitution. It
+//! deploys no predictor and fits no threshold (that is #837), and it changes
+//! no serving surface (that is #839). It binds the frozen S2 evaluation
+//! vocabulary of #832 (`s2-answerability-ood`): `ControlKind`, the
+//! integer-fraction `MetricStatus`, the degeneracy check, the CID helpers, and
+//! the leakage check all come from `uor_r4_api::capability_suite`.
+//!
+//! The completion this file evidences explicitly records: **current semantic
+//! abstention is NOT ESTABLISHED** — the deployed D4 policy is a coverage
+//! policy, and a coverage-only report cannot render a semantic verdict
+//! (`coverage_result_cannot_render_semantic_pass`).
+
+use std::collections::BTreeMap;
+
+use uor_r4_api::capability_suite::{
+    compute_cid, detect_document_leakage, is_degenerate_control, verify_cid, ControlKind,
+    MetricStatus,
+};
+
+// --- §2: the typed status space ---------------------------------------------
+
+/// The eight selective-prediction statuses (spec §2). Each is a separate
+/// typed concept with exactly one meaning and one canonical label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum SelectiveStatus {
+    Covered,
+    DistributionallyNovel,
+    InsufficientEvidence,
+    ConflictingEvidence,
+    SupportedAnswer,
+    LowConfidence,
+    Abstention,
+    HardIncompatibility,
+}
+
+impl SelectiveStatus {
+    const ALL: [SelectiveStatus; 8] = [
+        SelectiveStatus::Covered,
+        SelectiveStatus::DistributionallyNovel,
+        SelectiveStatus::InsufficientEvidence,
+        SelectiveStatus::ConflictingEvidence,
+        SelectiveStatus::SupportedAnswer,
+        SelectiveStatus::LowConfidence,
+        SelectiveStatus::Abstention,
+        SelectiveStatus::HardIncompatibility,
+    ];
+
+    /// Canonical kebab-case wire label (spec §2), used verbatim on every
+    /// surface except OpenAI-compatible `error.code`, which applies the
+    /// deterministic rewrite `-` → `_` (spec §5).
+    fn label(self) -> &'static str {
+        match self {
+            SelectiveStatus::Covered => "covered",
+            SelectiveStatus::DistributionallyNovel => "distributionally-novel",
+            SelectiveStatus::InsufficientEvidence => "insufficient-evidence",
+            SelectiveStatus::ConflictingEvidence => "conflicting-evidence",
+            SelectiveStatus::SupportedAnswer => "supported-answer",
+            SelectiveStatus::LowConfidence => "low-confidence",
+            SelectiveStatus::Abstention => "abstention",
+            SelectiveStatus::HardIncompatibility => "hard-incompatibility",
+        }
+    }
+
+    fn parse(label: &str) -> Option<SelectiveStatus> {
+        SelectiveStatus::ALL
+            .into_iter()
+            .find(|s| s.label() == label)
+    }
+}
+
+/// Coverage axis (spec §2): the structural D4 reading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Coverage {
+    Covered,
+    DistributionallyNovel,
+}
+
+impl Coverage {
+    fn status(self) -> SelectiveStatus {
+        match self {
+            Coverage::Covered => SelectiveStatus::Covered,
+            Coverage::DistributionallyNovel => SelectiveStatus::DistributionallyNovel,
+        }
+    }
+}
+
+/// Evidence axis (spec §2): the evidential reading (#837 fits its deployed
+/// classifier; here it is a reference input).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Evidence {
+    Supported,
+    Insufficient,
+    Conflicting,
+}
+
+/// Compatibility gate (spec §2): fail-closed, evaluated first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Compat {
+    Compatible,
+    HardIncompatibility,
+}
+
+/// Calibration-data state (spec §6): absent is legacy mode; corrupt is a
+/// hard incompatibility and never silently degrades to legacy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Calibration {
+    Absent,
+    Valid,
+    Corrupt,
+}
+
+/// Served outcome (spec §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    SupportedAnswer,
+    Abstention,
+    HardIncompatibility,
+}
+
+impl Outcome {
+    fn status(self) -> SelectiveStatus {
+        match self {
+            Outcome::SupportedAnswer => SelectiveStatus::SupportedAnswer,
+            Outcome::Abstention => SelectiveStatus::Abstention,
+            Outcome::HardIncompatibility => SelectiveStatus::HardIncompatibility,
+        }
+    }
+}
+
+/// Typed abstention cause (spec §2 precedence order; `DistributionallyNovel`
+/// is legal only in legacy mode, spec §6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Cause {
+    ConflictingEvidence,
+    InsufficientEvidence,
+    LowConfidence,
+    DistributionallyNovel,
+}
+
+impl Cause {
+    fn status(self) -> SelectiveStatus {
+        match self {
+            Cause::ConflictingEvidence => SelectiveStatus::ConflictingEvidence,
+            Cause::InsufficientEvidence => SelectiveStatus::InsufficientEvidence,
+            Cause::LowConfidence => SelectiveStatus::LowConfidence,
+            Cause::DistributionallyNovel => SelectiveStatus::DistributionallyNovel,
+        }
+    }
+}
+
+// --- §4: evidence block and typed response -----------------------------------
+
+/// Bounded evidence counts carried by a served answer (spec §4). Integer-only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EvidenceBlock {
+    supporting: u32,
+    conflicting: u32,
+}
+
+/// The typed production response (spec §4): outcome plus the reported axes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Response {
+    outcome: Outcome,
+    coverage: Coverage,
+    cause: Option<Cause>,
+    confidence_permille: Option<u32>,
+    evidence: Option<EvidenceBlock>,
+}
+
+/// The witness record carries the same typed fields as the response
+/// (spec §4, `witness_carries_the_same_typed_fields`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Witness {
+    outcome: Outcome,
+    coverage: Coverage,
+    cause: Option<Cause>,
+    confidence_permille: Option<u32>,
+    evidence: Option<EvidenceBlock>,
+}
+
+fn witness_of(r: &Response) -> Witness {
+    Witness {
+        outcome: r.outcome,
+        coverage: r.coverage,
+        cause: r.cause,
+        confidence_permille: r.confidence_permille,
+        evidence: r.evidence,
+    }
+}
+
+/// Deterministic reference evidence block for an evidence-axis value.
+fn evidence_block(e: Evidence) -> EvidenceBlock {
+    match e {
+        Evidence::Supported => EvidenceBlock {
+            supporting: 3,
+            conflicting: 0,
+        },
+        Evidence::Insufficient => EvidenceBlock {
+            supporting: 0,
+            conflicting: 0,
+        },
+        Evidence::Conflicting => EvidenceBlock {
+            supporting: 2,
+            conflicting: 2,
+        },
+    }
+}
+
+// --- §2/§6: the total deterministic decision table ---------------------------
+
+/// The spec §2 outcome function, total over its input space. `evidence` and
+/// `q` are consulted only when `calibration` is `Valid`; a corrupt
+/// calibration or an incompatible request fails closed (spec §6).
+fn decide(
+    calibration: Calibration,
+    compat: Compat,
+    coverage: Coverage,
+    evidence: Evidence,
+    q: u32,
+    theta: u32,
+) -> Response {
+    if compat == Compat::HardIncompatibility || calibration == Calibration::Corrupt {
+        return Response {
+            outcome: Outcome::HardIncompatibility,
+            coverage,
+            cause: None,
+            confidence_permille: None,
+            evidence: None,
+        };
+    }
+    match calibration {
+        Calibration::Absent => match coverage {
+            // Legacy-coverage mode (spec §6): today's D4 policy through the
+            // typed schema; no confidence, no evidence axis, ever.
+            Coverage::Covered => Response {
+                outcome: Outcome::SupportedAnswer,
+                coverage,
+                cause: None,
+                confidence_permille: None,
+                evidence: None,
+            },
+            Coverage::DistributionallyNovel => Response {
+                outcome: Outcome::Abstention,
+                coverage,
+                cause: Some(Cause::DistributionallyNovel),
+                confidence_permille: None,
+                evidence: None,
+            },
+        },
+        Calibration::Corrupt => unreachable!("handled above"),
+        Calibration::Valid => match evidence {
+            Evidence::Conflicting => Response {
+                outcome: Outcome::Abstention,
+                coverage,
+                cause: Some(Cause::ConflictingEvidence),
+                confidence_permille: Some(q),
+                evidence: Some(evidence_block(evidence)),
+            },
+            Evidence::Insufficient => Response {
+                outcome: Outcome::Abstention,
+                coverage,
+                cause: Some(Cause::InsufficientEvidence),
+                confidence_permille: Some(q),
+                evidence: Some(evidence_block(evidence)),
+            },
+            Evidence::Supported => {
+                if q < theta {
+                    Response {
+                        outcome: Outcome::Abstention,
+                        coverage,
+                        cause: Some(Cause::LowConfidence),
+                        confidence_permille: Some(q),
+                        evidence: Some(evidence_block(evidence)),
+                    }
+                } else {
+                    Response {
+                        outcome: Outcome::SupportedAnswer,
+                        coverage,
+                        cause: None,
+                        confidence_permille: Some(q),
+                        evidence: Some(evidence_block(evidence)),
+                    }
+                }
+            }
+        },
+    }
+}
+
+// --- §5: deterministic surface encoders --------------------------------------
+
+fn opt_label(c: Option<Cause>) -> &'static str {
+    c.map_or("-", |c| c.status().label())
+}
+
+fn opt_permille(q: Option<u32>) -> String {
+    q.map_or_else(|| "-".to_owned(), |v| v.to_string())
+}
+
+fn json_opt_permille(q: Option<u32>) -> String {
+    q.map_or_else(|| "null".to_owned(), |v| v.to_string())
+}
+
+/// CLI surface (spec §5): typed record extending the #811 `ChatAbstention`
+/// shape. An abstention is a successful, honest outcome (exit 0); a hard
+/// incompatibility is a typed error (exit 2).
+fn encode_cli(r: &Response) -> String {
+    let exit = match r.outcome {
+        Outcome::SupportedAnswer | Outcome::Abstention => 0,
+        Outcome::HardIncompatibility => 2,
+    };
+    format!(
+        "exit={exit} status={} coverage={} cause={} confidence={}",
+        r.outcome.status().label(),
+        r.coverage.status().label(),
+        opt_label(r.cause),
+        opt_permille(r.confidence_permille),
+    )
+}
+
+/// Native HTTP surface (spec §5): status code + deterministic JSON with a
+/// fixed field order.
+fn encode_http(r: &Response) -> (u16, String) {
+    let code = match r.outcome {
+        Outcome::SupportedAnswer | Outcome::Abstention => 200,
+        Outcome::HardIncompatibility => 409,
+    };
+    let evidence = r.evidence.map_or_else(
+        || "null".to_owned(),
+        |e| {
+            format!(
+                "{{\"supporting\":{},\"conflicting\":{}}}",
+                e.supporting, e.conflicting
+            )
+        },
+    );
+    let cause = r.cause.map_or_else(
+        || "null".to_owned(),
+        |c| format!("{:?}", c.status().label()),
+    );
+    let confidence = r
+        .confidence_permille
+        .map_or_else(|| "null".to_owned(), |v| v.to_string());
+    let body = format!(
+        "{{\"status\":{:?},\"coverage\":{:?},\"cause\":{cause},\"confidence_permille\":{confidence},\"evidence\":{evidence}}}",
+        r.outcome.status().label(),
+        r.coverage.status().label(),
+    );
+    (code, body)
+}
+
+/// The deterministic `-` → `_` rewrite for OpenAI-compatible `error.code`
+/// values (spec §5).
+fn snake(label: &str) -> String {
+    label.replace('-', "_")
+}
+
+/// OpenAI-compatible non-streaming surface (spec §5). An abstention is a
+/// structured error body with a typed code — never an empty-`choices`
+/// success, never a generic server error.
+fn encode_openai_nonstream(r: &Response) -> (u16, String) {
+    match r.outcome {
+        Outcome::SupportedAnswer => (
+            200,
+            format!(
+                "{{\"choices\":[{{\"message\":\"<answer>\"}}],\"uor\":{{\"status\":{:?},\"coverage\":{:?},\"confidence_permille\":{}}}}}",
+                r.outcome.status().label(),
+                r.coverage.status().label(),
+                json_opt_permille(r.confidence_permille),
+            ),
+        ),
+        Outcome::Abstention => {
+            let cause = r.cause.expect("abstention carries a typed cause");
+            (
+                422,
+                format!(
+                    "{{\"error\":{{\"type\":\"uor_selective_prediction\",\"code\":\"uor_abstention_{}\",\"coverage\":{:?}}}}}",
+                    snake(cause.status().label()),
+                    r.coverage.status().label(),
+                ),
+            )
+        }
+        Outcome::HardIncompatibility => (
+            409,
+            "{\"error\":{\"type\":\"uor_selective_prediction\",\"code\":\"uor_incompatible_artifact\"}}"
+                .to_owned(),
+        ),
+    }
+}
+
+/// OpenAI-compatible streaming surface (spec §5): the ordered event list. An
+/// abstention emits **no** content chunk — one terminal typed error event,
+/// then `[DONE]`; never a silent stream end.
+fn encode_openai_stream(r: &Response) -> Vec<String> {
+    match r.outcome {
+        Outcome::SupportedAnswer => vec![
+            format!(
+                "data: {{\"choices\":[{{\"delta\":\"<answer>\"}}],\"uor\":{{\"coverage\":{:?},\"confidence_permille\":{}}}}}",
+                r.coverage.status().label(),
+                json_opt_permille(r.confidence_permille),
+            ),
+            "data: [DONE]".to_owned(),
+        ],
+        Outcome::Abstention => {
+            let cause = r.cause.expect("abstention carries a typed cause");
+            vec![
+                format!(
+                    "event: error\ndata: {{\"code\":\"uor_abstention_{}\"}}",
+                    snake(cause.status().label())
+                ),
+                "data: [DONE]".to_owned(),
+            ]
+        }
+        Outcome::HardIncompatibility => vec![
+            "event: error\ndata: {\"code\":\"uor_incompatible_artifact\"}".to_owned(),
+            "data: [DONE]".to_owned(),
+        ],
+    }
+}
+
+/// WASM host boundary (spec §5): a typed tagged value with the canonical
+/// labels — a hard incompatibility is a typed `Err`, never a trap.
+fn encode_wasm(r: &Response) -> (u8, String) {
+    match r.outcome {
+        Outcome::SupportedAnswer => (
+            0,
+            format!(
+                "served:{}:{}",
+                r.coverage.status().label(),
+                opt_permille(r.confidence_permille)
+            ),
+        ),
+        Outcome::Abstention => {
+            let cause = r.cause.expect("abstention carries a typed cause");
+            (
+                1,
+                format!(
+                    "abstained:{}:{}",
+                    cause.status().label(),
+                    r.coverage.status().label()
+                ),
+            )
+        }
+        Outcome::HardIncompatibility => (2, "incompatible".to_owned()),
+    }
+}
+
+/// Decode the outcome + cause back out of the CLI encoding (round-trip half).
+fn decode_cli(s: &str) -> (SelectiveStatus, Option<SelectiveStatus>) {
+    let mut status = None;
+    let mut cause = None;
+    for part in s.split(' ') {
+        if let Some(v) = part.strip_prefix("status=") {
+            status = SelectiveStatus::parse(v);
+        }
+        if let Some(v) = part.strip_prefix("cause=") {
+            cause = SelectiveStatus::parse(v);
+        }
+    }
+    (status.expect("cli status"), cause)
+}
+
+// --- §6: calibration-data state from bytes -----------------------------------
+
+/// Classify calibration data (spec §6): absent → legacy; CID-mismatched
+/// (tampered/truncated) → corrupt, which fails closed.
+fn classify_calibration(data: Option<(&str, &[u8])>) -> Calibration {
+    match data {
+        None => Calibration::Absent,
+        Some((expected_cid, bytes)) => {
+            if verify_cid(expected_cid, bytes).is_some() {
+                Calibration::Corrupt
+            } else {
+                Calibration::Valid
+            }
+        }
+    }
+}
+
+// --- §7: benchmark categories and items --------------------------------------
+
+/// The eight benchmark categories (spec §7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Category {
+    InDomainAnswerable,
+    ParaphrasedAnswerable,
+    NovelButSupported,
+    MissingEvidence,
+    PrivateInformation,
+    FalsePremise,
+    ContradictoryEvidence,
+    UnrelatedOod,
+}
+
+impl Category {
+    const ALL: [Category; 8] = [
+        Category::InDomainAnswerable,
+        Category::ParaphrasedAnswerable,
+        Category::NovelButSupported,
+        Category::MissingEvidence,
+        Category::PrivateInformation,
+        Category::FalsePremise,
+        Category::ContradictoryEvidence,
+        Category::UnrelatedOod,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Category::InDomainAnswerable => "in-domain-answerable",
+            Category::ParaphrasedAnswerable => "paraphrased-answerable",
+            Category::NovelButSupported => "novel-but-supported",
+            Category::MissingEvidence => "missing-evidence",
+            Category::PrivateInformation => "private-information",
+            Category::FalsePremise => "false-premise",
+            Category::ContradictoryEvidence => "contradictory-evidence",
+            Category::UnrelatedOod => "unrelated-ood",
+        }
+    }
+
+    fn answerable(self) -> bool {
+        matches!(
+            self,
+            Category::InDomainAnswerable
+                | Category::ParaphrasedAnswerable
+                | Category::NovelButSupported
+        )
+    }
+
+    /// Gold outcome and the set of acceptable typed causes (spec §7). The
+    /// legacy cause is permitted only for `unrelated-ood`.
+    fn gold(self) -> (Outcome, &'static [Cause]) {
+        match self {
+            Category::InDomainAnswerable
+            | Category::ParaphrasedAnswerable
+            | Category::NovelButSupported => (Outcome::SupportedAnswer, &[]),
+            Category::MissingEvidence | Category::PrivateInformation | Category::FalsePremise => {
+                (Outcome::Abstention, &[Cause::InsufficientEvidence])
+            }
+            Category::ContradictoryEvidence => (Outcome::Abstention, &[Cause::ConflictingEvidence]),
+            Category::UnrelatedOod => (
+                Outcome::Abstention,
+                &[Cause::InsufficientEvidence, Cause::DistributionallyNovel],
+            ),
+        }
+    }
+
+    /// The deterministic reference feature vector a working system would
+    /// read for this category (spec §7/§8): coverage, evidence, calibrated
+    /// confidence (‰), Hamming distance to the nearest calibrated region,
+    /// support count, conflict count, and whether a served answer would be
+    /// correct.
+    fn features(self) -> ItemFeatures {
+        match self {
+            Category::InDomainAnswerable => {
+                ItemFeatures::new(Coverage::Covered, Evidence::Supported, 800, 10, 4, 0, true)
+            }
+            // Paraphrase keeps the item covered and supported but pushes the
+            // surface Hamming distance past the distance-only threshold —
+            // the paraphrase-brittleness signature of that baseline (§8).
+            Category::ParaphrasedAnswerable => {
+                ItemFeatures::new(Coverage::Covered, Evidence::Supported, 750, 55, 3, 0, true)
+            }
+            Category::NovelButSupported => ItemFeatures::new(
+                Coverage::DistributionallyNovel,
+                Evidence::Supported,
+                700,
+                80,
+                3,
+                0,
+                true,
+            ),
+            Category::MissingEvidence => ItemFeatures::new(
+                Coverage::Covered,
+                Evidence::Insufficient,
+                200,
+                15,
+                0,
+                0,
+                false,
+            ),
+            Category::PrivateInformation => ItemFeatures::new(
+                Coverage::Covered,
+                Evidence::Insufficient,
+                150,
+                25,
+                0,
+                0,
+                false,
+            ),
+            Category::FalsePremise => ItemFeatures::new(
+                Coverage::Covered,
+                Evidence::Insufficient,
+                250,
+                12,
+                0,
+                0,
+                false,
+            ),
+            Category::ContradictoryEvidence => ItemFeatures::new(
+                Coverage::Covered,
+                Evidence::Conflicting,
+                300,
+                18,
+                3,
+                3,
+                false,
+            ),
+            Category::UnrelatedOod => ItemFeatures::new(
+                Coverage::DistributionallyNovel,
+                Evidence::Insufficient,
+                100,
+                90,
+                0,
+                0,
+                false,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ItemFeatures {
+    coverage: Coverage,
+    evidence: Evidence,
+    confidence_permille: u32,
+    hamming_distance: u32,
+    support_count: u32,
+    conflict_count: u32,
+    correct_if_served: bool,
+}
+
+impl ItemFeatures {
+    fn new(
+        coverage: Coverage,
+        evidence: Evidence,
+        confidence_permille: u32,
+        hamming_distance: u32,
+        support_count: u32,
+        conflict_count: u32,
+        correct_if_served: bool,
+    ) -> Self {
+        Self {
+            coverage,
+            evidence,
+            confidence_permille,
+            hamming_distance,
+            support_count,
+            conflict_count,
+            correct_if_served,
+        }
+    }
+}
+
+/// A benchmark item with its gold annotation and the four disjointness keys
+/// (spec §7).
+#[derive(Debug, Clone)]
+struct Item {
+    id: String,
+    category: Category,
+    document: String,
+    domain: String,
+    entity: String,
+    template: String,
+}
+
+fn make_item(category: Category, idx: usize, partition: &str) -> Item {
+    let c = category.label();
+    Item {
+        id: format!("{partition}-{c}-{idx}"),
+        category,
+        document: format!("doc-{partition}-{c}-{idx}"),
+        domain: format!("domain-{partition}-{}", idx % 2),
+        entity: format!("entity-{partition}-{c}-{idx}"),
+        template: format!("template-{partition}-{c}"),
+    }
+}
+
+// --- §8: baseline policies and confusion signatures --------------------------
+
+/// The six frozen baselines (spec §8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum BaselinePolicy {
+    AlwaysServe,
+    AlwaysDecline,
+    CurrentD4,
+    DistanceOnly,
+    EvidenceCountOnly,
+    TrivialPrior,
+}
+
+impl BaselinePolicy {
+    const ALL: [BaselinePolicy; 6] = [
+        BaselinePolicy::AlwaysServe,
+        BaselinePolicy::AlwaysDecline,
+        BaselinePolicy::CurrentD4,
+        BaselinePolicy::DistanceOnly,
+        BaselinePolicy::EvidenceCountOnly,
+        BaselinePolicy::TrivialPrior,
+    ];
+
+    /// Whether this policy serves an item with the given features. Pure and
+    /// deterministic; the distance threshold (50) and support threshold (2)
+    /// are fixed reference constants.
+    fn serves(self, f: &ItemFeatures) -> bool {
+        match self {
+            BaselinePolicy::AlwaysServe | BaselinePolicy::TrivialPrior => true,
+            BaselinePolicy::AlwaysDecline => false,
+            BaselinePolicy::CurrentD4 => f.coverage == Coverage::Covered,
+            BaselinePolicy::DistanceOnly => f.hamming_distance <= 50,
+            BaselinePolicy::EvidenceCountOnly => f.support_count >= 2,
+        }
+    }
+
+    /// Whether a served answer from this policy is correct on this item.
+    /// `trivial-prior` serves the no-context marginal, wrong even on
+    /// answerable items — the floor that separates it from `always-serve`.
+    fn served_correct(self, f: &ItemFeatures) -> bool {
+        match self {
+            BaselinePolicy::TrivialPrior => false,
+            _ => f.correct_if_served,
+        }
+    }
+}
+
+/// Per-category confusion cell: (served, false-answer, false-abstain).
+type ConfusionCell = (bool, bool, bool);
+
+/// The confusion signature of a policy over the eight categories, keyed by
+/// category label (BTreeMap: a deterministic ordered reduction).
+fn confusion_signature(policy: BaselinePolicy) -> BTreeMap<&'static str, ConfusionCell> {
+    let mut sig = BTreeMap::new();
+    for cat in Category::ALL {
+        let f = cat.features();
+        let served = policy.serves(&f);
+        let false_answer = served && (!cat.answerable() || !policy.served_correct(&f));
+        let false_abstain = !served && cat.answerable();
+        sig.insert(cat.label(), (served, false_answer, false_abstain));
+    }
+    sig
+}
+
+// --- §9: power constants and UCB arithmetic (fixed before any fitting) -------
+
+const N_PER_CATEGORY: u64 = 600;
+const N_TOTAL: u64 = 4_800;
+/// Frozen one-sided 95% upper-confidence-bound targets (‰) on the
+/// false-answer rate, per operating point (spec §9).
+const RELEASE_FALSE_ANSWER_UCB_PERMILLE: u32 = 10;
+const RESEARCH_FALSE_ANSWER_UCB_PERMILLE: u32 = 50;
+/// Frozen false-abstain ceilings (‰) on answerable items (spec §9).
+const RELEASE_FALSE_ABSTAIN_PERMILLE: u32 = 200;
+const RESEARCH_FALSE_ABSTAIN_PERMILLE: u32 = 300;
+
+/// The pre-registered conservative UCB95 reference arithmetic (‰):
+/// `(1000·k + 3000) / n`, the point estimate plus the rule-of-three margin,
+/// integer ceiling. The real report additionally states the exact
+/// Clopper–Pearson bound; this frozen form is what the reference selection
+/// rule uses, so the rule is deterministic and integer-only.
+fn ucb95_permille(failures: u64, n: u64) -> u32 {
+    assert!(
+        n > 0,
+        "UCB over an empty sample is UNAVAILABLE, never a value"
+    );
+    (1000_u64
+        .saturating_mul(failures)
+        .saturating_add(3_000)
+        .div_ceil(n)) as u32
+}
+
+/// One point on a calibration curve: threshold θ (‰), observed false
+/// answers among served unanswerable items, the unanswerable sample count,
+/// and the achieved coverage (‰) on answerable items.
+#[derive(Debug, Clone, Copy)]
+struct CurvePoint {
+    theta: u32,
+    false_answers: u64,
+    n_unanswerable: u64,
+    coverage_permille: u32,
+}
+
+/// The frozen operating-point selection rule (spec §9): maximize coverage
+/// subject to `ucb95 ≤ target`; ties break to the smaller θ. Returns `None`
+/// when no point satisfies the bound (a legitimate negative — the caller
+/// records it, never relaxes the target).
+fn select_operating_point(curve: &[CurvePoint], ucb_target_permille: u32) -> Option<u32> {
+    let mut best: Option<(u32, u32)> = None; // (coverage, theta)
+    for p in curve {
+        if ucb95_permille(p.false_answers, p.n_unanswerable) > ucb_target_permille {
+            continue;
+        }
+        let better = match best {
+            None => true,
+            Some((cov, th)) => {
+                p.coverage_permille > cov || (p.coverage_permille == cov && p.theta < th)
+            }
+        };
+        if better {
+            best = Some((p.coverage_permille, p.theta));
+        }
+    }
+    best.map(|(_, theta)| theta)
+}
+
+// --- §12: the claim gate ------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimVerdict {
+    NotEstablished,
+    Establishable,
+}
+
+/// The minimal report summary the claim gate consumes (spec §12).
+struct ReportSummary {
+    suite_id: &'static str,
+    calibrated: bool,
+    evidence_axis_measured: bool,
+    at_frozen_operating_point: bool,
+    false_answer_ucb_permille: Option<u32>,
+    false_abstain_permille: Option<u32>,
+}
+
+/// A "calibrated semantic abstention" claim is `Establishable` only from a
+/// calibrated `s2-answerability-ood` report with measured evidence axes that
+/// meets the frozen release targets at a frozen operating point. A
+/// coverage-only (D4) report — however green — is `NotEstablished`.
+fn semantic_abstention_claim(r: &ReportSummary) -> ClaimVerdict {
+    let bound_ok = matches!(
+        (r.false_answer_ucb_permille, r.false_abstain_permille),
+        (Some(ucb), Some(fa))
+            if ucb <= RELEASE_FALSE_ANSWER_UCB_PERMILLE && fa <= RELEASE_FALSE_ABSTAIN_PERMILLE
+    );
+    if r.suite_id == "s2-answerability-ood"
+        && r.calibrated
+        && r.evidence_axis_measured
+        && r.at_frozen_operating_point
+        && bound_ok
+    {
+        ClaimVerdict::Establishable
+    } else {
+        ClaimVerdict::NotEstablished
+    }
+}
+
+// --- helpers for exhaustive grids --------------------------------------------
+
+const THETA: u32 = 500;
+
+fn full_input_grid() -> Vec<(Calibration, Compat, Coverage, Evidence, u32)> {
+    let mut grid = Vec::new();
+    for calibration in [
+        Calibration::Absent,
+        Calibration::Valid,
+        Calibration::Corrupt,
+    ] {
+        for compat in [Compat::Compatible, Compat::HardIncompatibility] {
+            for coverage in [Coverage::Covered, Coverage::DistributionallyNovel] {
+                for evidence in [
+                    Evidence::Supported,
+                    Evidence::Insufficient,
+                    Evidence::Conflicting,
+                ] {
+                    for q in [0, THETA - 1, THETA, 1000] {
+                        grid.push((calibration, compat, coverage, evidence, q));
+                    }
+                }
+            }
+        }
+    }
+    grid
+}
+
+/// The seven canonical responses whose encodings must be pairwise distinct on
+/// every surface (they exercise all eight §2 statuses across their fields).
+fn canonical_responses() -> Vec<Response> {
+    vec![
+        // legacy served (covered)
+        decide(
+            Calibration::Absent,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Supported,
+            0,
+            THETA,
+        ),
+        // legacy abstention (distributionally-novel cause)
+        decide(
+            Calibration::Absent,
+            Compat::Compatible,
+            Coverage::DistributionallyNovel,
+            Evidence::Supported,
+            0,
+            THETA,
+        ),
+        // calibrated abstention: insufficient evidence
+        decide(
+            Calibration::Valid,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Insufficient,
+            400,
+            THETA,
+        ),
+        // calibrated abstention: conflicting evidence
+        decide(
+            Calibration::Valid,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Conflicting,
+            400,
+            THETA,
+        ),
+        // calibrated abstention: low confidence
+        decide(
+            Calibration::Valid,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Supported,
+            THETA - 1,
+            THETA,
+        ),
+        // calibrated served (supported answer)
+        decide(
+            Calibration::Valid,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Supported,
+            800,
+            THETA,
+        ),
+        // hard incompatibility (corrupt calibration)
+        decide(
+            Calibration::Corrupt,
+            Compat::Compatible,
+            Coverage::Covered,
+            Evidence::Supported,
+            800,
+            THETA,
+        ),
+    ]
+}
+
+// --- tests -------------------------------------------------------------------
+
+#[test]
+fn status_space_is_total_and_labels_round_trip() {
+    // Eight distinct statuses, eight distinct labels, total parse.
+    let labels: Vec<&str> = SelectiveStatus::ALL.iter().map(|s| s.label()).collect();
+    let unique: std::collections::BTreeSet<&str> = labels.iter().copied().collect();
+    assert_eq!(unique.len(), 8, "labels are pairwise distinct");
+    for s in SelectiveStatus::ALL {
+        assert_eq!(
+            SelectiveStatus::parse(s.label()),
+            Some(s),
+            "label round-trips"
+        );
+    }
+    assert_eq!(SelectiveStatus::parse("something-else"), None);
+}
+
+#[test]
+fn decision_table_is_total_and_deterministic() {
+    for (calibration, compat, coverage, evidence, q) in full_input_grid() {
+        let a = decide(calibration, compat, coverage, evidence, q, THETA);
+        let b = decide(calibration, compat, coverage, evidence, q, THETA);
+        assert_eq!(a, b, "identical inputs, identical outcome");
+        // Structural invariants of the table (spec §2):
+        match a.outcome {
+            Outcome::Abstention => {
+                assert!(a.cause.is_some(), "every abstention carries a typed cause");
+            }
+            Outcome::SupportedAnswer => assert!(a.cause.is_none()),
+            Outcome::HardIncompatibility => {
+                assert!(a.cause.is_none() && a.confidence_permille.is_none());
+            }
+        }
+        // The legacy cause appears only in legacy mode (spec §6).
+        if a.cause == Some(Cause::DistributionallyNovel) {
+            assert_eq!(calibration, Calibration::Absent);
+        }
+        // Confidence is never fabricated outside a valid calibration.
+        if calibration != Calibration::Valid {
+            assert_eq!(a.confidence_permille, None);
+        }
+    }
+}
+
+#[test]
+fn answerable_novelty_is_separable_from_unanswerability() {
+    // V3 (spec §2): a distributionally-novel input with supported evidence
+    // and passing confidence is SERVED — novelty alone is not
+    // unanswerability…
+    let novel_supported = decide(
+        Calibration::Valid,
+        Compat::Compatible,
+        Coverage::DistributionallyNovel,
+        Evidence::Supported,
+        700,
+        THETA,
+    );
+    assert_eq!(novel_supported.outcome, Outcome::SupportedAnswer);
+    assert_eq!(novel_supported.coverage, Coverage::DistributionallyNovel);
+
+    // …while a fully covered input with no supporting evidence abstains:
+    // coverage alone is not answerability (the #811 conflation, separated).
+    let covered_unsupported = decide(
+        Calibration::Valid,
+        Compat::Compatible,
+        Coverage::Covered,
+        Evidence::Insufficient,
+        700,
+        THETA,
+    );
+    assert_eq!(covered_unsupported.outcome, Outcome::Abstention);
+    assert_eq!(covered_unsupported.cause, Some(Cause::InsufficientEvidence));
+}
+
+#[test]
+fn cross_surface_encodings_round_trip_and_are_injective() {
+    let family = canonical_responses();
+    // Injectivity per surface: pairwise distinct wire forms.
+    let cli: Vec<String> = family.iter().map(encode_cli).collect();
+    let http: Vec<(u16, String)> = family.iter().map(encode_http).collect();
+    let oai: Vec<(u16, String)> = family.iter().map(encode_openai_nonstream).collect();
+    let stream: Vec<Vec<String>> = family.iter().map(encode_openai_stream).collect();
+    let wasm: Vec<(u8, String)> = family.iter().map(encode_wasm).collect();
+    for i in 0..family.len() {
+        for j in (i + 1)..family.len() {
+            assert_ne!(cli[i], cli[j], "CLI injective over {i}/{j}");
+            assert_ne!(http[i], http[j], "HTTP injective over {i}/{j}");
+            assert_ne!(oai[i], oai[j], "OpenAI injective over {i}/{j}");
+            assert_ne!(stream[i], stream[j], "stream injective over {i}/{j}");
+            assert_ne!(wasm[i], wasm[j], "WASM injective over {i}/{j}");
+        }
+    }
+    // Round-trip: the CLI encoding carries the typed status and cause back.
+    for r in &family {
+        let (status, cause) = decode_cli(&encode_cli(r));
+        assert_eq!(status, r.outcome.status());
+        assert_eq!(cause, r.cause.map(Cause::status));
+    }
+    // Canonical labels appear verbatim in the HTTP body; the OpenAI error
+    // code uses the deterministic snake rewrite.
+    for r in &family {
+        let (_, body) = encode_http(r);
+        assert!(body.contains(r.outcome.status().label()));
+        if let Some(cause) = r.cause {
+            let (_, oai_body) = encode_openai_nonstream(r);
+            assert!(oai_body.contains(&snake(cause.status().label())));
+        }
+    }
+}
+
+#[test]
+fn abstention_is_never_an_empty_success() {
+    for r in canonical_responses() {
+        let (code, body) = encode_openai_nonstream(&r);
+        let events = encode_openai_stream(&r);
+        match r.outcome {
+            Outcome::Abstention => {
+                assert_ne!(code, 200, "abstention is not an HTTP 200 success");
+                assert!(body.contains("\"error\""), "structured error body");
+                assert!(
+                    body.contains("uor_abstention_"),
+                    "typed abstention code, not a generic error"
+                );
+                assert!(
+                    !body.contains("\"choices\""),
+                    "no empty-choices success masquerade"
+                );
+                assert!(
+                    events.iter().all(|e| !e.contains("delta")),
+                    "no content chunk on an abstained stream"
+                );
+                assert!(
+                    events
+                        .first()
+                        .is_some_and(|e| e.starts_with("event: error")),
+                    "typed terminal stream event"
+                );
+                assert_eq!(events.last().map(String::as_str), Some("data: [DONE]"));
+            }
+            Outcome::SupportedAnswer => {
+                assert_eq!(code, 200);
+                assert!(body.contains("\"choices\""));
+            }
+            Outcome::HardIncompatibility => {
+                assert_eq!(code, 409);
+                assert!(body.contains("uor_incompatible_artifact"));
+            }
+        }
+    }
+}
+
+#[test]
+fn legacy_artifact_without_calibration_stays_coverage_only() {
+    // Spec §6: legacy mode never mints an evidence-axis status or a
+    // confidence value, whatever the evidence input claims.
+    for coverage in [Coverage::Covered, Coverage::DistributionallyNovel] {
+        for evidence in [
+            Evidence::Supported,
+            Evidence::Insufficient,
+            Evidence::Conflicting,
+        ] {
+            for q in [0, 1000] {
+                let r = decide(
+                    Calibration::Absent,
+                    Compat::Compatible,
+                    coverage,
+                    evidence,
+                    q,
+                    THETA,
+                );
+                assert_eq!(r.confidence_permille, None, "no fabricated confidence");
+                assert_eq!(r.evidence, None, "no fabricated evidence block");
+                assert!(
+                    !matches!(
+                        r.cause,
+                        Some(Cause::InsufficientEvidence)
+                            | Some(Cause::ConflictingEvidence)
+                            | Some(Cause::LowConfidence)
+                    ),
+                    "no calibrated cause in legacy mode"
+                );
+            }
+        }
+    }
+    // And a legacy report cannot establish the calibrated claim (§12).
+    let legacy_report = ReportSummary {
+        suite_id: "s2-answerability-ood",
+        calibrated: false,
+        evidence_axis_measured: false,
+        at_frozen_operating_point: false,
+        false_answer_ucb_permille: None,
+        false_abstain_permille: None,
+    };
+    assert_eq!(
+        semantic_abstention_claim(&legacy_report),
+        ClaimVerdict::NotEstablished
+    );
+}
+
+#[test]
+fn corrupt_calibration_fails_closed() {
+    let good = b"calibration-table-v1: theta 500".to_vec();
+    let cid = compute_cid(&good);
+    assert_eq!(
+        classify_calibration(Some((&cid, &good))),
+        Calibration::Valid
+    );
+
+    // A single flipped byte is corrupt — hard incompatibility, not legacy.
+    let mut tampered = good.clone();
+    tampered[0] ^= 0x01;
+    assert_eq!(
+        classify_calibration(Some((&cid, &tampered))),
+        Calibration::Corrupt
+    );
+    let r = decide(
+        Calibration::Corrupt,
+        Compat::Compatible,
+        Coverage::Covered,
+        Evidence::Supported,
+        900,
+        THETA,
+    );
+    assert_eq!(r.outcome, Outcome::HardIncompatibility);
+
+    // Absent is legacy (served under D4), NOT hard incompatibility — the
+    // corrupt/absent distinction of spec §6, in both directions.
+    assert_eq!(classify_calibration(None), Calibration::Absent);
+    let legacy = decide(
+        Calibration::Absent,
+        Compat::Compatible,
+        Coverage::Covered,
+        Evidence::Supported,
+        900,
+        THETA,
+    );
+    assert_eq!(legacy.outcome, Outcome::SupportedAnswer);
+    assert_ne!(
+        legacy.outcome, r.outcome,
+        "corrupt never degrades to legacy"
+    );
+}
+
+#[test]
+fn partitions_reject_leakage_and_tamper() {
+    // Three partitions, disjoint on all four axes by construction.
+    let cal: Vec<Item> = Category::ALL
+        .iter()
+        .map(|&c| make_item(c, 0, "cal"))
+        .collect();
+    let eval: Vec<Item> = Category::ALL
+        .iter()
+        .map(|&c| make_item(c, 1, "eval"))
+        .collect();
+
+    for axis in ["document", "domain", "entity", "template"] {
+        let key = |i: &Item| -> String {
+            match axis {
+                "document" => i.document.clone(),
+                "domain" => i.domain.clone(),
+                "entity" => i.entity.clone(),
+                _ => i.template.clone(),
+            }
+        };
+        let cal_keys: Vec<String> = cal.iter().map(key).collect();
+        let eval_keys: Vec<String> = eval.iter().map(key).collect();
+        let cal_refs: Vec<&str> = cal_keys.iter().map(String::as_str).collect();
+        let eval_refs: Vec<&str> = eval_keys.iter().map(String::as_str).collect();
+        assert!(
+            detect_document_leakage(&cal_refs, &eval_refs).is_none(),
+            "{axis}-disjoint split accepted"
+        );
+    }
+
+    // A planted leak on the entity axis is detected (positive control for
+    // the negative check above).
+    let leaked = [cal[0].entity.as_str()];
+    let eval_with_leak = [cal[0].entity.as_str(), "entity-eval-other"];
+    assert!(
+        detect_document_leakage(&leaked, &eval_with_leak).is_some(),
+        "planted entity leak detected"
+    );
+
+    // Gold annotations are CID-bound; a flipped byte fails verification.
+    let annotations: String = eval
+        .iter()
+        .map(|i| {
+            format!(
+                "{}|{}|answerable={}\n",
+                i.id,
+                i.category.label(),
+                i.category.answerable()
+            )
+        })
+        .collect();
+    let cid = compute_cid(annotations.as_bytes());
+    assert!(verify_cid(&cid, annotations.as_bytes()).is_none());
+    let mut tampered = annotations.into_bytes();
+    tampered[0] ^= 0x01;
+    assert!(verify_cid(&cid, &tampered).is_some(), "tamper detected");
+}
+
+#[test]
+fn planted_category_fixtures_classify_per_gold() {
+    // V2: each planted category fixture, read through its reference feature
+    // vector, classifies to its gold outcome and an acceptable typed cause.
+    for cat in Category::ALL {
+        let f = cat.features();
+        let r = decide(
+            Calibration::Valid,
+            Compat::Compatible,
+            f.coverage,
+            f.evidence,
+            f.confidence_permille,
+            THETA,
+        );
+        let (gold_outcome, gold_causes) = cat.gold();
+        assert_eq!(r.outcome, gold_outcome, "{} outcome", cat.label());
+        match r.cause {
+            None => assert!(gold_causes.is_empty(), "{} served", cat.label()),
+            Some(c) => assert!(
+                gold_causes.contains(&c),
+                "{} cause {c:?} is in the gold set",
+                cat.label()
+            ),
+        }
+        // Paraphrase stability: the paraphrased twin of an answerable item
+        // classifies identically to its in-domain original.
+        if cat == Category::ParaphrasedAnswerable {
+            let original = Category::InDomainAnswerable.features();
+            let ro = decide(
+                Calibration::Valid,
+                Compat::Compatible,
+                original.coverage,
+                original.evidence,
+                original.confidence_permille,
+                THETA,
+            );
+            assert_eq!(ro.outcome, r.outcome, "paraphrase-stable outcome");
+        }
+    }
+}
+
+#[test]
+fn baselines_produce_distinct_confusion_profiles() {
+    // V4: the six baselines are pairwise distinguishable by confusion
+    // signature over the eight categories.
+    let signatures: Vec<(BaselinePolicy, BTreeMap<&str, ConfusionCell>)> = BaselinePolicy::ALL
+        .iter()
+        .map(|&p| (p, confusion_signature(p)))
+        .collect();
+    for i in 0..signatures.len() {
+        for j in (i + 1)..signatures.len() {
+            assert_ne!(
+                signatures[i].1, signatures[j].1,
+                "{:?} vs {:?} signatures distinct",
+                signatures[i].0, signatures[j].0
+            );
+        }
+    }
+
+    // The #811 finding as a fixture: current-D4 (a coverage policy) falsely
+    // serves the covered-but-unanswerable categories…
+    let d4 = confusion_signature(BaselinePolicy::CurrentD4);
+    for cat in [
+        "false-premise",
+        "contradictory-evidence",
+        "missing-evidence",
+    ] {
+        let (_, false_answer, _) = d4[cat];
+        assert!(false_answer, "current-D4 falsely serves {cat}");
+    }
+    // …and falsely abstains on answerable novelty.
+    assert_eq!(d4["novel-but-supported"], (false, false, true));
+
+    // distance-only cannot separate answerable from unanswerable novelty,
+    // and is paraphrase-brittle (its two signatures):
+    let dist = confusion_signature(BaselinePolicy::DistanceOnly);
+    let (s1, _, _) = dist["novel-but-supported"];
+    let (s2, _, _) = dist["unrelated-ood"];
+    assert_eq!(s1, s2, "distance-only conflates the two novelty categories");
+    assert!(!s1, "distance-only abstains on both");
+    assert_eq!(
+        dist["paraphrased-answerable"],
+        (false, false, true),
+        "distance-only falsely abstains on a paraphrase"
+    );
+
+    // evidence-count-only serves conflicting evidence (its signature): the
+    // conflict structure is present in the features and ignored by the
+    // policy, which reads support counts alone.
+    let contradictory = Category::ContradictoryEvidence.features();
+    assert!(
+        contradictory.conflict_count > 0,
+        "conflict structure is present to be ignored"
+    );
+    let ec = confusion_signature(BaselinePolicy::EvidenceCountOnly);
+    let (served, false_answer, _) = ec["contradictory-evidence"];
+    assert!(
+        served && false_answer,
+        "count-only ignores conflict structure"
+    );
+
+    // always-serve/always-decline are the coverage ceiling and risk floor:
+    let always_serve = confusion_signature(BaselinePolicy::AlwaysServe);
+    let always_decline = confusion_signature(BaselinePolicy::AlwaysDecline);
+    for cat in Category::ALL {
+        let (s, _, fa) = always_serve[cat.label()];
+        assert!(s && !fa);
+        let (s, f, _) = always_decline[cat.label()];
+        assert!(!s && !f);
+    }
+
+    // #832 binding: the reference primary separates from the always-serve
+    // control on false-answer rate (non-degenerate), and the ControlKind
+    // vocabulary names the bound controls.
+    let primary_false_answer = MetricStatus::Measured {
+        numerator: 0,
+        denominator: 5,
+    };
+    let always_serve_false_answer = MetricStatus::Measured {
+        numerator: 5,
+        denominator: 5,
+    };
+    assert!(!is_degenerate_control(
+        &primary_false_answer,
+        &always_serve_false_answer,
+        50
+    ));
+    assert!(is_degenerate_control(
+        &primary_false_answer,
+        &primary_false_answer,
+        50
+    ));
+    for kind in [
+        ControlKind::AlwaysServe,
+        ControlKind::AlwaysDecline,
+        ControlKind::TrivialPrior,
+    ] {
+        assert!(ControlKind::ALL.contains(&kind));
+    }
+}
+
+#[test]
+fn power_and_ucb_targets_fixed_before_fitting() {
+    // The powered sample sizes and bound targets are compile-time constants
+    // of this spec, fixed before any calibrator fit (#837).
+    assert_eq!(N_TOTAL, N_PER_CATEGORY * Category::ALL.len() as u64);
+    let n_unanswerable =
+        N_PER_CATEGORY * Category::ALL.iter().filter(|c| !c.answerable()).count() as u64;
+    assert_eq!(n_unanswerable, 3_000);
+
+    // Rule-of-three arithmetic (spec §9): at zero failures the design
+    // resolves the release target with headroom…
+    assert_eq!(ucb95_permille(0, n_unanswerable), 1);
+    assert!(ucb95_permille(0, n_unanswerable) <= RELEASE_FALSE_ANSWER_UCB_PERMILLE);
+    // …the minimum zero-failure sample for the release bound is n = 300…
+    assert_eq!(ucb95_permille(0, 300), 10);
+    assert!(ucb95_permille(0, 299) > RELEASE_FALSE_ANSWER_UCB_PERMILLE);
+    // …and the research bound is the declared looser target. The frozen
+    // looser-than relation is checked through a function so the assertion
+    // reads the same values the selection rule consumes.
+    assert_eq!(ucb95_permille(0, 60), RESEARCH_FALSE_ANSWER_UCB_PERMILLE);
+    fn strictly_looser(research: u32, release: u32) -> bool {
+        research > release
+    }
+    assert!(strictly_looser(
+        RESEARCH_FALSE_ANSWER_UCB_PERMILLE,
+        RELEASE_FALSE_ANSWER_UCB_PERMILLE
+    ));
+    assert!(strictly_looser(
+        RESEARCH_FALSE_ABSTAIN_PERMILLE,
+        RELEASE_FALSE_ABSTAIN_PERMILLE
+    ));
+
+    // Category-level resolution at n = 600: a 100‰ rate carries a 95%
+    // half-width of ±24‰, so ≥50‰ baseline-profile differences resolve.
+    let n = N_PER_CATEGORY as f64;
+    let half_width_permille = 1.96 * (0.1_f64 * 0.9 / n).sqrt() * 1000.0;
+    assert!(half_width_permille < 25.0, "±{half_width_permille:.1}");
+
+    // Metric encoding is the #832 integer-fraction vocabulary: a missing
+    // fixture is Unavailable, never a vacuous Measured zero.
+    let unavailable = MetricStatus::Unavailable {
+        reason: "calibration partition absent".to_owned(),
+    };
+    assert!(!unavailable.is_measured());
+    assert_eq!(unavailable.rate_permille(), None);
+}
+
+#[test]
+fn operating_points_frozen_and_selection_rule_deterministic() {
+    // A synthetic calibration curve: higher θ serves less, errs less.
+    let curve = [
+        CurvePoint {
+            theta: 200,
+            false_answers: 60,
+            n_unanswerable: 3_000,
+            coverage_permille: 950,
+        },
+        CurvePoint {
+            theta: 400,
+            false_answers: 120,
+            n_unanswerable: 3_000,
+            coverage_permille: 900,
+        },
+        CurvePoint {
+            theta: 600,
+            false_answers: 20,
+            n_unanswerable: 3_000,
+            coverage_permille: 700,
+        },
+        CurvePoint {
+            theta: 800,
+            false_answers: 3,
+            n_unanswerable: 3_000,
+            coverage_permille: 450,
+        },
+        CurvePoint {
+            theta: 900,
+            false_answers: 0,
+            n_unanswerable: 3_000,
+            coverage_permille: 250,
+        },
+    ];
+    // Release (UCB ≤ 10‰): θ=600 (ucb (20·1000+3000)/3000 = 8‰), θ=800
+    // (2‰), and θ=900 (1‰) qualify; θ=200 (21‰) and θ=400 (41‰) do not.
+    // The rule maximizes coverage among qualifiers → θ=600 (700‰).
+    let release = select_operating_point(&curve, RELEASE_FALSE_ANSWER_UCB_PERMILLE);
+    assert_eq!(release, Some(600));
+    // Research (UCB ≤ 50‰): every point qualifies (21/41/8/2/1‰); max
+    // coverage → θ=200 (950‰).
+    let research = select_operating_point(&curve, RESEARCH_FALSE_ANSWER_UCB_PERMILLE);
+    assert_eq!(research, Some(200));
+    // Research serves strictly more than release (the two points differ and
+    // are both frozen before fitting).
+    assert!(research.unwrap() < release.unwrap());
+    // Deterministic under repetition and input reversal.
+    let mut reversed = curve;
+    reversed.reverse();
+    assert_eq!(
+        select_operating_point(&reversed, RELEASE_FALSE_ANSWER_UCB_PERMILLE),
+        release
+    );
+    // An unmeetable bound is a typed None — the target is never relaxed.
+    assert_eq!(select_operating_point(&curve, 0), None);
+}
+
+#[test]
+fn coverage_result_cannot_render_semantic_pass() {
+    // A D4/coverage-only report — however green — is NOT ESTABLISHED.
+    let coverage_only = ReportSummary {
+        suite_id: "s2-answerability-ood",
+        calibrated: false,
+        evidence_axis_measured: false,
+        at_frozen_operating_point: true,
+        false_answer_ucb_permille: Some(0),
+        false_abstain_permille: Some(0),
+    };
+    assert_eq!(
+        semantic_abstention_claim(&coverage_only),
+        ClaimVerdict::NotEstablished
+    );
+    // A different suite cannot establish it either.
+    let wrong_suite = ReportSummary {
+        suite_id: "s0-broad-text",
+        calibrated: true,
+        evidence_axis_measured: true,
+        at_frozen_operating_point: true,
+        false_answer_ucb_permille: Some(1),
+        false_abstain_permille: Some(100),
+    };
+    assert_eq!(
+        semantic_abstention_claim(&wrong_suite),
+        ClaimVerdict::NotEstablished
+    );
+    // Missing either frozen target is NOT ESTABLISHED (positive control
+    // included so the negative reading is non-vacuous).
+    let over_bound = ReportSummary {
+        suite_id: "s2-answerability-ood",
+        calibrated: true,
+        evidence_axis_measured: true,
+        at_frozen_operating_point: true,
+        false_answer_ucb_permille: Some(RELEASE_FALSE_ANSWER_UCB_PERMILLE + 1),
+        false_abstain_permille: Some(100),
+    };
+    assert_eq!(
+        semantic_abstention_claim(&over_bound),
+        ClaimVerdict::NotEstablished
+    );
+    let establishable = ReportSummary {
+        suite_id: "s2-answerability-ood",
+        calibrated: true,
+        evidence_axis_measured: true,
+        at_frozen_operating_point: true,
+        false_answer_ucb_permille: Some(2),
+        false_abstain_permille: Some(150),
+    };
+    assert_eq!(
+        semantic_abstention_claim(&establishable),
+        ClaimVerdict::Establishable
+    );
+}
+
+#[test]
+fn witness_carries_the_same_typed_fields() {
+    for r in canonical_responses() {
+        let w = witness_of(&r);
+        assert_eq!(w.outcome, r.outcome);
+        assert_eq!(w.coverage, r.coverage);
+        assert_eq!(w.cause, r.cause);
+        assert_eq!(w.confidence_permille, r.confidence_permille);
+        assert_eq!(w.evidence, r.evidence);
+    }
+}
+
+#[test]
+fn double_run_and_reordered_input_determinism() {
+    // The full grid, run twice, encodes identically on every surface.
+    let grid = full_input_grid();
+    let run = |g: &[(Calibration, Compat, Coverage, Evidence, u32)]| -> Vec<String> {
+        g.iter()
+            .map(|&(calibration, compat, coverage, evidence, q)| {
+                let r = decide(calibration, compat, coverage, evidence, q, THETA);
+                let (code, body) = encode_http(&r);
+                format!("{code} {body} | {}", encode_cli(&r))
+            })
+            .collect()
+    };
+    assert_eq!(run(&grid), run(&grid), "double run identical");
+
+    // Aggregation over reversed input order reduces identically (ordered
+    // BTreeMap reduction, the #832 shard rule in miniature).
+    let aggregate = |g: &[(Calibration, Compat, Coverage, Evidence, u32)]| {
+        let mut counts: BTreeMap<&'static str, u32> = BTreeMap::new();
+        for &(calibration, compat, coverage, evidence, q) in g {
+            let r = decide(calibration, compat, coverage, evidence, q, THETA);
+            *counts.entry(r.outcome.status().label()).or_insert(0) += 1;
+        }
+        counts
+    };
+    let mut reversed = grid.clone();
+    reversed.reverse();
+    assert_eq!(aggregate(&grid), aggregate(&reversed), "order-invariant");
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -396,6 +396,29 @@ arm of the #834 scope now carries an evidence-backed disposition and none cleare
 frozen causal floor — S1 meets the #822 kill/redesign criterion (two-plus independently
 motivated arms fail the causal gate); the stage verdict against the full child set is
 the maintainer's on #822.
+
+**S2 item A — the typed selective-prediction contract and the answerability benchmark
+constitution are frozen (#838, 2026-08-21).**
+[`docs/selective_prediction_spec_838.md`](selective_prediction_spec_838.md) separates
+coverage, answerability, and calibrated confidence into eight typed statuses with one
+meaning and one deterministic representation each across the CLI, native HTTP,
+OpenAI-compatible (non-streaming and streaming), and WASM surfaces — an abstention is
+never an empty success or a generic error, artifacts without calibration data stay
+coverage-only (no fabricated confidence), and corrupt calibration data fails closed as
+`hard-incompatibility` (corrupt never degrades to legacy). It freezes the
+`s2-answerability-ood` benchmark constitution: eight gold-annotated categories
+(including `novel-but-supported` — answerable novelty is explicitly separable from
+semantic unanswerability), four-axis disjoint partitions, six baselines with distinct
+planted confusion signatures (current-D4 falsely serves false-premise /
+contradictory-evidence / missing-evidence — the #811 finding made a fixture), and
+pre-registered metrics with powered n (600 per category, 4,800 total) and frozen UCB
+targets (false-answer UCB95 ≤ 10‰ release / ≤ 50‰ research) fixed before any threshold
+is fitted. The executable reference model is
+`crates/uor-r4-api/tests/selective_prediction_spec_838.rs` (15 machine-checked
+properties, including that a coverage-only report can never render a semantic PASS).
+**Current semantic abstention remains NOT ESTABLISHED**; #837 fits the calibrator
+against this constitution and #839 executes and certifies it on the production
+surfaces.
 The **geometric router** is a validated, real component (content-query
 retrieval MRR 0.88+, #486/#490/#502) but it is a retrieval/routing mechanism,
 not itself a generative model, and it runs on `f64` outside the P-4 kernel by

--- a/docs/selective_prediction_spec_838.md
+++ b/docs/selective_prediction_spec_838.md
@@ -1,0 +1,326 @@
+# Typed selective prediction and the answerability benchmark constitution (#838)
+
+- **Status:** Frozen contract + benchmark constitution (item A of S2 tracker #823, programme #820).
+- **Date:** 2026-08-21.
+- **Claim language:** follows `docs/formal_vocabulary.md` (normative). This record freezes
+  *meanings and measurement*. It deploys no predictor, fits no threshold, and asserts no
+  empirical capability result. **Current semantic abstention is NOT ESTABLISHED** (§13).
+- **Companion reference model:** `crates/uor-r4-api/tests/selective_prediction_spec_838.rs` —
+  the executable realization of every table in this document, with planted negatives.
+- **Relation to prior records:** uses the #830 execution-scope/verdict vocabulary
+  (`docs/conformance_execution_scope_830.md`), the ADR-0001 normative-scorer designation
+  (#831), and the #832 evaluation constitution (`docs/capability_suites_832.md`, suite
+  `s2-answerability-ood`). Records are appended, never rewritten.
+
+## 1. Problem and scope
+
+#811 established parity for the D4 resolution policy, and all five semantic-OOD probes
+remained SERVABLE: the deployed D4 axis (`exact_context` / `graph` / `novel` /
+`contradictory`) reports *representation and resolution coverage*, not whether an answer is
+*supported by evidence*. Covered, novel, unsupported, contradictory, low-confidence,
+declined, and answered are conflated today across surfaces: the CLI and the native server
+surface a D4 abstention (#811 `ChatAbstention`), the OpenAI-compatible surface reports a
+generic `engine_declined` error, and no surface carries evidence or calibrated confidence.
+The five hand-written probes cannot support a risk claim.
+
+**Definition (execution scope of this record).** Semantic contract, offline benchmark
+constitution, and production response *schema* — `reference-only` / `off-serving-path` in
+the #830 vocabulary. No predictor is deployed by this issue; evidence produced under this
+record is not a serving result. The calibrator fit is sibling item B (#837); deployed
+execution and certification across production surfaces is sibling item C (#839).
+
+## 2. The typed status space
+
+**Definition (the eight selective-prediction statuses).** Each is a separate typed concept
+with exactly one meaning and one canonical kebab-case label. No status is ever inferred
+from another; no surface may merge two of them into one representation.
+
+| # | Status | Label | Kind | One meaning |
+|---|---|---|---|---|
+| 1 | Covered | `covered` | coverage-axis value | the artifact's calibrated representation resolves this input (D4 serve-side reading) |
+| 2 | Distributionally novel | `distributionally-novel` | coverage-axis value | no calibrated region covers the input (D4 `novel` reading) |
+| 3 | Insufficient evidence | `insufficient-evidence` | evidence-axis value | the input resolves, but no candidate answer has supporting evidence above the floor |
+| 4 | Conflicting evidence | `conflicting-evidence` | evidence-axis value | active evidence materially disagrees between incompatible answers |
+| 5 | Supported answer | `supported-answer` | outcome | an answer is served, bound to its supporting evidence and calibrated confidence |
+| 6 | Low confidence | `low-confidence` | confidence reading | evidence supports an answer but calibrated confidence sits below the operating point |
+| 7 | Abstention | `abstention` | outcome | the system declines to answer, with a typed cause — never an empty success, never a generic error |
+| 8 | Hard incompatibility | `hard-incompatibility` | outcome | the request cannot be validly served by this artifact/surface at all (corrupt or version-incompatible calibration data, unsupported protocol form); fail-closed |
+
+**Definition (three axes plus an outcome).** The statuses compose on orthogonal axes rather
+than one flat scale — this is the separation #811 showed is missing:
+
+- **Coverage axis** `V ∈ {covered, distributionally-novel}` — a structural reading of the
+  artifact's calibrated geometry (today's D4 signal, `PolicyStatus` in
+  `crates/uor-r4-api/src/engine.rs`).
+- **Evidence axis** `E ∈ {supported, insufficient-evidence, conflicting-evidence}` — an
+  evidential reading over candidate answers and their provenance. The deployed classifier
+  for this axis does not exist yet (#837 fits it; #839 executes it).
+- **Confidence reading** `q ∈ [0, 1000]` (integer parts-per-thousand) with a frozen
+  operating point `θ`; `q < θ` reads `low-confidence`. Defined only when calibration data
+  is present (§6).
+- **Compatibility** `C ∈ {compatible, hard-incompatibility}` — a fail-closed structural
+  gate evaluated before everything else.
+
+**Definition (deterministic outcome function).** The served outcome is the total function
+`decide(C, V, E, q, θ, calibrated)`:
+
+| Rule (first match wins) | Outcome | Cause carried |
+|---|---|---|
+| `C = hard-incompatibility` | `hard-incompatibility` | — |
+| `E = conflicting-evidence` | `abstention` | `conflicting-evidence` |
+| `E = insufficient-evidence` | `abstention` | `insufficient-evidence` |
+| `E = supported ∧ calibrated ∧ q < θ` | `abstention` | `low-confidence` |
+| `E = supported ∧ (¬calibrated ⇒ legacy mode §6)` | `supported-answer` | — |
+
+Cause precedence is the row order above: `hard-incompatibility ≻ conflicting-evidence ≻
+insufficient-evidence ≻ low-confidence` (and, only in legacy mode, `distributionally-novel`
+— §6). The coverage value `V` is always *reported* alongside the outcome and is never
+itself a cause outside legacy mode: **novelty alone is not unanswerability**. A
+distributionally-novel input with supported evidence and passing confidence is served —
+this is answerable novelty, and it is separable from semantic unanswerability by
+construction (Verification V3).
+
+**Guarantee (totality and determinism). Status: Structural** (reference model;
+`decision_table_is_total_and_deterministic`). `decide` is defined for every input in the
+product space and identical inputs produce identical outcomes and identical wire bytes on
+every surface.
+
+## 3. Vocabulary classification of each status
+
+**Definition (what kind of claim each status makes).** Under `docs/formal_vocabulary.md`:
+
+- `covered` / `distributionally-novel` — readings of a **Guarantee**-class structural
+  signal (the D4 classification is deterministic integer arithmetic over the artifact;
+  proof-matrix statuses per #830). Whether coverage *correlates with answerability* is an
+  **Empirical Criterion**, measured by this benchmark, never assumed.
+- `insufficient-evidence` / `conflicting-evidence` / `low-confidence` — **Empirical
+  Criterion**-class readings: they are meaningful only relative to a fitted, calibrated
+  classifier with declared distribution, n, and uncertainty (#837). Until that exists they
+  are **Unproven** for the deployed system, and no deployed surface may emit them (§6).
+- `supported-answer` / `abstention` / `hard-incompatibility` — outcome semantics are
+  **Guarantee**-class (structural response-schema properties: typed, deterministic,
+  fail-closed); *the rates at which they are correct* are **Empirical Criteria** with the
+  §9 metrics.
+- **Assumption:** gold answerability annotations (§7) are treated as ground truth by every
+  metric; annotation quality is bounded by the rubric identity they pin, not established by
+  this repository.
+
+## 4. Evidence, provenance, and confidence fields
+
+**Definition (response evidence block).** A served `supported-answer` and every witness
+record carry, additively:
+
+- `evidence.supporting: u32` / `evidence.conflicting: u32` — bounded counts of evidence
+  units for/against the served answer at the operating point.
+- `evidence.paths` — the per-token `ResolutionPath` histogram of the served span (#832
+  vocabulary: `exact-context`, `ngram`, `graph`, `root-prior`, `patch-delta`,
+  `sampled-selection`, `decline`).
+- `provenance` — the identity set: `artifact_cid`, `calibration_cid` (absent in legacy
+  mode), `witness_cid`, and the ADR-0001 normative scorer id for every served token.
+- `confidence_permille: u32 ∈ [0, 1000]` — the calibrated confidence reading; present iff
+  calibration data is present and valid; **never fabricated** (§6).
+
+All fields are integers or content identifiers — no floats on any wire or witness surface
+(the #609–#613 serde-float lesson; #832 integer-fraction rule).
+
+**Guarantee (witness parity). Status: Structural** (reference model;
+`witness_carries_the_same_typed_fields`). The witness record carries the same status,
+cause, coverage, evidence, and confidence fields as the production response, so an
+independent verifier replays the abstention decision without the teacher.
+
+## 5. Deterministic cross-surface representation
+
+**Definition (surface mapping table).** One normative mapping per surface; the reference
+model implements each encoder and round-trips it. Canonical labels are the §2 kebab-case
+strings everywhere; `snake_case` variants appear only inside OpenAI-compatible `error.code`
+values, by the deterministic rewrite `s/-/_/g`.
+
+| Outcome | CLI (`r4 chat`/`ask`) | Native HTTP/API | OpenAI-compatible non-streaming | OpenAI-compatible streaming | WASM host |
+|---|---|---|---|---|---|
+| `supported-answer` | answer text; typed record carries status, coverage, `confidence_permille`, evidence | `200`, JSON `status: "supported-answer"` + §4 fields | normal `choices`; §4 fields under the vendored `uor` extension key | content chunks, then normal termination | `Ok(Served{…})` boundary enum, same labels |
+| `abstention` | no answer text; typed abstention record (extends #811 `ChatAbstention`) with `cause`, coverage, `confidence_permille?`; exit code 0 (an abstention is a *successful, honest* outcome) | `200`, JSON `status: "abstention"`, `cause`, coverage, §4 fields | HTTP 422, `error.code = "uor_abstention_<cause_snake>"`, `error.type = "uor_selective_prediction"`; **never** an empty-`choices` success | **no** content chunk; one terminal typed SSE `error` event with the same code, then `[DONE]`; never a silent stream end | `Ok(Abstained{cause, …})` |
+| `hard-incompatibility` | typed error, nonzero exit | `409`, JSON `status: "hard-incompatibility"`, `reason` | HTTP 409, `error.code = "uor_incompatible_artifact"` | terminal typed SSE `error` event, then `[DONE]` | `Err(Incompatible{reason})` — typed, never a trap |
+
+**Guarantee (deterministic, injective representation). Status: Structural** (reference
+model; `cross_surface_encodings_round_trip_and_are_injective`). For every surface the
+mapping status → wire form is injective (no two statuses share a representation), total
+over the §2 space, and byte-deterministic for identical inputs.
+
+**Guarantee (abstention is never hidden). Status: Structural** (reference model;
+`abstention_is_never_an_empty_success`). On no surface does an abstention serialize as an
+empty successful completion, a zero-length `choices` success, or a generic server error —
+the #838 non-goal made a falsifier. The current `/v1/*` `engine_declined` error body is the
+migration ancestor of the typed `uor_abstention_*` codes; #839 executes the migration.
+
+## 6. Backward compatibility and fail-closed calibration
+
+**Definition (legacy-coverage mode).** An artifact **without** calibration data (no
+calibration section/sidecar identity) serves under today's D4 policy, surfaced through the
+same typed schema: coverage axis populated; abstentions carry cause
+`distributionally-novel` (the only legacy cause); `confidence_permille` and the evidence
+axis are **absent** — never fabricated, never defaulted to a value. Legacy artifacts remain
+always-serve/current-D4 in behavior.
+
+**Guarantee (no calibrated claim without calibration). Status: Structural** (reference
+model; `legacy_artifact_without_calibration_stays_coverage_only`). Legacy-mode responses
+cannot mint `insufficient-evidence`, `conflicting-evidence`, `low-confidence`, or any
+confidence value, and a legacy-mode report cannot satisfy the §12 claim gate. Old artifacts
+do not inherit a calibrated-answerability claim.
+
+**Guarantee (fail-closed on corrupt calibration). Status: Structural** (reference model;
+`corrupt_calibration_fails_closed`). Calibration data that is *present but invalid* —
+CID-mismatched bytes, an unknown schema version, or a truncated table — is
+`hard-incompatibility` for every request that would consult it. Corrupt is distinguished
+from absent: absent means legacy mode (above); corrupt **never** silently degrades to
+legacy mode, because a tampered calibration must not reopen the always-serve surface.
+
+## 7. Benchmark categories and gold annotations
+
+**Definition (the eight categories).** The answerability benchmark populates the frozen
+`s2-answerability-ood` suite (#832) with eight input categories, each with a gold
+answerability annotation and a gold status:
+
+| Category | Answerable? | Gold outcome at a working operating point |
+|---|---|---|
+| `in-domain-answerable` | yes | `supported-answer` |
+| `paraphrased-answerable` | yes | `supported-answer` (paraphrase-stable) |
+| `novel-but-supported` | yes | `supported-answer` (answerable novelty; `V = distributionally-novel`) |
+| `missing-evidence` | no | `abstention` / `insufficient-evidence` |
+| `private-information` | no | `abstention` / `insufficient-evidence` (the evidence is absent from the artifact by construction) |
+| `false-premise` | no | `abstention` / `insufficient-evidence` (no evidence supports the presupposed entity/fact) |
+| `contradictory-evidence` | no | `abstention` / `conflicting-evidence` |
+| `unrelated-ood` | no | `abstention` (legacy cause `distributionally-novel` permitted here and only here) |
+
+**Definition (gold annotation schema).** Each item carries: category, `answerable ∈ {yes,
+no}`, gold outcome + cause, evidence references into the corpus (present for answerable
+items, absent-by-construction for `missing-evidence`/`private-information`), and the four
+disjointness keys `document / domain / entity / template`. The full annotation set, the
+generator configuration, and the rubric are CID-bound (`compute_cid`) and pinned in every
+report (#832 `SuiteIdentities`).
+
+**Definition (partitions).** Calibration, validation, and evaluation partitions are
+disjoint on **all four axes** — document, domain, entity, and template — checked by the
+#832 leakage machinery (`detect_document_leakage` extended per-axis in the reference
+model). A leaked key on any axis rejects the split; a tampered fixture fails `verify_cid`.
+
+## 8. Baselines and their expected confusion profiles
+
+**Definition (the six baselines).** Every benchmark run reports, on identical items and
+identities: `always-serve`, `always-decline`, `current-D4` (coverage-only policy),
+`distance-only` (monotone in Hamming distance to the nearest calibrated region),
+`evidence-count-only` (support count threshold, ignoring conflict structure), and
+`trivial-prior` (the no-context floor). The first two and last one bind to the #832
+`ControlKind` vocabulary (`always-serve`, `always-decline`, `trivial-prior`).
+
+**Empirical Criterion (distinct confusion profiles). Status: Structural for the planted
+populations; Empirical on the real benchmark.** The baselines are non-degenerate and
+pairwise distinguishable by their category-confusion signatures: `always-serve` maximizes
+false answers on every unanswerable category with zero false abstains; `always-decline`
+inverts it; `current-D4` abstains on `unrelated-ood` but **falsely serves**
+`false-premise`, `contradictory-evidence`, and `missing-evidence` (the #811 finding, made a
+fixture); `distance-only` cannot separate `novel-but-supported` from `unrelated-ood` and is
+paraphrase-brittle (it falsely abstains on `paraphrased-answerable`, whose surface distance
+exceeds its threshold while the item stays covered and supported); `evidence-count-only`
+cannot separate `contradictory-evidence` from strongly `in-domain-answerable`;
+`trivial-prior` is the floor. The reference model plants each
+signature (`baselines_produce_distinct_confusion_profiles`); a degenerate control
+(`is_degenerate_control`) invalidates a reading.
+
+## 9. Predeclared metrics, powered n, and upper-confidence-bound targets
+
+**Definition (metric set).** All metrics are integer fractions (#832 `MetricStatus`):
+
+- **Risk–coverage**: the curve of (coverage = served fraction, risk = error among served)
+  as `θ` sweeps; primary summary `risk-coverage-auc` (the `s2-answerability-ood` primary
+  metric), reported with the always-serve / always-decline endpoints.
+- **False-answer rate**: served ∧ unanswerable, over unanswerable items, with a one-sided
+  95% upper confidence bound (UCB95).
+- **False-abstain rate**: abstained ∧ answerable, over answerable items, with UCB95.
+- **Calibration error**: integer-bucketed (10 confidence deciles) expected calibration
+  error in parts-per-thousand.
+- **Category confusion**: the 8×3 outcome matrix per category, per policy.
+
+**Definition (powered sample sizes — fixed before any fitting).** `N_PER_CATEGORY = 600`,
+`N_TOTAL = 4,800` evaluation items (with calibration and validation partitions at least the
+same size). Arithmetic behind the choice, from the declared bounds: at zero observed false
+answers over `n` unanswerable items, the rule-of-three one-sided UCB95 is `≈ 3/n`; the
+release false-answer target (below) needs UCB95 ≤ 10‰, so `n ≥ 300` unanswerable items
+suffice at zero failures and `n = 5 × 600 = 3,000` unanswerable items give headroom for
+non-zero counts (UCB95 at 3,000 with up to ~24 failures stays ≤ 10‰ by the same
+approximation, reported exactly by the Clopper–Pearson bound in the real report).
+Category-level resolution: at `n = 600` per category a 100‰ confusion rate carries a 95%
+half-width of ±24‰, so ≥ 50‰ profile differences between baselines are resolvable
+per-category.
+
+**Definition (frozen UCB targets — the operating-point constitution).**
+
+| Operating point | Selection rule (frozen now, fitted by #837) | Targets on the frozen eval partition |
+|---|---|---|
+| `research` | maximize coverage subject to UCB95(false-answer) ≤ **50‰** on the calibration partition | UCB95(false-answer) ≤ 50‰; false-abstain ≤ 300‰ |
+| `release` | maximize coverage subject to UCB95(false-answer) ≤ **10‰** on the calibration partition | UCB95(false-answer) ≤ 10‰; false-abstain ≤ 200‰ |
+
+Thresholds `θ` are **fitted only on the calibration partition** and evaluated **once** on
+the evaluation partition; the selection rule and the targets above are frozen by this
+record *before* any fitting (`power_and_ucb_targets_fixed_before_fitting`,
+`operating_points_frozen_and_selection_rule_deterministic`).
+
+## 10. Identity binding
+
+**Definition (bound identities).** Every report pins, per #832: teacher, tokenizer, corpus,
+compiler, artifact, decoder — plus this benchmark's generator configuration, annotation
+set, rubric, split assignment, and report CIDs. A missing required identity forces the
+metric to `Unavailable` (never a vacuous zero); an absent fixture is `UNAVAILABLE`, never
+`PASS` (#830).
+
+## 11. Reference model and verification
+
+**Definition (executable reference model).** The companion test realizes: the §2 status
+space with canonical labels and parsers; the §2 decision table (total, exhaustively
+checked); the §5 encoders for CLI, native HTTP, OpenAI-compatible non-streaming and
+streaming, and the WASM boundary, with round-trip and injectivity checks; the §6
+legacy/fail-closed semantics with planted corrupt-calibration bytes; the §7 category and
+partition schema with per-axis leakage and tamper rejection; the §8 baseline signatures on
+planted populations; the §9 power constants and UCB arithmetic; and the §12 claim gate.
+Verification items V1–V5 of the issue map to named tests:
+
+- **V1** schema/status round-trips across surfaces → `cross_surface_encodings_round_trip_and_are_injective`.
+- **V2** planted false-premise / contradiction / answerable-novel / missing-evidence /
+  corrupt-calibration fixtures → `planted_category_fixtures_classify_per_gold`,
+  `corrupt_calibration_fails_closed`.
+- **V3** answerable novelty vs semantic unanswerability →
+  `answerable_novelty_is_separable_from_unanswerability`.
+- **V4** baseline confusion distinctness → `baselines_produce_distinct_confusion_profiles`.
+- **V5** power reproduction, split/leakage/tamper →
+  `power_and_ucb_targets_fixed_before_fitting`, `partitions_reject_leakage_and_tamper`,
+  plus the determinism check `double_run_and_reordered_input_determinism`.
+
+## 12. Coverage is not semantic PASS (the claim gate)
+
+**Guarantee (a coverage result cannot render a semantic verdict). Status: Structural**
+(reference model; `coverage_result_cannot_render_semantic_pass`). The reference claim gate
+accepts a "calibrated semantic abstention" claim only from a report that (a) binds the
+`s2-answerability-ood` suite identity, (b) carries measured evidence-axis metrics from a
+calibrated (non-legacy) run, and (c) meets the §9 targets at a frozen operating point.
+A D4/coverage-only report — however green — returns **NOT ESTABLISHED**. This is the
+conformance tooth against re-reading representation coverage as answerability.
+
+## 13. Repository conformance and claim status
+
+**Definition (RF mapping).** This record freezes contracts and measurement; it builds no
+deployed capability and adds **no** `model/ids.toml` row and **no** `CONFORMANCE.md`
+regeneration (generated conformance is never hand-edited). It extends the evidence
+language of RF-01 (behavioral probes), RF-22 (pathology/quality instruments), RF-23 (the
+deployed D4 selection/fallback path this schema wraps), and RF-29 (fixture-status
+discipline: absent is `UNAVAILABLE`, never `PASS`). A new selective-prediction capability
+ID is added only when #839 actually builds the typed capability, in the required order
+(IDs TOML → tagged Gherkin → failing marker/behavior test → implementation → regenerated
+`CONFORMANCE.md`).
+
+**Claim status and next action.** This completion **freezes meanings and measurement** and
+explicitly records: **current semantic abstention is NOT ESTABLISHED** — the deployed D4
+policy is a coverage policy; all five #811 semantic-OOD probes remained SERVABLE; no
+evidence-axis classifier exists. Next actions: #837 fits the artifact-only confidence
+calibrator against the §8 baselines and §9 targets on this constitution; #839 executes and
+certifies the typed contract across the production surfaces. A negative or sub-target
+outcome there is a legitimate, recordable result under this constitution, not a reason to
+move the frozen targets.


### PR DESCRIPTION
## Problem and outcome

#811 established D4 parity while all five semantic-OOD probes stayed SERVABLE: the deployed axis measures representation/resolution *coverage*, not whether an answer is *supported*. Covered, novel, unsupported, contradictory, low-confidence, declined, and answered were not separate typed concepts, and the five hand-written probes cannot support a risk claim. This PR freezes the S2 item-A contract: a typed selective-prediction status space with deterministic cross-surface representation, and a powered, CID-bound answerability benchmark constitution — **before any threshold is fitted**. It explicitly records **current semantic abstention as NOT ESTABLISHED**.

## Scope

- `docs/selective_prediction_spec_838.md` — the frozen contract + constitution:
  - Eight typed statuses (`covered`, `distributionally-novel`, `insufficient-evidence`, `conflicting-evidence`, `supported-answer`, `low-confidence`, `abstention`, `hard-incompatibility`), composed as coverage/evidence/confidence axes + a total deterministic outcome function with a fixed cause-precedence order. Answerable novelty (`novel-but-supported`) is separable from semantic unanswerability by construction.
  - Formal-vocabulary classification of every status (Guarantee vs Assumption vs Empirical Criterion, per `docs/formal_vocabulary.md`).
  - Evidence/provenance/confidence fields (integer-only) carried identically by witness and production response.
  - Deterministic mapping table for CLI, native HTTP, OpenAI-compatible non-streaming AND streaming, and WASM hosts. An abstention is never an empty success, an empty-`choices` completion, a silent stream end, or a generic server error.
  - Backward compatibility: no-calibration artifacts stay legacy/coverage-only (no fabricated confidence, no calibrated-answerability claim); corrupt/incompatible calibration **fails closed** as `hard-incompatibility` (corrupt never silently degrades to legacy).
  - Benchmark constitution for the frozen `s2-answerability-ood` suite (#832): 8 gold-annotated categories, document/domain/entity/template-disjoint partitions, 6 baselines (always-serve, always-decline, current-D4, distance-only, evidence-count-only, trivial-prior) with distinct expected confusion profiles, pre-declared metrics (risk-coverage, false-answer, false-abstain, calibration, category-confusion), powered n (600/category, 4,800 total) with UCB arithmetic, and frozen research/release operating-point selection rules + targets (false-answer UCB95 ≤ 50‰ / ≤ 10‰).
- `crates/uor-r4-api/tests/selective_prediction_spec_838.rs` — executable reference model: 15 machine-checked properties (totality/determinism, label round-trips, per-surface injectivity, abstention-never-hidden, legacy/fail-closed semantics with planted corrupt-calibration bytes, per-axis leakage + tamper rejection, planted category fixtures classifying per gold, pairwise-distinct baseline signatures incl. the #811 current-D4 false-serve fixture, power/UCB constants fixed before fitting, deterministic operating-point selection, the coverage-cannot-render-semantic-PASS claim gate, witness field parity, double-run/reordered determinism). Binds the #832 vocabulary (`ControlKind`, `MetricStatus`, `compute_cid`/`verify_cid`, `detect_document_leakage`, `is_degenerate_control`).
- `docs/RESEARCH.md` — S2 item-A summary paragraph appended.

## Non-goals

No predictor deployed, no threshold fitted (#837), no serving-surface changes (#839), no `model/ids.toml` row, no `CONFORMANCE.md` regeneration (spec-leaf per the #835/#832 precedent; a selective-prediction capability ID is added only when #839 builds the typed capability, in the required built-capability order). Code distance is not treated as factual truth; the five #811 probes are not a release benchmark.

## Acceptance-criteria status (issue #838)

- Every outcome has one typed meaning and deterministic cross-surface representation — DONE (spec §2/§5; injectivity + round-trip tests).
- Benchmark n sufficient for the declared false-answer upper bound with category-level power — DONE (spec §9: rule-of-three/UCB arithmetic, n=600/category; machine-checked constants).
- Answerable novelty vs semantic unanswerability explicitly separable — DONE (spec §2; `answerable_novelty_is_separable_from_unanswerability`).
- Baselines/controls non-degenerate; operating points frozen before fitting — DONE (spec §8/§9; distinct planted signatures; frozen selection rules + targets; `is_degenerate_control` bound).
- All data/annotations/generators/splits/rubrics/reports CID-bound and replayable — DONE (spec §7/§10; `compute_cid`/`verify_cid` fixtures; #830 UNAVAILABLE-never-PASS rule bound).

## Verification (issue items V1–V5 → named tests)

- V1 schema/status round-trip across CLI/API/server/WASM → `cross_surface_encodings_round_trip_and_are_injective`, `status_space_is_total_and_labels_round_trip`.
- V2 planted false-premise, contradiction, answerable-novel, missing-evidence, corrupt-calibration fixtures → `planted_category_fixtures_classify_per_gold`, `corrupt_calibration_fails_closed`.
- V3 power-analysis reproduction and split/leakage/tamper tests → `power_and_ucb_targets_fixed_before_fitting`, `partitions_reject_leakage_and_tamper`.
- V4 always-serve/always-decline/D4 baselines produce distinct expected confusion profiles → `baselines_produce_distinct_confusion_profiles`.
- V5 claim-wording/conformance tooth against rendering a coverage result as semantic PASS → `coverage_result_cannot_render_semantic_pass` (+ CI claim-wording gate green).

Local gates green before push: fmt --check; claim-wording; clippy -D warnings (workspace, all targets/features); no_std ladder; wasm lib; xtask validate (R1/R4/R5/gnaf); repo-conformance (R2/R3); cargo-deny bans (R6); doc tests; workspace test suite (the model-driven bdd soak is local-only and CI-skipped by design — all other binaries green).

## Compatibility and migration

Typed fields are additive where protocols permit; legacy-client and old-artifact behavior is explicitly defined (legacy-coverage mode); old artifacts cannot inherit a calibrated-answerability claim. No format or runtime bytes change in this PR.

## Conformance effects

None generated. Extends the evidence language of RF-01 / RF-22 / RF-23 / RF-29; no new built RF capability.

## Claim-boundary changes

`docs/RESEARCH.md` now records the frozen S2 contract and that semantic abstention is NOT ESTABLISHED — a narrowing, honesty-increasing change; no capability claim is added.

## Negative or unavailable results

None to report: this issue's deliverable is definitional infrastructure; the NOT-ESTABLISHED record is the required truthful claim status, not a measurement failure.

## Intentionally excluded

Pre-existing untracked user dirs (`obs-text/`, `tf1-pkg/`) are not part of this change and are not staged.

Closes #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2R2qs9kfcYpsjUua1SYmi
