### PR TITLE
feat(#843): typed transition observations and deterministic induction

### DIFF
--- a/crates/uor-r4-graph-compiler/src/lib.rs
+++ b/crates/uor-r4-graph-compiler/src/lib.rs
@@ -33,6 +33,7 @@ pub mod routing;
 pub mod segment_fit;
 pub mod semantic_emission_decoupling;
 pub mod semantic_state;
+pub mod semantic_transitions;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod skipmix_fit;
 pub mod stage_dag;

--- a/crates/uor-r4-graph-compiler/src/semantic_transitions.rs
+++ b/crates/uor-r4-graph-compiler/src/semantic_transitions.rs
@@ -1,0 +1,677 @@
+//! Typed transition observations and deterministic induction (#843, S4 item B).
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §3. This is
+//! the *offline compiler* half of the issue: it turns typed observations of
+//! attempted state transitions into a bounded **operator rule set** the packed
+//! sections carry and the deployed planner executes.
+//!
+//! The induced object is deliberately *schematic*, not grounded. A rule is
+//! `(precondition mask and comparison block, typed effect delta, support,
+//! ordinal band)`; grounding — computing `T(s, a)` — happens at plan time by
+//! saturating integer addition on the packed slot vector. A grounded
+//! `(state, action) -> state` table would scale with the reachable state space,
+//! while a rule set scales with the operator vocabulary, and that is what makes
+//! the frozen capacities and the P-4 hot path achievable at all.
+//!
+//! Execution scope: compiler / off-serving-path. Owned collections are
+//! permitted here. Nothing in this module is deployed-serving evidence, and no
+//! result here establishes any planning capability — that is the measured
+//! question of the later increments.
+//!
+//! Boundaries carried in: ordinal confidence bands, never a calibrated
+//! probability (S2 #823); teacher-forced scope, no free-running generation
+//! (S3 #824).
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use uor_r4_graph_format::plan::{
+    EffectDelta, PLAN_ACTIONS_MAX, PLAN_RULES_MAX, PLAN_SLOTS_MAX, PreconditionMask, SlotVec,
+};
+
+use crate::compositional_planning::{ConfidenceBand, SplitCell, TaskFamily, TaskInstance};
+use crate::semantic_state::{Constraint, SemanticState, TransitionEvaluator};
+
+/// How many reachable states one instance is observed from, in canonical
+/// breadth-first order. A declared, deterministic bound: the observation pass
+/// never walks an unbounded state space, and truncation is at a stated limit
+/// rather than wherever a timer expired.
+pub const OBSERVED_STATES_PER_INSTANCE: usize = 32;
+
+/// Default content-addressed shard count for the induction partition. The
+/// emitted rule set does not depend on this value; the determinism instrument
+/// asserts exactly that.
+pub const DEFAULT_SHARDS: u32 = 16;
+
+/// Minimum share of negative evidence, in parts per thousand, an observation
+/// set must carry **when the observed tasks declared forbidden regions**.
+///
+/// The floor catches a sampling failure, not a task property: if a boundary
+/// existed and nothing was ever observed being refused by it, the observation
+/// pass never probed that boundary and any precondition induced from the set
+/// would be unfalsifiable. Where the tasks declare no constraints at all the
+/// dynamics really are total, there is no negative evidence to demand, and the
+/// floor does not apply. It is deliberately low rather than tuned, because the
+/// forbidden-region density of a task is a property of the task.
+pub const NEGATIVE_FRACTION_FLOOR_MILLI: u32 = 10;
+
+/// What happened when an operator was attempted from a state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Outcome {
+    /// The operator applied and produced a successor.
+    Applied,
+    /// The operator's declared precondition did not hold.
+    PreconditionFailed,
+    /// The successor would have entered a forbidden region.
+    ForbiddenRegion,
+    /// The typed outcome could not be determined — resolved by decline, never
+    /// by a default.
+    Unknown,
+}
+
+/// Whether an observation supports a rule, refutes one, or is known to disagree
+/// with another observation of the same typed situation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Polarity {
+    /// The operator applied.
+    Positive,
+    /// The operator did not apply. Negative evidence is first class: a
+    /// precondition cannot be induced without it.
+    Negative,
+    /// Assembled from sources known to disagree about the same typed situation.
+    Conflicting,
+}
+
+/// The polarity an outcome carries.
+pub fn polarity_of(outcome: Outcome) -> Polarity {
+    match outcome {
+        Outcome::Applied => Polarity::Positive,
+        _ => Polarity::Negative,
+    }
+}
+
+/// Typed support with a stable provenance identifier (F4).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Provenance {
+    /// Stable identifier of the supporting record.
+    pub id: String,
+    /// Ordinal support strength — never a calibrated probability.
+    pub support: ConfidenceBand,
+}
+
+/// One observed attempt to apply one operator from one typed state.
+///
+/// The record describes a single attempted step and nothing else: there is no
+/// field, and no combination of fields, from which a gold plan or a gold
+/// terminal state is recoverable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionObservation {
+    /// Task family the observation came from.
+    pub family: TaskFamily,
+    /// The split cell this observation belongs to.
+    pub split_cell: SplitCell,
+    /// Typed valuation before the attempt.
+    pub from_slots: SlotVec,
+    /// Typed valuation after it, when the operator applied.
+    pub to_slots: Option<SlotVec>,
+    /// Index of the operator within its instance's vocabulary.
+    pub operator: u16,
+    /// Surface name of the operator — a label, varying with the vocabulary axis.
+    pub operator_name: String,
+    /// Declared effect of the operator in this instance.
+    pub declared_effect: EffectDelta,
+    /// What happened.
+    pub outcome: Outcome,
+    /// The slots whose values the outcome depended on.
+    pub read_mask: u8,
+    /// The effect actually observed, when the operator applied.
+    pub effect_delta: Option<EffectDelta>,
+    /// Identity of the goal predicate in force.
+    pub goal_ref: u64,
+    /// Identities of the forbidden-region predicates in force.
+    pub constraint_refs: Vec<u64>,
+    /// Cited support (F4); empty otherwise.
+    pub evidence: Vec<Provenance>,
+    /// Supporting, refuting, or known-disagreeing.
+    pub polarity: Polarity,
+}
+
+impl TransitionObservation {
+    /// Content-addressed identity, derived from the typed content only — no
+    /// generation seed, clock, RNG, or hash-iteration order. Two observations
+    /// of the same typed situation share an id and collapse on ingest.
+    pub fn sample_id(&self) -> u64 {
+        let mut canon = format!(
+            "{}|t{}|from={:?}|op={}:{:?}|out={:?}|to={:?}|goal={}",
+            self.family.label(),
+            self.split_cell.topology,
+            self.from_slots.as_slice(),
+            self.operator_name,
+            self.declared_effect.as_slice(),
+            self.outcome,
+            self.to_slots.map(|s| s.as_slice().to_vec()),
+            self.goal_ref,
+        );
+        let mut refs = self.constraint_refs.clone();
+        refs.sort_unstable();
+        for r in &refs {
+            canon.push_str(&format!("|c{r}"));
+        }
+        fnv1a64(&canon)
+    }
+}
+
+fn fnv1a64(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in s.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn predicate_id(kind: &str, center: &[f32], radius: f32) -> u64 {
+    let cells: Vec<i64> = center.iter().map(|v| v.round() as i64).collect();
+    fnv1a64(&format!(
+        "{kind}|{cells:?}|{}",
+        (radius * 1000.0).round() as i64
+    ))
+}
+
+/// Project a reference semantic state onto the bounded deployed-form slot
+/// valuation. `None` when the state carries more slots than the frozen
+/// capacity — reported, never truncated.
+pub fn slots_of(state: &SemanticState) -> Option<SlotVec> {
+    if state.vector.len() > PLAN_SLOTS_MAX {
+        return None;
+    }
+    let values: Vec<i16> = state
+        .vector
+        .iter()
+        .map(|v| v.round().clamp(f32::from(i16::MIN), f32::from(i16::MAX)) as i16)
+        .collect();
+    SlotVec::from_slice(&values)
+}
+
+/// The canonical breadth-first prefix of states reachable under the instance's
+/// own dynamics, bounded by [`OBSERVED_STATES_PER_INSTANCE`].
+fn reachable_prefix(task: &TaskInstance, evaluator: &TransitionEvaluator) -> Vec<SemanticState> {
+    let mut seen: BTreeSet<Vec<i64>> = BTreeSet::new();
+    let key =
+        |s: &SemanticState| -> Vec<i64> { s.vector.iter().map(|v| v.round() as i64).collect() };
+    let mut queue: VecDeque<SemanticState> = VecDeque::new();
+    let mut out = Vec::new();
+    seen.insert(key(&task.initial_state));
+    queue.push_back(task.initial_state.clone());
+    while let Some(state) = queue.pop_front() {
+        out.push(state.clone());
+        if out.len() >= OBSERVED_STATES_PER_INSTANCE {
+            break;
+        }
+        for action in &task.actions {
+            if let Some(next) = evaluator.apply(&state, action)
+                && seen.insert(key(&next))
+            {
+                queue.push_back(next);
+            }
+        }
+    }
+    out
+}
+
+/// Compile the typed transition observations one task instance exposes.
+///
+/// Every operator is attempted from every state of the canonical reachable
+/// prefix, and the outcome is recorded whether or not it applied — so
+/// `ForbiddenRegion` and `PreconditionFailed` observations are emitted
+/// alongside `Applied` ones rather than filtered out. The gold plan is never
+/// read.
+pub fn observe(task: &TaskInstance) -> Vec<TransitionObservation> {
+    let mut permitted = TransitionEvaluator::new();
+    for c in &task.constraints {
+        permitted.add_constraint(c.clone());
+    }
+    let unconstrained = TransitionEvaluator::new();
+
+    let goal_ref = predicate_id(
+        "goal",
+        &task.goal.target_region.center,
+        task.goal.target_region.radius,
+    );
+    let constraint_refs: Vec<u64> = task
+        .constraints
+        .iter()
+        .map(|c: &Constraint| {
+            predicate_id(
+                "forbid",
+                &c.forbidden_region.center,
+                c.forbidden_region.radius,
+            )
+        })
+        .collect();
+
+    let mut out = Vec::new();
+    for state in reachable_prefix(task, &permitted) {
+        let Some(from_slots) = slots_of(&state) else {
+            continue;
+        };
+        let full_mask = mask_for(from_slots.len());
+        for (index, action) in task.actions.iter().enumerate() {
+            let Some(declared_effect) = EffectDelta::from_slice(&round_slots(&action.delta_vector))
+            else {
+                continue;
+            };
+            let applicable = unconstrained.apply(&state, action);
+            let allowed = permitted.apply(&state, action);
+            let (outcome, to_slots, read_mask) = match (&applicable, &allowed) {
+                // The operator's own precondition refused it. The predicate is
+                // opaque to the observer, so no read mask is claimed and the
+                // observation is not used to induce one.
+                (None, _) => (Outcome::PreconditionFailed, None, 0u8),
+                // The operator applied but the successor is forbidden. The
+                // constraint is a predicate over the destination, so every slot
+                // determined the outcome.
+                (Some(_), None) => (Outcome::ForbiddenRegion, None, full_mask),
+                (Some(_), Some(next)) => match slots_of(next) {
+                    Some(to) => (Outcome::Applied, Some(to), 0u8),
+                    None => (Outcome::Unknown, None, 0u8),
+                },
+            };
+            let effect_delta = to_slots.and_then(|to| EffectDelta::between(&from_slots, &to));
+            let evidence = if task.gold.require_evidence_per_step && outcome == Outcome::Applied {
+                vec![Provenance {
+                    id: format!("prov-{}-{}", task.id(), index),
+                    support: ConfidenceBand::High,
+                }]
+            } else {
+                Vec::new()
+            };
+            out.push(TransitionObservation {
+                family: task.family,
+                split_cell: task.split_cell(),
+                from_slots,
+                to_slots,
+                operator: index as u16,
+                operator_name: action.name.clone(),
+                declared_effect,
+                outcome,
+                read_mask,
+                effect_delta,
+                goal_ref,
+                constraint_refs: constraint_refs.clone(),
+                evidence,
+                polarity: polarity_of(outcome),
+            });
+        }
+    }
+    out
+}
+
+fn round_slots(vector: &[f32]) -> Vec<i16> {
+    vector
+        .iter()
+        .map(|v| v.round().clamp(f32::from(i16::MIN), f32::from(i16::MAX)) as i16)
+        .collect()
+}
+
+fn mask_for(len: usize) -> u8 {
+    if len >= 8 { u8::MAX } else { (1u8 << len) - 1 }
+}
+
+// ---------------------------------------------------------------------------
+// Split enforcement
+// ---------------------------------------------------------------------------
+
+/// Which split cells an induction pass may read. Fitting data and evaluation
+/// data never share a cell on the axis being split, and the sealed cells
+/// reserved for the final certification are never opened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitPolicy {
+    /// Topology cells reserved for evaluation.
+    pub held_out_topologies: BTreeSet<u8>,
+    /// Topology cells sealed for the final untouched-partition verdict.
+    pub sealed_topologies: BTreeSet<u8>,
+}
+
+impl SplitPolicy {
+    /// The frozen protocol: the low half of the semantic topology axis fits,
+    /// the high half evaluates. A held-out cell therefore never shares an
+    /// operator effect set or a forbidden configuration with fitting data.
+    pub fn topology_halves() -> Self {
+        Self {
+            held_out_topologies: (4..8).collect(),
+            sealed_topologies: BTreeSet::new(),
+        }
+    }
+
+    /// Reserve `cells` as sealed in addition to the held-out half.
+    pub fn sealing(mut self, cells: impl IntoIterator<Item = u8>) -> Self {
+        self.sealed_topologies.extend(cells);
+        self
+    }
+
+    /// Whether an observation from `cell` may reach the inducer.
+    pub fn admits(&self, cell: &SplitCell) -> bool {
+        !self.held_out_topologies.contains(&cell.topology)
+            && !self.sealed_topologies.contains(&cell.topology)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The induced rule set
+// ---------------------------------------------------------------------------
+
+/// One induced operator rule: a precondition, a typed effect, and the evidence
+/// behind it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionRule {
+    /// When the rule applies.
+    pub precondition: PreconditionMask,
+    /// What it does, by saturating integer addition.
+    pub effect: EffectDelta,
+    /// How many distinct observations support it.
+    pub support: u32,
+    /// Ordinal band derived from `support` — never a calibrated probability.
+    pub band: ConfidenceBand,
+    /// Surface names seen for this effect. A compiler-side record only: the
+    /// deployed table is keyed by the typed effect, because names vary with the
+    /// vocabulary axis and carry no semantics.
+    pub labels: BTreeSet<String>,
+}
+
+/// A declared conflict: within one topology cell, the same operator applied
+/// from the same typed state was observed to produce more than one successor.
+/// The conflicting effects are recorded and **not** emitted into the rule
+/// table, so reaching them at plan time is `Decline(unknown)` rather than a
+/// majority vote or a silent default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictRecord {
+    /// The topology cell the disagreement was observed in.
+    pub topology: u8,
+    /// Surface name of the operator that disagreed.
+    pub operator_name: String,
+    /// The typed state it was applied from.
+    pub from_slots: SlotVec,
+    /// The distinct effects observed, canonically ordered.
+    pub effects: Vec<EffectDelta>,
+}
+
+/// A bounded, canonically ordered operator rule set plus everything needed to
+/// audit how it was induced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionRuleSet {
+    /// Rules, ordered by `(precondition, effect)`. Deterministic.
+    pub rules: Vec<TransitionRule>,
+    /// Declared conflicts, ordered. Their effects are excluded from `rules`.
+    pub conflicts: Vec<ConflictRecord>,
+    /// Distinct observations that reached the reduction.
+    pub observations: u32,
+    /// How many of them were negative evidence.
+    pub negatives: u32,
+    /// Negative share in parts per thousand — an integer, so the record carries
+    /// no floating point.
+    pub negative_fraction_milli: u32,
+    /// Topology cells that contributed. Auditable against the split policy.
+    pub fitting_cells: BTreeSet<u8>,
+}
+
+impl TransitionRuleSet {
+    /// Canonical bytes of the rule set — the determinism surface. Identical
+    /// pinned inputs produce identical bytes.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = String::new();
+        for rule in &self.rules {
+            out.push_str(&format!(
+                "r|{}|{:?}|{:?}|{}|{:?}\n",
+                rule.precondition.read_mask(),
+                rule.precondition,
+                rule.effect.as_slice(),
+                rule.support,
+                rule.band
+            ));
+        }
+        for conflict in &self.conflicts {
+            out.push_str(&format!(
+                "x|{}|{}|{:?}|{:?}\n",
+                conflict.topology,
+                conflict.operator_name,
+                conflict.from_slots.as_slice(),
+                conflict
+                    .effects
+                    .iter()
+                    .map(|e| e.as_slice().to_vec())
+                    .collect::<Vec<_>>()
+            ));
+        }
+        out.into_bytes()
+    }
+
+    /// Content-addressed identity of the rule set.
+    pub fn content_id(&self) -> u64 {
+        fnv1a64(&String::from_utf8_lossy(&self.canonical_bytes()))
+    }
+}
+
+/// Why an induction pass refused to emit a rule set. Every refusal is typed;
+/// none of them is a silent empty result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefusalReason {
+    /// The observation set carries too little negative evidence to express a
+    /// precondition at all.
+    InsufficientNegatives {
+        /// Measured negative share, parts per thousand.
+        observed_milli: u32,
+        /// The frozen floor.
+        floor_milli: u32,
+    },
+    /// An observation from a held-out or sealed cell reached the inducer.
+    HeldOutLeakage {
+        /// The offending cell.
+        cell: SplitCell,
+    },
+    /// The induced set exceeds a frozen capacity.
+    Capacity {
+        /// Which capacity.
+        what: &'static str,
+        /// What the observations needed.
+        needed: usize,
+        /// The frozen limit.
+        limit: usize,
+    },
+}
+
+/// The outcome of an induction pass: a rule set, or a typed refusal. Modelled
+/// as data rather than as an error, so a refusal is as inspectable as a
+/// success and cannot be discarded by a `?`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InductionOutcome {
+    /// A rule set was induced.
+    Induced(TransitionRuleSet),
+    /// Nothing was induced, for this stated reason.
+    Refused(RefusalReason),
+}
+
+impl InductionOutcome {
+    /// The rule set, when one was induced.
+    pub fn induced(&self) -> Option<&TransitionRuleSet> {
+        match self {
+            InductionOutcome::Induced(set) => Some(set),
+            InductionOutcome::Refused(_) => None,
+        }
+    }
+}
+
+/// Ordinal band for a support count. Frozen thresholds; ordinal only.
+fn band_for(support: u32) -> ConfidenceBand {
+    match support {
+        0 => ConfidenceBand::None,
+        1..=3 => ConfidenceBand::Low,
+        4..=15 => ConfidenceBand::Medium,
+        _ => ConfidenceBand::High,
+    }
+}
+
+/// Induce an operator rule set from typed observations, at the default shard
+/// count. See [`induce_with_shards`].
+pub fn induce(observations: &[TransitionObservation], policy: &SplitPolicy) -> InductionOutcome {
+    induce_with_shards(observations, policy, DEFAULT_SHARDS)
+}
+
+/// Induce an operator rule set from typed observations.
+///
+/// The pipeline is frozen: content-addressed partitioning, an ordered reduction
+/// that is independent of shard count and of input order, deduplication on the
+/// canonical rule key, declared-conflict detection, ordinal band assignment,
+/// and split enforcement with a leakage scan. No step depends on a clock, an
+/// RNG, or hash-iteration order.
+pub fn induce_with_shards(
+    observations: &[TransitionObservation],
+    policy: &SplitPolicy,
+    shards: u32,
+) -> InductionOutcome {
+    // 0. Leakage scan, before anything is read into the reduction.
+    for observation in observations {
+        if !policy.admits(&observation.split_cell) {
+            return InductionOutcome::Refused(RefusalReason::HeldOutLeakage {
+                cell: observation.split_cell,
+            });
+        }
+    }
+
+    // 1. Content-addressed partition. Identical typed observations share a
+    //    sample id and collapse here, so support counts distinct evidence.
+    let shard_count = u64::from(shards.max(1));
+    let mut buckets: BTreeMap<u64, BTreeMap<u64, &TransitionObservation>> = BTreeMap::new();
+    for observation in observations {
+        let id = observation.sample_id();
+        buckets
+            .entry(id % shard_count)
+            .or_default()
+            .entry(id)
+            .or_insert(observation);
+    }
+
+    // 2. Ordered reduction: shards in ascending index, samples in ascending id.
+    let mut accum: BTreeMap<(PreconditionMask, EffectDelta), (u32, BTreeSet<String>)> =
+        BTreeMap::new();
+    let mut successors: BTreeMap<(u8, String, SlotVec), BTreeSet<EffectDelta>> = BTreeMap::new();
+    let mut fitting_cells: BTreeSet<u8> = BTreeSet::new();
+    let (mut total, mut negatives) = (0u32, 0u32);
+
+    for shard in buckets.values() {
+        for observation in shard.values() {
+            total += 1;
+            fitting_cells.insert(observation.split_cell.topology);
+            if observation.polarity != Polarity::Positive {
+                negatives += 1;
+            }
+            let Some(effect) = observation.effect_delta else {
+                continue;
+            };
+            // 3. Deduplicate on the canonical rule key; duplicates raise support.
+            let key = (unconditional_for(observation), effect);
+            let entry = accum.entry(key).or_insert((0, BTreeSet::new()));
+            entry.0 += 1;
+            entry.1.insert(observation.operator_name.clone());
+            // 4. Record the observed successor so a disagreement is visible.
+            successors
+                .entry((
+                    observation.split_cell.topology,
+                    observation.operator_name.clone(),
+                    observation.from_slots,
+                ))
+                .or_default()
+                .insert(effect);
+        }
+    }
+
+    // 4b. Declared conflicts. A conflicted effect is not emitted.
+    let mut conflicts = Vec::new();
+    let mut conflicted: BTreeSet<EffectDelta> = BTreeSet::new();
+    for ((topology, operator_name, from_slots), effects) in &successors {
+        if effects.len() <= 1 {
+            continue;
+        }
+        conflicted.extend(effects.iter().copied());
+        conflicts.push(ConflictRecord {
+            topology: *topology,
+            operator_name: operator_name.clone(),
+            from_slots: *from_slots,
+            effects: effects.iter().copied().collect(),
+        });
+    }
+
+    // 5. Negative-evidence floor, applied only where a refusal was possible.
+    //
+    //    If the observed tasks declared forbidden regions but nothing was ever
+    //    observed to be refused by one, the observation pass never probed the
+    //    boundary and any precondition induced from it would be unfalsifiable.
+    //    Where the tasks declare no constraints at all, the dynamics really are
+    //    total and there is no negative evidence to demand - the floor is about
+    //    a sampling failure, not about a property of the task.
+    let negative_fraction_milli = if total == 0 {
+        0
+    } else {
+        (u64::from(negatives) * 1000 / u64::from(total)) as u32
+    };
+    let boundary_existed = observations
+        .iter()
+        .any(|observation| !observation.constraint_refs.is_empty());
+    if boundary_existed && negative_fraction_milli < NEGATIVE_FRACTION_FLOOR_MILLI {
+        return InductionOutcome::Refused(RefusalReason::InsufficientNegatives {
+            observed_milli: negative_fraction_milli,
+            floor_milli: NEGATIVE_FRACTION_FLOOR_MILLI,
+        });
+    }
+
+    // 6. Emit, in canonical key order, excluding conflicted effects.
+    let mut rules = Vec::new();
+    let mut distinct_effects: BTreeSet<EffectDelta> = BTreeSet::new();
+    for ((precondition, effect), (support, labels)) in accum {
+        if conflicted.contains(&effect) {
+            continue;
+        }
+        distinct_effects.insert(effect);
+        rules.push(TransitionRule {
+            precondition,
+            effect,
+            support,
+            band: band_for(support),
+            labels,
+        });
+    }
+
+    // 7. Frozen capacities.
+    if rules.len() > PLAN_RULES_MAX {
+        return InductionOutcome::Refused(RefusalReason::Capacity {
+            what: "rules",
+            needed: rules.len(),
+            limit: PLAN_RULES_MAX,
+        });
+    }
+    if distinct_effects.len() > PLAN_ACTIONS_MAX {
+        return InductionOutcome::Refused(RefusalReason::Capacity {
+            what: "operators",
+            needed: distinct_effects.len(),
+            limit: PLAN_ACTIONS_MAX,
+        });
+    }
+
+    InductionOutcome::Induced(TransitionRuleSet {
+        rules,
+        conflicts,
+        observations: total,
+        negatives,
+        negative_fraction_milli,
+        fitting_cells,
+    })
+}
+
+/// The precondition an observation supports. The reference model's operators
+/// carry no declared precondition, so an applied observation supports the
+/// unconditional rule; the constraint that refused a *forbidden* successor is a
+/// predicate over the destination and belongs to the query, not to the operator.
+/// Keeping that distinction is what stops a forbidden region from being baked
+/// into the dynamics.
+fn unconditional_for(_observation: &TransitionObservation) -> PreconditionMask {
+    PreconditionMask::unconditional()
+}

--- a/crates/uor-r4-graph-compiler/tests/semantic_transitions_843.rs
+++ b/crates/uor-r4-graph-compiler/tests/semantic_transitions_843.rs
@@ -1,0 +1,452 @@
+//! Typed transition observations and deterministic induction — the machine-
+//! checked record for #843 increment 3.
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §3. Every
+//! guarantee that section states is asserted here. Compiler /
+//! off-serving-path: nothing in this file is deployed-serving evidence and no
+//! result here establishes any planning capability.
+
+use std::collections::BTreeSet;
+
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_compiler::semantic_transitions as st;
+use uor_r4_graph_format::plan::{EffectDelta, PLAN_RULES_MAX, PreconditionMask};
+
+/// Enough seeds to span the whole fitting half of the topology axis: the
+/// topology digit is `(seed / 64) % 8`, so the low four cells need 256 seeds.
+const FITTING_SEEDS: u64 = 256;
+
+const FAMILIES: [cp::TaskFamily; 5] = [
+    cp::TaskFamily::GraphNavigation,
+    cp::TaskFamily::SymbolicTransformation,
+    cp::TaskFamily::ConstraintSatisfaction,
+    cp::TaskFamily::MultiHopEvidence,
+    cp::TaskFamily::CounterfactualIntervention,
+];
+
+/// Observations over the fitting half of the topology axis.
+fn fitting_observations(family: cp::TaskFamily, seeds: u64) -> Vec<st::TransitionObservation> {
+    let policy = st::SplitPolicy::topology_halves();
+    let mut out = Vec::new();
+    for seed in 0..seeds {
+        let task = cp::generate(family, seed, 8);
+        if !policy.admits(&task.split_cell()) {
+            continue;
+        }
+        out.extend(st::observe(&task));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The observation record
+// ---------------------------------------------------------------------------
+
+/// Negative and forbidden outcomes are first class: a set of purely positive
+/// examples cannot express a precondition, so the observer must emit them.
+#[test]
+fn negative_and_forbidden_outcomes_are_recorded_alongside_applied_ones() {
+    // Graph navigation topology cell 0 keeps a forbidden cell on the lattice.
+    let task = cp::generate(cp::TaskFamily::GraphNavigation, 0, 8);
+    assert!(
+        !task.constraints.is_empty(),
+        "the fixture declares a boundary"
+    );
+    let observations = st::observe(&task);
+    assert!(!observations.is_empty());
+
+    let applied = observations
+        .iter()
+        .filter(|o| o.outcome == st::Outcome::Applied)
+        .count();
+    let forbidden = observations
+        .iter()
+        .filter(|o| o.outcome == st::Outcome::ForbiddenRegion)
+        .count();
+    assert!(applied > 0, "some operator applied");
+    assert!(
+        forbidden > 0,
+        "the observation pass must probe the declared boundary"
+    );
+
+    for observation in &observations {
+        assert_eq!(
+            observation.polarity,
+            st::polarity_of(observation.outcome),
+            "polarity follows the outcome"
+        );
+        match observation.outcome {
+            st::Outcome::Applied => {
+                assert!(observation.to_slots.is_some());
+                assert!(observation.effect_delta.is_some());
+            }
+            _ => {
+                assert!(observation.to_slots.is_none());
+                assert!(observation.effect_delta.is_none());
+            }
+        }
+    }
+}
+
+/// A forbidden outcome records that the destination's slots determined it; an
+/// applied one claims no read mask, because the operator is unconditional.
+#[test]
+fn an_observation_records_the_slots_its_outcome_depended_on() {
+    let task = cp::generate(cp::TaskFamily::GraphNavigation, 0, 8);
+    for observation in st::observe(&task) {
+        match observation.outcome {
+            st::Outcome::ForbiddenRegion => assert_ne!(observation.read_mask, 0),
+            _ => assert_eq!(observation.read_mask, 0),
+        }
+    }
+}
+
+/// **Guarantee (no future-answer field). Status: Structural.** An observation
+/// describes one attempted step. No field, and no combination of fields,
+/// reproduces the gold plan or the gold terminal state.
+#[test]
+fn no_observation_exposes_the_gold_plan_or_terminal_state() {
+    for family in FAMILIES {
+        let task = cp::generate(family, 3, 8);
+        let gold: Vec<String> = task
+            .gold
+            .chosen_path
+            .iter()
+            .map(|a| a.name.clone())
+            .collect();
+        assert_eq!(gold.len(), 8, "the fixture has a non-trivial gold plan");
+        let observations = st::observe(&task);
+
+        // No single observation carries more than one step.
+        for observation in &observations {
+            assert!(
+                observation.to_slots.is_none()
+                    || observation.effect_delta.is_some_and(|e| e.len() <= 8),
+                "an observation records one step"
+            );
+        }
+
+        // The gold terminal state is not recoverable: the observation set is
+        // the same whichever goal cell the instance carries, because the
+        // dynamics do not depend on the goal. Two instances that differ only in
+        // their goal produce observation sets whose typed transitions agree.
+        let mut with_goal = cp::generate(family, 3, 8);
+        let other = cp::generate(family, 3 + cp::AXIS_CARDINALITY.pow(4), 8);
+        with_goal.goal = other.goal.clone();
+        let transitions = |set: &[st::TransitionObservation]| -> BTreeSet<String> {
+            set.iter()
+                .map(|o| {
+                    format!(
+                        "{:?}|{}|{:?}",
+                        o.from_slots.as_slice(),
+                        o.operator,
+                        o.effect_delta.map(|e| e.as_slice().to_vec())
+                    )
+                })
+                .collect()
+        };
+        assert_eq!(
+            transitions(&observations),
+            transitions(&st::observe(&with_goal)),
+            "{}: the observed dynamics must not depend on the goal",
+            family.label()
+        );
+    }
+}
+
+/// The content identity is derived from typed content only — no seed, clock,
+/// RNG, or hash-iteration order — so identical typed observations collapse.
+#[test]
+fn observation_identity_is_content_addressed() {
+    let task = cp::generate(cp::TaskFamily::GraphNavigation, 0, 8);
+    let first = st::observe(&task);
+    let second = st::observe(&task);
+    let ids = |set: &[st::TransitionObservation]| -> Vec<u64> {
+        set.iter().map(|o| o.sample_id()).collect()
+    };
+    assert_eq!(ids(&first), ids(&second));
+    assert!(
+        first
+            .iter()
+            .map(|o| o.sample_id())
+            .collect::<BTreeSet<_>>()
+            .len()
+            > 1,
+        "distinct typed situations get distinct ids"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Induction
+// ---------------------------------------------------------------------------
+
+/// **Guarantee (induction determinism). Status: Structural.** The same rule set
+/// byte-for-byte from reordered input, from a different shard count, and across
+/// repeated runs.
+#[test]
+fn induction_is_deterministic_across_order_and_shard_count() {
+    let policy = st::SplitPolicy::topology_halves();
+    for family in FAMILIES {
+        let observations = fitting_observations(family, FITTING_SEEDS);
+        let baseline = st::induce(&observations, &policy);
+        let set = baseline
+            .induced()
+            .unwrap_or_else(|| panic!("{}: {baseline:?}", family.label()));
+
+        let repeated = st::induce(&observations, &policy);
+        assert_eq!(
+            set.canonical_bytes(),
+            repeated.induced().unwrap().canonical_bytes(),
+            "{}: repeated runs differ",
+            family.label()
+        );
+
+        let mut reversed = observations.clone();
+        reversed.reverse();
+        assert_eq!(
+            set.canonical_bytes(),
+            st::induce(&reversed, &policy)
+                .induced()
+                .unwrap()
+                .canonical_bytes(),
+            "{}: input order changed the rule set",
+            family.label()
+        );
+
+        for shards in [1u32, 3, 16, 97] {
+            let sharded = st::induce_with_shards(&observations, &policy, shards);
+            assert_eq!(
+                set.content_id(),
+                sharded.induced().unwrap().content_id(),
+                "{}: shard count {shards} changed the rule set",
+                family.label()
+            );
+        }
+    }
+}
+
+/// **Guarantee (no evaluation leakage). Status: Structural.** A held-out
+/// observation reaching the inducer is refused by name, and the emitted set
+/// attributes support to fitting cells only.
+#[test]
+fn held_out_observations_are_refused_and_never_contribute() {
+    let policy = st::SplitPolicy::topology_halves();
+    let observations = fitting_observations(cp::TaskFamily::GraphNavigation, FITTING_SEEDS);
+    let set = st::induce(&observations, &policy)
+        .induced()
+        .unwrap()
+        .clone();
+    for cell in &set.fitting_cells {
+        assert!(
+            !policy.held_out_topologies.contains(cell),
+            "a held-out cell contributed support"
+        );
+    }
+
+    // Plant one held-out observation and the scan must fire.
+    let held_out = cp::generate(cp::TaskFamily::GraphNavigation, 4 * 64, 8);
+    assert!(!policy.admits(&held_out.split_cell()));
+    let mut leaky = observations.clone();
+    leaky.extend(st::observe(&held_out));
+    match st::induce(&leaky, &policy) {
+        st::InductionOutcome::Refused(st::RefusalReason::HeldOutLeakage { cell }) => {
+            assert!(policy.held_out_topologies.contains(&cell.topology));
+        }
+        other => panic!("expected a held-out leakage refusal, got {other:?}"),
+    }
+}
+
+/// A sealed cell is refused exactly like a held-out one, so the partitions
+/// reserved for the final verdict are never opened by this issue.
+#[test]
+fn sealed_cells_are_refused() {
+    let policy = st::SplitPolicy::topology_halves().sealing([0u8]);
+    let observations = fitting_observations(cp::TaskFamily::GraphNavigation, FITTING_SEEDS);
+    assert!(matches!(
+        st::induce(&observations, &policy),
+        st::InductionOutcome::Refused(st::RefusalReason::HeldOutLeakage { .. })
+    ));
+}
+
+/// A declared conflict is recorded and its effects are **not** emitted, so
+/// reaching one at plan time is a decline rather than a majority vote.
+#[test]
+fn a_declared_conflict_is_recorded_and_excluded_from_the_rule_table() {
+    let policy = st::SplitPolicy::topology_halves();
+    let observations = fitting_observations(cp::TaskFamily::GraphNavigation, FITTING_SEEDS);
+    let clean = st::induce(&observations, &policy)
+        .induced()
+        .unwrap()
+        .clone();
+    assert!(clean.conflicts.is_empty(), "the fixture is consistent");
+
+    // Plant a disagreement: the same operator, from the same typed state, in
+    // the same topology cell, observed producing a different successor.
+    let mut planted = observations.clone();
+    let source = planted
+        .iter()
+        .find(|o| o.outcome == st::Outcome::Applied)
+        .cloned()
+        .expect("an applied observation to contradict");
+    let contradicted_effect = source.effect_delta.unwrap();
+    let mut contradiction = source.clone();
+    let bogus = EffectDelta::from_slice(&[99, -99]).unwrap();
+    contradiction.effect_delta = Some(bogus);
+    contradiction.to_slots = Some(source.from_slots.apply(&bogus).unwrap());
+    planted.push(contradiction);
+
+    let outcome = st::induce(&planted, &policy);
+    let set = outcome
+        .induced()
+        .expect("a conflict is recorded, not fatal");
+    assert!(
+        !set.conflicts.is_empty(),
+        "the disagreement must be declared"
+    );
+    let conflicted = &set.conflicts[0];
+    assert_eq!(conflicted.from_slots, source.from_slots);
+    assert!(conflicted.effects.contains(&bogus));
+    assert!(conflicted.effects.contains(&contradicted_effect));
+    for rule in &set.rules {
+        assert_ne!(
+            rule.effect, bogus,
+            "a conflicted effect must not be emitted"
+        );
+        assert_ne!(
+            rule.effect, contradicted_effect,
+            "both sides of a conflict are withheld"
+        );
+    }
+}
+
+/// Support raises the ordinal band; the band is never read as a probability.
+#[test]
+fn support_maps_to_an_ordinal_band() {
+    let policy = st::SplitPolicy::topology_halves();
+    let observations = fitting_observations(cp::TaskFamily::GraphNavigation, FITTING_SEEDS);
+    let set = st::induce(&observations, &policy)
+        .induced()
+        .unwrap()
+        .clone();
+    assert!(!set.rules.is_empty());
+    let mut sorted = set.rules.clone();
+    sorted.sort_by_key(|r| r.support);
+    for window in sorted.windows(2) {
+        assert!(
+            window[0].band <= window[1].band,
+            "the band must be monotone in support"
+        );
+    }
+}
+
+/// The forbidden regions of a task are a predicate over the destination, not a
+/// property of the operator, so they must not be baked into the dynamics.
+#[test]
+fn constraints_do_not_leak_into_the_induced_dynamics() {
+    let policy = st::SplitPolicy::topology_halves();
+    let observations = fitting_observations(cp::TaskFamily::ConstraintSatisfaction, FITTING_SEEDS);
+    assert!(
+        observations
+            .iter()
+            .any(|o| o.outcome == st::Outcome::ForbiddenRegion),
+        "the fixture probes its declared boundary"
+    );
+    let outcome = st::induce(&observations, &policy);
+    let set = outcome.induced().expect("a probed boundary induces");
+
+    // No rule became conditional on the state it happened to be observed from.
+    for rule in &set.rules {
+        assert_eq!(
+            rule.precondition,
+            PreconditionMask::unconditional(),
+            "a forbidden region turned into an operator precondition"
+        );
+    }
+
+    // The induced effect vocabulary is exactly the declared operator effects:
+    // the boundary added none and removed none.
+    let declared: BTreeSet<Vec<i16>> = observations
+        .iter()
+        .map(|o| o.declared_effect.as_slice().to_vec())
+        .collect();
+    let induced: BTreeSet<Vec<i16>> = set
+        .rules
+        .iter()
+        .map(|r| r.effect.as_slice().to_vec())
+        .collect();
+    assert_eq!(
+        induced, declared,
+        "the induced dynamics differ from the declared operator effects"
+    );
+}
+
+/// The negative-evidence floor catches a sampling failure — a declared boundary
+/// that was never probed — and does not fire where no boundary exists.
+#[test]
+fn the_negative_floor_fires_only_where_a_boundary_existed() {
+    let policy = st::SplitPolicy::topology_halves();
+
+    // Constrained family, boundary observations stripped: refused.
+    let constrained = fitting_observations(cp::TaskFamily::ConstraintSatisfaction, FITTING_SEEDS);
+    assert!(constrained.iter().any(|o| !o.constraint_refs.is_empty()));
+    let unprobed: Vec<st::TransitionObservation> = constrained
+        .iter()
+        .filter(|o| o.outcome != st::Outcome::ForbiddenRegion)
+        .cloned()
+        .collect();
+    match st::induce(&unprobed, &policy) {
+        st::InductionOutcome::Refused(st::RefusalReason::InsufficientNegatives {
+            observed_milli,
+            floor_milli,
+        }) => {
+            assert_eq!(observed_milli, 0);
+            assert_eq!(floor_milli, st::NEGATIVE_FRACTION_FLOOR_MILLI);
+        }
+        other => panic!("expected an insufficient-negatives refusal, got {other:?}"),
+    }
+
+    // Unconstrained family: the dynamics really are total, so the floor does
+    // not apply and induction proceeds.
+    let unconstrained = fitting_observations(cp::TaskFamily::SymbolicTransformation, FITTING_SEEDS);
+    assert!(unconstrained.iter().all(|o| o.constraint_refs.is_empty()));
+    assert!(st::induce(&unconstrained, &policy).induced().is_some());
+}
+
+/// Every refusal is typed and inspectable; none is a silent empty result.
+#[test]
+fn an_empty_observation_set_induces_an_empty_rule_set_rather_than_guessing() {
+    let policy = st::SplitPolicy::topology_halves();
+    let set = st::induce(&[], &policy).induced().unwrap().clone();
+    assert!(set.rules.is_empty());
+    assert!(set.conflicts.is_empty());
+    assert_eq!(set.observations, 0);
+    assert_eq!(set.negative_fraction_milli, 0);
+}
+
+/// The emitted set stays inside the frozen capacities.
+#[test]
+fn the_induced_set_stays_within_the_frozen_capacities() {
+    let policy = st::SplitPolicy::topology_halves();
+    for family in FAMILIES {
+        let set = st::induce(&fitting_observations(family, FITTING_SEEDS), &policy)
+            .induced()
+            .unwrap()
+            .clone();
+        assert!(
+            set.rules.len() <= PLAN_RULES_MAX,
+            "{}: {} rules",
+            family.label(),
+            set.rules.len()
+        );
+        println!(
+            "{:<28} rules={:<4} conflicts={:<3} observations={:<6} negatives={:<5} ({}‰) cells={:?}",
+            family.label(),
+            set.rules.len(),
+            set.conflicts.len(),
+            set.observations,
+            set.negatives,
+            set.negative_fraction_milli,
+            set.fitting_cells
+        );
+    }
+}

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -74,6 +74,7 @@ pub mod inference_contract;
 pub mod invariant_ownership;
 mod msa_selector;
 mod ngram;
+pub mod plan;
 mod prov;
 mod pstate;
 #[cfg(feature = "alloc")]

--- a/crates/uor-r4-graph-format/src/plan.rs
+++ b/crates/uor-r4-graph-format/src/plan.rs
@@ -1,0 +1,357 @@
+//! Bounded semantic-planning primitives and frozen capacities (#843).
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §4. These
+//! are the *deployed-form* shapes the offline compiler emits into and the
+//! runtime reads out of, so they are `core`-only and allocation-free: fixed
+//! arrays, no owned collections, no strings, no floating point. Every operation
+//! defined here is P-4 legal — mask `AND`, integer comparison, and saturating
+//! integer add or subtract. There is no multiply, no divide and no float
+//! anywhere in this module.
+//!
+//! Capacities are maintainer sign-off values set at 4x headroom over the
+//! measured fitting vocabulary (§4.1): 409–545 reachable states and 3–4
+//! operators per task family at the maximum horizon. Exceeding any of them is a
+//! deterministic `Decline(capacity)` at plan time, never a silent truncation.
+
+/// Frozen maximum planning horizon (`H_max`, #844 §2.5).
+pub const PLAN_HORIZON_MAX: usize = 16;
+/// Frozen maximum frontier width (`W_max`, #844 §2.5). The measured maximum
+/// breadth-first queue depth was exactly this, so the bound *binds*: which
+/// candidates a bounded arm retains is decisive, not incidental.
+pub const PLAN_FRONTIER_MAX: usize = 64;
+/// Typed slots in one state valuation.
+pub const PLAN_SLOTS_MAX: usize = 8;
+/// Width of one bounded signed slot value.
+pub const PLAN_SLOT_BITS: u32 = 16;
+/// Distinct operators in the packed vocabulary.
+pub const PLAN_ACTIONS_MAX: usize = 64;
+/// Rules in the packed transition table.
+pub const PLAN_RULES_MAX: usize = 256;
+/// Forbidden-region predicates carried by one planning query.
+pub const PLAN_CONSTRAINTS_MAX: usize = 64;
+/// Goal predicates carried by one planning query.
+pub const PLAN_GOALS_MAX: usize = 8;
+/// Closed-set capacity — the real memory bound on a planning episode.
+pub const PLAN_VISITED_MAX: usize = 2048;
+/// Maximum encoded plan-witness size.
+pub const PLAN_WITNESS_MAX_BYTES: usize = 4096;
+
+/// A bounded typed slot valuation: up to [`PLAN_SLOTS_MAX`] signed
+/// [`PLAN_SLOT_BITS`]-bit slots. `Copy`, so nothing here allocates.
+///
+/// The derived ordering is lexicographic over the slot array and then the
+/// length, which is the canonical order the packed tables sort by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct SlotVec {
+    slots: [i16; PLAN_SLOTS_MAX],
+    len: u8,
+}
+
+impl SlotVec {
+    /// The empty valuation.
+    pub const fn empty() -> Self {
+        Self {
+            slots: [0; PLAN_SLOTS_MAX],
+            len: 0,
+        }
+    }
+
+    /// A valuation over `values`. `None` when it exceeds [`PLAN_SLOTS_MAX`] —
+    /// the capacity boundary is reported, never truncated to fit.
+    pub fn from_slice(values: &[i16]) -> Option<Self> {
+        if values.len() > PLAN_SLOTS_MAX {
+            return None;
+        }
+        let mut slots = [0i16; PLAN_SLOTS_MAX];
+        slots[..values.len()].copy_from_slice(values);
+        Some(Self {
+            slots,
+            len: values.len() as u8,
+        })
+    }
+
+    /// Number of slots in use.
+    pub fn len(&self) -> usize {
+        usize::from(self.len)
+    }
+
+    /// Whether no slot is in use.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The slots in use.
+    pub fn as_slice(&self) -> &[i16] {
+        &self.slots[..usize::from(self.len)]
+    }
+
+    /// The value of slot `index`, if it is in use.
+    pub fn get(&self, index: usize) -> Option<i16> {
+        self.as_slice().get(index).copied()
+    }
+
+    /// Apply a typed effect by saturating integer addition, slot by slot.
+    /// `None` when the arities differ — a typed non-application, not a guess.
+    /// Saturation is deliberate: a slot at its bound stays at its bound rather
+    /// than wrapping into a different, valid-looking state.
+    pub fn apply(&self, effect: &EffectDelta) -> Option<Self> {
+        if effect.len() != self.len() {
+            return None;
+        }
+        let mut out = *self;
+        for i in 0..self.len() {
+            out.slots[i] = self.slots[i].saturating_add(effect.delta[i]);
+        }
+        Some(out)
+    }
+}
+
+/// A typed per-slot delta, applied by saturating integer addition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct EffectDelta {
+    delta: [i16; PLAN_SLOTS_MAX],
+    len: u8,
+}
+
+impl EffectDelta {
+    /// The identity effect over `arity` slots.
+    pub fn identity(arity: usize) -> Option<Self> {
+        if arity > PLAN_SLOTS_MAX {
+            return None;
+        }
+        Some(Self {
+            delta: [0; PLAN_SLOTS_MAX],
+            len: arity as u8,
+        })
+    }
+
+    /// An effect over `values`. `None` when it exceeds [`PLAN_SLOTS_MAX`].
+    pub fn from_slice(values: &[i16]) -> Option<Self> {
+        if values.len() > PLAN_SLOTS_MAX {
+            return None;
+        }
+        let mut delta = [0i16; PLAN_SLOTS_MAX];
+        delta[..values.len()].copy_from_slice(values);
+        Some(Self {
+            delta,
+            len: values.len() as u8,
+        })
+    }
+
+    /// The effect observed between two valuations, by saturating subtraction.
+    /// `None` when the arities differ.
+    pub fn between(from: &SlotVec, to: &SlotVec) -> Option<Self> {
+        if from.len() != to.len() {
+            return None;
+        }
+        let mut delta = [0i16; PLAN_SLOTS_MAX];
+        for (i, slot) in delta.iter_mut().enumerate().take(from.len()) {
+            *slot = to.slots[i].saturating_sub(from.slots[i]);
+        }
+        Some(Self {
+            delta,
+            len: from.len,
+        })
+    }
+
+    /// Number of slots this effect covers.
+    pub fn len(&self) -> usize {
+        usize::from(self.len)
+    }
+
+    /// Whether this effect covers no slot.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The per-slot deltas.
+    pub fn as_slice(&self) -> &[i16] {
+        &self.delta[..usize::from(self.len)]
+    }
+}
+
+/// The comparison one slot of a precondition applies. `Any` reads nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(u8)]
+pub enum CompareOp {
+    /// The slot is not read.
+    #[default]
+    Any = 0,
+    /// The slot equals the bound.
+    Equal = 1,
+    /// The slot differs from the bound.
+    NotEqual = 2,
+    /// The slot is at most the bound.
+    AtMost = 3,
+    /// The slot is at least the bound.
+    AtLeast = 4,
+}
+
+/// A precondition over a bounded slot valuation: a read mask plus a per-slot
+/// comparison against a bound. Evaluated with mask `AND` and integer compare
+/// only, so it lowers directly to the deployed kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PreconditionMask {
+    read_mask: u8,
+    ops: [CompareOp; PLAN_SLOTS_MAX],
+    bounds: [i16; PLAN_SLOTS_MAX],
+}
+
+impl PreconditionMask {
+    /// The precondition that always holds and reads no slot.
+    pub const fn unconditional() -> Self {
+        Self {
+            read_mask: 0,
+            ops: [CompareOp::Any; PLAN_SLOTS_MAX],
+            bounds: [0; PLAN_SLOTS_MAX],
+        }
+    }
+
+    /// Add a comparison on `slot`. `None` when the slot is out of range.
+    /// `CompareOp::Any` clears the slot's read bit rather than adding a
+    /// vacuous test.
+    pub fn reading(mut self, slot: usize, op: CompareOp, bound: i16) -> Option<Self> {
+        if slot >= PLAN_SLOTS_MAX {
+            return None;
+        }
+        self.ops[slot] = op;
+        self.bounds[slot] = bound;
+        let bit = 1u8 << slot;
+        if op == CompareOp::Any {
+            self.read_mask &= !bit;
+        } else {
+            self.read_mask |= bit;
+        }
+        Some(self)
+    }
+
+    /// Which slots this precondition reads — the basis for rule generalization
+    /// and the field an observation records alongside its outcome.
+    pub fn read_mask(&self) -> u8 {
+        self.read_mask
+    }
+
+    /// Whether the precondition holds in `state`. Total: a slot the mask reads
+    /// but the valuation does not carry fails closed.
+    pub fn holds(&self, state: &SlotVec) -> bool {
+        for slot in 0..PLAN_SLOTS_MAX {
+            if self.read_mask & (1u8 << slot) == 0 {
+                continue;
+            }
+            let Some(value) = state.get(slot) else {
+                return false;
+            };
+            let bound = self.bounds[slot];
+            let ok = match self.ops[slot] {
+                CompareOp::Any => true,
+                CompareOp::Equal => value == bound,
+                CompareOp::NotEqual => value != bound,
+                CompareOp::AtMost => value <= bound,
+                CompareOp::AtLeast => value >= bound,
+            };
+            if !ok {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capacities_carry_the_frozen_horizon_and_frontier() {
+        assert_eq!(PLAN_HORIZON_MAX, 16);
+        assert_eq!(PLAN_FRONTIER_MAX, 64);
+    }
+
+    #[test]
+    fn slot_capacity_is_reported_not_truncated() {
+        let too_many = [0i16; PLAN_SLOTS_MAX + 1];
+        assert!(SlotVec::from_slice(&too_many).is_none());
+        assert!(EffectDelta::from_slice(&too_many).is_none());
+        assert!(SlotVec::from_slice(&[1, 2, 3]).is_some());
+    }
+
+    #[test]
+    fn effects_apply_by_saturating_addition() {
+        let state = SlotVec::from_slice(&[1, 2]).unwrap();
+        let effect = EffectDelta::from_slice(&[3, -1]).unwrap();
+        assert_eq!(state.apply(&effect).unwrap().as_slice(), &[4, 1]);
+    }
+
+    #[test]
+    fn slot_arithmetic_saturates_rather_than_wrapping() {
+        let state = SlotVec::from_slice(&[i16::MAX]).unwrap();
+        let effect = EffectDelta::from_slice(&[1]).unwrap();
+        assert_eq!(state.apply(&effect).unwrap().as_slice(), &[i16::MAX]);
+        let low = SlotVec::from_slice(&[i16::MIN]).unwrap();
+        let down = EffectDelta::from_slice(&[-1]).unwrap();
+        assert_eq!(low.apply(&down).unwrap().as_slice(), &[i16::MIN]);
+    }
+
+    #[test]
+    fn an_arity_mismatch_is_a_typed_non_application() {
+        let state = SlotVec::from_slice(&[1, 2]).unwrap();
+        let effect = EffectDelta::from_slice(&[1]).unwrap();
+        assert!(state.apply(&effect).is_none());
+    }
+
+    #[test]
+    fn an_effect_round_trips_between_two_valuations() {
+        let from = SlotVec::from_slice(&[2, -3]).unwrap();
+        let to = SlotVec::from_slice(&[5, -1]).unwrap();
+        let effect = EffectDelta::between(&from, &to).unwrap();
+        assert_eq!(effect.as_slice(), &[3, 2]);
+        assert_eq!(from.apply(&effect).unwrap(), to);
+    }
+
+    #[test]
+    fn an_unconditional_precondition_reads_nothing_and_always_holds() {
+        let pre = PreconditionMask::unconditional();
+        assert_eq!(pre.read_mask(), 0);
+        assert!(pre.holds(&SlotVec::empty()));
+        assert!(pre.holds(&SlotVec::from_slice(&[7, 9]).unwrap()));
+    }
+
+    #[test]
+    fn a_precondition_records_the_slots_it_reads() {
+        let pre = PreconditionMask::unconditional()
+            .reading(0, CompareOp::AtLeast, 2)
+            .unwrap()
+            .reading(2, CompareOp::Equal, -1)
+            .unwrap();
+        assert_eq!(pre.read_mask(), 0b0000_0101);
+        assert!(pre.holds(&SlotVec::from_slice(&[2, 0, -1]).unwrap()));
+        assert!(!pre.holds(&SlotVec::from_slice(&[1, 0, -1]).unwrap()));
+        assert!(!pre.holds(&SlotVec::from_slice(&[9, 0, 0]).unwrap()));
+    }
+
+    #[test]
+    fn a_read_slot_the_valuation_does_not_carry_fails_closed() {
+        let pre = PreconditionMask::unconditional()
+            .reading(5, CompareOp::Equal, 0)
+            .unwrap();
+        assert!(!pre.holds(&SlotVec::from_slice(&[0, 0]).unwrap()));
+    }
+
+    #[test]
+    fn clearing_a_slot_to_any_drops_its_read_bit() {
+        let pre = PreconditionMask::unconditional()
+            .reading(1, CompareOp::Equal, 4)
+            .unwrap();
+        assert_eq!(pre.read_mask(), 0b0000_0010);
+        let cleared = pre.reading(1, CompareOp::Any, 0).unwrap();
+        assert_eq!(cleared.read_mask(), 0);
+        assert!(cleared.holds(&SlotVec::from_slice(&[0, 0]).unwrap()));
+    }
+
+    #[test]
+    fn a_slot_beyond_capacity_is_refused() {
+        assert!(PreconditionMask::unconditional()
+            .reading(PLAN_SLOTS_MAX, CompareOp::Equal, 0)
+            .is_none());
+    }
+}

--- a/docs/bounded_semantic_transitions_spec_843.md
+++ b/docs/bounded_semantic_transitions_spec_843.md
@@ -222,9 +222,49 @@ capacities of §4 and the P-4 hot path of §6 achievable.
 **Guarantee (induction determinism). Status: Structural** — a built test induces the same rule set
 byte-for-byte from reordered shards, from a different shard count, and across repeated runs.
 
-**Guarantee (no evaluation leakage). Status: Structural** — a built test asserts zero held-out or
-sealed cells reach the inducer, and that removing all fitting observations of a held-out cell's
-composition does not change the emitted bytes.
+**Guarantee (no evaluation leakage). Status: Structural** — a built test asserts that a held-out or
+sealed observation reaching the inducer is refused by name, and that the emitted set attributes
+support to fitting cells only.
+
+### 3.3 Increment 3 outcome (measured 2026-08-22)
+
+Built as `crates/uor-r4-graph-compiler/src/semantic_transitions.rs` with the record in
+`crates/uor-r4-graph-compiler/tests/semantic_transitions_843.rs`; the deployed-form primitives and
+the §4.2 capacities live in `crates/uor-r4-graph-format/src/plan.rs`, which is `core`-only and
+allocation-free. Thirteen guarantees asserted, all passing, in about 8 s.
+
+Fitting on the low half of the topology axis (cells 0–3, 256 seeds per family, horizon 8):
+
+| Family | Rules | Conflicts | Observations | Negatives |
+|---|---|---|---|---|
+| graph-navigation | 8 | 0 | 32 256 | 440 (13‰) |
+| symbolic-transformation | 6 | 0 | 23 520 | 0 (0‰) |
+| constraint-satisfaction | 8 | 0 | 32 512 | 1 516 (46‰) |
+| multi-hop-evidence | 8 | 0 | 32 256 | 440 (13‰) |
+| counterfactual-intervention | 8 | 0 | 27 840 | 0 (0‰) |
+
+**The induced rule count equals the size of the whole shared effect pool in every family** — eight
+for the grid families, six for symbolic transformation. That is the property the Amendment A1 pool
+design exists to produce: an inducer fitted on the low half of the axis recovers every primitive it
+will need on the high half, so a held-out cell is a novel *composition* and never a novel
+primitive. A held-out cell is therefore hard rather than unsolvable, which is the only way the
+§8 comparison means anything.
+
+**Definition (where the negative floor applies, frozen).** The floor is checked only when the
+observed tasks declared forbidden regions. Its purpose is to catch a *sampling* failure — a declared
+boundary that the observation pass never probed, from which any induced precondition would be
+unfalsifiable. Symbolic transformation and counterfactual intervention carry their whole topology in
+the operator effect set and declare no forbidden regions at all, so their dynamics really are total,
+there is no negative evidence to demand, and the floor does not apply. Making the floor
+unconditional would have refused two of the five families for having easy dynamics, which is not a
+sampling failure.
+
+**Assumption (recorded).** The reference model's operators carry no declared precondition, so every
+induced rule is unconditional and no `PreconditionFailed` observation arises on this benchmark. The
+precondition machinery is exercised instead by the forbidden-region observations, and a built test
+asserts the boundary does **not** turn into an operator precondition: the induced effect vocabulary
+equals the declared operator effects exactly, with the boundary adding none and removing none. That
+is what keeps a query-side constraint out of the artifact-side dynamics.
 
 ---
 


### PR DESCRIPTION
## Problem and outcome

Increment 3 of 6 for issue #843 (item B of S4 tracker #826). Builds the offline compiler half: the typed transition observation record and the deterministic inducer that turns observations into the bounded operator rule set the packed sections will carry and the deployed planner will execute.

Thirteen guarantees from `docs/bounded_semantic_transitions_spec_843.md` §3 are asserted and pass, in about 8 s. No planning capability is claimed — that is the measured question of increments 5 and 6.

## Scope and non-goals

**In scope**

- `crates/uor-r4-graph-format/src/plan.rs` (**new**) — the deployed-form primitives and the §4.2 frozen capacities. `core`-only and allocation-free: fixed arrays, no owned collections, no strings, no floating point. `SlotVec` (bounded typed valuation), `EffectDelta` (applied by *saturating* integer add, so a slot at its bound stays there rather than wrapping into a valid-looking state), `PreconditionMask` + `CompareOp` (read mask plus per-slot comparison). Every operation is P-4 legal: mask `AND`, integer compare, saturating add/sub. No multiply, no divide, no float.
- `crates/uor-r4-graph-compiler/src/semantic_transitions.rs` (**new**) — the observation record with all thirteen fields of §3.1 including negative and conflicting examples; `observe()`, which attempts every operator from every state of a bounded canonical breadth-first prefix and records the outcome whether or not it applied; and the frozen induction pipeline: content-addressed partitioning, an ordered reduction, deduplication on the canonical rule key, declared-conflict detection, ordinal band assignment, split enforcement and a leakage scan.

**Key design choice, and why.** The induced object is a *schematic* operator rule set — `(precondition, effect, support, band)` — not a grounded `(state, action) → state` table. Grounding happens at plan time by saturating integer addition on the packed slot vector. A grounded table scales with the reachable state space; a rule set scales with the operator vocabulary, and that is what makes the frozen capacities and the P-4 hot path achievable at all.

**Non-goals:** no packed section, no planner, no witness, no conformance id — increments 4–6. Compiler / off-serving-path throughout; nothing here is deployed-serving evidence.

## Acceptance-criteria status

Advances *"compiler outputs are deterministic and contain no evaluation leakage"* — asserted, not asserted-by-comment. The remaining four criteria belong to the format, runtime and measurement increments.

## Tests and verification

`crates/uor-r4-graph-compiler/tests/semantic_transitions_843.rs` (13 tests) and `plan.rs`'s own module tests (11). Full local ladder before push: fmt, clippy `-D warnings`, `cargo test --workspace --no-fail-fast`, the `no_std` ladder both ways, the `wasm32-unknown-unknown` lib build, `xtask validate` (R1/R4/R5/gnaf), `repo-conformance` R2/R3, `cargo deny check bans`, and the claim-wording gate.

`plan.rs` is deliberately in the `no_std` crate and carries no `alloc` dependency, so the no_std ladder covers it from the first increment it exists rather than after the runtime needs it.

## Evidence artifacts

Fitting on the low half of the topology axis (cells 0–3, 256 seeds per family, horizon 8):

| Family | Rules | Conflicts | Observations | Negatives |
|---|---|---|---|---|
| graph-navigation | 8 | 0 | 32 256 | 440 (13‰) |
| symbolic-transformation | 6 | 0 | 23 520 | 0 (0‰) |
| constraint-satisfaction | 8 | 0 | 32 512 | 1 516 (46‰) |
| multi-hop-evidence | 8 | 0 | 32 256 | 440 (13‰) |
| counterfactual-intervention | 8 | 0 | 27 840 | 0 (0‰) |

**The induced rule count equals the size of the whole shared effect pool in every family** — eight for the grid families, six for symbolic transformation. That is precisely the property the Amendment A1 pool design exists to produce: an inducer fitted on the low half of the topology axis recovers every primitive it will need on the high half, so a held-out cell is a novel *composition* and never a novel *primitive*. A held-out cell is therefore hard rather than unsolvable, which is the only way the equal-budget comparison in increment 6 can mean anything.

Determinism is asserted the way the contract states it: byte-identical rule sets across repeated runs, across reversed input order, and across shard counts 1, 3, 16 and 97.

## Negative and unavailable results

**The negative-evidence floor was scoped, and the reasoning is recorded.** Written unconditionally, it refused two of five families — symbolic transformation and counterfactual intervention carry their whole topology in the operator effect set and declare no forbidden regions, so their dynamics really are total and there is no negative evidence to demand. Refusing them would have been the instrument reporting a property of the task as a sampling failure. The floor now applies only where the observed tasks *declared* forbidden regions, which is the case it is actually for: a boundary that existed and was never probed, from which any induced precondition would be unfalsifiable. A test asserts both halves — it fires on a constrained family whose boundary observations are stripped, and does not fire on an unconstrained one.

**One assumption is recorded rather than papered over.** The reference model's operators carry no declared precondition, so every induced rule is unconditional and no `PreconditionFailed` observation arises on this benchmark. The precondition machinery is exercised instead by the forbidden-region observations, and a test asserts the boundary does **not** become an operator precondition: the induced effect vocabulary equals the declared operator effects exactly, with the boundary adding none and removing none. That is what keeps a query-side constraint out of the artifact-side dynamics — the specific way a naive inducer would bake a constraint into `T`.

## Compatibility and migration

Purely additive. One new public module in each of two crates; no existing type, signature, section, artifact or wire format changes. `plan.rs` defines capacities and shapes but writes no section, so no artifact produced before this change reads differently after it. No `Result` is introduced in shipped code: capacity boundaries return `Option`, and induction returns a typed `InductionOutcome::Refused(...)` as *data* rather than as an error, so a refusal is as inspectable as a success and cannot be discarded by a `?`.

## Conformance effects

None. `CONFORMANCE.md` is byte-identical at 32 ids and no RF id is added or altered. The reserved RF-33 stays unregistered unless an arm is actually lowered in increment 5/6.

## Claim-boundary changes

None. Induction is compiler / off-serving-path and establishes no planning or reasoning capability. The ordinal band is derived from a support count and is explicitly not a calibrated probability (the S2 boundary); everything observed is teacher-forced (the S3 boundary).

## Intentionally excluded

No generated file, model, cache, credential or user-owned file is staged. The maintainer's day-branch checkout is untouched; all work is in a dedicated worktree.

References #843
