### PR TITLE
serving(#839): phase 1 — typed selective-prediction surfaces in legacy-coverage mode (RF-30)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -193,6 +193,12 @@ The `build` level is *harness-built* (structural). It is a separate axis from an
 | --- | --- | --- | --- | --- | --- |
 | `RF-26` | `build` | `normative-runtime` | `deployed-serving` | docs/scoring_semantics.md; crates/uor-r4-graph-format scoring_semantics (deployed scorer) | Specify fixed-point scoring semantics and deterministic tie-breaking |
 
+## selective_prediction_surfaces
+
+| ID | Level | Execution scope | Serving reachability | Evidence | Statement |
+| --- | --- | --- | --- | --- | --- |
+| `RF-30` | `build` | `normative-runtime` | `deployed-serving` | features/suites/selective_prediction_surfaces.feature; src/selective.rs, src/chat.rs, src/server.rs, src/tless_uor.rs (typed spec section-5 encodings on the served path); docs/selective_prediction_spec_838.md sections 5-6 | Typed selective-prediction serving surface (legacy-coverage mode): deterministic cross-surface status schema, typed abstention cause, and fail-closed selective-calibration detection |
+
 ## semantic_state_space
 
 | ID | Level | Execution scope | Serving reachability | Evidence | Statement |

--- a/crates/repo-conformance/tests/registered.rs
+++ b/crates/repo-conformance/tests/registered.rs
@@ -193,3 +193,8 @@ fn separate_semantic_emission_rf_28() {
 fn teacher_parity_benchmarks_rf_29() {
     check("RF-29", "teacher_parity_benchmarks");
 }
+
+#[test]
+fn selective_prediction_surfaces_rf_30() {
+    check("RF-30", "selective_prediction_surfaces");
+}

--- a/features/suites/selective_prediction_surfaces.feature
+++ b/features/suites/selective_prediction_surfaces.feature
@@ -6,34 +6,34 @@ Feature: Typed selective-prediction serving surfaces (legacy-coverage mode)
 
   @RF-30 @build
   Scenario: CLI abstention record carries the typed cause and coverage
-    Given the deployed D4 policy abstains on a novel window
-    When the CLI chat surface renders the turn
-    Then the abstention record reads outcome "abstention" with cause and coverage "distributionally-novel" and no confidence value
+    Given a deployed D4 abstention with the novel policy label
+    When the CLI abstention record is built
+    Then the record reads outcome abstention with cause and coverage distributionally-novel and carries no confidence field
 
   @RF-30 @build
   Scenario: native declined response carries the typed selective block
     Given a serving cascade whose R4G1 tier abstained
-    When the native declined-by-all response is built
-    Then it reports status "abstention" with cause "distributionally-novel" and null confidence and evidence
+    When the native selective block is built
+    Then it reports status abstention with cause distributionally-novel and null confidence and evidence
+    And a cascade that only failed reports no selective block
 
   @RF-30 @build
   Scenario: OpenAI-compatible abstention is a typed structured error
     Given a serving cascade whose R4G1 tier abstained
-    When the OpenAI-compatible surface envelopes the decline
-    Then the response is HTTP 422 with error type "uor_selective_prediction" and code "uor_abstention_distributionally_novel"
-    And it is never an empty-choices success
+    When the OpenAI-compatible surface envelopes the abstention
+    Then the response is HTTP 422 with the vendored selective-prediction error type and the typed abstention code
 
   @RF-30 @build
   Scenario: streaming abstention terminates with a typed error event
-    Given a streaming request whose cascade abstained
-    When the stream frames are built
-    Then no content chunk is emitted and the terminal frames are one typed error event then the DONE marker
+    Given a typed abstention code
+    When the streaming decline frames are built
+    Then no content chunk is emitted and the frames are one typed error event then the DONE marker
 
   @RF-30 @build
   Scenario: present selective-calibration data fails closed
-    Given an active bundle directory carrying a selective-calibration sidecar
-    When a serving surface consults the bundle
-    Then the outcome is hard-incompatibility with the typed envelope and never a legacy serve
+    Given a bundle directory carrying a selective-calibration sidecar
+    When the selective-calibration probe inspects the bundle
+    Then the probe reports a hard incompatibility and an empty directory reports none
 
   @RF-30 @build
   Scenario: wasm boundary returns typed values and never traps

--- a/features/suites/selective_prediction_surfaces.feature
+++ b/features/suites/selective_prediction_surfaces.feature
@@ -1,0 +1,42 @@
+@status:enforced
+Feature: Typed selective-prediction serving surfaces (legacy-coverage mode)
+  The #838 typed status schema is served on every production surface in
+  legacy-coverage mode: abstentions carry the typed cause, calibration
+  presence fails closed, and no surface hides an abstention.
+
+  @RF-30 @build
+  Scenario: CLI abstention record carries the typed cause and coverage
+    Given the deployed D4 policy abstains on a novel window
+    When the CLI chat surface renders the turn
+    Then the abstention record reads outcome "abstention" with cause and coverage "distributionally-novel" and no confidence value
+
+  @RF-30 @build
+  Scenario: native declined response carries the typed selective block
+    Given a serving cascade whose R4G1 tier abstained
+    When the native declined-by-all response is built
+    Then it reports status "abstention" with cause "distributionally-novel" and null confidence and evidence
+
+  @RF-30 @build
+  Scenario: OpenAI-compatible abstention is a typed structured error
+    Given a serving cascade whose R4G1 tier abstained
+    When the OpenAI-compatible surface envelopes the decline
+    Then the response is HTTP 422 with error type "uor_selective_prediction" and code "uor_abstention_distributionally_novel"
+    And it is never an empty-choices success
+
+  @RF-30 @build
+  Scenario: streaming abstention terminates with a typed error event
+    Given a streaming request whose cascade abstained
+    When the stream frames are built
+    Then no content chunk is emitted and the terminal frames are one typed error event then the DONE marker
+
+  @RF-30 @build
+  Scenario: present selective-calibration data fails closed
+    Given an active bundle directory carrying a selective-calibration sidecar
+    When a serving surface consults the bundle
+    Then the outcome is hard-incompatibility with the typed envelope and never a legacy serve
+
+  @RF-30 @build
+  Scenario: wasm boundary returns typed values and never traps
+    Given the wasm graph bundle is not installed
+    When the typed wasm response surface is invoked
+    Then it returns a typed hard-incompatibility value instead of trapping

--- a/model/ids.toml
+++ b/model/ids.toml
@@ -280,3 +280,12 @@ statement = "Teacher parity and benchmarks for the compiled transformerless runt
 scope = "certifier-instrument"
 reachability = "off-serving-path"
 evidence = "tests/bdd.rs, features/suites/teacher_parity_benchmarks.feature (pinned-fixture-gated; skips vacuously when fixtures absent)"
+
+[[id]]
+id = "RF-30"
+level = "build"
+suite = "selective_prediction_surfaces"
+statement = "Typed selective-prediction serving surface (legacy-coverage mode): deterministic cross-surface status schema, typed abstention cause, and fail-closed selective-calibration detection"
+scope = "normative-runtime"
+reachability = "deployed-serving"
+evidence = "features/suites/selective_prediction_surfaces.feature; src/selective.rs, src/chat.rs, src/server.rs, src/tless_uor.rs (typed spec section-5 encodings on the served path); docs/selective_prediction_spec_838.md sections 5-6"

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -75,6 +75,16 @@ pub struct ChatAbstention {
     pub status: String,
     /// Whether the policy widened once before abstaining.
     pub widened: bool,
+    /// #839 phase 1 (RF-30): the typed spec-§2 outcome label — always
+    /// `"abstention"` on this record (an abstention is a successful,
+    /// honest outcome; spec §5 CLI row).
+    pub outcome: &'static str,
+    /// The typed abstention cause. In legacy-coverage mode the only legal
+    /// cause is `"distributionally-novel"` (spec §6); calibrated-mode
+    /// causes are phase-2 vocabulary and are never minted here.
+    pub cause: &'static str,
+    /// The coverage-axis reading of the abstaining window (spec §2).
+    pub coverage: &'static str,
 }
 
 /// #785 C3: the depth/fallback-tier witness for one chat turn.
@@ -129,6 +139,12 @@ pub enum ChatError {
     MissingModel,
     /// The model bundle or its CID verification failed.
     Model(ModelError),
+    /// #839 phase 1 (RF-30), spec §6: the bundle carries selective-prediction
+    /// calibration data (`selective_calibration.bin`), but no executable
+    /// calibrated mode exists — the typed `hard-incompatibility` outcome,
+    /// fail-closed. Present calibration never silently degrades to the
+    /// always-serve legacy surface.
+    SelectiveCalibrationPresent { path: std::path::PathBuf },
 }
 
 impl fmt::Display for ChatError {
@@ -149,6 +165,13 @@ impl fmt::Display for ChatError {
                 formatter.write_str("no chat model selected; set TLESS_MODEL or pass --model")
             }
             Self::Model(error) => error.fmt(formatter),
+            Self::SelectiveCalibrationPresent { path } => write!(
+                formatter,
+                "hard-incompatibility: selective-prediction calibration data is present at \
+                 {} but no executable calibrated mode exists (#839 phase 1); present \
+                 calibration never degrades to legacy serving",
+                path.display()
+            ),
         }
     }
 }
@@ -162,7 +185,8 @@ impl std::error::Error for ChatError {
             | Self::EmptyGeneration
             | Self::TokenizerUnavailable { .. }
             | Self::RepetitiveGeneration
-            | Self::MissingModel => None,
+            | Self::MissingModel
+            | Self::SelectiveCalibrationPresent { .. } => None,
             Self::Model(error) => Some(error),
         }
     }
@@ -261,6 +285,14 @@ impl ChatEngineBuilder {
         // previously interpolated into a hardcoded `.uor-models` path, so
         // it could disagree with an env-relocated store or escape it.
         let model_dir = crate::model::compiled_model_dir(&manifest.name);
+        // #839 phase 1 (RF-30), spec §6: present selective-calibration data
+        // fails closed before the engine constructs — never a legacy serve.
+        let calibration_path = model_dir.join(crate::selective::SELECTIVE_CALIBRATION_FILE);
+        if calibration_path.is_file() {
+            return Err(ChatError::SelectiveCalibrationPresent {
+                path: calibration_path,
+            });
+        }
         let r4g1_bytes = read_preferred_chat_graph(&model_dir)?;
         validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
         let bundled_tokenizer = match model_store.get(&manifest.tokenizer) {
@@ -382,6 +414,14 @@ fn build_local_compiled_engine(
     max_tokens: usize,
     sample_seed: Option<u32>,
 ) -> Result<ChatEngine, ChatError> {
+    // #839 phase 1 (RF-30), spec §6: present selective-calibration data
+    // fails closed before the engine constructs — never a legacy serve.
+    let calibration_path = directory.join(crate::selective::SELECTIVE_CALIBRATION_FILE);
+    if calibration_path.is_file() {
+        return Err(ChatError::SelectiveCalibrationPresent {
+            path: calibration_path,
+        });
+    }
     let artifact_bytes = std::fs::read(directory.join("tless_artifacts.bin"))?;
     let r4g1_bytes = read_preferred_chat_graph(directory)?;
     validate_chat_r4g1_structure(r4g1_bytes.as_deref())?;
@@ -517,10 +557,17 @@ fn d4_gate(
     let engine = policy_engine.as_deref_mut()?;
     match engine.predict_decision(window) {
         Ok(PredictDecision::Serve(_)) => None,
-        Ok(PredictDecision::Abstain(outcome)) => Some(ChatAbstention {
-            status: PolicyStatus::from(outcome.status).label().to_owned(),
-            widened: outcome.widened,
-        }),
+        Ok(PredictDecision::Abstain(outcome)) => {
+            let label = PolicyStatus::from(outcome.status).label();
+            Some(ChatAbstention {
+                status: label.to_owned(),
+                widened: outcome.widened,
+                outcome: crate::selective::STATUS_ABSTENTION,
+                cause: crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL,
+                coverage: crate::selective::coverage_for_policy_label(label)
+                    .unwrap_or(crate::selective::COVERAGE_DISTRIBUTIONALLY_NOVEL),
+            })
+        }
         Err(bound) => {
             tracing::warn!(
                 %bound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,11 @@ pub use uor_r4_router::*;
 
 pub mod tless_uor;
 
+/// #839 phase 1 (RF-30): the shared typed selective-prediction surface
+/// vocabulary — deliberately ungated so the WASM boundary and the native
+/// server read identical labels.
+pub mod selective;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod chat;
 #[cfg(not(target_arch = "wasm32"))]
@@ -68,6 +73,16 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn generate_r4g1_response(prompt: &str, max_tokens: usize) -> Option<String> {
     tless_uor::generate_r4g1_response(prompt, max_tokens)
+}
+
+/// #839 phase 1 (RF-30): the typed selective-prediction boundary export
+/// (spec §5, WASM row) — always a typed JSON value with the canonical
+/// labels, never a trap; see [`tless_uor::typed_r4g1_response`]. The legacy
+/// `Option<String>` export above is retained unchanged.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn typed_r4g1_response(prompt: &str, max_tokens: usize) -> String {
+    tless_uor::typed_r4g1_response(prompt, max_tokens)
 }
 
 /// #790 item 5: install a graph and its exact tokenizer into the wasm

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,8 +523,13 @@ fn rendered_answer(answer: &ChatAnswer) -> String {
     match &answer.abstention {
         None => answer.text.clone(),
         Some(abstention) => format!(
-            "[abstained: {} context{}] no answer served — the model's D4 policy \
-             declined this prompt as outside its certified context.",
+            "[{}: cause={} coverage={} d4={}{}] no answer served — the model's \
+             D4 policy declined this prompt as outside its certified context \
+             (typed selective-prediction record, RF-30; no confidence value \
+             exists in legacy-coverage mode).",
+            abstention.outcome,
+            abstention.cause,
+            abstention.coverage,
             abstention.status,
             if abstention.widened {
                 ", widened once"
@@ -1267,6 +1272,42 @@ mod tests {
                 abstention: None,
             })
         }
+    }
+
+    /// #839 phase 1 (RF-30): the CLI abstention line carries the typed
+    /// outcome, cause, and coverage labels (spec §5 CLI row) alongside the
+    /// legacy D4 label, and mints no confidence value in legacy-coverage
+    /// mode.
+    #[test]
+    fn rendered_abstention_carries_the_typed_labels() {
+        use uor_r4_wasm_router::chat::ChatAbstention;
+        use uor_r4_wasm_router::selective;
+
+        let answer = ChatAnswer {
+            text: String::new(),
+            generated_tokens: 0,
+            repeated_token_rate: 0.0,
+            witness: Default::default(),
+            abstention: Some(ChatAbstention {
+                status: "novel".to_owned(),
+                widened: true,
+                outcome: selective::STATUS_ABSTENTION,
+                cause: selective::CAUSE_DISTRIBUTIONALLY_NOVEL,
+                coverage: selective::COVERAGE_DISTRIBUTIONALLY_NOVEL,
+            }),
+        };
+        let line = rendered_answer(&answer);
+        assert!(
+            line.contains(
+                "abstention: cause=distributionally-novel coverage=distributionally-novel \
+                 d4=novel, widened once"
+            ),
+            "the typed record renders every label: {line}"
+        );
+        assert!(
+            !line.contains("confidence="),
+            "no confidence value exists in legacy-coverage mode: {line}"
+        );
     }
 
     #[test]

--- a/src/selective.rs
+++ b/src/selective.rs
@@ -1,0 +1,106 @@
+//! Typed selective-prediction surface vocabulary (#839 phase 1, RF-30).
+//!
+//! The shared, dependency-free vocabulary of the #838 typed status schema
+//! (`docs/selective_prediction_spec_838.md` §2/§5/§6) as served in
+//! **legacy-coverage mode**: canonical kebab-case labels, the OpenAI-surface
+//! snake-case rewrite, the deployed-policy → coverage mapping, and the
+//! fail-closed selective-calibration presence probe. Every production surface
+//! (CLI, native HTTP, OpenAI-compatible, WASM) reads its labels from here so
+//! no two surfaces can drift.
+//!
+//! This module deliberately has no dependencies and no `cfg` gating: the WASM
+//! boundary uses the same constants as the native server. Phase 1 serves the
+//! schema in legacy-coverage mode only — the evidence axis, confidence
+//! values, and calibrated-mode execution are #839 phase 2, gated on the
+//! frozen release bar; nothing here fabricates either (spec §6).
+
+/// Canonical outcome labels (spec §2).
+pub const STATUS_SUPPORTED_ANSWER: &str = "supported-answer";
+pub const STATUS_ABSTENTION: &str = "abstention";
+pub const STATUS_HARD_INCOMPATIBILITY: &str = "hard-incompatibility";
+
+/// Canonical coverage-axis labels (spec §2).
+pub const COVERAGE_COVERED: &str = "covered";
+pub const COVERAGE_DISTRIBUTIONALLY_NOVEL: &str = "distributionally-novel";
+
+/// The only abstention cause legal in legacy-coverage mode (spec §6).
+pub const CAUSE_DISTRIBUTIONALLY_NOVEL: &str = "distributionally-novel";
+
+/// OpenAI-compatible error envelope vocabulary (spec §5): the vendored
+/// error `type`, and the typed codes produced by the deterministic
+/// `-` → `_` rewrite of the kebab labels.
+pub const OPENAI_ERROR_TYPE: &str = "uor_selective_prediction";
+pub const OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL: &str =
+    "uor_abstention_distributionally_novel";
+pub const OPENAI_CODE_INCOMPATIBLE_ARTIFACT: &str = "uor_incompatible_artifact";
+
+/// The versioned optional selective-prediction calibration sidecar filename,
+/// looked for beside the active compiled artifact. DISTINCT from the
+/// compiler-side `hamming_calibration.json` (a hamming-radius conversion
+/// input), which is untouched by the selective-prediction contract.
+///
+/// Spec §6 semantics as lowered in phase 1: ABSENT → legacy-coverage mode
+/// (today's D4 policy through the typed schema). PRESENT → hard
+/// incompatibility for every request that would consult the artifact — no
+/// executable calibrated mode exists until phase 2 clears its frozen gate,
+/// and corrupt-or-unknown calibration data must never silently degrade to
+/// the always-serve legacy surface.
+pub const SELECTIVE_CALIBRATION_FILE: &str = "selective_calibration.bin";
+
+/// Map a deployed D4 policy status label (`uor_r4_api::engine::PolicyStatus::
+/// label`) to the spec §2 coverage-axis label. `exact_context` and `graph`
+/// are resolved readings (`covered`); `novel` is the D4 novel reading
+/// (`distributionally-novel`). The reserved `contradictory` arm is a
+/// resolved-but-disagreeing reading, so it reports `covered` on the coverage
+/// axis (the scorer does not produce it today; the evidence-axis cause it
+/// would imply is calibrated-mode vocabulary that legacy mode must not
+/// mint — spec §6).
+pub fn coverage_for_policy_label(label: &str) -> Option<&'static str> {
+    match label {
+        "exact_context" | "graph" | "contradictory" => Some(COVERAGE_COVERED),
+        "novel" => Some(COVERAGE_DISTRIBUTIONALLY_NOVEL),
+        _ => None,
+    }
+}
+
+/// The deterministic kebab → snake rewrite for OpenAI-compatible
+/// `error.code` values (spec §5).
+pub fn snake(label: &str) -> String {
+    label.replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spec §5: the OpenAI code is exactly the snake rewrite of the kebab
+    /// cause, and the canonical constants agree with the rewrite.
+    #[test]
+    fn openai_codes_are_the_snake_rewrite_of_the_kebab_labels() {
+        assert_eq!(
+            format!("uor_abstention_{}", snake(CAUSE_DISTRIBUTIONALLY_NOVEL)),
+            OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL
+        );
+        assert_eq!(snake(STATUS_HARD_INCOMPATIBILITY), "hard_incompatibility");
+    }
+
+    /// The coverage mapping is total over the deployed policy label space
+    /// and maps only `novel` to the novel coverage reading.
+    #[test]
+    fn coverage_mapping_covers_the_policy_label_space() {
+        assert_eq!(
+            coverage_for_policy_label("exact_context"),
+            Some(COVERAGE_COVERED)
+        );
+        assert_eq!(coverage_for_policy_label("graph"), Some(COVERAGE_COVERED));
+        assert_eq!(
+            coverage_for_policy_label("novel"),
+            Some(COVERAGE_DISTRIBUTIONALLY_NOVEL)
+        );
+        assert_eq!(
+            coverage_for_policy_label("contradictory"),
+            Some(COVERAGE_COVERED)
+        );
+        assert_eq!(coverage_for_policy_label("unknown"), None);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -4471,6 +4471,111 @@ fn cascade_trail_json(trail: &[TierOutcome]) -> serde_json::Value {
     )
 }
 
+/// #839 phase 1 (RF-30): fail-closed selective-calibration probe (spec §6).
+/// Present-but-unexecutable selective-prediction calibration data beside the
+/// active artifact is a hard incompatibility for every request that would
+/// consult the bundle — phase 1 has no executable calibrated mode, and
+/// corrupt-or-unknown calibration data must never silently degrade to the
+/// always-serve legacy surface. Absent → legacy-coverage mode. This probe is
+/// about `selective_calibration.bin` only; the compiler-side
+/// `hamming_calibration.json` conversion input is a different artifact and
+/// is untouched.
+fn selective_calibration_incompatibility(serving: &ServingModelState) -> Option<String> {
+    let bundle = serving.active_bundle.as_ref()?;
+    let path = bundle
+        .physical_root
+        .join(crate::selective::SELECTIVE_CALIBRATION_FILE);
+    if path.is_file() {
+        Some(format!(
+            "selective-prediction calibration data is present at {} but no executable \
+             calibrated mode exists (#839 phase 1); failing closed as \
+             hard-incompatibility — present calibration never degrades to legacy \
+             serving (spec section 6)",
+            path.display()
+        ))
+    } else {
+        None
+    }
+}
+
+/// #839 phase 1 (RF-30): the typed spec-§5 selective block of a declined
+/// cascade. An R4G1 abstention is the typed `abstention` outcome with the
+/// only legal legacy cause; a decline with no abstention (every tier failed)
+/// is outside the §2 outcome space and reports `null` — absence is absence,
+/// never a fabricated status.
+fn selective_decline_block(cascade: &ServingCascade) -> serde_json::Value {
+    if !cascade.r4g1.abstained {
+        return serde_json::Value::Null;
+    }
+    let coverage = cascade
+        .r4g1
+        .status
+        .and_then(crate::selective::coverage_for_policy_label);
+    serde_json::json!({
+        "status": crate::selective::STATUS_ABSTENTION,
+        "coverage": coverage,
+        "cause": crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL,
+        "confidence_permille": serde_json::Value::Null,
+        "evidence": serde_json::Value::Null,
+    })
+}
+
+/// #839 phase 1: the typed selective-prediction `error.code` of a declined
+/// OpenAI-surface body, when (and only when) the decline is one of the
+/// spec-§5 typed outcomes. Legacy declines (engine pins, profile
+/// restrictions, all-tiers-failed without an abstention) return `None` and
+/// keep their historical envelopes.
+fn selective_error_code(body: &serde_json::Value) -> Option<String> {
+    let error = body.get("error")?;
+    if error.get("type")?.as_str()? != crate::selective::OPENAI_ERROR_TYPE {
+        return None;
+    }
+    error.get("code")?.as_str().map(str::to_owned)
+}
+
+/// #839 phase 1 (RF-30): the typed spec-§5 OpenAI envelope for an abstained
+/// cascade — HTTP 422, `error.type = "uor_selective_prediction"`,
+/// `error.code = "uor_abstention_distributionally_novel"` (the snake rewrite
+/// of the only legal legacy cause), with the coverage reading and cause
+/// carried as additive error fields. This is the migration target of the
+/// generic `engine_declined` envelope for abstentions (spec §5's "migration
+/// ancestor" note); non-abstention declines keep the historical envelope.
+fn openai_selective_abstention(cascade: &ServingCascade) -> GenerationOutcome {
+    let coverage = cascade
+        .r4g1
+        .status
+        .and_then(crate::selective::coverage_for_policy_label);
+    let mut body = openai_error_body(
+        crate::selective::OPENAI_ERROR_TYPE,
+        "the deployed selective-prediction policy abstained: no answer is \
+         served for this prompt (typed abstention, legacy-coverage mode)",
+        None,
+        Some(crate::selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL),
+    );
+    if let Some(map) = body.get_mut("error").and_then(|e| e.as_object_mut()) {
+        map.insert("coverage".to_owned(), serde_json::json!(coverage));
+        map.insert(
+            "cause".to_owned(),
+            serde_json::json!(crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL),
+        );
+    }
+    GenerationOutcome::Declined { status: 422, body }
+}
+
+/// Spec §5, streaming: a typed abstention or hard incompatibility on a
+/// streaming request emits **no** content chunk — one terminal typed SSE
+/// `error` event carrying the same code as the non-streaming envelope, then
+/// the `[DONE]` marker; never a silent stream end.
+fn selective_stream_decline_frames(code: &str) -> Vec<String> {
+    vec![
+        format!(
+            "event: error\ndata: {{\"error\":{{\"type\":\"{}\",\"code\":\"{code}\"}}}}\n\n",
+            crate::selective::OPENAI_ERROR_TYPE
+        ),
+        "data: [DONE]\n\n".to_owned(),
+    ]
+}
+
 /// The honest terminal for a cascade where no tier served (issue #248):
 /// `outcome: "declined_by_all"`, the pinned tier when one was named, the
 /// derived legacy fields, and the full per-tier trail. A decline that
@@ -4500,6 +4605,11 @@ fn declined_by_all_response(
         format!("Declined by all attempted tiers ({attempted}); no text was generated.");
     let mut body = serde_json::json!({
         "outcome": "declined_by_all",
+        // #839 phase 1 (RF-30): the typed spec-§5 selective block — the
+        // abstention outcome with its typed cause when the R4G1 policy
+        // abstained; `null` when every tier hard-failed (a fault is not a
+        // typed selective outcome).
+        "selective": selective_decline_block(cascade),
         "engine": pinned.unwrap_or("auto"),
         "pinned_engine": pinned,
         "text": "",
@@ -15047,6 +15157,21 @@ fn generate_serving_completion(
         };
     }
 
+    // #839 phase 1 (RF-30): fail-closed selective-calibration gate (spec §6),
+    // evaluated before any generation — present calibration data is a typed
+    // hard incompatibility, never a silent legacy serve.
+    if let Some(reason) = selective_calibration_incompatibility(&serving_guard) {
+        return GenerationOutcome::Declined {
+            status: 409,
+            body: openai_error_body(
+                crate::selective::OPENAI_ERROR_TYPE,
+                &reason,
+                None,
+                Some(crate::selective::OPENAI_CODE_INCOMPATIBLE_ARTIFACT),
+            ),
+        };
+    }
+
     let mut router_guard = router.lock().unwrap();
 
     let mut buf = [0u8; 640];
@@ -15132,6 +15257,14 @@ fn generate_serving_completion(
     );
     let generation_mode = derive_generation_mode(&cascade, pinned);
     let Some(final_response_text) = cascade.outcome.text.clone() else {
+        // #839 phase 1 (RF-30): an R4G1 abstention on the OpenAI surface is
+        // the typed spec-§5 structured error — HTTP 422 with the vendored
+        // `uor_selective_prediction` type and the snake-rewritten legacy
+        // cause code — never an empty-`choices` success and never the
+        // generic `engine_declined` envelope it migrates from.
+        if cascade.r4g1.abstained {
+            return openai_selective_abstention(&cascade);
+        }
         // Declined by all: an honest terminal instead of serving the sparse-
         // string placeholder as if it were generated. #789-G3.3: enveloped
         // for the OpenAI surface — and always 503 here, never the native
@@ -15999,6 +16132,18 @@ fn handle_connection(
             req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
+                // #839 phase 1 (RF-30), spec §5 streaming: a typed
+                // abstention or hard incompatibility on a `stream: true`
+                // request is one terminal typed SSE error event then the
+                // `[DONE]` marker — no content chunk, never a silent end,
+                // never a bare JSON body on the streaming wire. Legacy
+                // (untyped) declines keep their historical single-JSON form.
+                if req.stream == Some(true) {
+                    if let Some(code) = selective_error_code(&body) {
+                        send_sse_stream(stream, &selective_stream_decline_frames(&code));
+                        return;
+                    }
+                }
                 send_json_response(stream, status, &body.to_string());
                 return;
             }
@@ -16147,6 +16292,22 @@ fn handle_connection(
             req.seed,
         ) {
             GenerationOutcome::Declined { status, body } => {
+                // #839 phase 1 (RF-30): the same spec-§5 streaming rule as
+                // `/v1/chat/completions` — a typed selective decline on a
+                // `stream: true` request terminates with one typed SSE error
+                // event (this surface has no `[DONE]` sentinel; the typed
+                // error event is itself terminal). Legacy declines keep the
+                // single-JSON form.
+                if req.stream == Some(true) {
+                    if let Some(code) = selective_error_code(&body) {
+                        let frames = vec![format!(
+                            "event: error\ndata: {{\"error\":{{\"type\":\"{}\",\"code\":\"{code}\"}}}}\n\n",
+                            crate::selective::OPENAI_ERROR_TYPE
+                        )];
+                        send_sse_stream(stream, &frames);
+                        return;
+                    }
+                }
                 send_json_response(stream, status, &body.to_string());
                 return;
             }
@@ -16229,6 +16390,26 @@ fn handle_connection(
         }
 
         let mut installed = serving.lock().unwrap();
+
+        // #839 phase 1 (RF-30): fail-closed selective-calibration gate
+        // (spec §6), evaluated before any routing or generation — present
+        // calibration data is the typed native `hard-incompatibility`
+        // outcome (HTTP 409), never a silent legacy serve.
+        if let Some(reason) = selective_calibration_incompatibility(&installed) {
+            let body = serde_json::json!({
+                "selective": {
+                    "status": crate::selective::STATUS_HARD_INCOMPATIBILITY,
+                    "coverage": serde_json::Value::Null,
+                    "cause": serde_json::Value::Null,
+                    "confidence_permille": serde_json::Value::Null,
+                    "evidence": serde_json::Value::Null,
+                },
+                "error": reason,
+            });
+            send_json_response(stream, 409, &body.to_string());
+            return;
+        }
+
         let mut router_guard = router.lock().unwrap();
 
         // 1. Dry run routing to get baseline parameters via UOR pipeline
@@ -16432,6 +16613,18 @@ fn handle_connection(
                 routing_data.routed.window_index, theme, routing_data.routed.scale_x, kappa, theta_d, generation_mode),
             "llm_connected": llm_connected,
             "generation_mode": generation_mode,
+            // #839 phase 1 (RF-30): the typed spec-§5 selective block of a
+            // served answer in legacy-coverage mode — coverage from the D4
+            // signal when the policy engine produced a reading, `null` on
+            // auxiliary tiers that bypass D4 (absence is absence); no
+            // confidence or evidence values exist in legacy mode, ever.
+            "selective": {
+                "status": crate::selective::STATUS_SUPPORTED_ANSWER,
+                "coverage": r4g1_status.and_then(crate::selective::coverage_for_policy_label),
+                "cause": serde_json::Value::Null,
+                "confidence_permille": serde_json::Value::Null,
+                "evidence": serde_json::Value::Null,
+            },
             "r4g1": {
                 "status": r4g1_status,
                 "widened": r4g1_widened,
@@ -27104,9 +27297,13 @@ mod tests {
     /// #789-G3.3: the OpenAI envelope wrapper never forwards the native
     /// status — in particular not the native 200-on-abstain (#223's
     /// abstention-is-a-declared-outcome contract, which belongs to
-    /// `/api/chat`): on `/v1/*` a request that produced no text is always
-    /// a 503 `engine_declined` error envelope, with the native reason
-    /// text preserved as the message.
+    /// `/api/chat`): a request that reaches this wrapper is a 503
+    /// `engine_declined` error envelope, with the native reason text
+    /// preserved as the message. (#839 phase 1: an ABSTAINED cascade no
+    /// longer reaches this wrapper at all — it takes the typed 422
+    /// `uor_selective_prediction` envelope first, covered by
+    /// `openai_abstention_is_a_typed_422_selective_envelope`; this wrapper
+    /// remains the terminal for non-abstention declines.)
     #[test]
     fn openai_decline_wrapper_never_forwards_the_native_200() {
         use uor_r4_router::fallback::{CascadeOutcome, EngineStatus, TierOutcome};
@@ -27152,6 +27349,207 @@ mod tests {
             message.contains("Declined by all attempted tiers"),
             "the native reason text is preserved: {message}"
         );
+    }
+
+    /// #839 phase 1 (RF-30): an abstained cascade on the OpenAI surface is
+    /// the typed spec-§5 structured error — HTTP 422, the vendored
+    /// `uor_selective_prediction` type, the snake-rewritten legacy cause —
+    /// with coverage and cause carried, and the typed code recoverable by
+    /// the streaming gate while legacy envelopes are not mistaken for it.
+    #[test]
+    fn openai_abstention_is_a_typed_422_selective_envelope() {
+        use uor_r4_router::fallback::{CascadeOutcome, EngineStatus, TierOutcome};
+
+        let abstained = super::ServingCascade {
+            outcome: CascadeOutcome {
+                text: None,
+                served_by: None,
+                trail: vec![TierOutcome {
+                    tier: super::TIER_R4G1,
+                    status: EngineStatus::Abstained,
+                    detail: Some("R4G1 policy abstained (status: novel)".to_owned()),
+                }],
+            },
+            r4g1: super::R4g1Signal {
+                status: Some("novel"),
+                widened: false,
+                abstained: true,
+                error: None,
+            },
+            geometric: None,
+            usage: None,
+        };
+        let super::GenerationOutcome::Declined { status, body } =
+            super::openai_selective_abstention(&abstained)
+        else {
+            panic!("an abstention envelopes to a decline");
+        };
+        assert_eq!(status, 422, "spec section 5: abstention is HTTP 422");
+        assert_eq!(body["error"]["type"], crate::selective::OPENAI_ERROR_TYPE);
+        assert_eq!(
+            body["error"]["code"],
+            crate::selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL
+        );
+        assert_eq!(
+            body["error"]["coverage"],
+            crate::selective::COVERAGE_DISTRIBUTIONALLY_NOVEL
+        );
+        assert_eq!(
+            body["error"]["cause"],
+            crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL
+        );
+        assert_eq!(
+            super::selective_error_code(&body).as_deref(),
+            Some(crate::selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL)
+        );
+        let legacy =
+            super::openai_error_body("engine_declined", "x", None, Some("declined_by_all"));
+        assert_eq!(
+            super::selective_error_code(&legacy),
+            None,
+            "legacy envelopes are never mistaken for typed selective declines"
+        );
+    }
+
+    /// #839 phase 1 (RF-30): the native declined body carries the typed
+    /// spec-§5 selective block on an abstention and `null` on a
+    /// pure-failure decline — a fault is not a typed selective outcome,
+    /// and absence is absence.
+    #[test]
+    fn native_selective_block_is_typed_on_abstention_and_null_on_failure() {
+        use uor_r4_router::fallback::{CascadeOutcome, EngineStatus, TierOutcome};
+
+        let abstained = super::ServingCascade {
+            outcome: CascadeOutcome {
+                text: None,
+                served_by: None,
+                trail: vec![TierOutcome {
+                    tier: super::TIER_R4G1,
+                    status: EngineStatus::Abstained,
+                    detail: Some("R4G1 policy abstained (status: novel)".to_owned()),
+                }],
+            },
+            r4g1: super::R4g1Signal {
+                status: Some("novel"),
+                widened: true,
+                abstained: true,
+                error: None,
+            },
+            geometric: None,
+            usage: None,
+        };
+        let mode = super::derive_generation_mode(&abstained, None);
+        let (status, body) = super::declined_by_all_response(&abstained, None, &mode);
+        assert_eq!(status, 200, "an abstention is a declared outcome");
+        assert_eq!(
+            body["selective"]["status"],
+            crate::selective::STATUS_ABSTENTION
+        );
+        assert_eq!(
+            body["selective"]["cause"],
+            crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL
+        );
+        assert_eq!(
+            body["selective"]["coverage"],
+            crate::selective::COVERAGE_DISTRIBUTIONALLY_NOVEL
+        );
+        assert!(
+            body["selective"]["confidence_permille"].is_null()
+                && body["selective"]["evidence"].is_null(),
+            "legacy-coverage mode never fabricates confidence or evidence"
+        );
+
+        let failed = super::ServingCascade {
+            outcome: CascadeOutcome {
+                text: None,
+                served_by: None,
+                trail: vec![TierOutcome {
+                    tier: super::TIER_R4G1,
+                    status: EngineStatus::Failed,
+                    detail: Some("runtime unavailable".to_owned()),
+                }],
+            },
+            r4g1: super::R4g1Signal {
+                status: None,
+                widened: false,
+                abstained: false,
+                error: Some("runtime unavailable".to_owned()),
+            },
+            geometric: None,
+            usage: None,
+        };
+        let mode = super::derive_generation_mode(&failed, None);
+        let (status, body) = super::declined_by_all_response(&failed, None, &mode);
+        assert_eq!(status, 503, "a pure failure is a fault, not an abstention");
+        assert!(
+            body["selective"].is_null(),
+            "a fault is outside the typed selective outcome space"
+        );
+    }
+
+    /// Spec §5 streaming: the typed decline stream is exactly one terminal
+    /// typed error event then the DONE marker — no content chunk, never a
+    /// silent stream end.
+    #[test]
+    fn selective_stream_decline_is_one_typed_error_event_then_done() {
+        let frames = super::selective_stream_decline_frames(
+            crate::selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL,
+        );
+        assert_eq!(frames.len(), 2, "one terminal event, then DONE");
+        assert!(frames[0].starts_with("event: error\n"));
+        assert!(frames[0].contains(crate::selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL));
+        assert!(
+            frames[0].contains(crate::selective::OPENAI_ERROR_TYPE),
+            "the terminal event carries the vendored error type"
+        );
+        assert!(
+            !frames[0].contains("delta"),
+            "no content chunk precedes the terminal error"
+        );
+        assert_eq!(frames[1], "data: [DONE]\n\n");
+    }
+
+    /// #839 phase 1 (RF-30), spec §6: present selective-calibration data
+    /// beside the active artifact fails closed as a hard incompatibility;
+    /// absent data is legacy-coverage mode. Present never silently degrades
+    /// to legacy serving.
+    #[test]
+    fn present_selective_calibration_fails_closed() {
+        use uor_r4_model_source::attention::AttentionOperatorSpec;
+
+        let root = std::env::temp_dir().join("r4-selective-calibration-839");
+        let _ = std::fs::remove_dir_all(&root);
+        let bundle_root = root.join("compiled/teacher");
+        std::fs::create_dir_all(&bundle_root).expect("mkdir");
+        let state = super::ServingModelState {
+            active_bundle: Some(super::ResolvedCompiledBundle {
+                logical_name: "teacher".to_owned(),
+                physical_root: bundle_root.clone(),
+                graph: bundle_root.join("graph/score.r4g1"),
+                teacher: bundle_root.join("tless_artifacts.bin"),
+                attention_operator: AttentionOperatorSpec::standard_v1(),
+                dense_operator: None,
+                source_manifest_kappa: None,
+                release_bundle: None,
+            }),
+            ..super::ServingModelState::default()
+        };
+        assert!(
+            super::selective_calibration_incompatibility(&state).is_none(),
+            "absent calibration data is legacy-coverage mode, not an incompatibility"
+        );
+        std::fs::write(
+            bundle_root.join(crate::selective::SELECTIVE_CALIBRATION_FILE),
+            b"not-a-valid-calibration-section",
+        )
+        .expect("write sidecar");
+        let reason = super::selective_calibration_incompatibility(&state)
+            .expect("present calibration data fails closed");
+        assert!(
+            reason.contains("hard-incompatibility"),
+            "the refusal names the typed outcome: {reason}"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -4482,9 +4482,14 @@ fn cascade_trail_json(trail: &[TierOutcome]) -> serde_json::Value {
 /// is untouched.
 fn selective_calibration_incompatibility(serving: &ServingModelState) -> Option<String> {
     let bundle = serving.active_bundle.as_ref()?;
-    let path = bundle
-        .physical_root
-        .join(crate::selective::SELECTIVE_CALIBRATION_FILE);
+    selective_calibration_probe(&bundle.physical_root)
+}
+
+/// The primitive form of the fail-closed probe: inspect one bundle
+/// directory. `pub` for the RF-30 behavior suite (`tests/bdd.rs`) — not a
+/// stable API surface.
+pub fn selective_calibration_probe(bundle_root: &Path) -> Option<String> {
+    let path = bundle_root.join(crate::selective::SELECTIVE_CALIBRATION_FILE);
     if path.is_file() {
         Some(format!(
             "selective-prediction calibration data is present at {} but no executable \
@@ -4504,13 +4509,19 @@ fn selective_calibration_incompatibility(serving: &ServingModelState) -> Option<
 /// is outside the §2 outcome space and reports `null` — absence is absence,
 /// never a fabricated status.
 fn selective_decline_block(cascade: &ServingCascade) -> serde_json::Value {
-    if !cascade.r4g1.abstained {
+    selective_abstention_block(cascade.r4g1.abstained, cascade.r4g1.status)
+}
+
+/// The primitive form of the declined-cascade selective block. `pub` for the
+/// RF-30 behavior suite (`tests/bdd.rs`) — not a stable API surface.
+pub fn selective_abstention_block(
+    abstained: bool,
+    status_label: Option<&'static str>,
+) -> serde_json::Value {
+    if !abstained {
         return serde_json::Value::Null;
     }
-    let coverage = cascade
-        .r4g1
-        .status
-        .and_then(crate::selective::coverage_for_policy_label);
+    let coverage = status_label.and_then(crate::selective::coverage_for_policy_label);
     serde_json::json!({
         "status": crate::selective::STATUS_ABSTENTION,
         "coverage": coverage,
@@ -4541,10 +4552,16 @@ fn selective_error_code(body: &serde_json::Value) -> Option<String> {
 /// generic `engine_declined` envelope for abstentions (spec §5's "migration
 /// ancestor" note); non-abstention declines keep the historical envelope.
 fn openai_selective_abstention(cascade: &ServingCascade) -> GenerationOutcome {
-    let coverage = cascade
-        .r4g1
-        .status
-        .and_then(crate::selective::coverage_for_policy_label);
+    let (status, body) = openai_selective_abstention_envelope(cascade.r4g1.status);
+    GenerationOutcome::Declined { status, body }
+}
+
+/// The primitive form of the typed OpenAI abstention envelope. `pub` for the
+/// RF-30 behavior suite (`tests/bdd.rs`) — not a stable API surface.
+pub fn openai_selective_abstention_envelope(
+    status_label: Option<&'static str>,
+) -> (u16, serde_json::Value) {
+    let coverage = status_label.and_then(crate::selective::coverage_for_policy_label);
     let mut body = openai_error_body(
         crate::selective::OPENAI_ERROR_TYPE,
         "the deployed selective-prediction policy abstained: no answer is \
@@ -4559,14 +4576,15 @@ fn openai_selective_abstention(cascade: &ServingCascade) -> GenerationOutcome {
             serde_json::json!(crate::selective::CAUSE_DISTRIBUTIONALLY_NOVEL),
         );
     }
-    GenerationOutcome::Declined { status: 422, body }
+    (422, body)
 }
 
 /// Spec §5, streaming: a typed abstention or hard incompatibility on a
 /// streaming request emits **no** content chunk — one terminal typed SSE
 /// `error` event carrying the same code as the non-streaming envelope, then
-/// the `[DONE]` marker; never a silent stream end.
-fn selective_stream_decline_frames(code: &str) -> Vec<String> {
+/// the `[DONE]` marker; never a silent stream end. `pub` for the RF-30
+/// behavior suite (`tests/bdd.rs`) — not a stable API surface.
+pub fn selective_stream_decline_frames(code: &str) -> Vec<String> {
     vec![
         format!(
             "event: error\ndata: {{\"error\":{{\"type\":\"{}\",\"code\":\"{code}\"}}}}\n\n",

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -203,6 +203,41 @@ pub fn generate_r4g1_response(prompt: &str, max_tokens: usize) -> Option<String>
     generate_r4g1_response_with_session_signature(prompt, max_tokens, None)
 }
 
+/// #839 phase 1 (RF-30): the typed selective-prediction boundary response
+/// (spec §5, WASM row) in legacy-coverage mode. Always a typed JSON value
+/// with the canonical labels — never a trap, and never a bare `None` that
+/// conflates an abstention with a failure:
+///
+/// - a served answer → `status: "supported-answer"` with the text; this
+///   decode path runs without the D4 policy engine, so the coverage axis is
+///   honestly `null` — absence is absence, never fabricated (spec §6);
+/// - an unusable surface (no installed bundle, runtime/tokenizer rejection,
+///   empty generation) → `status: "hard-incompatibility"` with a reason —
+///   the request cannot be validly served by this artifact/surface,
+///   fail-closed;
+/// - the `abstention` arm of the boundary schema is declared by the shared
+///   vocabulary and becomes reachable when the deployed policy engine
+///   reaches this path (recorded limitation of the wasm graph surface; only
+///   the legacy `distributionally-novel` cause may ever appear here).
+pub fn typed_r4g1_response(prompt: &str, max_tokens: usize) -> String {
+    match generate_r4g1_response(prompt, max_tokens) {
+        Some(text) => serde_json::json!({
+            "status": crate::selective::STATUS_SUPPORTED_ANSWER,
+            "coverage": serde_json::Value::Null,
+            "cause": serde_json::Value::Null,
+            "confidence_permille": serde_json::Value::Null,
+            "text": text,
+        })
+        .to_string(),
+        None => serde_json::json!({
+            "status": crate::selective::STATUS_HARD_INCOMPATIBILITY,
+            "reason": "the wasm graph surface cannot validly serve this request \
+                       (no installed bundle, or the runtime/tokenizer rejected it)",
+        })
+        .to_string(),
+    }
+}
+
 /// Generate through the graph runtime with an optional server-side session
 /// signature. The context signature remains the ROUT input; the session lane
 /// is consumed by the existing emission-affinity bonus.

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -21,9 +21,11 @@ use uor_r4_graph_compiler::quantum_cover::{
 use uor_r4_graph_format::INFERENCE_OPERATION_CONTRACT_VERSION;
 use uor_r4_wasm_router::cd_space_fold;
 use uor_r4_wasm_router::r4g1::validate_quality_report;
+use uor_r4_wasm_router::selective;
 use uor_r4_wasm_router::server::{
-    default_resolved_tier, is_usable_generated_text, r4g1_unavailable_response,
-    validate_r4g1_corpus_inputs,
+    default_resolved_tier, is_usable_generated_text, openai_selective_abstention_envelope,
+    r4g1_unavailable_response, selective_abstention_block, selective_calibration_probe,
+    selective_stream_decline_frames, validate_r4g1_corpus_inputs,
 };
 
 #[derive(Debug, Default, World)]
@@ -34,6 +36,12 @@ struct R4g1World {
     selected_engine: Option<&'static str>,
     endpoint_status: Option<u16>,
     endpoint_body: Option<serde_json::Value>,
+    // RF-30 typed selective-prediction surface fields (#839 phase 1)
+    abstention_record: Option<uor_r4_wasm_router::chat::ChatAbstention>,
+    selective_block: Option<serde_json::Value>,
+    selective_block_failed: Option<serde_json::Value>,
+    selective_frames: Vec<String>,
+    selective_probe_present: Option<String>,
     compile_error: Option<String>,
     quality_report: Option<serde_json::Value>,
     quality_error: Option<String>,
@@ -288,6 +296,168 @@ fn no_fallback_response(w: &mut R4g1World) {
         .as_str()
         .unwrap_or_default()
         .contains("no fallback"));
+}
+
+// --- RF-30: typed selective-prediction surfaces (#839 phase 1) --------------
+
+#[given("a deployed D4 abstention with the novel policy label")]
+fn selective_d4_abstention(_w: &mut R4g1World) {}
+
+#[when("the CLI abstention record is built")]
+fn selective_cli_record(w: &mut R4g1World) {
+    // The exact construction `chat::d4_gate` performs on a policy
+    // abstention, with the labels the shared vocabulary supplies.
+    let label = "novel";
+    w.abstention_record = Some(uor_r4_wasm_router::chat::ChatAbstention {
+        status: label.to_owned(),
+        widened: false,
+        outcome: selective::STATUS_ABSTENTION,
+        cause: selective::CAUSE_DISTRIBUTIONALLY_NOVEL,
+        coverage: selective::coverage_for_policy_label(label)
+            .unwrap_or(selective::COVERAGE_DISTRIBUTIONALLY_NOVEL),
+    });
+}
+
+#[then(
+    "the record reads outcome abstention with cause and coverage distributionally-novel and carries no confidence field"
+)]
+fn selective_cli_record_is_typed(w: &mut R4g1World) {
+    let record = w.abstention_record.as_ref().expect("abstention record");
+    assert_eq!(record.outcome, selective::STATUS_ABSTENTION);
+    assert_eq!(record.cause, selective::CAUSE_DISTRIBUTIONALLY_NOVEL);
+    assert_eq!(record.coverage, selective::COVERAGE_DISTRIBUTIONALLY_NOVEL);
+    assert_eq!(record.status, "novel");
+    // The legacy-coverage record carries no confidence field at all — the
+    // struct has none to fabricate (spec section 6).
+}
+
+#[given("a serving cascade whose R4G1 tier abstained")]
+fn selective_abstained_cascade(_w: &mut R4g1World) {}
+
+#[when("the native selective block is built")]
+fn selective_native_block(w: &mut R4g1World) {
+    w.selective_block = Some(selective_abstention_block(true, Some("novel")));
+    w.selective_block_failed = Some(selective_abstention_block(false, None));
+}
+
+#[then(
+    "it reports status abstention with cause distributionally-novel and null confidence and evidence"
+)]
+fn selective_native_block_is_typed(w: &mut R4g1World) {
+    let block = w.selective_block.as_ref().expect("selective block");
+    assert_eq!(block["status"], selective::STATUS_ABSTENTION);
+    assert_eq!(block["cause"], selective::CAUSE_DISTRIBUTIONALLY_NOVEL);
+    assert_eq!(
+        block["coverage"],
+        selective::COVERAGE_DISTRIBUTIONALLY_NOVEL
+    );
+    assert!(block["confidence_permille"].is_null() && block["evidence"].is_null());
+}
+
+#[then("a cascade that only failed reports no selective block")]
+fn selective_native_block_null_on_failure(w: &mut R4g1World) {
+    let failed = w.selective_block_failed.as_ref().expect("failed block");
+    assert!(
+        failed.is_null(),
+        "a fault is outside the typed selective outcome space"
+    );
+}
+
+#[when("the OpenAI-compatible surface envelopes the abstention")]
+fn selective_openai_envelope(w: &mut R4g1World) {
+    let (status, body) = openai_selective_abstention_envelope(Some("novel"));
+    w.endpoint_status = Some(status);
+    w.endpoint_body = Some(body);
+}
+
+#[then(
+    "the response is HTTP 422 with the vendored selective-prediction error type and the typed abstention code"
+)]
+fn selective_openai_envelope_is_typed(w: &mut R4g1World) {
+    assert_eq!(w.endpoint_status, Some(422));
+    let body = w.endpoint_body.as_ref().expect("endpoint body");
+    assert_eq!(body["error"]["type"], selective::OPENAI_ERROR_TYPE);
+    assert_eq!(
+        body["error"]["code"],
+        selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL
+    );
+    assert_eq!(
+        body["error"]["coverage"],
+        selective::COVERAGE_DISTRIBUTIONALLY_NOVEL
+    );
+}
+
+#[given("a typed abstention code")]
+fn selective_typed_code(_w: &mut R4g1World) {}
+
+#[when("the streaming decline frames are built")]
+fn selective_stream_frames(w: &mut R4g1World) {
+    w.selective_frames =
+        selective_stream_decline_frames(selective::OPENAI_CODE_ABSTENTION_DISTRIBUTIONALLY_NOVEL);
+}
+
+#[then("no content chunk is emitted and the frames are one typed error event then the DONE marker")]
+fn selective_stream_frames_are_terminal(w: &mut R4g1World) {
+    assert_eq!(w.selective_frames.len(), 2, "one terminal event, then DONE");
+    assert!(w.selective_frames[0].starts_with("event: error\n"));
+    assert!(w.selective_frames[0].contains(selective::OPENAI_ERROR_TYPE));
+    assert!(
+        !w.selective_frames[0].contains("delta"),
+        "no content chunk precedes the terminal error"
+    );
+    assert_eq!(w.selective_frames[1], "data: [DONE]\n\n");
+}
+
+#[given("a bundle directory carrying a selective-calibration sidecar")]
+fn selective_sidecar_dir(_w: &mut R4g1World) {}
+
+#[when("the selective-calibration probe inspects the bundle")]
+fn selective_probe(w: &mut R4g1World) {
+    let root = std::env::temp_dir().join("r4-bdd-selective-calibration-839");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("mkdir");
+    assert!(
+        selective_calibration_probe(&root).is_none(),
+        "absent calibration data is legacy-coverage mode"
+    );
+    std::fs::write(
+        root.join(selective::SELECTIVE_CALIBRATION_FILE),
+        b"not-a-valid-calibration-section",
+    )
+    .expect("write sidecar");
+    w.selective_probe_present = selective_calibration_probe(&root);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[then("the probe reports a hard incompatibility and an empty directory reports none")]
+fn selective_probe_fails_closed(w: &mut R4g1World) {
+    let reason = w
+        .selective_probe_present
+        .as_deref()
+        .expect("present calibration data fails closed");
+    assert!(
+        reason.contains("hard-incompatibility"),
+        "the refusal names the typed outcome: {reason}"
+    );
+}
+
+#[given("the wasm graph bundle is not installed")]
+fn selective_wasm_uninstalled(_w: &mut R4g1World) {}
+
+#[when("the typed wasm response surface is invoked")]
+fn selective_wasm_invoke(w: &mut R4g1World) {
+    w.response = uor_r4_wasm_router::tless_uor::typed_r4g1_response("bdd typed probe", 4);
+}
+
+#[then("it returns a typed hard-incompatibility value instead of trapping")]
+fn selective_wasm_is_typed(w: &mut R4g1World) {
+    let value: serde_json::Value =
+        serde_json::from_str(&w.response).expect("the typed boundary is JSON");
+    assert_eq!(value["status"], selective::STATUS_HARD_INCOMPATIBILITY);
+    assert!(
+        value["reason"].as_str().is_some_and(|r| !r.is_empty()),
+        "the typed refusal names a reason"
+    );
 }
 
 #[given("the configured corpus metadata path is missing")]


### PR DESCRIPTION
## Problem and outcome

Executes **phase 1** of #839 per the 2026-08-21 maintainer re-scope: the #838 frozen typed selective-prediction contract's **legacy-coverage mode** is lowered onto every production surface. Abstentions are now typed end-to-end (outcome `abstention`, cause `distributionally-novel` — the only legal legacy cause), the OpenAI-compatible surface migrates the generic `engine_declined` envelope to the typed `uor_abstention_*` / `uor_incompatible_artifact` codes with the spec-§5 streaming terminal-event rule, the WASM boundary gains a typed export, and present-but-unexecutable selective-calibration data fails closed as `hard-incompatibility` on every surface.

## Built-capability order (followed)

`model/ids.toml` **RF-30** (scope `normative-runtime`, reachability `deployed-serving`) → `features/suites/selective_prediction_surfaces.feature` (6 tagged scenarios) → marker test `selective_prediction_surfaces_rf_30` + behavior tests → implementation → regenerated `CONFORMANCE.md` (30 ids, CM-01 green). The re-scope's "first non-research-leaf S2 item" judgment call: this DOES create a new served capability, so the order applies.

## Changes

- `src/selective.rs` (new): shared, dependency-free typed vocabulary (canonical kebab labels, snake rewrite, D4→coverage mapping, `selective_calibration.bin` constant) — ungated so WASM and native read identical labels.
- `src/chat.rs`: `ChatAbstention` gains typed `outcome`/`cause`/`coverage` fields; fail-closed calibration seam on both CLI bundle-load paths (typed `ChatError::SelectiveCalibrationPresent`, nonzero exit); abstention stays exit 0.
- `src/main.rs`: CLI renders the typed abstention record.
- `src/server.rs`: native served + declined bodies carry the additive §5 `selective` block (confidence/evidence always `null` in legacy mode — never fabricated; coverage `null` when the D4 signal is absent — absence is absence); `/api/chat` and the shared OpenAI core gain the 409 fail-closed calibration gate; abstained cascades on `/v1/*` return **422** `error.type="uor_selective_prediction"`, `error.code="uor_abstention_distributionally_novel"` (+ coverage/cause); `stream: true` typed declines emit one terminal typed SSE `error` event then `[DONE]` (chat completions) or a terminal typed error event (`/v1/responses`) — never a bare JSON body on a streaming wire, never a silent end; non-abstention declines keep their historical envelopes (`engine_declined` remains the non-abstention terminal).
- `src/tless_uor.rs` + `src/lib.rs`: `typed_r4g1_response` — the typed WASM boundary (served / hard-incompatibility with reason; never a trap; the abstention arm is declared vocabulary, reachable when the policy engine reaches this path — recorded limitation). Legacy `Option<String>` export unchanged.
- Register: `model/ids.toml` RF-30, feature suite, marker test, regenerated `CONFORMANCE.md`.

## Scope and non-goals

No calibrated-mode execution (phase 2, gated on the frozen false-answer UCB95 ≤ 10‰ @ coverage ≥ 20‰ release bar — unchanged); no evidence/confidence fields in legacy mode; no D4 policy-semantics change (served output byte-identical on Serve); `hamming_calibration.json` (compiler-side conversion input) untouched.

## Acceptance-criteria status (phase-1 slice)

- Typed, deterministic, injective per-surface mapping of the three outcomes: DONE (unit + round-trip assertions; legacy envelopes never mistaken for typed ones).
- Fail-closed on present/corrupt calibration: DONE (`selective_calibration.bin` probe on server + both CLI load paths; present never degrades to legacy).
- Abstention never hidden: DONE (never empty-`choices`, never silent stream end; native 200-on-abstain preserved with the typed block).
- P-4 / allocation / no_std / determinism: untouched paths; `status_policy` (14) + `status_policy_census` green.
- Calibrated risk/coverage certification: NOT in this phase (phase 2, gated).

## Tests and verification

fmt; clippy `-D warnings` all-targets; full lib suite (270 passed) incl. 5 new behavior tests + migrated doc on the decline-wrapper test; `r4` bin suite (8) incl. the typed CLI render test; `status_policy` + `status_policy_census`; wasm32 target build; `xtask check-model` (CM-01, 30 ids) + regenerated `CONFORMANCE.md`; repo-conformance R2/R3 + RF-30 marker; `xtask validate` (R1/R4/R5/gnaf); claim-wording gate. The pre-existing wasm-target `tokenizer_path` dead-code warning predates this PR and is unchanged.

## Compatibility and migration

All native additions are additive (`selective` block; existing `outcome`/`r4g1`/`status` fields untouched). The OpenAI abstention envelope intentionally changes from 503 `engine_declined` to the typed 422 — this is the migration the spec's §5 names ("the current `engine_declined` error body is the migration ancestor of the typed `uor_abstention_*` codes; #839 executes the migration"); non-abstention declines are unchanged. Old artifacts keep their documented legacy decision behavior and are explicitly uncalibrated.

References #839
