### PR TITLE
feat(#843): Amendment A1 — repair the S4 benchmark generator so it can separate

### DIFF
--- a/crates/uor-r4-graph-compiler/src/compositional_planning.rs
+++ b/crates/uor-r4-graph-compiler/src/compositional_planning.rs
@@ -1,6 +1,21 @@
-//! Compositional-planning reference semantics (#844, S4 item A).
+//! Compositional-planning reference semantics (#844, S4 item A), carrying
+//! Amendment A1 (#843 increment 2).
 //!
-//! Frozen contract: `docs/compositional_planning_spec_844.md`. This module
+//! Frozen contract: `docs/compositional_planning_spec_844.md`, including its
+//! appended section 11 (Amendment A1). A1 repairs the *generator*, not the
+//! constitution: no frozen number moves. It makes instance difficulty scale
+//! with the requested horizon so every frozen cell is non-vacuous; gives each
+//! family real entity, vocabulary, topology, template, and operator-composition
+//! variation so a split is a partition rather than a one-element set; derives
+//! the content identity from problem content with the generation seed excluded,
+//! so an identity-keyed control can actually fire; and leaves the strongest
+//! non-oracle control headroom above the effect floor. Before it, a
+//! structure-keyed memorization control saturated at a valid-plan rate of
+//! 1.0000 and the S4 promotion statistic was at or below zero by construction.
+//! The horizon-1 cell is gated on honest decline rather than valid-plan rate
+//! (section 11.6): a one-step answer is a function of the observable state,
+//! goal, and operator set, so retrieval is optimal there whatever the
+//! generator does. This module
 //! extends the RF-27 semantic-state reference model ([`crate::semantic_state`])
 //! and the RF-08 future-state planner with the typed objects the S4 benchmark
 //! and #843 planner consume: a replayable, independently-verifiable plan
@@ -201,14 +216,62 @@ pub const H_MAX: usize = 16;
 /// Frozen maximum frontier width (spec section 2.5).
 pub const W_MAX: usize = 64;
 
+/// Number of distinct cells on each surface/structure split axis (Amendment
+/// A1-b, #843). Every §2.2 axis a seed can vary carries this many cells, so a
+/// disjoint fitting/held-out partition is constructible rather than vacuous.
+pub const AXIS_CARDINALITY: u64 = 8;
+
+/// The split-axis cell an instance belongs to (#844 §2.2, repaired by A1-b).
+/// Fitting and evaluation data never share a cell on an axis being split.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SplitCell {
+    /// Entity-naming scheme (surface; a semantic no-op).
+    pub entity: u8,
+    /// Operator surface vocabulary (surface; a semantic no-op).
+    pub vocabulary: u8,
+    /// Topology / dynamics configuration (semantic).
+    pub topology: u8,
+    /// Goal/prompt template naming (surface; a semantic no-op).
+    pub template: u8,
+    /// Reasoning horizon (semantic).
+    pub horizon: usize,
+}
+
+impl SplitCell {
+    /// The cell a `(seed, horizon)` pair lands in. Deterministic; the four
+    /// surface/structure axes are independent base-`AXIS_CARDINALITY` digits of
+    /// the seed, so seeds `0..AXIS_CARDINALITY.pow(4)` cover every combination.
+    pub fn of(seed: u64, horizon: usize) -> Self {
+        let c = AXIS_CARDINALITY;
+        Self {
+            entity: (seed % c) as u8,
+            vocabulary: ((seed / c) % c) as u8,
+            topology: ((seed / (c * c)) % c) as u8,
+            template: ((seed / (c * c * c)) % c) as u8,
+            horizon,
+        }
+    }
+
+    /// A deterministic in-cell variant index. Mixed from the whole seed rather
+    /// than read off its high digits, so the goal varies rapidly *within* a
+    /// cell and is distributed identically across both halves of every axis:
+    /// it is a nuisance parameter, not a fifth split axis. Taking it from the
+    /// high digits instead left every seed in a sampling window sharing one
+    /// goal, which by itself made a constant-plan control score 1.0000.
+    fn variant(seed: u64) -> u64 {
+        fnv1a64(&format!("in-cell-variant-{seed}"))
+    }
+}
+
 /// A generated task instance with a replayable gold plan.
 #[derive(Debug, Clone)]
 pub struct TaskInstance {
     /// Task family.
     pub family: TaskFamily,
-    /// Deterministic generation seed (sample identity input).
+    /// Deterministic generation seed. Selects the split cell and the in-cell
+    /// variant; it is **not** part of the content identity (A1-c).
     pub seed: u64,
-    /// Planning horizon (bounded).
+    /// Planning horizon (bounded). The gold plan is exactly this long.
     pub horizon: usize,
     /// Initial state.
     pub initial_state: SemanticState,
@@ -216,6 +279,11 @@ pub struct TaskInstance {
     pub goal: Goal,
     /// Forbidden regions.
     pub constraints: Vec<Constraint>,
+    /// F5 only: the action *names* of the plan that is optimal under the
+    /// *pre-intervention* (base) dynamics. Replaying it under this instance's
+    /// intervened dynamics must be `Invalid` — that is what makes the family a
+    /// counterfactual rather than a re-run. Empty for F1-F4.
+    pub counterfactual_base: Vec<String>,
     /// Available actions/operators.
     pub actions: Vec<Action>,
     /// Replayable gold plan (or an honest decline when unsolvable).
@@ -223,23 +291,54 @@ pub struct TaskInstance {
 }
 
 impl TaskInstance {
-    /// Content-addressed identity derived from the frozen generation inputs.
-    /// Identical inputs share an id (deterministic; no clock/RNG/order).
+    /// Content-addressed identity derived from the typed problem content alone.
+    ///
+    /// **Amendment A1-c (#843).** The generation seed is *excluded*: it is a
+    /// generator input, not problem content, and mixing it in gave every
+    /// instance a unique id while only a handful of structurally distinct
+    /// problems existed — which made an identity-keyed memorization control
+    /// unable to fire and therefore vacuous. Structurally identical instances
+    /// now share an id. Deterministic; no clock, RNG, or hash-iteration order.
     pub fn id(&self) -> u64 {
         let mut canon = format!(
-            "{}|{}|{}|init={:?}|goal={:?}:{}",
+            "{}|entity={}|init={:?}|tmpl={}|goal={:?}:{}",
             self.family.label(),
-            self.seed,
-            self.horizon,
+            self.initial_state.id,
             round_vec(&self.initial_state.vector),
+            self.goal.name,
             round_vec(&self.goal.target_region.center),
             (self.goal.target_region.radius * 1000.0).round() as i64,
         );
-        for c in &self.constraints {
-            canon.push_str(&format!("|f={:?}", round_vec(&c.forbidden_region.center)));
+        let mut forbidden: Vec<String> = self
+            .constraints
+            .iter()
+            .map(|c| format!("{:?}", round_vec(&c.forbidden_region.center)))
+            .collect();
+        forbidden.sort();
+        for f in &forbidden {
+            canon.push_str("|f=");
+            canon.push_str(f);
+        }
+        for a in &self.actions {
+            canon.push_str(&format!("|a={}:{:?}", a.name, round_vec(&a.delta_vector)));
         }
         fnv1a64(&canon)
     }
+
+    /// The A1-b split cell this instance belongs to.
+    pub fn split_cell(&self) -> SplitCell {
+        SplitCell::of(self.seed, self.horizon)
+    }
+}
+
+/// Resolve action names against a task's own action set, so a submitted plan is
+/// evaluated under the task's dynamics rather than under whatever deltas the
+/// caller happened to hold. `None` when a name is not in the task's vocabulary.
+pub fn resolve_actions(task: &TaskInstance, names: &[String]) -> Option<Vec<Action>> {
+    names
+        .iter()
+        .map(|n| task.actions.iter().find(|a| &a.name == n).cloned())
+        .collect()
 }
 
 fn round_vec(v: &[f32]) -> Vec<i64> {
@@ -250,13 +349,112 @@ fn state_key(s: &SemanticState) -> String {
     format!("{:?}|{:?}", round_vec(&s.vector), s.boolean_signature)
 }
 
+// ---------------------------------------------------------------------------
+// Amendment A1-b (#843): split-axis vocabularies, effect sets, and topologies.
+//
+// Two kinds of axis, deliberately separated:
+//
+// * **Surface axes** - entity naming, operator vocabulary, goal template. These
+//   are semantic no-ops, so splitting on them isolates exactly one failure
+//   mode: a mechanism keyed on labels rather than on the typed dynamics.
+// * **Semantic axes** - topology (the operator *effect set* plus the forbidden
+//   configuration) and horizon. Splitting on these is what separates planning
+//   from retrieval: under a held-out effect set, a plan memorised or retrieved
+//   from fitting data no longer applies, while a planner re-plans with the
+//   operators the instance actually offers.
+//
+// The effect sets are drawn from a **shared pool**, and the low and high halves
+// of the topology axis each cover the whole pool. That is deliberate: an
+// inducer fitted on the low half sees every effect it will need on the high
+// half, so a held-out cell is a novel *composition*, never a novel primitive.
+// A benchmark whose held-out cells needed unseen primitives would be
+// unsolvable rather than hard.
+// ---------------------------------------------------------------------------
+
+/// Entity-naming schemes (surface axis).
+const ENTITY_NAMES: [&str; 8] = [
+    "start", "origin", "home", "base", "root", "anchor", "source", "depot",
+];
+
+/// Goal/prompt template names (surface axis).
+const GOAL_TEMPLATES: [&str; 8] = [
+    "reach", "arrive", "attain", "achieve", "satisfy", "fulfil", "obtain", "complete",
+];
+
+/// Operator surface vocabularies (surface axis). Vocabulary 0 keeps the
+/// historical compass names, which pair with topology 0's axis-aligned effect
+/// set and so keep the pinned seed-0 fixtures readable; the rest are abstract,
+/// because an operator's name is a label and its effect comes from the topology.
+const MOVE_VOCAB: [[&str; 4]; 8] = [
+    ["east", "north", "west", "south"],
+    ["alpha", "beta", "gamma", "delta"],
+    ["push", "pull", "lift", "drop"],
+    ["p0", "p1", "p2", "p3"],
+    ["rho", "sigma", "tau", "upsilon"],
+    ["step-1", "step-2", "step-3", "step-4"],
+    ["mv-a", "mv-b", "mv-c", "mv-d"],
+    ["op-w", "op-x", "op-y", "op-z"],
+];
+
+/// Operator *effect* sets for the grid families (semantic topology axis). Drawn
+/// from the eight-effect pool {(+-1,0), (0,+-1), (+-1,+-1)}; topologies 0-3 and
+/// topologies 4-7 each cover the whole pool.
+const TOPOLOGY_EFFECTS: [[(i64, i64); 4]; 8] = [
+    [(1, 0), (0, 1), (-1, 0), (0, -1)],
+    [(1, 1), (1, -1), (-1, 1), (-1, -1)],
+    [(1, 0), (0, 1), (1, 1), (-1, -1)],
+    [(0, -1), (-1, 0), (1, -1), (-1, 1)],
+    [(1, 0), (0, -1), (-1, 1), (1, 1)],
+    [(0, 1), (-1, 0), (1, -1), (-1, -1)],
+    [(1, 0), (-1, 0), (1, 1), (-1, -1)],
+    [(0, 1), (0, -1), (1, -1), (-1, 1)],
+];
+
+/// Symbolic-operator surface vocabularies (surface axis).
+const SYMBOL_VOCAB: [[&str; 3]; 8] = [
+    ["op-a", "op-b", "op-c"],
+    ["rewrite-a", "rewrite-b", "rewrite-c"],
+    ["t1", "t2", "t3"],
+    ["apply-alpha", "apply-beta", "apply-gamma"],
+    ["reduce", "expand", "shift"],
+    ["sigma", "tau", "rho"],
+    ["f", "g", "h"],
+    ["norm-a", "norm-b", "norm-c"],
+];
+
+/// Symbolic-operator effect sets (semantic topology axis for F2), drawn from the
+/// six-effect pool {(2,0), (0,1), (-1,0), (1,1), (0,-1), (1,0)}. As above, the
+/// low and high halves of the axis each cover the whole pool.
+const SYMBOL_EFFECTS: [[(i64, i64); 3]; 8] = [
+    [(2, 0), (0, 1), (-1, 0)],
+    [(1, 1), (0, -1), (1, 0)],
+    [(2, 0), (1, 1), (0, -1)],
+    [(0, 1), (-1, 0), (1, 0)],
+    [(1, 0), (0, 1), (1, 1)],
+    [(2, 0), (0, -1), (-1, 0)],
+    [(0, 1), (1, 1), (0, -1)],
+    [(2, 0), (1, 0), (-1, 0)],
+];
+
+/// Surface names for the F5 twin operator (surface axis).
+const TWIN_NAMES: [&str; 8] = [
+    "twin-east",
+    "alt-alpha",
+    "mirror-push",
+    "p0-prime",
+    "rho-alt",
+    "step-1b",
+    "mv-a2",
+    "op-w-alt",
+];
+
 fn cell(id: &str, x: i64, y: i64) -> SemanticState {
     SemanticState::new(id, vec![x as f32, y as f32], vec![0], 1.0)
 }
 
-fn goal_at(x: i64, y: i64) -> Goal {
+fn goal_at(template: &str, x: i64, y: i64) -> Goal {
     Goal::new(
-        "reach",
+        template,
         Region::new("goal", vec![x as f32, y as f32], 0.5, "goal-cell"),
         0.0,
     )
@@ -269,13 +467,118 @@ fn forbid(id: &str, x: i64, y: i64) -> Constraint {
     )
 }
 
-fn grid_actions() -> Vec<Action> {
-    vec![
-        Action::new("east", vec![1.0, 0.0], vec![0]),
-        Action::new("north", vec![0.0, 1.0], vec![0]),
-        Action::new("west", vec![-1.0, 0.0], vec![0]),
-        Action::new("south", vec![0.0, -1.0], vec![0]),
-    ]
+/// Forbidden-cell configuration for a family's topology cell. Index 0 keeps the
+/// historical `(2, 0)` block for the grid families, so the pinned seed-0
+/// fixtures keep their meaning. Every configuration is finite and the lattice is
+/// unbounded, so no configuration can disconnect the state space.
+fn obstacles(family: TaskFamily, topology: u8) -> Vec<(i64, i64)> {
+    match family {
+        // F2 and F5 carry their whole topology in the operator effect set.
+        TaskFamily::SymbolicTransformation | TaskFamily::CounterfactualIntervention => Vec::new(),
+        TaskFamily::ConstraintSatisfaction => {
+            // A wall with exactly one gap: the classic typed-constraint shape.
+            let col = 2 + i64::from(topology / 4);
+            let gap = -1 + i64::from(topology % 4);
+            (-2..=3).filter(|y| *y != gap).map(|y| (col, y)).collect()
+        }
+        _ => {
+            const PATTERNS: [&[(i64, i64)]; 8] = [
+                &[(2, 0)],
+                &[],
+                &[(1, 0)],
+                &[(1, 0), (1, 1)],
+                &[(2, 0), (2, 1)],
+                &[(1, -1), (2, 0)],
+                &[(1, 0), (2, 1), (3, -1)],
+                &[(2, -1), (2, 0), (2, 1)],
+            ];
+            PATTERNS[usize::from(topology) % 8].to_vec()
+        }
+    }
+}
+
+fn named_actions(names: &[&str], deltas: &[(i64, i64)]) -> Vec<Action> {
+    names
+        .iter()
+        .zip(deltas.iter())
+        .map(|(n, (dx, dy))| Action::new(*n, vec![*dx as f32, *dy as f32], vec![0]))
+        .collect()
+}
+
+/// The operator set for a family's (vocabulary, topology) cell. For F5 the twin
+/// operator is listed first and carries its *intervened* effect; `base` selects
+/// the pre-intervention effect instead.
+fn family_actions(family: TaskFamily, vocabulary: u8, topology: u8, base: bool) -> Vec<Action> {
+    let v = usize::from(vocabulary) % 8;
+    let t = usize::from(topology) % 8;
+    match family {
+        TaskFamily::SymbolicTransformation => named_actions(&SYMBOL_VOCAB[v], &SYMBOL_EFFECTS[t]),
+        TaskFamily::CounterfactualIntervention => {
+            // Pre-intervention the twin duplicates the first operator's effect;
+            // the declared intervention changes it to the second operator's.
+            let effect = if base {
+                TOPOLOGY_EFFECTS[t][0]
+            } else {
+                TOPOLOGY_EFFECTS[t][1]
+            };
+            let mut acts = vec![Action::new(
+                TWIN_NAMES[v],
+                vec![effect.0 as f32, effect.1 as f32],
+                vec![0],
+            )];
+            acts.extend(named_actions(&MOVE_VOCAB[v], &TOPOLOGY_EFFECTS[t]));
+            acts
+        }
+        _ => named_actions(&MOVE_VOCAB[v], &TOPOLOGY_EFFECTS[t]),
+    }
+}
+
+/// Every cell first reached at exactly `depth` steps, in canonical order.
+///
+/// **Amendment A1-a (#843).** Placing the goal on this layer makes the shortest
+/// valid plan exactly `depth` long, so an instance generated for horizon `H` is
+/// a genuine `H`-step task. Before the amendment the goal was fixed and the
+/// horizon merely truncated the search, which made every H = 1 and H = 2 cell
+/// unsolvable and therefore unable to separate any mechanism. Falls back to the
+/// deepest reachable layer, so the function is total.
+fn layer_at_depth(
+    initial: &SemanticState,
+    constraints: &[Constraint],
+    actions: &[Action],
+    depth: usize,
+) -> Vec<(i64, i64)> {
+    let mut evaluator = TransitionEvaluator::new();
+    for c in constraints {
+        evaluator.add_constraint(c.clone());
+    }
+    let mut visited = std::collections::BTreeSet::new();
+    visited.insert(state_key(initial));
+    let mut frontier = vec![initial.clone()];
+    let mut deepest = frontier.clone();
+    for _ in 0..depth {
+        let mut next: Vec<SemanticState> = Vec::new();
+        for state in &frontier {
+            for action in actions {
+                if let Some(successor) = evaluator.apply(state, action)
+                    && visited.insert(state_key(&successor))
+                {
+                    next.push(successor);
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+        deepest = frontier.clone();
+    }
+    let mut cells: Vec<(i64, i64)> = deepest
+        .iter()
+        .map(|s| (s.vector[0].round() as i64, s.vector[1].round() as i64))
+        .collect();
+    cells.sort_unstable();
+    cells.dedup();
+    cells
 }
 
 /// Deterministic breadth-first reference solver: the shortest action sequence
@@ -323,6 +626,27 @@ fn bfs_plan(
     None
 }
 
+/// Does `plan` reach `goal` from `initial` without entering a forbidden region?
+fn plan_reaches(
+    initial: &SemanticState,
+    goal: &Goal,
+    constraints: &[Constraint],
+    plan: &[Action],
+) -> bool {
+    let mut evaluator = TransitionEvaluator::new();
+    for c in constraints {
+        evaluator.add_constraint(c.clone());
+    }
+    let mut state = initial.clone();
+    for action in plan {
+        match evaluator.apply(&state, action) {
+            Some(next) => state = next,
+            None => return false,
+        }
+    }
+    goal.is_satisfied_by(&state)
+}
+
 /// The problem components of a task instance (grouped to keep `finish` within
 /// the argument-count lint and to make the generators read declaratively).
 struct Problem {
@@ -330,6 +654,9 @@ struct Problem {
     goal: Goal,
     constraints: Vec<Constraint>,
     actions: Vec<Action>,
+    /// F5 only: action names of the plan optimal under the pre-intervention
+    /// dynamics. Empty for F1-F4.
+    counterfactual_base: Vec<String>,
 }
 
 fn finish(
@@ -344,6 +671,7 @@ fn finish(
         goal,
         constraints,
         actions,
+        counterfactual_base,
     } = problem;
     let solved = bfs_plan(&initial, &goal, &constraints, &actions, horizon);
     let (chosen, decline): (Vec<Action>, Option<DeclineReason>) = match solved {
@@ -394,104 +722,145 @@ fn finish(
         initial_state: initial,
         goal,
         constraints,
+        counterfactual_base,
         actions,
         gold,
     }
 }
 
-/// Generate a deterministic task instance for `family` from `seed`. Instances
-/// are constructed to be solvable within `horizon`; the gold plan is the BFS
-/// reference solver's shortest valid plan. Teacher-forced scope (S3 boundary).
-pub fn generate(family: TaskFamily, seed: u64, horizon: usize) -> TaskInstance {
-    match family {
-        TaskFamily::GraphNavigation => {
-            let tx = 3 + (seed % 3) as i64;
-            finish(
-                family,
-                seed,
-                horizon,
-                Problem {
-                    initial: cell("start", 0, 0),
-                    goal: goal_at(tx, 0),
-                    constraints: vec![forbid("block", 2, 0)],
-                    actions: grid_actions(),
-                },
-                false,
-            )
+/// Pick F5's goal and its pre-intervention plan: the first layer cell, scanning
+/// canonically from the in-cell variant, whose base-dynamics optimal plan uses
+/// the twin operator and no longer reaches the goal once the twin's declared
+/// effect changes. That is what makes the family a counterfactual rather than a
+/// re-run, at every horizon including H = 1.
+struct CounterfactualSearch<'a> {
+    initial: &'a SemanticState,
+    constraints: &'a [Constraint],
+    actions: &'a [Action],
+    base_actions: &'a [Action],
+    layer: &'a [(i64, i64)],
+    template: &'a str,
+    depth: usize,
+    variant: u64,
+}
+
+fn counterfactual_goal(search: &CounterfactualSearch<'_>) -> ((i64, i64), Vec<String>) {
+    let CounterfactualSearch {
+        initial,
+        constraints,
+        actions,
+        base_actions,
+        layer,
+        template,
+        depth,
+        variant,
+    } = *search;
+    let start = (variant as usize) % layer.len();
+    let twin = actions[0].name.clone();
+    let mut fallback = None;
+    for k in 0..layer.len() {
+        let (gx, gy) = layer[(start + k) % layer.len()];
+        let goal = goal_at(template, gx, gy);
+        let Some(base_plan) = bfs_plan(initial, &goal, constraints, base_actions, depth) else {
+            continue;
+        };
+        let names: Vec<String> = base_plan.iter().map(|a| a.name.clone()).collect();
+        if fallback.is_none() {
+            fallback = Some(((gx, gy), names.clone()));
         }
-        TaskFamily::ConstraintSatisfaction => {
-            let gap = 1 + (seed % 2) as i64;
-            let mut constraints = Vec::new();
-            for y in -1..=3 {
-                if y != gap {
-                    constraints.push(forbid(&format!("wall-{y}"), 2, y));
-                }
-            }
-            finish(
-                family,
-                seed,
-                horizon,
-                Problem {
-                    initial: cell("start", 0, 0),
-                    goal: goal_at(4, 0),
-                    constraints,
-                    actions: grid_actions(),
-                },
-                false,
-            )
+        if !names.contains(&twin) {
+            continue;
         }
-        TaskFamily::SymbolicTransformation => {
-            let tx = 4 + (seed % 3) as i64;
-            let actions = vec![
-                Action::new("op-add2x", vec![2.0, 0.0], vec![0]),
-                Action::new("op-inc-y", vec![0.0, 1.0], vec![0]),
-                Action::new("op-dec-x", vec![-1.0, 0.0], vec![0]),
-            ];
-            finish(
-                family,
-                seed,
-                horizon,
-                Problem {
-                    initial: cell("term0", 0, 0),
-                    goal: goal_at(tx, 2),
-                    constraints: Vec::new(),
-                    actions,
-                },
-                false,
-            )
-        }
-        TaskFamily::MultiHopEvidence => {
-            let tx = 3 + (seed % 3) as i64;
-            finish(
-                family,
-                seed,
-                horizon,
-                Problem {
-                    initial: cell("q", 0, 0),
-                    goal: goal_at(tx, 0),
-                    constraints: Vec::new(),
-                    actions: grid_actions(),
-                },
-                true,
-            )
-        }
-        TaskFamily::CounterfactualIntervention => {
-            let tx = 3 + (seed % 3) as i64;
-            let block_x = 1 + (seed % (tx as u64 - 1)) as i64;
-            finish(
-                family,
-                seed,
-                horizon,
-                Problem {
-                    initial: cell("start", 0, 0),
-                    goal: goal_at(tx, 0),
-                    constraints: vec![forbid("intervened", block_x, 0)],
-                    actions: grid_actions(),
-                },
-                false,
-            )
+        let replay: Vec<Action> = names
+            .iter()
+            .filter_map(|n| actions.iter().find(|a| &a.name == n).cloned())
+            .collect();
+        if replay.len() == names.len() && !plan_reaches(initial, &goal, constraints, &replay) {
+            return ((gx, gy), names);
         }
     }
+    fallback.unwrap_or((layer[start], Vec::new()))
+}
+
+/// Generate a deterministic task instance for `family` from `seed` at `horizon`.
+///
+/// The seed selects the A1-b split cell - entity naming, operator vocabulary,
+/// topology, goal template - plus an in-cell variant; the horizon sets the
+/// task's *difficulty*, so the gold plan is exactly `horizon` steps long
+/// (A1-a). Teacher-forced scope (S3 boundary).
+pub fn generate(family: TaskFamily, seed: u64, horizon: usize) -> TaskInstance {
+    let split = SplitCell::of(seed, horizon);
+    let variant = SplitCell::variant(seed);
+    let depth = horizon.clamp(1, H_MAX);
+    let entity = ENTITY_NAMES[usize::from(split.entity) % 8];
+    let template = GOAL_TEMPLATES[usize::from(split.template) % 8];
+    let initial = cell(entity, 0, 0);
+    let actions = family_actions(family, split.vocabulary, split.topology, false);
+    let constraints: Vec<Constraint> = obstacles(family, split.topology)
+        .into_iter()
+        .enumerate()
+        .map(|(i, (x, y))| forbid(&format!("blocked-{i}"), x, y))
+        .collect();
+
+    // The horizon-1 cell is the honest-decline cell (#843, maintainer sign-off
+    // 2026-08-22). A one-step task's answer is a deterministic function of the
+    // observable state, goal, and operator set, and the fitting split must
+    // cover the whole operator pool or induction has nothing to learn from - so
+    // a displacement-indexed retrieval baseline is optimal at horizon 1 by
+    // construction and valid-plan rate cannot separate it from planning there.
+    // A quarter of horizon-1 instances therefore place the goal one step beyond
+    // the horizon: they are genuinely unsolvable within it and the correct
+    // outcome is Decline(no_plan), which a replaying baseline cannot produce.
+    // Deciding correctly requires evaluating reachability, which is planning.
+    let beyond_horizon = depth == 1 && variant.is_multiple_of(4);
+    let layer = layer_at_depth(
+        &initial,
+        &constraints,
+        &actions,
+        if beyond_horizon { depth + 1 } else { depth },
+    );
+
+    if family == TaskFamily::CounterfactualIntervention && !beyond_horizon {
+        let base_actions = family_actions(family, split.vocabulary, split.topology, true);
+        let ((gx, gy), base) = counterfactual_goal(&CounterfactualSearch {
+            initial: &initial,
+            constraints: &constraints,
+            actions: &actions,
+            base_actions: &base_actions,
+            layer: &layer,
+            template,
+            depth,
+            variant,
+        });
+        return finish(
+            family,
+            seed,
+            depth,
+            Problem {
+                initial,
+                goal: goal_at(template, gx, gy),
+                constraints,
+                actions,
+                counterfactual_base: base,
+            },
+            false,
+        );
+    }
+
+    let (gx, gy) = layer[(variant as usize) % layer.len()];
+    finish(
+        family,
+        seed,
+        depth,
+        Problem {
+            initial,
+            goal: goal_at(template, gx, gy),
+            constraints,
+            actions,
+            counterfactual_base: Vec::new(),
+        },
+        family == TaskFamily::MultiHopEvidence,
+    )
 }
 
 /// Verify a submitted action sequence against a task's frozen goal and
@@ -574,6 +943,7 @@ pub fn relabel(task: &TaskInstance, dx: i64, dy: i64) -> TaskInstance {
         initial_state: initial,
         goal,
         constraints,
+        counterfactual_base: task.counterfactual_base.clone(),
         actions: task.actions.clone(),
         gold,
     }
@@ -612,12 +982,39 @@ mod tests {
         }
     }
 
+    /// Amendment A1-a: an instance generated for horizon `H` is a genuine
+    /// `H`-step task, at every frozen horizon including the low ones that were
+    /// entirely unsolvable before the repair.
+    #[test]
+    fn gold_length_equals_the_requested_horizon_at_every_frozen_horizon() {
+        for family in FAMILIES {
+            for horizon in [1usize, 2, 4, 8] {
+                for seed in 0..8u64 {
+                    let t = generate(family, seed, horizon);
+                    if t.gold.decline.is_some() {
+                        // Horizon-1 decline instances are deliberate (the
+                        // honest-decline cell); every other cell is solvable.
+                        assert_eq!(horizon, 1, "{} seed {seed}", family.label());
+                        continue;
+                    }
+                    assert_eq!(
+                        t.gold.chosen_path.len(),
+                        horizon,
+                        "{} seed {seed} H={horizon} gold length",
+                        family.label()
+                    );
+                    assert_eq!(t.gold.verify(), WitnessVerdict::Valid);
+                }
+            }
+        }
+    }
+
     #[test]
     fn verifier_rejects_a_step_into_a_forbidden_region() {
-        // GraphNavigation seed 0: target (3,0), forbidden (2,0).
+        // GraphNavigation seed 0 is topology cell 0, which keeps the historical
+        // forbidden cell at (2, 0); vocabulary cell 0 names +x "east" first.
         let t = generate(TaskFamily::GraphNavigation, 0, H_MAX);
-        let acts = grid_actions();
-        let east = acts[0].clone();
+        let east = t.actions[0].clone();
         let two_easts = vec![east.clone(), east];
         match verify_submission(&t, &two_easts) {
             WitnessVerdict::Invalid { step, .. } => assert_eq!(step, 1),
@@ -655,22 +1052,30 @@ mod tests {
         assert!(matches!(stripped.verify(), WitnessVerdict::Invalid { .. }));
     }
 
+    /// F5 is a counterfactual, not a re-run: the plan that was optimal under the
+    /// pre-intervention dynamics must fail under the declared intervened
+    /// dynamics, at every horizon.
     #[test]
-    fn counterfactual_intervention_invalidates_the_base_straight_path() {
-        // seed 0: target (3,0), intervention blocks a cell on the straight path.
-        let t = generate(TaskFamily::CounterfactualIntervention, 0, H_MAX);
-        assert_eq!(t.gold.verify(), WitnessVerdict::Valid); // the detour gold is valid
-        let acts = grid_actions();
-        let east = acts[0].clone();
-        let tx = t.goal.target_region.center[0].round() as usize;
-        let straight = vec![east; tx];
-        assert!(
-            matches!(
-                verify_submission(&t, &straight),
-                WitnessVerdict::Invalid { .. }
-            ),
-            "the pre-intervention straight path must fail under the intervened dynamics"
-        );
+    fn counterfactual_base_plan_is_invalid_under_the_intervened_dynamics() {
+        for horizon in [1usize, 2, 4, 8, H_MAX] {
+            for seed in 0..16u64 {
+                let t = generate(TaskFamily::CounterfactualIntervention, seed, horizon);
+                if t.gold.decline.is_some() {
+                    // A horizon-1 decline instance has no counterfactual to
+                    // express: there is no plan under either dynamics.
+                    assert!(t.counterfactual_base.is_empty());
+                    continue;
+                }
+                assert_eq!(t.gold.verify(), WitnessVerdict::Valid);
+                assert_eq!(t.counterfactual_base.len(), horizon);
+                let base = resolve_actions(&t, &t.counterfactual_base)
+                    .expect("the base plan names the task's own operators");
+                assert!(
+                    matches!(verify_submission(&t, &base), WitnessVerdict::Invalid { .. }),
+                    "seed {seed} H={horizon}: the pre-intervention plan must fail here"
+                );
+            }
+        }
     }
 
     #[test]
@@ -711,6 +1116,82 @@ mod tests {
                 assert_ne!(a, b, "two families share a content id (from index {i})");
             }
         }
+    }
+
+    /// Amendment A1-c: the identity is derived from problem content, so
+    /// structurally identical instances at different seeds share it. Before the
+    /// repair the seed was mixed in and they never did, which left an
+    /// identity-keyed memorization control unable to fire.
+    #[test]
+    fn content_id_excludes_the_generation_seed() {
+        let period = AXIS_CARDINALITY.pow(4);
+        let a = generate(TaskFamily::GraphNavigation, 3, 8);
+        let mut matched = false;
+        for k in 1..64u64 {
+            let b = generate(TaskFamily::GraphNavigation, 3 + k * period, 8);
+            if round_vec(&b.goal.target_region.center) == round_vec(&a.goal.target_region.center) {
+                assert_ne!(a.seed, b.seed, "the two instances differ by seed");
+                assert_eq!(
+                    a.id(),
+                    b.id(),
+                    "structurally identical instances must share a content id"
+                );
+                matched = true;
+                break;
+            }
+        }
+        assert!(matched, "expected a structurally identical instance");
+    }
+
+    /// Amendment A1-b: the four seed-varied axes are independent digits, so
+    /// seeds `0..AXIS_CARDINALITY^4` cover every combination exactly once.
+    #[test]
+    fn split_cell_axes_are_independent_digits_of_the_seed() {
+        let c = AXIS_CARDINALITY;
+        let mut seen = std::collections::BTreeSet::new();
+        for seed in 0..c.pow(4) {
+            let cell = SplitCell::of(seed, 8);
+            assert!(seen.insert((cell.entity, cell.vocabulary, cell.topology, cell.template)));
+        }
+        assert_eq!(seen.len() as u64, c.pow(4));
+    }
+
+    /// A1-a holds across surface cells too: the plan length is the horizon
+    /// whichever entity, vocabulary, or template cell the seed lands in.
+    #[test]
+    fn plan_length_is_the_horizon_across_surface_cells() {
+        let c = AXIS_CARDINALITY;
+        for seed in [0u64, 1, 2, c, c + 1, c * c * c, c * c * c + 1] {
+            let t = generate(TaskFamily::GraphNavigation, seed, 8);
+            assert_eq!(
+                t.gold.chosen_path.len(),
+                8,
+                "seed {seed} in cell {:?}",
+                t.split_cell()
+            );
+            assert_eq!(t.gold.verify(), WitnessVerdict::Valid);
+        }
+    }
+
+    /// The topology axis is semantic: two topology cells offer different
+    /// operator effect sets, so a plan is not transferable between them by
+    /// operator index alone. This is what separates planning from retrieval.
+    #[test]
+    fn topology_cells_offer_different_operator_effects() {
+        let c = AXIS_CARDINALITY;
+        let effects = |seed: u64| -> Vec<Vec<i64>> {
+            generate(TaskFamily::GraphNavigation, seed, 8)
+                .actions
+                .iter()
+                .map(|a| round_vec(&a.delta_vector))
+                .collect()
+        };
+        // seeds 0 and 4 * c * c differ only in the topology digit.
+        assert_ne!(
+            effects(0),
+            effects(4 * c * c),
+            "two topology cells must not share an effect set"
+        );
     }
 
     #[test]

--- a/crates/uor-r4-graph-compiler/tests/amendment_a1_843.rs
+++ b/crates/uor-r4-graph-compiler/tests/amendment_a1_843.rs
@@ -1,0 +1,409 @@
+//! Amendment A1 gate instruments (#843 increment 2).
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §2, which
+//! implements `docs/compositional_planning_spec_844.md` §11 (Amendment A1).
+//!
+//! These four instruments are the binding gate that #843's run contract places
+//! *before* any packed section is written or any arm is fitted. Run against the
+//! pre-amendment generator they returned DEGENERATE:
+//!
+//! - 13 of the 20 frozen (family x horizon) cells were 0/512 solvable;
+//! - a structure-keyed memorized-trajectory null saturated at valid-plan rate
+//!   1.0000 in every non-vacuous cell, which put the #826 promotion statistic
+//!   at or below zero by construction;
+//! - five of six split axes had exactly one cell;
+//! - the task identity carried the generator seed, so an identity-keyed null
+//!   could never fire and read as healthy while the structure-keyed one was
+//!   saturated.
+//!
+//! Certifier-instrument / off-serving-path. Deterministic, teacher-free, and
+//! fixture-free: nothing here is deployed-serving evidence.
+
+use std::collections::BTreeMap;
+
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_compiler::semantic_state::Action;
+
+/// Frozen effect floor (#844 §2.5, D3). Unchanged by Amendment A1.
+const DELTA_MIN: f64 = 0.05;
+/// Frozen sample size per held-out cell per horizon (#844 §2.5, D4).
+const N_PER_CELL: usize = 512;
+/// Frozen horizon progression (#844 §2.5, D2).
+const FROZEN_HORIZONS: [usize; 4] = [1, 2, 4, 8];
+/// A1-b threshold: distinct cells required per split axis per family.
+const MIN_AXIS_CARDINALITY: usize = 8;
+/// A1-a threshold: solvable fraction required in every frozen cell.
+const MIN_SOLVABLE_FRACTION: f64 = 0.5;
+
+const FAMILIES: [cp::TaskFamily; 5] = [
+    cp::TaskFamily::GraphNavigation,
+    cp::TaskFamily::SymbolicTransformation,
+    cp::TaskFamily::ConstraintSatisfaction,
+    cp::TaskFamily::MultiHopEvidence,
+    cp::TaskFamily::CounterfactualIntervention,
+];
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn ints(v: &[f32]) -> Vec<i64> {
+    v.iter().map(|x| x.round() as i64).collect()
+}
+
+/// The *semantic* content of an instance: goal, forbidden regions, and operator
+/// effects. Surface names and the generation seed are deliberately excluded, so
+/// a memorizer keyed on this is the strongest one available - it already sees
+/// through entity, vocabulary, and template renaming.
+fn semantic_key(t: &cp::TaskInstance) -> String {
+    let mut forbidden: Vec<Vec<i64>> = t
+        .constraints
+        .iter()
+        .map(|c| ints(&c.forbidden_region.center))
+        .collect();
+    forbidden.sort();
+    let deltas: Vec<Vec<i64>> = t.actions.iter().map(|a| ints(&a.delta_vector)).collect();
+    format!(
+        "{}|{:?}|{:?}|{:?}",
+        t.family.label(),
+        ints(&t.goal.target_region.center),
+        forbidden,
+        deltas
+    )
+}
+
+/// A plan as a sequence of operator *effects*. This is the strongest form a
+/// memorised or retrieved plan can take: it is invariant to operator naming and
+/// to operator ordering, so replaying it transfers by semantics rather than by
+/// label or slot. It fails only when the target instance does not offer the
+/// effect - which is exactly the generalization the topology axis tests.
+fn plan_effects(t: &cp::TaskInstance) -> Vec<Vec<i64>> {
+    t.gold
+        .chosen_path
+        .iter()
+        .map(|a| ints(&a.delta_vector))
+        .collect()
+}
+
+fn replay_is_valid(t: &cp::TaskInstance, effects: &[Vec<i64>]) -> bool {
+    if effects.is_empty() {
+        return false;
+    }
+    let mut submitted: Vec<Action> = Vec::with_capacity(effects.len());
+    for effect in effects {
+        match t.actions.iter().find(|a| ints(&a.delta_vector) == *effect) {
+            Some(a) => submitted.push(a.clone()),
+            None => return false,
+        }
+    }
+    cp::verify_submission(t, &submitted) == cp::WitnessVerdict::Valid
+}
+
+/// The outcome statistic the gate reads: a valid plan on a solvable instance,
+/// or a correct honest decline on one with no plan inside the horizon. On every
+/// cell whose instances are all solvable this is exactly the frozen valid-plan
+/// rate; on the horizon-1 honest-decline cell it is what separates planning
+/// from a baseline that always answers.
+fn outcome_correct(t: &cp::TaskInstance, emitted: &Option<Vec<Vec<i64>>>) -> bool {
+    let unsolvable = t.gold.decline.is_some();
+    match (emitted, unsolvable) {
+        (None, true) => true,
+        (None, false) => false,
+        (Some(_), true) => false,
+        (Some(plan), false) => replay_is_valid(t, plan),
+    }
+}
+
+/// The topology digit of a seed - the *semantic* split axis. Fitting takes the
+/// low half, held-out the high half, so held-out cells never share a dynamics
+/// configuration with fitting data.
+fn topology_digit(seed: u64) -> u64 {
+    let c = cp::AXIS_CARDINALITY;
+    (seed / (c * c)) % c
+}
+
+fn seeds_where(high_half: bool, n: usize) -> Vec<u64> {
+    let mut out = Vec::with_capacity(n);
+    let mut seed = 0u64;
+    while out.len() < n {
+        if (topology_digit(seed) >= cp::AXIS_CARDINALITY / 2) == high_half {
+            out.push(seed);
+        }
+        seed += 1;
+    }
+    out
+}
+
+struct NullRates {
+    memorized: f64,
+    retrieval: f64,
+    trivial_prior: f64,
+}
+
+impl NullRates {
+    fn strongest(&self) -> f64 {
+        self.memorized.max(self.retrieval).max(self.trivial_prior)
+    }
+}
+
+/// Fit the three computable non-oracle nulls on the fitting half of the
+/// *topology* axis - the semantic one - and score them on the held-out half,
+/// so a held-out cell never shares an operator effect set or a forbidden
+/// configuration with fitting data.
+fn null_rates(family: cp::TaskFamily, horizon: usize) -> NullRates {
+    let fit_seeds = seeds_where(false, N_PER_CELL);
+    let eval_seeds = seeds_where(true, N_PER_CELL);
+
+    type Emission = Option<Vec<Vec<i64>>>;
+    let mut by_key: BTreeMap<String, Emission> = BTreeMap::new();
+    let mut by_goal: Vec<(Vec<i64>, Emission)> = Vec::new();
+    let mut frequency: BTreeMap<Emission, usize> = BTreeMap::new();
+    for s in &fit_seeds {
+        let t = cp::generate(family, *s, horizon);
+        // Declines are fitted too, so the controls are not strawmen: a baseline
+        // that has seen honest declines in fitting data can emit them.
+        let emission: Emission = if t.gold.decline.is_some() {
+            None
+        } else {
+            Some(plan_effects(&t))
+        };
+        by_key
+            .entry(semantic_key(&t))
+            .or_insert_with(|| emission.clone());
+        by_goal.push((ints(&t.goal.target_region.center), emission.clone()));
+        *frequency.entry(emission).or_default() += 1;
+    }
+    // Ties break by the canonical plan order, never by hash-iteration order.
+    let modal: Emission = frequency
+        .iter()
+        .max_by_key(|(plan, count)| (**count, std::cmp::Reverse((*plan).clone())))
+        .map(|(plan, _)| plan.clone())
+        .unwrap_or(None);
+
+    let (mut memorized, mut retrieval, mut trivial, mut total) = (0usize, 0usize, 0usize, 0usize);
+    for s in &eval_seeds {
+        let t = cp::generate(family, *s, horizon);
+        total += 1;
+
+        // N3 memorized-trajectory: emit by semantic key, falling back to the
+        // modal fitting emission so the control can still fire off-key.
+        let remembered = by_key.get(&semantic_key(&t)).unwrap_or(&modal);
+        if outcome_correct(&t, remembered) {
+            memorized += 1;
+        }
+
+        // N1 retrieval-only: nearest fitting instance by goal displacement.
+        let goal = ints(&t.goal.target_region.center);
+        let nearest = by_goal
+            .iter()
+            .min_by_key(|(g, _)| {
+                g.iter()
+                    .zip(goal.iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .sum::<i64>()
+            })
+            .map(|(_, p)| p.clone())
+            .unwrap_or(None);
+        if outcome_correct(&t, &nearest) {
+            retrieval += 1;
+        }
+
+        // trivial-prior: always emit the modal fitting emission.
+        if outcome_correct(&t, &modal) {
+            trivial += 1;
+        }
+    }
+
+    let rate = |k: usize| {
+        if total == 0 {
+            1.0
+        } else {
+            k as f64 / total as f64
+        }
+    };
+    NullRates {
+        memorized: rate(memorized),
+        retrieval: rate(retrieval),
+        trivial_prior: rate(trivial),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A1 gate instruments
+// ---------------------------------------------------------------------------
+
+/// A1-a: every one of the 20 frozen (family x horizon) cells is non-vacuous.
+#[test]
+fn a1_a_non_vacuity_per_frozen_cell() {
+    let mut failures = Vec::new();
+    for horizon in FROZEN_HORIZONS {
+        for family in FAMILIES {
+            let solvable = (0..N_PER_CELL as u64)
+                .filter(|s| cp::generate(family, *s, horizon).gold.decline.is_none())
+                .count();
+            let fraction = solvable as f64 / N_PER_CELL as f64;
+            println!(
+                "A1-a H={horizon:<2} {:<28} solvable {solvable:>3}/{N_PER_CELL} = {fraction:.4}",
+                family.label()
+            );
+            if fraction < MIN_SOLVABLE_FRACTION {
+                failures.push(format!("{} H={horizon}: {fraction:.4}", family.label()));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "vacuous frozen cells (a cell that cannot separate any mechanism): {failures:?}"
+    );
+}
+
+/// A1-b: every split axis a seed varies has at least eight distinct cells, so a
+/// disjoint fitting/held-out partition is constructible rather than vacuous.
+#[test]
+fn a1_b_axis_cardinality() {
+    for family in FAMILIES {
+        let mut entity = std::collections::BTreeSet::new();
+        let mut vocabulary = std::collections::BTreeSet::new();
+        let mut topology = std::collections::BTreeSet::new();
+        let mut template = std::collections::BTreeSet::new();
+        let mut composition = std::collections::BTreeSet::new();
+        for horizon in FROZEN_HORIZONS {
+            for seed in 0..cp::AXIS_CARDINALITY.pow(4) {
+                let t = cp::generate(family, seed, horizon);
+                entity.insert(t.initial_state.id.clone());
+                template.insert(t.goal.name.clone());
+                vocabulary.insert(
+                    t.actions
+                        .iter()
+                        .map(|a| a.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(">"),
+                );
+                let mut forbidden: Vec<Vec<i64>> = t
+                    .constraints
+                    .iter()
+                    .map(|c| ints(&c.forbidden_region.center))
+                    .collect();
+                forbidden.sort();
+                let deltas: Vec<Vec<i64>> =
+                    t.actions.iter().map(|a| ints(&a.delta_vector)).collect();
+                topology.insert(format!("{forbidden:?}|{deltas:?}"));
+                composition.insert(
+                    t.gold
+                        .chosen_path
+                        .iter()
+                        .map(|a| a.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(">"),
+                );
+            }
+        }
+        println!(
+            "A1-b {:<28} entity={} vocabulary={} topology={} template={} composition={}",
+            family.label(),
+            entity.len(),
+            vocabulary.len(),
+            topology.len(),
+            template.len(),
+            composition.len()
+        );
+        for (axis, n) in [
+            ("by_entity", entity.len()),
+            ("by_vocabulary", vocabulary.len()),
+            ("by_topology", topology.len()),
+            ("by_template", template.len()),
+            ("by_operator_composition", composition.len()),
+        ] {
+            assert!(
+                n >= MIN_AXIS_CARDINALITY,
+                "{} axis {axis} has {n} cells; a split on it would be vacuous",
+                family.label()
+            );
+        }
+    }
+}
+
+/// A1-c: the identity is content-derived, so an identity-keyed control can fire.
+#[test]
+fn a1_c_identity_is_content_derived() {
+    let period = cp::AXIS_CARDINALITY.pow(4);
+    for family in FAMILIES {
+        for horizon in FROZEN_HORIZONS {
+            let a = cp::generate(family, 5, horizon);
+            let mut matched = false;
+            for k in 1..128u64 {
+                let b = cp::generate(family, 5 + k * period, horizon);
+                if semantic_key(&b) == semantic_key(&a)
+                    && b.initial_state.id == a.initial_state.id
+                    && b.goal.name == a.goal.name
+                    && b.actions.iter().map(|x| x.name.clone()).collect::<Vec<_>>()
+                        == a.actions.iter().map(|x| x.name.clone()).collect::<Vec<_>>()
+                {
+                    assert_ne!(a.seed, b.seed);
+                    assert_eq!(
+                        a.id(),
+                        b.id(),
+                        "{} H={horizon}: structurally identical instances must share an id",
+                        family.label()
+                    );
+                    matched = true;
+                    break;
+                }
+            }
+            assert!(
+                matched,
+                "{} H={horizon}: expected a structurally identical instance at another seed",
+                family.label()
+            );
+        }
+    }
+}
+
+/// A1-d: the strongest non-oracle null leaves at least delta_min of headroom in
+/// every frozen cell. Without this the promotion statistic of #826 is at or
+/// below zero by construction and no mechanism can ever clear the gate.
+#[test]
+fn a1_d_strongest_null_headroom() {
+    let ceiling = 1.0 - DELTA_MIN;
+    let mut failures = Vec::new();
+    for horizon in FROZEN_HORIZONS {
+        for family in FAMILIES {
+            let rates = null_rates(family, horizon);
+            let headroom = 1.0 - rates.strongest();
+            println!(
+                "A1-d H={horizon:<2} {:<28} memorized={:.4} retrieval={:.4} trivial={:.4} strongest={:.4} headroom={headroom:.4}{}",
+                family.label(),
+                rates.memorized,
+                rates.retrieval,
+                rates.trivial_prior,
+                rates.strongest(),
+                if headroom < 2.0 * DELTA_MIN {
+                    "  <- TIGHT (under 2x delta_min)"
+                } else {
+                    ""
+                }
+            );
+            if rates.strongest() > ceiling {
+                failures.push(format!(
+                    "{} H={horizon}: strongest null {:.4}",
+                    family.label(),
+                    rates.strongest()
+                ));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "saturated non-oracle nulls leave no headroom above delta_min: {failures:?}"
+    );
+}
+
+/// Amendment A1 repairs the generator; it moves no number the constitution froze.
+#[test]
+fn a1_does_not_move_a_frozen_number() {
+    assert_eq!(cp::H_MAX, 16, "H_max is frozen (#844 D2)");
+    assert_eq!(cp::W_MAX, 64, "W_max is frozen (#844 D2)");
+    assert_eq!(DELTA_MIN, 0.05, "delta_min is frozen (#844 D3)");
+    assert_eq!(N_PER_CELL, 512, "n per cell is frozen (#844 D4)");
+    assert_eq!(FROZEN_HORIZONS, [1, 2, 4, 8], "the horizon grid is frozen");
+}

--- a/docs/bounded_semantic_transitions_spec_843.md
+++ b/docs/bounded_semantic_transitions_spec_843.md
@@ -134,8 +134,29 @@ repaired generator, and each is reported per (family × frozen horizon):
 δ_min = 0.05, n = 512, H ∈ {1, 2, 4, 8}, `H_MAX` = 16, and `W_MAX` = 64 hold their #844 values after
 the repair.
 
-**Empirical Criterion (A1 gate). Status: Empirical.** All four instruments pass before increment 3
-begins. A failure is reported as the recorded outcome, not routed around.
+**Empirical Criterion (A1 gate). Status: Empirical — PASSED 2026-08-22 (increment 2).** All four
+instruments pass, so increment 3 may begin. Measured values and the per-cell tables are recorded in
+[`docs/compositional_planning_spec_844.md`](compositional_planning_spec_844.md) §11.5; the
+instruments live in `crates/uor-r4-graph-compiler/tests/amendment_a1_843.rs` and run in the default
+`cargo test`. Headline: non-vacuity 1.0000 at H ∈ {2, 4, 8} and 0.7500 at H = 1; every split axis at
+8 cells or more; identity content-derived; strongest non-oracle null between 0.2773 and 0.9355,
+against a ceiling of 0.95. A failure would have been reported as the recorded outcome, not routed
+around.
+
+**Definition (the horizon-1 cell, frozen — maintainer sign-off 2026-08-22).** Valid-plan rate cannot
+separate planning from retrieval at horizon 1: a one-step answer is a deterministic function of the
+observable state, goal, and operator set, and the fitting split must cover the whole operator pool
+or induction has nothing to learn from. Measured, a retrieval baseline scored exactly 1.0000 there.
+The H = 1 cell is therefore gated on the **correct-outcome rate** — a valid plan on a solvable
+instance, or a correct `Decline(no_plan)` on one with no plan inside the horizon — and a quarter of
+horizon-1 instances are generated beyond the horizon so that decision is real. On every H ≥ 2 cell,
+where all instances are solvable, the correct-outcome rate *is* the frozen valid-plan rate. Full
+reasoning: `compositional_planning_spec_844.md` §11.6.
+
+**Watch item for increment 6.** The tightest cell is symbolic-transformation at H = 1: strongest null
+0.9355, headroom 0.0645, only 1.29 × δ_min. The A1-d instrument prints a `TIGHT` marker for any cell
+whose headroom falls under 2 × δ_min. A candidate has barely more than the effect floor of room
+there, so that cell's reading carries the least weight in the §8 selection.
 
 ---
 

--- a/docs/compositional_planning_spec_844.md
+++ b/docs/compositional_planning_spec_844.md
@@ -484,3 +484,68 @@ null-headroom instruments named above, and recorded in
 [`docs/bounded_semantic_transitions_spec_843.md`](bounded_semantic_transitions_spec_843.md) §2.
 It establishes **no** planning or reasoning capability; it restores the ability of the #844 instrument
 to separate one, which #843 then measures and #846 certifies.
+
+### 11.5 Amendment A1 outcome (measured 2026-08-22, #843 increment 2)
+
+All four A1 gate instruments pass. Measured by
+`crates/uor-r4-graph-compiler/tests/amendment_a1_843.rs` at the frozen n = 512 per cell per
+horizon; deterministic, teacher-free, fixture-free, about 40 s.
+
+**A1-a — per-cell non-vacuity. Status: Empirical, PASS.** All 20 frozen cells clear the 0.5
+threshold. H ∈ {2, 4, 8}: 512/512 = 1.0000 in all fifteen cells. H = 1: 384/512 = 0.7500 in all
+five, by design — see §11.6.
+
+**A1-b — axis cardinality. Status: Empirical, PASS.** Per family, over the frozen horizons:
+`by_entity` = 8, `by_vocabulary` = 8, `by_topology` = 8, `by_template` = 8, and
+`by_operator_composition` = 32 (64 for symbolic-transformation). Every axis clears the threshold of
+8, so a disjoint fitting/held-out partition is constructible rather than vacuous.
+
+**A1-c — content-derived identity. Status: Structural, PASS.** `TaskInstance::id()` no longer
+carries the generation seed; structurally identical instances at different seeds share an id, in
+every family at every frozen horizon.
+
+**A1-d — strongest-null headroom. Status: Empirical, PASS.** Splitting on the *semantic* topology
+axis (fitting = topology cells 0–3, held-out = 4–7, so a held-out cell never shares an operator
+effect set or a forbidden configuration with fitting data), the strongest non-oracle null scores:
+
+| H | graph-nav | symbolic | constraint-sat | multi-hop | counterfactual |
+|---|---|---|---|---|---|
+| 1 | 0.5352 | **0.9355** | 0.5625 | 0.5352 | 0.5898 |
+| 2 | 0.5859 | 0.6777 | 0.4688 | 0.5859 | 0.3652 |
+| 4 | 0.4023 | 0.5918 | 0.3906 | 0.4023 | 0.3535 |
+| 8 | 0.2773 | 0.4922 | 0.3516 | 0.2773 | 0.3398 |
+
+All are below the 1 − δ_min = 0.95 ceiling, so the promotion statistic is no longer at or below zero
+by construction. **Tightest cell, flagged: symbolic-transformation at H = 1, headroom 0.0645 —
+1.29 × δ_min.** The instrument prints a `TIGHT` marker for any cell whose headroom falls under
+2 × δ_min; that cell is the one to watch when the arms are measured, because a candidate has barely
+more than the effect floor of room there. The controls are not strawmen: they are fitted on the
+declines as well as on the plans, they transfer plans by *effect* rather than by name or slot (so
+they already see through entity, vocabulary, and template renaming), and the retrieval control
+indexes by goal displacement.
+
+For contrast, the pre-amendment numbers were 1.0000 in every non-vacuous cell (§11.1).
+
+### 11.6 The horizon-1 cell is gated on honest decline (maintainer sign-off, 2026-08-22)
+
+**Definition (why valid-plan rate cannot separate at H = 1).** A one-step task's correct answer is a
+deterministic function of the initial state, the goal, and the operator set — all observable at
+inference — and the fitting split must cover the whole operator pool or an inducer has nothing to
+learn from. A baseline that indexes goal displacement to operator effect is therefore *optimal at
+horizon 1 by construction*, and no generator repair changes that: measured, retrieval scored exactly
+1.0000 at H = 1 in four of the five families once the other three instruments had passed. This is a
+property of horizon-1 tasks, not a defect of the generator.
+
+**Definition (the frozen resolution).** The H = 1 cell is gated on the **correct-outcome rate** —
+a valid plan on a solvable instance, or a correct `Decline(no_plan)` on one with no plan inside the
+horizon — rather than on valid-plan rate. A quarter of horizon-1 instances place the goal one step
+beyond the horizon, so they are genuinely unsolvable within it. Deciding which is which requires
+evaluating reachability, which is planning; a baseline that always answers cannot. On every cell
+whose instances are all solvable — every H ≥ 2 cell — the correct-outcome rate *is* the frozen
+valid-plan rate, so this adds a per-cell reading at H = 1 and changes nothing elsewhere.
+
+**What this does and does not change.** The honest-decline rate was already a frozen §2.5 *secondary*
+metric; this makes it the gating statistic in one cell. No frozen *value* moves: δ_min = 0.05,
+n = 512, H ∈ {1, 2, 4, 8}, H_max = 16, and W_max = 64 all stand, and the primary metric elsewhere is
+unchanged. The alternative considered and rejected was to report H = 1 without gating on it, which
+would have left five of the twenty cells descriptive rather than evidential.


### PR DESCRIPTION
## Problem and outcome

Increment 2 of 6 for issue #843 (item B of S4 tracker #826). Implements **Amendment A1**, frozen in `docs/compositional_planning_spec_844.md` §11 by the previous increment, and re-runs the binding cheap instrument that had returned DEGENERATE.

**All four A1 gate instruments now pass**, so the packed-section, planner, and measurement increments may proceed. Before the repair, the S4 promotion statistic was at or below zero *by construction* for every candidate mechanism, geometric or not.

## Scope and non-goals

**In scope:** the generator half of `crates/uor-r4-graph-compiler/src/compositional_planning.rs`, the four gate instruments, and the outcome record appended to the two specifications.

- **A1-a — low-horizon non-vacuity.** The goal is now placed on the BFS layer at *exactly* the requested depth, so the gold plan is exactly `H` steps long and a horizon-1 instance is a genuine one-step task. Non-vacuity is restored by making instances easier at low `H`, **not** by moving the frozen horizon grid.
- **A1-b — real split-axis cardinality.** Eight entity-naming schemes, eight operator surface vocabularies and eight goal templates (all *surface* axes — semantic no-ops, so splitting on them isolates label-keyed mechanisms), plus eight topologies. **Topology varies the operator effect set**, drawn from a shared eight-effect pool, and topologies 0–3 and 4–7 each cover the whole pool. That is deliberate: a held-out cell must be a novel *composition*, never a novel primitive, or an inducer fitted on the low half would find the high half unsolvable rather than hard.
- **A1-c — content-derived identity.** `TaskInstance::id()` no longer mixes in the generation seed, so structurally identical instances share an id and an identity-keyed control can fire.
- **A1-d — strongest-null headroom.** Measured below.
- **F5 is now a counterfactual at every horizon.** A *twin* operator carries one effect before the declared intervention and another after; the additive field `TaskInstance.counterfactual_base` records the pre-intervention optimal plan by operator name (resolved through the new `resolve_actions`), and the generator deterministically scans the layer for a goal whose base plan uses the twin and *fails* once the twin's declared effect changes. Previously the family had no way to express a counterfactual at H = 1 at all.

**Non-goals:** no observation record, no inducer, no packed section, no planner, no conformance id — those are increments 3–6. Nothing here is deployed-serving evidence; the module stays reference-only / off-serving-path.

## Acceptance-criteria status

None of #843's five acceptance criteria are claimed by this increment. It clears the **entry gate** that its own run contract places before any packed or full fitting, and it does so by measurement rather than by assertion.

## Tests and verification

New file `crates/uor-r4-graph-compiler/tests/amendment_a1_843.rs` — the four gate instruments plus a frozen-number guard, at the frozen n = 512 per cell per horizon, deterministic, teacher-free, fixture-free, about 40 s in the default `cargo test`.

Existing suite: the module's tests grew from 11 to 16 and all pass, including the pinned seed-0 fixtures. Topology cell 0 deliberately keeps the historical `(2, 0)` forbidden cell and vocabulary cell 0 the compass names, so `features/suites/compositional_planning_benchmarks.feature` (RF-32) needs no change and its five scenarios pass unaltered.

Full local ladder before push: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --no-fail-fast --offline`, the `no_std` ladder both ways, the `wasm32-unknown-unknown` lib build, `xtask validate` (R1/R4/R5/gnaf), `cargo test -p repo-conformance` (R2/R3), `cargo deny check bans` (R6), and `scripts/check_claim_wording.py`.

## Evidence artifacts

`docs/compositional_planning_spec_844.md` §11.5 carries the full per-cell tables. Headline, with the pre-repair figure alongside:

| Instrument | Before | After |
|---|---|---|
| A1-a non-vacuity | 13 of 20 cells at 0/512 | 1.0000 at H ∈ {2,4,8}; 0.7500 at H = 1 |
| A1-b axis cardinality | 5 of 6 axes had one cell | 8 per axis; 32–64 compositions |
| A1-c identity | seed-carrying; 4096/4096 unique | content-derived; structurally identical instances share an id |
| A1-d strongest null | 1.0000 in every non-vacuous cell | 0.2773 – 0.9355, against a 0.95 ceiling |

The controls are not strawmen: they are fitted on the honest declines as well as on the plans, they transfer plans by **effect** rather than by name or slot — so they already see through all three surface axes — and the retrieval control indexes goal displacement. The split is taken on the *semantic* topology axis, so a held-out cell never shares an operator effect set or a forbidden configuration with fitting data.

## Negative and unavailable results

**One result is negative and is recorded rather than engineered away.** At horizon 1, a retrieval baseline scored exactly 1.0000 in four of five families even after A1-a/b/c had passed. This is structural: a one-step answer is a deterministic function of the initial state, the goal and the operator set — all observable at inference — and the fitting split must cover the whole operator pool or induction has nothing to learn from. Valid-plan rate cannot separate planning from retrieval at horizon 1, and no generator repair changes that.

Per maintainer sign-off (2026-08-22), the horizon-1 cell is therefore gated on **correct-outcome rate** — a valid plan on a solvable instance, or a correct `Decline(no_plan)` on one with no plan inside the horizon — and a quarter of horizon-1 instances now place the goal one step beyond the horizon so that decision is real. Deciding which is which requires evaluating reachability, which is planning; a baseline that always answers cannot. On every H ≥ 2 cell, where all instances are solvable, the correct-outcome rate *is* the frozen valid-plan rate. Reasoning and the rejected alternative are in §11.6.

**A tight cell is flagged, not hidden.** Symbolic-transformation at H = 1 leaves headroom 0.0645 — only 1.29 × δ_min. The instrument prints a `TIGHT` marker for any cell under 2 × δ_min, and §11.5 names that cell as the one to watch when the arms are measured.

## Compatibility and migration

No format, artifact, API-response or wire change. `TaskInstance` gains one additive field (`counterfactual_base`) and the module gains one function (`resolve_actions`); both are additive to a reference-only, off-serving-path model that no deployed path reads. `CONFORMANCE.md` is untouched.

The generated *content* of the benchmark changes, by design — that is the whole point of the amendment. Any figure measured against the pre-amendment generator is superseded; the only such figures are the degeneracy measurements themselves, which §11.1 keeps as the record of what was believed and when, per the append-only rule.

## Conformance effects

None. No RF id is added, removed or altered, and `CONFORMANCE.md` is byte-identical. RF-32 keeps its Gherkin, its marker and all five scenarios unchanged. The reserved RF-33 is still unregistered and stays that way unless an arm is actually lowered in increment 5/6.

## Claim-boundary changes

No claim is strengthened; the module still establishes a falsifiable target and a byte-level meaning, not reasoning performance. Two boundaries move, both toward honesty: the item-A no-split-leakage guarantee stops being vacuous and becomes a partition of a genuine eight-cell axis, and the baseline-non-degeneracy guarantee gains a measured headroom figure instead of an untested assertion. The horizon-1 reading is explicitly narrowed to honest decline.

## Intentionally excluded

The two scratch probe harnesses used to find the degeneracy; their shipped successors are the four gate instruments in this diff. No generated file, model, cache, credential or user-owned file is staged. The maintainer's day-branch checkout is untouched; all work is in a dedicated worktree.

References #843
