### PR TITLE
test(#845): W(3,3) reference object, state mapping, and the failure-surface probe

### DIFF
--- a/crates/uor-r4-graph-certify/tests/geometry_probe_845.rs
+++ b/crates/uor-r4-graph-certify/tests/geometry_probe_845.rs
@@ -1,0 +1,776 @@
+//! #845 binding cheap instrument — the `bounded-breadth-first` failure-surface
+//! probe authorized by the maintainer decision of 2026-08-22 on #845.
+//!
+//! Maps where the lowered non-geometric baseline (RF-33, `bounded-breadth-first`)
+//! actually degrades: five families × H ∈ {1, 2, 4, 8, 12, 16} at the frozen
+//! `PlanBudget`, plus a tightened frontier/expansion ladder at H = 8. All four
+//! #843 nulls are measured alongside, so an Amendment A2(b) correctness cell is
+//! admitted only where the strongest of {baseline, nulls} sits at or below
+//! 1 − δ_min — otherwise the cell would recreate the saturated-baseline trap
+//! this probe exists to prevent.
+//!
+//! Certifier-instrument / off-serving-path. Teacher-free, fixture-free,
+//! deterministic. The full grid is `#[ignore]`d because it is a measurement;
+//! the default test asserts the probe itself is non-vacuous.
+//!
+//! Helper construction mirrors `compositional_planning_measurement_843.rs`
+//! (the #843 increment-6 harness), which is the protocol A2 inherits.
+
+use std::collections::BTreeMap;
+
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_compiler::semantic_state::Action;
+use uor_r4_graph_compiler::semantic_transitions as st;
+use uor_r4_graph_format::plan::{CompareOp, EffectDelta, PreconditionMask, SlotVec};
+use uor_r4_graph_format::plan_sections::{
+    build_predicate_set, build_rule_table, build_schema, PackedRule, PlanSchema, PredicateSet,
+    RuleTable,
+};
+use uor_r4_graph_runtime::plan::{
+    plan, PlanBudget, PlanOutcome, PlanQuery, PlanScratch, PlanStrategy,
+};
+
+/// Frozen effect floor (#844 §2.5).
+const DELTA_MIN: f64 = 0.05;
+/// Frozen sample size per held-out cell per horizon (#844 §2.5).
+const N_PER_CELL: usize = 512;
+/// The probed horizons: the frozen grid plus the extended-capacity points.
+const PROBE_HORIZONS: [usize; 6] = [1, 2, 4, 8, 12, 16];
+
+const FAMILIES: [cp::TaskFamily; 5] = [
+    cp::TaskFamily::GraphNavigation,
+    cp::TaskFamily::SymbolicTransformation,
+    cp::TaskFamily::ConstraintSatisfaction,
+    cp::TaskFamily::MultiHopEvidence,
+    cp::TaskFamily::CounterfactualIntervention,
+];
+
+// ---------------------------------------------------------------------------
+// The joint split (#844 §2.2): a held-out instance is in the high half of
+// EVERY seed-varied axis, a fitting instance in the low half of every axis.
+// ---------------------------------------------------------------------------
+
+fn axis_digits(seed: u64) -> [u64; 4] {
+    let c = cp::AXIS_CARDINALITY;
+    [
+        seed % c,
+        (seed / c) % c,
+        (seed / (c * c)) % c,
+        (seed / (c * c * c)) % c,
+    ]
+}
+
+fn joint_held_out(seed: u64) -> bool {
+    axis_digits(seed)
+        .iter()
+        .all(|d| *d >= cp::AXIS_CARDINALITY / 2)
+}
+
+fn joint_fitting(seed: u64) -> bool {
+    axis_digits(seed)
+        .iter()
+        .all(|d| *d < cp::AXIS_CARDINALITY / 2)
+}
+
+fn seeds(held_out: bool, count: usize) -> Vec<u64> {
+    let mut out = Vec::with_capacity(count);
+    let mut seed = 0u64;
+    while out.len() < count {
+        let keep = if held_out {
+            joint_held_out(seed)
+        } else {
+            joint_fitting(seed)
+        };
+        if keep {
+            out.push(seed);
+        }
+        seed += 1;
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Packing: reference instance -> packed sections (the #843 harness protocol)
+// ---------------------------------------------------------------------------
+
+fn ints(values: &[f32]) -> Vec<i16> {
+    values.iter().map(|v| v.round() as i16).collect()
+}
+
+fn band_code(band: cp::ConfidenceBand) -> u8 {
+    match band {
+        cp::ConfidenceBand::None => 0,
+        cp::ConfidenceBand::Low => 1,
+        cp::ConfidenceBand::Medium => 2,
+        cp::ConfidenceBand::High => 3,
+    }
+}
+
+fn cell_predicate(values: &[i16]) -> PreconditionMask {
+    let mut predicate = PreconditionMask::unconditional();
+    for (slot, value) in values.iter().enumerate() {
+        predicate = predicate.reading(slot, CompareOp::Equal, *value).unwrap();
+    }
+    predicate
+}
+
+/// The artifact side of an episode: schema and rule table from the induced
+/// rule set alone.
+struct Packed {
+    schema: Vec<u8>,
+    rules: Vec<u8>,
+    effects: Vec<Vec<i16>>,
+}
+
+/// Pack an induced rule set. `rotate` canonically rotates each operator's
+/// effect (the shuffled-state null); `rotate = 0` is the faithful artifact.
+fn pack(set: &st::TransitionRuleSet, rotate: usize) -> Option<Packed> {
+    let mut effects: Vec<Vec<i16>> = set
+        .rules
+        .iter()
+        .map(|r| r.effect.as_slice().to_vec())
+        .collect();
+    effects.sort();
+    effects.dedup();
+    if effects.is_empty() {
+        return None;
+    }
+    let vocabulary: Vec<EffectDelta> = effects
+        .iter()
+        .map(|e| EffectDelta::from_slice(e).unwrap())
+        .collect();
+    let schema = build_schema(2, &vocabulary, (1, 4, 16))?;
+    let parsed = PlanSchema::parse(&schema).ok()?;
+
+    let mut rules = Vec::new();
+    for rule in &set.rules {
+        let effect = rule.effect.as_slice().to_vec();
+        let operator = effects.iter().position(|e| *e == effect)?;
+        let carried = (operator + rotate) % effects.len();
+        rules.push(PackedRule {
+            operator: operator as u16,
+            precondition: rule.precondition,
+            effect: parsed.operator(carried)?,
+            support: rule.support,
+            band: band_code(rule.band),
+        });
+    }
+    rules.sort_by_key(|r| (r.operator, r.effect.as_slice().to_vec()));
+    rules.dedup_by_key(|r| (r.operator, r.effect.as_slice().to_vec()));
+    let rules = build_rule_table(2, effects.len() as u16, &rules)?;
+    Some(Packed {
+        schema,
+        rules,
+        effects,
+    })
+}
+
+fn predicates_for(task: &cp::TaskInstance) -> Option<Vec<u8>> {
+    let goal = cell_predicate(&ints(&task.goal.target_region.center));
+    let mut constraints: Vec<PreconditionMask> = task
+        .constraints
+        .iter()
+        .map(|c| cell_predicate(&ints(&c.forbidden_region.center)))
+        .collect();
+    constraints.sort_by_key(|c| (0..2).map(|s| c.bound(s)).collect::<Vec<_>>());
+    constraints.dedup_by_key(|c| (0..2).map(|s| c.bound(s)).collect::<Vec<_>>());
+    build_predicate_set(2, &[goal], &constraints)
+}
+
+fn initial_of(task: &cp::TaskInstance) -> SlotVec {
+    SlotVec::from_slice(&ints(&task.initial_state.vector)).unwrap()
+}
+
+fn mask_for(packed: &Packed, task: &cp::TaskInstance) -> u64 {
+    let mut mask = 0u64;
+    for action in &task.actions {
+        let effect = ints(&action.delta_vector);
+        if let Some(index) = packed.effects.iter().position(|e| *e == effect) {
+            if index < 64 {
+                mask |= 1u64 << index;
+            }
+        }
+    }
+    mask
+}
+
+/// A plan as a sequence of operator effects, or an honest decline.
+type Emission = Option<Vec<Vec<i16>>>;
+
+fn as_actions(task: &cp::TaskInstance, effects: &[Vec<i16>]) -> Option<Vec<Action>> {
+    effects
+        .iter()
+        .map(|effect| {
+            task.actions
+                .iter()
+                .find(|a| ints(&a.delta_vector) == *effect)
+                .cloned()
+        })
+        .collect()
+}
+
+/// Judge an emitted outcome against the frozen benchmark verifier (correct =
+/// valid plan on a solvable instance, or a correct decline on an unsolvable
+/// one — the #844 §11.6 reading; on all-solvable cells this is exactly the
+/// frozen valid-plan rate).
+fn outcome_correct(task: &cp::TaskInstance, emitted: &Emission) -> bool {
+    let unsolvable = task.gold.decline.is_some();
+    match (emitted, unsolvable) {
+        (None, true) => true,
+        (None, false) => false,
+        (Some(_), true) => false,
+        (Some(effects), false) => match as_actions(task, effects) {
+            Some(actions) => cp::verify_submission(task, &actions) == cp::WitnessVerdict::Valid,
+            None => false,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The deployed arm under an explicit budget, with counters
+// ---------------------------------------------------------------------------
+
+type Episode = (Emission, uor_r4_graph_runtime::plan::PlanCounters);
+
+fn production_measured(
+    strategy: PlanStrategy,
+    packed: &Packed,
+    task: &cp::TaskInstance,
+    budget: PlanBudget,
+    scratch: &mut PlanScratch,
+) -> Option<Episode> {
+    let schema = PlanSchema::parse(&packed.schema).ok()?;
+    let rules = RuleTable::parse(&packed.rules, &schema).ok()?;
+    let predicate_bytes = predicates_for(task)?;
+    let predicates = PredicateSet::parse(&predicate_bytes, &schema).ok()?;
+    let result = plan(
+        &PlanQuery {
+            strategy,
+            schema: &schema,
+            rules: &rules,
+            predicates: &predicates,
+            initial: initial_of(task),
+            available: mask_for(packed, task),
+            budget,
+        },
+        scratch,
+    );
+    let emitted = match result.outcome {
+        PlanOutcome::Plan { steps } => Some(
+            (0..steps)
+                .filter_map(|i| {
+                    scratch
+                        .path_step(i)
+                        .map(|(e, _, _, _)| e.as_slice().to_vec())
+                })
+                .collect(),
+        ),
+        PlanOutcome::Declined(_) => None,
+    };
+    Some((emitted, result.counters))
+}
+
+// ---------------------------------------------------------------------------
+// The four #843 nulls (budget-independent replays plus the shuffled artifact)
+// ---------------------------------------------------------------------------
+
+struct Fitted {
+    by_structure: BTreeMap<String, Emission>,
+    by_goal: Vec<(Vec<i16>, Emission)>,
+    modal: Emission,
+}
+
+fn structure_key(task: &cp::TaskInstance) -> String {
+    let mut forbidden: Vec<Vec<i16>> = task
+        .constraints
+        .iter()
+        .map(|c| ints(&c.forbidden_region.center))
+        .collect();
+    forbidden.sort();
+    let effects: Vec<Vec<i16>> = task.actions.iter().map(|a| ints(&a.delta_vector)).collect();
+    format!(
+        "{}|{:?}|{:?}|{:?}",
+        task.family.label(),
+        ints(&task.goal.target_region.center),
+        forbidden,
+        effects
+    )
+}
+
+fn gold_effects(task: &cp::TaskInstance) -> Emission {
+    if task.gold.decline.is_some() {
+        return None;
+    }
+    Some(
+        task.gold
+            .chosen_path
+            .iter()
+            .map(|a| ints(&a.delta_vector))
+            .collect(),
+    )
+}
+
+fn fit_nulls(family: cp::TaskFamily, horizon: usize) -> Fitted {
+    let mut by_structure = BTreeMap::new();
+    let mut by_goal = Vec::new();
+    let mut frequency: BTreeMap<Emission, usize> = BTreeMap::new();
+    for seed in seeds(false, N_PER_CELL) {
+        let Some(task) = try_generate(family, seed, horizon) else {
+            continue;
+        };
+        let emission = gold_effects(&task);
+        by_structure
+            .entry(structure_key(&task))
+            .or_insert_with(|| emission.clone());
+        by_goal.push((ints(&task.goal.target_region.center), emission.clone()));
+        *frequency.entry(emission).or_default() += 1;
+    }
+    let modal = frequency
+        .iter()
+        .max_by_key(|(plan, count)| (**count, std::cmp::Reverse((*plan).clone())))
+        .map(|(plan, _)| plan.clone())
+        .unwrap_or(None);
+    Fitted {
+        by_structure,
+        by_goal,
+        modal,
+    }
+}
+
+/// N1 retrieval-only: nearest fitting instance by goal displacement.
+fn retrieval_only(fitted: &Fitted, task: &cp::TaskInstance) -> Emission {
+    let goal = ints(&task.goal.target_region.center);
+    fitted
+        .by_goal
+        .iter()
+        .min_by_key(|(g, _)| {
+            g.iter()
+                .zip(goal.iter())
+                .map(|(a, b)| i64::from(*a - *b).abs())
+                .sum::<i64>()
+        })
+        .and_then(|(_, plan)| plan.clone())
+}
+
+/// N2 direct-continuation: greedy one-step descent on goal distance, no
+/// lookahead, no backtracking, no honest decline.
+fn direct_continuation(task: &cp::TaskInstance, horizon: usize) -> Emission {
+    let goal = ints(&task.goal.target_region.center);
+    let mut state = ints(&task.initial_state.vector);
+    let mut out = Vec::new();
+    let distance = |s: &[i16]| -> i64 {
+        s.iter()
+            .zip(goal.iter())
+            .map(|(a, b)| i64::from(*a - *b).abs())
+            .sum()
+    };
+    for _ in 0..horizon {
+        if distance(&state) == 0 {
+            return Some(out);
+        }
+        let mut best: Option<(i64, Vec<i16>, Vec<i16>)> = None;
+        for action in &task.actions {
+            let effect = ints(&action.delta_vector);
+            let next: Vec<i16> = state
+                .iter()
+                .zip(effect.iter())
+                .map(|(s, d)| s.saturating_add(*d))
+                .collect();
+            let score = distance(&next);
+            let better = match &best {
+                None => true,
+                Some((current, _, current_effect)) => {
+                    score < *current || (score == *current && effect < *current_effect)
+                }
+            };
+            if better {
+                best = Some((score, next, effect));
+            }
+        }
+        let (_, next, effect) = best?;
+        state = next;
+        out.push(effect);
+    }
+    Some(out)
+}
+
+/// N3 memorized-trajectory: replay by structural key with a modal fallback.
+fn memorized(fitted: &Fitted, task: &cp::TaskInstance) -> Emission {
+    match fitted.by_structure.get(&structure_key(task)) {
+        Some(plan) => plan.clone(),
+        None => fitted.modal.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generator viability and induction
+// ---------------------------------------------------------------------------
+
+/// `cp::generate` places the goal on the BFS layer at exactly `depth`; a
+/// (family, topology, horizon) whose layer is empty panics. The probe records
+/// that as generator-unavailable rather than crashing: an extended-horizon
+/// cell the generator cannot populate is excluded by evidence.
+fn try_generate(family: cp::TaskFamily, seed: u64, horizon: usize) -> Option<cp::TaskInstance> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        cp::generate(family, seed, horizon)
+    }))
+    .ok()
+}
+
+/// Induce the artifact-side rule set from the fitting half of the joint split
+/// (the #843 harness protocol: N/4 fitting seeds, held-out topologies armed).
+fn induce_for(family: cp::TaskFamily, horizon: usize) -> Option<st::TransitionRuleSet> {
+    let mut observations = Vec::new();
+    for seed in seeds(false, N_PER_CELL / 4) {
+        let task = try_generate(family, seed, horizon)?;
+        observations.extend(st::observe(&task));
+    }
+    let held_out: std::collections::BTreeSet<u8> = (0..cp::AXIS_CARDINALITY)
+        .filter(|d| *d >= cp::AXIS_CARDINALITY / 2)
+        .map(|d| d as u8)
+        .collect();
+    let policy = st::SplitPolicy {
+        held_out_topologies: held_out,
+        sealed_topologies: std::collections::BTreeSet::new(),
+    };
+    st::induce(&observations, &policy).induced().cloned()
+}
+
+// ---------------------------------------------------------------------------
+// The probe grid
+// ---------------------------------------------------------------------------
+
+/// One probed (family × horizon × budget) cell.
+#[derive(Debug, Clone)]
+struct ProbeCell {
+    family: &'static str,
+    horizon: usize,
+    budget_label: String,
+    n: usize,
+    generator_unavailable: usize,
+    arm_correct: usize,
+    null_correct: [usize; 4],
+    mean_expansions: f64,
+    max_expansions: u32,
+    mean_candidates: f64,
+    mean_table_reads: f64,
+}
+
+const NULL_NAMES: [&str; 4] = [
+    "retrieval-only",
+    "direct-continuation",
+    "memorized-trajectory",
+    "shuffled-state",
+];
+
+impl ProbeCell {
+    fn arm_rate(&self) -> f64 {
+        if self.n == 0 {
+            return 0.0;
+        }
+        self.arm_correct as f64 / self.n as f64
+    }
+
+    fn null_rate(&self, index: usize) -> f64 {
+        if self.n == 0 {
+            return 0.0;
+        }
+        self.null_correct[index] as f64 / self.n as f64
+    }
+
+    fn strongest(&self) -> (usize, f64) {
+        let index = (0..4).max_by_key(|i| self.null_correct[*i]).unwrap();
+        (index, self.null_rate(index))
+    }
+
+    /// A2(b) admissibility: the strongest of {baseline, nulls} must sit at or
+    /// below 1 − δ_min, or geometry has nothing measurable to beat.
+    fn admissible(&self) -> bool {
+        if self.n == 0 {
+            return false;
+        }
+        let (_, strongest_null) = self.strongest();
+        self.arm_rate().max(strongest_null) <= 1.0 - DELTA_MIN
+    }
+}
+
+fn frozen_with(horizon: usize) -> PlanBudget {
+    PlanBudget {
+        horizon: horizon as u8,
+        ..PlanBudget::frozen()
+    }
+}
+
+/// The tightened ladder at the anchor horizon: frontier alone, then
+/// expansions alone, each stepped down from the frozen value.
+fn ladder(horizon: usize) -> Vec<(String, PlanBudget)> {
+    let mut out = Vec::new();
+    for frontier in [32u16, 16, 8, 4] {
+        out.push((
+            format!("frontier-{frontier}"),
+            PlanBudget {
+                frontier,
+                ..frozen_with(horizon)
+            },
+        ));
+    }
+    for expansions in [256u32, 128, 64, 32] {
+        out.push((
+            format!("expansions-{expansions}"),
+            PlanBudget {
+                max_expansions: expansions,
+                ..frozen_with(horizon)
+            },
+        ));
+    }
+    out
+}
+
+/// Everything a (family, horizon) pair fits once and every budget reuses:
+/// the packed faithful artifact, the shuffled artifact, and the fitted nulls.
+struct FittedCell {
+    packed: Packed,
+    shuffled: Packed,
+    fitted: Fitted,
+}
+
+fn fit_cell(family: cp::TaskFamily, horizon: usize) -> Option<FittedCell> {
+    let set = induce_for(family, horizon)?;
+    let packed = pack(&set, 0)?;
+    let shuffled = pack(&set, 1)?;
+    let fitted = fit_nulls(family, horizon);
+    Some(FittedCell {
+        packed,
+        shuffled,
+        fitted,
+    })
+}
+
+fn probe_cell(
+    family: cp::TaskFamily,
+    horizon: usize,
+    budget_label: &str,
+    budget: PlanBudget,
+    cellfit: &FittedCell,
+    scratch: &mut PlanScratch,
+) -> ProbeCell {
+    let mut cell = ProbeCell {
+        family: family.label(),
+        horizon,
+        budget_label: budget_label.to_string(),
+        n: 0,
+        generator_unavailable: 0,
+        arm_correct: 0,
+        null_correct: [0; 4],
+        mean_expansions: 0.0,
+        max_expansions: 0,
+        mean_candidates: 0.0,
+        mean_table_reads: 0.0,
+    };
+    let mut expansions = 0u64;
+    let mut candidates = 0u64;
+    let mut table_reads = 0u64;
+    for seed in seeds(true, N_PER_CELL) {
+        let Some(task) = try_generate(family, seed, horizon) else {
+            cell.generator_unavailable += 1;
+            continue;
+        };
+        cell.n += 1;
+        let (emitted, counters) = production_measured(
+            PlanStrategy::BreadthFirst,
+            &cellfit.packed,
+            &task,
+            budget,
+            scratch,
+        )
+        .unwrap_or_default();
+        if outcome_correct(&task, &emitted) {
+            cell.arm_correct += 1;
+        }
+        expansions += u64::from(counters.expansions);
+        candidates += u64::from(counters.candidates);
+        table_reads += u64::from(counters.table_reads);
+        cell.max_expansions = cell.max_expansions.max(counters.expansions);
+        let shuffled_emission = production_measured(
+            PlanStrategy::BreadthFirst,
+            &cellfit.shuffled,
+            &task,
+            budget,
+            scratch,
+        )
+        .and_then(|(plan, _)| plan);
+        let nulls: [Emission; 4] = [
+            retrieval_only(&cellfit.fitted, &task),
+            direct_continuation(&task, horizon),
+            memorized(&cellfit.fitted, &task),
+            shuffled_emission,
+        ];
+        for (index, null) in nulls.iter().enumerate() {
+            if outcome_correct(&task, null) {
+                cell.null_correct[index] += 1;
+            }
+        }
+    }
+    if cell.n > 0 {
+        cell.mean_expansions = expansions as f64 / cell.n as f64;
+        cell.mean_candidates = candidates as f64 / cell.n as f64;
+        cell.mean_table_reads = table_reads as f64 / cell.n as f64;
+    }
+    cell
+}
+
+fn print_cell(cell: &ProbeCell) {
+    let (strongest_index, strongest_rate) = cell.strongest();
+    println!(
+        "PROBE | {:<26} | H={:<2} | {:<14} | n={} unavail={} | arm={:.4} | strongest={}@{:.4} | nulls r={:.4} d={:.4} m={:.4} s={:.4} | exp mean={:.1} max={} | cand mean={:.1} | reads mean={:.1} | {}",
+        cell.family,
+        cell.horizon,
+        cell.budget_label,
+        cell.n,
+        cell.generator_unavailable,
+        cell.arm_rate(),
+        NULL_NAMES[strongest_index],
+        strongest_rate,
+        cell.null_rate(0),
+        cell.null_rate(1),
+        cell.null_rate(2),
+        cell.null_rate(3),
+        cell.mean_expansions,
+        cell.max_expansions,
+        cell.mean_candidates,
+        cell.mean_table_reads,
+        if cell.admissible() { "ADMISSIBLE" } else { "saturated" },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The probe itself
+// ---------------------------------------------------------------------------
+
+/// The full failure surface. `--ignored` because it is a measurement, not a
+/// gate; run with `-- --ignored --nocapture` and read the PROBE lines.
+#[test]
+#[ignore = "measurement probe: run explicitly with --ignored --nocapture"]
+fn breadth_first_failure_surface() {
+    let quiet = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let mut scratch = Box::new(PlanScratch::new());
+    let mut cells: Vec<ProbeCell> = Vec::new();
+    for family in FAMILIES {
+        for horizon in PROBE_HORIZONS {
+            let Some(cellfit) = fit_cell(family, horizon) else {
+                println!(
+                    "PROBE | {:<26} | H={:<2} | GENERATOR-UNAVAILABLE (fitting half)",
+                    family.label(),
+                    horizon
+                );
+                continue;
+            };
+            let cell = probe_cell(
+                family,
+                horizon,
+                "frozen",
+                frozen_with(horizon),
+                &cellfit,
+                &mut scratch,
+            );
+            print_cell(&cell);
+            cells.push(cell);
+            if horizon == 8 {
+                for (label, budget) in ladder(horizon) {
+                    let cell = probe_cell(family, horizon, &label, budget, &cellfit, &mut scratch);
+                    print_cell(&cell);
+                    cells.push(cell);
+                }
+            }
+        }
+    }
+    std::panic::set_hook(quiet);
+    let admissible: Vec<&ProbeCell> = cells.iter().filter(|c| c.admissible()).collect();
+    println!(
+        "PROBE-SUMMARY | cells={} admissible={} | delta_min={} n_per_cell={}",
+        cells.len(),
+        admissible.len(),
+        DELTA_MIN,
+        N_PER_CELL
+    );
+    for cell in &admissible {
+        println!(
+            "PROBE-ADMISSIBLE | {} H={} {} arm={:.4} strongest_null={:.4}",
+            cell.family,
+            cell.horizon,
+            cell.budget_label,
+            cell.arm_rate(),
+            cell.strongest().1
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-vacuity gates — run by default, so the probe cannot silently rot
+// ---------------------------------------------------------------------------
+
+/// The probe's machinery is real: induction packs, the deployed planner plans
+/// on the packed artifact, and the verifier accepts the outcome.
+#[test]
+fn the_probe_packs_and_plans() {
+    let mut scratch = Box::new(PlanScratch::new());
+    let cellfit = fit_cell(cp::TaskFamily::GraphNavigation, 8).expect("fit succeeds at H=8");
+    let task = cp::generate(cp::TaskFamily::GraphNavigation, 4, 8);
+    let (emitted, counters) = production_measured(
+        PlanStrategy::BreadthFirst,
+        &cellfit.packed,
+        &task,
+        frozen_with(8),
+        &mut scratch,
+    )
+    .expect("the packed artifact parses and plans");
+    assert!(
+        outcome_correct(&task, &emitted),
+        "the deployed planner did not produce an accepted outcome"
+    );
+    assert!(counters.expansions > 0, "the planner did no work");
+}
+
+/// The admissibility judge can fire in both directions: a trap family at H=8
+/// has direct-continuation failures (so headroom can exist), and a saturated
+/// null is judged inadmissible (so the trap this probe exists to prevent is
+/// actually prevented).
+#[test]
+fn the_admissibility_judge_can_fire_and_can_fail() {
+    let mut dc_failures = 0usize;
+    for seed in seeds(true, 64) {
+        let task = cp::generate(cp::TaskFamily::GraphNavigation, seed, 8);
+        let emission = direct_continuation(&task, 8);
+        if !outcome_correct(&task, &emission) {
+            dc_failures += 1;
+        }
+    }
+    assert!(
+        dc_failures > 0,
+        "direct-continuation never fails on the trap family — the probe cannot separate anything"
+    );
+    let saturated = ProbeCell {
+        family: "synthetic",
+        horizon: 8,
+        budget_label: "synthetic".to_string(),
+        n: 512,
+        generator_unavailable: 0,
+        arm_correct: 512,
+        null_correct: [512, 0, 0, 0],
+        mean_expansions: 0.0,
+        max_expansions: 0,
+        mean_candidates: 0.0,
+        mean_table_reads: 0.0,
+    };
+    assert!(!saturated.admissible(), "a saturated cell must be excluded");
+    let open = ProbeCell {
+        arm_correct: 384,
+        null_correct: [256, 128, 64, 32],
+        ..saturated
+    };
+    assert!(
+        open.admissible(),
+        "a cell with real headroom must be admitted"
+    );
+}

--- a/crates/uor-r4-graph-certify/tests/support/mod.rs
+++ b/crates/uor-r4-graph-certify/tests/support/mod.rs
@@ -1,0 +1,8 @@
+//! Shared reference-support modules for the #845 geometry-qualification
+//! instruments.
+//!
+//! Files in subdirectories of `tests/` are not test binaries; each test file
+//! that declares `mod support;` compiles its own copy, so the shared surface
+//! is allowed to be partially used per binary.
+
+pub mod w33;

--- a/crates/uor-r4-graph-certify/tests/support/w33.rs
+++ b/crates/uor-r4-graph-certify/tests/support/w33.rs
@@ -1,0 +1,190 @@
+//! The normative W(3,3) reference object for #845 — the symplectic generalized
+//! quadrangle over GF(3) — exactly as frozen in
+//! `docs/w33_geometry_qualification_spec_845.md` §2–§3.
+//!
+//! Reference mathematics (Definition scope): nothing here asserts semantic
+//! usefulness, activation, or empirical superiority. Certifier-instrument /
+//! off-serving-path; ordinary integer arithmetic is in scope here (the P-4
+//! projection in the spec concerns a possible later lowering, not this code).
+#![allow(dead_code)]
+
+/// A vector of GF(3)^4 with entries in {0, 1, 2}.
+pub type Vec4 = [u8; 4];
+
+/// The number of projective points of PG(3,3), all of which are W(3) points.
+pub const POINTS: usize = 40;
+
+/// The pinned non-degenerate alternating form:
+/// `<u, v> = u0*v1 - u1*v0 + u2*v3 - u3*v2  (mod 3)`.
+pub fn symplectic(u: &Vec4, v: &Vec4) -> u8 {
+    let a = u32::from(u[0]) * u32::from(v[1]) + 2 * u32::from(u[1]) * u32::from(v[0]);
+    let b = u32::from(u[2]) * u32::from(v[3]) + 2 * u32::from(u[3]) * u32::from(v[2]);
+    ((a + b) % 3) as u8
+}
+
+/// Scale a vector by a GF(3) scalar.
+fn scale(u: &Vec4, s: u8) -> Vec4 {
+    [
+        (u[0] * s) % 3,
+        (u[1] * s) % 3,
+        (u[2] * s) % 3,
+        (u[3] * s) % 3,
+    ]
+}
+
+/// The canonical representative of a nonzero vector's projective class: the
+/// unique scalar multiple whose first nonzero coordinate is 1.
+pub fn canonical(u: &Vec4) -> Vec4 {
+    let first = u.iter().copied().find(|c| *c != 0).unwrap_or(0);
+    match first {
+        2 => scale(u, 2),
+        _ => *u,
+    }
+}
+
+/// The 40 canonical representatives in lexicographic order — the pinned point
+/// indexing every table below uses.
+pub fn points() -> Vec<Vec4> {
+    let mut out = Vec::with_capacity(POINTS);
+    for code in 1u16..81 {
+        let u = [
+            (code / 27 % 3) as u8,
+            (code / 9 % 3) as u8,
+            (code / 3 % 3) as u8,
+            (code % 3) as u8,
+        ];
+        if canonical(&u) == u {
+            out.push(u);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Collinearity distance `d_W` in {0, 1, 2}: 0 iff equal, 1 iff distinct and
+/// collinear (form value 0), 2 otherwise. Total with diameter 2 (the
+/// collinearity graph is strongly regular (40, 12, 2, 4); asserted by test).
+pub fn distance(points: &[Vec4], p: usize, q: usize) -> u8 {
+    if p == q {
+        return 0;
+    }
+    if symplectic(&points[p], &points[q]) == 0 {
+        1
+    } else {
+        2
+    }
+}
+
+/// Phase `phi(p, q) = <u_p, u_q>` on canonical representatives, in GF(3).
+/// Zero iff equal or collinear; antisymmetric mod 3. Convention-dependent by
+/// design — the adversarial phase permutation exercises exactly that.
+pub fn phase(points: &[Vec4], p: usize, q: usize) -> u8 {
+    symplectic(&points[p], &points[q])
+}
+
+/// The 40 x 40 `d_W` table in the pinned point order.
+pub fn distance_table(points: &[Vec4]) -> Vec<[u8; POINTS]> {
+    (0..POINTS)
+        .map(|p| {
+            let mut row = [0u8; POINTS];
+            for (q, slot) in row.iter_mut().enumerate() {
+                *slot = distance(points, p, q);
+            }
+            row
+        })
+        .collect()
+}
+
+/// The 40 x 40 phase table in the pinned point order.
+pub fn phase_table(points: &[Vec4]) -> Vec<[u8; POINTS]> {
+    (0..POINTS)
+        .map(|p| {
+            let mut row = [0u8; POINTS];
+            for (q, slot) in row.iter_mut().enumerate() {
+                *slot = phase(points, p, q);
+            }
+            row
+        })
+        .collect()
+}
+
+/// The totally isotropic projective lines, each as a sorted quadruple of point
+/// indices, sorted and deduplicated — the 40 lines of W(3) (asserted by test).
+pub fn lines(points: &[Vec4]) -> Vec<[usize; 4]> {
+    let index_of = |v: &Vec4| -> usize { points.iter().position(|p| p == v).unwrap() };
+    let mut out = Vec::new();
+    for p in 0..POINTS {
+        for q in (p + 1)..POINTS {
+            if symplectic(&points[p], &points[q]) != 0 {
+                continue;
+            }
+            // The projective line through p and q: u, v, u+v, u+2v.
+            let (u, v) = (points[p], points[q]);
+            let sum = |a: &Vec4, b: &Vec4| -> Vec4 {
+                [
+                    (a[0] + b[0]) % 3,
+                    (a[1] + b[1]) % 3,
+                    (a[2] + b[2]) % 3,
+                    (a[3] + b[3]) % 3,
+                ]
+            };
+            let w1 = canonical(&sum(&u, &v));
+            let w2 = canonical(&sum(&u, &scale(&v, 2)));
+            let mut line = [p, q, index_of(&w1), index_of(&w2)];
+            line.sort_unstable();
+            out.push(line);
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// The state mapping mu (spec §3): digitize each slot mod 9 into two base-3
+/// digits, read the four digits as a GF(3)^4 vector, take its projective
+/// class; the zero vector maps to the basepoint [1:0:0:0]. Total on all i16
+/// slot pairs; reads only slot values (label-independent by construction).
+pub fn map_state(points: &[Vec4], s0: i16, s1: i16) -> usize {
+    let digits = |s: i16| -> (u8, u8) {
+        let a = s.rem_euclid(9) as u8;
+        (a % 3, a / 3)
+    };
+    let (d00, d01) = digits(s0);
+    let (d10, d11) = digits(s1);
+    let v: Vec4 = [d00, d01, d10, d11];
+    let target = if v == [0, 0, 0, 0] {
+        [1, 0, 0, 0]
+    } else {
+        canonical(&v)
+    };
+    points.iter().position(|p| *p == target).unwrap()
+}
+
+/// The pinned symplectomorphism for the isomorphic-relabel control:
+/// (u0, u1, u2, u3) -> (u2, u3, u0, u1), which preserves the pinned form and
+/// therefore collinearity (asserted by test), while moving points.
+pub fn relabel_point(u: &Vec4) -> Vec4 {
+    canonical(&[u[2], u[3], u[0], u[1]])
+}
+
+/// The point-index permutation the relabel control conjugates tables by.
+pub fn relabel_permutation(points: &[Vec4]) -> Vec<usize> {
+    points
+        .iter()
+        .map(|u| {
+            let image = relabel_point(u);
+            points.iter().position(|p| *p == image).unwrap()
+        })
+        .collect()
+}
+
+/// The pinned adversarial phase permutation: swap the nonzero phase values
+/// (1 <-> 2), keep 0. Preserves the collinearity relation encoded by phase
+/// zero while destroying the pinned sign convention.
+pub fn permute_phase(value: u8) -> u8 {
+    match value {
+        1 => 2,
+        2 => 1,
+        other => other,
+    }
+}

--- a/crates/uor-r4-graph-certify/tests/w33_mapping_845.rs
+++ b/crates/uor-r4-graph-certify/tests/w33_mapping_845.rs
@@ -1,0 +1,228 @@
+//! #845 increment 2 — the normative W(3,3) object and the state mapping mu,
+//! verified against the frozen Definitions of
+//! `docs/w33_geometry_qualification_spec_845.md` §2–§3.
+//!
+//! Reference mathematics checks (Definition scope): these tests verify that
+//! the constructed object *is* the symplectic generalized quadrangle of order
+//! (3,3) and that mu has the frozen totality/surjectivity/periodicity and
+//! label-independence properties. Nothing here is a semantic-usefulness or
+//! empirical-superiority claim; those are #845 increments 3–4.
+
+mod support;
+
+use support::w33;
+
+#[test]
+fn forty_points_in_canonical_lex_order() {
+    let points = w33::points();
+    assert_eq!(points.len(), w33::POINTS);
+    let mut sorted = points.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(sorted, points, "points are distinct and lex-ordered");
+    for u in &points {
+        assert_eq!(w33::canonical(u), *u, "every representative is canonical");
+        assert_eq!(
+            u.iter().copied().find(|c| *c != 0),
+            Some(1),
+            "first nonzero coordinate is 1"
+        );
+    }
+}
+
+#[test]
+fn the_collinearity_graph_is_srg_40_12_2_4() {
+    let points = w33::points();
+    let collinear = |p: usize, q: usize| w33::distance(&points, p, q) == 1;
+    for p in 0..w33::POINTS {
+        let degree = (0..w33::POINTS).filter(|q| collinear(p, *q)).count();
+        assert_eq!(degree, 12, "every point is collinear with exactly 12");
+    }
+    for p in 0..w33::POINTS {
+        for q in (p + 1)..w33::POINTS {
+            let common = (0..w33::POINTS)
+                .filter(|r| collinear(p, *r) && collinear(q, *r))
+                .count();
+            let expected = if collinear(p, q) { 2 } else { 4 };
+            assert_eq!(common, expected, "SRG lambda/mu at pair ({p}, {q})");
+        }
+    }
+}
+
+#[test]
+fn forty_totally_isotropic_lines_four_by_four() {
+    let points = w33::points();
+    let lines = w33::lines(&points);
+    assert_eq!(lines.len(), 40, "W(3) has 40 lines");
+    let mut per_point = [0usize; w33::POINTS];
+    for line in &lines {
+        let mut distinct = line.to_vec();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(distinct.len(), 4, "every line carries 4 distinct points");
+        for a in 0..4 {
+            per_point[line[a]] += 1;
+            for b in (a + 1)..4 {
+                assert_eq!(
+                    w33::distance(&points, line[a], line[b]),
+                    1,
+                    "line points are pairwise collinear (total isotropy)"
+                );
+            }
+        }
+    }
+    for (point, count) in per_point.iter().enumerate() {
+        assert_eq!(*count, 4, "point {point} lies on exactly 4 lines");
+    }
+}
+
+#[test]
+fn the_generalized_quadrangle_axiom_holds() {
+    let points = w33::points();
+    let lines = w33::lines(&points);
+    for p in 0..w33::POINTS {
+        for line in &lines {
+            if line.contains(&p) {
+                continue;
+            }
+            let collinear_on_line = line
+                .iter()
+                .filter(|q| w33::distance(&points, p, **q) == 1)
+                .count();
+            assert_eq!(
+                collinear_on_line, 1,
+                "a point off a line is collinear with exactly one of its points"
+            );
+        }
+    }
+}
+
+#[test]
+fn distance_and_phase_tables_match_their_definitions() {
+    let points = w33::points();
+    let distance = w33::distance_table(&points);
+    let phase = w33::phase_table(&points);
+    for (p, (distance_row, phase_row)) in distance.iter().zip(phase.iter()).enumerate() {
+        for q in 0..w33::POINTS {
+            assert_eq!(distance_row[q], w33::distance(&points, p, q));
+            assert_eq!(phase_row[q], w33::phase(&points, p, q));
+            assert!(distance_row[q] <= 2, "d_W is total with diameter 2");
+            assert_eq!(
+                distance_row[q],
+                w33::distance(&points, q, p),
+                "d_W is symmetric"
+            );
+            assert_eq!((distance_row[q] == 0), (p == q), "d_W is zero iff equal");
+            assert_eq!(
+                phase_row[q],
+                (3 - w33::phase(&points, q, p)) % 3,
+                "phi is antisymmetric mod 3"
+            );
+            assert_eq!(
+                (phase_row[q] == 0),
+                (distance_row[q] <= 1),
+                "phi is zero exactly on the collinear-or-equal pairs"
+            );
+        }
+    }
+}
+
+#[test]
+fn mu_is_total_surjective_nine_periodic_and_reads_only_residues() {
+    let points = w33::points();
+    let mut seen = [false; w33::POINTS];
+    for s0 in -20i16..=20 {
+        for s1 in -20i16..=20 {
+            let point = w33::map_state(&points, s0, s1);
+            assert!(point < w33::POINTS, "mu is total");
+            seen[point] = true;
+            assert_eq!(
+                point,
+                w33::map_state(&points, s0.rem_euclid(9), s1.rem_euclid(9)),
+                "mu is a pure function of the slot residues mod 9"
+            );
+            assert_eq!(
+                point,
+                w33::map_state(&points, s0.wrapping_add(9), s1),
+                "mu is 9-periodic in slot 0"
+            );
+            assert_eq!(
+                point,
+                w33::map_state(&points, s0, s1.wrapping_add(9)),
+                "mu is 9-periodic in slot 1"
+            );
+        }
+    }
+    assert!(seen.iter().all(|hit| *hit), "mu is onto the 40 points");
+}
+
+#[test]
+fn the_readout_fibers_partition_the_residue_classes() {
+    let points = w33::points();
+    let basepoint = w33::map_state(&points, 0, 0);
+    assert_eq!(
+        points[basepoint],
+        [1, 0, 0, 0],
+        "zero maps to the basepoint"
+    );
+    let mut fiber_sizes = [0usize; w33::POINTS];
+    for a0 in 0i16..9 {
+        for a1 in 0i16..9 {
+            fiber_sizes[w33::map_state(&points, a0, a1)] += 1;
+        }
+    }
+    assert_eq!(fiber_sizes.iter().sum::<usize>(), 81, "fibers partition");
+    for (point, size) in fiber_sizes.iter().enumerate() {
+        let expected = if point == basepoint { 3 } else { 2 };
+        assert_eq!(
+            *size, expected,
+            "point {point}: two residue classes per point, three at the basepoint"
+        );
+    }
+}
+
+#[test]
+fn the_relabel_control_is_a_nonidentity_collinearity_automorphism() {
+    let points = w33::points();
+    let sigma = w33::relabel_permutation(&points);
+    let mut sorted = sigma.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, (0..w33::POINTS).collect::<Vec<_>>(), "a bijection");
+    assert!(
+        sigma.iter().enumerate().any(|(p, image)| p != *image),
+        "the relabel moves at least one point"
+    );
+    for p in 0..w33::POINTS {
+        for q in 0..w33::POINTS {
+            assert_eq!(
+                w33::distance(&points, sigma[p], sigma[q]),
+                w33::distance(&points, p, q),
+                "the relabel preserves d_W"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_phase_permutation_is_adversarial_but_metric_safe() {
+    let points = w33::points();
+    assert_eq!(w33::permute_phase(0), 0, "zero (collinearity) is kept");
+    assert_eq!(w33::permute_phase(1), 2);
+    assert_eq!(w33::permute_phase(2), 1);
+    let mut changed = 0usize;
+    for p in 0..w33::POINTS {
+        for q in 0..w33::POINTS {
+            let original = w33::phase(&points, p, q);
+            let permuted = w33::permute_phase(original);
+            assert_eq!(
+                (permuted == 0),
+                (w33::distance(&points, p, q) <= 1),
+                "the permuted phase keeps the collinearity pattern"
+            );
+            if permuted != original {
+                changed += 1;
+            }
+        }
+    }
+    assert!(changed > 0, "the permutation actually changes the table");
+}


### PR DESCRIPTION
## Problem and outcome

References #845 (S4 item C, increment 2 of 4 — mapping and instruments).

The frozen design contract (`docs/w33_geometry_qualification_spec_845.md`, PR #926) pins the normative W(3,3) as Definitions and requires the binding failure-surface probe to ship as a repository instrument. This PR delivers both as certifier-instrument test code: the reference object with its invariants machine-checked as tests, the state mapping mu, and the probe with its non-vacuity gates.

## What this PR contains

- `crates/uor-r4-graph-certify/tests/support/w33.rs` (new, shared support module) — the symplectic quadrangle over GF(3) exactly as the spec pins it: the 40 canonical points in lex order, the pinned alternating form, collinearity distance d_W, phase phi, the 40x40 tables, the 40 totally isotropic lines, the state mapping mu (total, content-derived, 9-periodic), the pinned relabel symplectomorphism, and the adversarial phase permutation.
- `crates/uor-r4-graph-certify/tests/w33_mapping_845.rs` (new) — 9 tests asserting the frozen Definitions hold of the constructed object: 40 canonical points; the collinearity graph is SRG(40, 12, 2, 4) checked over every pair; 40 lines, 4 points each, each point on 4 lines, pairwise-collinear; the generalized-quadrangle axiom at every (point, line) pair; table/definition agreement with d_W symmetry, diameter 2, phi antisymmetry, and phi = 0 exactly on collinear-or-equal pairs; mu totality, surjectivity, 9-periodicity, and residue-purity over a signed lattice; readout fibers partitioning the 81 residue classes (3 at the basepoint, 2 elsewhere); the relabel control a non-identity collinearity automorphism; the phase permutation adversarial but metric-safe.
- `crates/uor-r4-graph-certify/tests/geometry_probe_845.rs` (new) — the binding cheap instrument (already run 2026-08-22; its record is in Amendment A2 and the spec §6): the bounded-breadth-first failure surface over five families x H in {1, 2, 4, 8, 12, 16} at the frozen budget plus the frontier/expansion ladder at H = 8, with all four #843 nulls measured alongside and the A2(b) admissibility judge. The full grid is `#[ignore]`d (a measurement, not a gate); two default tests assert the instrument packs-and-plans and that the admissibility judge can fire and can fail.

## Verification

- fmt clean; clippy `--workspace --all-targets --all-features -D warnings` clean; wasm lib build clean.
- `cargo test --workspace --no-fail-fast --offline` green (worktree, teacher-gated suites skip as expected).
- `xtask validate` (R1/R4/R5/gnaf), `cargo deny check bans`, and the claim-wording gate all pass; `audit-limits` re-run immediately before push.
- Test code only in `crates/uor-r4-graph-certify/tests/`; no shipped-crate source changes.

## Conformance, compatibility, claim boundary

Certifier-instrument / off-serving-path additions only; no production format, runtime, or dependency changes; CONFORMANCE.md untouched; no new RF id. These tests verify reference mathematics and instrument non-vacuity — they license no semantic-usefulness, activation, or empirical-superiority claim (those are increments 3–4 under the pre-registered statistics).

## Intentionally excluded

The ordering-arm skeleton, controls, and byte-parity audit (increment 3); all measurements beyond the recorded probe (increment 4).
