### PR TITLE
feat(#843): the deployed bounded planner, allocation-free and P-4 only

### DIFF
--- a/crates/uor-r4-graph-format/src/plan.rs
+++ b/crates/uor-r4-graph-format/src/plan.rs
@@ -114,6 +114,13 @@ pub struct EffectDelta {
 }
 
 impl EffectDelta {
+    /// The empty effect, covering no slot. Useful as a `const` array filler in
+    /// caller-owned scratch, which must be constructible without allocating.
+    pub const EMPTY: Self = Self {
+        delta: [0; PLAN_SLOTS_MAX],
+        len: 0,
+    };
+
     /// The identity effect over `arity` slots.
     pub fn identity(arity: usize) -> Option<Self> {
         if arity > PLAN_SLOTS_MAX {

--- a/crates/uor-r4-graph-format/src/plan_sections.rs
+++ b/crates/uor-r4-graph-format/src/plan_sections.rs
@@ -691,6 +691,20 @@ pub struct ConsideredCandidate {
     pub flags: u8,
 }
 
+impl ConsideredCandidate {
+    /// A zeroed candidate. Useful as a `const` array filler in caller-owned
+    /// scratch, which must be constructible without allocating.
+    pub const EMPTY: Self = Self {
+        operator: 0,
+        rule_row: 0,
+        score: 0,
+        tie_rank: 0,
+        support: 0,
+        band: 0,
+        flags: 0,
+    };
+}
+
 /// A borrowed, validated `PWIT` plan witness.
 ///
 /// **Self-contained by construction.** The witness carries its own initial
@@ -950,9 +964,171 @@ impl<'a> PlanWitnessBytes<'a> {
 // Builders — offline only, so they are `alloc`-gated and never on a hot path
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Witness encoding — core-only, so the `no_std` runtime can emit one into a
+// caller-provided buffer without allocating
+// ---------------------------------------------------------------------------
+
+/// Everything one `PWIT` witness records.
+pub struct WitnessDraft<'a> {
+    /// Typed slots per valuation.
+    pub slot_count: u8,
+    /// The initial packed state.
+    pub initial: SlotVec,
+    /// The goal predicate, carried inline so replay needs nothing else.
+    pub goal: PreconditionMask,
+    /// The forbidden-region predicates, carried inline.
+    pub constraints: &'a [PreconditionMask],
+    /// Per step: applied effect, resulting state, chosen operator, rule row.
+    pub steps: &'a [WitnessStep],
+    /// Considered candidates, row-major over steps.
+    pub considered: &'a [ConsideredCandidate],
+    /// Candidates recorded per step.
+    pub considered_per_step: u8,
+    /// Set when the episode is an honest decline rather than a plan.
+    pub decline: Option<PackedDecline>,
+    /// The verdict the producer recorded, and the step it names.
+    pub verdict: (u8, u16),
+}
+
+fn encode_predicate(predicate: &PreconditionMask) -> [u8; PREDICATE_LEN] {
+    let mut row = [0u8; PREDICATE_LEN];
+    row[0] = predicate.read_mask();
+    for slot in 0..PLAN_SLOTS_MAX {
+        row[2 + slot] = predicate.op(slot).code();
+        let bound = predicate.bound(slot).to_le_bytes();
+        row[10 + slot * 2] = bound[0];
+        row[11 + slot * 2] = bound[1];
+    }
+    row
+}
+
+struct Cursor<'a> {
+    buf: &'a mut [u8],
+    at: usize,
+}
+
+impl Cursor<'_> {
+    fn push(&mut self, byte: u8) -> Option<()> {
+        *self.buf.get_mut(self.at)? = byte;
+        self.at += 1;
+        Some(())
+    }
+
+    fn extend(&mut self, bytes: &[u8]) -> Option<()> {
+        let end = self.at.checked_add(bytes.len())?;
+        self.buf.get_mut(self.at..end)?.copy_from_slice(bytes);
+        self.at = end;
+        Some(())
+    }
+
+    fn u16(&mut self, value: u16) -> Option<()> {
+        self.extend(&value.to_le_bytes())
+    }
+
+    fn u32(&mut self, value: u32) -> Option<()> {
+        self.extend(&value.to_le_bytes())
+    }
+
+    fn slots(&mut self, values: &[i16]) -> Option<()> {
+        for slot in 0..PLAN_SLOTS_MAX {
+            let value = values.get(slot).copied().unwrap_or(0);
+            self.extend(&value.to_le_bytes())?;
+        }
+        Some(())
+    }
+}
+
+/// The exact encoded length of `draft`, or `None` when a bound is exceeded.
+pub fn witness_len(draft: &WitnessDraft<'_>) -> Option<usize> {
+    let steps = draft.steps.len();
+    let per_step = usize::from(draft.considered_per_step);
+    if steps > PLAN_HORIZON_MAX
+        || draft.constraints.len() > PLAN_CONSTRAINTS_MAX
+        || per_step > PLAN_ACTIONS_MAX
+        || draft.considered.len() != steps.checked_mul(per_step)?
+    {
+        return None;
+    }
+    Some(
+        PWIT_HEADER_LEN
+            + PLAN_SLOTS_MAX * 2
+            + PREDICATE_LEN
+            + draft.constraints.len() * PREDICATE_LEN
+            + steps * PWIT_STEP_LEN
+            + steps * per_step * PWIT_CONSIDERED_LEN,
+    )
+}
+
+/// Encode `draft` into `out`, returning the bytes written.
+///
+/// `None` when a bound is exceeded — including the frozen witness-byte
+/// envelope, which a producer must turn into `Decline(capacity)` rather than a
+/// truncated record — or when `out` is too small. Allocates nothing, so the
+/// deployed planner can emit a witness into caller-owned bytes.
+pub fn encode_witness_into(draft: &WitnessDraft<'_>, out: &mut [u8]) -> Option<usize> {
+    if draft.slot_count == 0 || usize::from(draft.slot_count) > PLAN_SLOTS_MAX {
+        return None;
+    }
+    let needed = witness_len(draft)?;
+    if needed > PLAN_WITNESS_MAX_BYTES || needed > out.len() {
+        return None;
+    }
+
+    // Constraints are canonical in the section, and sorting them needs no
+    // allocation: the frozen capacity bounds the buffer.
+    let mut rows = [[0u8; PREDICATE_LEN]; PLAN_CONSTRAINTS_MAX];
+    for (slot, predicate) in draft.constraints.iter().enumerate() {
+        rows[slot] = encode_predicate(predicate);
+    }
+    let used = draft.constraints.len();
+    rows[..used].sort_unstable();
+    if rows[..used].windows(2).any(|w| w[0] == w[1]) {
+        return None;
+    }
+
+    let mut cursor = Cursor { buf: out, at: 0 };
+    cursor.extend(&PWIT_MAGIC)?;
+    cursor.u16(PLAN_SECTION_VERSION)?;
+    cursor.push(draft.slot_count)?;
+    cursor.push(draft.steps.len() as u8)?;
+    cursor.push(draft.considered_per_step)?;
+    cursor.push(used as u8)?;
+    cursor.push(draft.decline.map_or(0, PackedDecline::code))?;
+    cursor.push(draft.verdict.0)?;
+    cursor.u16(draft.verdict.1)?;
+    cursor.u16(0)?;
+    cursor.slots(draft.initial.as_slice())?;
+    cursor.extend(&encode_predicate(&draft.goal))?;
+    for row in &rows[..used] {
+        cursor.extend(row)?;
+    }
+    for (effect, resulting, chosen, rule_row) in draft.steps {
+        cursor.slots(effect.as_slice())?;
+        cursor.slots(resulting.as_slice())?;
+        cursor.u16(*chosen)?;
+        cursor.u16(*rule_row)?;
+    }
+    for candidate in draft.considered {
+        if candidate.band > 3 {
+            return None;
+        }
+        cursor.u16(candidate.operator)?;
+        cursor.u16(candidate.rule_row)?;
+        cursor.extend(&candidate.score.to_le_bytes())?;
+        cursor.u16(candidate.tie_rank)?;
+        cursor.u32(candidate.support)?;
+        cursor.push(candidate.band)?;
+        cursor.push(candidate.flags)?;
+    }
+    debug_assert_eq!(cursor.at, needed);
+    Some(cursor.at)
+}
+
 #[cfg(feature = "alloc")]
 mod build {
     use super::*;
+    use alloc::vec;
     use alloc::vec::Vec;
 
     fn put_u16(out: &mut Vec<u8>, value: u16) {
@@ -1143,93 +1319,20 @@ mod build {
         Some(out)
     }
 
-    /// Everything one `PWIT` witness records.
-    pub struct WitnessDraft<'a> {
-        /// Typed slots per valuation.
-        pub slot_count: u8,
-        /// The initial packed state.
-        pub initial: SlotVec,
-        /// The goal predicate, carried inline so replay needs nothing else.
-        pub goal: PreconditionMask,
-        /// The forbidden-region predicates, carried inline.
-        pub constraints: &'a [PreconditionMask],
-        /// Per step: applied effect, resulting state, chosen candidate slot,
-        /// and the rule row it came from.
-        pub steps: &'a [WitnessStep],
-        /// Considered candidates, row-major over steps.
-        pub considered: &'a [ConsideredCandidate],
-        /// Candidates recorded per step.
-        pub considered_per_step: u8,
-        /// Set when the episode is an honest decline rather than a plan.
-        pub decline: Option<PackedDecline>,
-        /// The verdict the producer recorded, and the step it names.
-        pub verdict: (u8, u16),
-    }
-
-    /// Encode a `PWIT` witness. `None` when a bound is exceeded — including the
-    /// frozen witness-byte envelope, which a producer must turn into
-    /// `Decline(capacity)` rather than a truncated record.
+    /// Encode a `PWIT` witness into a fresh buffer. Delegates to the
+    /// `core`-only [`super::encode_witness_into`], so the offline and deployed
+    /// producers share exactly one encoder.
     pub fn build_witness(draft: &WitnessDraft<'_>) -> Option<Vec<u8>> {
-        if draft.slot_count == 0 || usize::from(draft.slot_count) > PLAN_SLOTS_MAX {
+        let needed = super::witness_len(draft)?;
+        if needed > PLAN_WITNESS_MAX_BYTES {
             return None;
         }
-        if draft.steps.len() > PLAN_HORIZON_MAX
-            || draft.constraints.len() > PLAN_CONSTRAINTS_MAX
-            || usize::from(draft.considered_per_step) > PLAN_ACTIONS_MAX
-        {
-            return None;
-        }
-        if draft.considered.len() != draft.steps.len() * usize::from(draft.considered_per_step) {
-            return None;
-        }
-        let mut constraint_rows: Vec<[u8; PREDICATE_LEN]> =
-            draft.constraints.iter().map(encode_predicate).collect();
-        constraint_rows.sort_unstable();
-        if constraint_rows.windows(2).any(|w| w[0] == w[1]) {
-            return None;
-        }
-
-        let mut out = Vec::new();
-        out.extend_from_slice(&PWIT_MAGIC);
-        put_u16(&mut out, PLAN_SECTION_VERSION);
-        out.push(draft.slot_count);
-        out.push(draft.steps.len() as u8);
-        out.push(draft.considered_per_step);
-        out.push(constraint_rows.len() as u8);
-        out.push(draft.decline.map_or(0, PackedDecline::code));
-        out.push(draft.verdict.0);
-        put_u16(&mut out, draft.verdict.1);
-        put_u16(&mut out, 0);
-        debug_assert_eq!(out.len(), PWIT_HEADER_LEN);
-        put_slots(&mut out, draft.initial.as_slice());
-        out.extend_from_slice(&encode_predicate(&draft.goal));
-        for row in &constraint_rows {
-            out.extend_from_slice(row);
-        }
-        for (effect, resulting, chosen, rule_row) in draft.steps {
-            put_slots(&mut out, effect.as_slice());
-            put_slots(&mut out, resulting.as_slice());
-            put_u16(&mut out, *chosen);
-            put_u16(&mut out, *rule_row);
-        }
-        for candidate in draft.considered {
-            if candidate.band > 3 {
-                return None;
-            }
-            put_u16(&mut out, candidate.operator);
-            put_u16(&mut out, candidate.rule_row);
-            out.extend_from_slice(&candidate.score.to_le_bytes());
-            put_u16(&mut out, candidate.tie_rank);
-            put_u32(&mut out, candidate.support);
-            out.push(candidate.band);
-            out.push(candidate.flags);
-        }
-        if out.len() > PLAN_WITNESS_MAX_BYTES {
-            return None;
-        }
+        let mut out = vec![0u8; needed];
+        let written = super::encode_witness_into(draft, &mut out)?;
+        out.truncate(written);
         Some(out)
     }
 }
 
 #[cfg(feature = "alloc")]
-pub use build::{build_predicate_set, build_rule_table, build_schema, build_witness, WitnessDraft};
+pub use build::{build_predicate_set, build_rule_table, build_schema, build_witness};

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -186,6 +186,44 @@ impl<'a> R4G1Runtime<'a> {
         self.chain.base_graph().node_count().unwrap_or(0)
     }
 
+    /// Run one bounded planning episode against this artifact's packed
+    /// planning sections (#843).
+    ///
+    /// `Ok(None)` when the artifact carries no `PSCH`, `PTRN` or `PGOL`
+    /// section — in which case serving is identical to the pre-#843 baseline,
+    /// which is what absent-section identity means. `Err` when a planning
+    /// section is present but is not a product of these bytes; the episode
+    /// fails closed rather than planning on a partially-read table.
+    ///
+    /// Deterministic and allocation-free: all state lives in the caller's
+    /// [`crate::plan::PlanScratch`].
+    pub fn plan_bounded(
+        &self,
+        request: &crate::plan::PlanRequest,
+        scratch: &mut crate::plan::PlanScratch,
+    ) -> Result<Option<crate::plan::PlanResult>, NotAProduct> {
+        let view = self.view();
+        let Some(schema) = view.plan_schema()? else {
+            return Ok(None);
+        };
+        let (Some(rules), Some(predicates)) = (view.plan_rule_table()?, view.plan_predicates()?)
+        else {
+            return Ok(None);
+        };
+        Ok(Some(crate::plan::plan(
+            &crate::plan::PlanQuery {
+                strategy: request.strategy,
+                schema: &schema,
+                rules: &rules,
+                predicates: &predicates,
+                initial: request.initial,
+                available: request.available,
+                budget: request.budget,
+            },
+            scratch,
+        )))
+    }
+
     pub fn edge_count(&self) -> u32 {
         self.chain.base_graph().edge_count().unwrap_or(0)
     }

--- a/crates/uor-r4-graph-runtime/src/lib.rs
+++ b/crates/uor-r4-graph-runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod engine;
 pub mod msa_selector;
 pub mod packed_kernels;
 pub mod patch_chain;
+pub mod plan;
 pub mod route_attention;
 pub mod routing;
 pub mod runtime_state;

--- a/crates/uor-r4-graph-runtime/src/plan.rs
+++ b/crates/uor-r4-graph-runtime/src/plan.rs
@@ -1,0 +1,796 @@
+//! Bounded semantic planner — normative deployed serving (#843 §6).
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §6 and §7.
+//! Executes only the P-4 permitted operation classes — XOR/AND/OR/NOT, shift
+//! and rotate, popcount, saturating and wrapping integer add-sub, integer
+//! comparison, and fixed-offset table reads. **There is no multiply, no divide
+//! and no float anywhere in this module**, including the scoring and the
+//! visited-set hash.
+//!
+//! Everything the planner touches lives in a caller-provided [`PlanScratch`]:
+//! the planner allocates nothing, in steady state or otherwise, and its scratch
+//! size is a compile-time function of the frozen capacities. Exceeding a
+//! capacity is a deterministic [`PackedDecline::Capacity`], never a silent
+//! truncation; slot and score arithmetic saturates rather than wrapping into a
+//! valid-looking value.
+//!
+//! Three bounded strategies share one search core, one visited index, one
+//! successor generator and one witness surface, so a comparison between them is
+//! a comparison of search order and nothing else.
+
+use uor_r4_graph_format::plan::{
+    EffectDelta, PLAN_ACTIONS_MAX, PLAN_FRONTIER_MAX, PLAN_HORIZON_MAX, PLAN_SLOTS_MAX,
+    PLAN_VISITED_MAX, PreconditionMask, SlotVec,
+};
+use uor_r4_graph_format::plan_sections::{
+    ConsideredCandidate, PackedDecline, PlanSchema, PredicateSet, RuleTable, WitnessStep,
+};
+
+/// Probe bound for the visited index. A membership test costs at most this many
+/// fixed-offset reads whatever the set holds, so lookup cost is never a
+/// function of how many states have been seen.
+pub const VISITED_MAX_PROBE: u8 = 16;
+
+/// Slots in the visited open-addressing index. A power of two, so the modulus
+/// is a mask rather than a division.
+const VISITED_INDEX_SLOTS: usize = PLAN_VISITED_MAX * 2;
+const VISITED_INDEX_MASK: u32 = (VISITED_INDEX_SLOTS - 1) as u32;
+const EMPTY: u16 = u16::MAX;
+
+/// Which bounded strategy an episode runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanStrategy {
+    /// Frontier-limited breadth-first search.
+    BreadthFirst,
+    /// Depth-limited depth-first search with an increasing bound.
+    IterativeDeepening,
+    /// Beam ordered by an integer score read from the rule table and the goal.
+    BestFirstBeam,
+}
+
+/// The declared budget one episode may spend. Every arm runs under the same
+/// budget, so a comparison between them is not a comparison of effort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlanBudget {
+    /// Maximum plan length.
+    pub horizon: u8,
+    /// Maximum retained frontier width.
+    pub frontier: u16,
+    /// Maximum state expansions.
+    pub max_expansions: u32,
+    /// Maximum candidate rule tests.
+    pub max_candidates: u32,
+    /// Maximum fixed-offset table reads.
+    pub max_table_reads: u32,
+}
+
+impl PlanBudget {
+    /// The frozen capacities as a budget: the largest episode this build runs.
+    pub const fn frozen() -> Self {
+        Self {
+            horizon: PLAN_HORIZON_MAX as u8,
+            frontier: PLAN_FRONTIER_MAX as u16,
+            max_expansions: PLAN_VISITED_MAX as u32,
+            max_candidates: (PLAN_VISITED_MAX * PLAN_ACTIONS_MAX) as u32,
+            max_table_reads: (PLAN_VISITED_MAX * PLAN_ACTIONS_MAX * 4) as u32,
+        }
+    }
+}
+
+/// What an episode actually spent. Recorded on every path, including every
+/// decline, so a budget-parity check has something to compare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PlanCounters {
+    /// States expanded.
+    pub expansions: u32,
+    /// Candidate rules tested.
+    pub candidates: u32,
+    /// Fixed-offset table reads.
+    pub table_reads: u32,
+    /// Integer operations on the hot path.
+    pub integer_ops: u32,
+    /// Deepest probe used by the visited index.
+    pub max_probe: u8,
+}
+
+/// The outcome of an episode: a plan of the recorded length, or a typed honest
+/// decline. There is no third possibility and no fabricated plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanOutcome {
+    /// A plan was found; its steps are readable from the scratch.
+    Plan {
+        /// Steps in the chosen path.
+        steps: usize,
+    },
+    /// The episode declined, for this stated reason.
+    Declined(PackedDecline),
+}
+
+/// One planning query: the packed sections, the initial state, which operators
+/// this instance offers, and the budget.
+pub struct PlanQuery<'a, 'b> {
+    /// Search order.
+    pub strategy: PlanStrategy,
+    /// The artifact's planning schema.
+    pub schema: &'a PlanSchema<'b>,
+    /// The artifact's transition rule table.
+    pub rules: &'a RuleTable<'b>,
+    /// The query's goal and forbidden predicates.
+    pub predicates: &'a PredicateSet<'b>,
+    /// Where the episode starts.
+    pub initial: SlotVec,
+    /// Bit `i` set when operator `i` is available to this instance. The
+    /// vocabulary is artifact-wide; which operators an instance offers is a
+    /// property of the query, so it is a mask rather than a second table.
+    pub available: u64,
+    /// The declared budget.
+    pub budget: PlanBudget,
+}
+
+/// The result of an episode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlanResult {
+    /// Plan or typed decline.
+    pub outcome: PlanOutcome,
+    /// What it spent.
+    pub counters: PlanCounters,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct VisitedNode {
+    state: SlotVec,
+    parent: u16,
+    rule_row: u16,
+    operator: u16,
+    depth: u8,
+}
+
+impl VisitedNode {
+    const fn empty() -> Self {
+        Self {
+            state: SlotVec::empty(),
+            parent: EMPTY,
+            rule_row: 0,
+            operator: 0,
+            depth: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Frame {
+    state: SlotVec,
+    node: u16,
+    depth: u8,
+}
+
+impl Frame {
+    const fn empty() -> Self {
+        Self {
+            state: SlotVec::empty(),
+            node: 0,
+            depth: 0,
+        }
+    }
+}
+
+/// Caller-owned scratch. Its size is a compile-time function of the frozen
+/// capacities; the planner never allocates.
+pub struct PlanScratch {
+    visited: [VisitedNode; PLAN_VISITED_MAX],
+    visited_len: u16,
+    index: [u16; VISITED_INDEX_SLOTS],
+    frontier: [Frame; PLAN_FRONTIER_MAX],
+    frontier_len: u16,
+    next: [Frame; PLAN_FRONTIER_MAX],
+    next_len: u16,
+    scores: [i32; PLAN_FRONTIER_MAX],
+    path: [WitnessStep; PLAN_HORIZON_MAX],
+    path_len: u8,
+    considered: [ConsideredCandidate; PLAN_HORIZON_MAX * PLAN_ACTIONS_MAX],
+    considered_len: u16,
+    considered_per_step: u8,
+}
+
+impl Default for PlanScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PlanScratch {
+    /// A zeroed scratch. Large by design — it is the bounded working set of a
+    /// whole episode — so a caller places it in a static, an arena, or a box
+    /// rather than on a small stack.
+    pub const fn new() -> Self {
+        Self {
+            visited: [VisitedNode::empty(); PLAN_VISITED_MAX],
+            visited_len: 0,
+            index: [EMPTY; VISITED_INDEX_SLOTS],
+            frontier: [Frame::empty(); PLAN_FRONTIER_MAX],
+            frontier_len: 0,
+            next: [Frame::empty(); PLAN_FRONTIER_MAX],
+            next_len: 0,
+            scores: [0; PLAN_FRONTIER_MAX],
+            path: [(EffectDelta::EMPTY, SlotVec::empty(), 0, 0); PLAN_HORIZON_MAX],
+            path_len: 0,
+            considered: [ConsideredCandidate::EMPTY; PLAN_HORIZON_MAX * PLAN_ACTIONS_MAX],
+            considered_len: 0,
+            considered_per_step: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.visited_len = 0;
+        self.frontier_len = 0;
+        self.next_len = 0;
+        self.path_len = 0;
+        self.considered_len = 0;
+        self.considered_per_step = 0;
+        for slot in self.index.iter_mut() {
+            *slot = EMPTY;
+        }
+    }
+
+    /// Steps in the chosen path.
+    pub fn path_len(&self) -> usize {
+        usize::from(self.path_len)
+    }
+
+    /// Step `index` of the chosen path, in witness form: the applied effect,
+    /// the resulting state, the *operator index* of the chosen candidate, and
+    /// the `PTRN` row its rule came from.
+    pub fn path_step(&self, index: usize) -> Option<WitnessStep> {
+        if index >= self.path_len() {
+            return None;
+        }
+        Some(self.path[index])
+    }
+
+    /// Candidates recorded per step of the chosen path.
+    pub fn considered_per_step(&self) -> usize {
+        usize::from(self.considered_per_step)
+    }
+
+    /// The recorded candidates, row-major over the chosen path's steps.
+    pub fn considered(&self) -> &[ConsideredCandidate] {
+        &self.considered[..usize::from(self.considered_len)]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P-4 helpers
+// ---------------------------------------------------------------------------
+
+/// Multiply-free add/rotate/xor mixer in the Jenkins one-at-a-time family, the
+/// same construction already normative for the packed skip-mix tables. Unseeded
+/// and unrandomized, so identical inputs hash identically on every platform —
+/// the determinism a keyed hash cannot give.
+fn hash_state(state: &SlotVec) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for value in state.as_slice() {
+        let bytes = value.to_le_bytes();
+        for byte in bytes {
+            hash = hash.wrapping_add(u32::from(byte));
+            hash = hash.wrapping_add(hash << 10);
+            hash ^= hash >> 6;
+        }
+    }
+    hash = hash.wrapping_add(hash << 3);
+    hash ^= hash >> 11;
+    hash.wrapping_add(hash << 15)
+}
+
+/// Saturating absolute distance from `state` to the slots a goal predicate
+/// pins by equality. Comparison and saturating subtraction only.
+fn goal_distance(goal: &PreconditionMask, state: &SlotVec) -> i32 {
+    let mut total: i32 = 0;
+    for slot in 0..PLAN_SLOTS_MAX {
+        if goal.read_mask() & (1u8 << slot) == 0 {
+            continue;
+        }
+        let Some(value) = state.get(slot) else {
+            continue;
+        };
+        let bound = goal.bound(slot);
+        let gap = if value >= bound {
+            value.saturating_sub(bound)
+        } else {
+            bound.saturating_sub(value)
+        };
+        total = total.saturating_add(i32::from(gap));
+    }
+    total
+}
+
+// ---------------------------------------------------------------------------
+// The planner
+// ---------------------------------------------------------------------------
+
+struct Episode<'q, 'a, 'b> {
+    query: &'q PlanQuery<'a, 'b>,
+    counters: PlanCounters,
+}
+
+/// The reason a step could not be taken. Kept separate from a decline so a
+/// blocked candidate does not end the episode.
+enum Step {
+    Taken(u16),
+    Blocked,
+    Capacity,
+    Unknown,
+}
+
+impl Episode<'_, '_, '_> {
+    fn read(&mut self, count: u32) {
+        self.counters.table_reads = self.counters.table_reads.saturating_add(count);
+    }
+
+    fn op(&mut self, count: u32) {
+        self.counters.integer_ops = self.counters.integer_ops.saturating_add(count);
+    }
+
+    fn over_budget(&self) -> bool {
+        self.counters.expansions > self.query.budget.max_expansions
+            || self.counters.candidates > self.query.budget.max_candidates
+            || self.counters.table_reads > self.query.budget.max_table_reads
+    }
+
+    /// Record `state` in the visited set. `Some(index)` when it is new,
+    /// `None` when already present; the probe bound is checked.
+    fn admit(&mut self, scratch: &mut PlanScratch, state: &SlotVec) -> Option<Option<u16>> {
+        let mut slot = (hash_state(state) & VISITED_INDEX_MASK) as usize;
+        for probe in 0..=VISITED_MAX_PROBE {
+            if probe == VISITED_MAX_PROBE {
+                // A checked bound, not a best effort: the episode declines
+                // rather than degrading into an unbounded scan.
+                return None;
+            }
+            self.counters.max_probe = self.counters.max_probe.max(probe.saturating_add(1));
+            self.read(1);
+            let occupant = scratch.index[slot];
+            if occupant == EMPTY {
+                if usize::from(scratch.visited_len) >= PLAN_VISITED_MAX {
+                    return None;
+                }
+                let node = scratch.visited_len;
+                scratch.index[slot] = node;
+                scratch.visited_len = scratch.visited_len.saturating_add(1);
+                return Some(Some(node));
+            }
+            self.read(1);
+            if scratch.visited[usize::from(occupant)].state == *state {
+                return Some(None);
+            }
+            slot = (slot + 1) & (VISITED_INDEX_SLOTS - 1);
+        }
+        None
+    }
+
+    /// Apply one candidate rule from `state`, admitting the successor.
+    fn take(
+        &mut self,
+        scratch: &mut PlanScratch,
+        state: &SlotVec,
+        parent: u16,
+        depth: u8,
+        operator: u16,
+        rule_row: usize,
+    ) -> Step {
+        self.counters.candidates = self.counters.candidates.saturating_add(1);
+        self.read(1);
+        let Some(rule) = self.query.rules.rule(rule_row) else {
+            return Step::Unknown;
+        };
+        self.op(1);
+        if !rule.precondition.holds(state) {
+            return Step::Blocked;
+        }
+        let Some(successor) = state.apply(&rule.effect) else {
+            // An arity mismatch is an unknown typed situation, resolved by
+            // decline rather than by a default.
+            return Step::Unknown;
+        };
+        self.op(successor.len() as u32);
+        self.read(1);
+        if self.query.predicates.is_forbidden(&successor) {
+            return Step::Blocked;
+        }
+        match self.admit(scratch, &successor) {
+            None => Step::Capacity,
+            Some(None) => Step::Blocked,
+            Some(Some(node)) => {
+                scratch.visited[usize::from(node)] = VisitedNode {
+                    state: successor,
+                    parent,
+                    rule_row: rule_row as u16,
+                    operator,
+                    depth: depth.saturating_add(1),
+                };
+                Step::Taken(node)
+            }
+        }
+    }
+
+    /// Walk the parent chain from `node` into the scratch's path buffer.
+    fn unwind(&mut self, scratch: &mut PlanScratch, node: u16) -> bool {
+        let mut depth = usize::from(scratch.visited[usize::from(node)].depth);
+        if depth > PLAN_HORIZON_MAX {
+            return false;
+        }
+        scratch.path_len = depth as u8;
+        let mut cursor = node;
+        while depth > 0 {
+            let current = scratch.visited[usize::from(cursor)];
+            let parent = current.parent;
+            if parent == EMPTY {
+                return false;
+            }
+            let from = scratch.visited[usize::from(parent)].state;
+            let Some(rule) = self.query.rules.rule(usize::from(current.rule_row)) else {
+                return false;
+            };
+            self.read(1);
+            // The recorded effect must really carry the predecessor to the
+            // recorded successor; the witness is verified from this, so it is
+            // checked here rather than asserted.
+            match from.apply(&rule.effect) {
+                Some(next) if next == current.state => {}
+                _ => return false,
+            }
+            depth -= 1;
+            scratch.path[depth] = (
+                rule.effect,
+                current.state,
+                current.operator,
+                current.rule_row,
+            );
+            cursor = parent;
+        }
+        true
+    }
+
+    /// Record what was considered at each step of the chosen path. Purely
+    /// informational: replay never reads it, so it is gathered in a bounded
+    /// post-pass rather than carried through the search.
+    fn record_considered(&mut self, scratch: &mut PlanScratch) {
+        let operators = self.query.schema.operator_count().min(PLAN_ACTIONS_MAX);
+        let available: usize = (0..operators)
+            .filter(|i| self.query.available & (1u64 << i) != 0)
+            .count();
+        scratch.considered_per_step = available.min(PLAN_ACTIONS_MAX) as u8;
+        scratch.considered_len = 0;
+        let mut state = self.query.initial;
+        for step in 0..scratch.path_len() {
+            let (effect, resulting, chosen_operator, _) = scratch.path[step];
+            let mut rank: u16 = 0;
+            for operator in 0..operators {
+                if self.query.available & (1u64 << operator) == 0 {
+                    continue;
+                }
+                let Some((first, end)) = self.query.rules.rules_for(operator) else {
+                    continue;
+                };
+                // The canonical first rule of each available operator stands
+                // for it, so the record is one row per operator per step and
+                // its width is the declared `considered_per_step`.
+                let row = first;
+                if row >= end {
+                    continue;
+                }
+                self.read(1);
+                let Some(rule) = self.query.rules.rule(row) else {
+                    continue;
+                };
+                let score = (i32::from(rule.band) << 10)
+                    .saturating_sub(goal_distance_for(self.query.predicates, &resulting));
+                let flags = u8::from(operator as u16 == chosen_operator);
+                let at = usize::from(scratch.considered_len);
+                if at < scratch.considered.len() {
+                    scratch.considered[at] = ConsideredCandidate {
+                        operator: operator as u16,
+                        rule_row: row as u16,
+                        score,
+                        tie_rank: rank,
+                        support: rule.support,
+                        band: rule.band,
+                        flags,
+                    };
+                    scratch.considered_len = scratch.considered_len.saturating_add(1);
+                }
+                rank = rank.saturating_add(1);
+            }
+            let _ = effect;
+            state = resulting;
+        }
+        let _ = state;
+    }
+}
+
+/// Distance to the first goal predicate, or zero when the query pins none.
+fn goal_distance_for(predicates: &PredicateSet<'_>, state: &SlotVec) -> i32 {
+    match predicates.goal(0) {
+        Some(goal) => goal_distance(&goal, state),
+        None => 0,
+    }
+}
+
+/// Run one bounded planning episode.
+///
+/// Total and deterministic: every path, including every capacity and conflict
+/// boundary, ends in a plan or a typed decline, and the counters are recorded
+/// either way. Ties break by the canonical order — operator index ascending,
+/// then rule row ascending — with no clock, RNG, or hash-iteration order
+/// anywhere.
+pub fn plan(query: &PlanQuery<'_, '_>, scratch: &mut PlanScratch) -> PlanResult {
+    scratch.reset();
+    let mut episode = Episode {
+        query,
+        counters: PlanCounters::default(),
+    };
+
+    // A query whose initial state already satisfies the goal is a zero-step
+    // plan, not a search.
+    if query.predicates.satisfies_goal(&query.initial) {
+        scratch.path_len = 0;
+        return PlanResult {
+            outcome: PlanOutcome::Plan { steps: 0 },
+            counters: episode.counters,
+        };
+    }
+    if query.predicates.is_forbidden(&query.initial) {
+        return decline(PackedDecline::NoPlan, episode.counters);
+    }
+    if usize::from(query.budget.horizon) > PLAN_HORIZON_MAX
+        || usize::from(query.budget.frontier) > PLAN_FRONTIER_MAX
+    {
+        return decline(PackedDecline::Capacity, episode.counters);
+    }
+
+    let Some(Some(root)) = episode.admit(scratch, &query.initial) else {
+        return decline(PackedDecline::Capacity, episode.counters);
+    };
+    scratch.visited[usize::from(root)] = VisitedNode {
+        state: query.initial,
+        parent: EMPTY,
+        rule_row: 0,
+        operator: 0,
+        depth: 0,
+    };
+
+    let found = match query.strategy {
+        PlanStrategy::BreadthFirst => search_layered(&mut episode, scratch, root, false),
+        PlanStrategy::BestFirstBeam => search_layered(&mut episode, scratch, root, true),
+        PlanStrategy::IterativeDeepening => search_deepening(&mut episode, scratch, root),
+    };
+
+    match found {
+        Ok(Some(node)) => {
+            if !episode.unwind(scratch, node) {
+                return decline(PackedDecline::Unknown, episode.counters);
+            }
+            episode.record_considered(scratch);
+            let steps = scratch.path_len();
+            PlanResult {
+                outcome: PlanOutcome::Plan { steps },
+                counters: episode.counters,
+            }
+        }
+        Ok(None) => decline(PackedDecline::NoPlan, episode.counters),
+        Err(reason) => decline(reason, episode.counters),
+    }
+}
+
+fn decline(reason: PackedDecline, counters: PlanCounters) -> PlanResult {
+    PlanResult {
+        outcome: PlanOutcome::Declined(reason),
+        counters,
+    }
+}
+
+/// Layered search. With `ordered` clear this is a frontier-limited
+/// breadth-first sweep; with it set the retained frontier is the highest-scoring
+/// prefix, which is the table-guided beam. They differ only in which candidates
+/// survive the frontier bound — and the bound *binds* on this task shape, so
+/// that difference is the whole comparison.
+fn search_layered(
+    episode: &mut Episode<'_, '_, '_>,
+    scratch: &mut PlanScratch,
+    root: u16,
+    ordered: bool,
+) -> Result<Option<u16>, PackedDecline> {
+    scratch.frontier[0] = Frame {
+        state: scratch.visited[usize::from(root)].state,
+        node: root,
+        depth: 0,
+    };
+    scratch.frontier_len = 1;
+
+    for _ in 0..episode.query.budget.horizon {
+        scratch.next_len = 0;
+        let width = usize::from(scratch.frontier_len);
+        for slot in 0..width {
+            if episode.over_budget() {
+                return Err(PackedDecline::Capacity);
+            }
+            let frame = scratch.frontier[slot];
+            episode.counters.expansions = episode.counters.expansions.saturating_add(1);
+            let operators = episode.query.schema.operator_count().min(PLAN_ACTIONS_MAX);
+            for operator in 0..operators {
+                if episode.query.available & (1u64 << operator) == 0 {
+                    continue;
+                }
+                let Some((first, end)) = episode.query.rules.rules_for(operator) else {
+                    continue;
+                };
+                for row in first..end {
+                    match episode.take(
+                        scratch,
+                        &frame.state,
+                        frame.node,
+                        frame.depth,
+                        operator as u16,
+                        row,
+                    ) {
+                        Step::Taken(node) => {
+                            let successor = scratch.visited[usize::from(node)].state;
+                            if episode.query.predicates.satisfies_goal(&successor) {
+                                return Ok(Some(node));
+                            }
+                            let at = usize::from(scratch.next_len);
+                            if at >= usize::from(episode.query.budget.frontier) {
+                                // The frontier bound binds. Which candidate is
+                                // dropped is the strategy's decision, and it is
+                                // recorded as such rather than as an error.
+                                if ordered {
+                                    replace_weakest(episode, scratch, node, successor, frame.depth);
+                                }
+                                continue;
+                            }
+                            scratch.next[at] = Frame {
+                                state: successor,
+                                node,
+                                depth: frame.depth.saturating_add(1),
+                            };
+                            scratch.scores[at] =
+                                -goal_distance_for(episode.query.predicates, &successor);
+                            scratch.next_len = scratch.next_len.saturating_add(1);
+                        }
+                        Step::Blocked => {}
+                        Step::Capacity => return Err(PackedDecline::Capacity),
+                        Step::Unknown => return Err(PackedDecline::Unknown),
+                    }
+                }
+            }
+        }
+        if scratch.next_len == 0 {
+            return Ok(None);
+        }
+        scratch.frontier_len = scratch.next_len;
+        for slot in 0..usize::from(scratch.next_len) {
+            scratch.frontier[slot] = scratch.next[slot];
+        }
+    }
+    Ok(None)
+}
+
+/// Swap `node` in for the retained candidate furthest from the goal, when it is
+/// closer. Ties keep the incumbent, so the retained set is a deterministic
+/// function of the arrival order the canonical expansion already fixes.
+fn replace_weakest(
+    episode: &mut Episode<'_, '_, '_>,
+    scratch: &mut PlanScratch,
+    node: u16,
+    successor: SlotVec,
+    depth: u8,
+) {
+    let score = -goal_distance_for(episode.query.predicates, &successor);
+    let mut weakest = 0usize;
+    for slot in 1..usize::from(scratch.next_len) {
+        if scratch.scores[slot] < scratch.scores[weakest] {
+            weakest = slot;
+        }
+    }
+    if usize::from(scratch.next_len) == 0 || score <= scratch.scores[weakest] {
+        return;
+    }
+    scratch.scores[weakest] = score;
+    scratch.next[weakest] = Frame {
+        state: successor,
+        node,
+        depth: depth.saturating_add(1),
+    };
+}
+
+/// Depth-limited depth-first search with an increasing bound. Frontier memory
+/// is bounded by depth rather than by width, which is the point of the arm: it
+/// pays repeated expansions to avoid the frontier bound that binds above.
+fn search_deepening(
+    episode: &mut Episode<'_, '_, '_>,
+    scratch: &mut PlanScratch,
+    root: u16,
+) -> Result<Option<u16>, PackedDecline> {
+    let root_state = scratch.visited[usize::from(root)].state;
+    for limit in 1..=episode.query.budget.horizon {
+        // Each round starts from a clean visited set, so a state pruned at a
+        // shallower depth is reachable again at a deeper one.
+        let saved = root_state;
+        scratch.visited_len = 0;
+        for entry in scratch.index.iter_mut() {
+            *entry = EMPTY;
+        }
+        let Some(Some(fresh_root)) = episode.admit(scratch, &saved) else {
+            return Err(PackedDecline::Capacity);
+        };
+        scratch.visited[usize::from(fresh_root)] = VisitedNode {
+            state: saved,
+            parent: EMPTY,
+            rule_row: 0,
+            operator: 0,
+            depth: 0,
+        };
+        if let Some(node) = descend(episode, scratch, fresh_root, limit)? {
+            return Ok(Some(node));
+        }
+    }
+    Ok(None)
+}
+
+fn descend(
+    episode: &mut Episode<'_, '_, '_>,
+    scratch: &mut PlanScratch,
+    node: u16,
+    remaining: u8,
+) -> Result<Option<u16>, PackedDecline> {
+    if remaining == 0 {
+        return Ok(None);
+    }
+    if episode.over_budget() {
+        return Err(PackedDecline::Capacity);
+    }
+    let state = scratch.visited[usize::from(node)].state;
+    let depth = scratch.visited[usize::from(node)].depth;
+    episode.counters.expansions = episode.counters.expansions.saturating_add(1);
+    let operators = episode.query.schema.operator_count().min(PLAN_ACTIONS_MAX);
+    for operator in 0..operators {
+        if episode.query.available & (1u64 << operator) == 0 {
+            continue;
+        }
+        let Some((first, end)) = episode.query.rules.rules_for(operator) else {
+            continue;
+        };
+        for row in first..end {
+            match episode.take(scratch, &state, node, depth, operator as u16, row) {
+                Step::Taken(child) => {
+                    let successor = scratch.visited[usize::from(child)].state;
+                    if episode.query.predicates.satisfies_goal(&successor) {
+                        return Ok(Some(child));
+                    }
+                    if let Some(found) =
+                        descend(episode, scratch, child, remaining.saturating_sub(1))?
+                    {
+                        return Ok(Some(found));
+                    }
+                }
+                Step::Blocked => {}
+                Step::Capacity => return Err(PackedDecline::Capacity),
+                Step::Unknown => return Err(PackedDecline::Unknown),
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// A planning request in the form the engine takes: everything a query needs
+/// except the packed sections, which the engine resolves from its own artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlanRequest {
+    /// Search order.
+    pub strategy: PlanStrategy,
+    /// Where the episode starts.
+    pub initial: SlotVec,
+    /// Bit `i` set when operator `i` is available to this instance.
+    pub available: u64,
+    /// The declared budget.
+    pub budget: PlanBudget,
+}

--- a/crates/uor-r4-graph-runtime/src/plan.rs
+++ b/crates/uor-r4-graph-runtime/src/plan.rs
@@ -312,6 +312,22 @@ struct Episode<'q, 'a, 'b> {
     counters: PlanCounters,
 }
 
+/// The outcome of a bounded search: a goal node, an exhausted space, or a typed
+/// decline.
+///
+/// Modelled as data rather than as a `Result`, for two reasons that point the
+/// same way. A decline is an outcome the planner *reports*, not an error it
+/// suffers, so it should be as inspectable as a plan and impossible to discard
+/// with a `?`. And the repository sanctions only a fixed set of error types on
+/// a shipped boundary (R5): a bound is a property of the caller's chosen
+/// instantiation, so a `Result` over anything else would be claiming a
+/// limitation the model does not sanction.
+enum Search {
+    Found(u16),
+    Exhausted,
+    Declined(PackedDecline),
+}
+
 /// The reason a step could not be taken. Kept separate from a decline so a
 /// blocked candidate does not end the episode.
 enum Step {
@@ -565,7 +581,7 @@ pub fn plan(query: &PlanQuery<'_, '_>, scratch: &mut PlanScratch) -> PlanResult 
     };
 
     match found {
-        Ok(Some(node)) => {
+        Search::Found(node) => {
             if !episode.unwind(scratch, node) {
                 return decline(PackedDecline::Unknown, episode.counters);
             }
@@ -576,8 +592,8 @@ pub fn plan(query: &PlanQuery<'_, '_>, scratch: &mut PlanScratch) -> PlanResult 
                 counters: episode.counters,
             }
         }
-        Ok(None) => decline(PackedDecline::NoPlan, episode.counters),
-        Err(reason) => decline(reason, episode.counters),
+        Search::Exhausted => decline(PackedDecline::NoPlan, episode.counters),
+        Search::Declined(reason) => decline(reason, episode.counters),
     }
 }
 
@@ -598,7 +614,7 @@ fn search_layered(
     scratch: &mut PlanScratch,
     root: u16,
     ordered: bool,
-) -> Result<Option<u16>, PackedDecline> {
+) -> Search {
     scratch.frontier[0] = Frame {
         state: scratch.visited[usize::from(root)].state,
         node: root,
@@ -611,7 +627,7 @@ fn search_layered(
         let width = usize::from(scratch.frontier_len);
         for slot in 0..width {
             if episode.over_budget() {
-                return Err(PackedDecline::Capacity);
+                return Search::Declined(PackedDecline::Capacity);
             }
             let frame = scratch.frontier[slot];
             episode.counters.expansions = episode.counters.expansions.saturating_add(1);
@@ -635,7 +651,7 @@ fn search_layered(
                         Step::Taken(node) => {
                             let successor = scratch.visited[usize::from(node)].state;
                             if episode.query.predicates.satisfies_goal(&successor) {
-                                return Ok(Some(node));
+                                return Search::Found(node);
                             }
                             let at = usize::from(scratch.next_len);
                             if at >= usize::from(episode.query.budget.frontier) {
@@ -657,21 +673,21 @@ fn search_layered(
                             scratch.next_len = scratch.next_len.saturating_add(1);
                         }
                         Step::Blocked => {}
-                        Step::Capacity => return Err(PackedDecline::Capacity),
-                        Step::Unknown => return Err(PackedDecline::Unknown),
+                        Step::Capacity => return Search::Declined(PackedDecline::Capacity),
+                        Step::Unknown => return Search::Declined(PackedDecline::Unknown),
                     }
                 }
             }
         }
         if scratch.next_len == 0 {
-            return Ok(None);
+            return Search::Exhausted;
         }
         scratch.frontier_len = scratch.next_len;
         for slot in 0..usize::from(scratch.next_len) {
             scratch.frontier[slot] = scratch.next[slot];
         }
     }
-    Ok(None)
+    Search::Exhausted
 }
 
 /// Swap `node` in for the retained candidate furthest from the goal, when it is
@@ -709,7 +725,7 @@ fn search_deepening(
     episode: &mut Episode<'_, '_, '_>,
     scratch: &mut PlanScratch,
     root: u16,
-) -> Result<Option<u16>, PackedDecline> {
+) -> Search {
     let root_state = scratch.visited[usize::from(root)].state;
     for limit in 1..=episode.query.budget.horizon {
         // Each round starts from a clean visited set, so a state pruned at a
@@ -720,7 +736,7 @@ fn search_deepening(
             *entry = EMPTY;
         }
         let Some(Some(fresh_root)) = episode.admit(scratch, &saved) else {
-            return Err(PackedDecline::Capacity);
+            return Search::Declined(PackedDecline::Capacity);
         };
         scratch.visited[usize::from(fresh_root)] = VisitedNode {
             state: saved,
@@ -729,11 +745,13 @@ fn search_deepening(
             operator: 0,
             depth: 0,
         };
-        if let Some(node) = descend(episode, scratch, fresh_root, limit)? {
-            return Ok(Some(node));
+        match descend(episode, scratch, fresh_root, limit) {
+            Search::Found(node) => return Search::Found(node),
+            Search::Declined(reason) => return Search::Declined(reason),
+            Search::Exhausted => {}
         }
     }
-    Ok(None)
+    Search::Exhausted
 }
 
 fn descend(
@@ -741,12 +759,12 @@ fn descend(
     scratch: &mut PlanScratch,
     node: u16,
     remaining: u8,
-) -> Result<Option<u16>, PackedDecline> {
+) -> Search {
     if remaining == 0 {
-        return Ok(None);
+        return Search::Exhausted;
     }
     if episode.over_budget() {
-        return Err(PackedDecline::Capacity);
+        return Search::Declined(PackedDecline::Capacity);
     }
     let state = scratch.visited[usize::from(node)].state;
     let depth = scratch.visited[usize::from(node)].depth;
@@ -764,21 +782,21 @@ fn descend(
                 Step::Taken(child) => {
                     let successor = scratch.visited[usize::from(child)].state;
                     if episode.query.predicates.satisfies_goal(&successor) {
-                        return Ok(Some(child));
+                        return Search::Found(child);
                     }
-                    if let Some(found) =
-                        descend(episode, scratch, child, remaining.saturating_sub(1))?
-                    {
-                        return Ok(Some(found));
+                    match descend(episode, scratch, child, remaining.saturating_sub(1)) {
+                        Search::Found(found) => return Search::Found(found),
+                        Search::Declined(reason) => return Search::Declined(reason),
+                        Search::Exhausted => {}
                     }
                 }
                 Step::Blocked => {}
-                Step::Capacity => return Err(PackedDecline::Capacity),
-                Step::Unknown => return Err(PackedDecline::Unknown),
+                Step::Capacity => return Search::Declined(PackedDecline::Capacity),
+                Step::Unknown => return Search::Declined(PackedDecline::Unknown),
             }
         }
     }
-    Ok(None)
+    Search::Exhausted
 }
 
 /// A planning request in the form the engine takes: everything a query needs

--- a/crates/uor-r4-graph-runtime/tests/plan_843.rs
+++ b/crates/uor-r4-graph-runtime/tests/plan_843.rs
@@ -1,0 +1,410 @@
+//! The deployed bounded planner — the machine-checked record for #843
+//! increment 5.
+//!
+//! Frozen contract: `docs/bounded_semantic_transitions_spec_843.md` §6 and §7.
+//! Normative deployed-serving scope: the planner runs on packed sections with
+//! caller-owned scratch, executes only P-4 operations, and allocates nothing.
+//! Nothing here claims a planning *capability* — that is increment 6's
+//! measurement. What is asserted here is that the machinery is total,
+//! deterministic, bounded, and honest at its boundaries.
+
+use uor_r4_graph_format::plan::{
+    CompareOp, EffectDelta, PLAN_FRONTIER_MAX, PLAN_HORIZON_MAX, PLAN_WITNESS_MAX_BYTES,
+    PreconditionMask, SlotVec,
+};
+use uor_r4_graph_format::plan_sections::{
+    PackedDecline, PackedRule, PlanSchema, PlanWitnessBytes, PredicateSet, ReplayVerdict,
+    RuleTable, WitnessDraft, WitnessStep, build_predicate_set, build_rule_table, build_schema,
+    encode_witness_into,
+};
+use uor_r4_graph_runtime::plan::{
+    PlanBudget, PlanOutcome, PlanQuery, PlanScratch, PlanStrategy, plan,
+};
+
+const ARITY: u8 = 2;
+const BANDS: (u32, u32, u32) = (1, 4, 16);
+
+fn effect(x: i16, y: i16) -> EffectDelta {
+    EffectDelta::from_slice(&[x, y]).unwrap()
+}
+
+fn slots(x: i16, y: i16) -> SlotVec {
+    SlotVec::from_slice(&[x, y]).unwrap()
+}
+
+fn cell_predicate(x: i16, y: i16) -> PreconditionMask {
+    PreconditionMask::unconditional()
+        .reading(0, CompareOp::Equal, x)
+        .unwrap()
+        .reading(1, CompareOp::Equal, y)
+        .unwrap()
+}
+
+/// A four-operator grid artifact: the packed sections a query reads.
+struct Fixture {
+    schema: Vec<u8>,
+    rules: Vec<u8>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let vocabulary = vec![effect(1, 0), effect(0, 1), effect(-1, 0), effect(0, -1)];
+        let schema = build_schema(ARITY, &vocabulary, BANDS).unwrap();
+        let parsed = PlanSchema::parse(&schema).unwrap();
+        let rules: Vec<PackedRule> = (0..parsed.operator_count())
+            .map(|index| PackedRule {
+                operator: index as u16,
+                precondition: PreconditionMask::unconditional(),
+                effect: parsed.operator(index).unwrap(),
+                support: 8,
+                band: 2,
+            })
+            .collect();
+        let rules = build_rule_table(ARITY, parsed.operator_count() as u16, &rules).unwrap();
+        Self { schema, rules }
+    }
+}
+
+fn budget() -> PlanBudget {
+    PlanBudget {
+        horizon: 8,
+        frontier: PLAN_FRONTIER_MAX as u16,
+        ..PlanBudget::frozen()
+    }
+}
+
+/// Run one episode against the standard fixture: reach `(3, 0)` from the
+/// origin without entering `(2, 0)`.
+fn run(
+    strategy: PlanStrategy,
+    goal: (i16, i16),
+    blocked: &[(i16, i16)],
+    available: u64,
+    budget: PlanBudget,
+    scratch: &mut PlanScratch,
+) -> (PlanOutcome, uor_r4_graph_runtime::plan::PlanCounters) {
+    let fixture = Fixture::new();
+    let schema = PlanSchema::parse(&fixture.schema).unwrap();
+    let rules = RuleTable::parse(&fixture.rules, &schema).unwrap();
+    let constraints: Vec<PreconditionMask> = blocked
+        .iter()
+        .map(|(x, y)| cell_predicate(*x, *y))
+        .collect();
+    let raw = build_predicate_set(ARITY, &[cell_predicate(goal.0, goal.1)], &constraints).unwrap();
+    let predicates = PredicateSet::parse(&raw, &schema).unwrap();
+    let result = plan(
+        &PlanQuery {
+            strategy,
+            schema: &schema,
+            rules: &rules,
+            predicates: &predicates,
+            initial: slots(0, 0),
+            available,
+            budget,
+        },
+        scratch,
+    );
+    (result.outcome, result.counters)
+}
+
+/// Encode the scratch's plan as a witness and replay it independently.
+fn replay_plan(scratch: &PlanScratch, goal: (i16, i16), blocked: &[(i16, i16)]) -> ReplayVerdict {
+    let steps: Vec<WitnessStep> = (0..scratch.path_len())
+        .map(|i| scratch.path_step(i).unwrap())
+        .collect();
+    let constraints: Vec<PreconditionMask> = blocked
+        .iter()
+        .map(|(x, y)| cell_predicate(*x, *y))
+        .collect();
+    let draft = WitnessDraft {
+        slot_count: ARITY,
+        initial: slots(0, 0),
+        goal: cell_predicate(goal.0, goal.1),
+        constraints: &constraints,
+        steps: &steps,
+        considered: scratch.considered(),
+        considered_per_step: scratch.considered_per_step() as u8,
+        decline: None,
+        verdict: (0, 0),
+    };
+    let mut buffer = [0u8; PLAN_WITNESS_MAX_BYTES];
+    let written = encode_witness_into(&draft, &mut buffer).expect("the witness fits the envelope");
+    PlanWitnessBytes::parse(&buffer[..written])
+        .expect("the emitted witness is a product of its own bytes")
+        .replay()
+}
+
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_bounded_episode_finds_a_plan_that_replays_valid() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, counters) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[(2, 0)],
+        0b1111,
+        budget(),
+        &mut scratch,
+    );
+    let PlanOutcome::Plan { steps } = outcome else {
+        panic!("expected a plan, got {outcome:?}");
+    };
+    assert_eq!(steps, scratch.path_len());
+    assert!(
+        steps >= 3,
+        "a detour around the block takes at least 3 steps"
+    );
+    assert!(steps <= usize::from(budget().horizon));
+    assert!(counters.expansions > 0 && counters.table_reads > 0);
+    assert_eq!(
+        replay_plan(&scratch, (3, 0), &[(2, 0)]),
+        ReplayVerdict::Valid
+    );
+}
+
+/// All three arms read the same sections, execute the same operation set, and
+/// run under the same budget, so a difference between them is a difference of
+/// search order and nothing else.
+#[test]
+fn every_strategy_finds_a_plan_that_replays_valid_under_the_same_budget() {
+    for strategy in [
+        PlanStrategy::BreadthFirst,
+        PlanStrategy::IterativeDeepening,
+        PlanStrategy::BestFirstBeam,
+    ] {
+        let mut scratch = PlanScratch::new();
+        let (outcome, counters) = run(strategy, (3, 0), &[(2, 0)], 0b1111, budget(), &mut scratch);
+        let PlanOutcome::Plan { steps } = outcome else {
+            panic!("{strategy:?} declined: {outcome:?}");
+        };
+        assert!(steps > 0, "{strategy:?} returned an empty plan");
+        assert_eq!(
+            replay_plan(&scratch, (3, 0), &[(2, 0)]),
+            ReplayVerdict::Valid,
+            "{strategy:?} emitted a witness that does not replay"
+        );
+        assert!(
+            counters.expansions <= budget().max_expansions
+                && counters.candidates <= budget().max_candidates
+                && counters.table_reads <= budget().max_table_reads,
+            "{strategy:?} overspent its declared budget: {counters:?}"
+        );
+        assert!(
+            counters.max_probe <= uor_r4_graph_runtime::plan::VISITED_MAX_PROBE,
+            "{strategy:?} exceeded the checked probe bound"
+        );
+    }
+}
+
+#[test]
+fn no_step_of_a_plan_enters_a_forbidden_region() {
+    let blocked = [(2, 0), (1, 1)];
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &blocked,
+        0b1111,
+        budget(),
+        &mut scratch,
+    );
+    assert!(matches!(outcome, PlanOutcome::Plan { .. }));
+    for index in 0..scratch.path_len() {
+        let (_, state, _, _) = scratch.path_step(index).unwrap();
+        for (x, y) in blocked {
+            assert_ne!(
+                state,
+                slots(x, y),
+                "step {index} entered the forbidden cell ({x}, {y})"
+            );
+        }
+    }
+    assert_eq!(
+        replay_plan(&scratch, (3, 0), &blocked),
+        ReplayVerdict::Valid
+    );
+}
+
+#[test]
+fn an_unreachable_goal_declines_no_plan_rather_than_fabricating_one() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, counters) = run(
+        PlanStrategy::BreadthFirst,
+        (100, 0),
+        &[],
+        0b1111,
+        PlanBudget {
+            horizon: 4,
+            ..budget()
+        },
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Declined(PackedDecline::NoPlan));
+    assert_eq!(scratch.path_len(), 0, "a decline emits no plan");
+    assert!(
+        counters.expansions > 0,
+        "the decline is measured, not assumed"
+    );
+}
+
+#[test]
+fn a_budget_beyond_the_frozen_capacity_declines_capacity() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[(2, 0)],
+        0b1111,
+        PlanBudget {
+            horizon: (PLAN_HORIZON_MAX + 1) as u8,
+            ..budget()
+        },
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Declined(PackedDecline::Capacity));
+
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[(2, 0)],
+        0b1111,
+        PlanBudget {
+            frontier: (PLAN_FRONTIER_MAX + 1) as u16,
+            ..budget()
+        },
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Declined(PackedDecline::Capacity));
+}
+
+/// An exhausted expansion budget is a capacity decline, not a truncated plan.
+#[test]
+fn an_exhausted_expansion_budget_declines_rather_than_truncating() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, counters) = run(
+        PlanStrategy::BreadthFirst,
+        (100, 0),
+        &[],
+        0b1111,
+        PlanBudget {
+            horizon: PLAN_HORIZON_MAX as u8,
+            max_expansions: 4,
+            ..budget()
+        },
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Declined(PackedDecline::Capacity));
+    assert_eq!(scratch.path_len(), 0);
+    assert!(counters.expansions >= 4);
+}
+
+#[test]
+fn planning_is_deterministic() {
+    let plan_once = || {
+        let mut scratch = PlanScratch::new();
+        let (outcome, counters) = run(
+            PlanStrategy::BestFirstBeam,
+            (3, 0),
+            &[(2, 0)],
+            0b1111,
+            budget(),
+            &mut scratch,
+        );
+        let path: Vec<WitnessStep> = (0..scratch.path_len())
+            .map(|i| scratch.path_step(i).unwrap())
+            .collect();
+        (outcome, counters, path)
+    };
+    let first = plan_once();
+    let second = plan_once();
+    assert_eq!(first.0, second.0);
+    assert_eq!(first.1, second.1, "the counters must be reproducible too");
+    assert_eq!(first.2, second.2);
+}
+
+/// The operator vocabulary is artifact-wide; which operators an instance offers
+/// is a property of the query. An operator the mask withholds is never used.
+#[test]
+fn an_unavailable_operator_is_never_used() {
+    let fixture = Fixture::new();
+    let schema = PlanSchema::parse(&fixture.schema).unwrap();
+    // Withhold the +x operator and the goal on the +x axis becomes unreachable.
+    let plus_x = (0..schema.operator_count())
+        .find(|i| schema.operator(*i).unwrap() == effect(1, 0))
+        .unwrap();
+    let mask = 0b1111u64 & !(1u64 << plus_x);
+
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[],
+        mask,
+        budget(),
+        &mut scratch,
+    );
+    assert_eq!(
+        outcome,
+        PlanOutcome::Declined(PackedDecline::NoPlan),
+        "withholding the only operator that can reach the goal must decline"
+    );
+
+    // With it available the same query succeeds, so the decline was the mask.
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[],
+        0b1111,
+        budget(),
+        &mut scratch,
+    );
+    assert!(matches!(outcome, PlanOutcome::Plan { .. }));
+}
+
+#[test]
+fn an_initial_state_on_the_goal_is_a_zero_step_plan() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (0, 0),
+        &[],
+        0b1111,
+        budget(),
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Plan { steps: 0 });
+    assert_eq!(scratch.path_len(), 0);
+}
+
+#[test]
+fn a_forbidden_initial_state_declines() {
+    let mut scratch = PlanScratch::new();
+    let (outcome, _) = run(
+        PlanStrategy::BreadthFirst,
+        (3, 0),
+        &[(0, 0)],
+        0b1111,
+        budget(),
+        &mut scratch,
+    );
+    assert_eq!(outcome, PlanOutcome::Declined(PackedDecline::NoPlan));
+}
+
+/// The scratch is a compile-time function of the frozen capacities. The number
+/// is asserted rather than described, so it cannot drift unnoticed.
+#[test]
+fn the_scratch_size_is_a_compile_time_function_of_the_frozen_capacities() {
+    let size = core::mem::size_of::<PlanScratch>();
+    assert!(
+        size <= 96 * 1024,
+        "the caller-owned scratch grew past its declared envelope: {size} bytes"
+    );
+    assert!(
+        size > 32 * 1024,
+        "the scratch should hold the frozen capacities"
+    );
+    println!("PlanScratch = {size} bytes");
+}

--- a/crates/uor-r4-graph-runtime/tests/plan_allocation_census_843.rs
+++ b/crates/uor-r4-graph-runtime/tests/plan_allocation_census_843.rs
@@ -1,0 +1,288 @@
+//! Allocation census and P-4 operation scan for the deployed bounded planner
+//! (#843 §6).
+//!
+//! A counting global allocator measures what a planning episode actually
+//! allocates. One `#[test]` for the census by design: the gate and counters are
+//! thread-local and libtest runs tests in parallel, so a second measured test
+//! could let one episode's bookkeeping land in another's census. The fixture is
+//! built with the gate closed; only the episode itself is measured.
+//!
+//! Run with:
+//! `cargo test -p uor-r4-graph-runtime --test plan_allocation_census_843 -- --nocapture`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+use uor_r4_graph_format::plan::{CompareOp, EffectDelta, PreconditionMask, SlotVec};
+use uor_r4_graph_format::plan_sections::{
+    PackedRule, PlanSchema, PredicateSet, RuleTable, WitnessDraft, WitnessStep,
+    build_predicate_set, build_rule_table, build_schema, encode_witness_into,
+};
+use uor_r4_graph_runtime::plan::{
+    PlanBudget, PlanOutcome, PlanQuery, PlanScratch, PlanStrategy, plan,
+};
+
+struct CountingAlloc;
+
+thread_local! {
+    static GATE: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+    static BYTES: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let _ = GATE.try_with(|gate| {
+                if gate.get() {
+                    let _ = ALLOCATIONS.try_with(|n| n.set(n.get() + 1));
+                    let _ = BYTES.try_with(|n| n.set(n.get() + layout.size()));
+                }
+            });
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc;
+
+/// Reset the counters, open the gate, run `body`, close the gate, and return
+/// `(allocations, bytes)`. Reporting happens with the gate closed.
+fn measure<T>(body: impl FnOnce() -> T) -> (usize, usize, T) {
+    ALLOCATIONS.with(|n| n.set(0));
+    BYTES.with(|n| n.set(0));
+    GATE.with(|g| g.set(true));
+    let value = body();
+    GATE.with(|g| g.set(false));
+    (
+        ALLOCATIONS.with(|n| n.get()),
+        BYTES.with(|n| n.get()),
+        value,
+    )
+}
+
+fn effect(x: i16, y: i16) -> EffectDelta {
+    EffectDelta::from_slice(&[x, y]).unwrap()
+}
+
+fn cell_predicate(x: i16, y: i16) -> PreconditionMask {
+    PreconditionMask::unconditional()
+        .reading(0, CompareOp::Equal, x)
+        .unwrap()
+        .reading(1, CompareOp::Equal, y)
+        .unwrap()
+}
+
+#[test]
+fn a_planning_episode_and_its_witness_are_allocation_free() {
+    // Fixture: built offline, with the gate closed.
+    let vocabulary = vec![effect(1, 0), effect(0, 1), effect(-1, 0), effect(0, -1)];
+    let schema_bytes = build_schema(2, &vocabulary, (1, 4, 16)).unwrap();
+    let schema = PlanSchema::parse(&schema_bytes).unwrap();
+    let rules: Vec<PackedRule> = (0..schema.operator_count())
+        .map(|index| PackedRule {
+            operator: index as u16,
+            precondition: PreconditionMask::unconditional(),
+            effect: schema.operator(index).unwrap(),
+            support: 8,
+            band: 2,
+        })
+        .collect();
+    let rule_bytes = build_rule_table(2, schema.operator_count() as u16, &rules).unwrap();
+    let rule_table = RuleTable::parse(&rule_bytes, &schema).unwrap();
+    let predicate_bytes =
+        build_predicate_set(2, &[cell_predicate(3, 0)], &[cell_predicate(2, 0)]).unwrap();
+    let predicates = PredicateSet::parse(&predicate_bytes, &schema).unwrap();
+    let mut scratch = Box::new(PlanScratch::new());
+    let mut witness = vec![0u8; 4096];
+    let constraints = [cell_predicate(2, 0)];
+    let goal = cell_predicate(3, 0);
+    let initial = SlotVec::from_slice(&[0, 0]).unwrap();
+    let query = PlanQuery {
+        strategy: PlanStrategy::BreadthFirst,
+        schema: &schema,
+        rules: &rule_table,
+        predicates: &predicates,
+        initial,
+        available: 0b1111,
+        budget: PlanBudget {
+            horizon: 8,
+            ..PlanBudget::frozen()
+        },
+    };
+    // Warm the paths once outside the census.
+    let _ = plan(&query, &mut scratch);
+
+    // Measured: one whole episode, on an already-allocated scratch.
+    let (episode_allocations, episode_bytes, outcome) =
+        measure(|| plan(&query, &mut scratch).outcome);
+    assert!(
+        matches!(outcome, PlanOutcome::Plan { .. }),
+        "the measured episode must actually plan, or the census is vacuous"
+    );
+
+    // Measured: emitting the witness into caller-owned bytes.
+    let mut steps: [WitnessStep; 16] = [(EffectDelta::EMPTY, SlotVec::empty(), 0, 0); 16];
+    let step_count = scratch.path_len();
+    for (index, slot) in steps.iter_mut().enumerate().take(step_count) {
+        *slot = scratch.path_step(index).unwrap();
+    }
+    let considered_per_step = scratch.considered_per_step() as u8;
+    let considered = scratch.considered();
+    let (witness_allocations, witness_bytes, written) = measure(|| {
+        encode_witness_into(
+            &WitnessDraft {
+                slot_count: 2,
+                initial,
+                goal,
+                constraints: &constraints,
+                steps: &steps[..step_count],
+                considered,
+                considered_per_step,
+                decline: None,
+                verdict: (0, 0),
+            },
+            &mut witness,
+        )
+    });
+
+    println!(
+        "planning episode: {episode_allocations} allocations, {episode_bytes} bytes\n\
+         witness emit:     {witness_allocations} allocations, {witness_bytes} bytes\n\
+         witness size:     {written:?} bytes"
+    );
+    assert!(written.is_some(), "the witness must encode");
+    assert_eq!(
+        episode_allocations, 0,
+        "a planning episode must be allocation-free in steady state"
+    );
+    assert_eq!(
+        witness_allocations, 0,
+        "emitting a witness into caller-owned bytes must not allocate"
+    );
+}
+
+/// A machine-checked source scan of the deployed planner: the P-4 permitted
+/// classes only. No multiply, no divide, no float — the guarantee §6 states,
+/// asserted against the source rather than described in a comment.
+#[test]
+fn the_deployed_planner_uses_only_p4_operations() {
+    let source = include_str!("../src/plan.rs");
+    let mut offenders = Vec::new();
+    let mut const_folded: Vec<String> = Vec::new();
+    for (number, line) in source.lines().enumerate() {
+        let code = match line.find("//") {
+            Some(at) => &line[..at],
+            None => line,
+        };
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        for forbidden in ["f32", "f64", " as f", "sqrt", "powi", "powf"] {
+            if trimmed.contains(forbidden) {
+                offenders.push(format!("{}: float `{forbidden}` — {trimmed}", number + 1));
+            }
+        }
+        // A bare `*` or `/` that is not a dereference, a reference, a
+        // generic bound, or a path separator.
+        let bytes = trimmed.as_bytes();
+        for (at, byte) in bytes.iter().enumerate() {
+            if *byte != b'*' && *byte != b'/' {
+                continue;
+            }
+            let previous = at.checked_sub(1).map(|i| bytes[i]);
+            let next = bytes.get(at + 1).copied();
+            // `*self`, `&mut *`, `*=`, `//` and `/*` are not arithmetic; an
+            // operator with whitespace on both sides is.
+            if previous != Some(b' ') || next != Some(b' ') {
+                continue;
+            }
+            let name = if *byte == b'*' { "multiply" } else { "divide" };
+            // A compile-time constant expression emits no instruction, so it is
+            // not a deployed-kernel operation. Exempt it only when BOTH
+            // operands are constants - a SCREAMING_SNAKE identifier or an
+            // integer literal - and record the exemption so it is visible
+            // rather than silent.
+            if is_constant(operand_left(trimmed, at)) && is_constant(operand_right(trimmed, at)) {
+                const_folded.push(format!("{}: {name} — {trimmed}", number + 1));
+                continue;
+            }
+            offenders.push(format!("{}: {name} — {trimmed}", number + 1));
+        }
+    }
+    println!(
+        "P-4 scan: {} compile-time constant expressions exempted (they emit no instruction):\n{}",
+        const_folded.len(),
+        const_folded.join("\n")
+    );
+    assert!(
+        offenders.is_empty(),
+        "the deployed planner must execute only P-4 operations:\n{}",
+        offenders.join("\n")
+    );
+    // The scan must be able to fire, or it is not evidence: a runtime multiply
+    // between two non-constant operands is detected.
+    assert!(
+        source.contains("saturating_add"),
+        "the scan is reading the planner source"
+    );
+    assert!(
+        !const_folded.is_empty(),
+        "the constant-expression exemption must be exercised, or it hides nothing"
+    );
+    let planted = "    let poisoned = width * depth;";
+    let mut caught = false;
+    for (at, byte) in planted.as_bytes().iter().enumerate() {
+        if *byte == b'*'
+            && !(is_constant(operand_left(planted.trim(), at - 4))
+                && is_constant(operand_right(planted.trim(), at - 4)))
+        {
+            caught = true;
+        }
+    }
+    assert!(caught, "a runtime multiply must still be caught");
+}
+
+/// The identifier or literal immediately left of `at`, ignoring whitespace.
+fn operand_left(line: &str, at: usize) -> &str {
+    let bytes = line.as_bytes();
+    let mut end = at;
+    while end > 0 && bytes[end - 1] == b' ' {
+        end -= 1;
+    }
+    let mut start = end;
+    while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+        start -= 1;
+    }
+    &line[start..end]
+}
+
+/// The identifier or literal immediately right of `at`, ignoring whitespace.
+fn operand_right(line: &str, at: usize) -> &str {
+    let bytes = line.as_bytes();
+    let mut start = at + 1;
+    while start < bytes.len() && bytes[start] == b' ' {
+        start += 1;
+    }
+    let mut end = start;
+    while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+        end += 1;
+    }
+    &line[start..end]
+}
+
+/// Whether an operand is a compile-time constant: a SCREAMING_SNAKE identifier
+/// or an integer literal.
+fn is_constant(operand: &str) -> bool {
+    !operand.is_empty()
+        && operand
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+}

--- a/docs/bounded_semantic_transitions_spec_843.md
+++ b/docs/bounded_semantic_transitions_spec_843.md
@@ -299,8 +299,18 @@ the measured basis of §4.1, with the two #844 values carried through unchanged:
 | `PLAN_WITNESS_MAX_BYTES` | 4096 | `PLAN_HORIZON_MAX` steps × per-step record, ≥ 4× headroom |
 
 **Definition (caller-owned scratch).** All of the above live in a caller-provided `PlanScratch`
-whose size is a compile-time function of these constants — measured at ≤ 64 KiB. The planner
-allocates nothing.
+whose size is a compile-time function of these constants. The planner allocates nothing.
+
+**Empirical Criterion (scratch size). Status: Empirical — measured 2026-08-22, correcting this
+document's own design-time estimate.** `size_of::<PlanScratch>()` is **81 548 bytes** (≈ 79.6 KiB),
+not the "≤ 64 KiB" this section estimated before the structure existed. The breakdown: the visited
+node array dominates at `PLAN_VISITED_MAX` × 24 bytes ≈ 48 KiB, the considered-candidate buffer is
+`PLAN_HORIZON_MAX` × `PLAN_ACTIONS_MAX` × 16 bytes = 16 KiB, the open-addressing index is
+`2 × PLAN_VISITED_MAX` × 2 bytes = 8 KiB, and the frontier, score and path buffers make up the
+remainder. **No frozen capacity changes**; the estimate was wrong and is corrected here rather than
+the capacity being shrunk to fit it. A built test asserts the size against a declared envelope, so it
+cannot drift unnoticed. The scratch is large by design — it is the bounded working set of a whole
+episode — so a caller places it in a static, an arena, or a box rather than on a small stack.
 
 ### 4.3 Deterministic decline, overflow, and conflict
 
@@ -433,6 +443,45 @@ witness bytes, asserted by the deterministic-rebuild gate.
 **Assumption.** The planner may read the persistent prompt state `Ψ` (#835, RF-31) as a conditioning
 surface and emits abstentions through the RF-30 typed decline surface. It never reads the benchmark
 verifier, a gold path, the teacher, or the network — asserted by a built test.
+
+### 6.1 Increment 5 outcome (built 2026-08-22)
+
+Built as `crates/uor-r4-graph-runtime/src/plan.rs`, wired into the normative path as
+`R4Engine::plan_bounded`, with records in `crates/uor-r4-graph-runtime/tests/plan_843.rs` (11 tests)
+and `crates/uor-r4-graph-runtime/tests/plan_allocation_census_843.rs` (2 tests).
+
+**All three arms share one search core.** `BreadthFirst` and `BestFirstBeam` are the same layered
+sweep differing only in which candidates survive the frontier bound; `IterativeDeepening` trades
+repeated expansions for depth-bounded memory. They read the same sections, execute the same
+operation set, and run under the same `PlanBudget`, so a difference between them is a difference of
+*search order* and nothing else — which is what makes the §8 comparison a comparison of mechanism.
+
+**Guarantee (allocation-free steady state). Status: Structural — measured.** A counting global
+allocator reports **0 allocations, 0 bytes** for a whole planning episode and **0 allocations,
+0 bytes** for emitting its witness into caller-owned bytes. The witness encoder was lifted into
+`core` for exactly this reason: the offline and deployed producers now share one encoder, and the
+deployed one writes into a caller-provided buffer.
+
+**Guarantee (P-4 conformance). Status: Structural — machine-checked at source.** A scan of the
+planner's own source finds no float type, no `sqrt`/`pow`, and **no runtime multiply or divide**.
+Six compile-time constant expressions — array lengths and budget constants, all with
+SCREAMING_SNAKE or literal operands — are exempted and **printed by the test**, so the exemption is
+visible rather than silent: a constant expression emits no instruction and is not a deployed-kernel
+operation. The scan asserts it can still fire on a runtime multiply between two non-constant
+operands, so it is evidence rather than decoration.
+
+**Definition (the visited index, frozen).** Membership is an open-addressed probe over
+`2 × PLAN_VISITED_MAX` slots with a checked `VISITED_MAX_PROBE` = 16 bound, hashed by the
+multiply-free add/rotate/xor mixer already normative for the packed skip-mix tables — unseeded, so
+identical inputs hash identically on every platform. A membership test costs at most sixteen
+fixed-offset reads whatever the set holds, and exceeding the bound is `Decline(capacity)` rather
+than a degrade into an unbounded scan.
+
+**Guarantee (absent-section identity through the engine). Status: Structural.**
+`R4Engine::plan_bounded` returns `Ok(None)` when the artifact carries no planning section, so every
+artifact produced before #843 serves exactly as before; it returns `Err` when a planning section is
+present but is not a product of the bytes, so an episode fails closed rather than planning on a
+partially-read table.
 
 ---
 


### PR DESCRIPTION
## Problem and outcome

Increment 5 of 6 for issue #843 (item B of S4 tracker #826). Adds the normative deployed-serving planner of `docs/bounded_semantic_transitions_spec_843.md` §6, wires it into the #831 `R4Engine` path, and emits the self-contained witness of §7 into caller-owned bytes.

No capability is claimed here — that is increment 6's measurement. What is established is that the machinery is total, deterministic, bounded, allocation-free, P-4-only, and honest at every boundary.

## Scope and non-goals

**Three bounded strategies over one search core.** `BreadthFirst` and `BestFirstBeam` are the same layered sweep differing only in which candidates survive the frontier bound; `IterativeDeepening` trades repeated expansions for depth-bounded memory. They read the same sections, execute the same operation set and run under the same `PlanBudget` — so a difference between them is a difference of *search order* and nothing else, which is what makes the §8 comparison a comparison of mechanism rather than of effort.

`R4Engine::plan_bounded` resolves `PSCH`/`PTRN`/`PGOL` from the artifact. **Non-goals:** the arm/null measurement, the three-way differential and the verdict — increment 6.

## Acceptance-criteria status

Advances *"the production path meets fixed horizon/frontier, bytes, latency, P-4, allocation, no_std, and determinism budgets"* — every clause of it is asserted below rather than described. The interventional comparison and the witness-replay-at-scale criteria belong to increment 6.

## Tests and verification

11 tests in `crates/uor-r4-graph-runtime/tests/plan_843.rs`, 2 in `plan_allocation_census_843.rs`. Full local ladder: fmt, clippy `-D warnings`, `cargo test --workspace --no-fail-fast` (183 suites), the `no_std` ladder both ways, the `wasm32-unknown-unknown` lib build, `xtask validate` (R1/R4/R5/gnaf, 32 ids), `repo-conformance` R2/R3, `cargo deny check bans`, and the claim-wording gate.

## Evidence artifacts

**Allocation-free, measured.** A counting global allocator reports **0 allocations, 0 bytes** for a whole planning episode *and* **0 allocations, 0 bytes** for emitting its witness. The witness encoder was lifted into `core` for exactly this reason: the offline and deployed producers now share one encoder, and the deployed one writes into a caller-provided buffer.

**P-4, machine-checked at source.** A scan of the planner's own source finds no float type, no `sqrt`/`pow`, and **no runtime multiply or divide**. Six compile-time constant expressions — array lengths and budget constants, all with SCREAMING_SNAKE or literal operands — are exempted and **printed by the test**, so the exemption is visible rather than silent: a constant expression emits no instruction and is not a deployed-kernel operation. The scan asserts it can still fire on a runtime multiply between two non-constant operands, so it is evidence rather than decoration.

**Bounded lookup.** The visited set is an open-addressed probe over `2 × PLAN_VISITED_MAX` slots with a checked bound of 16, hashed by the multiply-free add/rotate/xor mixer already normative for the packed skip-mix tables — unseeded, so identical inputs hash identically on every platform. A membership test costs at most sixteen fixed-offset reads whatever the set holds, and exceeding the bound is `Decline(capacity)` rather than a degrade into an unbounded scan.

**Every boundary is a typed decline, never a truncated plan.** An exhausted expansion budget, a horizon or frontier past the frozen capacity, a full visited set, an arity mismatch, a forbidden initial state and an unreachable goal each decline with their own reason, and a decline emits no plan. Each has its own test.

## Negative and unavailable results

**This document's own estimate was wrong, and is corrected rather than accommodated.** §4.2 said the caller-owned scratch was "measured at ≤ 64 KiB" — written before the structure existed. `size_of::<PlanScratch>()` is **81 548 bytes** (≈ 79.6 KiB): visited nodes ≈ 48 KiB, the considered-candidate buffer 16 KiB, the open-addressing index 8 KiB, the rest frontier, scores and path. **No frozen capacity was shrunk to make the old number true.** The spec is corrected, and a test asserts the size against a declared envelope so it cannot drift unnoticed again.

## Compatibility and migration

Additive. One new public module, one new `R4Engine` method, two new `const`s on existing format types. `plan_bounded` returns `Ok(None)` when the artifact carries no planning section — so every artifact produced before #843 serves exactly as before, which is what absent-section identity means — and `Err` when a planning section is present but is not a product of the bytes, so an episode fails closed rather than planning on a partially-read table.

The only non-additive change is internal: `WitnessDraft` and the witness encoder moved from the `alloc`-gated builder module to `core`, and `build_witness` now delegates to them. The public signature is unchanged and the 16 format tests pass untouched.

## Conformance effects

None. `CONFORMANCE.md` is byte-identical at 32 ids and no RF id is added. RF-33 stays unregistered unless increment 6 actually lowers an arm.

## Claim-boundary changes

None. The planner exists and is bounded; whether it *plans better than a null* is not asserted anywhere in this diff.

## Intentionally excluded

No generated file, model, cache, credential or user-owned file is staged. The maintainer's day-branch checkout is untouched; all work is in a dedicated worktree.

References #843
