### PR TITLE
feat(#844): register RF-32 compositional-planning benchmarks (Gherkin, bdd, conformance)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -67,6 +67,12 @@ The `build` level is *harness-built* (structural). It is a separate axis from an
 | --- | --- | --- | --- | --- | --- |
 | `RF-05` | `build` | `offline-compiler` | `off-serving-path` | features/suites/compiler_stage_dag.feature | Compiler stage ownership and parallelization DAG |
 
+## compositional_planning_benchmarks
+
+| ID | Level | Execution scope | Serving reachability | Evidence | Statement |
+| --- | --- | --- | --- | --- | --- |
+| `RF-32` | `build` | `certifier-instrument` | `off-serving-path` | features/suites/compositional_planning_benchmarks.feature; crates/uor-r4-graph-compiler/src/compositional_planning.rs; docs/compositional_planning_spec_844.md | Compositional-planning benchmark constitution and typed plan-witness/state/action reference semantics (fixture-gated certifier instrument; absent fixtures are UNAVAILABLE, never PASS) |
+
 ## expand_proof_model
 
 | ID | Level | Execution scope | Serving reachability | Evidence | Statement |

--- a/crates/repo-conformance/tests/registered.rs
+++ b/crates/repo-conformance/tests/registered.rs
@@ -203,3 +203,8 @@ fn selective_prediction_surfaces_rf_30() {
 fn skipmix_serving_lane_rf_31() {
     check("RF-31", "skipmix_serving_lane");
 }
+
+#[test]
+fn compositional_planning_benchmarks_rf_32() {
+    check("RF-32", "compositional_planning_benchmarks");
+}

--- a/features/suites/compositional_planning_benchmarks.feature
+++ b/features/suites/compositional_planning_benchmarks.feature
@@ -1,0 +1,38 @@
+@status:enforced
+Feature: Compositional-planning benchmarks and typed plan-witness semantics
+  The frozen S4 compositional-planning reference model (docs/compositional_planning_spec_844.md)
+  generates deterministic task instances with replayable gold plans, verifies plan witnesses
+  independently, rejects invalid intermediate steps and missing evidence, reports honest typed
+  declines, and is stable under relabeling. Reference-only / off-serving-path; teacher-forced
+  scope (S3 boundary); ordinal confidence, not calibrated (S2 boundary).
+
+  @RF-32 @build
+  Scenario: The gold plan for a graph-navigation task verifies
+    Given a graph-navigation compositional-planning task with seed 0
+    When the gold plan is verified
+    Then the plan-witness verdict is valid
+
+  @RF-32 @build
+  Scenario: The verifier rejects a path that enters a forbidden region
+    Given a graph-navigation compositional-planning task with seed 0
+    When a two-step east path is submitted
+    Then the plan-witness verdict is invalid
+
+  @RF-32 @build
+  Scenario: Relabeling preserves the plan and its action sequence
+    Given a constraint-satisfaction compositional-planning task with seed 1
+    When the task is relabeled
+    Then the relabeled gold plan verdict is valid
+    And the relabeled action sequence equals the original
+
+  @RF-32 @build
+  Scenario: A multi-hop-evidence plan stripped of cited evidence is invalid
+    Given a multi-hop-evidence compositional-planning task with seed 2
+    When the gold plan's cited evidence is removed and verified
+    Then the plan-witness verdict is invalid
+
+  @RF-32 @build
+  Scenario: An unsolvable episode reports a typed decline
+    Given a graph-navigation compositional-planning task with seed 0
+    When the gold plan is marked as a no-plan decline and verified
+    Then the plan-witness verdict is a typed decline

--- a/model/ids.toml
+++ b/model/ids.toml
@@ -298,3 +298,12 @@ statement = "Deployed serving routes next-token selection through the promoted s
 scope = "normative-runtime"
 reachability = "deployed-serving"
 evidence = "features/suites/skipmix_serving_lane.feature; crates/uor-r4-api/src/engine.rs (predict_decision routes through predict_decision_candidates_with_skipmix); crates/uor-r4-graph-cli/src/lib.rs (score stage fits and emits SKMX/PSIB via skipmix_fit::fit_skipmix_tables); docs/skipmix_endtoend_causal_908.md (deployed end-to-end causal evidence, +28.45permille, #822/#908)"
+
+[[id]]
+id = "RF-32"
+level = "build"
+suite = "compositional_planning_benchmarks"
+statement = "Compositional-planning benchmark constitution and typed plan-witness/state/action reference semantics (fixture-gated certifier instrument; absent fixtures are UNAVAILABLE, never PASS)"
+scope = "certifier-instrument"
+reachability = "off-serving-path"
+evidence = "features/suites/compositional_planning_benchmarks.feature; crates/uor-r4-graph-compiler/src/compositional_planning.rs; docs/compositional_planning_spec_844.md"

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -158,6 +158,10 @@ struct R4g1World {
     belief_in: Option<f32>,
     belief_out: Option<f32>,
     trajectory_step_rejected: bool,
+    // Compositional planning fields (#844, RF-32)
+    cp_task: Option<uor_r4_graph_compiler::compositional_planning::TaskInstance>,
+    cp_relabeled: Option<uor_r4_graph_compiler::compositional_planning::TaskInstance>,
+    cp_verdict: Option<uor_r4_graph_compiler::compositional_planning::WitnessVerdict>,
     contract_doc_text: String,
     contract_doc_version: Option<String>,
     contract_module_version: Option<String>,
@@ -3940,4 +3944,99 @@ async fn main() {
         .fail_on_skipped()
         .run_and_exit(concat!(env!("CARGO_MANIFEST_DIR"), "/features/suites"))
         .await;
+}
+
+// =========================================================================
+// Compositional-planning benchmark BDD steps (#844, RF-32)
+// =========================================================================
+use uor_r4_graph_compiler::compositional_planning::{
+    self as cp, DeclineReason as CpDecline, TaskFamily as CpFamily, WitnessVerdict as CpVerdict,
+};
+
+#[given("a graph-navigation compositional-planning task with seed 0")]
+fn cp_given_graph_nav(w: &mut R4g1World) {
+    w.cp_task = Some(cp::generate(CpFamily::GraphNavigation, 0, cp::H_MAX));
+}
+
+#[given("a constraint-satisfaction compositional-planning task with seed 1")]
+fn cp_given_constraint(w: &mut R4g1World) {
+    w.cp_task = Some(cp::generate(CpFamily::ConstraintSatisfaction, 1, cp::H_MAX));
+}
+
+#[given("a multi-hop-evidence compositional-planning task with seed 2")]
+fn cp_given_multihop(w: &mut R4g1World) {
+    w.cp_task = Some(cp::generate(CpFamily::MultiHopEvidence, 2, cp::H_MAX));
+}
+
+#[when("the gold plan is verified")]
+fn cp_when_verify_gold(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    w.cp_verdict = Some(t.gold.verify());
+}
+
+#[when("a two-step east path is submitted")]
+fn cp_when_two_easts(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    let east = SemAction::new("east", vec![1.0, 0.0], vec![0]);
+    let path = vec![east.clone(), east];
+    w.cp_verdict = Some(cp::verify_submission(t, &path));
+}
+
+#[when("the task is relabeled")]
+fn cp_when_relabel(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    w.cp_relabeled = Some(cp::relabel(t, 7, -3));
+}
+
+#[when("the gold plan's cited evidence is removed and verified")]
+fn cp_when_strip_evidence(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    let mut witness = t.gold.clone();
+    witness.step_evidence = Vec::new();
+    w.cp_verdict = Some(witness.verify());
+}
+
+#[when("the gold plan is marked as a no-plan decline and verified")]
+fn cp_when_mark_decline(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    let mut witness = t.gold.clone();
+    witness.decline = Some(CpDecline::NoPlan);
+    w.cp_verdict = Some(witness.verify());
+}
+
+#[then("the plan-witness verdict is valid")]
+fn cp_then_valid(w: &mut R4g1World) {
+    assert_eq!(w.cp_verdict.as_ref().expect("a verdict"), &CpVerdict::Valid);
+}
+
+#[then("the plan-witness verdict is invalid")]
+fn cp_then_invalid(w: &mut R4g1World) {
+    assert!(matches!(
+        w.cp_verdict.as_ref().expect("a verdict"),
+        CpVerdict::Invalid { .. }
+    ));
+}
+
+#[then("the relabeled gold plan verdict is valid")]
+fn cp_then_relabeled_valid(w: &mut R4g1World) {
+    let r = w.cp_relabeled.as_ref().expect("a relabeled task");
+    assert_eq!(r.gold.verify(), CpVerdict::Valid);
+}
+
+#[then("the relabeled action sequence equals the original")]
+fn cp_then_relabeled_sequence(w: &mut R4g1World) {
+    let t = w.cp_task.as_ref().expect("a task");
+    let r = w.cp_relabeled.as_ref().expect("a relabeled task");
+    let names = |ti: &cp::TaskInstance| -> Vec<String> {
+        ti.gold.chosen_path.iter().map(|a| a.name.clone()).collect()
+    };
+    assert_eq!(names(t), names(r));
+}
+
+#[then("the plan-witness verdict is a typed decline")]
+fn cp_then_decline(w: &mut R4g1World) {
+    assert!(matches!(
+        w.cp_verdict.as_ref().expect("a verdict"),
+        CpVerdict::Declined(_)
+    ));
 }


### PR DESCRIPTION
## Problem and outcome

Completes #844 (S4 item A). The design (#916), benchmark constitution (#917), and typed
reference model (#918) are on main. This **build increment 3 of 3** registers the capability as
conformance id **RF-32**, wiring the reference model into the register with a tagged Gherkin
suite, executable bdd steps, a marker test, and a regenerated `CONFORMANCE.md`.

## Scope and non-goals

**In scope:** `model/ids.toml` (RF-32); `features/suites/compositional_planning_benchmarks.feature`
(five `@RF-32 @build` scenarios); executable cucumber steps in root `tests/bdd.rs` (+3
`R4g1World` fields); the `repo-conformance` marker; `CONFORMANCE.md` regenerated by
`xtask check-model --write` (31 → 32 ids).

**Non-goals:** the deployed integer/table planner (S4 item B), geometry qualification (item C),
and certification (item D) are separate issues; no free-running generation (S3 boundary).

## Acceptance-criteria status

Completes #844's built-capability order (ids → Gherkin → marker → impl → regenerated
conformance). The frozen constitution, the total/deterministic reference semantics with typed
decline, the deterministic verifiers with replayable gold, the split axes and the six baselines,
and the metamorphic relabeling control are all in place across #916/#917/#918 and this PR, and
now conformance-visible under RF-32.

## Tests and verification

Five new `@RF-32 @build` scenarios run in the workspace bdd suite (114 scenarios / 377 steps,
all passing). Full local ladder green: fmt; clippy `-D warnings`
(workspace/all-targets/all-features); `cargo test --workspace --no-fail-fast` (178 suites, 0
failures); no_std ladder; wasm lib build; `xtask validate` (R1 check-model **32 ids** / R4 / R5
/ gnaf); `check_claim_wording.py`. `xtask check-model` confirms `CONFORMANCE.md` equals the
model.

## Evidence artifacts

`features/suites/compositional_planning_benchmarks.feature`, the RF-32 rows in `model/ids.toml`
and `CONFORMANCE.md`, and the reference model + record from #918 / the constitution from #917.

## Compatibility and migration

Additive: a new conformance id and suite; three new test-only `R4g1World` fields. No existing
id, artifact, or public API changes. `CONFORMANCE.md` is generated, not hand-edited.

## Conformance effects

Adds RF-32 `compositional_planning_benchmarks` (certifier-instrument / off-serving-path,
fixture-gated empirical). Id count 31 → 32; `register conformance` stays green.

## Claim-boundary changes

None beyond the frozen doc's: reference-only / off-serving-path; teacher-forced (S3 LIMIT);
ordinal confidence, not calibrated (S2 REVISE); a falsifiable target and byte-level meaning, not
reasoning performance. RF-32 evidence is not deployed-planning evidence.

## Negative or unavailable results

None (registration + wiring). The suite fixes that an absent benchmark fixture is UNAVAILABLE,
never PASS.

## Intentionally excluded work

None for #844's build. Downstream S4 work — the planner (item B), geometry (item C), and
certification (item D) — is tracked on the S4 tracker and its sibling items, not here.

Closes #844
