### PR TITLE
feat(#844): freeze the S4 compositional-reasoning benchmark constitution

### DIFF
--- a/crates/uor-r4-api/capability_suites/compositional_reasoning.json
+++ b/crates/uor-r4-api/capability_suites/compositional_reasoning.json
@@ -4,18 +4,24 @@
   "stage": "s4",
   "workload": "compositional-reasoning",
   "mode": "teacher-forced",
-  "primary_metric": "held-out-composition-accuracy",
-  "promotion_statistic": "held-out composition accuracy survives relabeling/unseen-composition/topology change; shuffled-state control separates",
+  "primary_metric": "held-out-valid-plan-rate",
+  "promotion_statistic": "held-out valid-plan rate (terminal outcome AND every intermediate transition accepted by the deterministic verifier) beats the strongest non-oracle baseline (retrieval-only / direct-continuation / memorized-trajectory / shuffled-state) by a one-sided 95% lower bound above delta_min on every held-out entity/vocabulary/topology/operator-composition/relabeling/horizon cell, under equal bytes/candidates/expansions/operations; the shortest-path oracle is an upper reference only, and gains that vanish under relabeling or unseen composition are memorization",
   "split": {
     "by_entity": true,
     "by_topology": true,
     "by_template": true,
+    "by_vocabulary": true,
+    "by_operator_composition": true,
+    "by_horizon": true,
     "leakage_check": true,
     "tamper_check": true
   },
   "controls": [
+    "retrieval-only",
+    "direct-continuation",
+    "memorized-trajectory",
     "shuffled-state",
-    "prompt-swap",
+    "shortest-path-oracle",
     "trivial-prior"
   ],
   "report_schema": 1,
@@ -25,7 +31,8 @@
     "corpus",
     "compiler",
     "artifact",
-    "decoder"
+    "decoder",
+    "seed"
   ],
-  "notes": "S4 planning/geometry: generalization across held-out entities, compositions, topologies, relabelings."
+  "notes": "S4 item A (#844) frozen constitution; see docs/compositional_planning_spec_844.md. Five task families (graph navigation, symbolic transformation, constraint satisfaction, multi-hop evidence composition, counterfactual intervention), each with a deterministic verifier and replayable gold/intermediate state. Teacher-forced only (S3 #824 LIMIT boundary); honest decline, not calibrated confidence (S2 #823 REVISE). Horizons H in {1,2,4,8}, H_max=16, W_max=64; effect floor delta_min=0.05 valid-plan rate; n=512 per held-out cell per horizon with Holm-Bonferroni over the axis x horizon x family grid. Reference-only / off-serving-path; establishes a falsifiable target and byte-level meaning, not reasoning performance. Generators, verifiers, and the typed reference model are the follow-on build increment."
 }

--- a/crates/uor-r4-api/src/capability_suite.rs
+++ b/crates/uor-r4-api/src/capability_suite.rs
@@ -321,6 +321,16 @@ pub enum ControlKind {
     ShuffledState,
     /// Trivial (unigram/base) prior: the no-context floor.
     TrivialPrior,
+    /// Retrieval-only: the nearest stored instance/answer — the planning
+    /// memorization null (#844).
+    RetrievalOnly,
+    /// Direct continuation: next-token continuation with no typed state (#844).
+    DirectContinuation,
+    /// Memorized trajectory: a fitting-set plan replayed by surface match (#844).
+    MemorizedTrajectory,
+    /// Shortest-path oracle: an upper reference (not a beat-target) computed
+    /// from the gold dynamics (#844).
+    ShortestPathOracle,
     /// Always serve: the coverage ceiling of an abstaining policy.
     AlwaysServe,
     /// Always decline: the risk floor of an abstaining policy.
@@ -328,13 +338,17 @@ pub enum ControlKind {
 }
 
 impl ControlKind {
-    pub const ALL: [ControlKind; 8] = [
+    pub const ALL: [ControlKind; 12] = [
         ControlKind::ExctDisabled,
         ControlKind::PromptSwap,
         ControlKind::SuffixOnly,
         ControlKind::ShuffledEmission,
         ControlKind::ShuffledState,
         ControlKind::TrivialPrior,
+        ControlKind::RetrievalOnly,
+        ControlKind::DirectContinuation,
+        ControlKind::MemorizedTrajectory,
+        ControlKind::ShortestPathOracle,
         ControlKind::AlwaysServe,
         ControlKind::AlwaysDecline,
     ];
@@ -347,6 +361,10 @@ impl ControlKind {
             ControlKind::ShuffledEmission => "shuffled-emission",
             ControlKind::ShuffledState => "shuffled-state",
             ControlKind::TrivialPrior => "trivial-prior",
+            ControlKind::RetrievalOnly => "retrieval-only",
+            ControlKind::DirectContinuation => "direct-continuation",
+            ControlKind::MemorizedTrajectory => "memorized-trajectory",
+            ControlKind::ShortestPathOracle => "shortest-path-oracle",
             ControlKind::AlwaysServe => "always-serve",
             ControlKind::AlwaysDecline => "always-decline",
         }
@@ -581,6 +599,12 @@ pub struct SplitRules {
     pub by_entity: bool,
     #[serde(default)]
     pub by_topology: bool,
+    #[serde(default)]
+    pub by_vocabulary: bool,
+    #[serde(default)]
+    pub by_operator_composition: bool,
+    #[serde(default)]
+    pub by_horizon: bool,
     pub leakage_check: bool,
     pub tamper_check: bool,
 }
@@ -594,6 +618,9 @@ impl SplitRules {
             self.by_template,
             self.by_entity,
             self.by_topology,
+            self.by_vocabulary,
+            self.by_operator_composition,
+            self.by_horizon,
         ]
         .into_iter()
         .filter(|&b| b)

--- a/crates/uor-r4-api/tests/compositional_planning_spec_844.rs
+++ b/crates/uor-r4-api/tests/compositional_planning_spec_844.rs
@@ -1,0 +1,111 @@
+//! #844 (S4 item A) — compositional-planning benchmark constitution and typed
+//! state/action reference semantics. Frozen contract:
+//! `docs/compositional_planning_spec_844.md`.
+//!
+//! This is the machine-checked record for #844. Increment 1 (this file) freezes
+//! the `s4-compositional-reasoning` benchmark constitution in the #832
+//! capability-suite framework: the primary metric, the promotion statistic, the
+//! six held-out generalization split axes, and the six planning baselines. The
+//! typed reference model (states/actions/transitions/plan-witnesses) and the
+//! F1–F5 deterministic generators/verifiers are the follow-on build increment;
+//! their tests append here.
+//!
+//! Boundary (S4 entry reconciliation, #826): teacher-forced only (S3 #824
+//! LIMIT — no free-running generation); honest decline, not calibrated
+//! confidence (S2 #823 REVISE). Nothing here is deployed-serving evidence.
+
+use uor_r4_api::capability_suite::{
+    builtin_constitution, builtin_manifests, ControlKind, SuiteManifest, Workload,
+};
+
+/// The single committed manifest for the S4 compositional-reasoning workload.
+fn s4_manifest() -> SuiteManifest {
+    builtin_manifests()
+        .into_iter()
+        .find(|m| m.workload == Workload::CompositionalReasoning)
+        .expect("a committed manifest covers the compositional-reasoning workload")
+}
+
+#[test]
+fn s4_constitution_manifest_validates_and_is_named_primary() {
+    let m = s4_manifest();
+    assert_eq!(m.validate(), None, "the frozen S4 manifest validates");
+    assert_eq!(m.id, "s4-compositional-reasoning");
+    // the constitution names it as the S4 primary suite and validates whole.
+    let manifests = builtin_manifests();
+    assert_eq!(
+        builtin_constitution().validate(&manifests),
+        None,
+        "the constitution validates against the committed manifests"
+    );
+}
+
+#[test]
+fn s4_primary_metric_is_the_frozen_valid_plan_rate() {
+    let m = s4_manifest();
+    assert_eq!(m.primary_metric, "held-out-valid-plan-rate");
+    // the promotion statistic is frozen prose naming the beat-target and the
+    // memorization kill; it is intentionally non-empty and specific.
+    assert!(m.promotion_statistic.contains("lower bound"));
+    assert!(m.promotion_statistic.contains("memorization"));
+}
+
+#[test]
+fn s4_freezes_the_six_generalization_split_axes() {
+    let s = s4_manifest().split;
+    assert!(s.by_entity && s.by_topology && s.by_template);
+    assert!(s.by_vocabulary && s.by_operator_composition && s.by_horizon);
+    assert!(s.leakage_check && s.tamper_check);
+    assert_eq!(s.axis_count(), 6, "six disjointness axes are frozen");
+}
+
+#[test]
+fn s4_freezes_the_six_planning_baselines() {
+    let controls = s4_manifest().controls;
+    for expected in [
+        ControlKind::RetrievalOnly,
+        ControlKind::DirectContinuation,
+        ControlKind::MemorizedTrajectory,
+        ControlKind::ShuffledState,
+        ControlKind::ShortestPathOracle,
+        ControlKind::TrivialPrior,
+    ] {
+        assert!(
+            controls.contains(&expected),
+            "baseline {} must be frozen in the S4 controls",
+            expected.label()
+        );
+    }
+    assert_eq!(
+        controls.len(),
+        6,
+        "exactly the six frozen baselines, no more"
+    );
+}
+
+#[test]
+fn new_planning_baseline_labels_are_kebab_case() {
+    assert_eq!(ControlKind::RetrievalOnly.label(), "retrieval-only");
+    assert_eq!(
+        ControlKind::DirectContinuation.label(),
+        "direct-continuation"
+    );
+    assert_eq!(
+        ControlKind::MemorizedTrajectory.label(),
+        "memorized-trajectory"
+    );
+    assert_eq!(
+        ControlKind::ShortestPathOracle.label(),
+        "shortest-path-oracle"
+    );
+    // ALL is exhaustive and includes the new variants exactly once.
+    assert_eq!(ControlKind::ALL.len(), 12);
+    for c in ControlKind::ALL {
+        assert_eq!(
+            ControlKind::ALL.iter().filter(|&&x| x == c).count(),
+            1,
+            "control {} appears exactly once in ALL",
+            c.label()
+        );
+    }
+}


### PR DESCRIPTION
## Problem and outcome

#844 (S4 item A) freezes the compositional-planning benchmark target and the typed
state/action contract for S4. Its design was frozen in `docs/compositional_planning_spec_844.md`
(PR #916). This is **build increment 1 of 2**: it lands the frozen **benchmark constitution**
in the #832 capability-suite framework, converting the `s4-compositional-reasoning` placeholder
into the frozen declaration the stage is judged on. Increment 2 lands the typed reference model
+ generators/verifiers + RF-32 + Gherkin.

## Scope and non-goals

**In scope:** expand `capability_suites/compositional_reasoning.json`; add the three new
generalization split axes (`by_vocabulary`, `by_operator_composition`, `by_horizon`) to
`SplitRules`; add the four planning-baseline `ControlKind` variants (`retrieval-only`,
`direct-continuation`, `memorized-trajectory`, `shortest-path-oracle`); freeze the primary
metric, promotion statistic, controls, and pinned identities; add the machine-checked record
`tests/compositional_planning_spec_844.rs`.

**Non-goals (this increment):** no typed reference model, generators, verifiers, RF-32, or
Gherkin (increment 2); no planner (#843); no geometry (#845); no verdict (#846); no
free-running generation (S3 #824 boundary).

## Acceptance-criteria status

Advances #844's "freeze compositional benchmarks" scope: the frozen split axes prevent
entity/topology/vocabulary/composition memorization, and the six baselines (incl. the two
memorization nulls) are frozen. The reference-semantics acceptance items are increment 2. This
PR does not close #844.

## Tests and verification

New: 5 tests in `compositional_planning_spec_844.rs` (manifest validates + is the named S4
primary; frozen valid-plan-rate metric; six split axes; six baselines; kebab-case labels + ALL
exhaustiveness). Existing `capability_suites_832.rs` (9) still green. Full local ladder green:
`cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
`cargo test --workspace --no-fail-fast` (178 suites, 0 failures); no_std ladder
(`uor-r4-graph-format` `--no-default-features` ± `alloc`); wasm lib build; `xtask validate`
(R1 check-model 31 ids / R4 / R5 / gnaf); `check_claim_wording.py`.

## Evidence artifacts

`crates/uor-r4-api/capability_suites/compositional_reasoning.json` (frozen manifest);
`crates/uor-r4-api/tests/compositional_planning_spec_844.rs` (record).

## Compatibility and migration

Additive. The three new `SplitRules` fields are `#[serde(default)]`, so the other nine committed
manifests deserialize unchanged. The four new `ControlKind` variants extend the enum without
altering existing ones. `CAPABILITY_SUITE_SCHEMA`/`CAPABILITY_REPORT_SCHEMA` stay at 1. The
primary metric is renamed from the placeholder `held-out-composition-accuracy` to
`held-out-valid-plan-rate`; no committed report references the old name (S4 has not run).

## Conformance effects

None. No id/feature/marker change this increment; `CONFORMANCE.md` unchanged (`xtask check-model`
reports it equal to the model, 31 ids). RF-32 registration is increment 2.

## Claim-boundary changes

None beyond the frozen doc's: reference-only / off-serving-path; establishes a falsifiable
target, not reasoning performance. Teacher-forced only (S3 LIMIT); honest decline, not calibrated
confidence (S2 REVISE).

## Negative or unavailable results

None (schema/constitution freeze). The manifest fixes that an absent benchmark fixture is
UNAVAILABLE, never PASS (framework invariant).

## Intentionally excluded work

Typed reference model, F1–F5 generators/verifiers, RF-32 + Gherkin + marker/bdd steps, and the
metamorphic/tamper/power/witness-replay tests are increment 2. References #844.
