### PR TITLE
serving(#910): activate the promoted skip-mix lane (RF-31) — S1 PROMOTE follow-through

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -211,6 +211,12 @@ The `build` level is *harness-built* (structural). It is a separate axis from an
 | --- | --- | --- | --- | --- | --- |
 | `RF-28` | `build` | `reference-only` | `off-serving-path` | features/suites/separate_semantic_emission.feature (reference reasoning/emission model) | Separate semantic reasoning and state transitions from language emission (reference/f32 model; off the deployed serving path) |
 
+## skipmix_serving_lane
+
+| ID | Level | Execution scope | Serving reachability | Evidence | Statement |
+| --- | --- | --- | --- | --- | --- |
+| `RF-31` | `build` | `normative-runtime` | `deployed-serving` | features/suites/skipmix_serving_lane.feature; crates/uor-r4-api/src/engine.rs (predict_decision routes through predict_decision_candidates_with_skipmix); crates/uor-r4-graph-cli/src/lib.rs (score stage fits and emits SKMX/PSIB via skipmix_fit::fit_skipmix_tables); docs/skipmix_endtoend_causal_908.md (deployed end-to-end causal evidence, +28.45permille, #822/#908) | Deployed serving routes next-token selection through the promoted skip-mix lane: R4Engine::predict_decision consults the compiled SKMX joint and PSIB fallback sections to re-select the served token from window-token co-occurrence partners, and is byte-identical to the base decision when the sections are absent (absent-section identity) |
+
 ## teacher_parity_benchmarks
 
 | ID | Level | Execution scope | Serving reachability | Evidence | Statement |

--- a/crates/repo-conformance/tests/registered.rs
+++ b/crates/repo-conformance/tests/registered.rs
@@ -198,3 +198,8 @@ fn teacher_parity_benchmarks_rf_29() {
 fn selective_prediction_surfaces_rf_30() {
     check("RF-30", "selective_prediction_surfaces");
 }
+
+#[test]
+fn skipmix_serving_lane_rf_31() {
+    check("RF-31", "skipmix_serving_lane");
+}

--- a/crates/uor-r4-api/src/engine.rs
+++ b/crates/uor-r4-api/src/engine.rs
@@ -1245,9 +1245,18 @@ impl R4Engine {
     /// signature through the D4 policy. Abstention is a typed outcome —
     /// no guessed token is emitted.
     pub fn predict_decision(&mut self, window: &[u32]) -> Result<PredictDecision, ObservedBound> {
-        self.check_window(window)?;
-        let (sig, code) = self.derive_sig_code(window);
-        Ok(self.predict_signature_status_with_recent(&sig, Some(&code), window))
+        // #910: the deployed decision routes through the promoted skip-mix
+        // lane. On a bundle without SKMX/PSIB sections this is byte-identical
+        // to the base decision (absent-section identity, proven by
+        // `predict_decision_candidates_with_skipmix` returning the base
+        // decision unchanged when neither section is present); when the
+        // sections are present the lane re-selects only the served token —
+        // never the status, and never overriding an abstention.
+        // `StepCandidates` is a fixed-capacity stack buffer, so the hot path
+        // stays allocation-free. The raw base decision (no lane) remains
+        // available as `predict_decision_candidates`.
+        let mut candidates = StepCandidates::default();
+        self.predict_decision_candidates_with_skipmix(window, &mut candidates)
     }
 
     /// Predict one window and retain the compact proof claim for the

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -5497,6 +5497,15 @@ fn score_command_with_authority(
     let emissions =
         score::compile_emissions(&corpus, &store, &regions, &train, max_depth, vocab, &config);
     phases.mark("emission compilation");
+    // #910: fit the promoted skip-mix lane (SKMX joint table + PSIB fallback)
+    // so compiled bundles carry the optional sections and the deployed serving
+    // lane is live. Teacher-free (reads recorded `t_argmax`); it re-splits the
+    // corpus internally to the same TRAIN partition the other stages use.
+    let (skipmix_rows, psi_bag_rows) = uor_r4_graph_compiler::skipmix_fit::fit_skipmix_tables(
+        &corpus,
+        uor_r4_graph_compiler::segment_fit::DEFAULT_TOP_K,
+    );
+    phases.mark("skip-mix lane fit");
     let (artifact_bytes, info) = score::emit_scored_r4g1_with_tokenizer_cid(
         &artifact_container,
         (&meta_bytes, &recs_bytes),
@@ -5511,11 +5520,11 @@ fn score_command_with_authority(
             exct_tls1: &tls1,
             exct_top_x: config.exct_top_x,
             fwd_rows: &fwd_rows,
-            // #897: skip-mix lowering is not yet wired into this compile
-            // path's fitting stage; empty means the SKMX/PSIB sections are
-            // not emitted (absent-section identity, unchanged behavior).
-            skipmix_rows: &[],
-            psi_bag_rows: &[],
+            // #910: the promoted skip-mix lane, fitted above, is emitted so
+            // compiled bundles carry the SKMX/PSIB sections and the deployed
+            // serving lane is live (S1 PROMOTE, #822/#908).
+            skipmix_rows: &skipmix_rows,
+            psi_bag_rows: &psi_bag_rows,
         },
         tokenizer_cid,
     );

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -178,6 +178,33 @@ comment, 2026-08-21).
   ceiling); the **frozen 20‰ end-to-end floor remains the promotion gate**. S2's #839
   phase-1 typed surfaces proceed per its re-scope.
 
+### S1 stage verdict — PROMOTE (2026-08-21)
+
+The lowering track cleared the frozen 20‰ end-to-end causal floor, so **S1 is
+promoted** and S3 (#824) is unlocked. This entry is the readable mirror of the
+tracker verdict; **GitHub #822 remains the source of record** (PROMOTE decision
+comment, 2026-08-21). It does not retract the REVISE entry above — the redesign
+happened, and this is its resolution.
+
+- **The D1-selected lowering re-entered and cleared the gate.** #897 (PR #903)
+  lowered the confirmed 1-token skip-mix scorer onto the deployed `R4Engine`,
+  shipped dormant after a spot-check fidelity gap; #904 (PR #905) diagnosed the
+  gap as breadth-bound; #906 (PR #907) fixed it with candidate injection
+  (deployed fidelity 58/87, clearing the 60% bar); #908 (PR #909) measured the
+  deployed **end-to-end causal** effect at **+28.45‰ [25.57, 31.32]** — the
+  paired 95% lower bound clears the 20‰ floor — with the
+  conditioning-specificity (label-shuffle) null collapsing to −236.95‰
+  (`docs/skipmix_endtoend_causal_908.md`, result_cid `blake3:e32e4e33…`).
+- **Real against the deployed base.** As pre-registered, the off-serving +56.2‰
+  (toy suffix-rate base) overestimated the deployed delta; the lowered lane
+  still clears the floor against the real deployed base.
+- **Frozen gates held.** The 20‰ causal floor and the #838 selective-prediction
+  gates did not move (the #887 discipline); D3 stays deferred (the end-to-end
+  measurement did not hit the 128-token label ceiling).
+- **Activation.** The promoted lane is turned on — the deployed serving decision
+  routes through the lane, the compile path fits and emits the SKMX/PSIB
+  sections, and the capability is registered as **RF-31** — under #910.
+
 ### S2 stage verdict — REVISE (2026-08-21)
 
 Items A and B are closed and item C is re-scoped, so **S2 is revised**: abstention

--- a/features/suites/skipmix_serving_lane.feature
+++ b/features/suites/skipmix_serving_lane.feature
@@ -1,0 +1,29 @@
+@status:enforced
+Feature: Promoted skip-mix serving lane (S1)
+  The deployed serving decision (R4Engine::predict_decision) routes next-token
+  selection through the promoted skip-mix lane. Compiled bundles carry the
+  optional SKMX joint table and PSIB fallback sections, and the lane discovers
+  a served candidate from those tables for the window's own tokens; on a bundle
+  without the sections the decision is byte-identical to the base
+  (absent-section identity). Deployed causal evidence: #822/#908
+  (+28.45permille, docs/skipmix_endtoend_causal_908.md). Reroute:
+  crates/uor-r4-api/src/engine.rs; compile-path fit:
+  crates/uor-r4-graph-cli/src/lib.rs.
+
+  @RF-31 @build
+  Scenario: the skip-mix joint table surfaces a co-occurrence partner
+    Given a skip-mix joint table binding content 10 and last token 20 to partner 99
+    When the deployed lane looks up content 10 with last token 20
+    Then partner 99 is surfaced as a supported skip-mix candidate
+
+  @RF-31 @build
+  Scenario: an unbound joint key surfaces no skip-mix candidate
+    Given a skip-mix joint table binding content 10 and last token 20 to partner 99
+    When the deployed lane looks up content 30 with last token 40
+    Then no skip-mix candidate is surfaced
+
+  @RF-31 @build
+  Scenario: the psi-bag fallback surfaces an unconditioned content partner
+    Given a psi-bag fallback binding content 10 to partner 77
+    When the deployed lane consults the psi-bag for content 10
+    Then partner 77 is surfaced as a supported fallback candidate

--- a/model/ids.toml
+++ b/model/ids.toml
@@ -289,3 +289,12 @@ statement = "Typed selective-prediction serving surface (legacy-coverage mode): 
 scope = "normative-runtime"
 reachability = "deployed-serving"
 evidence = "features/suites/selective_prediction_surfaces.feature; src/selective.rs, src/chat.rs, src/server.rs, src/tless_uor.rs (typed spec section-5 encodings on the served path); docs/selective_prediction_spec_838.md sections 5-6"
+
+[[id]]
+id = "RF-31"
+level = "build"
+suite = "skipmix_serving_lane"
+statement = "Deployed serving routes next-token selection through the promoted skip-mix lane: R4Engine::predict_decision consults the compiled SKMX joint and PSIB fallback sections to re-select the served token from window-token co-occurrence partners, and is byte-identical to the base decision when the sections are absent (absent-section identity)"
+scope = "normative-runtime"
+reachability = "deployed-serving"
+evidence = "features/suites/skipmix_serving_lane.feature; crates/uor-r4-api/src/engine.rs (predict_decision routes through predict_decision_candidates_with_skipmix); crates/uor-r4-graph-cli/src/lib.rs (score stage fits and emits SKMX/PSIB via skipmix_fit::fit_skipmix_tables); docs/skipmix_endtoend_causal_908.md (deployed end-to-end causal evidence, +28.45permille, #822/#908)"

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -42,6 +42,10 @@ struct R4g1World {
     selective_block_failed: Option<serde_json::Value>,
     selective_frames: Vec<String>,
     selective_probe_present: Option<String>,
+    // RF-31 promoted skip-mix serving lane (#910)
+    skmx_bytes: Vec<u8>,
+    psib_bytes: Vec<u8>,
+    lane_found_score: Option<i32>,
     compile_error: Option<String>,
     quality_report: Option<serde_json::Value>,
     quality_error: Option<String>,
@@ -389,6 +393,77 @@ fn selective_openai_envelope_is_typed(w: &mut R4g1World) {
 
 #[given("a typed abstention code")]
 fn selective_typed_code(_w: &mut R4g1World) {}
+
+// --- RF-31: promoted skip-mix serving lane (#910) ---------------------------
+// Exercises the deployed lane's candidate-discovery guarantee via the public
+// SKMX/PSIB table format that the serving reroute (R4Engine::predict_decision
+// -> predict_decision_candidates_with_skipmix) consults. Light and
+// deterministic (no engine or model load); the engine-level reroute and the
+// absent-section identity are covered by the uor-r4-api engine tests and the
+// #908 deployed causal harness.
+
+#[given("a skip-mix joint table binding content 10 and last token 20 to partner 99")]
+fn skipmix_bind_joint(w: &mut R4g1World) {
+    let rows = vec![(10u32, 20u32, vec![(99u32, 1i32)])];
+    w.skmx_bytes = uor_r4_graph_format::build_skipmix_table(&rows).expect("build skmx table");
+}
+
+#[when("the deployed lane looks up content 10 with last token 20")]
+fn skipmix_lookup_hit(w: &mut R4g1World) {
+    let table = uor_r4_graph_format::SkipmixTable::parse(&w.skmx_bytes).expect("parse skmx");
+    w.lane_found_score = table
+        .find(10, 20)
+        .and_then(|row| row.entries().find(99))
+        .map(|_score| 1i32);
+}
+
+#[then("partner 99 is surfaced as a supported skip-mix candidate")]
+fn skipmix_partner_surfaced(w: &mut R4g1World) {
+    assert!(
+        w.lane_found_score.is_some(),
+        "the joint table must surface the bound co-occurrence partner"
+    );
+}
+
+#[when("the deployed lane looks up content 30 with last token 40")]
+fn skipmix_lookup_miss(w: &mut R4g1World) {
+    let table = uor_r4_graph_format::SkipmixTable::parse(&w.skmx_bytes).expect("parse skmx");
+    w.lane_found_score = table
+        .find(30, 40)
+        .and_then(|row| row.entries().find(99))
+        .map(|_score| 1i32);
+}
+
+#[then("no skip-mix candidate is surfaced")]
+fn skipmix_no_candidate(w: &mut R4g1World) {
+    assert!(
+        w.lane_found_score.is_none(),
+        "an unbound joint key must surface no candidate"
+    );
+}
+
+#[given("a psi-bag fallback binding content 10 to partner 77")]
+fn skipmix_bind_psib(w: &mut R4g1World) {
+    let rows = vec![(10u32, vec![(77u32, 1i32)])];
+    w.psib_bytes = uor_r4_graph_format::build_psi_bag_table(&rows).expect("build psib table");
+}
+
+#[when("the deployed lane consults the psi-bag for content 10")]
+fn skipmix_psib_lookup(w: &mut R4g1World) {
+    let table = uor_r4_graph_format::PsiBagTable::parse(&w.psib_bytes).expect("parse psib");
+    w.lane_found_score = table
+        .find(10)
+        .and_then(|row| row.entries().find(77))
+        .map(|_score| 1i32);
+}
+
+#[then("partner 77 is surfaced as a supported fallback candidate")]
+fn skipmix_psib_partner_surfaced(w: &mut R4g1World) {
+    assert!(
+        w.lane_found_score.is_some(),
+        "the psi-bag fallback must surface the bound content partner"
+    );
+}
 
 #[when("the streaming decline frames are built")]
 fn selective_stream_frames(w: &mut R4g1World) {


### PR DESCRIPTION
## Problem and outcome

The S1 skip-mix lowering cleared the frozen 20‰ end-to-end causal floor (#908 / PR #909: deployed **+28.45‰ [25.57, 31.32]**, null −236.95‰), and the maintainer S1 verdict is **PROMOTE + activate** (#822). This PR turns the promoted lane on: the deployed serving decision routes through it, compiled bundles carry its sections, and the capability is registered as **RF-31**.

## Scope / non-goals

Deployed serving path + offline compile path + the RF register. No teacher, no corpus change, no wire-format change (the SKMX/PSIB sections exist since #897). Every change is **byte-identical on a bundle without the sections** (absent-section identity), so this alters what serving does on a bundle that carries the lane, not behavior on today's sections-absent fixtures. The segment lane (#836), the `serving_eval` Gate C readiness probe, and the `cover_sweep` analysis tool are intentionally left on the base decision.

## What changed (three parts)

1. **Serving reroute** — `crates/uor-r4-api/src/engine.rs`: `R4Engine::predict_decision` now routes through `predict_decision_candidates_with_skipmix`, so every serving entry (generation loop, chat single-step, HTTP) applies the lane at one point. Safe by construction: `predict_decision` and `predict_decision_candidates` share one implementation (`predict_signature_status_with_recent_candidates`, sink `None` vs `Some`) → identical served token/status/widening; and the lane returns the base decision unchanged when neither section is present. The lane re-selects only the served **token** — never the status, never overriding an abstention — so status-reading scan paths are unaffected. `StepCandidates` is a fixed-capacity stack buffer ⇒ hot path stays allocation-free.

2. **Compile-path wiring** — `crates/uor-r4-graph-cli/src/lib.rs`: the release score stage now fits (`skipmix_fit::fit_skipmix_tables`) and emits the SKMX/PSIB sections, so compiled bundles carry the lane. Teacher-free; re-splits the corpus to the same TRAIN partition the other stages use.

3. **RF-31 registration** — `model/ids.toml` row (scope `normative-runtime`, reachability `deployed-serving`) → `features/suites/skipmix_serving_lane.feature` (`@RF-31 @build`, 3 scenarios) → marker in `crates/repo-conformance/tests/registered.rs` + executable steps in `tests/bdd.rs` → regenerated `CONFORMANCE.md` (31 ids, CM-01, via `check-model --write`; never hand-edited).

## Acceptance-criteria status

- Serving routes through the lane; byte-identical on sections-absent bundles — **met** (root serving tests + `status_path_allocation_census` green).
- Compiled bundles carry SKMX/PSIB — **met** (score stage fits + emits; the #908 harness demonstrated fit→emit→`skipmix_tables_present() == (true, true)`).
- RF-31 registered, CONFORMANCE regenerated, marker green — **met**.
- Invariants preserved: allocation-free hot path, P-4/gnaf (no multiply/divide/float in the deployed kernel), no_std ladder, wasm — **met** (`xtask validate` incl. `gnaf-scan` clean; wasm build green).

## Tests / verification (all green)

`cargo test --workspace` (crate suites + root package incl. allocation census, 0 failures); `bdd` (109 scenarios / 361 steps); `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo run -p xtask -- validate` (R1/R4/R5/gnaf incl. the forbidden-construct P-4 scan); `python3 scripts/check_claim_wording.py`; `cargo build --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`.

## Evidence artifacts

Deployed causal evidence: `docs/skipmix_endtoend_causal_908.md` (result_cid `blake3:e32e4e33…`, #908). Plan doc reconciled S1 REVISE → PROMOTE (`docs/r4_intelligence_completion_plan.md`, append-only).

## Compatibility / migration

Backward-compatible: a bundle without the sections serves byte-identically to before. A newly-compiled bundle carries the lane and serves the promoted behavior. No recompile of an already-released bundle is forced by this PR; a bundle goes live on its next compile through the wired `score` path.

## Conformance effects / claim-boundary

New built capability **RF-31** (deployed-serving). The Guarantee-class structural properties (typed reroute, absent-section identity, allocation-free, P-4-legal) are asserted; the deployed-serving quality claim is the #908 Empirical Criterion.

## Negative / unavailable results

None — this is the promotion follow-through; the causal evidence is positive (#908).

## Intentionally excluded

`serving_eval` (Gate C readiness probe) and `cover_sweep` stay on the base decision; re-emitting/republishing the deployed `smollm2-360m-broad-clean` bundle is a release/ops step (the wired `score` path produces the sections on the next compile).

Closes #910
