### PR TITLE
test(#845): reference ordering skeleton, arm/control roster, and parity proofs

### DIFF
--- a/crates/uor-r4-graph-certify/tests/support/arms.rs
+++ b/crates/uor-r4-graph-certify/tests/support/arms.rs
@@ -1,0 +1,634 @@
+//! The #845 ordering arms and controls — one scorer per roster entry of
+//! `docs/w33_geometry_qualification_spec_845.md` §4, each a frontier-retention
+//! functional for the reference skeleton in [`super::ordering`].
+//!
+//! Pinned constants live here and are mirrored in the spec's §4-A appendix.
+//! Every fitted control fits on the fitting half only and is deterministic;
+//! every control reports its auxiliary table bytes for the byte-parity audit
+//! (the geometry arm's byte count is the shared budget).
+#![allow(dead_code)]
+
+use super::ordering::Scorer;
+use super::w33;
+use uor_r4_graph_format::plan::SlotVec;
+
+/// One fitted observation: (state, goal, remaining gold steps).
+pub type RemainingObservation = ((i16, i16), (i16, i16), u8);
+/// One fitted transition: (state, successor).
+pub type Transition = ((i16, i16), (i16, i16));
+
+/// Geometry auxiliary bytes: the two 40 x 40 tables (`d_W`, `phi`). This is
+/// the byte budget every control is matched against.
+pub const GEOMETRY_TABLE_BYTES: usize = 2 * w33::POINTS * w33::POINTS;
+
+/// splitmix64 — the pinned deterministic generator for every seeded table.
+pub fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+fn slots_of(state: &SlotVec) -> (i16, i16) {
+    let slice = state.as_slice();
+    (
+        slice.first().copied().unwrap_or(0),
+        slice.get(1).copied().unwrap_or(0),
+    )
+}
+
+/// The shared W(3,3) context every geometry-shaped scorer borrows: the pinned
+/// point list and the two tables.
+pub struct W33Tables {
+    pub points: Vec<w33::Vec4>,
+    pub distance: Vec<[u8; w33::POINTS]>,
+    pub phase: Vec<[u8; w33::POINTS]>,
+}
+
+impl W33Tables {
+    pub fn build() -> Self {
+        let points = w33::points();
+        let distance = w33::distance_table(&points);
+        let phase = w33::phase_table(&points);
+        Self {
+            points,
+            distance,
+            phase,
+        }
+    }
+}
+
+/// The W(3,3) geometry arm: retention score `-(4 * d_W + t(phi))` of the
+/// successor's mapped point against the goal's mapped point (spec §3).
+pub struct GeometryScorer<'t> {
+    tables: &'t W33Tables,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> GeometryScorer<'t> {
+    pub fn new(tables: &'t W33Tables, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for GeometryScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let d = i32::from(self.tables.distance[point][self.goal_point]);
+        let t = i32::from(self.tables.phase[point][self.goal_point]);
+        -(4 * d + t)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        GEOMETRY_TABLE_BYTES
+    }
+    fn name(&self) -> &'static str {
+        "w33-geometry"
+    }
+}
+
+/// Hamming/popcount control: retention score = negated popcount of the raw
+/// 32-bit slot pair XORed against the goal's. No auxiliary tables.
+pub struct HammingScorer {
+    goal_bits: u32,
+}
+
+impl HammingScorer {
+    pub fn new(goal: (i16, i16)) -> Self {
+        Self {
+            goal_bits: pack_bits(goal),
+        }
+    }
+}
+
+fn pack_bits(slots: (i16, i16)) -> u32 {
+    (u32::from(slots.0 as u16)) | (u32::from(slots.1 as u16) << 16)
+}
+
+impl Scorer for HammingScorer {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let bits = pack_bits(slots_of(successor));
+        -((bits ^ self.goal_bits).count_ones() as i32)
+    }
+    fn lookups(&self) -> u64 {
+        0
+    }
+    fn table_bytes(&self) -> usize {
+        0
+    }
+    fn name(&self) -> &'static str {
+        "hamming-popcount"
+    }
+}
+
+/// Learned control over the *same* quantization as the geometry arm: a
+/// 40 x 40 table of mean remaining-gold-steps between mapped point classes,
+/// fitted on the fitting half (u8 saturating; 255 = never observed), plus the
+/// 40 x 16-bit binary codes derived from it by row-median thresholding. The
+/// retention score is the learned-table distance with the code Hamming
+/// distance as refinement — the sharpest non-geometric test of whether the
+/// quadrangle *structure*, rather than any table over the same 40 classes,
+/// carries the signal.
+pub struct LearnedTable {
+    table: Vec<[u8; w33::POINTS]>,
+    codes: Vec<u16>,
+}
+
+impl LearnedTable {
+    /// `observations` are (state, goal, remaining-gold-steps) triples drawn
+    /// from fitting-half gold paths.
+    pub fn fit(tables: &W33Tables, observations: &[RemainingObservation]) -> Self {
+        let mut sum = vec![[0u32; w33::POINTS]; w33::POINTS];
+        let mut count = vec![[0u32; w33::POINTS]; w33::POINTS];
+        for ((s0, s1), (g0, g1), remaining) in observations {
+            let s = w33::map_state(&tables.points, *s0, *s1);
+            let g = w33::map_state(&tables.points, *g0, *g1);
+            sum[s][g] += u32::from(*remaining);
+            count[s][g] += 1;
+        }
+        let mut table = vec![[255u8; w33::POINTS]; w33::POINTS];
+        for s in 0..w33::POINTS {
+            for g in 0..w33::POINTS {
+                if let Some(mean) = sum[s][g].checked_div(count[s][g]) {
+                    table[s][g] = mean.min(254) as u8;
+                }
+            }
+        }
+        // Row codes: bit b set when the row entry at column-block b sits at or
+        // below the row's observed median (16 four-column blocks).
+        let codes = table
+            .iter()
+            .map(|row| {
+                let mut observed: Vec<u8> = row.iter().copied().filter(|v| *v != 255).collect();
+                observed.sort_unstable();
+                let median = observed.get(observed.len() / 2).copied().unwrap_or(255);
+                let mut code = 0u16;
+                for block in 0..16 {
+                    let start = block * w33::POINTS / 16;
+                    let end = (block + 1) * w33::POINTS / 16;
+                    let hit = row[start..end].iter().any(|v| *v <= median);
+                    if hit {
+                        code |= 1 << block;
+                    }
+                }
+                code
+            })
+            .collect();
+        Self { table, codes }
+    }
+}
+
+/// The per-episode learned-control scorer.
+pub struct LearnedScorer<'t> {
+    tables: &'t W33Tables,
+    fitted: &'t LearnedTable,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> LearnedScorer<'t> {
+    pub fn new(tables: &'t W33Tables, fitted: &'t LearnedTable, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            fitted,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for LearnedScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let learned = i32::from(self.fitted.table[point][self.goal_point]);
+        let code = self.fitted.codes[point] ^ self.fitted.codes[self.goal_point];
+        -(learned * 32 + code.count_ones() as i32)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        w33::POINTS * w33::POINTS + 2 * w33::POINTS
+    }
+    fn name(&self) -> &'static str {
+        "learned-table-codes"
+    }
+}
+
+/// VSA/binding control: per-slot role tables of 128-bit fillers over the nine
+/// slot residues (pinned seed), bound by XOR; retention score = negated
+/// Hamming distance of the bound state and goal hypervectors.
+pub struct VsaTables {
+    fillers: [[u128; 9]; 2],
+}
+
+impl VsaTables {
+    pub fn build() -> Self {
+        let mut state = 0x845a_0001_u64;
+        let mut fillers = [[0u128; 9]; 2];
+        for role in &mut fillers {
+            for filler in role.iter_mut() {
+                let high = splitmix64(&mut state) as u128;
+                let low = splitmix64(&mut state) as u128;
+                *filler = (high << 64) | low;
+            }
+        }
+        Self { fillers }
+    }
+
+    fn hyper(&self, slots: (i16, i16)) -> u128 {
+        let r0 = slots.0.rem_euclid(9) as usize;
+        let r1 = slots.1.rem_euclid(9) as usize;
+        self.fillers[0][r0] ^ self.fillers[1][r1]
+    }
+}
+
+pub struct VsaScorer<'t> {
+    tables: &'t VsaTables,
+    goal: u128,
+    lookups: u64,
+}
+
+impl<'t> VsaScorer<'t> {
+    pub fn new(tables: &'t VsaTables, goal: (i16, i16)) -> Self {
+        Self {
+            tables,
+            goal: tables.hyper(goal),
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for VsaScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        self.lookups += 2;
+        let bound = self.tables.hyper(slots_of(successor));
+        -((bound ^ self.goal).count_ones() as i32)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        2 * 9 * 16
+    }
+    fn name(&self) -> &'static str {
+        "vsa-binding"
+    }
+}
+
+/// Random-embedding null: seed-pinned tables of the same shape and value
+/// range as the geometry tables (d in {0,1,2}, t in {0,1,2}), scored with the
+/// same functional. Matched in bytes and form; devoid of quadrangle structure.
+pub struct RandomTables {
+    d: Vec<[u8; w33::POINTS]>,
+    t: Vec<[u8; w33::POINTS]>,
+}
+
+impl RandomTables {
+    pub fn build() -> Self {
+        let mut state = 0x845a_0002_u64;
+        let mut fill = || {
+            (0..w33::POINTS)
+                .map(|_| {
+                    let mut row = [0u8; w33::POINTS];
+                    for slot in row.iter_mut() {
+                        *slot = (splitmix64(&mut state) % 3) as u8;
+                    }
+                    row
+                })
+                .collect::<Vec<_>>()
+        };
+        let d = fill();
+        let t = fill();
+        Self { d, t }
+    }
+}
+
+pub struct RandomScorer<'t> {
+    tables: &'t W33Tables,
+    random: &'t RandomTables,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> RandomScorer<'t> {
+    pub fn new(tables: &'t W33Tables, random: &'t RandomTables, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            random,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for RandomScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let d = i32::from(self.random.d[point][self.goal_point]);
+        let t = i32::from(self.random.t[point][self.goal_point]);
+        -(4 * d + t)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        GEOMETRY_TABLE_BYTES
+    }
+    fn name(&self) -> &'static str {
+        "random-embedding"
+    }
+}
+
+/// Isomorphic-relabel control: the true geometry tables conjugated by a
+/// pinned *scrambling* permutation of the 40 points (Fisher–Yates, seeded) —
+/// the quadrangle's internal structure survives, its alignment with the state
+/// space does not. The permutation is asserted NOT to be a collinearity
+/// automorphism (else the control would be vacuous). Tables are conjugated at
+/// build time, so the byte budget equals the geometry arm's exactly.
+pub struct RelabeledTables {
+    d: Vec<[u8; w33::POINTS]>,
+    t: Vec<[u8; w33::POINTS]>,
+    pub rho: Vec<usize>,
+}
+
+impl RelabeledTables {
+    pub fn build(tables: &W33Tables) -> Self {
+        let mut state = 0x845a_0003_u64;
+        let mut rho: Vec<usize> = (0..w33::POINTS).collect();
+        for i in (1..w33::POINTS).rev() {
+            let j = (splitmix64(&mut state) % (i as u64 + 1)) as usize;
+            rho.swap(i, j);
+        }
+        let mut d = vec![[0u8; w33::POINTS]; w33::POINTS];
+        let mut t = vec![[0u8; w33::POINTS]; w33::POINTS];
+        for p in 0..w33::POINTS {
+            for q in 0..w33::POINTS {
+                d[p][q] = tables.distance[rho[p]][rho[q]];
+                t[p][q] = tables.phase[rho[p]][rho[q]];
+            }
+        }
+        Self { d, t, rho }
+    }
+
+    /// Whether the pinned permutation preserves d_W everywhere — the control
+    /// requires this to be FALSE (asserted by test).
+    pub fn is_automorphism(&self, tables: &W33Tables) -> bool {
+        (0..w33::POINTS).all(|p| (0..w33::POINTS).all(|q| self.d[p][q] == tables.distance[p][q]))
+    }
+}
+
+pub struct RelabeledScorer<'t> {
+    tables: &'t W33Tables,
+    relabeled: &'t RelabeledTables,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> RelabeledScorer<'t> {
+    pub fn new(tables: &'t W33Tables, relabeled: &'t RelabeledTables, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            relabeled,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for RelabeledScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let d = i32::from(self.relabeled.d[point][self.goal_point]);
+        let t = i32::from(self.relabeled.t[point][self.goal_point]);
+        -(4 * d + t)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        GEOMETRY_TABLE_BYTES
+    }
+    fn name(&self) -> &'static str {
+        "isomorphic-relabel"
+    }
+}
+
+/// Adversarial phase-permutation control: the true d_W with the phase values
+/// swapped (1 <-> 2) — isolates whether the pinned phase convention
+/// specifically carries signal beyond the collinearity metric.
+pub struct PhasePermutedScorer<'t> {
+    tables: &'t W33Tables,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> PhasePermutedScorer<'t> {
+    pub fn new(tables: &'t W33Tables, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for PhasePermutedScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let d = i32::from(self.tables.distance[point][self.goal_point]);
+        let t = i32::from(w33::permute_phase(
+            self.tables.phase[point][self.goal_point],
+        ));
+        -(4 * d + t)
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        GEOMETRY_TABLE_BYTES
+    }
+    fn name(&self) -> &'static str {
+        "phase-permuted"
+    }
+}
+
+/// Spectral control: an offline f64 Laplacian eigen-embedding of the observed
+/// class-transition graph (fitting half only), quantized to i16 tables. The
+/// eigensolver is a fixed-sweep cyclic Jacobi rotation — deterministic by
+/// construction (fixed sweep order and count, no convergence branching on
+/// accumulated error). f64 is compiler/certifier scope, per the spec.
+pub struct SpectralEmbedding {
+    embed: Vec<[i16; SPECTRAL_DIMS]>,
+}
+
+/// Embedding width. 40 x 8 x 2 bytes = 640 auxiliary bytes.
+pub const SPECTRAL_DIMS: usize = 8;
+/// Fixed Jacobi sweep count (each sweep visits every upper-triangle pair).
+pub const JACOBI_SWEEPS: usize = 32;
+
+impl SpectralEmbedding {
+    /// `transitions` are (state, successor) pairs from fitting-half gold
+    /// paths, mapped to point classes.
+    pub fn fit(tables: &W33Tables, transitions: &[Transition]) -> Self {
+        let n = w33::POINTS;
+        let mut weight = vec![[0f64; w33::POINTS]; w33::POINTS];
+        for ((s0, s1), (t0, t1)) in transitions {
+            let a = w33::map_state(&tables.points, *s0, *s1);
+            let b = w33::map_state(&tables.points, *t0, *t1);
+            if a != b {
+                weight[a][b] += 1.0;
+                weight[b][a] += 1.0;
+            }
+        }
+        // L = D - W.
+        let mut matrix = vec![[0f64; w33::POINTS]; w33::POINTS];
+        for i in 0..n {
+            let degree: f64 = weight[i].iter().sum();
+            for j in 0..n {
+                matrix[i][j] = if i == j { degree } else { -weight[i][j] };
+            }
+        }
+        let (values, vectors) = jacobi_eigen(&mut matrix);
+        // Ascending eigenvalues; skip the constant kernel vector; take the
+        // next SPECTRAL_DIMS. Ties break by original index (stable sort).
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|a, b| {
+            values[*a]
+                .partial_cmp(&values[*b])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let chosen: Vec<usize> = order.into_iter().skip(1).take(SPECTRAL_DIMS).collect();
+        let embed = (0..n)
+            .map(|point| {
+                let mut row = [0i16; SPECTRAL_DIMS];
+                for (dim, source) in chosen.iter().enumerate() {
+                    let value = vectors[point][*source] * 1024.0;
+                    row[dim] = value.clamp(-32768.0, 32767.0) as i16;
+                }
+                row
+            })
+            .collect();
+        Self { embed }
+    }
+}
+
+/// Cyclic Jacobi over a symmetric matrix: returns (eigenvalues on the
+/// diagonal, eigenvector columns). Fixed sweeps in a fixed pair order.
+fn jacobi_eigen(matrix: &mut [[f64; w33::POINTS]]) -> (Vec<f64>, Vec<[f64; w33::POINTS]>) {
+    let n = w33::POINTS;
+    let mut vectors = vec![[0f64; w33::POINTS]; w33::POINTS];
+    for (i, row) in vectors.iter_mut().enumerate() {
+        row[i] = 1.0;
+    }
+    for _sweep in 0..JACOBI_SWEEPS {
+        for p in 0..n {
+            for q in (p + 1)..n {
+                let apq = matrix[p][q];
+                if apq == 0.0 {
+                    continue;
+                }
+                let app = matrix[p][p];
+                let aqq = matrix[q][q];
+                let theta = 0.5 * (aqq - app) / apq;
+                let t = if theta >= 0.0 {
+                    1.0 / (theta + (1.0 + theta * theta).sqrt())
+                } else {
+                    1.0 / (theta - (1.0 + theta * theta).sqrt())
+                };
+                let c = 1.0 / (1.0 + t * t).sqrt();
+                let s = t * c;
+                for row in matrix.iter_mut() {
+                    let akp = row[p];
+                    let akq = row[q];
+                    row[p] = c * akp - s * akq;
+                    row[q] = s * akp + c * akq;
+                }
+                let (head, tail) = matrix.split_at_mut(q);
+                let row_p = &mut head[p];
+                let row_q = &mut tail[0];
+                for (apk, aqk) in row_p.iter_mut().zip(row_q.iter_mut()) {
+                    let a = *apk;
+                    let b = *aqk;
+                    *apk = c * a - s * b;
+                    *aqk = s * a + c * b;
+                }
+                for row in vectors.iter_mut() {
+                    let vp = row[p];
+                    let vq = row[q];
+                    row[p] = c * vp - s * vq;
+                    row[q] = s * vp + c * vq;
+                }
+            }
+        }
+    }
+    let values = (0..n).map(|i| matrix[i][i]).collect();
+    (values, vectors)
+}
+
+pub struct SpectralScorer<'t> {
+    tables: &'t W33Tables,
+    embedding: &'t SpectralEmbedding,
+    goal_point: usize,
+    lookups: u64,
+}
+
+impl<'t> SpectralScorer<'t> {
+    pub fn new(tables: &'t W33Tables, embedding: &'t SpectralEmbedding, goal: (i16, i16)) -> Self {
+        let goal_point = w33::map_state(&tables.points, goal.0, goal.1);
+        Self {
+            tables,
+            embedding,
+            goal_point,
+            lookups: 0,
+        }
+    }
+}
+
+impl Scorer for SpectralScorer<'_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        let (s0, s1) = slots_of(successor);
+        let point = w33::map_state(&self.tables.points, s0, s1);
+        self.lookups += 2;
+        let a = &self.embedding.embed[point];
+        let b = &self.embedding.embed[self.goal_point];
+        let l1: i32 = a
+            .iter()
+            .zip(b.iter())
+            .map(|(x, y)| (i32::from(*x) - i32::from(*y)).abs())
+            .sum();
+        -l1
+    }
+    fn lookups(&self) -> u64 {
+        self.lookups
+    }
+    fn table_bytes(&self) -> usize {
+        w33::POINTS * SPECTRAL_DIMS * 2
+    }
+    fn name(&self) -> &'static str {
+        "spectral-embedding"
+    }
+}

--- a/crates/uor-r4-graph-certify/tests/support/episode.rs
+++ b/crates/uor-r4-graph-certify/tests/support/episode.rs
@@ -1,0 +1,487 @@
+//! Shared #845 episode machinery: benchmark instance -> packed sections ->
+//! one deployed or reference planning episode, judged by the frozen #844
+//! verifier. The construction mirrors the #843 increment-6 harness protocol
+//! (and the frozen probe instrument `geometry_probe_845.rs`).
+#![allow(dead_code)]
+
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_compiler::semantic_state::Action;
+use uor_r4_graph_compiler::semantic_transitions as st;
+use uor_r4_graph_format::plan::{CompareOp, EffectDelta, PreconditionMask, SlotVec};
+use uor_r4_graph_format::plan_sections::{
+    build_predicate_set, build_rule_table, build_schema, PackedRule, PlanSchema, PredicateSet,
+    RuleTable,
+};
+use uor_r4_graph_runtime::plan::{
+    plan, PlanBudget, PlanCounters, PlanOutcome, PlanQuery, PlanScratch, PlanStrategy,
+};
+
+use super::arms::{RemainingObservation, Transition};
+use super::ordering::{plan_reference, RefOutcome, RefQuery, RefScratch, Scorer, SeamMode};
+
+/// Frozen sample size per held-out cell per horizon (#844 §2.5).
+pub const N_PER_CELL: usize = 512;
+
+pub const FAMILIES: [cp::TaskFamily; 5] = [
+    cp::TaskFamily::GraphNavigation,
+    cp::TaskFamily::SymbolicTransformation,
+    cp::TaskFamily::ConstraintSatisfaction,
+    cp::TaskFamily::MultiHopEvidence,
+    cp::TaskFamily::CounterfactualIntervention,
+];
+
+/// The three A2(b) separating families.
+pub const SEPARATING: [cp::TaskFamily; 3] = [
+    cp::TaskFamily::GraphNavigation,
+    cp::TaskFamily::ConstraintSatisfaction,
+    cp::TaskFamily::MultiHopEvidence,
+];
+
+fn axis_digits(seed: u64) -> [u64; 4] {
+    let c = cp::AXIS_CARDINALITY;
+    [
+        seed % c,
+        (seed / c) % c,
+        (seed / (c * c)) % c,
+        (seed / (c * c * c)) % c,
+    ]
+}
+
+/// Joint-split seed walk (#844 §2.2): held-out = high half of every axis,
+/// fitting = low half of every axis.
+pub fn seeds(held_out: bool, count: usize) -> Vec<u64> {
+    let half = cp::AXIS_CARDINALITY / 2;
+    let mut out = Vec::with_capacity(count);
+    let mut seed = 0u64;
+    while out.len() < count {
+        let keep = if held_out {
+            axis_digits(seed).iter().all(|d| *d >= half)
+        } else {
+            axis_digits(seed).iter().all(|d| *d < half)
+        };
+        if keep {
+            out.push(seed);
+        }
+        seed += 1;
+    }
+    out
+}
+
+/// Generator viability guard (`cp::generate` panics when a requested BFS layer
+/// is empty); unavailable instances are recorded, never crashed on.
+pub fn try_generate(family: cp::TaskFamily, seed: u64, horizon: usize) -> Option<cp::TaskInstance> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        cp::generate(family, seed, horizon)
+    }))
+    .ok()
+}
+
+pub fn ints(values: &[f32]) -> Vec<i16> {
+    values.iter().map(|v| v.round() as i16).collect()
+}
+
+fn band_code(band: cp::ConfidenceBand) -> u8 {
+    match band {
+        cp::ConfidenceBand::None => 0,
+        cp::ConfidenceBand::Low => 1,
+        cp::ConfidenceBand::Medium => 2,
+        cp::ConfidenceBand::High => 3,
+    }
+}
+
+fn cell_predicate(values: &[i16]) -> PreconditionMask {
+    let mut predicate = PreconditionMask::unconditional();
+    for (slot, value) in values.iter().enumerate() {
+        predicate = predicate.reading(slot, CompareOp::Equal, *value).unwrap();
+    }
+    predicate
+}
+
+/// The artifact side of an episode.
+pub struct Packed {
+    pub schema: Vec<u8>,
+    pub rules: Vec<u8>,
+    pub effects: Vec<Vec<i16>>,
+}
+
+/// Pack an induced rule set; `rotate` is the shuffled-state null (0 = faithful).
+pub fn pack(set: &st::TransitionRuleSet, rotate: usize) -> Option<Packed> {
+    let mut effects: Vec<Vec<i16>> = set
+        .rules
+        .iter()
+        .map(|r| r.effect.as_slice().to_vec())
+        .collect();
+    effects.sort();
+    effects.dedup();
+    if effects.is_empty() {
+        return None;
+    }
+    let vocabulary: Vec<EffectDelta> = effects
+        .iter()
+        .map(|e| EffectDelta::from_slice(e).unwrap())
+        .collect();
+    let schema = build_schema(2, &vocabulary, (1, 4, 16))?;
+    let parsed = PlanSchema::parse(&schema).ok()?;
+    let mut rules = Vec::new();
+    for rule in &set.rules {
+        let effect = rule.effect.as_slice().to_vec();
+        let operator = effects.iter().position(|e| *e == effect)?;
+        let carried = (operator + rotate) % effects.len();
+        rules.push(PackedRule {
+            operator: operator as u16,
+            precondition: rule.precondition,
+            effect: parsed.operator(carried)?,
+            support: rule.support,
+            band: band_code(rule.band),
+        });
+    }
+    rules.sort_by_key(|r| (r.operator, r.effect.as_slice().to_vec()));
+    rules.dedup_by_key(|r| (r.operator, r.effect.as_slice().to_vec()));
+    let rules = build_rule_table(2, effects.len() as u16, &rules)?;
+    Some(Packed {
+        schema,
+        rules,
+        effects,
+    })
+}
+
+/// Induce the artifact-side rule set from the fitting half (joint split).
+pub fn induce_for(family: cp::TaskFamily, horizon: usize) -> Option<st::TransitionRuleSet> {
+    let mut observations = Vec::new();
+    for seed in seeds(false, N_PER_CELL / 4) {
+        let task = try_generate(family, seed, horizon)?;
+        observations.extend(st::observe(&task));
+    }
+    let held_out: std::collections::BTreeSet<u8> = (0..cp::AXIS_CARDINALITY)
+        .filter(|d| *d >= cp::AXIS_CARDINALITY / 2)
+        .map(|d| d as u8)
+        .collect();
+    let policy = st::SplitPolicy {
+        held_out_topologies: held_out,
+        sealed_topologies: std::collections::BTreeSet::new(),
+    };
+    st::induce(&observations, &policy).induced().cloned()
+}
+
+pub fn predicates_for(task: &cp::TaskInstance) -> Option<Vec<u8>> {
+    let goal = cell_predicate(&ints(&task.goal.target_region.center));
+    let mut constraints: Vec<PreconditionMask> = task
+        .constraints
+        .iter()
+        .map(|c| cell_predicate(&ints(&c.forbidden_region.center)))
+        .collect();
+    constraints.sort_by_key(|c| (0..2).map(|s| c.bound(s)).collect::<Vec<_>>());
+    constraints.dedup_by_key(|c| (0..2).map(|s| c.bound(s)).collect::<Vec<_>>());
+    build_predicate_set(2, &[goal], &constraints)
+}
+
+pub fn initial_of(task: &cp::TaskInstance) -> SlotVec {
+    SlotVec::from_slice(&ints(&task.initial_state.vector)).unwrap()
+}
+
+pub fn goal_center(task: &cp::TaskInstance) -> (i16, i16) {
+    let center = ints(&task.goal.target_region.center);
+    (
+        center.first().copied().unwrap_or(0),
+        center.get(1).copied().unwrap_or(0),
+    )
+}
+
+pub fn mask_for(packed: &Packed, task: &cp::TaskInstance) -> u64 {
+    let mut mask = 0u64;
+    for action in &task.actions {
+        let effect = ints(&action.delta_vector);
+        if let Some(index) = packed.effects.iter().position(|e| *e == effect) {
+            if index < 64 {
+                mask |= 1u64 << index;
+            }
+        }
+    }
+    mask
+}
+
+/// A plan as operator-effect steps, or an honest decline.
+pub type Emission = Option<Vec<Vec<i16>>>;
+
+pub fn as_actions(task: &cp::TaskInstance, effects: &[Vec<i16>]) -> Option<Vec<Action>> {
+    effects
+        .iter()
+        .map(|effect| {
+            task.actions
+                .iter()
+                .find(|a| ints(&a.delta_vector) == *effect)
+                .cloned()
+        })
+        .collect()
+}
+
+/// Judge an emission against the frozen #844 verifier (correct-outcome rate,
+/// the #844 §11.6 reading).
+pub fn outcome_correct(task: &cp::TaskInstance, emitted: &Emission) -> bool {
+    let unsolvable = task.gold.decline.is_some();
+    match (emitted, unsolvable) {
+        (None, true) => true,
+        (None, false) => false,
+        (Some(_), true) => false,
+        (Some(effects), false) => match as_actions(task, effects) {
+            Some(actions) => cp::verify_submission(task, &actions) == cp::WitnessVerdict::Valid,
+            None => false,
+        },
+    }
+}
+
+/// One deployed episode under an explicit budget.
+pub fn run_deployed(
+    strategy: PlanStrategy,
+    packed: &Packed,
+    task: &cp::TaskInstance,
+    budget: PlanBudget,
+    scratch: &mut PlanScratch,
+) -> Option<(Emission, PlanCounters)> {
+    let schema = PlanSchema::parse(&packed.schema).ok()?;
+    let rules = RuleTable::parse(&packed.rules, &schema).ok()?;
+    let predicate_bytes = predicates_for(task)?;
+    let predicates = PredicateSet::parse(&predicate_bytes, &schema).ok()?;
+    let result = plan(
+        &PlanQuery {
+            strategy,
+            schema: &schema,
+            rules: &rules,
+            predicates: &predicates,
+            initial: initial_of(task),
+            available: mask_for(packed, task),
+            budget,
+        },
+        scratch,
+    );
+    let emitted = match result.outcome {
+        PlanOutcome::Plan { steps } => Some(
+            (0..steps)
+                .filter_map(|i| {
+                    scratch
+                        .path_step(i)
+                        .map(|(e, _, _, _)| e.as_slice().to_vec())
+                })
+                .collect(),
+        ),
+        PlanOutcome::Declined(_) => None,
+    };
+    Some((emitted, result.counters))
+}
+
+/// One reference episode under the same budget and artifact, with the
+/// retention seam opened to `scorer`.
+pub fn run_reference(
+    packed: &Packed,
+    task: &cp::TaskInstance,
+    budget: PlanBudget,
+    mode: SeamMode,
+    scorer: &mut dyn Scorer,
+    scratch: &mut RefScratch,
+) -> Option<(Emission, PlanCounters)> {
+    let schema = PlanSchema::parse(&packed.schema).ok()?;
+    let rules = RuleTable::parse(&packed.rules, &schema).ok()?;
+    let predicate_bytes = predicates_for(task)?;
+    let predicates = PredicateSet::parse(&predicate_bytes, &schema).ok()?;
+    let query = RefQuery {
+        schema: &schema,
+        rules: &rules,
+        predicates: &predicates,
+        initial: initial_of(task),
+        available: mask_for(packed, task),
+        horizon: budget.horizon,
+        frontier: budget.frontier,
+        max_expansions: budget.max_expansions,
+        max_candidates: budget.max_candidates,
+        max_table_reads: budget.max_table_reads,
+    };
+    let result = plan_reference(&query, scratch, mode, scorer);
+    let emitted = match result.outcome {
+        RefOutcome::Plan(path) => Some(
+            path.iter()
+                .map(|(effect, _, _, _)| effect.as_slice().to_vec())
+                .collect(),
+        ),
+        RefOutcome::Declined(_) => None,
+    };
+    Some((emitted, result.counters))
+}
+
+/// Gold-path observations for the fitted controls: (state, goal, remaining
+/// steps) triples and (state, successor) transitions from the fitting half.
+pub struct FittingObservations {
+    pub remaining: Vec<RemainingObservation>,
+    pub transitions: Vec<Transition>,
+}
+
+pub fn fitting_observations(family: cp::TaskFamily, horizon: usize) -> FittingObservations {
+    let mut remaining = Vec::new();
+    let mut transitions = Vec::new();
+    for seed in seeds(false, N_PER_CELL / 4) {
+        let Some(task) = try_generate(family, seed, horizon) else {
+            continue;
+        };
+        if task.gold.decline.is_some() {
+            continue;
+        }
+        let goal = goal_center(&task);
+        let mut state = {
+            let v = ints(&task.initial_state.vector);
+            (
+                v.first().copied().unwrap_or(0),
+                v.get(1).copied().unwrap_or(0),
+            )
+        };
+        let steps = task.gold.chosen_path.len();
+        for (index, action) in task.gold.chosen_path.iter().enumerate() {
+            let left = (steps - index).min(254) as u8;
+            remaining.push((state, goal, left));
+            let delta = ints(&action.delta_vector);
+            let next = (
+                state.0.saturating_add(delta.first().copied().unwrap_or(0)),
+                state.1.saturating_add(delta.get(1).copied().unwrap_or(0)),
+            );
+            transitions.push((state, next));
+            state = next;
+        }
+        remaining.push((state, goal, 0));
+    }
+    FittingObservations {
+        remaining,
+        transitions,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The four #843 nulls (harness protocol, ported unchanged)
+// ---------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+/// What the replay nulls learned from the fitting half.
+pub struct Fitted {
+    by_structure: BTreeMap<String, Emission>,
+    by_goal: Vec<(Vec<i16>, Emission)>,
+    modal: Emission,
+}
+
+fn structure_key(task: &cp::TaskInstance) -> String {
+    let mut forbidden: Vec<Vec<i16>> = task
+        .constraints
+        .iter()
+        .map(|c| ints(&c.forbidden_region.center))
+        .collect();
+    forbidden.sort();
+    let effects: Vec<Vec<i16>> = task.actions.iter().map(|a| ints(&a.delta_vector)).collect();
+    format!(
+        "{}|{:?}|{:?}|{:?}",
+        task.family.label(),
+        ints(&task.goal.target_region.center),
+        forbidden,
+        effects
+    )
+}
+
+pub fn gold_effects(task: &cp::TaskInstance) -> Emission {
+    if task.gold.decline.is_some() {
+        return None;
+    }
+    Some(
+        task.gold
+            .chosen_path
+            .iter()
+            .map(|a| ints(&a.delta_vector))
+            .collect(),
+    )
+}
+
+pub fn fit_nulls(family: cp::TaskFamily, horizon: usize) -> Fitted {
+    let mut by_structure = BTreeMap::new();
+    let mut by_goal = Vec::new();
+    let mut frequency: BTreeMap<Emission, usize> = BTreeMap::new();
+    for seed in seeds(false, N_PER_CELL) {
+        let Some(task) = try_generate(family, seed, horizon) else {
+            continue;
+        };
+        let emission = gold_effects(&task);
+        by_structure
+            .entry(structure_key(&task))
+            .or_insert_with(|| emission.clone());
+        by_goal.push((ints(&task.goal.target_region.center), emission.clone()));
+        *frequency.entry(emission).or_default() += 1;
+    }
+    let modal = frequency
+        .iter()
+        .max_by_key(|(plan, count)| (**count, std::cmp::Reverse((*plan).clone())))
+        .map(|(plan, _)| plan.clone())
+        .unwrap_or(None);
+    Fitted {
+        by_structure,
+        by_goal,
+        modal,
+    }
+}
+
+/// N1 retrieval-only: nearest fitting instance by goal displacement.
+pub fn retrieval_only(fitted: &Fitted, task: &cp::TaskInstance) -> Emission {
+    let goal = ints(&task.goal.target_region.center);
+    fitted
+        .by_goal
+        .iter()
+        .min_by_key(|(g, _)| {
+            g.iter()
+                .zip(goal.iter())
+                .map(|(a, b)| i64::from(*a - *b).abs())
+                .sum::<i64>()
+        })
+        .and_then(|(_, plan)| plan.clone())
+}
+
+/// N2 direct-continuation: greedy descent on goal distance, no lookahead.
+pub fn direct_continuation(task: &cp::TaskInstance, horizon: usize) -> Emission {
+    let goal = ints(&task.goal.target_region.center);
+    let mut state = ints(&task.initial_state.vector);
+    let mut out = Vec::new();
+    let distance = |s: &[i16]| -> i64 {
+        s.iter()
+            .zip(goal.iter())
+            .map(|(a, b)| i64::from(*a - *b).abs())
+            .sum()
+    };
+    for _ in 0..horizon {
+        if distance(&state) == 0 {
+            return Some(out);
+        }
+        let mut best: Option<(i64, Vec<i16>, Vec<i16>)> = None;
+        for action in &task.actions {
+            let effect = ints(&action.delta_vector);
+            let next: Vec<i16> = state
+                .iter()
+                .zip(effect.iter())
+                .map(|(s, d)| s.saturating_add(*d))
+                .collect();
+            let score = distance(&next);
+            let better = match &best {
+                None => true,
+                Some((current, _, current_effect)) => {
+                    score < *current || (score == *current && effect < *current_effect)
+                }
+            };
+            if better {
+                best = Some((score, next, effect));
+            }
+        }
+        let (_, next, effect) = best?;
+        state = next;
+        out.push(effect);
+    }
+    Some(out)
+}
+
+/// N3 memorized-trajectory: structural-key replay with a modal fallback.
+pub fn memorized(fitted: &Fitted, task: &cp::TaskInstance) -> Emission {
+    match fitted.by_structure.get(&structure_key(task)) {
+        Some(plan) => plan.clone(),
+        None => fitted.modal.clone(),
+    }
+}

--- a/crates/uor-r4-graph-certify/tests/support/mod.rs
+++ b/crates/uor-r4-graph-certify/tests/support/mod.rs
@@ -5,4 +5,8 @@
 //! that declares `mod support;` compiles its own copy, so the shared surface
 //! is allowed to be partially used per binary.
 
+pub mod arms;
+pub mod episode;
+pub mod ordering;
+pub mod stats;
 pub mod w33;

--- a/crates/uor-r4-graph-certify/tests/support/ordering.rs
+++ b/crates/uor-r4-graph-certify/tests/support/ordering.rs
@@ -1,0 +1,565 @@
+//! The #845 reference search skeleton — the deployed bounded layered search
+//! (`uor_r4_graph_runtime::plan`) ported faithfully with exactly one seam
+//! opened: the frontier-retention score. Certifier-instrument code.
+//!
+//! Parity is a proven-by-test property, not an aspiration: with the incumbent
+//! goal-distance scorer this skeleton must reproduce the deployed planner's
+//! outcome, plan, and every counter field, episode by episode (breadth-first
+//! and beam alike; asserted in `w33_ordering_harness_845.rs`). Counter
+//! accounting therefore mirrors the deployed `Episode` call-for-call,
+//! including the post-search unwind and considered-record reads.
+//!
+//! Scoring work an ordering performs is deliberately *not* part of
+//! `PlanCounters` (the deployed scorer's goal-distance reads are uncounted
+//! there too); each scorer reports its auxiliary lookups and table bytes
+//! separately for the equal-bytes/equal-operations audit.
+#![allow(dead_code)]
+
+use uor_r4_graph_format::plan::{
+    EffectDelta, SlotVec, PLAN_ACTIONS_MAX, PLAN_FRONTIER_MAX, PLAN_HORIZON_MAX, PLAN_SLOTS_MAX,
+    PLAN_VISITED_MAX,
+};
+use uor_r4_graph_format::plan_sections::{PackedDecline, PlanSchema, PredicateSet, RuleTable};
+use uor_r4_graph_runtime::plan::PlanCounters;
+
+const VISITED_MAX_PROBE: u8 = 16;
+const VISITED_INDEX_SLOTS: usize = PLAN_VISITED_MAX * 2;
+const VISITED_INDEX_MASK: u32 = (VISITED_INDEX_SLOTS - 1) as u32;
+const EMPTY: u16 = u16::MAX;
+
+/// A frontier-retention scorer: higher survives the frontier bound. The
+/// incumbent (deployed-parity) scorer returns the negated goal distance.
+pub trait Scorer {
+    /// Retention score of an admitted successor against the episode's goal.
+    fn score(&mut self, successor: &SlotVec) -> i32;
+    /// Auxiliary table lookups spent scoring so far (reported, not budgeted).
+    fn lookups(&self) -> u64;
+    /// Bytes of auxiliary tables this ordering consults (byte-parity audit).
+    fn table_bytes(&self) -> usize;
+    /// Stable arm label.
+    fn name(&self) -> &'static str;
+}
+
+/// The reference episode outcome: a plan as (effect, resulting state,
+/// operator, rule row) steps, or the typed decline the deployed planner would
+/// report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefOutcome {
+    Plan(Vec<(EffectDelta, SlotVec, u16, u16)>),
+    Declined(PackedDecline),
+}
+
+/// One reference episode result: outcome plus deployed-equivalent counters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefResult {
+    pub outcome: RefOutcome,
+    pub counters: PlanCounters,
+}
+
+/// The query, mirroring the deployed `PlanQuery` field for field.
+pub struct RefQuery<'a, 'b> {
+    pub schema: &'a PlanSchema<'b>,
+    pub rules: &'a RuleTable<'b>,
+    pub predicates: &'a PredicateSet<'b>,
+    pub initial: SlotVec,
+    pub available: u64,
+    pub horizon: u8,
+    pub frontier: u16,
+    pub max_expansions: u32,
+    pub max_candidates: u32,
+    pub max_table_reads: u32,
+}
+
+/// The deployed multiply-free state hash, ported unchanged (Jenkins
+/// one-at-a-time over the slot bytes).
+fn hash_state(state: &SlotVec) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for value in state.as_slice() {
+        let bytes = value.to_le_bytes();
+        for byte in bytes {
+            hash = hash.wrapping_add(u32::from(byte));
+            hash = hash.wrapping_add(hash << 10);
+            hash ^= hash >> 6;
+        }
+    }
+    hash = hash.wrapping_add(hash << 3);
+    hash ^= hash >> 11;
+    hash.wrapping_add(hash << 15)
+}
+
+/// The deployed saturating goal distance, ported unchanged.
+pub fn goal_distance_for(predicates: &PredicateSet<'_>, state: &SlotVec) -> i32 {
+    let Some(goal) = predicates.goal(0) else {
+        return 0;
+    };
+    let mut total: i32 = 0;
+    for slot in 0..PLAN_SLOTS_MAX {
+        if goal.read_mask() & (1u8 << slot) == 0 {
+            continue;
+        }
+        let Some(value) = state.get(slot) else {
+            continue;
+        };
+        let bound = goal.bound(slot);
+        let gap = if value >= bound {
+            value.saturating_sub(bound)
+        } else {
+            bound.saturating_sub(value)
+        };
+        total = total.saturating_add(i32::from(gap));
+    }
+    total
+}
+
+/// The incumbent retention scorer: exactly the deployed beam's signal.
+pub struct GoalDistanceScorer<'a, 'b> {
+    predicates: &'a PredicateSet<'b>,
+}
+
+impl<'a, 'b> GoalDistanceScorer<'a, 'b> {
+    pub fn new(predicates: &'a PredicateSet<'b>) -> Self {
+        Self { predicates }
+    }
+}
+
+impl Scorer for GoalDistanceScorer<'_, '_> {
+    fn score(&mut self, successor: &SlotVec) -> i32 {
+        -goal_distance_for(self.predicates, successor)
+    }
+    fn lookups(&self) -> u64 {
+        0
+    }
+    fn table_bytes(&self) -> usize {
+        0
+    }
+    fn name(&self) -> &'static str {
+        "table-guided-beam"
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Node {
+    state: SlotVec,
+    parent: u16,
+    rule_row: u16,
+    operator: u16,
+    depth: u8,
+}
+
+#[derive(Clone, Copy)]
+struct Frame {
+    state: SlotVec,
+    node: u16,
+    depth: u8,
+}
+
+/// Reference scratch: same capacities as the deployed scratch, Vec-backed
+/// (reference scope allows allocation).
+pub struct RefScratch {
+    visited: Vec<Node>,
+    index: Vec<u16>,
+    frontier: Vec<Frame>,
+    next: Vec<Frame>,
+    scores: Vec<i32>,
+}
+
+impl Default for RefScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RefScratch {
+    pub fn new() -> Self {
+        Self {
+            visited: Vec::with_capacity(PLAN_VISITED_MAX),
+            index: vec![EMPTY; VISITED_INDEX_SLOTS],
+            frontier: Vec::with_capacity(PLAN_FRONTIER_MAX),
+            next: Vec::with_capacity(PLAN_FRONTIER_MAX),
+            scores: Vec::with_capacity(PLAN_FRONTIER_MAX),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.visited.clear();
+        self.frontier.clear();
+        self.next.clear();
+        self.scores.clear();
+        for slot in self.index.iter_mut() {
+            *slot = EMPTY;
+        }
+    }
+}
+
+enum Search {
+    Found(u16),
+    Exhausted,
+    Declined(PackedDecline),
+}
+
+enum Step {
+    Taken(u16),
+    Blocked,
+    Capacity,
+    Unknown,
+}
+
+struct Episode<'q, 'a, 'b> {
+    query: &'q RefQuery<'a, 'b>,
+    counters: PlanCounters,
+}
+
+impl Episode<'_, '_, '_> {
+    fn read(&mut self, count: u32) {
+        self.counters.table_reads = self.counters.table_reads.saturating_add(count);
+    }
+
+    fn op(&mut self, count: u32) {
+        self.counters.integer_ops = self.counters.integer_ops.saturating_add(count);
+    }
+
+    fn over_budget(&self) -> bool {
+        self.counters.expansions > self.query.max_expansions
+            || self.counters.candidates > self.query.max_candidates
+            || self.counters.table_reads > self.query.max_table_reads
+    }
+
+    fn admit(&mut self, scratch: &mut RefScratch, state: &SlotVec) -> Option<Option<u16>> {
+        let mut slot = (hash_state(state) & VISITED_INDEX_MASK) as usize;
+        for probe in 0..=VISITED_MAX_PROBE {
+            if probe == VISITED_MAX_PROBE {
+                return None;
+            }
+            self.counters.max_probe = self.counters.max_probe.max(probe.saturating_add(1));
+            self.read(1);
+            let occupant = scratch.index[slot];
+            if occupant == EMPTY {
+                if scratch.visited.len() >= PLAN_VISITED_MAX {
+                    return None;
+                }
+                let node = scratch.visited.len() as u16;
+                scratch.index[slot] = node;
+                scratch.visited.push(Node {
+                    state: *state,
+                    parent: EMPTY,
+                    rule_row: 0,
+                    operator: 0,
+                    depth: 0,
+                });
+                return Some(Some(node));
+            }
+            self.read(1);
+            if scratch.visited[usize::from(occupant)].state == *state {
+                return Some(None);
+            }
+            slot = (slot + 1) & (VISITED_INDEX_SLOTS - 1);
+        }
+        None
+    }
+
+    fn take(
+        &mut self,
+        scratch: &mut RefScratch,
+        state: &SlotVec,
+        parent: u16,
+        depth: u8,
+        operator: u16,
+        rule_row: usize,
+    ) -> Step {
+        self.counters.candidates = self.counters.candidates.saturating_add(1);
+        self.read(1);
+        let Some(rule) = self.query.rules.rule(rule_row) else {
+            return Step::Unknown;
+        };
+        self.op(1);
+        if !rule.precondition.holds(state) {
+            return Step::Blocked;
+        }
+        let Some(successor) = state.apply(&rule.effect) else {
+            return Step::Unknown;
+        };
+        self.op(successor.len() as u32);
+        self.read(1);
+        if self.query.predicates.is_forbidden(&successor) {
+            return Step::Blocked;
+        }
+        match self.admit(scratch, &successor) {
+            None => Step::Capacity,
+            Some(None) => Step::Blocked,
+            Some(Some(node)) => {
+                scratch.visited[usize::from(node)] = Node {
+                    state: successor,
+                    parent,
+                    rule_row: rule_row as u16,
+                    operator,
+                    depth: depth.saturating_add(1),
+                };
+                Step::Taken(node)
+            }
+        }
+    }
+
+    fn unwind(
+        &mut self,
+        scratch: &RefScratch,
+        node: u16,
+    ) -> Option<Vec<(EffectDelta, SlotVec, u16, u16)>> {
+        let mut depth = usize::from(scratch.visited[usize::from(node)].depth);
+        if depth > PLAN_HORIZON_MAX {
+            return None;
+        }
+        let mut path = vec![(EffectDelta::EMPTY, SlotVec::empty(), 0u16, 0u16); depth];
+        let mut cursor = node;
+        while depth > 0 {
+            let current = scratch.visited[usize::from(cursor)];
+            let parent = current.parent;
+            if parent == EMPTY {
+                return None;
+            }
+            let from = scratch.visited[usize::from(parent)].state;
+            let rule = self.query.rules.rule(usize::from(current.rule_row))?;
+            self.read(1);
+            match from.apply(&rule.effect) {
+                Some(next) if next == current.state => {}
+                _ => return None,
+            }
+            depth -= 1;
+            path[depth] = (
+                rule.effect,
+                current.state,
+                current.operator,
+                current.rule_row,
+            );
+            cursor = parent;
+        }
+        Some(path)
+    }
+
+    /// The deployed considered-record post-pass, ported for its counter
+    /// effects (one table read per available ruled operator per path step);
+    /// the record itself is informational and is not rebuilt here.
+    fn record_considered_reads(&mut self, steps: usize) {
+        let operators = self.query.schema.operator_count().min(PLAN_ACTIONS_MAX);
+        for _step in 0..steps {
+            for operator in 0..operators {
+                if self.query.available & (1u64 << operator) == 0 {
+                    continue;
+                }
+                let Some((first, end)) = self.query.rules.rules_for(operator) else {
+                    continue;
+                };
+                if first >= end {
+                    continue;
+                }
+                self.read(1);
+                let _ = self.query.rules.rule(first);
+            }
+        }
+    }
+}
+
+/// How the seam is opened.
+///
+/// - `Parity(false)` — FIFO retention, arrival-order expansion: the deployed
+///   breadth-first, counter-exact.
+/// - `Parity(true)` — score retention, arrival-order expansion: the deployed
+///   table-guided beam, counter-exact (with the goal-distance scorer).
+/// - `Arm` — score retention AND the retained layer expands in descending
+///   score order (stable): the arm mode of spec §3/§4-A, where an ordering
+///   can actually reduce expansions by reaching the goal-generating
+///   expansion sooner. Same budget accounting as the deployed planner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeamMode {
+    Parity(bool),
+    Arm,
+}
+
+impl SeamMode {
+    fn ordered(self) -> bool {
+        match self {
+            SeamMode::Parity(ordered) => ordered,
+            SeamMode::Arm => true,
+        }
+    }
+
+    fn sorted_expansion(self) -> bool {
+        matches!(self, SeamMode::Arm)
+    }
+}
+
+/// Run one reference episode: the deployed layered search with the seam
+/// opened per `mode`.
+pub fn plan_reference(
+    query: &RefQuery<'_, '_>,
+    scratch: &mut RefScratch,
+    mode: SeamMode,
+    scorer: &mut dyn Scorer,
+) -> RefResult {
+    scratch.reset();
+    let mut episode = Episode {
+        query,
+        counters: PlanCounters::default(),
+    };
+
+    if query.predicates.satisfies_goal(&query.initial) {
+        return RefResult {
+            outcome: RefOutcome::Plan(Vec::new()),
+            counters: episode.counters,
+        };
+    }
+    if query.predicates.is_forbidden(&query.initial) {
+        return declined(PackedDecline::NoPlan, episode.counters);
+    }
+    if usize::from(query.horizon) > PLAN_HORIZON_MAX
+        || usize::from(query.frontier) > PLAN_FRONTIER_MAX
+    {
+        return declined(PackedDecline::Capacity, episode.counters);
+    }
+
+    let Some(Some(root)) = episode.admit(scratch, &query.initial) else {
+        return declined(PackedDecline::Capacity, episode.counters);
+    };
+    scratch.visited[usize::from(root)] = Node {
+        state: query.initial,
+        parent: EMPTY,
+        rule_row: 0,
+        operator: 0,
+        depth: 0,
+    };
+
+    match search_layered(&mut episode, scratch, root, mode, scorer) {
+        Search::Found(node) => match episode.unwind(scratch, node) {
+            Some(path) => {
+                episode.record_considered_reads(path.len());
+                RefResult {
+                    outcome: RefOutcome::Plan(path),
+                    counters: episode.counters,
+                }
+            }
+            None => declined(PackedDecline::Unknown, episode.counters),
+        },
+        Search::Exhausted => declined(PackedDecline::NoPlan, episode.counters),
+        Search::Declined(reason) => declined(reason, episode.counters),
+    }
+}
+
+fn declined(reason: PackedDecline, counters: PlanCounters) -> RefResult {
+    RefResult {
+        outcome: RefOutcome::Declined(reason),
+        counters,
+    }
+}
+
+fn search_layered(
+    episode: &mut Episode<'_, '_, '_>,
+    scratch: &mut RefScratch,
+    root: u16,
+    mode: SeamMode,
+    scorer: &mut dyn Scorer,
+) -> Search {
+    let ordered = mode.ordered();
+    scratch.frontier.clear();
+    scratch.frontier.push(Frame {
+        state: scratch.visited[usize::from(root)].state,
+        node: root,
+        depth: 0,
+    });
+
+    for _ in 0..episode.query.horizon {
+        scratch.next.clear();
+        scratch.scores.clear();
+        let width = scratch.frontier.len();
+        for slot in 0..width {
+            if episode.over_budget() {
+                return Search::Declined(PackedDecline::Capacity);
+            }
+            let frame = scratch.frontier[slot];
+            episode.counters.expansions = episode.counters.expansions.saturating_add(1);
+            let operators = episode.query.schema.operator_count().min(PLAN_ACTIONS_MAX);
+            for operator in 0..operators {
+                if episode.query.available & (1u64 << operator) == 0 {
+                    continue;
+                }
+                let Some((first, end)) = episode.query.rules.rules_for(operator) else {
+                    continue;
+                };
+                for row in first..end {
+                    match episode.take(
+                        scratch,
+                        &frame.state,
+                        frame.node,
+                        frame.depth,
+                        operator as u16,
+                        row,
+                    ) {
+                        Step::Taken(node) => {
+                            let successor = scratch.visited[usize::from(node)].state;
+                            if episode.query.predicates.satisfies_goal(&successor) {
+                                return Search::Found(node);
+                            }
+                            if scratch.next.len() >= usize::from(episode.query.frontier) {
+                                if ordered {
+                                    replace_weakest(scratch, scorer, node, successor, frame.depth);
+                                }
+                                continue;
+                            }
+                            scratch.next.push(Frame {
+                                state: successor,
+                                node,
+                                depth: frame.depth.saturating_add(1),
+                            });
+                            scratch.scores.push(scorer.score(&successor));
+                        }
+                        Step::Blocked => {}
+                        Step::Capacity => return Search::Declined(PackedDecline::Capacity),
+                        Step::Unknown => return Search::Declined(PackedDecline::Unknown),
+                    }
+                }
+            }
+        }
+        if scratch.next.is_empty() {
+            return Search::Exhausted;
+        }
+        if mode.sorted_expansion() {
+            // Arm mode: expand the retained layer in descending score order.
+            // The sort is stable, so equal scores keep the canonical arrival
+            // order and determinism is preserved.
+            let mut order: Vec<usize> = (0..scratch.next.len()).collect();
+            order.sort_by_key(|slot| std::cmp::Reverse(scratch.scores[*slot]));
+            let reordered: Vec<Frame> = order.iter().map(|slot| scratch.next[*slot]).collect();
+            let rescored: Vec<i32> = order.iter().map(|slot| scratch.scores[*slot]).collect();
+            scratch.next.clear();
+            scratch.next.extend_from_slice(&reordered);
+            scratch.scores.clear();
+            scratch.scores.extend_from_slice(&rescored);
+        }
+        scratch.frontier.clear();
+        scratch.frontier.extend_from_slice(&scratch.next);
+    }
+    Search::Exhausted
+}
+
+fn replace_weakest(
+    scratch: &mut RefScratch,
+    scorer: &mut dyn Scorer,
+    node: u16,
+    successor: SlotVec,
+    depth: u8,
+) {
+    let score = scorer.score(&successor);
+    let mut weakest = 0usize;
+    for slot in 1..scratch.next.len() {
+        if scratch.scores[slot] < scratch.scores[weakest] {
+            weakest = slot;
+        }
+    }
+    if scratch.next.is_empty() || score <= scratch.scores[weakest] {
+        return;
+    }
+    scratch.scores[weakest] = score;
+    scratch.next[weakest] = Frame {
+        state: successor,
+        node,
+        depth: depth.saturating_add(1),
+    };
+}

--- a/crates/uor-r4-graph-certify/tests/support/stats.rs
+++ b/crates/uor-r4-graph-certify/tests/support/stats.rs
@@ -1,0 +1,63 @@
+//! Paired statistics for the #845 measurement — the #843 harness arithmetic
+//! (normal-approximation one-sided lower bounds, degenerate-case p-values,
+//! standard-direction Holm step-down) generalized to f64 paired differences.
+#![allow(dead_code)]
+
+/// One-sided 95% normal quantile.
+pub const Z95: f64 = 1.645;
+
+/// One-sided 95% lower confidence bound on a paired difference:
+/// (mean, standard error, lower bound). Deterministic; no bootstrap, no RNG.
+pub fn paired_lower_bound(differences: &[f64]) -> (f64, f64, f64) {
+    let n = differences.len();
+    if n == 0 {
+        return (0.0, 0.0, 0.0);
+    }
+    let sum: f64 = differences.iter().sum();
+    let mean = sum / n as f64;
+    let variance: f64 = differences
+        .iter()
+        .map(|d| {
+            let centred = d - mean;
+            centred * centred
+        })
+        .sum::<f64>()
+        / n as f64;
+    let standard_error = (variance / n as f64).sqrt();
+    (mean, standard_error, mean - Z95 * standard_error)
+}
+
+/// Standard normal upper tail.
+fn upper_tail(z: f64) -> f64 {
+    0.5 * libm::erfc(z / core::f64::consts::SQRT_2)
+}
+
+/// p-value for `H0: mean difference <= threshold`. A zero standard error is
+/// degenerate: 0 when the point estimate clears the threshold, 1 otherwise.
+pub fn p_value(mean: f64, standard_error: f64, threshold: f64) -> f64 {
+    if standard_error == 0.0 {
+        return if mean > threshold { 0.0 } else { 1.0 };
+    }
+    upper_tail((mean - threshold) / standard_error)
+}
+
+/// Holm–Bonferroni step-down in the standard direction at alpha = 0.05.
+pub fn holm_pass(p_values: &[f64]) -> Vec<bool> {
+    let m = p_values.len();
+    let mut order: Vec<usize> = (0..m).collect();
+    order.sort_by(|a, b| {
+        p_values[*a]
+            .partial_cmp(&p_values[*b])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut pass = vec![false; m];
+    for (rank, index) in order.iter().enumerate() {
+        let level = 0.05 / (m - rank) as f64;
+        if p_values[*index] <= level {
+            pass[*index] = true;
+        } else {
+            break;
+        }
+    }
+    pass
+}

--- a/crates/uor-r4-graph-certify/tests/w33_ordering_harness_845.rs
+++ b/crates/uor-r4-graph-certify/tests/w33_ordering_harness_845.rs
@@ -1,0 +1,310 @@
+//! #845 increment 3 — the reference ordering skeleton, its deployed-parity
+//! proof-by-test, the arm/control roster, and the equal-bytes audit, per
+//! `docs/w33_geometry_qualification_spec_845.md` §4 and §4-A.
+//!
+//! The load-bearing property is counter-exact parity: the reference skeleton
+//! with the incumbent scorer must reproduce the deployed planner — outcome,
+//! plan, and every `PlanCounters` field — episode by episode, for both the
+//! breadth-first and the beam retention rules. Everything increment 4
+//! measures rests on that equivalence.
+
+mod support;
+
+use support::arms;
+use support::episode::{self, Packed};
+use support::ordering::{GoalDistanceScorer, RefScratch, Scorer, SeamMode};
+use support::w33;
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_runtime::plan::{PlanBudget, PlanScratch, PlanStrategy};
+
+const PARITY_HORIZONS: [usize; 3] = [2, 4, 8];
+const PARITY_SEEDS: usize = 32;
+
+fn frozen_with(horizon: usize) -> PlanBudget {
+    PlanBudget {
+        horizon: horizon as u8,
+        ..PlanBudget::frozen()
+    }
+}
+
+fn parity_budgets(horizon: usize) -> Vec<(String, PlanBudget)> {
+    vec![
+        ("frozen".to_string(), frozen_with(horizon)),
+        (
+            "frontier-16".to_string(),
+            PlanBudget {
+                frontier: 16,
+                ..frozen_with(horizon)
+            },
+        ),
+        (
+            "frontier-8".to_string(),
+            PlanBudget {
+                frontier: 8,
+                ..frozen_with(horizon)
+            },
+        ),
+        (
+            "expansions-64".to_string(),
+            PlanBudget {
+                max_expansions: 64,
+                ..frozen_with(horizon)
+            },
+        ),
+    ]
+}
+
+fn fitted_cell(family: cp::TaskFamily, horizon: usize) -> Option<Packed> {
+    let set = episode::induce_for(family, horizon)?;
+    episode::pack(&set, 0)
+}
+
+/// Reference FIFO retention == deployed breadth-first: same emission, same
+/// counters, every episode of the parity grid.
+#[test]
+fn reference_fifo_reproduces_deployed_breadth_first() {
+    parity_grid(PlanStrategy::BreadthFirst, false);
+}
+
+/// Reference goal-distance retention == deployed table-guided beam.
+#[test]
+fn reference_goal_distance_reproduces_deployed_beam() {
+    parity_grid(PlanStrategy::BestFirstBeam, true);
+}
+
+fn parity_grid(strategy: PlanStrategy, ordered: bool) {
+    let mut deployed_scratch = Box::new(PlanScratch::new());
+    let mut reference_scratch = RefScratch::new();
+    let mut episodes = 0usize;
+    for family in episode::SEPARATING {
+        for horizon in PARITY_HORIZONS {
+            let Some(packed) = fitted_cell(family, horizon) else {
+                panic!("{}: induction failed at H={horizon}", family.label());
+            };
+            for (label, budget) in parity_budgets(horizon) {
+                for seed in episode::seeds(true, PARITY_SEEDS) {
+                    let Some(task) = episode::try_generate(family, seed, horizon) else {
+                        continue;
+                    };
+                    let (deployed_emission, deployed_counters) = episode::run_deployed(
+                        strategy,
+                        &packed,
+                        &task,
+                        budget,
+                        &mut deployed_scratch,
+                    )
+                    .expect("deployed episode runs");
+                    let predicate_bytes = episode::predicates_for(&task).unwrap();
+                    let schema =
+                        uor_r4_graph_format::plan_sections::PlanSchema::parse(&packed.schema)
+                            .unwrap();
+                    let predicates = uor_r4_graph_format::plan_sections::PredicateSet::parse(
+                        &predicate_bytes,
+                        &schema,
+                    )
+                    .unwrap();
+                    let mut scorer = GoalDistanceScorer::new(&predicates);
+                    let (reference_emission, reference_counters) = episode::run_reference(
+                        &packed,
+                        &task,
+                        budget,
+                        SeamMode::Parity(ordered),
+                        &mut scorer,
+                        &mut reference_scratch,
+                    )
+                    .expect("reference episode runs");
+                    assert_eq!(
+                        deployed_emission,
+                        reference_emission,
+                        "{} H={horizon} {label} seed={seed}: emission diverged",
+                        family.label()
+                    );
+                    assert_eq!(
+                        deployed_counters,
+                        reference_counters,
+                        "{} H={horizon} {label} seed={seed}: counters diverged",
+                        family.label()
+                    );
+                    episodes += 1;
+                }
+            }
+        }
+    }
+    assert!(episodes >= 1000, "the parity grid must not be vacuous");
+}
+
+/// Every arm is deterministic across independent constructions and can
+/// separate states (at least two distinct scores over a successor sample) —
+/// a control unable to fire or to fail voids a cell, never passes it.
+#[test]
+fn every_arm_is_deterministic_and_can_separate() {
+    let tables = arms::W33Tables::build();
+    let tables_again = arms::W33Tables::build();
+    let observations = episode::fitting_observations(cp::TaskFamily::GraphNavigation, 8);
+    let learned = arms::LearnedTable::fit(&tables, &observations.remaining);
+    let learned_again = arms::LearnedTable::fit(&tables_again, &observations.remaining);
+    let spectral = arms::SpectralEmbedding::fit(&tables, &observations.transitions);
+    let spectral_again = arms::SpectralEmbedding::fit(&tables_again, &observations.transitions);
+    let vsa = arms::VsaTables::build();
+    let random = arms::RandomTables::build();
+    let relabeled = arms::RelabeledTables::build(&tables);
+
+    let goal = (6i16, 4i16);
+    let sample: Vec<uor_r4_graph_format::plan::SlotVec> = (0..24)
+        .map(|i| {
+            uor_r4_graph_format::plan::SlotVec::from_slice(&[i % 9, (i * 5 + 2) % 11]).unwrap()
+        })
+        .collect();
+
+    let mut roster: Vec<Box<dyn Scorer>> = vec![
+        Box::new(arms::GeometryScorer::new(&tables, goal)),
+        Box::new(arms::HammingScorer::new(goal)),
+        Box::new(arms::LearnedScorer::new(&tables, &learned, goal)),
+        Box::new(arms::VsaScorer::new(&vsa, goal)),
+        Box::new(arms::SpectralScorer::new(&tables, &spectral, goal)),
+        Box::new(arms::RandomScorer::new(&tables, &random, goal)),
+        Box::new(arms::RelabeledScorer::new(&tables, &relabeled, goal)),
+        Box::new(arms::PhasePermutedScorer::new(&tables, goal)),
+    ];
+    let mut roster_again: Vec<Box<dyn Scorer>> = vec![
+        Box::new(arms::GeometryScorer::new(&tables_again, goal)),
+        Box::new(arms::HammingScorer::new(goal)),
+        Box::new(arms::LearnedScorer::new(
+            &tables_again,
+            &learned_again,
+            goal,
+        )),
+        Box::new(arms::VsaScorer::new(&vsa, goal)),
+        Box::new(arms::SpectralScorer::new(
+            &tables_again,
+            &spectral_again,
+            goal,
+        )),
+        Box::new(arms::RandomScorer::new(&tables_again, &random, goal)),
+        Box::new(arms::RelabeledScorer::new(&tables_again, &relabeled, goal)),
+        Box::new(arms::PhasePermutedScorer::new(&tables_again, goal)),
+    ];
+
+    for (arm, twin) in roster.iter_mut().zip(roster_again.iter_mut()) {
+        let scores: Vec<i32> = sample.iter().map(|s| arm.score(s)).collect();
+        let twin_scores: Vec<i32> = sample.iter().map(|s| twin.score(s)).collect();
+        assert_eq!(scores, twin_scores, "{}: not deterministic", arm.name());
+        let mut distinct = scores.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert!(
+            distinct.len() >= 2,
+            "{}: cannot separate the successor sample",
+            arm.name()
+        );
+    }
+}
+
+/// The relabel scramble must NOT be a collinearity automorphism, or the
+/// control is vacuous by construction.
+#[test]
+fn the_relabel_scramble_is_not_an_automorphism() {
+    let tables = arms::W33Tables::build();
+    let relabeled = arms::RelabeledTables::build(&tables);
+    assert!(
+        !relabeled.is_automorphism(&tables),
+        "the pinned scramble preserves d_W everywhere — pick a different seed"
+    );
+}
+
+/// Equal-bytes audit: no control consults more auxiliary table bytes than the
+/// geometry arm's budget; the geometry arm consumes its budget exactly.
+#[test]
+fn the_byte_parity_audit_holds() {
+    let tables = arms::W33Tables::build();
+    let observations = episode::fitting_observations(cp::TaskFamily::GraphNavigation, 8);
+    let learned = arms::LearnedTable::fit(&tables, &observations.remaining);
+    let spectral = arms::SpectralEmbedding::fit(&tables, &observations.transitions);
+    let vsa = arms::VsaTables::build();
+    let random = arms::RandomTables::build();
+    let relabeled = arms::RelabeledTables::build(&tables);
+    let goal = (0i16, 0i16);
+    let roster: Vec<Box<dyn Scorer>> = vec![
+        Box::new(arms::GeometryScorer::new(&tables, goal)),
+        Box::new(arms::HammingScorer::new(goal)),
+        Box::new(arms::LearnedScorer::new(&tables, &learned, goal)),
+        Box::new(arms::VsaScorer::new(&vsa, goal)),
+        Box::new(arms::SpectralScorer::new(&tables, &spectral, goal)),
+        Box::new(arms::RandomScorer::new(&tables, &random, goal)),
+        Box::new(arms::RelabeledScorer::new(&tables, &relabeled, goal)),
+        Box::new(arms::PhasePermutedScorer::new(&tables, goal)),
+    ];
+    for arm in &roster {
+        assert!(
+            arm.table_bytes() <= arms::GEOMETRY_TABLE_BYTES,
+            "{}: {} auxiliary bytes exceed the geometry budget {}",
+            arm.name(),
+            arm.table_bytes(),
+            arms::GEOMETRY_TABLE_BYTES
+        );
+    }
+    assert_eq!(
+        roster[0].table_bytes(),
+        arms::GEOMETRY_TABLE_BYTES,
+        "the geometry arm defines the budget exactly"
+    );
+    assert_eq!(w33::POINTS, 40, "the budget is over the 40-point tables");
+}
+
+/// The retention seam is live: in a tightened-frontier cell, geometry-ordered
+/// retention and FIFO retention must actually diverge somewhere — otherwise
+/// increment 4 would be comparing an arm against itself.
+#[test]
+fn the_ordering_seam_is_live() {
+    let family = cp::TaskFamily::GraphNavigation;
+    let horizon = 8usize;
+    let packed = fitted_cell(family, horizon).expect("induction at H=8");
+    let tables = arms::W33Tables::build();
+    let budget = PlanBudget {
+        frontier: 8,
+        ..frozen_with(horizon)
+    };
+    let mut reference_scratch = RefScratch::new();
+    let mut diverged = 0usize;
+    let mut episodes = 0usize;
+    for seed in episode::seeds(true, 64) {
+        let Some(task) = episode::try_generate(family, seed, horizon) else {
+            continue;
+        };
+        episodes += 1;
+        let goal = episode::goal_center(&task);
+        let mut geometry = arms::GeometryScorer::new(&tables, goal);
+        let (geometry_emission, geometry_counters) = episode::run_reference(
+            &packed,
+            &task,
+            budget,
+            SeamMode::Arm,
+            &mut geometry,
+            &mut reference_scratch,
+        )
+        .expect("geometry episode runs");
+        let predicate_bytes = episode::predicates_for(&task).unwrap();
+        let schema = uor_r4_graph_format::plan_sections::PlanSchema::parse(&packed.schema).unwrap();
+        let predicates =
+            uor_r4_graph_format::plan_sections::PredicateSet::parse(&predicate_bytes, &schema)
+                .unwrap();
+        let mut fifo = GoalDistanceScorer::new(&predicates);
+        let (fifo_emission, fifo_counters) = episode::run_reference(
+            &packed,
+            &task,
+            budget,
+            SeamMode::Parity(false),
+            &mut fifo,
+            &mut reference_scratch,
+        )
+        .expect("fifo episode runs");
+        if geometry_emission != fifo_emission || geometry_counters != fifo_counters {
+            diverged += 1;
+        }
+    }
+    assert!(episodes >= 32, "the seam check must not be vacuous");
+    assert!(
+        diverged > 0,
+        "geometry-ordered retention never diverged from FIFO at frontier-8"
+    );
+}

--- a/docs/w33_geometry_qualification_spec_845.md
+++ b/docs/w33_geometry_qualification_spec_845.md
@@ -151,9 +151,49 @@ fitting half only):
 memorized-trajectory, shuffled-state), fitted and measured exactly as in the #843 harness.
 
 The exact fitted-control constants (k, hypervector width, eigen-count, seeds) are pinned in
-increment 3 as an appended section before any measurement runs; their fitting data access
+increment 3 as an appended section (§4-A) before any measurement runs; their fitting data access
 (fitting half only), determinism, byte parity, and non-degeneracy obligations are frozen here.
 A control unable to fire or unable to fail voids the cell (`NOT TRIGGERED`), never a pass.
+
+### 4-A. Pinned control constants (appended in increment 3, before any measurement)
+
+Implementation: `crates/uor-r4-graph-certify/tests/support/{ordering,arms,episode}.rs`; every
+constant below is asserted by `w33_ordering_harness_845.rs` before increment 4 runs.
+
+- **The seam, and its two modes.** The reference skeleton is the deployed layered search with one
+  seam: the ordering score. **Parity mode** applies it to frontier retention only and is
+  machine-checked per episode — outcome, plan, and every `PlanCounters` field — against the
+  deployed planner for both retention rules (FIFO ≡ breadth-first; goal-distance ≡ table-guided
+  beam) over a 3-family × 3-horizon × 4-budget × 32-seed grid. **Arm mode** (the §3 "ordering
+  functional for beam/best-first expansion") additionally expands the retained layer in descending
+  score order (stable sort; equal scores keep the canonical arrival order), which is what lets an
+  ordering reduce expansions by reaching the goal-generating expansion sooner — layers before the
+  goal layer are swept in full regardless of order, so retention quality and last-layer order are
+  exactly what an ordering can influence. Every measured arm and ordering control runs in arm mode
+  under identical budget accounting; parity mode anchors that accounting to the deployed planner.
+  Scoring work is outside `PlanCounters` (the deployed beam's goal-distance evaluations are
+  uncounted there too); each arm reports auxiliary lookups and table bytes separately.
+- **Byte budget** = the geometry arm's 3,200 bytes (two 40 × 40 tables); the audit asserts every
+  control at or under it. Seeded tables use splitmix64.
+- **w33-geometry:** retention −(4·d_W + t(φ)); 3,200 B; μ per §3.
+- **hamming-popcount:** −popcount(raw 32-bit slot pair XOR goal); 0 B.
+- **learned-table-codes:** 40 × 40 u8 mean remaining-gold-steps between mapped classes (255 =
+  unseen) + 40 row-median-threshold 16-bit codes; retention −(32·table + code-Hamming); 1,680 B;
+  fitted on fitting-half gold paths only. Deliberately the same 40-class quantization as the
+  geometry arm: it isolates whether the quadrangle *structure*, not any table over μ's classes,
+  carries the signal.
+- **vsa-binding:** two roles × nine residues × 128-bit fillers, seed `0x845a_0001`, XOR binding;
+  −Hamming of bound state/goal hypervectors; 288 B.
+- **spectral-embedding:** Laplacian of the fitting-half class-transition graph; fixed-sweep cyclic
+  Jacobi (32 sweeps, fixed pair order — deterministic by construction); kernel vector skipped;
+  8 dimensions quantized ×1024 to i16; −L1; 640 B. f64 in fitting only (compiler/certifier scope).
+- **random-embedding:** two 40 × 40 tables with values in {0, 1, 2}, seed `0x845a_0002`, scored
+  with the geometry functional; 3,200 B — matched in bytes, shape, and range; devoid of structure.
+- **isomorphic-relabel:** the true geometry tables conjugated by a pinned Fisher–Yates scramble of
+  the 40 points, seed `0x845a_0003`, asserted **not** to be a collinearity automorphism (a
+  symplectomorphism would leave d_W invariant and make the control vacuous); 3,200 B.
+- **phase-permuted:** true d_W, φ values swapped 1 ↔ 2; 3,200 B.
+- **table-guided-beam (incumbent):** −goal-distance, 0 B — the deployed beam's exact signal.
 
 ## 5. Statistics, generalization controls, and the verdict space
 
@@ -164,6 +204,27 @@ least **ρ_min = 0.10** relative reduction in expansions against the **strongest
 ordering control** that also holds 1.0000, intersection-union over the 12 cells, Holm reported
 alongside. Candidates and table reads are co-reported; a correctness regression anywhere voids the
 axis for the regressing arm.
+
+### 5-A. A2(a) per-cell reading (appended in increment 3, before any measurement)
+
+**The structural fact.** An episode that finds an L-step plan expands at least L states (the root
+and each intermediate), and a horizon-1 episode expands exactly one state whatever the retention
+rule — declines included (the root is expanded, the next layer is empty or unreached). Every arm
+therefore spends *identically* one expansion in every H = 1 cell, the relative reduction is zero by
+arithmetic identity, and a ρ_min bar can never be cleared there by any mechanism. A criterion a
+correct arm cannot pass is as broken as one a wrong arm cannot fail — the #844 §11.6 shape, on the
+budget axis.
+
+**Definition (the per-cell reading; the 12-cell conjunction and every frozen value stand).**
+Classify each A2(a) cell from *non-geometry* data alone (the bar arm's measured expansions against
+the per-instance gold-length floor, so no geometry result is consulted): a cell whose bar arm's
+mean relative headroom over the floor is at least ρ_min is a **reduction cell**, read exactly as
+frozen (paired one-sided 95% LB of relative expansion reduction ≥ ρ_min = 0.10); a cell with less
+structural headroom than ρ_min is a **no-regression cell**, read as: correctness exactly equal AND
+the paired LB of relative reduction ≥ 0 (identical work reads as the degenerate LB = 0, which
+passes; regression fails). Expected classification, to be confirmed by the run: the five H = 1
+cells are no-regression cells; the seven H ≥ 2 cells are reduction cells. The intersection-union
+conjunction still ranges over all 12 cells; Holm is still reported alongside.
 
 **Empirical Criterion (A2(b), the correctness axis — co-primary). Status: pre-registered.** On the
 nine frozen primary cells (#844 spec §12): the geometry arm's paired one-sided 95% lower bound over


### PR DESCRIPTION
## Problem and outcome

References #845 (S4 item C, increment 3 of 4 — arms and harness).

The design contract requires every geometry claim to be earned against non-geometric ordering controls under equal budgets and equal bytes, on a search harness whose accounting provably matches the deployed planner. This PR delivers that harness and roster, with the parity claim machine-checked rather than assumed.

## What this PR contains

- `tests/support/ordering.rs` — the deployed layered search ported with exactly one seam (the ordering score) in two modes: parity mode (retention only; counter-exact against the deployed planner) and arm mode (retention plus stable descending-score expansion of the retained layer, the spec §3 ordering functional). Counter accounting mirrors the deployed `Episode` call-for-call, including the post-search unwind and considered-record reads.
- `tests/support/arms.rs` — the ordering-arm roster with pinned constants (spec §4-A): W(3,3) geometry, Hamming/popcount, learned-table-codes (same 40-class quantization as the geometry arm, deliberately), VSA-binding, spectral-embedding (fixed-sweep cyclic Jacobi, deterministic by construction), random-embedding (byte/shape/range-matched), isomorphic-relabel (tables conjugated by a pinned scramble asserted NOT to be a collinearity automorphism), phase-permuted, and the goal-distance incumbent.
- `tests/support/episode.rs` — shared episode machinery (generate/induce/pack/predicates/verify, deployed and reference runners, the four #843 nulls, fitting observations).
- `tests/support/stats.rs` — paired lower bounds, degenerate-case p-values, standard-direction Holm.
- `tests/w33_ordering_harness_845.rs` — the gates: counter-exact parity (outcome, plan, every `PlanCounters` field) for FIFO ≡ deployed breadth-first and goal-distance ≡ deployed beam over a 3-family x 3-horizon x 4-budget x 32-seed grid (>1,000 episodes per rule, non-vacuity asserted); per-arm determinism and separation; scramble non-automorphism; equal-bytes audit (every control at or under the geometry arm's 3,200-byte budget); seam liveness.
- `docs/w33_geometry_qualification_spec_845.md` — §4-A (pinned constants and the two seam modes) and §5-A (the A2(a) per-cell reading: reduction cells vs no-regression cells, from the structural fact that an L-step plan needs at least L expansions and every H=1 episode spends exactly one — recorded before any measurement, the #844 §11.6 shape on the budget axis).

## Verification

fmt, clippy `-D warnings` (workspace, all targets/features), wasm lib build, `cargo test --workspace --no-fail-fast --offline` (188 suites, 0 failures), `xtask validate` (R1/R4/R5/gnaf), `cargo deny check bans`, claim-wording gate — all green locally on this content; `audit-limits` re-run immediately before push. Certifier-instrument test code only; no shipped-crate source changes.

## Conformance, compatibility, claim boundary

No production format, runtime, or dependency changes; CONFORMANCE.md untouched; no new RF id. Nothing here licenses any geometry claim — this increment builds the instrument that can refute one, and its controls are asserted able to fire and to fail.

## Intentionally excluded

The measurement itself, its record, and the verdict (increment 4, next PR).
