### PR TITLE
research(#845): the equal-budget measurement and the NO GEOMETRIC ADVANTAGE verdict

### DIFF
--- a/crates/uor-r4-graph-certify/tests/w33_measurement_845.rs
+++ b/crates/uor-r4-graph-certify/tests/w33_measurement_845.rs
@@ -1,0 +1,760 @@
+//! #845 increment 4 — the equal-budget geometry measurement on both A2 axes,
+//! per `docs/w33_geometry_qualification_spec_845.md` §5/§5-A/§6 and
+//! `docs/compositional_planning_spec_844.md` §12.
+//!
+//! The full grids are `#[ignore]`d (measurements, not gates); the default
+//! tests assert the instrument's own non-vacuity. Run with
+//! `-- --ignored --nocapture` and read the MEAS/VERDICT lines.
+
+mod support;
+
+use support::arms;
+use support::episode::{self, Packed};
+use support::ordering::{GoalDistanceScorer, RefScratch, Scorer, SeamMode};
+use support::stats;
+use uor_r4_graph_compiler::compositional_planning as cp;
+use uor_r4_graph_runtime::plan::{PlanBudget, PlanScratch, PlanStrategy};
+
+/// Frozen effect floor (#844 §2.5).
+const DELTA_MIN: f64 = 0.05;
+/// Frozen A2(a) work-reduction floor (spec §5).
+const RHO_MIN: f64 = 0.10;
+
+/// The 12 separating cells of the #843 record §3 (A2(a), frozen budget).
+const A2A_CELLS: [(cp::TaskFamily, usize); 12] = [
+    (cp::TaskFamily::GraphNavigation, 1),
+    (cp::TaskFamily::GraphNavigation, 2),
+    (cp::TaskFamily::GraphNavigation, 4),
+    (cp::TaskFamily::GraphNavigation, 8),
+    (cp::TaskFamily::SymbolicTransformation, 1),
+    (cp::TaskFamily::ConstraintSatisfaction, 1),
+    (cp::TaskFamily::ConstraintSatisfaction, 8),
+    (cp::TaskFamily::MultiHopEvidence, 1),
+    (cp::TaskFamily::MultiHopEvidence, 2),
+    (cp::TaskFamily::MultiHopEvidence, 4),
+    (cp::TaskFamily::MultiHopEvidence, 8),
+    (cp::TaskFamily::CounterfactualIntervention, 1),
+];
+
+/// The A2(b) budget variants (#844 spec §12): primary = the frontier ladder
+/// at H = 8; secondary = the expansion ladder at H = 8 and frozen H = 16.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellBudget {
+    Frozen,
+    Frontier(u16),
+    Expansions(u32),
+}
+
+impl CellBudget {
+    fn label(self) -> String {
+        match self {
+            CellBudget::Frozen => "frozen".to_string(),
+            CellBudget::Frontier(width) => format!("frontier-{width}"),
+            CellBudget::Expansions(cap) => format!("expansions-{cap}"),
+        }
+    }
+
+    fn budget(self, horizon: usize) -> PlanBudget {
+        let frozen = PlanBudget {
+            horizon: horizon as u8,
+            ..PlanBudget::frozen()
+        };
+        match self {
+            CellBudget::Frozen => frozen,
+            CellBudget::Frontier(width) => PlanBudget {
+                frontier: width,
+                ..frozen
+            },
+            CellBudget::Expansions(cap) => PlanBudget {
+                max_expansions: cap,
+                ..frozen
+            },
+        }
+    }
+}
+
+const A2B_PRIMARY_BUDGETS: [CellBudget; 3] = [
+    CellBudget::Frontier(16),
+    CellBudget::Frontier(8),
+    CellBudget::Frontier(4),
+];
+const A2B_SECONDARY_BUDGETS: [CellBudget; 2] =
+    [CellBudget::Expansions(64), CellBudget::Expansions(32)];
+
+/// Everything one (family, horizon) pair fits once: the packed artifacts, the
+/// replay nulls, and the fitted controls.
+struct CellFit {
+    packed: Packed,
+    shuffled: Packed,
+    nulls: episode::Fitted,
+    learned: arms::LearnedTable,
+    spectral: arms::SpectralEmbedding,
+}
+
+fn fit_cell(tables: &arms::W33Tables, family: cp::TaskFamily, horizon: usize) -> Option<CellFit> {
+    let set = episode::induce_for(family, horizon)?;
+    let packed = episode::pack(&set, 0)?;
+    let shuffled = episode::pack(&set, 1)?;
+    let nulls = episode::fit_nulls(family, horizon);
+    let observations = episode::fitting_observations(family, horizon);
+    let learned = arms::LearnedTable::fit(tables, &observations.remaining);
+    let spectral = arms::SpectralEmbedding::fit(tables, &observations.transitions);
+    Some(CellFit {
+        packed,
+        shuffled,
+        nulls,
+        learned,
+        spectral,
+    })
+}
+
+/// Per-arm episode traces over one cell's held-out instances.
+#[derive(Debug, Clone)]
+struct ArmTrace {
+    name: &'static str,
+    correct: Vec<bool>,
+    expansions: Vec<f64>,
+    lookups: u64,
+}
+
+impl ArmTrace {
+    fn rate(&self) -> f64 {
+        if self.correct.is_empty() {
+            return 0.0;
+        }
+        self.correct.iter().filter(|c| **c).count() as f64 / self.correct.len() as f64
+    }
+
+    fn perfect(&self) -> bool {
+        self.correct.iter().all(|c| *c)
+    }
+
+    fn mean_expansions(&self) -> f64 {
+        if self.expansions.is_empty() {
+            return 0.0;
+        }
+        self.expansions.iter().sum::<f64>() / self.expansions.len() as f64
+    }
+}
+
+/// The ordering-arm roster for one episode. The geometry arm is index 0; the
+/// rest are the non-geometric ordering controls.
+const ORDERING_ARMS: [&str; 9] = [
+    "w33-geometry",
+    "table-guided-beam",
+    "hamming-popcount",
+    "learned-table-codes",
+    "vsa-binding",
+    "spectral-embedding",
+    "random-embedding",
+    "isomorphic-relabel",
+    "phase-permuted",
+];
+
+/// One cell's full measurement: the FIFO baseline, the nine ordering arms in
+/// arm mode, and the four #843 nulls, all under one budget.
+struct CellData {
+    family: &'static str,
+    horizon: usize,
+    budget_label: String,
+    n: usize,
+    baseline: ArmTrace,
+    arms: Vec<ArmTrace>,
+    nulls: [ArmTrace; 4],
+    gold_floor: Vec<f64>,
+}
+
+/// Run one arm-mode episode with a freshly constructed scorer.
+#[allow(clippy::too_many_arguments)]
+fn run_ordering_arm(
+    name: &'static str,
+    tables: &arms::W33Tables,
+    vsa: &arms::VsaTables,
+    random: &arms::RandomTables,
+    relabeled: &arms::RelabeledTables,
+    fit: &CellFit,
+    task: &cp::TaskInstance,
+    budget: PlanBudget,
+    scratch: &mut RefScratch,
+) -> (bool, f64, u64) {
+    let goal = episode::goal_center(task);
+    let run = |scorer: &mut dyn Scorer, scratch: &mut RefScratch| -> (bool, f64, u64) {
+        let (emission, counters) =
+            episode::run_reference(&fit.packed, task, budget, SeamMode::Arm, scorer, scratch)
+                .expect("arm episode runs");
+        (
+            episode::outcome_correct(task, &emission),
+            f64::from(counters.expansions),
+            scorer.lookups(),
+        )
+    };
+    match name {
+        "w33-geometry" => run(&mut arms::GeometryScorer::new(tables, goal), scratch),
+        "table-guided-beam" => {
+            let schema =
+                uor_r4_graph_format::plan_sections::PlanSchema::parse(&fit.packed.schema).unwrap();
+            let bytes = episode::predicates_for(task).unwrap();
+            let predicates =
+                uor_r4_graph_format::plan_sections::PredicateSet::parse(&bytes, &schema).unwrap();
+            run(&mut GoalDistanceScorer::new(&predicates), scratch)
+        }
+        "hamming-popcount" => run(&mut arms::HammingScorer::new(goal), scratch),
+        "learned-table-codes" => run(
+            &mut arms::LearnedScorer::new(tables, &fit.learned, goal),
+            scratch,
+        ),
+        "vsa-binding" => run(&mut arms::VsaScorer::new(vsa, goal), scratch),
+        "spectral-embedding" => run(
+            &mut arms::SpectralScorer::new(tables, &fit.spectral, goal),
+            scratch,
+        ),
+        "random-embedding" => run(&mut arms::RandomScorer::new(tables, random, goal), scratch),
+        "isomorphic-relabel" => run(
+            &mut arms::RelabeledScorer::new(tables, relabeled, goal),
+            scratch,
+        ),
+        "phase-permuted" => run(&mut arms::PhasePermutedScorer::new(tables, goal), scratch),
+        other => panic!("unknown arm {other}"),
+    }
+}
+
+/// Measure one cell completely.
+#[allow(clippy::too_many_arguments)]
+fn run_cell(
+    tables: &arms::W33Tables,
+    vsa: &arms::VsaTables,
+    random: &arms::RandomTables,
+    relabeled: &arms::RelabeledTables,
+    fit: &CellFit,
+    family: cp::TaskFamily,
+    horizon: usize,
+    cell_budget: CellBudget,
+    n: usize,
+) -> CellData {
+    let budget = cell_budget.budget(horizon);
+    let mut deployed_scratch = Box::new(PlanScratch::new());
+    let mut scratch = RefScratch::new();
+    let trace = |name: &'static str| ArmTrace {
+        name,
+        correct: Vec::new(),
+        expansions: Vec::new(),
+        lookups: 0,
+    };
+    let mut baseline = trace("bounded-breadth-first");
+    let mut arm_traces: Vec<ArmTrace> = ORDERING_ARMS.iter().map(|name| trace(name)).collect();
+    let mut null_traces = [
+        trace("retrieval-only"),
+        trace("direct-continuation"),
+        trace("memorized-trajectory"),
+        trace("shuffled-state"),
+    ];
+    let mut gold_floor = Vec::new();
+    let mut measured = 0usize;
+    for seed in episode::seeds(true, n) {
+        let Some(task) = episode::try_generate(family, seed, horizon) else {
+            continue;
+        };
+        measured += 1;
+        gold_floor.push(if task.gold.decline.is_some() {
+            1.0
+        } else {
+            task.gold.chosen_path.len() as f64
+        });
+        {
+            let schema =
+                uor_r4_graph_format::plan_sections::PlanSchema::parse(&fit.packed.schema).unwrap();
+            let bytes = episode::predicates_for(&task).unwrap();
+            let predicates =
+                uor_r4_graph_format::plan_sections::PredicateSet::parse(&bytes, &schema).unwrap();
+            let mut fifo = GoalDistanceScorer::new(&predicates);
+            let (emission, counters) = episode::run_reference(
+                &fit.packed,
+                &task,
+                budget,
+                SeamMode::Parity(false),
+                &mut fifo,
+                &mut scratch,
+            )
+            .expect("baseline episode runs");
+            baseline
+                .correct
+                .push(episode::outcome_correct(&task, &emission));
+            baseline.expansions.push(f64::from(counters.expansions));
+        }
+        for (index, name) in ORDERING_ARMS.iter().enumerate() {
+            let (correct, expansions, lookups) = run_ordering_arm(
+                name,
+                tables,
+                vsa,
+                random,
+                relabeled,
+                fit,
+                &task,
+                budget,
+                &mut scratch,
+            );
+            arm_traces[index].correct.push(correct);
+            arm_traces[index].expansions.push(expansions);
+            arm_traces[index].lookups = lookups;
+        }
+        let replays: [episode::Emission; 3] = [
+            episode::retrieval_only(&fit.nulls, &task),
+            episode::direct_continuation(&task, horizon),
+            episode::memorized(&fit.nulls, &task),
+        ];
+        for (index, emission) in replays.iter().enumerate() {
+            null_traces[index]
+                .correct
+                .push(episode::outcome_correct(&task, emission));
+            null_traces[index].expansions.push(0.0);
+        }
+        let shuffled = episode::run_deployed(
+            PlanStrategy::BreadthFirst,
+            &fit.shuffled,
+            &task,
+            budget,
+            &mut deployed_scratch,
+        )
+        .map(|(emission, _)| emission)
+        .unwrap_or(None);
+        null_traces[3]
+            .correct
+            .push(episode::outcome_correct(&task, &shuffled));
+        null_traces[3].expansions.push(0.0);
+    }
+    CellData {
+        family: family.label(),
+        horizon,
+        budget_label: cell_budget.label(),
+        n: measured,
+        baseline,
+        arms: arm_traces,
+        nulls: null_traces,
+        gold_floor,
+    }
+}
+
+/// The A2(a) per-cell reading (spec §5/§5-A).
+#[derive(Debug, Clone)]
+struct A2aReading {
+    family: &'static str,
+    horizon: usize,
+    class: &'static str,
+    bar: &'static str,
+    bar_mean: f64,
+    geometry_mean: f64,
+    headroom: f64,
+    mean: f64,
+    standard_error: f64,
+    lower_bound: f64,
+    p: f64,
+    geometry_perfect: bool,
+    pass: bool,
+}
+
+fn read_a2a(cell: &CellData) -> A2aReading {
+    let geometry = &cell.arms[0];
+    let bar = cell.arms[1..]
+        .iter()
+        .filter(|arm| arm.perfect())
+        .min_by(|a, b| {
+            a.mean_expansions()
+                .partial_cmp(&b.mean_expansions())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    let Some(bar) = bar else {
+        return A2aReading {
+            family: cell.family,
+            horizon: cell.horizon,
+            class: "NOT-TRIGGERED",
+            bar: "none-perfect",
+            bar_mean: 0.0,
+            geometry_mean: geometry.mean_expansions(),
+            headroom: 0.0,
+            mean: 0.0,
+            standard_error: 0.0,
+            lower_bound: 0.0,
+            p: 1.0,
+            geometry_perfect: geometry.perfect(),
+            pass: false,
+        };
+    };
+    let headroom_terms: Vec<f64> = bar
+        .expansions
+        .iter()
+        .zip(cell.gold_floor.iter())
+        .map(|(b, floor)| (b - floor).max(0.0) / b.max(1.0))
+        .collect();
+    let headroom = headroom_terms.iter().sum::<f64>() / headroom_terms.len().max(1) as f64;
+    let class = if headroom >= RHO_MIN {
+        "reduction"
+    } else {
+        "no-regression"
+    };
+    let reductions: Vec<f64> = bar
+        .expansions
+        .iter()
+        .zip(geometry.expansions.iter())
+        .map(|(b, g)| (b - g) / b.max(1.0))
+        .collect();
+    let (mean, standard_error, lower_bound) = stats::paired_lower_bound(&reductions);
+    let threshold = if class == "reduction" { RHO_MIN } else { 0.0 };
+    // The no-regression reading admits the degenerate identical case (spec
+    // §5-A): a zero-variance zero-mean difference reads as LB = 0, which
+    // passes at threshold 0 and fails any positive threshold.
+    let pass = geometry.perfect()
+        && if standard_error == 0.0 {
+            mean >= threshold
+        } else {
+            lower_bound >= threshold
+        };
+    let p = stats::p_value(mean, standard_error, threshold);
+    A2aReading {
+        family: cell.family,
+        horizon: cell.horizon,
+        class,
+        bar: bar.name,
+        bar_mean: bar.mean_expansions(),
+        geometry_mean: geometry.mean_expansions(),
+        headroom,
+        mean,
+        standard_error,
+        lower_bound,
+        p,
+        geometry_perfect: geometry.perfect(),
+        pass,
+    }
+}
+
+/// The A2(b) per-cell reading (spec §5; #844 §12).
+#[derive(Debug, Clone)]
+struct A2bReading {
+    family: &'static str,
+    horizon: usize,
+    budget_label: String,
+    primary: bool,
+    geometry_rate: f64,
+    bar: &'static str,
+    bar_rate: f64,
+    mean: f64,
+    standard_error: f64,
+    lower_bound: f64,
+    p: f64,
+    pass: bool,
+}
+
+fn read_a2b(cell: &CellData, primary: bool) -> A2bReading {
+    let geometry = &cell.arms[0];
+    let mut candidates: Vec<&ArmTrace> = vec![&cell.baseline];
+    candidates.extend(cell.arms[1..].iter());
+    candidates.extend(cell.nulls.iter());
+    let bar = candidates
+        .into_iter()
+        .max_by(|a, b| {
+            a.rate()
+                .partial_cmp(&b.rate())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .expect("bar candidates exist");
+    let differences: Vec<f64> = geometry
+        .correct
+        .iter()
+        .zip(bar.correct.iter())
+        .map(|(g, b)| f64::from(u8::from(*g)) - f64::from(u8::from(*b)))
+        .collect();
+    let (mean, standard_error, lower_bound) = stats::paired_lower_bound(&differences);
+    let pass = if standard_error == 0.0 {
+        mean > DELTA_MIN
+    } else {
+        lower_bound >= DELTA_MIN
+    };
+    A2bReading {
+        family: cell.family,
+        horizon: cell.horizon,
+        budget_label: cell.budget_label.clone(),
+        primary,
+        geometry_rate: geometry.rate(),
+        bar: bar.name,
+        bar_rate: bar.rate(),
+        mean,
+        standard_error,
+        lower_bound,
+        p: stats::p_value(mean, standard_error, DELTA_MIN),
+        pass,
+    }
+}
+
+fn print_arm_rates(cell: &CellData) {
+    let rates: Vec<String> = cell
+        .arms
+        .iter()
+        .map(|arm| {
+            format!(
+                "{}={:.4}/{:.1}",
+                arm.name,
+                arm.rate(),
+                arm.mean_expansions()
+            )
+        })
+        .collect();
+    let nulls: Vec<String> = cell
+        .nulls
+        .iter()
+        .map(|null| format!("{}={:.4}", null.name, null.rate()))
+        .collect();
+    println!(
+        "MEAS-CELL | {:<26} | H={:<2} | {:<14} | n={} | baseline={:.4}/{:.1} | {} | {}",
+        cell.family,
+        cell.horizon,
+        cell.budget_label,
+        cell.n,
+        cell.baseline.rate(),
+        cell.baseline.mean_expansions(),
+        rates.join(" "),
+        nulls.join(" ")
+    );
+}
+
+/// The full A2 measurement — both axes, every cell, the pre-registered
+/// readings, and the axis verdict inputs. `--ignored` because it is the
+/// measurement; the record is `docs/w33_geometry_qualification_845.md`.
+#[test]
+#[ignore = "the #845 measurement: run explicitly with --ignored --nocapture"]
+fn geometry_qualification_measurement() {
+    let tables = arms::W33Tables::build();
+    let vsa = arms::VsaTables::build();
+    let random = arms::RandomTables::build();
+    let relabeled = arms::RelabeledTables::build(&tables);
+
+    // ---- A2(a): the 12 separating cells at the frozen budget ----
+    let mut a2a = Vec::new();
+    for (family, horizon) in A2A_CELLS {
+        let fit = fit_cell(&tables, family, horizon).expect("cell fits");
+        let cell = run_cell(
+            &tables,
+            &vsa,
+            &random,
+            &relabeled,
+            &fit,
+            family,
+            horizon,
+            CellBudget::Frozen,
+            episode::N_PER_CELL,
+        );
+        print_arm_rates(&cell);
+        let reading = read_a2a(&cell);
+        println!(
+            "MEAS-A2A | {:<26} | H={:<2} | {} | bar={}@{:.1} geom@{:.1} | headroom={:.4} | r mean={:.4} se={:.4} lb={:.4} p={:.4} | geometry_perfect={} | {}",
+            reading.family,
+            reading.horizon,
+            reading.class,
+            reading.bar,
+            reading.bar_mean,
+            reading.geometry_mean,
+            reading.headroom,
+            reading.mean,
+            reading.standard_error,
+            reading.lower_bound,
+            reading.p,
+            reading.geometry_perfect,
+            if reading.pass { "PASS" } else { "fail" }
+        );
+        a2a.push(reading);
+    }
+    let a2a_pass = a2a.iter().all(|r| r.pass);
+    let a2a_holm = stats::holm_pass(&a2a.iter().map(|r| r.p).collect::<Vec<_>>());
+    println!(
+        "VERDICT-A2A | conjunction={} | cells_pass={}/12 | holm_pass={}/12",
+        if a2a_pass { "PASS" } else { "FAIL" },
+        a2a.iter().filter(|r| r.pass).count(),
+        a2a_holm.iter().filter(|h| **h).count()
+    );
+
+    // ---- A2(b): nine primary + nine secondary cells ----
+    let mut a2b = Vec::new();
+    for family in episode::SEPARATING {
+        let fit = fit_cell(&tables, family, 8).expect("cell fits at H=8");
+        for budget in A2B_PRIMARY_BUDGETS {
+            let cell = run_cell(
+                &tables,
+                &vsa,
+                &random,
+                &relabeled,
+                &fit,
+                family,
+                8,
+                budget,
+                episode::N_PER_CELL,
+            );
+            print_arm_rates(&cell);
+            a2b.push(read_a2b(&cell, true));
+        }
+        for budget in A2B_SECONDARY_BUDGETS {
+            let cell = run_cell(
+                &tables,
+                &vsa,
+                &random,
+                &relabeled,
+                &fit,
+                family,
+                8,
+                budget,
+                episode::N_PER_CELL,
+            );
+            print_arm_rates(&cell);
+            a2b.push(read_a2b(&cell, false));
+        }
+        let fit16 = fit_cell(&tables, family, 16).expect("cell fits at H=16");
+        let cell = run_cell(
+            &tables,
+            &vsa,
+            &random,
+            &relabeled,
+            &fit16,
+            family,
+            16,
+            CellBudget::Frozen,
+            episode::N_PER_CELL,
+        );
+        print_arm_rates(&cell);
+        a2b.push(read_a2b(&cell, false));
+    }
+    for reading in &a2b {
+        println!(
+            "MEAS-A2B | {:<26} | H={:<2} | {:<14} | {} | geom={:.4} bar={}@{:.4} | d mean={:.4} se={:.4} lb={:.4} p={:.4} | {}",
+            reading.family,
+            reading.horizon,
+            reading.budget_label,
+            if reading.primary { "PRIMARY" } else { "secondary" },
+            reading.geometry_rate,
+            reading.bar,
+            reading.bar_rate,
+            reading.mean,
+            reading.standard_error,
+            reading.lower_bound,
+            reading.p,
+            if reading.pass { "PASS" } else { "fail" }
+        );
+    }
+    let primary: Vec<&A2bReading> = a2b.iter().filter(|r| r.primary).collect();
+    let a2b_pass = primary.iter().all(|r| r.pass);
+    let a2b_holm = stats::holm_pass(&primary.iter().map(|r| r.p).collect::<Vec<_>>());
+    println!(
+        "VERDICT-A2B | conjunction={} | primary_pass={}/9 | holm_pass={}/9 | secondary_pass={}/9",
+        if a2b_pass { "PASS" } else { "FAIL" },
+        primary.iter().filter(|r| r.pass).count(),
+        a2b_holm.iter().filter(|h| **h).count(),
+        a2b.iter().filter(|r| !r.primary && r.pass).count()
+    );
+
+    println!(
+        "VERDICT | A2a={} A2b={} | verdict-space: both=PROMOTE-FOR-LOWERING one=REVISE neither=NO-GEOMETRIC-ADVANTAGE",
+        if a2a_pass { "PASS" } else { "FAIL" },
+        if a2b_pass { "PASS" } else { "FAIL" }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-vacuity gates — run by default
+// ---------------------------------------------------------------------------
+
+/// The A2(a) classifier and both pass rules can fire and can fail.
+#[test]
+fn the_a2a_reading_fires_in_both_directions() {
+    let synthetic = |name: &'static str, expansions: Vec<f64>, correct: bool| ArmTrace {
+        name,
+        correct: vec![correct; expansions.len()],
+        expansions,
+        lookups: 0,
+    };
+    // Reduction cell: bar mean 10 vs floor 2 (headroom 0.8), geometry cuts to 6.
+    let cell = CellData {
+        family: "synthetic",
+        horizon: 8,
+        budget_label: "frozen".to_string(),
+        n: 4,
+        baseline: synthetic("bounded-breadth-first", vec![12.0; 4], true),
+        arms: vec![
+            synthetic("w33-geometry", vec![6.0, 6.0, 5.0, 7.0], true),
+            synthetic("table-guided-beam", vec![10.0; 4], true),
+        ],
+        nulls: [
+            synthetic("retrieval-only", vec![0.0; 4], false),
+            synthetic("direct-continuation", vec![0.0; 4], false),
+            synthetic("memorized-trajectory", vec![0.0; 4], false),
+            synthetic("shuffled-state", vec![0.0; 4], false),
+        ],
+        gold_floor: vec![2.0; 4],
+    };
+    let reading = read_a2a(&cell);
+    assert_eq!(reading.class, "reduction");
+    assert!(reading.pass, "a real reduction must pass");
+
+    // The same cell with geometry doing MORE work must fail.
+    let mut regressed = cell;
+    regressed.arms[0] = synthetic("w33-geometry", vec![11.0; 4], true);
+    let reading = read_a2a(&regressed);
+    assert!(!reading.pass, "a regression must fail");
+
+    // No-regression cell: bar at the floor, geometry identical -> degenerate
+    // LB = 0 passes; geometry above the bar fails.
+    let flat = CellData {
+        family: "synthetic",
+        horizon: 1,
+        budget_label: "frozen".to_string(),
+        n: 4,
+        baseline: synthetic("bounded-breadth-first", vec![1.0; 4], true),
+        arms: vec![
+            synthetic("w33-geometry", vec![1.0; 4], true),
+            synthetic("table-guided-beam", vec![1.0; 4], true),
+        ],
+        nulls: [
+            synthetic("retrieval-only", vec![0.0; 4], false),
+            synthetic("direct-continuation", vec![0.0; 4], false),
+            synthetic("memorized-trajectory", vec![0.0; 4], false),
+            synthetic("shuffled-state", vec![0.0; 4], false),
+        ],
+        gold_floor: vec![1.0; 4],
+    };
+    let reading = read_a2a(&flat);
+    assert_eq!(reading.class, "no-regression");
+    assert!(reading.pass, "identical work at the floor must pass");
+    let mut worse = flat;
+    worse.arms[0] = synthetic("w33-geometry", vec![2.0; 4], true);
+    assert!(!read_a2a(&worse).pass, "regression at the floor must fail");
+}
+
+/// The measurement machinery runs end-to-end on a small live cell and the
+/// A2(b) bar can actually be beaten and be unbeaten.
+#[test]
+fn the_measurement_machinery_is_live() {
+    let tables = arms::W33Tables::build();
+    let vsa = arms::VsaTables::build();
+    let random = arms::RandomTables::build();
+    let relabeled = arms::RelabeledTables::build(&tables);
+    let family = cp::TaskFamily::GraphNavigation;
+    let fit = fit_cell(&tables, family, 4).expect("fit at H=4");
+    let cell = run_cell(
+        &tables,
+        &vsa,
+        &random,
+        &relabeled,
+        &fit,
+        family,
+        4,
+        CellBudget::Frozen,
+        64,
+    );
+    assert_eq!(cell.n, 64, "the smoke cell is not vacuous");
+    assert!(
+        cell.baseline.perfect(),
+        "the frozen-budget baseline must be perfect at H=4 (the #843 record)"
+    );
+    let reading = read_a2b(&cell, false);
+    assert!(reading.bar_rate > 0.0, "the A2(b) bar must be able to fire");
+    let reading_a = read_a2a(&cell);
+    assert!(
+        reading_a.bar != "none-perfect",
+        "at the frozen budget a perfect non-geometric ordering control exists"
+    );
+}

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -414,6 +414,34 @@ amendment: [`docs/compositional_planning_spec_844.md`](compositional_planning_sp
 Next executable work: **#845 increments 2–4** (mapping and instruments → arms and harness →
 measurement and verdict).
 
+### S4 item C (#845) — CLOSED = NO GEOMETRIC ADVANTAGE (2026-08-22)
+
+Readable mirror; **#845 and #826 remain the source of record**. Full measurement:
+[`docs/w33_geometry_qualification_845.md`](w33_geometry_qualification_845.md); frozen contract:
+[`docs/w33_geometry_qualification_spec_845.md`](w33_geometry_qualification_spec_845.md).
+
+- **Verdict: NO GEOMETRIC ADVANTAGE** — the pre-registered negative branch, a successful
+  falsification. Under equal budgets and equal bytes the pinned W(3,3) mapping fails both axes:
+  A2(a) 5/12 (only the structurally degenerate H = 1 cells; it does 12–37% *more* work than the
+  goal-distance beam wherever reduction is possible) and A2(b) 0/9 primary, 0/9 secondary.
+- **The controls did the deciding.** Geometry sits at the level of its own randomized, relabelled,
+  and phase-swapped controls (0.62 vs 0.64–0.71 at frontier-16), while two informed non-geometric
+  orderings — goal-distance and Hamming/popcount — hold 1.0000 in the same cells. The gain over
+  breadth-first attributes to *any ordering*, not to quadrangle structure; the mod-9 digit
+  quantization's wrap-around severs slot distance from task-step distance.
+- **The falsifier discharged.** "If a geometry arm cannot beat Hamming/binary/VSA/spectral
+  controls under equal bytes, candidates, and operation budgets, keep it out of the production
+  runtime" — it is kept out. W(3,3) stays a visualization/reference construct; the f64 router's
+  separately measured retrieval results are untouched; re-entry requires a new mapping Definition
+  with a fresh design contract and probe under the same frozen controls.
+- **Method delivered along the way (reusable):** counter-exact parity between a seam-opened
+  reference search and the deployed planner (>1,000 episodes per retention rule); an equal-bytes
+  ordering-arm roster; the probe-admitted cell discipline (Amendment A2); and the §5-A
+  no-regression reading for structurally-floored cells.
+- **Downstream.** #846 (S4 item D) is the next executable issue: certification against the lowered
+  non-geometric baseline on the sealed partitions, with the #826 geometry-gain clause resolved
+  negatively by this record. Frozen gates unchanged; `CONFORMANCE.md` unchanged (33 ids).
+
 ## Dependency order
 
 ```text
@@ -470,7 +498,7 @@ authority:
 
 | Component | Role | Status |
 |---|---|---|
-| **W(3,3)** visualization / dashboard field | 96 rendered vertices in the browser dashboard; a research/visualization construct | **Not** a normative construction of the 40-point/40-line W(3,3) quadrangle; **not** an input or output of the Rust router; separately qualified research hypothesis |
+| **W(3,3)** visualization / dashboard field | 96 rendered vertices in the browser dashboard; a research/visualization construct | **Not** a normative construction of the 40-point/40-line W(3,3) quadrangle; **not** an input or output of the Rust router; equal-budget planning advantage **refuted for the pinned mapping** (#845, `NO GEOMETRIC ADVANTAGE`, 2026-08-22) — any re-entry needs a new mapping Definition under the recorded conditions |
 | **Geometric prime router** (`crates/uor-r4-router`) | Validated `f64` content-query retrieval/routing (MRR 0.88+, #486/#490/#502) | Real, load-bearing for retrieval; runs on `f64` **outside** the P-4 kernel by design; strengthens the product, is not itself the product |
 | **R4G1 graph scoring** (`uor-r4-core` `score.rs` / R4G1 adapter) | The compiled-artifact scoring path | On the normative production path; the S0 designation of *one* normative scorer is #831 |
 | **Route-attention reference work** (`R4RouteAttentionV1`, #604/#605/#804) | P-4-legal integer attention analog | **Dormant**; S1 verdict FAIL (instrument vacuous); wired into no serving path; ledger-gated |

--- a/docs/w33_geometry_qualification_845.md
+++ b/docs/w33_geometry_qualification_845.md
@@ -1,0 +1,160 @@
+# W(3,3) geometry qualification — measurement record and verdict (#845)
+
+- **Issue:** #845 — "research/#826-C: qualify W(3,3) against Hamming, binary, VSA, and spectral
+  baselines" (item C of S4 tracker #826, programme #820).
+- **Date:** 2026-08-22. **Records are append-only.**
+- **Frozen contract:** [`docs/w33_geometry_qualification_spec_845.md`](w33_geometry_qualification_spec_845.md)
+  (§5/§5-A statistics pre-registered before this run), measured under Amendment A2 of
+  [`docs/compositional_planning_spec_844.md`](compositional_planning_spec_844.md) §12.
+- **Claim language:** normative per [`docs/formal_vocabulary.md`](formal_vocabulary.md).
+- **Execution scope:** offline / reference geometry evaluated through fixed production-planning
+  readouts; certifier-instrument / off-serving-path. Nothing here is deployed-serving evidence,
+  and no production code changed anywhere in #845.
+
+---
+
+## 1. Verdict — NO GEOMETRIC ADVANTAGE
+
+**Empirical Criterion (S4 item C outcome). Status: Empirical.**
+
+> Under the frozen equal-budget, equal-byte comparison, the pinned W(3,3) mapping provides **no
+> measurable planning advantage** on either pre-registered axis. On the budget axis it does
+> strictly **more** search work than the incumbent non-geometric ordering in every cell where
+> reduction is structurally possible (0 of 12 reduction/no-regression conjunction cells beyond the
+> five degenerate ones). On the correctness axis it fails all nine primary tightened-budget cells —
+> and sits at the level of its **own randomized and scrambled controls**, while two non-geometric
+> orderings (goal-distance, Hamming/popcount) hold correct-outcome rate 1.0000 in the same cells.
+> The pre-registered negative branch applies: W(3,3) stays in exploratory/reference scope, the
+> production planner remains the lowered non-geometric baseline, and this is a **successful
+> falsification**, not an incomplete measurement.
+
+The programme falsifier this verdict discharges (completion plan, global falsifiers): *"if a
+geometry arm cannot beat Hamming/binary/VSA/spectral controls under equal bytes, candidates, and
+operation budgets, keep it out of the production runtime."* It is kept out.
+
+## 2. What was measured
+
+Both axes ran on 2026-08-22 in one deterministic pass (`w33_measurement_845.rs`, ignored grid;
+single-threaded, teacher-free, fixture-free, ~50 s): n = **512** held-out joint-split instances
+per cell, the frozen #844 identities with Amendment A1+A2, the deployed capacities, and the arm
+roster of spec §4/§4-A — the W(3,3) geometry arm, eight non-geometric ordering controls
+(goal-distance incumbent, Hamming/popcount, learned-table-codes, VSA-binding, spectral-embedding,
+random-embedding, isomorphic-relabel, phase-permuted), the `bounded-breadth-first` baseline, and
+the four #843 nulls, all under one `PlanBudget` per cell, all in arm mode on the parity-proven
+reference skeleton.
+
+## 3. A2(a) — the budget axis (12 separating cells, frozen budget)
+
+Geometry holds correct-outcome **1.0000 in all 12 cells** (the mapping does no harm at the frozen
+budget). It never reduces work: the bar (strongest perfect non-geometric ordering) is
+`table-guided-beam` in every cell.
+
+| cell | class | bar mean exp | geometry mean exp | paired r̄ | LB(95%) | reading |
+|---|---|---|---|---|---|---|
+| graph-navigation H=1 | no-regression | 1.0 | 1.0 | 0.0000 | 0.0000 | PASS (degenerate) |
+| graph-navigation H=2 | no-regression | 2.1 | 2.6 | −0.2461 | −0.2735 | fail |
+| graph-navigation H=4 | reduction | 12.8 | 17.6 | −0.3704 | −0.3877 | fail |
+| graph-navigation H=8 | reduction | 88.5 | 99.9 | −0.1276 | −0.1342 | fail |
+| symbolic-transformation H=1 | no-regression | 1.0 | 1.0 | 0.0000 | 0.0000 | PASS (degenerate) |
+| constraint-satisfaction H=1 | no-regression | 1.0 | 1.0 | 0.0000 | 0.0000 | PASS (degenerate) |
+| constraint-satisfaction H=8 | reduction | 84.8 | 96.2 | −0.1355 | −0.1424 | fail |
+| multi-hop-evidence H=1 | no-regression | 1.0 | 1.0 | 0.0000 | 0.0000 | PASS (degenerate) |
+| multi-hop-evidence H=2 | no-regression | 2.1 | 2.6 | −0.2461 | −0.2735 | fail |
+| multi-hop-evidence H=4 | reduction | 12.8 | 17.6 | −0.3704 | −0.3877 | fail |
+| multi-hop-evidence H=8 | reduction | 88.5 | 99.9 | −0.1276 | −0.1342 | fail |
+| counterfactual-intervention H=1 | no-regression | 1.0 | 1.0 | 0.0000 | 0.0000 | PASS (degenerate) |
+
+**Conjunction: FAIL (5/12; the five passes are the structurally degenerate H = 1 cells; Holm:
+0/12).** The §5-A classification confirmed its pre-registered expectation exactly: the five H = 1
+cells are no-regression cells; the H ≥ 2 cells carry real headroom (up to 0.91) — headroom the
+geometry ordering not only failed to take but *spent against*, doing 12–37% more work than the
+goal-distance beam.
+
+## 4. A2(b) — the correctness axis (9 primary + 9 secondary cells)
+
+The bar (strongest of baseline, nulls, and non-geometric ordering controls, all under the cell's
+budget) is an *informed non-geometric ordering* in every primary cell — never a null.
+
+| cell | kind | geometry | bar | LB(95%) vs bar | reading |
+|---|---|---|---|---|---|
+| graph-navigation frontier-16 | PRIMARY | 0.6230 | hamming-popcount 1.0000 | −0.4122 | fail |
+| graph-navigation frontier-8 | PRIMARY | 0.2656 | table-guided-beam 1.0000 | −0.7665 | fail |
+| graph-navigation frontier-4 | PRIMARY | 0.0742 | table-guided-beam 1.0000 | −0.9448 | fail |
+| constraint-satisfaction frontier-16 | PRIMARY | 0.6426 | hamming-popcount 1.0000 | −0.3923 | fail |
+| constraint-satisfaction frontier-8 | PRIMARY | 0.2617 | table-guided-beam 1.0000 | −0.7702 | fail |
+| constraint-satisfaction frontier-4 | PRIMARY | 0.1387 | table-guided-beam 0.9961 | −0.8828 | fail |
+| multi-hop-evidence frontier-16 | PRIMARY | 0.6230 | hamming-popcount 1.0000 | −0.4122 | fail |
+| multi-hop-evidence frontier-8 | PRIMARY | 0.2656 | table-guided-beam 1.0000 | −0.7665 | fail |
+| multi-hop-evidence frontier-4 | PRIMARY | 0.0742 | table-guided-beam 1.0000 | −0.9448 | fail |
+
+**Conjunction: FAIL (0/9; Holm 0/9).** All nine secondary cells (the expansion ladder, where the
+baseline is fully collapsed and the bar degenerates to `direct-continuation`, and the TIGHT frozen
+H = 16 cells) also fail, 0/9 — at H = 16 geometry reaches 0.9707–0.9824 while Hamming holds
+1.0000.
+
+## 5. Attribution — where the signal actually is, and is not
+
+The per-arm table at graph-navigation H = 8 frontier-16 (constraint-satisfaction and
+multi-hop-evidence read the same within noise):
+
+| arm | rate | | arm | rate |
+|---|---|---|---|---|
+| bounded-breadth-first (baseline) | 0.5391 | | **w33-geometry** | **0.6230** |
+| table-guided-beam | 1.0000 | | random-embedding | 0.6641 |
+| hamming-popcount | 1.0000 | | isomorphic-relabel | 0.6445 |
+| learned-table-codes | 0.8945 | | phase-permuted | 0.7090 |
+| spectral-embedding | 0.8965 | | vsa-binding | 0.7871 |
+
+Three attributions follow, each pre-registered as a reading rule before the run:
+
+1. **The geometry arm sits at the level of its own randomized and scrambled controls** — random
+   tables of the same shape and bytes (0.6641), the alignment-destroying relabel (0.6445), and the
+   phase-swapped variant (0.7090) all match or slightly exceed it. Whatever the W(3,3) tables
+   contribute over FIFO is what *any* table of that shape contributes: the generic
+   informed-ordering effect, not quadrangle structure.
+2. **The small gain over the baseline attributes to "any ordering", not geometry** (the §5
+   attribution rule): every ordering arm beats FIFO's 0.5391; the non-geometric informed ones beat
+   it to saturation.
+3. **The pinned phase convention is mildly anti-aligned on these tasks** — the phase-swapped
+   control outperforms the true phase (0.7090 vs 0.6230). A sign flip would not rescue the arm:
+   0.7090 is still far below the 1.0000 non-geometric bars. Recorded, not optimized against.
+
+The mechanism is not mysterious: μ quantizes slot values through mod-9 digit residues, and the
+wrap-around of residue classes destroys the monotone relationship between slot distance and
+task-step distance that the goal-distance and Hamming orderings exploit directly. A 40-point
+incidence geometry over wrapped digit classes carries almost no information about how many grid
+steps remain.
+
+## 6. Verification behind the numbers
+
+- **Counter-exact parity (Structural).** The reference skeleton reproduces the deployed planner —
+  outcome, plan, every `PlanCounters` field — for both parity retention rules over a
+  3-family × 3-horizon × 4-budget × 32-seed grid (>1,000 episodes per rule), machine-checked in
+  `w33_ordering_harness_845.rs` before this measurement ran.
+- **Equal budgets, equal bytes (Structural).** One `PlanBudget` per cell for every arm and null;
+  every control's auxiliary tables at or under the geometry arm's 3,200 bytes, audited by test.
+- **Controls fire and fail (Structural).** Determinism and separation asserted per arm; the
+  relabel scramble asserted non-automorphic; the A2(a) classifier and both pass rules asserted to
+  fire in both directions on synthetic cells; the A2(b) bar asserted able to fire.
+- **Reproduction.** Deterministic, seedless beyond pinned constants:
+  `cargo test -p uor-r4-graph-certify --release --test w33_measurement_845 -- --ignored --nocapture`.
+
+## 7. Boundaries — what this verdict does and does not say
+
+It says exactly: **the pinned μ mapping of W(3,3) into the #844 planning benchmark provides no
+equal-budget advantage on the measured tasks, horizons, and budgets.** It does not refute W(3,3)
+as mathematics; it does not touch the f64 geometric router's separately measured content-retrieval
+results (MRR 0.88+, #486/#490/#502), which are outside the P-4 kernel by design; and it licenses
+no claim about other mappings. **Re-entry condition:** a new mapping Definition (not mod-9 digit
+quantization) with a pre-registered alignment rationale, a fresh design contract and probe, under
+the same frozen controls and budgets. Absent that, W(3,3) remains a visualization/reference
+construct and no geometry enters the production runtime.
+
+## 8. Downstream
+
+- **#846 (S4 item D)** inherits a fully-dispositioned item C: certification proceeds against the
+  lowered non-geometric baseline (RF-33 `bounded-breadth-first`) on the sealed partitions #843
+  never opened; the S4 promotion verdict remains #846's to make, with the geometry-gain clause of
+  the #826 gate resolved negatively by this record.
+- The #824 free-running-coherence and #823 calibrated-confidence boundaries stand untouched.
+- `CONFORMANCE.md` is unchanged by #845 (no new RF id; reference/certifier scope only).


### PR DESCRIPTION
## Problem and outcome

Increment 4 of 4 for issue 845 (S4 item C): the equal-budget measurement on both pre-registered A2 axes, its append-only record, and the verdict — **NO GEOMETRIC ADVANTAGE**, the pre-registered negative branch, a successful falsification.

## Result

- **A2(a), budget axis (12 separating cells, frozen budget):** the geometry arm holds correct-outcome 1.0000 everywhere (the mapping does no harm) but reduces work nowhere: conjunction FAIL, 5/12 (the five passes are the structurally degenerate H = 1 no-regression cells; in every reduction cell geometry does 12–37% MORE work than the goal-distance beam; Holm 0/12).
- **A2(b), correctness axis (9 primary + 9 secondary tightened-budget cells):** conjunction FAIL, 0/9 primary and 0/9 secondary. The bar is an informed non-geometric ordering in every primary cell — goal-distance or Hamming/popcount at 1.0000 (0.9961 once) against geometry at 0.0742–0.6426.
- **Attribution (pre-registered reading rules):** geometry sits at the level of its own randomized, relabelled, and phase-swapped controls (0.6230 vs 0.6445–0.7090 at frontier-16), so its gain over breadth-first attributes to informed ordering generally, not to quadrangle structure; the pinned phase convention is mildly anti-aligned (recorded, not optimized against). Mechanism: mod-9 digit quantization wrap-around severs slot distance from task-step distance.
- The programme falsifier is discharged: a geometry arm that cannot beat Hamming/binary/VSA/spectral controls under equal bytes, candidates, and operation budgets stays out of the production runtime.

## What this PR contains

- `crates/uor-r4-graph-certify/tests/w33_measurement_845.rs` — the measurement instrument: both axes over the frozen grids (n = 512/cell, joint split, one `PlanBudget` per cell, arm mode on the parity-proven skeleton), the §5/§5-A per-cell readings, IU + Holm; the full grid `#[ignore]`d, with default non-vacuity gates asserting the A2(a) classifier and both pass rules fire in both directions and the machinery runs live end-to-end.
- `docs/w33_geometry_qualification_845.md` (new, append-only) — the complete measurement record: verdict, both result tables, the attribution table, verification behind the numbers, claim boundaries, the re-entry condition (a new mapping Definition with a fresh contract and probe), and downstream state.
- `docs/r4_intelligence_completion_plan.md` — the readable-mirror verdict entry for item C.

## Acceptance-criteria status (issue-level)

- Mapping/readout total, testable, label-independent: DONE (increment 2, machine-checked).
- Equal storage/candidate/operation budgets, non-degenerate baselines: DONE (increment 3, audited; every control able to fire and to fail).
- Primary interventional metric first; trajectory stability never gated: DONE (no trajectory metric was needed).
- Gain survives relabeling/isomorphism/topology/composition controls: the antecedent is empty — no gain exists to survive; the controls are what established that.
- Verdict recorded from the pre-registered space: **NO GEOMETRIC ADVANTAGE**.
- W(3,3) remains exploratory/reference; no production lowering is proposed; the f64 router is unmodified; no production graph crate gained any dependency.

## Verification

fmt, clippy `-D warnings` (workspace, all targets/features), wasm lib build, `cargo test --workspace --no-fail-fast --offline` (188 suites, 0 failures), `xtask validate` (R1/R4/R5/gnaf), `cargo deny check bans`, claim-wording gate — all green locally on exactly this tree; `audit-limits` re-run immediately before push. The measurement reproduces deterministically with `cargo test -p uor-r4-graph-certify --release --test w33_measurement_845 -- --ignored --nocapture`.

## Conformance, compatibility, claim boundary

Research/reference scope; certifier-instrument code and docs only. CONFORMANCE.md unchanged (33 ids); no new RF id; model/ledger.toml untouched; no production format, runtime, or dependency changes. The negative verdict narrows the public claim: no geometry statement stronger than "no equal-budget advantage measured for the pinned mapping" is licensed.

## Negative results

The verdict itself is the negative result, recorded as first-class completion evidence per the programme rules. No result in this issue is UNAVAILABLE: every declared instrument ran and returned a definite reading.

Closes #845
