### PR TITLE
serving(#906): inject skip-mix/psi-bag-known candidates into the decided list

### DIFF
--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -812,13 +812,55 @@ fn skipmix_supported_count(
         .count()
 }
 
-/// #897 skip-mix-adjusted argmax over the decided candidate list: each
-/// candidate's base `ScoreQ` gains its skip-mix contribution (design spec §5),
-/// under the canonical tie-break (score descending, token id ascending).
-/// Byte-identical to `base_token`'s own argmax when both tables are absent
-/// (every contribution is zero) or the window is empty -- absent-section
-/// identity, with no separate "is active" gate needed.
-fn skipmix_adjusted_token(
+// ---------------------------------------------------------------------
+// #906 (follow-up to #897/#904): the skip-mix lane's own tables are a
+// candidate SOURCE, not only a re-ranker. #904 diagnosed the #897
+// LOWERING-FIDELITY GAP as breadth-bound -- 35/87 favorable pairs have a
+// teacher target absent from the base engine's own decided candidate list
+// (`StepCandidates::ranked()`, capped at `STEP_TOP_CANDIDATES = 8`) before
+// any skip-mix scoring runs, and every width/selection lever available to
+// the base engine's own candidate generation was tested and found not to
+// close it (#906 issue body). Separately, #906 found that SKMX/PSIB
+// already record the correct answer for 45/45 (100%) of the currently-
+// missing pair-sides -- #897's original re-rank-only combine (replaced
+// below; see git history for its exact prior form) simply never had a
+// path to use that knowledge, since `segment_argmax` only ever considers
+// tokens already present in `ranked`. The functions below extend the
+// candidate space to include every SKMX/PSIB-known token, combined under
+// the non-additive "unit-safe" rule #904 arm 3 validated (never summing
+// the base `ScoreQ` and the skip-mix contribution across their two
+// incompatible scales).
+// ---------------------------------------------------------------------
+
+/// The unit-safe argmax over the union of `ranked` and every candidate
+/// token present in a relevant SKMX row (keyed `(content_token,
+/// last_window_token)`) or PSIB row (keyed `content_token` alone) for the
+/// window's own unique tokens -- not merely a re-rank of `ranked`. Ranking
+/// key: `(has_support, contribution_if_supported_else_base_raw)`. A
+/// candidate with positive skip-mix support always outranks one with
+/// none -- every stored SKMX/PSIB entry contributes a strictly positive
+/// residual (`segment_fit::quantize_rate`'s `clamp(1, ..)` floor), so
+/// `skipmix_token_contribution`'s saturating sum of one or more such
+/// entries is positive for any discovered candidate -- and among
+/// supported candidates the tie-break is contribution magnitude; among
+/// unsupported candidates (only `ranked`'s own entries can ever land here,
+/// since discovery only ever finds supported ones) the tie-break is the
+/// real base `ScoreQ`. Final ties broken by ascending token id, matching
+/// every other combinator in this module.
+///
+/// Absent-section identity: with both tables absent, no candidate is ever
+/// discovered and every `ranked` entry's contribution is 0, so the
+/// combine reduces to `ranked`'s own top entry (already score-descending,
+/// token-ascending) -- byte-identical to the base decision.
+///
+/// Allocation-free (P-4 discipline): no set or list is materialized for
+/// the expanded candidate space. A candidate discovered via more than one
+/// row is simply reconsidered rather than deduplicated -- its
+/// contribution is deterministic regardless of how many times it is
+/// visited, so revisits cost cycles, never correctness. Work is bounded:
+/// at most `WINDOW` unique tokens, each yielding at most one row, each row
+/// bounded by the compiled table's own `max_entries()`.
+fn skipmix_injected_argmax(
     ranked: &[(u32, ScoreQ)],
     primary: Option<&SkipmixTable<'_>>,
     fallback: Option<&PsiBagTable<'_>>,
@@ -826,22 +868,58 @@ fn skipmix_adjusted_token(
     last_token: u32,
     base_token: u32,
 ) -> u32 {
+    if ranked.is_empty() {
+        return base_token;
+    }
     let sup_ts = skipmix_supported_count(primary, unique_tokens, last_token);
-    segment_argmax(ranked, base_token, |candidate| {
-        skipmix_scale_by_lambda_and_support(
-            skipmix_token_contribution(primary, fallback, unique_tokens, last_token, candidate),
+
+    let mut best_token = base_token;
+    let mut best_key: (bool, i32) = (false, i32::MIN);
+    let mut consider = |token: u32, base_raw: Option<i32>| {
+        let contribution = skipmix_scale_by_lambda_and_support(
+            skipmix_token_contribution(primary, fallback, unique_tokens, last_token, token),
             sup_ts,
             unique_tokens.len(),
-        )
-    })
+        );
+        let key = if contribution > 0 {
+            (true, contribution)
+        } else {
+            (false, base_raw.unwrap_or(i32::MIN))
+        };
+        if key > best_key || (key == best_key && token < best_token) {
+            best_key = key;
+            best_token = token;
+        }
+    };
+
+    for &(token, score) in ranked {
+        consider(token, Some(score.raw()));
+    }
+    for &t in unique_tokens {
+        let entries = if let Some(row) = primary.and_then(|table| table.find(t, last_token)) {
+            Some(row.entries())
+        } else {
+            fallback
+                .and_then(|table| table.find(t))
+                .map(|row| row.entries())
+        };
+        if let Some(entries) = entries {
+            for entry in entries.iter() {
+                consider(entry.token, None);
+            }
+        }
+    }
+
+    best_token
 }
 
-/// The #897 skip-mix witness attribution over a decided candidate list:
-/// `Some` only when at least one table is present AND the skip-mix re-rank
-/// promotes a different token than the base winner; `None` otherwise
-/// (neither table present, or no change -> no attribution, preserving
-/// witness identity). Pure.
-fn skipmix_lane_attribution(
+/// The #906 skip-mix-lane witness attribution, built from
+/// [`skipmix_injected_argmax`]'s candidate-injection combine. `Some` only
+/// when at least one table is present AND the combine promotes a
+/// different token than the base winner; `None` otherwise (neither table
+/// present, or no change -> no attribution, preserving witness identity).
+/// Pure.
+fn skipmix_injected_lane_attribution(
     ranked: &[(u32, ScoreQ)],
     primary: Option<&SkipmixTable<'_>>,
     fallback: Option<&PsiBagTable<'_>>,
@@ -852,7 +930,7 @@ fn skipmix_lane_attribution(
     if primary.is_none() && fallback.is_none() {
         return None;
     }
-    let promoted = skipmix_adjusted_token(
+    let promoted = skipmix_injected_argmax(
         ranked,
         primary,
         fallback,
@@ -1488,16 +1566,16 @@ impl R4Engine {
     ///
     /// Byte-identical to [`Self::predict_decision_candidates`] when the
     /// artifact carries neither an SKMX nor a PSIB section (absent-section
-    /// identity). When present, the served token becomes the skip-mix-
-    /// adjusted argmax over the decided candidate list: each candidate gains
-    /// the sum, over the window's own unique tokens, of that token's learned
-    /// contribution -- joint `(token, last_window_token)` evidence where the
-    /// primary table supports it, verbatim Ψ-bag (content-token-only)
-    /// evidence otherwise -- under the same canonical tie-break (score
-    /// descending, token id ascending) `predict_decision_candidates_with_segment`
-    /// uses. Unlike the #836 segment lane, no persistent session object is
-    /// needed: the evidence is entirely the current window. An abstention is
-    /// never overridden into a served token.
+    /// identity). When present, the served token becomes
+    /// [`skipmix_injected_argmax`]'s pick over the union of the decided
+    /// candidate list and every token either table records evidence for at
+    /// the current window (#906, follow-up to #897/#904's
+    /// LOWERING-FIDELITY GAP diagnosis: the decided list alone structurally
+    /// excludes some teacher targets the tables already know about, no
+    /// matter how the decided list's own width or selection rule is
+    /// tuned -- closing that gap requires the tables to act as a candidate
+    /// source, not only a re-ranker). An abstention is never overridden
+    /// into a served token.
     pub fn predict_decision_candidates_with_skipmix(
         &mut self,
         window: &[u32],
@@ -1513,7 +1591,7 @@ impl R4Engine {
                     let primary = self.skipmix_primary_table();
                     let fallback = self.skipmix_fallback_table();
                     let (unique_buf, unique_len) = unique_window_tokens(window);
-                    outcome.token = skipmix_adjusted_token(
+                    outcome.token = skipmix_injected_argmax(
                         candidates.ranked(),
                         primary.as_ref(),
                         fallback.as_ref(),
@@ -1552,7 +1630,7 @@ impl R4Engine {
                 let primary = self.skipmix_primary_table();
                 let fallback = self.skipmix_fallback_table();
                 let (unique_buf, unique_len) = unique_window_tokens(window);
-                let attribution = skipmix_lane_attribution(
+                let attribution = skipmix_injected_lane_attribution(
                     candidates.ranked(),
                     primary.as_ref(),
                     fallback.as_ref(),
@@ -2347,31 +2425,35 @@ mod tests {
     }
 
     #[test]
-    fn skipmix_absent_tables_keep_base_winner() {
+    fn skipmix_injected_absent_tables_keep_base_winner() {
         let ranked = [(5u32, ScoreQ::from_raw(100)), (9, ScoreQ::from_raw(80))];
         let window = [1u32, 9, 3];
         let (unique, ulen) = unique_window_tokens(&window);
-        // Neither table present -> zero contribution everywhere -> base winner stands.
+        // Neither table present -> no candidate is ever discovered, and
+        // every `ranked` entry's contribution is zero -> base winner stands.
         assert_eq!(
-            skipmix_adjusted_token(&ranked, None, None, &unique[..ulen], 3, 5),
+            skipmix_injected_argmax(&ranked, None, None, &unique[..ulen], 3, 5),
             5
         );
-        assert!(skipmix_lane_attribution(&ranked, None, None, &unique[..ulen], 3, 5).is_none());
-        // Empty unique-token list -> zero contribution everywhere -> the
-        // result is the plain argmax of `ranked` (5, the higher base score),
-        // independent of `base_token`'s value (`segment_argmax` only falls
-        // back to `base_token` when `ranked` itself is empty).
-        assert_eq!(skipmix_adjusted_token(&ranked, None, None, &[], 3, 7), 5);
+        assert!(
+            skipmix_injected_lane_attribution(&ranked, None, None, &unique[..ulen], 3, 5).is_none()
+        );
+        // Empty unique-token list -> no row is ever consulted -> the result
+        // is the plain argmax of `ranked` (5, the higher base score),
+        // independent of `base_token`'s value (only a genuinely empty
+        // `ranked` falls back to `base_token`).
+        assert_eq!(skipmix_injected_argmax(&ranked, None, None, &[], 3, 7), 5);
         // A genuinely empty candidate list does fall back to `base_token`.
         assert_eq!(
-            skipmix_adjusted_token(&[], None, None, &unique[..ulen], 3, 7),
+            skipmix_injected_argmax(&[], None, None, &unique[..ulen], 3, 7),
             7
         );
     }
 
     #[test]
-    fn skipmix_promotes_via_joint_table() {
-        // Joint key (9, 3) -> candidate 9 gets a large boost.
+    fn skipmix_injected_promotes_candidate_already_in_ranked() {
+        // Joint key (9, 3) -> candidate 9 (already in `ranked`) gets strong
+        // support and wins under the unit-safe combine.
         let bytes = build_skipmix_table(&[(9, 3, vec![(9, 2_000_000)])]).expect("valid row");
         let table = SkipmixTable::parse(&bytes).expect("parse");
         let ranked = [(5u32, ScoreQ::from_raw(100)), (9, ScoreQ::from_raw(80))];
@@ -2379,19 +2461,55 @@ mod tests {
         let (unique, ulen) = unique_window_tokens(&window);
         let last_token = 3u32;
         assert_eq!(
-            skipmix_adjusted_token(&ranked, Some(&table), None, &unique[..ulen], last_token, 5),
+            skipmix_injected_argmax(&ranked, Some(&table), None, &unique[..ulen], last_token, 5),
             9
         );
-        let attr =
-            skipmix_lane_attribution(&ranked, Some(&table), None, &unique[..ulen], last_token, 5)
-                .expect("promotion attributed");
+        let attr = skipmix_injected_lane_attribution(
+            &ranked,
+            Some(&table),
+            None,
+            &unique[..ulen],
+            last_token,
+            5,
+        )
+        .expect("promotion attributed");
         assert_eq!(attr.promoted_token, 9);
         assert_eq!(attr.base_token, 5);
         assert_eq!(attr.boost, 2_000_000);
     }
 
     #[test]
-    fn skipmix_falls_back_to_psi_bag_when_joint_key_absent() {
+    fn skipmix_injects_candidate_absent_from_ranked() {
+        // #906's core fix: candidate 7 is NOT in `ranked` at all (the base
+        // engine's decided list only contains 5 and 9), but SKMX has strong
+        // evidence for it at (9, 3). Under the old re-rank-only design this
+        // was permanently invisible; it must now be discoverable and served.
+        let bytes = build_skipmix_table(&[(9, 3, vec![(7, 2_000_000)])]).expect("valid row");
+        let table = SkipmixTable::parse(&bytes).expect("parse");
+        let ranked = [(5u32, ScoreQ::from_raw(100)), (9, ScoreQ::from_raw(80))];
+        let window = [1u32, 9];
+        let (unique, ulen) = unique_window_tokens(&window);
+        let last_token = 3u32;
+        assert_eq!(
+            skipmix_injected_argmax(&ranked, Some(&table), None, &unique[..ulen], last_token, 5),
+            7
+        );
+        let attr = skipmix_injected_lane_attribution(
+            &ranked,
+            Some(&table),
+            None,
+            &unique[..ulen],
+            last_token,
+            5,
+        )
+        .expect("promotion attributed");
+        assert_eq!(attr.promoted_token, 7);
+        assert_eq!(attr.base_token, 5);
+        assert_eq!(attr.boost, 2_000_000);
+    }
+
+    #[test]
+    fn skipmix_injected_falls_back_to_psi_bag_when_joint_key_absent() {
         // No SKMX row for (9, 3) at all -> falls back to the PSIB row for
         // content token 9 alone.
         let skmx = build_skipmix_table(&[(9, 99, vec![(9, 1)])]).expect("valid row");
@@ -2404,7 +2522,7 @@ mod tests {
         let (unique, ulen) = unique_window_tokens(&window);
         let last_token = 3u32; // does NOT match the SKMX row's key (9, 99)
         assert_eq!(
-            skipmix_adjusted_token(
+            skipmix_injected_argmax(
                 &ranked,
                 Some(&skmx_table),
                 Some(&psib_table),
@@ -2417,14 +2535,18 @@ mod tests {
     }
 
     #[test]
-    fn skipmix_joint_row_presence_gates_fallback_even_without_candidate_match() {
+    fn skipmix_injected_joint_row_presence_gates_fallback_and_still_injects() {
         // SKMX HAS a row for (9, 3), but that row's entries do not include
-        // candidate 9 -- contributes 0 for candidate 9 from the joint table,
-        // and must NOT fall back to PSIB's row for content token 9 (which
-        // does have an entry for candidate 9). This is the load-bearing
-        // joint-vs-fallback asymmetry `skipmix_confirm_897.rs::skipmix_scores`
-        // validated: row PRESENCE gates the fallback, not per-candidate
-        // entry presence.
+        // candidate 9 -- contributes 0 for candidate 9 from the joint
+        // table, and must NOT fall back to PSIB's row for content token 9
+        // (which does have an entry for candidate 9). This is the
+        // load-bearing joint-vs-fallback asymmetry
+        // `skipmix_confirm_897.rs::skipmix_scores` validated: row PRESENCE
+        // gates the fallback, not per-candidate entry presence -- that
+        // property is unchanged by #906. What #906 DOES change: the same
+        // row's entry for candidate 2 (not in `ranked` at all) is now
+        // discovered and, having real support, wins over both `ranked`
+        // candidates (neither of which has any support here).
         let skmx = build_skipmix_table(&[(9, 3, vec![(2, 500)])]).expect("valid row");
         let skmx_table = SkipmixTable::parse(&skmx).expect("parse skmx");
         let psib = build_psi_bag_table(&[(9, vec![(9, 3_000_000)])]).expect("valid row");
@@ -2433,9 +2555,11 @@ mod tests {
         let ranked = [(5u32, ScoreQ::from_raw(100)), (9, ScoreQ::from_raw(80))];
         let window = [9u32];
         let (unique, ulen) = unique_window_tokens(&window);
-        // Base winner (5) stands: candidate 9 gets 80 + 0 = 80 < 100.
+        // Candidate 2 (injected, supported) outranks both 5 and 9
+        // (neither supported here -- gating held, PSIB's entry for
+        // candidate 9 never leaked through).
         assert_eq!(
-            skipmix_adjusted_token(
+            skipmix_injected_argmax(
                 &ranked,
                 Some(&skmx_table),
                 Some(&psib_table),
@@ -2443,21 +2567,22 @@ mod tests {
                 3,
                 5
             ),
-            5
+            2
         );
     }
 
     #[test]
-    fn skipmix_tie_breaks_by_lower_id() {
+    fn skipmix_injected_tie_breaks_by_lower_id() {
         let bytes =
             build_skipmix_table(&[(9, 1, vec![(9, 10)]), (4, 1, vec![(4, 10)])]).expect("valid");
         let table = SkipmixTable::parse(&bytes).expect("parse");
         let ranked = [(9u32, ScoreQ::from_raw(50)), (4, ScoreQ::from_raw(50))];
         let window = [9u32, 4];
         let (unique, ulen) = unique_window_tokens(&window);
-        // Both boosted equally (+10) -> canonical tie-break keeps the lower id.
+        // Both boosted equally (+10), neither newly discovered (both
+        // already in `ranked`) -> canonical tie-break keeps the lower id.
         assert_eq!(
-            skipmix_adjusted_token(&ranked, Some(&table), None, &unique[..ulen], 1, 9),
+            skipmix_injected_argmax(&ranked, Some(&table), None, &unique[..ulen], 1, 9),
             4
         );
     }

--- a/crates/uor-r4-api/tests/skipmix_candidate_injection_906.rs
+++ b/crates/uor-r4-api/tests/skipmix_candidate_injection_906.rs
@@ -1,0 +1,665 @@
+//! #906 -- confirms the candidate-injection fix (follow-up to #897/#904)
+//! against the REAL production serving path, not a simulated harness.
+//!
+//! #904 diagnosed the #897 LOWERING-FIDELITY GAP
+//! (`docs/skipmix_lane_897_result.json`: deployed-lane follow 41/87, below
+//! the predeclared 53/87 = 60% bar) as breadth-bound: 35/87 favorable
+//! pairs have at least one side's teacher target absent from the base
+//! engine's own decided candidate list (`StepCandidates::ranked()`,
+//! capped at `STEP_TOP_CANDIDATES = 8`), before any skip-mix scoring runs.
+//! Every width/selection lever available to the base engine's own
+//! candidate generation was then tested (off-serving) and found not to
+//! close it (#906 issue body); separately, 45/45 (100%) of the missing
+//! pair-sides were found to already have their teacher target recorded as
+//! a co-occurrence partner in the SKMX/PSIB tables -- the deployed lane
+//! simply never had a code path to use that knowledge, since it only
+//! re-ranked the base engine's already-decided list. `crates/uor-r4-api/
+//! src/engine.rs`'s `skipmix_injected_argmax`/`skipmix_injected_lane_
+//! attribution` (this issue) fix that: they extend the candidate space to
+//! every SKMX/PSIB-known token, combined under the non-additive
+//! "unit-safe" rule #904 arm 3 validated.
+//!
+//! A prototype-measured simulation (off-serving, same mining/fit/emit
+//! machinery as this test) projected 58/87 (66.7%) under that combine
+//! rule -- clearing the 60% bar. This test reuses the exact same
+//! mining/fit/emit machinery as `skipmix_gap_diagnostic_904.rs`
+//! (same corpus, same fit, same real bundle, same 87 reference-favorable
+//! pairs), but replays them through the REAL, now-patched
+//! `predict_decision_candidates_with_skipmix` rather than a simulated
+//! combine, to confirm the production code path actually delivers the
+//! projected improvement.
+//!
+//! Off-serving; gated behind `--ignored`, same discipline as
+//! `skipmix_gap_diagnostic_904.rs`. Result written to
+//! `docs/skipmix_candidate_injection_906_result.json`.
+//!
+//! Run:
+//!   cargo test -p uor-r4-api --release --test skipmix_candidate_injection_906 \
+//!       -- --ignored --nocapture
+//! Env: R4_CAUSAL_BUNDLE (bundle dir), same default as #897/#904's harness.
+
+#![allow(clippy::doc_lazy_continuation)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use uor_r4_api::capability_suite::compute_cid;
+use uor_r4_api::engine::{EngineParts, PredictDecision, R4Engine};
+use uor_r4_api::serving_eval::ServingBundle;
+use uor_r4_core::transformerless::{compiler, runtime};
+use uor_r4_graph_certify as score;
+use uor_r4_graph_certify::StepCandidates;
+use uor_r4_graph_compiler::{induction, skipmix_fit};
+
+// --- pre-registered constants (identical to skipmix_gap_diagnostic_904.rs) -
+const SUFFIX_K: usize = 2;
+const CAP: usize = uor_r4_graph_compiler::segment_fit::DEFAULT_TOP_K;
+const CAND_SUFFIX: usize = 32;
+const CAND_CONTENT: usize = 32;
+const CAND_JOINT: usize = 32;
+const LAMBDA_NUM: f64 = 1.0;
+const LAMBDA_DEN: f64 = 1.0;
+const REFERENCE_FAVORABLE_EXPECTED: u64 = 87;
+/// The #897/#904 recorded deployed-lane follow count under the OLD
+/// re-rank-only combine -- reproduced here only as a before/after anchor,
+/// not asserted (this test exercises the NEW combine).
+const OLD_DEPLOYED_FOLLOW: u64 = 41;
+/// The predeclared #897 fidelity bar (60% of 87).
+const FIDELITY_BAR: u64 = 53;
+/// The #906 confirmed deployed-lane follow count under the new
+/// candidate-injection combine, against the real production code path
+/// (measured by this test's own first clean run; see
+/// `docs/skipmix_candidate_injection_906_result.json`).
+const NEW_DEPLOYED_FOLLOW_EXPECTED: u64 = 58;
+const ATTESTED_CORPUS_CID_PREFIX: &str = "blake3:aa9d1767";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn bundle_root() -> PathBuf {
+    match std::env::var_os("R4_CAUSAL_BUNDLE") {
+        Some(v) => PathBuf::from(v),
+        None => repo_root()
+            .join(".uor-models")
+            .join("compiled")
+            .join("smollm2-360m-broad-clean"),
+    }
+}
+
+fn suffix_key(window: &[u32]) -> (u32, u32) {
+    let n = window.len();
+    if n >= 2 {
+        (window[n - 2], window[n - 1])
+    } else if n == 1 {
+        (u32::MAX, window[0])
+    } else {
+        (u32::MAX, u32::MAX)
+    }
+}
+
+fn uniq_tokens(w: &[u32]) -> Vec<u32> {
+    let mut uniq: Vec<u32> = w.to_vec();
+    uniq.sort_unstable();
+    uniq.dedup();
+    uniq
+}
+
+fn argmax(scores: &HashMap<u32, f64>) -> u32 {
+    let mut best_id = u32::MAX;
+    let mut best = f64::NEG_INFINITY;
+    for (&id, &s) in scores {
+        if s > best || (s == best && id < best_id) {
+            best = s;
+            best_id = id;
+        }
+    }
+    best_id
+}
+
+/// Counts of teacher argmax under one key, capped to the top `CAP` by count
+/// (ties broken by the smaller token id) -- verbatim from
+/// `skipmix_gap_diagnostic_904.rs`.
+#[derive(Default, Clone)]
+struct Counter {
+    map: HashMap<u32, u32>,
+}
+
+impl Counter {
+    fn bump(&mut self, tok: u32) {
+        *self.map.entry(tok).or_insert(0) += 1;
+    }
+    fn cap_to_top(&mut self, cap: usize) {
+        if self.map.len() <= cap {
+            return;
+        }
+        let mut v: Vec<(u32, u32)> = self.map.drain().collect();
+        v.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        v.truncate(cap);
+        self.map = v.into_iter().collect();
+    }
+    fn total(&self) -> u64 {
+        self.map.values().map(|&c| c as u64).sum()
+    }
+}
+
+/// The reference tables needed to mine the same 87 favorable pairs --
+/// verbatim from `skipmix_gap_diagnostic_904.rs::Tables` (trimmed to only
+/// what mining needs; this test does not re-run arms 1-3).
+struct Tables {
+    suffix_next: HashMap<(u32, u32), Counter>,
+    content_next: HashMap<u32, Counter>,
+    joint_next: HashMap<(u32, (u32, u32)), Counter>,
+    d4skip_next: HashMap<(u32, u32), Counter>,
+    marginal_tok: u32,
+}
+
+impl Tables {
+    fn content_rates(&self, w: &[u32]) -> HashMap<u32, f64> {
+        let mut content_rate: HashMap<u32, f64> = HashMap::new();
+        let uniq = uniq_tokens(w);
+        let ncontent = uniq.len().max(1) as f64;
+        for t in &uniq {
+            if let Some(cn) = self.content_next.get(t) {
+                let tot = cn.total().max(1) as f64;
+                for (&c, &cnt) in &cn.map {
+                    *content_rate.entry(c).or_insert(0.0) += (cnt as f64 / tot) / ncontent;
+                }
+            }
+        }
+        content_rate
+    }
+
+    fn suffix_cands(&self, w: &[u32]) -> Vec<u32> {
+        let mut suffix_cands: Vec<u32> = Vec::new();
+        if let Some(c) = self.suffix_next.get(&suffix_key(w)) {
+            let mut v: Vec<(u32, u32)> = c.map.iter().map(|(&k, &n)| (k, n)).collect();
+            v.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+            suffix_cands.extend(v.into_iter().take(CAND_SUFFIX).map(|(k, _)| k));
+        }
+        suffix_cands.push(self.marginal_tok);
+        suffix_cands.sort_unstable();
+        suffix_cands.dedup();
+        suffix_cands
+    }
+
+    fn widened_cands(&self, suffix_cands: &[u32], content_rate: &HashMap<u32, f64>) -> Vec<u32> {
+        let mut cr: Vec<(u32, f64)> = content_rate.iter().map(|(&k, &v)| (k, v)).collect();
+        cr.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap().then(a.0.cmp(&b.0)));
+        let mut all_cands = suffix_cands.to_vec();
+        all_cands.extend(cr.into_iter().take(CAND_CONTENT).map(|(k, _)| k));
+        all_cands.sort_unstable();
+        all_cands.dedup();
+        all_cands
+    }
+
+    fn joint_acc(&self, tokens: &[u32], sfx: (u32, u32)) -> HashMap<u32, f64> {
+        let mut acc: HashMap<u32, f64> = HashMap::new();
+        for t in uniq_tokens(tokens) {
+            if let Some(cn) = self.joint_next.get(&(t, sfx)) {
+                let tot = cn.total().max(1) as f64;
+                for (&c, &cnt) in &cn.map {
+                    *acc.entry(c).or_insert(0.0) += cnt as f64 / tot;
+                }
+            }
+        }
+        acc
+    }
+
+    fn joint_widened(&self, legacy: &[u32], joint_acc: &HashMap<u32, f64>) -> Vec<u32> {
+        let mut jr: Vec<(u32, f64)> = joint_acc.iter().map(|(&k, &v)| (k, v)).collect();
+        jr.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap().then(a.0.cmp(&b.0)));
+        let mut all = legacy.to_vec();
+        all.extend(jr.into_iter().take(CAND_JOINT).map(|(k, _)| k));
+        all.sort_unstable();
+        all.dedup();
+        all
+    }
+
+    fn suffix_rate(&self, w: &[u32], c: u32) -> f64 {
+        let sfx = self.suffix_next.get(&suffix_key(w));
+        let sfx_total = sfx.map(|c| c.total()).unwrap_or(0).max(1) as f64;
+        sfx.and_then(|s| s.map.get(&c)).copied().unwrap_or(0) as f64 / sfx_total
+    }
+
+    /// The confirmed PRIMARY `skipmix` arm, verbatim from
+    /// `skipmix_gap_diagnostic_904.rs::Tables::skipmix_scores` -- used only
+    /// to mine the same 87 favorable pairs here, not to re-score anything.
+    fn skipmix_scores(
+        &self,
+        w: &[u32],
+        cond_last: u32,
+        cands: &[u32],
+        lam: f64,
+    ) -> HashMap<u32, f64> {
+        let uniq = uniq_tokens(w);
+        let ntot = uniq.len().max(1) as f64;
+        let mut contrib: HashMap<u32, f64> = HashMap::new();
+        let mut sup_ts = 0usize;
+        for t in &uniq {
+            if let Some(cn) = self.d4skip_next.get(&(*t, cond_last)) {
+                sup_ts += 1;
+                let tot = cn.total().max(1) as f64;
+                for (&c, &cnt) in &cn.map {
+                    *contrib.entry(c).or_insert(0.0) += cnt as f64 / tot;
+                }
+            } else if let Some(cn) = self.content_next.get(t) {
+                let tot = cn.total().max(1) as f64;
+                for (&c, &cnt) in &cn.map {
+                    *contrib.entry(c).or_insert(0.0) += cnt as f64 / tot;
+                }
+            }
+        }
+        let mut m = HashMap::new();
+        for &c in cands {
+            let base = self.suffix_rate(w, c);
+            let resid = (contrib.get(&c).copied().unwrap_or(0.0) - sup_ts as f64 * base) / ntot;
+            m.insert(c, base + lam * resid);
+        }
+        m
+    }
+}
+
+/// One held-out position's reference predictions (full-width `d1_cands`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct Preds {
+    base: u32,
+    skipmix: u32,
+}
+
+fn score_position(t: &Tables, w: &[u32], lam: f64) -> Preds {
+    let sfx = suffix_key(w);
+    let content_rate = t.content_rates(w);
+    let suffix_cands = t.suffix_cands(w);
+    let legacy_cands = t.widened_cands(&suffix_cands, &content_rate);
+    let joint_acc = t.joint_acc(w, sfx);
+    let d1_cands = t.joint_widened(&legacy_cands, &joint_acc);
+
+    let mut base_scores: HashMap<u32, f64> = HashMap::new();
+    for &c in &suffix_cands {
+        base_scores.insert(c, t.suffix_rate(w, c));
+    }
+    let own_last = w.last().copied().unwrap_or(u32::MAX);
+    let skipmix_scores = t.skipmix_scores(w, own_last, &d1_cands, lam);
+
+    Preds {
+        base: argmax(&base_scores),
+        skipmix: argmax(&skipmix_scores),
+    }
+}
+
+/// A reproduced phase-0 favorable minimal pair (positions + teacher targets).
+struct FavPair {
+    ia: usize,
+    ib: usize,
+    ta: u32,
+    tb: u32,
+}
+
+#[test]
+#[ignore = "heavy: needs the compiled #833 bundle (corpus+store+cover+artifacts); run with --ignored"]
+fn skipmix_candidate_injection_906() {
+    let root = bundle_root();
+    let Some(bundle) = ServingBundle::discover(&root) else {
+        eprintln!(
+            "SKIP skipmix_candidate_injection_906: no serving bundle at {}",
+            root.display()
+        );
+        return;
+    };
+    let meta_bytes = std::fs::read(&bundle.corpus_meta).expect("corpus meta");
+    let recs_bytes = std::fs::read(&bundle.corpus_records).expect("corpus records");
+    let corpus = compiler::load_corpus_from(
+        bundle.corpus_meta.to_str().expect("meta utf8"),
+        bundle.corpus_records.to_str().expect("recs utf8"),
+    )
+    .expect("load corpus");
+    let (train_positions, held_out_positions) = induction::split_positions(&corpus);
+    assert!(
+        !train_positions.is_empty() && !held_out_positions.is_empty(),
+        "non-empty split"
+    );
+
+    let corpus_cid = compute_cid(&meta_bytes);
+    assert!(
+        corpus_cid.starts_with(ATTESTED_CORPUS_CID_PREFIX),
+        "confirmation is only valid on the attested #833 bundle (corpus.meta CID \
+         prefix {ATTESTED_CORPUS_CID_PREFIX}); got {corpus_cid}"
+    );
+
+    let started = Instant::now();
+
+    // === 1. reproduce the phase-0 `skipmix` favorable pairs (verbatim) =====
+    let mut suffix_next: HashMap<(u32, u32), Counter> = HashMap::new();
+    let mut content_next: HashMap<u32, Counter> = HashMap::new();
+    let mut joint_next: HashMap<(u32, (u32, u32)), Counter> = HashMap::new();
+    let mut d4skip_next: HashMap<(u32, u32), Counter> = HashMap::new();
+    let mut marginal = Counter::default();
+    for &i in &train_positions {
+        let w = induction::context_window(&corpus, i);
+        let target = corpus.t_argmax[i];
+        let sfx = suffix_key(&w);
+        marginal.bump(target);
+        suffix_next.entry(sfx).or_default().bump(target);
+        for t in uniq_tokens(&w) {
+            content_next.entry(t).or_default().bump(target);
+            joint_next.entry((t, sfx)).or_default().bump(target);
+        }
+        let n = w.len();
+        if n >= 2 {
+            let last = w[n - 1];
+            let mut skip_pairs: Vec<(u32, u32)> = w[..n - 1].iter().map(|&t| (t, last)).collect();
+            skip_pairs.sort_unstable();
+            skip_pairs.dedup();
+            for key in skip_pairs {
+                d4skip_next.entry(key).or_default().bump(target);
+            }
+        }
+    }
+    for c in suffix_next.values_mut() {
+        c.cap_to_top(CAP);
+    }
+    for c in content_next.values_mut() {
+        c.cap_to_top(CAP);
+    }
+    for c in joint_next.values_mut() {
+        c.cap_to_top(CAP);
+    }
+    for c in d4skip_next.values_mut() {
+        c.cap_to_top(CAP);
+    }
+    let marginal_tok = marginal
+        .map
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+        .map(|(&t, _)| t)
+        .unwrap_or(0);
+
+    let tables = Tables {
+        suffix_next,
+        content_next,
+        joint_next,
+        d4skip_next,
+        marginal_tok,
+    };
+    let lambda = LAMBDA_NUM / LAMBDA_DEN;
+
+    let windows: Vec<Vec<u32>> = held_out_positions
+        .iter()
+        .map(|&i| induction::context_window(&corpus, i))
+        .collect();
+    let preds: Vec<Preds> = windows
+        .iter()
+        .map(|w| score_position(&tables, w, lambda))
+        .collect();
+
+    let mut by_suffix: HashMap<(u32, u32), Vec<usize>> = HashMap::new();
+    for (idx, w) in windows.iter().enumerate() {
+        if w.len() >= SUFFIX_K {
+            by_suffix.entry(suffix_key(w)).or_default().push(idx);
+        }
+    }
+    let mut favorable: Vec<FavPair> = Vec::new();
+    for group in by_suffix.values() {
+        let mut made = 0usize;
+        'outer: for a in 0..group.len() {
+            for b in (a + 1)..group.len() {
+                let (xa, xb) = (group[a], group[b]);
+                let (ia, ib) = (held_out_positions[xa], held_out_positions[xb]);
+                if corpus.story[ia] == corpus.story[ib] {
+                    continue;
+                }
+                let (ta, tb) = (corpus.t_argmax[ia], corpus.t_argmax[ib]);
+                if ta == tb {
+                    continue;
+                }
+                let (pa, pb) = (preds[xa], preds[xb]);
+                if pa.skipmix == ta && pb.skipmix == tb && pa.skipmix != pb.skipmix {
+                    favorable.push(FavPair { ia, ib, ta, tb });
+                }
+                made += 1;
+                if made >= 1 {
+                    break 'outer;
+                }
+            }
+        }
+    }
+    let reference_favorable = favorable.len() as u64;
+    assert_eq!(
+        reference_favorable, REFERENCE_FAVORABLE_EXPECTED,
+        "the reproduced skipmix favorable-pair count must match #904's \
+         (same mining logic, same bundle)"
+    );
+
+    // === 2. fit + emit the deployed tables via the REAL release emitter ====
+    let rows_top_k = CAP;
+    let (skipmix_rows, psi_bag_rows) = skipmix_fit::fit_skipmix_tables(&corpus, rows_top_k);
+    assert!(!skipmix_rows.is_empty(), "the fit must learn joint keys");
+    assert!(!psi_bag_rows.is_empty(), "the fit must learn psi-bag keys");
+
+    let artifact_container = std::fs::read(&bundle.teacher).expect("teacher artifacts");
+    let artifacts = compiler::parse_artifacts(&artifact_container).expect("parse artifacts");
+    let threads = std::thread::available_parallelism()
+        .map(|c| c.get().min(8))
+        .unwrap_or(1);
+    let train_obs =
+        induction::build_observations_with_threads(&artifacts, &corpus, &train_positions, threads);
+
+    let cover_bytes = std::fs::read(bundle.root.join("graph-cover").join("cover.r4g1"))
+        .expect("cached cover artifact");
+    let (regions, structural) =
+        score::recover_from_artifact(&cover_bytes).expect("recover regions/structural");
+    let max_depth = regions.iter().map(|r| r.depth as usize).max().unwrap_or(1);
+
+    let store_file_bytes = std::fs::read(bundle.root.join("tless_store.bin")).expect("store bytes");
+    let store = runtime::parse_store(&store_file_bytes).expect("parse store (u32)");
+
+    let config = score::ScoreConfig::default();
+    let (transitions, transition_quantization) = score::compile_transitions_with_quantization(
+        &corpus,
+        &regions,
+        &train_obs,
+        max_depth,
+        config.transition_out_degree,
+    );
+    let vocab =
+        u32::try_from(artifacts.token_codes.len() / compiler::STAGES).expect("vocab fits u32");
+    let context_rows = score::compile_context_rows(&corpus, &train_obs, vocab, &config);
+    let fwd_rows = score::compile_forward_anchor_rows(&corpus, &train_obs);
+    let emissions = score::compile_emissions(
+        &corpus, &store, &regions, &train_obs, max_depth, vocab, &config,
+    );
+    let tls1 = runtime::store_bytes(&store);
+
+    let sections = score::ScoredGraphSections {
+        regions: &regions,
+        structural: &structural,
+        transitions: &transitions,
+        transition_quantization,
+        emissions: &emissions,
+        context_rows: &context_rows,
+        exct_tls1: &tls1,
+        exct_top_x: config.exct_top_x,
+        fwd_rows: &fwd_rows,
+        skipmix_rows: &skipmix_rows,
+        psi_bag_rows: &psi_bag_rows,
+    };
+    let (graph_bytes, info) = score::emit_scored_r4g1(
+        &artifact_container,
+        (&meta_bytes, &recs_bytes),
+        vocab,
+        &sections,
+    );
+    assert_eq!(info.skipmix_row_count as usize, skipmix_rows.len());
+    assert_eq!(info.psi_bag_row_count as usize, psi_bag_rows.len());
+
+    let tokenizer_bytes = std::fs::read(bundle.root.join("tokenizer.bin")).ok();
+    let mut engine = R4Engine::load_accepting_quality(EngineParts {
+        graph: &graph_bytes,
+        signature_artifact: &artifact_container,
+        tokenizer: tokenizer_bytes.as_deref(),
+        score_report: None,
+    })
+    .expect("re-emitted engine load");
+    assert_eq!(
+        engine.skipmix_tables_present(),
+        (true, true),
+        "the engine must consume both the SKMX and PSIB sections"
+    );
+
+    // === 3. replay the REAL (patched) deployed lane on the favorable pairs =
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let eval = |engine: &mut R4Engine, i: usize| -> Option<Option<u32>> {
+        engine.reset();
+        let w = induction::context_window(&corpus, i);
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut cands = StepCandidates::default();
+            match engine.predict_decision_candidates_with_skipmix(&w, &mut cands) {
+                Ok(PredictDecision::Serve(outcome)) => Some(outcome.token),
+                _ => None,
+            }
+        }))
+        .ok()
+    };
+
+    let mut served = 0u64;
+    let mut abstained = 0u64;
+    let mut unservable = 0u64;
+    let mut deployed_follow = 0u64;
+    let mut pair_lines: Vec<String> = Vec::new();
+
+    for (idx, p) in favorable.iter().enumerate() {
+        let ra = eval(&mut engine, p.ia);
+        let rb = eval(&mut engine, p.ib);
+        match ra {
+            Some(Some(_)) => served += 1,
+            Some(None) => abstained += 1,
+            None => unservable += 1,
+        }
+        match rb {
+            Some(Some(_)) => served += 1,
+            Some(None) => abstained += 1,
+            None => unservable += 1,
+        }
+        let (Some(served_a), Some(served_b)) = (ra, rb) else {
+            pair_lines.push(format!("  pair {idx}: UNSERVABLE-AT-REPLAY"));
+            continue;
+        };
+        let follow = served_a == Some(p.ta) && served_b == Some(p.tb) && served_a != served_b;
+        if follow {
+            deployed_follow += 1;
+        }
+        pair_lines.push(format!(
+            "  pair {idx}: served=({served_a:?},{served_b:?}) follow={follow}"
+        ));
+    }
+
+    std::panic::set_hook(prev_hook);
+    let positions = reference_favorable * 2;
+    assert!(positions > 0, "no favorable positions evaluated");
+
+    let elapsed = started.elapsed();
+    let artifact_cid = compute_cid(&graph_bytes);
+
+    println!("=== #906 skip-mix candidate-injection confirmation (follow-up to #897/#904) ===");
+    println!("bundle              : {}", bundle.root.display());
+    println!("reemit_artifact_cid : {artifact_cid}");
+    println!("corpus_meta_cid     : {corpus_cid}");
+    println!(
+        "train / held_out    : {} / {}",
+        train_positions.len(),
+        held_out_positions.len()
+    );
+    println!(
+        "reference favorable : {reference_favorable} (expected {REFERENCE_FAVORABLE_EXPECTED})"
+    );
+    for line in &pair_lines {
+        println!("{line}");
+    }
+    println!(
+        "servability         : served {served}, abstained {abstained}, unservable {unservable} of {positions} positions"
+    );
+    println!(
+        "deployed follow (NEW, candidate-injection combine): {deployed_follow}/{reference_favorable}"
+    );
+    println!(
+        "deployed follow (OLD, re-rank-only combine, #897/#904 record): {OLD_DEPLOYED_FOLLOW}/{reference_favorable}"
+    );
+    println!("predeclared 60% fidelity bar: {FIDELITY_BAR}/{reference_favorable}");
+    println!("elapsed             : {:.1}s", elapsed.as_secs_f64());
+
+    assert_eq!(
+        deployed_follow, NEW_DEPLOYED_FOLLOW_EXPECTED,
+        "the real, patched predict_decision_candidates_with_skipmix must \
+         reproduce this test's own confirmed measurement exactly (same fit, \
+         same emitter, same engine, same replay) -- a mismatch means \
+         something about the bundle or the candidate-injection code changed \
+         since this measurement was taken"
+    );
+    assert!(
+        deployed_follow >= FIDELITY_BAR,
+        "the candidate-injection fix must clear the predeclared 60% \
+         fidelity bar ({FIDELITY_BAR}/{reference_favorable}); got \
+         {deployed_follow}/{reference_favorable}"
+    );
+    assert!(
+        deployed_follow > OLD_DEPLOYED_FOLLOW,
+        "the candidate-injection fix must strictly improve on the #897/#904 \
+         recorded re-rank-only follow count ({OLD_DEPLOYED_FOLLOW}/{reference_favorable}); \
+         got {deployed_follow}/{reference_favorable}"
+    );
+
+    let result_cid = compute_cid(
+        format!("{deployed_follow}:{reference_favorable}:{artifact_cid}:{corpus_cid}").as_bytes(),
+    );
+    println!("result_cid          : {result_cid}");
+
+    let json = format!(
+        concat!(
+            "{{\n",
+            "  \"issue\": 906,\n",
+            "  \"parent_issues\": [897, 904],\n",
+            "  \"check\": \"skipmix-candidate-injection-confirmation\",\n",
+            "  \"decision_kind\": \"real production code path (predict_decision_candidates_with_skipmix, patched)\",\n",
+            "  \"bundle\": \"{}\",\n",
+            "  \"reemit_artifact_cid\": \"{}\",\n",
+            "  \"corpus_meta_cid\": \"{}\",\n",
+            "  \"reference_favorable\": {},\n",
+            "  \"positions\": {},\n",
+            "  \"served\": {},\n",
+            "  \"abstained\": {},\n",
+            "  \"unservable\": {},\n",
+            "  \"deployed_follow_new\": {},\n",
+            "  \"deployed_follow_old_897_904\": {},\n",
+            "  \"fidelity_bar\": {},\n",
+            "  \"clears_fidelity_bar\": {},\n",
+            "  \"result_cid\": \"{}\"\n",
+            "}}\n"
+        ),
+        bundle.root.display(),
+        artifact_cid,
+        corpus_cid,
+        reference_favorable,
+        positions,
+        served,
+        abstained,
+        unservable,
+        deployed_follow,
+        OLD_DEPLOYED_FOLLOW,
+        FIDELITY_BAR,
+        deployed_follow >= FIDELITY_BAR,
+        result_cid,
+    );
+    let out = repo_root()
+        .join("docs")
+        .join("skipmix_candidate_injection_906_result.json");
+    std::fs::write(&out, json).expect("write result json");
+    println!("wrote               : {}", out.display());
+}

--- a/docs/skipmix_candidate_injection_906.md
+++ b/docs/skipmix_candidate_injection_906.md
@@ -1,0 +1,137 @@
+# Skip-mix candidate-injection fix (#906, follow-up to #897/#904)
+
+Empirical record. Implements and confirms the fix for the #904 BREADTH-BOUND
+finding (`docs/skipmix_gap_diagnostic_904.md`): the deployed skip-mix lane
+(`predict_decision_candidates_with_skipmix`) only re-ranked the base
+engine's already-decided candidate list and never consulted its own
+SKMX/PSIB tables as a candidate *source*, capping deployed follow at
+41/87 against a 52/87 (59.8%) breadth ceiling that itself falls below the
+predeclared 53/87 (60%) fidelity bar.
+
+Harness: `crates/uor-r4-api/tests/skipmix_candidate_injection_906.rs`
+(`--ignored`; exercises the real, patched production code path, not a
+simulation). Machine result:
+`docs/skipmix_candidate_injection_906_result.json`.
+
+## Investigation preceding the fix (off-serving, no production change)
+
+Before implementing anything, every width/selection lever available to the
+*base* engine's own candidate generation was tested empirically, per
+Casey's "do this properly, do not prematurely dismiss" standing guidance:
+
+1. **`STEP_TOP_CANDIDATES` alone** (8 -> 16/32/64): coverage ceiling
+   plateaus at 52-53/87; deployed follow does not improve.
+2. **All four compile/load-time candidate-breadth caps together**
+   (`emission_entries`/`context_entries`/`exct_top_x`/`root_top_b`: 64 ->
+   4096, a 64x widening, plus `STEP_TOP_CANDIDATES` -> 300): confirmed via
+   direct debug instrumentation that the overrides genuinely reached the
+   engine, and via the compiler's own `[emission-selection]` diagnostic
+   that this was a real, substantial widening (held-out probability mass
+   captured jumped from 1.57% to 37.32%). Outcome: **unchanged** (52-53/87
+   ceiling throughout).
+3. **`EmissionSelection::Probability`** (an existing, already-implemented,
+   never-selected-in-production alternative ranking rule to the shipped
+   `Ratio` selection -- `crates/uor-r4-graph-certify/src/score.rs:251-257`):
+   tested directly at the default width. Verified as a huge, real quality
+   improvement (probability mass captured jumped from 1.57% to 58.77% at
+   the same E=64). Outcome: **unchanged** (52/87 ceiling, 41/87 deployed
+   follow -- identical to the shipped `Ratio` numbers).
+4. **Skip-mix/psi-bag table rescue check**: of the 45 pair-sides missing
+   their teacher target from the candidate list, **45/45 (100%)** already
+   have that exact token present as a recorded co-occurrence partner in the
+   SKMX/PSIB tables (`crates/uor-r4-graph-format/src/skipmix.rs`) --
+   verified directly against the real parsed tables, not simulated.
+
+**Root cause**: the base engine's own candidate generation (region
+clustering + bigram/trigram context rows) is structurally incapable of
+surfacing these pairs' targets at any tested width or selection rule, and
+the skip-mix lane -- being a pure re-ranker of `state.touched`/`ranked` --
+could never close this portion of the gap regardless of how its own tables
+were tuned, since it never looked at them as a candidate source.
+
+## Prototype (off-serving) before implementing
+
+Simulating candidate injection -- adding every SKMX/PSIB-known token as a
+new candidate, not just re-ranking `ranked` -- combined with a
+non-additive "unit-safe" combine rule (already validated in #904 arm 3:
+candidates with positive skip-mix support always outrank candidates with
+none; among supported candidates, rank by contribution magnitude; among
+unsupported candidates, fall back to the real base `ScoreQ`; never sum the
+two incompatible scales) projected 58/87 (66.7%) deployed follow, clearing
+the 60% bar, with an 85/87 (97.7%) idealized ceiling if the combine rule
+itself were later improved. Per Casey's sign-off ("Implement the real fix
+now"), the real production change was then made.
+
+## The fix
+
+`crates/uor-r4-api/src/engine.rs`:
+
+- `skipmix_adjusted_token`/`skipmix_lane_attribution` (re-rank-only) were
+  removed and replaced by `skipmix_injected_argmax`/
+  `skipmix_injected_lane_attribution`, which extend the candidate space to
+  every token discoverable via a relevant SKMX row `(t, last_token)` or
+  PSIB row `t`, for the window's own unique tokens, in addition to the base
+  `ranked` list -- ranked by the same unit-safe rule #904 arm 3 validated.
+- `predict_decision_candidates_with_skipmix` and
+  `predict_decision_candidates_with_skipmix_witness` were rewired onto the
+  new functions.
+- Allocation-free (P-4 discipline, matching every other combinator in this
+  module): no set/Vec is materialized for the expanded candidate space; a
+  single-pass running-best accumulator considers each candidate as
+  discovered, and a candidate reachable via more than one row is simply
+  reconsidered (harmless, deterministic) rather than deduplicated.
+- Absent-section identity preserved: with neither SKMX nor PSIB present, no
+  candidates are ever discovered beyond `ranked`, so behavior is
+  byte-identical to today.
+- Unit tests updated/added (7 tests in `engine.rs`'s `skipmix` module,
+  including a new `skipmix_injects_candidate_absent_from_ranked` that
+  demonstrates the core new capability: a candidate not present in
+  `ranked` at all is discovered and wins via table support alone).
+
+## Result (confirmed against the real, patched production code path)
+
+| quantity | value |
+|---|---|
+| reference favorable pairs (reproduced) | 87 / 87 expected |
+| positions (served / abstained / unservable) | 174 / 0 / 0 |
+| **deployed follow, NEW (candidate-injection combine)** | **58 / 87 (66.7%)** |
+| deployed follow, OLD (re-rank-only, #897/#904 record) | 41 / 87 (47.1%) |
+| predeclared 60% fidelity bar | 53 / 87 |
+| clears fidelity bar | **yes** |
+
+The real production measurement (58/87) matched the off-serving prototype
+projection exactly on the first clean run -- no adjustment to the
+pre-registered expectation was needed.
+
+## Read
+
+**FIXED, bar cleared.** Candidate injection closes the architectural gap
+identified in #904: the skip-mix lane can now recover targets the base
+engine's own candidate generation structurally cannot surface, using
+tables the lane already ships and fits today. Deployed follow rises from
+41/87 (47.1%, below bar) to 58/87 (66.7%, above the 53/87 bar), a 17-pair
+absolute improvement, without widening any shared base-engine constant
+(`STEP_TOP_CANDIDATES` and friends are untouched -- out of scope, per
+#906's issue body) and without any wire-format or compile-time change to
+already-released bundles.
+
+The idealized reference-math ceiling on the same expanded candidate list
+(85/87, 97.7%, measured off-serving in the prototype phase) shows headroom
+remains if the combine rule itself is refined further -- out of scope for
+this issue.
+
+## Scope / conformance
+
+Production code changed: `crates/uor-r4-api/src/engine.rs` only. The base
+engine's own candidate generation (region clustering, context rows,
+`STEP_TOP_CANDIDATES`) and the #836 segment lane are untouched. No
+compile-time/wire-format change; no recompile of any released bundle is
+required. The skip-mix lane remains **dormant** (no `model/ids.toml`
+serving row) -- this changes what the lane *would* do if turned on, not
+live production behavior today; `CONFORMANCE.md` is unaffected.
+
+This record supersedes `docs/skipmix_gap_diagnostic_904.md`'s
+"Implications" section's open question ("whether to attempt the wider
+candidate-list change... is left to the maintainer") -- the narrower,
+skip-mix-local candidate-injection fix (not a `STEP_TOP_CANDIDATES` widen)
+was chosen and closes the gap.

--- a/docs/skipmix_candidate_injection_906_result.json
+++ b/docs/skipmix_candidate_injection_906_result.json
@@ -1,0 +1,19 @@
+{
+  "issue": 906,
+  "parent_issues": [897, 904],
+  "check": "skipmix-candidate-injection-confirmation",
+  "decision_kind": "real production code path (predict_decision_candidates_with_skipmix, patched)",
+  "bundle": "/Users/casey.allard/uor-r4/.uor-models/compiled/smollm2-360m-broad-clean",
+  "reemit_artifact_cid": "blake3:19eb04d7dbf3fccd126069982ad8cbc1de31d536fff7e77ef2dacb26e64106cc",
+  "corpus_meta_cid": "blake3:aa9d176779c1d2411e872c49c95ed585ee805ded5fa1b808ddf2f517a245b0ce",
+  "reference_favorable": 87,
+  "positions": 174,
+  "served": 174,
+  "abstained": 0,
+  "unservable": 0,
+  "deployed_follow_new": 58,
+  "deployed_follow_old_897_904": 41,
+  "fidelity_bar": 53,
+  "clears_fidelity_bar": true,
+  "result_cid": "blake3:ce198b58729f75fbf989f906933a9d6f14cbf534e3a31a23ace5836c357be7da"
+}


### PR DESCRIPTION
## Summary

Closes #906 (follow-up to #897/#904).

#904 diagnosed the #897 skip-mix lane's LOWERING-FIDELITY GAP (deployed
follow 41/87, below the predeclared 53/87 = 60% bar) as **breadth-bound**:
the deployed lane (`predict_decision_candidates_with_skipmix`) only
re-ranked the base engine's already-decided candidate list
(`StepCandidates::ranked()`, capped at `STEP_TOP_CANDIDATES = 8`) and
never consulted its own SKMX/PSIB tables as a candidate *source* — even
though 45/45 (100%) of the missing pair-sides already have their teacher
target recorded there as a co-occurrence partner.

Before choosing this fix, every width/selection lever on the *base*
engine's own candidate generation was tested empirically and ruled out
(full detail in `docs/skipmix_candidate_injection_906.md`):

- `STEP_TOP_CANDIDATES` alone (8 → 16/32/64): plateaus at 52-53/87.
- All four compile-time candidate-breadth caps together (64x widening,
  confirmed real via the compiler's own diagnostic): unchanged, 52-53/87.
- `EmissionSelection::Probability` (an existing, unused alternative
  ranking rule, verified as a large real quality change on its own terms):
  unchanged, 52/87 ceiling, 41/87 deployed follow.

Candidate injection was then prototyped off-serving (58/87 projected,
clearing the 60% bar) and implemented for real in this PR.

## Changes

- `crates/uor-r4-api/src/engine.rs`: `skipmix_adjusted_token`/
  `skipmix_lane_attribution` (re-rank-only) replaced by
  `skipmix_injected_argmax`/`skipmix_injected_lane_attribution`, which
  discover every token in a relevant SKMX row `(t, last_token)` or PSIB row
  `t` for the window's own unique tokens, in addition to the base `ranked`
  list — ranked by the non-additive "unit-safe" combine rule #904 arm 3
  already validated. Allocation-free (single-pass running-best
  accumulator, no set/Vec materialized); absent-section byte-identity
  preserved (neither table present ⇒ behavior unchanged).
- `predict_decision_candidates_with_skipmix` and
  `predict_decision_candidates_with_skipmix_witness` rewired onto the new
  functions.
- Unit tests updated/added (7 tests), including a new
  `skipmix_injects_candidate_absent_from_ranked` demonstrating the core
  new capability: a candidate not present in `ranked` at all is discovered
  and wins via table support alone.
- New confirmation test `crates/uor-r4-api/tests/skipmix_candidate_injection_906.rs`
  (`--ignored`, heavy): replays the same 87 favorable pairs used
  throughout #897/#904/#906 through the **real, patched**
  `predict_decision_candidates_with_skipmix` (not a simulation). Result
  written to `docs/skipmix_candidate_injection_906_result.json`.
- `docs/skipmix_candidate_injection_906.md`: full empirical record (ruled-out
  hypotheses, prototype, fix, confirmed result).

## Result

| quantity | value |
|---|---|
| deployed follow, **NEW** (candidate-injection combine) | **58 / 87 (66.7%)** |
| deployed follow, OLD (re-rank-only, #897/#904 record) | 41 / 87 (47.1%) |
| predeclared 60% fidelity bar | 53 / 87 |
| clears fidelity bar | **yes** |

The real production measurement matched the off-serving prototype
projection exactly on the first clean run.

## Scope / conformance

Production code changed: `engine.rs` only. Base engine candidate
generation (`STEP_TOP_CANDIDATES`, region clustering, context rows) and
the #836 segment lane are untouched. No wire-format/compile-time change;
no recompile of any released bundle required. The skip-mix lane remains
**dormant** (no `model/ids.toml` serving row) — this changes what the lane
*would* do if turned on, not live production behavior today.
`CONFORMANCE.md` is unaffected.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo run -p xtask -- validate`
- [x] wasm32 build (`uor-r4-core`/`uor-r4-graph-format`/workspace-excl-xtask)
- [x] `cargo deny check`
- [x] `python3 scripts/check_claim_wording.py`
- [x] `cargo test -p uor-r4-api --release --test skipmix_candidate_injection_906 -- --ignored --nocapture` → 58/87, bar cleared

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01R6gqsnxp6JUa5jDtN43dCF
