### PR TITLE
test/perf(#932): make live teacher parity bounded and observable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,14 +130,77 @@ next to Gate C's anchors (Gate C scores a held-out partition with the
 compiler-side plain baseline; S6 replays recorded positions, so its ~0.43
 figures sit above the 0.181 anchor by construction). It runs
 in the default `cargo test --test bdd` when `.uor-models/sources/
-smollm2-135m-instruct` and the compiled bundle are present, and vacuously
-skips otherwise (κ-test convention — check the fixture before trusting green).
-Budgets: `R4_PARITY_POSITIONS` (256), `R4_PARITY_GEN_TOKENS` (128),
-`R4_PARITY_RUNS` (3), `R4_PARITY_CORPUS_POSITIONS` (1000). Thresholds are
-pinned empirical floors with ~20%
+smollm2-135m-instruct` and the compiled bundle are present. If a conditional
+fixture is absent, that evidence is **UNAVAILABLE** even when the enclosing test
+process exits successfully; never report the unexercised parity scenario as
+PASS.
+Budgets: `R4_PARITY_POSITIONS` (256), `R4_PARITY_GEN_TOKENS` (8, a hard
+adaptive ceiling), `R4_PARITY_RUNS` (1), `R4_PARITY_CORPUS_POSITIONS` (1000).
+Thresholds are pinned empirical floors with ~20%
 margin; the ~1% top-1 figures are out-of-distribution honesty, not a bug —
 the suite's 8 prompts are novel text, unlike Gate C's same-corpus replay
 (see the comment above the constants in `tests/bdd.rs`).
+
+The fixture-present live-teacher work is required to be an exact-parallel,
+multi-stream host measurement, not a single-stream latency benchmark hidden
+behind an intra-forward thread pool. `S = R4_PARITY_STREAMS` is the independent
+private-state trajectory/batch width; `W = R4_PARITY_WORKERS` is the one
+persistent exact output-row worker pool. Scientific coverage stays fixed at
+eight canonical lanes in an `S = 8` shared-weight batch. `S` and `W` are
+independent: the bounded tuner compares the host's all-logical-CPU width with
+its four-worker candidate (deduplicated when equal) over the same eight-lane
+work and selects the faster exact point. On the binding M1 these candidates are
+`W = 8` and `W = 4`; neither width is a utilization quota or performance goal.
+A physical teacher
+batch must advance all `S` states through shared immutable weights while the
+`W` pool divides output rows only; no worker may split or reassociate a row's
+pinned exact dot-product reduction. Compiled candidates must receive the same
+lane seeds and logical workload, and all results must reduce in canonical
+prompt/position order. The shared teacher transcript also retains the S4 prefix
+states, eliminating duplicate teacher prefill and the independent S4 warm-up.
+
+Every live run must emit flushed JSONL progress events, deterministic evidence,
+and a final JSON report with fixture identities/status, actual tokenized work,
+configured/effective/current/peak stream and worker occupancy, complete
+physical-batch/logical-forward/matrix/tile/cell/scalar-term accounting,
+per-lane state/output identities, elapsed/rate/ETA basis, CPU/RSS readings, a
+retained-workspace capacity/growth ledger, and a typed final `PASS`, `FAIL`,
+`UNAVAILABLE`, `ABORTED`, or `NOT_RUN` verdict. Model, transpose/output, and
+per-worker exact scratch buffers are prepared outside timed work; any capacity
+growth during a measured forward fails the steady-state evidence. A heartbeat
+must continue while an individual exact forward is in flight; its liveness and
+ETA use monotonic in-flight exact scalar-term progress (worker-task progress is
+the fallback), while completed-forward throughput remains a separate rate. The
+bounded live tuner compares equal S=8 work at W=available/W=4 without full-model
+candidate warm-ups, establishes exact trace equality plus owner-plan
+reconciliation, and selects the faster exact point. W=1/2/4/8 equality remains
+a focused structural gate. Speedup and CPU utilization are recorded diagnostics
+rather than admission floors. Full work launches only when the selected exact
+point has complete evidence and a safety-adjusted projection below the
+configured hard wall ceiling, capped at eight hours. S4 starts with one causal
+decode step per lane and extends through 2, 4, then 8 only while more work can
+change its verdict. Any missing or failed evidence refuses the full run. See
+`docs/teacher_parity_parallelism_932.md` and `docs/CONFIGURATION.md`.
+
+The exact teacher, pinned `uor-matmul` crates, and both compiled S4 engine paths
+have narrow `profile.test.package` opt-level 3 overrides in the root manifest.
+Do not remove them and then interpret an opt-level-0 BDD rate as serving
+performance. The rest of the workspace retains the normal test profile.
+
+Before spending any live-teacher work, run
+`R4_PARITY_PREFLIGHT_ONLY=1 cargo test --test bdd --offline`. This teacher-free
+gate parses the tokenizer and every compiled prerequisite, exercises all eight
+canonical legacy and graph seeds through typed deployed decisions, and writes a
+content-bound `uor-r4.teacher-parity-preflight/1` success or refusal artifact
+before exiting. The ordinary BDD fixture loader publishes the same artifact
+before it can open the teacher. Refusals retain the exact reason, safe input
+paths/CIDs, `teacher_source_opened=false`, and `teacher_forwards=0`; an
+unwritable artifact path is itself a visible failure. A failed preflight blocks
+the tuner and full suite; it is not bypassed as a fixture skip. The artifact's
+`authorizing_contract_cid` binds the current executor, BDD, model, manifest,
+and toolchain sources. Direct tuner invocation validates that binding plus the
+selected paths and current compiled-input plus complete production-admission
+CIDs before loading teacher weights.
 
 ## Process conventions
 
@@ -269,7 +332,8 @@ never sit between two pieces of code work.
 ## Things that bite
 
 - `/tmp/ref/out/model.bin` disappears on reboot/periodic /tmp cleanup — κ tests
-  skip silently and report vacuous green.
+  may still exit successfully without exercising reproduction; the Gate E
+  evidence is **UNAVAILABLE**, not PASS.
 - `crates/uor-r4-graph-format/fuzz/target` must never be committed (gitignored).
 - Fuzz targets need nightly (`cargo +nightly fuzz run …`); the stable
   deterministic mutation smoke runs under plain `cargo test`.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -233,7 +233,7 @@ The `build` level is *harness-built* (structural). It is a separate axis from an
 
 | ID | Level | Execution scope | Serving reachability | Evidence | Statement |
 | --- | --- | --- | --- | --- | --- |
-| `RF-29` | `build` | `certifier-instrument` | `off-serving-path` | tests/bdd.rs, features/suites/teacher_parity_benchmarks.feature (pinned-fixture-gated; skips vacuously when fixtures absent) | Teacher parity and benchmarks for the compiled transformerless runtimes (fixture-gated empirical instrument; absent fixtures are UNAVAILABLE, never PASS) |
+| `RF-29` | `build` | `certifier-instrument` | `off-serving-path` | features/suites/teacher_parity_benchmarks.feature; tests/bdd.rs; tests/parity_determinism_932.rs; tests/parity_observability_932.rs; crates/uor-r4-model-source/src/exact_probe.rs (pinned-fixture-gated; adaptive exact W={4,available_parallelism} tuner with deduplication and durable UNAVAILABLE/non-PASS evidence) | Teacher parity and benchmarks for the compiled transformerless runtimes (fixture-gated empirical instrument; absent fixtures are UNAVAILABLE, never PASS) |
 
 ## Cited authorities
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,10 +2019,12 @@ dependencies = [
  "blake3",
  "hex",
  "libm",
+ "rayon",
  "safetensors",
  "serde",
  "serde_json",
  "uor-matmul",
+ "uor-r4-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,46 @@ uor-foundation-sdk = { git = "https://github.com/UOR-Foundation/UOR-Framework.gi
 # workspace exclude) when uor-addr/uor-prism-crypto move to a blake3 (>=1.6) that
 # no longer depends on arrayref. Tracked in #868.
 arrayref = { path = "third_party/arrayref" }
+
+# #932: fixture-present host verification executes the exact certifier-side
+# teacher harness. These narrow overrides intentionally affect every test build
+# of the listed packages so that verification never becomes an opt-level-0 run.
+[profile.test.package.uor-r4-model-source]
+opt-level = 3
+
+[profile.test.package.uor-matmul]
+opt-level = 3
+
+[profile.test.package.uor-matmul-core]
+opt-level = 3
+
+[profile.test.package.uor-matmul-codec]
+opt-level = 3
+
+[profile.test.package.uor-matmul-gemm]
+opt-level = 3
+
+[profile.test.package.uor-matmul-kernels]
+opt-level = 3
+
+# S4 compares the deployed compiled engines with the teacher. Leaving those
+# engines at test-profile opt-level 0 would waste wall time and turn the
+# empirical ratio into a debug-build comparison rather than the shipped CPU
+# path. Keep only the packages on that measured path optimized.
+[profile.test.package.uor-r4-core]
+opt-level = 3
+
+[profile.test.package.uor-r4-graph-format]
+opt-level = 3
+
+[profile.test.package.uor-r4-graph-runtime]
+opt-level = 3
+
+[profile.test.package.uor-r4-graph-certify]
+opt-level = 3
+
+[profile.test.package.uor-r4-api]
+opt-level = 3
+
+[profile.test.package.uor-r4-wasm-router]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ whole method is measurement.
 > was **124 / 124**, but live-teacher parity fixtures were absent and those
 > scenarios vacuously skipped, so it is not parity evidence. See the
 > [#933 evidence record](docs/normative_r4g1_quality_933.md) and
-> [#934 genealogy](docs/canonical_quality_baseline_934.md); #932's observable
-> exact live-teacher BDD work remains a distinct downstream verification task.
+> [#934 genealogy](docs/canonical_quality_baseline_934.md). #932 subsequently
+> landed the observable host instrument, while live parity remains **NOT
+> ESTABLISHED**; see the [#932 evidence record](docs/teacher_parity_parallelism_932.md).
 
 **Solid, exercised by CI:**
 
@@ -670,7 +671,18 @@ for script compatibility), `R4_TLESS_TLA6`,
 size and standard error travel with every rate, so a sampled number cannot be
 read as a census), `R4_GATE_C_SKIP_ARMS=right_context` (skips the whole-corpus
 right-context code pass — about 60% of a sampled run's wall clock), plus
-per-harness caps.
+per-harness caps. Live teacher parity requests a logical private-state batch
+cohort of `S = R4_PARITY_STREAMS` lanes and one shared physical exact row-worker
+pool of `W = R4_PARITY_WORKERS` workers. `S` is not a second worker pool, and
+`W` workers are not paired or nested per lane. The pinned scientific workload
+keeps eight canonical lanes; the bounded tuner compares identical S=8 work at
+the host's all-logical-CPU width and its four-worker candidate, selecting the
+faster exact point. Those are W=8 and W=4 on the binding M1, not prescribed
+utilization targets. It does not spend live-model
+time on a ceremonial 1/2/4/8 sweep or candidate warm-ups. Progress,
+deterministic evidence, adaptive work counters, final JSON, and the eight-hour
+maximum safety ceiling are specified in [the #932 exact-parallel run
+contract](docs/teacher_parity_parallelism_932.md).
 
 **Capacity overrides** — the `R4_COVER_*` and `R4_*_SAMPLE` family share one
 contract: **unset is κ-neutral; set-but-invalid or zero panics.** A knob that
@@ -698,9 +710,37 @@ cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib
 ```
 
 Other suites: `cargo test --test bdd` (or `just bdd`) runs the Cucumber
-teacher-parity suite — it **vacuously skips** without a compiled bundle, so check
-the fixture before trusting green. `cargo test --doc --workspace` runs doc tests.
-`cargo +nightly fuzz run parse_arbitrary` fuzzes the format parser.
+teacher-parity suite. Without every required conditional fixture its parity
+evidence is **UNAVAILABLE**, not PASS, even if the enclosing test process exits
+successfully. With fixtures present, the harness is required to advance a
+full-width cohort of distinct prompts/generation trajectories through shared
+weights while one persistent worker pool partitions output rows; it must not
+change the reduction order within any dot product. The live tuner keeps all
+eight lanes and compares the host's W=available/W=4 candidates over exactly the
+same work, then adopts the faster bit-exact result. Candidate widths are a
+bounded break-even tuning choice, not a quota. Speedup and utilization are
+reported, not arbitrary gates. Admission requires complete trace/accounting
+evidence and a safety-adjusted projection below the configured hard wall. The
+expensive S4 work reuses transcript prefix states and extends one causal
+continuation from 1 to at most 8 steps only when another step can still change
+the verdict. Exact model, transpose/output, and per-worker scratch buffers are
+retained: one-time preparation is reported outside timing, and measured
+forwards must add zero workspace capacity. Heartbeats expose in-flight exact
+matrix/tile/cell/scalar progress and base ETA on that monotonic work instead of
+mislabeling a long active forward as stalled.
+Before opening the teacher, run
+`R4_PARITY_PREFLIGHT_ONLY=1 cargo test --test bdd --offline`; this teacher-free
+check parses every compiled prerequisite, exercises all eight canonical legacy
+and graph seeds, and records a content-bound preflight artifact with zero
+teacher forwards. Both the explicit preflight and the ordinary BDD loader write
+the refusal artifact before returning non-PASS, including the exact reason and
+safe per-input identities. The direct tuner also requires the artifact's
+current code-contract identity, selected paths, and recomputed compiled-input
+plus complete production-admission CIDs before it can open teacher weights. A
+non-PASS preflight blocks the expensive phases rather than becoming a vacuous
+green skip.
+`cargo test --doc --workspace` runs doc tests. `cargo +nightly fuzz run
+parse_arbitrary` fuzzes the format parser.
 
 **CI** reports five required checks. On `pull_request` they are fast — claim
 wording, fmt, clippy, `cargo audit`. On `merge_group` the full ladder runs
@@ -727,7 +767,7 @@ harness inventory is in [docs/RESEARCH.md](docs/RESEARCH.md).
 
 | Symptom | Cause and fix |
 |---|---|
-| κ tests pass suspiciously fast | `/tmp/ref/out/model.bin` is missing, so they **skip silently and report vacuous green**. `/tmp` cleanup deletes it. Re-fetch (below) and confirm the file exists before trusting a pass. |
+| κ tests pass suspiciously fast | `/tmp/ref/out/model.bin` may be missing. The enclosing test can exit successfully, but Gate E evidence is **UNAVAILABLE**, not PASS. `/tmp` cleanup deletes the fixture; re-fetch it below and confirm the file exists before recording a verdict. |
 | fmt/clippy disagree with CI | A non-rustup Rust earlier in `PATH` ignores the toolchain pin. Check `which cargo`. |
 | clippy passes locally, fails in CI | You omitted `--all-features`. Use the exact invocation above. |
 | `r4 ask` refuses to run | Production mode requires a schema-2 envelope bound to the exact full deployed-quality census. Historical release or locally compiled bundles are research-only; inspect them with explicit `r4 ask --research ...`. Do not treat that warning-bearing path as production evidence. |
@@ -735,7 +775,7 @@ harness inventory is in [docs/RESEARCH.md](docs/RESEARCH.md).
 | Port 8000 already in use | Use `--port` / `UOR_R4_PORT`, or `PORT=9000 ./uor-r4-cli`. |
 | Compiled bundle behaves oddly after an upgrade | The on-disk store in `.uor-models/` may predate the u32 token migration. A full recompile refreshes it. |
 | `--revision` rejected | It must be a full 40-character commit hash; the server refuses unpinned revisions. |
-| Measurement harness prints `SKIP` | Its corpus fixtures or `R4_*` inputs are absent. Check the harness header for what it needs. |
+| Measurement harness prints `SKIP` | Its corpus fixtures or `R4_*` inputs are absent. Record the affected evidence as **UNAVAILABLE**, then check the harness header for what it needs. |
 
 Fetch the reference checkpoint:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@ programme — what has been measured, refuted and left open — lives in
 purpose. Research direction is set by measurement and changes faster than this
 list does.
 
-_Last reviewed: 2026-08-25 (#933 completed the exact normative-runtime evidence
-branch with RATIFY and strict schema-2 admission). Prior: 2026-08-24 (#933
-reopened S0 after the scorer-scope audit)._
+_Last reviewed: 2026-08-25 (#932 completed the exact-parallel host instrument
+and refused the pre-#933 135M bundle before teacher access). Prior: 2026-08-25
+(#933 completed the exact normative-runtime evidence branch with RATIFY and
+strict schema-2 admission)._
 
 > **Post-v0.1 intelligence sequencing lives in the
 > [R4 Intelligence Completion Plan](docs/r4_intelligence_completion_plan.md)** —
@@ -37,12 +38,13 @@ claiming live-teacher parity.
 
 Current order:
 
-1. **Continue through the native dependency chain #932 → #931 → #839.** #932
-   owns the exact-parallel, observable live-teacher BDD harness. #933 ran no
-   teacher forward or parity marathon; its full-census quality evidence is
-   teacher-free over already-recorded canonical labels. The repository BDD run
-   was 124 / 124, but live-teacher fixtures were absent and those scenarios
-   vacuously skipped.
+1. **Continue through the native dependency chain #931 → #839.** #932 now
+   provides the exact-parallel, observable live-teacher BDD harness, but its
+   teacher-free gate refused the selected 135M bundle because that bundle has
+   no schema-2 production envelope. The tuner and fixture-present measurement
+   were therefore `NOT_RUN`, with zero teacher work; live throughput, speedup,
+   and parity remain `NOT ESTABLISHED`. #931 must preserve that boundary rather
+   than treating the structural harness pass as live parity evidence.
 2. **Keep the claim boundary fixed.** The #933 RATIFY is exact-artifact and
    teacher-forced-position evidence, not instruction following, reasoning, or
    free-running coherence.
@@ -52,6 +54,14 @@ Current order:
    route-attention contract, and eventual `uor-r4` alias removal.
 
 ## Landed
+
+- [x] **#932 exact-parallel live-teacher parity instrument** — *negative
+  prerequisite outcome, 2026-08-25*. Deterministic scheduling, durable
+  observability, planted negatives, and fail-closed preflight are implemented.
+  The selected canonical 135M bundle predates #933's schema-2 production
+  envelope, so the preflight refused before opening teacher weights and the
+  live tuner/parity marathon did not run. See the
+  [append-only record](docs/teacher_parity_parallelism_932.md).
 
 - [x] **#933 normative R4G1 serving and deployed-quality reconciliation** —
   *RATIFY, 2026-08-25*. One `R4G1Runtime` candidate/token owner now reaches the

--- a/crates/uor-r4-model-source/Cargo.toml
+++ b/crates/uor-r4-model-source/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # #804 measurement-only exception (maintainer-approved 2026-08-18): route
 # the TEACHER weight matmuls through Apple Accelerate for observation
 # passes. Never a default; the matrix_operation_census gate pins the
-# exception file, its feature gating, and its single dispatch site. The
+# exception file, its feature gating, and its two dispatch sites. The
 # deployed serving runtime is unaffected by construction (P-4 contract).
 observation-blas-exception = []
 
@@ -19,9 +19,18 @@ serde_json = "1.0"
 blake3 = "=1.5.0"
 libm = "0.2"
 hex = "0.4.3"
-# #655-B: the pinned exact matmul substrate. Promoted from the dev-only parity
-# pin (#622, crates/uor-r4-graph-cli) to a production dependency here; #655-B
-# wires it into the teacher executor in place of the Accelerate `cblas_*` FFI.
-# no_std, forbid(unsafe), zero-heap — its numerical path is byte-identical across
-# targets, so promoting it makes teacher output cross-machine reproducible.
+# #655-B/#932: the pinned exact matmul substrate. Hosted teacher builds enable
+# only its `std` runtime CPU-feature detection; exact output-bit identity across
+# selected kernels is an enforced #932 requirement. Wasm retains the
+# feature-free portable build.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rayon = "1.10"
+uor-matmul = { git = "https://github.com/UOR-Foundation/uor-matmul.git", version = "0.1.0", rev = "b13c98449948174f590e337c4dc25dfc394a07d0", default-features = false, features = ["std"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 uor-matmul = { git = "https://github.com/UOR-Foundation/uor-matmul.git", version = "0.1.0", rev = "b13c98449948174f590e337c4dc25dfc394a07d0", default-features = false }
+
+[dev-dependencies]
+# #932: the direct ignored tuner independently exercises the same filesystem-
+# free schema-2 admission used by production immediately before teacher access.
+uor-r4-api = { version = "0.1.0", path = "../uor-r4-api", default-features = false, features = ["runtime"] }

--- a/crates/uor-r4-model-source/src/exact_executor.rs
+++ b/crates/uor-r4-model-source/src/exact_executor.rs
@@ -466,6 +466,7 @@ mod platform {
         TeacherExecutionConfig, TeacherExecutionObserver, TeacherExecutionPreparation,
         TeacherExecutionSnapshot,
     };
+    use crate::SourceUnavailable;
     use rayon::prelude::*;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::Mutex;
@@ -532,7 +533,7 @@ mod platform {
     }
 
     impl ExactExecutor {
-        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, String> {
+        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, SourceUnavailable> {
             let workers = config.resolved_workers();
             let pool = if workers == 1 {
                 None
@@ -542,7 +543,7 @@ mod platform {
                         .num_threads(workers)
                         .thread_name(|index| format!("r4-exact-teacher-{index}"))
                         .build()
-                        .map_err(|error| error.to_string())?,
+                        .map_err(|error| SourceUnavailable::new(error.to_string()))?,
                 )
             };
             Ok(Self {
@@ -710,9 +711,11 @@ mod platform {
             batch_width: usize,
             maximum_k: usize,
             maximum_rows: usize,
-        ) -> Result<TeacherExecutionPreparation, String> {
+        ) -> Result<TeacherExecutionPreparation, SourceUnavailable> {
             if batch_width == 0 {
-                return Err("exact executor prestart batch width must be nonzero".to_owned());
+                return Err(SourceUnavailable::new(
+                    "exact executor prestart batch width must be nonzero",
+                ));
             }
             let started = std::time::Instant::now();
             let workers_observed = if let Some(pool) = &self.pool {
@@ -724,10 +727,10 @@ mod platform {
                 1
             };
             if workers_observed != self.effective_workers {
-                return Err(format!(
+                return Err(SourceUnavailable::new(format!(
                     "exact executor prestart observed {workers_observed} of {} workers",
                     self.effective_workers
-                ));
+                )));
             }
 
             self.prepare_workspace(maximum_k, maximum_rows, batch_width);
@@ -759,7 +762,9 @@ mod platform {
                 })
             });
             if !backend_exercised {
-                return Err("exact executor prestart produced unexpected output bits".to_owned());
+                return Err(SourceUnavailable::new(
+                    "exact executor prestart produced unexpected output bits",
+                ));
             }
             Ok(TeacherExecutionPreparation {
                 elapsed_seconds: started.elapsed().as_secs_f64(),
@@ -1088,6 +1093,7 @@ mod platform {
 #[cfg(target_arch = "wasm32")]
 mod platform {
     use super::{TeacherExecutionConfig, TeacherExecutionObserver, TeacherExecutionSnapshot};
+    use crate::SourceUnavailable;
     use std::cell::Cell;
     use uor_matmul::PackedCode;
 
@@ -1098,7 +1104,7 @@ mod platform {
     }
 
     impl ExactExecutor {
-        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, String> {
+        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, SourceUnavailable> {
             let workers = config.resolved_workers();
             Ok(Self {
                 counters: Cell::new(TeacherExecutionSnapshot {

--- a/crates/uor-r4-model-source/src/exact_executor.rs
+++ b/crates/uor-r4-model-source/src/exact_executor.rs
@@ -1,0 +1,1285 @@
+//! Bounded exact-matmul execution for the offline teacher.
+//!
+//! Parallel work is partitioned only across complete output rows. Every output
+//! cell still owns its full `k`-term exact accumulator and is rounded once by
+//! `uor-matmul`; worker count and completion order therefore cannot change a
+//! result bit. Hosted builds use one persistent, dedicated Rayon pool. Wasm
+//! keeps the same public configuration and counters but executes sequentially.
+
+#![cfg_attr(
+    all(feature = "observation-blas-exception", target_os = "macos"),
+    allow(dead_code)
+)]
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+/// Git revision of the exact arithmetic dependency bound into probe evidence.
+pub const UOR_MATMUL_REVISION: &str = "b13c98449948174f590e337c4dc25dfc394a07d0";
+
+/// A point-in-time view of exact teacher execution.
+///
+/// Counters are monotonic for one executor. Replacing an oracle's execution
+/// configuration installs a fresh executor and resets them.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct TeacherExecutionSnapshot {
+    /// Monotonic sequence assigned to observer callbacks from this executor.
+    /// Consumers must ignore a callback older than the newest epoch seen.
+    pub observer_epoch: u64,
+    /// Worker bound requested after resolving explicit host discovery.
+    pub requested_workers: usize,
+    /// Dedicated workers actually installed (one on the portable fallback).
+    pub effective_workers: usize,
+    /// Output-row tile tasks currently inside exact GEMM.
+    pub active_workers: usize,
+    /// Largest observed simultaneous exact-GEMM task count.
+    pub max_active_workers: usize,
+    /// Largest simultaneous exact-GEMM task count in the current or most
+    /// recently completed physical forward. Reset at every forward boundary.
+    pub forward_max_active_workers: usize,
+    /// Physical forwards that observed at least two simultaneous row tasks.
+    /// This monotonic counter proves genuine multiworker execution without
+    /// requiring every configured worker to be scheduled at the same instant.
+    pub multiworker_forward_calls: u64,
+    /// Single-stream or batched forward invocations begun.
+    pub forward_calls: u64,
+    /// Independent sequence steps begun across all forward invocations.
+    pub streams_started: u64,
+    /// Independent sequence steps completed across all forward invocations.
+    pub streams_completed: u64,
+    /// Independent sequence states currently inside one or more forwards.
+    pub active_streams: usize,
+    /// Largest independent-stream cohort observed in flight.
+    pub max_active_streams: usize,
+    /// Exact matrix operations begun.
+    pub matrix_calls: u64,
+    /// Exact matrix operations executed as one shared-weight multi-stream GEMM.
+    pub batched_matrix_calls: u64,
+    /// Largest matrix batch width passed to one shared-weight exact GEMM.
+    pub max_matrix_batch_width: usize,
+    /// Disjoint output-row tiles completed.
+    pub tiles_completed: u64,
+    /// Exact output cells completed.
+    pub output_cells_completed: u64,
+    /// Scalar product terms absorbed into complete accumulators.
+    pub scalar_terms_completed: u64,
+    /// Retained workspace buffers whose capacity grew during this measurement.
+    pub workspace_growth_events: u64,
+    /// Actual `Vec` capacity bytes added by those workspace growth events.
+    pub workspace_growth_bytes: u64,
+}
+
+/// Thread-safe progress callback used by long-running teacher harnesses.
+///
+/// It may be invoked by a dedicated executor worker and should return quickly.
+pub type TeacherExecutionObserver = Arc<dyn Fn(TeacherExecutionSnapshot) + Send + Sync + 'static>;
+
+/// Excluded, bounded preparation of retained exact-forward workspaces.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct TeacherExecutionPreparation {
+    /// Wall time spent waking the pool, reserving real-model workspaces, and
+    /// exercising a tiny known exact product.
+    pub elapsed_seconds: f64,
+    /// Dedicated workers observed through the pool-wide barrier.
+    pub workers_observed: usize,
+    /// Shared-weight batch width prepared.
+    pub batch_width: usize,
+    /// Whether the known exact product returned every expected output bit.
+    pub backend_exercised: bool,
+    /// Total retained model/executor workspace capacity after preparation.
+    pub workspace_capacity_bytes: u64,
+    /// Retained buffers whose capacity grew during preparation.
+    pub workspace_growth_events: u64,
+    /// Actual `Vec` capacity bytes added during preparation.
+    pub workspace_growth_bytes: u64,
+}
+
+/// Nonblocking publication bridge for heartbeat-only execution progress.
+///
+/// Executor workers never wait for a consumer: one publisher claims the
+/// atomic slot, and a concurrent coarse update may be dropped. Forward-end
+/// publication and the executor's own final snapshot remain exact. Readers use
+/// the version latch to avoid observing a partially published snapshot.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[derive(Default)]
+pub(crate) struct AtomicTeacherExecutionProgress {
+    writer_claimed: std::sync::atomic::AtomicBool,
+    version: std::sync::atomic::AtomicU64,
+    observer_epoch: std::sync::atomic::AtomicU64,
+    requested_workers: std::sync::atomic::AtomicUsize,
+    effective_workers: std::sync::atomic::AtomicUsize,
+    active_workers: std::sync::atomic::AtomicUsize,
+    max_active_workers: std::sync::atomic::AtomicUsize,
+    forward_max_active_workers: std::sync::atomic::AtomicUsize,
+    multiworker_forward_calls: std::sync::atomic::AtomicU64,
+    forward_calls: std::sync::atomic::AtomicU64,
+    streams_started: std::sync::atomic::AtomicU64,
+    streams_completed: std::sync::atomic::AtomicU64,
+    active_streams: std::sync::atomic::AtomicUsize,
+    max_active_streams: std::sync::atomic::AtomicUsize,
+    matrix_calls: std::sync::atomic::AtomicU64,
+    batched_matrix_calls: std::sync::atomic::AtomicU64,
+    max_matrix_batch_width: std::sync::atomic::AtomicUsize,
+    tiles_completed: std::sync::atomic::AtomicU64,
+    output_cells_completed: std::sync::atomic::AtomicU64,
+    scalar_terms_completed: std::sync::atomic::AtomicU64,
+    workspace_growth_events: std::sync::atomic::AtomicU64,
+    workspace_growth_bytes: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+impl AtomicTeacherExecutionProgress {
+    /// Publish a newer coarse snapshot without blocking an executor worker.
+    pub(crate) fn publish(&self, snapshot: TeacherExecutionSnapshot) {
+        use std::sync::atomic::Ordering;
+
+        if self
+            .writer_claimed
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+        if snapshot.observer_epoch > self.observer_epoch.load(Ordering::Acquire) {
+            self.version.fetch_add(1, Ordering::AcqRel);
+            self.requested_workers
+                .store(snapshot.requested_workers, Ordering::Relaxed);
+            self.effective_workers
+                .store(snapshot.effective_workers, Ordering::Relaxed);
+            self.active_workers
+                .store(snapshot.active_workers, Ordering::Relaxed);
+            self.max_active_workers
+                .store(snapshot.max_active_workers, Ordering::Relaxed);
+            self.forward_max_active_workers
+                .store(snapshot.forward_max_active_workers, Ordering::Relaxed);
+            self.multiworker_forward_calls
+                .store(snapshot.multiworker_forward_calls, Ordering::Relaxed);
+            self.forward_calls
+                .store(snapshot.forward_calls, Ordering::Relaxed);
+            self.streams_started
+                .store(snapshot.streams_started, Ordering::Relaxed);
+            self.streams_completed
+                .store(snapshot.streams_completed, Ordering::Relaxed);
+            self.active_streams
+                .store(snapshot.active_streams, Ordering::Relaxed);
+            self.max_active_streams
+                .store(snapshot.max_active_streams, Ordering::Relaxed);
+            self.matrix_calls
+                .store(snapshot.matrix_calls, Ordering::Relaxed);
+            self.batched_matrix_calls
+                .store(snapshot.batched_matrix_calls, Ordering::Relaxed);
+            self.max_matrix_batch_width
+                .store(snapshot.max_matrix_batch_width, Ordering::Relaxed);
+            self.tiles_completed
+                .store(snapshot.tiles_completed, Ordering::Relaxed);
+            self.output_cells_completed
+                .store(snapshot.output_cells_completed, Ordering::Relaxed);
+            self.scalar_terms_completed
+                .store(snapshot.scalar_terms_completed, Ordering::Relaxed);
+            self.workspace_growth_events
+                .store(snapshot.workspace_growth_events, Ordering::Relaxed);
+            self.workspace_growth_bytes
+                .store(snapshot.workspace_growth_bytes, Ordering::Relaxed);
+            self.observer_epoch
+                .store(snapshot.observer_epoch, Ordering::Relaxed);
+            self.version.fetch_add(1, Ordering::Release);
+        }
+        self.writer_claimed.store(false, Ordering::Release);
+    }
+
+    /// Read one internally consistent published snapshot.
+    pub(crate) fn snapshot(&self) -> TeacherExecutionSnapshot {
+        use std::sync::atomic::Ordering;
+
+        loop {
+            let before = self.version.load(Ordering::Acquire);
+            if !before.is_multiple_of(2) {
+                std::hint::spin_loop();
+                continue;
+            }
+            let snapshot = TeacherExecutionSnapshot {
+                observer_epoch: self.observer_epoch.load(Ordering::Relaxed),
+                requested_workers: self.requested_workers.load(Ordering::Relaxed),
+                effective_workers: self.effective_workers.load(Ordering::Relaxed),
+                active_workers: self.active_workers.load(Ordering::Relaxed),
+                max_active_workers: self.max_active_workers.load(Ordering::Relaxed),
+                forward_max_active_workers: self.forward_max_active_workers.load(Ordering::Relaxed),
+                multiworker_forward_calls: self.multiworker_forward_calls.load(Ordering::Relaxed),
+                forward_calls: self.forward_calls.load(Ordering::Relaxed),
+                streams_started: self.streams_started.load(Ordering::Relaxed),
+                streams_completed: self.streams_completed.load(Ordering::Relaxed),
+                active_streams: self.active_streams.load(Ordering::Relaxed),
+                max_active_streams: self.max_active_streams.load(Ordering::Relaxed),
+                matrix_calls: self.matrix_calls.load(Ordering::Relaxed),
+                batched_matrix_calls: self.batched_matrix_calls.load(Ordering::Relaxed),
+                max_matrix_batch_width: self.max_matrix_batch_width.load(Ordering::Relaxed),
+                tiles_completed: self.tiles_completed.load(Ordering::Relaxed),
+                output_cells_completed: self.output_cells_completed.load(Ordering::Relaxed),
+                scalar_terms_completed: self.scalar_terms_completed.load(Ordering::Relaxed),
+                workspace_growth_events: self.workspace_growth_events.load(Ordering::Relaxed),
+                workspace_growth_bytes: self.workspace_growth_bytes.load(Ordering::Relaxed),
+            };
+            let after = self.version.load(Ordering::Acquire);
+            if before == after {
+                return snapshot;
+            }
+        }
+    }
+}
+
+/// Truthful provenance for the exact teacher arithmetic backend.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ExactBackendReport {
+    /// Numerical owner used by the default teacher projection path.
+    pub arithmetic_owner: String,
+    /// Whether uor-matmul was built with hosted runtime CPU detection.
+    pub std_runtime_detection_enabled: bool,
+    /// Rust compilation target architecture.
+    pub target_arch: String,
+    /// Rust compilation target operating system.
+    pub target_os: String,
+    /// Pinned git revision of the exact arithmetic implementation.
+    pub uor_matmul_revision: String,
+    /// Backends the dependency reports available for the Atlas reduction
+    /// family consumed by exact float GEMM, in registry order without repeats.
+    pub available_backends: Vec<String>,
+    /// Actual private auto-selection, when externally observable.
+    ///
+    /// The pinned dependency does not expose its float auto-selection cache,
+    /// so this is currently `None`; callers must not infer it from availability.
+    pub selected_backend: Option<String>,
+    /// Machine-readable reason for [`ExactBackendReport::selected_backend`].
+    pub selection_status: String,
+}
+
+/// Report exact arithmetic ownership and observable uor-matmul availability.
+pub fn exact_backend_report() -> ExactBackendReport {
+    let mut available_backends = Vec::new();
+    for spec in uor_matmul::kernels::cached::available_reduce_i8().filter(|spec| spec.k_group == 1)
+    {
+        let name = spec.backend.as_str().to_owned();
+        if !available_backends.contains(&name) {
+            available_backends.push(name);
+        }
+    }
+    #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+    let (arithmetic_owner, selected_backend, selection_status) = (
+        "Apple Accelerate observation BLAS exception".to_owned(),
+        Some("Apple Accelerate".to_owned()),
+        "AVAILABLE: explicitly selected by observation-blas-exception".to_owned(),
+    );
+    #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
+    let (arithmetic_owner, selected_backend, selection_status) = (
+        "uor-matmul exact GEMM".to_owned(),
+        None,
+        "UNAVAILABLE: uor-matmul does not expose the private float auto-selection cache".to_owned(),
+    );
+
+    ExactBackendReport {
+        arithmetic_owner,
+        std_runtime_detection_enabled: !cfg!(target_arch = "wasm32"),
+        target_arch: std::env::consts::ARCH.to_owned(),
+        target_os: std::env::consts::OS.to_owned(),
+        uor_matmul_revision: UOR_MATMUL_REVISION.to_owned(),
+        available_backends,
+        selected_backend,
+        selection_status,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkerRequest {
+    Fixed(NonZeroUsize),
+    AvailableParallelism,
+}
+
+/// Bounded execution policy for the exact offline teacher.
+///
+/// [`Default`] and [`TeacherExecutionConfig::sequential`] never inspect the
+/// host and install one worker. Host-core discovery occurs only when
+/// [`TeacherExecutionConfig::available_parallelism`] is explicitly selected.
+#[derive(Clone)]
+pub struct TeacherExecutionConfig {
+    workers: WorkerRequest,
+    tiles_per_worker: NonZeroUsize,
+    observer: Option<TeacherExecutionObserver>,
+}
+
+impl Default for TeacherExecutionConfig {
+    fn default() -> Self {
+        Self::sequential()
+    }
+}
+
+impl TeacherExecutionConfig {
+    /// A one-worker deterministic executor without host-core discovery.
+    pub fn sequential() -> Self {
+        Self {
+            workers: WorkerRequest::Fixed(NonZeroUsize::MIN),
+            tiles_per_worker: NonZeroUsize::new(4).expect("four is nonzero"),
+            observer: None,
+        }
+    }
+
+    /// A fixed, nonzero dedicated worker bound.
+    pub fn fixed_workers(workers: NonZeroUsize) -> Self {
+        Self {
+            workers: WorkerRequest::Fixed(workers),
+            ..Self::sequential()
+        }
+    }
+
+    /// Size the dedicated pool from `std::thread::available_parallelism()`.
+    ///
+    /// This is the sole policy that discovers host capacity. A failed query
+    /// conservatively resolves to one worker.
+    pub fn available_parallelism() -> Self {
+        Self {
+            workers: WorkerRequest::AvailableParallelism,
+            ..Self::sequential()
+        }
+    }
+
+    /// Bound scheduler granularity per worker (default: four row tiles).
+    pub fn with_tiles_per_worker(mut self, tiles_per_worker: NonZeroUsize) -> Self {
+        self.tiles_per_worker = tiles_per_worker;
+        self
+    }
+
+    /// Observe forward boundaries, concurrency high-water marks, and coarse
+    /// output-row progress. Exact per-tile totals remain in [`TeacherExecutionSnapshot`].
+    pub fn with_observer(mut self, observer: TeacherExecutionObserver) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolved_workers(&self) -> usize {
+        match self.workers {
+            WorkerRequest::Fixed(workers) => workers.get(),
+            WorkerRequest::AvailableParallelism => {
+                std::thread::available_parallelism().map_or(1, NonZeroUsize::get)
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn resolved_workers(&self) -> usize {
+        // No threaded exact executor is installed for this target. Preserve
+        // the configuration API while reporting the truthful effective bound.
+        match self.workers {
+            WorkerRequest::Fixed(requested) => {
+                let _ = requested;
+                1
+            }
+            WorkerRequest::AvailableParallelism => 1,
+        }
+    }
+}
+
+pub(crate) fn exact_tile_rows_for(
+    rows: usize,
+    effective_workers: usize,
+    tiles_per_worker: usize,
+) -> usize {
+    if effective_workers <= 1 {
+        return rows.max(1);
+    }
+    let target_tiles = effective_workers.saturating_mul(tiles_per_worker).max(1);
+    rows.div_ceil(target_tiles).max(1)
+}
+
+pub(crate) fn exact_row_tiles_for(
+    rows: usize,
+    effective_workers: usize,
+    tiles_per_worker: usize,
+) -> usize {
+    if rows == 0 {
+        0
+    } else {
+        rows.div_ceil(exact_tile_rows_for(
+            rows,
+            effective_workers,
+            tiles_per_worker,
+        ))
+    }
+}
+
+/// Portable shared-weight batched exact product used by the sequential wasm
+/// executor and its host-side bit-identity test.
+#[cfg(any(test, target_arch = "wasm32"))]
+fn portable_shared_weight_matmul_batched(
+    output: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    k: usize,
+    batch: usize,
+) -> usize {
+    assert!(batch > 0, "teacher batch must be nonzero");
+    assert_eq!(output.len() % batch, 0);
+    let rows = output.len() / batch;
+    assert_eq!(x.len(), batch.saturating_mul(k));
+    assert!(w.len() >= rows.saturating_mul(k));
+    if rows == 0 {
+        return 0;
+    }
+
+    let input_words = k
+        .checked_mul(batch)
+        .expect("portable exact input shape must fit usize");
+    let output_words = rows
+        .checked_mul(batch)
+        .expect("portable exact output shape must fit usize");
+    let mut x_transposed = vec![0.0f32; input_words];
+    let mut output_transposed = vec![0.0f32; output_words];
+    for stream in 0..batch {
+        for depth in 0..k {
+            x_transposed[depth * batch + stream] = x[stream * k + depth];
+        }
+    }
+
+    let mut pa = vec![uor_matmul::PackedCode::default(); k];
+    let mut pb = vec![uor_matmul::PackedCode::default(); input_words];
+    uor_matmul::slice::gemm_float(
+        rows,
+        k,
+        batch,
+        &w[..rows * k],
+        &x_transposed,
+        &mut output_transposed,
+        &mut pa,
+        &mut pb,
+    )
+    .expect("portable exact shared-weight batch product is valid");
+
+    for row in 0..rows {
+        for stream in 0..batch {
+            output[stream * rows + row] = output_transposed[row * batch + stream];
+        }
+    }
+    rows
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod platform {
+    use super::{
+        TeacherExecutionConfig, TeacherExecutionObserver, TeacherExecutionPreparation,
+        TeacherExecutionSnapshot,
+    };
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use uor_matmul::{PackedCode, Partition, Shape};
+
+    #[derive(Default)]
+    struct Counters {
+        observer_epoch: AtomicU64,
+        active_workers: AtomicUsize,
+        max_active_workers: AtomicUsize,
+        forward_max_active_workers: AtomicUsize,
+        multiworker_forward_calls: AtomicU64,
+        multiworker_observed_forward: AtomicU64,
+        forward_calls: AtomicU64,
+        streams_started: AtomicU64,
+        streams_completed: AtomicU64,
+        active_streams: AtomicUsize,
+        max_active_streams: AtomicUsize,
+        matrix_calls: AtomicU64,
+        batched_matrix_calls: AtomicU64,
+        max_matrix_batch_width: AtomicUsize,
+        tiles_completed: AtomicU64,
+        output_cells_completed: AtomicU64,
+        scalar_terms_completed: AtomicU64,
+        workspace_growth_events: AtomicU64,
+        workspace_growth_bytes: AtomicU64,
+    }
+
+    /// Persistent owner of the dedicated exact-teacher worker pool.
+    pub(crate) struct ExactExecutor {
+        requested_workers: usize,
+        effective_workers: usize,
+        tiles_per_worker: usize,
+        pool: Option<rayon::ThreadPool>,
+        counters: Counters,
+        observer: Option<TeacherExecutionObserver>,
+        batch_workspace: Mutex<Box<ExactBatchWorkspace>>,
+        worker_scratch: Vec<Mutex<ExactScratch>>,
+    }
+
+    #[derive(Default)]
+    struct ExactScratch {
+        pa: Vec<PackedCode>,
+        pb: Vec<PackedCode>,
+    }
+
+    #[derive(Default)]
+    struct ExactBatchWorkspace {
+        x_transposed: Vec<f32>,
+        output_transposed: Vec<f32>,
+    }
+
+    struct ActiveTask<'a> {
+        executor: &'a ExactExecutor,
+    }
+
+    impl Drop for ActiveTask<'_> {
+        fn drop(&mut self) {
+            self.executor
+                .counters
+                .active_workers
+                .fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    impl ExactExecutor {
+        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, String> {
+            let workers = config.resolved_workers();
+            let pool = if workers == 1 {
+                None
+            } else {
+                Some(
+                    rayon::ThreadPoolBuilder::new()
+                        .num_threads(workers)
+                        .thread_name(|index| format!("r4-exact-teacher-{index}"))
+                        .build()
+                        .map_err(|error| error.to_string())?,
+                )
+            };
+            Ok(Self {
+                requested_workers: workers,
+                effective_workers: workers,
+                tiles_per_worker: config.tiles_per_worker.get(),
+                pool,
+                counters: Counters::default(),
+                observer: config.observer,
+                batch_workspace: Mutex::new(Box::new(ExactBatchWorkspace::default())),
+                worker_scratch: (0..workers)
+                    .map(|_| Mutex::new(ExactScratch::default()))
+                    .collect(),
+            })
+        }
+
+        pub(crate) fn snapshot(&self) -> TeacherExecutionSnapshot {
+            TeacherExecutionSnapshot {
+                observer_epoch: self.counters.observer_epoch.load(Ordering::Acquire),
+                requested_workers: self.requested_workers,
+                effective_workers: self.effective_workers,
+                active_workers: self.counters.active_workers.load(Ordering::Acquire),
+                max_active_workers: self.counters.max_active_workers.load(Ordering::Acquire),
+                forward_max_active_workers: self
+                    .counters
+                    .forward_max_active_workers
+                    .load(Ordering::Acquire),
+                multiworker_forward_calls: self
+                    .counters
+                    .multiworker_forward_calls
+                    .load(Ordering::Acquire),
+                forward_calls: self.counters.forward_calls.load(Ordering::Acquire),
+                streams_started: self.counters.streams_started.load(Ordering::Acquire),
+                streams_completed: self.counters.streams_completed.load(Ordering::Acquire),
+                active_streams: self.counters.active_streams.load(Ordering::Acquire),
+                max_active_streams: self.counters.max_active_streams.load(Ordering::Acquire),
+                matrix_calls: self.counters.matrix_calls.load(Ordering::Acquire),
+                batched_matrix_calls: self.counters.batched_matrix_calls.load(Ordering::Acquire),
+                max_matrix_batch_width: self
+                    .counters
+                    .max_matrix_batch_width
+                    .load(Ordering::Acquire),
+                tiles_completed: self.counters.tiles_completed.load(Ordering::Acquire),
+                output_cells_completed: self
+                    .counters
+                    .output_cells_completed
+                    .load(Ordering::Acquire),
+                scalar_terms_completed: self
+                    .counters
+                    .scalar_terms_completed
+                    .load(Ordering::Acquire),
+                workspace_growth_events: self
+                    .counters
+                    .workspace_growth_events
+                    .load(Ordering::Acquire),
+                workspace_growth_bytes: self
+                    .counters
+                    .workspace_growth_bytes
+                    .load(Ordering::Acquire),
+            }
+        }
+
+        pub(crate) fn begin_measured_execution(&mut self, observer: TeacherExecutionObserver) {
+            self.counters = Counters::default();
+            self.observer = Some(observer);
+        }
+
+        /// Account one retained workspace capacity increase. The byte count is
+        /// the actual `Vec::capacity` delta, not the requested logical length.
+        pub(crate) fn record_workspace_growth_bytes(&self, bytes: usize) {
+            if bytes == 0 {
+                return;
+            }
+            saturating_add(&self.counters.workspace_growth_events, 1);
+            saturating_add(&self.counters.workspace_growth_bytes, as_u64(bytes));
+        }
+
+        fn grow_vec<T: Clone>(&self, values: &mut Vec<T>, length: usize, fill: T) {
+            if values.len() >= length {
+                return;
+            }
+            let before = values.capacity();
+            values.resize(length, fill);
+            let added_elements = values.capacity().saturating_sub(before);
+            self.record_workspace_growth_bytes(
+                added_elements.saturating_mul(std::mem::size_of::<T>()),
+            );
+        }
+
+        fn ensure_scratch(&self, scratch: &mut ExactScratch, k: usize, columns: usize) {
+            let packed_columns = k
+                .checked_mul(columns)
+                .expect("exact scratch shape must fit usize");
+            self.grow_vec(&mut scratch.pa, k, PackedCode::default());
+            self.grow_vec(&mut scratch.pb, packed_columns, PackedCode::default());
+        }
+
+        pub(crate) fn prepare_workspace(&self, k: usize, rows: usize, batch: usize) {
+            let transposed_input = k
+                .checked_mul(batch)
+                .expect("exact input workspace shape must fit usize");
+            let transposed_output = rows
+                .checked_mul(batch)
+                .expect("exact output workspace shape must fit usize");
+            {
+                let mut workspace = self
+                    .batch_workspace
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                self.grow_vec(&mut workspace.x_transposed, transposed_input, 0.0f32);
+                self.grow_vec(&mut workspace.output_transposed, transposed_output, 0.0f32);
+            }
+            for scratch in &self.worker_scratch {
+                let mut scratch = scratch
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                self.ensure_scratch(&mut scratch, k, batch);
+            }
+        }
+
+        fn workspace_capacity_bytes(&self) -> usize {
+            let workspace = self
+                .batch_workspace
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut bytes = workspace
+                .x_transposed
+                .capacity()
+                .saturating_add(workspace.output_transposed.capacity())
+                .saturating_mul(std::mem::size_of::<f32>());
+            drop(workspace);
+            for scratch in &self.worker_scratch {
+                let scratch = scratch
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                bytes = bytes.saturating_add(
+                    scratch
+                        .pa
+                        .capacity()
+                        .saturating_add(scratch.pb.capacity())
+                        .saturating_mul(std::mem::size_of::<PackedCode>()),
+                );
+            }
+            bytes
+        }
+
+        fn current_worker_scratch(&self) -> std::sync::MutexGuard<'_, ExactScratch> {
+            let index = rayon::current_thread_index()
+                .unwrap_or(0)
+                .min(self.worker_scratch.len().saturating_sub(1));
+            self.worker_scratch[index]
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+
+        /// Wake every dedicated worker and exercise the exact GEMM dispatcher
+        /// without running a model forward.
+        ///
+        /// The tiny product has one-hot weight rows and exactly representable
+        /// inputs, so its expected bits are known independently of worker
+        /// ordering. Callers reset measurement counters after this excluded
+        /// prestart.
+        pub(crate) fn prestart(
+            &self,
+            batch_width: usize,
+            maximum_k: usize,
+            maximum_rows: usize,
+        ) -> Result<TeacherExecutionPreparation, String> {
+            if batch_width == 0 {
+                return Err("exact executor prestart batch width must be nonzero".to_owned());
+            }
+            let started = std::time::Instant::now();
+            let workers_observed = if let Some(pool) = &self.pool {
+                let mut indices = pool.broadcast(|context| context.index());
+                indices.sort_unstable();
+                indices.dedup();
+                indices.len()
+            } else {
+                1
+            };
+            if workers_observed != self.effective_workers {
+                return Err(format!(
+                    "exact executor prestart observed {workers_observed} of {} workers",
+                    self.effective_workers
+                ));
+            }
+
+            self.prepare_workspace(maximum_k, maximum_rows, batch_width);
+
+            const K: usize = 8;
+            // The synthetic fan-out never exceeds a real model matrix. An
+            // operator-selected tile count can refine scheduling but cannot
+            // turn excluded preparation into an unbounded allocation.
+            let rows = self
+                .effective_workers
+                .saturating_mul(self.tiles_per_worker)
+                .min(maximum_rows)
+                .max(1);
+            let mut weights = vec![0.0f32; rows.saturating_mul(K)];
+            for row in 0..rows {
+                weights[row * K + row % K] = 1.0;
+            }
+            let mut input = vec![0.0f32; batch_width.saturating_mul(K)];
+            for stream in 0..batch_width {
+                for depth in 0..K {
+                    input[stream * K + depth] = (1 + stream + depth) as f32;
+                }
+            }
+            let mut output = vec![f32::NAN; rows.saturating_mul(batch_width)];
+            self.matmul_batched(&mut output, &input, &weights, K, batch_width);
+            let backend_exercised = (0..batch_width).all(|stream| {
+                (0..rows).all(|row| {
+                    output[stream * rows + row].to_bits() == input[stream * K + row % K].to_bits()
+                })
+            });
+            if !backend_exercised {
+                return Err("exact executor prestart produced unexpected output bits".to_owned());
+            }
+            Ok(TeacherExecutionPreparation {
+                elapsed_seconds: started.elapsed().as_secs_f64(),
+                workers_observed,
+                batch_width,
+                backend_exercised,
+                workspace_capacity_bytes: as_u64(self.workspace_capacity_bytes()),
+                workspace_growth_events: self
+                    .counters
+                    .workspace_growth_events
+                    .load(Ordering::Acquire),
+                workspace_growth_bytes: self
+                    .counters
+                    .workspace_growth_bytes
+                    .load(Ordering::Acquire),
+            })
+        }
+
+        pub(crate) fn begin_forward(&self, streams: usize) {
+            // The model owns one bounded physical-forward lane at a time. Reset
+            // only the per-forward high-water; lifetime diagnostics remain
+            // monotonic across the measured execution.
+            self.counters
+                .forward_max_active_workers
+                .store(0, Ordering::Release);
+            saturating_add(&self.counters.forward_calls, 1);
+            saturating_add(&self.counters.streams_started, as_u64(streams));
+            let active = self
+                .counters
+                .active_streams
+                .fetch_add(streams, Ordering::AcqRel)
+                .saturating_add(streams);
+            self.counters
+                .max_active_streams
+                .fetch_max(active, Ordering::AcqRel);
+            self.emit();
+        }
+
+        pub(crate) fn complete_forward(&self, streams: usize) {
+            saturating_add(&self.counters.streams_completed, as_u64(streams));
+            self.counters
+                .active_streams
+                .fetch_sub(streams, Ordering::AcqRel);
+            self.emit();
+        }
+
+        fn emit(&self) {
+            if let Some(observer) = &self.observer {
+                let epoch = self
+                    .counters
+                    .observer_epoch
+                    .fetch_add(1, Ordering::AcqRel)
+                    .saturating_add(1);
+                let mut snapshot = self.snapshot();
+                snapshot.observer_epoch = epoch;
+                observer(snapshot);
+            }
+        }
+
+        fn enter_task(&self) -> ActiveTask<'_> {
+            let previous_active = self.counters.active_workers.fetch_add(1, Ordering::AcqRel);
+            let active = previous_active.saturating_add(1);
+            self.counters
+                .max_active_workers
+                .fetch_max(active, Ordering::AcqRel);
+            let previous_forward_max = self
+                .counters
+                .forward_max_active_workers
+                .fetch_max(active, Ordering::AcqRel);
+            if active > 1 {
+                let forward = self.counters.forward_calls.load(Ordering::Acquire);
+                let newly_multiworker = self
+                    .counters
+                    .multiworker_observed_forward
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |observed| {
+                        (observed < forward).then_some(forward)
+                    })
+                    .is_ok();
+                if newly_multiworker {
+                    saturating_add(&self.counters.multiworker_forward_calls, 1);
+                }
+            }
+            // Long exact tiles can take far longer than a heartbeat interval.
+            // Publish entry after the active/peak counters move so an observer
+            // can distinguish healthy in-flight work from a stalled black box.
+            // Bound callback overhead: only a newly observed *per-forward*
+            // concurrency high-water emits (at most W callbacks per physical
+            // forward). A lifetime-only high-water would make later forwards
+            // invisible after their phase-local observer state resets.
+            if active > previous_forward_max {
+                self.emit();
+            }
+            ActiveTask { executor: self }
+        }
+
+        fn tile_rows(&self, rows: usize) -> usize {
+            super::exact_tile_rows_for(rows, self.effective_workers, self.tiles_per_worker)
+        }
+
+        pub(crate) fn row_tiles(&self, rows: usize) -> usize {
+            super::exact_row_tiles_for(rows, self.effective_workers, self.tiles_per_worker)
+        }
+
+        fn record_tile(&self, output_cells: usize, k: usize) {
+            let tiles_completed = saturating_add(&self.counters.tiles_completed, 1);
+            saturating_add(&self.counters.output_cells_completed, as_u64(output_cells));
+            saturating_add(
+                &self.counters.scalar_terms_completed,
+                as_u64(output_cells).saturating_mul(as_u64(k)),
+            );
+            // Exact final counters advance for every tile. Progress callbacks
+            // are deliberately coarse: the first tile and then one actual
+            // worker-wave quantum. A matrix with at most W*T row tiles emits
+            // at most T+1 tile-progress callbacks, so large matrices visibly
+            // advance without putting observer synchronization in every tile.
+            let progress_quantum = as_u64(self.effective_workers.max(1));
+            if tiles_completed == 1 || tiles_completed.is_multiple_of(progress_quantum) {
+                self.emit();
+            }
+        }
+
+        /// Compute `W[rows,k] * x[k]`, partitioning only complete output rows.
+        pub(crate) fn matmul(&self, output: &mut [f32], x: &[f32], w: &[f32], k: usize) {
+            let rows = output.len();
+            assert_eq!(x.len(), k, "teacher input vector must have k elements");
+            assert!(
+                w.len() >= rows.saturating_mul(k),
+                "teacher weight matrix does not contain every output row"
+            );
+            saturating_add(&self.counters.matrix_calls, 1);
+            if rows == 0 {
+                return;
+            }
+            let w = &w[..rows * k];
+            let tile_rows = self.tile_rows(rows);
+            let partition = Partition::new(Shape { m: rows, k, n: 1 }, tile_rows, 1);
+
+            if let Some(pool) = &self.pool {
+                pool.install(|| {
+                    output
+                        .par_chunks_mut(tile_rows)
+                        .zip(w.par_chunks(tile_rows * k))
+                        .enumerate()
+                        .for_each(|(tile_index, (tile_output, tile_weights))| {
+                            let tile = partition
+                                .tile(tile_index)
+                                .expect("parallel row chunk belongs to the partition");
+                            debug_assert_eq!(tile.col, 0);
+                            debug_assert_eq!(tile.cols, 1);
+                            debug_assert_eq!(tile.rows, tile_output.len());
+                            let mut scratch = self.current_worker_scratch();
+                            self.ensure_scratch(&mut scratch, k, 1);
+                            let ExactScratch { pa, pb } = &mut *scratch;
+                            let task = self.enter_task();
+                            uor_matmul::slice::gemm_float(
+                                tile.rows,
+                                k,
+                                1,
+                                tile_weights,
+                                x,
+                                tile_output,
+                                &mut pa[..k],
+                                &mut pb[..k],
+                            )
+                            .expect("exact output-row tile is a valid product");
+                            drop(task);
+                            self.record_tile(tile.rows, k);
+                        });
+                });
+            } else {
+                let mut scratch = self.current_worker_scratch();
+                self.ensure_scratch(&mut scratch, k, 1);
+                let ExactScratch { pa, pb } = &mut *scratch;
+                let task = self.enter_task();
+                uor_matmul::slice::gemm_float(rows, k, 1, w, x, output, &mut pa[..k], &mut pb[..k])
+                    .expect("exact teacher matrix-vector product is a valid product");
+                drop(task);
+                self.record_tile(rows, k);
+            }
+        }
+
+        /// Compute independent `W[rows,k] * x_b[k]` products with shared
+        /// immutable weights and private per-worker exact scratch.
+        pub(crate) fn matmul_batched(
+            &self,
+            output: &mut [f32],
+            x: &[f32],
+            w: &[f32],
+            k: usize,
+            batch: usize,
+        ) {
+            assert!(batch > 0, "teacher batch must be nonzero");
+            assert_eq!(output.len() % batch, 0);
+            let rows = output.len() / batch;
+            assert_eq!(x.len(), batch.saturating_mul(k));
+            assert!(w.len() >= rows.saturating_mul(k));
+            saturating_add(&self.counters.matrix_calls, 1);
+            saturating_add(&self.counters.batched_matrix_calls, 1);
+            self.counters
+                .max_matrix_batch_width
+                .fetch_max(batch, Ordering::AcqRel);
+            if rows == 0 {
+                return;
+            }
+            let w = &w[..rows * k];
+
+            // The caller stores X sequence-major (`batch x k`). One canonical
+            // transpose makes every stream a column, so each output-row tile
+            // is ONE exact GEMM over shared weights:
+            //
+            //   W_tile[tr,k] * X^T[k,batch] -> C_tile[tr,batch].
+            //
+            // K is never partitioned. A weight row is decoded once per tile,
+            // then reused across all stream columns by the exact driver.
+            let input_words = k
+                .checked_mul(batch)
+                .expect("exact input workspace shape must fit usize");
+            let output_words = rows
+                .checked_mul(batch)
+                .expect("exact output workspace shape must fit usize");
+            let mut workspace = self
+                .batch_workspace
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            self.grow_vec(&mut workspace.x_transposed, input_words, 0.0f32);
+            self.grow_vec(&mut workspace.output_transposed, output_words, 0.0f32);
+            let ExactBatchWorkspace {
+                x_transposed,
+                output_transposed,
+            } = &mut **workspace;
+            let x_transposed = &mut x_transposed[..input_words];
+            let output_transposed = &mut output_transposed[..output_words];
+            for stream in 0..batch {
+                for depth in 0..k {
+                    x_transposed[depth * batch + stream] = x[stream * k + depth];
+                }
+            }
+
+            let tile_rows = self.tile_rows(rows);
+            let partition = Partition::new(
+                Shape {
+                    m: rows,
+                    k,
+                    n: batch,
+                },
+                tile_rows,
+                0,
+            );
+
+            if let Some(pool) = &self.pool {
+                pool.install(|| {
+                    output_transposed
+                        .par_chunks_mut(tile_rows * batch)
+                        .zip(w.par_chunks(tile_rows * k))
+                        .enumerate()
+                        .for_each(|(tile_index, (tile_output, tile_weights))| {
+                            let tile = partition
+                                .tile(tile_index)
+                                .expect("parallel row tile belongs to the partition");
+                            debug_assert_eq!(tile.col, 0);
+                            debug_assert_eq!(tile.cols, batch);
+                            debug_assert_eq!(tile_output.len(), tile.rows * batch);
+                            let mut scratch = self.current_worker_scratch();
+                            self.ensure_scratch(&mut scratch, k, batch);
+                            let ExactScratch { pa, pb } = &mut *scratch;
+                            let task = self.enter_task();
+                            uor_matmul::slice::gemm_float(
+                                tile.rows,
+                                k,
+                                batch,
+                                tile_weights,
+                                x_transposed,
+                                tile_output,
+                                &mut pa[..k],
+                                &mut pb[..input_words],
+                            )
+                            .expect("exact shared-weight batch tile is a valid product");
+                            drop(task);
+                            self.record_tile(tile.rows * batch, k);
+                        });
+                });
+            } else {
+                let mut scratch = self.current_worker_scratch();
+                self.ensure_scratch(&mut scratch, k, batch);
+                let ExactScratch { pa, pb } = &mut *scratch;
+                let task = self.enter_task();
+                uor_matmul::slice::gemm_float(
+                    rows,
+                    k,
+                    batch,
+                    w,
+                    x_transposed,
+                    output_transposed,
+                    &mut pa[..k],
+                    &mut pb[..input_words],
+                )
+                .expect("exact shared-weight batch product is a valid product");
+                drop(task);
+                self.record_tile(rows * batch, k);
+            }
+
+            // Canonical ordered scatter back to the public sequence-major
+            // layout. Completion order cannot affect bytes or write ownership.
+            for row in 0..rows {
+                for stream in 0..batch {
+                    output[stream * rows + row] = output_transposed[row * batch + stream];
+                }
+            }
+        }
+    }
+
+    fn as_u64(value: usize) -> u64 {
+        u64::try_from(value).unwrap_or(u64::MAX)
+    }
+
+    fn saturating_add(counter: &AtomicU64, value: u64) -> u64 {
+        counter
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_add(value))
+            })
+            .unwrap_or_else(|current| current)
+            .saturating_add(value)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod platform {
+    use super::{TeacherExecutionConfig, TeacherExecutionObserver, TeacherExecutionSnapshot};
+    use std::cell::Cell;
+    use uor_matmul::PackedCode;
+
+    /// Sequential portable counterpart; no thread or host-feature dependency.
+    pub(crate) struct ExactExecutor {
+        counters: Cell<TeacherExecutionSnapshot>,
+        observer: Option<TeacherExecutionObserver>,
+    }
+
+    impl ExactExecutor {
+        pub(crate) fn new(config: TeacherExecutionConfig) -> Result<Self, String> {
+            let workers = config.resolved_workers();
+            Ok(Self {
+                counters: Cell::new(TeacherExecutionSnapshot {
+                    requested_workers: workers,
+                    effective_workers: 1,
+                    ..TeacherExecutionSnapshot::default()
+                }),
+                observer: config.observer,
+            })
+        }
+
+        pub(crate) fn snapshot(&self) -> TeacherExecutionSnapshot {
+            self.counters.get()
+        }
+
+        pub(crate) fn begin_measured_execution(&mut self, observer: TeacherExecutionObserver) {
+            let snapshot = self.snapshot();
+            self.counters.set(TeacherExecutionSnapshot {
+                requested_workers: snapshot.requested_workers,
+                effective_workers: snapshot.effective_workers,
+                ..TeacherExecutionSnapshot::default()
+            });
+            self.observer = Some(observer);
+        }
+
+        pub(crate) fn record_workspace_growth_bytes(&self, bytes: usize) {
+            if bytes == 0 {
+                return;
+            }
+            self.update(|snapshot| {
+                snapshot.workspace_growth_events =
+                    snapshot.workspace_growth_events.saturating_add(1);
+                snapshot.workspace_growth_bytes = snapshot
+                    .workspace_growth_bytes
+                    .saturating_add(u64::try_from(bytes).unwrap_or(u64::MAX));
+            });
+        }
+
+        pub(crate) fn prepare_workspace(&self, _k: usize, _rows: usize, _batch: usize) {
+            // The wasm32 fallback remains sequential and portable. Model-level
+            // stacked buffers are retained; uor-matmul scratch stays local to
+            // the portable call because there is no hosted worker pool.
+        }
+
+        pub(crate) fn row_tiles(&self, rows: usize) -> usize {
+            usize::from(rows > 0)
+        }
+
+        fn update(&self, change: impl FnOnce(&mut TeacherExecutionSnapshot)) {
+            let mut snapshot = self.snapshot();
+            change(&mut snapshot);
+            if self.observer.is_some() {
+                snapshot.observer_epoch = snapshot.observer_epoch.saturating_add(1);
+            }
+            self.counters.set(snapshot);
+            if let Some(observer) = &self.observer {
+                observer(snapshot);
+            }
+        }
+
+        pub(crate) fn begin_forward(&self, streams: usize) {
+            self.update(|snapshot| {
+                snapshot.forward_max_active_workers = 0;
+                snapshot.forward_calls = snapshot.forward_calls.saturating_add(1);
+                snapshot.streams_started = snapshot
+                    .streams_started
+                    .saturating_add(u64::try_from(streams).unwrap_or(u64::MAX));
+                snapshot.active_streams = snapshot.active_streams.saturating_add(streams);
+                snapshot.max_active_streams =
+                    snapshot.max_active_streams.max(snapshot.active_streams);
+            });
+        }
+
+        pub(crate) fn complete_forward(&self, streams: usize) {
+            self.update(|snapshot| {
+                snapshot.streams_completed = snapshot
+                    .streams_completed
+                    .saturating_add(u64::try_from(streams).unwrap_or(u64::MAX));
+                snapshot.active_streams = snapshot.active_streams.saturating_sub(streams);
+            });
+        }
+
+        pub(crate) fn matmul(&self, output: &mut [f32], x: &[f32], w: &[f32], k: usize) {
+            let rows = output.len();
+            let mut pa = vec![PackedCode::default(); k];
+            let mut pb = vec![PackedCode::default(); k];
+            uor_matmul::slice::gemm_float(rows, k, 1, &w[..rows * k], x, output, &mut pa, &mut pb)
+                .expect("portable exact teacher product is valid");
+            self.update(|snapshot| {
+                snapshot.matrix_calls = snapshot.matrix_calls.saturating_add(1);
+                snapshot.tiles_completed = snapshot.tiles_completed.saturating_add(1);
+                snapshot.output_cells_completed = snapshot
+                    .output_cells_completed
+                    .saturating_add(u64::try_from(rows).unwrap_or(u64::MAX));
+                snapshot.scalar_terms_completed = snapshot.scalar_terms_completed.saturating_add(
+                    u64::try_from(rows)
+                        .unwrap_or(u64::MAX)
+                        .saturating_mul(u64::try_from(k).unwrap_or(u64::MAX)),
+                );
+                snapshot.max_active_workers = 1;
+                snapshot.forward_max_active_workers = 1;
+            });
+        }
+
+        pub(crate) fn matmul_batched(
+            &self,
+            output: &mut [f32],
+            x: &[f32],
+            w: &[f32],
+            k: usize,
+            batch: usize,
+        ) {
+            let rows = super::portable_shared_weight_matmul_batched(output, x, w, k, batch);
+            self.update(|snapshot| {
+                snapshot.matrix_calls = snapshot.matrix_calls.saturating_add(1);
+                snapshot.batched_matrix_calls = snapshot.batched_matrix_calls.saturating_add(1);
+                snapshot.max_matrix_batch_width = snapshot.max_matrix_batch_width.max(batch);
+                if rows > 0 {
+                    let output_cells = u64::try_from(rows)
+                        .unwrap_or(u64::MAX)
+                        .saturating_mul(u64::try_from(batch).unwrap_or(u64::MAX));
+                    snapshot.tiles_completed = snapshot.tiles_completed.saturating_add(1);
+                    snapshot.output_cells_completed =
+                        snapshot.output_cells_completed.saturating_add(output_cells);
+                    snapshot.scalar_terms_completed =
+                        snapshot.scalar_terms_completed.saturating_add(
+                            output_cells.saturating_mul(u64::try_from(k).unwrap_or(u64::MAX)),
+                        );
+                    snapshot.max_active_workers = 1;
+                    snapshot.forward_max_active_workers = 1;
+                }
+            });
+        }
+    }
+}
+
+pub(crate) use platform::ExactExecutor;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn portable_shared_weight_batch_matches_serial_exact_bits() {
+        const ROWS: usize = 11;
+        const K: usize = 13;
+        const BATCH: usize = 5;
+        let weights = (0..ROWS * K)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect::<Vec<_>>();
+        let input = (0..BATCH * K)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect::<Vec<_>>();
+        let mut expected = vec![0.0f32; BATCH * ROWS];
+        for (stream, stream_input) in input.chunks_exact(K).enumerate() {
+            let mut pa = vec![uor_matmul::PackedCode::default(); K];
+            let mut pb = vec![uor_matmul::PackedCode::default(); K];
+            uor_matmul::slice::gemm_float(
+                ROWS,
+                K,
+                1,
+                &weights,
+                stream_input,
+                &mut expected[stream * ROWS..(stream + 1) * ROWS],
+                &mut pa,
+                &mut pb,
+            )
+            .expect("serial exact product");
+        }
+
+        let mut actual = vec![0.0f32; BATCH * ROWS];
+        let rows =
+            super::portable_shared_weight_matmul_batched(&mut actual, &input, &weights, K, BATCH);
+        assert_eq!(rows, ROWS);
+        assert_eq!(
+            actual
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/uor-r4-model-source/src/exact_probe.rs
+++ b/crates/uor-r4-model-source/src/exact_probe.rs
@@ -1,0 +1,3109 @@
+//! Durable admission evidence for the exact multicore teacher probe.
+
+use crate::{
+    exact_backend_report, ExactBackendReport, ExactForwardPlan, TeacherExecutionSnapshot,
+    UOR_MATMUL_REVISION,
+};
+use serde::{Deserialize, Serialize};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn normalized_report_parent(path: &std::path::Path) -> &std::path::Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."))
+}
+
+/// Resolve one direct-tuner path exactly as a repository-root invocation.
+///
+/// Cargo executes a package unit test with that package as its working
+/// directory, even when the user invoked Cargo from the workspace root. The
+/// BDD owner and documented commands instead interpret relative fixture/report
+/// paths at the repository root. Deriving that root from this crate's manifest
+/// keeps both entry points on the same files. Empty paths remain empty so their
+/// caller can publish the intended typed refusal.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) fn resolve_direct_probe_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return path;
+    }
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = crate_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("model-source crate belongs to the workspace crates directory");
+    workspace_root.join(path)
+}
+
+/// Versioned JSON schema written by the exact multicore admission probe.
+pub const EXACT_MULTICORE_PROBE_SCHEMA: &str = "uor-r4.exact-multicore-probe/2";
+/// Admission deadline for the cheap probe, including fixture load.
+///
+/// Work that is already inside a non-cancellable fixture load or exact forward
+/// is allowed to finish, but no later forward is admitted and a run at or past
+/// the deadline cannot qualify.
+pub const EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS: u64 = 3_600;
+/// Machine-readable deadline semantics bound into every qualified report.
+pub const EXACT_MULTICORE_PROBE_DEADLINE_POLICY: &str = "NO_NEW_EXACT_FORWARD_AFTER_DEADLINE; ACTIVE_FIXTURE_LOAD_OR_EXACT_FORWARD_FINISHES_THEN_ABORTS; NEVER_QUALIFY_AT_OR_AFTER_DEADLINE";
+/// Deterministic adaptive selection rule bound into every report.
+pub const EXACT_MULTICORE_PROBE_SELECTION_POLICY: &str =
+    "MIN_SAFETY_ADJUSTED_PROJECTED_SECONDS; TIE_LOWER_WORKER_COUNT";
+/// Registered pinned transcript work exposed by the eight prompt fixtures.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_FORWARDS: usize = 36;
+/// Registered S8 transcript batch widths in canonical scheduler order.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_BATCH_WIDTHS: [usize; 6] = [8, 8, 8, 7, 4, 1];
+/// Registered maximum optimized continuation per cloned lane.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS: usize = 8;
+/// Registered independent cloned continuation lanes.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_LANES: usize = 8;
+/// Registered maximum zero-based private-state position. Canonical prompt
+/// lengths are `[6, 7, 6, 5, 4, 5, 6, 5]`; retaining each distinct final
+/// teacher-forced prefix makes the longest prefix occupy positions `0..=5`,
+/// followed by eight continuation positions `6..=13`.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_MAX_SEQUENCE_POSITION: usize = 13;
+/// Registered private-state capacity covering positions `0..=13`.
+pub const EXACT_MULTICORE_PROBE_REGISTERED_STATE_SEQUENCE_CAPACITY: usize = 14;
+/// Registered empirical context-length boundary for projection admission.
+pub const EXACT_MULTICORE_PROBE_CONTEXT_ASSUMPTION: &str = "Empirical Criterion (not Guarantee): every timed probe repetition uses the declared bounded per-state horizon covering the longest registered retained prefix plus the maximum continuation; aggregate transcript work is scheduled separately in registered S8 batches; the optimized suite reuses cloned transcript states and charges no duplicate prefill or warm-up forwards; the registered 1.25 factor is an additional projection margin";
+
+/// Complete settled generation captured by the schema-2 production loader.
+///
+/// The logical names are stable report keys and the relative paths are the
+/// exact layout consumed by `src/release_bundle_loader.rs`. A teacher-free
+/// AVAILABLE token binds every one of these bytes; the direct tuner rehashes
+/// the same set immediately before teacher access.
+pub const PRODUCTION_ADMISSION_COMPONENTS: [(&str, &str); 15] = [
+    ("release_manifest", "release-bundle.json"),
+    ("graph", "graph/score.r4g1"),
+    ("sections_absent_graph", "graph/score_sections_absent.r4g1"),
+    ("label_shuffled_graph", "graph/score_label_shuffled.r4g1"),
+    ("signature_artifact", "tless_artifacts.bin"),
+    ("tla_comparator_store", "tless_store.bin"),
+    ("tokenizer", "tokenizer.bin"),
+    ("score_report", "graph/score_report.json"),
+    ("compile_report", "graph-cover/cover_report.json"),
+    (
+        "deployed_quality_report",
+        "graph/deployed_quality_report.json",
+    ),
+    ("cross_surface_parity", "graph/cross_surface_parity.json"),
+    ("witness_replay", "graph/witness_replay.json"),
+    ("corpus_meta", "corpus.meta"),
+    ("corpus_records", "corpus.records"),
+    ("tokenizer_adapter", "tokenizer_adapter.json"),
+];
+
+/// Recompute the complete schema-2 production-generation identity map.
+///
+/// Missing components are `UNAVAILABLE`; unreadable, non-regular, or symlinked
+/// components are `FAILED`. The production loader has the same regular-file
+/// boundary, so this helper cannot bless bytes that loader would not capture.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn production_admission_component_cids(
+    bundle_dir: impl AsRef<std::path::Path>,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    use std::io::Read;
+
+    let bundle_dir = bundle_dir.as_ref();
+    let mut cids = std::collections::BTreeMap::new();
+    for (name, relative) in PRODUCTION_ADMISSION_COMPONENTS {
+        let path = bundle_dir.join(relative);
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                format!(
+                    "UNAVAILABLE: required production component {} is absent: {error}",
+                    path.display()
+                )
+            } else {
+                format!(
+                    "FAILED: inspect required production component {}: {error}",
+                    path.display()
+                )
+            }
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "FAILED: required production component {} is not a regular non-symlink file",
+                path.display()
+            ));
+        }
+        let mut file = std::fs::File::open(&path).map_err(|error| {
+            format!(
+                "FAILED: open required production component {}: {error}",
+                path.display()
+            )
+        })?;
+        let mut hasher = blake3::Hasher::new();
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer).map_err(|error| {
+                format!(
+                    "FAILED: read required production component {}: {error}",
+                    path.display()
+                )
+            })?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        cids.insert(
+            name.to_owned(),
+            format!("blake3:{}", hasher.finalize().to_hex()),
+        );
+    }
+    Ok(cids)
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) const TEACHER_FREE_PREFLIGHT_SCHEMA: &str = "uor-r4.teacher-parity-preflight/1";
+
+/// Current teacher-free prerequisite evidence consumed by the direct ignored
+/// tuner before it is allowed to open teacher weights.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct TeacherFreePreflightAdmission {
+    pub report_cid: String,
+    pub selected_source_dir: String,
+    pub selected_bundle_dir: String,
+    pub compiled_input_cids: std::collections::BTreeMap<String, String>,
+    pub production_admission_cids: std::collections::BTreeMap<String, String>,
+}
+
+/// Typed reason that a direct live tuner cannot consume teacher-free evidence.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TeacherFreePreflightAdmissionError {
+    Unavailable(String),
+    Refused(String),
+    Failed(String),
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+impl std::fmt::Display for TeacherFreePreflightAdmissionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            Self::Unavailable(reason) | Self::Refused(reason) | Self::Failed(reason) => reason,
+        };
+        formatter.write_str(reason)
+    }
+}
+
+/// Capture and semantically verify the exact schema-2 generation that the
+/// direct tuner is about to use as its teacher-free admission authority.
+///
+/// Digest agreement alone is insufficient: mutually inconsistent bytes can
+/// all match a forged AVAILABLE report. The production API owns the portable
+/// envelope semantics, so the tuner invokes that same verifier over one
+/// captured byte generation and returns the identities of those exact bytes.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn verify_production_envelope_semantics(
+    bundle_dir: &std::path::Path,
+) -> Result<std::collections::BTreeMap<String, String>, TeacherFreePreflightAdmissionError> {
+    use TeacherFreePreflightAdmissionError as Error;
+
+    let mut components = std::collections::BTreeMap::<String, Vec<u8>>::new();
+    for (name, relative) in PRODUCTION_ADMISSION_COMPONENTS {
+        let path = bundle_dir.join(relative);
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                Error::Unavailable(format!(
+                    "UNAVAILABLE: required production component {} is absent: {error}",
+                    path.display()
+                ))
+            } else {
+                Error::Failed(format!(
+                    "FAILED: inspect required production component {}: {error}",
+                    path.display()
+                ))
+            }
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(Error::Failed(format!(
+                "FAILED: required production component {} is not a regular non-symlink file",
+                path.display()
+            )));
+        }
+        let bytes = std::fs::read(&path).map_err(|error| {
+            Error::Failed(format!(
+                "FAILED: capture required production component {}: {error}",
+                path.display()
+            ))
+        })?;
+        components.insert(name.to_owned(), bytes);
+    }
+
+    let component = |name: &str| {
+        components
+            .get(name)
+            .map(Vec::as_slice)
+            .ok_or_else(|| Error::Failed(format!("FAILED: internal component map omitted {name}")))
+    };
+    uor_r4_api::verify_production_envelope(uor_r4_api::ProductionEnvelopeParts {
+        graph: component("graph")?,
+        sections_absent_graph: component("sections_absent_graph")?,
+        label_shuffled_graph: component("label_shuffled_graph")?,
+        signature_artifact: component("signature_artifact")?,
+        tla_comparator_store: component("tla_comparator_store")?,
+        tokenizer: component("tokenizer")?,
+        score_report: component("score_report")?,
+        compile_report: component("compile_report")?,
+        deployed_quality_report: component("deployed_quality_report")?,
+        cross_surface_parity: component("cross_surface_parity")?,
+        witness_replay: component("witness_replay")?,
+        corpus_meta: component("corpus_meta")?,
+        corpus_records: component("corpus_records")?,
+        tokenizer_adapter: component("tokenizer_adapter")?,
+        release_manifest: component("release_manifest")?,
+    })
+    .map_err(|error| {
+        Error::Failed(format!(
+            "FAILED: schema-2 production envelope semantic verification: {error}"
+        ))
+    })?;
+
+    Ok(components
+        .into_iter()
+        .map(|(name, bytes)| (name, format!("blake3:{}", blake3::hash(&bytes).to_hex())))
+        .collect())
+}
+
+/// Validate the atomically published teacher-free prerequisite against the
+/// exact source/bundle selection and the current compiled input bytes.
+///
+/// This intentionally lives in the test-only certifier surface: it authorizes
+/// the direct ignored tuner, not deployed serving. Every compiled input is
+/// rehashed, so a copied or stale AVAILABLE report cannot spend teacher work.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) fn validate_teacher_free_preflight(
+    report_path: &std::path::Path,
+    source_dir: &std::path::Path,
+    bundle_dir: &std::path::Path,
+) -> Result<TeacherFreePreflightAdmission, TeacherFreePreflightAdmissionError> {
+    use std::io::Read;
+    use TeacherFreePreflightAdmissionError as Error;
+
+    fn canonical(
+        path: &std::path::Path,
+        label: &str,
+    ) -> Result<std::path::PathBuf, TeacherFreePreflightAdmissionError> {
+        std::fs::canonicalize(path).map_err(|error| {
+            TeacherFreePreflightAdmissionError::Unavailable(format!(
+                "UNAVAILABLE: resolve {label} {}: {error}",
+                path.display()
+            ))
+        })
+    }
+
+    fn file_cid(path: &std::path::Path) -> Result<String, TeacherFreePreflightAdmissionError> {
+        let mut file = std::fs::File::open(path).map_err(|error| {
+            TeacherFreePreflightAdmissionError::Unavailable(format!(
+                "UNAVAILABLE: open teacher-free prerequisite {}: {error}",
+                path.display()
+            ))
+        })?;
+        let mut hasher = blake3::Hasher::new();
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer).map_err(|error| {
+                TeacherFreePreflightAdmissionError::Unavailable(format!(
+                    "UNAVAILABLE: read teacher-free prerequisite {}: {error}",
+                    path.display()
+                ))
+            })?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+    }
+
+    let report_bytes = std::fs::read(report_path).map_err(|error| {
+        Error::Unavailable(format!(
+            "UNAVAILABLE: read teacher-free preflight {}: {error}",
+            report_path.display()
+        ))
+    })?;
+    let report: serde_json::Value = serde_json::from_slice(&report_bytes).map_err(|error| {
+        Error::Failed(format!(
+            "FAILED: parse teacher-free preflight {}: {error}",
+            report_path.display()
+        ))
+    })?;
+    let object = report.as_object().ok_or_else(|| {
+        Error::Failed("FAILED: teacher-free preflight root is not an object".to_owned())
+    })?;
+    if object.get("schema").and_then(serde_json::Value::as_str)
+        != Some(TEACHER_FREE_PREFLIGHT_SCHEMA)
+    {
+        return Err(Error::Failed(
+            "FAILED: teacher-free preflight schema is absent or unsupported".to_owned(),
+        ));
+    }
+    let current_contract_cid = exact_executor_contract_cid();
+    if object
+        .get("authorizing_contract_cid")
+        .and_then(serde_json::Value::as_str)
+        != Some(current_contract_cid.as_str())
+    {
+        return Err(Error::Refused(
+            "NOT_RUN / REFUSED: teacher-free preflight was not emitted by the current authorizing contract"
+                .to_owned(),
+        ));
+    }
+    let status = object
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| Error::Failed("FAILED: teacher-free preflight omitted status".to_owned()))?;
+    if status != "AVAILABLE" {
+        let reason = object
+            .get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("teacher-free prerequisite did not qualify");
+        return Err(Error::Refused(format!(
+            "NOT_RUN / REFUSED: teacher-free preflight status is {status}: {reason}"
+        )));
+    }
+    if object
+        .get("teacher_source_opened")
+        .and_then(serde_json::Value::as_bool)
+        != Some(false)
+        || object
+            .get("teacher_forwards")
+            .and_then(serde_json::Value::as_u64)
+            != Some(0)
+    {
+        return Err(Error::Failed(
+            "FAILED: teacher-free preflight does not prove zero teacher work".to_owned(),
+        ));
+    }
+
+    let report_path = canonical(report_path, "teacher-free preflight report")?;
+    let source_dir = canonical(source_dir, "selected teacher source")?;
+    let bundle_dir = canonical(bundle_dir, "selected compiled bundle")?;
+    for (field, expected) in [
+        ("report_path", report_path.as_path()),
+        ("selected_source_dir", source_dir.as_path()),
+        ("selected_bundle_dir", bundle_dir.as_path()),
+    ] {
+        let recorded = object
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                Error::Failed(format!("FAILED: teacher-free preflight omitted {field}"))
+            })?;
+        let recorded = canonical(std::path::Path::new(recorded), field)?;
+        if recorded != expected {
+            return Err(Error::Refused(format!(
+                "NOT_RUN / REFUSED: teacher-free preflight {field} does not match the current selection"
+            )));
+        }
+    }
+
+    let inputs = object
+        .get("inputs")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| Error::Failed("FAILED: teacher-free preflight omitted inputs".to_owned()))?;
+    let mut compiled_input_cids = std::collections::BTreeMap::new();
+    for (name, relative) in [
+        ("tokenizer", "tokenizer.bin"),
+        ("legacy_artifact", "tless_artifacts.bin"),
+        ("legacy_store", "tless_store.bin"),
+        ("graph", "graph/score.r4g1"),
+        ("graph_report", "graph/score_report.json"),
+    ] {
+        let recorded = inputs
+            .get(name)
+            .and_then(serde_json::Value::as_str)
+            .filter(|cid| cid.starts_with("blake3:"))
+            .ok_or_else(|| {
+                Error::Failed(format!(
+                    "FAILED: teacher-free preflight omitted the content identity for {name}"
+                ))
+            })?;
+        let current = file_cid(&bundle_dir.join(relative))?;
+        if current != recorded {
+            return Err(Error::Refused(format!(
+                "NOT_RUN / REFUSED: teacher-free preflight {name} identity is stale"
+            )));
+        }
+        compiled_input_cids.insert(name.to_owned(), current);
+    }
+
+    let recorded_production = object
+        .get("production_admission")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            Error::Failed("FAILED: teacher-free preflight omitted production_admission".to_owned())
+        })?;
+    let current_production =
+        production_admission_component_cids(&bundle_dir).map_err(|reason| {
+            if reason.starts_with("UNAVAILABLE:") {
+                Error::Unavailable(reason)
+            } else {
+                Error::Failed(reason)
+            }
+        })?;
+    if recorded_production.len() != current_production.len() {
+        return Err(Error::Refused(
+            "NOT_RUN / REFUSED: teacher-free preflight production generation is incomplete"
+                .to_owned(),
+        ));
+    }
+    for (name, current) in &current_production {
+        let recorded = recorded_production
+            .get(name)
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                Error::Failed(format!(
+                    "FAILED: teacher-free preflight omitted production component {name}"
+                ))
+            })?;
+        if recorded != current {
+            return Err(Error::Refused(format!(
+                "NOT_RUN / REFUSED: teacher-free preflight production component {name} is stale"
+            )));
+        }
+    }
+    let semantically_verified_production = verify_production_envelope_semantics(&bundle_dir)?;
+    if semantically_verified_production != current_production {
+        return Err(Error::Refused(
+            "NOT_RUN / REFUSED: production generation changed during schema-2 semantic verification"
+                .to_owned(),
+        ));
+    }
+
+    Ok(TeacherFreePreflightAdmission {
+        report_cid: format!("blake3:{}", blake3::hash(&report_bytes).to_hex()),
+        selected_source_dir: source_dir.display().to_string(),
+        selected_bundle_dir: bundle_dir.display().to_string(),
+        compiled_input_cids,
+        production_admission_cids: current_production,
+    })
+}
+
+/// Content identity of the exact executor, probe contract, and teacher call
+/// surface compiled into this crate.
+///
+/// Binding admission to source bytes prevents evidence from an older scheduler
+/// or teacher implementation from admitting a newly built full run.
+fn exact_executor_contract_components() -> Vec<(&'static str, &'static [u8])> {
+    macro_rules! workspace_component {
+        ($path:literal) => {
+            (
+                $path,
+                include_bytes!(concat!("../../../", $path)).as_slice(),
+            )
+        };
+    }
+
+    vec![
+        ("schema", EXACT_MULTICORE_PROBE_SCHEMA.as_bytes()),
+        ("uor-matmul-revision", UOR_MATMUL_REVISION.as_bytes()),
+        workspace_component!("Cargo.toml"),
+        workspace_component!("Cargo.lock"),
+        workspace_component!("rust-toolchain.toml"),
+        workspace_component!(".cargo/config.toml"),
+        workspace_component!("tests/bdd.rs"),
+        workspace_component!("tests/support/parity_observability.rs"),
+        workspace_component!("features/suites/teacher_parity_benchmarks.feature"),
+        workspace_component!("model/ids.toml"),
+        workspace_component!("src/lib.rs"),
+        workspace_component!("src/r4g1.rs"),
+        workspace_component!("src/release_bundle_loader.rs"),
+        workspace_component!("crates/uor-r4-api/Cargo.toml"),
+        workspace_component!("crates/uor-r4-api/src/capability_suite.rs"),
+        workspace_component!("crates/uor-r4-api/src/compile.rs"),
+        workspace_component!("crates/uor-r4-api/src/deployed_quality.rs"),
+        workspace_component!("crates/uor-r4-api/src/engine.rs"),
+        workspace_component!("crates/uor-r4-api/src/lib.rs"),
+        workspace_component!("crates/uor-r4-api/src/production_envelope.rs"),
+        workspace_component!("crates/uor-r4-api/src/release_bundle.rs"),
+        workspace_component!("crates/uor-r4-api/src/serving.rs"),
+        workspace_component!("crates/uor-r4-api/src/serving_eval.rs"),
+        workspace_component!("crates/uor-r4-api/src/witness_replay.rs"),
+        workspace_component!("crates/uor-r4-core/Cargo.toml"),
+        workspace_component!("crates/uor-r4-core/src/cayley_dickson.rs"),
+        workspace_component!("crates/uor-r4-core/src/lib.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/manifest.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/merkle.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/mod.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/reasoning.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/reference.rs"),
+        workspace_component!("crates/uor-r4-core/src/semantic/vsa.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/bott_fock.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/cd_space.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/code_sidecar.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/compiler.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/convert_r4g1.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/endomorphism.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/graph_patch.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/hf_bpe.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/lie_jordan.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/mod.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/reference_state.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/region_store.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/resolution_status.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/runtime.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/scenarios.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/score_q.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/sentencepiece.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/simd.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/source_scan.rs"),
+        workspace_component!("crates/uor-r4-core/src/transformerless/transitions.rs"),
+        workspace_component!("crates/uor-r4-core/src/zeta_projection.rs"),
+        workspace_component!("crates/uor-r4-core/src/zeta_zeros.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/Cargo.toml"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/behavioral_probes.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/compositional_planning.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/dependency_audit.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/executor.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/future_state_planner.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/graph.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/induction.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/jobs_config.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/lib.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/lower_semantic_regions.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/memory_budget.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/monograph.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/observation.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/observation_shards.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/observation_text.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/pack.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/patch_induction.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/perturbation.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/probability_calibration.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/quantum_cover.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/rate_distortion_compression.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/recorded_corpus.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/reference_compiler_ir.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/reproducibility.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/residual.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/route_fit.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/routing.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/segment_fit.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/semantic_emission_decoupling.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/semantic_state.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/semantic_transitions.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/skipmix_fit.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/stage_dag.rs"),
+        workspace_component!("crates/uor-r4-graph-compiler/src/trace_profile.rs"),
+        workspace_component!("crates/uor-r4-graph-format/Cargo.toml"),
+        workspace_component!("crates/uor-r4-graph-format/src/code.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/error.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/fmm.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/fwda.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/head.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/header.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/inference_contract.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/invariant_ownership.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/lib.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/msa_selector.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/ngram.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/plan.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/plan_sections.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/prov.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/pstate.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/r4g1.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/records.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/rout.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/route_attention.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/sanctioned.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/scoring_semantics.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/ser.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/skipmix.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/stage2.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/types.rs"),
+        workspace_component!("crates/uor-r4-graph-format/src/view.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/Cargo.toml"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/engine.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/lib.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/msa_selector.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/packed_kernels.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/patch_chain.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/plan.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/route_attention.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/routing.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/runtime_state.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/scoring.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/status.rs"),
+        workspace_component!("crates/uor-r4-graph-runtime/src/vp_tree.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/Cargo.toml"),
+        workspace_component!("crates/uor-r4-graph-certify/src/anti_degeneracy.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/certificate.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/certify.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/compare.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/compiler_scaling.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/fairness_provenance.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/fmm.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/frame_consistency.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/holographic_encoding.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/lib.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/long_context.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/msa_ab_harness.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/msa_selector.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/octeract.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/octeract_trace_screen.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/patch_lifecycle.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/performance_certificate.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/predictive_sufficiency.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/route_attention.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/route_cost.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/route_fit_report.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/score.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/score_runtime.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/shortlist_evaluator.rs"),
+        workspace_component!("crates/uor-r4-graph-certify/src/target_operator_certificate.rs"),
+        workspace_component!("crates/uor-r4-model-source/Cargo.toml"),
+        workspace_component!("crates/uor-r4-model-source/src/attention.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/conformance.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/dense.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/exact_executor.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/exact_probe.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/geometry.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/gpt2.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/lib.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/observation_blas_exception.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/progress.rs"),
+        workspace_component!("crates/uor-r4-model-source/src/teacher.rs"),
+        workspace_component!("third_party/arrayref/Cargo.toml"),
+        workspace_component!("third_party/arrayref/src/lib.rs"),
+    ]
+}
+
+pub fn exact_executor_contract_cid() -> String {
+    let mut hasher = blake3::Hasher::new();
+    for (label, bytes) in exact_executor_contract_components() {
+        hasher.update(&u64::try_from(label.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(label.as_bytes());
+        hasher.update(&u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(bytes);
+    }
+    for (label, value) in [
+        ("target-arch", std::env::consts::ARCH),
+        ("target-os", std::env::consts::OS),
+        ("target-family", std::env::consts::FAMILY),
+        (
+            "target-endian",
+            if cfg!(target_endian = "little") {
+                "little"
+            } else {
+                "big"
+            },
+        ),
+        (
+            "target-pointer-width",
+            if cfg!(target_pointer_width = "64") {
+                "64"
+            } else if cfg!(target_pointer_width = "32") {
+                "32"
+            } else {
+                "other"
+            },
+        ),
+        (
+            "debug-assertions",
+            if cfg!(debug_assertions) { "on" } else { "off" },
+        ),
+        (
+            "observation-blas-exception",
+            if cfg!(feature = "observation-blas-exception") {
+                "on"
+            } else {
+                "off"
+            },
+        ),
+    ] {
+        hasher.update(&u64::try_from(label.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(label.as_bytes());
+        hasher.update(&u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+    #[cfg(target_arch = "aarch64")]
+    for (feature, enabled) in [
+        ("aes", cfg!(target_feature = "aes")),
+        ("crc", cfg!(target_feature = "crc")),
+        ("dotprod", cfg!(target_feature = "dotprod")),
+        ("fp16", cfg!(target_feature = "fp16")),
+        ("neon", cfg!(target_feature = "neon")),
+        ("sve", cfg!(target_feature = "sve")),
+    ] {
+        hasher.update(feature.as_bytes());
+        hasher.update(&[u8::from(enabled)]);
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    for (feature, enabled) in [
+        ("avx", cfg!(target_feature = "avx")),
+        ("avx2", cfg!(target_feature = "avx2")),
+        ("fma", cfg!(target_feature = "fma")),
+        ("sse2", cfg!(target_feature = "sse2")),
+        ("sse4.1", cfg!(target_feature = "sse4.1")),
+    ] {
+        hasher.update(feature.as_bytes());
+        hasher.update(&[u8::from(enabled)]);
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+/// Content-bound identity of the live teacher fixture used by a probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeSource {
+    /// Loader κ over the validated Safetensors shard bytes.
+    pub model_kappa: String,
+    /// BLAKE3 CID of the exact `config.json` bytes.
+    pub config_cid: String,
+    /// Total validated Safetensors bytes.
+    pub source_bytes: u64,
+}
+
+/// Host identity and capacity that bound a probe result.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeHost {
+    /// Rust target architecture.
+    pub target_arch: String,
+    /// Rust target operating system.
+    pub target_os: String,
+    /// Capacity returned by `std::thread::available_parallelism()`.
+    pub available_parallelism: usize,
+    /// Operating-system version, when the host exposes it safely.
+    pub operating_system_version: Option<String>,
+    /// CPU model string, when the host exposes it safely.
+    pub cpu_model: Option<String>,
+    /// Physical CPU core count, when the host exposes it safely.
+    pub physical_core_count: Option<usize>,
+    /// Performance-cluster logical cores, when the host distinguishes them.
+    pub performance_logical_core_count: Option<usize>,
+    /// Efficiency-cluster logical cores, when the host distinguishes them.
+    pub efficiency_logical_core_count: Option<usize>,
+    /// Explicit reason for every unavailable topology field.
+    pub topology_unavailable_reason: Option<String>,
+}
+
+/// Discover the host identity used to bind exact probe admission.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
+    let available_parallelism = std::thread::available_parallelism().map_or(1, usize::from);
+    #[cfg(target_os = "macos")]
+    {
+        fn sysctl(name: &str) -> Result<String, String> {
+            let output = std::process::Command::new("/usr/sbin/sysctl")
+                .args(["-n", name])
+                .output()
+                .map_err(|error| format!("sysctl {name}: {error}"))?;
+            if !output.status.success() {
+                return Err(format!("sysctl {name} exited {}", output.status));
+            }
+            String::from_utf8(output.stdout)
+                .map(|value| value.trim().to_owned())
+                .map_err(|error| format!("sysctl {name} returned non-UTF-8 output: {error}"))
+        }
+
+        fn nonempty(name: &str, unavailable: &mut Vec<String>) -> Option<String> {
+            match sysctl(name) {
+                Ok(value) if !value.is_empty() => Some(value),
+                Ok(_) => {
+                    unavailable.push(format!("{name} returned an empty value"));
+                    None
+                }
+                Err(reason) => {
+                    unavailable.push(reason);
+                    None
+                }
+            }
+        }
+
+        fn positive_usize(name: &str, unavailable: &mut Vec<String>) -> Option<usize> {
+            match sysctl(name).and_then(|raw| {
+                raw.parse::<usize>()
+                    .map_err(|error| format!("{name} returned {raw:?}: {error}"))
+            }) {
+                Ok(value) if value > 0 => Some(value),
+                Ok(_) => {
+                    unavailable.push(format!("{name} reported zero"));
+                    None
+                }
+                Err(reason) => {
+                    unavailable.push(reason);
+                    None
+                }
+            }
+        }
+
+        let mut unavailable = Vec::new();
+        let operating_system_version = nonempty("kern.osproductversion", &mut unavailable);
+        let cpu_model = nonempty("machdep.cpu.brand_string", &mut unavailable)
+            .or_else(|| nonempty("hw.model", &mut unavailable));
+        let physical_core_count = positive_usize("hw.physicalcpu", &mut unavailable);
+        let performance_logical_core_count =
+            positive_usize("hw.perflevel0.logicalcpu", &mut unavailable);
+        let efficiency_logical_core_count =
+            positive_usize("hw.perflevel1.logicalcpu", &mut unavailable);
+        ExactMulticoreProbeHost {
+            target_arch: std::env::consts::ARCH.to_owned(),
+            target_os: std::env::consts::OS.to_owned(),
+            available_parallelism,
+            operating_system_version,
+            cpu_model,
+            physical_core_count,
+            performance_logical_core_count,
+            efficiency_logical_core_count,
+            topology_unavailable_reason: (!unavailable.is_empty()).then(|| unavailable.join("; ")),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        ExactMulticoreProbeHost {
+            target_arch: std::env::consts::ARCH.to_owned(),
+            target_os: std::env::consts::OS.to_owned(),
+            available_parallelism,
+            operating_system_version: None,
+            cpu_model: None,
+            physical_core_count: None,
+            performance_logical_core_count: None,
+            efficiency_logical_core_count: None,
+            topology_unavailable_reason: Some(format!(
+                "safe exact-probe topology discovery is not implemented for {}",
+                std::env::consts::OS
+            )),
+        }
+    }
+}
+
+/// Portable counterpart for a target without hosted topology discovery.
+#[cfg(target_arch = "wasm32")]
+pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
+    ExactMulticoreProbeHost {
+        target_arch: std::env::consts::ARCH.to_owned(),
+        target_os: std::env::consts::OS.to_owned(),
+        available_parallelism: 1,
+        operating_system_version: None,
+        cpu_model: None,
+        physical_core_count: None,
+        performance_logical_core_count: None,
+        efficiency_logical_core_count: None,
+        topology_unavailable_reason: Some(
+            "host topology discovery is unavailable on wasm32".to_owned(),
+        ),
+    }
+}
+
+/// Per-configuration CPU/RSS evidence.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeResources {
+    /// `AVAILABLE`, `PARTIAL`, or `UNAVAILABLE`.
+    pub status: String,
+    /// `EXACT_FORWARD_INTERVALS_ONLY` or `FULL_PROBE_WALL`.
+    pub measurement_scope: String,
+    /// Process CPU time at configuration start.
+    pub cpu_time_start_seconds: Option<f64>,
+    /// Process CPU time at configuration completion.
+    pub cpu_time_end_seconds: Option<f64>,
+    /// CPU seconds consumed by this configuration.
+    pub cpu_time_consumed_seconds: Option<f64>,
+    /// Resident bytes at configuration completion.
+    pub current_rss_bytes: Option<u64>,
+    /// Largest resident-set sample observed during the configuration.
+    pub max_sampled_rss_bytes: Option<u64>,
+    /// True OS-maintained peak resident bytes, when safely exposed.
+    pub peak_rss_bytes: Option<u64>,
+    /// Mean CPU core-equivalents (`CPU seconds / wall seconds`).
+    pub mean_cpu_core_equivalents: Option<f64>,
+    /// Mean process CPU percentage (`100 * core-equivalents`).
+    pub mean_cpu_percent: Option<f64>,
+    /// Required explanation for unavailable fields.
+    pub reason: Option<String>,
+}
+
+/// Redundant completeness accounting for every content-bound output trace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeTraceShape {
+    /// Forward positions retained in the trace.
+    pub positions: usize,
+    /// Independent state records retained at every position.
+    pub streams_per_position: usize,
+    /// Private KV/attention position capacity allocated per state.
+    pub sequence_capacity: usize,
+    /// Total position/stream state records.
+    pub state_records: u64,
+    /// Full raw-logit words retained per state record.
+    pub logits_per_state: usize,
+    /// Total raw-logit words retained across the trace.
+    pub logit_words: u64,
+    /// Total raw-logit bytes retained across the trace.
+    pub logit_bytes: u64,
+    /// Persistent state words retained per state record.
+    pub persistent_state_words_per_state: usize,
+    /// Total persistent state words retained across the trace.
+    pub persistent_state_words: u64,
+    /// One canonical greedy token retained per state record.
+    pub greedy_tokens: u64,
+    /// Canonical top-k width retained per state record.
+    pub top_k: usize,
+    /// Total canonical top-k token ids retained across the trace.
+    pub top_tokens: u64,
+}
+
+impl ExactMulticoreProbeResources {
+    /// Explicitly unavailable portable process-resource evidence.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            status: "UNAVAILABLE".to_owned(),
+            measurement_scope: "UNAVAILABLE".to_owned(),
+            cpu_time_start_seconds: None,
+            cpu_time_end_seconds: None,
+            cpu_time_consumed_seconds: None,
+            current_rss_bytes: None,
+            max_sampled_rss_bytes: None,
+            peak_rss_bytes: None,
+            mean_cpu_core_equivalents: None,
+            mean_cpu_percent: None,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Cheap executor/backend initialization excluded from candidate timing.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbePrestart {
+    /// Wall time spent waking the pool and exercising a tiny exact GEMM.
+    pub elapsed_seconds: f64,
+    /// Dedicated workers observed through the pool-wide barrier.
+    pub workers_observed: usize,
+    /// Shared-weight width exercised by the tiny exact GEMM.
+    pub batch_width: usize,
+    /// Whether the known one-hot product returned every expected output bit.
+    pub backend_exercised: bool,
+    /// Retained model/executor workspace capacity prepared for this candidate.
+    pub workspace_capacity_bytes: u64,
+    /// Retained buffers whose capacity grew during excluded preparation.
+    pub workspace_growth_events: u64,
+    /// Actual `Vec` capacity bytes added during excluded preparation.
+    pub workspace_growth_bytes: u64,
+    /// Must remain true: prestart is not part of the projected forward rate.
+    pub excluded_from_measurement: bool,
+}
+
+/// One fixed-worker adaptive candidate result.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeRun {
+    /// Dedicated worker count.
+    pub workers: usize,
+    /// Independent sequence states advanced together through shared weights.
+    pub batch_width: usize,
+    /// Cheap pool/backend initialization, never a model forward.
+    pub prestart: ExactMulticoreProbePrestart,
+    /// Wall time for the fixed all-stream workload.
+    pub elapsed_ms: u64,
+    /// Exact wall seconds used to derive rates and CPU core-equivalents.
+    pub elapsed_seconds: f64,
+    /// Aggregate logical stream-forwards per second.
+    pub aggregate_forwards_per_second: f64,
+    /// Rate divided by the four-worker candidate rate (diagnostic only).
+    pub relative_throughput_vs_worker4: f64,
+    /// Whether all persistent output/state bits equal the first candidate.
+    pub equal_to_reference: bool,
+    /// Canonical BLAKE3 identity of every tested position and sequence state.
+    pub output_trace_cid: String,
+    /// Redundant trace-completeness counters bound by admission.
+    pub trace_shape: ExactMulticoreProbeTraceShape,
+    /// Owner-computed counter plan for one shared-weight batch forward.
+    pub forward_plan: ExactForwardPlan,
+    /// Whether peak row tasks reached the effective worker bound.
+    pub all_workers_active: bool,
+    /// Whether the full independent-stream cohort was observed in flight.
+    pub all_streams_active: bool,
+    /// Raw full-suite projection at this rate.
+    pub raw_projected_suite_seconds: f64,
+    /// Safety-adjusted full-suite projection at this rate.
+    pub safety_adjusted_projected_suite_seconds: f64,
+    /// Exact execution counters after the workload.
+    pub snapshot: TeacherExecutionSnapshot,
+    /// CPU/RSS evidence or an explicit unavailability reason.
+    pub resources: ExactMulticoreProbeResources,
+}
+
+/// Fastest measured exact candidate selected for the full suite.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeSelection {
+    /// Worker count.
+    pub workers: usize,
+    /// Output-row tiles requested per worker.
+    pub tiles_per_worker: usize,
+    /// Aggregate logical stream-forwards per second.
+    pub aggregate_forwards_per_second: f64,
+    /// Raw projected exact-teacher wall time for the optimized suite.
+    pub raw_projected_suite_seconds: f64,
+    /// Safety-adjusted projected exact-teacher wall time.
+    pub safety_adjusted_projected_suite_seconds: f64,
+}
+
+/// Owner-computed exact counter plan for one fixed worker configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExactMulticoreProbeWorkerPlan {
+    pub workers: usize,
+    pub forward_plan: ExactForwardPlan,
+}
+
+/// Config-only expectation geometry computed without opening model weights.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactMulticoreProbeExpectationShapes {
+    pub forward_plans: Vec<ExactMulticoreProbeWorkerPlan>,
+    pub trace_shape: ExactMulticoreProbeTraceShape,
+}
+
+/// Configured/default live teacher work projected by the probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeWork {
+    /// Exact teacher forwards used to build the shared transcript templates.
+    pub transcript_logical_forwards: usize,
+    /// Maximum continuation forwards measured per cloned lane.
+    pub generation_tokens_per_lane: usize,
+    /// Independent cloned continuation lanes.
+    pub generation_lanes: usize,
+    /// Derived optimized logical forward count; no duplicated prefill/warm-up.
+    pub logical_forwards: usize,
+    /// Physical shared-weight transcript forwards under the registered S8
+    /// scheduler (six at the pinned 36-forward cap).
+    pub transcript_physical_batches: usize,
+    /// Physical S8 continuation forwards (one per continuation token step).
+    pub generation_physical_batches: usize,
+    /// Derived physical forwards used for conservative projection.
+    pub physical_batches: usize,
+    /// Maximum zero-based private-state position exercised by the suite.
+    pub max_sequence_position: usize,
+    /// Allocated private-state capacity covering that maximum position.
+    pub state_sequence_capacity: usize,
+}
+
+impl ExactMulticoreProbeWork {
+    /// Recompute the declared logical work with saturating arithmetic.
+    pub fn derived_logical_forwards(&self) -> usize {
+        self.transcript_logical_forwards.saturating_add(
+            self.generation_lanes
+                .saturating_mul(self.generation_tokens_per_lane),
+        )
+    }
+
+    /// Recompute registered transcript batches for the configured logical cap.
+    pub fn derived_transcript_physical_batches(&self) -> usize {
+        let mut remaining = self.transcript_logical_forwards;
+        let mut batches = 0usize;
+        for width in EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_BATCH_WIDTHS {
+            if remaining == 0 {
+                break;
+            }
+            remaining = remaining.saturating_sub(width);
+            batches = batches.saturating_add(1);
+        }
+        batches
+    }
+
+    /// Recompute the optimized suite's physical shared-weight forwards.
+    pub fn derived_physical_batches(&self) -> usize {
+        self.derived_transcript_physical_batches()
+            .saturating_add(self.generation_tokens_per_lane)
+    }
+
+    /// Conservative bounded context exercised by the cheap probe.
+    ///
+    /// Return the explicitly bound maximum private-state horizon.
+    pub fn derived_probe_context_ceiling_tokens(&self) -> usize {
+        self.state_sequence_capacity
+    }
+
+    /// Whether this is the complete registered work shape authorized to admit
+    /// the optimized live suite. Smaller operator caps remain useful as
+    /// diagnostics but can never publish a binding qualified verdict.
+    pub(crate) fn is_registered_binding_work(&self) -> bool {
+        self.transcript_logical_forwards == EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_FORWARDS
+            && self.generation_tokens_per_lane == EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS
+            && self.generation_lanes == EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_LANES
+            && self.logical_forwards
+                == EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_FORWARDS.saturating_add(
+                    EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_LANES
+                        .saturating_mul(EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS),
+                )
+            && self.transcript_physical_batches
+                == EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_BATCH_WIDTHS.len()
+            && self.generation_physical_batches
+                == EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS
+            && self.physical_batches
+                == EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_BATCH_WIDTHS
+                    .len()
+                    .saturating_add(EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS)
+            && self.max_sequence_position == EXACT_MULTICORE_PROBE_REGISTERED_MAX_SEQUENCE_POSITION
+            && self.state_sequence_capacity
+                == EXACT_MULTICORE_PROBE_REGISTERED_STATE_SEQUENCE_CAPACITY
+    }
+}
+
+/// Binding admission status.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExactMulticoreProbeStatus {
+    /// All predeclared gates qualified the full run.
+    Qualified,
+    /// At least one gate refused the full run.
+    RefuseFullRun,
+}
+
+/// Machine-readable full-run admission verdict.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeVerdict {
+    /// Qualified/refused status.
+    pub status: ExactMulticoreProbeStatus,
+    /// Adaptive rule used to choose the measured exact configuration.
+    pub selection_policy: String,
+    /// Operator-configured wall limit.
+    pub configured_max_wall_seconds: u64,
+    /// Binding ceiling (never greater than eight hours).
+    pub qualification_wall_seconds: u64,
+    /// Redundant fail-closed boolean for simple consumers.
+    pub qualifies_full_run: bool,
+}
+
+/// Content binding for the finalized sibling JSONL event artifact.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeEventsBinding {
+    /// Sibling file name derived from the canonical report path.
+    pub file_name: String,
+    /// BLAKE3 identity of every finalized JSONL byte.
+    pub content_cid: String,
+    /// Exact finalized JSONL byte count.
+    pub byte_len: u64,
+    /// Exact nonempty JSONL record count.
+    pub record_count: u64,
+    /// One-based record number of the required last `FINAL` event.
+    pub final_record_number: u64,
+    /// Required terminal event name (`FINAL`).
+    pub final_event: String,
+    /// Terminal status copied from the binding verdict.
+    pub final_status: ExactMulticoreProbeStatus,
+    /// Terminal qualification flag copied from the binding verdict.
+    pub final_qualifies_full_run: bool,
+    /// CID of canonical report fields with this binding replaced by its
+    /// deterministic pending placeholder, avoiding a cyclic hash.
+    pub report_body_cid: String,
+}
+
+impl ExactMulticoreProbeEventsBinding {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn pending(file_name: impl Into<String>, status: ExactMulticoreProbeStatus) -> Self {
+        Self {
+            file_name: file_name.into(),
+            content_cid: "PENDING".to_owned(),
+            byte_len: 0,
+            record_count: 0,
+            final_record_number: 0,
+            final_event: "PENDING".to_owned(),
+            final_status: status,
+            final_qualifies_full_run: false,
+            report_body_cid: "PENDING".to_owned(),
+        }
+    }
+}
+
+/// Durable exact multicore probe report consumed by live-suite admission.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactMulticoreProbeReport {
+    /// [`EXACT_MULTICORE_PROBE_SCHEMA`].
+    pub schema: String,
+    /// Content identity returned by [`exact_executor_contract_cid`].
+    pub executor_contract_cid: String,
+    /// Bound teacher source identity.
+    pub source: ExactMulticoreProbeSource,
+    /// Bound host identity/capacity.
+    pub host: ExactMulticoreProbeHost,
+    /// Exact arithmetic and observable kernel provenance.
+    pub backend: ExactBackendReport,
+    /// Positions run by every worker configuration.
+    pub probe_positions: usize,
+    /// Configured maximum context shape represented by the timed probe.
+    pub probe_context_ceiling_tokens: usize,
+    /// Exact full-context prefix index timed by every measured repetition.
+    pub probe_position_indices: Vec<usize>,
+    /// Independent streams used by every worker configuration.
+    pub probe_streams: usize,
+    /// Binding cheap-probe admission deadline.
+    pub probe_wall_ceiling_seconds: u64,
+    /// Exact semantics for an operation already active at the deadline.
+    pub probe_deadline_policy: String,
+    /// Finalized content identity and terminal record of the sibling JSONL.
+    pub events: ExactMulticoreProbeEventsBinding,
+    /// Observed probe wall time including fixture load.
+    pub probe_elapsed_seconds: f64,
+    /// Fixed-worker measurements (four workers and all available workers,
+    /// deduplicated when the host exposes exactly four).
+    pub runs: Vec<ExactMulticoreProbeRun>,
+    /// Worker count of the first candidate whose exact trace is the reference.
+    pub reference_workers: usize,
+    /// Fastest observed qualified candidate.
+    pub selected_best_config: ExactMulticoreProbeSelection,
+    /// Exact worker/tile configuration the full suite will execute.
+    pub configured_execution: ExactMulticoreProbeSelection,
+    /// Aggregate bit-equality verdict.
+    pub exact_equality: bool,
+    /// Aggregate worker-participation diagnostic.
+    pub all_workers_active: bool,
+    /// Aggregate independent-stream participation verdict.
+    pub all_streams_active: bool,
+    /// Configured/default suite work.
+    pub configured_suite_work: ExactMulticoreProbeWork,
+    /// Selected-candidate projection before safety margin.
+    pub raw_projected_suite_seconds: f64,
+    /// Multiplicative projection safety margin.
+    pub projection_safety_factor: f64,
+    /// Explicit formal-vocabulary boundary for context-length projection.
+    pub projection_context_assumption: String,
+    /// Selected-candidate projection after safety margin.
+    pub safety_adjusted_projected_suite_seconds: f64,
+    /// Binding admission verdict.
+    pub binding_verdict: ExactMulticoreProbeVerdict,
+    /// Overall CPU/RSS evidence or explicit unavailability.
+    pub resources: ExactMulticoreProbeResources,
+}
+
+/// Live state a consumer requires a durable report to match.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExactMulticoreProbeExpectation {
+    /// Current executor/build contract identity.
+    pub executor_contract_cid: String,
+    /// Current live source identity.
+    pub source: ExactMulticoreProbeSource,
+    /// Current host identity and capacity.
+    pub host: ExactMulticoreProbeHost,
+    /// Exact full-suite work budget.
+    pub configured_suite_work: ExactMulticoreProbeWork,
+    /// Owner-computed counter plans for every measured worker configuration.
+    pub forward_plans: Vec<ExactMulticoreProbeWorkerPlan>,
+    /// Expected complete trace dimensions for the cheap probe.
+    pub trace_shape: ExactMulticoreProbeTraceShape,
+    /// Output-row tiles per worker the admitted full suite will actually use.
+    pub tiles_per_worker: usize,
+    /// Full-suite wall ceiling configured by the operator.
+    pub configured_max_wall_seconds: u64,
+}
+
+/// Focused reason durable evidence cannot admit live teacher work.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExactMulticoreProbeValidationError {
+    SchemaMismatch,
+    ExecutorContractMismatch,
+    SourceIdentityMismatch,
+    HostIdentityMismatch,
+    HostTopologyUnavailable,
+    BudgetMismatch(&'static str),
+    BackendMismatch,
+    MissingWorkerConfiguration(usize),
+    ExactEqualityNotEstablished,
+    WorkerParticipationNotEstablished,
+    BatchedExecutionNotEstablished,
+    ResourceEvidenceUnavailable,
+    EventsEvidenceUnavailable,
+    EventsEvidenceMismatch(&'static str),
+    ProbeWallCeilingExceeded,
+    ProjectionExceedsLimit,
+    NumericEvidenceMismatch(&'static str),
+    VerdictNotQualified,
+}
+
+impl std::fmt::Display for ExactMulticoreProbeValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "exact multicore probe admission refused: {self:?}"
+        )
+    }
+}
+
+impl std::error::Error for ExactMulticoreProbeValidationError {}
+
+impl ExactMulticoreProbeReport {
+    /// Validate report fields without treating the report alone as admission
+    /// evidence. Live callers must use [`Self::validate_for_with_events`].
+    pub fn validate_for(
+        &self,
+        expected: &ExactMulticoreProbeExpectation,
+    ) -> Result<(), ExactMulticoreProbeValidationError> {
+        use ExactMulticoreProbeValidationError as Error;
+
+        fn same_f64(left: f64, right: f64) -> bool {
+            left.to_bits() == right.to_bits()
+        }
+
+        fn validate_resources_if_available(
+            resources: &ExactMulticoreProbeResources,
+            elapsed_seconds: f64,
+            expected_scope: &str,
+        ) -> Result<(), Error> {
+            if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
+                return Err(Error::NumericEvidenceMismatch("resource_elapsed"));
+            }
+            if resources.status == "UNAVAILABLE" {
+                if resources.measurement_scope != "UNAVAILABLE"
+                    || resources
+                        .reason
+                        .as_deref()
+                        .map(str::is_empty)
+                        .unwrap_or(true)
+                    || resources.cpu_time_start_seconds.is_some()
+                    || resources.cpu_time_end_seconds.is_some()
+                    || resources.cpu_time_consumed_seconds.is_some()
+                    || resources.current_rss_bytes.is_some()
+                    || resources.max_sampled_rss_bytes.is_some()
+                    || resources.peak_rss_bytes.is_some()
+                    || resources.mean_cpu_core_equivalents.is_some()
+                    || resources.mean_cpu_percent.is_some()
+                {
+                    return Err(Error::NumericEvidenceMismatch("resource_unavailable"));
+                }
+                return Ok(());
+            }
+            let (
+                Some(cpu_start),
+                Some(cpu_end),
+                Some(cpu_consumed),
+                Some(current_rss),
+                Some(max_sampled_rss),
+                Some(mean_cores),
+                Some(mean_percent),
+            ) = (
+                resources.cpu_time_start_seconds,
+                resources.cpu_time_end_seconds,
+                resources.cpu_time_consumed_seconds,
+                resources.current_rss_bytes,
+                resources.max_sampled_rss_bytes,
+                resources.mean_cpu_core_equivalents,
+                resources.mean_cpu_percent,
+            )
+            else {
+                return Err(Error::NumericEvidenceMismatch("resource_evidence"));
+            };
+            if !matches!(resources.status.as_str(), "AVAILABLE" | "PARTIAL")
+                || resources.measurement_scope != expected_scope
+                || !cpu_start.is_finite()
+                || !cpu_end.is_finite()
+                || !cpu_consumed.is_finite()
+                || cpu_start < 0.0
+                || cpu_end < cpu_start
+                || current_rss == 0
+                || max_sampled_rss < current_rss
+                || !mean_cores.is_finite()
+                || mean_cores < 0.0
+                || !mean_percent.is_finite()
+                || mean_percent < 0.0
+                || cpu_consumed > cpu_end - cpu_start + f64::EPSILON
+                || !same_f64(mean_cores, cpu_consumed / elapsed_seconds)
+                || !same_f64(mean_percent, mean_cores * 100.0)
+            {
+                return Err(Error::NumericEvidenceMismatch("resource_evidence"));
+            }
+            if resources.peak_rss_bytes.is_none()
+                && (resources.status != "PARTIAL" || resources.reason.is_none())
+            {
+                return Err(Error::NumericEvidenceMismatch("resource_peak_status"));
+            }
+            if let Some(peak_rss) = resources.peak_rss_bytes {
+                if peak_rss < max_sampled_rss {
+                    return Err(Error::NumericEvidenceMismatch("resource_peak_rss"));
+                }
+            }
+            Ok(())
+        }
+
+        if self.schema != EXACT_MULTICORE_PROBE_SCHEMA {
+            return Err(Error::SchemaMismatch);
+        }
+        if self.executor_contract_cid != expected.executor_contract_cid
+            || self.executor_contract_cid != exact_executor_contract_cid()
+        {
+            return Err(Error::ExecutorContractMismatch);
+        }
+        if self.source != expected.source {
+            return Err(Error::SourceIdentityMismatch);
+        }
+        if self.host != expected.host {
+            return Err(Error::HostIdentityMismatch);
+        }
+        if self.host.cpu_model.is_none() || self.host.physical_core_count.is_none() {
+            return Err(Error::HostTopologyUnavailable);
+        }
+        if self.host.available_parallelism < 4 {
+            return Err(Error::BudgetMismatch("minimum_adaptive_host"));
+        }
+        if self.configured_suite_work != expected.configured_suite_work {
+            return Err(Error::BudgetMismatch("configured_suite_work"));
+        }
+        if self.configured_suite_work.logical_forwards
+            != self.configured_suite_work.derived_logical_forwards()
+        {
+            return Err(Error::BudgetMismatch("logical_forwards"));
+        }
+        if self.configured_suite_work.transcript_physical_batches
+            != self
+                .configured_suite_work
+                .derived_transcript_physical_batches()
+            || self.configured_suite_work.generation_physical_batches
+                != self.configured_suite_work.generation_tokens_per_lane
+            || self.configured_suite_work.physical_batches
+                != self.configured_suite_work.derived_physical_batches()
+        {
+            return Err(Error::BudgetMismatch("physical_batches"));
+        }
+        if !self.configured_suite_work.is_registered_binding_work() {
+            return Err(Error::BudgetMismatch("optimized_suite_work"));
+        }
+        if self.probe_streams != 8 || self.probe_positions == 0 {
+            return Err(Error::BudgetMismatch("probe_shape"));
+        }
+        // Aggregate teacher-forced work and one private state's bounded
+        // sequence horizon are deliberately independent. The caller computes
+        // the latter through the config-only trace-shape owner; never recover
+        // it by treating all logical transcript positions as one sequence.
+        let context_ceiling = expected.trace_shape.sequence_capacity;
+        if context_ceiling == 0
+            || self.probe_context_ceiling_tokens != context_ceiling
+            || context_ceiling
+                < self
+                    .configured_suite_work
+                    .derived_probe_context_ceiling_tokens()
+            || self.probe_position_indices.len() != self.probe_positions
+            || self
+                .probe_position_indices
+                .iter()
+                .any(|&position| position != context_ceiling - 1)
+        {
+            return Err(Error::BudgetMismatch("probe_context_shape"));
+        }
+        if self.probe_deadline_policy != EXACT_MULTICORE_PROBE_DEADLINE_POLICY {
+            return Err(Error::BudgetMismatch("probe_deadline_policy"));
+        }
+        if self.probe_wall_ceiling_seconds != EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS
+            || !self.probe_elapsed_seconds.is_finite()
+            || self.probe_elapsed_seconds <= 0.0
+            || self.probe_elapsed_seconds >= self.probe_wall_ceiling_seconds as f64
+        {
+            return Err(Error::ProbeWallCeilingExceeded);
+        }
+        if self.projection_context_assumption != EXACT_MULTICORE_PROBE_CONTEXT_ASSUMPTION {
+            return Err(Error::BudgetMismatch("projection_context_assumption"));
+        }
+        let current_backend = exact_backend_report();
+        if self.backend != current_backend
+            || current_backend.arithmetic_owner != "uor-matmul exact GEMM"
+            || !current_backend.std_runtime_detection_enabled
+            || current_backend.uor_matmul_revision != UOR_MATMUL_REVISION
+            || current_backend.target_arch != self.host.target_arch
+            || current_backend.target_os != self.host.target_os
+        {
+            return Err(Error::BackendMismatch);
+        }
+
+        let mut required_workers = vec![4usize, self.host.available_parallelism];
+        required_workers.sort_unstable();
+        required_workers.dedup();
+        let mut planned_workers: Vec<usize> = expected
+            .forward_plans
+            .iter()
+            .map(|plan| plan.workers)
+            .collect();
+        planned_workers.sort_unstable();
+        planned_workers.dedup();
+        if planned_workers != required_workers
+            || expected.forward_plans.len() != required_workers.len()
+        {
+            return Err(Error::BudgetMismatch("candidate_worker_plans"));
+        }
+        if self.runs.len() != required_workers.len() {
+            for workers in &required_workers {
+                if !self.runs.iter().any(|run| run.workers == *workers) {
+                    return Err(Error::MissingWorkerConfiguration(*workers));
+                }
+            }
+            return Err(Error::NumericEvidenceMismatch("candidate_count"));
+        }
+        if self.reference_workers != self.runs[0].workers
+            || !required_workers.contains(&self.reference_workers)
+        {
+            return Err(Error::NumericEvidenceMismatch("reference_workers"));
+        }
+        for workers in &required_workers {
+            if self
+                .runs
+                .iter()
+                .filter(|run| run.workers == *workers)
+                .count()
+                != 1
+            {
+                return Err(Error::MissingWorkerConfiguration(*workers));
+            }
+        }
+        let worker4 = self
+            .runs
+            .iter()
+            .find(|run| run.workers == 4)
+            .ok_or(Error::MissingWorkerConfiguration(4))?;
+        if !worker4.aggregate_forwards_per_second.is_finite()
+            || worker4.aggregate_forwards_per_second <= 0.0
+        {
+            return Err(Error::NumericEvidenceMismatch("worker4_rate"));
+        }
+
+        let physical_batches = self.configured_suite_work.physical_batches as f64;
+        let measured_forwards =
+            self.probe_streams
+                .checked_mul(self.probe_positions)
+                .ok_or(Error::NumericEvidenceMismatch("probe_forward_count"))? as f64;
+        let trace_records = u64::try_from(self.probe_streams)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(u64::try_from(self.probe_positions).unwrap_or(u64::MAX));
+        if expected.trace_shape.positions != self.probe_positions
+            || expected.trace_shape.streams_per_position != self.probe_streams
+            || expected.trace_shape.sequence_capacity != self.probe_context_ceiling_tokens
+            || expected.trace_shape.state_records != trace_records
+            || expected.trace_shape.logit_words
+                != trace_records.saturating_mul(
+                    u64::try_from(expected.trace_shape.logits_per_state).unwrap_or(u64::MAX),
+                )
+            || expected.trace_shape.logit_bytes
+                != expected.trace_shape.logit_words.saturating_mul(4)
+            || expected.trace_shape.persistent_state_words
+                != trace_records.saturating_mul(
+                    u64::try_from(expected.trace_shape.persistent_state_words_per_state)
+                        .unwrap_or(u64::MAX),
+                )
+            || expected.trace_shape.greedy_tokens != trace_records
+            || expected.trace_shape.top_tokens
+                != trace_records
+                    .saturating_mul(u64::try_from(expected.trace_shape.top_k).unwrap_or(u64::MAX))
+        {
+            return Err(Error::NumericEvidenceMismatch("trace_completeness"));
+        }
+        for run in &self.runs {
+            if run.workers == 0
+                || run.batch_width != self.probe_streams
+                || self
+                    .runs
+                    .iter()
+                    .filter(|candidate| candidate.workers == run.workers)
+                    .count()
+                    != 1
+                || !run.aggregate_forwards_per_second.is_finite()
+                || run.aggregate_forwards_per_second <= 0.0
+                || !run.elapsed_seconds.is_finite()
+                || run.elapsed_seconds <= 0.0
+                || !run.prestart.elapsed_seconds.is_finite()
+                || run.prestart.elapsed_seconds < 0.0
+                || run.prestart.workers_observed != run.workers
+                || run.prestart.batch_width != self.probe_streams
+                || !run.prestart.backend_exercised
+                || run.prestart.workspace_capacity_bytes == 0
+                || run.prestart.workspace_growth_events == 0
+                || run.prestart.workspace_growth_bytes == 0
+                || !run.prestart.excluded_from_measurement
+            {
+                return Err(Error::NumericEvidenceMismatch("run_rate"));
+            }
+            let measured_rate = measured_forwards / run.elapsed_seconds;
+            let relative_to_worker4 =
+                run.aggregate_forwards_per_second / worker4.aggregate_forwards_per_second;
+            let raw_projection =
+                physical_batches * run.elapsed_seconds / self.probe_positions as f64;
+            let adjusted_projection = raw_projection * self.projection_safety_factor;
+            if !same_f64(run.aggregate_forwards_per_second, measured_rate)
+                || !same_f64(run.relative_throughput_vs_worker4, relative_to_worker4)
+                || !same_f64(run.raw_projected_suite_seconds, raw_projection)
+                || !same_f64(
+                    run.safety_adjusted_projected_suite_seconds,
+                    adjusted_projection,
+                )
+            {
+                return Err(Error::NumericEvidenceMismatch("run_arithmetic"));
+            }
+            let Some(expected_plan) = expected
+                .forward_plans
+                .iter()
+                .find(|plan| plan.workers == run.workers)
+            else {
+                return Err(Error::MissingWorkerConfiguration(run.workers));
+            };
+            if expected
+                .forward_plans
+                .iter()
+                .filter(|plan| plan.workers == run.workers)
+                .count()
+                != 1
+                || run.forward_plan != expected_plan.forward_plan
+                || run.trace_shape != expected.trace_shape
+                || run.trace_shape.positions != self.probe_positions
+                || run.trace_shape.streams_per_position != self.probe_streams
+            {
+                return Err(Error::NumericEvidenceMismatch("trace_or_plan_shape"));
+            }
+            let positions_u64 = u64::try_from(self.probe_positions).unwrap_or(u64::MAX);
+            let expected_matrix_calls = run.forward_plan.matrix_calls.saturating_mul(positions_u64);
+            let expected_tiles = run.forward_plan.row_tiles.saturating_mul(positions_u64);
+            let expected_cells = run.forward_plan.output_cells.saturating_mul(positions_u64);
+            let expected_terms = run.forward_plan.scalar_terms.saturating_mul(positions_u64);
+            if run.snapshot.requested_workers != run.workers
+                || run.snapshot.effective_workers != run.workers
+                || run.snapshot.active_workers != 0
+                || run.snapshot.max_active_workers > run.workers
+                || run.snapshot.forward_max_active_workers > run.snapshot.max_active_workers
+                || run.snapshot.forward_calls != positions_u64
+                || run.snapshot.matrix_calls != expected_matrix_calls
+                || run.snapshot.batched_matrix_calls != expected_matrix_calls
+                || run.snapshot.max_matrix_batch_width != self.probe_streams
+                || run.snapshot.tiles_completed != expected_tiles
+                || run.snapshot.output_cells_completed != expected_cells
+                || run.snapshot.scalar_terms_completed != expected_terms
+                || run.snapshot.multiworker_forward_calls != positions_u64
+                || !(2..=run.workers).contains(&run.snapshot.forward_max_active_workers)
+                || run.snapshot.workspace_growth_events != 0
+                || run.snapshot.workspace_growth_bytes != 0
+                || run.snapshot.observer_epoch == 0
+            {
+                return Err(Error::BatchedExecutionNotEstablished);
+            }
+            validate_resources_if_available(
+                &run.resources,
+                run.elapsed_seconds,
+                "EXACT_FORWARD_INTERVALS_ONLY",
+            )?;
+            if !run.output_trace_cid.starts_with("blake3:")
+                || run.equal_to_reference != (run.output_trace_cid == self.runs[0].output_trace_cid)
+            {
+                return Err(Error::NumericEvidenceMismatch("output_trace_cid"));
+            }
+            let observed_all_workers = run.snapshot.requested_workers == run.workers
+                && run.snapshot.effective_workers == run.workers
+                && run.snapshot.active_workers == 0
+                && run.snapshot.max_active_workers == run.workers;
+            if run.all_workers_active != observed_all_workers {
+                return Err(Error::NumericEvidenceMismatch("run_participation"));
+            }
+            let expected_stream_steps = self.probe_streams.saturating_mul(self.probe_positions);
+            let observed_all_streams = run.snapshot.active_streams == 0
+                && run.snapshot.max_active_streams == run.batch_width
+                && run.snapshot.streams_started
+                    == u64::try_from(expected_stream_steps).unwrap_or(u64::MAX)
+                && run.snapshot.streams_completed
+                    == u64::try_from(expected_stream_steps).unwrap_or(u64::MAX);
+            if run.all_streams_active != observed_all_streams {
+                return Err(Error::NumericEvidenceMismatch("run_stream_participation"));
+            }
+        }
+
+        for workers in &required_workers {
+            let Some(run) = self.runs.iter().find(|run| run.workers == *workers) else {
+                return Err(Error::MissingWorkerConfiguration(*workers));
+            };
+            if !run.equal_to_reference {
+                return Err(Error::ExactEqualityNotEstablished);
+            }
+            if !run.all_streams_active {
+                return Err(Error::WorkerParticipationNotEstablished);
+            }
+        }
+
+        let aggregate_equality = self.runs.iter().all(|run| run.equal_to_reference);
+        let aggregate_participation = self.runs.iter().all(|run| run.all_workers_active);
+        let aggregate_stream_participation = self.runs.iter().all(|run| run.all_streams_active);
+        if self.exact_equality != aggregate_equality {
+            return Err(Error::NumericEvidenceMismatch("aggregate_equality"));
+        }
+        if self.all_workers_active != aggregate_participation {
+            return Err(Error::NumericEvidenceMismatch("aggregate_participation"));
+        }
+        if self.all_streams_active != aggregate_stream_participation {
+            return Err(Error::NumericEvidenceMismatch(
+                "aggregate_stream_participation",
+            ));
+        }
+        if !self.exact_equality {
+            return Err(Error::ExactEqualityNotEstablished);
+        }
+        if !self.all_streams_active {
+            return Err(Error::WorkerParticipationNotEstablished);
+        }
+
+        let selected_run = self
+            .runs
+            .iter()
+            .min_by(|left, right| {
+                left.safety_adjusted_projected_suite_seconds
+                    .total_cmp(&right.safety_adjusted_projected_suite_seconds)
+                    .then_with(|| left.workers.cmp(&right.workers))
+            })
+            .ok_or(Error::NumericEvidenceMismatch("selected_run"))?;
+        if self.configured_execution.tiles_per_worker != expected.tiles_per_worker
+            || self.selected_best_config.tiles_per_worker != expected.tiles_per_worker
+        {
+            return Err(Error::BudgetMismatch("tiles_per_worker"));
+        }
+        let expected_selection = ExactMulticoreProbeSelection {
+            workers: selected_run.workers,
+            tiles_per_worker: expected.tiles_per_worker,
+            aggregate_forwards_per_second: selected_run.aggregate_forwards_per_second,
+            raw_projected_suite_seconds: selected_run.raw_projected_suite_seconds,
+            safety_adjusted_projected_suite_seconds: selected_run
+                .safety_adjusted_projected_suite_seconds,
+        };
+        if self.selected_best_config != expected_selection
+            || self.configured_execution != expected_selection
+        {
+            return Err(Error::NumericEvidenceMismatch("selected_best_config"));
+        }
+
+        if !self.projection_safety_factor.is_finite() || self.projection_safety_factor < 1.25 {
+            return Err(Error::ProjectionExceedsLimit);
+        }
+        if !same_f64(
+            self.raw_projected_suite_seconds,
+            selected_run.raw_projected_suite_seconds,
+        ) || !same_f64(
+            self.safety_adjusted_projected_suite_seconds,
+            selected_run.safety_adjusted_projected_suite_seconds,
+        ) {
+            return Err(Error::NumericEvidenceMismatch("configured_projection"));
+        }
+        if self.binding_verdict.selection_policy != EXACT_MULTICORE_PROBE_SELECTION_POLICY {
+            return Err(Error::BudgetMismatch("selection_policy"));
+        }
+        validate_resources_if_available(
+            &self.resources,
+            self.probe_elapsed_seconds,
+            "FULL_PROBE_WALL",
+        )?;
+        let qualification_wall_seconds = expected.configured_max_wall_seconds.min(28_800);
+        if self.binding_verdict.configured_max_wall_seconds != expected.configured_max_wall_seconds
+            || self.binding_verdict.qualification_wall_seconds != qualification_wall_seconds
+            || qualification_wall_seconds == 0
+            || !self.safety_adjusted_projected_suite_seconds.is_finite()
+            || self.safety_adjusted_projected_suite_seconds >= qualification_wall_seconds as f64
+        {
+            return Err(Error::ProjectionExceedsLimit);
+        }
+
+        let recomputed_qualification = self.exact_equality
+            && self.all_streams_active
+            && self.safety_adjusted_projected_suite_seconds < qualification_wall_seconds as f64;
+        if self.binding_verdict.qualifies_full_run != recomputed_qualification
+            || (self.binding_verdict.status == ExactMulticoreProbeStatus::Qualified)
+                != recomputed_qualification
+        {
+            return Err(Error::NumericEvidenceMismatch("binding_verdict"));
+        }
+        if self.binding_verdict.status != ExactMulticoreProbeStatus::Qualified
+            || !self.binding_verdict.qualifies_full_run
+        {
+            return Err(Error::VerdictNotQualified);
+        }
+        Ok(())
+    }
+
+    /// Fail-closed admission validation of both the typed report and its
+    /// finalized sibling JSONL artifact.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn validate_for_with_events(
+        &self,
+        report_path: impl AsRef<std::path::Path>,
+        expected: &ExactMulticoreProbeExpectation,
+    ) -> Result<(), ExactMulticoreProbeValidationError> {
+        use ExactMulticoreProbeValidationError as Error;
+
+        self.validate_for(expected)?;
+        let report_path = report_path.as_ref();
+        let expected_file_name = events_file_name_for_report(report_path);
+        if self.events.file_name != expected_file_name {
+            return Err(Error::EventsEvidenceMismatch("events_file_name"));
+        }
+        let events_path = normalized_report_parent(report_path).join(&expected_file_name);
+        let bytes = std::fs::read(events_path).map_err(|_| Error::EventsEvidenceUnavailable)?;
+        let report_body_cid = self
+            .report_body_cid()
+            .map_err(|_| Error::EventsEvidenceMismatch("report_body_cid"))?;
+        let observed = finalized_events_binding(
+            expected_file_name,
+            &bytes,
+            &report_body_cid,
+            self.binding_verdict.status,
+            self.binding_verdict.qualifies_full_run,
+        )?;
+        if self.events != observed {
+            return Err(Error::EventsEvidenceMismatch("events_content_binding"));
+        }
+        Ok(())
+    }
+
+    /// Portable targets cannot admit a host-qualified probe without the
+    /// required local event artifact.
+    #[cfg(target_arch = "wasm32")]
+    pub fn validate_for_with_events(
+        &self,
+        _report_path: impl AsRef<std::path::Path>,
+        _expected: &ExactMulticoreProbeExpectation,
+    ) -> Result<(), ExactMulticoreProbeValidationError> {
+        Err(ExactMulticoreProbeValidationError::EventsEvidenceUnavailable)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn report_body_cid(&self) -> std::io::Result<String> {
+        let mut body = self.clone();
+        body.events = ExactMulticoreProbeEventsBinding::pending(
+            self.events.file_name.clone(),
+            self.binding_verdict.status,
+        );
+        let mut bytes = serde_json::to_vec_pretty(&body)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        bytes.push(b'\n');
+        Ok(format!("blake3:{}", blake3::hash(&bytes).to_hex()))
+    }
+
+    /// Atomically publish a flushed report in the destination directory.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn write_atomic(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        let path = path.as_ref();
+        let bytes = self.canonical_bytes()?;
+        write_atomic_bytes(path, &bytes)
+    }
+
+    /// Commit a canonical report only after its required `FINAL` event has
+    /// been durably written by `emit_final`.
+    ///
+    /// The callback receives the CID of canonical report fields excluding the
+    /// cyclic event binding. If it fails, this method never touches the report
+    /// path, so an earlier RUNNING or non-PASS state cannot become qualified.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn write_after_durable_final(
+        &mut self,
+        report_path: impl AsRef<std::path::Path>,
+        events_path: impl AsRef<std::path::Path>,
+        emit_final: impl FnOnce(&str, u64) -> std::io::Result<()>,
+    ) -> std::io::Result<String> {
+        let report_path = report_path.as_ref();
+        let events_path = events_path.as_ref();
+        let events_file_name = events_file_name_for_report(report_path);
+        if events_path.file_name() != Some(std::ffi::OsStr::new(&events_file_name)) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "exact probe events path does not match report-derived sibling name",
+            ));
+        }
+        self.events = ExactMulticoreProbeEventsBinding::pending(
+            events_file_name.clone(),
+            self.binding_verdict.status,
+        );
+        let report_body_cid = self.report_body_cid()?;
+        let prefix_bytes = std::fs::read(events_path)?;
+        if !prefix_bytes.is_empty() && prefix_bytes.last() != Some(&b'\n') {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "exact probe JSONL prefix is not newline terminated",
+            ));
+        }
+        let final_record_number =
+            u64::try_from(prefix_bytes.iter().filter(|&&byte| byte == b'\n').count())
+                .unwrap_or(u64::MAX)
+                .checked_add(1)
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "exact probe JSONL record count overflow",
+                    )
+                })?;
+        emit_final(&report_body_cid, final_record_number)?;
+        let events_bytes = std::fs::read(events_path)?;
+        self.events = finalized_events_binding(
+            events_file_name,
+            &events_bytes,
+            &report_body_cid,
+            self.binding_verdict.status,
+            self.binding_verdict.qualifies_full_run,
+        )
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        let bytes = self.canonical_bytes()?;
+        let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+        write_atomic_bytes(report_path, &bytes)?;
+        Ok(cid)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn canonical_bytes(&self) -> std::io::Result<Vec<u8>> {
+        let mut bytes = serde_json::to_vec_pretty(self)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn events_file_name_for_report(report_path: &std::path::Path) -> String {
+    let stem = report_path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("exact-multicore-probe");
+    format!("{stem}.events.jsonl")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn finalized_events_binding(
+    file_name: String,
+    bytes: &[u8],
+    expected_report_body_cid: &str,
+    expected_status: ExactMulticoreProbeStatus,
+    expected_qualifies_full_run: bool,
+) -> Result<ExactMulticoreProbeEventsBinding, ExactMulticoreProbeValidationError> {
+    use ExactMulticoreProbeValidationError as Error;
+
+    if bytes.is_empty() || bytes.last() != Some(&b'\n') {
+        return Err(Error::EventsEvidenceMismatch("events_termination"));
+    }
+    let mut record_count = 0u64;
+    let mut final_record = None;
+    for line in bytes[..bytes.len() - 1].split(|byte| *byte == b'\n') {
+        if line.is_empty() {
+            return Err(Error::EventsEvidenceMismatch("events_empty_record"));
+        }
+        let record: serde_json::Value = serde_json::from_slice(line)
+            .map_err(|_| Error::EventsEvidenceMismatch("events_jsonl"))?;
+        record_count = record_count
+            .checked_add(1)
+            .ok_or(Error::EventsEvidenceMismatch("events_record_count"))?;
+        final_record = Some(record);
+    }
+    let final_record = final_record.ok_or(Error::EventsEvidenceMismatch("events_final"))?;
+    let expected_status = match expected_status {
+        ExactMulticoreProbeStatus::Qualified => "QUALIFIED",
+        ExactMulticoreProbeStatus::RefuseFullRun => "REFUSE_FULL_RUN",
+    };
+    if final_record
+        .get("schema")
+        .and_then(serde_json::Value::as_str)
+        != Some(EXACT_MULTICORE_PROBE_SCHEMA)
+        || final_record
+            .get("record")
+            .and_then(serde_json::Value::as_str)
+            != Some("EXACT_MULTICORE_PROBE")
+        || final_record
+            .get("event")
+            .and_then(serde_json::Value::as_str)
+            != Some("FINAL")
+        || final_record
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            != Some(expected_status)
+        || final_record
+            .get("qualifies_full_run")
+            .and_then(serde_json::Value::as_bool)
+            != Some(expected_qualifies_full_run)
+        || final_record
+            .get("report_body_cid")
+            .and_then(serde_json::Value::as_str)
+            != Some(expected_report_body_cid)
+        || final_record
+            .get("sequence")
+            .and_then(serde_json::Value::as_u64)
+            != Some(record_count)
+    {
+        return Err(Error::EventsEvidenceMismatch("events_final"));
+    }
+    Ok(ExactMulticoreProbeEventsBinding {
+        file_name,
+        content_cid: format!("blake3:{}", blake3::hash(bytes).to_hex()),
+        byte_len: u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+        record_count,
+        final_record_number: record_count,
+        final_event: "FINAL".to_owned(),
+        final_status: match expected_status {
+            "QUALIFIED" => ExactMulticoreProbeStatus::Qualified,
+            _ => ExactMulticoreProbeStatus::RefuseFullRun,
+        },
+        final_qualifies_full_run: expected_qualifies_full_run,
+        report_body_cid: expected_report_body_cid.to_owned(),
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn write_atomic_bytes(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let parent = normalized_report_parent(path);
+    std::fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("exact-multicore-probe.json");
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    let mut file = std::fs::File::create(&temporary)?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    file.sync_all()?;
+    std::fs::rename(&temporary, path)?;
+    std::fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(all(
+    test,
+    not(all(feature = "observation-blas-exception", target_os = "macos"))
+))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_executor_contract_binds_complete_local_source_closure() {
+        fn collect_rust_sources(
+            workspace_root: &std::path::Path,
+            directory: &std::path::Path,
+            sources: &mut std::collections::BTreeSet<String>,
+        ) {
+            let entries = std::fs::read_dir(directory).unwrap_or_else(|error| {
+                panic!(
+                    "read contract source directory {}: {error}",
+                    directory.display()
+                )
+            });
+            for entry in entries {
+                let path = entry.unwrap().path();
+                if path.is_dir() {
+                    collect_rust_sources(workspace_root, &path, sources);
+                } else if path.extension().is_some_and(|extension| extension == "rs") {
+                    let relative = path.strip_prefix(workspace_root).unwrap();
+                    sources.insert(relative.to_string_lossy().replace('\\', "/"));
+                }
+            }
+        }
+
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .unwrap();
+        let components = exact_executor_contract_components();
+        let labels = components
+            .iter()
+            .map(|(label, _)| (*label).to_owned())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            labels.len(),
+            components.len(),
+            "contract component labels must be unique"
+        );
+
+        let mut required = std::collections::BTreeSet::from(["src/lib.rs".to_owned()]);
+        for crate_path in [
+            "crates/uor-r4-api",
+            "crates/uor-r4-core",
+            "crates/uor-r4-graph-compiler",
+            "crates/uor-r4-graph-format",
+            "crates/uor-r4-graph-runtime",
+            "crates/uor-r4-graph-certify",
+            "crates/uor-r4-model-source",
+            "third_party/arrayref",
+        ] {
+            required.insert(format!("{crate_path}/Cargo.toml"));
+            collect_rust_sources(
+                workspace_root,
+                &workspace_root.join(crate_path).join("src"),
+                &mut required,
+            );
+        }
+
+        let missing = required.difference(&labels).collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "exact executor contract omitted local production sources: {missing:#?}"
+        );
+    }
+
+    fn resources(elapsed_seconds: f64, mean_cores: f64) -> ExactMulticoreProbeResources {
+        let consumed = elapsed_seconds * mean_cores;
+        let mean_cores = consumed / elapsed_seconds;
+        ExactMulticoreProbeResources {
+            status: "PARTIAL".to_owned(),
+            measurement_scope: "EXACT_FORWARD_INTERVALS_ONLY".to_owned(),
+            cpu_time_start_seconds: Some(0.0),
+            cpu_time_end_seconds: Some(consumed),
+            cpu_time_consumed_seconds: Some(consumed),
+            current_rss_bytes: Some(100),
+            max_sampled_rss_bytes: Some(120),
+            peak_rss_bytes: None,
+            mean_cpu_core_equivalents: Some(mean_cores),
+            mean_cpu_percent: Some(mean_cores * 100.0),
+            reason: Some("test OS peak RSS unavailable".to_owned()),
+        }
+    }
+
+    fn work() -> ExactMulticoreProbeWork {
+        let mut work = ExactMulticoreProbeWork {
+            transcript_logical_forwards: 36,
+            generation_tokens_per_lane: 8,
+            generation_lanes: 8,
+            logical_forwards: 0,
+            transcript_physical_batches: 0,
+            generation_physical_batches: 0,
+            physical_batches: 0,
+            max_sequence_position: 13,
+            state_sequence_capacity: 14,
+        };
+        work.logical_forwards = work.derived_logical_forwards();
+        work.transcript_physical_batches = work.derived_transcript_physical_batches();
+        work.generation_physical_batches = work.generation_tokens_per_lane;
+        work.physical_batches = work.derived_physical_batches();
+        work
+    }
+
+    fn source() -> ExactMulticoreProbeSource {
+        ExactMulticoreProbeSource {
+            model_kappa: "blake3:model".to_owned(),
+            config_cid: "blake3:config".to_owned(),
+            source_bytes: 42,
+        }
+    }
+
+    fn host() -> ExactMulticoreProbeHost {
+        ExactMulticoreProbeHost {
+            target_arch: std::env::consts::ARCH.to_owned(),
+            target_os: std::env::consts::OS.to_owned(),
+            available_parallelism: 8,
+            operating_system_version: Some("test-os".to_owned()),
+            cpu_model: Some("test-cpu".to_owned()),
+            physical_core_count: Some(8),
+            performance_logical_core_count: Some(4),
+            efficiency_logical_core_count: Some(4),
+            topology_unavailable_reason: None,
+        }
+    }
+
+    fn run(workers: usize, aggregate_forwards_per_second: f64) -> ExactMulticoreProbeRun {
+        let elapsed_seconds = 8.0 / aggregate_forwards_per_second;
+        let raw_projected_suite_seconds = work().physical_batches as f64 * elapsed_seconds;
+        let forward_plan = ExactForwardPlan {
+            batch_width: 8,
+            matrix_calls: 2,
+            row_tiles: u64::try_from(workers).unwrap(),
+            worker_tasks: u64::try_from(workers).unwrap(),
+            output_cells: 80,
+            scalar_terms: 800,
+        };
+        ExactMulticoreProbeRun {
+            workers,
+            batch_width: 8,
+            prestart: ExactMulticoreProbePrestart {
+                elapsed_seconds: 0.01,
+                workers_observed: workers,
+                batch_width: 8,
+                backend_exercised: true,
+                workspace_capacity_bytes: 1_024,
+                workspace_growth_events: 4,
+                workspace_growth_bytes: 1_024,
+                excluded_from_measurement: true,
+            },
+            elapsed_ms: u64::try_from((elapsed_seconds * 1_000.0) as u128).unwrap(),
+            elapsed_seconds,
+            aggregate_forwards_per_second,
+            relative_throughput_vs_worker4: aggregate_forwards_per_second / 20.0,
+            equal_to_reference: true,
+            output_trace_cid: "blake3:trace".to_owned(),
+            trace_shape: trace_shape(),
+            forward_plan,
+            all_workers_active: true,
+            all_streams_active: true,
+            raw_projected_suite_seconds,
+            safety_adjusted_projected_suite_seconds: raw_projected_suite_seconds * 1.25,
+            snapshot: TeacherExecutionSnapshot {
+                observer_epoch: 1,
+                requested_workers: workers,
+                effective_workers: workers,
+                max_active_workers: workers,
+                forward_max_active_workers: workers,
+                multiworker_forward_calls: 1,
+                forward_calls: 1,
+                streams_started: 8,
+                streams_completed: 8,
+                max_active_streams: 8,
+                matrix_calls: 2,
+                batched_matrix_calls: 2,
+                max_matrix_batch_width: 8,
+                tiles_completed: u64::try_from(workers).unwrap(),
+                output_cells_completed: 80,
+                scalar_terms_completed: 800,
+                ..TeacherExecutionSnapshot::default()
+            },
+            resources: resources(elapsed_seconds, workers as f64 * 0.8),
+        }
+    }
+
+    fn trace_shape() -> ExactMulticoreProbeTraceShape {
+        ExactMulticoreProbeTraceShape {
+            positions: 1,
+            streams_per_position: 8,
+            sequence_capacity: 14,
+            state_records: 8,
+            logits_per_state: 10,
+            logit_words: 80,
+            logit_bytes: 320,
+            persistent_state_words_per_state: 20,
+            persistent_state_words: 160,
+            greedy_tokens: 8,
+            top_k: 8,
+            top_tokens: 64,
+        }
+    }
+
+    fn report() -> ExactMulticoreProbeReport {
+        let mut overall_resources = resources(1.0, 6.4);
+        overall_resources.measurement_scope = "FULL_PROBE_WALL".to_owned();
+        ExactMulticoreProbeReport {
+            schema: EXACT_MULTICORE_PROBE_SCHEMA.to_owned(),
+            executor_contract_cid: exact_executor_contract_cid(),
+            source: source(),
+            host: host(),
+            backend: exact_backend_report(),
+            probe_positions: 1,
+            probe_context_ceiling_tokens: 14,
+            probe_position_indices: vec![13],
+            probe_streams: 8,
+            probe_wall_ceiling_seconds: EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+            probe_deadline_policy: EXACT_MULTICORE_PROBE_DEADLINE_POLICY.to_owned(),
+            events: ExactMulticoreProbeEventsBinding::pending(
+                "probe.events.jsonl",
+                ExactMulticoreProbeStatus::Qualified,
+            ),
+            probe_elapsed_seconds: 1.0,
+            runs: vec![run(8, 40.0), run(4, 20.0)],
+            reference_workers: 8,
+            selected_best_config: ExactMulticoreProbeSelection {
+                workers: 8,
+                tiles_per_worker: 4,
+                aggregate_forwards_per_second: 40.0,
+                raw_projected_suite_seconds: work().physical_batches as f64 * (8.0 / 40.0),
+                safety_adjusted_projected_suite_seconds: work().physical_batches as f64
+                    * (8.0 / 40.0)
+                    * 1.25,
+            },
+            configured_execution: ExactMulticoreProbeSelection {
+                workers: 8,
+                tiles_per_worker: 4,
+                aggregate_forwards_per_second: 40.0,
+                raw_projected_suite_seconds: work().physical_batches as f64 * (8.0 / 40.0),
+                safety_adjusted_projected_suite_seconds: work().physical_batches as f64
+                    * (8.0 / 40.0)
+                    * 1.25,
+            },
+            exact_equality: true,
+            all_workers_active: true,
+            all_streams_active: true,
+            configured_suite_work: work(),
+            raw_projected_suite_seconds: work().physical_batches as f64 * (8.0 / 40.0),
+            projection_safety_factor: 1.25,
+            projection_context_assumption: EXACT_MULTICORE_PROBE_CONTEXT_ASSUMPTION.to_owned(),
+            safety_adjusted_projected_suite_seconds: work().physical_batches as f64
+                * (8.0 / 40.0)
+                * 1.25,
+            binding_verdict: ExactMulticoreProbeVerdict {
+                status: ExactMulticoreProbeStatus::Qualified,
+                selection_policy: EXACT_MULTICORE_PROBE_SELECTION_POLICY.to_owned(),
+                configured_max_wall_seconds: 28_800,
+                qualification_wall_seconds: 28_800,
+                qualifies_full_run: true,
+            },
+            resources: overall_resources,
+        }
+    }
+
+    fn expectation() -> ExactMulticoreProbeExpectation {
+        ExactMulticoreProbeExpectation {
+            executor_contract_cid: exact_executor_contract_cid(),
+            source: source(),
+            host: host(),
+            configured_suite_work: work(),
+            forward_plans: [4usize, 8]
+                .into_iter()
+                .map(|workers| ExactMulticoreProbeWorkerPlan {
+                    workers,
+                    forward_plan: run(workers, if workers == 4 { 20.0 } else { 40.0 }).forward_plan,
+                })
+                .collect(),
+            trace_shape: trace_shape(),
+            tiles_per_worker: 4,
+            configured_max_wall_seconds: 28_800,
+        }
+    }
+
+    #[test]
+    fn qualified_report_validates() {
+        let encoded = serde_json::to_vec(&report()).unwrap();
+        let decoded: ExactMulticoreProbeReport = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(
+            decoded.configured_suite_work.transcript_logical_forwards,
+            36
+        );
+        assert_eq!(decoded.configured_suite_work.logical_forwards, 100);
+        assert_eq!(decoded.probe_context_ceiling_tokens, 14);
+        decoded.validate_for(&expectation()).unwrap();
+    }
+
+    #[test]
+    fn four_core_host_deduplicates_the_adaptive_candidates() {
+        let mut report = report();
+        report.host.available_parallelism = 4;
+        report.host.physical_core_count = Some(4);
+        report.host.performance_logical_core_count = Some(4);
+        report.host.efficiency_logical_core_count = None;
+        report.runs = vec![run(4, 20.0)];
+        report.reference_workers = 4;
+        let selection = ExactMulticoreProbeSelection {
+            workers: 4,
+            tiles_per_worker: 4,
+            aggregate_forwards_per_second: 20.0,
+            raw_projected_suite_seconds: work().physical_batches as f64 * (8.0 / 20.0),
+            safety_adjusted_projected_suite_seconds: work().physical_batches as f64
+                * (8.0 / 20.0)
+                * 1.25,
+        };
+        report.selected_best_config = selection.clone();
+        report.configured_execution = selection;
+        report.raw_projected_suite_seconds = work().physical_batches as f64 * (8.0 / 20.0);
+        report.safety_adjusted_projected_suite_seconds = report.raw_projected_suite_seconds * 1.25;
+        let mut expected = expectation();
+        expected.host = report.host.clone();
+        expected.forward_plans = vec![ExactMulticoreProbeWorkerPlan {
+            workers: 4,
+            forward_plan: run(4, 20.0).forward_plan,
+        }];
+        report.validate_for(&expected).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn relative_report_path_uses_current_directory_parent() {
+        assert_eq!(
+            normalized_report_parent(std::path::Path::new("probe.json")),
+            std::path::Path::new(".")
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn direct_tuner_relative_paths_resolve_from_workspace_root() {
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .unwrap();
+        for relative in [
+            "target/teacher-parity/exact-multicore-probe.json",
+            "target/teacher-parity/teacher-free-preflight.json",
+            ".uor-models/sources/smollm2-135m-instruct",
+            ".uor-models/compiled/smollm2-135m-instruct",
+        ] {
+            assert_eq!(
+                resolve_direct_probe_path(std::path::PathBuf::from(relative)),
+                workspace_root.join(relative)
+            );
+        }
+        let absolute = std::env::temp_dir().join("absolute-direct-probe-path");
+        assert_eq!(resolve_direct_probe_path(absolute.clone()), absolute);
+        assert!(resolve_direct_probe_path(std::path::PathBuf::new())
+            .as_os_str()
+            .is_empty());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn teacher_free_preflight_fixture(
+        label: &str,
+    ) -> (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+    ) {
+        let directory = std::env::temp_dir().join(format!(
+            "uor-r4-teacher-free-preflight-{}-{label}",
+            std::process::id()
+        ));
+        if directory.exists() {
+            std::fs::remove_dir_all(&directory).unwrap();
+        }
+        let source = directory.join("source");
+        let bundle = directory.join("bundle");
+        std::fs::create_dir_all(source.as_path()).unwrap();
+        std::fs::create_dir_all(bundle.join("graph")).unwrap();
+        let files = [
+            ("tokenizer", "tokenizer.bin", b"tokenizer".as_slice()),
+            (
+                "legacy_artifact",
+                "tless_artifacts.bin",
+                b"artifact".as_slice(),
+            ),
+            ("legacy_store", "tless_store.bin", b"store".as_slice()),
+            ("graph", "graph/score.r4g1", b"graph".as_slice()),
+            (
+                "graph_report",
+                "graph/score_report.json",
+                b"report".as_slice(),
+            ),
+        ];
+        let mut inputs = serde_json::Map::new();
+        for (name, relative, bytes) in files {
+            if let Some(parent) = bundle.join(relative).parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(bundle.join(relative), bytes).unwrap();
+            inputs.insert(
+                name.to_owned(),
+                serde_json::Value::String(format!("blake3:{}", blake3::hash(bytes).to_hex())),
+            );
+        }
+        let mut production_admission = serde_json::Map::new();
+        for (name, relative) in PRODUCTION_ADMISSION_COMPONENTS {
+            let path = bundle.join(relative);
+            if !path.exists() {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).unwrap();
+                }
+                std::fs::write(&path, format!("production component {name}\n")).unwrap();
+            }
+            let bytes = std::fs::read(&path).unwrap();
+            production_admission.insert(
+                name.to_owned(),
+                serde_json::Value::String(format!("blake3:{}", blake3::hash(&bytes).to_hex())),
+            );
+        }
+        let report_path = directory.join("preflight.json");
+        let report = serde_json::json!({
+            "schema": TEACHER_FREE_PREFLIGHT_SCHEMA,
+            "authorizing_contract_cid": exact_executor_contract_cid(),
+            "status": "AVAILABLE",
+            "teacher_source_opened": false,
+            "teacher_forwards": 0,
+            "report_path": report_path.display().to_string(),
+            "selected_source_dir": source.display().to_string(),
+            "selected_bundle_dir": bundle.display().to_string(),
+            "inputs": inputs,
+            "production_admission": production_admission,
+        });
+        std::fs::write(&report_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+        (directory, report_path, source, bundle)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn digest_consistent_but_semantically_invalid_preflight_never_authorizes_tuner() {
+        let (directory, report_path, source, bundle) =
+            teacher_free_preflight_fixture("semantic-invalid");
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Failed(reason))
+                if reason.contains("schema-2 production envelope semantic verification")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_stale_compiled_input_refuses_direct_tuner() {
+        let (directory, report_path, source, bundle) = teacher_free_preflight_fixture("stale");
+        std::fs::write(bundle.join("graph/score.r4g1"), b"changed graph").unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Refused(reason))
+                if reason.contains("graph identity is stale")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_stale_production_component_refuses_direct_tuner() {
+        let (directory, report_path, source, bundle) =
+            teacher_free_preflight_fixture("stale-production");
+        std::fs::write(
+            bundle.join("graph/deployed_quality_report.json"),
+            b"changed deployed quality",
+        )
+        .unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Refused(reason))
+                if reason.contains("deployed_quality_report is stale")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_missing_release_manifest_never_authorizes_direct_tuner() {
+        let (directory, report_path, source, bundle) =
+            teacher_free_preflight_fixture("missing-release-manifest");
+        std::fs::remove_file(bundle.join("release-bundle.json")).unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Unavailable(reason))
+                if reason.contains("release-bundle.json is absent")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), unix))]
+    #[test]
+    fn planted_symlinked_production_component_never_authorizes_direct_tuner() {
+        use std::os::unix::fs::symlink;
+
+        let (directory, report_path, source, bundle) =
+            teacher_free_preflight_fixture("symlinked-production");
+        let component = bundle.join("graph/deployed_quality_report.json");
+        let target = bundle.join("graph/deployed_quality_report-target.json");
+        std::fs::rename(&component, &target).unwrap();
+        symlink(&target, &component).unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Failed(reason))
+                if reason.contains("not a regular non-symlink file")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_nonavailable_preflight_refuses_direct_tuner() {
+        let (directory, report_path, source, bundle) = teacher_free_preflight_fixture("refused");
+        let mut report: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&report_path).unwrap()).unwrap();
+        report["status"] = serde_json::Value::String("FAILED".to_owned());
+        report["reason"] = serde_json::Value::String("planted compiled gate failure".to_owned());
+        std::fs::write(&report_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Refused(reason))
+                if reason.contains("planted compiled gate failure")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_stale_preflight_contract_refuses_direct_tuner() {
+        let (directory, report_path, source, bundle) = teacher_free_preflight_fixture("contract");
+        let mut report: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&report_path).unwrap()).unwrap();
+        report["authorizing_contract_cid"] =
+            serde_json::Value::String("blake3:stale-contract".to_owned());
+        std::fs::write(&report_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+        let result = validate_teacher_free_preflight(&report_path, &source, &bundle);
+        assert!(matches!(
+            result,
+            Err(TeacherFreePreflightAdmissionError::Refused(reason))
+                if reason.contains("current authorizing contract")
+        ));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_final_event_failure_cannot_publish_qualified_report() {
+        let path = std::env::temp_dir().join(format!(
+            "uor-r4-exact-probe-finalization-{}.json",
+            std::process::id()
+        ));
+        let events_path = normalized_report_parent(&path).join(events_file_name_for_report(&path));
+        let running = b"{\"status\":\"NOT_QUALIFIED\",\"event\":\"RUNNING\"}\n";
+        std::fs::write(&path, running).unwrap();
+
+        let mut report = report();
+        let result = report.write_after_durable_final(
+            &path,
+            &events_path,
+            |_report_body_cid, _final_record_number| {
+                Err(std::io::Error::other("planted FINAL event failure"))
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), running);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn finalized_fixture(
+        label: &str,
+    ) -> (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        ExactMulticoreProbeReport,
+    ) {
+        use std::io::Write;
+
+        let directory = std::env::temp_dir().join(format!(
+            "uor-r4-exact-probe-events-{}-{label}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let report_path = directory.join("probe.json");
+        let events_path = directory.join("probe.events.jsonl");
+        let _ = std::fs::remove_file(&report_path);
+        let _ = std::fs::remove_file(&events_path);
+        std::fs::File::create(&events_path).unwrap();
+
+        let mut report = report();
+        let status = report.binding_verdict.status;
+        let qualifies = report.binding_verdict.qualifies_full_run;
+        report
+            .write_after_durable_final(
+                &report_path,
+                &events_path,
+                |report_body_cid, final_record_number| {
+                    let record = serde_json::json!({
+                        "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                        "record": "EXACT_MULTICORE_PROBE",
+                        "event": "FINAL",
+                        "sequence": final_record_number,
+                        "status": status,
+                        "qualifies_full_run": qualifies,
+                        "report_body_cid": report_body_cid,
+                    });
+                    let mut file = std::fs::OpenOptions::new()
+                        .append(true)
+                        .open(&events_path)?;
+                    serde_json::to_writer(&mut file, &record).map_err(|error| {
+                        std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+                    })?;
+                    file.write_all(b"\n")?;
+                    file.flush()?;
+                    file.sync_all()
+                },
+            )
+            .unwrap();
+        (report_path, events_path, report)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn remove_finalized_fixture(report_path: &std::path::Path, events_path: &std::path::Path) {
+        if report_path.is_file() {
+            std::fs::remove_file(report_path).unwrap();
+        }
+        if events_path.is_file() {
+            std::fs::remove_file(events_path).unwrap();
+        }
+        std::fs::remove_dir(report_path.parent().unwrap()).unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn finalized_events_and_report_validate_together() {
+        let (report_path, events_path, report) = finalized_fixture("qualified");
+        report
+            .validate_for_with_events(&report_path, &expectation())
+            .unwrap();
+        remove_finalized_fixture(&report_path, &events_path);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_deleted_events_refuse_admission() {
+        let (report_path, events_path, report) = finalized_fixture("deleted");
+        std::fs::remove_file(&events_path).unwrap();
+        assert_eq!(
+            report.validate_for_with_events(&report_path, &expectation()),
+            Err(ExactMulticoreProbeValidationError::EventsEvidenceUnavailable)
+        );
+        remove_finalized_fixture(&report_path, &events_path);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_truncated_events_refuse_admission() {
+        let (report_path, events_path, report) = finalized_fixture("truncated");
+        let mut bytes = std::fs::read(&events_path).unwrap();
+        assert_eq!(bytes.pop(), Some(b'\n'));
+        std::fs::write(&events_path, bytes).unwrap();
+        assert_eq!(
+            report.validate_for_with_events(&report_path, &expectation()),
+            Err(ExactMulticoreProbeValidationError::EventsEvidenceMismatch(
+                "events_termination"
+            ))
+        );
+        remove_finalized_fixture(&report_path, &events_path);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn planted_tampered_events_refuse_admission() {
+        let (report_path, events_path, report) = finalized_fixture("tampered");
+        let contents = std::fs::read_to_string(&events_path).unwrap();
+        let tampered = contents.replacen("\"FINAL\"", "\"FINAX\"", 1);
+        assert_ne!(tampered, contents);
+        std::fs::write(&events_path, tampered).unwrap();
+        assert_eq!(
+            report.validate_for_with_events(&report_path, &expectation()),
+            Err(ExactMulticoreProbeValidationError::EventsEvidenceMismatch(
+                "events_final"
+            ))
+        );
+        remove_finalized_fixture(&report_path, &events_path);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_host_identity_binds_model_and_topology() {
+        let host = exact_probe_host_identity();
+        assert!(host
+            .cpu_model
+            .as_ref()
+            .is_some_and(|model| !model.is_empty()));
+        assert!(host.physical_core_count.is_some_and(|cores| cores > 0));
+        assert!(host.available_parallelism > 0);
+    }
+
+    #[test]
+    fn planted_equality_negative_refuses_admission() {
+        let mut report = report();
+        report.exact_equality = false;
+        report.runs[1].equal_to_reference = false;
+        report.runs[1].output_trace_cid = "blake3:different".to_owned();
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::ExactEqualityNotEstablished)
+        );
+    }
+
+    #[test]
+    fn partial_worker_high_water_is_diagnostic_when_multicore_execution_is_established() {
+        let mut report = report();
+        report.all_workers_active = false;
+        report.runs[0].all_workers_active = false;
+        report.runs[0].snapshot.max_active_workers = report.runs[0].workers.saturating_sub(1);
+        report.runs[0].snapshot.forward_max_active_workers =
+            report.runs[0].snapshot.max_active_workers;
+        report
+            .validate_for(&expectation())
+            .expect("full worker occupancy is diagnostic once exact multicore execution is bound");
+    }
+
+    #[test]
+    fn planted_nonterminal_worker_counter_refuses_admission() {
+        let mut report = report();
+        report.runs[0].snapshot.active_workers = 1;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BatchedExecutionNotEstablished)
+        );
+    }
+
+    #[test]
+    fn planted_genuine_serial_fallback_refuses_admission() {
+        let mut report = report();
+        report.runs[0].snapshot.forward_max_active_workers = 1;
+        report.runs[0].snapshot.multiworker_forward_calls = 0;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BatchedExecutionNotEstablished)
+        );
+    }
+
+    #[test]
+    fn planted_stream_participation_negative_refuses_admission() {
+        let mut report = report();
+        report.all_streams_active = false;
+        report.runs[0].all_streams_active = false;
+        report.runs[0].snapshot.max_active_streams = 1;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::WorkerParticipationNotEstablished)
+        );
+    }
+
+    #[test]
+    fn planted_missing_candidate_refuses_admission() {
+        let mut report = report();
+        report.runs.retain(|run| run.workers != 4);
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::MissingWorkerConfiguration(4))
+        );
+    }
+
+    #[test]
+    fn planted_wrong_selection_refuses_admission() {
+        let mut report = report();
+        let slower = &report.runs[1];
+        let wrong = ExactMulticoreProbeSelection {
+            workers: slower.workers,
+            tiles_per_worker: 4,
+            aggregate_forwards_per_second: slower.aggregate_forwards_per_second,
+            raw_projected_suite_seconds: slower.raw_projected_suite_seconds,
+            safety_adjusted_projected_suite_seconds: slower.safety_adjusted_projected_suite_seconds,
+        };
+        report.selected_best_config = wrong.clone();
+        report.configured_execution = wrong;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "selected_best_config"
+            ))
+        );
+    }
+
+    #[test]
+    fn adaptive_selection_can_choose_four_workers_when_it_is_faster() {
+        let mut report = report();
+        report.runs[1] = run(4, 50.0);
+        report.runs[0].relative_throughput_vs_worker4 = 40.0 / 50.0;
+        report.runs[1].relative_throughput_vs_worker4 = 1.0;
+        let selected_run = &report.runs[1];
+        let raw_projection = selected_run.raw_projected_suite_seconds;
+        let adjusted_projection = selected_run.safety_adjusted_projected_suite_seconds;
+        let selection = ExactMulticoreProbeSelection {
+            workers: 4,
+            tiles_per_worker: 4,
+            aggregate_forwards_per_second: selected_run.aggregate_forwards_per_second,
+            raw_projected_suite_seconds: raw_projection,
+            safety_adjusted_projected_suite_seconds: adjusted_projection,
+        };
+        report.selected_best_config = selection.clone();
+        report.configured_execution = selection;
+        report.raw_projected_suite_seconds = raw_projection;
+        report.safety_adjusted_projected_suite_seconds = adjusted_projection;
+        report.validate_for(&expectation()).unwrap();
+    }
+
+    #[test]
+    fn planted_projection_negative_refuses_admission() {
+        let mut report = report();
+        let exact_boundary = 3;
+        report.binding_verdict.configured_max_wall_seconds = exact_boundary;
+        report.binding_verdict.qualification_wall_seconds = exact_boundary;
+        let mut expected = expectation();
+        expected.configured_max_wall_seconds = exact_boundary;
+        assert_eq!(
+            report.validate_for(&expected),
+            Err(ExactMulticoreProbeValidationError::ProjectionExceedsLimit)
+        );
+    }
+
+    #[test]
+    fn planted_context_horizon_tamper_refuses_admission() {
+        let mut report = report();
+        report.probe_context_ceiling_tokens = 36;
+        report.probe_position_indices.fill(35);
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "probe_context_shape"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_source_and_budget_negatives_refuse_admission() {
+        let mut wrong_source = report();
+        wrong_source.source.config_cid = "blake3:wrong".to_owned();
+        assert_eq!(
+            wrong_source.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::SourceIdentityMismatch)
+        );
+
+        let mut wrong_budget = report();
+        wrong_budget
+            .configured_suite_work
+            .generation_tokens_per_lane += 1;
+        assert_eq!(
+            wrong_budget.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "configured_suite_work"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_reduced_but_consistent_work_cannot_authorize_the_full_suite() {
+        let mut reduced = work();
+        reduced.transcript_logical_forwards -= 1;
+        reduced.logical_forwards = reduced.derived_logical_forwards();
+        reduced.transcript_physical_batches = reduced.derived_transcript_physical_batches();
+        reduced.physical_batches = reduced.derived_physical_batches();
+        assert!(!reduced.is_registered_binding_work());
+
+        let mut report = report();
+        report.configured_suite_work = reduced.clone();
+        let mut expected = expectation();
+        expected.configured_suite_work = reduced;
+        assert_eq!(
+            report.validate_for(&expected),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "optimized_suite_work"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_stale_executor_build_refuses_admission() {
+        let mut stale = report();
+        stale.executor_contract_cid = "blake3:stale-build".to_owned();
+        assert_eq!(
+            stale.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::ExecutorContractMismatch)
+        );
+    }
+
+    #[test]
+    fn planted_backend_inventory_tamper_refuses_admission() {
+        let mut stale = report();
+        stale
+            .backend
+            .available_backends
+            .push("fabricated-backend".to_owned());
+        assert_eq!(
+            stale.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BackendMismatch)
+        );
+    }
+
+    #[test]
+    fn optimized_work_omits_duplicate_prefill_and_warmup() {
+        let bounded = work();
+        assert_eq!(bounded.logical_forwards, 36 + 8 * 8);
+        assert_eq!(bounded.transcript_physical_batches, 6);
+        assert_eq!(bounded.generation_physical_batches, 8);
+        assert_eq!(bounded.physical_batches, 14);
+        assert_eq!(bounded.derived_probe_context_ceiling_tokens(), 14);
+        assert!(bounded.is_registered_binding_work());
+    }
+
+    #[test]
+    fn planted_redundant_arithmetic_tamper_refuses_admission() {
+        let mut report = report();
+        report.runs[0].relative_throughput_vs_worker4 = 4.01;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "run_arithmetic"
+            ))
+        );
+    }
+
+    #[test]
+    fn resource_unavailability_is_truthful_diagnostic_evidence() {
+        let mut report = report();
+        report.runs[0].resources = ExactMulticoreProbeResources::unavailable("planted gap");
+        report.validate_for(&expectation()).unwrap();
+    }
+
+    #[test]
+    fn planted_serial_fallback_counter_refuses_admission() {
+        let mut report = report();
+        report.runs[0].snapshot.batched_matrix_calls = 0;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BatchedExecutionNotEstablished)
+        );
+    }
+
+    #[test]
+    fn planted_truncated_trace_refuses_admission() {
+        let mut truncated_lane = report();
+        truncated_lane.runs[0].trace_shape.streams_per_position = 7;
+        assert_eq!(
+            truncated_lane.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "trace_or_plan_shape"
+            ))
+        );
+
+        let mut truncated_position = report();
+        truncated_position.runs[0].trace_shape.positions = 0;
+        assert_eq!(
+            truncated_position.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "trace_or_plan_shape"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_generation_lane_mismatch_refuses_admission() {
+        let mut report = report();
+        report.configured_suite_work.generation_lanes = 7;
+        report.configured_suite_work.logical_forwards =
+            report.configured_suite_work.derived_logical_forwards();
+        let mut expected = expectation();
+        expected.configured_suite_work = report.configured_suite_work.clone();
+        assert_eq!(
+            report.validate_for(&expected),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "optimized_suite_work"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_prestart_tamper_refuses_admission() {
+        let mut backend_tamper = report();
+        backend_tamper.runs[0].prestart.backend_exercised = false;
+        assert_eq!(
+            backend_tamper.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "run_rate"
+            ))
+        );
+
+        let mut missing_workspace = report();
+        missing_workspace.runs[0].prestart.workspace_capacity_bytes = 0;
+        assert_eq!(
+            missing_workspace.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::NumericEvidenceMismatch(
+                "run_rate"
+            ))
+        );
+
+        let mut timed_growth = report();
+        timed_growth.runs[0].snapshot.workspace_growth_events = 1;
+        timed_growth.runs[0].snapshot.workspace_growth_bytes = 4;
+        assert_eq!(
+            timed_growth.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BatchedExecutionNotEstablished)
+        );
+    }
+
+    #[test]
+    fn planted_host_below_four_workers_refuses_admission() {
+        let mut report = report();
+        report.host.available_parallelism = 3;
+        let mut expected = expectation();
+        expected.host = report.host.clone();
+        assert_eq!(
+            report.validate_for(&expected),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "minimum_adaptive_host"
+            ))
+        );
+    }
+
+    #[test]
+    fn planted_probe_wall_overrun_refuses_admission() {
+        let mut report = report();
+        report.probe_elapsed_seconds = 3_601.0;
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::ProbeWallCeilingExceeded)
+        );
+    }
+
+    #[test]
+    fn planted_deadline_policy_tamper_refuses_admission() {
+        let mut report = report();
+        report.probe_deadline_policy = "HARD_KILL_IN_FLIGHT_FORWARD".to_owned();
+        assert_eq!(
+            report.validate_for(&expectation()),
+            Err(ExactMulticoreProbeValidationError::BudgetMismatch(
+                "probe_deadline_policy"
+            ))
+        );
+    }
+}

--- a/crates/uor-r4-model-source/src/exact_probe.rs
+++ b/crates/uor-r4-model-source/src/exact_probe.rs
@@ -100,7 +100,7 @@ pub const PRODUCTION_ADMISSION_COMPONENTS: [(&str, &str); 15] = [
 #[cfg(not(target_arch = "wasm32"))]
 pub fn production_admission_component_cids(
     bundle_dir: impl AsRef<std::path::Path>,
-) -> Result<std::collections::BTreeMap<String, String>, String> {
+) -> Result<std::collections::BTreeMap<String, String>, crate::SourceUnavailable> {
     use std::io::Read;
 
     let bundle_dir = bundle_dir.as_ref();
@@ -109,37 +109,37 @@ pub fn production_admission_component_cids(
         let path = bundle_dir.join(relative);
         let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
             if error.kind() == std::io::ErrorKind::NotFound {
-                format!(
+                crate::SourceUnavailable::new(format!(
                     "UNAVAILABLE: required production component {} is absent: {error}",
                     path.display()
-                )
+                ))
             } else {
-                format!(
+                crate::SourceUnavailable::new(format!(
                     "FAILED: inspect required production component {}: {error}",
                     path.display()
-                )
+                ))
             }
         })?;
         if !metadata.file_type().is_file() {
-            return Err(format!(
+            return Err(crate::SourceUnavailable::new(format!(
                 "FAILED: required production component {} is not a regular non-symlink file",
                 path.display()
-            ));
+            )));
         }
         let mut file = std::fs::File::open(&path).map_err(|error| {
-            format!(
+            crate::SourceUnavailable::new(format!(
                 "FAILED: open required production component {}: {error}",
                 path.display()
-            )
+            ))
         })?;
         let mut hasher = blake3::Hasher::new();
         let mut buffer = [0u8; 64 * 1024];
         loop {
             let read = file.read(&mut buffer).map_err(|error| {
-                format!(
+                crate::SourceUnavailable::new(format!(
                     "FAILED: read required production component {}: {error}",
                     path.display()
-                )
+                ))
             })?;
             if read == 0 {
                 break;
@@ -438,6 +438,7 @@ pub(crate) fn validate_teacher_free_preflight(
         })?;
     let current_production =
         production_admission_component_cids(&bundle_dir).map_err(|reason| {
+            let reason = reason.reason;
             if reason.starts_with("UNAVAILABLE:") {
                 Error::Unavailable(reason)
             } else {
@@ -785,17 +786,26 @@ pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
     let available_parallelism = std::thread::available_parallelism().map_or(1, usize::from);
     #[cfg(target_os = "macos")]
     {
-        fn sysctl(name: &str) -> Result<String, String> {
+        fn sysctl(name: &str) -> Result<String, crate::SourceUnavailable> {
             let output = std::process::Command::new("/usr/sbin/sysctl")
                 .args(["-n", name])
                 .output()
-                .map_err(|error| format!("sysctl {name}: {error}"))?;
+                .map_err(|error| {
+                    crate::SourceUnavailable::new(format!("sysctl {name}: {error}"))
+                })?;
             if !output.status.success() {
-                return Err(format!("sysctl {name} exited {}", output.status));
+                return Err(crate::SourceUnavailable::new(format!(
+                    "sysctl {name} exited {}",
+                    output.status
+                )));
             }
             String::from_utf8(output.stdout)
                 .map(|value| value.trim().to_owned())
-                .map_err(|error| format!("sysctl {name} returned non-UTF-8 output: {error}"))
+                .map_err(|error| {
+                    crate::SourceUnavailable::new(format!(
+                        "sysctl {name} returned non-UTF-8 output: {error}"
+                    ))
+                })
         }
 
         fn nonempty(name: &str, unavailable: &mut Vec<String>) -> Option<String> {
@@ -806,7 +816,7 @@ pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
                     None
                 }
                 Err(reason) => {
-                    unavailable.push(reason);
+                    unavailable.push(reason.to_string());
                     None
                 }
             }
@@ -814,8 +824,9 @@ pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
 
         fn positive_usize(name: &str, unavailable: &mut Vec<String>) -> Option<usize> {
             match sysctl(name).and_then(|raw| {
-                raw.parse::<usize>()
-                    .map_err(|error| format!("{name} returned {raw:?}: {error}"))
+                raw.parse::<usize>().map_err(|error| {
+                    crate::SourceUnavailable::new(format!("{name} returned {raw:?}: {error}"))
+                })
             }) {
                 Ok(value) if value > 0 => Some(value),
                 Ok(_) => {
@@ -823,7 +834,7 @@ pub fn exact_probe_host_identity() -> ExactMulticoreProbeHost {
                     None
                 }
                 Err(reason) => {
-                    unavailable.push(reason);
+                    unavailable.push(reason.to_string());
                     None
                 }
             }
@@ -1335,7 +1346,7 @@ impl ExactMulticoreProbeReport {
             resources: &ExactMulticoreProbeResources,
             elapsed_seconds: f64,
             expected_scope: &str,
-        ) -> Result<(), Error> {
+        ) -> Result<(), ExactMulticoreProbeValidationError> {
             if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
                 return Err(Error::NumericEvidenceMismatch("resource_elapsed"));
             }
@@ -1848,21 +1859,23 @@ impl ExactMulticoreProbeReport {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn report_body_cid(&self) -> std::io::Result<String> {
+    fn report_body_cid(&self) -> Result<String, crate::SourceUnavailable> {
         let mut body = self.clone();
         body.events = ExactMulticoreProbeEventsBinding::pending(
             self.events.file_name.clone(),
             self.binding_verdict.status,
         );
-        let mut bytes = serde_json::to_vec_pretty(&body)
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        let mut bytes = serde_json::to_vec_pretty(&body)?;
         bytes.push(b'\n');
         Ok(format!("blake3:{}", blake3::hash(&bytes).to_hex()))
     }
 
     /// Atomically publish a flushed report in the destination directory.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn write_atomic(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+    pub fn write_atomic(
+        &self,
+        path: impl AsRef<std::path::Path>,
+    ) -> Result<(), crate::SourceUnavailable> {
         let path = path.as_ref();
         let bytes = self.canonical_bytes()?;
         write_atomic_bytes(path, &bytes)
@@ -1894,7 +1907,9 @@ impl ExactMulticoreProbeReport {
             events_file_name.clone(),
             self.binding_verdict.status,
         );
-        let report_body_cid = self.report_body_cid()?;
+        let report_body_cid = self
+            .report_body_cid()
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
         let prefix_bytes = std::fs::read(events_path)?;
         if !prefix_bytes.is_empty() && prefix_bytes.last() != Some(&b'\n') {
             return Err(std::io::Error::new(
@@ -1922,16 +1937,17 @@ impl ExactMulticoreProbeReport {
             self.binding_verdict.qualifies_full_run,
         )
         .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-        let bytes = self.canonical_bytes()?;
+        let bytes = self
+            .canonical_bytes()
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
         let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
-        write_atomic_bytes(report_path, &bytes)?;
+        write_atomic_bytes(report_path, &bytes).map_err(std::io::Error::other)?;
         Ok(cid)
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn canonical_bytes(&self) -> std::io::Result<Vec<u8>> {
-        let mut bytes = serde_json::to_vec_pretty(self)
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    fn canonical_bytes(&self) -> Result<Vec<u8>, crate::SourceUnavailable> {
+        let mut bytes = serde_json::to_vec_pretty(self)?;
         bytes.push(b'\n');
         Ok(bytes)
     }
@@ -2025,7 +2041,10 @@ fn finalized_events_binding(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn write_atomic_bytes(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+fn write_atomic_bytes(
+    path: &std::path::Path,
+    bytes: &[u8],
+) -> Result<(), crate::SourceUnavailable> {
     use std::io::Write;
 
     let parent = normalized_report_parent(path);

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -804,7 +804,7 @@ impl Llama {
     pub(crate) fn set_execution_config(
         &mut self,
         config: TeacherExecutionConfig,
-    ) -> Result<(), String> {
+    ) -> Result<(), SourceUnavailable> {
         self.exact_executor = ExactExecutor::new(config)?;
         Ok(())
     }
@@ -817,7 +817,7 @@ impl Llama {
     pub(crate) fn prestart_exact_execution(
         &self,
         batch_width: usize,
-    ) -> Result<TeacherExecutionPreparation, String> {
+    ) -> Result<TeacherExecutionPreparation, SourceUnavailable> {
         let started = std::time::Instant::now();
         let _forward_guard = self
             .forward_gate
@@ -1992,7 +1992,7 @@ pub fn exact_probe_expectation_shapes_from_config(
                 forward_plan,
             })
         })
-        .collect::<Result<Vec<_>, _>>()
+        .collect::<Result<Vec<_>, ExactForwardPlanError>>()
         .map_err(|error| SourceUnavailable::new(error.to_string()))?;
     let trace_shape = exact_probe_trace_shape_for_geometry(
         &cfg,
@@ -3202,9 +3202,7 @@ impl HuggingFaceLlamaOracle {
         &mut self,
         execution: TeacherExecutionConfig,
     ) -> Result<(), SourceUnavailable> {
-        self.model
-            .set_execution_config(execution)
-            .map_err(SourceUnavailable::new)
+        self.model.set_execution_config(execution)
     }
 
     /// Reset exact counters after excluded executor prestart while retaining
@@ -3222,7 +3220,7 @@ impl HuggingFaceLlamaOracle {
     pub fn prepare_exact_execution(
         &self,
         batch_width: usize,
-    ) -> Result<TeacherExecutionPreparation, String> {
+    ) -> Result<TeacherExecutionPreparation, SourceUnavailable> {
         self.model.prestart_exact_execution(batch_width)
     }
 

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -3,13 +3,15 @@
 //! rmsnorm/softmax/RoPE/SwiGLU op-for-op, libm via glibc on gnu targets.
 //! The Safetensors adapter also loads pinned Hugging Face SmolLM2 weights
 //! into this same source-only teacher surface. Llama/shared projections use the
-//! pinned portable exact `uor-matmul` owner. GPT-2 uses its declared
+//! pinned exact `uor-matmul` owner. GPT-2 uses its declared
 //! certified-native/exact-fallback dense and attention owners; canonical mode
 //! separately selects the remaining libm and ordered-reduction family.
 
 pub mod attention;
 pub mod conformance;
 pub mod dense;
+mod exact_executor;
+mod exact_probe;
 pub mod geometry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gpt2;
@@ -21,6 +23,32 @@ pub mod progress;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod teacher;
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+use exact_executor::AtomicTeacherExecutionProgress;
+use exact_executor::ExactExecutor;
+pub use exact_executor::{
+    exact_backend_report, ExactBackendReport, TeacherExecutionConfig, TeacherExecutionObserver,
+    TeacherExecutionPreparation, TeacherExecutionSnapshot, UOR_MATMUL_REVISION,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use exact_probe::production_admission_component_cids;
+pub use exact_probe::{
+    exact_executor_contract_cid, exact_probe_host_identity, ExactMulticoreProbeEventsBinding,
+    ExactMulticoreProbeExpectation, ExactMulticoreProbeExpectationShapes, ExactMulticoreProbeHost,
+    ExactMulticoreProbePrestart, ExactMulticoreProbeReport, ExactMulticoreProbeResources,
+    ExactMulticoreProbeRun, ExactMulticoreProbeSelection, ExactMulticoreProbeSource,
+    ExactMulticoreProbeStatus, ExactMulticoreProbeTraceShape, ExactMulticoreProbeValidationError,
+    ExactMulticoreProbeVerdict, ExactMulticoreProbeWork, ExactMulticoreProbeWorkerPlan,
+    EXACT_MULTICORE_PROBE_CONTEXT_ASSUMPTION, EXACT_MULTICORE_PROBE_DEADLINE_POLICY,
+    EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_LANES,
+    EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS,
+    EXACT_MULTICORE_PROBE_REGISTERED_MAX_SEQUENCE_POSITION,
+    EXACT_MULTICORE_PROBE_REGISTERED_STATE_SEQUENCE_CAPACITY,
+    EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_BATCH_WIDTHS,
+    EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_FORWARDS, EXACT_MULTICORE_PROBE_SCHEMA,
+    EXACT_MULTICORE_PROBE_SELECTION_POLICY, EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+    PRODUCTION_ADMISSION_COMPONENTS,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use gpt2::HuggingFaceGpt2Oracle;
 #[cfg(not(target_arch = "wasm32"))]
@@ -37,6 +65,234 @@ pub struct Config {
     pub rms_norm_eps: f32,
     pub rope_interleaved: bool,
     pub r4_attention: bool,
+}
+
+/// Exact executor work owned by one serial or batched teacher forward.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ExactForwardPlan {
+    /// Independent sequence states advanced together through shared weights.
+    pub batch_width: usize,
+    /// Exact matrix calls (`7 * layers + vocabulary projection`).
+    pub matrix_calls: u64,
+    /// Disjoint output-row tiles owned by the executor.
+    pub row_tiles: u64,
+    /// Scheduler tasks; one task owns each complete output-row tile.
+    pub worker_tasks: u64,
+    /// Output cells completed across every batch lane.
+    pub output_cells: u64,
+    /// Scalar product terms absorbed into complete exact accumulators.
+    pub scalar_terms: u64,
+}
+
+/// Why an exact forward counter plan cannot be represented.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExactForwardPlanError {
+    /// A forward batch must contain at least one independent sequence.
+    EmptyBatch,
+    /// A trace-state capacity must be nonzero and within model context.
+    InvalidSequenceCapacity,
+    /// Model geometry or the requested batch exceeds the counter domain.
+    ArithmeticOverflow,
+    /// This build routes teacher projections through a non-exact exception.
+    ExactBackendUnavailable,
+}
+
+impl std::fmt::Display for ExactForwardPlanError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "exact forward plan unavailable: {self:?}")
+    }
+}
+
+impl std::error::Error for ExactForwardPlanError {}
+
+fn exact_forward_plan_for_geometry(
+    cfg: &Config,
+    batch_width: usize,
+    mut row_tiles_for: impl FnMut(usize) -> usize,
+) -> Result<ExactForwardPlan, ExactForwardPlanError> {
+    use ExactForwardPlanError as Error;
+
+    if batch_width == 0 {
+        return Err(Error::EmptyBatch);
+    }
+    if exact_backend_report().arithmetic_owner != "uor-matmul exact GEMM" {
+        return Err(Error::ExactBackendUnavailable);
+    }
+    let checked_mul =
+        |left: usize, right: usize| left.checked_mul(right).ok_or(Error::ArithmeticOverflow);
+    let checked_add =
+        |left: usize, right: usize| left.checked_add(right).ok_or(Error::ArithmeticOverflow);
+    let dim = cfg.dim;
+    let hidden = cfg.hidden;
+    let layers = cfg.n_layers;
+    let kv_dim = checked_mul(dim, cfg.n_kv_heads)?
+        .checked_div(cfg.n_heads)
+        .ok_or(Error::ArithmeticOverflow)?;
+    let matrix_calls = checked_add(checked_mul(layers, 7)?, 1)?;
+    let dim_tiles = row_tiles_for(dim);
+    let kv_tiles = row_tiles_for(kv_dim);
+    let hidden_tiles = row_tiles_for(hidden);
+    let layer_tiles = checked_add(
+        checked_add(checked_mul(dim_tiles, 3)?, checked_mul(kv_tiles, 2)?)?,
+        checked_mul(hidden_tiles, 2)?,
+    )?;
+    let row_tiles = checked_add(checked_mul(layer_tiles, layers)?, row_tiles_for(cfg.vocab))?;
+    let layer_output_rows = checked_add(
+        checked_add(checked_mul(dim, 3)?, checked_mul(kv_dim, 2)?)?,
+        checked_mul(hidden, 2)?,
+    )?;
+    let output_rows = checked_add(checked_mul(layer_output_rows, layers)?, cfg.vocab)?;
+    let output_cells = checked_mul(output_rows, batch_width)?;
+    let dim_squared = checked_mul(dim, dim)?;
+    let kv_terms = checked_mul(kv_dim, dim)?;
+    let hidden_terms = checked_mul(hidden, dim)?;
+    let layer_scalar_terms = checked_add(
+        checked_add(checked_mul(dim_squared, 2)?, checked_mul(kv_terms, 2)?)?,
+        checked_mul(hidden_terms, 3)?,
+    )?;
+    let vocabulary_terms = checked_mul(cfg.vocab, dim)?;
+    let scalar_terms = checked_mul(
+        checked_add(checked_mul(layer_scalar_terms, layers)?, vocabulary_terms)?,
+        batch_width,
+    )?;
+    let as_u64 = |value| u64::try_from(value).map_err(|_| Error::ArithmeticOverflow);
+    let row_tiles = as_u64(row_tiles)?;
+    Ok(ExactForwardPlan {
+        batch_width,
+        matrix_calls: as_u64(matrix_calls)?,
+        row_tiles,
+        worker_tasks: row_tiles,
+        output_cells: as_u64(output_cells)?,
+        scalar_terms: as_u64(scalar_terms)?,
+    })
+}
+
+fn exact_probe_trace_shape_for_geometry(
+    cfg: &Config,
+    sequence_capacity: usize,
+    positions: usize,
+    batch_width: usize,
+    top_k: usize,
+) -> Result<ExactMulticoreProbeTraceShape, ExactForwardPlanError> {
+    use ExactForwardPlanError as Error;
+
+    if positions == 0 || batch_width == 0 {
+        return Err(Error::EmptyBatch);
+    }
+    if sequence_capacity == 0 || sequence_capacity > cfg.seq_len {
+        return Err(Error::InvalidSequenceCapacity);
+    }
+    let checked_mul =
+        |left: usize, right: usize| left.checked_mul(right).ok_or(Error::ArithmeticOverflow);
+    let checked_add =
+        |left: usize, right: usize| left.checked_add(right).ok_or(Error::ArithmeticOverflow);
+    let kv_dim = checked_mul(cfg.dim, cfg.n_kv_heads)?
+        .checked_div(cfg.n_heads)
+        .ok_or(Error::ArithmeticOverflow)?;
+    let cache_words = checked_mul(checked_mul(cfg.n_layers, sequence_capacity)?, kv_dim)?;
+    let persistent_state_words_per_state = checked_add(
+        checked_add(cfg.dim, checked_mul(cache_words, 2)?)?,
+        cfg.vocab,
+    )?;
+    let state_records = checked_mul(positions, batch_width)?;
+    let logit_words = checked_mul(state_records, cfg.vocab)?;
+    let persistent_state_words = checked_mul(state_records, persistent_state_words_per_state)?;
+    let top_k = top_k.min(cfg.vocab);
+    let top_tokens = checked_mul(state_records, top_k)?;
+    let as_u64 = |value| u64::try_from(value).map_err(|_| Error::ArithmeticOverflow);
+    Ok(ExactMulticoreProbeTraceShape {
+        positions,
+        streams_per_position: batch_width,
+        sequence_capacity,
+        state_records: as_u64(state_records)?,
+        logits_per_state: cfg.vocab,
+        logit_words: as_u64(logit_words)?,
+        logit_bytes: as_u64(checked_mul(logit_words, std::mem::size_of::<u32>())?)?,
+        persistent_state_words_per_state,
+        persistent_state_words: as_u64(persistent_state_words)?,
+        greedy_tokens: as_u64(state_records)?,
+        top_k,
+        top_tokens: as_u64(top_tokens)?,
+    })
+}
+
+#[derive(Default)]
+struct BatchForwardWorkspace {
+    norm: Vec<f32>,
+    q: Vec<f32>,
+    ktmp: Vec<f32>,
+    vtmp: Vec<f32>,
+    attn: Vec<f32>,
+    o: Vec<f32>,
+    hb: Vec<f32>,
+    hb2: Vec<f32>,
+    ffn: Vec<f32>,
+    xstack: Vec<f32>,
+    logits_stacked: Vec<f32>,
+}
+
+impl BatchForwardWorkspace {
+    fn grow(values: &mut Vec<f32>, length: usize, executor: &ExactExecutor) {
+        if values.len() >= length {
+            return;
+        }
+        let before = values.capacity();
+        values.resize(length, 0.0);
+        executor.record_workspace_growth_bytes(
+            values
+                .capacity()
+                .saturating_sub(before)
+                .saturating_mul(std::mem::size_of::<f32>()),
+        );
+    }
+
+    fn ensure(&mut self, cfg: &Config, batch: usize, executor: &ExactExecutor) {
+        let kv_dim = cfg.dim * cfg.n_kv_heads / cfg.n_heads;
+        let dim_words = batch
+            .checked_mul(cfg.dim)
+            .expect("batched teacher dimension workspace must fit usize");
+        let kv_words = batch
+            .checked_mul(kv_dim)
+            .expect("batched teacher KV workspace must fit usize");
+        let hidden_words = batch
+            .checked_mul(cfg.hidden)
+            .expect("batched teacher hidden workspace must fit usize");
+        let logit_words = batch
+            .checked_mul(cfg.vocab)
+            .expect("batched teacher logit workspace must fit usize");
+        Self::grow(&mut self.norm, dim_words, executor);
+        Self::grow(&mut self.q, dim_words, executor);
+        Self::grow(&mut self.ktmp, kv_words, executor);
+        Self::grow(&mut self.vtmp, kv_words, executor);
+        Self::grow(&mut self.attn, dim_words, executor);
+        Self::grow(&mut self.o, dim_words, executor);
+        Self::grow(&mut self.hb, hidden_words, executor);
+        Self::grow(&mut self.hb2, hidden_words, executor);
+        Self::grow(&mut self.ffn, dim_words, executor);
+        Self::grow(&mut self.xstack, dim_words, executor);
+        Self::grow(&mut self.logits_stacked, logit_words, executor);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn capacity_bytes(&self) -> usize {
+        [
+            &self.norm,
+            &self.q,
+            &self.ktmp,
+            &self.vtmp,
+            &self.attn,
+            &self.o,
+            &self.hb,
+            &self.hb2,
+            &self.ffn,
+            &self.xstack,
+            &self.logits_stacked,
+        ]
+        .into_iter()
+        .fold(0usize, |bytes, values| {
+            bytes.saturating_add(values.capacity().saturating_mul(std::mem::size_of::<f32>()))
+        })
+    }
 }
 
 pub struct Llama {
@@ -61,8 +317,17 @@ pub struct Llama {
     wcls: usize,
     /// Use the portable pure-Rust math path required by D2 canonical mode.
     canonical_math: bool,
+    /// Persistent bounded owner of exact output-row work.
+    exact_executor: ExactExecutor,
+    /// One physical teacher forward owns the shared exact pool at a time. The
+    /// scientific multi-stream dimension is the explicit batch, never nested
+    /// outer forward concurrency.
+    forward_gate: std::sync::Mutex<()>,
+    /// Retained shape-bounded scratch shared by successive batched forwards.
+    batch_workspace: std::sync::Mutex<Box<BatchForwardWorkspace>>,
 }
 
+#[derive(Clone)]
 pub struct State {
     pub x: Vec<f32>,
     xb: Vec<f32>,
@@ -74,11 +339,64 @@ pub struct State {
     key_cache: Vec<f32>,
     value_cache: Vec<f32>,
     pub logits: Vec<f32>,
+    sequence_capacity: usize,
 }
+
+/// Invalid bounded sequence-state capacity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TeacherStateCapacityError {
+    Zero,
+    ExceedsModel { requested: usize, maximum: usize },
+    BoundedAllocationUnavailable { requested: usize, model: usize },
+    ArithmeticOverflow,
+}
+
+impl std::fmt::Display for TeacherStateCapacityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "invalid teacher state capacity: {self:?}")
+    }
+}
+
+impl std::error::Error for TeacherStateCapacityError {}
 
 impl State {
     pub fn new(c: &Config) -> Self {
-        let kv_dim = c.dim * c.n_kv_heads / c.n_heads;
+        Self::allocate(
+            c,
+            c.seq_len,
+            c.n_layers * c.seq_len * (c.dim * c.n_kv_heads / c.n_heads),
+        )
+    }
+
+    /// Allocate sequence state only for the actual prompt/generation horizon.
+    pub fn new_bounded(
+        c: &Config,
+        sequence_capacity: usize,
+    ) -> Result<Self, TeacherStateCapacityError> {
+        use TeacherStateCapacityError as Error;
+        if sequence_capacity == 0 {
+            return Err(Error::Zero);
+        }
+        if sequence_capacity > c.seq_len {
+            return Err(Error::ExceedsModel {
+                requested: sequence_capacity,
+                maximum: c.seq_len,
+            });
+        }
+        let kv_dim = c
+            .dim
+            .checked_mul(c.n_kv_heads)
+            .and_then(|value| value.checked_div(c.n_heads))
+            .ok_or(Error::ArithmeticOverflow)?;
+        let cache_words = c
+            .n_layers
+            .checked_mul(sequence_capacity)
+            .and_then(|value| value.checked_mul(kv_dim))
+            .ok_or(Error::ArithmeticOverflow)?;
+        Ok(Self::allocate(c, sequence_capacity, cache_words))
+    }
+
+    fn allocate(c: &Config, sequence_capacity: usize, cache_words: usize) -> Self {
         State {
             x: vec![0.0; c.dim],
             xb: vec![0.0; c.dim],
@@ -86,11 +404,53 @@ impl State {
             hb: vec![0.0; c.hidden],
             hb2: vec![0.0; c.hidden],
             q: vec![0.0; c.dim],
-            att: vec![0.0; c.n_heads * c.seq_len],
-            key_cache: vec![0.0; c.n_layers * c.seq_len * kv_dim],
-            value_cache: vec![0.0; c.n_layers * c.seq_len * kv_dim],
+            att: vec![0.0; c.n_heads * sequence_capacity],
+            key_cache: vec![0.0; cache_words],
+            value_cache: vec![0.0; cache_words],
             logits: vec![0.0; c.vocab],
+            sequence_capacity,
         }
+    }
+
+    /// Maximum position count owned by this private sequence state.
+    pub fn sequence_capacity(&self) -> usize {
+        self.sequence_capacity
+    }
+
+    /// Deterministic content identity of the causal state retained across
+    /// teacher forwards.
+    ///
+    /// Overwrite-only projection scratch is deliberately excluded. The
+    /// identity binds the bounded sequence capacity plus the exact bits of the
+    /// residual stream, both KV caches, and exposed logits. It is suitable for
+    /// proving that cloned transcript templates start equal and then evolve in
+    /// private storage.
+    pub fn persistent_state_cid(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4.teacher-persistent-state/1");
+        hasher.update(
+            &u64::try_from(self.sequence_capacity)
+                .unwrap_or(u64::MAX)
+                .to_le_bytes(),
+        );
+        for (label, values) in [
+            ("x", &self.x),
+            ("key_cache", &self.key_cache),
+            ("value_cache", &self.value_cache),
+            ("logits", &self.logits),
+        ] {
+            hasher.update(&u64::try_from(label.len()).unwrap_or(u64::MAX).to_le_bytes());
+            hasher.update(label.as_bytes());
+            hasher.update(
+                &u64::try_from(values.len())
+                    .unwrap_or(u64::MAX)
+                    .to_le_bytes(),
+            );
+            for value in values {
+                hasher.update(&value.to_bits().to_le_bytes());
+            }
+        }
+        format!("blake3:{}", hasher.finalize().to_hex())
     }
 
     /// Begin a new sequence by zeroing state buffers and the KV cache.
@@ -196,12 +556,19 @@ pub(crate) fn softmax_with_mode(x: &mut [f32], canonical: bool) {
 
 /// W (d,n) @ x (n,) -> xout (d,), computed by the pinned `uor-matmul` exact
 /// GEMM (#655-B2). `gemm_float` accumulates every product into a complete
-/// accumulator and rounds once, so the result is the correctly-rounded exact
-/// dot product — byte-identical across targets (no per-machine Accelerate
-/// variance), which is what teacher-side κ reproduction needs. The former
+/// accumulator and rounds once. The enforced output-bit contract is exercised
+/// across fixed worker counts by `exact_matmul_matches_serial_bits_for_1_2_4_8_workers`
+/// and by the fixture-present exact probe. The former
 /// `fast` (Accelerate BLAS `sgemv`) / hand-rolled canonical paths are gone;
 /// `_fast` is retained in the signature only so callers need not change.
-fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, _fast: bool) {
+fn matmul(
+    _executor: &ExactExecutor,
+    xout: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    n: usize,
+    _fast: bool,
+) {
     // #804 measurement-only exception (maintainer-approved 2026-08-18):
     // under the opt-in feature, observation builds route through Apple
     // Accelerate — see `observation_blas_exception`'s module docs. Every
@@ -212,12 +579,7 @@ fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, _fast: bool) {
     }
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
     {
-        // xout[d] = W[d, n] · x[n]  ==>  C[d, 1] = A[d, n] · B[n, 1].
-        let d = xout.len();
-        let mut pa = vec![uor_matmul::PackedCode::default(); n];
-        let mut pb = vec![uor_matmul::PackedCode::default(); n];
-        uor_matmul::slice::gemm_float(d, n, 1, w, x, xout, &mut pa, &mut pb)
-            .expect("teacher matrix-vector product is total over finite f32 operands");
+        _executor.matmul(xout, x, w, n);
     }
 }
 
@@ -226,9 +588,17 @@ fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, _fast: bool) {
 /// sequence-major (`x` is `batch * n`, `xout` is `batch * rows`). Computes
 /// `C[batch, rows] = X[batch, n] · W[rows, n]ᵀ` with the pinned `uor-matmul`
 /// exact GEMM (#655-B2), replacing the former Accelerate BLAS `sgemm` /
-/// hand-rolled `dot_fast` reuse. Byte-identical across targets, so the batched
-/// teacher path reproduces the serial [`matmul`] exactly on every machine.
-fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize) {
+/// hand-rolled `dot_fast` reuse. Exact serial/batched output-bit identity is an
+/// enforced contract covered by `exact_batched_matmul_matches_serial_bits_for_1_2_4_8_workers`
+/// and the fixture-present probe; unavailable live evidence is not a pass.
+fn matmul_batched(
+    _executor: &ExactExecutor,
+    xout: &mut [f32],
+    x: &[f32],
+    w: &[f32],
+    n: usize,
+    batch: usize,
+) {
     debug_assert!(batch > 0);
     debug_assert_eq!(xout.len() % batch, 0);
     let rows = xout.len() / batch;
@@ -242,25 +612,16 @@ fn matmul_batched(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, batch: usize
     }
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
     {
-        // gemm_float is C = A·B (no transpose), so transpose W[rows, n] → Wt[n, rows]
-        // and compute X[batch, n] · Wt[n, rows] into the sequence-major `xout`.
-        let mut wt = vec![0f32; n * rows];
-        for r in 0..rows {
-            for j in 0..n {
-                wt[j * rows + r] = w[r * n + j];
-            }
-        }
-        let mut pa = vec![uor_matmul::PackedCode::default(); n];
-        let mut pb = vec![uor_matmul::PackedCode::default(); n * rows];
-        uor_matmul::slice::gemm_float(batch, n, rows, x, &wt, xout, &mut pa, &mut pb)
-            .expect("batched teacher product is total over finite f32 operands");
+        _executor.matmul_batched(xout, x, w, n, batch);
     }
 }
 
 /// The teacher's matrix-operation backend, for the "teacher model ready"
 /// diagnostic. Since #655-B2 every Llama/shared weight projection is the
-/// pinned portable `uor-matmul` exact GEMM — no per-machine SIMD/Accelerate
-/// path. GPT-2 owns its separate declared dense implementation.
+/// pinned `uor-matmul` exact GEMM. Hosted builds may select different exact
+/// kernels through runtime CPU-feature detection while retaining the pinned
+/// arithmetic/output-bit contract; wasm uses the portable fallback. GPT-2
+/// owns its separate declared dense implementation.
 fn fast_matmul_backend() -> &'static str {
     #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
     {
@@ -371,6 +732,10 @@ impl Llama {
             rms_final,
             wcls,
             canonical_math: false,
+            exact_executor: ExactExecutor::new(TeacherExecutionConfig::default())
+                .expect("the one-worker exact executor must build"),
+            forward_gate: std::sync::Mutex::new(()),
+            batch_workspace: std::sync::Mutex::new(Box::new(BatchForwardWorkspace::default())),
         };
         model.rebuild_rope_cache();
         model
@@ -422,20 +787,139 @@ impl Llama {
             rms_final,
             wcls,
             canonical_math: false,
+            exact_executor: ExactExecutor::new(TeacherExecutionConfig::default())
+                .expect("the one-worker exact executor must build"),
+            forward_gate: std::sync::Mutex::new(()),
+            batch_workspace: std::sync::Mutex::new(Box::new(BatchForwardWorkspace::default())),
         };
         model.rebuild_rope_cache();
         model
     }
 
+    /// Replace the bounded exact executor while holding exclusive model access.
+    ///
+    /// Weights and numerical configuration are unchanged. Requiring `&mut`
+    /// makes replacement mutually exclusive with every forward and resets the
+    /// execution counters for the new run.
+    pub(crate) fn set_execution_config(
+        &mut self,
+        config: TeacherExecutionConfig,
+    ) -> Result<(), String> {
+        self.exact_executor = ExactExecutor::new(config)?;
+        Ok(())
+    }
+
+    pub(crate) fn begin_measured_execution(&mut self, observer: TeacherExecutionObserver) {
+        self.exact_executor.begin_measured_execution(observer);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn prestart_exact_execution(
+        &self,
+        batch_width: usize,
+    ) -> Result<TeacherExecutionPreparation, String> {
+        let started = std::time::Instant::now();
+        let _forward_guard = self
+            .forward_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let batch_capacity_bytes = {
+            let mut workspace = self
+                .batch_workspace
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            workspace.ensure(&self.cfg, batch_width, &self.exact_executor);
+            workspace.capacity_bytes()
+        };
+        let maximum_k = self.cfg.dim.max(self.cfg.hidden);
+        let kv_dim = self.cfg.dim * self.cfg.n_kv_heads / self.cfg.n_heads;
+        let maximum_rows = self
+            .cfg
+            .dim
+            .max(self.cfg.hidden)
+            .max(kv_dim)
+            .max(self.cfg.vocab);
+        let mut evidence = self
+            .exact_executor
+            .prestart(batch_width, maximum_k, maximum_rows)?;
+        evidence.elapsed_seconds = started.elapsed().as_secs_f64();
+        evidence.workspace_capacity_bytes = evidence
+            .workspace_capacity_bytes
+            .saturating_add(u64::try_from(batch_capacity_bytes).unwrap_or(u64::MAX));
+        Ok(evidence)
+    }
+
+    /// Current bounded-execution counters.
+    pub fn execution_snapshot(&self) -> TeacherExecutionSnapshot {
+        self.exact_executor.snapshot()
+    }
+
+    /// Counter oracle for one forward at the current geometry and tiling.
+    ///
+    /// Output rows are the sole scheduler partition. Batch width therefore
+    /// scales output cells and exact scalar terms, but not matrix calls or row
+    /// tiles: all lanes share each weight tile in one exact GEMM.
+    pub fn exact_forward_plan(
+        &self,
+        batch_width: usize,
+    ) -> Result<ExactForwardPlan, ExactForwardPlanError> {
+        exact_forward_plan_for_geometry(&self.cfg, batch_width, |rows| {
+            self.exact_executor.row_tiles(rows)
+        })
+    }
+
+    /// Complete raw-output/state trace dimensions for a bounded probe.
+    pub fn exact_probe_trace_shape(
+        &self,
+        positions: usize,
+        batch_width: usize,
+        top_k: usize,
+    ) -> Result<ExactMulticoreProbeTraceShape, ExactForwardPlanError> {
+        exact_probe_trace_shape_for_geometry(
+            &self.cfg,
+            self.cfg.seq_len,
+            positions,
+            batch_width,
+            top_k,
+        )
+    }
+
+    /// Complete trace dimensions for explicitly bounded private states.
+    pub fn exact_probe_trace_shape_bounded(
+        &self,
+        sequence_capacity: usize,
+        positions: usize,
+        batch_width: usize,
+        top_k: usize,
+    ) -> Result<ExactMulticoreProbeTraceShape, ExactForwardPlanError> {
+        exact_probe_trace_shape_for_geometry(
+            &self.cfg,
+            sequence_capacity,
+            positions,
+            batch_width,
+            top_k,
+        )
+    }
+
     /// One forward step. After return, st.x holds the post-final-rmsnorm
     /// hidden state (the kNN-LM context vector) and st.logits the logits.
     pub fn forward(&self, st: &mut State, token: usize, pos: usize, fast_matmul: bool) {
+        let _forward_guard = self
+            .forward_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            pos < st.sequence_capacity,
+            "teacher state capacity exceeded"
+        );
+        self.exact_executor.begin_forward(1);
         let dim = self.cfg.dim;
         st.x.copy_from_slice(&self.w[self.emb + token * dim..self.emb + (token + 1) * dim]);
         for l in 0..self.cfg.n_layers {
             self.layer_forward(st, l, pos, fast_matmul);
         }
         self.finish_forward(st, fast_matmul);
+        self.exact_executor.complete_forward(1);
     }
 
     /// One forward step with the residual stream captured after each layer in
@@ -455,6 +939,15 @@ impl Llama {
         capture_layers: &[usize],
         sink: &mut dyn FnMut(usize, &[f32]),
     ) {
+        let _forward_guard = self
+            .forward_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            pos < st.sequence_capacity,
+            "teacher state capacity exceeded"
+        );
+        self.exact_executor.begin_forward(1);
         let dim = self.cfg.dim;
         st.x.copy_from_slice(&self.w[self.emb + token * dim..self.emb + (token + 1) * dim]);
         for l in 0..self.cfg.n_layers {
@@ -464,6 +957,7 @@ impl Llama {
             }
         }
         self.finish_forward(st, fast_matmul);
+        self.exact_executor.complete_forward(1);
     }
 
     /// One forward step with the #603 teacher-trace lanes captured at
@@ -496,6 +990,15 @@ impl Llama {
         request: &TraceCaptureRequest<'_>,
         sinks: &mut TraceCaptureSinks<'_, '_>,
     ) {
+        let _forward_guard = self
+            .forward_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            pos < st.sequence_capacity,
+            "teacher state capacity exceeded"
+        );
+        self.exact_executor.begin_forward(1);
         let dim = self.cfg.dim;
         let kv_dim = self.cfg.dim * self.cfg.n_kv_heads / self.cfg.n_heads;
         st.x.copy_from_slice(&self.w[self.emb + token * dim..self.emb + (token + 1) * dim]);
@@ -506,12 +1009,12 @@ impl Llama {
                     (sinks.attention)(
                         l,
                         h,
-                        &st.att[h * self.cfg.seq_len..h * self.cfg.seq_len + pos + 1],
+                        &st.att[h * st.sequence_capacity..h * st.sequence_capacity + pos + 1],
                     );
                 }
             }
             if request.qkv_layers.contains(&l) {
-                let loff = l * self.cfg.seq_len * kv_dim;
+                let loff = l * st.sequence_capacity * kv_dim;
                 let k = &st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
                 let v = &st.value_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
                 (sinks.qkv)(l, &st.q, k, v);
@@ -521,6 +1024,7 @@ impl Llama {
             }
         }
         self.finish_forward(st, fast_matmul);
+        self.exact_executor.complete_forward(1);
     }
 
     /// One transformer layer of the exact forward step, factored out of
@@ -543,8 +1047,9 @@ impl Llama {
                 self.canonical_math,
             );
 
-            let loff = l * c.seq_len * kv_dim;
+            let loff = l * st.sequence_capacity * kv_dim;
             matmul(
+                &self.exact_executor,
                 &mut st.q,
                 &st.xb,
                 &w[self.wq + l * dim * dim..],
@@ -554,6 +1059,7 @@ impl Llama {
             {
                 let k = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
                 matmul(
+                    &self.exact_executor,
                     k,
                     &st.xb,
                     &w[self.wk + l * dim * kv_dim..],
@@ -564,6 +1070,7 @@ impl Llama {
             {
                 let v = &mut st.value_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
                 matmul(
+                    &self.exact_executor,
                     v,
                     &st.xb,
                     &w[self.wv + l * dim * kv_dim..],
@@ -620,7 +1127,7 @@ impl Llama {
             // uses the historical floor-multiple-of-four domain).
             for h in 0..c.n_heads {
                 let q = &st.q[h * head_size..(h + 1) * head_size];
-                let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                let att = &mut st.att[h * st.sequence_capacity..h * st.sequence_capacity + pos + 1];
                 let kv_head_offset = (h / kv_mul) * head_size;
 
                 if c.r4_attention {
@@ -643,7 +1150,7 @@ impl Llama {
                     );
                 }
 
-                let att = &st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                let att = &st.att[h * st.sequence_capacity..h * st.sequence_capacity + pos + 1];
                 let xb = &mut st.xb[h * head_size..(h + 1) * head_size];
                 attention::head_attention_value_aggregate(
                     xb,
@@ -655,6 +1162,7 @@ impl Llama {
             }
 
             matmul(
+                &self.exact_executor,
                 &mut st.xb2,
                 &st.xb,
                 &w[self.wo + l * dim * dim..],
@@ -672,6 +1180,7 @@ impl Llama {
                 self.canonical_math,
             );
             matmul(
+                &self.exact_executor,
                 &mut st.hb,
                 &st.xb,
                 &w[self.w1 + l * dim * hid..],
@@ -679,6 +1188,7 @@ impl Llama {
                 fast_matmul,
             );
             matmul(
+                &self.exact_executor,
                 &mut st.hb2,
                 &st.xb,
                 &w[self.w3 + l * dim * hid..],
@@ -692,6 +1202,7 @@ impl Llama {
                 st.hb[i] = val;
             }
             matmul(
+                &self.exact_executor,
                 &mut st.xb,
                 &st.hb,
                 &w[self.w2 + l * hid * dim..],
@@ -715,7 +1226,14 @@ impl Llama {
             let (wslice, x) = (&w[rf..rf + dim], &mut st.x);
             rmsnorm_inplace_with_mode(x, wslice, self.canonical_math);
         }
-        matmul(&mut st.logits, &st.x, &w[self.wcls..], dim, fast_matmul);
+        matmul(
+            &self.exact_executor,
+            &mut st.logits,
+            &st.x,
+            &w[self.wcls..],
+            dim,
+            fast_matmul,
+        );
     }
 
     /// Batched forward: advance `states.len()` independent sequences by one
@@ -726,9 +1244,10 @@ impl Llama {
     /// amortization that lifts the teacher off the per-token memory-bandwidth
     /// wall. Every per-sequence op (rmsnorm, RoPE, attention, SwiGLU, residual)
     /// mirrors [`Llama::forward`] exactly. `matmul_batched` and the serial path
-    /// share the pinned exact `uor-matmul` owner, so their projection bits agree
-    /// on every target. `fast_matmul` is a compatibility parameter and does not
-    /// select another arithmetic owner.
+    /// share the pinned exact `uor-matmul` owner; exact bit agreement is an
+    /// enforced contract checked by focused per-target tests and the live
+    /// probe, not a universal cross-target claim. `fast_matmul` is a
+    /// compatibility parameter and does not select another arithmetic owner.
     pub fn forward_batch(
         &self,
         states: &mut [State],
@@ -736,6 +1255,24 @@ impl Llama {
         positions: &[usize],
         fast_matmul: bool,
     ) {
+        assert!(
+            !states.is_empty(),
+            "batched teacher forward requires at least one state"
+        );
+        assert_eq!(
+            tokens.len(),
+            states.len(),
+            "batched teacher token/state lengths must match"
+        );
+        assert_eq!(
+            positions.len(),
+            states.len(),
+            "batched teacher position/state lengths must match"
+        );
+        let _forward_guard = self
+            .forward_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _ = fast_matmul;
         let c = &self.cfg;
         let (dim, hid) = (c.dim, c.hidden);
@@ -744,20 +1281,56 @@ impl Llama {
         let head_size = dim / c.n_heads;
         let w = &self.w;
         let b = states.len();
-        debug_assert_eq!(tokens.len(), b);
-        debug_assert_eq!(positions.len(), b);
+        assert!(
+            states
+                .iter()
+                .zip(positions)
+                .all(|(state, &position)| position < state.sequence_capacity),
+            "teacher state capacity exceeded"
+        );
+        self.exact_executor.prepare_workspace(
+            dim.max(hid),
+            dim.max(hid).max(kv_dim).max(c.vocab),
+            b,
+        );
+        self.exact_executor.begin_forward(b);
 
-        // Sequence-major stacked scratch for the batched matmuls.
-        let mut norm = vec![0f32; b * dim];
-        let mut q = vec![0f32; b * dim];
-        let mut ktmp = vec![0f32; b * kv_dim];
-        let mut vtmp = vec![0f32; b * kv_dim];
-        let mut attn = vec![0f32; b * dim];
-        let mut o = vec![0f32; b * dim];
-        let mut hb = vec![0f32; b * hid];
-        let mut hb2 = vec![0f32; b * hid];
-        let mut ffn = vec![0f32; b * dim];
-        let mut xstack = vec![0f32; b * dim];
+        // Shape-bounded sequence-major buffers persist across physical
+        // forwards. Preparation grows them once; steady-state forwards reuse
+        // the same capacities without changing any arithmetic or lane order.
+        let mut workspace = self
+            .batch_workspace
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        workspace.ensure(c, b, &self.exact_executor);
+        let BatchForwardWorkspace {
+            norm,
+            q,
+            ktmp,
+            vtmp,
+            attn,
+            o,
+            hb,
+            hb2,
+            ffn,
+            xstack,
+            logits_stacked,
+        } = &mut **workspace;
+        let dim_words = b * dim;
+        let kv_words = b * kv_dim;
+        let hidden_words = b * hid;
+        let logit_words = b * c.vocab;
+        let norm = &mut norm[..dim_words];
+        let q = &mut q[..dim_words];
+        let ktmp = &mut ktmp[..kv_words];
+        let vtmp = &mut vtmp[..kv_words];
+        let attn = &mut attn[..dim_words];
+        let o = &mut o[..dim_words];
+        let hb = &mut hb[..hidden_words];
+        let hb2 = &mut hb2[..hidden_words];
+        let ffn = &mut ffn[..dim_words];
+        let xstack = &mut xstack[..dim_words];
+        let logits_stacked = &mut logits_stacked[..logit_words];
 
         for bi in 0..b {
             let token = tokens[bi];
@@ -767,7 +1340,6 @@ impl Llama {
         }
 
         for l in 0..c.n_layers {
-            let loff = l * c.seq_len * kv_dim;
             for bi in 0..b {
                 rmsnorm_with_mode(
                     &mut norm[bi * dim..(bi + 1) * dim],
@@ -776,10 +1348,32 @@ impl Llama {
                     self.canonical_math,
                 );
             }
-            matmul_batched(&mut q, &norm, &w[self.wq + l * dim * dim..], dim, b);
-            matmul_batched(&mut ktmp, &norm, &w[self.wk + l * dim * kv_dim..], dim, b);
-            matmul_batched(&mut vtmp, &norm, &w[self.wv + l * dim * kv_dim..], dim, b);
+            matmul_batched(
+                &self.exact_executor,
+                q,
+                norm,
+                &w[self.wq + l * dim * dim..],
+                dim,
+                b,
+            );
+            matmul_batched(
+                &self.exact_executor,
+                ktmp,
+                norm,
+                &w[self.wk + l * dim * kv_dim..],
+                dim,
+                b,
+            );
+            matmul_batched(
+                &self.exact_executor,
+                vtmp,
+                norm,
+                &w[self.wv + l * dim * kv_dim..],
+                dim,
+                b,
+            );
             for bi in 0..b {
+                let loff = l * states[bi].sequence_capacity * kv_dim;
                 let dst = loff + positions[bi] * kv_dim;
                 states[bi].key_cache[dst..dst + kv_dim]
                     .copy_from_slice(&ktmp[bi * kv_dim..(bi + 1) * kv_dim]);
@@ -792,6 +1386,7 @@ impl Llama {
                 let qb = &mut q[bi * dim..(bi + 1) * dim];
                 let out = &mut attn[bi * dim..(bi + 1) * dim];
                 let st = &mut states[bi];
+                let loff = l * st.sequence_capacity * kv_dim;
 
                 if c.rope_interleaved {
                     let k = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
@@ -834,7 +1429,8 @@ impl Llama {
                 // switch selects between the two registered operators.
                 for h in 0..c.n_heads {
                     let qh = &qb[h * head_size..(h + 1) * head_size];
-                    let att = &mut st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                    let att =
+                        &mut st.att[h * st.sequence_capacity..h * st.sequence_capacity + pos + 1];
                     let kv_head_offset = (h / kv_mul) * head_size;
                     if c.r4_attention {
                         attention::experimental_r4_head_attention_weights(
@@ -855,7 +1451,7 @@ impl Llama {
                             self.canonical_math,
                         );
                     }
-                    let att = &st.att[h * c.seq_len..h * c.seq_len + pos + 1];
+                    let att = &st.att[h * st.sequence_capacity..h * st.sequence_capacity + pos + 1];
                     let outh = &mut out[h * head_size..(h + 1) * head_size];
                     attention::head_attention_value_aggregate(
                         outh,
@@ -867,7 +1463,14 @@ impl Llama {
                 }
             }
 
-            matmul_batched(&mut o, &attn, &w[self.wo + l * dim * dim..], dim, b);
+            matmul_batched(
+                &self.exact_executor,
+                o,
+                attn,
+                &w[self.wo + l * dim * dim..],
+                dim,
+                b,
+            );
             for bi in 0..b {
                 for i in 0..dim {
                     states[bi].x[i] += o[bi * dim + i];
@@ -882,15 +1485,36 @@ impl Llama {
                     self.canonical_math,
                 );
             }
-            matmul_batched(&mut hb, &norm, &w[self.w1 + l * dim * hid..], dim, b);
-            matmul_batched(&mut hb2, &norm, &w[self.w3 + l * dim * hid..], dim, b);
+            matmul_batched(
+                &self.exact_executor,
+                hb,
+                norm,
+                &w[self.w1 + l * dim * hid..],
+                dim,
+                b,
+            );
+            matmul_batched(
+                &self.exact_executor,
+                hb2,
+                norm,
+                &w[self.w3 + l * dim * hid..],
+                dim,
+                b,
+            );
             for idx in 0..b * hid {
                 let mut val = hb[idx];
                 val *= 1.0f32 / (1.0f32 + expf(-val, self.canonical_math));
                 val *= hb2[idx];
                 hb[idx] = val;
             }
-            matmul_batched(&mut ffn, &hb, &w[self.w2 + l * hid * dim..], hid, b);
+            matmul_batched(
+                &self.exact_executor,
+                ffn,
+                hb,
+                &w[self.w2 + l * hid * dim..],
+                hid,
+                b,
+            );
             for bi in 0..b {
                 for i in 0..dim {
                     states[bi].x[i] += ffn[bi * dim + i];
@@ -904,13 +1528,20 @@ impl Llama {
             rmsnorm_inplace_with_mode(x, wslice, self.canonical_math);
             xstack[bi * dim..(bi + 1) * dim].copy_from_slice(x);
         }
-        let mut logits_stacked = vec![0f32; b * c.vocab];
-        matmul_batched(&mut logits_stacked, &xstack, &w[self.wcls..], dim, b);
+        matmul_batched(
+            &self.exact_executor,
+            logits_stacked,
+            xstack,
+            &w[self.wcls..],
+            dim,
+            b,
+        );
         for bi in 0..b {
             states[bi]
                 .logits
                 .copy_from_slice(&logits_stacked[bi * c.vocab..(bi + 1) * c.vocab]);
         }
+        self.exact_executor.complete_forward(b);
     }
 }
 
@@ -1295,6 +1926,86 @@ fn default_bos_token() -> usize {
 }
 fn default_eos_token() -> usize {
     2
+}
+
+/// Compute fail-closed probe admission geometry from `config.json` only.
+///
+/// This function never opens a Safetensors shard or allocates model weights,
+/// so a caller can validate durable probe evidence before authorizing the
+/// multi-gigabyte teacher load. The same owner functions used by a live
+/// [`Llama`] compute every counter and trace dimension.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn exact_probe_expectation_shapes_from_config(
+    source: impl AsRef<std::path::Path>,
+    sequence_length: usize,
+    worker_counts: &[usize],
+    tiles_per_worker: usize,
+    streams: usize,
+    probe_positions: usize,
+    top_k: usize,
+) -> Result<ExactMulticoreProbeExpectationShapes, SourceUnavailable> {
+    if sequence_length == 0
+        || streams == 0
+        || probe_positions == 0
+        || tiles_per_worker == 0
+        || worker_counts.is_empty()
+        || worker_counts.contains(&0)
+    {
+        return Err(SourceUnavailable::new(
+            "exact probe config-only planner requires nonzero geometry and worker bounds",
+        ));
+    }
+    let mut unique_workers = std::collections::BTreeSet::new();
+    if !worker_counts
+        .iter()
+        .all(|workers| unique_workers.insert(*workers))
+    {
+        return Err(SourceUnavailable::new(
+            "exact probe config-only planner worker counts must be unique",
+        ));
+    }
+    let config_bytes = std::fs::read(source.as_ref().join("config.json"))?;
+    let raw_config: serde_json::Value = serde_json::from_slice(&config_bytes)?;
+    conformance::AdapterFeatures::huggingface_llama().validate_config(&raw_config)?;
+    let config: HuggingFaceConfig = serde_json::from_slice(&config_bytes)?;
+    let cfg = Config {
+        dim: config.hidden_size,
+        hidden: config.intermediate_size,
+        n_layers: config.num_hidden_layers,
+        n_heads: config.num_attention_heads,
+        n_kv_heads: config.num_key_value_heads,
+        vocab: config.vocab_size,
+        seq_len: sequence_length.min(config.max_position_embeddings),
+        rope_theta: config.rope_theta,
+        rms_norm_eps: config.rms_norm_eps,
+        rope_interleaved: config.rope_interleaved,
+        r4_attention: false,
+    };
+    let forward_plans = worker_counts
+        .iter()
+        .map(|&workers| {
+            exact_forward_plan_for_geometry(&cfg, streams, |rows| {
+                exact_executor::exact_row_tiles_for(rows, workers, tiles_per_worker)
+            })
+            .map(|forward_plan| ExactMulticoreProbeWorkerPlan {
+                workers,
+                forward_plan,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| SourceUnavailable::new(error.to_string()))?;
+    let trace_shape = exact_probe_trace_shape_for_geometry(
+        &cfg,
+        sequence_length,
+        probe_positions,
+        streams,
+        top_k,
+    )
+    .map_err(|error| SourceUnavailable::new(error.to_string()))?;
+    Ok(ExactMulticoreProbeExpectationShapes {
+        forward_plans,
+        trace_shape,
+    })
 }
 
 /// Offline teacher adapter for Hugging Face Llama-family Safetensors
@@ -2320,6 +3031,30 @@ pub trait BatchedTeacher {
     type State;
     /// A fresh per-sequence state for this teacher.
     fn new_state(&self) -> Self::State;
+    /// A state bounded to an actual prompt/generation position count.
+    /// Implementations that cannot allocate a smaller private state refuse
+    /// rather than silently allocating their model maximum.
+    fn new_state_bounded(
+        &self,
+        sequence_capacity: usize,
+    ) -> Result<Self::State, TeacherStateCapacityError> {
+        if sequence_capacity == 0 {
+            return Err(TeacherStateCapacityError::Zero);
+        }
+        if sequence_capacity > self.seq_len() {
+            return Err(TeacherStateCapacityError::ExceedsModel {
+                requested: sequence_capacity,
+                maximum: self.seq_len(),
+            });
+        }
+        if sequence_capacity != self.seq_len() {
+            return Err(TeacherStateCapacityError::BoundedAllocationUnavailable {
+                requested: sequence_capacity,
+                model: self.seq_len(),
+            });
+        }
+        Ok(self.new_state())
+    }
     /// Reset a state to begin a new sequence (zero its caches/buffers).
     fn reset_state(&self, state: &mut Self::State);
     /// Mutable view of the logits the last
@@ -2359,6 +3094,12 @@ impl BatchedTeacher for HuggingFaceLlamaOracle {
     fn new_state(&self) -> State {
         State::new(&self.model.cfg)
     }
+    fn new_state_bounded(
+        &self,
+        sequence_capacity: usize,
+    ) -> Result<State, TeacherStateCapacityError> {
+        State::new_bounded(&self.model.cfg, sequence_capacity)
+    }
     fn reset_state(&self, state: &mut State) {
         state.reset();
     }
@@ -2389,12 +3130,30 @@ impl BatchedTeacher for HuggingFaceLlamaOracle {
 impl HuggingFaceLlamaOracle {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(source: impl AsRef<std::path::Path>) -> Result<Self, SourceUnavailable> {
-        Self::load_inner(source, None)
+        Self::load_inner(source, None, TeacherExecutionConfig::default())
+    }
+
+    /// Load a teacher with an explicit bounded exact-execution policy.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn load_with_execution(
+        source: impl AsRef<std::path::Path>,
+        execution: TeacherExecutionConfig,
+    ) -> Result<Self, SourceUnavailable> {
+        Self::load_inner(source, None, execution)
     }
 
     /// This teacher's configuration (dims, heads, vocab, sequence length).
     pub fn cfg(&self) -> &Config {
         &self.model.cfg
+    }
+
+    /// Allocate one private sequence state at the actual prompt/generation
+    /// horizon rather than the model's maximum context.
+    pub fn new_state_bounded(
+        &self,
+        sequence_capacity: usize,
+    ) -> Result<State, TeacherStateCapacityError> {
+        State::new_bounded(&self.model.cfg, sequence_capacity)
     }
 
     /// Load an offline teacher with a bounded context allocation. Compilation
@@ -2411,7 +3170,102 @@ impl HuggingFaceLlamaOracle {
                 "teacher sequence length must be greater than zero",
             ));
         }
-        Self::load_inner(source, Some(sequence_length))
+        Self::load_inner(
+            source,
+            Some(sequence_length),
+            TeacherExecutionConfig::default(),
+        )
+    }
+
+    /// Load a teacher with both bounded context storage and an explicit
+    /// bounded exact-execution policy.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn load_with_sequence_length_and_execution(
+        source: impl AsRef<std::path::Path>,
+        sequence_length: usize,
+        execution: TeacherExecutionConfig,
+    ) -> Result<Self, SourceUnavailable> {
+        if sequence_length == 0 {
+            return Err(SourceUnavailable::new(
+                "teacher sequence length must be greater than zero",
+            ));
+        }
+        Self::load_inner(source, Some(sequence_length), execution)
+    }
+
+    /// Replace only the exact execution policy, retaining the loaded weights.
+    ///
+    /// Exclusive access prevents a pool replacement from racing a forward or
+    /// [`HuggingFaceLlamaOracle::set_r4_attention`] configuration mutation.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn set_execution_config(
+        &mut self,
+        execution: TeacherExecutionConfig,
+    ) -> Result<(), SourceUnavailable> {
+        self.model
+            .set_execution_config(execution)
+            .map_err(SourceUnavailable::new)
+    }
+
+    /// Reset exact counters after excluded executor prestart while retaining
+    /// the same dedicated worker pool, then install the measured-run observer.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn begin_measured_execution(&mut self, observer: TeacherExecutionObserver) {
+        self.model.begin_measured_execution(observer);
+    }
+
+    /// Prepare all shape-bounded model/executor workspaces, wake the dedicated
+    /// pool, and exercise a tiny exact GEMM without a model forward. Call
+    /// [`Self::begin_measured_execution`] afterwards to exclude preparation
+    /// growth and wall time from measured teacher work.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn prepare_exact_execution(
+        &self,
+        batch_width: usize,
+    ) -> Result<TeacherExecutionPreparation, String> {
+        self.model.prestart_exact_execution(batch_width)
+    }
+
+    /// Current exact-execution progress and bounded-concurrency evidence.
+    pub fn execution_snapshot(&self) -> TeacherExecutionSnapshot {
+        self.model.execution_snapshot()
+    }
+
+    /// Exact counter plan for one forward at `batch_width` under the current
+    /// model geometry and executor tiling.
+    pub fn exact_forward_plan(
+        &self,
+        batch_width: usize,
+    ) -> Result<ExactForwardPlan, ExactForwardPlanError> {
+        self.model.exact_forward_plan(batch_width)
+    }
+
+    /// Complete raw-output/state trace dimensions for a bounded probe.
+    pub fn exact_probe_trace_shape(
+        &self,
+        positions: usize,
+        batch_width: usize,
+        top_k: usize,
+    ) -> Result<ExactMulticoreProbeTraceShape, ExactForwardPlanError> {
+        self.model
+            .exact_probe_trace_shape(positions, batch_width, top_k)
+    }
+
+    /// Complete trace dimensions for explicitly bounded private states.
+    pub fn exact_probe_trace_shape_bounded(
+        &self,
+        sequence_capacity: usize,
+        positions: usize,
+        batch_width: usize,
+        top_k: usize,
+    ) -> Result<ExactMulticoreProbeTraceShape, ExactForwardPlanError> {
+        self.model
+            .exact_probe_trace_shape_bounded(sequence_capacity, positions, batch_width, top_k)
+    }
+
+    /// Exact arithmetic owner and observable hosted-kernel availability.
+    pub fn exact_backend_report(&self) -> ExactBackendReport {
+        exact_backend_report()
     }
 
     /// Enable or disable the experimental attention variant
@@ -2473,6 +3327,7 @@ impl HuggingFaceLlamaOracle {
     fn load_inner(
         source: impl AsRef<std::path::Path>,
         sequence_length: Option<usize>,
+        execution: TeacherExecutionConfig,
     ) -> Result<Self, SourceUnavailable> {
         let source = source.as_ref();
         let config_bytes = std::fs::read(source.join("config.json"))?;
@@ -2573,6 +3428,9 @@ impl HuggingFaceLlamaOracle {
         let canonical_math =
             std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0");
         let mut model = Llama::from_flat(cfg, weights, config.tie_word_embeddings);
+        model
+            .set_execution_config(execution)
+            .map_err(SourceUnavailable::new)?;
         model.canonical_math = canonical_math;
         // `from_flat` builds the fast native-math cache first; rebuild it if
         // D2 canonical math was requested so the cache uses the same libm
@@ -2587,7 +3445,10 @@ impl HuggingFaceLlamaOracle {
         } else {
             fast_matmul_backend()
         };
-        eprintln!("teacher model ready (κ {kappa}, matmul={backend})");
+        eprintln!(
+            "teacher model ready (κ {kappa}, matmul={backend}, exact_workers={})",
+            model.execution_snapshot().effective_workers
+        );
         Ok(Self {
             model,
             state,
@@ -2841,10 +3702,12 @@ mod tests {
         let weights: Vec<f32> = (0..ROWS * COLUMNS)
             .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
             .collect();
+        let executor = ExactExecutor::new(TeacherExecutionConfig::sequential())
+            .expect("serial exact executor");
         let mut exact = [0.0f32; ROWS];
         let mut fast = [0.0f32; ROWS];
-        matmul(&mut exact, &input, &weights, COLUMNS, false);
-        matmul(&mut fast, &input, &weights, COLUMNS, true);
+        matmul(&executor, &mut exact, &input, &weights, COLUMNS, false);
+        matmul(&executor, &mut fast, &input, &weights, COLUMNS, true);
         assert_eq!(
             exact.map(f32::to_bits),
             fast.map(f32::to_bits),
@@ -2863,11 +3726,20 @@ mod tests {
         let x: Vec<f32> = (0..BATCH * N)
             .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
             .collect();
+        let executor = ExactExecutor::new(TeacherExecutionConfig::sequential())
+            .expect("serial exact executor");
         let mut batched = vec![0.0f32; BATCH * ROWS];
-        matmul_batched(&mut batched, &x, &weights, N, BATCH);
+        matmul_batched(&executor, &mut batched, &x, &weights, N, BATCH);
         for bi in 0..BATCH {
             let mut serial = [0.0f32; ROWS];
-            matmul(&mut serial, &x[bi * N..(bi + 1) * N], &weights, N, true);
+            matmul(
+                &executor,
+                &mut serial,
+                &x[bi * N..(bi + 1) * N],
+                &weights,
+                N,
+                true,
+            );
             for row in 0..ROWS {
                 let want = serial[row];
                 let got = batched[bi * ROWS + row];
@@ -2880,6 +3752,682 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn teacher_execution_is_sequential_unless_parallelism_is_explicit() {
+        let sequential = ExactExecutor::new(TeacherExecutionConfig::default())
+            .expect("the one-worker exact executor must build");
+        assert_eq!(sequential.snapshot().requested_workers, 1);
+        assert_eq!(sequential.snapshot().effective_workers, 1);
+
+        let discovered = ExactExecutor::new(TeacherExecutionConfig::available_parallelism())
+            .expect("the explicitly requested host-sized executor must build");
+        assert_eq!(
+            discovered.snapshot().effective_workers,
+            std::thread::available_parallelism().map_or(1, usize::from)
+        );
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(all(feature = "observation-blas-exception", target_os = "macos"))
+    ))]
+    #[test]
+    fn hosted_uor_matmul_uses_runtime_feature_detection() {
+        let report = exact_backend_report();
+        assert_eq!(report.arithmetic_owner, "uor-matmul exact GEMM");
+        assert!(report.std_runtime_detection_enabled);
+        assert_eq!(report.target_arch, std::env::consts::ARCH);
+        assert_eq!(report.target_os, std::env::consts::OS);
+        assert!(report
+            .available_backends
+            .iter()
+            .any(|backend| backend == "portable"));
+        assert_eq!(report.uor_matmul_revision, UOR_MATMUL_REVISION);
+        assert_eq!(report.selected_backend, None);
+        assert!(report.selection_status.starts_with("UNAVAILABLE:"));
+
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            uor_matmul::kernels::isa::arm::dotprod_available(),
+            std::arch::is_aarch64_feature_detected!("dotprod")
+        );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        assert_eq!(
+            uor_matmul::kernels::isa::x86::avx2_available(),
+            std::arch::is_x86_feature_detected!("avx2")
+        );
+    }
+
+    #[cfg(all(target_os = "macos", feature = "observation-blas-exception"))]
+    #[test]
+    fn observation_blas_exception_reports_non_exact_owner() {
+        let report = exact_backend_report();
+        assert_eq!(
+            report.arithmetic_owner,
+            "Apple Accelerate observation BLAS exception"
+        );
+        assert_eq!(report.selected_backend.as_deref(), Some("Apple Accelerate"));
+        assert!(report.selection_status.starts_with("AVAILABLE:"));
+        assert_eq!(report.target_os, std::env::consts::OS);
+        assert_eq!(report.uor_matmul_revision, UOR_MATMUL_REVISION);
+    }
+
+    #[test]
+    fn declared_uor_matmul_revision_matches_both_target_dependencies() {
+        let manifest = include_str!("../Cargo.toml");
+        let pin = format!("rev = \"{UOR_MATMUL_REVISION}\"");
+        assert_eq!(
+            manifest.matches(&pin).count(),
+            2,
+            "hosted and wasm exact arithmetic dependencies must share the declared revision"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn exact_matmul_matches_serial_bits_for_1_2_4_8_workers() {
+        use std::num::NonZeroUsize;
+
+        const ROWS: usize = 67;
+        const COLUMNS: usize = 73;
+        let input: Vec<f32> = (0..COLUMNS)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect();
+        let weights: Vec<f32> = (0..ROWS * COLUMNS)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect();
+        let serial = ExactExecutor::new(TeacherExecutionConfig::sequential())
+            .expect("serial exact executor");
+        let mut expected = [0.0f32; ROWS];
+        serial.matmul(&mut expected, &input, &weights, COLUMNS);
+
+        for workers in [1usize, 2, 4, 8] {
+            let executor = ExactExecutor::new(TeacherExecutionConfig::fixed_workers(
+                NonZeroUsize::new(workers).expect("worker count is nonzero"),
+            ))
+            .expect("fixed exact executor");
+            let mut actual = [0.0f32; ROWS];
+            executor.matmul(&mut actual, &input, &weights, COLUMNS);
+            assert_eq!(
+                actual.map(f32::to_bits),
+                expected.map(f32::to_bits),
+                "worker count {workers} changed exact matmul bits"
+            );
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn exact_batched_matmul_matches_serial_bits_for_1_2_4_8_workers() {
+        use std::num::NonZeroUsize;
+
+        const N: usize = 73;
+        const ROWS: usize = 67;
+        const BATCH: usize = 5;
+        let weights: Vec<f32> = (0..ROWS * N)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect();
+        let x: Vec<f32> = (0..BATCH * N)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect();
+        let serial = ExactExecutor::new(TeacherExecutionConfig::sequential())
+            .expect("serial exact executor");
+        let mut expected = vec![0.0f32; BATCH * ROWS];
+        serial.matmul_batched(&mut expected, &x, &weights, N, BATCH);
+
+        for workers in [1usize, 2, 4, 8] {
+            let executor = ExactExecutor::new(TeacherExecutionConfig::fixed_workers(
+                NonZeroUsize::new(workers).expect("worker count is nonzero"),
+            ))
+            .expect("fixed exact executor");
+            let mut actual = vec![0.0f32; BATCH * ROWS];
+            executor.matmul_batched(&mut actual, &x, &weights, N, BATCH);
+            assert_eq!(
+                actual
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                expected
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                "worker count {workers} changed exact batched-matmul bits"
+            );
+            if workers == 8 {
+                let snapshot = executor.snapshot();
+                assert!(
+                    snapshot.max_active_workers >= 2,
+                    "shared-weight batched GEMM did not overlap output-row tiles"
+                );
+                assert!(snapshot.max_active_workers <= snapshot.effective_workers);
+                assert!(snapshot.tiles_completed > 1);
+            }
+        }
+    }
+
+    /// Bounded synthetic decision instrument for the caller-owned Atlas
+    /// A-panel offer. The shapes are the row tiles one W=8 SmolLM2-135M
+    /// forward presents to `uor-matmul` at batch width eight. The weighted
+    /// aggregate uses their calls per layer/forward, including the single
+    /// vocabulary tile, without loading model weights.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    #[ignore = "bounded exact A-panel cache benchmark; run explicitly with --nocapture"]
+    fn bench_exact_a_panel_cache_rows_on_smollm2_tiles() {
+        use std::hint::black_box;
+        use std::time::{Duration, Instant};
+        use uor_matmul::PackedCode;
+
+        #[derive(Clone, Copy)]
+        struct Case {
+            label: &'static str,
+            m: usize,
+            k: usize,
+            calls_per_forward: u32,
+            samples: usize,
+        }
+
+        fn measure(
+            case: Case,
+            a: &[f32],
+            b: &[f32],
+            c: &mut [f32],
+            pa: &mut [PackedCode],
+            pb: &mut [PackedCode],
+        ) -> Duration {
+            let started = Instant::now();
+            uor_matmul::slice::gemm_float(case.m, case.k, 8, a, b, c, pa, pb)
+                .expect("representative exact product is conformant");
+            let elapsed = started.elapsed();
+            black_box(c);
+            elapsed
+        }
+
+        let cases = [
+            Case {
+                label: "q_o",
+                m: 18,
+                k: 576,
+                calls_per_forward: 60,
+                samples: 5,
+            },
+            Case {
+                label: "k_v",
+                m: 6,
+                k: 576,
+                calls_per_forward: 60,
+                samples: 5,
+            },
+            Case {
+                label: "w1_w3",
+                m: 48,
+                k: 576,
+                calls_per_forward: 60,
+                samples: 5,
+            },
+            Case {
+                label: "w2",
+                m: 18,
+                k: 1_536,
+                calls_per_forward: 30,
+                samples: 5,
+            },
+            Case {
+                label: "vocab",
+                m: 1_536,
+                k: 576,
+                calls_per_forward: 1,
+                samples: 3,
+            },
+        ];
+
+        let mut weighted_one_row_ns = 0u128;
+        let mut weighted_eight_row_ns = 0u128;
+        for case in cases {
+            let a: Vec<f32> = (0..case.m * case.k)
+                .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+                .collect();
+            let b: Vec<f32> = (0..case.k * 8)
+                .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+                .collect();
+            let mut one_row_output = vec![0.0f32; case.m * 8];
+            let mut eight_row_output = vec![0.0f32; case.m * 8];
+            let mut one_row_pa = vec![PackedCode::default(); case.k];
+            let mut eight_row_pa = vec![PackedCode::default(); case.k * case.m.min(8)];
+            let mut one_row_pb = vec![PackedCode::default(); case.k * 8];
+            let mut eight_row_pb = vec![PackedCode::default(); case.k * 8];
+
+            // Excluded per-offer warm-up resolves the same pinned backend and
+            // fills each retained cache before the interleaved samples.
+            measure(
+                case,
+                &a,
+                &b,
+                &mut one_row_output,
+                &mut one_row_pa,
+                &mut one_row_pb,
+            );
+            measure(
+                case,
+                &a,
+                &b,
+                &mut eight_row_output,
+                &mut eight_row_pa,
+                &mut eight_row_pb,
+            );
+            assert_eq!(
+                one_row_output
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                eight_row_output
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                "A-panel offer changed exact bits for {}",
+                case.label
+            );
+
+            let mut one_row = Vec::with_capacity(case.samples);
+            let mut eight_row = Vec::with_capacity(case.samples);
+            for sample in 0..case.samples {
+                if sample % 2 == 0 {
+                    one_row.push(measure(
+                        case,
+                        &a,
+                        &b,
+                        &mut one_row_output,
+                        &mut one_row_pa,
+                        &mut one_row_pb,
+                    ));
+                    eight_row.push(measure(
+                        case,
+                        &a,
+                        &b,
+                        &mut eight_row_output,
+                        &mut eight_row_pa,
+                        &mut eight_row_pb,
+                    ));
+                } else {
+                    eight_row.push(measure(
+                        case,
+                        &a,
+                        &b,
+                        &mut eight_row_output,
+                        &mut eight_row_pa,
+                        &mut eight_row_pb,
+                    ));
+                    one_row.push(measure(
+                        case,
+                        &a,
+                        &b,
+                        &mut one_row_output,
+                        &mut one_row_pa,
+                        &mut one_row_pb,
+                    ));
+                }
+                assert_eq!(
+                    one_row_output
+                        .iter()
+                        .map(|value| value.to_bits())
+                        .collect::<Vec<_>>(),
+                    eight_row_output
+                        .iter()
+                        .map(|value| value.to_bits())
+                        .collect::<Vec<_>>(),
+                    "sample {sample} changed exact bits for {}",
+                    case.label
+                );
+            }
+            one_row.sort_unstable();
+            eight_row.sort_unstable();
+            let one_row_median = one_row[case.samples / 2];
+            let eight_row_median = eight_row[case.samples / 2];
+            weighted_one_row_ns = weighted_one_row_ns.saturating_add(
+                one_row_median
+                    .as_nanos()
+                    .saturating_mul(u128::from(case.calls_per_forward)),
+            );
+            weighted_eight_row_ns = weighted_eight_row_ns.saturating_add(
+                eight_row_median
+                    .as_nanos()
+                    .saturating_mul(u128::from(case.calls_per_forward)),
+            );
+            println!(
+                "EXACT_A_PANEL_CACHE label={} m={} k={} n=8 calls={} pa1_ns={} pa8_ns={} speedup={:.4}",
+                case.label,
+                case.m,
+                case.k,
+                case.calls_per_forward,
+                one_row_median.as_nanos(),
+                eight_row_median.as_nanos(),
+                one_row_median.as_secs_f64() / eight_row_median.as_secs_f64()
+            );
+        }
+
+        println!(
+            "EXACT_A_PANEL_CACHE weighted_pa1_ns={} weighted_pa8_ns={} weighted_speedup={:.4}",
+            weighted_one_row_ns,
+            weighted_eight_row_ns,
+            weighted_one_row_ns as f64 / weighted_eight_row_ns as f64
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn exact_executor_reports_real_bounded_concurrency_and_progress() {
+        use std::num::NonZeroUsize;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier, Mutex};
+
+        const N: usize = 257;
+        const ROWS: usize = 128;
+        let callbacks = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&callbacks);
+        // The planted product is intentionally small, so an unconstrained
+        // scheduler can occasionally finish one row tile before another pool
+        // worker starts. Hold only the first two real task-entry callbacks at
+        // a barrier. Both tasks have already incremented `active_workers` and
+        // retain their `ActiveTask` guards, making the observed overlap real
+        // while leaving production scheduling and arithmetic untouched.
+        let entry_barrier = Arc::new(Barrier::new(2));
+        let observer_barrier = Arc::clone(&entry_barrier);
+        let entry_arrivals = Arc::new(AtomicUsize::new(0));
+        let observer_arrivals = Arc::clone(&entry_arrivals);
+        let config = TeacherExecutionConfig::fixed_workers(
+            NonZeroUsize::new(4).expect("worker count is nonzero"),
+        )
+        .with_tiles_per_worker(NonZeroUsize::new(4).expect("tile count is nonzero"))
+        .with_observer(Arc::new(move |snapshot| {
+            seen.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(snapshot.observer_epoch);
+            if snapshot.active_workers > 0 && snapshot.tiles_completed == 0 {
+                let arrival = observer_arrivals.fetch_add(1, Ordering::AcqRel);
+                if arrival < 2 {
+                    observer_barrier.wait();
+                }
+            }
+        }));
+        let executor = ExactExecutor::new(config).expect("fixed exact executor");
+        let input: Vec<f32> = (0..N)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect();
+        let weights: Vec<f32> = (0..ROWS * N)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect();
+        let mut output = [0.0f32; ROWS];
+        executor.matmul(&mut output, &input, &weights, N);
+
+        let snapshot = executor.snapshot();
+        assert_eq!(snapshot.effective_workers, 4);
+        assert!(
+            entry_arrivals.load(Ordering::Acquire) >= 2,
+            "fewer than two real exact tasks reached the planted start barrier"
+        );
+        assert!(
+            snapshot.max_active_workers >= 2,
+            "no overlapping exact work"
+        );
+        assert!(snapshot.max_active_workers <= snapshot.effective_workers);
+        assert_eq!(snapshot.active_workers, 0);
+        assert_eq!(snapshot.matrix_calls, 1);
+        assert!(snapshot.tiles_completed > 1);
+        assert_eq!(snapshot.output_cells_completed, ROWS as u64);
+        assert_eq!(snapshot.scalar_terms_completed, (ROWS * N) as u64);
+        let mut callback_epochs = callbacks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert!(!callback_epochs.is_empty());
+        assert!(
+            callback_epochs.len() < snapshot.tiles_completed as usize,
+            "observer publication unexpectedly returned to one callback per timed tile"
+        );
+        let tile_progress_bound =
+            1usize.saturating_add((snapshot.tiles_completed as usize).div_ceil(4));
+        let task_entry_bound = snapshot.effective_workers;
+        assert!(
+            callback_epochs.len() <= tile_progress_bound.saturating_add(task_entry_bound),
+            "observer publication exceeded one callback per worker wave plus bounded task entry"
+        );
+        assert!(callback_epochs.iter().all(|&epoch| epoch > 0));
+        let callback_count = callback_epochs.len();
+        callback_epochs.sort_unstable();
+        callback_epochs.dedup();
+        assert_eq!(callback_epochs.len(), callback_count);
+        assert_eq!(
+            snapshot.observer_epoch,
+            callback_epochs.last().copied().unwrap()
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn every_physical_forward_republishes_actual_multiworker_occupancy() {
+        use std::collections::BTreeMap;
+        use std::num::NonZeroUsize;
+        use std::sync::{Arc, Mutex};
+
+        const N: usize = 257;
+        const ROWS: usize = 128;
+        const STREAMS: usize = 8;
+        let observed_peaks = Arc::new(Mutex::new(BTreeMap::<u64, usize>::new()));
+        let observer_peaks = Arc::clone(&observed_peaks);
+        let config = TeacherExecutionConfig::fixed_workers(
+            NonZeroUsize::new(4).expect("worker count is nonzero"),
+        )
+        .with_tiles_per_worker(NonZeroUsize::new(4).expect("tile count is nonzero"))
+        .with_observer(Arc::new(move |snapshot| {
+            observer_peaks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .entry(snapshot.forward_calls)
+                .and_modify(|peak| *peak = (*peak).max(snapshot.active_workers))
+                .or_insert(snapshot.active_workers);
+        }));
+        let executor = ExactExecutor::new(config).expect("fixed exact executor");
+        let input: Vec<f32> = (0..STREAMS * N)
+            .map(|index| ((index * 17 % 31) as f32 - 15.0) / 16.0)
+            .collect();
+        let weights: Vec<f32> = (0..ROWS * N)
+            .map(|index| ((index * 29 % 43) as f32 - 21.0) / 32.0)
+            .collect();
+
+        for _ in 0..2 {
+            let mut output = vec![0.0f32; STREAMS * ROWS];
+            let before = executor.snapshot();
+            executor.begin_forward(STREAMS);
+            executor.matmul_batched(&mut output, &input, &weights, N, STREAMS);
+            executor.complete_forward(STREAMS);
+            let after = executor.snapshot();
+            assert_eq!(after.forward_calls - before.forward_calls, 1);
+            assert_eq!(
+                after.multiworker_forward_calls - before.multiworker_forward_calls,
+                1
+            );
+            assert!(after.forward_max_active_workers >= 2);
+            assert!(after.forward_max_active_workers <= after.effective_workers);
+        }
+
+        let observed_peaks = observed_peaks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for forward in [1, 2] {
+            assert!(
+                observed_peaks.get(&forward).copied().unwrap_or(0) >= 2,
+                "physical forward {forward} never republished overlapping row workers"
+            );
+        }
+    }
+
+    #[cfg(not(all(target_os = "macos", feature = "observation-blas-exception")))]
+    #[test]
+    fn repeated_batched_forwards_reuse_every_exact_workspace_capacity() {
+        use std::num::NonZeroUsize;
+
+        let mut model = tiny_llama();
+        model
+            .set_execution_config(
+                TeacherExecutionConfig::fixed_workers(
+                    NonZeroUsize::new(4).expect("worker count is nonzero"),
+                )
+                .with_tiles_per_worker(NonZeroUsize::new(4).expect("tiles per worker is nonzero")),
+            )
+            .expect("fixed exact executor");
+        let tokens = [1usize, 2, 3, 4, 5, 6, 7, 8];
+        let positions = [0usize; 8];
+
+        let mut first_states: Vec<State> = (0..8).map(|_| State::new(&model.cfg)).collect();
+        model.forward_batch(&mut first_states, &tokens, &positions, true);
+        let after_first = model.execution_snapshot();
+        assert!(after_first.workspace_growth_events > 0);
+        assert!(after_first.workspace_growth_bytes > 0);
+
+        let mut second_states: Vec<State> = (0..8).map(|_| State::new(&model.cfg)).collect();
+        model.forward_batch(&mut second_states, &tokens, &positions, true);
+        let after_second = model.execution_snapshot();
+        assert_eq!(
+            after_second.workspace_growth_events, after_first.workspace_growth_events,
+            "steady-state batched forward grew a retained workspace"
+        );
+        assert_eq!(
+            after_second.workspace_growth_bytes, after_first.workspace_growth_bytes,
+            "steady-state batched forward allocated new workspace capacity"
+        );
+        assert_eq!(
+            first_states
+                .iter()
+                .flat_map(|state| state.logits.iter().map(|value| value.to_bits()))
+                .collect::<Vec<_>>(),
+            second_states
+                .iter()
+                .flat_map(|state| state.logits.iter().map(|value| value.to_bits()))
+                .collect::<Vec<_>>(),
+            "workspace reuse changed teacher output bits"
+        );
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(all(target_os = "macos", feature = "observation-blas-exception"))
+    ))]
+    #[test]
+    fn every_adaptive_candidate_prepares_workspace_outside_measurement() {
+        use std::num::NonZeroUsize;
+        use std::sync::Arc;
+
+        let mut model = tiny_llama();
+        let tokens = [1usize, 2, 3, 4, 5, 6, 7, 8];
+        let positions = [0usize; 8];
+        let mut reference_logits = None;
+        for workers in [8usize, 4] {
+            model
+                .set_execution_config(
+                    TeacherExecutionConfig::fixed_workers(
+                        NonZeroUsize::new(workers).expect("worker count is nonzero"),
+                    )
+                    .with_tiles_per_worker(
+                        NonZeroUsize::new(4).expect("tiles per worker is nonzero"),
+                    ),
+                )
+                .expect("adaptive exact executor");
+            let preparation = model
+                .prestart_exact_execution(8)
+                .expect("excluded exact workspace preparation");
+            assert_eq!(preparation.workers_observed, workers);
+            assert!(preparation.workspace_capacity_bytes > 0);
+            assert!(preparation.workspace_growth_events > 0);
+            assert!(preparation.workspace_growth_bytes > 0);
+
+            model.begin_measured_execution(Arc::new(|_| {}));
+            let mut states: Vec<State> = (0..8).map(|_| State::new(&model.cfg)).collect();
+            model.forward_batch(&mut states, &tokens, &positions, true);
+            let measured = model.execution_snapshot();
+            assert_eq!(measured.workspace_growth_events, 0);
+            assert_eq!(measured.workspace_growth_bytes, 0);
+            let logits = states
+                .iter()
+                .flat_map(|state| state.logits.iter().map(|value| value.to_bits()))
+                .collect::<Vec<_>>();
+            if let Some(reference) = &reference_logits {
+                assert_eq!(
+                    &logits, reference,
+                    "candidate worker count changed exact bits"
+                );
+            } else {
+                reference_logits = Some(logits);
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn atomic_progress_bridge_ignores_stale_epochs_and_publishes_exact_final_snapshot() {
+        let bridge = AtomicTeacherExecutionProgress::default();
+        let newest = TeacherExecutionSnapshot {
+            observer_epoch: 9,
+            effective_workers: 8,
+            max_active_workers: 8,
+            forward_calls: 3,
+            streams_started: 24,
+            streams_completed: 24,
+            max_active_streams: 8,
+            matrix_calls: 17,
+            batched_matrix_calls: 17,
+            max_matrix_batch_width: 8,
+            tiles_completed: 99,
+            output_cells_completed: 1234,
+            scalar_terms_completed: 5678,
+            ..TeacherExecutionSnapshot::default()
+        };
+        bridge.publish(newest);
+        bridge.publish(TeacherExecutionSnapshot {
+            observer_epoch: 8,
+            tiles_completed: 1,
+            ..TeacherExecutionSnapshot::default()
+        });
+        assert_eq!(bridge.snapshot(), newest);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn measured_execution_excludes_cheap_pool_backend_prestart() {
+        use std::num::NonZeroUsize;
+        use std::sync::Arc;
+
+        let mut executor = ExactExecutor::new(TeacherExecutionConfig::fixed_workers(
+            NonZeroUsize::new(4).expect("worker count is nonzero"),
+        ))
+        .expect("fixed exact executor");
+        let prestart = executor.prestart(8, 32, 64).expect("cheap exact prestart");
+        assert_eq!(prestart.workers_observed, 4);
+        assert_eq!(prestart.batch_width, 8);
+        assert!(prestart.backend_exercised);
+        assert!(prestart.workspace_capacity_bytes > 0);
+        assert!(prestart.workspace_growth_events > 0);
+        assert!(prestart.workspace_growth_bytes > 0);
+        assert_eq!(executor.snapshot().forward_calls, 0);
+        assert_eq!(executor.snapshot().matrix_calls, 1);
+
+        executor.begin_measured_execution(Arc::new(|_| {}));
+        assert_eq!(executor.snapshot().matrix_calls, 0);
+        assert_eq!(executor.snapshot().workspace_growth_events, 0);
+        assert_eq!(executor.snapshot().workspace_growth_bytes, 0);
+        let input = [0.25f32; 32];
+        let weights = [0.5f32; 64 * 32];
+        let mut output = [0.0f32; 64];
+        executor.matmul(&mut output, &input, &weights, 32);
+        let measured = executor.snapshot();
+        assert_eq!(measured.requested_workers, 4);
+        assert_eq!(measured.effective_workers, 4);
+        assert_eq!(measured.matrix_calls, 1);
+        assert_eq!(measured.workspace_growth_events, 0);
+        assert_eq!(measured.workspace_growth_bytes, 0);
+        assert!(measured.observer_epoch > 0);
     }
 
     /// A tiny synthetic Llama with deterministic weights, for exercising the
@@ -2933,9 +4481,116 @@ mod tests {
             rms_final,
             wcls: emb,
             canonical_math: false,
+            exact_executor: ExactExecutor::new(TeacherExecutionConfig::default())
+                .expect("the one-worker exact executor must build"),
+            forward_gate: std::sync::Mutex::new(()),
+            batch_workspace: std::sync::Mutex::new(Box::new(BatchForwardWorkspace::default())),
         };
         model.rebuild_rope_cache();
         model
+    }
+
+    #[cfg(not(all(target_os = "macos", feature = "observation-blas-exception")))]
+    #[test]
+    fn exact_forward_plan_matches_observed_tiny_batch_delta() {
+        use std::num::NonZeroUsize;
+
+        let mut model = tiny_llama();
+        model
+            .set_execution_config(
+                TeacherExecutionConfig::fixed_workers(
+                    NonZeroUsize::new(4).expect("worker count is nonzero"),
+                )
+                .with_tiles_per_worker(NonZeroUsize::new(4).expect("tiles per worker is nonzero")),
+            )
+            .expect("fixed exact executor");
+        let batch_width = 3usize;
+        let plan = model
+            .exact_forward_plan(batch_width)
+            .expect("tiny exact forward plan");
+        let before = model.execution_snapshot();
+        let mut states: Vec<State> = (0..batch_width).map(|_| State::new(&model.cfg)).collect();
+        model.forward_batch(&mut states, &[1, 2, 3], &[0, 0, 0], true);
+        let after = model.execution_snapshot();
+
+        assert_eq!(after.matrix_calls - before.matrix_calls, plan.matrix_calls);
+        assert_eq!(
+            after.tiles_completed - before.tiles_completed,
+            plan.row_tiles
+        );
+        assert_eq!(plan.worker_tasks, plan.row_tiles);
+        assert_eq!(
+            after.output_cells_completed - before.output_cells_completed,
+            plan.output_cells
+        );
+        assert_eq!(
+            after.scalar_terms_completed - before.scalar_terms_completed,
+            plan.scalar_terms
+        );
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(all(feature = "observation-blas-exception", target_os = "macos"))
+    ))]
+    #[test]
+    fn eight_stream_forward_keeps_private_states_and_observes_row_workers() {
+        use std::num::NonZeroUsize;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let saw_streams_and_workers = Arc::new(AtomicBool::new(false));
+        let observer_flag = Arc::clone(&saw_streams_and_workers);
+        let mut model = tiny_llama();
+        model
+            .set_execution_config(
+                TeacherExecutionConfig::fixed_workers(
+                    NonZeroUsize::new(8).expect("worker count is nonzero"),
+                )
+                .with_tiles_per_worker(NonZeroUsize::new(4).expect("tiles per worker is nonzero"))
+                .with_observer(Arc::new(move |snapshot| {
+                    if snapshot.active_streams == 8 && snapshot.active_workers > 0 {
+                        observer_flag.store(true, Ordering::Release);
+                    }
+                })),
+            )
+            .expect("eight-worker exact executor");
+        let mut states: Vec<State> = (0..8).map(|_| State::new(&model.cfg)).collect();
+        model.forward_batch(
+            &mut states,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
+            true,
+        );
+
+        let snapshot = model.execution_snapshot();
+        assert_eq!(snapshot.effective_workers, 8);
+        assert_eq!(snapshot.streams_started, 8);
+        assert_eq!(snapshot.streams_completed, 8);
+        assert_eq!(snapshot.active_streams, 0);
+        assert_eq!(snapshot.max_active_streams, 8);
+        assert_eq!(snapshot.batched_matrix_calls, snapshot.matrix_calls);
+        assert_eq!(snapshot.max_matrix_batch_width, 8);
+        assert!(snapshot.observer_epoch > 0);
+        assert!(snapshot.max_active_workers >= 2);
+        assert!(snapshot.max_active_workers <= 8);
+        assert!(saw_streams_and_workers.load(Ordering::Acquire));
+        let state_bits: Vec<Vec<u32>> = states.iter().map(persistent_state_bits).collect();
+        for left in 0..state_bits.len() {
+            for right in left + 1..state_bits.len() {
+                assert_ne!(
+                    state_bits[left], state_bits[right],
+                    "independent stream states {left} and {right} collapsed"
+                );
+            }
+        }
+        assert_eq!(
+            model
+                .exact_forward_plan(8)
+                .expect("eight-stream exact plan")
+                .batch_width,
+            8
+        );
     }
 
     #[test]
@@ -3033,44 +4688,1915 @@ mod tests {
         }
     }
 
-    /// forward_batch over B sequences, stepped position by position, must
-    /// produce the exact logits of B independent forward() streams. Off macOS
-    /// the batched matmul reuses the serial dot_fast, so this is bit-identical;
-    /// guards the batched teacher path added for #531.
-    #[cfg(not(target_os = "macos"))]
+    fn persistent_state_bits(state: &State) -> Vec<u32> {
+        // xb/xb2/hb/hb2/q/att are overwrite-only forward scratch and the
+        // batched executor intentionally keeps their equivalents in stacked
+        // private buffers. x, both KV caches, and logits are the persistent
+        // sequence state consumed or exposed after the call.
+        [
+            &state.x,
+            &state.key_cache,
+            &state.value_cache,
+            &state.logits,
+        ]
+        .into_iter()
+        .flat_map(|values| values.iter().map(|value| value.to_bits()))
+        .collect()
+    }
+
+    #[test]
+    fn cloned_teacher_state_preserves_bits_and_owns_private_storage() {
+        let model = tiny_llama();
+        let mut template = State::new_bounded(&model.cfg, 4).expect("bounded template state");
+        model.forward(&mut template, 1, 0, true);
+        model.forward(&mut template, 3, 1, true);
+
+        let template_cid = template.persistent_state_cid();
+        let mut clone = template.clone();
+        assert_eq!(clone.persistent_state_cid(), template_cid);
+        assert_eq!(
+            persistent_state_bits(&clone),
+            persistent_state_bits(&template)
+        );
+
+        clone.key_cache[0] = f32::from_bits(clone.key_cache[0].to_bits() ^ 1);
+        assert_eq!(template.persistent_state_cid(), template_cid);
+        assert_ne!(clone.persistent_state_cid(), template_cid);
+
+        let mut continuation = template.clone();
+        model.forward(&mut continuation, 5, 2, true);
+        assert_eq!(template.persistent_state_cid(), template_cid);
+        assert_ne!(continuation.persistent_state_cid(), template_cid);
+    }
+
+    /// Exact output-row tiling must preserve every persistent sequence-state
+    /// bit, including on macOS, at each supported fixed worker count.
     #[test]
     #[allow(clippy::needless_range_loop)]
-    fn forward_batch_matches_serial_forward() {
-        let model = tiny_llama();
+    fn forward_batch_matches_serial_forward_for_1_2_4_8_workers() {
+        use std::num::NonZeroUsize;
+
+        let serial_model = tiny_llama();
         let seqs: [[usize; 4]; 3] = [[1, 3, 5, 2], [4, 0, 7, 8], [2, 9, 1, 6]];
         let len = 4;
 
         // Serial reference: one State per sequence, stepped token by token.
-        let mut serial: Vec<Vec<f32>> = Vec::new();
-        let mut sstates: Vec<State> = (0..3).map(|_| State::new(&model.cfg)).collect();
+        let mut serial: Vec<Vec<u32>> = Vec::new();
+        let mut sstates: Vec<State> = (0..3).map(|_| State::new(&serial_model.cfg)).collect();
         sstates.iter_mut().for_each(State::reset);
         for pos in 0..len {
             for (b, st) in sstates.iter_mut().enumerate() {
-                model.forward(st, seqs[b][pos], pos, true);
-                serial.push(st.logits.clone());
+                serial_model.forward(st, seqs[b][pos], pos, true);
+                serial.push(persistent_state_bits(st));
             }
         }
 
-        // Batched: all three sequences advanced together each step.
-        let mut bstates: Vec<State> = (0..3).map(|_| State::new(&model.cfg)).collect();
-        bstates.iter_mut().for_each(State::reset);
-        for pos in 0..len {
-            let tokens: Vec<usize> = (0..3).map(|b| seqs[b][pos]).collect();
-            let positions = vec![pos; 3];
-            model.forward_batch(&mut bstates, &tokens, &positions, true);
-            for (b, st) in bstates.iter().enumerate() {
+        for workers in [1usize, 2, 4, 8] {
+            let mut model = tiny_llama();
+            model
+                .set_execution_config(TeacherExecutionConfig::fixed_workers(
+                    NonZeroUsize::new(workers).expect("worker count is nonzero"),
+                ))
+                .expect("fixed exact executor");
+            let mut bstates: Vec<State> = (0..3).map(|_| State::new(&model.cfg)).collect();
+            bstates.iter_mut().for_each(State::reset);
+            for pos in 0..len {
+                let tokens: Vec<usize> = (0..3).map(|b| seqs[b][pos]).collect();
+                let positions = vec![pos; 3];
+                model.forward_batch(&mut bstates, &tokens, &positions, true);
+                for (b, st) in bstates.iter().enumerate() {
+                    assert_eq!(
+                        persistent_state_bits(st),
+                        serial[pos * 3 + b],
+                        "state differs with {workers} workers at pos {pos} seq {b}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "batched teacher forward requires at least one state")]
+    fn forward_batch_rejects_an_empty_cohort_before_executor_work() {
+        let model = tiny_llama();
+        model.forward_batch(&mut [], &[], &[], true);
+    }
+
+    #[test]
+    #[should_panic(expected = "batched teacher token/state lengths must match")]
+    fn forward_batch_rejects_mismatched_cohort_shapes_in_release_builds() {
+        let model = tiny_llama();
+        let mut states = vec![State::new(&model.cfg)];
+        model.forward_batch(&mut states, &[], &[0], true);
+    }
+
+    #[test]
+    fn bounded_state_matches_full_state_and_rejects_invalid_bounds() {
+        let model = tiny_llama();
+        assert_eq!(
+            State::new_bounded(&model.cfg, 0).err(),
+            Some(TeacherStateCapacityError::Zero)
+        );
+        assert_eq!(
+            State::new_bounded(&model.cfg, model.cfg.seq_len + 1).err(),
+            Some(TeacherStateCapacityError::ExceedsModel {
+                requested: model.cfg.seq_len + 1,
+                maximum: model.cfg.seq_len,
+            })
+        );
+
+        let horizon = 4usize;
+        let full_shape = model
+            .exact_probe_trace_shape(1, 8, 8)
+            .expect("full trace shape");
+        let bounded_shape = model
+            .exact_probe_trace_shape_bounded(horizon, 1, 8, 8)
+            .expect("bounded trace shape");
+        assert_eq!(full_shape.sequence_capacity, model.cfg.seq_len);
+        assert_eq!(bounded_shape.sequence_capacity, horizon);
+        assert!(bounded_shape.persistent_state_words < full_shape.persistent_state_words);
+        let mut full = State::new(&model.cfg);
+        let mut bounded = State::new_bounded(&model.cfg, horizon).expect("bounded state");
+        assert_eq!(bounded.sequence_capacity(), horizon);
+        assert_eq!(bounded.att.len(), model.cfg.n_heads * horizon);
+        let kv_dim = model.cfg.dim * model.cfg.n_kv_heads / model.cfg.n_heads;
+        assert_eq!(
+            bounded.key_cache.len(),
+            model.cfg.n_layers * horizon * kv_dim
+        );
+        for pos in 0..horizon {
+            model.forward(&mut full, pos + 1, pos, true);
+            model.forward(&mut bounded, pos + 1, pos, true);
+            assert_eq!(
+                full.x
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                bounded
+                    .x
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(
+                full.logits
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                bounded
+                    .logits
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>()
+            );
+            for layer in 0..model.cfg.n_layers {
+                let full_offset = layer * model.cfg.seq_len * kv_dim;
+                let bounded_offset = layer * horizon * kv_dim;
+                let words = (pos + 1) * kv_dim;
                 assert_eq!(
-                    st.logits,
-                    serial[pos * 3 + b],
-                    "logits differ at pos {pos} seq {b}"
+                    &full.key_cache[full_offset..full_offset + words],
+                    &bounded.key_cache[bounded_offset..bounded_offset + words]
+                );
+                assert_eq!(
+                    &full.value_cache[full_offset..full_offset + words],
+                    &bounded.value_cache[bounded_offset..bounded_offset + words]
                 );
             }
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn direct_probe_budget_contract_error(
+        generation_tokens_per_lane: usize,
+        max_wall_seconds: usize,
+    ) -> Option<String> {
+        if generation_tokens_per_lane > EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS
+            || !generation_tokens_per_lane.is_power_of_two()
+        {
+            return Some(format!(
+                "R4_PARITY_GEN_TOKENS must be a power of two in 1..={EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS}; got {generation_tokens_per_lane}"
+            ));
+        }
+        if max_wall_seconds > 28_800 {
+            return Some(format!(
+                "R4_PARITY_MAX_WALL_SECS must be in 1..=28800; got {max_wall_seconds}"
+            ));
+        }
+        None
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn direct_probe_budget_bounds_match_the_binding_bdd_owner() {
+        for tokens in [1, 2, 4, 8] {
+            assert_eq!(direct_probe_budget_contract_error(tokens, 28_800), None);
+        }
+        for tokens in [3, 9, 128] {
+            assert!(direct_probe_budget_contract_error(tokens, 28_800)
+                .is_some_and(|reason| reason.contains("R4_PARITY_GEN_TOKENS")));
+        }
+        assert!(direct_probe_budget_contract_error(8, 28_801)
+            .is_some_and(|reason| reason.contains("R4_PARITY_MAX_WALL_SECS")));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn direct_probe_revalidates_production_generation_immediately_before_teacher_load() {
+        let source = include_str!("lib.rs");
+        let start = source
+            .rfind("fn live_exact_multicore_probe_emits_json_and_preserves_bits()")
+            .expect("direct probe exists");
+        let body = &source[start..];
+        let load = body
+            .find(
+                "let mut oracle = HuggingFaceLlamaOracle::load_with_sequence_length_and_execution(",
+            )
+            .expect("teacher load exists");
+        let validations = body[..load]
+            .match_indices("exact_probe::validate_teacher_free_preflight")
+            .map(|(offset, _)| offset)
+            .collect::<Vec<_>>();
+        assert_eq!(validations.len(), 2);
+        let final_validation = *validations.last().expect("final validation");
+        let final_interval = &body[final_validation..load];
+        assert!(final_interval.contains("current_preflight != preflight"));
+        assert!(final_interval.contains("production generation changed"));
+    }
+
+    /// Cheap live proof harness for #932. It loads source weights once, times
+    /// identical eight-stream work at four and all available exact workers,
+    /// selects the lowest projected wall time, compares every output and
+    /// persistent-state bit, flushes JSONL progress, and atomically publishes
+    /// typed admission evidence. Missing fixtures are a truthful unavailable
+    /// result, never a skip.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    #[ignore = "requires the pinned live SmolLM2 source fixture"]
+    fn live_exact_multicore_probe_emits_json_and_preserves_bits() {
+        use std::fs::File;
+        use std::io::Write;
+        use std::num::NonZeroUsize;
+        use std::path::PathBuf;
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+        use std::sync::{Arc, Mutex};
+        use std::time::{Duration, Instant};
+
+        fn try_emit_probe_record(
+            events: &Arc<Mutex<File>>,
+            record: &serde_json::Value,
+            durable: bool,
+        ) -> std::io::Result<()> {
+            {
+                let mut file = events
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                serde_json::to_writer(&mut *file, record)
+                    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+                file.write_all(b"\n")?;
+                file.flush()?;
+                if durable {
+                    file.sync_all()?;
+                }
+            }
+            let stderr = std::io::stderr();
+            let mut output = stderr.lock();
+            serde_json::to_writer(&mut output, record)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            output.write_all(b"\n")?;
+            output.flush()?;
+            Ok(())
+        }
+
+        fn emit_probe_record(events: &Arc<Mutex<File>>, record: &serde_json::Value) {
+            try_emit_probe_record(events, record, false)
+                .expect("write and flush exact probe JSONL record");
+        }
+
+        fn write_probe_state_atomic(
+            path: &std::path::Path,
+            state: &serde_json::Value,
+        ) -> std::io::Result<()> {
+            let parent = exact_probe::normalized_report_parent(path);
+            let name = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or("exact-multicore-probe.json");
+            let temporary = parent.join(format!(".{name}.{}.state.tmp", std::process::id()));
+            let mut file = File::create(&temporary)?;
+            serde_json::to_writer_pretty(&mut file, state)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            file.write_all(b"\n")?;
+            file.flush()?;
+            file.sync_all()?;
+            std::fs::rename(&temporary, path)?;
+            File::open(parent)?.sync_all()?;
+            Ok(())
+        }
+
+        #[derive(Clone, Copy)]
+        enum ProbeTerminalKind {
+            Aborted,
+            Unavailable,
+            Refused,
+            Failed,
+        }
+
+        impl ProbeTerminalKind {
+            fn event(self) -> &'static str {
+                match self {
+                    Self::Aborted => "ABORTED",
+                    Self::Unavailable => "UNAVAILABLE",
+                    Self::Refused => "NOT_RUN",
+                    Self::Failed => "FAIL",
+                }
+            }
+
+            fn status(self) -> &'static str {
+                match self {
+                    Self::Aborted => "ABORTED",
+                    Self::Unavailable => "UNAVAILABLE",
+                    Self::Refused => "REFUSE_FULL_RUN",
+                    Self::Failed => "FAIL",
+                }
+            }
+        }
+
+        fn terminal_probe(
+            events: &Arc<Mutex<File>>,
+            report_path: &std::path::Path,
+            elapsed_seconds: f64,
+            reason: &str,
+            kind: ProbeTerminalKind,
+            overall_heartbeat: &mut ProbeOverallHeartbeat,
+        ) -> ! {
+            let heartbeat_failure = overall_heartbeat.stop_and_join().err();
+            let terminal_reason = heartbeat_failure.as_ref().map_or_else(
+                || reason.to_owned(),
+                |heartbeat_reason| {
+                    format!("{reason}; terminal heartbeat join failed: {heartbeat_reason}")
+                },
+            );
+            let state = serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE_STATE",
+                "event": kind.event(),
+                "status": kind.status(),
+                "qualifies_full_run": false,
+                "probe_wall_ceiling_seconds": EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+                "probe_deadline_policy": EXACT_MULTICORE_PROBE_DEADLINE_POLICY,
+                "probe_elapsed_seconds": elapsed_seconds,
+                "reason": terminal_reason,
+            });
+            let state_error = write_probe_state_atomic(report_path, &state).err();
+            emit_probe_record(events, &state);
+            if let Some(error) = state_error {
+                panic!(
+                    "NOT_RUN / {}: {terminal_reason}; durable terminal state write failed: {error}",
+                    kind.status()
+                );
+            }
+            panic!("NOT_RUN / {}: {terminal_reason}", kind.status());
+        }
+
+        fn abort_probe(
+            events: &Arc<Mutex<File>>,
+            report_path: &std::path::Path,
+            elapsed_seconds: f64,
+            reason: &str,
+            overall_heartbeat: &mut ProbeOverallHeartbeat,
+        ) -> ! {
+            terminal_probe(
+                events,
+                report_path,
+                elapsed_seconds,
+                reason,
+                ProbeTerminalKind::Aborted,
+                overall_heartbeat,
+            )
+        }
+
+        fn unavailable_probe(
+            events: &Arc<Mutex<File>>,
+            report_path: &std::path::Path,
+            elapsed_seconds: f64,
+            reason: &str,
+            overall_heartbeat: &mut ProbeOverallHeartbeat,
+        ) -> ! {
+            terminal_probe(
+                events,
+                report_path,
+                elapsed_seconds,
+                reason,
+                ProbeTerminalKind::Unavailable,
+                overall_heartbeat,
+            )
+        }
+
+        fn refuse_probe(
+            events: &Arc<Mutex<File>>,
+            report_path: &std::path::Path,
+            elapsed_seconds: f64,
+            reason: &str,
+            overall_heartbeat: &mut ProbeOverallHeartbeat,
+        ) -> ! {
+            terminal_probe(
+                events,
+                report_path,
+                elapsed_seconds,
+                reason,
+                ProbeTerminalKind::Refused,
+                overall_heartbeat,
+            )
+        }
+
+        fn fail_probe(
+            events: &Arc<Mutex<File>>,
+            report_path: &std::path::Path,
+            elapsed_seconds: f64,
+            reason: &str,
+            overall_heartbeat: &mut ProbeOverallHeartbeat,
+        ) -> ! {
+            terminal_probe(
+                events,
+                report_path,
+                elapsed_seconds,
+                reason,
+                ProbeTerminalKind::Failed,
+                overall_heartbeat,
+            )
+        }
+
+        #[derive(Clone, Copy, Debug, serde::Serialize)]
+        struct ProbeProcessSample {
+            cpu_time_seconds: f64,
+            resident_set_bytes: u64,
+        }
+
+        #[cfg(target_os = "macos")]
+        fn process_sample() -> Result<ProbeProcessSample, String> {
+            fn parse_cpu_time(raw: &str) -> Result<f64, String> {
+                let (days, clock) = match raw.split_once('-') {
+                    Some((days, clock)) => (
+                        days.parse::<u64>()
+                            .map_err(|error| format!("ps TIME days {days:?}: {error}"))?,
+                        clock,
+                    ),
+                    None => (0, raw),
+                };
+                let fields: Vec<&str> = clock.split(':').collect();
+                let (hours, minutes, seconds) = match fields.as_slice() {
+                    [minutes, seconds] => (0, *minutes, *seconds),
+                    [hours, minutes, seconds] => (
+                        hours
+                            .parse::<u64>()
+                            .map_err(|error| format!("ps TIME hours {hours:?}: {error}"))?,
+                        *minutes,
+                        *seconds,
+                    ),
+                    _ => return Err(format!("ps TIME had unexpected shape {raw:?}")),
+                };
+                let minutes = minutes
+                    .parse::<u64>()
+                    .map_err(|error| format!("ps TIME minutes {minutes:?}: {error}"))?;
+                let seconds = seconds
+                    .parse::<f64>()
+                    .map_err(|error| format!("ps TIME seconds {seconds:?}: {error}"))?;
+                let total = days as f64 * 86_400.0
+                    + hours as f64 * 3_600.0
+                    + minutes as f64 * 60.0
+                    + seconds;
+                (total.is_finite() && total >= 0.0)
+                    .then_some(total)
+                    .ok_or_else(|| format!("ps TIME was invalid: {raw:?}"))
+            }
+
+            let process_id = std::process::id().to_string();
+            let output = std::process::Command::new("/bin/ps")
+                .args(["-o", "rss=", "-o", "time=", "-p", &process_id])
+                .output()
+                .map_err(|error| format!("ps process sample: {error}"))?;
+            if !output.status.success() {
+                return Err(format!("ps process sample exited {}", output.status));
+            }
+            let text = String::from_utf8(output.stdout)
+                .map_err(|error| format!("ps returned non-UTF-8 output: {error}"))?;
+            let mut fields = text.split_whitespace();
+            let resident_kib = fields
+                .next()
+                .ok_or_else(|| "ps omitted RSS".to_owned())?
+                .parse::<u64>()
+                .map_err(|error| format!("ps RSS parse: {error}"))?;
+            let cpu_time_seconds = parse_cpu_time(
+                fields
+                    .next()
+                    .ok_or_else(|| "ps omitted process CPU time".to_owned())?,
+            )?;
+            if fields.next().is_some() {
+                return Err(format!("ps returned unexpected fields: {text:?}"));
+            }
+            let resident_set_bytes = resident_kib
+                .checked_mul(1024)
+                .ok_or_else(|| "ps RSS byte conversion overflow".to_owned())?;
+            Ok(ProbeProcessSample {
+                cpu_time_seconds,
+                resident_set_bytes,
+            })
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        fn process_sample() -> Result<ProbeProcessSample, String> {
+            Err(format!(
+                "safe exact-probe process sampler is not implemented for {}",
+                std::env::consts::OS
+            ))
+        }
+
+        fn completed_resources(
+            start: &Result<ProbeProcessSample, String>,
+            end: &Result<ProbeProcessSample, String>,
+            max_sampled_rss_bytes: u64,
+            elapsed_seconds: f64,
+            measurement_scope: &str,
+            cpu_time_consumed_override: Option<f64>,
+        ) -> ExactMulticoreProbeResources {
+            match (start, end) {
+                (Ok(start), Ok(end))
+                    if end.cpu_time_seconds >= start.cpu_time_seconds
+                        && elapsed_seconds.is_finite()
+                        && elapsed_seconds > 0.0 =>
+                {
+                    let max_sampled_rss_bytes = max_sampled_rss_bytes
+                        .max(start.resident_set_bytes)
+                        .max(end.resident_set_bytes);
+                    let cpu_time_consumed_seconds = cpu_time_consumed_override
+                        .unwrap_or(end.cpu_time_seconds - start.cpu_time_seconds);
+                    let mean_cpu_core_equivalents = cpu_time_consumed_seconds / elapsed_seconds;
+                    ExactMulticoreProbeResources {
+                        status: "PARTIAL".to_owned(),
+                        measurement_scope: measurement_scope.to_owned(),
+                        cpu_time_start_seconds: Some(start.cpu_time_seconds),
+                        cpu_time_end_seconds: Some(end.cpu_time_seconds),
+                        cpu_time_consumed_seconds: Some(cpu_time_consumed_seconds),
+                        current_rss_bytes: Some(end.resident_set_bytes),
+                        max_sampled_rss_bytes: Some(max_sampled_rss_bytes),
+                        peak_rss_bytes: None,
+                        mean_cpu_core_equivalents: Some(mean_cpu_core_equivalents),
+                        mean_cpu_percent: Some(mean_cpu_core_equivalents * 100.0),
+                        reason: Some(
+                            "safe macOS ps sampling exposes current/max-sampled RSS but not an OS-maintained process peak RSS"
+                                .to_owned(),
+                        ),
+                    }
+                }
+                (Ok(_), Ok(_)) => ExactMulticoreProbeResources::unavailable(
+                    "process CPU time moved backwards between ps samples",
+                ),
+                (Err(start), Err(end)) => ExactMulticoreProbeResources::unavailable(format!(
+                    "start sample: {start}; end sample: {end}"
+                )),
+                (Err(reason), _) => {
+                    ExactMulticoreProbeResources::unavailable(format!("start sample: {reason}"))
+                }
+                (_, Err(reason)) => {
+                    ExactMulticoreProbeResources::unavailable(format!("end sample: {reason}"))
+                }
+            }
+        }
+
+        fn process_sample_value(sample: &Result<ProbeProcessSample, String>) -> serde_json::Value {
+            match sample {
+                Ok(sample) => serde_json::json!({
+                    "status": "AVAILABLE",
+                    "sample": sample,
+                }),
+                Err(reason) => serde_json::json!({
+                    "status": "UNAVAILABLE",
+                    "reason": reason,
+                }),
+            }
+        }
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct ProbeTracePoint {
+            logits_bits: Vec<u32>,
+            greedy_token: u32,
+            top_tokens: Vec<u32>,
+            persistent_state_bits: Vec<u32>,
+        }
+
+        struct ProbeRunMeasurement {
+            workers: usize,
+            prestart: ExactMulticoreProbePrestart,
+            elapsed_ms: u64,
+            elapsed_seconds: f64,
+            aggregate_forwards_per_second: f64,
+            equal_to_reference: bool,
+            snapshot: TeacherExecutionSnapshot,
+            output_trace_cid: String,
+            resources: ExactMulticoreProbeResources,
+            forward_plan: ExactForwardPlan,
+            trace_shape: ExactMulticoreProbeTraceShape,
+        }
+
+        fn canonical_top_tokens(logits: &[f32], k: usize) -> Vec<u32> {
+            let mut best = Vec::with_capacity(k.min(logits.len()));
+            for token in 0..logits.len() {
+                let insertion = best.iter().position(|&incumbent| {
+                    logits[token].total_cmp(&logits[incumbent as usize]).is_gt()
+                        || (logits[token].to_bits() == logits[incumbent as usize].to_bits()
+                            && token < incumbent as usize)
+                });
+                if let Some(index) = insertion {
+                    best.insert(index, u32::try_from(token).unwrap_or(u32::MAX));
+                } else if best.len() < k {
+                    best.push(u32::try_from(token).unwrap_or(u32::MAX));
+                }
+                best.truncate(k);
+            }
+            best
+        }
+
+        fn capture_trace_point(state: &State) -> ProbeTracePoint {
+            let top_tokens = canonical_top_tokens(&state.logits, 8);
+            ProbeTracePoint {
+                logits_bits: state.logits.iter().map(|value| value.to_bits()).collect(),
+                greedy_token: top_tokens.first().copied().unwrap_or(0),
+                top_tokens,
+                persistent_state_bits: persistent_state_bits(state),
+            }
+        }
+
+        fn output_trace_cid(trace: &[Vec<ProbeTracePoint>]) -> String {
+            let mut hasher = blake3::Hasher::new();
+            for (position, streams) in trace.iter().enumerate() {
+                hasher.update(&u64::try_from(position).unwrap_or(u64::MAX).to_le_bytes());
+                hasher.update(
+                    &u64::try_from(streams.len())
+                        .unwrap_or(u64::MAX)
+                        .to_le_bytes(),
+                );
+                for state in streams {
+                    hasher.update(
+                        &u64::try_from(state.logits_bits.len())
+                            .unwrap_or(u64::MAX)
+                            .to_le_bytes(),
+                    );
+                    for bits in &state.logits_bits {
+                        hasher.update(&bits.to_le_bytes());
+                    }
+                    hasher.update(&state.greedy_token.to_le_bytes());
+                    hasher.update(
+                        &u64::try_from(state.top_tokens.len())
+                            .unwrap_or(u64::MAX)
+                            .to_le_bytes(),
+                    );
+                    for token in &state.top_tokens {
+                        hasher.update(&token.to_le_bytes());
+                    }
+                    hasher.update(
+                        &u64::try_from(state.persistent_state_bits.len())
+                            .unwrap_or(u64::MAX)
+                            .to_le_bytes(),
+                    );
+                    for bits in &state.persistent_state_bits {
+                        hasher.update(&bits.to_le_bytes());
+                    }
+                }
+            }
+            format!("blake3:{}", hasher.finalize().to_hex())
+        }
+
+        #[derive(Default)]
+        struct ProbeOverallPhase(Mutex<(String, Option<usize>)>);
+
+        impl ProbeOverallPhase {
+            fn set(&self, phase: &str, workers: Option<usize>) {
+                *self
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    (phase.to_owned(), workers);
+            }
+
+            fn get(&self) -> (String, Option<usize>) {
+                self.0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone()
+            }
+        }
+
+        struct ProbeOverallHeartbeat {
+            stop: Arc<AtomicBool>,
+            handle: Option<std::thread::JoinHandle<()>>,
+        }
+
+        impl ProbeOverallHeartbeat {
+            fn idle() -> Self {
+                Self {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                }
+            }
+
+            fn stop_and_join(&mut self) -> Result<(), String> {
+                self.stop.store(true, Ordering::Release);
+                let Some(handle) = self.handle.take() else {
+                    return Ok(());
+                };
+                handle.thread().unpark();
+                handle
+                    .join()
+                    .map_err(|_| "overall exact-probe heartbeat thread panicked".to_owned())
+            }
+        }
+
+        impl Drop for ProbeOverallHeartbeat {
+            fn drop(&mut self) {
+                self.stop.store(true, Ordering::Release);
+                if let Some(handle) = self.handle.take() {
+                    handle.thread().unpark();
+                    let _ = handle.join();
+                }
+            }
+        }
+
+        let report_path = exact_probe::resolve_direct_probe_path(
+            std::env::var_os("R4_EXACT_PROBE_REPORT")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    PathBuf::from("target/teacher-parity/exact-multicore-probe.json")
+                }),
+        );
+        if report_path.as_os_str().is_empty() {
+            let state = serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE_STATE",
+                "event": "NOT_RUN",
+                "status": "REFUSE_FULL_RUN",
+                "qualifies_full_run": false,
+                "reason": "R4_EXACT_PROBE_REPORT must be a nonempty path",
+            });
+            eprintln!("{state}");
+            panic!("NOT_RUN / REFUSE_FULL_RUN: R4_EXACT_PROBE_REPORT must be a nonempty path");
+        }
+        let report_parent = exact_probe::normalized_report_parent(&report_path);
+        std::fs::create_dir_all(report_parent).unwrap_or_else(|error| {
+            let state = serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE_STATE",
+                "event": "UNAVAILABLE",
+                "status": "UNAVAILABLE",
+                "qualifies_full_run": false,
+                "reason": format!("create probe report directory {}: {error}", report_parent.display()),
+            });
+            eprintln!("{state}");
+            panic!("UNAVAILABLE: cannot create exact probe report directory: {error}");
+        });
+        let report_stem = report_path
+            .file_stem()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or("exact-multicore-probe");
+        let events_path = report_parent.join(format!("{report_stem}.events.jsonl"));
+        let events_file = File::create(&events_path).unwrap_or_else(|error| {
+            let state = serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE_STATE",
+                "event": "UNAVAILABLE",
+                "status": "UNAVAILABLE",
+                "qualifies_full_run": false,
+                "reason": format!("create durable probe JSONL {}: {error}", events_path.display()),
+            });
+            let _ = write_probe_state_atomic(&report_path, &state);
+            eprintln!("{state}");
+            panic!("UNAVAILABLE: cannot create exact probe JSONL: {error}");
+        });
+        let events = Arc::new(Mutex::new(events_file));
+        let mut overall_heartbeat = ProbeOverallHeartbeat::idle();
+        let probe_started = Instant::now();
+        let overall_process_start = process_sample();
+        if let Err(error) = write_probe_state_atomic(
+            &report_path,
+            &serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE_STATE",
+                "event": "RUNNING",
+                "status": "NOT_QUALIFIED",
+                "qualifies_full_run": false,
+                "probe_wall_ceiling_seconds": EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+                "probe_deadline_policy": EXACT_MULTICORE_PROBE_DEADLINE_POLICY,
+            }),
+        ) {
+            let reason = format!("publish initial RUNNING probe state: {error}");
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let progress_every_seconds = match std::env::var("R4_PARITY_PROGRESS_EVERY_SECS") {
+            Ok(raw) => raw
+                .parse::<u64>()
+                .ok()
+                .filter(|value| *value > 0)
+                .unwrap_or_else(|| {
+                    let reason =
+                        format!("R4_PARITY_PROGRESS_EVERY_SECS={raw:?} must be a positive integer");
+                    refuse_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }),
+            Err(std::env::VarError::NotPresent) => 10,
+            Err(std::env::VarError::NotUnicode(_)) => refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                "R4_PARITY_PROGRESS_EVERY_SECS is not valid Unicode",
+                &mut overall_heartbeat,
+            ),
+        };
+        let progress_every = Duration::from_secs(progress_every_seconds);
+        let overall_phase = Arc::new(ProbeOverallPhase::default());
+        overall_phase.set("TEACHER_FREE_PREFLIGHT", None);
+        let overall_max_sampled_rss = Arc::new(AtomicU64::new(
+            overall_process_start
+                .as_ref()
+                .map_or(0, |sample| sample.resident_set_bytes),
+        ));
+        let overall_heartbeat_stop = Arc::new(AtomicBool::new(false));
+        overall_heartbeat.stop = Arc::clone(&overall_heartbeat_stop);
+        {
+            let worker_stop = Arc::clone(&overall_heartbeat_stop);
+            let phase = Arc::clone(&overall_phase);
+            let heartbeat_events = Arc::clone(&events);
+            let max_rss = Arc::clone(&overall_max_sampled_rss);
+            let handle = match std::thread::Builder::new()
+                .name("r4-exact-probe-overall-heartbeat".to_owned())
+                .spawn(move || loop {
+                    std::thread::park_timeout(progress_every);
+                    if worker_stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let elapsed_seconds = probe_started.elapsed().as_secs_f64();
+                    let process = process_sample();
+                    if let Ok(sample) = &process {
+                        max_rss.fetch_max(sample.resident_set_bytes, Ordering::AcqRel);
+                    }
+                    let (phase, current_workers) = phase.get();
+                    emit_probe_record(
+                        &heartbeat_events,
+                        &serde_json::json!({
+                            "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                            "record": "EXACT_MULTICORE_PROBE",
+                            "event": "OVERALL_PROGRESS",
+                            "phase": phase,
+                            "current_workers": current_workers,
+                            "elapsed_seconds": elapsed_seconds,
+                            "deadline_seconds": EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+                            "deadline_policy": EXACT_MULTICORE_PROBE_DEADLINE_POLICY,
+                            "deadline_remaining_seconds": (EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS as f64 - elapsed_seconds).max(0.0),
+                            "process": process_sample_value(&process),
+                        }),
+                    );
+                })
+            {
+                Ok(handle) => handle,
+                Err(error) => {
+                    let reason = format!("spawn overall exact probe heartbeat: {error}");
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+            };
+            overall_heartbeat.handle = Some(handle);
+        }
+
+        let source = exact_probe::resolve_direct_probe_path(
+            std::env::var_os("R4_PARITY_SOURCE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from(".uor-models/sources/smollm2-135m-instruct")),
+        );
+        let bundle = exact_probe::resolve_direct_probe_path(
+            std::env::var_os("R4_PARITY_BUNDLE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from(".uor-models/compiled/smollm2-135m-instruct")),
+        );
+        let preflight_path = exact_probe::resolve_direct_probe_path(
+            std::env::var_os("R4_PARITY_PREFLIGHT_REPORT")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    PathBuf::from("target/teacher-parity/teacher-free-preflight.json")
+                }),
+        );
+        let preflight =
+            match exact_probe::validate_teacher_free_preflight(&preflight_path, &source, &bundle) {
+                Ok(preflight) => preflight,
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Unavailable(reason)) => {
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Refused(reason)) => {
+                    refuse_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Failed(reason)) => fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                ),
+            };
+        emit_probe_record(
+            &events,
+            &serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE",
+                "event": "TEACHER_FREE_PREFLIGHT_VALIDATED",
+                "preflight_report_path": &preflight_path,
+                "preflight": &preflight,
+                "teacher_source_opened": false,
+                "teacher_forwards": 0,
+            }),
+        );
+        overall_phase.set("LOAD", None);
+        emit_probe_record(
+            &events,
+            &serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE",
+                "event": "LOAD_START",
+                "source": &source,
+                "report_path": &report_path,
+                "events_path": &events_path,
+                "probe_wall_ceiling_seconds": EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+                "probe_deadline_policy": EXACT_MULTICORE_PROBE_DEADLINE_POLICY,
+                "process_start": process_sample_value(&overall_process_start),
+            }),
+        );
+        let backend = exact_backend_report();
+        if backend.arithmetic_owner != "uor-matmul exact GEMM" {
+            refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                "the observation BLAS exception does not execute the exact uor-matmul owner",
+                &mut overall_heartbeat,
+            );
+        }
+        if !source.join("config.json").is_file() {
+            let reason = format!(
+                "live teacher source fixture does not exist at {}",
+                source.display()
+            );
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let positions = match std::env::var("R4_EXACT_PROBE_POSITIONS") {
+            Ok(raw) => raw.parse::<usize>().unwrap_or_else(|error| {
+                let reason = format!("R4_EXACT_PROBE_POSITIONS={raw:?} is invalid: {error}");
+                refuse_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                )
+            }),
+            Err(std::env::VarError::NotPresent) => 1,
+            Err(std::env::VarError::NotUnicode(_)) => refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                "R4_EXACT_PROBE_POSITIONS is not valid Unicode",
+                &mut overall_heartbeat,
+            ),
+        };
+        if !(1..=8).contains(&positions) {
+            refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                "R4_EXACT_PROBE_POSITIONS must be in 1..=8",
+                &mut overall_heartbeat,
+            );
+        }
+        let available = std::thread::available_parallelism()
+            .unwrap_or(NonZeroUsize::MIN)
+            .get();
+        if available < 4 {
+            let reason = format!(
+                "the adaptive exact probe requires at least 4 available workers; host reports {available}"
+            );
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let mut suite_budget = |name: &str, default: usize| {
+            let value = match std::env::var(name) {
+                Ok(raw) => raw.parse::<usize>().unwrap_or_else(|error| {
+                    let reason = format!("{name}={raw:?} is invalid: {error}");
+                    refuse_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }),
+                Err(std::env::VarError::NotPresent) => default,
+                Err(std::env::VarError::NotUnicode(_)) => {
+                    let reason = format!("{name} is not valid Unicode");
+                    refuse_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+            };
+            if value == 0 {
+                let reason = format!("{name} must be greater than zero");
+                refuse_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                );
+            }
+            value
+        };
+        let tiles_per_worker = suite_budget("R4_PARITY_BATCH_PER_WORKER", 4);
+        let transcript_logical_forwards = suite_budget("R4_PARITY_POSITIONS", 256)
+            .min(EXACT_MULTICORE_PROBE_REGISTERED_TRANSCRIPT_FORWARDS);
+        let generation_tokens_per_lane = suite_budget(
+            "R4_PARITY_GEN_TOKENS",
+            EXACT_MULTICORE_PROBE_REGISTERED_GENERATION_TOKENS,
+        );
+        let generation_lanes = suite_budget("R4_PARITY_STREAMS", 8);
+        if generation_lanes != 8 {
+            let reason = format!(
+                "the adaptive probe and optimized suite require exactly 8 independent lanes; R4_PARITY_STREAMS={generation_lanes}"
+            );
+            refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let configured_max_wall = suite_budget("R4_PARITY_MAX_WALL_SECS", 28_800);
+        if let Some(reason) =
+            direct_probe_budget_contract_error(generation_tokens_per_lane, configured_max_wall)
+        {
+            refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let configured_max_wall = u64::try_from(configured_max_wall)
+            .expect("validated maximum wall seconds fit into u64");
+        let mut configured_suite_work = ExactMulticoreProbeWork {
+            transcript_logical_forwards,
+            generation_tokens_per_lane,
+            generation_lanes,
+            logical_forwards: 0,
+            transcript_physical_batches: 0,
+            generation_physical_batches: 0,
+            physical_batches: 0,
+            max_sequence_position: EXACT_MULTICORE_PROBE_REGISTERED_MAX_SEQUENCE_POSITION,
+            state_sequence_capacity: EXACT_MULTICORE_PROBE_REGISTERED_STATE_SEQUENCE_CAPACITY,
+        };
+        configured_suite_work.logical_forwards = configured_suite_work.derived_logical_forwards();
+        configured_suite_work.transcript_physical_batches =
+            configured_suite_work.derived_transcript_physical_batches();
+        configured_suite_work.generation_physical_batches = generation_tokens_per_lane;
+        configured_suite_work.physical_batches = configured_suite_work.derived_physical_batches();
+        let probe_context_ceiling_tokens =
+            configured_suite_work.derived_probe_context_ceiling_tokens();
+        let probe_position_indices = vec![probe_context_ceiling_tokens - 1; positions];
+        let streams = 8usize;
+        // Close the interval between initial teacher-free admission and the
+        // first teacher-weight read. Rehash the preflight, compiled inputs,
+        // and complete production generation immediately before load, and
+        // require byte-for-byte admission identity equality with the token we
+        // validated above.
+        let current_preflight =
+            match exact_probe::validate_teacher_free_preflight(&preflight_path, &source, &bundle) {
+                Ok(current) => current,
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Unavailable(reason)) => {
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Refused(reason)) => {
+                    refuse_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                }
+                Err(exact_probe::TeacherFreePreflightAdmissionError::Failed(reason)) => fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                ),
+            };
+        if current_preflight != preflight {
+            refuse_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                "teacher-free preflight or production generation changed between admission and teacher load",
+                &mut overall_heartbeat,
+            );
+        }
+        let mut oracle = HuggingFaceLlamaOracle::load_with_sequence_length_and_execution(
+            &source,
+            probe_context_ceiling_tokens,
+            TeacherExecutionConfig::sequential(),
+        )
+        .unwrap_or_else(|error| {
+            let reason = format!("live teacher source fixture could not load: {error}");
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            )
+        });
+        let config_bytes = std::fs::read(source.join("config.json")).unwrap_or_else(|error| {
+            let reason = format!("live teacher config identity is unavailable: {error}");
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            )
+        });
+        let source_identity = ExactMulticoreProbeSource {
+            model_kappa: oracle.kappa(),
+            config_cid: format!("blake3:{}", blake3::hash(&config_bytes).to_hex()),
+            source_bytes: u64::try_from(oracle.source_bytes()).unwrap_or(u64::MAX),
+        };
+        let host_identity = exact_probe_host_identity();
+        if host_identity.available_parallelism != available
+            || host_identity.cpu_model.is_none()
+            || host_identity.physical_core_count.is_none()
+        {
+            let reason = format!(
+                "exact probe host model/capacity identity is incomplete or changed: {:?}",
+                host_identity.topology_unavailable_reason
+            );
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        emit_probe_record(
+            &events,
+            &serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE",
+                "event": "LOAD_COMPLETE",
+                "source_identity": &source_identity,
+                "host": &host_identity,
+            }),
+        );
+        overall_phase.set("BETWEEN_CONFIGS", None);
+        let vocab = oracle.cfg().vocab;
+        let reference_workers = available;
+        let mut reference_trace: Option<Vec<Vec<ProbeTracePoint>>> = None;
+        let mut runs = Vec::new();
+        let mut exact_equality = true;
+
+        // Measure the likely fastest point first. Four workers remains the
+        // bounded comparison because the M1 performance-core cluster can beat
+        // mixed performance/efficiency scheduling. Both candidates execute
+        // identical eight-stream work; a four-core host deduplicates them.
+        let mut worker_counts = Vec::new();
+        for workers in [available, 4usize] {
+            if !worker_counts.contains(&workers) {
+                worker_counts.push(workers);
+            }
+        }
+        for workers in worker_counts {
+            if probe_started.elapsed()
+                >= Duration::from_secs(EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS)
+            {
+                abort_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the cheap exact multicore probe reached its 60-minute wall ceiling before starting the next configuration",
+                    &mut overall_heartbeat,
+                );
+            }
+            overall_phase.set("PRESTART", Some(workers));
+            emit_probe_record(
+                &events,
+                &serde_json::json!({
+                    "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                    "record": "EXACT_MULTICORE_PROBE",
+                    "event": "PRESTART_BEGIN",
+                    "workers": workers,
+                    "tiles_per_worker": tiles_per_worker,
+                    "streams": streams,
+                    "batch_width": streams,
+                    "model_forward": false,
+                    "excluded_from_measurement": true,
+                    "backend": &backend,
+                }),
+            );
+            oracle
+                .set_execution_config(
+                    TeacherExecutionConfig::fixed_workers(
+                        NonZeroUsize::new(workers).expect("worker count is nonzero"),
+                    )
+                    .with_tiles_per_worker(
+                        NonZeroUsize::new(tiles_per_worker).expect("tiles per worker is nonzero"),
+                    ),
+                )
+                .unwrap_or_else(|error| {
+                    let reason = format!(
+                        "construct fixed {workers}-worker exact executor for adaptive candidate: {error}"
+                    );
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                });
+            let prestart = oracle
+                .prepare_exact_execution(streams)
+                .map(|evidence| ExactMulticoreProbePrestart {
+                    elapsed_seconds: evidence.elapsed_seconds,
+                    workers_observed: evidence.workers_observed,
+                    batch_width: evidence.batch_width,
+                    backend_exercised: evidence.backend_exercised,
+                    workspace_capacity_bytes: evidence.workspace_capacity_bytes,
+                    workspace_growth_events: evidence.workspace_growth_events,
+                    workspace_growth_bytes: evidence.workspace_growth_bytes,
+                    excluded_from_measurement: true,
+                })
+                .unwrap_or_else(|error| {
+                    let reason = format!(
+                        "prestart fixed {workers}-worker pool and exact backend without a model forward: {error}"
+                    );
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                });
+            emit_probe_record(
+                &events,
+                &serde_json::json!({
+                    "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                    "record": "EXACT_MULTICORE_PROBE",
+                    "event": "PRESTART_COMPLETE",
+                    "workers": workers,
+                    "streams": streams,
+                    "prestart": &prestart,
+                    "model_forward": false,
+                    "excluded_from_measurement": true,
+                }),
+            );
+            if probe_started.elapsed()
+                >= Duration::from_secs(EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS)
+            {
+                abort_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the cheap exact multicore probe reached its 60-minute wall ceiling after excluded pool/backend prestart",
+                    &mut overall_heartbeat,
+                );
+            }
+            let live = Arc::new(AtomicTeacherExecutionProgress::default());
+            let live_observer = Arc::clone(&live);
+            oracle.begin_measured_execution(Arc::new(move |snapshot| {
+                live_observer.publish(snapshot);
+            }));
+            overall_phase.set("MEASURED_FORWARD_AND_TRACE", Some(workers));
+            let forward_plan = oracle.exact_forward_plan(streams).unwrap_or_else(|error| {
+                let reason = format!("owner exact shared-weight forward plan: {error}");
+                unavailable_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                )
+            });
+            let trace_shape = oracle
+                .exact_probe_trace_shape_bounded(
+                    probe_context_ceiling_tokens,
+                    positions,
+                    streams,
+                    8,
+                )
+                .unwrap_or_else(|error| {
+                    let reason = format!("owner complete exact probe trace shape: {error}");
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                });
+            let mut states: Vec<State> = (0..streams)
+                .map(|_| oracle.new_state_bounded(probe_context_ceiling_tokens))
+                .collect::<Result<_, _>>()
+                .unwrap_or_else(|error| {
+                    let reason = format!("allocate bounded private probe states: {error}");
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                });
+            let process_start = process_sample();
+            emit_probe_record(
+                &events,
+                &serde_json::json!({
+                    "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                    "record": "EXACT_MULTICORE_PROBE",
+                    "event": "START",
+                    "measurement_scope": "EXACT_FORWARD_INTERVALS_ONLY",
+                    "workers": workers,
+                    "tiles_per_worker": tiles_per_worker,
+                    "streams": streams,
+                    "batch_width": streams,
+                    "positions": positions,
+                    "position_indices": &probe_position_indices,
+                    "backend": &backend,
+                    "process_start": process_sample_value(&process_start),
+                }),
+            );
+            let heartbeat_live = Arc::clone(&live);
+            let heartbeat_events = Arc::clone(&events);
+            let heartbeat_stop = Arc::new(AtomicBool::new(false));
+            let heartbeat_stop_worker = Arc::clone(&heartbeat_stop);
+            let max_sampled_rss = Arc::new(AtomicU64::new(
+                process_start
+                    .as_ref()
+                    .map_or(0, |sample| sample.resident_set_bytes),
+            ));
+            let heartbeat_max_rss = Arc::clone(&max_sampled_rss);
+            let heartbeat_started = Instant::now();
+            let heartbeat = std::thread::Builder::new()
+                .name(format!("r4-exact-probe-heartbeat-{workers}"))
+                .spawn(move || loop {
+                    std::thread::park_timeout(progress_every);
+                    if heartbeat_stop_worker.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let snapshot = heartbeat_live.snapshot();
+                    let process = process_sample();
+                    if let Ok(sample) = &process {
+                        heartbeat_max_rss
+                            .fetch_max(sample.resident_set_bytes, Ordering::AcqRel);
+                    }
+                    emit_probe_record(
+                        &heartbeat_events,
+                        &serde_json::json!({
+                            "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                            "record": "EXACT_MULTICORE_PROBE",
+                            "event": "PROGRESS",
+                            "elapsed_ms": u64::try_from(heartbeat_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                            "workers": workers,
+                            "tiles_per_worker": tiles_per_worker,
+                            "streams": streams,
+                            "observer_epoch": snapshot.observer_epoch,
+                            "forward_calls": snapshot.forward_calls,
+                            "streams_started": snapshot.streams_started,
+                            "streams_completed": snapshot.streams_completed,
+                            "active_streams": snapshot.active_streams,
+                            "peak_streams": snapshot.max_active_streams,
+                            "matrix_calls": snapshot.matrix_calls,
+                            "batched_matrix_calls": snapshot.batched_matrix_calls,
+                            "max_matrix_batch_width": snapshot.max_matrix_batch_width,
+                            "tiles": snapshot.tiles_completed,
+                            "output_cells": snapshot.output_cells_completed,
+                            "scalar_terms": snapshot.scalar_terms_completed,
+                            "active_workers": snapshot.active_workers,
+                            "peak_workers": snapshot.max_active_workers,
+                            "forward_peak_workers": snapshot.forward_max_active_workers,
+                            "multiworker_forward_calls": snapshot.multiworker_forward_calls,
+                            "workspace_growth_events": snapshot.workspace_growth_events,
+                            "workspace_growth_bytes": snapshot.workspace_growth_bytes,
+                            "process": process_sample_value(&process),
+                        }),
+                    );
+                })
+                .unwrap_or_else(|error| {
+                    let reason = format!("spawn exact probe heartbeat for {workers} workers: {error}");
+                    unavailable_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        &reason,
+                        &mut overall_heartbeat,
+                    )
+                });
+            let config_started = Instant::now();
+            let mut forward_elapsed = Duration::ZERO;
+            let mut forward_cpu_seconds = 0.0f64;
+            let mut forward_sample_error: Option<String> = None;
+            let mut first_forward_sample: Option<Result<ProbeProcessSample, String>> = None;
+            let mut last_forward_sample: Option<Result<ProbeProcessSample, String>> = None;
+            let mut output_trace: Vec<Vec<ProbeTracePoint>> = Vec::with_capacity(positions);
+            let mut wall_ceiling_reached = false;
+            for (step, &pos) in probe_position_indices.iter().enumerate() {
+                if probe_started.elapsed()
+                    >= Duration::from_secs(EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS)
+                {
+                    wall_ceiling_reached = true;
+                    break;
+                }
+                let tokens: Vec<usize> = (0..streams)
+                    .map(|stream| ((stream + step + 1) % vocab).max(1))
+                    .collect();
+                let position_batch = vec![pos; streams];
+                let interval_start = process_sample();
+                if let Ok(sample) = &interval_start {
+                    max_sampled_rss.fetch_max(sample.resident_set_bytes, Ordering::AcqRel);
+                }
+                if first_forward_sample.is_none() {
+                    first_forward_sample = Some(interval_start.clone());
+                }
+                let forward_started = Instant::now();
+                oracle.forward_batch_into(&mut states, &tokens, &position_batch);
+                forward_elapsed = forward_elapsed.saturating_add(forward_started.elapsed());
+                let interval_end = process_sample();
+                if let Ok(sample) = &interval_end {
+                    max_sampled_rss.fetch_max(sample.resident_set_bytes, Ordering::AcqRel);
+                }
+                match (&interval_start, &interval_end) {
+                    (Ok(start), Ok(end)) if end.cpu_time_seconds >= start.cpu_time_seconds => {
+                        forward_cpu_seconds += end.cpu_time_seconds - start.cpu_time_seconds;
+                    }
+                    (Ok(_), Ok(_)) => {
+                        forward_sample_error =
+                            Some("process CPU time moved backwards within a forward".to_owned());
+                    }
+                    (Err(reason), _) | (_, Err(reason)) => {
+                        forward_sample_error = Some(reason.clone());
+                    }
+                }
+                last_forward_sample = Some(interval_end);
+                output_trace.push(states.iter().map(capture_trace_point).collect());
+                if probe_started.elapsed()
+                    >= Duration::from_secs(EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS)
+                {
+                    wall_ceiling_reached = true;
+                    break;
+                }
+            }
+            let inclusive_config_elapsed = config_started.elapsed();
+            heartbeat_stop.store(true, Ordering::Release);
+            heartbeat.thread().unpark();
+            if heartbeat.join().is_err() {
+                let reason = format!(
+                    "exact probe heartbeat for {workers} workers panicked during measurement"
+                );
+                unavailable_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    &reason,
+                    &mut overall_heartbeat,
+                );
+            }
+            if wall_ceiling_reached {
+                abort_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the cheap exact multicore probe reached its 60-minute wall ceiling; the in-flight forward completed and no additional work was admitted",
+                    &mut overall_heartbeat,
+                );
+            }
+            let elapsed_ms = u64::try_from(forward_elapsed.as_millis()).unwrap_or(u64::MAX);
+            let aggregate_forwards = streams.saturating_mul(positions);
+            let forwards_per_second =
+                aggregate_forwards as f64 / forward_elapsed.as_secs_f64().max(f64::MIN_POSITIVE);
+            if output_trace.len() != trace_shape.positions {
+                fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "exact probe trace omitted one or more measured positions",
+                    &mut overall_heartbeat,
+                );
+            }
+            for position_trace in &output_trace {
+                if position_trace.len() != trace_shape.streams_per_position {
+                    fail_probe(
+                        &events,
+                        &report_path,
+                        probe_started.elapsed().as_secs_f64(),
+                        "exact probe trace omitted one or more independent streams",
+                        &mut overall_heartbeat,
+                    );
+                }
+                for point in position_trace {
+                    if point.logits_bits.len() != trace_shape.logits_per_state
+                        || point.persistent_state_bits.len()
+                            != trace_shape.persistent_state_words_per_state
+                        || point.top_tokens.len() != trace_shape.top_k
+                        || point.top_tokens.first().copied() != Some(point.greedy_token)
+                    {
+                        fail_probe(
+                            &events,
+                            &report_path,
+                            probe_started.elapsed().as_secs_f64(),
+                            "exact probe trace shape or canonical token evidence is incomplete",
+                            &mut overall_heartbeat,
+                        );
+                    }
+                }
+            }
+            let equal_to_reference = if let Some(reference) = &reference_trace {
+                &output_trace == reference
+            } else {
+                reference_trace = Some(output_trace.clone());
+                true
+            };
+            let output_trace_cid = output_trace_cid(&output_trace);
+            exact_equality &= equal_to_reference;
+            let snapshot = oracle.execution_snapshot();
+            let mut resource_start = first_forward_sample.unwrap_or_else(|| process_start.clone());
+            let resource_end = last_forward_sample.unwrap_or_else(|| process_start.clone());
+            if let Some(reason) = forward_sample_error {
+                resource_start = Err(reason);
+            }
+            let resources = completed_resources(
+                &resource_start,
+                &resource_end,
+                max_sampled_rss.load(Ordering::Acquire),
+                forward_elapsed.as_secs_f64(),
+                "EXACT_FORWARD_INTERVALS_ONLY",
+                Some(forward_cpu_seconds),
+            );
+            emit_probe_record(
+                &events,
+                &serde_json::json!({
+                    "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                    "record": "EXACT_MULTICORE_PROBE",
+                    "event": "CONFIG_COMPLETE",
+                    "elapsed_ms": elapsed_ms,
+                    "elapsed_seconds": forward_elapsed.as_secs_f64(),
+                    "inclusive_config_elapsed_seconds": inclusive_config_elapsed.as_secs_f64(),
+                    "measurement_scope": "EXACT_FORWARD_INTERVALS_ONLY",
+                    "workers": workers,
+                    "tiles_per_worker": tiles_per_worker,
+                    "streams": streams,
+                    "aggregate_forwards_per_second": forwards_per_second,
+                    "equal_to_reference": equal_to_reference,
+                    "reference_workers": reference_workers,
+                    "output_trace_cid": &output_trace_cid,
+                    "trace_shape": trace_shape,
+                    "forward_plan": forward_plan,
+                    "all_workers_active": snapshot.max_active_workers == snapshot.effective_workers,
+                    "all_streams_active": snapshot.active_streams == 0 && snapshot.max_active_streams == streams,
+                    "snapshot": snapshot,
+                    "resources": &resources,
+                }),
+            );
+            runs.push(ProbeRunMeasurement {
+                workers,
+                prestart,
+                elapsed_ms,
+                elapsed_seconds: forward_elapsed.as_secs_f64(),
+                aggregate_forwards_per_second: forwards_per_second,
+                equal_to_reference,
+                snapshot,
+                output_trace_cid,
+                resources,
+                forward_plan,
+                trace_shape,
+            });
+            overall_phase.set("BETWEEN_CONFIGS", None);
+        }
+
+        let reference_trace_cid = runs
+            .first()
+            .map(|run| run.output_trace_cid.as_str())
+            .unwrap_or_else(|| {
+                fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the adaptive exact probe produced no reference trace",
+                    &mut overall_heartbeat,
+                )
+            });
+        let worker4_rate = runs
+            .iter()
+            .find(|run| run.workers == 4)
+            .map(|run| run.aggregate_forwards_per_second)
+            .unwrap_or_else(|| {
+                fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the adaptive exact probe omitted its required four-worker candidate",
+                    &mut overall_heartbeat,
+                )
+            });
+        exact_equality &= runs
+            .iter()
+            .all(|run| run.equal_to_reference && run.output_trace_cid == reference_trace_cid);
+        let qualification_wall_seconds = configured_max_wall.min(28_800);
+        let projection_safety_factor = 1.25f64;
+        let run_records: Vec<ExactMulticoreProbeRun> = runs
+            .iter()
+            .map(|run| {
+                let raw_projection = configured_suite_work.physical_batches as f64
+                    * run.elapsed_seconds
+                    / positions as f64;
+                ExactMulticoreProbeRun {
+                    workers: run.workers,
+                    batch_width: streams,
+                    prestart: run.prestart.clone(),
+                    elapsed_ms: run.elapsed_ms,
+                    elapsed_seconds: run.elapsed_seconds,
+                    aggregate_forwards_per_second: run.aggregate_forwards_per_second,
+                    relative_throughput_vs_worker4: run.aggregate_forwards_per_second
+                        / worker4_rate,
+                    equal_to_reference: run.output_trace_cid == reference_trace_cid,
+                    all_workers_active: run.snapshot.requested_workers == run.workers
+                        && run.snapshot.effective_workers == run.workers
+                        && run.snapshot.active_workers == 0
+                        && run.snapshot.max_active_workers == run.workers,
+                    all_streams_active: run.snapshot.active_streams == 0
+                        && run.snapshot.max_active_streams == streams
+                        && run.snapshot.streams_started
+                            == u64::try_from(streams.saturating_mul(positions)).unwrap_or(u64::MAX)
+                        && run.snapshot.streams_completed
+                            == u64::try_from(streams.saturating_mul(positions)).unwrap_or(u64::MAX),
+                    output_trace_cid: run.output_trace_cid.clone(),
+                    trace_shape: run.trace_shape,
+                    forward_plan: run.forward_plan,
+                    raw_projected_suite_seconds: raw_projection,
+                    safety_adjusted_projected_suite_seconds: raw_projection
+                        * projection_safety_factor,
+                    snapshot: run.snapshot,
+                    resources: run.resources.clone(),
+                }
+            })
+            .collect();
+        let best = run_records
+            .iter()
+            .min_by(|left, right| {
+                left.safety_adjusted_projected_suite_seconds
+                    .total_cmp(&right.safety_adjusted_projected_suite_seconds)
+                    .then_with(|| left.workers.cmp(&right.workers))
+            })
+            .unwrap_or_else(|| {
+                fail_probe(
+                    &events,
+                    &report_path,
+                    probe_started.elapsed().as_secs_f64(),
+                    "the exact probe produced no fixed-worker measurements",
+                    &mut overall_heartbeat,
+                )
+            });
+        let selected_best_config = ExactMulticoreProbeSelection {
+            workers: best.workers,
+            tiles_per_worker,
+            aggregate_forwards_per_second: best.aggregate_forwards_per_second,
+            raw_projected_suite_seconds: best.raw_projected_suite_seconds,
+            safety_adjusted_projected_suite_seconds: best.safety_adjusted_projected_suite_seconds,
+        };
+        let configured_execution = selected_best_config.clone();
+        let raw_projected_suite_seconds = best.raw_projected_suite_seconds;
+        let safety_adjusted_projected_suite_seconds = best.safety_adjusted_projected_suite_seconds;
+        let all_workers_active = run_records.iter().all(|run| run.all_workers_active);
+        let all_streams_active = run_records.iter().all(|run| run.all_streams_active);
+        let registered_binding_work = configured_suite_work.is_registered_binding_work();
+        emit_probe_record(
+            &events,
+            &serde_json::json!({
+                "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                "record": "EXACT_MULTICORE_PROBE",
+                "event": "SELECTION",
+                "selection_policy": EXACT_MULTICORE_PROBE_SELECTION_POLICY,
+                "selected": &selected_best_config,
+                "candidate_count": run_records.len(),
+                "physical_batches": configured_suite_work.physical_batches,
+                "logical_forwards": configured_suite_work.logical_forwards,
+                "registered_binding_work": registered_binding_work,
+            }),
+        );
+        overall_phase.set("PUBLISH", None);
+        let overall_process_end = process_sample();
+        let probe_elapsed_seconds = probe_started.elapsed().as_secs_f64();
+        if probe_elapsed_seconds >= EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS as f64 {
+            abort_probe(
+                &events,
+                &report_path,
+                probe_elapsed_seconds,
+                "the cheap exact multicore probe exceeded its 60-minute wall ceiling before publication",
+                &mut overall_heartbeat,
+            );
+        }
+        let overall_max_rss_bytes = run_records
+            .iter()
+            .filter_map(|run| run.resources.max_sampled_rss_bytes)
+            .chain(
+                overall_process_start
+                    .as_ref()
+                    .ok()
+                    .map(|sample| sample.resident_set_bytes),
+            )
+            .chain(
+                overall_process_end
+                    .as_ref()
+                    .ok()
+                    .map(|sample| sample.resident_set_bytes),
+            )
+            .chain(Some(overall_max_sampled_rss.load(Ordering::Acquire)))
+            .max()
+            .unwrap_or(0);
+        let overall_resources = completed_resources(
+            &overall_process_start,
+            &overall_process_end,
+            overall_max_rss_bytes,
+            probe_elapsed_seconds,
+            "FULL_PROBE_WALL",
+            None,
+        );
+        let qualifies_full_run = registered_binding_work
+            && exact_equality
+            && all_streams_active
+            && safety_adjusted_projected_suite_seconds < qualification_wall_seconds as f64;
+        let mut report = ExactMulticoreProbeReport {
+            schema: EXACT_MULTICORE_PROBE_SCHEMA.to_owned(),
+            executor_contract_cid: exact_executor_contract_cid(),
+            source: source_identity,
+            host: host_identity,
+            backend,
+            probe_positions: positions,
+            probe_context_ceiling_tokens,
+            probe_position_indices,
+            probe_streams: streams,
+            probe_wall_ceiling_seconds: EXACT_MULTICORE_PROBE_WALL_CEILING_SECONDS,
+            probe_deadline_policy: EXACT_MULTICORE_PROBE_DEADLINE_POLICY.to_owned(),
+            events: ExactMulticoreProbeEventsBinding {
+                file_name: events_path
+                    .file_name()
+                    .and_then(std::ffi::OsStr::to_str)
+                    .unwrap_or("exact-multicore-probe.events.jsonl")
+                    .to_owned(),
+                content_cid: "PENDING".to_owned(),
+                byte_len: 0,
+                record_count: 0,
+                final_record_number: 0,
+                final_event: "PENDING".to_owned(),
+                final_status: if qualifies_full_run {
+                    ExactMulticoreProbeStatus::Qualified
+                } else {
+                    ExactMulticoreProbeStatus::RefuseFullRun
+                },
+                final_qualifies_full_run: false,
+                report_body_cid: "PENDING".to_owned(),
+            },
+            probe_elapsed_seconds,
+            runs: run_records,
+            reference_workers,
+            selected_best_config,
+            configured_execution,
+            exact_equality,
+            all_workers_active,
+            all_streams_active,
+            configured_suite_work,
+            raw_projected_suite_seconds,
+            projection_safety_factor,
+            projection_context_assumption: EXACT_MULTICORE_PROBE_CONTEXT_ASSUMPTION.to_owned(),
+            safety_adjusted_projected_suite_seconds,
+            binding_verdict: ExactMulticoreProbeVerdict {
+                status: if qualifies_full_run {
+                    ExactMulticoreProbeStatus::Qualified
+                } else {
+                    ExactMulticoreProbeStatus::RefuseFullRun
+                },
+                selection_policy: EXACT_MULTICORE_PROBE_SELECTION_POLICY.to_owned(),
+                configured_max_wall_seconds: configured_max_wall,
+                qualification_wall_seconds,
+                qualifies_full_run,
+            },
+            resources: overall_resources,
+        };
+        if let Err(reason) = overall_heartbeat.stop_and_join() {
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        let final_status = report.binding_verdict.status;
+        let final_qualifies_full_run = report.binding_verdict.qualifies_full_run;
+        let finalization = report.write_after_durable_final(
+            &report_path,
+            &events_path,
+            |report_body_cid, final_record_number| {
+                try_emit_probe_record(
+                    &events,
+                    &serde_json::json!({
+                        "schema": EXACT_MULTICORE_PROBE_SCHEMA,
+                        "record": "EXACT_MULTICORE_PROBE",
+                        "event": "FINAL",
+                        "sequence": final_record_number,
+                        "source_path": &source,
+                        "report_path": &report_path,
+                        "events_path": &events_path,
+                        "report_body_cid": report_body_cid,
+                        "status": final_status,
+                        "qualifies_full_run": final_qualifies_full_run,
+                    }),
+                    true,
+                )
+            },
+        );
+        if let Err(error) = finalization {
+            // Every progress producer has already been joined. A failure after
+            // FINAL therefore may append only this terminal non-PASS record;
+            // no PROGRESS record can appear after either terminal event.
+            let reason = format!(
+                "durably append FINAL before publishing exact multicore probe report: {error}"
+            );
+            unavailable_probe(
+                &events,
+                &report_path,
+                probe_started.elapsed().as_secs_f64(),
+                &reason,
+                &mut overall_heartbeat,
+            );
+        }
+        assert!(
+            exact_equality,
+            "live exact outputs or persistent state changed across worker counts"
+        );
     }
 
     /// Raw teacher throughput: serial `step` vs batched `forward_batch_into` on
@@ -3273,7 +6799,8 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     mod shard_ingestion {
         use crate::{
-            HuggingFaceLlamaOracle, SafetensorsSnapshot, SourceIngestKind, TensorRequirement,
+            exact_probe_expectation_shapes_from_config, HuggingFaceLlamaOracle,
+            SafetensorsSnapshot, SourceIngestKind, TensorRequirement,
         };
         use std::path::{Path, PathBuf};
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -3744,6 +7271,28 @@ mod tests {
             "max_position_embeddings": 8,
             "tie_word_embeddings": true
         }"#;
+
+        #[test]
+        fn config_only_probe_planner_never_requires_weight_files() {
+            let dir = temp_snapshot_dir("probe-plan-config-only");
+            write(&dir, "config.json", TINY_CONFIG.as_bytes());
+            assert!(!dir.join("model.safetensors").exists());
+            let shapes = exact_probe_expectation_shapes_from_config(&dir, 8, &[4, 8], 4, 8, 1, 8)
+                .expect("config-only exact probe plan");
+            assert_eq!(shapes.forward_plans.len(), 2);
+            assert!(shapes
+                .forward_plans
+                .iter()
+                .all(|plan| plan.forward_plan.batch_width == 8));
+            assert!(shapes
+                .forward_plans
+                .iter()
+                .all(|plan| plan.forward_plan.matrix_calls == 8));
+            assert_eq!(shapes.trace_shape.positions, 1);
+            assert_eq!(shapes.trace_shape.streams_per_position, 8);
+            assert_eq!(shapes.trace_shape.logits_per_state, 10);
+            assert_eq!(shapes.trace_shape.state_records, 8);
+        }
 
         fn as_entries<'a>(
             tensors: &'a [(String, &'static str, Vec<usize>, Vec<u8>)],

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -80,6 +80,9 @@ These are κ-relevant: changing them can change artifact bytes.
 | `R4_CAP_THREADS` | `capacity_scaling` harness | 2 |
 | `R4_SCALING_THREADS` | `cover_scaling` harness | 2 |
 | `R4_TS_THREADS` | `two_sided_context` harness | env-derived |
+| `R4_PARITY_WORKERS` | Size `W` of the one persistent exact output-row worker pool. Diagnostic range is `1..=available_parallelism()`; `0`, malformed values, and requests above the host budget fail instead of being clamped. Fixture-present execution adopts the faster exact W=available/W=min(4, available) tuner result, so this input cannot force a different binding selection. The candidate widths are a bounded tuning choice, not a utilization target. | all available logical CPUs before probe selection |
+| `R4_PARITY_STREAMS` | Independent private-state trajectory and physical-batch width `S`. `S` is scientific work, not a worker bound: it may exceed or be less than `W`. The binding fixture-present workload requires the eight canonical prompt lanes. | 8 |
+| `R4_PARITY_BATCH_PER_WORKER` | Bounded exact output-row task fan-out per worker. This changes scheduling granularity only; it cannot select Accelerate or change exact arithmetic. Requested and effective fan-out are recorded. | 4 |
 
 ## Cover induction and compiler capacity
 
@@ -255,12 +258,96 @@ test ! -e .uor-models/compiled/<model>-staging/graph/deployed_quality_full.log
 | `R4_MEMLIFT_CONSTR_STORIES` / `R4_MEMLIFT_PROBES` | 2,000 / 500 | `memory_lift_corpus` |
 | `R4_ARM_SKIP_SAMPLE` / `R4_ARM_SKIP_FIXTURE_DIR` | 10,000 / the committed fixtures | `gate_c_arm_skip` |
 | `R4_STATUS_FIXTURE_DIR` | `/tmp/r4-status-fixture` | `status_policy` |
-| `R4_PARITY_POSITIONS` / `_GEN_TOKENS` / `_RUNS` / `_CORPUS_POSITIONS` | 256 / 128 / 3 / 1000 | BDD teacher parity |
+| `R4_PARITY_POSITIONS` / `_GEN_TOKENS` / `_RUNS` / `_CORPUS_POSITIONS` | 256 / 8 / 1 / 1000. The binding registered work uses exactly eight lanes and an eight-token maximum; S4 starts at one causal continuation step per lane, then may extend through 2, 4, and 8 only while more work can change the verdict. Smaller generation caps are diagnostic only and cannot qualify the full run. Fixture-present execution requires one causal run. The report records actual tokenized/executed work; caps are not forward-count claims. | BDD teacher parity |
+| `R4_PARITY_PREFLIGHT_ONLY` | Off. Set to `1` to validate the schema-2 `release-bundle.json` production envelope and deployed-quality bindings, then parse and exercise the tokenizer, legacy artifact/store, graph, graph report, and all eight canonical deployed seeds without opening the live teacher. It writes a `uor-r4.teacher-parity-preflight/1` success or refusal artifact with `teacher_source_opened=false` and `teacher_forwards=0`, then exits before Cucumber. The ordinary BDD fixture loader publishes the same artifact automatically. Any missing or invalid prerequisite blocks expensive teacher work truthfully. | Teacher-free BDD preflight |
+| `R4_PARITY_PREFLIGHT_REPORT` | `target/teacher-parity/teacher-free-preflight.json`. Relative paths resolve from the repository workspace root for both the BDD owner and direct tuner. Atomic deterministic output used by explicit and automatic preflight. Non-PASS artifacts retain the exact reason, selected paths, safe per-input presence/CIDs, and current `authorizing_contract_cid` before returning; an empty, non-Unicode, uncreatable, or unwritable path fails the preflight visibly. The direct tuner validates the current contract, exact report/source/bundle paths, and recomputed compiled-input plus complete production-admission CIDs before opening teacher weights. | Teacher-free BDD preflight and exact live admission probe |
+| `R4_PARITY_PROGRESS_EVERY_SECS` | 10. Periodic human-readable and flushed JSONL heartbeat cadence, including while no exact forward has completed. In-flight matrix/tile/cell/scalar counters drive liveness and the ETA basis; whole-forward throughput remains separate. Zero or malformed values fail. | BDD teacher parity |
+| `R4_PARITY_MAX_WALL_SECS` | 28,800 (8 h). Stops dispatching new work at the ceiling and records `ABORTED`; it never converts partial work into PASS. Values above 28,800 fail: the override may shorten but never widen the hard ceiling. The full run is also refused before launch unless the cheap probe projects completion below this ceiling. | BDD teacher parity |
+| `R4_PARITY_REPORT` | `target/teacher-parity/parity-report.json`. Final versioned JSON report; the flushed event stream is written beside it as `parity-report.events.jsonl`. A create/write/flush failure is `FAIL`, not missing telemetry on a PASS. | BDD teacher parity |
+| `R4_PARITY_TELEMETRY` | `1` / enabled. `0` exists only for focused planted/unit controls; fixture-present parity refuses to run without telemetry. Invalid booleans fail. | BDD teacher parity |
+| `R4_EXACT_PROBE_REPORT` | `target/teacher-parity/exact-multicore-probe.json`; relative paths resolve from the repository workspace root and flushed events use `exact-multicore-probe.events.jsonl`. An empty/non-Unicode path refuses admission. | Exact live admission probe and BDD consumer |
+| `R4_EXACT_PROBE_POSITIONS` | 1; valid range `1..=8`. Every configured position is exercised over the same eight canonical states at W=available and W=min(4, available), deduplicated when equal. | Exact live admission probe |
+| `R4_PARITY_SOURCE` | `.uor-models/sources/smollm2-135m-instruct`. Teacher source directory used consistently by the exact probe and fixture-present BDD run. Relative paths resolve from the repository workspace root; empty or non-Unicode values fail closed. The teacher-free preflight records this selection but does not open it. | Exact live admission probe and BDD teacher parity |
+| `R4_PARITY_BUNDLE` | `.uor-models/compiled/smollm2-135m-instruct`. Compiled schema-2 `release-bundle.json`/deployed-quality envelope plus tokenizer/artifact/store/graph/report bundle used consistently by teacher-free preflight and fixture-present BDD work. A pre-schema-2 bundle is refused before teacher access. Relative paths resolve from the repository workspace root; empty or non-Unicode values fail closed. | Teacher-free preflight and BDD teacher parity |
 | `R4_FMM_POSITIONS` / `R4_FMM_RANK` / `R4_FMM_TOLERANCE` | 256 / — / — | BDD FMM |
 | `SMOLLM2_SOURCE` | — | `smollm2_adapter` tests |
 | `UOR_R4_API_E2E_SOURCE` | — | `uor-r4-api` E2E test |
 | `UOR_R4_RELEASE_BUNDLE_PATH` | — | `release_bundle_packager` real-local-bundle test (`#[ignore]`d; mirrors the `UOR_R4_API_E2E_SOURCE` convention) |
 | `PORT` | 8000 | `./uor-r4-cli` orchestrator only (shell script; the `r4` binary itself reads `UOR_R4_PORT`) |
+
+Teacher-parity controls govern host-side verification only and do not enter
+artifact identities or deployed serving. `S` private sequence states must share
+one immutable weight allocation and advance in one physical exact batch; the one
+`W`-thread pool must schedule disjoint output rows without nested
+oversubscription.
+Every output row must keep the pinned `uor-matmul` dot reduction intact;
+splitting or reassociating the reduction dimension is not permitted. Results
+return to canonical prompt/position order before metrics are reduced.
+
+The 36 logical teacher-forced positions are executed once in six physical
+batches with registered widths `8, 8, 8, 7, 4, 1`. That transcript retains each
+canonical lane at its distinct final teacher-forced prompt prefix (lengths
+`5, 6, 5, 4, 3, 4, 5, 4` for the pinned tokenizer), rather than truncating
+different prompts to a colliding common prefix. S4 clones the templates,
+appends the already-computed teacher next token to each logical seed, and times
+only new causal continuation steps. Exact batches carry the per-lane sequence
+positions explicitly, so variable histories do not serialize the cohort.
+There is no duplicate live-teacher prefill and no independent full-model S4
+warm-up. Preparation, decode, and one-shot elapsed time remain separate
+evidence fields.
+
+Before measurement, the harness reserves the bounded model-wide batch buffers,
+exact input/output transpose buffers, and one exact scratch slot per dedicated
+worker, then exercises the worker pool/backend with a tiny known product. Its
+elapsed time, retained capacity, capacity-growth event count, and actual added
+capacity bytes are recorded as excluded preparation. Measurement counters are
+reset without discarding those buffers. Every transcript and S4 physical
+forward must subsequently report zero workspace-growth events and bytes;
+otherwise the run fails rather than presenting allocation churn as steady-state
+throughput.
+
+Conditional source, artifact, store, graph, tokenizer, or corpus evidence is
+reported as `AVAILABLE`, `UNAVAILABLE`, `FAILED`, or `NOT_RUN`. An absent
+fixture is never a parity PASS merely because the enclosing test executable
+returns success. The progress/event/report schema and the launch gate are
+specified in [the #932 run record](teacher_parity_parallelism_932.md).
+
+The durable artifact set is:
+
+| Artifact | Schema id | Default path | Role |
+|---|---|---|---|
+| Progress events | `uor-r4.teacher-parity-progress/2` | `target/teacher-parity/parity-report.events.jsonl` | Flushed heartbeat, phase, work, failure, and completion snapshots |
+| Final run report | `uor-r4.teacher-parity-report/2` | `target/teacher-parity/parity-report.json` | Empirical timing/resource/occupancy verdict and exact reason |
+| Deterministic evidence | `uor-r4.teacher-parity-evidence/2` | `target/teacher-parity/parity-report.evidence.json` | Timing-free identities, exact outputs, reductions, and verdict inputs |
+| Exact admission probe | `uor-r4.exact-multicore-probe/2` | `target/teacher-parity/exact-multicore-probe.json` plus `.events.jsonl` | Source/host/executor-bound equal-work W=available/W=min(4, available) selection evidence |
+
+For `uor-r4.exact-multicore-probe/2`, `probe_deadline_policy` means that no new
+exact forward is admitted after 3,600 seconds; an already-active fixture load or
+exact forward may finish, then the probe records `ABORTED`, and elapsed time at
+or beyond the deadline cannot qualify. The report's required `events` object
+binds the sibling `file_name`, full-byte `content_cid`, `byte_len`,
+`record_count`, `final_record_number`, `final_event`, `final_status`,
+`final_qualifies_full_run`, and non-cyclic `report_body_cid`. FINAL is synchronized
+before the report is atomically committed, carries
+`sequence == final_record_number == record_count`, and must be the last JSONL
+record. Admission validates the current sidecar before teacher weights load;
+missing, truncated, appended, or tampered bytes refuse the run.
+
+Schema `/1` bytes describe the superseded fixed-sweep design and remain
+historical evidence. Schema `/2` binds the adaptive candidate set, fastest-exact
+selection policy, and the complete registered admission shape: 36 transcript
+logical forwards in batch widths `8, 8, 8, 7, 4, 1`; eight continuation tokens
+across eight lanes; 100 logical forwards in 14 physical shared-weight batches;
+zero-based maximum sequence position 13; and private-state capacity 14. A
+smaller operator cap may produce diagnostic evidence but cannot qualify the
+binding suite. `reference_workers` names the first measured exact candidate,
+`equal_to_reference` binds every candidate's raw trace to it, and the cheap
+worker-pool/backend `prestart` is recorded separately and excluded from timed
+forward rates. CPU and RSS fields are diagnostics: they must be structurally
+valid and truthful, but a platform-reported `UNAVAILABLE` value does not by
+itself refuse exact admission. A later change to field meaning, type,
+requiredness, units, or artifact partition requires another schema id rather
+than reinterpreting an existing record.
 
 ## Served model identity (#655-F)
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -32,10 +32,13 @@ witness failures, a collapsing shuffled-label control, deterministic 4/8-worker
 rebuilds, and strict empty-store schema-2 admission, #933 records **RATIFY** for
 that exact artifact, population, selector, and greedy decode. #908's **29.702%**
 remains valid `R4Engine` reference/off-serving evidence rather than being
-relabeled. The repository BDD run was 124 / 124, but live-teacher parity
-fixtures were absent and those scenarios vacuously skipped; this is not parity
-evidence. #932's exact-parallel, observable live-teacher BDD harness remains a
-distinct downstream task.
+relabeled. #932 has since implemented the exact-parallel, observable
+live-teacher BDD harness, but its teacher-free production gate rejected the
+selected canonical 135M bundle because it has no schema-2 `release-bundle.json`
+envelope. The tuner and fixture-present measurement were `NOT_RUN` with zero
+teacher work. The structural harness gates pass; live exact-multicore
+throughput, speedup, and parity remain **NOT ESTABLISHED**. See the
+[append-only #932 record](teacher_parity_parallelism_932.md).
 
 ## Measurement discipline
 

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -54,14 +54,58 @@ The shared Llama teacher **weight matmuls** now call the pinned `uor-matmul`
 exact GEMM (`uor_matmul::slice::gemm_float`). The Accelerate `cblas_sgemv` /
 `cblas_sgemm` FFI and all hand-rolled SIMD dot helpers are removed. GPT-2's
 separate dense sites are covered by their own certified-exact row below.
-The migrated Llama result is correctly-rounded exact and byte-identical across
-targets (no per-machine Accelerate variance) — a determinism improvement for
-teacher outputs and the derived corpus/artifact bytes that bind those outputs.
+The migrated Llama path requires the correctly rounded exact dot-product owner
+and requires byte-identical results whenever supported exact backends or targets
+are compared; it does not opt into per-machine Accelerate accumulation order.
+The #932 structural gates establish worker-schedule equality on the local
+target. Cross-target and cross-machine live-model equality remain empirical
+criteria with status **NOT_RUN**, as recorded below; they are not inferred from
+ownership of the exact substrate.
 
 | Site | Operation | Backend | Classification |
 |---|---|---|---|
 | `uor-r4-model-source/src/lib.rs` `matmul` | matrix–vector (`W·x`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
 | `uor-r4-model-source/src/lib.rs` `matmul_batched` | matrix–matrix (`X·Wᵀ`) | `uor_matmul::slice::gemm_float` | uor-matmul-owned |
+
+### Exact-parallel teacher-parity boundary (#932)
+
+The live SmolLM2 parity contract has two independent dimensions. `S` is the
+number of private-state trajectories advanced together through one immutable
+weight allocation; `W` is the size of the one persistent exact output-row
+worker pool. Scientific work stays fixed at eight canonical lanes in an
+`S = 8` shared-weight batch. The binding M1 tuner compares identical work at
+`W = 4` and `W = 8`, then selects the faster exact point; W=1/2/4/8 remain
+focused structural schedules rather than four expensive live-model runs. `S`
+and `W` are independent, so selecting four row workers does not delete or
+serialize the eight private trajectories.
+
+**Guarantee.** Parallel work may divide only a projection's **output-row set**.
+Each assigned row must retain the complete pinned `uor-matmul` exact dot
+product; the reduction dimension may not be split, partially reduced,
+reassociated, or merged across workers. Completion order may vary, but rows,
+streams, and metrics must return to canonical input order before becoming
+observable. Status: **Structural**. The #932 exact-bit, owner-plan,
+shuffled-completion, and deterministic-schedule integration gates pass on the
+local target; this status does not promote the unrun live-model criterion
+below.
+
+The structural gate must cover every configured position, stream, raw-logit
+word, top-k row/tie, greedy choice, persistent-state record, lane output CID,
+transcript byte, metric, and ordered reduction. Observed physical batches,
+logical forwards, matrix calls and widths, row tiles, output cells, and scalar
+terms must equal the plan derived from the owner `exact_forward_plan(S)`; a
+declared `states.len()` or planned occupancy is not observation evidence.
+Consequently this work must neither select the #804 Accelerate exception nor add
+a new teacher-arithmetic era. Any raw-logit mismatch refuses the configuration.
+
+**Empirical Criterion.** Both live tuner points must preserve the complete exact
+trace and owner-plan totals. The faster exact point is selected with a
+deterministic tie-break, and its safety-adjusted projection for the optimized
+actual work must remain below the configured wall ceiling (never more than
+eight hours). Speedup and CPU utilization are diagnostic measurements, not
+arbitrary qualification floors. Status: **Unproven**; execution verdict:
+**NOT_RUN**. Current evidence is recorded append-only in
+[`teacher_parity_parallelism_932.md`](teacher_parity_parallelism_932.md).
 
 No `cblas_*` symbol remains anywhere in the default production chain; the CI
 guard now enforces zero library-BLAS use (only the two dependency-audit files,

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -182,6 +182,25 @@ live-teacher fixtures were absent and those scenarios vacuously skipped; no
 instruction-following, reasoning, or free-running generation claim is promoted.
 The next native dependency is #932 → #931 → #839.
 
+### S2 verification instrument — negative prerequisite outcome (2026-08-25, #932)
+
+#932 implemented the deterministic exact-parallel scheduler, a complete
+registered trace shape,
+durable progress/final reports, resource sampling, and planted-negative gates
+for the live SmolLM2-135M parity suite. Its post-#933 teacher-free preflight
+then rejected the selected canonical 135M bundle before opening teacher weights:
+the bundle predates the required schema-2 `release-bundle.json` production
+envelope. The direct tuner and fixture-present parity measurement are therefore
+`NOT_RUN`, and every live-work counter is zero.
+
+**Verdict: close #932 on its predeclared negative branch.** The host instrument
+is established; live exact-multicore throughput, speedup, resource ceilings,
+and parity are **NOT ESTABLISHED** for this bundle. No different-CID bundle was
+substituted and no admission or quality threshold was weakened. The next native
+dependency is #931 → #839, carrying this explicit non-pass boundary. Full
+bindings and refusal evidence are in
+[`teacher_parity_parallelism_932.md`](teacher_parity_parallelism_932.md).
+
 ### S1 stage verdict — REVISE (2026-08-21)
 
 All S1 child work is resolved and the pre-registered kill/redesign criterion is met, so

--- a/docs/teacher_parity_parallelism_932.md
+++ b/docs/teacher_parity_parallelism_932.md
@@ -1,0 +1,741 @@
+# Exact-parallel live teacher parity — issue #932
+
+## Status
+
+This is the append-only design, run contract, and evidence record for issue
+#932, the verification blocker nested under #931. It concerns host-side
+SmolLM2-135M parity only. It does not change deployed serving, artifact formats,
+the multiplication-free runtime kernel, parity thresholds, or teacher
+arithmetic.
+
+Current status (2026-08-25, after #933 merged):
+
+- exact scheduler, deterministic trace, observability, and planted-negative
+  implementation: **PASS** on focused structural gates;
+- canonical 135M teacher-free production preflight: **UNAVAILABLE** because the
+  bundle has no schema-2 `release-bundle.json` production envelope required by
+  the sole normative selector after #933;
+- exact live tuner: **NOT_RUN / REFUSED by preflight** with zero teacher work;
+- fixture-present parity measurement: **NOT_RUN / REFUSED by preflight**;
+- throughput, speedup, resource, and projected-runtime claims: **NOT
+  ESTABLISHED**;
+- ordinary BDD runner: 124/124 scenarios and 414/414 steps structurally green,
+  with its separate machine parity verdict correctly finalized as
+  **UNAVAILABLE** and every live-work counter zero.
+
+Historical status (2026-08-24):
+
+- prior fixture-present workspace run: **ABORTED**;
+- focused exactness, owner-plan, observability, and planted-negative gates:
+  **PASS**;
+- bounded A-panel cache instrument: **NEGATIVE / no material improvement**;
+- canonical teacher-free deployed-path preflight: **FAILED** because the
+  present graph scores 25.65% top-1 against its required 30.12% TLA baseline;
+- exact live tuner: **NOT_RUN / REFUSED by preflight**;
+- throughput, resource, and projected-runtime evidence: **NOT ESTABLISHED**;
+- new fixture-present full parity suite: **NOT_RUN / REFUSED by preflight**;
+- speedup claim: **NOT ESTABLISHED**.
+
+No placeholder below is a PASS. Measurements are appended after they execute;
+historical entries are not rewritten.
+
+The fixed-shape design and launch gate below are historical. They were
+superseded before any #932 live measurement by the dated optimization amendment
+at the end of this record. Current code and future evidence use that amendment;
+the earlier text remains only to preserve the decision history.
+
+## Why this exists
+
+On 2026-08-23/24, `cargo test --workspace --no-fail-fast --offline` entered the
+fixture-present exact teacher path and ran for more than 34 hours without a
+forward counter, current stream, rolling rate, defensible ETA, worker count,
+CPU/RSS reading, or durable partial report. A read-only one-second sample
+located it in S4 `timed_teacher_generate`, still executing the pinned exact
+`uor-matmul` path rather than hung. It was then stopped deliberately; the cargo
+process exited 130 and no complete BDD verdict exists.
+
+The evidence available after the abort is limited. S2's actual tokenized work
+required 36 exact teacher forwards and took about 4 h 29 min, approximately
+448 s/forward. S4's old three-run sequential shape required hundreds more
+forwards. Those observations explain why the earlier estimate was invalid;
+they do not measure the new scheduler and do not establish its speedup.
+
+## Exact multi-stream design
+
+Autoregressive dependence is local to one trajectory: token `t + 1` in that
+trajectory depends on token `t`. It does not impose a single stream on the
+suite. The bounded scheduler exposes two independently enforced dimensions:
+
+- `S = R4_PARITY_STREAMS` is the number of independent private-state
+  trajectories advanced in one physical exact batch;
+- `W = R4_PARITY_WORKERS` is the size of the one persistent exact output-row
+  worker pool.
+
+Model weights must be loaded once and shared immutably. Every stream must own
+isolated mutable KV/model state sized to its actual prompt and generation horizon. One
+physical `forward_batch` must advance all `S` states; reporting `states.len()`
+without observed full-width matrix work is not multistream evidence. The `W`
+pool schedules disjoint output rows, and no nested stream/row pool may exceed
+that physical CPU-worker budget. Completed work is placed in fixed
+prompt/position/run slots and reduced in canonical order.
+
+The only configuration that may authorize a full run is
+`W = S = available_parallelism()`. The binding M1 host therefore requires eight
+independent states and eight exact row workers. The diagnostic probe holds
+`S = 8` while sweeping `W = 1/2/4/8`; smaller/larger overrides remain useful
+diagnostics but can never authorize a different full-run shape.
+
+S2 must construct one content-bound teacher transcript for the pinned prompt
+set. S3 and S7 must consume that transcript instead of repeating equivalent
+live-teacher forwards. S4 must tokenize `S` distinct pinned prompts and truncate
+them to their common nonzero length so every teacher batch stays full-width.
+Teacher, legacy runtime, and graph runtime must receive the same resulting seed
+in each lane. Every timing sample must retain per-lane
+seed CID, output CID, private-state identity, and completion status; identical
+fan-out cannot satisfy the contract. Repetitions remain separate temporal
+samples so the median can measure run-to-run variation. Teacher exact-row
+occupancy and each compiled engine's stream-worker occupancy must be separate
+observed fields, and planned occupancy may never be reported as observed
+occupancy.
+
+### Arithmetic and accuracy boundary
+
+**Guarantee.** Parallel work may partition **output rows only**. Each output row
+must retain the complete pinned exact dot-product reduction. The reduction
+dimension may not be split, partially accumulated, reassociated, or combined
+across workers. Batch or completion order may vary, but it must not alter
+raw-logit bits. Status: **Unproven** until the focused #932 gates pass.
+
+The equality gate compares, byte for byte where applicable:
+
+- every configured position/stream/raw-logit word, including signed-zero/NaN
+  handling defined by the existing exact owner;
+- top-k rows and tie order;
+- every greedy choice and generated token sequence;
+- persistent-state records and distinct per-lane completion/output CIDs;
+- content-bound transcript bytes and CID;
+- per-prompt/per-run metrics;
+- canonical ordered reductions and final verdict inputs.
+
+The trace shape must contain every expected item; comparing a partial prefix is
+`FAIL`. Observed physical batches, logical forwards, matrix calls and widths,
+row tiles, output cells, and scalar terms must reconcile exactly with the owner
+`exact_forward_plan(S)`. Any mismatch is `FAIL`. The harness must not fall back
+to Accelerate, approximate arithmetic, relaxed thresholds, or a different
+teacher era.
+
+## Configuration
+
+| Variable | Default | Contract |
+|---|---:|---|
+| `R4_PARITY_WORKERS` | all available logical CPUs | Persistent exact row-worker pool `W`; diagnostic range `1..=available_parallelism()`; only `W = S = available_parallelism()` may authorize a full run |
+| `R4_PARITY_STREAMS` | all available logical CPUs | Independent private-state/batch width `S`; diagnostic configurations require `S >= W`, and the binding probe holds `S` at host width for every worker point |
+| `R4_PARITY_BATCH_PER_WORKER` | 4 | Bounded exact output-row task fan-out per scheduled worker; requested and effective fan-out are reported |
+| `R4_PARITY_PROGRESS_EVERY_SECS` | 10 | Human status and flushed JSONL heartbeat cadence, even during a long forward |
+| `R4_PARITY_MAX_WALL_SECS` | 28,800 | Eight-hour ceiling; crossing it records `ABORTED`, never partial PASS |
+| `R4_PARITY_REPORT` | `target/teacher-parity/parity-report.json` | Final JSON; events are the sibling `parity-report.events.jsonl` |
+| `R4_PARITY_TELEMETRY` | enabled | Disabling is available only to focused planted/unit controls; fixture-present parity refuses it |
+| `R4_PARITY_POSITIONS` | 256 | Teacher-forced position cap |
+| `R4_PARITY_GEN_TOKENS` | 128 | Per-run generation-token cap |
+| `R4_PARITY_RUNS` | 3 | Independent S4 repetitions |
+| `R4_PARITY_CORPUS_POSITIONS` | 1000 | Teacher-free S6 replay cap |
+| `R4_EXACT_PROBE_REPORT` | `target/teacher-parity/exact-multicore-probe.json` | Source/host/executor-bound admission record; events are the sibling `.events.jsonl` |
+| `R4_EXACT_PROBE_POSITIONS` | 1 | Valid range `1..=8`; every configured position is exercised at every worker point, including the configured maximum-prefix shape |
+| `R4_EXACT_PROBE_SEED_TOKENS` | 64 | Conservative projection/maximum-context budget for registered positions and suite-work arithmetic; not the actual live-probe or S4 lane-seed length |
+| `R4_PARITY_SOURCE` | `.uor-models/sources/smollm2-135m-instruct` | Probe-only source override; it does not retarget BDD bundle/source identities |
+
+Zero, malformed, impossible, or host-out-of-range values fail explicitly. The
+final report records both requested and effective values plus the actual
+tokenized work; configured caps are never presented as completed-forward
+counts. The probe has a 3,600-second admission deadline including fixture load;
+it is not widened by the full-suite wall control. No new exact forward begins
+at or after that deadline. A non-cancellable fixture load or exact forward that
+is already active may finish, after which the probe records `ABORTED`; a probe
+whose total elapsed time reaches the deadline cannot qualify.
+
+The live probe uses deterministic distinct token inputs at its registered
+positions. S4's actual common seed length is derived separately by truncating
+the distinct tokenized pinned prompts; `R4_EXACT_PROBE_SEED_TOKENS` controls
+neither input construction.
+
+## Durable observability contract
+
+The durable artifacts are:
+
+| Artifact | Schema id | Default path | Determinism boundary |
+|---|---|---|---|
+| Progress events | `uor-r4.teacher-parity-progress/1` | `target/teacher-parity/parity-report.events.jsonl` | Empirical/run-variant |
+| Final run report | `uor-r4.teacher-parity-report/1` | `target/teacher-parity/parity-report.json` | Empirical/run-variant |
+| Deterministic evidence | `uor-r4.teacher-parity-evidence/1` | `target/teacher-parity/parity-report.evidence.json` | Timing-free exact identities and outputs |
+| Exact admission probe | `uor-r4.exact-multicore-probe/1` | `target/teacher-parity/exact-multicore-probe.json` plus `.events.jsonl` | Source/host/executor-bound admission evidence |
+
+The exact admission report binds `probe_deadline_policy` to the registered
+finish-current-operation-then-abort semantics above. Its required `events`
+object binds the sibling JSONL `file_name`, full-byte `content_cid`, `byte_len`,
+`record_count`, and `final_record_number`; the final record must be `FINAL`, its
+`final_status` and `final_qualifies_full_run` must match the report verdict, and
+its `report_body_cid` must match the canonical report fields with the cyclic
+events binding replaced by the registered pending placeholder. The FINAL record
+also carries `sequence == record_count`. The producer synchronizes FINAL before
+atomically publishing the report. Admission re-reads and validates the current
+sibling bytes before loading teacher weights; a missing, truncated, appended,
+or tampered event stream is a typed refusal even when the report file remains.
+
+Schema `/1` bytes remain historical evidence. A change to field meaning, type,
+requiredness, units, or artifact partition requires a new schema id instead of
+reinterpreting an existing record. Human-readable status and JSONL events carry
+the same counter snapshot. JSONL is flushed at every event so an interrupted
+run retains evidence. The heartbeat runs independently of forward completion.
+
+Event kinds on the wire are:
+
+- `SUITE_STARTED`;
+- `FIXTURE_STATUS`;
+- `PHASE_STARTED` and `PHASE_COMPLETED`;
+- `WORK_STARTED` and `WORK_COMPLETED`;
+- `HEARTBEAT`;
+- `WORK_FAILED`;
+- `SUITE_COMPLETED` or `SUITE_ABORTED`.
+
+Every applicable event/report contains:
+
+- schema id, suite/run id, event sequence, event kind, and timestamp;
+- source, artifact, store, graph, tokenizer, and corpus presence plus CID where
+  available;
+- per-fixture `AVAILABLE`, `UNAVAILABLE`, `FAILED`, or `NOT_RUN` status and
+  exact reason;
+- requested budgets and actual tokenized prompts, positions, warm-ups,
+  replays, generation tokens, and exact teacher forwards;
+- phase/scenario, lane seed/output CID, private-state/completion identity,
+  queue depth, active/completed/failed work, forwards completed/total, tokens
+  completed/total, and per-stream progress;
+- configured/effective/current/peak streams and teacher exact-row workers, plus
+  separately configured/effective/current/peak compiled-engine stream workers;
+- requested/effective batch width, logical/physical cores, architecture, OS,
+  model geometry, and exact backend/kernel/ISA identity where observable;
+- planned and observed physical batches, logical forwards, matrix calls and
+  maximum widths, row tiles, output cells, scalar terms, and their
+  `exact_forward_plan(S)` reconciliation verdict;
+- expected and observed counts for every position, stream, raw-logit word,
+  top-k row/tie, greedy choice, persistent-state record, transcript byte/CID,
+  metric, and ordered reduction;
+- phase and total elapsed time, rolling and cumulative forwards/s,
+  seconds/forward, completed-token throughput, longest active-forward age, and
+  ETA value plus status (`WARMING_UP`, `ESTIMATED`, `UNAVAILABLE`, or `STALL`);
+- process CPU percentage/time, mean CPU core-equivalents, mean
+  core-equivalents divided by `W`, current/peak RSS, and virtual memory when the
+  host exposes them; unsupported readings are `UNAVAILABLE`, not zero and
+  cannot authorize the binding macOS run;
+- warm-up versus measured work, per-run tokens/duration/throughput, canonical
+  reduction status, selected configuration, measured speedup, and projection;
+- final `PASS`, `FAIL`, `UNAVAILABLE`, `ABORTED`, or `NOT_RUN` state with the
+  exact reason and durable report/event paths.
+
+A report create, write, or flush failure is `FAIL`. A worker failure is
+`FAIL`, cancels admission of new work, and cannot contribute partial metrics.
+A missing conditional fixture is `UNAVAILABLE`; an enclosing test-process exit
+code of zero does not promote it to PASS.
+
+Telemetry is empirical evidence. Timing and resource fields do not enter
+deterministic transcript/artifact bytes and do not add teacher evaluations.
+
+## Pre-registered launch gate
+
+**Empirical Criterion.** The cheap live probe loads the pinned model once and
+runs the same real-model workload at `W = 1/2/4/8` plus supported bounded batch
+widths while holding `S = available_parallelism()` (eight on the binding M1) at
+every point. It records exact trace/accounting equality, wall time, sustained
+CPU, and RSS. Its cost ceiling is 60 minutes. Claim status: **Unproven**;
+execution verdict: **NOT_RUN**.
+
+Required verdict before a full live suite:
+
+1. every worker/batch configuration contains the complete expected trace shape
+   and matches the one-worker logits, top-k/ties, greedy choices, persistent
+   states, output/transcript CIDs, metrics, and ordered reductions exactly;
+2. observed physical-batch/logical-forward/matrix/tile/cell/scalar-term totals
+   equal the owner `exact_forward_plan(S)` at every point;
+3. configured/effective/current/peak evidence proves all `S = 8` independent
+   states in flight at every M1 worker point, with no lost/failed lane;
+4. observed teacher exact-row occupancy and compiled-engine stream-worker
+   occupancy are reported separately and never exceed `W`; every configured
+   worker is observed doing useful work;
+5. the configured all-core `W = S = available_parallelism()` point—not merely
+   the fastest diagnostic point—measures at least 4.0x the `W = 1` aggregate
+   forward rate (target at least 6.0x);
+6. for `W > 1`, mean process CPU core-equivalents divided by `W` is at least
+   0.75 (target 0.90), and measured CPU-time evidence is available;
+7. safety-adjusted reachability arithmetic projects the fixture-present default
+   suite below 28,800 seconds;
+8. every required fixture, heartbeat, report/evidence write, source/host/executor
+   identity, and counter reconciliation is available and non-failing.
+
+If any condition fails, the full suite is refused. The measurements remain as
+a truthful negative result and scheduler/batch/row-partition work continues
+without weakening exactness or a threshold. If all conditions pass, the full
+run uses exactly `W = S = available_parallelism()` under the same eight-hour
+ceiling and continuous event stream. The fastest diagnostic point is retained
+as evidence but cannot select a different full-run shape.
+
+The wall ceiling is checked at work boundaries. Once reached, no new forward is
+admitted; finalization records `ABORTED` even if an already-running exact
+forward returns after the boundary.
+
+## Evidence ledger
+
+### #932 focused structural and negative-control gates
+
+| Evidence | Required content | Verdict |
+|---|---|---|
+| `tests/parity_determinism_932.rs` | 1/2/4/8 and supported-batch raw bits, top-k/ties, greedy tokens, persistent state, transcript/CID, metrics, canonical reductions, shuffled completion, workers>work, batch remainder, shared weights/private state | NOT_RUN |
+| `tests/parity_observability_932.rs` | invalid/zero/out-of-host budgets, planted slow/stall, worker failure, wall abort, missing fixture, write failure, counter mismatch, typed non-PASS verdicts, heartbeat persistence, schema/path checks | NOT_RUN |
+| Model-source exact executor/probe tests | owner-plan reconciliation, full trace shape, stream/worker occupancy, CPU threshold, speed/projection refusal, source/host/executor binding | NOT_RUN |
+| RF-29 BDD/conformance gates | tagged steps, explicit UNAVAILABLE, durable artifacts, generated conformance equality | NOT_RUN |
+
+These rows become PASS only from exact command output. The live probe and full
+suite remain independently `NOT_RUN`; a focused structural PASS cannot promote
+either empirical verdict.
+
+### 2026-08-24 — prior serial run
+
+| Field | Verdict |
+|---|---|
+| Fixture presence | AVAILABLE during the run |
+| Exact backend | pinned `uor-matmul` path |
+| Elapsed before intervention | more than 34 h |
+| Last located phase | S4 exact teacher generation |
+| Progress/resource artifact | UNAVAILABLE — old harness emitted none |
+| Cargo verdict | ABORTED, exit 130 |
+| Complete BDD verdict | NOT_RUN/ABORTED; no PASS claimed |
+| Decision | do not restart the old single-stream shape |
+
+### #932 cheap exact-parallel probe
+
+| W | Required S | Role | Batch schedule | Exact trace | Stream/row occupancy | Owner-plan counters | Aggregate forwards/s | Speedup | Mean CPU/W | Peak RSS | Verdict |
+|---:|---:|---|---|---|---|---|---:|---:|---:|---:|---|
+| 1 | 8 | diagnostic reference | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | 1.0x reference, NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN |
+| 2 | 8 | diagnostic | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN |
+| 4 | 8 | diagnostic | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN |
+| 8 | 8 | binding all-core point | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN | NOT_RUN |
+
+Configured/effective/current/peak stream evidence: **NOT_RUN**.
+
+Configured/effective/current/peak teacher row-worker evidence: **NOT_RUN**.
+
+Separate compiled-engine stream-worker evidence: **NOT_RUN**.
+
+Full trace-shape and per-lane seed/state/output-CID evidence: **NOT_RUN**.
+
+CPU-time/core-equivalent evidence and 0.75 utilization criterion: **NOT_RUN**.
+
+Projection inputs, safety factor, and arithmetic: **NOT_RUN**.
+
+Binding probe verdict: **NOT_RUN**.
+
+### #932 fixture-present full suite
+
+Launch authorization: **REFUSED / NOT_RUN pending the cheap probe**.
+
+Required launch shape: `W = S = available_parallelism()`; binding M1 `8/8`.
+
+Matched teacher/legacy/graph lane-seed and per-lane output evidence: **NOT_RUN**.
+
+Progress/report/deterministic-evidence artifact paths and CIDs: **NOT_RUN**.
+
+Final report path/CID: **NOT_RUN**.
+
+Final parity verdict: **NOT_RUN**.
+
+## 2026-08-24 — superseding pre-measurement optimization amendment
+
+No #932 live probe or fixture-present parity run had executed when this
+amendment was adopted. The objective is the least exact end-to-end wall time to
+a decision that can unblock #931. Worker count, stream count, utilization,
+speedup, and sample count are instruments rather than goals.
+
+### Why the fixed shape was retired
+
+The eight pinned prompts tokenize to lengths `6, 7, 6, 5, 4, 5, 6, 5`. The
+shared S2/S3/S7 transcript therefore needs 36 logical teacher forwards in six
+physical `S = 8` batches. The superseded S4 shape added:
+
+- 96 logical forwards for a separate seed-plus-eight-token warm-up; and
+- 3,168 logical forwards for three seed-plus-128-token measured waves.
+
+Including the old eight-forward W=1/2/4/8 probe, that plan requested 3,364
+logical forwards, or 452,390,289,408 owner-counted exact scalar terms. S4 was
+97% of the work. At the prior observed 448 seconds per serial logical forward,
+even ideal eight-way scaling could not approach the eight-hour safety ceiling.
+The old `>= 4x` gate could not make its own workload reachable, so launching it
+would have had no decision value.
+
+### Current bounded work
+
+- Preserve eight canonical prompt/lane identities, shared immutable weights,
+  private mutable state, complete raw-bit equality, canonical reductions, and
+  exact owner-plan counters.
+- Retain every lane's distinct final teacher-forced prompt-prefix state and
+  next token while building the required 36-forward transcript. Prefix lengths
+  may differ; the exact S=8 batch carries each lane's position explicitly. S4
+  clones those content-bound states and performs no duplicate teacher prefill.
+- The transcript already exercises the complete exact stack, so S4 performs no
+  independent live-teacher warm-up.
+- Run one causal S4 continuation. Start at one decode step per lane and extend
+  cumulatively through 2, 4, then 8 only while more work can change the pinned
+  compiled-versus-teacher verdict. Eight steps per lane is the hard ceiling.
+  Exact repeatability is established by the focused structural suite, not by
+  repeating an expensive live-model wave.
+- Report transcript preparation, state-clone preparation, decode, and one-shot
+  elapsed time separately. The empirical performance statement is limited to
+  the executed interval; it is not a three-run median or a broader sustained
+  performance claim.
+- Retain the model-wide batch buffers, exact transpose/output buffers, and one
+  exact scratch workspace per dedicated worker. Reserve their bounded capacity
+  during excluded preparation, record actual capacity growth, reset counters
+  without freeing capacity, and require zero growth during every measured
+  forward.
+- Overlay monotonic exact matrix, tile, output-cell, and scalar-term counters
+  into every durable heartbeat while a physical forward is still active.
+  Scalar terms are the ETA/liveness unit when planned, worker tasks are the
+  fallback, and completed-forward throughput remains separately reported; an
+  advancing long forward is never labeled stalled merely because it has not
+  returned yet.
+- Compile the exact teacher substrate and the measured legacy/graph engine path
+  with narrow test-profile opt-level 3 package overrides. An opt-level-0 debug
+  engine is neither an efficient harness nor a truthful proxy for shipped CPU
+  throughput; unrelated workspace packages keep the normal test profile.
+
+The BDD work is therefore 36 transcript forwards plus 8 initially and at most
+64 S4 forwards: 44 initially and 100 at the ceiling. The tuner adds 16 logical
+forwards. Combined live work is 60 initially and 116 at the ceiling, reductions
+of 98.2% and 96.6% respectively from the superseded 3,364-forward design.
+
+### Current adaptive tuner and admission
+
+The tuner holds the scientific work fixed at eight canonical lanes in one
+shared-weight `S = 8` batch. It measures the host's `W = available` and
+`W = min(4, available)` candidates over identical work, without a full-model
+warm-up per point, and selects the faster exact result with a deterministic
+tie-break. These are `W = 8` and `W = 4` on the binding M1; they are a bounded
+break-even search, not prescribed utilization targets. A cheap worker-pool/backend
+prestart is recorded separately and excluded from forward timing. The
+deterministic structural suite retains W=1/2/4/8 exactness and planted-negative
+coverage; the live fixture is not spent re-proving every diagnostic width.
+
+This contract is serialized as `uor-r4.exact-multicore-probe/2`; schema `/1`
+remains the historical fixed-sweep shape. The `/2` work record requires the
+complete registered binding shape: transcript batch widths `8, 8, 8, 7, 4, 1`
+for 36 logical forwards in six physical batches; eight continuation tokens on
+each of eight lanes for 64 logical forwards in eight physical batches; 100
+logical forwards and 14 physical batches in total; zero-based maximum private-
+state position 13; and state capacity 14. A smaller configured cap may emit a
+diagnostic record but cannot authorize the full suite. Projection uses the
+selected S8 elapsed time times exactly 14 physical batches before applying the
+safety factor; the 100 logical-forward total is retained as accounting, not
+misused as a same-width rate estimate. The report names its first measured
+candidate through `reference_workers`, binds every candidate through
+`equal_to_reference`, and excludes the recorded cheap worker-pool/backend
+prestart from timed forward rates.
+
+The current run artifacts are likewise versioned
+`uor-r4.teacher-parity-progress/2`, `uor-r4.teacher-parity-report/2`, and
+`uor-r4.teacher-parity-evidence/2` because adaptive cumulative checkpoints,
+one-time compiled-cohort preparation, and the expanded work/resource ledger
+change the meaning of the historical `/1` fields. The `/1` table above remains
+an unmodified record of the superseded design.
+
+Speedup versus W=1 and CPU utilization remain reported diagnostics. They are
+not admission thresholds, and `S` need not equal `W`. Full-run admission now
+requires:
+
+1. current source, host, executor/build, backend, report, and finalized event
+   identities;
+2. complete raw-bit trace equality and all eight canonical lane identities;
+3. no serial fallback, lost lane, counter mismatch, structurally invalid
+   resource record, or incomplete candidate; a truthful platform-reported
+   resource status of `UNAVAILABLE` remains diagnostic rather than a gate;
+4. selection of the faster measured exact W=available/W=min(4, available)
+   candidate; and
+5. a safety-adjusted projection for the actual optimized work strictly below
+   the configured hard wall ceiling, which is capped at 28,800 seconds.
+
+A later candidate is worth measuring only when its plausible saving on the
+remaining declared work exceeds the candidate's own measurement cost. This
+break-even rule prevents tuning from costing more time than it can save.
+
+### Cheap exact-kernel optimization decision
+
+Before opening the live fixture, the bounded ignored instrument
+`tests::bench_exact_a_panel_cache_rows_on_smollm2_tiles` compared the existing
+one-row Atlas A-panel offer with an eight-row offer on the five W=8/S=8 tile
+shapes used by SmolLM2 (Q/O, K/V, W1/W3, W2, and vocabulary). It interleaved
+samples, took per-shape medians, weighted them by calls per forward, and
+required raw-bit equality for every sample. Run command:
+
+```bash
+cargo test -p uor-r4-model-source --lib \
+  bench_exact_a_panel_cache_rows_on_smollm2_tiles --offline -- \
+  --ignored --nocapture --test-threads=1
+```
+
+The run completed in 2.96 seconds. Weighted time was 1,601,233,947 ns for the
+one-row offer and 1,596,652,561 ns for eight rows, or 1.0029x. Per-shape ratios
+were mixed: 0.9497x, 0.9382x, 1.0289x, 0.9687x, and 1.0432x. This is a
+non-material/noisy result, so production retains the simpler `pa = k` offer;
+no claimed speedup or live-model work rests on it. The benchmark remains as a
+reproducible negative decision instrument.
+
+### Predeclared outcomes
+
+- If the smallest causal continuation puts both compiled/runtime ratios above
+  the pinned 1.0 floor with the registered early-stop margin, stop and record
+  the positive measurement.
+- If it is inconclusive, extend only to the next cumulative bound. At eight
+  steps, record the exact positive, negative, or `NOT ESTABLISHED` result; do
+  not silently increase the budget.
+- Any equality, fixture, counter, structurally invalid resource record,
+  durability, or projection failure refuses the full run and preserves its
+  typed evidence. Truthful CPU/RSS `UNAVAILABLE` evidence is retained without
+  being reclassified as a scientific failure.
+
+Before either live-teacher phase, run the teacher-free deployed-path preflight:
+
+```bash
+R4_PARITY_PREFLIGHT_ONLY=1 cargo test --test bdd --offline
+```
+
+It parses the tokenizer, legacy artifact/store, graph and graph report, then
+exercises one typed deployed decision for every canonical legacy and graph lane.
+Its `uor-r4.teacher-parity-preflight/1` artifact binds fixture and output
+identities plus the current authorizing code contract while proving
+`teacher_source_opened=false` and `teacher_forwards=0`.
+It is atomically written to
+`target/teacher-parity/teacher-free-preflight.json`, or the explicit
+`R4_PARITY_PREFLIGHT_REPORT` path. A missing or malformed prerequisite—or an
+unwritable evidence path—therefore blocks the expensive tuner or BDD run before
+any teacher forward is spent.
+
+Amendment implementation status: **COMPLETE**. Adaptive tuner:
+**NOT_RUN / REFUSED**. Fixture-present bounded parity:
+**NOT_RUN / REFUSED**. The exact reason and zero-teacher counters are recorded
+below; no performance conclusion is inferred from the prerequisite failure.
+
+## 2026-08-24 — canonical teacher-free outcome
+
+The explicit teacher-free preflight used the configured canonical 135M source
+and compiled bundle:
+
+```bash
+R4_PARITY_SOURCE=/Users/casey.allard/uor-r4/.uor-models/sources/smollm2-135m-instruct \
+R4_PARITY_BUNDLE=/Users/casey.allard/uor-r4/.uor-models/compiled/smollm2-135m-instruct \
+R4_PARITY_PREFLIGHT_ONLY=1 \
+R4_PARITY_PREFLIGHT_REPORT=target/teacher-parity/teacher-free-preflight.json \
+cargo test --test bdd --offline
+```
+
+It completed in 4.05 seconds and exited 101 with the predeclared refusal. The
+atomically published `uor-r4.teacher-parity-preflight/1` artifact was 2,745
+bytes and recorded:
+
+| Field | Evidence |
+|---|---|
+| Preflight status | `FAILED` |
+| Teacher source opened | `false` |
+| Exact teacher forwards | `0` |
+| Graph | present, 30,486,100 bytes, `blake3:10715ebc2df0f885163d80c8afd1ef22406caa7add1571179b5082ba652ddee0` |
+| Graph report | present, 24,534 bytes, `blake3:29c64e28e89d2ba21d766abd57c2c9511f9dcc6072de72c19f2a3c27dae7b14f` |
+| Legacy artifact | present, `blake3:487532dda0b33ac0306d939126b0da54ac802036446dd8514905531cfc8c23df` |
+| Legacy store | present, `blake3:a65671b7aa0c7706a632c2f3922928353208b8e8ae4dd0e49a00f1a17e3947fc` |
+| Tokenizer | present, `blake3:70af0cb08bbcd3b323d3387ca1d7d33da39873820604d183711e8e99f9903fc1` |
+| Exact refusal | graph runtime top-1 25.65% is below its 30.12% TLA baseline |
+
+The same inputs were then exercised through the ordinary BDD entry point, not
+the special preflight-only path. The command completed in 4.85 seconds with
+120/120 scenarios and 402/402 steps structurally green. Its finalized
+`uor-r4.teacher-parity-report/2` verdict was nevertheless `FAIL`, accompanied
+by `uor-r4.teacher-parity-evidence/2`, five flushed progress events, the same
+quality-gate reason, and zero logical forwards, physical batches, matrix calls,
+output cells, scalar terms, or teacher tokens. A zero-work telemetry regression
+found during this run was fixed: seconds-per-forward is now unavailable when
+the measured rate is zero, while explicit non-finite telemetry remains rejected
+by strict serialization readback.
+
+The live tuner and full parity suite were therefore not launched. A historical
+different-CID bundle was not substituted, the quality floor was not changed,
+and `load_accepting_quality` was not used. This is an evidence-backed negative
+prerequisite outcome, not a parity PASS and not a speed measurement. The
+implemented automatic gate is still the time-saving result needed by #931:
+ordinary workspace verification now refuses this invalid graph before opening
+the teacher instead of entering the former multi-day path. A future canonical
+graph must legitimately clear its own TLA-relative quality gate before the
+live tuner can establish multicore throughput or authorize full parity.
+
+### Post-audit hardened rerun
+
+The historical run above exposed the intended blocker, then final review added
+a current-code admission binding, exact published-byte CID semantics, and
+distinct `FAILED`/`UNAVAILABLE`/`NOT_RUN` projection. The canonical inputs were
+rerun after those changes. The explicit preflight completed in 2.91 seconds,
+exited 101 with the same predeclared graph-quality refusal, and wrote 2,850
+bytes with:
+
+- authorizing contract CID
+  `blake3:12eaeeb0bb52f34e9f4ee276a4b4dc7258a175c7e2cbb93396f6f82d20a95160`;
+- exact published preflight CID
+  `blake3:8126381f4ec713cc0310d3e1e223ee150761b50d8f3086264cd68b1a3eee9494`;
+- `teacher_source_opened=false`, `teacher_forwards=0`, and unchanged compiled
+  input CIDs;
+- the unchanged 25.65% graph versus 30.12% TLA refusal.
+
+The ordinary BDD entry point then completed in 2.58 seconds with 120/120
+scenarios and 402/402 steps structurally green. Its machine verdict remained
+`FAIL`, with the graph `FAILED`, its parsed report `AVAILABLE`, teacher source
+rows `NOT_RUN`, and every live-work counter zero. The direct tuner now validates
+the current authorizing contract, report/source/bundle paths, and recomputed
+compiled-input CIDs before its teacher loader is reachable; planted stale-code,
+stale-input, and non-available artifacts all refuse.
+
+### Final path-normalized refusal and readback rerun
+
+The final code was rerun after relative input/report paths were normalized to
+the workspace root and the BDD consumer learned to distinguish a full qualified
+probe report from a truthful `EXACT_MULTICORE_PROBE_STATE` refusal. The explicit
+preflight completed in 2.52 seconds, exited 101 as predeclared, and atomically
+wrote 2,850 bytes. Its current bindings are:
+
+- authorizing contract CID
+  `blake3:340299452fb9574a0f76f72850472e2bd495053eaa6c55f0ff7eb1ff702c24a4`;
+- exact published preflight CID
+  `blake3:8b300e87f5feb62565197867cbb5f2e009a0b92ad3350729b8a536b9efc309f2`;
+- `teacher_source_opened=false`, `teacher_forwards=0`, and the unchanged
+  tokenizer/TLA/TLS/graph/report CIDs recorded above;
+- the unchanged graph-quality refusal: 25.65% graph top-1 versus the required
+  30.12% same-corpus TLA baseline.
+
+The direct ignored tuner then revalidated that current artifact and refused in
+0.057 seconds of probe time, before opening the teacher. Its
+`uor-r4.exact-multicore-probe/2` state is `NOT_RUN / REFUSE_FULL_RUN`, explicitly
+sets `qualifies_full_run=false`, and has published-byte CID
+`blake3:2a4347c7f25686ace455b8824992c06039ff08068f6aab02779d4f4d3cc9f18a`.
+The surrounding one-time test command spent 6.93 seconds compiling the changed
+model-source crate; that build time is not probe work.
+
+Finally, the ordinary BDD entry point consumed that present refusal state
+without promoting it to qualification. It completed in 2.80 seconds with
+120/120 scenarios and 402/402 steps structurally green. The final machine
+verdict remained `FAIL`; the preflight is `FAILED`, the exact probe is
+`NOT_RUN` with its content CID, teacher model/config remain metadata-only
+`NOT_RUN`, and every logical-forward, physical-batch, matrix, tile, cell,
+scalar-term, stream, worker-task, and teacher-token counter is zero. Malformed,
+unknown, contradictory, or incomplete probe artifacts remain fail-closed.
+
+### Post-gate current-code binding
+
+The full model-source suite subsequently exposed a scheduler-sensitive planted
+overlap test. Its test-only observer was hardened to synchronize two genuinely
+entered worker tasks; production execution was unchanged. Because the
+authorizing contract binds that source file, the complete evidence trio was
+rerun once more after 21/21 overlap stress repetitions, the full workspace
+suite, strict Clippy, no-std/wasm checks, and non-vacuous κ reproduction passed.
+
+This final-code rerun recorded:
+
+- authorizing contract CID
+  `blake3:22e9f35d6333f3c25f526ce0ec2315a2461504cc77c75f26d19ab26251147b94`;
+- exact published preflight CID
+  `blake3:f09672bce4019e779e93151c15dcc1d6b3094bf9bff49335bc67a6b7e5cd0f9b`;
+- exact direct-tuner refusal CID
+  `blake3:423ae9b88a343eb5a3f61fe5c1075269c58529c2e8affc56edfb684279ab743a`;
+- explicit preflight process time 2.63 seconds;
+- direct tuner probe time 0.037 seconds and warm command time 0.16 seconds;
+- ordinary BDD process time 2.61 seconds, with 120/120 scenarios and 402/402
+  steps structurally green and 2.149 seconds recorded inside the final report.
+
+The machine verdict and decision boundary are unchanged: graph prerequisite
+`FAILED`, exact tuner `NOT_RUN / REFUSED`, teacher unopened, and every expensive
+work counter zero.
+
+## 2026-08-25 — post-#933 normative-production preflight
+
+The parked branch was fast-forwarded to `origin/main` at
+`e346816cb40b089583cbd3fff2cdd84924362c65` after #933 restored
+`R4G1Runtime` as the sole production selector and required a schema-2,
+CID-bound production envelope. The final #932 code additionally binds the full
+local source closure, invokes production envelope semantics before teacher
+access, reparses only content-bound `tokenizer.bin` bytes, and excludes
+worker/tile/workspace observations from deterministic evidence. Its focused
+gates are green:
+
+- `uor-r4-model-source` library: 155 passed, 4 fixture/benchmark tests ignored;
+- deterministic schedule integration: 4 passed;
+- fail-closed observability integration: 49 passed;
+- strict workspace Clippy, format, and diff checks: PASS.
+
+The explicit teacher-free command spent 25.22 seconds compiling the frozen
+BDD binary, then exited 101 with the predeclared refusal:
+
+```bash
+R4_PARITY_SOURCE=/Users/casey.allard/uor-r4/.uor-models/sources/smollm2-135m-instruct \
+R4_PARITY_BUNDLE=/Users/casey.allard/uor-r4/.uor-models/compiled/smollm2-135m-instruct \
+R4_PARITY_PREFLIGHT_ONLY=1 \
+R4_PARITY_PREFLIGHT_REPORT=target/teacher-parity/teacher-free-preflight.json \
+cargo test --test bdd --offline
+```
+
+The `uor-r4.teacher-parity-preflight/1` artifact records:
+
+| Field | Evidence |
+|---|---|
+| Status | `UNAVAILABLE` |
+| Exact reason | required production component `release-bundle.json` is absent from the selected 135M bundle |
+| Authorizing contract | `blake3:c16bdf54615c45db06b1ed2f3655128009b4890d49d03adfed66cf0556e893ab` |
+| Preflight artifact CID | `blake3:6978404f3f627abe82c46cfd0bd0434f1a68eef2c2d251c584c8eb0d7d8600bf` |
+| Teacher source opened / forwards | `false` / `0` |
+| Graph | `blake3:10715ebc2df0f885163d80c8afd1ef22406caa7add1571179b5082ba652ddee0` |
+| Graph report | `blake3:29c64e28e89d2ba21d766abd57c2c9511f9dcc6072de72c19f2a3c27dae7b14f` |
+| TLA artifact | `blake3:487532dda0b33ac0306d939126b0da54ac802036446dd8514905531cfc8c23df` |
+| TLS store | `blake3:a65671b7aa0c7706a632c2f3922928353208b8e8ae4dd0e49a00f1a17e3947fc` |
+| Tokenizer | `blake3:70af0cb08bbcd3b323d3387ca1d7d33da39873820604d183711e8e99f9903fc1` |
+
+The complete production inventory also records the absent sections-absent and
+label-shuffled graphs, deployed-quality report, cross-surface parity, witness
+replay, and tokenizer adapter; none is silently treated as present. The direct
+ignored tuner then consumed that current refusal artifact and terminated after
+0.14 test seconds before loading teacher weights. Its
+`uor-r4.exact-multicore-probe/2` state is `NOT_RUN / REFUSE_FULL_RUN`, with
+content CID
+`blake3:706395f99a10ee2346e31026edeae51697817600f5d34dc6be49e97b909f38d4`.
+The nonzero test-process exit is the required fail-closed signal, not a broken
+measurement.
+
+Finally, the ordinary BDD entry point re-ran against the same current inputs.
+All 124 scenarios and 414 steps completed structurally green in 2.83 command
+seconds, while `uor-r4.teacher-parity-report/2` finalized truthfully as
+`UNAVAILABLE` after 2.207 recorded seconds. The preflight is `UNAVAILABLE`; the
+exact probe is `NOT_RUN`; teacher model/config are
+metadata-only `NOT_RUN`; and logical forwards, physical batches, matrix calls,
+row tiles, output cells, scalar terms, streams, worker tasks, and teacher tokens
+are all zero. The final artifact CIDs are:
+
+- run report:
+  `blake3:065b79a5f427db3f7fefeee165bff75d841d30f22aebecb18e0831ad89bbb123`;
+- deterministic evidence:
+  `blake3:b99930011ba7f0d1f5c0066a5adf3772ca6a9b4eb0317548cc508af23e7e0116`;
+- terminal event log:
+  `blake3:3ecd48208d712f32bddc8f3db7cee506168c240a9e9b0b5746e574d92dca206a`.
+
+The deterministic evidence contains no absolute path, elapsed-time field,
+selected-worker row, worker/tile/workspace counter, or empirical concurrency
+peak. The event log's final record is `SUITE_COMPLETED / UNAVAILABLE`.
+
+### Final issue verdict
+
+The host-side capability is implemented and its structural/falsifier gates
+pass, but live exact multicore throughput and fixture-present parity remain
+**NOT ESTABLISHED** for the selected canonical 135M bundle. The binding
+production prerequisite is unavailable before teacher access because that
+bundle predates #933's required envelope and companion evidence. The frozen negative branch therefore
+applies: do not launch or retune the live experiment, do not substitute the
+different-CID #933 broad bundle, and retain the exact refusal evidence. A
+future 135M bundle must be re-emitted, schema-2 quality-bound, and production
+admitted before this harness can measure live scaling.

--- a/docs/transformerless/BASELINE.md
+++ b/docs/transformerless/BASELINE.md
@@ -114,7 +114,10 @@ This does not relabel #908's 29.702% `R4Engine` reference/off-serving row and
 does not establish instruction following, reasoning, factuality, semantic
 abstention, free-running coherence, live-teacher parity, or a cross-model
 floor. The BDD suite was 124 / 124, but live-teacher parity fixtures were absent
-and those scenarios vacuously skipped; #932 remains downstream.
+and those scenarios vacuously skipped. #932 subsequently landed the structural
+host instrument on an `UNAVAILABLE` / `NOT_RUN` live branch; live parity remains
+**NOT ESTABLISHED** (see
+[`teacher_parity_parallelism_932.md`](../teacher_parity_parallelism_932.md)).
 
 **Canonical bits/token (issue #76, resolved 2026-07-22):** one definition — mean cross-entropy of
 the true next token under a scorer's predicted distribution, `(1/N) Σ −log2 P_scorer(v_i|c_i)`

--- a/features/suites/teacher_parity_benchmarks.feature
+++ b/features/suites/teacher_parity_benchmarks.feature
@@ -1,27 +1,37 @@
+@serial
 Feature: Teacher parity and benchmarks for the compiled transformerless runtimes
   These scenarios run the pinned SmolLM2-135M teacher side by side with both
   compiled transformerless runtimes (the legacy TLS store and the R4G1 graph
-  engine) on the same token histories. Every accuracy and speed figure here is
-  an Empirical Criterion measured on pinned fixtures and pinned against a
+  engine). Teacher-forced scenarios replay the same token histories. S4 starts
+  every engine from the same canonical logical seeds and matched work shape,
+  then records each engine's causal outputs as the free-running continuations
+  diverge. Every accuracy and interval-limited speed figure here is an
+  Empirical Criterion measured on pinned fixtures and pinned against a
   conservative threshold; no equivalence with the teacher is claimed. The
   corpus-replay scenario (S6) compares predictions against the recorded
   teacher labels in the compiled corpus records; it does not re-run the live
-  teacher. When the pinned fixtures are absent (as in CI), each scenario
-  vacuously passes,
-  following the same skip convention as the kappa-reproduction suite — check
-  fixture presence before trusting a green run.
+  teacher. The feature is externally serial so it owns one bounded CPU budget;
+  the live work inside that exclusive lane is explicitly multi-stream and
+  multicore. When pinned fixtures are absent (as in CI), each scenario records
+  UNAVAILABLE in the durable parity report; absence is never an empirical PASS.
+  The live suite always keeps the eight canonical private trajectories. Stream
+  width and exact output-row workers are independent: admission selects the
+  faster exact configuration from the bounded four-worker/all-available probe.
 
   @RF-29 @build
   Scenario: S1 provenance — every parity input is content-addressed by blake3 kappa
     Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
     When the provenance of every parity input is recorded
     Then every parity input carries a blake3 kappa and the graph provenance matches the compiled artifact
+    And teacher-free compiled preflight and exact admission are bound to their source and host identities
 
   @RF-29 @build
   Scenario: S2 teacher-forced replay accuracy of the legacy TLS store
     Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
     When the legacy TLS store is replayed against the teacher on pinned prompts
     Then the legacy store parity metrics meet the pinned empirical criteria
+    And the teacher transcript proves full-width private streams and complete exact owner-plan accounting
+    And every configured exact trace row has canonical deterministic evidence
 
   @RF-29 @build
   Scenario: S3 teacher-forced replay accuracy of the R4G1 graph engine
@@ -34,7 +44,10 @@ Feature: Teacher parity and benchmarks for the compiled transformerless runtimes
   Scenario: S4 free-running generation speed against the teacher
     Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
     When free-running generation is timed for the teacher and both compiled runtimes
-    Then both compiled runtimes sustain a higher token rate than the teacher
+    Then the measured concurrent token rate of both compiled runtimes is higher than the teacher
+    And the speed report covers distinct lane identities and matched full-width workloads
+    And the adaptive causal wave records its exact stop or extension decision
+    And the fastest exact bounded probe configuration projects below the hard wall and authorizes the independent worker count
 
   @RF-29 @build
   Scenario: S5 compiled runtime kernel invariants
@@ -55,3 +68,4 @@ Feature: Teacher parity and benchmarks for the compiled transformerless runtimes
     Given the pinned SmolLM2 teacher and compiled transformerless bundle are present
     When the certifier FMM candidate is replayed against the teacher on pinned prompts
     Then the FMM candidate produces a reproducible novel-context measurement
+    And the parity run writes versioned event report evidence and probe artifacts, flushes durable in-flight progress at cadence, and records a machine-readable final status

--- a/model/ids.toml
+++ b/model/ids.toml
@@ -279,7 +279,7 @@ suite = "teacher_parity_benchmarks"
 statement = "Teacher parity and benchmarks for the compiled transformerless runtimes (fixture-gated empirical instrument; absent fixtures are UNAVAILABLE, never PASS)"
 scope = "certifier-instrument"
 reachability = "off-serving-path"
-evidence = "tests/bdd.rs, features/suites/teacher_parity_benchmarks.feature (pinned-fixture-gated; skips vacuously when fixtures absent)"
+evidence = "features/suites/teacher_parity_benchmarks.feature; tests/bdd.rs; tests/parity_determinism_932.rs; tests/parity_observability_932.rs; crates/uor-r4-model-source/src/exact_probe.rs (pinned-fixture-gated; adaptive exact W={4,available_parallelism} tuner with deduplication and durable UNAVAILABLE/non-PASS evidence)"
 
 [[id]]
 id = "RF-30"

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -5,7 +5,10 @@
 //! behavior; implementation details stay in the server module.
 
 use cucumber::{given, then, when, World};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+#[path = "support/parity_observability.rs"]
+mod parity_observability;
 use uor_r4_core::transformerless::bott_fock::BottFockContextStore;
 use uor_r4_core::transformerless::compiler::SIG_BYTES;
 use uor_r4_core::transformerless::endomorphism::EndomorphismAlgebra;
@@ -229,6 +232,7 @@ struct R4g1World {
     parity_corpus_graph: Option<ParityMetrics>,
     parity_fmm_metrics: Option<ParityMetrics>,
     parity_fmm_fixed_metrics: Option<ParityMetrics>,
+    parity_transcript_evidence: Option<ParityTranscriptEvidence>,
 }
 
 #[given("the R4G1 runtime returned the browser's repetitive hello response")]
@@ -1859,7 +1863,9 @@ fn bdd_decouple_emission_result_check(w: &mut R4g1World) {
     assert!(!em.token_probabilities.is_empty());
 }
 
-#[then("a multi-dimensional certification report evaluates state coherence and language fidelity separately")]
+#[then(
+    "a multi-dimensional certification report evaluates state coherence and language fidelity separately"
+)]
 fn bdd_decouple_cert_report_check(w: &mut R4g1World) {
     let cert = w.decouple_cert.as_ref().expect("cert");
     assert!(cert.is_certified);
@@ -2144,7 +2150,9 @@ fn bdd_evidence_traceability_passes(w: &mut R4g1World) {
     assert!(report.verified);
 }
 
-#[then("duplicate evidence IDs [\"ev_1\", \"ev_1\", \"ev_3\"] fail with an evidence traceability error")]
+#[then(
+    "duplicate evidence IDs [\"ev_1\", \"ev_1\", \"ev_3\"] fail with an evidence traceability error"
+)]
 fn bdd_evidence_traceability_fails(_w: &mut R4g1World) {
     let report = StructuralGuaranteeVerifier::verify_evidence_traceability(
         "OBL-EVID-BDD",
@@ -2175,7 +2183,9 @@ fn bdd_replay_witness_passes(w: &mut R4g1World) {
     assert!(report.verified);
 }
 
-#[then("actual witness hash \"hash_abc123\" against expected hash \"hash_xyz999\" fails with a witness mismatch error")]
+#[then(
+    "actual witness hash \"hash_abc123\" against expected hash \"hash_xyz999\" fails with a witness mismatch error"
+)]
 fn bdd_replay_witness_fails(_w: &mut R4g1World) {
     let report = StructuralGuaranteeVerifier::verify_replay_witness_integrity(
         "OBL-WIT-BDD",
@@ -3053,7 +3063,9 @@ fn bdd_perf_cert_given(w: &mut R4g1World) {
 #[when("audited for evidence link integrity")]
 fn bdd_perf_cert_audit_when(_w: &mut R4g1World) {}
 
-#[then("all declared-zero fields contain non-empty evidence links and steady-state allocations are zero")]
+#[then(
+    "all declared-zero fields contain non-empty evidence links and steady-state allocations are zero"
+)]
 fn bdd_perf_cert_links_check(w: &mut R4g1World) {
     let cert = w.perf_cert.as_ref().expect("perf cert");
     assert!(cert.verify_evidence_links());
@@ -3480,20 +3492,47 @@ fn bdd_obs_shard_process_then(w: &mut R4g1World) {
 // zero-allocation hot path, witness self-consistency). All thresholds are
 // Empirical Criteria pinned from measurements on the pinned fixtures with a
 // conservative margin — they are not equivalence claims. Fixtures absent (CI)
-// ⇒ every scenario vacuously passes, the κ-test skip convention.
+// ⇒ the empirical parity verdict is UNAVAILABLE, never PASS.
 
-use std::cell::RefCell;
-use std::time::Instant;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use uor_r4_core::transformerless::compiler::{
     load_corpus_from, parse_artifacts, Compiled, Corpus, WINDOW,
 };
-use uor_r4_core::transformerless::runtime::{parse_store, Prediction, Runtime, Store};
+use uor_r4_core::transformerless::runtime::{parse_store, Runtime, Store};
 // The on-disk store predates the u32 token migration (TLS1-u16); the legacy
 // reader is the only way to load it until a full recompile refreshes it.
+use parity_observability::{
+    adaptive_decode_checkpoints, adaptive_decode_decision,
+    apply_teacher_free_preflight_failure_metadata, classify_exact_probe_artifact,
+    configured_exact_probe_report_path, configured_fixture_dir, configured_preflight_report_path,
+    deterministic_evidence_identities, deterministic_teacher_execution, estimate_eta,
+    events_path_for_report, evidence_path_for_report, heartbeat_progress_units,
+    invalidate_final_reports_checked, mark_finalization_failed, prepare_final_reports,
+    publish_atomic_preflight_outcome, sample_host_resources, seconds_per_forward_from_rate,
+    take_run_report_ownership, unix_millis_now, validate_binding_host_shape,
+    validate_full_width_exact_heartbeat, validate_in_flight_heartbeat_cadence,
+    validate_nonqualified_probe_prepublication, validate_private_multistream_evidence,
+    CancellableStartGate, DeterministicEvidence, EtaInput, EventKind, ExactProbeArtifact,
+    ExactProbeNonQualifiedState, ExactProgressObservation, FixtureStatus, FixtureVerdict,
+    HeartbeatEvent, HeartbeatWorker, ObservabilityMode, ParityConfig, RateSnapshot, RunMetadata,
+    RunReport, RunStatus, SchedulerSnapshot, SharedProgress, StreamProgress, StreamState,
+    TeacherFreeGraphFailureStage, WorkCounters, WorkPlan, ADAPTIVE_ACCEPTANCE_RATIO,
+    ADAPTIVE_EARLY_STOP_RATIO, EVENT_SCHEMA,
+};
 #[allow(deprecated)]
 use uor_r4_core::transformerless::runtime::parse_store_legacy_u16;
 use uor_r4_core::transformerless::scenarios::Tokenizer;
-use uor_r4_model_source::{BehaviorSource, SmolLm2Oracle, TeacherOracle};
+use uor_r4_model_source::{
+    exact_backend_report, exact_executor_contract_cid, exact_probe_expectation_shapes_from_config,
+    exact_probe_host_identity, production_admission_component_cids, BatchedTeacher,
+    ExactMulticoreProbeExpectation, ExactMulticoreProbeReport, ExactMulticoreProbeSource,
+    ExactMulticoreProbeStatus, ExactMulticoreProbeWork, SmolLm2Oracle, State as TeacherState,
+    TeacherExecutionConfig, TeacherExecutionObserver, TeacherExecutionPreparation,
+    TeacherExecutionSnapshot, EXACT_MULTICORE_PROBE_SCHEMA, PRODUCTION_ADMISSION_COMPONENTS,
+};
 use uor_r4_wasm_router::r4g1::{PredictDecision, R4g1State};
 
 /// Hardcoded short replay prompts: plain questions in the chat register the
@@ -3508,16 +3547,21 @@ const PARITY_PROMPTS: [&str; 8] = [
     "how does a bicycle work?",
     "what is the internet?",
 ];
+const S4_CANONICAL_STREAMS: usize = 8;
+const S4_MAX_DECODE_STEPS: usize = 8;
+const S4_REGISTERED_PROMPT_TOKEN_LENGTHS: [usize; S4_CANONICAL_STREAMS] = [6, 7, 6, 5, 4, 5, 6, 5];
 
 // Pinned empirical thresholds, measured on this machine's pinned fixtures
 // (96 replay positions over the 8 pinned prompts; debug build) with a
 // conservative ~20% margin. Observed values: legacy top-1 0.0104, top-8
 // recall 0.177, Δbits 9.21; graph top-1 0.0104, top-8 recall 0.052, Δbits
-// 11.46, abstains 3; speed ratios legacy 66.7× / graph 20.9× against a
-// 15.0 tok/s teacher. The top-1 floors require at least one agreeing
-// position (1/96 ≈ 0.0104) — enough to catch a fully disconnected runtime
-// without punishing honest libm drift. The speed floor stays 1.0 by design:
-// compiled-faster-than-teacher is the meaningful claim.
+// 11.46, abstains 3. The top-1 floors require at least one agreeing position
+// (1/96 ≈ 0.0104) — enough to catch a fully disconnected runtime without
+// punishing honest libm drift. S4 is now an interval-limited adaptive
+// measurement over one causal cohort, so historical long-run speed ratios are
+// not its acceptance evidence. Its floor stays 1.0 by design: the measured
+// concurrent compiled interval must be faster than the matched teacher
+// interval.
 //
 // Why top-1 sits far below Gate C's tla3 baseline (≈0.181): Gate C replays
 // a held-out partition of the SAME corpus stream the store was compiled
@@ -3566,20 +3610,170 @@ struct ParityMetrics {
 
 /// Median free-running generation rates (tokens/second) and compiled/teacher
 /// ratios from the speed benchmark.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone)]
 struct ParitySpeed {
+    /// Median of measured S-wide wave aggregate rates.
     teacher_tps: f64,
     legacy_tps: f64,
     graph_tps: f64,
+    /// Total generated tokens divided by the sum of measured wave intervals.
+    teacher_total_tps: f64,
+    legacy_total_tps: f64,
+    graph_total_tps: f64,
     legacy_ratio: f64,
     graph_ratio: f64,
+    legacy_wave_ratios: Vec<f64>,
+    graph_wave_ratios: Vec<f64>,
+    streams: usize,
+    runs: usize,
+    teacher_logical_forwards: usize,
+    teacher_physical_batches: usize,
+    teacher_max_active_workers: usize,
+    teacher_waves: Vec<GenerationWaveSample>,
+    legacy_waves: Vec<GenerationWaveSample>,
+    graph_waves: Vec<GenerationWaveSample>,
+    warmup: Vec<GenerationWaveSample>,
+    adaptive_decisions: Vec<serde_json::Value>,
+    stop_reason: String,
+    decoded_steps_per_lane: usize,
+    compiled_precomputed_steps_per_lane: usize,
+    legacy_runtime_preparations: usize,
+    graph_state_preparations: usize,
+    compiled_worker_cohorts_per_engine: usize,
+    compiled_full_ceiling_verified_before_teacher: bool,
+    teacher_template_state_cids: Vec<String>,
+    teacher_execution_preparation: TeacherExecutionPreparation,
+    teacher_preparation_elapsed_seconds: f64,
+    teacher_prefill_logical_forwards: usize,
+    ordered_reduction: bool,
 }
 
-/// Heavy fixtures, cached per test thread so the 260 MiB teacher is loaded
-/// once per process, not once per scenario (each scenario gets a fresh
-/// World). `None` = fixtures absent or unloadable ⇒ vacuous skip.
+#[derive(Debug, Clone)]
+struct GenerationWaveSample {
+    wave: usize,
+    engine: &'static str,
+    warmup: bool,
+    streams: usize,
+    retained_prefix_tokens_per_lane: Vec<usize>,
+    seed_tokens_per_lane: Vec<usize>,
+    generated_tokens: usize,
+    cumulative_generated_tokens: usize,
+    preparation_elapsed_seconds: f64,
+    prefill_elapsed_seconds: f64,
+    decode_elapsed_seconds: f64,
+    one_shot_elapsed_seconds: f64,
+    elapsed_seconds: f64,
+    aggregate_tps: f64,
+    peak_active_streams: usize,
+    peak_trajectory_workers: usize,
+    peak_exact_row_workers: usize,
+    private_state_instances: usize,
+    state_sequence_capacity: usize,
+    completed_stream_records: usize,
+    lane_seed_cids: Vec<String>,
+    stream_output_cids: Vec<String>,
+    output_cid: String,
+    execution_delta: Option<TeacherExecutionSnapshot>,
+    ordered_reduction: bool,
+}
+
+struct LegacyGenerationTrajectory<'a> {
+    stream: usize,
+    root_seed: Vec<u32>,
+    history: Vec<u32>,
+    runtime: Runtime<'a>,
+    output: Vec<u32>,
+}
+
+struct GraphGenerationTrajectory {
+    stream: usize,
+    root_seed: Vec<u32>,
+    history: Vec<u32>,
+    state: R4g1State,
+    output: Vec<u32>,
+}
+
+/// Canonically ordered live-teacher output for one prompt position. Timing,
+/// worker scheduling, and resource samples deliberately do not enter this
+/// deterministic transcript.
+#[derive(Debug)]
+struct ParityTranscriptRow {
+    prompt: usize,
+    position: usize,
+    window: Vec<u32>,
+    logits: Vec<f32>,
+    top8: Vec<u32>,
+}
+
+/// Exact state after one canonical prompt's final teacher-forced prefix has
+/// been consumed. S4 clones these variable-length templates and begins at
+/// `next_token`; it never repeats teacher prefill or a teacher warm-up wave.
+struct TeacherGenerationTemplate {
+    prompt: usize,
+    lane_seed: Vec<u32>,
+    next_token: usize,
+    persistent_state_cid: String,
+    state: TeacherState,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+struct TranscriptExactPlan {
+    forward_calls: u64,
+    full_width_forward_calls: u64,
+    tail_forward_calls: u64,
+    minimum_batch_width: usize,
+    streams: u64,
+    matrix_calls: u64,
+    batched_matrix_calls: u64,
+    max_matrix_batch_width: usize,
+    worker_tasks: u64,
+    row_tiles: u64,
+    output_cells: u64,
+    scalar_terms: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ParityTranscriptEvidence {
+    cid: String,
+    positions: usize,
+    logical_forwards: usize,
+    physical_batches: usize,
+    streams_planned: usize,
+    max_active_streams: usize,
+    cache_hits: usize,
+    peak_active_row_workers: usize,
+    private_state_instances: usize,
+    state_sequence_capacities: Vec<usize>,
+    stream_seed_cids: Vec<String>,
+    stream_output_cids: Vec<String>,
+    generation_retained_prefix_tokens_per_lane: Vec<usize>,
+    generation_logical_seed_tokens_per_lane: Vec<usize>,
+    generation_state_sequence_capacity: usize,
+    generation_template_state_cids: Vec<String>,
+    generation_template_next_tokens: Vec<usize>,
+    execution_preparation: TeacherExecutionPreparation,
+    first_forward_workspace_growth_events: u64,
+    first_forward_workspace_growth_bytes: u64,
+    steady_state_workspace_growth_events: u64,
+    steady_state_workspace_growth_bytes: u64,
+    owner_plan: TranscriptExactPlan,
+    execution: TeacherExecutionSnapshot,
+}
+
+struct ParityTranscript {
+    rows: Vec<ParityTranscriptRow>,
+    evidence: ParityTranscriptEvidence,
+    generation_templates: Vec<TeacherGenerationTemplate>,
+}
+
+/// Heavy fixtures, cached once for the externally-serial parity feature. The
+/// suite owns one shared immutable teacher weight allocation; independent
+/// prompts and generation trajectories receive private state from
+/// [`BatchedTeacher::new_state`]. `None` means empirical evidence is
+/// UNAVAILABLE, never a parity PASS.
 struct ParityFixtures {
     teacher: SmolLm2Oracle,
+    teacher_execution_preparation: TeacherExecutionPreparation,
     artifacts: Compiled,
     store: Store,
     tokenizer: Tokenizer,
@@ -3587,67 +3781,2511 @@ struct ParityFixtures {
     corpus: Option<Corpus>,
     fmm: Option<FmmCandidateScorer>,
     fmm_fixed: Option<uor_r4_graph_certify::FmmFixedCandidateScorer>,
+    artifact_bytes: Arc<Vec<u8>>,
+    transcripts: std::collections::BTreeMap<usize, Arc<ParityTranscript>>,
+    transcript_cache_hits: usize,
 }
 
-thread_local! {
-    static PARITY_FIXTURES: RefCell<Option<Option<ParityFixtures>>> = const { RefCell::new(None) };
+static PARITY_FIXTURES: OnceLock<Mutex<Result<ParityFixtures, String>>> = OnceLock::new();
+
+struct ParityRunState {
+    config: ParityConfig,
+    counters: Arc<WorkCounters>,
+    progress: SharedProgress,
+    heartbeat: Option<HeartbeatWorker>,
+    started: Instant,
+    started_unix_millis: u64,
+    scenario_status: std::collections::BTreeMap<String, (RunStatus, String)>,
+    deterministic_output: std::collections::BTreeMap<String, serde_json::Value>,
+    empirical_output: std::collections::BTreeMap<String, serde_json::Value>,
+    /// Exact current expectation admitted with the qualified probe. Retained
+    /// so final publication can revalidate the report and events after all
+    /// potentially expensive work has completed.
+    probe_expectation: Option<ExactMulticoreProbeExpectation>,
+    phase_peak_row_workers: Arc<AtomicUsize>,
+    phase_peak_streams: Arc<AtomicUsize>,
+    finalized: bool,
 }
 
-fn parity_source_dir() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join(".uor-models/sources/smollm2-135m-instruct")
+static PARITY_RUN: OnceLock<Result<Mutex<ParityRunState>, String>> = OnceLock::new();
+const PENDING_SCENARIO_DETAIL: &str = "scenario began but did not reach its final checked step";
+
+fn initialize_parity_run() -> Result<Mutex<ParityRunState>, String> {
+    let started = Instant::now();
+    let started_unix_millis = unix_millis_now();
+    let current_dir = std::env::current_dir()
+        .map_err(|error| format!("FAIL: resolve parity artifact paths: {error}"))?;
+    // Take ownership of the canonical report before any other fallible config,
+    // probe, preflight, or fixture work. Otherwise an early error could leave
+    // a prior PASS visible as though it belonged to this invocation.
+    let run_report_path =
+        take_run_report_ownership(&current_dir, std::env::var("R4_PARITY_REPORT").ok())
+            .map_err(|error| format!("FAIL: invalidate stale parity companions: {error}"))?;
+    let config = ParityConfig::from_env().map_err(|error| format!("FAIL: {error}"))?;
+    let backend = exact_backend_report();
+    let scheduler = SchedulerSnapshot::from_config(&config);
+    let absolute = |path: &Path| {
+        if path.is_absolute() {
+            path.to_owned()
+        } else {
+            current_dir.join(path)
+        }
+    };
+    let configured_run_report_path = absolute(&config.report_path);
+    if configured_run_report_path != run_report_path {
+        return Err("FAIL: early and configured parity report paths disagree".to_owned());
+    }
+    let evidence_path = absolute(
+        &evidence_path_for_report(&config.report_path)
+            .map_err(|error| format!("FAIL: parity evidence path: {error}"))?,
+    );
+    let events_path = absolute(
+        &events_path_for_report(&config.report_path)
+            .map_err(|error| format!("FAIL: parity event path: {error}"))?,
+    );
+    let probe_report_path = absolute(&parity_probe_report_path()?);
+    let preflight_report_path = absolute(&parity_preflight_report_path()?);
+    let fixture_dirs = parity_fixture_dirs()?;
+    let mut metadata = RunMetadata::new(
+        scheduler,
+        backend.arithmetic_owner,
+        backend
+            .selected_backend
+            .unwrap_or_else(|| "UNAVAILABLE".to_owned()),
+        "UNAVAILABLE",
+    )
+    .with_identity("backend_selection_status", backend.selection_status)
+    .with_identity("target_arch", backend.target_arch)
+    .with_budget("teacher_forced_positions", config.positions.get() as u64)
+    .with_budget("generation_tokens", config.gen_tokens.get() as u64)
+    .with_budget("generation_runs", config.runs.get() as u64)
+    .with_budget("corpus_positions", config.corpus_positions.get() as u64)
+    .with_budget("fmm_positions", config.fmm_positions.get() as u64)
+    .with_budget("probe_positions", config.probe_positions.get() as u64)
+    .with_budget("max_wall_seconds", config.max_wall.get())
+    .with_path("run_report", run_report_path.display().to_string())
+    .with_path(
+        "deterministic_evidence",
+        evidence_path.display().to_string(),
+    )
+    .with_path("event_jsonl", events_path.display().to_string())
+    .with_path(
+        "teacher_source_dir",
+        fixture_dirs.source.display().to_string(),
+    )
+    .with_path(
+        "compiled_bundle_dir",
+        fixture_dirs.bundle.display().to_string(),
+    )
+    .with_path(
+        "exact_probe_report",
+        probe_report_path.display().to_string(),
+    )
+    .with_path(
+        "teacher_free_preflight_report",
+        preflight_report_path.display().to_string(),
+    );
+    metadata.identities.insert(
+        "available_exact_backends".to_owned(),
+        backend.available_backends.join(","),
+    );
+    metadata.fixtures.insert(
+        "exact_multicore_probe".to_owned(),
+        FixtureStatus::not_run("probe admission has not been evaluated"),
+    );
+    for fixture in [
+        "teacher_weights",
+        "teacher_config",
+        "tla_artifact",
+        "tls_store",
+        "tokenizer",
+        "teacher_free_s4_preflight",
+        "r4g1_graph",
+        "r4g1_graph_report",
+        "corpus",
+        "fmm_candidate",
+    ] {
+        metadata.fixtures.insert(
+            fixture.to_owned(),
+            FixtureStatus::not_run("fixture has not been inspected"),
+        );
+    }
+    for (name, _) in PRODUCTION_ADMISSION_COMPONENTS {
+        metadata.fixtures.insert(
+            format!("production_{name}"),
+            FixtureStatus::not_run("production component has not been inspected"),
+        );
+    }
+    let counters = Arc::new(WorkCounters::unplanned());
+    let run_id = format!("teacher-parity-{}", std::process::id());
+    let progress = SharedProgress::new(&run_id, metadata);
+    let heartbeat = HeartbeatWorker::spawn_with_stall_after(
+        events_path,
+        Duration::from_secs(config.progress_every.get()),
+        Duration::from_secs(config.stall_after.get()),
+        Arc::clone(&counters),
+        progress.clone(),
+    )
+    .map_err(|error| format!("FAIL: parity heartbeat start: {error}"))?;
+    heartbeat
+        .emit(EventKind::SuiteStarted)
+        .map_err(|error| format!("FAIL: parity suite-start event: {error}"))?;
+    Ok(Mutex::new(ParityRunState {
+        config,
+        counters,
+        progress,
+        heartbeat: Some(heartbeat),
+        started,
+        started_unix_millis,
+        scenario_status: std::collections::BTreeMap::new(),
+        deterministic_output: std::collections::BTreeMap::new(),
+        empirical_output: std::collections::BTreeMap::new(),
+        probe_expectation: None,
+        phase_peak_row_workers: Arc::new(AtomicUsize::new(0)),
+        phase_peak_streams: Arc::new(AtomicUsize::new(0)),
+        finalized: false,
+    }))
 }
 
-fn parity_bundle_dir() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join(".uor-models/compiled/smollm2-135m-instruct")
+fn parity_run() -> Result<&'static Mutex<ParityRunState>, String> {
+    match PARITY_RUN.get_or_init(initialize_parity_run) {
+        Ok(state) => Ok(state),
+        Err(reason) => Err(reason.clone()),
+    }
+}
+
+fn parity_config() -> ParityConfig {
+    let state = parity_run().unwrap_or_else(|reason| panic!("{reason}"));
+    state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .config
+        .clone()
+}
+
+fn parity_progress() -> SharedProgress {
+    let state = parity_run().unwrap_or_else(|reason| panic!("{reason}"));
+    state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .progress
+        .clone()
+}
+
+fn parity_counters() -> Arc<WorkCounters> {
+    let state = parity_run().unwrap_or_else(|reason| panic!("{reason}"));
+    Arc::clone(
+        &state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .counters,
+    )
+}
+
+fn parity_reset_phase_peak() {
+    if let Ok(state) = parity_run() {
+        let guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard
+            .phase_peak_row_workers
+            .store(0, AtomicOrdering::Release);
+        guard.phase_peak_streams.store(0, AtomicOrdering::Release);
+    }
+}
+
+fn parity_phase_peak() -> usize {
+    parity_run()
+        .map(|state| {
+            state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .phase_peak_row_workers
+                .load(AtomicOrdering::Acquire)
+        })
+        .unwrap_or(0)
+}
+
+fn parity_stream_phase_peak() -> usize {
+    parity_run()
+        .map(|state| {
+            state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .phase_peak_streams
+                .load(AtomicOrdering::Acquire)
+        })
+        .unwrap_or(0)
+}
+
+fn parity_emit(kind: EventKind) -> Result<(), String> {
+    let state = parity_run()?;
+    let guard = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard
+        .heartbeat
+        .as_ref()
+        .ok_or_else(|| "parity heartbeat is already finalized".to_owned())?
+        .emit(kind)
+        .map_err(|error| format!("parity event write: {error}"))
+}
+
+fn parity_mark_scenario(scenario: &str, status: RunStatus, reason: impl Into<String>) {
+    if let Ok(state) = parity_run() {
+        state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .scenario_status
+            .insert(scenario.to_owned(), (status, reason.into()));
+    }
+}
+
+/// Promote only the untouched scenario sentinel. An earlier explicit
+/// FAIL/ABORTED/UNAVAILABLE/NOT_RUN verdict must never be overwritten by a
+/// later Gherkin `And` step that happens to complete.
+fn parity_mark_scenario_pass_if_pending(
+    scenario: &str,
+    reason: impl Into<String>,
+) -> Result<(), String> {
+    let state = parity_run()?;
+    let mut guard = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some((status, detail)) = guard.scenario_status.get_mut(scenario) else {
+        return Err(format!(
+            "FAIL: {scenario} cannot pass before its scenario sentinel is installed"
+        ));
+    };
+    if *status == RunStatus::Fail && detail == PENDING_SCENARIO_DETAIL {
+        *status = RunStatus::Pass;
+        *detail = reason.into();
+    }
+    Ok(())
+}
+
+fn parity_record_output(name: &str, value: serde_json::Value) {
+    if let Ok(state) = parity_run() {
+        state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .deterministic_output
+            .insert(name.to_owned(), value);
+    }
+}
+
+fn parity_record_measurement(name: &str, value: serde_json::Value) {
+    if let Ok(state) = parity_run() {
+        state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .empirical_output
+            .insert(name.to_owned(), value);
+    }
+}
+
+fn parity_status_for_reason(reason: &str) -> RunStatus {
+    if reason.starts_with("ABORTED:") {
+        RunStatus::Aborted
+    } else if reason.starts_with("FAILED:") || reason.starts_with("FAIL:") {
+        RunStatus::Fail
+    } else if reason.starts_with("NOT_RUN") || reason.contains("REFUSED") {
+        RunStatus::NotRun
+    } else {
+        RunStatus::Unavailable
+    }
+}
+
+fn parity_begin_scenario(scenario: &str) {
+    if let Ok(state) = parity_run() {
+        let mut guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard
+            .scenario_status
+            .entry(scenario.to_owned())
+            .or_insert_with(|| (RunStatus::Fail, PENDING_SCENARIO_DETAIL.to_owned()));
+        let _ = guard.progress.update(|progress| {
+            progress.phase = format!("{scenario}_active");
+        });
+    }
+}
+
+fn parity_abort_step(scenario: &str, reason: impl Into<String>) -> ! {
+    let reason = reason.into();
+    let status = parity_status_for_reason(&reason);
+    parity_mark_scenario(scenario, status, reason.clone());
+    if let Ok(progress) = parity_run().map(|state| {
+        state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .progress
+            .clone()
+    }) {
+        let _ = progress.update(|live| {
+            live.status = status;
+            live.phase = format!("{scenario}_failed");
+        });
+    }
+    // A panicking Cucumber step may prevent S7 from ever reaching the normal
+    // finalization step. Finalize here so every durable terminal event is the
+    // writer's last row and every failure still gets a machine-readable
+    // report. `finalize_parity_run` emits and stops atomically.
+    match finalize_parity_run() {
+        Ok(_) => panic!("{reason}"),
+        Err(finalization) => panic!("{reason}; {finalization}"),
+    }
+}
+
+fn parity_requested_status(
+    statuses: &std::collections::BTreeMap<String, (RunStatus, String)>,
+) -> (RunStatus, String) {
+    for status in [
+        RunStatus::Fail,
+        RunStatus::Aborted,
+        RunStatus::Unavailable,
+        RunStatus::NotRun,
+    ] {
+        let reasons: Vec<_> = statuses
+            .iter()
+            .filter(|(_, (actual, _))| *actual == status)
+            .map(|(scenario, (_, reason))| format!("{scenario}: {reason}"))
+            .collect();
+        if !reasons.is_empty() {
+            return (status, reasons.join("; "));
+        }
+    }
+    let missing: Vec<_> = (1..=7)
+        .map(|index| format!("S{index}"))
+        .filter(|scenario| !statuses.contains_key(scenario))
+        .collect();
+    if !missing.is_empty() {
+        return (
+            RunStatus::NotRun,
+            format!("scenario status absent for {}", missing.join(", ")),
+        );
+    }
+    (RunStatus::Pass, "all S1-S7 checks completed".to_owned())
+}
+
+fn parity_run_finalized() -> bool {
+    parity_run()
+        .map(|state| {
+            state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .finalized
+        })
+        .unwrap_or(false)
+}
+
+fn parity_elapsed() -> Duration {
+    parity_run()
+        .map(|state| {
+            state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .started
+                .elapsed()
+        })
+        .unwrap_or(Duration::ZERO)
+}
+
+fn parity_check_deadline(context: &str) -> Result<(), String> {
+    let config = parity_config();
+    let elapsed = parity_elapsed();
+    if elapsed >= Duration::from_secs(config.max_wall.get()) {
+        Err(format!(
+            "ABORTED: suite wall ceiling R4_PARITY_MAX_WALL_SECS={} reached during {context} after {:.3}s",
+            config.max_wall,
+            elapsed.as_secs_f64()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ParityResolvedPaths {
+    run: std::path::PathBuf,
+    evidence: std::path::PathBuf,
+    events: std::path::PathBuf,
+    probe: std::path::PathBuf,
+}
+
+fn parity_resolved_paths(config: &ParityConfig) -> Result<ParityResolvedPaths, String> {
+    let current_dir = std::env::current_dir()
+        .map_err(|error| format!("FAIL: resolve parity artifact paths: {error}"))?;
+    let absolute = |path: &Path| {
+        if path.is_absolute() {
+            path.to_owned()
+        } else {
+            current_dir.join(path)
+        }
+    };
+    Ok(ParityResolvedPaths {
+        run: absolute(&config.report_path),
+        evidence: absolute(
+            &evidence_path_for_report(&config.report_path)
+                .map_err(|error| format!("FAIL: parity evidence path: {error}"))?,
+        ),
+        events: absolute(
+            &events_path_for_report(&config.report_path)
+                .map_err(|error| format!("FAIL: parity event path: {error}"))?,
+        ),
+        probe: absolute(&parity_probe_report_path()?),
+    })
+}
+
+fn read_parity_events(path: &Path) -> Result<Vec<HeartbeatEvent>, String> {
+    let event_bytes = std::fs::read_to_string(path)
+        .map_err(|error| format!("FAIL: read {}: {error}", path.display()))?;
+    let events = event_bytes
+        .lines()
+        .enumerate()
+        .map(|(line, row)| {
+            serde_json::from_str::<HeartbeatEvent>(row).map_err(|error| {
+                format!(
+                    "FAIL: parse {} JSONL event line {}: {error}",
+                    path.display(),
+                    line + 1
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if events.is_empty() {
+        return Err("FAIL: durable parity event stream is empty".to_owned());
+    }
+    Ok(events)
+}
+
+fn validate_parity_event_rows(
+    events: &[HeartbeatEvent],
+    run_id: &str,
+    terminal: Option<(EventKind, RunStatus)>,
+) -> Result<(), String> {
+    if events.iter().any(|event| event.schema != EVENT_SCHEMA) {
+        return Err("FAIL: parity event stream contains an unknown schema".to_owned());
+    }
+    if events.iter().any(|event| event.run_id != run_id) {
+        return Err("FAIL: parity event stream contains a foreign run_id".to_owned());
+    }
+    if !events
+        .windows(2)
+        .all(|pair| pair[0].sequence < pair[1].sequence)
+    {
+        return Err("FAIL: parity event sequence is not strictly ordered".to_owned());
+    }
+    if let Some((kind, status)) = terminal {
+        let last = events
+            .last()
+            .ok_or_else(|| "FAIL: parity terminal event is absent".to_owned())?;
+        if last.event_kind != kind || last.status != status {
+            return Err(format!(
+                "FAIL: parity terminal row is {:?}/{}; expected {:?}/{}",
+                last.event_kind,
+                last.status.as_str(),
+                kind,
+                status.as_str()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_parity_prepublication(
+    config: &ParityConfig,
+    status: RunStatus,
+    run_id: &str,
+    metadata: &RunMetadata,
+    admitted_probe_expectation: Option<&ExactMulticoreProbeExpectation>,
+) -> Result<(), String> {
+    let paths = parity_resolved_paths(config)?;
+    for (name, path) in [
+        ("run_report", &paths.run),
+        ("deterministic_evidence", &paths.evidence),
+        ("event_jsonl", &paths.events),
+        ("exact_probe_report", &paths.probe),
+    ] {
+        if metadata.paths.get(name).map(String::as_str) != Some(path.to_string_lossy().as_ref()) {
+            return Err(format!(
+                "FAIL: run metadata does not bind resolved {name} path {}",
+                path.display()
+            ));
+        }
+    }
+    if paths.probe.is_file() {
+        let probe_bytes = std::fs::read(&paths.probe)
+            .map_err(|error| format!("FAIL: read {}: {error}", paths.probe.display()))?;
+        let probe_cid = format!("blake3:{}", blake3::hash(&probe_bytes).to_hex());
+        match classify_exact_probe_artifact(&probe_bytes, EXACT_MULTICORE_PROBE_SCHEMA)? {
+            ExactProbeArtifact::QualifiedCandidate(value) => {
+                let probe: ExactMulticoreProbeReport = serde_json::from_value(value)
+                    .map_err(|error| format!("FAIL: parse {}: {error}", paths.probe.display()))?;
+                if probe.schema != EXACT_MULTICORE_PROBE_SCHEMA {
+                    return Err(format!(
+                        "FAIL: exact probe schema {:?} does not match {EXACT_MULTICORE_PROBE_SCHEMA}",
+                        probe.schema
+                    ));
+                }
+                let fixture = metadata
+                    .fixtures
+                    .get("exact_multicore_probe")
+                    .ok_or_else(|| {
+                        "FAIL: qualified probe has no admitted fixture row".to_owned()
+                    })?;
+                if fixture.verdict != FixtureVerdict::Available
+                    || fixture.cid.as_deref() != Some(probe_cid.as_str())
+                    || fixture.reason.is_some()
+                {
+                    return Err(
+                        "FAIL: current qualified probe bytes do not match the admitted AVAILABLE fixture identity"
+                            .to_owned(),
+                    );
+                }
+                let expectation = admitted_probe_expectation.ok_or_else(|| {
+                    "FAIL: qualified probe expectation was not retained for final validation"
+                        .to_owned()
+                })?;
+                probe
+                    .validate_for_with_events(&paths.probe, expectation)
+                    .map_err(|error| {
+                        format!("FAIL: final exact probe/event revalidation: {error}")
+                    })?;
+                let reread_cid = file_kappa(&paths.probe)?.0;
+                if reread_cid != probe_cid {
+                    return Err(
+                        "FAIL: exact probe changed during final prepublication validation"
+                            .to_owned(),
+                    );
+                }
+            }
+            ExactProbeArtifact::NonQualified(state) => {
+                validate_nonqualified_probe_prepublication(
+                    status,
+                    metadata.fixtures.get("exact_multicore_probe"),
+                    &state,
+                    &probe_cid,
+                )?;
+            }
+        }
+    } else if status == RunStatus::Pass {
+        return Err("FAIL: a PASS may not omit the exact multicore probe artifact".to_owned());
+    } else {
+        let fixture = metadata
+            .fixtures
+            .get("exact_multicore_probe")
+            .ok_or_else(|| "FAIL: missing probe has no explicit fixture status".to_owned())?;
+        if fixture.reason.is_none() || fixture.cid.is_some() {
+            return Err(
+                "FAIL: missing probe must retain a reason and no content identity".to_owned(),
+            );
+        }
+    }
+    let events = read_parity_events(&paths.events)?;
+    validate_parity_event_rows(&events, run_id, None)?;
+    if status == RunStatus::Pass {
+        validate_in_flight_heartbeat_cadence(
+            &events,
+            Duration::from_secs(config.progress_every.get()),
+            config.streams.get(),
+            config.workers.get(),
+        )
+        .map_err(|reason| format!("FAIL: {reason}"))?;
+        validate_full_width_exact_heartbeat(&events, config.streams.get(), config.workers.get())
+            .map_err(|reason| format!("FAIL: {reason}"))?;
+    }
+    Ok(())
+}
+
+fn append_operational_failure(slot: &mut Option<String>, failure: impl Into<String>) {
+    let failure = failure.into();
+    *slot = Some(match slot.take() {
+        Some(previous) => format!("{previous}; {failure}"),
+        None => failure,
+    });
+}
+
+fn parity_terminal_event(status: RunStatus) -> EventKind {
+    match status {
+        RunStatus::Fail => EventKind::WorkFailed,
+        RunStatus::Aborted => EventKind::SuiteAborted,
+        RunStatus::Pass | RunStatus::Unavailable | RunStatus::NotRun => EventKind::SuiteCompleted,
+    }
+}
+
+fn stop_parity_before_terminal_failure(guard: &mut ParityRunState, reason: String) -> String {
+    let _ = mark_finalization_failed(&guard.progress, "telemetry_finalize_failed");
+    let mut failure = reason;
+    if let Err(error) = invalidate_final_reports_checked(&guard.config.report_path) {
+        failure.push_str(&format!(
+            "; FAIL: invalidate parity companions after finalization error: {error}"
+        ));
+    }
+    if let Some(heartbeat) = guard.heartbeat.take() {
+        if let Err(error) = heartbeat.emit_and_stop(EventKind::WorkFailed) {
+            failure.push_str(&format!(
+                "; FAIL: stop parity heartbeat after finalization error: {error}"
+            ));
+        }
+    } else {
+        failure.push_str("; FAIL: parity heartbeat absent after finalization error");
+    }
+    guard.finalized = true;
+    failure
+}
+
+fn finalize_parity_run() -> Result<RunStatus, String> {
+    let state = parity_run()?;
+    let mut guard = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if guard.finalized {
+        return guard
+            .progress
+            .snapshot()
+            .map(|snapshot| snapshot.live.status)
+            .map_err(|error| format!("FAIL: read finalized parity status: {error}"));
+    }
+    let (requested, requested_detail) = parity_requested_status(&guard.scenario_status);
+    let completion = guard.counters.completion_status(requested);
+    let mut status = completion.status;
+    let mut detail = completion.detail.unwrap_or(requested_detail);
+    if let Err(error) = guard.progress.update(|progress| {
+        progress.phase = "finalizing".to_owned();
+        // PASS remains only a candidate until every companion has been
+        // prepared and the terminal writer is ready to stop.
+        progress.status = if status == RunStatus::Pass {
+            RunStatus::NotRun
+        } else {
+            status
+        };
+        progress.queue.active_streams = 0;
+        progress.queue.active_row_workers = 0;
+        progress.queue.active_worker_tasks = 0;
+        progress.streams.clear();
+    }) {
+        let reason = stop_parity_before_terminal_failure(
+            &mut guard,
+            format!("FAIL: finalize parity progress: {error}"),
+        );
+        return Err(reason);
+    }
+    let scenario_status = guard
+        .scenario_status
+        .iter()
+        .map(|(scenario, (scenario_status, reason))| {
+            (
+                scenario.clone(),
+                serde_json::json!({
+                    "status": scenario_status.as_str(),
+                    "detail": reason,
+                }),
+            )
+        })
+        .collect::<serde_json::Map<String, serde_json::Value>>();
+    guard.empirical_output.insert(
+        "scenario_status".to_owned(),
+        serde_json::Value::Object(scenario_status),
+    );
+    let mut operational_failure = None;
+    // Synchronize with the independent writer before inspecting the live event
+    // file. This row is deliberately idle/finalizing and therefore cannot
+    // satisfy the active in-flight cadence predicate.
+    if let Some(heartbeat) = guard.heartbeat.as_ref() {
+        if let Err(error) = heartbeat.emit(EventKind::Heartbeat) {
+            append_operational_failure(
+                &mut operational_failure,
+                format!("FAIL: synchronize parity event readback: {error}"),
+            );
+        }
+    } else {
+        append_operational_failure(
+            &mut operational_failure,
+            "FAIL: parity heartbeat is absent before final publication",
+        );
+    }
+    let prepublication = match guard.progress.snapshot() {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let reason = stop_parity_before_terminal_failure(
+                &mut guard,
+                format!("FAIL: snapshot prepublication parity progress: {error}"),
+            );
+            return Err(reason);
+        }
+    };
+    if operational_failure.is_none() {
+        if let Err(error) = validate_parity_prepublication(
+            &guard.config,
+            status,
+            &prepublication.live.run_id,
+            &prepublication.live.metadata,
+            guard.probe_expectation.as_ref(),
+        ) {
+            append_operational_failure(&mut operational_failure, error);
+        }
+    }
+    if let Some(failure) = &operational_failure {
+        status = RunStatus::Fail;
+        detail = failure.clone();
+        let _ = guard.progress.update(|progress| {
+            progress.status = RunStatus::Fail;
+            progress.phase = "telemetry_prepublication_failed".to_owned();
+        });
+    }
+
+    // Construct, serialize, sync, and read back every final companion before
+    // the terminal event. After the terminal writer stops, the only remaining
+    // operation is the canonical evidence/run rename, with the run report as
+    // the last commit marker.
+    let max_sampled_rss = guard
+        .heartbeat
+        .as_ref()
+        .and_then(HeartbeatWorker::max_sampled_rss_bytes);
+    let live = match guard.progress.snapshot() {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let reason = stop_parity_before_terminal_failure(
+                &mut guard,
+                format!("FAIL: snapshot final parity progress: {error}"),
+            );
+            return Err(reason);
+        }
+    };
+    let elapsed = guard.started.elapsed();
+    let work = guard.counters.snapshot();
+    let elapsed_seconds = elapsed.as_secs_f64();
+    let cumulative_rate = (elapsed_seconds > 0.0)
+        .then_some(work.logical_forwards as f64 / elapsed_seconds)
+        .filter(|rate| rate.is_finite());
+    let (eta_progress_unit, eta_progress_completed, eta_progress_total) =
+        heartbeat_progress_units(&work);
+    let rates = RateSnapshot {
+        rolling_forwards_per_second: None,
+        cumulative_forwards_per_second: cumulative_rate,
+        seconds_per_forward: seconds_per_forward_from_rate(cumulative_rate),
+        tokens_per_second: (elapsed_seconds > 0.0)
+            .then_some(work.tokens as f64 / elapsed_seconds)
+            .filter(|rate| rate.is_finite()),
+        rolling_worker_tasks_per_second: None,
+        rolling_scalar_terms_per_second: None,
+        cumulative_scalar_terms_per_second: (elapsed_seconds > 0.0)
+            .then_some(work.scalar_terms as f64 / elapsed_seconds)
+            .filter(|rate| rate.is_finite()),
+        eta_progress_unit,
+        eta_progress_completed,
+        eta_progress_total,
+    };
+    let eta = estimate_eta(EtaInput {
+        completed: eta_progress_completed,
+        total: eta_progress_total,
+        elapsed,
+        last_progress_age: live.state_age,
+        stall_after: Duration::from_secs(guard.config.stall_after.get()),
+        minimum_samples: 3,
+    });
+    let mut resources = sample_host_resources();
+    resources.set_max_sampled_resident_set_bytes(max_sampled_rss);
+    let mut report = RunReport::new(
+        live.live.run_id.clone(),
+        guard.config.mode,
+        status,
+        work,
+        eta,
+        resources,
+    )
+    .with_detail(detail.clone())
+    .with_metadata(live.live.metadata.clone())
+    .with_queue(live.live.queue)
+    .with_streams(live.live.streams.clone())
+    .with_rates(rates)
+    .with_measurements(guard.empirical_output.clone());
+    report.elapsed_millis = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+    report.started_unix_millis = guard.started_unix_millis;
+    let deterministic_output = match serde_json::to_value(&guard.deterministic_output) {
+        Ok(output) => output,
+        Err(error) => {
+            let reason = stop_parity_before_terminal_failure(
+                &mut guard,
+                format!("FAIL: serialize deterministic parity evidence: {error}"),
+            );
+            return Err(reason);
+        }
+    };
+    let deterministic_identities =
+        match deterministic_evidence_identities(&live.live.metadata, &deterministic_output) {
+            Ok(identities) => identities,
+            Err(error) => {
+                let reason = stop_parity_before_terminal_failure(
+                    &mut guard,
+                    format!("FAIL: derive deterministic parity identities: {error}"),
+                );
+                return Err(reason);
+            }
+        };
+    let evidence =
+        DeterministicEvidence::new(status, deterministic_identities, deterministic_output);
+    let prepared = match prepare_final_reports(&guard.config.report_path, &report, &evidence) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            let reason = stop_parity_before_terminal_failure(
+                &mut guard,
+                format!("FAIL: prepare parity final report: {error}"),
+            );
+            return Err(reason);
+        }
+    };
+    if let Err(error) = guard.progress.update(|progress| {
+        progress.phase = "finalized".to_owned();
+        progress.status = status;
+    }) {
+        drop(prepared);
+        let reason = stop_parity_before_terminal_failure(
+            &mut guard,
+            format!("FAIL: publish finalized parity progress: {error}"),
+        );
+        return Err(reason);
+    }
+    let terminal = parity_terminal_event(status);
+    let terminal_result = guard
+        .heartbeat
+        .take()
+        .ok_or_else(|| "FAIL: parity heartbeat disappeared before terminal publication".to_owned())
+        .and_then(|heartbeat| {
+            heartbeat
+                .emit_and_stop(terminal)
+                .map_err(|error| format!("FAIL: write terminal and stop parity heartbeat: {error}"))
+        });
+    if let Err(error) = terminal_result {
+        drop(prepared);
+        let invalidation = invalidate_final_reports_checked(&guard.config.report_path).err();
+        let _ = mark_finalization_failed(&guard.progress, "telemetry_terminal_failed");
+        guard.finalized = true;
+        return Err(match invalidation {
+            Some(invalidation) => {
+                format!("{error}; FAIL: invalidate parity companions: {invalidation}")
+            }
+            None => error,
+        });
+    }
+    let terminal_readback = parity_resolved_paths(&guard.config)
+        .and_then(|paths| read_parity_events(&paths.events))
+        .and_then(|events| {
+            validate_parity_event_rows(
+                &events,
+                &prepublication.live.run_id,
+                Some((terminal, status)),
+            )
+        });
+    if let Err(error) = terminal_readback {
+        drop(prepared);
+        let invalidation = invalidate_final_reports_checked(&guard.config.report_path).err();
+        let _ = mark_finalization_failed(&guard.progress, "telemetry_terminal_readback_failed");
+        guard.finalized = true;
+        return Err(match invalidation {
+            Some(invalidation) => format!(
+                "FAIL: terminal parity event readback: {error}; FAIL: invalidate parity companions: {invalidation}"
+            ),
+            None => format!("FAIL: terminal parity event readback: {error}"),
+        });
+    }
+    if let Err(error) = prepared.commit() {
+        // The commit implementation removes both canonical companions. The
+        // durable event stream alone is not a completed artifact set; without
+        // the run-report commit marker it cannot authorize a PASS.
+        let _ = mark_finalization_failed(&guard.progress, "telemetry_commit_failed");
+        guard.finalized = true;
+        return Err(format!("FAIL: commit parity final report: {error}"));
+    }
+    guard.finalized = true;
+    match operational_failure {
+        Some(failure) => Err(failure),
+        None => Ok(status),
+    }
+}
+
+#[derive(Debug)]
+struct ParityFixtureDirs {
+    source: std::path::PathBuf,
+    bundle: std::path::PathBuf,
+}
+
+static PARITY_FIXTURE_DIRS: OnceLock<Result<ParityFixtureDirs, String>> = OnceLock::new();
+
+fn parity_fixture_env(name: &str) -> Result<Option<String>, String> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(format!("is not valid Unicode: {error}")),
+    }
+}
+
+fn resolve_parity_fixture_dir(
+    name: &str,
+    default: std::path::PathBuf,
+) -> Result<std::path::PathBuf, String> {
+    let selected = configured_fixture_dir(name, parity_fixture_env(name), default)
+        .map_err(|reason| format!("NOT_RUN / REFUSED: {reason}"))?;
+    if selected.is_absolute() {
+        Ok(selected)
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(selected))
+            .map_err(|error| format!("NOT_RUN / REFUSED: resolve {name} relative path: {error}"))
+    }
+}
+
+fn parity_fixture_dirs() -> Result<&'static ParityFixtureDirs, String> {
+    match PARITY_FIXTURE_DIRS.get_or_init(|| {
+        Ok(ParityFixtureDirs {
+            source: resolve_parity_fixture_dir(
+                "R4_PARITY_SOURCE",
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join(".uor-models/sources/smollm2-135m-instruct"),
+            )?,
+            bundle: resolve_parity_fixture_dir(
+                "R4_PARITY_BUNDLE",
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join(".uor-models/compiled/smollm2-135m-instruct"),
+            )?,
+        })
+    }) {
+        Ok(paths) => Ok(paths),
+        Err(reason) => Err(reason.clone()),
+    }
+}
+
+fn parity_source_dir() -> Result<std::path::PathBuf, String> {
+    parity_fixture_dirs().map(|paths| paths.source.clone())
+}
+
+fn parity_bundle_dir() -> Result<std::path::PathBuf, String> {
+    parity_fixture_dirs().map(|paths| paths.bundle.clone())
+}
+
+fn parity_probe_report_path() -> Result<std::path::PathBuf, String> {
+    match std::env::var("R4_EXACT_PROBE_REPORT") {
+        Ok(path) => configured_exact_probe_report_path(Some(path))
+            .map_err(|error| format!("NOT_RUN / REFUSED: {error}")),
+        Err(std::env::VarError::NotPresent) => configured_exact_probe_report_path(None)
+            .map(|path| Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+            .map_err(|error| format!("NOT_RUN / REFUSED: {error}")),
+        Err(error) => Err(format!(
+            "NOT_RUN / REFUSED: R4_EXACT_PROBE_REPORT is not valid Unicode: {error}"
+        )),
+    }
+}
+
+fn parity_preflight_report_path() -> Result<std::path::PathBuf, String> {
+    match std::env::var("R4_PARITY_PREFLIGHT_REPORT") {
+        Ok(path) => configured_preflight_report_path(Some(path)).map_err(|error| error.to_string()),
+        Err(std::env::VarError::NotPresent) => {
+            configured_preflight_report_path(None).map_err(|error| error.to_string())
+        }
+        Err(error) => Err(format!(
+            "R4_PARITY_PREFLIGHT_REPORT is not valid Unicode: {error}"
+        )),
+    }
+}
+
+fn read_parity_probe_report() -> Result<ExactMulticoreProbeReport, String> {
+    let path = parity_probe_report_path()?;
+    let bytes = std::fs::read(&path)
+        .map_err(|error| format!("UNAVAILABLE: read exact probe {}: {error}", path.display()))?;
+    match classify_exact_probe_artifact(&bytes, EXACT_MULTICORE_PROBE_SCHEMA)? {
+        ExactProbeArtifact::QualifiedCandidate(value) => serde_json::from_value(value)
+            .map_err(|error| format!("FAILED: parse exact probe {}: {error}", path.display())),
+        ExactProbeArtifact::NonQualified(state) => Err(state.outcome_reason()),
+    }
+}
+
+/// Read only a recognized non-qualified state for early-failure metadata.
+/// Qualified candidates and malformed/unknown artifacts remain untouched here
+/// so the ordinary prepublication validator remains their fail-closed owner.
+fn present_nonqualified_probe_fixture_status() -> Option<FixtureStatus> {
+    let path = parity_probe_report_path().ok()?;
+    let bytes = std::fs::read(path).ok()?;
+    let ExactProbeArtifact::NonQualified(state) =
+        classify_exact_probe_artifact(&bytes, EXACT_MULTICORE_PROBE_SCHEMA).ok()?
+    else {
+        return None;
+    };
+    let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    Some(state.fixture_status(cid))
+}
+
+fn file_kappa(path: &Path) -> Result<(String, u64), String> {
+    let bytes = std::fs::read(path)
+        .map_err(|error| format!("UNAVAILABLE: read {}: {error}", path.display()))?;
+    Ok((
+        format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+        u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+    ))
+}
+
+fn file_set_kappa(paths: &[&Path]) -> Result<String, String> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.parity-file-set/1\0");
+    for path in paths {
+        let bytes = std::fs::read(path)
+            .map_err(|error| format!("UNAVAILABLE: read {}: {error}", path.display()))?;
+        let name = path.to_string_lossy();
+        hasher.update(&(name.len() as u64).to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update(&(bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+fn model_sequence_ceiling(source: &Path) -> Result<usize, String> {
+    let config_path = source.join("config.json");
+    let bytes = std::fs::read(&config_path)
+        .map_err(|error| format!("FAILED: read {}: {error}", config_path.display()))?;
+    let config: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("FAILED: parse {}: {error}", config_path.display()))?;
+    let value = config["max_position_embeddings"]
+        .as_u64()
+        .ok_or_else(|| "FAILED: teacher config omitted max_position_embeddings".to_owned())?;
+    usize::try_from(value)
+        .map_err(|_| "FAILED: max_position_embeddings exceeds host usize".to_owned())
+}
+
+fn refuse_parity_probe<T>(reason: impl Into<String>) -> Result<T, String> {
+    let reason = reason.into();
+    parity_progress()
+        .update(|state| {
+            state.metadata.fixtures.insert(
+                "exact_multicore_probe".to_owned(),
+                FixtureStatus::not_run(reason.clone()),
+            );
+            state.status = RunStatus::NotRun;
+            state.phase = "probe_refused".to_owned();
+        })
+        .map_err(|error| format!("FAIL: refused-probe telemetry state: {error}"))?;
+    parity_emit(EventKind::FixtureStatus)
+        .map_err(|error| format!("FAIL: refused-probe fixture event: {error}"))?;
+    Err(format!("NOT_RUN / REFUSED: {reason}"))
+}
+
+fn project_parity_probe_nonpass<T>(
+    run_status: RunStatus,
+    fixture_status: FixtureStatus,
+    phase: &str,
+    outcome_reason: String,
+) -> Result<T, String> {
+    parity_progress()
+        .update(|state| {
+            state
+                .metadata
+                .fixtures
+                .insert("exact_multicore_probe".to_owned(), fixture_status);
+            state.status = run_status;
+            state.phase = phase.to_owned();
+        })
+        .map_err(|error| format!("FAIL: non-qualified probe telemetry state: {error}"))?;
+    parity_emit(EventKind::FixtureStatus)
+        .map_err(|error| format!("FAIL: non-qualified probe fixture event: {error}"))?;
+    Err(outcome_reason)
+}
+
+fn project_parity_probe_state<T>(
+    state: ExactProbeNonQualifiedState,
+    report_cid: String,
+) -> Result<T, String> {
+    let run_status = state.run_status;
+    let fixture_status = state.fixture_status(report_cid.clone());
+    let outcome_reason = state.outcome_reason();
+    let phase = match run_status {
+        RunStatus::NotRun => "probe_refused",
+        RunStatus::Unavailable => "probe_unavailable",
+        RunStatus::Fail | RunStatus::Pass => "probe_failed",
+        RunStatus::Aborted => "probe_aborted",
+    };
+    parity_record_output(
+        "exact_multicore_probe_nonqualified",
+        serde_json::json!({
+            "event": state.event,
+            "status": state.probe_status,
+            "qualifies_full_run": false,
+        }),
+    );
+    project_parity_probe_nonpass(run_status, fixture_status, phase, outcome_reason)
+}
+
+#[derive(Debug, Clone)]
+struct ParityAdmissionShape {
+    selected_workers: NonZeroUsize,
+    selected_tiles_per_worker: NonZeroUsize,
+    planned_streams: usize,
+    transcript_state_capacity: usize,
+    generation_retained_prefix_tokens_per_lane: Vec<usize>,
+    generation_logical_seed_tokens_per_lane: Vec<usize>,
+    generation_state_capacity: usize,
+    sequence_length: usize,
+    probe_context_ceiling_tokens: usize,
+}
+
+fn adopt_probe_execution(shape: &ParityAdmissionShape) -> Result<ParityConfig, String> {
+    let state = parity_run()?;
+    let mut guard = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.config.workers = shape.selected_workers;
+    guard.config.batch_per_worker = shape.selected_tiles_per_worker;
+    guard
+        .progress
+        .update(|progress| {
+            progress.metadata.scheduler.effective_workers = shape.selected_workers;
+            progress.metadata.scheduler.configured_trajectory_workers = shape.selected_workers;
+            progress.metadata.scheduler.effective_trajectory_workers =
+                NonZeroUsize::new(shape.selected_workers.get().min(S4_CANONICAL_STREAMS))
+                    .unwrap_or(NonZeroUsize::MIN);
+            progress.metadata.scheduler.configured_row_workers = shape.selected_workers;
+            progress.metadata.scheduler.effective_row_workers = shape.selected_workers;
+            progress.metadata.scheduler.batch_per_worker = shape.selected_tiles_per_worker;
+            progress.metadata.identities.insert(
+                "probe_selected_execution".to_owned(),
+                format!(
+                    "workers={},tiles_per_worker={}",
+                    shape.selected_workers, shape.selected_tiles_per_worker
+                ),
+            );
+        })
+        .map_err(|error| format!("FAILED: adopt probe-selected execution: {error}"))?;
+    Ok(guard.config.clone())
+}
+
+fn validate_parity_probe(
+    source: &Path,
+    tokenizer: &Tokenizer,
+    config: &ParityConfig,
+) -> Result<ParityAdmissionShape, String> {
+    if config.mode == ObservabilityMode::Disabled {
+        return refuse_parity_probe(
+            "R4_PARITY_TELEMETRY=0 is forbidden for fixture-present live parity",
+        );
+    }
+    let available = std::thread::available_parallelism().map_or(1, NonZeroUsize::get);
+    if let Err(error) = validate_binding_host_shape(config, available) {
+        return refuse_parity_probe(error.to_string());
+    }
+    if available < 4 {
+        return refuse_parity_probe(format!(
+            "fixture-present exact probe requires at least four available CPU workers, host reports {available}"
+        ));
+    }
+    let model_path = source.join("model.safetensors");
+    let config_path = source.join("config.json");
+    let (model_kappa, source_bytes) = file_kappa(&model_path)?;
+    let (config_cid, _) = file_kappa(&config_path)?;
+    let master_positions = config.positions.get().max(config.fmm_positions.get());
+    let planned_work = planned_prompt_work(tokenizer, master_positions);
+    let planned_streams = planned_work.len();
+    if config.streams.get().min(planned_streams) <= 1 {
+        return refuse_parity_probe(format!(
+            "configured/tokenized work exposes only {} independent logical stream(s)",
+            config.streams.get().min(planned_streams)
+        ));
+    }
+    let generation_retained_prefixes = generation_lane_seeds(tokenizer, config.streams.get())?;
+    let generation_retained_prefix_tokens_per_lane = generation_retained_prefixes
+        .iter()
+        .map(Vec::len)
+        .collect::<Vec<_>>();
+    let generation_logical_seed_tokens_per_lane = generation_retained_prefix_tokens_per_lane
+        .iter()
+        .map(|tokens| {
+            tokens.checked_add(1).ok_or_else(|| {
+                "NOT_RUN / REFUSED: configured generation logical seed overflows usize".to_owned()
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let maximum_retained_prefix_tokens = generation_retained_prefix_tokens_per_lane
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(0);
+    // Transcript templates are a reusable fixture for the registered S4
+    // ceiling, even when an operator asks the adaptive decoder to stop below
+    // eight steps. Admission therefore binds the actual allocation horizon,
+    // not merely the requested stopping ceiling.
+    let generation_state_capacity = maximum_retained_prefix_tokens
+        .checked_add(S4_MAX_DECODE_STEPS)
+        .ok_or_else(|| {
+            "NOT_RUN / REFUSED: configured generation state horizon overflows usize".to_owned()
+        })?;
+    let transcript_state_capacity = planned_work
+        .iter()
+        .map(|work| work.positions.max(generation_state_capacity))
+        .max()
+        .unwrap_or(1);
+    let sequence_length = transcript_state_capacity.max(generation_state_capacity);
+    let mut transcript_pending: std::collections::VecDeque<usize> =
+        planned_work.iter().map(|work| work.positions).collect();
+    let mut transcript_active = Vec::with_capacity(config.streams.get());
+    for _ in 0..config.streams.get().min(transcript_pending.len()) {
+        transcript_active.push(
+            transcript_pending
+                .pop_front()
+                .expect("planned transcript lane exists"),
+        );
+    }
+    let mut transcript_physical_batches = 0usize;
+    while !transcript_active.is_empty() {
+        transcript_physical_batches = transcript_physical_batches.saturating_add(1);
+        for remaining in &mut transcript_active {
+            *remaining -= 1;
+        }
+        for lane in (0..transcript_active.len()).rev() {
+            if transcript_active[lane] == 0 {
+                if let Some(next) = transcript_pending.pop_front() {
+                    transcript_active[lane] = next;
+                } else {
+                    transcript_active.remove(lane);
+                }
+            }
+        }
+    }
+    let mut configured_suite_work = ExactMulticoreProbeWork {
+        transcript_logical_forwards: planned_work.iter().map(|work| work.positions).sum(),
+        transcript_physical_batches,
+        generation_tokens_per_lane: config.gen_tokens.get(),
+        generation_lanes: config.streams.get(),
+        generation_physical_batches: config.gen_tokens.get(),
+        logical_forwards: 0,
+        physical_batches: 0,
+        max_sequence_position: sequence_length.saturating_sub(1),
+        state_sequence_capacity: sequence_length,
+    };
+    configured_suite_work.logical_forwards = configured_suite_work.derived_logical_forwards();
+    configured_suite_work.physical_batches = configured_suite_work.derived_physical_batches();
+    let probe_context_ceiling_tokens = configured_suite_work.derived_probe_context_ceiling_tokens();
+    if sequence_length > probe_context_ceiling_tokens {
+        return refuse_parity_probe(format!(
+            "tokenizer-derived maximum private-state horizon {sequence_length} exceeds admitted exact-probe context {probe_context_ceiling_tokens}"
+        ));
+    }
+    let mut worker_counts = vec![4usize.min(available), available];
+    worker_counts.sort_unstable();
+    worker_counts.dedup();
+    let shapes = match exact_probe_expectation_shapes_from_config(
+        source,
+        probe_context_ceiling_tokens,
+        &worker_counts,
+        config.batch_per_worker.get(),
+        config.streams.get(),
+        config.probe_positions.get(),
+        8,
+    ) {
+        Ok(shapes) => shapes,
+        Err(error) => {
+            return refuse_parity_probe(format!(
+                "config-only exact probe expectation is unavailable: {error}"
+            ));
+        }
+    };
+    let expectation = ExactMulticoreProbeExpectation {
+        executor_contract_cid: exact_executor_contract_cid(),
+        source: ExactMulticoreProbeSource {
+            model_kappa: model_kappa.clone(),
+            config_cid: config_cid.clone(),
+            source_bytes,
+        },
+        host: exact_probe_host_identity(),
+        configured_suite_work,
+        forward_plans: shapes.forward_plans,
+        trace_shape: shapes.trace_shape,
+        tiles_per_worker: config.batch_per_worker.get(),
+        configured_max_wall_seconds: config.max_wall.get(),
+    };
+    let report_path = parity_probe_report_path()?;
+    let report_bytes = match std::fs::read(&report_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let reason = format!(
+                "UNAVAILABLE: probe report {} is unavailable: {error}",
+                report_path.display()
+            );
+            return project_parity_probe_nonpass(
+                RunStatus::Unavailable,
+                FixtureStatus::unavailable(reason.clone()),
+                "probe_unavailable",
+                reason,
+            );
+        }
+    };
+    let report_cid = format!("blake3:{}", blake3::hash(&report_bytes).to_hex());
+    let artifact = match classify_exact_probe_artifact(&report_bytes, EXACT_MULTICORE_PROBE_SCHEMA)
+    {
+        Ok(artifact) => artifact,
+        Err(reason) => {
+            return project_parity_probe_nonpass(
+                RunStatus::Fail,
+                FixtureStatus::failed_with_cid(report_cid, reason.clone()),
+                "probe_failed",
+                reason,
+            )
+        }
+    };
+    let report: ExactMulticoreProbeReport = match artifact {
+        ExactProbeArtifact::NonQualified(state) => {
+            return project_parity_probe_state(state, report_cid)
+        }
+        ExactProbeArtifact::QualifiedCandidate(value) => match serde_json::from_value(value) {
+            Ok(report) => report,
+            Err(error) => {
+                let reason = format!(
+                    "FAILED: parse qualified exact probe {}: {error}",
+                    report_path.display()
+                );
+                return project_parity_probe_nonpass(
+                    RunStatus::Fail,
+                    FixtureStatus::failed_with_cid(report_cid, reason.clone()),
+                    "probe_failed",
+                    reason,
+                );
+            }
+        },
+    };
+    let progress = parity_progress();
+    match report.validate_for_with_events(&report_path, &expectation) {
+        Ok(()) => {
+            let report_cid = file_kappa(&report_path)?.0;
+            parity_run()?
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .probe_expectation = Some(expectation.clone());
+            progress
+                .update(|state| {
+                    state.metadata.fixtures.insert(
+                        "exact_multicore_probe".to_owned(),
+                        FixtureStatus::available(report_cid),
+                    );
+                    state
+                        .metadata
+                        .identities
+                        .insert("teacher_weights".to_owned(), model_kappa);
+                    state
+                        .metadata
+                        .identities
+                        .insert("teacher_config".to_owned(), config_cid);
+                    state.metadata.identities.insert(
+                        "exact_executor_contract".to_owned(),
+                        report.executor_contract_cid.clone(),
+                    );
+                    state.metadata.identities.insert(
+                        "uor_matmul_revision".to_owned(),
+                        report.backend.uor_matmul_revision.clone(),
+                    );
+                })
+                .map_err(|error| format!("FAIL: probe telemetry state: {error}"))?;
+            parity_emit(EventKind::FixtureStatus)
+                .map_err(|error| format!("FAIL: probe fixture event: {error}"))?;
+            parity_record_measurement(
+                "exact_multicore_admission",
+                serde_json::json!({
+                    "configured_execution": report.configured_execution,
+                    "selected_best_config": report.selected_best_config,
+                    "raw_projected_suite_seconds": report.raw_projected_suite_seconds,
+                    "projection_safety_factor": report.projection_safety_factor,
+                    "safety_adjusted_projected_suite_seconds": report.safety_adjusted_projected_suite_seconds,
+                    "binding_verdict": report.binding_verdict,
+                    "actual_tokenizer_shape": {
+                        "master_teacher_forced_positions": master_positions,
+                        "planned_streams": planned_streams,
+                        "transcript_state_sequence_capacity": transcript_state_capacity,
+                        "generation_retained_prefix_tokens_per_lane": generation_retained_prefix_tokens_per_lane,
+                        "generation_logical_seed_tokens_per_lane": generation_logical_seed_tokens_per_lane,
+                        "generation_state_sequence_capacity": generation_state_capacity,
+                        "maximum_private_state_sequence_capacity": sequence_length,
+                        "admitted_probe_context_sequence_capacity": probe_context_ceiling_tokens,
+                    },
+                }),
+            );
+            Ok(ParityAdmissionShape {
+                selected_workers: NonZeroUsize::new(report.selected_best_config.workers)
+                    .ok_or_else(|| "FAILED: probe selected zero workers".to_owned())?,
+                selected_tiles_per_worker: NonZeroUsize::new(
+                    report.selected_best_config.tiles_per_worker,
+                )
+                .ok_or_else(|| "FAILED: probe selected zero tiles per worker".to_owned())?,
+                planned_streams,
+                transcript_state_capacity,
+                generation_retained_prefix_tokens_per_lane,
+                generation_logical_seed_tokens_per_lane,
+                generation_state_capacity,
+                sequence_length,
+                probe_context_ceiling_tokens,
+            })
+        }
+        Err(error) => refuse_parity_probe(error.to_string()),
+    }
+}
+
+fn parity_teacher_observer() -> TeacherExecutionObserver {
+    let progress = parity_progress();
+    let phase_peak = parity_run()
+        .unwrap_or_else(|reason| panic!("{reason}"))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .phase_peak_row_workers
+        .clone();
+    let stream_peak = parity_run()
+        .unwrap_or_else(|reason| panic!("{reason}"))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .phase_peak_streams
+        .clone();
+    Arc::new(move |snapshot| {
+        phase_peak.fetch_max(snapshot.forward_max_active_workers, AtomicOrdering::AcqRel);
+        stream_peak.fetch_max(snapshot.active_streams, AtomicOrdering::AcqRel);
+        progress.publish_exact(ExactProgressObservation {
+            observer_epoch: snapshot.observer_epoch,
+            streams_started: snapshot.streams_started,
+            streams_completed: snapshot.streams_completed,
+            active_streams: snapshot.active_streams,
+            peak_active_streams: snapshot.max_active_streams,
+            active_row_workers: snapshot.active_workers,
+            peak_active_row_workers: snapshot.max_active_workers,
+            matrix_calls: snapshot.matrix_calls,
+            batched_matrix_calls: snapshot.batched_matrix_calls,
+            max_matrix_batch_width: snapshot.max_matrix_batch_width,
+            completed_worker_tasks: snapshot.tiles_completed,
+            output_cells_completed: snapshot.output_cells_completed,
+            scalar_terms_completed: snapshot.scalar_terms_completed,
+            effective_workers: snapshot.effective_workers,
+        });
+    })
+}
+
+fn teacher_execution_delta(
+    before: TeacherExecutionSnapshot,
+    after: TeacherExecutionSnapshot,
+) -> Result<TeacherExecutionSnapshot, String> {
+    macro_rules! delta {
+        ($field:ident) => {
+            after.$field.checked_sub(before.$field).ok_or_else(|| {
+                format!(
+                    "FAILED: exact executor counter {} regressed from {} to {}",
+                    stringify!($field),
+                    before.$field,
+                    after.$field
+                )
+            })?
+        };
+    }
+    Ok(TeacherExecutionSnapshot {
+        observer_epoch: after.observer_epoch,
+        requested_workers: after.requested_workers,
+        effective_workers: after.effective_workers,
+        active_workers: after.active_workers,
+        // Peak occupancy is phase-local state tracked separately; the exact
+        // executor's lifetime high-water counter is not an additive delta.
+        max_active_workers: 0,
+        forward_max_active_workers: after.forward_max_active_workers,
+        multiworker_forward_calls: delta!(multiworker_forward_calls),
+        forward_calls: delta!(forward_calls),
+        streams_started: delta!(streams_started),
+        streams_completed: delta!(streams_completed),
+        active_streams: after.active_streams,
+        max_active_streams: 0,
+        matrix_calls: delta!(matrix_calls),
+        batched_matrix_calls: delta!(batched_matrix_calls),
+        max_matrix_batch_width: after.max_matrix_batch_width,
+        tiles_completed: delta!(tiles_completed),
+        output_cells_completed: delta!(output_cells_completed),
+        scalar_terms_completed: delta!(scalar_terms_completed),
+        workspace_growth_events: delta!(workspace_growth_events),
+        workspace_growth_bytes: delta!(workspace_growth_bytes),
+    })
+}
+
+fn record_teacher_execution_delta(
+    before: TeacherExecutionSnapshot,
+    after: TeacherExecutionSnapshot,
+) -> Result<TeacherExecutionSnapshot, String> {
+    let result = teacher_execution_delta(before, after)?;
+    let counters = parity_counters();
+    counters.record_physical_batches(result.forward_calls);
+    counters.record_logical_forwards(result.streams_completed);
+    counters.record_tokens(result.streams_completed);
+    counters.record_matrix_calls(result.matrix_calls);
+    counters.record_batched_matrix_calls(result.batched_matrix_calls);
+    counters.record_max_matrix_batch_width(result.max_matrix_batch_width);
+    counters.record_worker_tasks(result.tiles_completed);
+    counters.record_row_tiles(result.tiles_completed);
+    counters.record_output_cells(result.output_cells_completed);
+    counters.record_scalar_terms(result.scalar_terms_completed);
+    parity_progress().finish_exact_forward();
+    Ok(result)
+}
+
+fn teacher_forward_accounted(
+    teacher: &SmolLm2Oracle,
+    states: &mut [<SmolLm2Oracle as BatchedTeacher>::State],
+    tokens: &[usize],
+    positions: &[usize],
+) -> Result<TeacherExecutionSnapshot, String> {
+    if states.len() != tokens.len() || states.len() != positions.len() || states.is_empty() {
+        return Err(
+            "FAILED: exact teacher forward received an incomplete stream cohort".to_owned(),
+        );
+    }
+    // Reset the lightweight observer high-water marks for every physical
+    // forward. This makes occupancy evidence per-call rather than allowing one
+    // early full-width call to mask a later serial or partially idle call.
+    parity_reset_phase_peak();
+    let before = teacher.execution_snapshot();
+    teacher.forward_batch_into(states, tokens, positions);
+    let after = teacher.execution_snapshot();
+    let delta = record_teacher_execution_delta(before, after)?;
+    let observed_streams = parity_stream_phase_peak();
+    if observed_streams != states.len() {
+        return Err(format!(
+            "FAILED: physical teacher forward observed {observed_streams}/{} active streams",
+            states.len()
+        ));
+    }
+    let expected_workers = parity_config().workers.get();
+    let observed_workers = parity_phase_peak();
+    if delta.effective_workers != expected_workers {
+        return Err(format!(
+            "FAILED: physical teacher forward used effective worker bound {} instead of probe-selected {expected_workers}",
+            delta.effective_workers
+        ));
+    }
+    if delta.forward_calls != 1 || delta.multiworker_forward_calls != delta.forward_calls {
+        return Err(format!(
+            "FAILED: physical teacher forward fell back to serial row execution: {}/{} calls observed actual multiworker overlap",
+            delta.multiworker_forward_calls, delta.forward_calls
+        ));
+    }
+    if delta.forward_max_active_workers <= 1
+        || delta.forward_max_active_workers > delta.effective_workers
+    {
+        return Err(format!(
+            "FAILED: physical teacher forward reported per-call exact-row peak {} outside nonserial bound 2..={}",
+            delta.forward_max_active_workers, delta.effective_workers
+        ));
+    }
+    if observed_workers != delta.forward_max_active_workers {
+        return Err(format!(
+            "FAILED: physical teacher forward observer peak {observed_workers} disagrees with exact per-call peak {}",
+            delta.forward_max_active_workers
+        ));
+    }
+    Ok(delta)
 }
 
 /// Run `f` against the cached fixtures; `None` when they are unavailable.
 fn with_parity_fixtures<R>(f: impl FnOnce(&mut ParityFixtures) -> R) -> Option<R> {
-    PARITY_FIXTURES.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        let slot = guard.get_or_insert_with(load_parity_fixtures);
-        slot.as_mut().map(f)
+    let cache = PARITY_FIXTURES.get_or_init(|| Mutex::new(load_parity_fixtures()));
+    let mut guard = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.as_mut().ok().map(f)
+}
+
+fn parity_fixture_error() -> Option<String> {
+    let cache = PARITY_FIXTURES.get_or_init(|| Mutex::new(load_parity_fixtures()));
+    let guard = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.as_ref().err().cloned()
+}
+
+fn teacher_free_input_evidence(
+    path: Option<&Path>,
+    path_resolution_error: Option<&str>,
+    permit_content_read: bool,
+) -> serde_json::Value {
+    let Some(path) = path else {
+        return serde_json::json!({
+            "path": null,
+            "presence": "UNRESOLVED",
+            "cid": null,
+            "reason": path_resolution_error.unwrap_or("input directory did not resolve"),
+        });
+    };
+    // Ordinary teacher and legacy inputs follow the same symlink policy as
+    // their loaders. Hugging Face snapshots commonly expose model files via
+    // symlinks, so treating every symlink as unavailable would be a false
+    // teacher-free refusal.
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return serde_json::json!({
+                "path": path.display().to_string(),
+                "presence": "ABSENT",
+                "cid": null,
+                "reason": error.to_string(),
+            });
+        }
+        Err(error) => {
+            return serde_json::json!({
+                "path": path.display().to_string(),
+                "presence": "METADATA_ERROR",
+                "cid": null,
+                "reason": error.to_string(),
+            });
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "NON_FILE",
+            "cid": null,
+            "size_bytes": metadata.len(),
+        });
+    }
+    if !permit_content_read {
+        return serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "PRESENT",
+            "cid": null,
+            "size_bytes": metadata.len(),
+            "cid_status": "NOT_READ_TEACHER_FREE",
+        });
+    }
+    match file_kappa(path) {
+        Ok((cid, size_bytes)) => serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "PRESENT",
+            "cid": cid,
+            "size_bytes": size_bytes,
+        }),
+        Err(reason) => serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "READ_ERROR",
+            "cid": null,
+            "size_bytes": metadata.len(),
+            "reason": reason,
+        }),
+    }
+}
+
+fn production_admission_input_evidence(
+    path: Option<&Path>,
+    path_resolution_error: Option<&str>,
+) -> serde_json::Value {
+    let Some(path) = path else {
+        return serde_json::json!({
+            "path": null,
+            "presence": "UNRESOLVED",
+            "cid": null,
+            "reason": path_resolution_error.unwrap_or("bundle directory did not resolve"),
+        });
+    };
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return serde_json::json!({
+                "path": path.display().to_string(),
+                "presence": "ABSENT",
+                "cid": null,
+                "reason": error.to_string(),
+            });
+        }
+        Err(error) => {
+            return serde_json::json!({
+                "path": path.display().to_string(),
+                "presence": "METADATA_ERROR",
+                "cid": null,
+                "reason": error.to_string(),
+            });
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "NON_FILE",
+            "cid": null,
+            "size_bytes": metadata.len(),
+            "reason": "production admission requires a regular non-symlink file",
+        });
+    }
+    match file_kappa(path) {
+        Ok((cid, size_bytes)) => serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "PRESENT",
+            "cid": cid,
+            "size_bytes": size_bytes,
+        }),
+        Err(reason) => serde_json::json!({
+            "path": path.display().to_string(),
+            "presence": "READ_ERROR",
+            "cid": null,
+            "size_bytes": metadata.len(),
+            "reason": reason,
+        }),
+    }
+}
+
+fn teacher_free_preflight_failure_report(reason: &str) -> serde_json::Value {
+    let source = parity_source_dir();
+    let bundle = parity_bundle_dir();
+    let source_error = source.as_ref().err().map(String::as_str);
+    let bundle_error = bundle.as_ref().err().map(String::as_str);
+    let source_path = source.as_ref().ok();
+    let bundle_path = bundle.as_ref().ok();
+    let source_input = |name: &str| source_path.map(|directory| directory.join(name));
+    let bundle_input = |name: &str| bundle_path.map(|directory| directory.join(name));
+    let production_admission = PRODUCTION_ADMISSION_COMPONENTS
+        .into_iter()
+        .map(|(name, relative)| {
+            (
+                name.to_owned(),
+                production_admission_input_evidence(
+                    bundle_input(relative).as_deref(),
+                    bundle_error,
+                ),
+            )
+        })
+        .collect::<serde_json::Map<String, serde_json::Value>>();
+    let status = if reason.starts_with("UNAVAILABLE:") {
+        "UNAVAILABLE"
+    } else if reason.starts_with("NOT_RUN") {
+        "NOT_RUN"
+    } else {
+        "FAILED"
+    };
+    serde_json::json!({
+        "schema": "uor-r4.teacher-parity-preflight/1",
+        "status": status,
+        "reason": reason,
+        "authorizing_contract_cid": exact_executor_contract_cid(),
+        "teacher_source_opened": false,
+        "teacher_forwards": 0,
+        "selected_source_dir": source_path.map(|path| path.display().to_string()),
+        "selected_source_dir_error": source_error,
+        "selected_bundle_dir": bundle_path.map(|path| path.display().to_string()),
+        "selected_bundle_dir_error": bundle_error,
+        "claim_boundary": "teacher-free prerequisite refusal; no teacher evidence and no graph-gate bypass",
+        "production_admission": production_admission,
+        "inputs": {
+            "teacher_model": teacher_free_input_evidence(
+                source_input("model.safetensors").as_deref(),
+                source_error,
+                false,
+            ),
+            "teacher_config": teacher_free_input_evidence(
+                source_input("config.json").as_deref(),
+                source_error,
+                false,
+            ),
+            "tokenizer": teacher_free_input_evidence(
+                bundle_input("tokenizer.bin").as_deref(),
+                bundle_error,
+                true,
+            ),
+            "legacy_artifact": teacher_free_input_evidence(
+                bundle_input("tless_artifacts.bin").as_deref(),
+                bundle_error,
+                true,
+            ),
+            "legacy_store": teacher_free_input_evidence(
+                bundle_input("tless_store.bin").as_deref(),
+                bundle_error,
+                true,
+            ),
+            "graph": teacher_free_input_evidence(
+                bundle_input("graph/score.r4g1").as_deref(),
+                bundle_error,
+                true,
+            ),
+            "graph_report": teacher_free_input_evidence(
+                bundle_input("graph/score_report.json").as_deref(),
+                bundle_error,
+                true,
+            ),
+        },
     })
 }
 
-fn load_parity_fixtures() -> Option<ParityFixtures> {
-    let source = parity_source_dir();
-    let bundle = parity_bundle_dir();
-    let required = [
-        source.join("model.safetensors"),
-        bundle.join("tless_artifacts.bin"),
-        bundle.join("tless_store.bin"),
-        bundle.join("tokenizer.bin"),
-    ];
-    if !required.iter().all(|p| p.is_file()) {
-        eprintln!(
-            "[parity] pinned teacher/bundle fixtures absent — vacuous skip (κ-test convention)"
-        );
-        return None;
-    }
-    let teacher = match SmolLm2Oracle::load(&source) {
-        Ok(teacher) => teacher,
-        Err(error) => {
-            eprintln!("[parity] teacher load failed: {error} — vacuous skip");
-            return None;
-        }
+fn deterministic_preflight_component_map(value: &serde_json::Value) -> serde_json::Value {
+    let Some(components) = value.as_object() else {
+        return serde_json::Value::Null;
     };
-    let artifact_bytes = std::fs::read(bundle.join("tless_artifacts.bin")).ok()?;
-    let artifacts = parse_artifacts(&artifact_bytes)?;
-    let store_bytes = std::fs::read(bundle.join("tless_store.bin")).ok()?;
+    let projected = components
+        .iter()
+        .map(|(name, component)| {
+            if component.is_string() {
+                return (name.clone(), component.clone());
+            }
+            let stable = component
+                .as_object()
+                .map(|fields| {
+                    ["presence", "cid", "size_bytes", "cid_status"]
+                        .into_iter()
+                        .filter_map(|field| {
+                            fields
+                                .get(field)
+                                .map(|value| (field.to_owned(), value.clone()))
+                        })
+                        .collect::<serde_json::Map<String, serde_json::Value>>()
+                })
+                .map(serde_json::Value::Object)
+                .unwrap_or(serde_json::Value::Null);
+            (name.clone(), stable)
+        })
+        .collect::<serde_json::Map<String, serde_json::Value>>();
+    serde_json::Value::Object(projected)
+}
+
+/// Path- and telemetry-free projection admitted into deterministic evidence.
+/// The standalone preflight retains operator paths and exact error text; the
+/// deterministic companion carries only stable identities, shapes, and typed
+/// decisions.
+fn deterministic_teacher_free_preflight(report: &serde_json::Value) -> serde_json::Value {
+    let Some(object) = report.as_object() else {
+        return serde_json::json!({"status": "FAILED", "shape": "NON_OBJECT"});
+    };
+    let mut projected = serde_json::Map::new();
+    for field in [
+        "schema",
+        "status",
+        "authorizing_contract_cid",
+        "teacher_source_opened",
+        "teacher_forwards",
+        "claim_boundary",
+        "canonical_lanes",
+        "graph_state_preparations",
+        "bounded_steps_per_lane",
+        "seed_policy",
+        "retained_prefix_tokens_per_lane",
+        "seed_tokens_per_lane",
+        "lane_seed_cids",
+        "legacy_output_cids",
+        "legacy_cohort_cid",
+        "graph_output_cids",
+        "graph_cohort_cid",
+        "graph_typed_abstentions",
+        "graph_decisions",
+    ] {
+        if let Some(value) = object.get(field) {
+            projected.insert(field.to_owned(), value.clone());
+        }
+    }
+    for field in ["inputs", "production_admission"] {
+        if let Some(value) = object.get(field) {
+            projected.insert(
+                field.to_owned(),
+                deterministic_preflight_component_map(value),
+            );
+        }
+    }
+    serde_json::Value::Object(projected)
+}
+
+fn preflight_component_status(name: &str, value: &serde_json::Value) -> FixtureStatus {
+    if let Some(cid) = value.as_str().filter(|cid| cid.starts_with("blake3:")) {
+        return FixtureStatus::available(cid);
+    }
+    let Some(component) = value.as_object() else {
+        return FixtureStatus::failed(format!("{name} preflight evidence is malformed"));
+    };
+    let presence = component
+        .get("presence")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("UNKNOWN");
+    let cid = component
+        .get("cid")
+        .and_then(serde_json::Value::as_str)
+        .filter(|cid| cid.starts_with("blake3:"));
+    match (presence, cid) {
+        ("PRESENT", Some(cid)) => FixtureStatus::available(cid),
+        ("PRESENT", None) => FixtureStatus::not_run(format!(
+            "{name} is present but its content was not admitted"
+        )),
+        ("ABSENT" | "UNRESOLVED", _) => FixtureStatus::unavailable(format!("{name} is {presence}")),
+        _ => FixtureStatus::failed(format!("{name} preflight presence is {presence}")),
+    }
+}
+
+fn apply_preflight_component_inventory(metadata: &mut RunMetadata, report: &serde_json::Value) {
+    if let Some(components) = report
+        .get("production_admission")
+        .and_then(serde_json::Value::as_object)
+    {
+        for (name, value) in components {
+            let fixture_name = format!("production_{name}");
+            let status = preflight_component_status(&fixture_name, value);
+            if let Some(cid) = status.cid.clone() {
+                metadata.identities.insert(fixture_name.clone(), cid);
+            }
+            metadata.fixtures.insert(fixture_name, status);
+        }
+    }
+    let mappings = [
+        ("tokenizer", "tokenizer"),
+        ("legacy_artifact", "tla_artifact"),
+        ("legacy_store", "tls_store"),
+        ("graph", "r4g1_graph"),
+        ("graph_report", "r4g1_graph_report"),
+    ];
+    if let Some(inputs) = report.get("inputs").and_then(serde_json::Value::as_object) {
+        for (input, fixture_name) in mappings {
+            if let Some(value) = inputs.get(input) {
+                let status = preflight_component_status(fixture_name, value);
+                if let Some(cid) = status.cid.clone() {
+                    metadata.identities.insert(fixture_name.to_owned(), cid);
+                }
+                metadata.fixtures.insert(fixture_name.to_owned(), status);
+            }
+        }
+    }
+}
+
+fn bind_teacher_free_preflight_report_path(
+    mut report: serde_json::Value,
+    report_path: &Path,
+) -> serde_json::Value {
+    if let Some(object) = report.as_object_mut() {
+        object.insert(
+            "report_path".to_owned(),
+            serde_json::Value::String(report_path.display().to_string()),
+        );
+    }
+    report
+}
+
+struct TeacherFreePreflightFailure {
+    reason: String,
+    report_path: Option<PathBuf>,
+    durable_report: Option<serde_json::Value>,
+}
+
+fn run_teacher_free_parity_preflight(
+) -> Result<(serde_json::Value, PathBuf), TeacherFreePreflightFailure> {
+    let configured_report_path =
+        parity_preflight_report_path().map_err(|reason| TeacherFreePreflightFailure {
+            reason,
+            report_path: None,
+            durable_report: None,
+        })?;
+    let report_path = if configured_report_path.is_absolute() {
+        configured_report_path
+    } else {
+        std::env::current_dir()
+            .map(|directory| directory.join(configured_report_path))
+            .map_err(|error| TeacherFreePreflightFailure {
+                reason: format!("FAILED: resolve teacher-free preflight report path: {error}"),
+                report_path: None,
+                durable_report: None,
+            })?
+    };
+    let outcome = teacher_free_parity_preflight()
+        .map(|report| bind_teacher_free_preflight_report_path(report, &report_path));
+    let original_reason = outcome.as_ref().err().cloned();
+    let refusal_report = original_reason.as_deref().map(|reason| {
+        bind_teacher_free_preflight_report_path(
+            teacher_free_preflight_failure_report(reason),
+            &report_path,
+        )
+    });
+    let refusal_for_write = refusal_report.clone();
+    match publish_atomic_preflight_outcome(&report_path, outcome, |_| {
+        refusal_for_write.expect("error outcome has a refusal report")
+    }) {
+        Ok(report) => Ok((report, report_path)),
+        Err(reason) => {
+            let published = original_reason.as_deref() == Some(reason.as_str());
+            Err(TeacherFreePreflightFailure {
+                reason,
+                report_path: Some(report_path),
+                durable_report: published.then_some(refusal_report).flatten(),
+            })
+        }
+    }
+}
+
+fn teacher_free_failure_reached_graph_stage(reason: &str) -> bool {
+    [
+        "graph artifact/report",
+        "graph provenance",
+        "graph score report",
+        "score_report.json",
+        "R4G1 load",
+        "preflight graph lane",
+    ]
+    .iter()
+    .any(|marker| reason.contains(marker))
+}
+
+fn teacher_free_graph_failure_stage(reason: &str) -> TeacherFreeGraphFailureStage {
+    if reason.contains("R4G1 load") || reason.contains("preflight graph lane") {
+        TeacherFreeGraphFailureStage::GraphLoadAttempted
+    } else if reason.starts_with("FAILED:")
+        && (reason.contains("score_report.json") || reason.contains("graph score report omitted"))
+    {
+        TeacherFreeGraphFailureStage::ReportFailed
+    } else if reason.contains("graph provenance") {
+        TeacherFreeGraphFailureStage::ReportAccepted
+    } else {
+        TeacherFreeGraphFailureStage::NotReached
+    }
+}
+
+fn load_parity_fixtures() -> Result<ParityFixtures, String> {
+    let source = parity_source_dir()?;
+    let bundle = parity_bundle_dir()?;
+    // Bind the complete compiled fixture stack before even hashing, opening,
+    // or probing the live teacher source. This is the in-harness form of
+    // `R4_PARITY_PREFLIGHT_ONLY=1 cargo test --test bdd --offline` and is a
+    // hard cheap gate: a missing/bad graph can never spend an exact forward.
+    let (teacher_free_preflight, teacher_free_preflight_path) =
+        match run_teacher_free_parity_preflight() {
+            Ok(published) => published,
+            Err(failure) => {
+                let reason = failure.reason;
+                // A graph-gate failure returns before normal probe admission.
+                // If a direct tuner already published a recognized truthful
+                // refusal/state at the bound probe path, retain its exact CID,
+                // projected verdict, and reason so finalization can validate
+                // the present artifact without treating it as qualification.
+                let present_probe_fixture = present_nonqualified_probe_fixture_status();
+                let status = if reason.starts_with("FAILED:") || reason.starts_with("FAIL:") {
+                    FixtureStatus::failed(reason.clone())
+                } else if reason.starts_with("NOT_RUN") || reason.contains("REFUSED") {
+                    FixtureStatus::not_run(reason.clone())
+                } else {
+                    FixtureStatus::unavailable(reason.clone())
+                };
+                let report_cid = failure
+                    .report_path
+                    .as_deref()
+                    .and_then(|path| file_kappa(path).ok().map(|(cid, _)| cid));
+                parity_progress()
+                    .update(|state| {
+                        if let (Some(report_path), Some(report)) = (
+                            failure.report_path.as_deref(),
+                            failure.durable_report.as_ref(),
+                        ) {
+                            apply_teacher_free_preflight_failure_metadata(
+                                &mut state.metadata,
+                                report_path,
+                                report_cid.as_deref(),
+                                report,
+                                status.clone(),
+                                teacher_free_failure_reached_graph_stage(&reason),
+                                teacher_free_graph_failure_stage(&reason),
+                            );
+                            apply_preflight_component_inventory(&mut state.metadata, report);
+                        } else {
+                            state
+                                .metadata
+                                .fixtures
+                                .insert("teacher_free_s4_preflight".to_owned(), status);
+                        }
+                        if let Some(fixture) = present_probe_fixture {
+                            state
+                                .metadata
+                                .fixtures
+                                .insert("exact_multicore_probe".to_owned(), fixture);
+                        }
+                        state.status = parity_status_for_reason(&reason);
+                        state.phase = "teacher_free_preflight".to_owned();
+                    })
+                    .map_err(|error| {
+                        format!("FAILED: teacher-free preflight telemetry: {error}")
+                    })?;
+                if let Some(report) = failure.durable_report.as_ref() {
+                    parity_record_output(
+                        "S0_teacher_free_preflight",
+                        deterministic_teacher_free_preflight(report),
+                    );
+                }
+                parity_emit(EventKind::FixtureStatus)
+                    .map_err(|error| format!("FAILED: teacher-free preflight event: {error}"))?;
+                return Err(reason);
+            }
+        };
+    // Bind the exact atomically published bytes. Pretty-printing and the final
+    // newline are part of the standalone artifact, so hashing an alternate
+    // in-memory serialization would give success/refusal different semantics.
+    let preflight_cid = file_kappa(&teacher_free_preflight_path)?.0;
+    let admitted_production_generation: std::collections::BTreeMap<String, String> =
+        serde_json::from_value(
+            teacher_free_preflight
+                .get("production_admission")
+                .cloned()
+                .ok_or_else(|| {
+                    "FAILED: AVAILABLE teacher-free preflight omitted production_admission"
+                        .to_owned()
+                })?,
+        )
+        .map_err(|error| {
+            format!("FAILED: parse AVAILABLE preflight production_admission: {error}")
+        })?;
+    parity_progress()
+        .update(|state| {
+            state.metadata.fixtures.insert(
+                "teacher_free_s4_preflight".to_owned(),
+                FixtureStatus::available(preflight_cid.clone()),
+            );
+            state.metadata.identities.insert(
+                "teacher_free_s4_preflight".to_owned(),
+                preflight_cid.clone(),
+            );
+            apply_preflight_component_inventory(&mut state.metadata, &teacher_free_preflight);
+            state.phase = "teacher_free_preflight_complete".to_owned();
+        })
+        .map_err(|error| format!("FAILED: teacher-free preflight telemetry: {error}"))?;
+    parity_record_output(
+        "S0_teacher_free_preflight",
+        deterministic_teacher_free_preflight(&teacher_free_preflight),
+    );
+    parity_emit(EventKind::FixtureStatus)
+        .map_err(|error| format!("FAILED: teacher-free preflight event: {error}"))?;
+    let required = [
+        ("teacher_weights", source.join("model.safetensors")),
+        ("teacher_config", source.join("config.json")),
+        ("tla_artifact", bundle.join("tless_artifacts.bin")),
+        ("tls_store", bundle.join("tless_store.bin")),
+        ("tokenizer", bundle.join("tokenizer.bin")),
+    ];
+    let missing: Vec<String> = required
+        .iter()
+        .filter(|(_, path)| !path.is_file())
+        .map(|(_, path)| path.display().to_string())
+        .collect();
+    if !missing.is_empty() {
+        let missing_set: std::collections::BTreeSet<_> = required
+            .iter()
+            .filter(|(_, path)| !path.is_file())
+            .map(|(name, _)| *name)
+            .collect();
+        parity_progress()
+            .update(|state| {
+                for (name, path) in &required {
+                    let status = if missing_set.contains(name) {
+                        FixtureStatus::unavailable(format!("{} is absent", path.display()))
+                    } else {
+                        file_kappa(path)
+                            .map(|(cid, _)| FixtureStatus::available(cid))
+                            .unwrap_or_else(FixtureStatus::failed)
+                    };
+                    state.metadata.fixtures.insert((*name).to_owned(), status);
+                }
+                state.status = RunStatus::Unavailable;
+                state.phase = "fixture_admission".to_owned();
+            })
+            .map_err(|error| format!("FAILED: missing-fixture telemetry: {error}"))?;
+        parity_emit(EventKind::FixtureStatus)
+            .map_err(|error| format!("FAILED: missing-fixture event: {error}"))?;
+        return Err(format!(
+            "UNAVAILABLE: required pinned parity fixtures absent: {}",
+            missing.join(", ")
+        ));
+    }
+    // Publish verified required fixture identities before the probe gate. A
+    // missing or refused probe must leave only the probe NOT_RUN; it must not
+    // erase evidence that the source, artifact, store, and tokenizer exist.
+    let mut required_cids = std::collections::BTreeMap::new();
+    for (name, path) in &required {
+        match file_kappa(path) {
+            Ok((cid, _)) => {
+                required_cids.insert((*name).to_owned(), cid);
+            }
+            Err(reason) => {
+                parity_progress()
+                    .update(|state| {
+                        state
+                            .metadata
+                            .fixtures
+                            .insert((*name).to_owned(), FixtureStatus::failed(reason.clone()));
+                        state.status = RunStatus::Fail;
+                        state.phase = "fixture_admission".to_owned();
+                    })
+                    .map_err(|error| format!("FAILED: fixture hash telemetry: {error}"))?;
+                parity_emit(EventKind::FixtureStatus)
+                    .map_err(|error| format!("FAILED: fixture hash event: {error}"))?;
+                return Err(reason);
+            }
+        }
+    }
+    parity_progress()
+        .update(|state| {
+            for (name, cid) in &required_cids {
+                state
+                    .metadata
+                    .fixtures
+                    .insert(name.clone(), FixtureStatus::available(cid.clone()));
+                state.metadata.identities.insert(name.clone(), cid.clone());
+            }
+            state.phase = "probe_admission".to_owned();
+        })
+        .map_err(|error| format!("FAILED: required-fixture telemetry: {error}"))?;
+    parity_emit(EventKind::FixtureStatus)
+        .map_err(|error| format!("FAILED: required-fixture event: {error}"))?;
+    // Tokenizer admission is deliberately before the exact probe verdict and
+    // teacher weight load. It binds the real S4 per-lane seeds and private-state
+    // horizons to the conservative probe budget instead of trusting a
+    // tokenizer-free estimate.
+    let tokenizer_bytes = std::fs::read(bundle.join("tokenizer.bin"))
+        .map_err(|error| format!("FAILED: read tokenizer.bin: {error}"))?;
+    let tokenizer = Tokenizer::from_bytes(&tokenizer_bytes)
+        .ok_or_else(|| "FAILED: bound tokenizer.bin bytes did not parse".to_owned())?;
+    parity_check_deadline("fixture admission")?;
+    let requested_config = parity_config();
+    let admission_shape = validate_parity_probe(&source, &tokenizer, &requested_config)?;
+    let parity_config = adopt_probe_execution(&admission_shape)?;
+    let artifact_bytes = std::fs::read(bundle.join("tless_artifacts.bin"))
+        .map_err(|error| format!("FAILED: read tless_artifacts.bin: {error}"))?;
+    let artifacts = parse_artifacts(&artifact_bytes)
+        .ok_or_else(|| "FAILED: tless_artifacts.bin did not parse".to_owned())?;
+    let store_bytes = std::fs::read(bundle.join("tless_store.bin"))
+        .map_err(|error| format!("FAILED: read tless_store.bin: {error}"))?;
     // The on-disk store predates the u32 token migration (TLS1-u16): try the
     // current reader first, fall back to the legacy u16 reader.
-    let store = parse_store(&store_bytes).or_else(|| {
-        #[allow(deprecated)]
-        parse_store_legacy_u16(&store_bytes)
-    })?;
-    let tokenizer = Tokenizer::try_load(bundle.join("tokenizer.bin")).ok()?;
-    let r4g1 = load_r4g1(&bundle, &artifact_bytes);
+    let store = parse_store(&store_bytes)
+        .or_else(|| {
+            #[allow(deprecated)]
+            parse_store_legacy_u16(&store_bytes)
+        })
+        .ok_or_else(|| {
+            "FAILED: tless_store.bin did not parse as current or legacy TLS".to_owned()
+        })?;
+    let model_sequence_ceiling = model_sequence_ceiling(&source)?;
+    if admission_shape.sequence_length > model_sequence_ceiling {
+        return Err(format!(
+            "NOT_RUN / REFUSED: required private-state horizon {} exceeds model maximum {model_sequence_ceiling}",
+            admission_shape.sequence_length
+        ));
+    }
+    // Close the interval between the schema-2 semantic preflight and the first
+    // teacher-weight read. The preflight exercises the production loader; an
+    // unchanged complete generation map proves the bytes about to authorize
+    // teacher work are the same bytes that loader admitted. Re-read the
+    // published token too, so replacing either side of the admission pair
+    // cannot spend a forward.
+    let current_preflight_cid = file_kappa(&teacher_free_preflight_path)?.0;
+    if current_preflight_cid != preflight_cid {
+        return Err(
+            "NOT_RUN / REFUSED: teacher-free preflight changed between admission and teacher load"
+                .to_owned(),
+        );
+    }
+    let current_production_generation = production_admission_component_cids(&bundle)?;
+    if current_production_generation != admitted_production_generation {
+        return Err(
+            "NOT_RUN / REFUSED: schema-2 production generation changed between semantic admission and teacher load"
+                .to_owned(),
+        );
+    }
+    let execution = TeacherExecutionConfig::fixed_workers(parity_config.workers)
+        .with_tiles_per_worker(parity_config.batch_per_worker);
+    let mut teacher = match SmolLm2Oracle::load_with_sequence_length_and_execution(
+        &source,
+        admission_shape.sequence_length,
+        execution,
+    ) {
+        Ok(teacher) => teacher,
+        Err(error) => {
+            eprintln!("[parity] teacher load FAILED: {error}");
+            return Err(format!("FAILED: teacher load: {error}"));
+        }
+    };
+    let teacher_execution_preparation = teacher
+        .prepare_exact_execution(S4_CANONICAL_STREAMS)
+        .map_err(|error| format!("FAILED: prepare retained exact workspace: {error}"))?;
+    if teacher_execution_preparation.batch_width != S4_CANONICAL_STREAMS
+        || !teacher_execution_preparation.backend_exercised
+        || teacher_execution_preparation.workers_observed <= 1
+        || teacher_execution_preparation.workers_observed > parity_config.workers.get()
+        || teacher_execution_preparation.workspace_capacity_bytes == 0
+        || teacher_execution_preparation.workspace_growth_events == 0
+        || teacher_execution_preparation.workspace_growth_bytes == 0
+    {
+        return Err(format!(
+            "FAILED: exact workspace preparation was incomplete: {teacher_execution_preparation:?}"
+        ));
+    }
+    teacher.begin_measured_execution(parity_teacher_observer());
+    let measured_start = teacher.execution_snapshot();
+    if measured_start.forward_calls != 0
+        || measured_start.matrix_calls != 0
+        || measured_start.workspace_growth_events != 0
+        || measured_start.workspace_growth_bytes != 0
+    {
+        return Err(format!(
+            "FAILED: measured teacher counters were not reset after excluded preparation: {measured_start:?}"
+        ));
+    }
+    let r4g1_result = load_r4g1(&bundle, &artifact_bytes);
+    let graph_path = bundle.join("graph/score.r4g1");
+    let r4g1_status = match &r4g1_result {
+        Ok(_) => match file_kappa(&graph_path) {
+            Ok((cid, _)) => FixtureStatus::available(cid),
+            Err(reason) => FixtureStatus::failed(reason),
+        },
+        Err(reason) if reason.starts_with("FAILED:") => FixtureStatus::failed(reason.clone()),
+        Err(reason) => FixtureStatus::unavailable(reason.clone()),
+    };
+    let r4g1 = r4g1_result.ok();
     let corpus = load_parity_corpus(&bundle);
+    let corpus_cid = file_set_kappa(&[
+        bundle.join("corpus.meta").as_path(),
+        bundle.join("corpus.records").as_path(),
+    ])
+    .ok();
     let fmm = load_fmm_candidate(&bundle, &artifact_bytes);
     let fmm_fixed = fmm.as_ref().map(|candidate| candidate.fixed_point());
-    Some(ParityFixtures {
+    let artifact_kappa = format!("blake3:{}", blake3::hash(&artifact_bytes).to_hex());
+    let store_kappa = format!("blake3:{}", blake3::hash(&store_bytes).to_hex());
+    let tokenizer_kappa = file_kappa(&bundle.join("tokenizer.bin"))?.0;
+    let graph_available = r4g1.is_some();
+    let fmm_available = fmm.is_some() && fmm_fixed.is_some() && graph_available;
+    let fmm_source_cid = file_set_kappa(&[
+        bundle.join("tless_artifacts.bin").as_path(),
+        graph_path.as_path(),
+    ])
+    .ok();
+    let plan = parity_work_plan(
+        &teacher,
+        &tokenizer,
+        &parity_config,
+        parity_config.gen_tokens.get(),
+        graph_available,
+        fmm_available,
+    )?;
+    parity_counters()
+        .set_plan(plan)
+        .map_err(|error| format!("FAILED: install exact parity work plan: {error}"))?;
+    let cfg = teacher.cfg();
+    parity_progress()
+        .update(|state| {
+            state.metadata.scheduler.effective_streams = NonZeroUsize::new(
+                parity_config
+                    .streams
+                    .get()
+                    .min(admission_shape.planned_streams),
+            )
+            .unwrap_or(NonZeroUsize::MIN);
+            state.metadata.budgets.insert(
+                "transcript_state_sequence_capacity".to_owned(),
+                admission_shape.transcript_state_capacity as u64,
+            );
+            state.metadata.budgets.insert(
+                "generation_max_retained_prefix_tokens".to_owned(),
+                admission_shape
+                    .generation_retained_prefix_tokens_per_lane
+                    .iter()
+                    .copied()
+                    .max()
+                    .unwrap_or(0) as u64,
+            );
+            state.metadata.budgets.insert(
+                "generation_max_logical_seed_tokens".to_owned(),
+                admission_shape
+                    .generation_logical_seed_tokens_per_lane
+                    .iter()
+                    .copied()
+                    .max()
+                    .unwrap_or(0) as u64,
+            );
+            state.metadata.budgets.insert(
+                "generation_state_sequence_capacity".to_owned(),
+                admission_shape.generation_state_capacity as u64,
+            );
+            state.metadata.budgets.insert(
+                "probe_context_sequence_capacity".to_owned(),
+                admission_shape.probe_context_ceiling_tokens as u64,
+            );
+            state.metadata.identities.insert(
+                "generation_retained_prefix_tokens_per_lane".to_owned(),
+                serde_json::to_string(&admission_shape.generation_retained_prefix_tokens_per_lane)
+                    .expect("small integer vector serializes"),
+            );
+            state.metadata.identities.insert(
+                "generation_logical_seed_tokens_per_lane".to_owned(),
+                serde_json::to_string(&admission_shape.generation_logical_seed_tokens_per_lane)
+                    .expect("small integer vector serializes"),
+            );
+            state.metadata.budgets.insert(
+                "teacher_exact_workspace_capacity_bytes".to_owned(),
+                teacher_execution_preparation.workspace_capacity_bytes,
+            );
+            state
+                .metadata
+                .identities
+                .insert("tla_artifact".to_owned(), artifact_kappa.clone());
+            state
+                .metadata
+                .identities
+                .insert("tls_store".to_owned(), store_kappa.clone());
+            state
+                .metadata
+                .identities
+                .insert("tokenizer".to_owned(), tokenizer_kappa.clone());
+            for (name, value) in [
+                ("dimension", cfg.dim),
+                ("hidden", cfg.hidden),
+                ("layers", cfg.n_layers),
+                ("heads", cfg.n_heads),
+                ("kv_heads", cfg.n_kv_heads),
+                ("vocabulary", cfg.vocab),
+                ("sequence_length", cfg.seq_len),
+            ] {
+                state
+                    .metadata
+                    .model_geometry
+                    .insert(name.to_owned(), value as u64);
+            }
+            state.metadata.fixtures.insert(
+                "teacher_weights".to_owned(),
+                FixtureStatus::available(state.metadata.identities["teacher_weights"].clone()),
+            );
+            state.metadata.fixtures.insert(
+                "teacher_config".to_owned(),
+                FixtureStatus::available(state.metadata.identities["teacher_config"].clone()),
+            );
+            state.metadata.fixtures.insert(
+                "tla_artifact".to_owned(),
+                FixtureStatus::available(artifact_kappa),
+            );
+            state.metadata.fixtures.insert(
+                "tls_store".to_owned(),
+                FixtureStatus::available(store_kappa),
+            );
+            state.metadata.fixtures.insert(
+                "tokenizer".to_owned(),
+                FixtureStatus::available(tokenizer_kappa),
+            );
+            state
+                .metadata
+                .fixtures
+                .insert("r4g1_graph".to_owned(), r4g1_status);
+            state.metadata.fixtures.insert(
+                "corpus".to_owned(),
+                if let (Some(_), Some(cid)) = (&corpus, &corpus_cid) {
+                    FixtureStatus::available(cid.clone())
+                } else {
+                    FixtureStatus::unavailable("corpus.meta/corpus.records unavailable")
+                },
+            );
+            state.metadata.fixtures.insert(
+                "fmm_candidate".to_owned(),
+                if let (true, Some(cid)) = (fmm_available, &fmm_source_cid) {
+                    FixtureStatus::available(cid.clone())
+                } else {
+                    FixtureStatus::unavailable("FMM candidate or prerequisite graph unavailable")
+                },
+            );
+        })
+        .map_err(|error| format!("FAILED: fixture metadata: {error}"))?;
+    parity_record_measurement(
+        "exact_workspace_preparation",
+        serde_json::to_value(teacher_execution_preparation)
+            .map_err(|error| format!("FAILED: serialize exact workspace preparation: {error}"))?,
+    );
+    parity_emit(EventKind::FixtureStatus)
+        .map_err(|error| format!("FAILED: fixture status event: {error}"))?;
+    Ok(ParityFixtures {
         teacher,
+        teacher_execution_preparation,
         artifacts,
         store,
         tokenizer,
@@ -3655,13 +6293,16 @@ fn load_parity_fixtures() -> Option<ParityFixtures> {
         corpus,
         fmm,
         fmm_fixed,
+        artifact_bytes: Arc::new(artifact_bytes),
+        transcripts: std::collections::BTreeMap::new(),
+        transcript_cache_hits: 0,
     })
 }
 
 /// Build the exploratory FMM candidate from the same validated graph bytes
 /// used by the incumbent parity path. It is deliberately optional: fixtures
-/// without a certifier-readable graph continue to use the existing vacuous
-/// parity convention.
+/// without a certifier-readable graph record that conditional evidence as
+/// UNAVAILABLE.
 fn load_fmm_candidate(bundle: &Path, artifact_bytes: &[u8]) -> Option<FmmCandidateScorer> {
     let graph_path = bundle.join("graph/score.r4g1");
     let graph = std::fs::read(&graph_path).ok()?;
@@ -3705,43 +6346,771 @@ fn load_parity_corpus(bundle: &Path) -> Option<Corpus> {
 /// Load the R4G1 engine under the provenance guard: the score report's
 /// recorded input artifact κ must equal the artifact's blake3 κ, otherwise
 /// the graph scores a different artifact and graph scenarios skip.
-fn load_r4g1(bundle: &Path, artifact_bytes: &[u8]) -> Option<R4g1State> {
+fn load_r4g1(bundle: &Path, artifact_bytes: &[u8]) -> Result<R4g1State, String> {
     let graph = bundle.join("graph/score.r4g1");
     let report = bundle.join("graph/score_report.json");
     if !graph.is_file() || !report.is_file() {
-        eprintln!("[parity] graph artifacts absent — graph scenarios skip");
-        return None;
+        return Err(format!(
+            "UNAVAILABLE: graph artifact/report absent (graph={}, report={})",
+            graph.display(),
+            report.display()
+        ));
     }
-    let report_json: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(report).ok()?).ok()?;
-    let recorded = report_json["inputs"]["artifact_kappa"].as_str()?;
+    let report_bytes = std::fs::read(&report)
+        .map_err(|error| format!("FAILED: read {}: {error}", report.display()))?;
+    let report_json: serde_json::Value = serde_json::from_slice(&report_bytes)
+        .map_err(|error| format!("FAILED: parse {}: {error}", report.display()))?;
+    let recorded = report_json["inputs"]["artifact_kappa"]
+        .as_str()
+        .ok_or_else(|| "FAILED: graph score report omitted inputs.artifact_kappa".to_owned())?;
     let actual = format!("blake3:{}", blake3::hash(artifact_bytes).to_hex());
     if recorded != actual {
-        eprintln!(
-            "[parity] graph provenance κ mismatch (report {recorded}, artifact {actual}) — graph scenarios skip"
-        );
-        return None;
+        return Err(format!(
+            "UNAVAILABLE: graph provenance kappa mismatch (report {recorded}, artifact {actual})"
+        ));
     }
-    match R4g1State::load(&graph, &bundle.join("tless_artifacts.bin")) {
-        Ok(state) => Some(state),
-        Err(error) => {
-            eprintln!("[parity] R4G1 load failed: {error} — graph scenarios skip");
-            None
+    R4g1State::load(&graph, &bundle.join("tless_artifacts.bin"))
+        .map_err(|error| format!("FAILED: R4G1 load: {error}"))
+}
+
+/// Cheapest executable gate before the source-only exact tuner. This opens no
+/// teacher source and performs no teacher forward. It binds and parses the
+/// tokenizer, legacy artifact/store, and graph bundle, then asks every
+/// canonical lane for one typed deployed-path decision. Graph abstention is a
+/// truthful typed outcome here, not a structural failure; S4 later requires
+/// the exact transcript-matched seeds to complete all eight causal steps
+/// before admitting live-teacher continuation.
+fn teacher_free_parity_preflight() -> Result<serde_json::Value, String> {
+    let source = parity_source_dir()?;
+    let bundle = parity_bundle_dir()?;
+    let production_admission = production_admission_component_cids(&bundle)?;
+    let tokenizer_path = bundle.join("tokenizer.bin");
+    let artifact_path = bundle.join("tless_artifacts.bin");
+    let store_path = bundle.join("tless_store.bin");
+    let tokenizer_bytes = std::fs::read(&tokenizer_path)
+        .map_err(|error| format!("UNAVAILABLE: read {}: {error}", tokenizer_path.display()))?;
+    let tokenizer = Tokenizer::from_bytes(&tokenizer_bytes)
+        .ok_or_else(|| "FAILED: preflight tokenizer.bin bytes did not parse".to_owned())?;
+    let artifact_bytes = std::fs::read(&artifact_path)
+        .map_err(|error| format!("UNAVAILABLE: read {}: {error}", artifact_path.display()))?;
+    let artifacts = parse_artifacts(&artifact_bytes)
+        .ok_or_else(|| "FAILED: preflight tless_artifacts.bin did not parse".to_owned())?;
+    let store_bytes = std::fs::read(&store_path)
+        .map_err(|error| format!("UNAVAILABLE: read {}: {error}", store_path.display()))?;
+    let store = parse_store(&store_bytes)
+        .or_else(|| {
+            #[allow(deprecated)]
+            parse_store_legacy_u16(&store_bytes)
+        })
+        .ok_or_else(|| {
+            "FAILED: preflight tless_store.bin did not parse as current or legacy TLS".to_owned()
+        })?;
+    let mut lane_seeds = generation_lane_seeds(&tokenizer, S4_CANONICAL_STREAMS)?;
+    for (lane, seed) in lane_seeds.iter_mut().enumerate() {
+        let prompt_tokens = tokenizer.encode(PARITY_PROMPTS[lane]);
+        let next = prompt_tokens.get(seed.len()).copied().ok_or_else(|| {
+            format!("FAILED: preflight prompt {lane} has no token after its executable prefix")
+        })?;
+        seed.push(next);
+    }
+    let retained_prefix_tokens_per_lane = lane_seeds
+        .iter()
+        .map(|seed| seed.len().saturating_sub(1))
+        .collect::<Vec<_>>();
+    let seed_tokens_per_lane = lane_seeds.iter().map(Vec::len).collect::<Vec<_>>();
+    let mut legacy_outputs = Vec::with_capacity(lane_seeds.len());
+    for seed in &lane_seeds {
+        let mut runtime = Runtime::new(&artifacts);
+        let code = runtime.assign_window(seed);
+        legacy_outputs.push(vec![runtime.predict_witness(&store, &code).token]);
+    }
+    // Policy counters and `novel_seen` are mutable per serving session. Keep
+    // the teacher-free gate order-independent by giving every canonical lane
+    // its own state, matching the isolation required by measured S4.
+    let graph_states = (0..lane_seeds.len())
+        .map(|_| load_r4g1(&bundle, &artifact_bytes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut graph_outputs = Vec::with_capacity(lane_seeds.len());
+    let mut graph_decisions = Vec::with_capacity(lane_seeds.len());
+    let mut graph_abstentions = 0usize;
+    for (lane, (seed, graph)) in lane_seeds.iter().zip(&graph_states).enumerate() {
+        match graph
+            .predict_window_status(seed)
+            .map_err(|error| format!("FAILED: preflight graph lane {lane}: {error}"))?
+        {
+            PredictDecision::Serve(outcome) => {
+                graph_outputs.push(vec![outcome.token]);
+                graph_decisions.push(serde_json::json!({
+                    "lane": lane,
+                    "decision": "SERVE",
+                    "token": outcome.token,
+                    "status": format!("{:?}", outcome.status),
+                }));
+            }
+            PredictDecision::Abstain(outcome) => {
+                graph_abstentions += 1;
+                graph_outputs.push(Vec::new());
+                graph_decisions.push(serde_json::json!({
+                    "lane": lane,
+                    "decision": "ABSTAIN",
+                    "status": format!("{:?}", outcome.status),
+                }));
+            }
         }
     }
+    let (lane_seed_cids, legacy_output_cids, legacy_cohort_cid) =
+        generation_output_identities("preflight-legacy", &lane_seeds, &legacy_outputs)?;
+    let (_, graph_output_cids, graph_cohort_cid) =
+        generation_output_identities("preflight-graph", &lane_seeds, &graph_outputs)?;
+    Ok(serde_json::json!({
+        "schema": "uor-r4.teacher-parity-preflight/1",
+        "status": "AVAILABLE",
+        "authorizing_contract_cid": exact_executor_contract_cid(),
+        "teacher_source_opened": false,
+        "teacher_forwards": 0,
+        "selected_source_dir": source.display().to_string(),
+        "selected_bundle_dir": bundle.display().to_string(),
+        "canonical_lanes": lane_seeds.len(),
+        "graph_state_preparations": graph_states.len(),
+        "bounded_steps_per_lane": 1,
+        "seed_policy": "each lane's final teacher-forced prompt prefix plus its final pinned prompt token",
+        "retained_prefix_tokens_per_lane": retained_prefix_tokens_per_lane,
+        "seed_tokens_per_lane": seed_tokens_per_lane,
+        "claim_boundary": "teacher-free structural fixture and typed-decision preflight; not S4 matched-history speed evidence",
+        "production_admission": production_admission,
+        "inputs": {
+            "tokenizer": file_kappa(&tokenizer_path)?.0,
+            "legacy_artifact": file_kappa(&artifact_path)?.0,
+            "legacy_store": file_kappa(&store_path)?.0,
+            "graph": file_kappa(&bundle.join("graph/score.r4g1"))?.0,
+            "graph_report": file_kappa(&bundle.join("graph/score_report.json"))?.0,
+        },
+        "lane_seed_cids": lane_seed_cids,
+        "legacy_output_cids": legacy_output_cids,
+        "legacy_cohort_cid": legacy_cohort_cid,
+        "graph_output_cids": graph_output_cids,
+        "graph_cohort_cid": graph_cohort_cid,
+        "graph_typed_abstentions": graph_abstentions,
+        "graph_decisions": graph_decisions,
+    }))
 }
 
-fn parity_budget(var: &str, default: usize) -> usize {
-    std::env::var(var)
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(default)
+#[derive(Debug)]
+struct PromptWork {
+    prompt: usize,
+    tokens: Vec<u32>,
+    positions: usize,
+    next_position: usize,
 }
 
-/// Teacher-forced replay: at every position of every pinned prompt the
-/// teacher steps on the true token and the compiled side predicts from the
-/// same true history (last ≤ WINDOW tokens). No divergence compounding.
-fn teacher_forced_eval(fx: &mut ParityFixtures, graph: bool, budget: usize) -> ParityMetrics {
+fn planned_prompt_work(tokenizer: &Tokenizer, budget: usize) -> Vec<PromptWork> {
+    let tokenized: Vec<Vec<u32>> = PARITY_PROMPTS
+        .iter()
+        .map(|prompt| tokenizer.encode(prompt))
+        .collect();
+    let capacities: Vec<usize> = tokenized
+        .iter()
+        .map(|tokens| tokens.len().saturating_sub(1))
+        .collect();
+    let mut quotas = vec![0usize; tokenized.len()];
+    let mut remaining = budget;
+    while remaining > 0 {
+        let mut allocated = false;
+        for prompt in 0..tokenized.len() {
+            if remaining == 0 {
+                break;
+            }
+            if quotas[prompt] < capacities[prompt] {
+                quotas[prompt] += 1;
+                remaining -= 1;
+                allocated = true;
+            }
+        }
+        if !allocated {
+            break;
+        }
+    }
+    tokenized
+        .into_iter()
+        .zip(quotas)
+        .enumerate()
+        .filter_map(|(prompt, (tokens, positions))| {
+            (positions > 0).then_some(PromptWork {
+                prompt,
+                tokens,
+                positions,
+                next_position: 0,
+            })
+        })
+        .collect()
+}
+
+fn checked_u64(value: usize, label: &str) -> Result<u64, String> {
+    u64::try_from(value).map_err(|_| format!("NOT_RUN / REFUSED: {label} does not fit report u64"))
+}
+
+fn parity_work_plan(
+    teacher: &SmolLm2Oracle,
+    tokenizer: &Tokenizer,
+    config: &ParityConfig,
+    generation_tokens: usize,
+    graph_available: bool,
+    fmm_available: bool,
+) -> Result<WorkPlan, String> {
+    let master_budget = config.positions.get().max(config.fmm_positions.get());
+    let prompt_work = planned_prompt_work(tokenizer, master_budget);
+    let transcript_streams = prompt_work.len();
+    let transcript_forwards = prompt_work.iter().map(|work| work.positions).sum::<usize>();
+    let mut pending: std::collections::VecDeque<usize> =
+        prompt_work.iter().map(|work| work.positions).collect();
+    let stream_limit = config.streams.get().min(pending.len());
+    let mut active = Vec::with_capacity(stream_limit);
+    for _ in 0..stream_limit {
+        active.push(pending.pop_front().expect("planned prompt work exists"));
+    }
+    let mut transcript_batches = 0usize;
+    let mut matrix_calls = 0u64;
+    let mut batched_matrix_calls = 0u64;
+    let mut max_matrix_batch_width = 0u64;
+    let mut worker_tasks = 0u64;
+    let mut row_tiles = 0u64;
+    let mut output_cells = 0u64;
+    let mut scalar_terms = 0u64;
+    let mut add_exact_forward = |batch_width: usize, repetitions: usize| -> Result<(), String> {
+        let forward = teacher
+            .exact_forward_plan(batch_width)
+            .map_err(|error| format!("NOT_RUN / REFUSED: exact forward counter oracle: {error}"))?;
+        let repetitions = u64::try_from(repetitions)
+            .map_err(|_| "NOT_RUN / REFUSED: exact repetition count exceeds u64".to_owned())?;
+        let add = |total: &mut u64, per_forward: u64, label: &str| -> Result<(), String> {
+            *total = total
+                .checked_add(per_forward.checked_mul(repetitions).ok_or_else(|| {
+                    format!("NOT_RUN / REFUSED: {label} plan multiplication overflow")
+                })?)
+                .ok_or_else(|| format!("NOT_RUN / REFUSED: {label} plan addition overflow"))?;
+            Ok(())
+        };
+        add(&mut matrix_calls, forward.matrix_calls, "matrix calls")?;
+        if forward.batch_width > 1 {
+            add(
+                &mut batched_matrix_calls,
+                forward.matrix_calls,
+                "batched matrix calls",
+            )?;
+        }
+        max_matrix_batch_width = max_matrix_batch_width.max(
+            u64::try_from(forward.batch_width)
+                .map_err(|_| "NOT_RUN / REFUSED: matrix batch width exceeds u64".to_owned())?,
+        );
+        add(&mut worker_tasks, forward.worker_tasks, "worker tasks")?;
+        add(&mut row_tiles, forward.row_tiles, "row tiles")?;
+        add(&mut output_cells, forward.output_cells, "output cells")?;
+        add(&mut scalar_terms, forward.scalar_terms, "scalar terms")?;
+        Ok(())
+    };
+    while !active.is_empty() {
+        transcript_batches = transcript_batches.checked_add(1).ok_or_else(|| {
+            "NOT_RUN / REFUSED: transcript physical-batch plan overflow".to_owned()
+        })?;
+        add_exact_forward(active.len(), 1)?;
+        for remaining in &mut active {
+            *remaining -= 1;
+        }
+        for lane in (0..active.len()).rev() {
+            if active[lane] == 0 {
+                if let Some(next) = pending.pop_front() {
+                    active[lane] = next;
+                } else {
+                    active.remove(lane);
+                }
+            }
+        }
+    }
+
+    // S4 clones the canonical common-prefix states retained by the transcript.
+    // Its only exact work is the bounded adaptive continuation: no repeated
+    // prefill, no teacher warm-up, and exactly one causal cohort.
+    let generation_batches = generation_tokens;
+    add_exact_forward(config.streams.get(), generation_batches)?;
+    let generation_forwards = generation_batches
+        .checked_mul(config.streams.get())
+        .ok_or_else(|| "NOT_RUN / REFUSED: S4 logical-forward plan overflow".to_owned())?;
+    let physical_batches = transcript_batches
+        .checked_add(generation_batches)
+        .ok_or_else(|| "NOT_RUN / REFUSED: suite physical-batch plan overflow".to_owned())?;
+    let logical_forwards = transcript_forwards
+        .checked_add(generation_forwards)
+        .ok_or_else(|| "NOT_RUN / REFUSED: suite logical-forward plan overflow".to_owned())?;
+    let streams = transcript_streams
+        .checked_add(config.streams.get())
+        .ok_or_else(|| "NOT_RUN / REFUSED: stream plan overflow".to_owned())?;
+
+    let cache_hits = 1usize
+        .checked_add(usize::from(graph_available))
+        .and_then(|hits| hits.checked_add(if fmm_available { 2 } else { 0 }))
+        .ok_or_else(|| "NOT_RUN / REFUSED: cache-hit plan overflow".to_owned())?;
+    Ok(WorkPlan {
+        logical_forwards: checked_u64(logical_forwards, "logical forwards")?,
+        tokens: checked_u64(logical_forwards, "tokens")?,
+        physical_batches: checked_u64(physical_batches, "physical batches")?,
+        matrix_calls,
+        batched_matrix_calls,
+        max_matrix_batch_width,
+        padded_forwards: 0,
+        cache_hits: checked_u64(cache_hits, "cache hits")?,
+        streams: checked_u64(streams, "streams")?,
+        worker_tasks,
+        row_tiles,
+        output_cells,
+        scalar_terms,
+    })
+}
+
+fn parity_top_tokens(logits: &[f32], limit: usize) -> Vec<u32> {
+    let mut best: Vec<(u32, f32)> = Vec::with_capacity(limit);
+    for (token, &logit) in logits.iter().enumerate() {
+        let token = u32::try_from(token).expect("teacher vocabulary fits u32");
+        let insert_at = best
+            .iter()
+            .position(|&(other_token, other_logit)| {
+                logit > other_logit || (logit == other_logit && token < other_token)
+            })
+            .unwrap_or(best.len());
+        if insert_at < limit {
+            best.insert(insert_at, (token, logit));
+            best.truncate(limit);
+        } else if best.len() < limit {
+            best.push((token, logit));
+        }
+    }
+    best.into_iter().map(|(token, _)| token).collect()
+}
+
+fn transcript_cid(budget: usize, rows: &[ParityTranscriptRow]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.teacher-parity-transcript/1\0");
+    hasher.update(&(budget as u64).to_le_bytes());
+    for row in rows {
+        hasher.update(&(row.prompt as u64).to_le_bytes());
+        hasher.update(&(row.position as u64).to_le_bytes());
+        hasher.update(&(row.window.len() as u64).to_le_bytes());
+        for token in &row.window {
+            hasher.update(&token.to_le_bytes());
+        }
+        hasher.update(&(row.logits.len() as u64).to_le_bytes());
+        for logit in &row.logits {
+            hasher.update(&logit.to_bits().to_le_bytes());
+        }
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn transcript_seed_cid(prompt: usize, tokens: &[u32]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.teacher-parity-transcript-seed/1\0");
+    hasher.update(&(prompt as u64).to_le_bytes());
+    hasher.update(&(tokens.len() as u64).to_le_bytes());
+    for token in tokens {
+        hasher.update(&token.to_le_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn add_transcript_owner_forward(
+    total: &mut TranscriptExactPlan,
+    teacher: &SmolLm2Oracle,
+    batch_width: usize,
+    configured_width: usize,
+) -> Result<(), String> {
+    let forward = teacher
+        .exact_forward_plan(batch_width)
+        .map_err(|error| format!("FAILED: transcript exact owner plan: {error}"))?;
+    let add = |value: &mut u64, amount: u64, label: &str| -> Result<(), String> {
+        *value = value
+            .checked_add(amount)
+            .ok_or_else(|| format!("FAILED: transcript owner {label} overflow"))?;
+        Ok(())
+    };
+    add(&mut total.forward_calls, 1, "forward calls")?;
+    if batch_width == configured_width {
+        add(
+            &mut total.full_width_forward_calls,
+            1,
+            "full-width forward calls",
+        )?;
+    } else {
+        add(&mut total.tail_forward_calls, 1, "tail forward calls")?;
+    }
+    total.minimum_batch_width = if total.minimum_batch_width == 0 {
+        batch_width
+    } else {
+        total.minimum_batch_width.min(batch_width)
+    };
+    add(
+        &mut total.streams,
+        u64::try_from(batch_width)
+            .map_err(|_| "FAILED: transcript batch width exceeds u64".to_owned())?,
+        "streams",
+    )?;
+    add(
+        &mut total.matrix_calls,
+        forward.matrix_calls,
+        "matrix calls",
+    )?;
+    if batch_width > 1 {
+        add(
+            &mut total.batched_matrix_calls,
+            forward.matrix_calls,
+            "batched matrix calls",
+        )?;
+    }
+    total.max_matrix_batch_width = total.max_matrix_batch_width.max(forward.batch_width);
+    add(
+        &mut total.worker_tasks,
+        forward.worker_tasks,
+        "worker tasks",
+    )?;
+    add(&mut total.row_tiles, forward.row_tiles, "row tiles")?;
+    add(
+        &mut total.output_cells,
+        forward.output_cells,
+        "output cells",
+    )?;
+    add(
+        &mut total.scalar_terms,
+        forward.scalar_terms,
+        "scalar terms",
+    )?;
+    Ok(())
+}
+
+fn build_teacher_transcript(
+    fx: &mut ParityFixtures,
+    budget: usize,
+) -> Result<Arc<ParityTranscript>, String> {
+    let planned = planned_prompt_work(&fx.tokenizer, budget);
+    let canonical_lane_seeds = generation_lane_seeds(&fx.tokenizer, S4_CANONICAL_STREAMS)?;
+    let generation_retained_prefix_tokens_per_lane = canonical_lane_seeds
+        .iter()
+        .map(Vec::len)
+        .collect::<Vec<_>>();
+    let generation_logical_seed_tokens_per_lane = generation_retained_prefix_tokens_per_lane
+        .iter()
+        .map(|tokens| {
+            tokens
+                .checked_add(1)
+                .ok_or_else(|| "FAILED: transcript logical seed length overflow".to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let maximum_retained_prefix_tokens = generation_retained_prefix_tokens_per_lane
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(0);
+    let generation_state_capacity = maximum_retained_prefix_tokens
+        .checked_add(S4_MAX_DECODE_STEPS)
+        .ok_or_else(|| "FAILED: transcript generation-template horizon overflow".to_owned())?;
+    for (work, retained_prefix) in planned
+        .iter()
+        .take(S4_CANONICAL_STREAMS)
+        .zip(&generation_retained_prefix_tokens_per_lane)
+    {
+        if work.prompt >= S4_CANONICAL_STREAMS || work.positions != *retained_prefix {
+            return Err(format!(
+                "FAILED: transcript prompt {} planned {} teacher-forced positions but its canonical retained prefix has {retained_prefix}",
+                work.prompt, work.positions
+            ));
+        }
+    }
+    let stream_seed_cids = planned
+        .iter()
+        .map(|work| transcript_seed_cid(work.prompt, &work.tokens))
+        .collect::<Vec<_>>();
+    let state_sequence_capacities = planned
+        .iter()
+        .map(|work| work.positions.max(generation_state_capacity))
+        .collect::<Vec<_>>();
+    let mut pending: std::collections::VecDeque<_> = planned.into();
+    let logical_forwards = pending.iter().map(|work| work.positions).sum::<usize>();
+    if logical_forwards == 0 {
+        return Err("teacher transcript plan contains no tokenized positions".to_owned());
+    }
+    parity_reset_phase_peak();
+    let execution_before = fx.teacher.execution_snapshot();
+
+    let stream_limit = parity_config().streams.get().min(pending.len());
+    let mut active = Vec::with_capacity(stream_limit);
+    let mut states = Vec::with_capacity(stream_limit);
+    let mut private_state_instances = 0usize;
+    for _ in 0..stream_limit {
+        let work = pending.pop_front().expect("stream work exists");
+        let state_capacity = work.positions.max(generation_state_capacity);
+        let state = fx
+            .teacher
+            .new_state_bounded(state_capacity)
+            .map_err(|error| format!("FAILED: bounded transcript state: {error}"))?;
+        if state.sequence_capacity() != state_capacity {
+            return Err(format!(
+                "FAILED: transcript state capacity {} does not match planned horizon {}",
+                state.sequence_capacity(),
+                state_capacity
+            ));
+        }
+        active.push(work);
+        states.push(state);
+        private_state_instances += 1;
+    }
+    let streams_planned = active.len() + pending.len();
+    let mut max_active_streams = active.len();
+    let mut observed_peak_streams = 0usize;
+    let mut observed_peak_row_workers = 0usize;
+    let mut physical_batches = 0usize;
+    let mut first_forward_workspace_growth_events = 0u64;
+    let mut first_forward_workspace_growth_bytes = 0u64;
+    let mut steady_state_workspace_growth_events = 0u64;
+    let mut steady_state_workspace_growth_bytes = 0u64;
+    let mut owner_plan = TranscriptExactPlan::default();
+    let mut per_prompt: Vec<Vec<ParityTranscriptRow>> =
+        (0..PARITY_PROMPTS.len()).map(|_| Vec::new()).collect();
+    let mut generation_templates: Vec<Option<TeacherGenerationTemplate>> =
+        (0..S4_CANONICAL_STREAMS).map(|_| None).collect();
+    let progress = parity_progress();
+    progress
+        .update(|state| {
+            state.phase = "S2_teacher_transcript".to_owned();
+            state.queue.queue_depth = pending.len() as u64;
+            state.queue.active_streams = active.len() as u64;
+        })
+        .map_err(|error| format!("FAIL: transcript progress initialization: {error}"))?;
+    parity_emit(EventKind::PhaseStarted)
+        .map_err(|error| format!("FAIL: transcript phase event: {error}"))?;
+    while !active.is_empty() {
+        parity_check_deadline("S2 teacher transcript")?;
+        progress
+            .update(|state| {
+                state.queue.queue_depth = pending.len() as u64;
+                state.queue.active_streams = active.len() as u64;
+                state.streams = active
+                    .iter()
+                    .map(|work| StreamProgress {
+                        stream_id: format!("prompt-{}", work.prompt),
+                        phase: "teacher_forced".to_owned(),
+                        state: StreamState::Active,
+                        logical_forwards_completed: work.next_position as u64,
+                        logical_forwards_total: work.positions as u64,
+                        tokens_completed: work.next_position as u64,
+                        tokens_total: work.positions as u64,
+                        active_forward_age_millis: 0,
+                    })
+                    .collect();
+            })
+            .map_err(|error| format!("FAIL: transcript live progress: {error}"))?;
+        let tokens: Vec<usize> = active
+            .iter()
+            .map(|work| work.tokens[work.next_position] as usize)
+            .collect();
+        let positions: Vec<usize> = active.iter().map(|work| work.next_position).collect();
+        add_transcript_owner_forward(&mut owner_plan, &fx.teacher, active.len(), stream_limit)?;
+        let forward = teacher_forward_accounted(&fx.teacher, &mut states, &tokens, &positions)?;
+        if forward.workspace_growth_events != 0 || forward.workspace_growth_bytes != 0 {
+            return Err(format!(
+                "FAILED: transcript physical batch {} grew retained exact workspace after excluded preparation (events={}, bytes={})",
+                physical_batches + 1,
+                forward.workspace_growth_events,
+                forward.workspace_growth_bytes
+            ));
+        }
+        if physical_batches == 0 {
+            first_forward_workspace_growth_events = forward.workspace_growth_events;
+            first_forward_workspace_growth_bytes = forward.workspace_growth_bytes;
+        } else {
+            steady_state_workspace_growth_events = steady_state_workspace_growth_events
+                .saturating_add(forward.workspace_growth_events);
+            steady_state_workspace_growth_bytes =
+                steady_state_workspace_growth_bytes.saturating_add(forward.workspace_growth_bytes);
+        }
+        observed_peak_streams = observed_peak_streams.max(parity_stream_phase_peak());
+        observed_peak_row_workers = observed_peak_row_workers.max(parity_phase_peak());
+        physical_batches += 1;
+
+        for lane in 0..active.len() {
+            let work = &active[lane];
+            let logits = fx.teacher.logits_mut(&mut states[lane]).to_vec();
+            let position = work.next_position;
+            let window = work.tokens[(position + 1).saturating_sub(WINDOW)..=position].to_vec();
+            let top8 = parity_top_tokens(&logits, 8);
+            if work.prompt < S4_CANONICAL_STREAMS && position + 1 == work.positions {
+                let state = states[lane].clone();
+                let persistent_state_cid = state.persistent_state_cid();
+                generation_templates[work.prompt] = Some(TeacherGenerationTemplate {
+                    prompt: work.prompt,
+                    lane_seed: canonical_lane_seeds[work.prompt].clone(),
+                    next_token: teacher_argmax(&logits),
+                    persistent_state_cid,
+                    state,
+                });
+            }
+            per_prompt[work.prompt].push(ParityTranscriptRow {
+                prompt: work.prompt,
+                position,
+                window,
+                logits,
+                top8,
+            });
+        }
+        active.iter_mut().for_each(|work| work.next_position += 1);
+
+        for lane in (0..active.len()).rev() {
+            if active[lane].next_position == active[lane].positions {
+                parity_counters().record_stream_completed();
+                if let Some(next) = pending.pop_front() {
+                    let next_capacity = next.positions.max(generation_state_capacity);
+                    let next_state = fx
+                        .teacher
+                        .new_state_bounded(next_capacity)
+                        .map_err(|error| format!("FAILED: bounded transcript state: {error}"))?;
+                    if next_state.sequence_capacity() != next_capacity {
+                        return Err(format!(
+                            "FAILED: replacement transcript state capacity {} does not match planned horizon {}",
+                            next_state.sequence_capacity(),
+                            next_capacity
+                        ));
+                    }
+                    active[lane] = next;
+                    states[lane] = next_state;
+                    private_state_instances += 1;
+                } else {
+                    active.remove(lane);
+                    states.remove(lane);
+                }
+            }
+        }
+        max_active_streams = max_active_streams.max(active.len());
+    }
+    progress
+        .update(|state| {
+            state.queue.queue_depth = 0;
+            state.queue.active_streams = 0;
+            state.queue.completed_streams = state
+                .queue
+                .completed_streams
+                .saturating_add(streams_planned as u64);
+            state.streams.clear();
+        })
+        .map_err(|error| format!("FAIL: transcript completion progress: {error}"))?;
+    parity_emit(EventKind::PhaseCompleted)
+        .map_err(|error| format!("FAIL: transcript completion event: {error}"))?;
+
+    let stream_output_cids = per_prompt
+        .iter()
+        .filter(|rows| !rows.is_empty())
+        .map(|rows| transcript_cid(budget, rows))
+        .collect::<Vec<_>>();
+    validate_private_multistream_evidence(&stream_seed_cids, &stream_output_cids, streams_planned)
+        .map_err(|error| format!("FAILED: transcript private-stream evidence: {error}"))?;
+    let rows: Vec<ParityTranscriptRow> = per_prompt.into_iter().flatten().collect();
+    if rows.len() != logical_forwards {
+        return Err(format!(
+            "FAIL: transcript accounting mismatch: completed {} of {logical_forwards} logical forwards",
+            rows.len()
+        ));
+    }
+    let cid = transcript_cid(budget, &rows);
+    if observed_peak_streams != max_active_streams {
+        return Err(format!(
+            "FAILED: transcript exact executor observed peak {observed_peak_streams} streams, planned {max_active_streams}"
+        ));
+    }
+    let generation_templates = generation_templates
+        .into_iter()
+        .enumerate()
+        .map(|(prompt, template)| {
+            template.ok_or_else(|| {
+                format!(
+                    "FAILED: transcript omitted canonical generation template for prompt {prompt}"
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let generation_template_state_cids = generation_templates
+        .iter()
+        .map(|template| template.persistent_state_cid.clone())
+        .collect::<Vec<_>>();
+    let generation_template_next_tokens = generation_templates
+        .iter()
+        .map(|template| template.next_token)
+        .collect::<Vec<_>>();
+    validate_private_multistream_evidence(
+        &generation_template_state_cids,
+        &stream_output_cids,
+        streams_planned,
+    )
+    .map_err(|error| format!("FAILED: retained teacher template evidence: {error}"))?;
+    let evidence = ParityTranscriptEvidence {
+        cid,
+        positions: rows.len(),
+        logical_forwards,
+        physical_batches,
+        streams_planned,
+        max_active_streams: observed_peak_streams,
+        cache_hits: fx.transcript_cache_hits,
+        peak_active_row_workers: observed_peak_row_workers,
+        private_state_instances,
+        state_sequence_capacities,
+        stream_seed_cids,
+        stream_output_cids,
+        generation_retained_prefix_tokens_per_lane,
+        generation_logical_seed_tokens_per_lane,
+        generation_state_sequence_capacity: generation_state_capacity,
+        generation_template_state_cids,
+        generation_template_next_tokens,
+        execution_preparation: fx.teacher_execution_preparation,
+        first_forward_workspace_growth_events,
+        first_forward_workspace_growth_bytes,
+        steady_state_workspace_growth_events,
+        steady_state_workspace_growth_bytes,
+        owner_plan,
+        execution: teacher_execution_delta(execution_before, fx.teacher.execution_snapshot())?,
+    };
+    Ok(Arc::new(ParityTranscript {
+        rows,
+        evidence,
+        generation_templates,
+    }))
+}
+
+fn teacher_transcript(
+    fx: &mut ParityFixtures,
+    budget: usize,
+) -> Result<Arc<ParityTranscript>, String> {
+    // S2/S3/S7 share one master transcript even when their configured scoring
+    // caps differ. Consumers take their canonical prefix; no smaller cap may
+    // trigger a second live-teacher pass.
+    let config = parity_config();
+    let master_budget = budget
+        .max(config.positions.get())
+        .max(config.fmm_positions.get());
+    if let Some(transcript) = fx.transcripts.get(&master_budget).cloned() {
+        fx.transcript_cache_hits += 1;
+        parity_counters().record_cache_hits(1);
+        return Ok(transcript);
+    }
+    let transcript = build_teacher_transcript(fx, master_budget)?;
+    fx.transcripts
+        .insert(master_budget, Arc::clone(&transcript));
+    Ok(transcript)
+}
+
+/// Teacher-forced replay: the live teacher transcript is built once across
+/// independent prompt streams. Every compiled candidate consumes the same
+/// canonically ordered raw logits and true token history, so S2/S3/S7 cannot
+/// silently repeat teacher evaluation or compound generation divergence.
+fn teacher_forced_eval(
+    fx: &mut ParityFixtures,
+    graph: bool,
+    budget: usize,
+) -> Result<(ParityMetrics, ParityTranscriptEvidence), String> {
+    let transcript = teacher_transcript(fx, budget)?;
     let mut positions = 0usize;
     let mut abstains = 0usize;
     let mut top1_hits = 0usize;
@@ -3749,64 +7118,57 @@ fn teacher_forced_eval(fx: &mut ParityFixtures, graph: bool, budget: usize) -> P
     let mut delta_bits_sum = 0.0f64;
     let mut teacher_bits_sum = 0.0f64;
     let mut scored = 0usize;
-    let mut logits = vec![0.0f32; fx.teacher.vocab()];
-    let mut top8 = [(0u32, 0.0f32); 8];
-    let mut remaining = budget;
-    'prompts: for prompt in PARITY_PROMPTS {
-        let tokens = fx.tokenizer.encode(prompt);
-        if tokens.len() < 2 {
-            continue;
+    let mut current_prompt = usize::MAX;
+    let mut runtime = Runtime::new(&fx.artifacts);
+    for row in transcript.rows.iter().take(budget) {
+        if row.prompt != current_prompt {
+            runtime = Runtime::new(&fx.artifacts);
+            current_prompt = row.prompt;
         }
-        fx.teacher.reset();
-        let mut runtime = Runtime::new(&fx.artifacts);
-        for i in 0..tokens.len() - 1 {
-            if remaining == 0 {
-                break 'prompts;
-            }
-            remaining -= 1;
-            fx.teacher.step(tokens[i] as usize, i, &mut logits);
-            let k = fx.teacher.top_k(8, &mut top8);
-            let teacher_argmax = top8[0].0;
-            let window = &tokens[(i + 1).saturating_sub(WINDOW)..=i];
-            positions += 1;
-            let pick = if graph {
-                let state = fx.r4g1.as_ref().expect("graph fixtures loaded");
-                match state.predict_window_status(window) {
-                    Ok(PredictDecision::Serve(outcome)) => Some(outcome.token),
-                    Ok(PredictDecision::Abstain(_)) => {
-                        abstains += 1;
-                        None
-                    }
-                    Err(error) => panic!("graph prediction failed: {error}"),
+        let teacher_argmax = row.top8[0];
+        positions += 1;
+        let pick = if graph {
+            let state = fx.r4g1.as_ref().expect("graph fixtures loaded");
+            match state.predict_window_status(&row.window) {
+                Ok(PredictDecision::Serve(outcome)) => Some(outcome.token),
+                Ok(PredictDecision::Abstain(_)) => {
+                    abstains += 1;
+                    None
                 }
-            } else {
-                let code = runtime.assign_window(window);
-                Some(runtime.predict(&fx.store, &code))
-            };
-            let Some(pick) = pick.filter(|&t| (t as usize) < logits.len()) else {
-                continue;
-            };
-            if pick == teacher_argmax {
-                top1_hits += 1;
+                Err(error) => panic!("graph prediction failed: {error}"),
             }
-            if top8[..k].iter().any(|&(t, _)| t == pick) {
-                top8_hits += 1;
-            }
-            teacher_bits_sum += teacher_bits_for_token(&logits, pick);
-            let gap_nats = logits[teacher_argmax as usize] - logits[pick as usize];
-            delta_bits_sum += f64::from(gap_nats.max(0.0)) / std::f64::consts::LN_2;
-            scored += 1;
+        } else {
+            let code = runtime.assign_window(&row.window);
+            Some(runtime.predict(&fx.store, &code))
+        };
+        let Some(pick) = pick.filter(|&t| (t as usize) < row.logits.len()) else {
+            continue;
+        };
+        if pick == teacher_argmax {
+            top1_hits += 1;
         }
+        if row.top8.contains(&pick) {
+            top8_hits += 1;
+        }
+        teacher_bits_sum += teacher_bits_for_token(&row.logits, pick);
+        let gap_nats = row.logits[teacher_argmax as usize] - row.logits[pick as usize];
+        delta_bits_sum += f64::from(gap_nats.max(0.0)) / std::f64::consts::LN_2;
+        scored += 1;
     }
     let denom = positions.max(1) as f64;
-    ParityMetrics {
-        positions,
-        abstains,
-        top1_agreement: top1_hits as f64 / denom,
-        top8_recall: top8_hits as f64 / denom,
-        mean_delta_bits: delta_bits_sum / scored.max(1) as f64,
-        teacher_bits_per_token: teacher_bits_sum / scored.max(1) as f64,
-    }
+    let mut evidence = transcript.evidence.clone();
+    evidence.cache_hits = fx.transcript_cache_hits;
+    Ok((
+        ParityMetrics {
+            positions,
+            abstains,
+            top1_agreement: top1_hits as f64 / denom,
+            top8_recall: top8_hits as f64 / denom,
+            mean_delta_bits: delta_bits_sum / scored.max(1) as f64,
+            teacher_bits_per_token: teacher_bits_sum / scored.max(1) as f64,
+        },
+        evidence,
+    ))
 }
 
 /// Cross-entropy of a runtime-selected token under the live teacher,
@@ -3829,109 +7191,93 @@ fn teacher_bits_for_token(logits: &[f32], token: u32) -> f64 {
 /// Teacher-forced evaluation of the certifier-side FMM candidate. The
 /// candidate receives the same artifact-derived signature and true history as
 /// the incumbent, but it does not participate in serving status policy.
-fn fmm_teacher_forced_eval(fx: &mut ParityFixtures, budget: usize) -> Option<ParityMetrics> {
-    let fmm = fx.fmm.as_ref()?.clone();
-    let r4g1 = fx.r4g1.as_ref()?;
+fn fmm_teacher_forced_eval(
+    fx: &mut ParityFixtures,
+    budget: usize,
+) -> Result<Option<ParityMetrics>, String> {
+    let transcript = teacher_transcript(fx, budget)?;
+    let Some(fmm) = fx.fmm.as_ref().cloned() else {
+        return Ok(None);
+    };
+    let Some(r4g1) = fx.r4g1.as_ref() else {
+        return Ok(None);
+    };
     let mut positions = 0usize;
     let mut top1_hits = 0usize;
     let mut top8_hits = 0usize;
     let mut teacher_bits_sum = 0.0f64;
-    let mut remaining = budget;
-    let mut logits = vec![0.0f32; fx.teacher.vocab()];
-    let mut top8 = [(0u32, 0.0f32); 8];
-    'prompts: for prompt in PARITY_PROMPTS {
-        let tokens = fx.tokenizer.encode(prompt);
-        if tokens.len() < 2 {
-            continue;
+    for row in transcript.rows.iter().take(budget) {
+        let teacher_argmax = row.top8[0];
+        let Some(sig) = r4g1.signature_for_window(&row.window).ok() else {
+            return Ok(None);
+        };
+        let Some(outcome) = fmm.score(&sig, &[]) else {
+            return Ok(None);
+        };
+        positions += 1;
+        if outcome.selected == teacher_argmax {
+            top1_hits += 1;
         }
-        fx.teacher.reset();
-        for i in 0..tokens.len() - 1 {
-            if remaining == 0 {
-                break 'prompts;
-            }
-            remaining -= 1;
-            fx.teacher.step(tokens[i] as usize, i, &mut logits);
-            let k = fx.teacher.top_k(8, &mut top8);
-            let teacher_argmax = top8[0].0;
-            let window = &tokens[(i + 1).saturating_sub(WINDOW)..=i];
-            let sig = r4g1.signature_for_window(window).ok()?;
-            let outcome = fmm.score(&sig, &[])?;
-            positions += 1;
-            if outcome.selected == teacher_argmax {
-                top1_hits += 1;
-            }
-            if top8[..k]
-                .iter()
-                .any(|&(token, _)| token == outcome.selected)
-            {
-                top8_hits += 1;
-            }
-            teacher_bits_sum += teacher_bits_for_token(&logits, outcome.selected);
+        if row.top8.contains(&outcome.selected) {
+            top8_hits += 1;
         }
+        teacher_bits_sum += teacher_bits_for_token(&row.logits, outcome.selected);
     }
     let denom = positions.max(1) as f64;
-    Some(ParityMetrics {
+    Ok(Some(ParityMetrics {
         positions,
         abstains: 0,
         top1_agreement: top1_hits as f64 / denom,
         top8_recall: top8_hits as f64 / denom,
         mean_delta_bits: 0.0,
         teacher_bits_per_token: teacher_bits_sum / denom,
-    })
+    }))
 }
 
 /// The same teacher-forced replay through the quantized translation-table
 /// candidate. This measures fixed-point selection drift separately from the
 /// float candidate so quantization loss is visible.
-fn fmm_fixed_teacher_forced_eval(fx: &mut ParityFixtures, budget: usize) -> Option<ParityMetrics> {
-    let fmm = fx.fmm_fixed.as_ref()?.clone();
-    let r4g1 = fx.r4g1.as_ref()?;
+fn fmm_fixed_teacher_forced_eval(
+    fx: &mut ParityFixtures,
+    budget: usize,
+) -> Result<Option<ParityMetrics>, String> {
+    let transcript = teacher_transcript(fx, budget)?;
+    let Some(fmm) = fx.fmm_fixed.as_ref().cloned() else {
+        return Ok(None);
+    };
+    let Some(r4g1) = fx.r4g1.as_ref() else {
+        return Ok(None);
+    };
     let mut positions = 0usize;
     let mut top1_hits = 0usize;
     let mut top8_hits = 0usize;
     let mut teacher_bits_sum = 0.0f64;
-    let mut remaining = budget;
-    let mut logits = vec![0.0f32; fx.teacher.vocab()];
-    let mut top8 = [(0u32, 0.0f32); 8];
-    'prompts: for prompt in PARITY_PROMPTS {
-        let tokens = fx.tokenizer.encode(prompt);
-        if tokens.len() < 2 {
-            continue;
+    for row in transcript.rows.iter().take(budget) {
+        let teacher_argmax = row.top8[0];
+        let Some(sig) = r4g1.signature_for_window(&row.window).ok() else {
+            return Ok(None);
+        };
+        let Some(outcome) = fmm.score(&sig, &[]) else {
+            return Ok(None);
+        };
+        positions += 1;
+        if outcome.selected == teacher_argmax {
+            top1_hits += 1;
         }
-        fx.teacher.reset();
-        for i in 0..tokens.len() - 1 {
-            if remaining == 0 {
-                break 'prompts;
-            }
-            remaining -= 1;
-            fx.teacher.step(tokens[i] as usize, i, &mut logits);
-            let k = fx.teacher.top_k(8, &mut top8);
-            let teacher_argmax = top8[0].0;
-            let window = &tokens[(i + 1).saturating_sub(WINDOW)..=i];
-            let sig = r4g1.signature_for_window(window).ok()?;
-            let outcome = fmm.score(&sig, &[])?;
-            positions += 1;
-            if outcome.selected == teacher_argmax {
-                top1_hits += 1;
-            }
-            if top8[..k]
-                .iter()
-                .any(|&(token, _)| token == outcome.selected)
-            {
-                top8_hits += 1;
-            }
-            teacher_bits_sum += teacher_bits_for_token(&logits, outcome.selected);
+        if row.top8.contains(&outcome.selected) {
+            top8_hits += 1;
         }
+        teacher_bits_sum += teacher_bits_for_token(&row.logits, outcome.selected);
     }
     let denom = positions.max(1) as f64;
-    Some(ParityMetrics {
+    Ok(Some(ParityMetrics {
         positions,
         abstains: 0,
         top1_agreement: top1_hits as f64 / denom,
         top8_recall: top8_hits as f64 / denom,
         mean_delta_bits: 0.0,
         teacher_bits_per_token: teacher_bits_sum / denom,
-    })
+    }))
 }
 
 fn teacher_argmax(logits: &[f32]) -> usize {
@@ -3944,52 +7290,912 @@ fn teacher_argmax(logits: &[f32]) -> usize {
     best
 }
 
-/// Greedy-generate `n` tokens with the teacher on its default (fast) matmul
-/// path; returns sustained tokens/second for the generation loop only.
-fn timed_teacher_generate(fx: &mut ParityFixtures, seed: &[u32], n: usize) -> f64 {
-    let mut logits = vec![0.0f32; fx.teacher.vocab()];
-    fx.teacher.reset();
-    let mut token = 0usize;
-    let mut pos = 0usize;
-    for (p, &t) in seed.iter().enumerate() {
-        fx.teacher.step(t as usize, p, &mut logits);
-        token = teacher_argmax(&logits);
-        pos = p + 1;
+fn update_u32_sequence(hasher: &mut blake3::Hasher, values: &[u32]) {
+    hasher.update(&(values.len() as u64).to_le_bytes());
+    for value in values {
+        hasher.update(&value.to_le_bytes());
     }
-    let start = Instant::now();
-    for _ in 0..n {
-        fx.teacher.step(token, pos, &mut logits);
-        token = teacher_argmax(&logits);
-        pos += 1;
+}
+
+fn generation_lane_seeds(tokenizer: &Tokenizer, streams: usize) -> Result<Vec<Vec<u32>>, String> {
+    if streams <= 1 || streams > PARITY_PROMPTS.len() {
+        return Err(format!(
+            "NOT_RUN / REFUSED: distinct pinned lane seeds support 2..={} streams, got {streams}",
+            PARITY_PROMPTS.len()
+        ));
     }
-    n as f64 / start.elapsed().as_secs_f64()
+    let mut seeds: Vec<Vec<u32>> = PARITY_PROMPTS[..streams]
+        .iter()
+        .map(|prompt| tokenizer.encode(prompt))
+        .collect();
+    // Preserve all eight prompt identities by retaining each prompt's own
+    // complete teacher-forced prefix. The final token is the label, so every
+    // reusable transcript template stops at len - 1 without adding a forward.
+    for (lane, seed) in seeds.iter_mut().enumerate() {
+        if seed.len() != S4_REGISTERED_PROMPT_TOKEN_LENGTHS[lane] {
+            return Err(format!(
+                "NOT_RUN / REFUSED: S4 pinned lane {lane} tokenized to {} tokens, registered identity requires {}",
+                seed.len(),
+                S4_REGISTERED_PROMPT_TOKEN_LENGTHS[lane]
+            ));
+        }
+        if seed.len() <= 1 {
+            return Err(format!(
+                "FAILED: S4 pinned lane {lane} has no nonempty teacher-forced prefix"
+            ));
+        }
+        seed.pop();
+    }
+    let seed_cids = seeds
+        .iter()
+        .map(|seed| {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(b"uor-r4.parity-lane-seed/1\0");
+            update_u32_sequence(&mut hasher, seed);
+            format!("blake3:{}", hasher.finalize().to_hex())
+        })
+        .collect::<Vec<_>>();
+    let placeholders = vec!["not-yet-generated".to_owned(); streams];
+    validate_private_multistream_evidence(&seed_cids, &placeholders, streams)
+        .map_err(|error| format!("NOT_RUN / REFUSED: {error}"))?;
+    Ok(seeds)
 }
 
-fn timed_legacy_generate(fx: &mut ParityFixtures, seed: &[u32], n: usize) -> f64 {
-    let mut runtime = Runtime::new(&fx.artifacts);
-    let mut out = vec![Prediction::default(); n];
+fn generation_output_identities(
+    engine: &str,
+    lane_seeds: &[Vec<u32>],
+    outputs: &[Vec<u32>],
+) -> Result<(Vec<String>, Vec<String>, String), String> {
+    if lane_seeds.len() != outputs.len() {
+        return Err(format!(
+            "FAILED: {engine} S4 output records {}/{} lane seeds",
+            outputs.len(),
+            lane_seeds.len()
+        ));
+    }
+    let mut seed_cids = Vec::with_capacity(lane_seeds.len());
+    let mut output_cids = Vec::with_capacity(outputs.len());
+    for (seed, output) in lane_seeds.iter().zip(outputs) {
+        let mut seed_hasher = blake3::Hasher::new();
+        seed_hasher.update(b"uor-r4.parity-lane-seed/1\0");
+        update_u32_sequence(&mut seed_hasher, seed);
+        seed_cids.push(format!("blake3:{}", seed_hasher.finalize().to_hex()));
+
+        let mut output_hasher = blake3::Hasher::new();
+        output_hasher.update(b"uor-r4.parity-generation-stream/1\0");
+        output_hasher.update(&(engine.len() as u64).to_le_bytes());
+        output_hasher.update(engine.as_bytes());
+        update_u32_sequence(&mut output_hasher, seed);
+        update_u32_sequence(&mut output_hasher, output);
+        output_cids.push(format!("blake3:{}", output_hasher.finalize().to_hex()));
+    }
+    validate_private_multistream_evidence(&seed_cids, &output_cids, lane_seeds.len())
+        .map_err(|error| format!("FAILED: {engine} {error}"))?;
+    let mut wave_hasher = blake3::Hasher::new();
+    wave_hasher.update(b"uor-r4.parity-generation-wave/1\0");
+    wave_hasher.update(&(engine.len() as u64).to_le_bytes());
+    wave_hasher.update(engine.as_bytes());
+    wave_hasher.update(&(output_cids.len() as u64).to_le_bytes());
+    for cid in &output_cids {
+        wave_hasher.update(&(cid.len() as u64).to_le_bytes());
+        wave_hasher.update(cid.as_bytes());
+    }
+    Ok((
+        seed_cids,
+        output_cids,
+        format!("blake3:{}", wave_hasher.finalize().to_hex()),
+    ))
+}
+
+fn begin_generation_wave(
+    engine: &'static str,
+    wave: usize,
+    warmup: bool,
+    streams: usize,
+    seed_tokens: usize,
+    generated_tokens: usize,
+) -> Result<(), String> {
+    parity_progress()
+        .update(|state| {
+            state.phase = format!(
+                "S4_{engine}_{}_wave_{wave}",
+                if warmup { "warmup" } else { "measured" }
+            );
+            state.queue.queue_depth = streams as u64;
+            state.queue.active_streams = 0;
+            state.queue.active_worker_tasks = 0;
+            state.streams = (0..streams)
+                .map(|stream| StreamProgress {
+                    stream_id: format!("{engine}-wave-{wave}-stream-{stream}"),
+                    phase: if seed_tokens == 0 {
+                        "decode_from_transcript_template".to_owned()
+                    } else {
+                        "seed_and_decode".to_owned()
+                    },
+                    state: StreamState::Queued,
+                    logical_forwards_completed: 0,
+                    logical_forwards_total: generated_tokens as u64,
+                    tokens_completed: 0,
+                    tokens_total: generated_tokens as u64,
+                    active_forward_age_millis: 0,
+                })
+                .collect();
+        })
+        .map_err(|error| format!("FAILED: initialize S4 {engine} wave progress: {error}"))?;
+    parity_emit(EventKind::WorkStarted)
+        .map_err(|error| format!("FAILED: emit S4 {engine} wave start: {error}"))
+}
+
+fn update_generation_wave(completed: usize) -> Result<(), String> {
+    parity_progress()
+        .update(|state| {
+            state.queue.queue_depth = 0;
+            state.queue.active_streams = state.streams.len() as u64;
+            for stream in &mut state.streams {
+                stream.state = StreamState::Active;
+                stream.logical_forwards_completed = completed as u64;
+                stream.tokens_completed = completed as u64;
+            }
+        })
+        .map_err(|error| format!("FAILED: update S4 wave progress: {error}"))
+}
+
+fn finish_generation_wave(
+    engine: &str,
+    streams: usize,
+    completions_already_recorded: bool,
+) -> Result<(), String> {
+    parity_progress()
+        .update(|state| {
+            state.queue.queue_depth = 0;
+            state.queue.active_streams = 0;
+            state.queue.active_worker_tasks = 0;
+            if !completions_already_recorded {
+                state.queue.completed_streams =
+                    state.queue.completed_streams.saturating_add(streams as u64);
+            }
+            for stream in &mut state.streams {
+                stream.state = StreamState::Completed;
+                stream.logical_forwards_completed = stream.logical_forwards_total;
+                stream.tokens_completed = stream.tokens_total;
+            }
+        })
+        .map_err(|error| format!("FAILED: complete S4 {engine} wave progress: {error}"))?;
+    parity_emit(EventKind::WorkCompleted)
+        .map_err(|error| format!("FAILED: emit S4 {engine} wave completion: {error}"))?;
+    parity_progress()
+        .update(|state| state.streams.clear())
+        .map_err(|error| format!("FAILED: clear S4 {engine} streams: {error}"))
+}
+
+fn fail_generation_progress(reason: &str) {
+    let mut failed = 0usize;
+    let _ = parity_progress().update(|state| {
+        for stream in &mut state.streams {
+            if stream.state != StreamState::Completed {
+                stream.state = StreamState::Failed;
+                stream.phase = "failed".to_owned();
+                failed += 1;
+            }
+        }
+        state.phase = "S4_failed".to_owned();
+        state.status = RunStatus::Fail;
+        state.queue.failed_streams = state.queue.failed_streams.saturating_add(failed as u64);
+        state.queue.active_streams = 0;
+        state.queue.active_worker_tasks = 0;
+        state.queue.queue_depth = 0;
+    });
+    for _ in 0..failed {
+        parity_counters().record_stream_failed();
+    }
+    parity_record_measurement("S4_failure", serde_json::json!({ "reason": reason }));
+}
+
+struct TeacherGenerationCohort {
+    states: Vec<TeacherState>,
+    next_tokens: Vec<usize>,
+    lane_seeds: Vec<Vec<u32>>,
+    outputs: Vec<Vec<u32>>,
+    template_state_cids: Vec<String>,
+    retained_prefix_tokens_per_lane: Vec<usize>,
+    seed_tokens_per_lane: Vec<usize>,
+    state_sequence_capacity: usize,
+    decoded_steps: usize,
+    preparation_elapsed_seconds: f64,
+}
+
+fn matched_generation_lane_seeds(transcript: &ParityTranscript) -> Result<Vec<Vec<u32>>, String> {
+    if transcript.generation_templates.len() != S4_CANONICAL_STREAMS {
+        return Err(format!(
+            "FAILED: S4 transcript retained {}/{} canonical state templates",
+            transcript.generation_templates.len(),
+            S4_CANONICAL_STREAMS
+        ));
+    }
+    let lane_seeds = transcript
+        .generation_templates
+        .iter()
+        .enumerate()
+        .map(|(lane, template)| {
+            if template.prompt != lane {
+                return Err(format!(
+                    "FAILED: S4 transcript template order maps lane {lane} to prompt {}",
+                    template.prompt
+                ));
+            }
+            let mut seed = template.lane_seed.clone();
+            seed.push(template.next_token as u32);
+            Ok(seed)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    if lane_seeds.iter().any(Vec::is_empty) {
+        return Err("FAILED: an S4 template seed has an empty history".to_owned());
+    }
+    Ok(lane_seeds)
+}
+
+fn prepare_teacher_generation(
+    transcript: &ParityTranscript,
+) -> Result<TeacherGenerationCohort, String> {
+    let started = Instant::now();
+    let lane_seeds = matched_generation_lane_seeds(transcript)?;
+    let states = transcript
+        .generation_templates
+        .iter()
+        .map(|template| template.state.clone())
+        .collect::<Vec<_>>();
+    let next_tokens = transcript
+        .generation_templates
+        .iter()
+        .map(|template| template.next_token)
+        .collect::<Vec<_>>();
+    let retained_prefix_tokens_per_lane = transcript
+        .generation_templates
+        .iter()
+        .map(|template| template.lane_seed.len())
+        .collect::<Vec<_>>();
+    let template_state_cids = transcript
+        .generation_templates
+        .iter()
+        .map(|template| template.persistent_state_cid.clone())
+        .collect::<Vec<_>>();
+    for (lane, (template, state)) in transcript
+        .generation_templates
+        .iter()
+        .zip(&states)
+        .enumerate()
+    {
+        if template.prompt != lane || state.persistent_state_cid() != template.persistent_state_cid
+        {
+            return Err(format!(
+                "FAILED: S4 cloned template {lane} changed canonical persistent-state identity"
+            ));
+        }
+    }
+    let seed_tokens_per_lane = lane_seeds.iter().map(Vec::len).collect::<Vec<_>>();
+    if seed_tokens_per_lane.contains(&0) {
+        return Err("FAILED: an S4 template seed has an empty prefix".to_owned());
+    }
+    let state_sequence_capacity = states.first().map_or(0, TeacherState::sequence_capacity);
+    if retained_prefix_tokens_per_lane.iter().any(|retained| {
+        retained
+            .checked_add(S4_MAX_DECODE_STEPS)
+            .is_none_or(|required| state_sequence_capacity < required)
+    }) || states
+        .iter()
+        .any(|state| state.sequence_capacity() != state_sequence_capacity)
+    {
+        return Err(format!(
+            "FAILED: S4 template state capacity {state_sequence_capacity} does not cover per-lane retained prefixes {retained_prefix_tokens_per_lane:?}+{S4_MAX_DECODE_STEPS}"
+        ));
+    }
+    Ok(TeacherGenerationCohort {
+        states,
+        next_tokens,
+        lane_seeds,
+        outputs: (0..S4_CANONICAL_STREAMS)
+            .map(|_| Vec::with_capacity(S4_MAX_DECODE_STEPS))
+            .collect(),
+        template_state_cids,
+        retained_prefix_tokens_per_lane,
+        seed_tokens_per_lane,
+        state_sequence_capacity,
+        decoded_steps: 0,
+        preparation_elapsed_seconds: started.elapsed().as_secs_f64(),
+    })
+}
+
+/// Advance one cumulative causal cohort from its transcript-owned state
+/// templates. Only newly admitted decode steps execute exact teacher work.
+fn timed_teacher_decode_to(
+    teacher: &SmolLm2Oracle,
+    cohort: &mut TeacherGenerationCohort,
+    target_steps: usize,
+    stage: usize,
+) -> Result<GenerationWaveSample, String> {
+    if target_steps <= cohort.decoded_steps || target_steps > S4_MAX_DECODE_STEPS {
+        return Err(format!(
+            "FAILED: invalid adaptive teacher target {target_steps} after {} steps",
+            cohort.decoded_steps
+        ));
+    }
+    let streams = cohort.states.len();
+    let added_steps = target_steps - cohort.decoded_steps;
+    begin_generation_wave("teacher", stage, false, streams, 0, target_steps)?;
+    parity_reset_phase_peak();
+    let phase_before = teacher.execution_snapshot();
     let start = Instant::now();
-    let count = runtime.generate_greedy_into(&fx.store, seed, &mut out);
-    count as f64 / start.elapsed().as_secs_f64()
+    let mut positions = vec![0usize; streams];
+    for offset in cohort.decoded_steps..target_steps {
+        parity_check_deadline("S4 adaptive teacher decode")?;
+        for (lane, position) in positions.iter_mut().enumerate() {
+            *position = cohort.retained_prefix_tokens_per_lane[lane]
+                .checked_add(offset)
+                .ok_or_else(|| "FAILED: S4 teacher position overflow".to_owned())?;
+        }
+        teacher_forward_accounted(teacher, &mut cohort.states, &cohort.next_tokens, &positions)?;
+        for lane in 0..streams {
+            cohort.next_tokens[lane] = teacher_argmax(teacher.logits_mut(&mut cohort.states[lane]));
+            cohort.outputs[lane].push(cohort.next_tokens[lane] as u32);
+        }
+        update_generation_wave(offset + 1)?;
+    }
+    cohort.decoded_steps = target_steps;
+    let elapsed_seconds = start.elapsed().as_secs_f64();
+    let execution_delta = teacher_execution_delta(phase_before, teacher.execution_snapshot())?;
+    if execution_delta.multiworker_forward_calls != execution_delta.forward_calls {
+        return Err(format!(
+            "FAILED: S4 teacher stage {stage} observed actual multiworker overlap on {}/{} physical forwards",
+            execution_delta.multiworker_forward_calls, execution_delta.forward_calls
+        ));
+    }
+    if execution_delta.workspace_growth_events != 0 || execution_delta.workspace_growth_bytes != 0 {
+        return Err(format!(
+            "FAILED: S4 teacher stage {stage} grew retained workspace after transcript preparation (events={}, bytes={})",
+            execution_delta.workspace_growth_events, execution_delta.workspace_growth_bytes
+        ));
+    }
+    let peak_row_workers = parity_phase_peak();
+    let peak_streams = parity_stream_phase_peak();
+    if peak_streams != streams {
+        return Err(format!(
+            "FAILED: S4 teacher stage {stage} observed {peak_streams}/{streams} concurrent streams"
+        ));
+    }
+    finish_generation_wave("teacher", streams, false)?;
+    let (lane_seed_cids, stream_output_cids, output_cid) =
+        generation_output_identities("teacher", &cohort.lane_seeds, &cohort.outputs)?;
+    Ok(GenerationWaveSample {
+        wave: stage,
+        engine: "teacher",
+        warmup: false,
+        streams,
+        retained_prefix_tokens_per_lane: cohort.retained_prefix_tokens_per_lane.clone(),
+        seed_tokens_per_lane: cohort.seed_tokens_per_lane.clone(),
+        generated_tokens: added_steps * streams,
+        cumulative_generated_tokens: target_steps * streams,
+        preparation_elapsed_seconds: if stage == 0 {
+            cohort.preparation_elapsed_seconds
+        } else {
+            0.0
+        },
+        prefill_elapsed_seconds: 0.0,
+        decode_elapsed_seconds: elapsed_seconds,
+        one_shot_elapsed_seconds: elapsed_seconds
+            + if stage == 0 {
+                cohort.preparation_elapsed_seconds
+            } else {
+                0.0
+            },
+        elapsed_seconds,
+        aggregate_tps: (added_steps * streams) as f64 / elapsed_seconds.max(f64::MIN_POSITIVE),
+        peak_active_streams: peak_streams,
+        peak_trajectory_workers: 0,
+        peak_exact_row_workers: peak_row_workers,
+        private_state_instances: cohort.states.len(),
+        state_sequence_capacity: cohort.state_sequence_capacity,
+        completed_stream_records: cohort.outputs.len(),
+        lane_seed_cids,
+        stream_output_cids,
+        output_cid,
+        execution_delta: Some(execution_delta),
+        ordered_reduction: true,
+    })
 }
 
-fn timed_graph_generate(fx: &mut ParityFixtures, seed: &[u32], n: usize) -> Option<f64> {
-    let state = fx.r4g1.as_ref()?;
-    let mut out = vec![0u32; n];
-    let start = Instant::now();
-    let status = state.generate_into_status(seed, &mut out).ok()?;
-    let elapsed = start.elapsed().as_secs_f64();
-    (status.count > 0).then(|| status.count as f64 / elapsed)
+fn record_compiled_failure(failure: &Mutex<Option<String>>, reason: String) {
+    let mut slot = failure
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if slot.is_none() {
+        *slot = Some(reason);
+    }
 }
 
-fn median(mut samples: Vec<f64>) -> f64 {
-    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
-    samples[samples.len() / 2]
+fn compiled_generation_samples(
+    engine: &'static str,
+    lane_seeds: &[Vec<u32>],
+    outputs: &[Vec<u32>],
+    elapsed_by_step: &[Duration],
+    preparation_elapsed_seconds: f64,
+    peak_trajectory_workers: usize,
+    state_sequence_capacity: usize,
+) -> Result<Vec<GenerationWaveSample>, String> {
+    let streams = lane_seeds.len();
+    let seed_tokens_per_lane = lane_seeds.iter().map(Vec::len).collect::<Vec<_>>();
+    let retained_prefix_tokens_per_lane = seed_tokens_per_lane
+        .iter()
+        .map(|tokens| tokens.saturating_sub(1))
+        .collect::<Vec<_>>();
+    let maximum_steps = elapsed_by_step.len();
+    if outputs.len() != streams || outputs.iter().any(|output| output.len() != maximum_steps) {
+        return Err(format!(
+            "FAILED: {engine} S4 causal wave retained incomplete output prefixes"
+        ));
+    }
+    adaptive_decode_checkpoints(maximum_steps)
+        .into_iter()
+        .enumerate()
+        .map(|(wave, steps)| {
+            let elapsed_seconds = elapsed_by_step[steps - 1].as_secs_f64();
+            let prefixes = outputs
+                .iter()
+                .map(|output| output[..steps].to_vec())
+                .collect::<Vec<_>>();
+            let (lane_seed_cids, stream_output_cids, output_cid) =
+                generation_output_identities(engine, lane_seeds, &prefixes)?;
+            Ok(GenerationWaveSample {
+                wave,
+                engine,
+                warmup: false,
+                streams,
+                retained_prefix_tokens_per_lane: retained_prefix_tokens_per_lane.clone(),
+                seed_tokens_per_lane: seed_tokens_per_lane.clone(),
+                generated_tokens: steps * streams,
+                cumulative_generated_tokens: steps * streams,
+                preparation_elapsed_seconds: if wave == 0 {
+                    preparation_elapsed_seconds
+                } else {
+                    0.0
+                },
+                prefill_elapsed_seconds: 0.0,
+                decode_elapsed_seconds: elapsed_seconds,
+                one_shot_elapsed_seconds: preparation_elapsed_seconds + elapsed_seconds,
+                elapsed_seconds,
+                aggregate_tps: (steps * streams) as f64 / elapsed_seconds.max(f64::MIN_POSITIVE),
+                peak_active_streams: streams,
+                peak_trajectory_workers,
+                peak_exact_row_workers: 0,
+                private_state_instances: streams,
+                state_sequence_capacity,
+                completed_stream_records: streams,
+                lane_seed_cids,
+                stream_output_cids,
+                output_cid,
+                execution_delta: None,
+                ordered_reduction: true,
+            })
+        })
+        .collect()
+}
+
+/// Prepare every legacy lane once and advance one causal cohort through the
+/// full cheap ceiling. Per-checkpoint evidence is sliced from this single
+/// execution; no runtime, history, thread, or prefix is rebuilt.
+fn timed_legacy_causal_wave(
+    artifacts: &Compiled,
+    store: &Store,
+    lane_seeds: &[Vec<u32>],
+    maximum_steps: usize,
+    workers: usize,
+) -> Result<Vec<GenerationWaveSample>, String> {
+    let preparation_started = Instant::now();
+    let streams = lane_seeds.len();
+    let maximum_seed_tokens = lane_seeds.iter().map(Vec::len).max().unwrap_or(0);
+    if maximum_seed_tokens == 0 || lane_seeds.iter().any(Vec::is_empty) {
+        return Err("FAILED: S4 legacy lane seeds must be nonempty".to_owned());
+    }
+    let state_sequence_capacity = maximum_seed_tokens
+        .checked_add(maximum_steps)
+        .ok_or_else(|| "FAILED: S4 legacy state horizon overflow".to_owned())?;
+    let workers = workers.min(streams).max(1);
+    let mut buckets: Vec<Vec<LegacyGenerationTrajectory<'_>>> =
+        (0..workers).map(|_| Vec::new()).collect();
+    for stream in 0..streams {
+        let mut history = Vec::with_capacity(state_sequence_capacity);
+        history.extend_from_slice(&lane_seeds[stream]);
+        buckets[stream % workers].push(LegacyGenerationTrajectory {
+            stream,
+            root_seed: lane_seeds[stream].clone(),
+            history,
+            runtime: Runtime::new(artifacts),
+            output: Vec::with_capacity(maximum_steps),
+        });
+    }
+    let preparation_elapsed_seconds = preparation_started.elapsed().as_secs_f64();
+    begin_generation_wave(
+        "legacy",
+        0,
+        false,
+        streams,
+        maximum_seed_tokens,
+        maximum_steps,
+    )?;
+    parity_check_deadline("S4 legacy causal wave start")?;
+    let occupancy_barrier = Arc::new(std::sync::Barrier::new(workers));
+    let step_barrier = Arc::new(std::sync::Barrier::new(workers + 1));
+    let start_gate = Arc::new(CancellableStartGate::new());
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let failure = Arc::new(Mutex::new(None::<String>));
+    let (mut trajectories, elapsed_by_step) = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (worker, mut bucket) in buckets.into_iter().enumerate() {
+            let worker_start_gate = Arc::clone(&start_gate);
+            let occupancy_barrier = Arc::clone(&occupancy_barrier);
+            let step_barrier = Arc::clone(&step_barrier);
+            let active = Arc::clone(&active);
+            let peak = Arc::clone(&peak);
+            let failure = Arc::clone(&failure);
+            let handle = std::thread::Builder::new()
+                .name(format!("parity-legacy-{worker}"))
+                .spawn_scoped(
+                    scope,
+                    move || -> Result<Vec<LegacyGenerationTrajectory<'_>>, String> {
+                        worker_start_gate.wait()?;
+                        let now_active = active.fetch_add(1, AtomicOrdering::AcqRel) + 1;
+                        peak.fetch_max(now_active, AtomicOrdering::AcqRel);
+                        occupancy_barrier.wait();
+                        for _step in 0..maximum_steps {
+                            let may_run = failure
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .is_none();
+                            if may_run {
+                                let result = std::panic::catch_unwind(
+                                    std::panic::AssertUnwindSafe(|| -> Result<(), String> {
+                                        for trajectory in &mut bucket {
+                                            let window_start =
+                                                trajectory.history.len().saturating_sub(WINDOW);
+                                            let code = trajectory
+                                                .runtime
+                                                .assign_window(&trajectory.history[window_start..]);
+                                            let prediction =
+                                                trajectory.runtime.predict_witness(store, &code);
+                                            trajectory.history.push(prediction.token);
+                                            trajectory.output.push(prediction.token);
+                                        }
+                                        Ok(())
+                                    }),
+                                );
+                                match result {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(reason)) => record_compiled_failure(&failure, reason),
+                                    Err(_) => record_compiled_failure(
+                                        &failure,
+                                        format!("FAILED: legacy causal worker {worker} panicked"),
+                                    ),
+                                }
+                            }
+                            step_barrier.wait();
+                            step_barrier.wait();
+                        }
+                        active.fetch_sub(1, AtomicOrdering::AcqRel);
+                        Ok(bucket)
+                    },
+                );
+            match handle {
+                Ok(handle) => handles.push(handle),
+                Err(error) => {
+                    let reason =
+                        format!("FAILED: create legacy bounded worker {worker}/{workers}: {error}");
+                    start_gate.cancel(reason.clone());
+                    for handle in handles {
+                        let _ = handle.join();
+                    }
+                    return Err(reason);
+                }
+            }
+        }
+        let origin = Instant::now();
+        start_gate.start(origin);
+        let mut elapsed_by_step = Vec::with_capacity(maximum_steps);
+        for completed_steps in 1..=maximum_steps {
+            step_barrier.wait();
+            if let Err(reason) = update_generation_wave(completed_steps) {
+                record_compiled_failure(&failure, reason);
+            }
+            elapsed_by_step.push(origin.elapsed());
+            step_barrier.wait();
+        }
+        let mut trajectories = Vec::with_capacity(streams);
+        for handle in handles {
+            trajectories.extend(
+                handle
+                    .join()
+                    .map_err(|_| "FAILED: legacy bounded worker panicked".to_owned())??,
+            );
+        }
+        if let Some(reason) = failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            return Err(reason);
+        }
+        Ok((trajectories, elapsed_by_step))
+    })?;
+    trajectories.sort_by_key(|trajectory| trajectory.stream);
+    if trajectories.len() != streams
+        || trajectories
+            .iter()
+            .any(|trajectory| trajectory.output.len() != maximum_steps)
+    {
+        return Err(format!(
+            "FAILED: legacy S4 causal wave did not complete all {streams} streams through {maximum_steps} steps"
+        ));
+    }
+    parity_check_deadline("S4 legacy causal wave completion")?;
+    finish_generation_wave("legacy", streams, false)?;
+    let root_seeds = trajectories
+        .iter()
+        .map(|trajectory| trajectory.root_seed.clone())
+        .collect::<Vec<_>>();
+    let outputs = trajectories
+        .iter()
+        .map(|trajectory| trajectory.output.clone())
+        .collect::<Vec<_>>();
+    compiled_generation_samples(
+        "legacy",
+        &root_seeds,
+        &outputs,
+        &elapsed_by_step,
+        preparation_elapsed_seconds,
+        peak.load(AtomicOrdering::Acquire),
+        state_sequence_capacity,
+    )
+}
+
+/// Graph counterpart of [`timed_legacy_causal_wave`]. Each graph state is
+/// parsed once, remains owned by one lane, and advances only that lane's
+/// causal history for the complete wave. `R4g1State` contains mutable policy
+/// state, so sharing one instance between lanes would make results order
+/// dependent even when those lanes happen to share an OS worker.
+fn timed_graph_causal_wave(
+    artifact_bytes: &[u8],
+    lane_seeds: &[Vec<u32>],
+    maximum_steps: usize,
+    workers: usize,
+) -> Result<Vec<GenerationWaveSample>, String> {
+    let preparation_started = Instant::now();
+    let streams = lane_seeds.len();
+    let maximum_seed_tokens = lane_seeds.iter().map(Vec::len).max().unwrap_or(0);
+    if maximum_seed_tokens == 0 || lane_seeds.iter().any(Vec::is_empty) {
+        return Err("FAILED: S4 graph lane seeds must be nonempty".to_owned());
+    }
+    let state_sequence_capacity = maximum_seed_tokens
+        .checked_add(maximum_steps)
+        .ok_or_else(|| "FAILED: S4 graph state horizon overflow".to_owned())?;
+    let workers = workers.min(streams).max(1);
+    let bundle = parity_bundle_dir()?;
+    let mut trajectory_buckets: Vec<Vec<GraphGenerationTrajectory>> =
+        (0..workers).map(|_| Vec::new()).collect();
+    for stream in 0..streams {
+        let mut history = Vec::with_capacity(state_sequence_capacity);
+        history.extend_from_slice(&lane_seeds[stream]);
+        trajectory_buckets[stream % workers].push(GraphGenerationTrajectory {
+            stream,
+            root_seed: lane_seeds[stream].clone(),
+            history,
+            state: load_r4g1(&bundle, artifact_bytes)?,
+            output: Vec::with_capacity(maximum_steps),
+        });
+    }
+    let preparation_elapsed_seconds = preparation_started.elapsed().as_secs_f64();
+    begin_generation_wave(
+        "graph",
+        0,
+        false,
+        streams,
+        maximum_seed_tokens,
+        maximum_steps,
+    )?;
+    parity_check_deadline("S4 graph causal wave start")?;
+    let occupancy_barrier = Arc::new(std::sync::Barrier::new(workers));
+    let step_barrier = Arc::new(std::sync::Barrier::new(workers + 1));
+    let start_gate = Arc::new(CancellableStartGate::new());
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let failure = Arc::new(Mutex::new(None::<String>));
+    let (mut trajectories, elapsed_by_step) = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (worker, mut bucket) in trajectory_buckets.into_iter().enumerate() {
+            let worker_start_gate = Arc::clone(&start_gate);
+            let occupancy_barrier = Arc::clone(&occupancy_barrier);
+            let step_barrier = Arc::clone(&step_barrier);
+            let active = Arc::clone(&active);
+            let peak = Arc::clone(&peak);
+            let failure = Arc::clone(&failure);
+            let handle = std::thread::Builder::new()
+                .name(format!("parity-graph-{worker}"))
+                .spawn_scoped(scope, move || -> Result<Vec<GraphGenerationTrajectory>, String> {
+                    worker_start_gate.wait()?;
+                    let now_active = active.fetch_add(1, AtomicOrdering::AcqRel) + 1;
+                    peak.fetch_max(now_active, AtomicOrdering::AcqRel);
+                    occupancy_barrier.wait();
+                    for _step in 0..maximum_steps {
+                        let may_run = failure
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .is_none();
+                        if may_run {
+                            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                                || -> Result<(), String> {
+                                    for trajectory in &mut bucket {
+                                        let window_start =
+                                            trajectory.history.len().saturating_sub(WINDOW);
+                                        let window = &trajectory.history[window_start..];
+                                        match trajectory
+                                            .state
+                                            .predict_window_status(window)
+                                            .map_err(|error| {
+                                                format!(
+                                                    "FAILED: graph S4 stream {} prediction: {error}",
+                                                    trajectory.stream
+                                                )
+                                            })?
+                                        {
+                                            PredictDecision::Serve(outcome) => {
+                                                if outcome.token == 1 || outcome.token == 2 {
+                                                    return Err(format!(
+                                                        "FAILED: graph S4 stream {} emitted terminal token {} before the complete bounded prefix",
+                                                        trajectory.stream, outcome.token
+                                                    ));
+                                                }
+                                                trajectory.history.push(outcome.token);
+                                                trajectory.output.push(outcome.token);
+                                            }
+                                            PredictDecision::Abstain(outcome) => {
+                                                return Err(format!(
+                                                    "FAILED: graph S4 stream {} abstained before the complete bounded prefix: {outcome:?}",
+                                                    trajectory.stream
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    Ok(())
+                                },
+                            ));
+                            match result {
+                                Ok(Ok(())) => {}
+                                Ok(Err(reason)) => record_compiled_failure(&failure, reason),
+                                Err(_) => record_compiled_failure(
+                                    &failure,
+                                    format!("FAILED: graph causal worker {worker} panicked"),
+                                ),
+                            }
+                        }
+                        step_barrier.wait();
+                        step_barrier.wait();
+                    }
+                    active.fetch_sub(1, AtomicOrdering::AcqRel);
+                    Ok(bucket)
+                });
+            match handle {
+                Ok(handle) => handles.push(handle),
+                Err(error) => {
+                    let reason =
+                        format!("FAILED: create graph bounded worker {worker}/{workers}: {error}");
+                    start_gate.cancel(reason.clone());
+                    for handle in handles {
+                        let _ = handle.join();
+                    }
+                    return Err(reason);
+                }
+            }
+        }
+        let origin = Instant::now();
+        start_gate.start(origin);
+        let mut elapsed_by_step = Vec::with_capacity(maximum_steps);
+        for completed_steps in 1..=maximum_steps {
+            step_barrier.wait();
+            if let Err(reason) = update_generation_wave(completed_steps) {
+                record_compiled_failure(&failure, reason);
+            }
+            elapsed_by_step.push(origin.elapsed());
+            step_barrier.wait();
+        }
+        let mut trajectories = Vec::with_capacity(streams);
+        for handle in handles {
+            trajectories.extend(
+                handle
+                    .join()
+                    .map_err(|_| "FAILED: graph bounded worker panicked".to_owned())??,
+            );
+        }
+        if let Some(reason) = failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            return Err(reason);
+        }
+        Ok((trajectories, elapsed_by_step))
+    })?;
+    trajectories.sort_by_key(|trajectory| trajectory.stream);
+    if trajectories.len() != streams
+        || trajectories
+            .iter()
+            .any(|trajectory| trajectory.output.len() != maximum_steps)
+    {
+        return Err(format!(
+            "FAILED: graph S4 causal wave did not complete all {streams} streams through {maximum_steps} steps"
+        ));
+    }
+    parity_check_deadline("S4 graph causal wave completion")?;
+    finish_generation_wave("graph", streams, false)?;
+    let root_seeds = trajectories
+        .iter()
+        .map(|trajectory| trajectory.root_seed.clone())
+        .collect::<Vec<_>>();
+    let outputs = trajectories
+        .iter()
+        .map(|trajectory| trajectory.output.clone())
+        .collect::<Vec<_>>();
+    compiled_generation_samples(
+        "graph",
+        &root_seeds,
+        &outputs,
+        &elapsed_by_step,
+        preparation_elapsed_seconds,
+        peak.load(AtomicOrdering::Acquire),
+        state_sequence_capacity,
+    )
+}
+
+fn generation_wave_json(sample: &GenerationWaveSample) -> serde_json::Value {
+    serde_json::json!({
+        "wave": sample.wave,
+        "engine": sample.engine,
+        "warmup": sample.warmup,
+        "streams": sample.streams,
+        "retained_prefix_tokens_per_lane": &sample.retained_prefix_tokens_per_lane,
+        "seed_tokens_per_lane": &sample.seed_tokens_per_lane,
+        "generated_tokens": sample.generated_tokens,
+        "cumulative_generated_tokens": sample.cumulative_generated_tokens,
+        "preparation_elapsed_seconds": sample.preparation_elapsed_seconds,
+        "prefill_elapsed_seconds": sample.prefill_elapsed_seconds,
+        "decode_elapsed_seconds": sample.decode_elapsed_seconds,
+        "one_shot_elapsed_seconds": sample.one_shot_elapsed_seconds,
+        "elapsed_seconds": sample.elapsed_seconds,
+        "aggregate_tokens_per_second": sample.aggregate_tps,
+        "peak_active_streams": sample.peak_active_streams,
+        "peak_trajectory_workers": sample.peak_trajectory_workers,
+        "peak_exact_row_workers": sample.peak_exact_row_workers,
+        "private_state_instances": sample.private_state_instances,
+        "state_sequence_capacity": sample.state_sequence_capacity,
+        "completed_stream_records": sample.completed_stream_records,
+        "lane_seed_cids": &sample.lane_seed_cids,
+        "stream_output_cids": &sample.stream_output_cids,
+        "output_cid": &sample.output_cid,
+        "exact_execution_delta": sample.execution_delta,
+        "ordered_reduction": sample.ordered_reduction,
+        "timing_policy": "explicit_preparation_zero_prefill_decode_and_one_shot",
+        "in_flight_progress_included_in_decode_elapsed": true,
+        "post_decode_identity_reduction_included_in_decode_elapsed": false,
+    })
 }
 
 fn parity_skip(w: &R4g1World, scenario: &str) -> bool {
+    if parity_run_finalized() {
+        return true;
+    }
+    parity_begin_scenario(scenario);
     if !w.parity_available {
-        eprintln!("[parity] {scenario}: fixtures absent — vacuous pass");
+        let reason =
+            parity_fixture_error().unwrap_or_else(|| "UNAVAILABLE: fixtures absent".to_owned());
+        eprintln!("[parity] {scenario}: {}", reason);
+        parity_mark_scenario(scenario, parity_status_for_reason(&reason), reason);
         true
     } else {
         false
@@ -3998,9 +8204,21 @@ fn parity_skip(w: &R4g1World, scenario: &str) -> bool {
 
 #[given("the pinned SmolLM2 teacher and compiled transformerless bundle are present")]
 fn parity_fixtures_present(w: &mut R4g1World) {
+    if parity_run_finalized() {
+        w.parity_available = false;
+        return;
+    }
+    if let Err(reason) = parity_run() {
+        w.parity_available = false;
+        eprintln!("[parity] {reason}");
+        return;
+    }
     w.parity_available = with_parity_fixtures(|_| ()).is_some();
     if !w.parity_available {
-        eprintln!("[parity] fixtures absent — scenario vacuously passes (κ-test convention)");
+        eprintln!(
+            "[parity] {}",
+            parity_fixture_error().unwrap_or_else(|| "UNAVAILABLE: fixtures absent".to_owned())
+        );
     }
 }
 
@@ -4009,46 +8227,111 @@ fn parity_record_provenance(w: &mut R4g1World) {
     if parity_skip(w, "S1") {
         return;
     }
-    let source = parity_source_dir();
-    let bundle = parity_bundle_dir();
-    let inputs = [
+    let source = parity_source_dir().unwrap_or_else(|reason| parity_abort_step("S1", reason));
+    let bundle = parity_bundle_dir().unwrap_or_else(|reason| parity_abort_step("S1", reason));
+    let core_inputs = [
         ("teacher_weights", source.join("model.safetensors")),
         ("tla_artifact", bundle.join("tless_artifacts.bin")),
         ("tls_store", bundle.join("tless_store.bin")),
-        ("r4g1_graph", bundle.join("graph/score.r4g1")),
     ];
     let mut kappas = Vec::new();
-    for (label, path) in inputs {
-        let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    for (label, path) in core_inputs {
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                let reason = format!("FAILED: read provenance input {}: {error}", path.display());
+                parity_mark_scenario("S1", RunStatus::Fail, reason);
+                w.parity_kappas = Some(kappas);
+                return;
+            }
+        };
         kappas.push((
             label.to_string(),
             format!("blake3:{}", blake3::hash(&bytes).to_hex()),
         ));
     }
+    let graph_path = bundle.join("graph/score.r4g1");
+    let report_path = bundle.join("graph/score_report.json");
+    if !graph_path.is_file() || !report_path.is_file() {
+        let reason = format!(
+            "UNAVAILABLE: graph provenance inputs absent (graph={}, report={})",
+            graph_path.display(),
+            report_path.display()
+        );
+        parity_mark_scenario("S1", RunStatus::Unavailable, reason);
+        w.parity_kappas = Some(kappas);
+        return;
+    }
+    match std::fs::read(&graph_path) {
+        Ok(bytes) => kappas.push((
+            "r4g1_graph".to_owned(),
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+        )),
+        Err(error) => {
+            parity_mark_scenario(
+                "S1",
+                RunStatus::Fail,
+                format!("FAILED: read graph provenance input: {error}"),
+            );
+        }
+    }
     w.parity_kappas = Some(kappas);
 }
 
-#[then("every parity input carries a blake3 kappa and the graph provenance matches the compiled artifact")]
+#[then(
+    "every parity input carries a blake3 kappa and the graph provenance matches the compiled artifact"
+)]
 fn parity_provenance_checked(w: &mut R4g1World) {
     if parity_skip(w, "S1") {
         return;
     }
+    let bundle = parity_bundle_dir().unwrap_or_else(|reason| parity_abort_step("S1", reason));
     let kappas = w.parity_kappas.as_ref().expect("κ pins recorded");
-    assert_eq!(kappas.len(), 4, "every parity input is content-addressed");
+    if kappas.len() != 4 {
+        return;
+    }
     for (label, kappa) in kappas {
         assert!(
             kappa.starts_with("blake3:"),
             "{label} κ must be a blake3 address"
         );
     }
-    let artifact_kappa = &kappas[1].1;
-    let report: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(parity_bundle_dir().join("graph/score_report.json")).expect("score report"),
-    )
-    .expect("score report parses");
-    let recorded = report["inputs"]["artifact_kappa"]
-        .as_str()
-        .expect("report records an input artifact κ");
+    let artifact_kappa = &kappas
+        .iter()
+        .find(|(label, _)| label == "tla_artifact")
+        .expect("core artifact kappa recorded")
+        .1;
+    let report_path = bundle.join("graph/score_report.json");
+    let report_bytes = match std::fs::read(&report_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            parity_mark_scenario(
+                "S1",
+                RunStatus::Fail,
+                format!("FAILED: read {}: {error}", report_path.display()),
+            );
+            return;
+        }
+    };
+    let report: serde_json::Value = match serde_json::from_slice(&report_bytes) {
+        Ok(report) => report,
+        Err(error) => {
+            parity_mark_scenario(
+                "S1",
+                RunStatus::Fail,
+                format!("FAILED: parse {}: {error}", report_path.display()),
+            );
+            return;
+        }
+    };
+    let Some(recorded) = report["inputs"]["artifact_kappa"].as_str() else {
+        parity_mark_scenario(
+            "S1",
+            RunStatus::Fail,
+            "FAILED: graph score report omitted inputs.artifact_kappa",
+        );
+        return;
+    };
     assert_eq!(
         recorded, artifact_kappa,
         "graph provenance κ must match the compiled artifact κ"
@@ -4066,6 +8349,91 @@ fn parity_provenance_checked(w: &mut R4g1World) {
         "{}",
         serde_json::to_string_pretty(&report_json).expect("json")
     );
+    parity_record_output("S1_provenance", report_json);
+}
+
+#[then(
+    "teacher-free compiled preflight and exact admission are bound to their source and host identities"
+)]
+fn parity_admission_identity_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S1") {
+        return;
+    }
+    let report = read_parity_probe_report().unwrap_or_else(|reason| panic!("{reason}"));
+    assert_eq!(report.schema, EXACT_MULTICORE_PROBE_SCHEMA);
+    assert_eq!(
+        report.executor_contract_cid,
+        exact_executor_contract_cid(),
+        "probe must bind the exact executor bytes compiled into this BDD"
+    );
+    assert_eq!(
+        report.host,
+        exact_probe_host_identity(),
+        "probe host identity/capacity must match the live host"
+    );
+    let snapshot = parity_progress()
+        .snapshot()
+        .unwrap_or_else(|error| panic!("parity progress snapshot: {error}"));
+    let identities = &snapshot.live.metadata.identities;
+    assert_eq!(
+        identities.get("teacher_weights"),
+        Some(&report.source.model_kappa),
+        "probe source κ must match the admitted teacher weights"
+    );
+    assert_eq!(
+        identities.get("teacher_config"),
+        Some(&report.source.config_cid),
+        "probe config CID must match the admitted teacher config"
+    );
+    assert_eq!(
+        identities.get("exact_executor_contract"),
+        Some(&report.executor_contract_cid),
+        "durable run metadata must retain the exact executor identity"
+    );
+    assert_eq!(
+        identities.get("uor_matmul_revision"),
+        Some(&report.backend.uor_matmul_revision),
+        "durable run metadata must retain the exact arithmetic revision"
+    );
+    let fixture = snapshot
+        .live
+        .metadata
+        .fixtures
+        .get("exact_multicore_probe")
+        .expect("probe fixture status recorded");
+    assert!(
+        fixture
+            .cid
+            .as_deref()
+            .is_some_and(|cid| cid.starts_with("blake3:")),
+        "admitted probe report must itself be content-bound"
+    );
+    let preflight = snapshot
+        .live
+        .metadata
+        .fixtures
+        .get("teacher_free_s4_preflight")
+        .expect("teacher-free S4 preflight status recorded");
+    let preflight_cid = preflight
+        .cid
+        .as_deref()
+        .filter(|cid| cid.starts_with("blake3:"))
+        .expect("teacher-free S4 preflight must be available and content-bound");
+    assert_eq!(
+        snapshot
+            .live
+            .metadata
+            .identities
+            .get("teacher_free_s4_preflight")
+            .map(String::as_str),
+        Some(preflight_cid),
+        "durable metadata must bind the exact teacher-free preflight payload"
+    );
+    parity_mark_scenario_pass_if_pending(
+        "S1",
+        "provenance, graph binding, and exact admission identities checked",
+    )
+    .unwrap_or_else(|reason| parity_abort_step("S1", reason));
 }
 
 #[when("the legacy TLS store is replayed against the teacher on pinned prompts")]
@@ -4073,8 +8441,313 @@ fn parity_replay_legacy(w: &mut R4g1World) {
     if parity_skip(w, "S2") {
         return;
     }
-    let budget = parity_budget("R4_PARITY_POSITIONS", 256);
-    w.parity_legacy_metrics = with_parity_fixtures(|fx| teacher_forced_eval(fx, false, budget));
+    let budget = parity_config().positions.get();
+    let result = with_parity_fixtures(|fx| teacher_forced_eval(fx, false, budget))
+        .expect("available fixtures remain loaded")
+        .unwrap_or_else(|reason| panic!("S2 live teacher transcript failed: {reason}"));
+    w.parity_legacy_metrics = Some(result.0);
+    w.parity_transcript_evidence = Some(result.1);
+}
+
+#[then(
+    "the teacher transcript proves full-width private streams and complete exact owner-plan accounting"
+)]
+fn parity_transcript_concurrency_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S2") {
+        return;
+    }
+    let evidence = w
+        .parity_transcript_evidence
+        .as_ref()
+        .expect("S2 recorded transcript evidence");
+    assert!(
+        evidence.cid.starts_with("blake3:"),
+        "teacher transcript is content-bound"
+    );
+    assert_eq!(evidence.positions, evidence.logical_forwards);
+    assert!(evidence.physical_batches > 0);
+    assert!(
+        evidence.physical_batches < evidence.logical_forwards,
+        "multi-stream batching must use fewer physical batches than logical forwards"
+    );
+    let config = parity_config();
+    assert_eq!(
+        evidence.streams_planned,
+        config.streams.get(),
+        "teacher transcript must admit the full configured private-stream cohort"
+    );
+    assert_eq!(
+        evidence.max_active_streams,
+        config.streams.get(),
+        "exact observer must witness the full private-stream cohort in flight"
+    );
+    assert_eq!(
+        evidence.private_state_instances,
+        config.streams.get(),
+        "teacher transcript must allocate one bounded private state per stream"
+    );
+    assert_eq!(
+        evidence.state_sequence_capacities.len(),
+        config.streams.get(),
+        "every private state must retain its exact bounded horizon"
+    );
+    assert!(
+        evidence
+            .state_sequence_capacities
+            .iter()
+            .all(|&capacity| capacity == evidence.generation_state_sequence_capacity),
+        "every transcript state must retain the reusable S4 template horizon"
+    );
+    assert_eq!(
+        evidence.generation_retained_prefix_tokens_per_lane.len(),
+        config.streams.get()
+    );
+    assert_eq!(
+        evidence.generation_logical_seed_tokens_per_lane.len(),
+        config.streams.get()
+    );
+    assert!(evidence
+        .generation_retained_prefix_tokens_per_lane
+        .iter()
+        .all(|&tokens| tokens > 0));
+    assert!(
+        evidence
+            .generation_retained_prefix_tokens_per_lane
+            .iter()
+            .zip(&evidence.generation_logical_seed_tokens_per_lane)
+            .all(|(retained, seed)| *seed == retained + 1),
+        "every matched compiled history adds its transcript-predicted next token"
+    );
+    assert_eq!(
+        evidence.generation_state_sequence_capacity,
+        evidence
+            .generation_retained_prefix_tokens_per_lane
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0)
+            + S4_MAX_DECODE_STEPS,
+        "the reusable teacher templates must cover the longest per-lane adaptive horizon"
+    );
+    assert_eq!(
+        evidence.generation_template_state_cids.len(),
+        config.streams.get()
+    );
+    assert!(
+        evidence
+            .generation_template_state_cids
+            .iter()
+            .all(|cid| cid.starts_with("blake3:")),
+        "every retained teacher state template must be content-bound"
+    );
+    assert_eq!(
+        evidence.generation_template_next_tokens.len(),
+        config.streams.get()
+    );
+    validate_private_multistream_evidence(
+        &evidence.stream_seed_cids,
+        &evidence.stream_output_cids,
+        config.streams.get(),
+    )
+    .unwrap_or_else(|error| panic!("transcript private-stream evidence: {error}"));
+    assert!(
+        evidence.execution.effective_workers > 1 && evidence.peak_active_row_workers > 1,
+        "exact output-row work must use multiple bounded workers"
+    );
+    assert!(
+        evidence.peak_active_row_workers <= evidence.execution.effective_workers,
+        "observed worker concurrency exceeded its configured bound"
+    );
+    let owner = &evidence.owner_plan;
+    let actual = &evidence.execution;
+    assert_eq!(owner.forward_calls, evidence.physical_batches as u64);
+    assert_eq!(
+        owner
+            .full_width_forward_calls
+            .saturating_add(owner.tail_forward_calls),
+        owner.forward_calls
+    );
+    assert!(
+        owner.full_width_forward_calls > 0,
+        "transcript must contain a witnessed full-width physical forward"
+    );
+    assert!(owner.minimum_batch_width > 0);
+    assert_eq!(owner.streams, evidence.logical_forwards as u64);
+    assert_eq!(actual.forward_calls, owner.forward_calls);
+    assert_eq!(actual.streams_started, owner.streams);
+    assert_eq!(actual.streams_completed, owner.streams);
+    assert_eq!(actual.active_streams, 0);
+    assert_eq!(actual.active_workers, 0);
+    assert_eq!(actual.matrix_calls, owner.matrix_calls);
+    assert_eq!(actual.batched_matrix_calls, owner.batched_matrix_calls);
+    assert_eq!(actual.max_matrix_batch_width, owner.max_matrix_batch_width);
+    assert_eq!(actual.tiles_completed, owner.row_tiles);
+    assert_eq!(owner.worker_tasks, owner.row_tiles);
+    assert_eq!(actual.output_cells_completed, owner.output_cells);
+    assert_eq!(actual.scalar_terms_completed, owner.scalar_terms);
+    assert_eq!(actual.multiworker_forward_calls, actual.forward_calls);
+    assert!(evidence.execution_preparation.backend_exercised);
+    assert_eq!(
+        evidence.execution_preparation.batch_width,
+        config.streams.get()
+    );
+    assert!(evidence.execution_preparation.workers_observed > 1);
+    assert!(evidence.execution_preparation.workspace_capacity_bytes > 0);
+    assert!(evidence.execution_preparation.workspace_growth_events > 0);
+    assert!(evidence.execution_preparation.workspace_growth_bytes > 0);
+    assert_eq!(evidence.first_forward_workspace_growth_events, 0);
+    assert_eq!(evidence.first_forward_workspace_growth_bytes, 0);
+    assert_eq!(evidence.steady_state_workspace_growth_events, 0);
+    assert_eq!(evidence.steady_state_workspace_growth_bytes, 0);
+    assert_eq!(
+        actual.workspace_growth_events,
+        evidence.first_forward_workspace_growth_events
+    );
+    assert_eq!(
+        actual.workspace_growth_bytes,
+        evidence.first_forward_workspace_growth_bytes
+    );
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "suite": "teacher_parity_benchmarks",
+            "scenario": "S2 exact-parallel transcript",
+            "transcript_cid": evidence.cid,
+            "logical_forwards": evidence.logical_forwards,
+            "physical_batches": evidence.physical_batches,
+            "streams_planned": evidence.streams_planned,
+            "max_active_streams": evidence.max_active_streams,
+            "peak_active_row_workers": evidence.peak_active_row_workers,
+            "private_state_instances": evidence.private_state_instances,
+            "state_sequence_capacities": evidence.state_sequence_capacities,
+            "stream_seed_cids": evidence.stream_seed_cids,
+            "stream_output_cids": evidence.stream_output_cids,
+            "generation_retained_prefix_tokens_per_lane": evidence.generation_retained_prefix_tokens_per_lane,
+            "generation_logical_seed_tokens_per_lane": evidence.generation_logical_seed_tokens_per_lane,
+            "generation_state_sequence_capacity": evidence.generation_state_sequence_capacity,
+            "generation_template_state_cids": evidence.generation_template_state_cids,
+            "generation_template_next_tokens": evidence.generation_template_next_tokens,
+            "execution_preparation": evidence.execution_preparation,
+            "first_forward_workspace_growth_events": evidence.first_forward_workspace_growth_events,
+            "first_forward_workspace_growth_bytes": evidence.first_forward_workspace_growth_bytes,
+            "steady_state_workspace_growth_events": evidence.steady_state_workspace_growth_events,
+            "steady_state_workspace_growth_bytes": evidence.steady_state_workspace_growth_bytes,
+            "owner_plan": evidence.owner_plan,
+            "cohort_tail_policy": "full width while prompt horizons overlap; deterministic smaller tail batches only after shorter prompt streams complete; every physical forward proves actual nonserial exact-row overlap within the selected worker bound",
+            "cache_hits": evidence.cache_hits,
+            "execution": evidence.execution,
+        }))
+        .expect("json")
+    );
+    parity_record_measurement(
+        "S2_execution_observability",
+        serde_json::json!({
+            "max_active_streams": evidence.max_active_streams,
+            "peak_active_row_workers": evidence.peak_active_row_workers,
+            "execution_preparation": evidence.execution_preparation,
+            "first_forward_workspace_growth_events": evidence.first_forward_workspace_growth_events,
+            "first_forward_workspace_growth_bytes": evidence.first_forward_workspace_growth_bytes,
+            "steady_state_workspace_growth_events": evidence.steady_state_workspace_growth_events,
+            "steady_state_workspace_growth_bytes": evidence.steady_state_workspace_growth_bytes,
+            "owner_plan": evidence.owner_plan,
+            "execution_snapshot": evidence.execution,
+        }),
+    );
+    parity_record_output(
+        "S2_transcript",
+        serde_json::json!({
+            "transcript_cid": evidence.cid,
+            "logical_forwards": evidence.logical_forwards,
+            "physical_batches": evidence.physical_batches,
+            "streams_planned": evidence.streams_planned,
+            "private_state_instances": evidence.private_state_instances,
+            "state_sequence_capacities": evidence.state_sequence_capacities,
+            "stream_seed_cids": evidence.stream_seed_cids,
+            "stream_output_cids": evidence.stream_output_cids,
+            "generation_retained_prefix_tokens_per_lane": evidence.generation_retained_prefix_tokens_per_lane,
+            "generation_logical_seed_tokens_per_lane": evidence.generation_logical_seed_tokens_per_lane,
+            "generation_state_sequence_capacity": evidence.generation_state_sequence_capacity,
+            "generation_template_state_cids": evidence.generation_template_state_cids,
+            "generation_template_next_tokens": evidence.generation_template_next_tokens,
+            "cohort_tail_policy": "full width while prompt horizons overlap; deterministic smaller tail batches only after shorter prompt streams complete; every physical forward proves actual nonserial exact-row overlap within the selected worker bound",
+            "exact_work": deterministic_teacher_execution(evidence.execution),
+        }),
+    );
+}
+
+#[then("every configured exact trace row has canonical deterministic evidence")]
+fn parity_exact_trace_rows_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S2") {
+        return;
+    }
+    let report = read_parity_probe_report().unwrap_or_else(|reason| panic!("{reason}"));
+    assert!(
+        report.exact_equality,
+        "probe aggregate exact equality must hold"
+    );
+    assert_eq!(report.probe_positions, report.probe_position_indices.len());
+    let reference = report
+        .runs
+        .iter()
+        .find(|run| run.workers == report.reference_workers)
+        .expect("probe includes its canonical reference trace");
+    assert!(reference.output_trace_cid.starts_with("blake3:"));
+    assert!(
+        report
+            .probe_position_indices
+            .iter()
+            .all(|&position| { position + 1 == reference.trace_shape.sequence_capacity }),
+        "every configured trace row must exercise the canonical worst-horizon position"
+    );
+    let expected_records = u64::try_from(report.probe_positions)
+        .unwrap_or(u64::MAX)
+        .saturating_mul(u64::try_from(report.probe_streams).unwrap_or(u64::MAX));
+    for run in &report.runs {
+        assert_eq!(run.trace_shape, reference.trace_shape);
+        assert_eq!(run.trace_shape.positions, report.probe_positions);
+        assert_eq!(run.trace_shape.streams_per_position, report.probe_streams);
+        assert_eq!(run.trace_shape.state_records, expected_records);
+        assert_eq!(run.trace_shape.greedy_tokens, expected_records);
+        assert_eq!(
+            run.trace_shape.top_tokens,
+            expected_records.saturating_mul(run.trace_shape.top_k as u64)
+        );
+        assert_eq!(
+            run.trace_shape.logit_bytes,
+            run.trace_shape.logit_words.saturating_mul(4)
+        );
+        assert!(run.equal_to_reference);
+        assert_eq!(run.output_trace_cid, reference.output_trace_cid);
+    }
+    parity_record_measurement(
+        "exact_probe_worker_rows",
+        serde_json::json!({
+            "schema": report.schema,
+            "reference_workers": report.reference_workers,
+            "configured_execution": report.configured_execution,
+            "worker_rows": report.runs.iter().map(|run| serde_json::json!({
+                "workers": run.workers,
+                "forward_plan": run.forward_plan,
+                "output_trace_cid": run.output_trace_cid,
+                "equal_to_reference": run.equal_to_reference,
+            })).collect::<Vec<_>>(),
+        }),
+    );
+    parity_record_output(
+        "exact_probe_trace",
+        serde_json::json!({
+            "schema": report.schema,
+            "probe_position_indices": report.probe_position_indices,
+            "trace_shape": reference.trace_shape,
+            "canonical_output_trace_cid": reference.output_trace_cid,
+            "exact_equality": report.exact_equality,
+        }),
+    );
+    parity_mark_scenario_pass_if_pending(
+        "S2",
+        "legacy criteria, exact transcript accounting, and canonical trace rows checked",
+    )
+    .unwrap_or_else(|reason| parity_abort_step("S2", reason));
 }
 
 #[then("the legacy store parity metrics meet the pinned empirical criteria")]
@@ -4122,11 +8795,20 @@ fn parity_replay_graph(w: &mut R4g1World) {
     }
     let has_graph = with_parity_fixtures(|fx| fx.r4g1.is_some()).unwrap_or(false);
     if !has_graph {
-        eprintln!("[parity] S3: graph unavailable — vacuous pass");
+        eprintln!("[parity] S3: graph evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S3",
+            RunStatus::Unavailable,
+            "R4G1 graph fixture is unavailable",
+        );
         return;
     }
-    let budget = parity_budget("R4_PARITY_POSITIONS", 256);
-    w.parity_graph_metrics = with_parity_fixtures(|fx| teacher_forced_eval(fx, true, budget));
+    let budget = parity_config().positions.get();
+    let result = with_parity_fixtures(|fx| teacher_forced_eval(fx, true, budget))
+        .expect("available fixtures remain loaded")
+        .unwrap_or_else(|reason| panic!("S3 shared teacher transcript failed: {reason}"));
+    w.parity_graph_metrics = Some(result.0);
+    w.parity_transcript_evidence = Some(result.1);
 }
 
 #[then("the R4G1 graph parity metrics meet the pinned empirical criteria")]
@@ -4135,7 +8817,12 @@ fn parity_graph_checked(w: &mut R4g1World) {
         return;
     }
     let Some(m) = w.parity_graph_metrics else {
-        eprintln!("[parity] S3: graph unavailable — vacuous pass");
+        eprintln!("[parity] S3: graph evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S3",
+            RunStatus::Unavailable,
+            "graph replay produced no measurement",
+        );
         return;
     };
     let report_json = serde_json::json!({
@@ -4177,7 +8864,7 @@ fn parity_graph_abstains_checked(w: &mut R4g1World) {
         return;
     }
     let Some(m) = w.parity_graph_metrics else {
-        eprintln!("[parity] S3: graph unavailable — vacuous pass");
+        eprintln!("[parity] S3: graph evidence UNAVAILABLE");
         return;
     };
     assert!(
@@ -4185,6 +8872,18 @@ fn parity_graph_abstains_checked(w: &mut R4g1World) {
         "graph abstentions {} above pinned bound {GRAPH_ABSTAIN_BOUND}",
         m.abstains
     );
+    parity_record_output(
+        "S3_graph",
+        serde_json::json!({
+            "positions": m.positions,
+            "abstains": m.abstains,
+            "top1_agreement": m.top1_agreement,
+            "top8_recall": m.top8_recall,
+            "mean_delta_bits": m.mean_delta_bits,
+            "teacher_bits_per_token": m.teacher_bits_per_token,
+        }),
+    );
+    parity_mark_scenario("S3", RunStatus::Pass, "graph parity criteria checked");
 }
 
 #[when("the certifier FMM candidate is replayed against the teacher on pinned prompts")]
@@ -4196,13 +8895,32 @@ fn parity_replay_fmm(w: &mut R4g1World) {
         with_parity_fixtures(|fx| fx.fmm.is_some() && fx.fmm_fixed.is_some() && fx.r4g1.is_some())
             .unwrap_or(false);
     if !has_fmm {
-        eprintln!("[parity] S7: FMM candidate unavailable — vacuous pass");
+        eprintln!("[parity] S7: FMM candidate evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S7",
+            RunStatus::Unavailable,
+            "FMM candidate or prerequisite graph is unavailable",
+        );
         return;
     }
-    let budget = parity_budget("R4_FMM_POSITIONS", 256);
-    w.parity_fmm_metrics = with_parity_fixtures(|fx| fmm_teacher_forced_eval(fx, budget)).flatten();
+    let budget = parity_config().fmm_positions.get();
+    w.parity_fmm_metrics = with_parity_fixtures(|fx| fmm_teacher_forced_eval(fx, budget))
+        .unwrap_or_else(|| Err("FAILED: S7 fixtures disappeared during FMM replay".to_owned()))
+        .unwrap_or_else(|reason| parity_abort_step("S7", reason));
     w.parity_fmm_fixed_metrics =
-        with_parity_fixtures(|fx| fmm_fixed_teacher_forced_eval(fx, budget)).flatten();
+        with_parity_fixtures(|fx| fmm_fixed_teacher_forced_eval(fx, budget))
+            .unwrap_or_else(|| {
+                Err("FAILED: S7 fixtures disappeared during fixed FMM replay".to_owned())
+            })
+            .unwrap_or_else(|reason| parity_abort_step("S7", reason));
+    w.parity_transcript_evidence = with_parity_fixtures(|fx| {
+        fx.transcripts.values().next().map(|transcript| {
+            let mut evidence = transcript.evidence.clone();
+            evidence.cache_hits = fx.transcript_cache_hits;
+            evidence
+        })
+    })
+    .flatten();
     if let Some(metrics) = w.parity_fmm_metrics {
         let (rank, retained_energy, float_storage, fixed_storage, factor_bits) =
             with_parity_fixtures(|fx| {
@@ -4221,7 +8939,9 @@ fn parity_replay_fmm(w: &mut R4g1World) {
             })
             .flatten()
             .unwrap_or((0, 0.0, 0, 0, 0));
-        let fixed = w.parity_fmm_fixed_metrics.expect("fixed FMM measured");
+        let fixed = w.parity_fmm_fixed_metrics.unwrap_or_else(|| {
+            parity_abort_step("S7", "FAILED: fixed FMM replay produced no measurement")
+        });
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -4247,7 +8967,9 @@ fn parity_replay_fmm(w: &mut R4g1World) {
                 "budget": budget,
                 "decision_rule": "measurement_only; compare against S3 before considering promotion"
             }))
-            .expect("json")
+            .unwrap_or_else(|error| {
+                parity_abort_step("S7", format!("FAILED: serialize S7 measurement: {error}"))
+            })
         );
     }
 }
@@ -4258,19 +8980,65 @@ fn parity_fmm_checked(w: &mut R4g1World) {
         return;
     }
     let Some(metrics) = w.parity_fmm_metrics else {
-        eprintln!("[parity] S7: FMM candidate unavailable — vacuous pass");
+        eprintln!("[parity] S7: FMM candidate evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S7",
+            RunStatus::Unavailable,
+            "FMM candidate returned no scorable novel-context measurement",
+        );
         return;
     };
-    assert!(
-        metrics.positions > 0,
-        "FMM replay covered at least one position"
+    if metrics.positions == 0 {
+        parity_abort_step("S7", "FAILED: FMM replay covered zero positions");
+    }
+    if !metrics.teacher_bits_per_token.is_finite() {
+        parity_abort_step("S7", "FAILED: FMM replay produced non-finite bits/token");
+    }
+    let fixed = w.parity_fmm_fixed_metrics.unwrap_or_else(|| {
+        parity_abort_step("S7", "FAILED: fixed FMM replay produced no measurement")
+    });
+    if fixed.positions == 0 {
+        parity_abort_step("S7", "FAILED: fixed FMM replay covered zero positions");
+    }
+    if !fixed.teacher_bits_per_token.is_finite() {
+        parity_abort_step(
+            "S7",
+            "FAILED: fixed FMM replay produced non-finite bits/token",
+        );
+    }
+    parity_record_output(
+        "S7_fmm",
+        serde_json::json!({
+            "float": {
+                "positions": metrics.positions,
+                "top1_agreement": metrics.top1_agreement,
+                "top8_recall": metrics.top8_recall,
+                "teacher_bits_per_token": metrics.teacher_bits_per_token,
+            },
+            "fixed": {
+                "positions": fixed.positions,
+                "top1_agreement": fixed.top1_agreement,
+                "top8_recall": fixed.top8_recall,
+                "teacher_bits_per_token": fixed.teacher_bits_per_token,
+            }
+        }),
     );
-    assert!(metrics.teacher_bits_per_token.is_finite());
-    let fixed = w
-        .parity_fmm_fixed_metrics
-        .expect("fixed FMM replay measured");
-    assert!(fixed.positions > 0);
-    assert!(fixed.teacher_bits_per_token.is_finite());
+}
+
+#[then(
+    "the parity run writes versioned event report evidence and probe artifacts, flushes durable in-flight progress at cadence, and records a machine-readable final status"
+)]
+fn parity_final_status_written(_w: &mut R4g1World) {
+    // This is S7's last checked step. The pending sentinel is promoted only
+    // here; finalize_parity_run performs all path/probe/event/cadence readback
+    // before it can publish a canonical PASS companion pair.
+    parity_mark_scenario_pass_if_pending(
+        "S7",
+        "FMM measurements and versioned terminal evidence checked",
+    )
+    .unwrap_or_else(|reason| parity_abort_step("S7", reason));
+    let status = finalize_parity_run().unwrap_or_else(|reason| panic!("{reason}"));
+    eprintln!("[parity] final status {}", status.as_str());
 }
 
 #[when("free-running generation is timed for the teacher and both compiled runtimes")]
@@ -4278,80 +9046,654 @@ fn parity_time_generation(w: &mut R4g1World) {
     if parity_skip(w, "S4") {
         return;
     }
-    let gen_tokens = parity_budget("R4_PARITY_GEN_TOKENS", 128);
-    let runs = parity_budget("R4_PARITY_RUNS", 3);
-    w.parity_speed = with_parity_fixtures(|fx| {
-        let seed = fx.tokenizer.encode(PARITY_PROMPTS[0]);
-        // Warm-up (untimed): first-touch buffers for every engine.
-        let _ = timed_teacher_generate(fx, &seed, 8);
-        let _ = timed_legacy_generate(fx, &seed, 8);
-        let _ = timed_graph_generate(fx, &seed, 8);
-        let teacher_samples: Vec<f64> = (0..runs)
-            .map(|_| timed_teacher_generate(fx, &seed, gen_tokens))
-            .collect();
-        let legacy_samples: Vec<f64> = (0..runs)
-            .map(|_| timed_legacy_generate(fx, &seed, gen_tokens))
-            .collect();
-        let graph_samples: Vec<f64> = (0..runs)
-            .filter_map(|_| timed_graph_generate(fx, &seed, gen_tokens))
-            .collect();
-        let teacher_tps = median(teacher_samples);
-        let legacy_tps = median(legacy_samples);
-        let graph_tps = if graph_samples.is_empty() {
-            eprintln!("[parity] S4: graph generated nothing — ratio recorded as 0");
-            0.0
-        } else {
-            median(graph_samples)
+    let config = parity_config();
+    let gen_tokens = config.gen_tokens.get();
+    let streams = config.streams.get();
+    let result = with_parity_fixtures(|fx| -> Result<ParitySpeed, String> {
+        if fx.r4g1.is_none() {
+            return Err(
+                "UNAVAILABLE: S4 graph fixture absent; exact teacher continuation not launched"
+                    .to_owned(),
+            );
+        }
+        let master_budget = config.positions.get().max(config.fmm_positions.get());
+        let transcript = teacher_transcript(fx, master_budget)?;
+        let lane_seeds = matched_generation_lane_seeds(&transcript)?;
+        parity_emit(EventKind::PhaseStarted)
+            .map_err(|error| format!("FAILED: S4 phase start event: {error}"))?;
+        let graph_available = true;
+        // Both cheap compiled engines must first prove that the exact matched
+        // seeds can produce the complete bounded continuation. Each engine is
+        // prepared once and executes one max-eight causal pass; checkpoint
+        // rates and CIDs below are prefixes of that one pass. Only after both
+        // succeed do we clone and advance any live-teacher state.
+        let legacy_samples = timed_legacy_causal_wave(
+            &fx.artifacts,
+            &fx.store,
+            &lane_seeds,
+            gen_tokens,
+            config.workers.get(),
+        )?;
+        let graph_samples = timed_graph_causal_wave(
+            &fx.artifact_bytes,
+            &lane_seeds,
+            gen_tokens,
+            config.workers.get(),
+        )?;
+        let checkpoints = adaptive_decode_checkpoints(gen_tokens);
+        if legacy_samples.len() != checkpoints.len() || graph_samples.len() != checkpoints.len() {
+            return Err("FAILED: compiled S4 causal waves omitted an adaptive checkpoint".to_owned());
+        }
+        let mut teacher_cohort = prepare_teacher_generation(&transcript)?;
+        let mut teacher_samples = Vec::with_capacity(4);
+        let mut adaptive_decisions = Vec::with_capacity(4);
+        let mut legacy_wave_ratios = Vec::with_capacity(4);
+        let mut graph_wave_ratios = Vec::with_capacity(4);
+        let mut target_steps = 1usize;
+        let stop_reason = loop {
+            let stage = teacher_samples.len();
+            parity_check_deadline("S4 adaptive causal-stage admission")?;
+            teacher_samples.push(timed_teacher_decode_to(
+                &fx.teacher,
+                &mut teacher_cohort,
+                target_steps,
+                stage,
+            )?);
+            if checkpoints.get(stage).copied() != Some(target_steps) {
+                return Err(format!(
+                    "FAILED: adaptive stage {stage} requested {target_steps} steps outside the compiled causal checkpoints"
+                ));
+            }
+            let teacher_elapsed = teacher_samples
+                .iter()
+                .map(|sample| sample.decode_elapsed_seconds)
+                .sum::<f64>();
+            let teacher_tps =
+                (target_steps * streams) as f64 / teacher_elapsed.max(f64::MIN_POSITIVE);
+            let legacy_tps = legacy_samples[stage].aggregate_tps;
+            let graph_tps = graph_samples[stage].aggregate_tps;
+            let legacy_ratio = legacy_tps / teacher_tps;
+            let graph_ratio = graph_tps / teacher_tps;
+            legacy_wave_ratios.push(legacy_ratio);
+            graph_wave_ratios.push(graph_ratio);
+            let decision =
+                adaptive_decode_decision(target_steps, gen_tokens, legacy_ratio, graph_ratio);
+            adaptive_decisions.push(serde_json::json!({
+                "stage": stage,
+                "cumulative_decode_steps_per_lane": target_steps,
+                "teacher_decode_tokens_per_second": teacher_tps,
+                "legacy_decode_tokens_per_second": legacy_tps,
+                "graph_decode_tokens_per_second": graph_tps,
+                "legacy_over_teacher": legacy_ratio,
+                "graph_over_teacher": graph_ratio,
+                "early_stop_ratio": ADAPTIVE_EARLY_STOP_RATIO,
+                "acceptance_ratio": ADAPTIVE_ACCEPTANCE_RATIO,
+                "decision": decision.as_str(),
+            }));
+            if decision.is_terminal() {
+                break decision.as_str().to_owned();
+            }
+            target_steps = target_steps.saturating_mul(2).min(gen_tokens);
         };
-        ParitySpeed {
+        for _ in 0..streams {
+            parity_counters().record_stream_completed();
+        }
+        for template in &transcript.generation_templates {
+            if template.state.persistent_state_cid() != template.persistent_state_cid {
+                return Err(format!(
+                    "FAILED: S4 mutated transcript-owned template for prompt {}",
+                    template.prompt
+                ));
+            }
+        }
+        let teacher_elapsed = teacher_samples
+            .iter()
+            .map(|sample| sample.decode_elapsed_seconds)
+            .sum::<f64>();
+        let teacher_tps = (target_steps * streams) as f64 / teacher_elapsed.max(f64::MIN_POSITIVE);
+        let selected_stage = teacher_samples.len().saturating_sub(1);
+        let legacy_tps = legacy_samples[selected_stage].aggregate_tps;
+        let graph_tps = graph_samples[selected_stage].aggregate_tps;
+        let reduced_plan = parity_work_plan(
+            &fx.teacher,
+            &fx.tokenizer,
+            &config,
+            target_steps,
+            graph_available,
+            fx.fmm.is_some() && fx.fmm_fixed.is_some() && graph_available,
+        )?;
+        parity_counters()
+            .reduce_plan(reduced_plan)
+            .map_err(|error| format!("FAILED: close adaptive S4 work plan: {error}"))?;
+        parity_emit(EventKind::PhaseCompleted)
+            .map_err(|error| format!("FAILED: S4 phase completion event: {error}"))?;
+        Ok(ParitySpeed {
             teacher_tps,
             legacy_tps,
             graph_tps,
+            teacher_total_tps: teacher_tps,
+            legacy_total_tps: legacy_tps,
+            graph_total_tps: graph_tps,
             legacy_ratio: legacy_tps / teacher_tps,
             graph_ratio: graph_tps / teacher_tps,
+            legacy_wave_ratios,
+            graph_wave_ratios,
+            streams,
+            runs: 1,
+            teacher_logical_forwards: teacher_samples
+                .iter()
+                .map(|sample| {
+                    sample
+                        .execution_delta
+                        .as_ref()
+                        .map_or(0, |delta| delta.streams_completed as usize)
+                })
+                .sum(),
+            teacher_physical_batches: teacher_samples
+                .iter()
+                .map(|sample| {
+                    sample
+                        .execution_delta
+                        .as_ref()
+                        .map_or(0, |delta| delta.forward_calls as usize)
+                })
+                .sum(),
+            teacher_max_active_workers: teacher_samples
+                .iter()
+                .map(|sample| sample.peak_exact_row_workers)
+                .max()
+                .unwrap_or(0),
+            teacher_waves: teacher_samples,
+            legacy_waves: legacy_samples,
+            graph_waves: graph_samples,
+            warmup: Vec::new(),
+            adaptive_decisions,
+            stop_reason,
+            decoded_steps_per_lane: target_steps,
+            compiled_precomputed_steps_per_lane: gen_tokens,
+            legacy_runtime_preparations: streams,
+            graph_state_preparations: streams,
+            compiled_worker_cohorts_per_engine: 1,
+            compiled_full_ceiling_verified_before_teacher: true,
+            teacher_template_state_cids: teacher_cohort.template_state_cids.clone(),
+            teacher_execution_preparation: fx.teacher_execution_preparation,
+            teacher_preparation_elapsed_seconds: teacher_cohort.preparation_elapsed_seconds,
+            teacher_prefill_logical_forwards: 0,
+            ordered_reduction: true,
+        })
+    })
+    .expect("available fixtures remain loaded");
+    match result {
+        Ok(speed) => {
+            parity_record_measurement(
+                "S4_generation",
+                serde_json::json!({
+                    "teacher_waves": speed.teacher_waves.iter().map(generation_wave_json).collect::<Vec<_>>(),
+                    "legacy_waves": speed.legacy_waves.iter().map(generation_wave_json).collect::<Vec<_>>(),
+                    "graph_waves": speed.graph_waves.iter().map(generation_wave_json).collect::<Vec<_>>(),
+                    "warmup_waves": speed.warmup.iter().map(generation_wave_json).collect::<Vec<_>>(),
+                    "final_cumulative_decode_tokens_per_second": {
+                        "teacher": speed.teacher_tps,
+                        "legacy": speed.legacy_tps,
+                        "graph": speed.graph_tps,
+                    },
+                    "selected_decode_tokens_per_second": {
+                        "teacher": speed.teacher_total_tps,
+                        "legacy": speed.legacy_total_tps,
+                        "graph": speed.graph_total_tps,
+                    },
+                    "paired_wave_ratios": {
+                        "legacy_over_teacher": &speed.legacy_wave_ratios,
+                        "graph_over_teacher": &speed.graph_wave_ratios,
+                    },
+                    "adaptive_decisions": &speed.adaptive_decisions,
+                    "stop_reason": &speed.stop_reason,
+                    "decoded_steps_per_lane": speed.decoded_steps_per_lane,
+                    "compiled_precomputed_steps_per_lane": speed.compiled_precomputed_steps_per_lane,
+                    "legacy_runtime_preparations": speed.legacy_runtime_preparations,
+                    "graph_state_preparations": speed.graph_state_preparations,
+                    "compiled_worker_cohorts_per_engine": speed.compiled_worker_cohorts_per_engine,
+                    "compiled_full_ceiling_verified_before_teacher": speed.compiled_full_ceiling_verified_before_teacher,
+                    "teacher_template_state_cids": &speed.teacher_template_state_cids,
+                    "teacher_execution_preparation": speed.teacher_execution_preparation,
+                    "teacher_preparation_elapsed_seconds": speed.teacher_preparation_elapsed_seconds,
+                    "teacher_prefill_logical_forwards": speed.teacher_prefill_logical_forwards,
+                    "timing_policy": "one_preparation_and_one_causal_cohort_per_engine_with_cumulative_prefix_checkpoints",
+                    "in_flight_progress_included_in_decode_elapsed": true,
+                    "post_decode_identity_reduction_included_in_decode_elapsed": false,
+                    "ordered_reduction": speed.ordered_reduction,
+                }),
+            );
+            w.parity_speed = Some(speed);
         }
-    });
+        Err(reason) => {
+            fail_generation_progress(&reason);
+            parity_abort_step("S4", reason)
+        }
+    }
 }
 
-#[then("both compiled runtimes sustain a higher token rate than the teacher")]
+#[then("the measured concurrent token rate of both compiled runtimes is higher than the teacher")]
 fn parity_speed_checked(w: &mut R4g1World) {
     if parity_skip(w, "S4") {
         return;
     }
-    let s = w.parity_speed.expect("speed benchmark ran");
+    let s = w.parity_speed.as_ref().expect("speed benchmark ran");
     let report_json = serde_json::json!({
         "suite": "teacher_parity_benchmarks",
         "scenario": "S4 speed",
         "teacher_tokens_per_sec": s.teacher_tps,
         "legacy_tokens_per_sec": s.legacy_tps,
         "graph_tokens_per_sec": s.graph_tps,
+        "teacher_total_tokens_over_sum_intervals_per_sec": s.teacher_total_tps,
+        "legacy_total_tokens_over_sum_intervals_per_sec": s.legacy_total_tps,
+        "graph_total_tokens_over_sum_intervals_per_sec": s.graph_total_tps,
         "legacy_ratio": s.legacy_ratio,
         "graph_ratio": s.graph_ratio,
+        "legacy_paired_wave_ratios": &s.legacy_wave_ratios,
+        "graph_paired_wave_ratios": &s.graph_wave_ratios,
         "ratio_floor": SPEED_RATIO_FLOOR,
+        "streams": s.streams,
+        "runs": s.runs,
+        "teacher_logical_forwards": s.teacher_logical_forwards,
+        "teacher_physical_batches": s.teacher_physical_batches,
+        "teacher_max_active_workers": s.teacher_max_active_workers,
+        "decoded_steps_per_lane": s.decoded_steps_per_lane,
+        "compiled_precomputed_steps_per_lane": s.compiled_precomputed_steps_per_lane,
+        "legacy_runtime_preparations": s.legacy_runtime_preparations,
+        "graph_state_preparations": s.graph_state_preparations,
+        "compiled_worker_cohorts_per_engine": s.compiled_worker_cohorts_per_engine,
+        "compiled_full_ceiling_verified_before_teacher": s.compiled_full_ceiling_verified_before_teacher,
+        "teacher_execution_preparation": s.teacher_execution_preparation,
+        "stop_reason": s.stop_reason,
+        "adaptive_decisions": s.adaptive_decisions,
+        "teacher_prefill_logical_forwards": s.teacher_prefill_logical_forwards,
+        "timing_policy": "one_preparation_and_one_causal_cohort_per_engine_with_cumulative_prefix_checkpoints",
+        "in_flight_progress_included_in_decode_elapsed": true,
+        "post_decode_identity_reduction_included_in_decode_elapsed": false,
     });
     println!(
         "{}",
         serde_json::to_string_pretty(&report_json).expect("json")
     );
-    assert!(
-        s.legacy_ratio > SPEED_RATIO_FLOOR,
-        "legacy compiled token rate {:.1} tok/s not above teacher {:.1} tok/s (ratio {:.2})",
-        s.legacy_tps,
-        s.teacher_tps,
-        s.legacy_ratio
-    );
+    if s.legacy_ratio <= SPEED_RATIO_FLOOR {
+        parity_abort_step(
+            "S4",
+            format!(
+                "FAILED: S4 legacy speed NOT_ESTABLISHED after {} steps: {:.1} tok/s vs teacher {:.1} tok/s (ratio {:.2})",
+                s.decoded_steps_per_lane, s.legacy_tps, s.teacher_tps, s.legacy_ratio
+            ),
+        );
+    }
     let graph_available = with_parity_fixtures(|fx| fx.r4g1.is_some()).unwrap_or(false);
     if graph_available {
-        assert!(
-            s.graph_ratio > SPEED_RATIO_FLOOR,
-            "graph compiled token rate {:.1} tok/s not above teacher {:.1} tok/s (ratio {:.2})",
-            s.graph_tps,
-            s.teacher_tps,
-            s.graph_ratio
-        );
+        if s.graph_ratio <= SPEED_RATIO_FLOOR {
+            parity_abort_step(
+                "S4",
+                format!(
+                    "FAILED: S4 graph speed NOT_ESTABLISHED after {} steps: {:.1} tok/s vs teacher {:.1} tok/s (ratio {:.2})",
+                    s.decoded_steps_per_lane, s.graph_tps, s.teacher_tps, s.graph_ratio
+                ),
+            );
+        }
     } else {
         eprintln!("[parity] S4: graph unavailable — graph ratio skipped");
     }
+}
+
+#[then("the speed report covers distinct lane identities and matched full-width workloads")]
+fn parity_speed_concurrency_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S4") {
+        return;
+    }
+    let speed = w.parity_speed.as_ref().expect("S4 speed report exists");
+    assert!(
+        speed.streams > 1,
+        "S4 must measure multiple independent trajectories"
+    );
+    assert!(
+        speed.teacher_physical_batches < speed.teacher_logical_forwards,
+        "S4 physical batch accounting must demonstrate shared-weight multi-stream dispatch"
+    );
+    assert!(
+        speed.teacher_max_active_workers > 1,
+        "S4 exact projections must occupy more than one CPU worker"
+    );
+    assert_eq!(
+        speed.teacher_logical_forwards % speed.streams,
+        0,
+        "every S4 batch must account for every independent stream"
+    );
+    let config = parity_config();
+    assert_eq!(config.streams.get(), S4_CANONICAL_STREAMS);
+    assert_eq!(config.runs.get(), 1);
+    assert!(speed.warmup.is_empty(), "S4 must not repeat a warm-up wave");
+    assert_eq!(speed.teacher_prefill_logical_forwards, 0);
+    assert_eq!(
+        speed.compiled_precomputed_steps_per_lane,
+        config.gen_tokens.get(),
+        "compiled engines must execute one complete cheap causal ceiling before teacher admission"
+    );
+    assert_eq!(speed.legacy_runtime_preparations, config.streams.get());
+    assert_eq!(
+        speed.graph_state_preparations,
+        config.streams.get(),
+        "graph policy state must remain private to each logical lane"
+    );
+    assert_eq!(speed.compiled_worker_cohorts_per_engine, 1);
+    assert!(speed.compiled_full_ceiling_verified_before_teacher);
+    assert_eq!(speed.legacy_waves.len(), speed.graph_waves.len());
+    assert!(speed.teacher_waves.len() <= speed.legacy_waves.len());
+    assert_eq!(
+        speed
+            .legacy_waves
+            .last()
+            .map(|sample| sample.cumulative_generated_tokens / sample.streams),
+        Some(speed.compiled_precomputed_steps_per_lane)
+    );
+    for sample in speed
+        .teacher_waves
+        .iter()
+        .chain(speed.legacy_waves.iter())
+        .chain(speed.graph_waves.iter())
+        .chain(speed.warmup.iter())
+    {
+        assert_eq!(
+            sample.streams,
+            config.streams.get(),
+            "every measured wave must retain the configured logical-stream width"
+        );
+        assert_eq!(
+            sample.peak_active_streams,
+            config.streams.get(),
+            "every measured wave must observe all configured streams concurrently"
+        );
+        assert_eq!(
+            sample.private_state_instances,
+            config.streams.get(),
+            "every measured wave must instantiate one private state per lane"
+        );
+        assert_eq!(
+            sample.completed_stream_records,
+            config.streams.get(),
+            "every measured wave must retain one complete record per lane"
+        );
+        assert_eq!(
+            sample.retained_prefix_tokens_per_lane.len(),
+            config.streams.get(),
+            "every wave must report one retained-prefix length per lane"
+        );
+        assert_eq!(
+            sample.seed_tokens_per_lane.len(),
+            config.streams.get(),
+            "every wave must report one logical-seed length per lane"
+        );
+        assert!(sample
+            .retained_prefix_tokens_per_lane
+            .iter()
+            .zip(&sample.seed_tokens_per_lane)
+            .all(|(retained, seed)| *seed == retained + 1));
+        if sample.engine == "teacher" {
+            assert_eq!(
+                sample.state_sequence_capacity,
+                sample
+                    .retained_prefix_tokens_per_lane
+                    .iter()
+                    .copied()
+                    .max()
+                    .unwrap_or(0)
+                    + S4_MAX_DECODE_STEPS,
+                "teacher template allocation must cover the bounded adaptive horizon"
+            );
+            assert_eq!(sample.prefill_elapsed_seconds, 0.0);
+        } else {
+            assert_eq!(
+                sample.state_sequence_capacity,
+                sample
+                    .seed_tokens_per_lane
+                    .iter()
+                    .copied()
+                    .max()
+                    .unwrap_or(0)
+                    + speed.compiled_precomputed_steps_per_lane,
+                "compiled state allocation must be prepared once for its complete causal horizon"
+            );
+        }
+        validate_private_multistream_evidence(
+            &sample.lane_seed_cids,
+            &sample.stream_output_cids,
+            config.streams.get(),
+        )
+        .unwrap_or_else(|error| panic!("private multistream evidence: {error}"));
+        assert!(sample.ordered_reduction, "wave evidence must be ordered");
+    }
+    for sample in &speed.teacher_waves {
+        assert!(
+            sample.peak_exact_row_workers > 1
+                && sample.peak_exact_row_workers <= config.workers.get(),
+            "every live teacher stage must prove non-serial exact-row work within the probe-selected bound"
+        );
+        assert_eq!(
+            sample.peak_trajectory_workers, 0,
+            "teacher batched lanes are logical streams, not trajectory worker threads"
+        );
+        let execution = sample
+            .execution_delta
+            .as_ref()
+            .expect("teacher wave retains exact execution counters");
+        assert_eq!(
+            execution.streams_completed,
+            execution
+                .forward_calls
+                .saturating_mul(config.streams.get() as u64),
+            "every physical teacher forward must advance the entire S-wide cohort"
+        );
+        assert_eq!(execution.streams_started, execution.streams_completed);
+        assert_eq!(execution.active_streams, 0);
+        assert_eq!(execution.multiworker_forward_calls, execution.forward_calls);
+        assert_eq!(
+            execution.forward_max_active_workers,
+            sample.peak_exact_row_workers
+        );
+        assert_eq!(execution.workspace_growth_events, 0);
+        assert_eq!(execution.workspace_growth_bytes, 0);
+        assert_eq!(execution.batched_matrix_calls, execution.matrix_calls);
+        assert_eq!(
+            execution.max_matrix_batch_width,
+            config.streams.get(),
+            "every teacher matrix path must retain full stream width"
+        );
+    }
+    for sample in speed.legacy_waves.iter().chain(speed.graph_waves.iter()) {
+        assert_eq!(
+            sample.peak_trajectory_workers,
+            config.workers.get().min(config.streams.get()),
+            "compiled timing must observe every bounded trajectory worker active"
+        );
+        assert_eq!(
+            sample.peak_exact_row_workers, 0,
+            "compiled timing does not run the exact teacher row executor"
+        );
+    }
+    for samples in [&speed.legacy_waves, &speed.graph_waves] {
+        assert!(
+            samples
+                .iter()
+                .skip(1)
+                .all(|sample| sample.preparation_elapsed_seconds == 0.0),
+            "each compiled engine may report preparation only on its first checkpoint"
+        );
+        assert!(samples.windows(2).all(|pair| {
+            pair[0].decode_elapsed_seconds <= pair[1].decode_elapsed_seconds
+                && pair[1].cumulative_generated_tokens
+                    == pair[0].cumulative_generated_tokens.saturating_mul(2)
+        }));
+    }
+    for ((teacher, legacy), stage) in speed.teacher_waves.iter().zip(&speed.legacy_waves).zip(0..) {
+        assert_eq!(teacher.wave, stage);
+        assert_eq!(legacy.wave, stage);
+        assert_eq!(teacher.streams, legacy.streams);
+        assert_eq!(teacher.seed_tokens_per_lane, legacy.seed_tokens_per_lane);
+        assert_eq!(
+            teacher.retained_prefix_tokens_per_lane,
+            legacy.retained_prefix_tokens_per_lane
+        );
+        assert_eq!(teacher.cumulative_generated_tokens, legacy.generated_tokens);
+        assert_eq!(
+            teacher.lane_seed_cids, legacy.lane_seed_cids,
+            "paired engines must advance the same distinct lane identities"
+        );
+    }
+    for (teacher, graph) in speed.teacher_waves.iter().zip(&speed.graph_waves) {
+        assert_eq!(teacher.wave, graph.wave);
+        assert_eq!(teacher.streams, graph.streams);
+        assert_eq!(teacher.seed_tokens_per_lane, graph.seed_tokens_per_lane);
+        assert_eq!(
+            teacher.retained_prefix_tokens_per_lane,
+            graph.retained_prefix_tokens_per_lane
+        );
+        assert_eq!(teacher.cumulative_generated_tokens, graph.generated_tokens);
+        assert_eq!(teacher.lane_seed_cids, graph.lane_seed_cids);
+    }
+    let graph_available = with_parity_fixtures(|fx| fx.r4g1.is_some()).unwrap_or(false);
+    if graph_available {
+        assert_eq!(
+            speed.graph_waves.len(),
+            speed.legacy_waves.len(),
+            "both compiled engines must retain the complete precomputed causal wave"
+        );
+    } else {
+        parity_mark_scenario(
+            "S4",
+            RunStatus::Unavailable,
+            "graph timing fixture unavailable; teacher and legacy measurements retained",
+        );
+    }
+}
+
+#[then("the adaptive causal wave records its exact stop or extension decision")]
+fn parity_adaptive_generation_decision_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S4") {
+        return;
+    }
+    let speed = w.parity_speed.as_ref().expect("S4 speed report exists");
+    assert!(!speed.adaptive_decisions.is_empty());
+    let checkpoints = speed
+        .adaptive_decisions
+        .iter()
+        .map(|decision| {
+            decision["cumulative_decode_steps_per_lane"]
+                .as_u64()
+                .expect("adaptive decision records checkpoint") as usize
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        checkpoints
+            .windows(2)
+            .all(|pair| pair[1] == pair[0].saturating_mul(2)),
+        "adaptive checkpoints must advance 1 -> 2 -> 4 -> 8"
+    );
+    assert_eq!(checkpoints.first().copied(), Some(1));
+    assert_eq!(
+        checkpoints.last().copied(),
+        Some(speed.decoded_steps_per_lane)
+    );
+    assert!(speed.decoded_steps_per_lane <= S4_MAX_DECODE_STEPS);
+    let terminal = speed
+        .adaptive_decisions
+        .last()
+        .and_then(|decision| decision["decision"].as_str())
+        .expect("terminal adaptive decision reason");
+    assert_eq!(terminal, speed.stop_reason);
+    assert!(!terminal.starts_with("EXTEND_"));
+    if speed.decoded_steps_per_lane < S4_MAX_DECODE_STEPS {
+        assert!(speed.legacy_ratio > ADAPTIVE_EARLY_STOP_RATIO);
+        assert!(speed.graph_ratio > ADAPTIVE_EARLY_STOP_RATIO);
+        assert_eq!(terminal, "STOP_EARLY_CONSERVATIVE_MARGIN_CLEARED");
+    } else if speed.legacy_ratio > ADAPTIVE_ACCEPTANCE_RATIO
+        && speed.graph_ratio > ADAPTIVE_ACCEPTANCE_RATIO
+    {
+        assert_eq!(terminal, "STOP_AT_MAXIMUM_ACCEPTANCE_CLEARED");
+    } else {
+        assert_eq!(terminal, "STOP_AT_MAXIMUM_NOT_ESTABLISHED");
+    }
+}
+
+#[then(
+    "the fastest exact bounded probe configuration projects below the hard wall and authorizes the independent worker count"
+)]
+fn parity_probe_selected_configuration_checked(w: &mut R4g1World) {
+    if parity_skip(w, "S4") {
+        return;
+    }
+    let report = read_parity_probe_report().unwrap_or_else(|reason| panic!("{reason}"));
+    let config = parity_config();
+    let available = std::thread::available_parallelism().map_or(1, usize::from);
+    assert_eq!(report.probe_streams, S4_CANONICAL_STREAMS);
+    assert!(report.all_streams_active);
+    assert!(report.exact_equality);
+    assert_eq!(config.streams.get(), S4_CANONICAL_STREAMS);
+    assert_eq!(config.workers.get(), report.selected_best_config.workers);
+    assert_eq!(
+        report.configured_execution.workers,
+        report.selected_best_config.workers
+    );
+    assert_eq!(
+        report.configured_execution.tiles_per_worker,
+        report.selected_best_config.tiles_per_worker
+    );
+    let four_or_available = 4usize.min(available);
+    let expected_stream_steps = u64::try_from(report.probe_streams)
+        .unwrap_or(u64::MAX)
+        .saturating_mul(u64::try_from(report.probe_positions).unwrap_or(u64::MAX));
+    for run in &report.runs {
+        assert!(run.workers == four_or_available || run.workers == available);
+        assert_eq!(run.batch_width, report.probe_streams);
+        assert!(run.all_streams_active);
+        assert!(run.equal_to_reference);
+        assert_eq!(run.snapshot.forward_calls, report.probe_positions as u64);
+        assert_eq!(run.snapshot.streams_started, expected_stream_steps);
+        assert_eq!(run.snapshot.streams_completed, expected_stream_steps);
+        assert_eq!(run.snapshot.active_streams, 0);
+        assert_eq!(run.snapshot.max_active_streams, report.probe_streams);
+        assert_eq!(run.snapshot.batched_matrix_calls, run.snapshot.matrix_calls);
+        assert_eq!(run.snapshot.max_matrix_batch_width, report.probe_streams);
+        assert_eq!(run.trace_shape.state_records, expected_stream_steps);
+    }
+    let selected = report
+        .runs
+        .iter()
+        .find(|run| run.workers == report.selected_best_config.workers)
+        .expect("selected exact probe row exists");
+    assert!(selected.all_streams_active);
+    let fastest_exact_rate = report
+        .runs
+        .iter()
+        .filter(|run| run.equal_to_reference && run.all_streams_active)
+        .map(|run| run.aggregate_forwards_per_second)
+        .fold(0.0f64, f64::max);
+    assert_eq!(
+        selected.aggregate_forwards_per_second.to_bits(),
+        fastest_exact_rate.to_bits(),
+        "admission must select the fastest exact bounded candidate"
+    );
+    assert!(
+        report
+            .selected_best_config
+            .safety_adjusted_projected_suite_seconds
+            < config.max_wall.get() as f64,
+        "selected exact projection must remain below the operator hard wall"
+    );
+    assert_eq!(
+        report.binding_verdict.status,
+        ExactMulticoreProbeStatus::Qualified
+    );
+    assert!(report.binding_verdict.qualifies_full_run);
+    parity_mark_scenario_pass_if_pending(
+        "S4",
+        "adaptive S-wide timing and fastest exact bounded probe selection checked",
+    )
+    .unwrap_or_else(|reason| parity_abort_step("S4", reason));
 }
 
 #[when("the compiled runtime kernel invariants are examined")]
@@ -4359,6 +9701,8 @@ fn parity_examine_kernel(w: &mut R4g1World) {
     if parity_skip(w, "S5") {
         return;
     }
+    parity_check_deadline("S5 kernel examination")
+        .unwrap_or_else(|reason| parity_abort_step("S5", reason));
     let (op_report, zero_alloc, witness_consistent) = with_parity_fixtures(|fx| {
         let tokens = fx.tokenizer.encode(PARITY_PROMPTS[0]);
         assert!(tokens.len() > 2, "seed prompt tokenizes");
@@ -4448,6 +9792,15 @@ fn parity_witness_checked(w: &mut R4g1World) {
         Some(true),
         "predict_witness token must equal predict token on every sampled position"
     );
+    parity_record_output(
+        "S5_kernel",
+        serde_json::json!({
+            "operation_report": w.parity_op_report,
+            "steady_state_allocations": w.parity_zero_alloc,
+            "witness_consistent": w.parity_witness_consistent,
+        }),
+    );
+    parity_mark_scenario("S5", RunStatus::Pass, "kernel invariants checked");
 }
 
 /// S6 in-distribution replay: a deterministic strided sample of recorded
@@ -4519,10 +9872,17 @@ fn parity_replay_corpus(w: &mut R4g1World) {
     }
     let has_corpus = with_parity_fixtures(|fx| fx.corpus.is_some()).unwrap_or(false);
     if !has_corpus {
-        eprintln!("[parity] S6: corpus records unavailable — vacuous pass");
+        eprintln!("[parity] S6: corpus replay evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S6",
+            RunStatus::Unavailable,
+            "corpus.meta/corpus.records evidence unavailable",
+        );
         return;
     }
-    let budget = parity_budget("R4_PARITY_CORPUS_POSITIONS", 1000);
+    parity_check_deadline("S6 corpus replay")
+        .unwrap_or_else(|reason| parity_abort_step("S6", reason));
+    let budget = parity_config().corpus_positions.get();
     w.parity_corpus_legacy = with_parity_fixtures(|fx| corpus_replay(fx, false, budget)).flatten();
     let has_graph = with_parity_fixtures(|fx| fx.r4g1.is_some()).unwrap_or(false);
     if has_graph {
@@ -4539,20 +9899,48 @@ fn parity_corpus_checked(w: &mut R4g1World) {
         return;
     }
     let Some(legacy) = w.parity_corpus_legacy else {
-        eprintln!("[parity] S6: corpus records unavailable — vacuous pass");
+        eprintln!("[parity] S6: corpus replay evidence UNAVAILABLE");
+        parity_mark_scenario(
+            "S6",
+            RunStatus::Unavailable,
+            "corpus replay produced no legacy measurement",
+        );
         return;
     };
-    let bundle = parity_bundle_dir();
-    let meta_bytes = std::fs::read(bundle.join("corpus.meta")).expect("corpus.meta");
-    let records_bytes = std::fs::read(bundle.join("corpus.records")).expect("corpus.records");
+    let bundle = parity_bundle_dir().unwrap_or_else(|reason| parity_abort_step("S6", reason));
+    let meta_bytes = match std::fs::read(bundle.join("corpus.meta")) {
+        Ok(bytes) => bytes,
+        Err(error) => parity_abort_step("S6", format!("FAILED: read corpus.meta: {error}")),
+    };
+    let records_bytes = match std::fs::read(bundle.join("corpus.records")) {
+        Ok(bytes) => bytes,
+        Err(error) => parity_abort_step("S6", format!("FAILED: read corpus.records: {error}")),
+    };
     // Gate C anchors from the graph's score report, for context only: Gate C
     // replays a held-out partition with the compiler-side plain baseline,
     // this scenario replays recorded positions through the deployed paths.
-    let score_report: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(bundle.join("graph/score_report.json")).expect("score report"),
-    )
-    .expect("score report parses");
-    let gate_c = &score_report["gate_c"];
+    let score_path = bundle.join("graph/score_report.json");
+    let (gate_c_anchors, anchors_available) = match std::fs::read(&score_path) {
+        Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(score_report) => (
+                serde_json::json!({
+                    "status": "AVAILABLE",
+                    "tla3_baseline_top1": score_report["gate_c"]["tla3_baseline"]["top1_agreement"],
+                    "graph_no_exct_top1": score_report["gate_c"]["graph_no_exct"]["top1_agreement"],
+                    "graph_with_exct_top1": score_report["gate_c"]["graph_with_exct"]["top1_agreement"],
+                }),
+                true,
+            ),
+            Err(error) => (
+                serde_json::json!({"status": "UNAVAILABLE", "reason": format!("score report parse: {error}")}),
+                false,
+            ),
+        },
+        Err(error) => (
+            serde_json::json!({"status": "UNAVAILABLE", "reason": format!("score report read: {error}")}),
+            false,
+        ),
+    };
     let graph = w.parity_corpus_graph;
     let report_json = serde_json::json!({
         "suite": "teacher_parity_benchmarks",
@@ -4571,11 +9959,7 @@ fn parity_corpus_checked(w: &mut R4g1World) {
             "top1_agreement": g.top1_agreement,
             "top_label_recall": g.top8_recall,
         })),
-        "gate_c_anchors": {
-            "tla3_baseline_top1": gate_c["tla3_baseline"]["top1_agreement"],
-            "graph_no_exct_top1": gate_c["graph_no_exct"]["top1_agreement"],
-            "graph_with_exct_top1": gate_c["graph_with_exct"]["top1_agreement"],
-        },
+        "gate_c_anchors": gate_c_anchors,
         "floors": {
             "legacy_top1": CORPUS_LEGACY_TOP1_FLOOR,
             "graph_top1": CORPUS_GRAPH_TOP1_FLOOR,
@@ -4607,10 +9991,51 @@ fn parity_corpus_checked(w: &mut R4g1World) {
             g.abstains
         );
     }
+    parity_record_output("S6_corpus", report_json);
+    if graph.is_some() && anchors_available {
+        parity_mark_scenario("S6", RunStatus::Pass, "legacy/graph corpus replay checked");
+    } else {
+        parity_mark_scenario(
+            "S6",
+            RunStatus::Unavailable,
+            "legacy corpus measurement completed; graph replay or Gate C anchors unavailable",
+        );
+    }
 }
 
 #[tokio::main]
 async fn main() {
+    if std::env::var("R4_PARITY_PREFLIGHT_ONLY").as_deref() == Ok("1") {
+        let (report, report_path) = match run_teacher_free_parity_preflight() {
+            Ok(success) => success,
+            Err(failure) => {
+                if let (Some(report_path), Some(report)) = (
+                    failure.report_path.as_deref(),
+                    failure.durable_report.as_ref(),
+                ) {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(report)
+                            .expect("preflight refusal report serializes")
+                    );
+                    eprintln!(
+                        "[parity] teacher-free preflight refusal artifact {}",
+                        report_path.display()
+                    );
+                }
+                panic!("teacher-free parity preflight: {}", failure.reason);
+            }
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).expect("preflight report serializes")
+        );
+        eprintln!(
+            "[parity] teacher-free preflight artifact {}",
+            report_path.display()
+        );
+        return;
+    }
     R4g1World::cucumber()
         .fail_on_skipped()
         .run_and_exit(concat!(env!("CARGO_MANIFEST_DIR"), "/features/suites"))

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -6068,7 +6068,8 @@ fn load_parity_fixtures() -> Result<ParityFixtures, String> {
                 .to_owned(),
         );
     }
-    let current_production_generation = production_admission_component_cids(&bundle)?;
+    let current_production_generation =
+        production_admission_component_cids(&bundle).map_err(|error| error.reason)?;
     if current_production_generation != admitted_production_generation {
         return Err(
             "NOT_RUN / REFUSED: schema-2 production generation changed between semantic admission and teacher load"
@@ -6383,7 +6384,8 @@ fn load_r4g1(bundle: &Path, artifact_bytes: &[u8]) -> Result<R4g1State, String> 
 fn teacher_free_parity_preflight() -> Result<serde_json::Value, String> {
     let source = parity_source_dir()?;
     let bundle = parity_bundle_dir()?;
-    let production_admission = production_admission_component_cids(&bundle)?;
+    let production_admission =
+        production_admission_component_cids(&bundle).map_err(|error| error.reason)?;
     let tokenizer_path = bundle.join("tokenizer.bin");
     let artifact_path = bundle.join("tless_artifacts.bin");
     let store_path = bundle.join("tless_store.bin");

--- a/tests/parity_determinism_932.rs
+++ b/tests/parity_determinism_932.rs
@@ -1,0 +1,545 @@
+//! Fast derived-evidence tests for the #932 teacher-parity scheduler contract.
+//!
+//! Claim boundary: these tests exercise the public `BatchedTeacher` surface and
+//! the harness-level ordering/transcript logic with a deterministic tiny
+//! teacher. Exact projection arithmetic is owned by the model-source tests
+//! named in `derived_evidence_is_anchored_to_model_source_exact_bit_gates`.
+//! The fixture-present bounded four-worker/all-available probe remains
+//! empirical evidence.
+
+use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::thread;
+use uor_r4_model_source::{BatchedTeacher, TeacherExecutionConfig};
+
+const VOCAB: usize = 6;
+const TOP_K: usize = 3;
+const STREAMS: usize = 7;
+const HORIZON: usize = 5;
+
+#[derive(Clone)]
+struct MockWeights {
+    // Three exactly tied maxima exercise the canonical token-id tie break.
+    logit_lut: [f32; VOCAB],
+}
+
+#[derive(Clone)]
+struct MockTeacher {
+    weights: Arc<MockWeights>,
+}
+
+impl MockTeacher {
+    fn new() -> Self {
+        Self {
+            weights: Arc::new(MockWeights {
+                logit_lut: [0.0, 1.0, 1.0, -1.0, 0.5, 1.0],
+            }),
+        }
+    }
+
+    fn weight_address(&self) -> usize {
+        Arc::as_ptr(&self.weights) as usize
+    }
+}
+
+struct MockState {
+    stream_id: usize,
+    next_position: usize,
+    logits: Vec<f32>,
+    input_history: Vec<u32>,
+}
+
+impl MockState {
+    fn assign_stream(&mut self, stream_id: usize) {
+        assert_eq!(self.stream_id, usize::MAX, "state is assigned exactly once");
+        self.stream_id = stream_id;
+    }
+}
+
+impl BatchedTeacher for MockTeacher {
+    type State = MockState;
+
+    fn new_state(&self) -> Self::State {
+        MockState {
+            stream_id: usize::MAX,
+            next_position: 0,
+            logits: vec![0.0; VOCAB],
+            input_history: Vec::new(),
+        }
+    }
+
+    fn reset_state(&self, state: &mut Self::State) {
+        state.stream_id = usize::MAX;
+        state.next_position = 0;
+        state.logits.fill(0.0);
+        state.input_history.clear();
+    }
+
+    fn logits_mut<'a>(&self, state: &'a mut Self::State) -> &'a mut [f32] {
+        &mut state.logits
+    }
+
+    fn seq_len(&self) -> usize {
+        HORIZON
+    }
+
+    fn vocab(&self) -> usize {
+        VOCAB
+    }
+
+    fn forward_batch_into(
+        &self,
+        states: &mut [Self::State],
+        tokens: &[usize],
+        positions: &[usize],
+    ) {
+        assert_eq!(states.len(), tokens.len());
+        assert_eq!(states.len(), positions.len());
+        for ((state, &token), &position) in states.iter_mut().zip(tokens).zip(positions) {
+            assert_eq!(
+                position, state.next_position,
+                "a stream remains autoregressively ordered"
+            );
+            assert!(token < VOCAB);
+            let rotation = (state.stream_id + token + position) % VOCAB;
+            for (token_id, logit) in state.logits.iter_mut().enumerate() {
+                *logit = self.weights.logit_lut[(token_id + rotation) % VOCAB];
+            }
+            state
+                .input_history
+                .push(u32::try_from(token).expect("tiny token fits u32"));
+            state.next_position += 1;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TranscriptRow {
+    stream_id: usize,
+    position: usize,
+    input_token: u32,
+    logit_bits: Vec<u32>,
+    top_k: Vec<u32>,
+    greedy_token: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StreamMetric {
+    stream_id: usize,
+    rows: usize,
+    greedy_token_sum: u64,
+    tied_top_rows: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OrderedReduction {
+    row_count: usize,
+    rolling: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DerivedEvidence {
+    rows: Vec<TranscriptRow>,
+    transcript: Vec<u8>,
+    transcript_cid: String,
+    metrics: Vec<StreamMetric>,
+    reduction: OrderedReduction,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ScheduleStats {
+    requested_workers: usize,
+    batches: usize,
+    maximum_parallel_batches: usize,
+    batch_widths: Vec<usize>,
+    weight_addresses: Vec<usize>,
+    state_addresses: Vec<usize>,
+}
+
+struct BatchOutcome {
+    batch_index: usize,
+    rows: Vec<TranscriptRow>,
+    metrics: Vec<StreamMetric>,
+    weight_address: usize,
+    // Keep every state allocation alive until all batches have completed so
+    // pointer identity can witness private storage without allocator reuse.
+    states: Vec<MockState>,
+}
+
+fn canonical_top_k(logits: &[f32]) -> Vec<u32> {
+    let mut tokens: Vec<usize> = (0..logits.len()).collect();
+    tokens.sort_by(|&left, &right| {
+        logits[right]
+            .total_cmp(&logits[left])
+            .then_with(|| left.cmp(&right))
+    });
+    tokens
+        .into_iter()
+        .take(TOP_K)
+        .map(|token| u32::try_from(token).expect("tiny token fits u32"))
+        .collect()
+}
+
+fn run_batch(
+    teacher: Arc<MockTeacher>,
+    batch_index: usize,
+    stream_ids: Vec<usize>,
+) -> BatchOutcome {
+    let mut states: Vec<MockState> = stream_ids
+        .iter()
+        .map(|&stream_id| {
+            let mut state = teacher.new_state();
+            state.assign_stream(stream_id);
+            state
+        })
+        .collect();
+    let mut tokens: Vec<usize> = stream_ids.iter().map(|id| id % VOCAB).collect();
+    let mut rows = Vec::with_capacity(stream_ids.len() * HORIZON);
+    let mut greedy_sums = vec![0u64; stream_ids.len()];
+    let mut tie_counts = vec![0usize; stream_ids.len()];
+
+    for position in 0..HORIZON {
+        let positions = vec![position; states.len()];
+        teacher.forward_batch_into(&mut states, &tokens, &positions);
+        let mut next_tokens = Vec::with_capacity(states.len());
+        for (batch_slot, state) in states.iter_mut().enumerate() {
+            let stream_id = state.stream_id;
+            let logits = teacher.logits_mut(state);
+            let top_k = canonical_top_k(logits);
+            let greedy_token = top_k[0];
+            let top_value = logits[usize::try_from(greedy_token).expect("token fits usize")];
+            let tied = top_k
+                .iter()
+                .filter(|&&token| {
+                    logits[usize::try_from(token).expect("token fits usize")].to_bits()
+                        == top_value.to_bits()
+                })
+                .count();
+            if tied > 1 {
+                tie_counts[batch_slot] += 1;
+            }
+            greedy_sums[batch_slot] += u64::from(greedy_token);
+            rows.push(TranscriptRow {
+                stream_id,
+                position,
+                input_token: u32::try_from(tokens[batch_slot]).expect("tiny token fits u32"),
+                logit_bits: logits.iter().map(|value| value.to_bits()).collect(),
+                top_k,
+                greedy_token,
+            });
+            next_tokens.push(usize::try_from(greedy_token).expect("token fits usize"));
+        }
+        tokens = next_tokens;
+    }
+
+    let metrics = stream_ids
+        .into_iter()
+        .enumerate()
+        .map(|(slot, stream_id)| StreamMetric {
+            stream_id,
+            rows: HORIZON,
+            greedy_token_sum: greedy_sums[slot],
+            tied_top_rows: tie_counts[slot],
+        })
+        .collect();
+
+    BatchOutcome {
+        batch_index,
+        rows,
+        metrics,
+        weight_address: teacher.weight_address(),
+        states,
+    }
+}
+
+fn encode_transcript(rows: &[TranscriptRow]) -> Vec<u8> {
+    let mut bytes = b"uor-r4.teacher-parity-derived/1\0".to_vec();
+    bytes.extend_from_slice(
+        &u64::try_from(rows.len())
+            .expect("row count fits u64")
+            .to_le_bytes(),
+    );
+    for row in rows {
+        for value in [row.stream_id, row.position] {
+            bytes.extend_from_slice(
+                &u64::try_from(value)
+                    .expect("fixture index fits u64")
+                    .to_le_bytes(),
+            );
+        }
+        bytes.extend_from_slice(&row.input_token.to_le_bytes());
+        bytes.extend_from_slice(&row.greedy_token.to_le_bytes());
+        bytes.extend_from_slice(
+            &u64::try_from(row.logit_bits.len())
+                .expect("logit count fits u64")
+                .to_le_bytes(),
+        );
+        row.logit_bits
+            .iter()
+            .for_each(|bits| bytes.extend_from_slice(&bits.to_le_bytes()));
+        bytes.extend_from_slice(
+            &u64::try_from(row.top_k.len())
+                .expect("top-k count fits u64")
+                .to_le_bytes(),
+        );
+        row.top_k
+            .iter()
+            .for_each(|token| bytes.extend_from_slice(&token.to_le_bytes()));
+    }
+    bytes
+}
+
+fn reduce_in_canonical_order(rows: &[TranscriptRow]) -> OrderedReduction {
+    let rolling = rows.iter().fold(0xcbf2_9ce4_8422_2325u64, |value, row| {
+        let row_word = u64::try_from(row.stream_id)
+            .expect("stream id fits u64")
+            .rotate_left(7)
+            ^ u64::try_from(row.position)
+                .expect("position fits u64")
+                .rotate_left(19)
+            ^ u64::from(row.greedy_token)
+            ^ u64::from(row.logit_bits[0]).rotate_left(31);
+        value
+            .wrapping_mul(0x0000_0100_0000_01b3)
+            .wrapping_add(row_word)
+    });
+    OrderedReduction {
+        row_count: rows.len(),
+        rolling,
+    }
+}
+
+fn derive_evidence(mut outcomes: Vec<BatchOutcome>) -> (DerivedEvidence, ScheduleStats) {
+    let mut weight_addresses: Vec<usize> = outcomes
+        .iter()
+        .map(|outcome| outcome.weight_address)
+        .collect();
+    let mut state_addresses: Vec<usize> = outcomes
+        .iter()
+        .flat_map(|outcome| {
+            outcome
+                .states
+                .iter()
+                .map(|state| state.logits.as_ptr() as usize)
+        })
+        .collect();
+    weight_addresses.sort_unstable();
+    state_addresses.sort_unstable();
+
+    outcomes.sort_by_key(|outcome| outcome.batch_index);
+    let mut rows: Vec<TranscriptRow> = outcomes
+        .iter_mut()
+        .flat_map(|outcome| std::mem::take(&mut outcome.rows))
+        .collect();
+    rows.sort_by_key(|row| (row.stream_id, row.position));
+    let mut metrics: Vec<StreamMetric> = outcomes
+        .iter_mut()
+        .flat_map(|outcome| std::mem::take(&mut outcome.metrics))
+        .collect();
+    metrics.sort_by_key(|metric| metric.stream_id);
+
+    let transcript = encode_transcript(&rows);
+    let transcript_cid = format!("blake3:{}", blake3::hash(&transcript).to_hex());
+    let reduction = reduce_in_canonical_order(&rows);
+    let evidence = DerivedEvidence {
+        rows,
+        transcript,
+        transcript_cid,
+        metrics,
+        reduction,
+    };
+    let stats = ScheduleStats {
+        requested_workers: 0,
+        batches: outcomes.len(),
+        maximum_parallel_batches: 0,
+        batch_widths: Vec::new(),
+        weight_addresses,
+        state_addresses,
+    };
+    (evidence, stats)
+}
+
+fn run_schedule(
+    teacher: Arc<MockTeacher>,
+    workers: usize,
+    batch_width: usize,
+    shuffle_completion: bool,
+    stream_count: usize,
+) -> (DerivedEvidence, ScheduleStats) {
+    assert!(workers > 0);
+    assert!(batch_width > 0);
+    let batches: Vec<Vec<usize>> = (0..stream_count)
+        .collect::<Vec<_>>()
+        .chunks(batch_width)
+        .map(<[usize]>::to_vec)
+        .collect();
+    let batch_widths: Vec<usize> = batches.iter().map(Vec::len).collect();
+    let maximum_parallel_batches = workers.min(batches.len());
+    let mut outcomes = Vec::with_capacity(batches.len());
+
+    for wave_start in (0..batches.len()).step_by(workers) {
+        let wave_end = (wave_start + workers).min(batches.len());
+        let wave = &batches[wave_start..wave_end];
+        let mut completed = thread::scope(|scope| {
+            let handles: Vec<_> = wave
+                .iter()
+                .enumerate()
+                .map(|(offset, stream_ids)| {
+                    let teacher = Arc::clone(&teacher);
+                    let stream_ids = stream_ids.clone();
+                    scope.spawn(move || run_batch(teacher, wave_start + offset, stream_ids))
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("derived worker must complete"))
+                .collect::<Vec<_>>()
+        });
+        if shuffle_completion {
+            completed.reverse();
+        }
+        outcomes.extend(completed);
+    }
+    if shuffle_completion {
+        let rotate_by = outcomes.len() / 2;
+        outcomes.rotate_left(rotate_by);
+    }
+
+    let (evidence, mut stats) = derive_evidence(outcomes);
+    stats.requested_workers = workers;
+    stats.maximum_parallel_batches = maximum_parallel_batches;
+    stats.batch_widths = batch_widths;
+    (evidence, stats)
+}
+
+#[test]
+fn worker_and_batch_schedules_preserve_all_derived_evidence() {
+    let teacher = Arc::new(MockTeacher::new());
+    let (reference, _) = run_schedule(Arc::clone(&teacher), 1, 1, false, STREAMS);
+
+    // Fixed fixture row checks raw bits and canonical tie order independently
+    // of comparisons among scheduler configurations.
+    assert_eq!(
+        reference.rows[0].logit_bits,
+        [
+            0.0f32.to_bits(),
+            1.0f32.to_bits(),
+            1.0f32.to_bits(),
+            (-1.0f32).to_bits(),
+            0.5f32.to_bits(),
+            1.0f32.to_bits(),
+        ]
+    );
+    assert_eq!(reference.rows[0].top_k, [1, 2, 5]);
+    assert_eq!(reference.rows[0].greedy_token, 1);
+    assert_eq!(
+        reference
+            .rows
+            .iter()
+            .filter(|row| row.stream_id == 0)
+            .map(|row| row.greedy_token)
+            .collect::<Vec<_>>(),
+        [1, 0, 0, 2, 1],
+        "the fixed stream guards the greedy trajectory"
+    );
+    assert_eq!(
+        reference.transcript_cid,
+        format!("blake3:{}", blake3::hash(&reference.transcript).to_hex())
+    );
+
+    for workers in [1usize, 2, 4, 8] {
+        // These are the supported derived-evidence batch schedules. Production
+        // arithmetic is independently gated at the same worker counts below.
+        let _production_config = TeacherExecutionConfig::fixed_workers(
+            NonZeroUsize::new(workers).expect("supported worker count is nonzero"),
+        );
+        for batch_width in [1usize, 2, 4, 8] {
+            let (actual, stats) =
+                run_schedule(Arc::clone(&teacher), workers, batch_width, true, STREAMS);
+            assert_eq!(
+                actual, reference,
+                "derived evidence changed at workers={workers}, batch={batch_width}"
+            );
+            assert_eq!(stats.requested_workers, workers);
+            assert!(stats.maximum_parallel_batches <= workers);
+            assert!(stats.batch_widths.iter().all(|&width| width <= batch_width));
+            assert_eq!(stats.state_addresses.len(), STREAMS);
+            assert_eq!(
+                stats
+                    .state_addresses
+                    .iter()
+                    .copied()
+                    .collect::<BTreeSet<_>>()
+                    .len(),
+                STREAMS,
+                "every sequence owns distinct mutable logit storage"
+            );
+            assert_eq!(
+                stats
+                    .weight_addresses
+                    .iter()
+                    .copied()
+                    .collect::<BTreeSet<_>>()
+                    .len(),
+                1,
+                "every worker batch shares one immutable weight allocation"
+            );
+        }
+    }
+}
+
+#[test]
+fn workers_above_work_and_batch_remainder_are_bounded_and_exact() {
+    let teacher = Arc::new(MockTeacher::new());
+    let (reference, _) = run_schedule(Arc::clone(&teacher), 1, 1, false, 5);
+    let (actual, stats) = run_schedule(teacher, 8, 3, true, 5);
+
+    assert_eq!(actual, reference);
+    assert_eq!(stats.requested_workers, 8);
+    assert_eq!(stats.batches, 2);
+    assert_eq!(stats.batch_widths, [3, 2]);
+    assert_eq!(stats.maximum_parallel_batches, 2);
+}
+
+#[test]
+fn cloned_teachers_share_weights_while_sequence_state_remains_private() {
+    let first = MockTeacher::new();
+    let second = first.clone();
+    assert!(Arc::ptr_eq(&first.weights, &second.weights));
+
+    let mut left = first.new_state();
+    let mut right = first.new_state();
+    left.assign_stream(0);
+    right.assign_stream(1);
+    first.forward_batch_into(std::slice::from_mut(&mut left), &[0], &[0]);
+    assert_eq!(left.input_history, [0]);
+    assert!(right.input_history.is_empty());
+
+    second.forward_batch_into(std::slice::from_mut(&mut right), &[1], &[0]);
+    assert_eq!(left.input_history, [0]);
+    assert_eq!(right.input_history, [1]);
+    assert_ne!(left.logits.as_ptr(), right.logits.as_ptr());
+}
+
+#[test]
+fn derived_evidence_is_anchored_to_model_source_exact_bit_gates() {
+    // This source-level link prevents the cheap mock scheduler test from being
+    // mistaken for arithmetic proof. The named model-source tests execute the
+    // real pinned exact owner; this file exercises only evidence derivation.
+    let model_source = include_str!("../crates/uor-r4-model-source/src/lib.rs");
+    for required_gate in [
+        "exact_matmul_matches_serial_bits_for_1_2_4_8_workers",
+        "exact_batched_matmul_matches_serial_bits_for_1_2_4_8_workers",
+        "forward_batch_matches_serial_forward_for_1_2_4_8_workers",
+    ] {
+        assert!(
+            model_source.contains(required_gate),
+            "#932 derived evidence requires model-source gate {required_gate}"
+        );
+    }
+
+    let executor_source = include_str!("../crates/uor-r4-model-source/src/exact_executor.rs");
+    assert!(executor_source.contains("partitioning only complete output rows"));
+    assert!(executor_source.contains("full `k`-term exact accumulator"));
+}

--- a/tests/parity_observability_932.rs
+++ b/tests/parity_observability_932.rs
@@ -890,7 +890,7 @@ fn bdd_source_keeps_one_time_compiled_cohorts_before_teacher_continuation() {
         .rfind("file_kappa(&teacher_free_preflight_path)?.0")
         .expect("preflight token is rehashed immediately before teacher load");
     let final_generation_rehash = automatic
-        .rfind("production_admission_component_cids(&bundle)?")
+        .rfind("production_admission_component_cids(&bundle)")
         .expect("complete schema-2 generation is rehashed before teacher load");
     let teacher_load = automatic
         .find("SmolLm2Oracle::load_with_sequence_length_and_execution(")

--- a/tests/parity_observability_932.rs
+++ b/tests/parity_observability_932.rs
@@ -1,0 +1,2694 @@
+#[path = "support/parity_observability.rs"]
+mod parity_observability;
+
+use parity_observability::{
+    adaptive_decode_checkpoints, adaptive_decode_decision,
+    apply_teacher_free_preflight_failure_metadata, classify_exact_probe_artifact,
+    configured_exact_probe_report_path, configured_fixture_dir, configured_preflight_report_path,
+    deterministic_evidence_identities, deterministic_teacher_execution, estimate_eta,
+    events_path_for_report, heartbeat_progress_units, mark_finalization_failed,
+    prepare_final_reports, publish_atomic_preflight_outcome, sample_host_resources,
+    seconds_per_forward_from_rate, take_run_report_ownership, validate_binding_host_shape,
+    validate_full_width_exact_heartbeat, validate_in_flight_heartbeat_cadence,
+    validate_nonqualified_probe_prepublication, validate_private_multistream_evidence,
+    write_atomic_json, write_final_reports, AdaptiveDecodeDecision, CancellableStartGate,
+    ConfigError, DeterministicEvidence, EtaInput, EtaStatus, EventKind, ExactProbeArtifact,
+    ExactProgressObservation, FixtureStatus, FixtureVerdict, HeartbeatEvent, HeartbeatLog,
+    HeartbeatWorker, Measurement, ObservabilityMode, ParityConfig, PlanInstallError, ProgressUnit,
+    QueueSnapshot, ResourceAvailability, RunMetadata, RunReport, RunStatus, SchedulerSnapshot,
+    SharedProgress, StreamProgress, StreamState, TeacherFreeGraphFailureStage, WorkCounters,
+    WorkPlan,
+};
+use serde_json::json;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::num::{NonZeroU64, NonZeroUsize};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use uor_r4_model_source::TeacherExecutionSnapshot;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is nonzero")
+}
+
+fn assert_measured_or_reason<T>(measurement: &Measurement<T>) {
+    if let Measurement::Unavailable { reason } = measurement {
+        assert!(!reason.trim().is_empty());
+    }
+}
+
+fn unique_dir(label: &str) -> PathBuf {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "uor-r4-parity-observability-932-{label}-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+fn lookup(values: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+    move |name| values.get(name).map(|value| (*value).to_owned())
+}
+
+#[test]
+fn exact_probe_state_discriminator_projects_truthful_nonqualification_and_rejects_unknown_shapes() {
+    const SCHEMA: &str = "uor-r4.exact-multicore-probe/2";
+    for (event, status, expected_run, expected_fixture, expected_prefix) in [
+        (
+            "NOT_RUN",
+            "REFUSE_FULL_RUN",
+            RunStatus::NotRun,
+            FixtureVerdict::NotRun,
+            "NOT_RUN / REFUSED:",
+        ),
+        (
+            "UNAVAILABLE",
+            "UNAVAILABLE",
+            RunStatus::Unavailable,
+            FixtureVerdict::Unavailable,
+            "UNAVAILABLE:",
+        ),
+        (
+            "FAIL",
+            "FAIL",
+            RunStatus::Fail,
+            FixtureVerdict::Failed,
+            "FAILED:",
+        ),
+        (
+            "ABORTED",
+            "ABORTED",
+            RunStatus::Aborted,
+            FixtureVerdict::NotRun,
+            "ABORTED:",
+        ),
+    ] {
+        let bytes = serde_json::to_vec(&json!({
+            "schema": SCHEMA,
+            "record": "EXACT_MULTICORE_PROBE_STATE",
+            "event": event,
+            "status": status,
+            "qualifies_full_run": false,
+            "reason": "planted direct-tuner preflight refusal",
+        }))
+        .expect("state JSON");
+        let ExactProbeArtifact::NonQualified(state) =
+            classify_exact_probe_artifact(&bytes, SCHEMA).expect("recognized non-qualified state")
+        else {
+            panic!("state artifact must not be treated as a qualified report")
+        };
+        assert_eq!(state.run_status, expected_run);
+        assert!(state.outcome_reason().starts_with(expected_prefix));
+        let fixture = state.fixture_status("blake3:state-artifact");
+        assert_eq!(fixture.verdict, expected_fixture);
+        assert_eq!(fixture.cid.as_deref(), Some("blake3:state-artifact"));
+        assert!(fixture
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("planted")));
+    }
+
+    let running = serde_json::to_vec(&json!({
+        "schema": SCHEMA,
+        "record": "EXACT_MULTICORE_PROBE_STATE",
+        "event": "RUNNING",
+        "status": "NOT_QUALIFIED",
+        "qualifies_full_run": false,
+    }))
+    .expect("running state JSON");
+    let ExactProbeArtifact::NonQualified(running) =
+        classify_exact_probe_artifact(&running, SCHEMA).expect("running state is non-qualified")
+    else {
+        panic!("running state must not be treated as a qualified report")
+    };
+    assert_eq!(running.run_status, RunStatus::NotRun);
+    assert!(running.reason.contains("still running"));
+
+    let candidate = serde_json::to_vec(&json!({
+        "schema": SCHEMA,
+        "executor_contract_cid": "blake3:typed-owner-validates-the-rest",
+    }))
+    .expect("candidate JSON");
+    assert!(matches!(
+        classify_exact_probe_artifact(&candidate, SCHEMA),
+        Ok(ExactProbeArtifact::QualifiedCandidate(_))
+    ));
+
+    for invalid in [
+        b"not-json".to_vec(),
+        serde_json::to_vec(&json!({
+            "schema": SCHEMA,
+            "record": "UNKNOWN_RECORD",
+        }))
+        .expect("unknown record JSON"),
+        serde_json::to_vec(&json!({
+            "schema": SCHEMA,
+            "record": "EXACT_MULTICORE_PROBE_STATE",
+            "event": "FINAL",
+            "status": "QUALIFIED",
+            "qualifies_full_run": false,
+            "reason": "contradictory qualified state",
+        }))
+        .expect("unknown state JSON"),
+        serde_json::to_vec(&json!({
+            "schema": SCHEMA,
+            "record": "EXACT_MULTICORE_PROBE_STATE",
+            "event": "NOT_RUN",
+            "status": "REFUSE_FULL_RUN",
+            "qualifies_full_run": true,
+            "reason": "state may never qualify",
+        }))
+        .expect("qualified state JSON"),
+        serde_json::to_vec(&json!({
+            "schema": SCHEMA,
+            "record": "EXACT_MULTICORE_PROBE_STATE",
+            "event": "FAIL",
+            "status": "FAIL",
+            "qualifies_full_run": false,
+        }))
+        .expect("reasonless terminal state JSON"),
+    ] {
+        let error = classify_exact_probe_artifact(&invalid, SCHEMA)
+            .expect_err("malformed or unknown artifacts fail closed");
+        assert!(error.starts_with("FAILED:"), "{error}");
+    }
+
+    let bdd = include_str!("bdd.rs");
+    let validator_start = bdd
+        .find("fn validate_parity_probe(")
+        .expect("BDD probe validator exists");
+    let validator_end = bdd[validator_start..]
+        .find("fn parity_teacher_observer(")
+        .map(|offset| validator_start + offset)
+        .expect("BDD probe validator section is bounded");
+    let validator = &bdd[validator_start..validator_end];
+    assert!(validator.contains("classify_exact_probe_artifact"));
+    assert!(validator.contains("project_parity_probe_state"));
+    assert!(validator.contains("FixtureStatus::failed_with_cid"));
+}
+
+#[test]
+fn exact_probe_prepublication_binds_nonqualified_state_to_metadata_and_nonpass_outcome() {
+    const SCHEMA: &str = "uor-r4.exact-multicore-probe/2";
+    let bytes = serde_json::to_vec(&json!({
+        "schema": SCHEMA,
+        "record": "EXACT_MULTICORE_PROBE_STATE",
+        "event": "NOT_RUN",
+        "status": "REFUSE_FULL_RUN",
+        "qualifies_full_run": false,
+        "reason": "bounded preflight did not qualify the full run",
+    }))
+    .expect("state JSON");
+    let cid = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    let ExactProbeArtifact::NonQualified(state) =
+        classify_exact_probe_artifact(&bytes, SCHEMA).expect("recognized state")
+    else {
+        panic!("state artifact must remain non-qualified")
+    };
+    let fixture = state.fixture_status(cid.clone());
+    let initial_fixture = FixtureStatus::not_run("probe admission has not been evaluated");
+    assert!(validate_nonqualified_probe_prepublication(
+        RunStatus::Fail,
+        Some(&initial_fixture),
+        &state,
+        &cid,
+    )
+    .is_err());
+    validate_nonqualified_probe_prepublication(RunStatus::NotRun, Some(&fixture), &state, &cid)
+        .expect("truthful refusal may finalize as non-PASS");
+    validate_nonqualified_probe_prepublication(RunStatus::Fail, Some(&fixture), &state, &cid)
+        .expect("an independent failure may dominate the refusal");
+
+    for (label, overall, planted_fixture) in [
+        ("pass", RunStatus::Pass, fixture.clone()),
+        (
+            "wrong CID",
+            RunStatus::NotRun,
+            FixtureStatus::not_run_with_cid("blake3:stale", state.reason.clone()),
+        ),
+        (
+            "wrong verdict",
+            RunStatus::NotRun,
+            FixtureStatus::failed_with_cid(cid.clone(), state.reason.clone()),
+        ),
+        (
+            "wrong reason",
+            RunStatus::NotRun,
+            FixtureStatus::not_run_with_cid(cid.clone(), "stale reason"),
+        ),
+    ] {
+        let error = validate_nonqualified_probe_prepublication(
+            overall,
+            Some(&planted_fixture),
+            &state,
+            &cid,
+        )
+        .expect_err(label);
+        assert!(error.starts_with("FAIL:"), "{label}: {error}");
+    }
+    assert!(
+        validate_nonqualified_probe_prepublication(RunStatus::NotRun, None, &state, &cid,).is_err()
+    );
+
+    let bdd = include_str!("bdd.rs");
+    let validator_start = bdd
+        .find("fn validate_parity_prepublication(")
+        .expect("BDD prepublication validator exists");
+    let validator_end = bdd[validator_start..]
+        .find("fn append_operational_failure(")
+        .map(|offset| validator_start + offset)
+        .expect("BDD prepublication validator is bounded");
+    let validator = &bdd[validator_start..validator_end];
+    assert!(validator.contains("classify_exact_probe_artifact"));
+    assert!(validator.contains("validate_nonqualified_probe_prepublication"));
+    assert!(validator.contains("ExactMulticoreProbeReport = serde_json::from_value"));
+
+    let early_failure_start = bdd
+        .find("fn load_parity_fixtures()")
+        .expect("BDD fixture loader exists");
+    let early_failure_end = bdd[early_failure_start..]
+        .find("let execution = TeacherExecutionConfig")
+        .map(|offset| early_failure_start + offset)
+        .expect("BDD early preflight section is bounded");
+    let early_failure = &bdd[early_failure_start..early_failure_end];
+    assert!(early_failure.contains("present_nonqualified_probe_fixture_status"));
+    assert!(early_failure.contains("\"exact_multicore_probe\".to_owned(), fixture"));
+}
+
+#[test]
+fn config_defaults_to_all_available_workers_and_eight_independent_streams() {
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let available = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1);
+
+    assert_eq!(config.workers.get(), available);
+    assert_eq!(config.streams, nonzero(8));
+    assert_eq!(config.batch_per_worker, nonzero(4));
+    assert_eq!(config.progress_every, NonZeroU64::new(10).unwrap());
+    assert_eq!(config.max_wall, NonZeroU64::new(28_800).unwrap());
+    assert_eq!(config.positions, nonzero(256));
+    assert_eq!(config.gen_tokens, nonzero(8));
+    assert_eq!(config.runs, nonzero(1));
+    assert_eq!(config.corpus_positions, nonzero(1_000));
+    assert_eq!(config.fmm_positions, nonzero(256));
+    assert_eq!(config.probe_positions, nonzero(1));
+    assert_eq!(config.mode, ObservabilityMode::Enabled);
+    assert_eq!(
+        config.report_path,
+        PathBuf::from("target/teacher-parity/parity-report.json")
+    );
+}
+
+#[test]
+fn configured_wall_ceiling_cannot_exceed_eight_hours() {
+    let error = ParityConfig::from_lookup(|name| {
+        (name == "R4_PARITY_MAX_WALL_SECS").then(|| "28801".to_owned())
+    })
+    .expect_err("a longer live dispatch ceiling must fail closed");
+    assert!(matches!(
+        error,
+        ConfigError::OutOfRange {
+            name: "R4_PARITY_MAX_WALL_SECS",
+            value: 28_801,
+            minimum: 1,
+            maximum: 28_800,
+        }
+    ));
+}
+
+#[test]
+fn binding_shape_requires_canonical_streams_and_one_run_not_equal_workers() {
+    let mut config = ParityConfig::from_lookup(|_| None).expect("default config");
+    config.workers = nonzero(8);
+    config.streams = nonzero(8);
+    validate_binding_host_shape(&config, 8).expect("canonical S8/W8 shape");
+
+    config.streams = nonzero(16);
+    assert!(validate_binding_host_shape(&config, 8).is_err());
+    config.workers = nonzero(4);
+    config.streams = nonzero(8);
+    validate_binding_host_shape(&config, 8).expect("S8 and W4 are independent");
+    config.runs = nonzero(2);
+    assert!(validate_binding_host_shape(&config, 8).is_err());
+}
+
+#[test]
+fn diagnostic_worker_and_stream_bounds_remain_independently_configurable() {
+    let available = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1);
+    if available < 2 {
+        return;
+    }
+    let workers = (available / 2).max(1);
+    let streams = 8;
+    let worker_text = workers.to_string();
+    let default_streams = ParityConfig::from_lookup(|name| {
+        (name == "R4_PARITY_WORKERS").then(|| worker_text.clone())
+    })
+    .expect("worker-only diagnostic config");
+    assert_eq!(default_streams.workers.get(), workers);
+    assert_eq!(default_streams.streams.get(), 8);
+    let config = ParityConfig::from_lookup(|name| match name {
+        "R4_PARITY_WORKERS" => Some(workers.to_string()),
+        "R4_PARITY_STREAMS" => Some(streams.to_string()),
+        _ => None,
+    })
+    .expect("diagnostic asymmetric shape parses");
+    assert_eq!(config.workers.get(), workers);
+    assert_eq!(config.streams.get(), streams);
+    validate_binding_host_shape(&config, available)
+        .expect("canonical streams admit W independently");
+}
+
+#[test]
+fn planted_fan_out_lane_evidence_is_not_private_multistream_evidence() {
+    let duplicate_seeds = vec!["blake3:same".to_owned(); 8];
+    let outputs = (0..8)
+        .map(|lane| format!("blake3:out-{lane}"))
+        .collect::<Vec<_>>();
+    let error = validate_private_multistream_evidence(&duplicate_seeds, &outputs, 8)
+        .expect_err("one seed fanned to eight lanes must be refused");
+    assert!(error.to_string().contains("fan-out"));
+
+    let distinct_seeds = (0..8)
+        .map(|lane| format!("blake3:seed-{lane}"))
+        .collect::<Vec<_>>();
+    validate_private_multistream_evidence(&distinct_seeds, &outputs, 8)
+        .expect("complete ordered private lane evidence");
+}
+
+#[test]
+fn config_rejects_zero_invalid_and_out_of_range_values_without_coupling_streams_to_workers() {
+    let zero_workers =
+        ParityConfig::from_lookup(lookup(HashMap::from([("R4_PARITY_WORKERS", "0")])));
+    assert!(matches!(
+        zero_workers,
+        Err(ConfigError::NonPositive {
+            name: "R4_PARITY_WORKERS",
+            ..
+        })
+    ));
+
+    let invalid_interval = ParityConfig::from_lookup(lookup(HashMap::from([(
+        "R4_PARITY_PROGRESS_EVERY_SECS",
+        "soon",
+    )])));
+    assert!(matches!(
+        invalid_interval,
+        Err(ConfigError::InvalidInteger {
+            name: "R4_PARITY_PROGRESS_EVERY_SECS",
+            ..
+        })
+    ));
+
+    let available = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1);
+    let workers = available.to_string();
+    let independent_streams = ParityConfig::from_lookup(|name| match name {
+        "R4_PARITY_WORKERS" => Some(workers.clone()),
+        "R4_PARITY_STREAMS" => Some("1".to_owned()),
+        _ => None,
+    })
+    .expect("diagnostic stream width is independent of row workers");
+    assert_eq!(independent_streams.workers.get(), available);
+    assert_eq!(independent_streams.streams.get(), 1);
+
+    let zero_batch = ParityConfig::from_lookup(lookup(HashMap::from([
+        ("R4_PARITY_WORKERS", "1"),
+        ("R4_PARITY_STREAMS", "1"),
+        ("R4_PARITY_BATCH_PER_WORKER", "0"),
+    ])));
+    assert!(matches!(
+        zero_batch,
+        Err(ConfigError::NonPositive {
+            name: "R4_PARITY_BATCH_PER_WORKER",
+            ..
+        })
+    ));
+
+    let above_available = available.saturating_add(1).to_string();
+    let too_many_workers = ParityConfig::from_lookup(|name| {
+        (name == "R4_PARITY_WORKERS").then(|| above_available.clone())
+    });
+    assert!(matches!(
+        too_many_workers,
+        Err(ConfigError::WorkersAboveAvailable {
+            requested,
+            available: actual_available,
+        }) if requested == available + 1 && actual_available == available
+    ));
+
+    let blank_report =
+        ParityConfig::from_lookup(lookup(HashMap::from([("R4_PARITY_REPORT", "   ")])));
+    assert!(matches!(
+        blank_report,
+        Err(ConfigError::InvalidPath {
+            name: "R4_PARITY_REPORT",
+            ..
+        })
+    ));
+
+    for name in [
+        "R4_PARITY_POSITIONS",
+        "R4_PARITY_GEN_TOKENS",
+        "R4_PARITY_RUNS",
+        "R4_PARITY_CORPUS_POSITIONS",
+        "R4_FMM_POSITIONS",
+        "R4_EXACT_PROBE_POSITIONS",
+    ] {
+        let zero_budget =
+            ParityConfig::from_lookup(|candidate| (candidate == name).then(|| "0".to_owned()));
+        assert!(matches!(
+            zero_budget,
+            Err(ConfigError::NonPositive { name: actual, .. }) if actual == name
+        ));
+        let malformed_budget =
+            ParityConfig::from_lookup(|candidate| (candidate == name).then(|| "many".to_owned()));
+        assert!(matches!(
+            malformed_budget,
+            Err(ConfigError::InvalidInteger { name: actual, .. }) if actual == name
+        ));
+    }
+    let too_many_probe_positions = ParityConfig::from_lookup(|name| {
+        (name == "R4_EXACT_PROBE_POSITIONS").then(|| "9".to_owned())
+    });
+    assert!(matches!(
+        too_many_probe_positions,
+        Err(ConfigError::OutOfRange {
+            name: "R4_EXACT_PROBE_POSITIONS",
+            value: 9,
+            minimum: 1,
+            maximum: 8,
+        })
+    ));
+    let too_many_generation_tokens =
+        ParityConfig::from_lookup(|name| (name == "R4_PARITY_GEN_TOKENS").then(|| "9".to_owned()));
+    assert!(matches!(
+        too_many_generation_tokens,
+        Err(ConfigError::OutOfRange {
+            name: "R4_PARITY_GEN_TOKENS",
+            value: 9,
+            minimum: 1,
+            maximum: 8,
+        })
+    ));
+    let non_power_generation_tokens =
+        ParityConfig::from_lookup(|name| (name == "R4_PARITY_GEN_TOKENS").then(|| "3".to_owned()));
+    assert!(matches!(
+        non_power_generation_tokens,
+        Err(ConfigError::InvalidAdaptiveMaximum { value: 3 })
+    ));
+}
+
+#[test]
+fn every_present_nonunicode_parity_control_fails_instead_of_defaulting() {
+    for name in [
+        "R4_PARITY_WORKERS",
+        "R4_PARITY_STREAMS",
+        "R4_PARITY_BATCH_PER_WORKER",
+        "R4_PARITY_PROGRESS_EVERY_SECS",
+        "R4_PARITY_MAX_WALL_SECS",
+        "R4_PARITY_POSITIONS",
+        "R4_PARITY_GEN_TOKENS",
+        "R4_PARITY_RUNS",
+        "R4_PARITY_CORPUS_POSITIONS",
+        "R4_FMM_POSITIONS",
+        "R4_EXACT_PROBE_POSITIONS",
+        "R4_PARITY_TELEMETRY",
+        "R4_PARITY_REPORT",
+    ] {
+        let error = ParityConfig::from_env_lookup(|candidate| {
+            if candidate == name {
+                Err(std::env::VarError::NotUnicode(std::ffi::OsString::from(
+                    "planted-nonunicode",
+                )))
+            } else {
+                Err(std::env::VarError::NotPresent)
+            }
+        })
+        .expect_err("a present non-Unicode control must never select its default");
+        assert!(matches!(
+            error,
+            ConfigError::NonUnicode { name: actual } if actual == name
+        ));
+    }
+}
+
+#[test]
+fn counters_distinguish_logical_work_from_batches_padding_cache_and_worker_tiles() {
+    let plan = WorkPlan {
+        logical_forwards: 15,
+        tokens: 15,
+        physical_batches: 2,
+        matrix_calls: 10,
+        batched_matrix_calls: 8,
+        max_matrix_batch_width: 8,
+        padded_forwards: 1,
+        cache_hits: 7,
+        streams: 8,
+        worker_tasks: 24,
+        row_tiles: 48,
+        output_cells: 100,
+        scalar_terms: 1_000,
+    };
+    let counters = WorkCounters::new(plan);
+    counters.record_batch(8, 0, 4, 12, 24);
+    counters.record_batch(7, 1, 3, 12, 24);
+    counters.record_tokens(15);
+    counters.record_matrix_calls(10);
+    counters.record_batched_matrix_calls(8);
+    counters.record_max_matrix_batch_width(8);
+    counters.record_output_cells(100);
+    counters.record_scalar_terms(1_000);
+    for _ in 0..8 {
+        counters.record_stream_completed();
+    }
+
+    let snapshot = counters.snapshot();
+    assert_eq!(snapshot.logical_forwards, 15);
+    assert_eq!(snapshot.physical_batches, 2);
+    assert_eq!(snapshot.padded_forwards, 1);
+    assert_eq!(snapshot.cache_hits, 7);
+    assert_eq!(snapshot.streams, 8);
+    assert_eq!(snapshot.worker_tasks, 24);
+    assert_eq!(snapshot.row_tiles, 48);
+    assert_eq!(snapshot.failed_worker_tasks, 0);
+    assert_eq!(
+        counters.completion_status(RunStatus::Pass).status,
+        RunStatus::Pass
+    );
+}
+
+#[test]
+fn planted_worker_failure_and_incomplete_accounting_cannot_be_reported_as_pass() {
+    let plan = WorkPlan {
+        logical_forwards: 8,
+        physical_batches: 1,
+        padded_forwards: 0,
+        cache_hits: 0,
+        streams: 8,
+        worker_tasks: 16,
+        row_tiles: 32,
+        ..WorkPlan::default()
+    };
+    let counters = WorkCounters::new(plan);
+    counters.record_batch(8, 0, 0, 15, 31);
+    counters.record_worker_task_failed();
+
+    let verdict = counters.completion_status(RunStatus::Pass);
+    assert_eq!(verdict.status, RunStatus::Fail);
+    let detail = verdict.detail.expect("failure detail");
+    assert!(detail.contains("worker_tasks 15/16"), "{detail}");
+    assert!(detail.contains("row_tiles 31/32"), "{detail}");
+    assert!(detail.contains("failed_worker_tasks 1"), "{detail}");
+}
+
+#[test]
+fn work_plan_is_install_once_and_cannot_be_rewritten_after_work_starts() {
+    let plan = WorkPlan {
+        logical_forwards: 1,
+        physical_batches: 1,
+        ..WorkPlan::default()
+    };
+    let counters = WorkCounters::unplanned();
+    counters.set_plan(plan).expect("first plan installation");
+    assert_eq!(
+        counters.set_plan(plan),
+        Err(PlanInstallError::AlreadyInstalled)
+    );
+
+    let late = WorkCounters::unplanned();
+    late.record_logical_forwards(1);
+    assert_eq!(
+        late.set_plan(plan),
+        Err(PlanInstallError::WorkAlreadyStarted)
+    );
+    let verdict = late.completion_status(RunStatus::Pass);
+    assert_eq!(verdict.status, RunStatus::Fail);
+    assert!(verdict
+        .detail
+        .expect("fail-closed detail")
+        .contains("before the plan was installed"));
+}
+
+#[test]
+fn adaptive_plan_can_only_close_down_to_observed_work() {
+    let ceiling = WorkPlan {
+        logical_forwards: 100,
+        tokens: 100,
+        physical_batches: 14,
+        max_matrix_batch_width: 8,
+        streams: 16,
+        ..WorkPlan::default()
+    };
+    let counters = WorkCounters::new(ceiling);
+    counters.record_logical_forwards(44);
+    let reduced = WorkPlan {
+        logical_forwards: 44,
+        tokens: 44,
+        physical_batches: 14,
+        max_matrix_batch_width: 8,
+        streams: 16,
+        ..WorkPlan::default()
+    };
+    counters
+        .reduce_plan(reduced)
+        .expect("adaptive upper bound closes to selected work");
+    let increase = WorkPlan {
+        logical_forwards: 45,
+        ..reduced
+    };
+    assert_eq!(
+        counters.reduce_plan(increase),
+        Err(PlanInstallError::ReductionWouldIncrease)
+    );
+    let below_observed = WorkPlan {
+        logical_forwards: 43,
+        ..reduced
+    };
+    assert_eq!(
+        counters.reduce_plan(below_observed),
+        Err(PlanInstallError::ReductionBelowObserved)
+    );
+}
+
+#[test]
+fn adaptive_decode_stops_early_only_above_margin_and_is_truthful_at_maximum() {
+    assert_eq!(
+        adaptive_decode_decision(1, 8, 1.10, 9.0),
+        AdaptiveDecodeDecision::ExtendConservativeMarginNotCleared,
+        "the conservative early margin is strict"
+    );
+    assert_eq!(
+        adaptive_decode_decision(2, 8, 1.11, 1.11),
+        AdaptiveDecodeDecision::StopEarlyConservativeMarginCleared
+    );
+    assert_eq!(
+        adaptive_decode_decision(8, 8, 1.01, 1.01),
+        AdaptiveDecodeDecision::StopAtMaximumAcceptanceCleared
+    );
+    assert_eq!(
+        adaptive_decode_decision(8, 8, 1.0, 20.0),
+        AdaptiveDecodeDecision::StopAtMaximumNotEstablished,
+        "the >1.0 acceptance boundary is strict and requires both engines"
+    );
+}
+
+#[test]
+fn adaptive_checkpoints_are_one_cumulative_causal_wave_not_repeat_counts() {
+    assert_eq!(adaptive_decode_checkpoints(1), vec![1]);
+    assert_eq!(adaptive_decode_checkpoints(2), vec![1, 2]);
+    assert_eq!(adaptive_decode_checkpoints(4), vec![1, 2, 4]);
+    assert_eq!(adaptive_decode_checkpoints(8), vec![1, 2, 4, 8]);
+}
+
+#[test]
+fn bdd_source_keeps_one_time_compiled_cohorts_before_teacher_continuation() {
+    // This is deliberately a source-contract regression test. Fixture-backed
+    // execution counters remain the behavioral evidence; the source check
+    // prevents the expensive rebuild/reload loop from being reintroduced in
+    // environments where those fixtures are unavailable.
+    let source = include_str!("bdd.rs");
+    assert!(!source.contains("timed_legacy_generate"));
+    assert!(!source.contains("timed_graph_generate"));
+
+    let s4_start = source
+        .find("fn parity_time_generation(")
+        .expect("S4 timing step exists");
+    let s4_end = source[s4_start..]
+        .find("#[then(\"the measured concurrent token rate")
+        .map(|offset| s4_start + offset)
+        .expect("S4 timing step has a bounded source section");
+    let s4 = &source[s4_start..s4_end];
+    assert_eq!(s4.matches("timed_legacy_causal_wave(").count(), 1);
+    assert_eq!(s4.matches("timed_graph_causal_wave(").count(), 1);
+    let legacy = s4.find("timed_legacy_causal_wave(").unwrap();
+    let graph = s4.find("timed_graph_causal_wave(").unwrap();
+    let teacher_prepare = s4.find("prepare_teacher_generation(").unwrap();
+    let teacher_decode = s4.find("timed_teacher_decode_to(").unwrap();
+    assert!(legacy < graph && graph < teacher_prepare && teacher_prepare < teacher_decode);
+    assert!(s4.contains("legacy_samples[stage].aggregate_tps"));
+    assert!(s4.contains("graph_samples[stage].aggregate_tps"));
+
+    let graph_wave_start = source
+        .find("fn timed_graph_causal_wave(")
+        .expect("graph causal wave exists");
+    let graph_wave_end = source[graph_wave_start..]
+        .find("fn generation_wave_json(")
+        .map(|offset| graph_wave_start + offset)
+        .expect("graph causal wave has a bounded source section");
+    let graph_wave = &source[graph_wave_start..graph_wave_end];
+    assert_eq!(graph_wave.matches("load_r4g1(").count(), 1);
+    let lane_loop = graph_wave.find("for stream in 0..streams").unwrap();
+    let lane_state_load = graph_wave.find("state: load_r4g1(").unwrap();
+    assert!(lane_loop < lane_state_load && lane_state_load < graph_wave.find("for _step").unwrap());
+    let graph_trajectory_start = source
+        .find("struct GraphGenerationTrajectory")
+        .expect("graph trajectory owns its state");
+    let graph_trajectory_end = source[graph_trajectory_start..]
+        .find("fn parity_source_dir")
+        .map(|offset| graph_trajectory_start + offset)
+        .expect("graph trajectory declaration has a bounded source section");
+    let graph_trajectory = &source[graph_trajectory_start..graph_trajectory_end];
+    assert!(graph_trajectory.contains("state: R4g1State"));
+    assert!(!source.contains("struct GraphGenerationWorker"));
+    assert!(
+        graph_wave.contains("trajectory\n                                            .state"),
+        "each prediction must use the lane-owned mutable policy state"
+    );
+
+    let loader_start = source
+        .find("fn load_parity_fixtures(")
+        .expect("fixture loader exists");
+    let loader_end = source[loader_start..]
+        .find("fn load_fmm_candidate(")
+        .map(|offset| loader_start + offset)
+        .expect("fixture loader has a bounded source section");
+    let loader = &source[loader_start..loader_end];
+    assert!(
+        !loader.contains("Tokenizer::try_load"),
+        "parity admission must not consult unbound sibling or hard-coded vocab.json files"
+    );
+    assert_eq!(
+        loader
+            .matches("Tokenizer::from_bytes(&tokenizer_bytes)")
+            .count(),
+        1,
+        "fixture loading must parse only the content-bound tokenizer.bin bytes"
+    );
+    assert!(
+        loader.find("teacher_free_parity_preflight()").unwrap()
+            < loader.find("validate_parity_probe(").unwrap(),
+        "compiled structural preflight must gate the source-only tuner"
+    );
+
+    let adoption_start = source
+        .find("fn adopt_probe_execution(")
+        .expect("probe adoption exists");
+    let adoption_end = source[adoption_start..]
+        .find("fn validate_parity_probe(")
+        .map(|offset| adoption_start + offset)
+        .expect("probe adoption has a bounded source section");
+    let adoption = &source[adoption_start..adoption_end];
+    assert!(
+        !adoption.contains("requested_workers ="),
+        "probe selection must not rewrite the operator-requested worker count"
+    );
+    assert!(adoption.contains("effective_workers = shape.selected_workers"));
+    assert!(adoption.contains("probe_selected_execution"));
+
+    let preflight_start = source
+        .find("fn teacher_free_parity_preflight(")
+        .expect("teacher-free preflight entry exists");
+    let preflight_end = source[preflight_start..]
+        .find("struct PromptWork")
+        .map(|offset| preflight_start + offset)
+        .expect("teacher-free preflight has a bounded source section");
+    let preflight = &source[preflight_start..preflight_end];
+    for forbidden in [
+        "parity_run(",
+        "parity_progress(",
+        "validate_parity_probe(",
+        "SmolLm2Oracle",
+    ] {
+        assert!(
+            !preflight.contains(forbidden),
+            "standalone preflight must not initialize live teacher/run machinery: {forbidden}"
+        );
+    }
+    assert!(preflight.contains("\"teacher_forwards\": 0"));
+    assert!(preflight.contains("\"authorizing_contract_cid\": exact_executor_contract_cid()"));
+    assert!(preflight.contains("\"selected_source_dir\": source.display().to_string()"));
+    assert!(!preflight.contains("Tokenizer::try_load"));
+    assert!(preflight.contains("Tokenizer::from_bytes(&tokenizer_bytes)"));
+    assert!(preflight.contains("let graph_states = (0..lane_seeds.len())"));
+    assert!(preflight.contains("\"graph_state_preparations\": graph_states.len()"));
+    let ordinary_input_start = source
+        .find("fn teacher_free_input_evidence(")
+        .expect("ordinary teacher-free input evidence exists");
+    let production_input_start = source
+        .find("fn production_admission_input_evidence(")
+        .expect("production admission input evidence exists");
+    let ordinary_input = &source[ordinary_input_start..production_input_start];
+    assert!(ordinary_input.contains("std::fs::metadata(path)"));
+    assert!(!ordinary_input.contains("symlink_metadata"));
+    let production_input_end = source[production_input_start..]
+        .find("fn teacher_free_preflight_failure_report(")
+        .map(|offset| production_input_start + offset)
+        .expect("production evidence helper has a bounded source section");
+    let production_input = &source[production_input_start..production_input_end];
+    assert!(production_input.contains("std::fs::symlink_metadata(path)"));
+    assert!(production_input.contains("regular non-symlink file"));
+    let refusal_start = source
+        .find("fn teacher_free_preflight_failure_report(")
+        .expect("teacher-free refusal evidence builder exists");
+    let refusal_end = source[refusal_start..]
+        .find("fn bind_teacher_free_preflight_report_path(")
+        .map(|offset| refusal_start + offset)
+        .expect("teacher-free refusal builder has a bounded source section");
+    let refusal = &source[refusal_start..refusal_end];
+    for required in [
+        "\"reason\": reason",
+        "\"authorizing_contract_cid\": exact_executor_contract_cid()",
+        "\"teacher_source_opened\": false",
+        "\"teacher_forwards\": 0",
+        "\"selected_source_dir\"",
+        "\"selected_bundle_dir\"",
+        "\"teacher_model\"",
+        "\"legacy_artifact\"",
+        "\"graph\"",
+        "\"graph_report\"",
+        "\"production_admission\"",
+        "production_admission_input_evidence",
+    ] {
+        assert!(
+            refusal.contains(required),
+            "missing refusal field {required}"
+        );
+    }
+    assert!(refusal.contains("reason.starts_with(\"UNAVAILABLE:\")"));
+    assert!(refusal.contains("\"FAILED\""));
+
+    let automatic_start = source
+        .find("fn load_parity_fixtures(")
+        .expect("automatic fixture loader exists");
+    let automatic_end = source[automatic_start..]
+        .find("fn load_fmm_candidate(")
+        .map(|offset| automatic_start + offset)
+        .expect("automatic fixture loader has a bounded source section");
+    let automatic = &source[automatic_start..automatic_end];
+    assert!(automatic.contains("run_teacher_free_parity_preflight()"));
+    assert!(automatic.contains("file_kappa(&teacher_free_preflight_path)?.0"));
+    assert!(!automatic.contains("serde_json::to_vec(&teacher_free_preflight)"));
+    let final_preflight_rehash = automatic
+        .rfind("file_kappa(&teacher_free_preflight_path)?.0")
+        .expect("preflight token is rehashed immediately before teacher load");
+    let final_generation_rehash = automatic
+        .rfind("production_admission_component_cids(&bundle)?")
+        .expect("complete schema-2 generation is rehashed before teacher load");
+    let teacher_load = automatic
+        .find("SmolLm2Oracle::load_with_sequence_length_and_execution(")
+        .expect("live teacher load exists");
+    assert!(final_preflight_rehash < final_generation_rehash);
+    assert!(final_generation_rehash < teacher_load);
+    assert!(automatic.contains("current_preflight_cid != preflight_cid"));
+    assert!(automatic.contains("current_production_generation != admitted_production_generation"));
+    assert!(
+        automatic
+            .find("run_teacher_free_parity_preflight()")
+            .unwrap()
+            < automatic.find("validate_parity_probe(").unwrap()
+    );
+    let main_start = source.find("async fn main()").expect("BDD main exists");
+    let main_end = source[main_start..]
+        .find("// =========================================================================")
+        .map(|offset| main_start + offset)
+        .expect("BDD main has a bounded source section");
+    let main = &source[main_start..main_end];
+    assert!(main.contains("run_teacher_free_parity_preflight()"));
+    assert!(main.contains("teacher-free preflight refusal artifact"));
+    assert!(main.contains("panic!(\"teacher-free parity preflight: {}\", failure.reason)"));
+}
+
+#[test]
+fn bdd_source_preserves_all_variable_length_prompt_histories_without_extra_teacher_work() {
+    let source = include_str!("bdd.rs");
+    assert!(source.contains(
+        "S4_REGISTERED_PROMPT_TOKEN_LENGTHS: [usize; S4_CANONICAL_STREAMS] = [6, 7, 6, 5, 4, 5, 6, 5]"
+    ));
+
+    let seeds_start = source
+        .find("fn generation_lane_seeds(")
+        .expect("generation seed policy exists");
+    let seeds_end = source[seeds_start..]
+        .find("fn generation_output_identities(")
+        .map(|offset| seeds_start + offset)
+        .expect("generation seed policy has a bounded source section");
+    let seeds = &source[seeds_start..seeds_end];
+    assert!(seeds.contains("seed.pop();"));
+    assert!(!seeds.contains("seed.truncate("));
+    assert!(seeds.contains("S4_REGISTERED_PROMPT_TOKEN_LENGTHS[lane]"));
+
+    let transcript_start = source
+        .find("fn build_teacher_transcript(")
+        .expect("transcript builder exists");
+    let transcript_end = source[transcript_start..]
+        .find("fn teacher_transcript(")
+        .map(|offset| transcript_start + offset)
+        .expect("transcript builder has a bounded source section");
+    let transcript = &source[transcript_start..transcript_end];
+    assert!(transcript.contains("position + 1 == work.positions"));
+    assert!(transcript.contains("generation_retained_prefix_tokens_per_lane"));
+    assert!(!transcript.contains("common_prefix_tokens"));
+
+    let adaptive_start = source
+        .find("fn timed_teacher_decode_to(")
+        .expect("adaptive teacher decode exists");
+    let adaptive_end = source[adaptive_start..]
+        .find("fn record_compiled_failure(")
+        .map(|offset| adaptive_start + offset)
+        .expect("adaptive teacher decode has a bounded source section");
+    let adaptive = &source[adaptive_start..adaptive_end];
+    assert!(adaptive.contains("cohort.retained_prefix_tokens_per_lane[lane]"));
+    assert!(!adaptive.contains("positions.fill("));
+
+    let preflight_start = source
+        .find("fn teacher_free_parity_preflight(")
+        .expect("teacher-free preflight exists");
+    let preflight_end = source[preflight_start..]
+        .find("struct PromptWork")
+        .map(|offset| preflight_start + offset)
+        .expect("teacher-free preflight has a bounded source section");
+    let preflight = &source[preflight_start..preflight_end];
+    assert!(preflight.contains("each lane's final teacher-forced prompt prefix"));
+    assert!(preflight.contains("\"retained_prefix_tokens_per_lane\""));
+    assert!(preflight.contains("\"seed_tokens_per_lane\""));
+    assert!(preflight.contains("\"teacher_forwards\": 0"));
+}
+
+#[test]
+fn bdd_source_binds_per_forward_overlap_and_zero_growth_after_excluded_preparation() {
+    let source = include_str!("bdd.rs");
+    let observer_start = source
+        .find("fn parity_teacher_observer()")
+        .expect("teacher observer exists");
+    let observer_end = source[observer_start..]
+        .find("fn teacher_execution_delta(")
+        .map(|offset| observer_start + offset)
+        .expect("observer source section is bounded");
+    assert!(source[observer_start..observer_end].contains("snapshot.forward_max_active_workers"));
+
+    let forward_start = source
+        .find("fn teacher_forward_accounted(")
+        .expect("accounted forward exists");
+    let forward_end = source[forward_start..]
+        .find("fn with_parity_fixtures")
+        .map(|offset| forward_start + offset)
+        .expect("accounted forward source section is bounded");
+    let forward = &source[forward_start..forward_end];
+    assert!(forward.contains("delta.multiworker_forward_calls != delta.forward_calls"));
+    assert!(forward.contains("delta.forward_max_active_workers <= 1"));
+    assert!(forward.contains("observed_workers != delta.forward_max_active_workers"));
+
+    let loader_start = source
+        .find("fn load_parity_fixtures(")
+        .expect("fixture loader exists");
+    let loader_end = source[loader_start..]
+        .find("fn load_fmm_candidate(")
+        .map(|offset| loader_start + offset)
+        .expect("fixture loader source section is bounded");
+    let loader = &source[loader_start..loader_end];
+    let preparation = loader.find(".prepare_exact_execution(").unwrap();
+    let measured = loader.find(".begin_measured_execution(").unwrap();
+    assert!(preparation < measured);
+    assert!(loader.contains("measured_start.workspace_growth_events != 0"));
+
+    let transcript_start = source
+        .find("fn build_teacher_transcript(")
+        .expect("transcript builder exists");
+    let transcript_end = source[transcript_start..]
+        .find("fn teacher_transcript(")
+        .map(|offset| transcript_start + offset)
+        .expect("transcript source section is bounded");
+    let transcript = &source[transcript_start..transcript_end];
+    assert!(transcript.contains("forward.workspace_growth_events != 0"));
+
+    let adaptive_start = source
+        .find("fn timed_teacher_decode_to(")
+        .expect("adaptive teacher decode exists");
+    let adaptive_end = source[adaptive_start..]
+        .find("fn record_compiled_failure(")
+        .map(|offset| adaptive_start + offset)
+        .expect("adaptive decode source section is bounded");
+    let adaptive = &source[adaptive_start..adaptive_end];
+    assert!(adaptive.contains("execution_delta.multiworker_forward_calls"));
+    assert!(adaptive.contains("execution_delta.workspace_growth_events != 0"));
+}
+
+#[test]
+fn standalone_json_publication_is_atomic_and_replaces_by_readback_value() {
+    let dir = unique_dir("standalone-json");
+    let path = dir.join("teacher-free-preflight.json");
+    let first = json!({"schema": "preflight/1", "value": 1});
+    assert_eq!(
+        write_atomic_json(&path, &first).expect("first atomic publication"),
+        path
+    );
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&fs::read(&path).expect("first bytes"))
+            .expect("first JSON"),
+        first
+    );
+    let second = json!({"schema": "preflight/1", "value": 2});
+    write_atomic_json(&path, &second).expect("replacement atomic publication");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&fs::read(&path).expect("second bytes"))
+            .expect("second JSON"),
+        second
+    );
+    assert_eq!(
+        fs::read_dir(&dir)
+            .expect("list standalone directory")
+            .count(),
+        1,
+        "successful publication must leave no temporary siblings"
+    );
+    fs::remove_dir_all(dir).expect("remove standalone JSON output");
+}
+
+#[test]
+fn planted_graph_quality_refusal_is_atomically_published_before_non_pass_return() {
+    let path = unique_dir("graph-quality-refusal").join("preflight.json");
+    let reason =
+        "FAILED: R4G1 quality gate failed: graph runtime top-1 25.65% is below TLA baseline 30.12%";
+    let outcome = publish_atomic_preflight_outcome(&path, Err(reason.to_owned()), |reason| {
+        json!({
+            "schema": "uor-r4.teacher-parity-preflight/1",
+            "status": "FAILED",
+            "reason": reason,
+            "report_path": path.display().to_string(),
+            "selected_source_dir": "/fixture/source",
+            "selected_bundle_dir": "/fixture/bundle",
+            "teacher_source_opened": false,
+            "teacher_forwards": 0,
+            "inputs": {
+                "graph": {
+                    "path": "/fixture/bundle/graph/score.r4g1",
+                    "presence": "PRESENT",
+                    "cid": "blake3:graph",
+                },
+                "graph_report": {
+                    "path": "/fixture/bundle/graph/score_report.json",
+                    "presence": "PRESENT",
+                    "cid": "blake3:report",
+                },
+            },
+        })
+    });
+    assert_eq!(outcome.expect_err("quality refusal stays non-PASS"), reason);
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).expect("durable refusal bytes"))
+            .expect("durable refusal JSON");
+    assert_eq!(report["status"], "FAILED");
+    assert_eq!(report["reason"], reason);
+    assert_eq!(report["report_path"], path.display().to_string());
+    assert_eq!(report["teacher_source_opened"], false);
+    assert_eq!(report["teacher_forwards"], 0);
+    assert_eq!(report["inputs"]["graph"]["presence"], "PRESENT");
+}
+
+#[test]
+fn planted_graph_quality_refusal_projects_exact_fixture_evidence_into_final_metadata() {
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let mut metadata = RunMetadata::new(
+        SchedulerSnapshot::from_config(&config),
+        "exact",
+        "exact-gemm",
+        "test-isa",
+    );
+    let report_path = unique_dir("preflight-final-metadata").join("preflight.json");
+    let reason = "FAILED: R4G1 load: R4G1 quality gate failed: graph runtime top-1 25.65% is below TLA baseline 30.12%";
+    let report = json!({
+        "teacher_source_opened": false,
+        "teacher_forwards": 0,
+        "inputs": {
+            "teacher_model": {"presence": "PRESENT", "cid": null, "cid_status": "NOT_READ_TEACHER_FREE"},
+            "teacher_config": {"presence": "PRESENT", "cid": null, "cid_status": "NOT_READ_TEACHER_FREE"},
+            "tokenizer": {"presence": "PRESENT", "cid": "blake3:tokenizer"},
+            "legacy_artifact": {"presence": "PRESENT", "cid": "blake3:tla"},
+            "legacy_store": {"presence": "PRESENT", "cid": "blake3:tls"},
+            "graph": {"presence": "PRESENT", "cid": "blake3:graph"},
+            "graph_report": {"presence": "PRESENT", "cid": "blake3:graph-report"},
+        },
+    });
+    apply_teacher_free_preflight_failure_metadata(
+        &mut metadata,
+        &report_path,
+        Some("blake3:preflight-report"),
+        &report,
+        FixtureStatus::failed(reason),
+        true,
+        TeacherFreeGraphFailureStage::GraphLoadAttempted,
+    );
+
+    assert_eq!(
+        metadata.paths.get("teacher_free_preflight_report"),
+        Some(&report_path.display().to_string())
+    );
+    for fixture in ["tokenizer", "tla_artifact", "tls_store"] {
+        assert_eq!(
+            metadata.fixtures[fixture].verdict,
+            FixtureVerdict::Available
+        );
+        assert!(metadata.fixtures[fixture].cid.is_some());
+    }
+    for fixture in ["teacher_weights", "teacher_config"] {
+        assert_eq!(metadata.fixtures[fixture].verdict, FixtureVerdict::NotRun);
+        assert!(metadata.fixtures[fixture].cid.is_none());
+        assert!(metadata.fixtures[fixture]
+            .reason
+            .as_deref()
+            .is_some_and(|detail| detail.contains("not opened")));
+    }
+    assert_eq!(
+        metadata.fixtures["r4g1_graph"].verdict,
+        FixtureVerdict::Failed
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph"].cid.as_deref(),
+        Some("blake3:graph")
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph"].reason.as_deref(),
+        Some(reason)
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph_report"].verdict,
+        FixtureVerdict::Available
+    );
+    assert_eq!(
+        metadata
+            .identities
+            .get("r4g1_graph_report")
+            .map(String::as_str),
+        Some("blake3:graph-report")
+    );
+    assert_eq!(
+        metadata.fixtures["teacher_free_s4_preflight"]
+            .cid
+            .as_deref(),
+        Some("blake3:preflight-report")
+    );
+
+    let report_reason =
+        "FAILED: parse /fixture/bundle/graph/score_report.json: expected value at line 1";
+    apply_teacher_free_preflight_failure_metadata(
+        &mut metadata,
+        &report_path,
+        Some("blake3:preflight-report"),
+        &report,
+        FixtureStatus::failed(report_reason),
+        true,
+        TeacherFreeGraphFailureStage::ReportFailed,
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph"].verdict,
+        FixtureVerdict::NotRun
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph"].cid.as_deref(),
+        Some("blake3:graph")
+    );
+    assert!(metadata.fixtures["r4g1_graph"]
+        .reason
+        .as_deref()
+        .is_some_and(|reason| reason.contains(report_reason)));
+    assert_eq!(
+        metadata.fixtures["r4g1_graph_report"].verdict,
+        FixtureVerdict::Failed
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph_report"].cid.as_deref(),
+        Some("blake3:graph-report")
+    );
+    assert_eq!(
+        metadata.fixtures["r4g1_graph_report"].reason.as_deref(),
+        Some(report_reason)
+    );
+}
+
+#[test]
+fn planted_missing_input_refusal_retains_paths_presence_and_unavailable_status() {
+    let path = unique_dir("missing-input-refusal").join("preflight.json");
+    let reason = "UNAVAILABLE: graph artifact/report absent";
+    let outcome = publish_atomic_preflight_outcome(&path, Err(reason.to_owned()), |reason| {
+        json!({
+            "schema": "uor-r4.teacher-parity-preflight/1",
+            "status": "UNAVAILABLE",
+            "reason": reason,
+            "report_path": path.display().to_string(),
+            "selected_source_dir": "/fixture/source",
+            "selected_bundle_dir": "/fixture/bundle",
+            "teacher_source_opened": false,
+            "teacher_forwards": 0,
+            "inputs": {
+                "graph": {
+                    "path": "/fixture/bundle/graph/score.r4g1",
+                    "presence": "ABSENT",
+                    "cid": null,
+                },
+            },
+        })
+    });
+    assert_eq!(outcome.expect_err("missing input stays non-PASS"), reason);
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).expect("durable refusal bytes"))
+            .expect("durable refusal JSON");
+    assert_eq!(report["status"], "UNAVAILABLE");
+    assert_eq!(report["reason"], reason);
+    assert_eq!(report["inputs"]["graph"]["presence"], "ABSENT");
+    assert!(report["inputs"]["graph"]["cid"].is_null());
+
+    let report_cid = format!(
+        "blake3:{}",
+        blake3::hash(&fs::read(&path).expect("published refusal bytes")).to_hex()
+    );
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let mut metadata = RunMetadata::new(
+        SchedulerSnapshot::from_config(&config),
+        "exact",
+        "exact-gemm",
+        "test-isa",
+    );
+    apply_teacher_free_preflight_failure_metadata(
+        &mut metadata,
+        &path,
+        Some(&report_cid),
+        &report,
+        FixtureStatus::unavailable(reason),
+        true,
+        TeacherFreeGraphFailureStage::NotReached,
+    );
+    assert_eq!(
+        metadata.fixtures["teacher_free_s4_preflight"].verdict,
+        FixtureVerdict::Unavailable
+    );
+    assert_eq!(
+        metadata.fixtures["teacher_free_s4_preflight"]
+            .cid
+            .as_deref(),
+        Some(report_cid.as_str())
+    );
+    assert_eq!(
+        metadata
+            .identities
+            .get("teacher_free_s4_preflight")
+            .map(String::as_str),
+        Some(report_cid.as_str())
+    );
+    assert!(!metadata
+        .identities
+        .contains_key("teacher_free_preflight_report"));
+}
+
+#[test]
+fn planted_preflight_report_write_failure_retains_original_refusal_and_never_passes() {
+    let dir = unique_dir("preflight-write-failure");
+    fs::create_dir_all(&dir).expect("test directory");
+    let blocking_file = dir.join("not-a-directory");
+    fs::write(&blocking_file, b"block").expect("blocking file");
+    let path = blocking_file.join("preflight.json");
+    let reason = "FAILED: planted graph quality refusal";
+    let error = publish_atomic_preflight_outcome(&path, Err(reason.to_owned()), |reason| {
+        json!({
+            "schema": "uor-r4.teacher-parity-preflight/1",
+            "status": "FAILED",
+            "reason": reason,
+            "report_path": path.display().to_string(),
+            "teacher_source_opened": false,
+            "teacher_forwards": 0,
+        })
+    })
+    .expect_err("unwritable refusal report must fail closed");
+    assert!(error.contains(reason));
+    assert!(error.contains("invalidate stale report"));
+    assert!(error.contains(&path.display().to_string()));
+    assert!(!path.exists());
+}
+
+#[test]
+fn planted_preflight_publication_failure_cannot_leave_a_stale_available_token() {
+    let dir = unique_dir("preflight-stale-available");
+    fs::create_dir_all(&dir).expect("test directory");
+    let path = dir.join("preflight.json");
+    fs::write(
+        &path,
+        b"{\"schema\":\"uor-r4.teacher-parity-preflight/1\",\"status\":\"AVAILABLE\"}\n",
+    )
+    .expect("stale AVAILABLE artifact");
+
+    let publication = std::panic::catch_unwind(|| {
+        let _ = publish_atomic_preflight_outcome(
+            &path,
+            Err("FAILED: planted current refusal".to_owned()),
+            |_| panic!("planted failure after stale-token invalidation"),
+        );
+    });
+    assert!(publication.is_err());
+    assert!(
+        !path.exists(),
+        "a stale AVAILABLE admission token must be removed before current publication"
+    );
+    fs::remove_dir_all(dir).expect("remove stale-artifact test directory");
+}
+
+#[test]
+fn standalone_preflight_path_has_a_stable_default_and_rejects_empty_override() {
+    assert_eq!(
+        configured_preflight_report_path(None).expect("default preflight path"),
+        PathBuf::from("target/teacher-parity/teacher-free-preflight.json")
+    );
+    assert_eq!(
+        configured_preflight_report_path(Some("target/custom-preflight.json".to_owned()))
+            .expect("custom preflight path"),
+        PathBuf::from("target/custom-preflight.json")
+    );
+    assert!(matches!(
+        configured_preflight_report_path(Some("   ".to_owned())),
+        Err(ConfigError::InvalidPath {
+            name: "R4_PARITY_PREFLIGHT_REPORT",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn fixture_directory_overrides_are_explicit_and_fail_closed() {
+    let default = PathBuf::from("/registered/default");
+    assert_eq!(
+        configured_fixture_dir("R4_PARITY_SOURCE", Ok(None), default.clone())
+            .expect("missing override uses the registered default"),
+        default
+    );
+    assert_eq!(
+        configured_fixture_dir(
+            "R4_PARITY_BUNDLE",
+            Ok(Some("../shared/bundle".to_owned())),
+            PathBuf::from("/unused"),
+        )
+        .expect("explicit bundle path"),
+        PathBuf::from("../shared/bundle")
+    );
+    assert!(configured_fixture_dir(
+        "R4_PARITY_SOURCE",
+        Ok(Some(" \t".to_owned())),
+        PathBuf::from("/unused"),
+    )
+    .unwrap_err()
+    .contains("R4_PARITY_SOURCE is empty"));
+    assert!(configured_fixture_dir(
+        "R4_PARITY_BUNDLE",
+        Err("is not valid Unicode".to_owned()),
+        PathBuf::from("/unused"),
+    )
+    .unwrap_err()
+    .contains("R4_PARITY_BUNDLE is not valid Unicode"));
+}
+
+#[test]
+fn standalone_json_write_failure_leaves_no_temporary_artifact() {
+    let dir = unique_dir("standalone-json-failure");
+    let blocked = dir.join("blocked.json");
+    fs::create_dir_all(&blocked).expect("create blocking destination directory");
+    let error = write_atomic_json(&blocked, &json!({"status": "AVAILABLE"}))
+        .expect_err("a directory cannot be replaced by the standalone report");
+    assert!(error.to_string().contains("telemetry I/O"));
+    assert_eq!(
+        fs::read_dir(&dir)
+            .expect("list failed standalone directory")
+            .count(),
+        1,
+        "failed publication must remove its temporary sibling"
+    );
+    fs::remove_dir_all(dir).expect("remove failed standalone JSON output");
+}
+
+#[test]
+fn eta_reports_warming_estimated_unavailable_and_stall_without_guessing() {
+    let warming = estimate_eta(EtaInput {
+        completed: 1,
+        total: 100,
+        elapsed: Duration::from_secs(10),
+        last_progress_age: Duration::ZERO,
+        stall_after: Duration::from_secs(60),
+        minimum_samples: 3,
+    });
+    assert_eq!(warming.status, EtaStatus::WarmingUp);
+    assert_eq!(warming.remaining_seconds, None);
+
+    let estimated = estimate_eta(EtaInput {
+        completed: 25,
+        total: 100,
+        elapsed: Duration::from_secs(50),
+        last_progress_age: Duration::from_secs(2),
+        stall_after: Duration::from_secs(60),
+        minimum_samples: 3,
+    });
+    assert_eq!(estimated.status, EtaStatus::Estimated);
+    assert_eq!(estimated.remaining_seconds, Some(150));
+
+    let unavailable = estimate_eta(EtaInput {
+        completed: 0,
+        total: 0,
+        elapsed: Duration::from_secs(50),
+        last_progress_age: Duration::ZERO,
+        stall_after: Duration::from_secs(60),
+        minimum_samples: 3,
+    });
+    assert_eq!(unavailable.status, EtaStatus::Unavailable);
+
+    let stalled = estimate_eta(EtaInput {
+        completed: 25,
+        total: 100,
+        elapsed: Duration::from_secs(500),
+        last_progress_age: Duration::from_secs(61),
+        stall_after: Duration::from_secs(60),
+        minimum_samples: 3,
+    });
+    assert_eq!(stalled.status, EtaStatus::Stall);
+    assert_eq!(stalled.remaining_seconds, None);
+}
+
+#[test]
+fn heartbeat_jsonl_is_parseable_and_visible_before_the_log_is_dropped() {
+    let dir = unique_dir("heartbeat");
+    fs::create_dir_all(&dir).expect("create test output");
+    let path = dir.join("run.events.jsonl");
+    let mut log = HeartbeatLog::create(&path).expect("create heartbeat log");
+    let event = HeartbeatEvent::new(
+        "run-932",
+        RunStatus::NotRun,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test sampler".to_owned(),
+        },
+    );
+
+    log.append(event.clone()).expect("durably append heartbeat");
+    let first = fs::read_to_string(&path).expect("flushed heartbeat is immediately readable");
+    let parsed: HeartbeatEvent = serde_json::from_str(first.trim()).expect("heartbeat JSON");
+    assert_eq!(parsed.sequence, 0);
+    assert_eq!(parsed.run_id, "run-932");
+
+    log.append(event).expect("append second heartbeat");
+    let second = fs::read_to_string(&path).expect("read two heartbeats");
+    let events: Vec<HeartbeatEvent> = second
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("heartbeat line JSON"))
+        .collect();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[1].sequence, 1);
+    fs::remove_dir_all(&dir).expect("remove isolated test output");
+}
+
+#[test]
+fn empirical_run_changes_cannot_change_supplied_deterministic_evidence_bytes() {
+    let enabled_dir = unique_dir("enabled");
+    let disabled_dir = unique_dir("disabled");
+    fs::create_dir_all(&enabled_dir).expect("create enabled output");
+    fs::create_dir_all(&disabled_dir).expect("create disabled output");
+
+    let identity = BTreeMap::from([
+        ("teacher_kappa".to_owned(), "blake3:teacher".to_owned()),
+        ("artifact_kappa".to_owned(), "blake3:artifact".to_owned()),
+    ]);
+    let evidence = DeterministicEvidence::new(
+        RunStatus::Pass,
+        identity,
+        json!({"tokens": [3, 1, 4], "logit_bits": [1065353216u32]}),
+    );
+    let plan = WorkPlan {
+        logical_forwards: 1,
+        physical_batches: 1,
+        padded_forwards: 0,
+        cache_hits: 0,
+        streams: 1,
+        worker_tasks: 1,
+        row_tiles: 1,
+        ..WorkPlan::default()
+    };
+    let counters = WorkCounters::new(plan);
+    counters.record_batch(1, 0, 0, 1, 1);
+    counters.record_stream_completed();
+    let snapshot = counters.snapshot();
+
+    let enabled = RunReport::new(
+        "enabled-run",
+        ObservabilityMode::Enabled,
+        RunStatus::Pass,
+        snapshot,
+        estimate_eta(EtaInput {
+            completed: 1,
+            total: 1,
+            elapsed: Duration::from_secs(1),
+            last_progress_age: Duration::ZERO,
+            stall_after: Duration::from_secs(60),
+            minimum_samples: 1,
+        }),
+        ResourceAvailability::Unavailable {
+            reason: "enabled test".to_owned(),
+        },
+    );
+    let disabled = RunReport::new(
+        "disabled-run",
+        ObservabilityMode::Disabled,
+        RunStatus::Pass,
+        snapshot,
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "disabled".to_owned(),
+        },
+    );
+
+    let enabled_report = enabled_dir.join("same-evidence.json");
+    let disabled_report = disabled_dir.join("same-evidence.json");
+    let enabled_paths =
+        write_final_reports(&enabled_report, &enabled, &evidence).expect("write enabled reports");
+    let disabled_paths = write_final_reports(&disabled_report, &disabled, &evidence)
+        .expect("write disabled reports");
+
+    assert_eq!(enabled_paths.run, enabled_report);
+    assert!(enabled_paths
+        .evidence
+        .ends_with("same-evidence.evidence.json"));
+    assert!(events_path_for_report(&enabled_paths.run)
+        .expect("event path")
+        .ends_with("same-evidence.events.jsonl"));
+    assert_ne!(
+        fs::read(&enabled_paths.run).expect("enabled run bytes"),
+        fs::read(&disabled_paths.run).expect("disabled run bytes")
+    );
+    assert_eq!(
+        fs::read(&enabled_paths.evidence).expect("enabled evidence bytes"),
+        fs::read(&disabled_paths.evidence).expect("disabled evidence bytes"),
+        "timing/resource/instrumentation state must never enter deterministic evidence"
+    );
+    assert_eq!(
+        evidence.output,
+        json!({"tokens": [3, 1, 4], "logit_bits": [1065353216u32]})
+    );
+    write_final_reports(&enabled_report, &disabled, &evidence)
+        .expect("a new run atomically replaces the current report");
+    assert_eq!(
+        fs::read(&enabled_paths.run).expect("replaced empirical run"),
+        fs::read(&disabled_paths.run).expect("expected replacement bytes")
+    );
+
+    fs::remove_dir_all(&enabled_dir).expect("remove enabled output");
+    fs::remove_dir_all(&disabled_dir).expect("remove disabled output");
+}
+
+#[test]
+fn deterministic_identity_projection_excludes_path_and_timing_bound_admission_cids() {
+    let scheduler = SchedulerSnapshot::from_config(
+        &ParityConfig::from_lookup(|_| None).expect("default config"),
+    );
+    let mut first = RunMetadata::new(scheduler.clone(), "exact", "kernel", "isa")
+        .with_identity("model", "blake3:model")
+        .with_identity("teacher_free_s4_preflight", "blake3:absolute-path-a")
+        .with_identity("probe_selected_execution", "workers=8,tiles_per_worker=4");
+    let output = json!({
+        "S0_teacher_free_preflight": {
+            "schema": "uor-r4.teacher-parity-preflight/1",
+            "status": "UNAVAILABLE",
+            "production_admission": {"release_manifest": {"presence": "ABSENT", "cid": null}}
+        }
+    });
+    let projected_first =
+        deterministic_evidence_identities(&first, &output).expect("first projection");
+    first.identities.insert(
+        "teacher_free_s4_preflight".to_owned(),
+        "blake3:absolute-path-b-and-new-elapsed".to_owned(),
+    );
+    first.identities.insert(
+        "probe_selected_execution".to_owned(),
+        "workers=4,tiles_per_worker=4".to_owned(),
+    );
+    let projected_second =
+        deterministic_evidence_identities(&first, &output).expect("second projection");
+    assert_eq!(projected_first, projected_second);
+    assert_eq!(projected_first["model"], "blake3:model");
+    assert!(projected_first["teacher_free_s4_preflight"].starts_with("blake3:"));
+    assert!(!projected_first.contains_key("probe_selected_execution"));
+
+    let bdd = include_str!("bdd.rs");
+    let project_start = bdd
+        .find("fn project_parity_probe_state<T>(")
+        .expect("nonqualified probe projection exists");
+    let project_end = bdd[project_start..]
+        .find("struct ParityAdmissionShape")
+        .map(|offset| project_start + offset)
+        .expect("nonqualified probe projection is bounded");
+    let project = &bdd[project_start..project_end];
+    let deterministic_start = project
+        .find("parity_record_output(")
+        .expect("nonqualified deterministic record exists");
+    let deterministic_end = project[deterministic_start..]
+        .find("project_parity_probe_nonpass")
+        .map(|offset| deterministic_start + offset)
+        .expect("nonqualified deterministic record is bounded");
+    let deterministic = &project[deterministic_start..deterministic_end];
+    assert!(!deterministic.contains("state.reason"));
+    assert!(!deterministic.contains("artifact_cid"));
+}
+
+#[test]
+fn zero_work_refusal_final_report_round_trips_without_nonfinite_rates() {
+    let dir = unique_dir("zero-work-refusal-final-report");
+    fs::create_dir_all(&dir).expect("create refusal output");
+    let report_path = dir.join("parity-report.json");
+    let work = WorkCounters::new(WorkPlan::default()).snapshot();
+    let zero_rate = work.logical_forwards as f64 / 1.0;
+    let report = RunReport::new(
+        "graph-quality-refusal",
+        ObservabilityMode::Enabled,
+        RunStatus::Fail,
+        work,
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "graph quality gate refused before teacher work".to_owned(),
+        },
+    )
+    .with_rates(parity_observability::RateSnapshot {
+        cumulative_forwards_per_second: Some(zero_rate),
+        seconds_per_forward: seconds_per_forward_from_rate(Some(zero_rate)),
+        ..parity_observability::RateSnapshot::default()
+    });
+    let evidence = DeterministicEvidence::new(
+        RunStatus::Fail,
+        BTreeMap::new(),
+        json!({"teacher_forwards": 0, "refusal": "graph_quality"}),
+    );
+
+    let paths = write_final_reports(&report_path, &report, &evidence)
+        .expect("zero-work refusal companions remain serializable");
+    let decoded: RunReport =
+        serde_json::from_slice(&fs::read(&paths.run).expect("read zero-work refusal report"))
+            .expect("decode zero-work refusal report");
+    assert_eq!(decoded.status, RunStatus::Fail);
+    assert_eq!(decoded.work.logical_forwards, 0);
+    assert_eq!(decoded.rates.cumulative_forwards_per_second, Some(0.0));
+    assert_eq!(decoded.rates.seconds_per_forward, None);
+
+    fs::remove_dir_all(&dir).expect("remove refusal output");
+}
+
+#[test]
+fn explicit_nonfinite_final_rate_remains_rejected_by_semantic_readback() {
+    let dir = unique_dir("nonfinite-final-rate");
+    fs::create_dir_all(&dir).expect("create rejection output");
+    let report_path = dir.join("parity-report.json");
+    let report = RunReport::new(
+        "invalid-nonfinite-rate",
+        ObservabilityMode::Enabled,
+        RunStatus::Fail,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test".to_owned(),
+        },
+    )
+    .with_rates(parity_observability::RateSnapshot {
+        cumulative_forwards_per_second: Some(0.0),
+        seconds_per_forward: Some(f64::INFINITY),
+        ..parity_observability::RateSnapshot::default()
+    });
+    let evidence = DeterministicEvidence::new(RunStatus::Fail, BTreeMap::new(), json!({}));
+
+    let error = write_final_reports(&report_path, &report, &evidence)
+        .expect_err("strict readback rejects an explicit nonfinite rate");
+    assert!(error
+        .to_string()
+        .contains("temporary report readback changed serialized content"));
+    assert!(!report_path.exists());
+
+    fs::remove_dir_all(&dir).expect("remove rejection output");
+}
+
+#[test]
+fn companion_publication_failure_cannot_leave_a_stale_canonical_pass_report() {
+    let dir = unique_dir("publication-failure");
+    fs::create_dir_all(&dir).expect("create publication output");
+    let report_path = dir.join("parity-report.json");
+    fs::write(&report_path, br#"{"status":"PASS","run_id":"stale"}"#).expect("seed stale report");
+    let evidence_path = dir.join("parity-report.evidence.json");
+    fs::create_dir(&evidence_path).expect("plant non-replaceable evidence directory");
+
+    let report = RunReport::new(
+        "current-run",
+        ObservabilityMode::Enabled,
+        RunStatus::Pass,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test".to_owned(),
+        },
+    );
+    let evidence = DeterministicEvidence::new(
+        RunStatus::Pass,
+        BTreeMap::new(),
+        json!({"output": "current"}),
+    );
+    assert!(write_final_reports(&report_path, &report, &evidence).is_err());
+    assert!(
+        !report_path.exists(),
+        "a stale canonical PASS must not survive companion publication failure"
+    );
+    fs::remove_dir_all(&dir).expect("remove publication output");
+}
+
+#[test]
+fn new_run_start_invalidates_a_prior_canonical_pass_before_heartbeat_work() {
+    let dir = unique_dir("startup-stale-pass");
+    fs::create_dir_all(&dir).expect("create startup output");
+    let report_path = dir.join("parity-report.json");
+    let evidence_path = dir.join("parity-report.evidence.json");
+    fs::write(&report_path, br#"{"status":"PASS","run_id":"prior"}"#)
+        .expect("seed prior PASS report");
+    fs::write(&evidence_path, br#"{"status":"PASS"}"#).expect("seed prior PASS evidence");
+
+    let owned = take_run_report_ownership(&dir, Some("parity-report.json".to_owned()))
+        .expect("new run takes ownership of canonical companions");
+    assert_eq!(owned, report_path);
+    assert!(configured_exact_probe_report_path(Some("   ".to_owned())).is_err());
+    assert!(!report_path.exists());
+    assert!(!evidence_path.exists());
+
+    let bdd = include_str!("bdd.rs");
+    let init = bdd
+        .split("fn initialize_parity_run()")
+        .nth(1)
+        .and_then(|tail| tail.split("fn parity_run()").next())
+        .expect("bounded parity initialization source");
+    let invalidate = init
+        .find("take_run_report_ownership")
+        .expect("initialization takes canonical companion ownership");
+    let config = init
+        .find("ParityConfig::from_env")
+        .expect("initialization parses full config");
+    let probe = init
+        .find("parity_probe_report_path()")
+        .expect("initialization resolves probe path");
+    let preflight = init
+        .find("parity_preflight_report_path()")
+        .expect("initialization resolves preflight path");
+    let fixtures = init
+        .find("parity_fixture_dirs()")
+        .expect("initialization resolves fixture directories");
+    let heartbeat = init
+        .find("HeartbeatWorker::spawn_with_stall_after")
+        .expect("initialization starts heartbeat");
+    assert!(invalidate < config);
+    assert!(invalidate < probe);
+    assert!(invalidate < preflight);
+    assert!(invalidate < fixtures);
+    assert!(invalidate < heartbeat);
+
+    let support = include_str!("support/parity_observability.rs");
+    let ownership_start = support
+        .find("pub fn take_run_report_ownership(")
+        .expect("ownership helper exists");
+    let ownership_end = support[ownership_start..]
+        .find("pub fn events_path_for_report(")
+        .map(|offset| ownership_start + offset)
+        .expect("ownership helper has a bounded source section");
+    assert!(support[ownership_start..ownership_end]
+        .contains("invalidate_final_reports_checked(&report_path)?"));
+
+    fs::remove_dir_all(dir).expect("remove startup output");
+}
+
+#[test]
+fn post_terminal_commit_failure_invalidates_every_prepared_pass_companion() {
+    let dir = unique_dir("post-terminal-commit-failure");
+    fs::create_dir_all(&dir).expect("create publication output");
+    let report_path = dir.join("parity-report.json");
+    let evidence_path = dir.join("parity-report.evidence.json");
+    let report = RunReport::new(
+        "current-run",
+        ObservabilityMode::Enabled,
+        RunStatus::Pass,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test".to_owned(),
+        },
+    );
+    let evidence =
+        DeterministicEvidence::new(RunStatus::Pass, BTreeMap::new(), json!({"exact": true}));
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let progress = SharedProgress::new(
+        "current-run",
+        RunMetadata::new(
+            SchedulerSnapshot::from_config(&config),
+            "exact",
+            "exact-gemm",
+            "test-isa",
+        ),
+    );
+    progress
+        .update(|live| live.status = RunStatus::Pass)
+        .expect("candidate PASS progress");
+    let prepared = prepare_final_reports(&report_path, &report, &evidence)
+        .expect("PASS companions prepare before the terminal boundary");
+
+    // Model a failure in the only post-terminal operation: the canonical run
+    // path becomes non-replaceable after both temporary companions are synced.
+    fs::create_dir(&report_path).expect("plant non-replaceable commit marker path");
+    assert!(prepared.commit().is_err());
+    mark_finalization_failed(&progress, "telemetry_commit_failed")
+        .expect("failed commit downgrades retry/readback status");
+    assert_eq!(
+        progress.snapshot().expect("retry progress").live.status,
+        RunStatus::Fail
+    );
+    assert!(
+        !report_path.is_file(),
+        "a failed post-terminal rename must not publish a PASS commit marker"
+    );
+    assert!(
+        !evidence_path.exists(),
+        "a partially published PASS evidence sidecar must be invalidated"
+    );
+    fs::remove_dir_all(&dir).expect("remove publication output");
+}
+
+#[test]
+fn late_companion_validation_failure_invalidates_a_stale_canonical_pass() {
+    let dir = unique_dir("late-validation-failure");
+    fs::create_dir_all(&dir).expect("create publication output");
+    let report_path = dir.join("parity-report.json");
+    fs::write(&report_path, br#"{"status":"PASS","run_id":"stale"}"#).expect("seed stale report");
+    let report = RunReport::new(
+        "current-run",
+        ObservabilityMode::Enabled,
+        RunStatus::Pass,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test".to_owned(),
+        },
+    );
+    let mismatched_evidence =
+        DeterministicEvidence::new(RunStatus::Fail, BTreeMap::new(), json!({}));
+
+    assert!(write_final_reports(&report_path, &report, &mismatched_evidence).is_err());
+    assert!(
+        !report_path.exists(),
+        "a rejected late PASS candidate must invalidate the stale canonical PASS"
+    );
+    fs::remove_dir_all(&dir).expect("remove publication output");
+}
+
+#[test]
+fn every_terminal_state_has_an_explicit_stable_machine_spelling() {
+    for (status, spelling) in [
+        (RunStatus::Pass, "PASS"),
+        (RunStatus::Fail, "FAIL"),
+        (RunStatus::Unavailable, "UNAVAILABLE"),
+        (RunStatus::Aborted, "ABORTED"),
+        (RunStatus::NotRun, "NOT_RUN"),
+    ] {
+        assert_eq!(
+            serde_json::to_string(&status).expect("status JSON"),
+            format!("\"{spelling}\"")
+        );
+    }
+}
+
+#[test]
+fn resource_sampling_is_measured_or_explicitly_unavailable_never_zero_filled() {
+    match sample_host_resources() {
+        ResourceAvailability::Available(sample) => {
+            assert!(!sample.architecture.trim().is_empty());
+            assert!(!sample.operating_system.trim().is_empty());
+            assert_measured_or_reason(&sample.cpu_model);
+            assert_measured_or_reason(&sample.operating_system_version);
+            assert_measured_or_reason(&sample.physical_cores);
+            assert_measured_or_reason(&sample.logical_cores);
+            assert_measured_or_reason(&sample.performance_cores);
+            assert_measured_or_reason(&sample.efficiency_cores);
+            assert_measured_or_reason(&sample.total_memory_bytes);
+            assert_measured_or_reason(&sample.resident_set_bytes);
+            assert_measured_or_reason(&sample.virtual_memory_bytes);
+            assert_measured_or_reason(&sample.cpu_percent);
+            assert_measured_or_reason(&sample.process_cpu_time_seconds);
+            assert_measured_or_reason(&sample.thread_count);
+            assert_measured_or_reason(&sample.peak_resident_set_bytes);
+            #[cfg(target_os = "macos")]
+            {
+                assert!(matches!(
+                    sample.resident_set_bytes,
+                    Measurement::Available { .. }
+                ));
+                assert!(matches!(
+                    sample.virtual_memory_bytes,
+                    Measurement::Available { .. }
+                ));
+                assert!(matches!(sample.cpu_percent, Measurement::Available { .. }));
+                assert!(matches!(
+                    sample.process_cpu_time_seconds,
+                    Measurement::Available { .. }
+                ));
+                match &sample.thread_count {
+                    Measurement::Unavailable { reason } => assert!(reason.contains("thcount")),
+                    Measurement::Available { .. } => {
+                        panic!("macOS ps thread count must not be fabricated")
+                    }
+                }
+            }
+        }
+        ResourceAvailability::Unavailable { reason } => {
+            assert!(!reason.trim().is_empty());
+        }
+    }
+}
+
+#[test]
+fn exact_live_occupancy_ignores_out_of_order_observer_callbacks() {
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let progress = SharedProgress::new(
+        "run-932-epoch",
+        RunMetadata::new(
+            SchedulerSnapshot::from_config(&config),
+            "exact",
+            "exact-gemm",
+            "test-isa",
+        ),
+    );
+    progress
+        .update(|state| state.queue.queue_depth = 8)
+        .expect("publish queued lanes");
+    progress.publish_exact(ExactProgressObservation {
+        observer_epoch: 2,
+        streams_started: 8,
+        streams_completed: 0,
+        active_streams: 8,
+        peak_active_streams: 8,
+        active_row_workers: 6,
+        peak_active_row_workers: 6,
+        matrix_calls: 5,
+        batched_matrix_calls: 5,
+        max_matrix_batch_width: 8,
+        completed_worker_tasks: 12,
+        output_cells_completed: 120,
+        scalar_terms_completed: 1_200,
+        effective_workers: 8,
+    });
+    progress.publish_exact(ExactProgressObservation {
+        observer_epoch: 1,
+        streams_started: 1,
+        streams_completed: 0,
+        active_streams: 1,
+        peak_active_streams: 1,
+        active_row_workers: 1,
+        peak_active_row_workers: 1,
+        matrix_calls: 1,
+        batched_matrix_calls: 1,
+        max_matrix_batch_width: 1,
+        completed_worker_tasks: 1,
+        output_cells_completed: 1,
+        scalar_terms_completed: 1,
+        effective_workers: 1,
+    });
+    let snapshot = progress.snapshot().expect("epoch-safe snapshot");
+    assert_eq!(snapshot.live.queue.active_streams, 8);
+    assert_eq!(snapshot.live.queue.queue_depth, 0);
+    assert_eq!(snapshot.live.queue.active_row_workers, 6);
+    assert_eq!(snapshot.live.queue.peak_active_streams, 8);
+    assert_eq!(snapshot.live.queue.peak_active_row_workers, 6);
+    assert_eq!(
+        snapshot.live.metadata.scheduler.effective_row_workers.get(),
+        8
+    );
+
+    progress.finish_exact_forward();
+    let finished = progress.snapshot().expect("finished snapshot");
+    assert_eq!(finished.live.queue.active_streams, 0);
+    assert_eq!(finished.live.queue.active_row_workers, 0);
+}
+
+#[test]
+fn deterministic_s2_and_probe_evidence_ignore_schedule_geometry() {
+    let stable_work = TeacherExecutionSnapshot {
+        observer_epoch: 10,
+        requested_workers: 8,
+        effective_workers: 8,
+        active_workers: 0,
+        max_active_workers: 5,
+        forward_max_active_workers: 4,
+        multiworker_forward_calls: 7,
+        forward_calls: 8,
+        streams_started: 64,
+        streams_completed: 64,
+        active_streams: 0,
+        max_active_streams: 8,
+        matrix_calls: 144,
+        batched_matrix_calls: 144,
+        max_matrix_batch_width: 8,
+        tiles_completed: 576,
+        output_cells_completed: 2_048,
+        scalar_terms_completed: 65_536,
+        workspace_growth_events: 0,
+        workspace_growth_bytes: 0,
+    };
+    let scheduler_variant = TeacherExecutionSnapshot {
+        observer_epoch: 9_999,
+        requested_workers: 16,
+        effective_workers: 4,
+        active_workers: 3,
+        max_active_workers: 16,
+        forward_max_active_workers: 2,
+        multiworker_forward_calls: 1,
+        active_streams: 6,
+        max_active_streams: 64,
+        tiles_completed: 1_152,
+        workspace_growth_events: 3,
+        workspace_growth_bytes: 32_768,
+        ..stable_work
+    };
+
+    let reference = deterministic_teacher_execution(stable_work);
+    let actual = deterministic_teacher_execution(scheduler_variant);
+    let reference_bytes = serde_json::to_vec(&reference).expect("reference exact-work JSON");
+    let actual_bytes = serde_json::to_vec(&actual).expect("variant exact-work JSON");
+    assert_eq!(actual_bytes, reference_bytes);
+
+    let value = serde_json::to_value(actual).expect("deterministic exact-work JSON");
+    for empirical_field in [
+        "observer_epoch",
+        "requested_workers",
+        "effective_workers",
+        "active_workers",
+        "max_active_workers",
+        "forward_max_active_workers",
+        "multiworker_forward_calls",
+        "active_streams",
+        "max_active_streams",
+        "tiles_completed",
+        "workspace_growth_events",
+        "workspace_growth_bytes",
+    ] {
+        assert!(
+            value.get(empirical_field).is_none(),
+            "scheduler field {empirical_field} leaked into deterministic S2 evidence"
+        );
+    }
+
+    let different_work = TeacherExecutionSnapshot {
+        scalar_terms_completed: stable_work.scalar_terms_completed + 1,
+        ..stable_work
+    };
+    assert_ne!(
+        deterministic_teacher_execution(different_work),
+        reference,
+        "a logical exact-work change must remain evidence-visible"
+    );
+
+    let bdd = include_str!("bdd.rs");
+    let deterministic_start = bdd
+        .find("\"S2_transcript\",")
+        .expect("S2 deterministic evidence record exists");
+    let deterministic_end = bdd[deterministic_start..]
+        .find("\n    );\n}")
+        .map(|offset| deterministic_start + offset)
+        .expect("S2 deterministic evidence record is bounded");
+    let deterministic_record = &bdd[deterministic_start..deterministic_end];
+    assert!(deterministic_record
+        .contains("\"exact_work\": deterministic_teacher_execution(evidence.execution)"));
+    for empirical_field in [
+        "max_active_streams",
+        "peak_active_row_workers",
+        "execution_preparation",
+        "workspace_growth_events",
+        "workspace_growth_bytes",
+        "owner_plan",
+        "worker_tasks",
+        "row_tiles",
+        "tiles_completed",
+        "\"execution\": evidence.execution",
+    ] {
+        assert!(
+            !deterministic_record.contains(empirical_field),
+            "empirical field {empirical_field} leaked into the S2 deterministic record"
+        );
+    }
+    assert!(
+        bdd[..deterministic_start].contains("\"S2_execution_observability\"")
+            && bdd[..deterministic_start].contains("\"execution_snapshot\": evidence.execution"),
+        "the full S2 execution snapshot must remain available as empirical telemetry"
+    );
+
+    let probe_start = bdd
+        .find("\"exact_probe_trace\",")
+        .expect("exact-probe deterministic record exists");
+    let probe_end = bdd[probe_start..]
+        .find("\n    );")
+        .map(|offset| probe_start + offset)
+        .expect("exact-probe deterministic record is bounded");
+    let probe_record = &bdd[probe_start..probe_end];
+    for empirical_field in ["worker_rows", "workers", "forward_plan"] {
+        assert!(
+            !probe_record.contains(empirical_field),
+            "probe worker field {empirical_field} leaked into deterministic evidence"
+        );
+    }
+    assert!(
+        bdd[..probe_start].contains("\"exact_probe_worker_rows\"")
+            && bdd[..probe_start].contains("\"forward_plan\": run.forward_plan"),
+        "per-worker exact-probe plans must remain available as empirical telemetry"
+    );
+}
+
+#[test]
+fn host_resource_schema_round_trips_explicit_performance_and_efficiency_topology() {
+    let sample = sample_host_resources();
+    let bytes = serde_json::to_vec(&sample).expect("resource JSON");
+    let value: serde_json::Value = serde_json::from_slice(&bytes).expect("resource value");
+    if value["availability"] == "AVAILABLE" {
+        assert!(value.get("performance_cores").is_some());
+        assert!(value.get("efficiency_cores").is_some());
+        assert!(value.get("max_sampled_resident_set_bytes").is_some());
+        assert!(value.get("thread_count").is_some());
+    }
+    let decoded: ResourceAvailability =
+        serde_json::from_slice(&bytes).expect("resource schema round trip");
+    assert_eq!(decoded, sample);
+}
+
+#[test]
+fn heartbeat_schema_carries_scheduler_queue_stream_identity_budget_and_fixture_state() {
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let metadata = RunMetadata::new(
+        SchedulerSnapshot::from_config(&config),
+        "exact-uor-matmul",
+        "uor-matmul-exact-gemm",
+        "aarch64-neon",
+    )
+    .with_identity("teacher", "blake3:teacher")
+    .with_model_geometry("layers", 30)
+    .with_budget("positions", 256)
+    .with_fixture("teacher", FixtureStatus::available("blake3:teacher"))
+    .with_path("run_report", "/tmp/teacher-parity/parity-report.json")
+    .with_path(
+        "deterministic_evidence",
+        "/tmp/teacher-parity/parity-report.evidence.json",
+    )
+    .with_path(
+        "event_jsonl",
+        "/tmp/teacher-parity/parity-report.events.jsonl",
+    )
+    .with_path(
+        "exact_probe_report",
+        "/tmp/teacher-parity/exact-multicore-probe.json",
+    );
+    let queue = QueueSnapshot {
+        queue_depth: 3,
+        active_streams: 2,
+        peak_active_streams: 6,
+        active_row_workers: 4,
+        peak_active_row_workers: 8,
+        completed_streams: 4,
+        failed_streams: 0,
+        active_worker_tasks: 4,
+        completed_worker_tasks: 12,
+        failed_worker_tasks: 0,
+        longest_active_millis: 75,
+    };
+    let streams = vec![StreamProgress {
+        stream_id: "prompt-0/run-0".to_owned(),
+        phase: "teacher_generate".to_owned(),
+        state: StreamState::Active,
+        logical_forwards_completed: 7,
+        logical_forwards_total: 16,
+        tokens_completed: 7,
+        tokens_total: 16,
+        active_forward_age_millis: 75,
+    }];
+    let event = HeartbeatEvent::new(
+        "run-932",
+        RunStatus::NotRun,
+        WorkCounters::new(WorkPlan::default()).snapshot(),
+        estimate_eta(EtaInput::default()),
+        ResourceAvailability::Unavailable {
+            reason: "test sampler".to_owned(),
+        },
+    )
+    .with_event_kind(EventKind::Heartbeat)
+    .with_metadata(metadata)
+    .with_queue(queue)
+    .with_streams(streams)
+    .with_phase("teacher_generate")
+    .with_elapsed(Duration::from_secs(2));
+
+    let value = serde_json::to_value(&event).expect("event JSON");
+    assert_eq!(value["event_kind"], "HEARTBEAT");
+    assert_eq!(value["metadata"]["backend"], "exact-uor-matmul");
+    assert_eq!(value["metadata"]["model_geometry"]["layers"], 30);
+    assert_eq!(
+        value["metadata"]["paths"]["run_report"],
+        "/tmp/teacher-parity/parity-report.json"
+    );
+    assert_eq!(
+        value["metadata"]["scheduler"]["configured_trajectory_workers"],
+        config.workers.get()
+    );
+    assert_eq!(
+        value["metadata"]["scheduler"]["configured_row_workers"],
+        config.workers.get()
+    );
+    assert_eq!(value["queue"]["queue_depth"], 3);
+    assert_eq!(value["queue"]["peak_active_streams"], 6);
+    assert_eq!(value["queue"]["active_row_workers"], 4);
+    assert_eq!(value["queue"]["peak_active_row_workers"], 8);
+    assert_eq!(value["streams"][0]["logical_forwards_completed"], 7);
+    let human = event.human_summary();
+    assert!(human.contains("forwards=0/0"), "{human}");
+    assert!(human.contains("queue=3"), "{human}");
+    assert!(human.contains("active_streams=2"), "{human}");
+    assert!(human.contains("active_row_workers=4"), "{human}");
+    assert!(human.contains("exact_live_worker_tasks=12/0"), "{human}");
+}
+
+#[test]
+fn cadence_evidence_rejects_lifecycle_idle_and_cross_phase_pairs() {
+    fn event(
+        kind: EventKind,
+        phase: &str,
+        active_streams: u64,
+        active_row_workers: u64,
+        timestamp: u64,
+    ) -> HeartbeatEvent {
+        let mut event = HeartbeatEvent::new(
+            "run-cadence",
+            RunStatus::NotRun,
+            WorkCounters::new(WorkPlan::default()).snapshot(),
+            estimate_eta(EtaInput::default()),
+            ResourceAvailability::Unavailable {
+                reason: "test".to_owned(),
+            },
+        )
+        .with_event_kind(kind)
+        .with_phase(phase)
+        .with_queue(QueueSnapshot {
+            active_streams,
+            active_row_workers,
+            ..QueueSnapshot::default()
+        })
+        .with_streams(
+            (0..active_streams)
+                .map(|lane| StreamProgress {
+                    stream_id: format!("lane-{lane}"),
+                    phase: "exact_forward".to_owned(),
+                    state: StreamState::Active,
+                    logical_forwards_completed: 0,
+                    logical_forwards_total: 1,
+                    tokens_completed: 0,
+                    tokens_total: 1,
+                    active_forward_age_millis: 0,
+                })
+                .collect(),
+        );
+        event.timestamp_unix_millis = timestamp;
+        event
+    }
+
+    let cadence = Duration::from_millis(100);
+    let insufficient = vec![
+        event(EventKind::WorkStarted, "active-forward", 8, 8, 1_000),
+        event(EventKind::Heartbeat, "active-forward", 8, 8, 1_050),
+        event(EventKind::Heartbeat, "loading", 0, 0, 1_100),
+        event(EventKind::Heartbeat, "loading", 0, 0, 1_150),
+    ];
+    assert!(validate_in_flight_heartbeat_cadence(&insufficient, cadence, 8, 8).is_err());
+
+    let compiled_only = vec![
+        event(EventKind::Heartbeat, "compiled-decode", 8, 0, 1_050),
+        event(EventKind::Heartbeat, "compiled-decode", 8, 0, 1_150),
+    ];
+    assert!(
+        validate_in_flight_heartbeat_cadence(&compiled_only, cadence, 8, 8).is_err(),
+        "compiled trajectory activity cannot masquerade as an in-flight exact forward"
+    );
+
+    let established = vec![
+        event(EventKind::WorkStarted, "active-forward", 8, 8, 1_000),
+        event(EventKind::Heartbeat, "active-forward", 8, 3, 1_050),
+        event(EventKind::Heartbeat, "active-forward", 8, 5, 1_150),
+    ];
+    validate_in_flight_heartbeat_cadence(&established, cadence, 8, 8)
+        .expect("two same-phase bounded active periodic rows establish cadence");
+}
+
+#[test]
+fn binding_heartbeat_requires_distinct_full_width_streams_with_bounded_worker_diagnostics() {
+    fn heartbeat(stream_ids: &[&str], active_streams: u64, row_workers: u64) -> HeartbeatEvent {
+        HeartbeatEvent::new(
+            "run-full-width",
+            RunStatus::NotRun,
+            WorkCounters::new(WorkPlan::default()).snapshot(),
+            estimate_eta(EtaInput::default()),
+            ResourceAvailability::Unavailable {
+                reason: "test sampler".to_owned(),
+            },
+        )
+        .with_event_kind(EventKind::Heartbeat)
+        .with_queue(QueueSnapshot {
+            active_streams,
+            active_row_workers: row_workers,
+            ..QueueSnapshot::default()
+        })
+        .with_streams(
+            stream_ids
+                .iter()
+                .map(|stream_id| StreamProgress {
+                    stream_id: (*stream_id).to_owned(),
+                    phase: "exact_forward".to_owned(),
+                    state: StreamState::Active,
+                    logical_forwards_completed: 0,
+                    logical_forwards_total: 1,
+                    tokens_completed: 0,
+                    tokens_total: 1,
+                    active_forward_age_millis: 25,
+                })
+                .collect(),
+        )
+        .with_phase("exact_forward")
+    }
+
+    let distinct = (0..8)
+        .map(|lane| format!("lane-{lane}"))
+        .collect::<Vec<_>>();
+    let distinct_refs = distinct.iter().map(String::as_str).collect::<Vec<_>>();
+    let full_width = vec![heartbeat(&distinct_refs, 8, 4)];
+    validate_full_width_exact_heartbeat(&full_width, 8, 8)
+        .expect("one durable row binds eight private streams to bounded row activity");
+
+    let duplicate = vec!["lane-0"; 8];
+    assert!(validate_full_width_exact_heartbeat(&[heartbeat(&duplicate, 8, 8)], 8, 8).is_err());
+    validate_full_width_exact_heartbeat(&[heartbeat(&distinct_refs, 8, 7)], 8, 8)
+        .expect("worker saturation is diagnostic rather than binding");
+    assert!(validate_full_width_exact_heartbeat(&[heartbeat(&distinct_refs, 8, 0)], 8, 8).is_err());
+    assert!(validate_full_width_exact_heartbeat(&[heartbeat(&distinct_refs, 8, 9)], 8, 8).is_err());
+    assert!(validate_full_width_exact_heartbeat(&[heartbeat(&distinct_refs, 7, 8)], 8, 8).is_err());
+}
+
+#[test]
+fn cancelled_worker_start_gate_releases_a_partial_spawn_cohort() {
+    let gate = Arc::new(CancellableStartGate::new());
+    let waiting_gate = Arc::clone(&gate);
+    let worker = thread::spawn(move || waiting_gate.wait());
+    thread::sleep(Duration::from_millis(10));
+    gate.cancel("planted later worker creation failure");
+    let reason = worker
+        .join()
+        .expect("partial worker exits without panic")
+        .expect_err("partial worker is cancelled instead of entering a fixed barrier");
+    assert!(reason.contains("planted later worker creation failure"));
+}
+
+#[test]
+fn independent_heartbeat_worker_flushes_while_a_forward_is_still_in_flight() {
+    let dir = unique_dir("heartbeat-worker");
+    fs::create_dir_all(&dir).expect("create heartbeat worker output");
+    let path = dir.join("parity-report.events.jsonl");
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let metadata = RunMetadata::new(
+        SchedulerSnapshot::from_config(&config),
+        "exact",
+        "exact-gemm",
+        "test-isa",
+    );
+    let progress = SharedProgress::new("run-932-worker", metadata);
+    progress
+        .update(|state| {
+            state.phase = "long_exact_forward".to_owned();
+            state.queue.queue_depth = 0;
+            state.queue.active_streams = 2;
+            state.queue.peak_active_streams = 2;
+            state.queue.active_row_workers = 2;
+            state.queue.peak_active_row_workers = 2;
+            state.streams = (0..2)
+                .map(|lane| StreamProgress {
+                    stream_id: format!("stream-{lane}"),
+                    phase: "long_exact_forward".to_owned(),
+                    state: StreamState::Active,
+                    logical_forwards_completed: 0,
+                    logical_forwards_total: 1,
+                    tokens_completed: 0,
+                    tokens_total: 1,
+                    active_forward_age_millis: 0,
+                })
+                .collect();
+        })
+        .expect("seed live progress");
+    progress.publish_exact(ExactProgressObservation {
+        observer_epoch: 1,
+        streams_started: 2,
+        streams_completed: 0,
+        active_streams: 2,
+        peak_active_streams: 2,
+        active_row_workers: 2,
+        peak_active_row_workers: 2,
+        matrix_calls: 0,
+        batched_matrix_calls: 0,
+        max_matrix_batch_width: 0,
+        completed_worker_tasks: 0,
+        output_cells_completed: 0,
+        scalar_terms_completed: 0,
+        effective_workers: 2,
+    });
+    let counters = Arc::new(WorkCounters::new(WorkPlan {
+        logical_forwards: 2,
+        tokens: 2,
+        physical_batches: 1,
+        padded_forwards: 0,
+        cache_hits: 0,
+        streams: 2,
+        worker_tasks: 2,
+        row_tiles: 2,
+        ..WorkPlan::default()
+    }));
+    let worker = HeartbeatWorker::spawn(
+        &path,
+        Duration::from_millis(50),
+        Arc::clone(&counters),
+        progress.clone(),
+    )
+    .expect("spawn heartbeat worker");
+    worker
+        .emit(EventKind::WorkStarted)
+        .expect("durably emit lifecycle event");
+
+    thread::sleep(Duration::from_millis(320));
+    let in_flight = fs::read_to_string(&path).expect("read in-flight heartbeat stream");
+    let in_flight_events: Vec<HeartbeatEvent> = in_flight
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("heartbeat JSON line"))
+        .collect();
+    let periodic_heartbeats = in_flight_events
+        .iter()
+        .filter(|event| event.event_kind == EventKind::Heartbeat)
+        .count();
+    assert!(
+        periodic_heartbeats >= 2,
+        "expected repeated periodic HEARTBEAT rows, got {periodic_heartbeats}"
+    );
+    assert!(
+        in_flight_events
+            .iter()
+            .all(|event| event.work.logical_forwards == 0),
+        "the forward must still be visibly in flight"
+    );
+    validate_in_flight_heartbeat_cadence(&in_flight_events, Duration::from_millis(50), 2, 2)
+        .expect("same active forward receives repeated cadence heartbeats");
+
+    counters.record_batch(2, 0, 0, 2, 2);
+    counters.record_tokens(2);
+    counters.record_stream_completed();
+    counters.record_stream_completed();
+    progress.finish_exact_forward();
+    progress
+        .update(|state| {
+            state.status = RunStatus::Pass;
+            state.queue.queue_depth = 0;
+            state.queue.active_streams = 0;
+            state.queue.active_row_workers = 0;
+            state.queue.completed_streams = 2;
+            for stream in &mut state.streams {
+                stream.state = StreamState::Completed;
+                stream.logical_forwards_completed = 1;
+                stream.tokens_completed = 1;
+            }
+        })
+        .expect("complete live progress");
+    progress
+        .update(|state| state.streams.clear())
+        .expect("clear completed stream rows");
+    worker
+        .emit(EventKind::WorkCompleted)
+        .expect("emit completion after stream rows are cleared");
+    let completed_events = fs::read_to_string(&path).expect("read completion event");
+    let completed: HeartbeatEvent = serde_json::from_str(
+        completed_events
+            .lines()
+            .last()
+            .expect("completion JSONL row"),
+    )
+    .expect("completion event JSON");
+    assert_eq!(completed.work.tokens, 2);
+    #[cfg(target_os = "macos")]
+    assert!(worker.max_sampled_rss_bytes().is_some());
+    worker
+        .emit_and_stop(EventKind::SuiteCompleted)
+        .expect("terminal append and writer stop are one ordered operation");
+    let terminal_events = fs::read_to_string(&path).expect("read terminal event stream");
+    let terminal: HeartbeatEvent =
+        serde_json::from_str(terminal_events.lines().last().expect("terminal JSONL row"))
+            .expect("terminal event JSON");
+    assert_eq!(terminal.event_kind, EventKind::SuiteCompleted);
+    thread::sleep(Duration::from_millis(150));
+    assert_eq!(
+        fs::read_to_string(&path).expect("read stopped terminal event stream"),
+        terminal_events,
+        "no periodic progress may be appended after a terminal event"
+    );
+    fs::remove_dir_all(&dir).expect("remove heartbeat worker output");
+}
+
+#[test]
+fn advancing_inflight_exact_work_updates_eta_and_never_false_stalls() {
+    let dir = unique_dir("inflight-exact-eta");
+    fs::create_dir_all(&dir).expect("create in-flight ETA output");
+    let path = dir.join("parity-report.events.jsonl");
+    let config = ParityConfig::from_lookup(|_| None).expect("default config");
+    let progress = SharedProgress::new(
+        "run-932-inflight-eta",
+        RunMetadata::new(
+            SchedulerSnapshot::from_config(&config),
+            "exact",
+            "exact-gemm",
+            "test-isa",
+        ),
+    );
+    progress
+        .update(|state| {
+            state.phase = "long_exact_forward".to_owned();
+            state.queue.active_streams = 8;
+            state.streams = (0..8)
+                .map(|lane| StreamProgress {
+                    stream_id: format!("stream-{lane}"),
+                    phase: "long_exact_forward".to_owned(),
+                    state: StreamState::Active,
+                    logical_forwards_completed: 0,
+                    logical_forwards_total: 1,
+                    tokens_completed: 0,
+                    tokens_total: 1,
+                    active_forward_age_millis: 0,
+                })
+                .collect();
+        })
+        .expect("seed exact in-flight state");
+    let counters = Arc::new(WorkCounters::new(WorkPlan {
+        logical_forwards: 8,
+        tokens: 8,
+        physical_batches: 1,
+        matrix_calls: 20,
+        batched_matrix_calls: 20,
+        max_matrix_batch_width: 8,
+        worker_tasks: 100,
+        row_tiles: 100,
+        output_cells: 10_000,
+        scalar_terms: 1_000_000,
+        streams: 8,
+        ..WorkPlan::default()
+    }));
+    let worker = HeartbeatWorker::spawn_with_stall_after(
+        &path,
+        Duration::from_secs(3_600),
+        Duration::from_millis(20),
+        Arc::clone(&counters),
+        progress.clone(),
+    )
+    .expect("spawn planted-stall heartbeat worker");
+    thread::sleep(Duration::from_millis(30));
+    progress.publish_exact(ExactProgressObservation {
+        observer_epoch: 1,
+        streams_started: 8,
+        streams_completed: 0,
+        active_streams: 8,
+        peak_active_streams: 8,
+        active_row_workers: 4,
+        peak_active_row_workers: 4,
+        matrix_calls: 3,
+        batched_matrix_calls: 3,
+        max_matrix_batch_width: 8,
+        completed_worker_tasks: 5,
+        output_cells_completed: 500,
+        scalar_terms_completed: 50_000,
+        effective_workers: 8,
+    });
+    worker
+        .emit(EventKind::Heartbeat)
+        .expect("publish advancing exact work after planted stall age");
+    let rows = fs::read_to_string(&path).expect("read in-flight ETA event");
+    let event: HeartbeatEvent = serde_json::from_str(rows.lines().last().expect("heartbeat row"))
+        .expect("parse heartbeat row");
+    assert_eq!(event.work.logical_forwards, 0);
+    assert_eq!(event.work.matrix_calls, 3);
+    assert_eq!(event.work.batched_matrix_calls, 3);
+    assert_eq!(event.work.max_matrix_batch_width, 8);
+    assert_eq!(event.work.worker_tasks, 5);
+    assert_eq!(event.work.row_tiles, 5);
+    assert_eq!(event.work.output_cells, 500);
+    assert_eq!(event.work.scalar_terms, 50_000);
+    assert_eq!(event.queue.completed_worker_tasks, 5);
+    assert_eq!(event.rates.eta_progress_unit, ProgressUnit::ScalarTerms);
+    assert_eq!(event.rates.eta_progress_completed, 50_000);
+    assert_eq!(event.rates.eta_progress_total, 1_000_000);
+    assert_eq!(
+        heartbeat_progress_units(&event.work),
+        (ProgressUnit::ScalarTerms, 50_000, 1_000_000)
+    );
+    assert_eq!(event.eta.status, EtaStatus::Estimated);
+    let human = event.human_summary();
+    assert!(human.contains("worker_tasks=5/100"), "{human}");
+    assert!(human.contains("scalar_terms=50000/1000000"), "{human}");
+    assert!(
+        human.contains("eta_progress=ScalarTerms:50000/1000000"),
+        "{human}"
+    );
+    worker.stop().expect("stop planted-stall heartbeat worker");
+    fs::remove_dir_all(&dir).expect("remove in-flight ETA output");
+}
+
+#[test]
+fn disabled_mode_is_parseable_for_negative_evidence_but_not_a_binding_run() {
+    let workers = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1)
+        .min(4);
+    let streams = workers.max(8);
+    let worker_text = workers.to_string();
+    let stream_text = streams.to_string();
+    let config = ParityConfig::from_lookup(|name| match name {
+        "R4_PARITY_WORKERS" => Some(worker_text.clone()),
+        "R4_PARITY_STREAMS" => Some(stream_text.clone()),
+        "R4_PARITY_BATCH_PER_WORKER" => Some("4".to_owned()),
+        "R4_PARITY_TELEMETRY" => Some("0".to_owned()),
+        "R4_PARITY_PROGRESS_EVERY_SECS" => Some("5".to_owned()),
+        "R4_PARITY_MAX_WALL_SECS" => Some("600".to_owned()),
+        "R4_PARITY_REPORT" => Some("target/custom-parity.json".to_owned()),
+        _ => None,
+    })
+    .expect("explicit config");
+
+    assert_eq!(config.workers, nonzero(workers));
+    assert_eq!(config.streams, nonzero(streams));
+    assert_eq!(config.batch_per_worker, nonzero(4));
+    assert_eq!(config.mode, ObservabilityMode::Disabled);
+    assert_eq!(config.progress_every, NonZeroU64::new(5).unwrap());
+    assert_eq!(config.stall_after, NonZeroU64::new(120).unwrap());
+    assert_eq!(config.max_wall, NonZeroU64::new(600).unwrap());
+    assert_eq!(
+        config.report_path,
+        PathBuf::from("target/custom-parity.json")
+    );
+}

--- a/tests/support/parity_observability.rs
+++ b/tests/support/parity_observability.rs
@@ -1,0 +1,3704 @@
+//! Reusable, dependency-light observability for the live teacher-parity harness.
+//!
+//! This module deliberately keeps deterministic evidence separate from empirical
+//! run telemetry. Timings, resource measurements, ETA estimates, and scheduling
+//! observations may vary without changing the evidence bytes supplied by the
+//! harness.
+
+#![allow(
+    dead_code,
+    reason = "this support API is compiled independently by multiple integration-test crates"
+)]
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::num::{NonZeroU64, NonZeroUsize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use uor_r4_model_source::TeacherExecutionSnapshot;
+
+pub const EVENT_SCHEMA: &str = "uor-r4.teacher-parity-progress/2";
+pub const RUN_REPORT_SCHEMA: &str = "uor-r4.teacher-parity-report/2";
+pub const EVIDENCE_SCHEMA: &str = "uor-r4.teacher-parity-evidence/2";
+
+const DEFAULT_PROGRESS_SECONDS: u64 = 10;
+const DEFAULT_MAX_WALL_SECONDS: u64 = 28_800;
+const MINIMUM_DEFAULT_STALL_SECONDS: u64 = 120;
+pub const CANONICAL_PARITY_STREAMS: usize = 8;
+pub const MAXIMUM_ADAPTIVE_GENERATION_TOKENS: usize = 8;
+pub const ADAPTIVE_EARLY_STOP_RATIO: f64 = 1.10;
+pub const ADAPTIVE_ACCEPTANCE_RATIO: f64 = 1.0;
+pub const DEFAULT_PREFLIGHT_REPORT_PATH: &str = "target/teacher-parity/teacher-free-preflight.json";
+pub const DEFAULT_EXACT_PROBE_REPORT_PATH: &str =
+    "target/teacher-parity/exact-multicore-probe.json";
+
+/// Resolve one fixture directory from a fail-closed environment lookup.
+///
+/// The caller supplies the lookup result so focused tests can exercise the
+/// non-Unicode/error branch without mutating the process environment. Relative
+/// overrides are intentionally preserved here; the BDD harness resolves them
+/// against its startup working directory before recording the selected path.
+pub fn configured_fixture_dir(
+    name: &str,
+    configured: Result<Option<String>, String>,
+    default: PathBuf,
+) -> Result<PathBuf, String> {
+    let configured = configured.map_err(|reason| format!("{name} {reason}"))?;
+    match configured {
+        Some(path) if path.trim().is_empty() => Err(format!("{name} is empty")),
+        Some(path) => Ok(PathBuf::from(path)),
+        None => Ok(default),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AdaptiveDecodeDecision {
+    ExtendConservativeMarginNotCleared,
+    StopEarlyConservativeMarginCleared,
+    StopAtMaximumAcceptanceCleared,
+    StopAtMaximumNotEstablished,
+}
+
+impl AdaptiveDecodeDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExtendConservativeMarginNotCleared => "EXTEND_CONSERVATIVE_MARGIN_NOT_CLEARED",
+            Self::StopEarlyConservativeMarginCleared => "STOP_EARLY_CONSERVATIVE_MARGIN_CLEARED",
+            Self::StopAtMaximumAcceptanceCleared => "STOP_AT_MAXIMUM_ACCEPTANCE_CLEARED",
+            Self::StopAtMaximumNotEstablished => "STOP_AT_MAXIMUM_NOT_ESTABLISHED",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        self != Self::ExtendConservativeMarginNotCleared
+    }
+}
+
+pub fn adaptive_decode_decision(
+    current_steps: usize,
+    maximum_steps: usize,
+    legacy_ratio: f64,
+    graph_ratio: f64,
+) -> AdaptiveDecodeDecision {
+    let at_maximum = current_steps >= maximum_steps;
+    if !at_maximum
+        && legacy_ratio > ADAPTIVE_EARLY_STOP_RATIO
+        && graph_ratio > ADAPTIVE_EARLY_STOP_RATIO
+    {
+        AdaptiveDecodeDecision::StopEarlyConservativeMarginCleared
+    } else if at_maximum
+        && legacy_ratio > ADAPTIVE_ACCEPTANCE_RATIO
+        && graph_ratio > ADAPTIVE_ACCEPTANCE_RATIO
+    {
+        AdaptiveDecodeDecision::StopAtMaximumAcceptanceCleared
+    } else if at_maximum {
+        AdaptiveDecodeDecision::StopAtMaximumNotEstablished
+    } else {
+        AdaptiveDecodeDecision::ExtendConservativeMarginNotCleared
+    }
+}
+
+pub fn adaptive_decode_checkpoints(maximum_steps: usize) -> Vec<usize> {
+    let mut checkpoints = Vec::new();
+    let mut steps = 1usize;
+    while steps <= maximum_steps {
+        checkpoints.push(steps);
+        if steps == maximum_steps {
+            break;
+        }
+        steps = steps.saturating_mul(2).min(maximum_steps);
+    }
+    checkpoints
+}
+
+enum StartGateState {
+    Waiting,
+    Started(Instant),
+    Cancelled(String),
+}
+
+/// A start rendezvous that can release already-created workers when a later
+/// OS thread creation fails. Unlike a fixed-party barrier, cancellation never
+/// strands the partial worker cohort.
+pub struct CancellableStartGate {
+    state: Mutex<StartGateState>,
+    changed: Condvar,
+}
+
+impl CancellableStartGate {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(StartGateState::Waiting),
+            changed: Condvar::new(),
+        }
+    }
+
+    pub fn wait(&self) -> Result<Instant, String> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            match &*state {
+                StartGateState::Waiting => {
+                    state = self
+                        .changed
+                        .wait(state)
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                }
+                StartGateState::Started(origin) => return Ok(*origin),
+                StartGateState::Cancelled(reason) => return Err(reason.clone()),
+            }
+        }
+    }
+
+    pub fn start(&self, origin: Instant) {
+        *self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = StartGateState::Started(origin);
+        self.changed.notify_all();
+    }
+
+    pub fn cancel(&self, reason: impl Into<String>) {
+        *self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            StartGateState::Cancelled(reason.into());
+        self.changed.notify_all();
+    }
+}
+
+impl Default for CancellableStartGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ObservabilityMode {
+    Enabled,
+    Disabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParityConfig {
+    pub workers: NonZeroUsize,
+    pub streams: NonZeroUsize,
+    pub batch_per_worker: NonZeroUsize,
+    /// Human and JSONL heartbeat cadence, in seconds.
+    pub progress_every: NonZeroU64,
+    /// Age of the last completed work item at which ETA changes to STALL.
+    pub stall_after: NonZeroU64,
+    /// Maximum admitted run wall time, in seconds.
+    pub max_wall: NonZeroU64,
+    pub positions: NonZeroUsize,
+    /// Maximum cumulative decode steps per canonical lane (1/2/4/8).
+    pub gen_tokens: NonZeroUsize,
+    /// Diagnostic parse surface retained for compatibility; a fixture-present
+    /// binding run requires exactly one causal cohort.
+    pub runs: NonZeroUsize,
+    pub corpus_positions: NonZeroUsize,
+    pub fmm_positions: NonZeroUsize,
+    pub probe_positions: NonZeroUsize,
+    pub mode: ObservabilityMode,
+    /// Empirical final report. Evidence and JSONL event paths are siblings.
+    pub report_path: PathBuf,
+}
+
+impl ParityConfig {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Self::from_env_lookup(std::env::var)
+    }
+
+    /// Read every parity control exactly once while preserving the distinction
+    /// between an absent variable and a present non-Unicode value. The lookup
+    /// seam keeps the fail-closed branch directly testable without mutating the
+    /// process-wide environment.
+    pub fn from_env_lookup(
+        mut lookup: impl FnMut(&'static str) -> Result<String, std::env::VarError>,
+    ) -> Result<Self, ConfigError> {
+        const NAMES: [&str; 13] = [
+            "R4_PARITY_WORKERS",
+            "R4_PARITY_STREAMS",
+            "R4_PARITY_BATCH_PER_WORKER",
+            "R4_PARITY_PROGRESS_EVERY_SECS",
+            "R4_PARITY_MAX_WALL_SECS",
+            "R4_PARITY_POSITIONS",
+            "R4_PARITY_GEN_TOKENS",
+            "R4_PARITY_RUNS",
+            "R4_PARITY_CORPUS_POSITIONS",
+            "R4_FMM_POSITIONS",
+            "R4_EXACT_PROBE_POSITIONS",
+            "R4_PARITY_TELEMETRY",
+            "R4_PARITY_REPORT",
+        ];
+        let mut values = BTreeMap::new();
+        for name in NAMES {
+            match lookup(name) {
+                Ok(value) => {
+                    values.insert(name, value);
+                }
+                Err(std::env::VarError::NotPresent) => {}
+                Err(std::env::VarError::NotUnicode(_)) => {
+                    return Err(ConfigError::NonUnicode { name });
+                }
+            }
+        }
+        Self::from_lookup(|name| values.get(name).cloned())
+    }
+
+    pub fn from_lookup(
+        mut lookup: impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self, ConfigError> {
+        let available = std::thread::available_parallelism()
+            .unwrap_or(NonZeroUsize::MIN)
+            .get();
+        let workers =
+            parse_nonzero_usize("R4_PARITY_WORKERS", lookup("R4_PARITY_WORKERS"), available)?;
+        if workers.get() > available {
+            return Err(ConfigError::WorkersAboveAvailable {
+                requested: workers.get(),
+                available,
+            });
+        }
+        // Stream width is semantic coverage, not a CPU-worker bound. Keep the
+        // eight canonical prompt trajectories even on hosts with a different
+        // available row-worker count.
+        let streams = parse_nonzero_usize(
+            "R4_PARITY_STREAMS",
+            lookup("R4_PARITY_STREAMS"),
+            CANONICAL_PARITY_STREAMS,
+        )?;
+        let batch_per_worker = parse_nonzero_usize(
+            "R4_PARITY_BATCH_PER_WORKER",
+            lookup("R4_PARITY_BATCH_PER_WORKER"),
+            4,
+        )?;
+        let progress_every = parse_nonzero_u64(
+            "R4_PARITY_PROGRESS_EVERY_SECS",
+            lookup("R4_PARITY_PROGRESS_EVERY_SECS"),
+            DEFAULT_PROGRESS_SECONDS,
+        )?;
+        let default_stall = progress_every
+            .get()
+            .saturating_mul(4)
+            .max(MINIMUM_DEFAULT_STALL_SECONDS);
+        let stall_after =
+            NonZeroU64::new(default_stall).expect("derived stall interval is nonzero");
+        let max_wall = parse_nonzero_u64(
+            "R4_PARITY_MAX_WALL_SECS",
+            lookup("R4_PARITY_MAX_WALL_SECS"),
+            DEFAULT_MAX_WALL_SECONDS,
+        )?;
+        if max_wall.get() > DEFAULT_MAX_WALL_SECONDS {
+            return Err(ConfigError::OutOfRange {
+                name: "R4_PARITY_MAX_WALL_SECS",
+                value: usize::try_from(max_wall.get()).unwrap_or(usize::MAX),
+                minimum: 1,
+                maximum: usize::try_from(DEFAULT_MAX_WALL_SECONDS).unwrap_or(usize::MAX),
+            });
+        }
+        let positions =
+            parse_nonzero_usize("R4_PARITY_POSITIONS", lookup("R4_PARITY_POSITIONS"), 256)?;
+        let gen_tokens = parse_nonzero_usize(
+            "R4_PARITY_GEN_TOKENS",
+            lookup("R4_PARITY_GEN_TOKENS"),
+            MAXIMUM_ADAPTIVE_GENERATION_TOKENS,
+        )?;
+        if gen_tokens.get() > MAXIMUM_ADAPTIVE_GENERATION_TOKENS {
+            return Err(ConfigError::OutOfRange {
+                name: "R4_PARITY_GEN_TOKENS",
+                value: gen_tokens.get(),
+                minimum: 1,
+                maximum: MAXIMUM_ADAPTIVE_GENERATION_TOKENS,
+            });
+        }
+        if !gen_tokens.get().is_power_of_two() {
+            return Err(ConfigError::InvalidAdaptiveMaximum {
+                value: gen_tokens.get(),
+            });
+        }
+        let runs = parse_nonzero_usize("R4_PARITY_RUNS", lookup("R4_PARITY_RUNS"), 1)?;
+        let corpus_positions = parse_nonzero_usize(
+            "R4_PARITY_CORPUS_POSITIONS",
+            lookup("R4_PARITY_CORPUS_POSITIONS"),
+            1_000,
+        )?;
+        let fmm_positions =
+            parse_nonzero_usize("R4_FMM_POSITIONS", lookup("R4_FMM_POSITIONS"), 256)?;
+        let probe_positions = parse_nonzero_usize(
+            "R4_EXACT_PROBE_POSITIONS",
+            lookup("R4_EXACT_PROBE_POSITIONS"),
+            1,
+        )?;
+        if probe_positions.get() > 8 {
+            return Err(ConfigError::OutOfRange {
+                name: "R4_EXACT_PROBE_POSITIONS",
+                value: probe_positions.get(),
+                minimum: 1,
+                maximum: 8,
+            });
+        }
+        if gen_tokens
+            .get()
+            .checked_mul(runs.get())
+            .and_then(|measured| measured.checked_add(positions.get()))
+            .and_then(|per_stream| per_stream.checked_mul(streams.get()))
+            .is_none()
+        {
+            return Err(ConfigError::BudgetOverflow);
+        }
+        let mode = parse_mode(lookup("R4_PARITY_TELEMETRY"))?;
+        let report_path = match lookup("R4_PARITY_REPORT") {
+            None => PathBuf::from("target/teacher-parity/parity-report.json"),
+            Some(value) if value.trim().is_empty() => {
+                return Err(ConfigError::InvalidPath {
+                    name: "R4_PARITY_REPORT",
+                    value,
+                });
+            }
+            Some(value) => PathBuf::from(value),
+        };
+        Ok(Self {
+            workers,
+            streams,
+            batch_per_worker,
+            progress_every,
+            stall_after,
+            max_wall,
+            positions,
+            gen_tokens,
+            runs,
+            corpus_positions,
+            fmm_positions,
+            probe_positions,
+            mode,
+            report_path,
+        })
+    }
+}
+
+pub fn configured_preflight_report_path(
+    configured: Option<String>,
+) -> Result<PathBuf, ConfigError> {
+    match configured {
+        Some(path) if path.trim().is_empty() => Err(ConfigError::InvalidPath {
+            name: "R4_PARITY_PREFLIGHT_REPORT",
+            value: path,
+        }),
+        Some(path) => Ok(PathBuf::from(path)),
+        None => Ok(PathBuf::from(DEFAULT_PREFLIGHT_REPORT_PATH)),
+    }
+}
+
+pub fn configured_exact_probe_report_path(
+    configured: Option<String>,
+) -> Result<PathBuf, ConfigError> {
+    match configured {
+        Some(path) if path.trim().is_empty() => Err(ConfigError::InvalidPath {
+            name: "R4_EXACT_PROBE_REPORT",
+            value: path,
+        }),
+        Some(path) => Ok(PathBuf::from(path)),
+        None => Ok(PathBuf::from(DEFAULT_EXACT_PROBE_REPORT_PATH)),
+    }
+}
+
+fn parse_nonzero_usize(
+    name: &'static str,
+    raw: Option<String>,
+    default: usize,
+) -> Result<NonZeroUsize, ConfigError> {
+    let Some(raw) = raw else {
+        return NonZeroUsize::new(default).ok_or_else(|| ConfigError::NonPositive {
+            name,
+            value: default.to_string(),
+        });
+    };
+    let trimmed = raw.trim();
+    let value = trimmed
+        .parse::<usize>()
+        .map_err(|_| ConfigError::InvalidInteger {
+            name,
+            value: raw.clone(),
+        })?;
+    NonZeroUsize::new(value).ok_or(ConfigError::NonPositive { name, value: raw })
+}
+
+fn parse_nonzero_u64(
+    name: &'static str,
+    raw: Option<String>,
+    default: u64,
+) -> Result<NonZeroU64, ConfigError> {
+    let Some(raw) = raw else {
+        return NonZeroU64::new(default).ok_or_else(|| ConfigError::NonPositive {
+            name,
+            value: default.to_string(),
+        });
+    };
+    let trimmed = raw.trim();
+    let value = trimmed
+        .parse::<u64>()
+        .map_err(|_| ConfigError::InvalidInteger {
+            name,
+            value: raw.clone(),
+        })?;
+    NonZeroU64::new(value).ok_or(ConfigError::NonPositive { name, value: raw })
+}
+
+fn parse_mode(raw: Option<String>) -> Result<ObservabilityMode, ConfigError> {
+    let Some(raw) = raw else {
+        return Ok(ObservabilityMode::Enabled);
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(ObservabilityMode::Enabled),
+        "0" | "false" | "no" | "off" => Ok(ObservabilityMode::Disabled),
+        _ => Err(ConfigError::InvalidBoolean {
+            name: "R4_PARITY_TELEMETRY",
+            value: raw,
+        }),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    NonUnicode {
+        name: &'static str,
+    },
+    InvalidInteger {
+        name: &'static str,
+        value: String,
+    },
+    NonPositive {
+        name: &'static str,
+        value: String,
+    },
+    InvalidBoolean {
+        name: &'static str,
+        value: String,
+    },
+    WorkersAboveAvailable {
+        requested: usize,
+        available: usize,
+    },
+    InvalidPath {
+        name: &'static str,
+        value: String,
+    },
+    OutOfRange {
+        name: &'static str,
+        value: usize,
+        minimum: usize,
+        maximum: usize,
+    },
+    InvalidAdaptiveMaximum {
+        value: usize,
+    },
+    BudgetOverflow,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonUnicode { name } => {
+                write!(formatter, "{name} is present but is not valid Unicode")
+            }
+            Self::InvalidInteger { name, value } => {
+                write!(formatter, "{name} must be a decimal integer, got {value:?}")
+            }
+            Self::NonPositive { name, value } => {
+                write!(formatter, "{name} must be greater than zero, got {value:?}")
+            }
+            Self::InvalidBoolean { name, value } => write!(
+                formatter,
+                "{name} must be 1/0, true/false, yes/no, or on/off, got {value:?}"
+            ),
+            Self::WorkersAboveAvailable {
+                requested,
+                available,
+            } => write!(
+                formatter,
+                "R4_PARITY_WORKERS ({requested}) exceeds available_parallelism() ({available})"
+            ),
+            Self::InvalidPath { name, value } => {
+                write!(formatter, "{name} must be a non-empty path, got {value:?}")
+            }
+            Self::OutOfRange {
+                name,
+                value,
+                minimum,
+                maximum,
+            } => write!(
+                formatter,
+                "{name} must be in {minimum}..={maximum}, got {value}"
+            ),
+            Self::InvalidAdaptiveMaximum { value } => write!(
+                formatter,
+                "R4_PARITY_GEN_TOKENS must be one of 1, 2, 4, or 8 for cumulative adaptive checkpoints, got {value}"
+            ),
+            Self::BudgetOverflow => write!(
+                formatter,
+                "teacher-parity budgets overflow host addressable work arithmetic"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingShapeError {
+    NoHostCapacity,
+    CanonicalStreamsRequired { streams: usize },
+    SingleRunRequired { runs: usize },
+}
+
+impl fmt::Display for BindingShapeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoHostCapacity => write!(formatter, "available_parallelism reported zero"),
+            Self::CanonicalStreamsRequired { streams } => write!(
+                formatter,
+                "binding parity requires the {CANONICAL_PARITY_STREAMS} canonical private streams, got {streams}"
+            ),
+            Self::SingleRunRequired { runs } => write!(
+                formatter,
+                "fixture-present adaptive parity requires exactly one causal run, got {runs}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BindingShapeError {}
+
+/// A binding live run retains the canonical semantic cohort. The exact
+/// output-row worker count is independently selected by the bounded probe.
+pub fn validate_binding_host_shape(
+    config: &ParityConfig,
+    available: usize,
+) -> Result<(), BindingShapeError> {
+    if available == 0 {
+        return Err(BindingShapeError::NoHostCapacity);
+    }
+    if config.streams.get() != CANONICAL_PARITY_STREAMS {
+        return Err(BindingShapeError::CanonicalStreamsRequired {
+            streams: config.streams.get(),
+        });
+    }
+    if config.runs.get() != 1 {
+        return Err(BindingShapeError::SingleRunRequired {
+            runs: config.runs.get(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrivateStreamEvidenceError {
+    SingleStream,
+    SeedCount { actual: usize, expected: usize },
+    OutputCount { actual: usize, expected: usize },
+    DuplicateSeedIdentity { first: usize, duplicate: usize },
+}
+
+impl fmt::Display for PrivateStreamEvidenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SingleStream => write!(formatter, "private multistream evidence requires S > 1"),
+            Self::SeedCount { actual, expected } => {
+                write!(formatter, "lane seed identities {actual}/{expected}")
+            }
+            Self::OutputCount { actual, expected } => {
+                write!(formatter, "lane output identities {actual}/{expected}")
+            }
+            Self::DuplicateSeedIdentity { first, duplicate } => write!(
+                formatter,
+                "lane {duplicate} duplicates lane {first} seed identity (fan-out evidence is not private multistream evidence)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PrivateStreamEvidenceError {}
+
+/// Require complete ordered lane records and distinct seed identities. Output
+/// identities may coincide by model behavior; the caller separately proves S
+/// private states were instantiated and completed.
+pub fn validate_private_multistream_evidence(
+    seed_cids: &[String],
+    output_cids: &[String],
+    expected_streams: usize,
+) -> Result<(), PrivateStreamEvidenceError> {
+    if expected_streams <= 1 {
+        return Err(PrivateStreamEvidenceError::SingleStream);
+    }
+    if seed_cids.len() != expected_streams {
+        return Err(PrivateStreamEvidenceError::SeedCount {
+            actual: seed_cids.len(),
+            expected: expected_streams,
+        });
+    }
+    if output_cids.len() != expected_streams {
+        return Err(PrivateStreamEvidenceError::OutputCount {
+            actual: output_cids.len(),
+            expected: expected_streams,
+        });
+    }
+    for duplicate in 0..seed_cids.len() {
+        if let Some(first) = seed_cids[..duplicate]
+            .iter()
+            .position(|identity| identity == &seed_cids[duplicate])
+        {
+            return Err(PrivateStreamEvidenceError::DuplicateSeedIdentity { first, duplicate });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RunStatus {
+    Pass,
+    Fail,
+    Unavailable,
+    Aborted,
+    NotRun,
+}
+
+impl RunStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Fail => "FAIL",
+            Self::Unavailable => "UNAVAILABLE",
+            Self::Aborted => "ABORTED",
+            Self::NotRun => "NOT_RUN",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EventKind {
+    SuiteStarted,
+    FixtureStatus,
+    PhaseStarted,
+    PhaseCompleted,
+    WorkStarted,
+    WorkCompleted,
+    Heartbeat,
+    WorkFailed,
+    SuiteCompleted,
+    SuiteAborted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FixtureVerdict {
+    Available,
+    Unavailable,
+    Failed,
+    NotRun,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureStatus {
+    pub verdict: FixtureVerdict,
+    pub cid: Option<String>,
+    pub reason: Option<String>,
+}
+
+impl FixtureStatus {
+    pub fn available(cid: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::Available,
+            cid: Some(cid.into()),
+            reason: None,
+        }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::Unavailable,
+            cid: None,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn unavailable_with_cid(cid: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::Unavailable,
+            cid: Some(cid.into()),
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn failed(reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::Failed,
+            cid: None,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn failed_with_cid(cid: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::Failed,
+            cid: Some(cid.into()),
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn not_run(reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::NotRun,
+            cid: None,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn not_run_with_cid(cid: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            verdict: FixtureVerdict::NotRun,
+            cid: Some(cid.into()),
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Discriminated shape of an exact-probe artifact before full-report decoding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExactProbeArtifact {
+    /// Candidate full report; the model-source schema owner still performs its
+    /// complete typed deserialization and admission validation.
+    QualifiedCandidate(Value),
+    /// Truthful state/refusal written before a full qualified report existed.
+    NonQualified(ExactProbeNonQualifiedState),
+}
+
+/// Minimal fail-closed projection of `EXACT_MULTICORE_PROBE_STATE`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExactProbeNonQualifiedState {
+    pub event: String,
+    pub probe_status: String,
+    pub run_status: RunStatus,
+    pub reason: String,
+}
+
+impl ExactProbeNonQualifiedState {
+    /// Stable run-level reason returned by the BDD fixture loader.
+    pub fn outcome_reason(&self) -> String {
+        let detail = format!(
+            "exact probe state {} / {}: {}",
+            self.event, self.probe_status, self.reason
+        );
+        match self.run_status {
+            RunStatus::NotRun => format!("NOT_RUN / REFUSED: {detail}"),
+            RunStatus::Unavailable => format!("UNAVAILABLE: {detail}"),
+            RunStatus::Fail => format!("FAILED: {detail}"),
+            RunStatus::Aborted => format!("ABORTED: {detail}"),
+            RunStatus::Pass => format!("FAILED: non-qualified probe state claimed PASS: {detail}"),
+        }
+    }
+
+    /// Preserve the state artifact's exact bytes while keeping fixture and run
+    /// verdicts distinct. A probe abort is non-qualified/NOT_RUN as a fixture,
+    /// while the enclosing run retains its ABORTED status.
+    pub fn fixture_status(&self, cid: impl Into<String>) -> FixtureStatus {
+        let cid = cid.into();
+        match self.run_status {
+            RunStatus::Unavailable => FixtureStatus::unavailable_with_cid(cid, self.reason.clone()),
+            RunStatus::Fail | RunStatus::Pass => {
+                FixtureStatus::failed_with_cid(cid, self.reason.clone())
+            }
+            RunStatus::NotRun | RunStatus::Aborted => {
+                FixtureStatus::not_run_with_cid(cid, self.reason.clone())
+            }
+        }
+    }
+}
+
+/// Bind a present non-qualified probe artifact to the final run metadata.
+///
+/// A state/refusal is legitimate evidence for a non-PASS outcome, but it may
+/// never be reinterpreted as admission. Its exact persisted bytes, projected
+/// fixture verdict, and reason must be the same values recorded when the BDD
+/// first consumed the artifact.
+pub fn validate_nonqualified_probe_prepublication(
+    overall_status: RunStatus,
+    fixture: Option<&FixtureStatus>,
+    state: &ExactProbeNonQualifiedState,
+    artifact_cid: &str,
+) -> Result<(), String> {
+    if overall_status == RunStatus::Pass {
+        return Err("FAIL: a PASS may not publish a non-qualified exact probe state".to_owned());
+    }
+    let fixture = fixture.ok_or_else(|| {
+        "FAIL: present non-qualified exact probe has no explicit fixture status".to_owned()
+    })?;
+    let expected = state.fixture_status(artifact_cid);
+    if fixture.cid.as_deref() != Some(artifact_cid) {
+        return Err(format!(
+            "FAIL: non-qualified exact probe fixture CID {:?} does not bind persisted artifact {artifact_cid}",
+            fixture.cid
+        ));
+    }
+    if fixture.verdict != expected.verdict {
+        return Err(format!(
+            "FAIL: non-qualified exact probe fixture verdict {:?} does not match state {} / {}",
+            fixture.verdict, state.event, state.probe_status
+        ));
+    }
+    if fixture.reason.as_deref() != Some(state.reason.as_str()) {
+        return Err(
+            "FAIL: non-qualified exact probe fixture reason does not match persisted state"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// Parse only enough exact-probe structure to distinguish a candidate full
+/// report from the versioned, explicitly non-qualified state record. Unknown
+/// records, malformed JSON, contradictory status/event pairs, and any state
+/// that claims qualification fail closed before typed report deserialization.
+pub fn classify_exact_probe_artifact(
+    bytes: &[u8],
+    expected_schema: &str,
+) -> Result<ExactProbeArtifact, String> {
+    let value: Value = serde_json::from_slice(bytes)
+        .map_err(|error| format!("FAILED: exact probe JSON is malformed: {error}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "FAILED: exact probe JSON root must be an object".to_owned())?;
+    let schema = object
+        .get("schema")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "FAILED: exact probe JSON omitted string schema".to_owned())?;
+    if schema != expected_schema {
+        return Err(format!(
+            "FAILED: exact probe schema {schema:?} does not match {expected_schema:?}"
+        ));
+    }
+
+    let Some(record) = object.get("record") else {
+        return Ok(ExactProbeArtifact::QualifiedCandidate(value));
+    };
+    let record = record
+        .as_str()
+        .ok_or_else(|| "FAILED: exact probe record discriminator must be a string".to_owned())?;
+    if record != "EXACT_MULTICORE_PROBE_STATE" {
+        return Err(format!(
+            "FAILED: unknown exact probe record discriminator {record:?}"
+        ));
+    }
+    if object.get("qualifies_full_run").and_then(Value::as_bool) != Some(false) {
+        return Err(
+            "FAILED: exact probe state must explicitly set qualifies_full_run=false".to_owned(),
+        );
+    }
+    let event = object
+        .get("event")
+        .and_then(Value::as_str)
+        .filter(|event| !event.trim().is_empty())
+        .ok_or_else(|| "FAILED: exact probe state omitted nonempty string event".to_owned())?;
+    let probe_status = object
+        .get("status")
+        .and_then(Value::as_str)
+        .filter(|status| !status.trim().is_empty())
+        .ok_or_else(|| "FAILED: exact probe state omitted nonempty string status".to_owned())?;
+    let run_status = match (event, probe_status) {
+        ("NOT_RUN", "REFUSE_FULL_RUN") | ("RUNNING", "NOT_QUALIFIED") => RunStatus::NotRun,
+        ("UNAVAILABLE", "UNAVAILABLE") => RunStatus::Unavailable,
+        ("FAIL", "FAIL") => RunStatus::Fail,
+        ("ABORTED", "ABORTED") => RunStatus::Aborted,
+        _ => {
+            return Err(format!(
+                "FAILED: unknown or contradictory exact probe state event/status {event:?}/{probe_status:?}"
+            ))
+        }
+    };
+    let reason = object
+        .get("reason")
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.trim().is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            (event == "RUNNING" && probe_status == "NOT_QUALIFIED").then(|| {
+                "exact probe is still running and has not qualified the full run".to_owned()
+            })
+        })
+        .ok_or_else(|| "FAILED: terminal exact probe state omitted nonempty reason".to_owned())?;
+
+    Ok(ExactProbeArtifact::NonQualified(
+        ExactProbeNonQualifiedState {
+            event: event.to_owned(),
+            probe_status: probe_status.to_owned(),
+            run_status,
+            reason,
+        },
+    ))
+}
+
+/// Furthest graph-bundle stage reached by a failed teacher-free preflight.
+///
+/// The distinction prevents a content hash from being promoted into parser or
+/// runtime evidence. Every variant is non-PASS; it only identifies which
+/// fixture owned the refusal and which later fixture remained unexecuted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TeacherFreeGraphFailureStage {
+    /// Graph/report bytes may have been presence-checked or hashed, but the
+    /// report was not accepted.
+    NotReached,
+    /// Reading, parsing, or validating the graph report itself failed.
+    ReportFailed,
+    /// The graph report was accepted, but graph loading was not attempted.
+    ReportAccepted,
+    /// The report was accepted and graph loading or graph execution was tried.
+    GraphLoadAttempted,
+}
+
+/// Project a durable teacher-free graph-stage refusal into the final run
+/// metadata without promoting unopened teacher source files to AVAILABLE.
+/// `compiled_inputs_parsed` is supplied by the ordered preflight owner; a CID
+/// alone proves bytes were hashed, not that their parser accepted them.
+/// `graph_stage` distinguishes report read/parse/schema refusal, accepted
+/// provenance, and graph load/execution so later fixtures remain truthfully
+/// NOT_RUN rather than inheriting an earlier fixture's failure.
+pub fn apply_teacher_free_preflight_failure_metadata(
+    metadata: &mut RunMetadata,
+    report_path: &Path,
+    report_cid: Option<&str>,
+    report: &Value,
+    mut preflight_status: FixtureStatus,
+    compiled_inputs_parsed: bool,
+    graph_stage: TeacherFreeGraphFailureStage,
+) {
+    let refusal_reason = preflight_status
+        .reason
+        .clone()
+        .unwrap_or_else(|| "teacher-free preflight refused without a reason".to_owned());
+    metadata
+        .paths
+        .entry("teacher_free_preflight_report".to_owned())
+        .or_insert_with(|| report_path.display().to_string());
+    metadata.fixtures.insert(
+        "teacher_weights".to_owned(),
+        FixtureStatus::not_run(
+            "teacher source presence was inspected by metadata only; weights were not opened",
+        ),
+    );
+    metadata.fixtures.insert(
+        "teacher_config".to_owned(),
+        FixtureStatus::not_run(
+            "teacher source presence was inspected by metadata only; config was not opened",
+        ),
+    );
+    if let Some(report_cid) = report_cid {
+        preflight_status.cid = Some(report_cid.to_owned());
+        metadata.identities.insert(
+            "teacher_free_s4_preflight".to_owned(),
+            report_cid.to_owned(),
+        );
+    }
+    metadata
+        .fixtures
+        .insert("teacher_free_s4_preflight".to_owned(), preflight_status);
+
+    let input_cid = |name: &str| {
+        report
+            .pointer(&format!("/inputs/{name}/cid"))
+            .and_then(Value::as_str)
+            .filter(|cid| cid.starts_with("blake3:"))
+    };
+    if compiled_inputs_parsed {
+        for (input, fixture) in [
+            ("tokenizer", "tokenizer"),
+            ("legacy_artifact", "tla_artifact"),
+            ("legacy_store", "tls_store"),
+        ] {
+            if let Some(cid) = input_cid(input) {
+                metadata
+                    .fixtures
+                    .insert(fixture.to_owned(), FixtureStatus::available(cid));
+                metadata
+                    .identities
+                    .insert(fixture.to_owned(), cid.to_owned());
+            }
+        }
+    }
+    if let Some(cid) = input_cid("graph") {
+        metadata.fixtures.insert(
+            "r4g1_graph".to_owned(),
+            if graph_stage == TeacherFreeGraphFailureStage::GraphLoadAttempted {
+                FixtureStatus::failed_with_cid(cid, refusal_reason.clone())
+            } else {
+                FixtureStatus::not_run_with_cid(
+                    cid,
+                    format!(
+                        "graph bytes were present and hashed, but graph load was not attempted: {refusal_reason}"
+                    ),
+                )
+            },
+        );
+        metadata
+            .identities
+            .insert("r4g1_graph".to_owned(), cid.to_owned());
+    }
+    if let Some(cid) = input_cid("graph_report") {
+        metadata.fixtures.insert(
+            "r4g1_graph_report".to_owned(),
+            match graph_stage {
+                TeacherFreeGraphFailureStage::ReportFailed => {
+                    FixtureStatus::failed_with_cid(cid, refusal_reason.clone())
+                }
+                TeacherFreeGraphFailureStage::ReportAccepted
+                | TeacherFreeGraphFailureStage::GraphLoadAttempted => {
+                    FixtureStatus::available(cid)
+                }
+                TeacherFreeGraphFailureStage::NotReached => FixtureStatus::not_run_with_cid(
+                    cid,
+                    format!(
+                        "graph-report bytes were present and hashed, but report validation was not attempted: {refusal_reason}"
+                    ),
+                ),
+            },
+        );
+        metadata
+            .identities
+            .insert("r4g1_graph_report".to_owned(), cid.to_owned());
+    } else if graph_stage == TeacherFreeGraphFailureStage::ReportFailed {
+        metadata.fixtures.insert(
+            "r4g1_graph_report".to_owned(),
+            FixtureStatus::failed(refusal_reason),
+        );
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SchedulerSnapshot {
+    /// Backward-compatible generic worker bound; interpreted as the bounded
+    /// trajectory pool outside exact teacher matrix execution.
+    pub requested_workers: NonZeroUsize,
+    pub effective_workers: NonZeroUsize,
+    pub requested_streams: NonZeroUsize,
+    pub effective_streams: NonZeroUsize,
+    pub batch_per_worker: NonZeroUsize,
+    pub configured_trajectory_workers: NonZeroUsize,
+    pub effective_trajectory_workers: NonZeroUsize,
+    pub configured_row_workers: NonZeroUsize,
+    pub effective_row_workers: NonZeroUsize,
+}
+
+impl SchedulerSnapshot {
+    pub fn from_config(config: &ParityConfig) -> Self {
+        Self {
+            requested_workers: config.workers,
+            effective_workers: config.workers,
+            requested_streams: config.streams,
+            effective_streams: config.streams,
+            batch_per_worker: config.batch_per_worker,
+            configured_trajectory_workers: config.workers,
+            effective_trajectory_workers: config.workers,
+            configured_row_workers: config.workers,
+            effective_row_workers: config.workers,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunMetadata {
+    pub scheduler: SchedulerSnapshot,
+    pub backend: String,
+    pub kernel: String,
+    pub isa: String,
+    pub identities: BTreeMap<String, String>,
+    pub model_geometry: BTreeMap<String, u64>,
+    pub budgets: BTreeMap<String, u64>,
+    pub fixtures: BTreeMap<String, FixtureStatus>,
+    /// Absolute durable artifact paths for the current run.
+    pub paths: BTreeMap<String, String>,
+}
+
+impl RunMetadata {
+    pub fn new(
+        scheduler: SchedulerSnapshot,
+        backend: impl Into<String>,
+        kernel: impl Into<String>,
+        isa: impl Into<String>,
+    ) -> Self {
+        Self {
+            scheduler,
+            backend: backend.into(),
+            kernel: kernel.into(),
+            isa: isa.into(),
+            identities: BTreeMap::new(),
+            model_geometry: BTreeMap::new(),
+            budgets: BTreeMap::new(),
+            fixtures: BTreeMap::new(),
+            paths: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_identity(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.identities.insert(name.into(), value.into());
+        self
+    }
+
+    pub fn with_model_geometry(mut self, name: impl Into<String>, value: u64) -> Self {
+        self.model_geometry.insert(name.into(), value);
+        self
+    }
+
+    pub fn with_budget(mut self, name: impl Into<String>, value: u64) -> Self {
+        self.budgets.insert(name.into(), value);
+        self
+    }
+
+    pub fn with_fixture(mut self, name: impl Into<String>, status: FixtureStatus) -> Self {
+        self.fixtures.insert(name.into(), status);
+        self
+    }
+
+    pub fn with_path(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.paths.insert(name.into(), value.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StreamState {
+    Queued,
+    Active,
+    Completed,
+    Failed,
+    Aborted,
+    NotRun,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StreamProgress {
+    pub stream_id: String,
+    pub phase: String,
+    pub state: StreamState,
+    pub logical_forwards_completed: u64,
+    pub logical_forwards_total: u64,
+    pub tokens_completed: u64,
+    pub tokens_total: u64,
+    pub active_forward_age_millis: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueueSnapshot {
+    pub queue_depth: u64,
+    pub active_streams: u64,
+    pub peak_active_streams: u64,
+    pub active_row_workers: u64,
+    pub peak_active_row_workers: u64,
+    pub completed_streams: u64,
+    pub failed_streams: u64,
+    pub active_worker_tasks: u64,
+    pub completed_worker_tasks: u64,
+    pub failed_worker_tasks: u64,
+    pub longest_active_millis: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ProgressUnit {
+    #[default]
+    LogicalForwards,
+    WorkerTasks,
+    ScalarTerms,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RateSnapshot {
+    pub rolling_forwards_per_second: Option<f64>,
+    pub cumulative_forwards_per_second: Option<f64>,
+    pub seconds_per_forward: Option<f64>,
+    pub tokens_per_second: Option<f64>,
+    pub rolling_worker_tasks_per_second: Option<f64>,
+    pub rolling_scalar_terms_per_second: Option<f64>,
+    pub cumulative_scalar_terms_per_second: Option<f64>,
+    pub eta_progress_unit: ProgressUnit,
+    pub eta_progress_completed: u64,
+    pub eta_progress_total: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkPlan {
+    pub logical_forwards: u64,
+    pub tokens: u64,
+    pub physical_batches: u64,
+    pub matrix_calls: u64,
+    pub batched_matrix_calls: u64,
+    pub max_matrix_batch_width: u64,
+    pub padded_forwards: u64,
+    pub cache_hits: u64,
+    pub streams: u64,
+    pub worker_tasks: u64,
+    pub row_tiles: u64,
+    pub output_cells: u64,
+    pub scalar_terms: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkSnapshot {
+    pub plan: WorkPlan,
+    pub logical_forwards: u64,
+    pub tokens: u64,
+    pub physical_batches: u64,
+    pub matrix_calls: u64,
+    pub batched_matrix_calls: u64,
+    pub max_matrix_batch_width: u64,
+    pub padded_forwards: u64,
+    pub cache_hits: u64,
+    pub streams: u64,
+    pub worker_tasks: u64,
+    pub row_tiles: u64,
+    pub output_cells: u64,
+    pub scalar_terms: u64,
+    pub failed_streams: u64,
+    pub failed_worker_tasks: u64,
+}
+
+/// Select the cheapest monotonic unit that advances inside a physical exact
+/// forward. Scalar terms give the finest ETA signal; worker tasks are the
+/// fallback for producers without scalar accounting, and logical forwards
+/// remain the truthful final fallback.
+pub fn heartbeat_progress_units(work: &WorkSnapshot) -> (ProgressUnit, u64, u64) {
+    if work.plan.scalar_terms != 0 {
+        (
+            ProgressUnit::ScalarTerms,
+            work.scalar_terms,
+            work.plan.scalar_terms,
+        )
+    } else if work.plan.worker_tasks != 0 {
+        (
+            ProgressUnit::WorkerTasks,
+            work.worker_tasks,
+            work.plan.worker_tasks,
+        )
+    } else {
+        (
+            ProgressUnit::LogicalForwards,
+            work.logical_forwards,
+            work.plan.logical_forwards,
+        )
+    }
+}
+
+pub struct WorkCounters {
+    plan: Mutex<WorkPlan>,
+    plan_state: AtomicU8,
+    work_started: AtomicBool,
+    plan_violation: AtomicBool,
+    logical_forwards: AtomicU64,
+    tokens: AtomicU64,
+    physical_batches: AtomicU64,
+    matrix_calls: AtomicU64,
+    batched_matrix_calls: AtomicU64,
+    max_matrix_batch_width: AtomicU64,
+    padded_forwards: AtomicU64,
+    cache_hits: AtomicU64,
+    streams: AtomicU64,
+    worker_tasks: AtomicU64,
+    row_tiles: AtomicU64,
+    output_cells: AtomicU64,
+    scalar_terms: AtomicU64,
+    failed_streams: AtomicU64,
+    failed_worker_tasks: AtomicU64,
+}
+
+impl WorkCounters {
+    pub fn new(plan: WorkPlan) -> Self {
+        Self {
+            plan: Mutex::new(plan),
+            plan_state: AtomicU8::new(2),
+            work_started: AtomicBool::new(false),
+            plan_violation: AtomicBool::new(false),
+            logical_forwards: AtomicU64::new(0),
+            tokens: AtomicU64::new(0),
+            physical_batches: AtomicU64::new(0),
+            matrix_calls: AtomicU64::new(0),
+            batched_matrix_calls: AtomicU64::new(0),
+            max_matrix_batch_width: AtomicU64::new(0),
+            padded_forwards: AtomicU64::new(0),
+            cache_hits: AtomicU64::new(0),
+            streams: AtomicU64::new(0),
+            worker_tasks: AtomicU64::new(0),
+            row_tiles: AtomicU64::new(0),
+            output_cells: AtomicU64::new(0),
+            scalar_terms: AtomicU64::new(0),
+            failed_streams: AtomicU64::new(0),
+            failed_worker_tasks: AtomicU64::new(0),
+        }
+    }
+
+    /// Construct counters whose exact work totals are not known yet. The
+    /// caller must install them exactly once, before recording any work.
+    pub fn unplanned() -> Self {
+        Self {
+            plan: Mutex::new(WorkPlan::default()),
+            plan_state: AtomicU8::new(0),
+            work_started: AtomicBool::new(false),
+            plan_violation: AtomicBool::new(false),
+            logical_forwards: AtomicU64::new(0),
+            tokens: AtomicU64::new(0),
+            physical_batches: AtomicU64::new(0),
+            matrix_calls: AtomicU64::new(0),
+            batched_matrix_calls: AtomicU64::new(0),
+            max_matrix_batch_width: AtomicU64::new(0),
+            padded_forwards: AtomicU64::new(0),
+            cache_hits: AtomicU64::new(0),
+            streams: AtomicU64::new(0),
+            worker_tasks: AtomicU64::new(0),
+            row_tiles: AtomicU64::new(0),
+            output_cells: AtomicU64::new(0),
+            scalar_terms: AtomicU64::new(0),
+            failed_streams: AtomicU64::new(0),
+            failed_worker_tasks: AtomicU64::new(0),
+        }
+    }
+
+    /// Install the precomputed suite plan before any live forward is admitted.
+    pub fn set_plan(&self, plan: WorkPlan) -> Result<(), PlanInstallError> {
+        self.plan_state
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| PlanInstallError::AlreadyInstalled)?;
+        if self.work_started.load(Ordering::Acquire) {
+            self.plan_state.store(0, Ordering::Release);
+            return Err(PlanInstallError::WorkAlreadyStarted);
+        }
+        *self
+            .plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = plan;
+        self.plan_state.store(2, Ordering::Release);
+        if self.work_started.load(Ordering::Acquire) {
+            self.plan_violation.store(true, Ordering::Release);
+            return Err(PlanInstallError::WorkAlreadyStarted);
+        }
+        Ok(())
+    }
+
+    /// Close an adaptive upper-bound plan to the work actually selected. Every
+    /// field must move monotonically downward without falling below already
+    /// observed work. Later non-adaptive phases may continue recording against
+    /// the retained totals.
+    pub fn reduce_plan(&self, reduced: WorkPlan) -> Result<(), PlanInstallError> {
+        if self.plan_state.load(Ordering::Acquire) != 2 {
+            return Err(PlanInstallError::AlreadyInstalled);
+        }
+        let mut plan = self
+            .plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let observed = WorkPlan {
+            logical_forwards: self.logical_forwards.load(Ordering::Acquire),
+            tokens: self.tokens.load(Ordering::Acquire),
+            physical_batches: self.physical_batches.load(Ordering::Acquire),
+            matrix_calls: self.matrix_calls.load(Ordering::Acquire),
+            batched_matrix_calls: self.batched_matrix_calls.load(Ordering::Acquire),
+            max_matrix_batch_width: self.max_matrix_batch_width.load(Ordering::Acquire),
+            padded_forwards: self.padded_forwards.load(Ordering::Acquire),
+            cache_hits: self.cache_hits.load(Ordering::Acquire),
+            streams: self.streams.load(Ordering::Acquire),
+            worker_tasks: self.worker_tasks.load(Ordering::Acquire),
+            row_tiles: self.row_tiles.load(Ordering::Acquire),
+            output_cells: self.output_cells.load(Ordering::Acquire),
+            scalar_terms: self.scalar_terms.load(Ordering::Acquire),
+        };
+        macro_rules! check_field {
+            ($field:ident) => {
+                if reduced.$field > plan.$field {
+                    return Err(PlanInstallError::ReductionWouldIncrease);
+                }
+                if reduced.$field < observed.$field {
+                    return Err(PlanInstallError::ReductionBelowObserved);
+                }
+            };
+        }
+        check_field!(logical_forwards);
+        check_field!(tokens);
+        check_field!(physical_batches);
+        check_field!(matrix_calls);
+        check_field!(batched_matrix_calls);
+        check_field!(max_matrix_batch_width);
+        check_field!(padded_forwards);
+        check_field!(cache_hits);
+        check_field!(streams);
+        check_field!(worker_tasks);
+        check_field!(row_tiles);
+        check_field!(output_cells);
+        check_field!(scalar_terms);
+        *plan = reduced;
+        Ok(())
+    }
+
+    fn begin_recording(&self) {
+        self.work_started.store(true, Ordering::Release);
+        if self.plan_state.load(Ordering::Acquire) != 2 {
+            self.plan_violation.store(true, Ordering::Release);
+        }
+    }
+
+    pub fn record_batch(
+        &self,
+        logical_forwards: u64,
+        padded_forwards: u64,
+        cache_hits: u64,
+        worker_tasks: u64,
+        row_tiles: u64,
+    ) {
+        self.begin_recording();
+        self.physical_batches.fetch_add(1, Ordering::Relaxed);
+        self.logical_forwards
+            .fetch_add(logical_forwards, Ordering::Relaxed);
+        self.padded_forwards
+            .fetch_add(padded_forwards, Ordering::Relaxed);
+        self.cache_hits.fetch_add(cache_hits, Ordering::Relaxed);
+        self.worker_tasks.fetch_add(worker_tasks, Ordering::Relaxed);
+        self.row_tiles.fetch_add(row_tiles, Ordering::Relaxed);
+    }
+
+    pub fn record_logical_forwards(&self, count: u64) {
+        self.begin_recording();
+        self.logical_forwards.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_tokens(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.tokens.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_physical_batch(&self) {
+        self.begin_recording();
+        self.physical_batches.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_physical_batches(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.physical_batches.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_matrix_calls(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.matrix_calls.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_batched_matrix_calls(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.batched_matrix_calls
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_max_matrix_batch_width(&self, width: usize) {
+        if width == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.max_matrix_batch_width
+            .fetch_max(width as u64, Ordering::AcqRel);
+    }
+
+    pub fn record_padded_forwards(&self, count: u64) {
+        self.begin_recording();
+        self.padded_forwards.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_cache_hits(&self, count: u64) {
+        self.begin_recording();
+        self.cache_hits.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_stream_completed(&self) {
+        self.begin_recording();
+        self.streams.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_stream_failed(&self) {
+        self.begin_recording();
+        self.failed_streams.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_worker_tasks(&self, count: u64) {
+        self.begin_recording();
+        self.worker_tasks.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_worker_task_failed(&self) {
+        self.begin_recording();
+        self.failed_worker_tasks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_row_tiles(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.row_tiles.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_output_cells(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.output_cells.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_scalar_terms(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.begin_recording();
+        self.scalar_terms.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> WorkSnapshot {
+        WorkSnapshot {
+            plan: *self
+                .plan
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            logical_forwards: self.logical_forwards.load(Ordering::Relaxed),
+            tokens: self.tokens.load(Ordering::Relaxed),
+            physical_batches: self.physical_batches.load(Ordering::Relaxed),
+            matrix_calls: self.matrix_calls.load(Ordering::Relaxed),
+            batched_matrix_calls: self.batched_matrix_calls.load(Ordering::Relaxed),
+            max_matrix_batch_width: self.max_matrix_batch_width.load(Ordering::Relaxed),
+            padded_forwards: self.padded_forwards.load(Ordering::Relaxed),
+            cache_hits: self.cache_hits.load(Ordering::Relaxed),
+            streams: self.streams.load(Ordering::Relaxed),
+            worker_tasks: self.worker_tasks.load(Ordering::Relaxed),
+            row_tiles: self.row_tiles.load(Ordering::Relaxed),
+            output_cells: self.output_cells.load(Ordering::Relaxed),
+            scalar_terms: self.scalar_terms.load(Ordering::Relaxed),
+            failed_streams: self.failed_streams.load(Ordering::Relaxed),
+            failed_worker_tasks: self.failed_worker_tasks.load(Ordering::Relaxed),
+        }
+    }
+
+    /// A requested PASS is accepted only when every exact counter closes and
+    /// no worker or stream reported failure. Other truthful terminal states are
+    /// preserved without manufacturing a pass/fail interpretation.
+    pub fn completion_status(&self, requested: RunStatus) -> CompletionStatus {
+        if requested != RunStatus::Pass {
+            return CompletionStatus {
+                status: requested,
+                detail: None,
+            };
+        }
+        let snapshot = self.snapshot();
+        let mut mismatches = Vec::new();
+        if self.plan_state.load(Ordering::Acquire) != 2 {
+            mismatches.push("work plan was not installed".to_owned());
+        }
+        if self.plan_violation.load(Ordering::Acquire) {
+            mismatches.push("work was recorded before the plan was installed".to_owned());
+        }
+        push_mismatch(
+            &mut mismatches,
+            "logical_forwards",
+            snapshot.logical_forwards,
+            snapshot.plan.logical_forwards,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "tokens",
+            snapshot.tokens,
+            snapshot.plan.tokens,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "physical_batches",
+            snapshot.physical_batches,
+            snapshot.plan.physical_batches,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "matrix_calls",
+            snapshot.matrix_calls,
+            snapshot.plan.matrix_calls,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "batched_matrix_calls",
+            snapshot.batched_matrix_calls,
+            snapshot.plan.batched_matrix_calls,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "max_matrix_batch_width",
+            snapshot.max_matrix_batch_width,
+            snapshot.plan.max_matrix_batch_width,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "padded_forwards",
+            snapshot.padded_forwards,
+            snapshot.plan.padded_forwards,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "cache_hits",
+            snapshot.cache_hits,
+            snapshot.plan.cache_hits,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "streams",
+            snapshot.streams,
+            snapshot.plan.streams,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "worker_tasks",
+            snapshot.worker_tasks,
+            snapshot.plan.worker_tasks,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "row_tiles",
+            snapshot.row_tiles,
+            snapshot.plan.row_tiles,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "output_cells",
+            snapshot.output_cells,
+            snapshot.plan.output_cells,
+        );
+        push_mismatch(
+            &mut mismatches,
+            "scalar_terms",
+            snapshot.scalar_terms,
+            snapshot.plan.scalar_terms,
+        );
+        if snapshot.failed_streams != 0 {
+            mismatches.push(format!("failed_streams {}", snapshot.failed_streams));
+        }
+        if snapshot.failed_worker_tasks != 0 {
+            mismatches.push(format!(
+                "failed_worker_tasks {}",
+                snapshot.failed_worker_tasks
+            ));
+        }
+        if mismatches.is_empty() {
+            CompletionStatus {
+                status: RunStatus::Pass,
+                detail: None,
+            }
+        } else {
+            CompletionStatus {
+                status: RunStatus::Fail,
+                detail: Some(format!(
+                    "incomplete or failed parity work: {}",
+                    mismatches.join(", ")
+                )),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanInstallError {
+    AlreadyInstalled,
+    WorkAlreadyStarted,
+    ReductionWouldIncrease,
+    ReductionBelowObserved,
+}
+
+impl fmt::Display for PlanInstallError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyInstalled => write!(formatter, "parity work plan is already installed"),
+            Self::WorkAlreadyStarted => {
+                write!(formatter, "parity work began before its plan was installed")
+            }
+            Self::ReductionWouldIncrease => {
+                write!(
+                    formatter,
+                    "adaptive plan reduction would increase a planned field"
+                )
+            }
+            Self::ReductionBelowObserved => {
+                write!(
+                    formatter,
+                    "adaptive plan reduction would fall below observed work"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PlanInstallError {}
+
+fn push_mismatch(out: &mut Vec<String>, label: &str, actual: u64, planned: u64) {
+    if actual != planned {
+        out.push(format!("{label} {actual}/{planned}"));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompletionStatus {
+    pub status: RunStatus,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EtaStatus {
+    WarmingUp,
+    Estimated,
+    Unavailable,
+    Stall,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EtaInput {
+    pub completed: u64,
+    pub total: u64,
+    pub elapsed: Duration,
+    pub last_progress_age: Duration,
+    pub stall_after: Duration,
+    pub minimum_samples: u64,
+}
+
+impl Default for EtaInput {
+    fn default() -> Self {
+        Self {
+            completed: 0,
+            total: 0,
+            elapsed: Duration::ZERO,
+            last_progress_age: Duration::ZERO,
+            stall_after: Duration::from_secs(MINIMUM_DEFAULT_STALL_SECONDS),
+            minimum_samples: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EtaSnapshot {
+    pub status: EtaStatus,
+    pub completed: u64,
+    pub total: u64,
+    pub elapsed_seconds: u64,
+    pub last_progress_age_seconds: u64,
+    pub remaining_seconds: Option<u64>,
+}
+
+pub fn estimate_eta(input: EtaInput) -> EtaSnapshot {
+    let mut result = EtaSnapshot {
+        status: EtaStatus::Unavailable,
+        completed: input.completed,
+        total: input.total,
+        elapsed_seconds: input.elapsed.as_secs(),
+        last_progress_age_seconds: input.last_progress_age.as_secs(),
+        remaining_seconds: None,
+    };
+    if input.total == 0 || input.completed > input.total {
+        return result;
+    }
+    if input.completed < input.total && input.last_progress_age >= input.stall_after {
+        result.status = EtaStatus::Stall;
+        return result;
+    }
+    if input.completed < input.minimum_samples || input.elapsed.is_zero() {
+        result.status = EtaStatus::WarmingUp;
+        return result;
+    }
+    let elapsed = input.elapsed.as_secs_f64();
+    let rate = input.completed as f64 / elapsed;
+    if !rate.is_finite() || rate <= 0.0 {
+        return result;
+    }
+    let remaining = input.total - input.completed;
+    let estimate = (remaining as f64 / rate).ceil();
+    if estimate.is_finite() && estimate >= 0.0 && estimate <= u64::MAX as f64 {
+        result.status = EtaStatus::Estimated;
+        result.remaining_seconds = Some(estimate as u64);
+    }
+    result
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "availability", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Measurement<T> {
+    Available { value: T },
+    Unavailable { reason: String },
+}
+
+impl<T> Measurement<T> {
+    pub fn available(value: T) -> Self {
+        Self::Available { value }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "availability", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ResourceAvailability {
+    Available(Box<HostResourceSample>),
+    Unavailable { reason: String },
+}
+
+impl ResourceAvailability {
+    fn resident_set_bytes(&self) -> Option<NonZeroU64> {
+        match self {
+            Self::Available(sample) => match &sample.resident_set_bytes {
+                Measurement::Available { value } => Some(*value),
+                Measurement::Unavailable { .. } => None,
+            },
+            Self::Unavailable { .. } => None,
+        }
+    }
+
+    pub fn set_max_sampled_resident_set_bytes(&mut self, value: Option<NonZeroU64>) {
+        if let Self::Available(sample) = self {
+            sample.max_sampled_resident_set_bytes = value.map_or_else(
+                || Measurement::unavailable("no successful RSS sample was recorded"),
+                Measurement::available,
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostResourceSample {
+    pub sampled_unix_millis: u64,
+    pub architecture: String,
+    pub operating_system: String,
+    pub operating_system_version: Measurement<String>,
+    pub cpu_model: Measurement<String>,
+    pub physical_cores: Measurement<NonZeroUsize>,
+    pub logical_cores: Measurement<NonZeroUsize>,
+    pub performance_cores: Measurement<NonZeroUsize>,
+    pub efficiency_cores: Measurement<NonZeroUsize>,
+    pub total_memory_bytes: Measurement<NonZeroU64>,
+    pub resident_set_bytes: Measurement<NonZeroU64>,
+    /// Highest successful periodic RSS sample observed by this run.
+    pub max_sampled_resident_set_bytes: Measurement<NonZeroU64>,
+    pub virtual_memory_bytes: Measurement<NonZeroU64>,
+    /// Process CPU utilization; 800% means eight fully occupied logical CPUs.
+    pub cpu_percent: Measurement<f64>,
+    pub process_cpu_time_seconds: Measurement<f64>,
+    pub thread_count: Measurement<NonZeroUsize>,
+    /// macOS ps/sysctl do not expose a safe per-process peak-RSS sample.
+    pub peak_resident_set_bytes: Measurement<NonZeroU64>,
+}
+
+#[cfg(target_os = "macos")]
+pub fn sample_host_resources() -> ResourceAvailability {
+    ResourceAvailability::Available(Box::new(sample_macos_resources()))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn sample_host_resources() -> ResourceAvailability {
+    ResourceAvailability::Unavailable {
+        reason: format!(
+            "safe process RSS/CPU sampler is not implemented for {}",
+            std::env::consts::OS
+        ),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn sample_macos_resources() -> HostResourceSample {
+    fn sysctl(name: &str) -> Result<String, String> {
+        let output = std::process::Command::new("/usr/sbin/sysctl")
+            .args(["-n", name])
+            .output()
+            .map_err(|error| format!("sysctl {name}: {error}"))?;
+        if !output.status.success() {
+            return Err(format!("sysctl {name} exited {}", output.status));
+        }
+        String::from_utf8(output.stdout)
+            .map(|value| value.trim().to_owned())
+            .map_err(|error| format!("sysctl {name} returned non-UTF-8 output: {error}"))
+    }
+
+    fn parse_nonzero<T>(name: &str, raw: String) -> Result<T, String>
+    where
+        T: std::str::FromStr,
+        T::Err: fmt::Display,
+    {
+        raw.parse::<T>()
+            .map_err(|error| format!("{name} returned {raw:?}: {error}"))
+    }
+
+    fn measured_nonempty(result: Result<String, String>, name: &str) -> Measurement<String> {
+        match result {
+            Ok(value) if !value.trim().is_empty() => Measurement::available(value),
+            Ok(_) => Measurement::unavailable(format!("{name} returned an empty value")),
+            Err(reason) => Measurement::unavailable(reason),
+        }
+    }
+
+    fn measured_nonzero_usize(
+        result: Result<String, String>,
+        name: &str,
+    ) -> Measurement<NonZeroUsize> {
+        match result.and_then(|raw| parse_nonzero::<usize>(name, raw)) {
+            Ok(value) => NonZeroUsize::new(value)
+                .map(Measurement::available)
+                .unwrap_or_else(|| Measurement::unavailable(format!("{name} reported zero"))),
+            Err(reason) => Measurement::unavailable(reason),
+        }
+    }
+
+    fn measured_nonzero_u64(result: Result<String, String>, name: &str) -> Measurement<NonZeroU64> {
+        match result.and_then(|raw| parse_nonzero::<u64>(name, raw)) {
+            Ok(value) => NonZeroU64::new(value)
+                .map(Measurement::available)
+                .unwrap_or_else(|| Measurement::unavailable(format!("{name} reported zero"))),
+            Err(reason) => Measurement::unavailable(reason),
+        }
+    }
+
+    #[derive(Debug)]
+    struct ProcessSample {
+        resident_set_bytes: NonZeroU64,
+        virtual_memory_bytes: NonZeroU64,
+        cpu_percent: f64,
+        cpu_time_seconds: f64,
+    }
+
+    fn parse_cpu_time(raw: &str) -> Result<f64, String> {
+        let (days, clock) = match raw.split_once('-') {
+            Some((days, clock)) => (
+                days.parse::<u64>()
+                    .map_err(|error| format!("ps TIME days {days:?}: {error}"))?,
+                clock,
+            ),
+            None => (0, raw),
+        };
+        let fields: Vec<&str> = clock.split(':').collect();
+        let (hours, minutes, seconds) = match fields.as_slice() {
+            [minutes, seconds] => (0, *minutes, *seconds),
+            [hours, minutes, seconds] => (
+                hours
+                    .parse::<u64>()
+                    .map_err(|error| format!("ps TIME hours {hours:?}: {error}"))?,
+                *minutes,
+                *seconds,
+            ),
+            _ => return Err(format!("ps TIME had unexpected shape {raw:?}")),
+        };
+        let minutes = minutes
+            .parse::<u64>()
+            .map_err(|error| format!("ps TIME minutes {minutes:?}: {error}"))?;
+        let seconds = seconds
+            .parse::<f64>()
+            .map_err(|error| format!("ps TIME seconds {seconds:?}: {error}"))?;
+        let total =
+            days as f64 * 86_400.0 + hours as f64 * 3_600.0 + minutes as f64 * 60.0 + seconds;
+        if total.is_finite() && total >= 0.0 {
+            Ok(total)
+        } else {
+            Err(format!("ps TIME was not finite and nonnegative: {raw:?}"))
+        }
+    }
+
+    fn process_sample() -> Result<ProcessSample, String> {
+        let process_id = std::process::id().to_string();
+        let output = std::process::Command::new("/bin/ps")
+            .args([
+                "-o",
+                "rss=",
+                "-o",
+                "vsz=",
+                "-o",
+                "%cpu=",
+                "-o",
+                "time=",
+                "-p",
+                &process_id,
+            ])
+            .output()
+            .map_err(|error| format!("ps process sample: {error}"))?;
+        if !output.status.success() {
+            return Err(format!("ps process sample exited {}", output.status));
+        }
+        let text = String::from_utf8(output.stdout)
+            .map_err(|error| format!("ps returned non-UTF-8 output: {error}"))?;
+        let mut fields = text.split_whitespace();
+        let rss_kib = fields
+            .next()
+            .ok_or_else(|| "ps omitted RSS".to_owned())?
+            .parse::<u64>()
+            .map_err(|error| format!("ps RSS parse: {error}"))?;
+        let virtual_kib = fields
+            .next()
+            .ok_or_else(|| "ps omitted VSZ".to_owned())?
+            .parse::<u64>()
+            .map_err(|error| format!("ps VSZ parse: {error}"))?;
+        let cpu_percent = fields
+            .next()
+            .ok_or_else(|| "ps omitted CPU percentage".to_owned())?
+            .parse::<f64>()
+            .map_err(|error| format!("ps CPU parse: {error}"))?;
+        let cpu_time_seconds = parse_cpu_time(
+            fields
+                .next()
+                .ok_or_else(|| "ps omitted process CPU time".to_owned())?,
+        )?;
+        if fields.next().is_some() {
+            return Err(format!("ps returned unexpected fields: {text:?}"));
+        }
+        if !cpu_percent.is_finite() || cpu_percent < 0.0 {
+            return Err(format!("ps returned invalid CPU percentage {cpu_percent}"));
+        }
+        let resident_set_bytes = rss_kib
+            .checked_mul(1024)
+            .and_then(NonZeroU64::new)
+            .ok_or_else(|| format!("ps returned unusable RSS {rss_kib} KiB"))?;
+        let virtual_memory_bytes = virtual_kib
+            .checked_mul(1024)
+            .and_then(NonZeroU64::new)
+            .ok_or_else(|| format!("ps returned unusable VSZ {virtual_kib} KiB"))?;
+        Ok(ProcessSample {
+            resident_set_bytes,
+            virtual_memory_bytes,
+            cpu_percent,
+            cpu_time_seconds,
+        })
+    }
+
+    let process = process_sample();
+    let process_field = |select: fn(&ProcessSample) -> MeasurementField| match &process {
+        Ok(sample) => select(sample),
+        Err(reason) => MeasurementField::Unavailable(reason.clone()),
+    };
+
+    enum MeasurementField {
+        U64(NonZeroU64),
+        Float(f64),
+        Unavailable(String),
+    }
+
+    let measured_u64 = |field: MeasurementField| match field {
+        MeasurementField::U64(value) => Measurement::available(value),
+        MeasurementField::Unavailable(reason) => Measurement::unavailable(reason),
+        _ => Measurement::unavailable("internal resource field type mismatch"),
+    };
+    let measured_float = |field: MeasurementField| match field {
+        MeasurementField::Float(value) => Measurement::available(value),
+        MeasurementField::Unavailable(reason) => Measurement::unavailable(reason),
+        _ => Measurement::unavailable("internal resource field type mismatch"),
+    };
+
+    let resident_set_bytes = measured_u64(process_field(|sample| {
+        MeasurementField::U64(sample.resident_set_bytes)
+    }));
+    HostResourceSample {
+        sampled_unix_millis: unix_millis_now(),
+        architecture: std::env::consts::ARCH.to_owned(),
+        operating_system: std::env::consts::OS.to_owned(),
+        operating_system_version: measured_nonempty(
+            sysctl("kern.osproductversion"),
+            "kern.osproductversion",
+        ),
+        cpu_model: measured_nonempty(
+            sysctl("machdep.cpu.brand_string"),
+            "machdep.cpu.brand_string",
+        ),
+        physical_cores: measured_nonzero_usize(sysctl("hw.physicalcpu"), "hw.physicalcpu"),
+        logical_cores: measured_nonzero_usize(sysctl("hw.logicalcpu"), "hw.logicalcpu"),
+        performance_cores: measured_nonzero_usize(
+            sysctl("hw.perflevel0.logicalcpu"),
+            "hw.perflevel0.logicalcpu",
+        ),
+        efficiency_cores: measured_nonzero_usize(
+            sysctl("hw.perflevel1.logicalcpu"),
+            "hw.perflevel1.logicalcpu",
+        ),
+        total_memory_bytes: measured_nonzero_u64(sysctl("hw.memsize"), "hw.memsize"),
+        resident_set_bytes: resident_set_bytes.clone(),
+        max_sampled_resident_set_bytes: resident_set_bytes,
+        virtual_memory_bytes: measured_u64(process_field(|sample| {
+            MeasurementField::U64(sample.virtual_memory_bytes)
+        })),
+        cpu_percent: measured_float(process_field(|sample| {
+            MeasurementField::Float(sample.cpu_percent)
+        })),
+        process_cpu_time_seconds: measured_float(process_field(|sample| {
+            MeasurementField::Float(sample.cpu_time_seconds)
+        })),
+        thread_count: Measurement::unavailable(
+            "macOS /bin/ps does not expose a supported process thread-count keyword (thcount is rejected)",
+        ),
+        peak_resident_set_bytes: Measurement::unavailable(
+            "safe macOS ps/sysctl sampling does not expose per-process peak RSS",
+        ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HeartbeatEvent {
+    pub schema: String,
+    pub sequence: u64,
+    pub run_id: String,
+    pub event_kind: EventKind,
+    pub timestamp_unix_millis: u64,
+    pub phase: String,
+    pub phase_elapsed_millis: u64,
+    pub elapsed_millis: u64,
+    pub status: RunStatus,
+    pub metadata: Option<RunMetadata>,
+    pub work: WorkSnapshot,
+    pub queue: QueueSnapshot,
+    pub streams: Vec<StreamProgress>,
+    pub rates: RateSnapshot,
+    pub eta: EtaSnapshot,
+    pub resources: ResourceAvailability,
+}
+
+impl HeartbeatEvent {
+    pub fn new(
+        run_id: impl Into<String>,
+        status: RunStatus,
+        work: WorkSnapshot,
+        eta: EtaSnapshot,
+        resources: ResourceAvailability,
+    ) -> Self {
+        Self {
+            schema: EVENT_SCHEMA.to_owned(),
+            sequence: 0,
+            run_id: run_id.into(),
+            event_kind: EventKind::Heartbeat,
+            timestamp_unix_millis: unix_millis_now(),
+            phase: "not-set".to_owned(),
+            phase_elapsed_millis: 0,
+            elapsed_millis: 0,
+            status,
+            metadata: None,
+            work,
+            queue: QueueSnapshot::default(),
+            streams: Vec::new(),
+            rates: RateSnapshot::default(),
+            eta,
+            resources,
+        }
+    }
+
+    pub fn with_event_kind(mut self, event_kind: EventKind) -> Self {
+        self.event_kind = event_kind;
+        self
+    }
+
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = phase.into();
+        self
+    }
+
+    pub fn with_elapsed(mut self, elapsed: Duration) -> Self {
+        self.elapsed_millis = duration_millis(elapsed);
+        self
+    }
+
+    pub fn with_phase_elapsed(mut self, elapsed: Duration) -> Self {
+        self.phase_elapsed_millis = duration_millis(elapsed);
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: RunMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    pub fn with_queue(mut self, queue: QueueSnapshot) -> Self {
+        self.queue = queue;
+        self
+    }
+
+    pub fn with_streams(mut self, streams: Vec<StreamProgress>) -> Self {
+        self.streams = streams;
+        self
+    }
+
+    pub fn with_rates(mut self, rates: RateSnapshot) -> Self {
+        self.rates = rates;
+        self
+    }
+
+    pub fn human_summary(&self) -> String {
+        let rate = self
+            .rates
+            .rolling_forwards_per_second
+            .or(self.rates.cumulative_forwards_per_second)
+            .map(|value| format!("{value:.4}"))
+            .unwrap_or_else(|| "UNAVAILABLE".to_owned());
+        let worker_rate = self
+            .rates
+            .rolling_worker_tasks_per_second
+            .map(|value| format!("{value:.4}"))
+            .unwrap_or_else(|| "UNAVAILABLE".to_owned());
+        let scalar_rate = self
+            .rates
+            .rolling_scalar_terms_per_second
+            .or(self.rates.cumulative_scalar_terms_per_second)
+            .map(|value| format!("{value:.4}"))
+            .unwrap_or_else(|| "UNAVAILABLE".to_owned());
+        let eta = match (self.eta.status, self.eta.remaining_seconds) {
+            (EtaStatus::Estimated, Some(seconds)) => format!("{seconds}s"),
+            (status, _) => format!("{status:?}").to_ascii_uppercase(),
+        };
+        let (cpu, rss) = resource_summary(&self.resources);
+        format!(
+            "teacher-parity event={:?} phase={} status={} forwards={}/{} tokens={}/{} batches={}/{} matrix_calls={}/{} batched_matrix_calls={}/{} max_matrix_batch_width={}/{} worker_tasks={}/{} row_tiles={}/{} output_cells={}/{} scalar_terms={}/{} exact_live_worker_tasks={}/{} queue={} active_streams={} peak_streams={} active_row_workers={} peak_row_workers={} failed_streams={} elapsed={}ms rate_fwd_s={} rate_worker_task_s={} rate_scalar_term_s={} eta_progress={:?}:{}/{} eta={} cpu={} rss={}",
+            self.event_kind,
+            self.phase,
+            self.status.as_str(),
+            self.work.logical_forwards,
+            self.work.plan.logical_forwards,
+            self.work.tokens,
+            self.work.plan.tokens,
+            self.work.physical_batches,
+            self.work.plan.physical_batches,
+            self.work.matrix_calls,
+            self.work.plan.matrix_calls,
+            self.work.batched_matrix_calls,
+            self.work.plan.batched_matrix_calls,
+            self.work.max_matrix_batch_width,
+            self.work.plan.max_matrix_batch_width,
+            self.work.worker_tasks,
+            self.work.plan.worker_tasks,
+            self.work.row_tiles,
+            self.work.plan.row_tiles,
+            self.work.output_cells,
+            self.work.plan.output_cells,
+            self.work.scalar_terms,
+            self.work.plan.scalar_terms,
+            self.queue.completed_worker_tasks,
+            self.work.plan.worker_tasks,
+            self.queue.queue_depth,
+            self.queue.active_streams,
+            self.queue.peak_active_streams,
+            self.queue.active_row_workers,
+            self.queue.peak_active_row_workers,
+            self.queue.failed_streams,
+            self.elapsed_millis,
+            rate,
+            worker_rate,
+            scalar_rate,
+            self.rates.eta_progress_unit,
+            self.rates.eta_progress_completed,
+            self.rates.eta_progress_total,
+            eta,
+            cpu,
+            rss,
+        )
+    }
+}
+
+/// Require repeated periodic evidence for one still-active unit of work.
+///
+/// Lifecycle rows, idle/loading rows, and heartbeats from different phases do
+/// not establish that the independent writer remained alive while one exact
+/// forward was in flight. The two accepted rows must therefore both be
+/// heartbeats, retain the same full-width ordered private-stream state, expose
+/// bounded nonzero exact-row activity, remain in the same phase with the same
+/// completed forward counter, and arrive within two configured cadence
+/// intervals. Exact worker saturation is diagnostic, not a binding verdict.
+pub fn validate_in_flight_heartbeat_cadence(
+    events: &[HeartbeatEvent],
+    cadence: Duration,
+    expected_streams: usize,
+    expected_row_workers: usize,
+) -> Result<(), String> {
+    if cadence.is_zero() {
+        return Err("heartbeat cadence is zero".to_owned());
+    }
+    if expected_streams == 0 || expected_row_workers == 0 {
+        return Err("heartbeat occupancy bounds must be nonzero".to_owned());
+    }
+    let maximum_delta_millis = duration_millis(cadence).saturating_mul(2);
+    let heartbeats = events
+        .iter()
+        .filter(|event| event.event_kind == EventKind::Heartbeat)
+        .collect::<Vec<_>>();
+    if heartbeats.len() < 2 {
+        return Err(format!(
+            "expected at least two periodic HEARTBEAT rows, found {}",
+            heartbeats.len()
+        ));
+    }
+    let witnessed = heartbeats.windows(2).any(|pair| {
+        let stable_streams = pair[0].streams.len() == expected_streams
+            && pair[1].streams.len() == expected_streams
+            && pair[0].streams.iter().zip(&pair[1].streams).all(|(a, b)| {
+                a.stream_id == b.stream_id
+                    && a.phase == b.phase
+                    && a.state == StreamState::Active
+                    && b.state == StreamState::Active
+                    && a.logical_forwards_completed == b.logical_forwards_completed
+                    && a.logical_forwards_total == b.logical_forwards_total
+                    && a.tokens_completed == b.tokens_completed
+                    && a.tokens_total == b.tokens_total
+            });
+        let distinct_streams = pair[0]
+            .streams
+            .iter()
+            .map(|stream| stream.stream_id.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+            == expected_streams;
+        let delta = pair[1]
+            .timestamp_unix_millis
+            .saturating_sub(pair[0].timestamp_unix_millis);
+        pair[0].queue.active_streams == expected_streams as u64
+            && pair[1].queue.active_streams == expected_streams as u64
+            && pair[0].queue.active_row_workers > 0
+            && pair[1].queue.active_row_workers > 0
+            && pair[0].queue.active_row_workers <= expected_row_workers as u64
+            && pair[1].queue.active_row_workers <= expected_row_workers as u64
+            && stable_streams
+            && distinct_streams
+            && pair[0].phase == pair[1].phase
+            && pair[0].work.logical_forwards == pair[1].work.logical_forwards
+            && delta > 0
+            && delta <= maximum_delta_millis
+    });
+    if witnessed {
+        Ok(())
+    } else {
+        Err(format!(
+            "no same-phase HEARTBEAT pair retained {expected_streams} stable private streams, bounded nonzero exact-row activity (limit {expected_row_workers}), and an unchanged forward counter within {maximum_delta_millis} ms"
+        ))
+    }
+}
+
+/// Require one durable periodic sample that witnesses the entire private
+/// stream cohort and bounded nonzero exact-row activity simultaneously.
+/// Distinct stream rows bind the occupancy counters to independently named
+/// trajectories instead of permitting one trajectory to be fanned out. The
+/// exact worker count remains a diagnostic bounded by the selected executor.
+pub fn validate_full_width_exact_heartbeat(
+    events: &[HeartbeatEvent],
+    expected_streams: usize,
+    expected_row_workers: usize,
+) -> Result<(), String> {
+    if expected_streams <= 1 || expected_row_workers <= 1 {
+        return Err(format!(
+            "binding heartbeat requires multiple streams and row workers, got streams={expected_streams}, row_workers={expected_row_workers}"
+        ));
+    }
+    let witnessed = events.iter().any(|event| {
+        if event.event_kind != EventKind::Heartbeat
+            || event.queue.active_streams != expected_streams as u64
+            || event.queue.active_row_workers == 0
+            || event.queue.active_row_workers > expected_row_workers as u64
+            || event.streams.len() != expected_streams
+        {
+            return false;
+        }
+        let identities = event
+            .streams
+            .iter()
+            .map(|stream| stream.stream_id.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        identities.len() == expected_streams
+    });
+    if witnessed {
+        Ok(())
+    } else {
+        Err(format!(
+            "no HEARTBEAT row simultaneously witnessed {expected_streams} distinct private streams and bounded nonzero exact-row activity (limit {expected_row_workers})"
+        ))
+    }
+}
+
+fn resource_summary(resources: &ResourceAvailability) -> (String, String) {
+    match resources {
+        ResourceAvailability::Available(sample) => {
+            let cpu = match &sample.cpu_percent {
+                Measurement::Available { value } => format!("{value:.1}%"),
+                Measurement::Unavailable { .. } => "UNAVAILABLE".to_owned(),
+            };
+            let rss = match &sample.resident_set_bytes {
+                Measurement::Available { value } => value.get().to_string(),
+                Measurement::Unavailable { .. } => "UNAVAILABLE".to_owned(),
+            };
+            (cpu, rss)
+        }
+        ResourceAvailability::Unavailable { .. } => {
+            ("UNAVAILABLE".to_owned(), "UNAVAILABLE".to_owned())
+        }
+    }
+}
+
+pub struct HeartbeatLog {
+    file: File,
+    next_sequence: u64,
+}
+
+impl HeartbeatLog {
+    pub fn create(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        Ok(Self {
+            file,
+            next_sequence: 0,
+        })
+    }
+
+    /// Append one JSON object, then flush userspace buffers and request a data
+    /// sync before returning. A reader can therefore inspect every completed
+    /// heartbeat while the run is still active.
+    pub fn append(&mut self, mut event: HeartbeatEvent) -> Result<(), ReportError> {
+        event.sequence = self.next_sequence;
+        let mut bytes = serde_json::to_vec(&event)?;
+        bytes.push(b'\n');
+        self.file.write_all(&bytes)?;
+        self.file.flush()?;
+        self.file.sync_data()?;
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LiveProgress {
+    pub run_id: String,
+    pub status: RunStatus,
+    pub phase: String,
+    pub metadata: RunMetadata,
+    pub queue: QueueSnapshot,
+    pub streams: Vec<StreamProgress>,
+}
+
+struct TrackedProgress {
+    live: LiveProgress,
+    phase_started: Instant,
+    updated_at: Instant,
+}
+
+/// One monotonic callback observation from the exact row executor. Grouping
+/// these fields prevents positional call sites from swapping stream and row
+/// worker counters as the owner snapshot evolves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExactProgressObservation {
+    pub observer_epoch: u64,
+    pub streams_started: u64,
+    pub streams_completed: u64,
+    pub active_streams: usize,
+    pub peak_active_streams: usize,
+    pub active_row_workers: usize,
+    pub peak_active_row_workers: usize,
+    pub matrix_calls: u64,
+    pub batched_matrix_calls: u64,
+    pub max_matrix_batch_width: usize,
+    pub completed_worker_tasks: u64,
+    pub output_cells_completed: u64,
+    pub scalar_terms_completed: u64,
+    pub effective_workers: usize,
+}
+
+/// Scheduler-independent logical exact-work counters retained in deterministic
+/// S2 evidence. Observer epochs, worker/tile geometry, current/peak occupancy,
+/// workspace behavior, and the count of forwards that happened to witness
+/// concurrent workers are empirical scheduling observations and deliberately
+/// do not cross this boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeterministicTeacherExecution {
+    pub forward_calls: u64,
+    pub streams_started: u64,
+    pub streams_completed: u64,
+    pub matrix_calls: u64,
+    pub batched_matrix_calls: u64,
+    pub max_matrix_batch_width: usize,
+    pub output_cells_completed: u64,
+    pub scalar_terms_completed: u64,
+}
+
+pub fn deterministic_teacher_execution(
+    snapshot: TeacherExecutionSnapshot,
+) -> DeterministicTeacherExecution {
+    DeterministicTeacherExecution {
+        forward_calls: snapshot.forward_calls,
+        streams_started: snapshot.streams_started,
+        streams_completed: snapshot.streams_completed,
+        matrix_calls: snapshot.matrix_calls,
+        batched_matrix_calls: snapshot.batched_matrix_calls,
+        max_matrix_batch_width: snapshot.max_matrix_batch_width,
+        output_cells_completed: snapshot.output_cells_completed,
+        scalar_terms_completed: snapshot.scalar_terms_completed,
+    }
+}
+
+#[derive(Clone)]
+pub struct SharedProgress {
+    inner: Arc<Mutex<TrackedProgress>>,
+    exact: Arc<ExactLiveProgress>,
+}
+
+#[derive(Default)]
+struct ExactLiveProgress {
+    streams_started: AtomicU64,
+    streams_completed: AtomicU64,
+    current: Mutex<ExactCurrentProgress>,
+    peak_active_streams: AtomicU64,
+    peak_active_row_workers: AtomicU64,
+    matrix_calls: AtomicU64,
+    batched_matrix_calls: AtomicU64,
+    max_matrix_batch_width: AtomicU64,
+    completed_worker_tasks: AtomicU64,
+    output_cells_completed: AtomicU64,
+    scalar_terms_completed: AtomicU64,
+    effective_workers: AtomicU64,
+}
+
+#[derive(Default)]
+struct ExactCurrentProgress {
+    observer_epoch: Option<u64>,
+    active_streams: u64,
+    active_row_workers: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct LiveProgressSnapshot {
+    pub live: LiveProgress,
+    pub phase_elapsed: Duration,
+    pub state_age: Duration,
+}
+
+impl SharedProgress {
+    pub fn new(run_id: impl Into<String>, metadata: RunMetadata) -> Self {
+        let now = Instant::now();
+        Self {
+            inner: Arc::new(Mutex::new(TrackedProgress {
+                live: LiveProgress {
+                    run_id: run_id.into(),
+                    status: RunStatus::NotRun,
+                    phase: "not-set".to_owned(),
+                    metadata,
+                    queue: QueueSnapshot::default(),
+                    streams: Vec::new(),
+                },
+                phase_started: now,
+                updated_at: now,
+            })),
+            exact: Arc::new(ExactLiveProgress::default()),
+        }
+    }
+
+    /// Publish exact absolute counters without taking the rich progress lock.
+    /// A tiny independent lock makes current occupancy epoch-safe: callbacks
+    /// may arrive out of order, but an older callback cannot regress live
+    /// state or resurrect a completed forward.
+    pub fn publish_exact(&self, observation: ExactProgressObservation) {
+        let ExactProgressObservation {
+            observer_epoch,
+            streams_started,
+            streams_completed,
+            active_streams,
+            peak_active_streams,
+            active_row_workers,
+            peak_active_row_workers,
+            matrix_calls,
+            batched_matrix_calls,
+            max_matrix_batch_width,
+            completed_worker_tasks,
+            output_cells_completed,
+            scalar_terms_completed,
+            effective_workers,
+        } = observation;
+        let accepted = {
+            let mut current = self
+                .exact
+                .current
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if current
+                .observer_epoch
+                .is_some_and(|prior| observer_epoch <= prior)
+            {
+                false
+            } else {
+                current.observer_epoch = Some(observer_epoch);
+                current.active_streams = active_streams as u64;
+                current.active_row_workers = active_row_workers as u64;
+                true
+            }
+        };
+        if !accepted {
+            return;
+        }
+        self.exact
+            .streams_started
+            .fetch_max(streams_started, Ordering::AcqRel);
+        self.exact
+            .streams_completed
+            .fetch_max(streams_completed, Ordering::AcqRel);
+        self.exact
+            .peak_active_streams
+            .fetch_max(peak_active_streams as u64, Ordering::AcqRel);
+        self.exact
+            .peak_active_row_workers
+            .fetch_max(peak_active_row_workers as u64, Ordering::AcqRel);
+        self.exact
+            .matrix_calls
+            .fetch_max(matrix_calls, Ordering::AcqRel);
+        self.exact
+            .batched_matrix_calls
+            .fetch_max(batched_matrix_calls, Ordering::AcqRel);
+        self.exact.max_matrix_batch_width.fetch_max(
+            u64::try_from(max_matrix_batch_width).unwrap_or(u64::MAX),
+            Ordering::AcqRel,
+        );
+        self.exact
+            .completed_worker_tasks
+            .fetch_max(completed_worker_tasks, Ordering::AcqRel);
+        self.exact
+            .output_cells_completed
+            .fetch_max(output_cells_completed, Ordering::AcqRel);
+        self.exact
+            .scalar_terms_completed
+            .fetch_max(scalar_terms_completed, Ordering::AcqRel);
+        self.exact
+            .effective_workers
+            .fetch_max(effective_workers as u64, Ordering::AcqRel);
+    }
+
+    /// A synchronous forward boundary: all worker callbacks have returned, so
+    /// current in-flight occupancy may be cleared without a stale callback
+    /// resurrecting it.
+    pub fn finish_exact_forward(&self) {
+        let mut current = self
+            .exact
+            .current
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        current.active_streams = 0;
+        current.active_row_workers = 0;
+    }
+
+    pub fn update(&self, update: impl FnOnce(&mut LiveProgress)) -> Result<(), ProgressError> {
+        let mut tracked = self.inner.lock().map_err(|_| ProgressError::Poisoned)?;
+        let prior_phase = tracked.live.phase.clone();
+        update(&mut tracked.live);
+        tracked.live.queue.peak_active_streams = tracked
+            .live
+            .queue
+            .peak_active_streams
+            .max(tracked.live.queue.active_streams);
+        tracked.live.queue.peak_active_row_workers = tracked
+            .live
+            .queue
+            .peak_active_row_workers
+            .max(tracked.live.queue.active_row_workers);
+        let now = Instant::now();
+        if tracked.live.phase != prior_phase {
+            tracked.phase_started = now;
+        }
+        tracked.updated_at = now;
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> Result<LiveProgressSnapshot, ProgressError> {
+        let tracked = self.inner.lock().map_err(|_| ProgressError::Poisoned)?;
+        let now = Instant::now();
+        let mut live = tracked.live.clone();
+        let current = self
+            .exact
+            .current
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let exact_active_streams = current.active_streams;
+        let newly_observed_streams = exact_active_streams.saturating_sub(live.queue.active_streams);
+        live.queue.queue_depth = live
+            .queue
+            .queue_depth
+            .saturating_sub(newly_observed_streams);
+        live.queue.active_streams = live.queue.active_streams.max(exact_active_streams);
+        live.queue.active_row_workers = live
+            .queue
+            .active_row_workers
+            .max(current.active_row_workers);
+        if exact_active_streams == 0 {
+            live.queue.active_row_workers = 0;
+            live.queue.active_worker_tasks = 0;
+        } else {
+            live.queue.active_worker_tasks = live
+                .queue
+                .active_worker_tasks
+                .max(live.queue.active_row_workers);
+        }
+        live.queue.peak_active_row_workers = live
+            .queue
+            .peak_active_row_workers
+            .max(self.exact.peak_active_row_workers.load(Ordering::Acquire));
+        live.queue.peak_active_streams = live
+            .queue
+            .peak_active_streams
+            .max(self.exact.peak_active_streams.load(Ordering::Acquire));
+        live.queue.completed_worker_tasks = live
+            .queue
+            .completed_worker_tasks
+            .max(self.exact.completed_worker_tasks.load(Ordering::Acquire));
+        if let Some(effective_workers) = NonZeroUsize::new(
+            usize::try_from(self.exact.effective_workers.load(Ordering::Acquire))
+                .unwrap_or(usize::MAX),
+        ) {
+            live.metadata.scheduler.effective_row_workers = effective_workers;
+        }
+        Ok(LiveProgressSnapshot {
+            live,
+            phase_elapsed: now.saturating_duration_since(tracked.phase_started),
+            state_age: now.saturating_duration_since(tracked.updated_at),
+        })
+    }
+
+    /// Merge monotonic executor callbacks into the durable work view while a
+    /// physical forward is still running. Forward-boundary accounting later
+    /// records the same absolute totals, so `max` avoids double counting.
+    fn overlay_exact_work(&self, work: &mut WorkSnapshot) {
+        work.matrix_calls = work
+            .matrix_calls
+            .max(self.exact.matrix_calls.load(Ordering::Acquire));
+        work.batched_matrix_calls = work
+            .batched_matrix_calls
+            .max(self.exact.batched_matrix_calls.load(Ordering::Acquire));
+        work.max_matrix_batch_width = work
+            .max_matrix_batch_width
+            .max(self.exact.max_matrix_batch_width.load(Ordering::Acquire));
+        let completed_worker_tasks = self.exact.completed_worker_tasks.load(Ordering::Acquire);
+        work.worker_tasks = work.worker_tasks.max(completed_worker_tasks);
+        work.row_tiles = work.row_tiles.max(completed_worker_tasks);
+        work.output_cells = work
+            .output_cells
+            .max(self.exact.output_cells_completed.load(Ordering::Acquire));
+        work.scalar_terms = work
+            .scalar_terms
+            .max(self.exact.scalar_terms_completed.load(Ordering::Acquire));
+    }
+}
+
+/// Downgrade the in-memory terminal view when terminal emission or canonical
+/// report commitment fails. A retry/readback must never return a stale PASS.
+pub fn mark_finalization_failed(
+    progress: &SharedProgress,
+    phase: impl Into<String>,
+) -> Result<(), ProgressError> {
+    let phase = phase.into();
+    progress.update(|live| {
+        live.phase = phase;
+        live.status = RunStatus::Fail;
+        live.queue.active_streams = 0;
+        live.queue.active_row_workers = 0;
+        live.queue.active_worker_tasks = 0;
+        live.streams.clear();
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressError {
+    Poisoned,
+}
+
+impl fmt::Display for ProgressError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Poisoned => write!(formatter, "teacher-parity progress state is poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for ProgressError {}
+
+enum HeartbeatCommand {
+    Emit {
+        kind: EventKind,
+        acknowledgement: mpsc::SyncSender<Result<(), String>>,
+    },
+    EmitAndStop {
+        kind: EventKind,
+        acknowledgement: mpsc::SyncSender<Result<(), String>>,
+    },
+    Stop,
+}
+
+pub struct HeartbeatWorker {
+    commands: mpsc::Sender<HeartbeatCommand>,
+    join: Option<JoinHandle<Result<(), HeartbeatWorkerError>>>,
+    max_sampled_rss_bytes: Arc<AtomicU64>,
+}
+
+impl HeartbeatWorker {
+    pub fn spawn(
+        path: impl AsRef<Path>,
+        cadence: Duration,
+        counters: Arc<WorkCounters>,
+        progress: SharedProgress,
+    ) -> Result<Self, HeartbeatWorkerError> {
+        let stall_after = cadence
+            .checked_mul(4)
+            .unwrap_or(Duration::MAX)
+            .max(Duration::from_secs(MINIMUM_DEFAULT_STALL_SECONDS));
+        Self::spawn_with_stall_after(path, cadence, stall_after, counters, progress)
+    }
+
+    pub fn spawn_with_stall_after(
+        path: impl AsRef<Path>,
+        cadence: Duration,
+        stall_after: Duration,
+        counters: Arc<WorkCounters>,
+        progress: SharedProgress,
+    ) -> Result<Self, HeartbeatWorkerError> {
+        if cadence.is_zero() || stall_after.is_zero() {
+            return Err(HeartbeatWorkerError::InvalidCadence);
+        }
+        let log = HeartbeatLog::create(path).map_err(ReportError::from)?;
+        let (commands, receiver) = mpsc::channel();
+        let max_sampled_rss_bytes = Arc::new(AtomicU64::new(0));
+        let worker_max_sampled_rss = Arc::clone(&max_sampled_rss_bytes);
+        let join = thread::Builder::new()
+            .name("parity-heartbeat".to_owned())
+            .spawn(move || {
+                heartbeat_loop(
+                    log,
+                    cadence,
+                    stall_after,
+                    counters,
+                    progress,
+                    receiver,
+                    worker_max_sampled_rss,
+                )
+            })
+            .map_err(ReportError::from)?;
+        Ok(Self {
+            commands,
+            join: Some(join),
+            max_sampled_rss_bytes,
+        })
+    }
+
+    /// Emit and durably flush a non-periodic lifecycle event before returning.
+    pub fn emit(&self, kind: EventKind) -> Result<(), HeartbeatWorkerError> {
+        let (acknowledgement, received) = mpsc::sync_channel(0);
+        self.commands
+            .send(HeartbeatCommand::Emit {
+                kind,
+                acknowledgement,
+            })
+            .map_err(|_| HeartbeatWorkerError::WorkerStopped)?;
+        match received.recv() {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(reason)) => Err(HeartbeatWorkerError::Writer(reason)),
+            Err(_) => Err(HeartbeatWorkerError::WorkerStopped),
+        }
+    }
+
+    pub fn stop(mut self) -> Result<(), HeartbeatWorkerError> {
+        self.stop_inner()
+    }
+
+    /// Durably append the terminal event and stop the writer as one ordered
+    /// worker command. No periodic heartbeat can be appended after `kind`.
+    pub fn emit_and_stop(mut self, kind: EventKind) -> Result<(), HeartbeatWorkerError> {
+        let (acknowledgement, received) = mpsc::sync_channel(0);
+        let sent = self
+            .commands
+            .send(HeartbeatCommand::EmitAndStop {
+                kind,
+                acknowledgement,
+            })
+            .map_err(|_| HeartbeatWorkerError::WorkerStopped);
+        let emitted = match sent {
+            Ok(()) => match received.recv() {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(reason)) => Err(HeartbeatWorkerError::Writer(reason)),
+                Err(_) => Err(HeartbeatWorkerError::WorkerStopped),
+            },
+            Err(error) => Err(error),
+        };
+        let joined = match self.join.take() {
+            Some(join) => join.join().map_err(|_| HeartbeatWorkerError::Panicked)?,
+            None => Ok(()),
+        };
+        emitted?;
+        joined
+    }
+
+    pub fn max_sampled_rss_bytes(&self) -> Option<NonZeroU64> {
+        NonZeroU64::new(self.max_sampled_rss_bytes.load(Ordering::Acquire))
+    }
+
+    fn stop_inner(&mut self) -> Result<(), HeartbeatWorkerError> {
+        let _ = self.commands.send(HeartbeatCommand::Stop);
+        let Some(join) = self.join.take() else {
+            return Ok(());
+        };
+        join.join().map_err(|_| HeartbeatWorkerError::Panicked)?
+    }
+}
+
+impl Drop for HeartbeatWorker {
+    fn drop(&mut self) {
+        let _ = self.stop_inner();
+    }
+}
+
+struct HeartbeatTiming {
+    started: Instant,
+    last_progress: Instant,
+    prior_sample: Instant,
+    prior_forwards: u64,
+    prior_tokens: u64,
+    prior_worker_tasks: u64,
+    prior_scalar_terms: u64,
+    prior_progress_unit: ProgressUnit,
+    prior_progress_completed: u64,
+    stall_after: Duration,
+}
+
+fn heartbeat_loop(
+    mut log: HeartbeatLog,
+    cadence: Duration,
+    stall_after: Duration,
+    counters: Arc<WorkCounters>,
+    progress: SharedProgress,
+    receiver: mpsc::Receiver<HeartbeatCommand>,
+    max_sampled_rss_bytes: Arc<AtomicU64>,
+) -> Result<(), HeartbeatWorkerError> {
+    let now = Instant::now();
+    let mut timing = HeartbeatTiming {
+        started: now,
+        last_progress: now,
+        prior_sample: now,
+        prior_forwards: 0,
+        prior_tokens: 0,
+        prior_worker_tasks: 0,
+        prior_scalar_terms: 0,
+        prior_progress_unit: ProgressUnit::LogicalForwards,
+        prior_progress_completed: 0,
+        stall_after,
+    };
+    emit_live_event(
+        &mut log,
+        EventKind::Heartbeat,
+        &counters,
+        &progress,
+        &mut timing,
+        &max_sampled_rss_bytes,
+    )?;
+    loop {
+        match receiver.recv_timeout(cadence) {
+            Ok(HeartbeatCommand::Emit {
+                kind,
+                acknowledgement,
+            }) => {
+                let result = emit_live_event(
+                    &mut log,
+                    kind,
+                    &counters,
+                    &progress,
+                    &mut timing,
+                    &max_sampled_rss_bytes,
+                );
+                let acknowledgement_result =
+                    result.as_ref().map(|_| ()).map_err(ToString::to_string);
+                let _ = acknowledgement.send(acknowledgement_result);
+                result?;
+            }
+            Ok(HeartbeatCommand::EmitAndStop {
+                kind,
+                acknowledgement,
+            }) => {
+                let result = emit_live_event(
+                    &mut log,
+                    kind,
+                    &counters,
+                    &progress,
+                    &mut timing,
+                    &max_sampled_rss_bytes,
+                );
+                let acknowledgement_result =
+                    result.as_ref().map(|_| ()).map_err(ToString::to_string);
+                let _ = acknowledgement.send(acknowledgement_result);
+                result?;
+                return Ok(());
+            }
+            Ok(HeartbeatCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(()),
+            Err(mpsc::RecvTimeoutError::Timeout) => emit_live_event(
+                &mut log,
+                EventKind::Heartbeat,
+                &counters,
+                &progress,
+                &mut timing,
+                &max_sampled_rss_bytes,
+            )?,
+        }
+    }
+}
+
+fn emit_live_event(
+    log: &mut HeartbeatLog,
+    kind: EventKind,
+    counters: &WorkCounters,
+    progress: &SharedProgress,
+    timing: &mut HeartbeatTiming,
+    max_sampled_rss_bytes: &AtomicU64,
+) -> Result<(), HeartbeatWorkerError> {
+    let now = Instant::now();
+    let mut work = counters.snapshot();
+    progress.overlay_exact_work(&mut work);
+    let (progress_unit, progress_completed, progress_total) = heartbeat_progress_units(&work);
+    if progress_unit != timing.prior_progress_unit
+        || progress_completed != timing.prior_progress_completed
+    {
+        timing.last_progress = now;
+    }
+    let progress = progress.snapshot()?;
+    let LiveProgressSnapshot {
+        live,
+        phase_elapsed,
+        state_age,
+    } = progress;
+    let LiveProgress {
+        run_id,
+        status,
+        phase,
+        metadata,
+        mut queue,
+        mut streams,
+    } = live;
+    let elapsed = now.saturating_duration_since(timing.started);
+    let tokens = work.tokens;
+    let sample_elapsed = now
+        .saturating_duration_since(timing.prior_sample)
+        .as_secs_f64();
+    let elapsed_seconds = elapsed.as_secs_f64();
+    let forward_delta = work.logical_forwards.saturating_sub(timing.prior_forwards);
+    let token_delta = tokens.saturating_sub(timing.prior_tokens);
+    let worker_task_delta = work.worker_tasks.saturating_sub(timing.prior_worker_tasks);
+    let scalar_term_delta = work.scalar_terms.saturating_sub(timing.prior_scalar_terms);
+    let rolling_forwards_per_second = positive_rate(forward_delta, sample_elapsed);
+    let cumulative_forwards_per_second = positive_rate(work.logical_forwards, elapsed_seconds);
+    let rates = RateSnapshot {
+        rolling_forwards_per_second,
+        cumulative_forwards_per_second,
+        seconds_per_forward: seconds_per_forward_from_rate(cumulative_forwards_per_second),
+        tokens_per_second: positive_rate(token_delta, sample_elapsed)
+            .or_else(|| positive_rate(tokens, elapsed_seconds)),
+        rolling_worker_tasks_per_second: positive_rate(worker_task_delta, sample_elapsed),
+        rolling_scalar_terms_per_second: positive_rate(scalar_term_delta, sample_elapsed),
+        cumulative_scalar_terms_per_second: positive_rate(work.scalar_terms, elapsed_seconds),
+        eta_progress_unit: progress_unit,
+        eta_progress_completed: progress_completed,
+        eta_progress_total: progress_total,
+    };
+    let eta = estimate_eta(EtaInput {
+        completed: progress_completed,
+        total: progress_total,
+        elapsed,
+        last_progress_age: now.saturating_duration_since(timing.last_progress),
+        stall_after: timing.stall_after,
+        minimum_samples: 3,
+    });
+    let state_age_millis = duration_millis(state_age);
+    if queue.active_streams != 0 {
+        queue.longest_active_millis = queue.longest_active_millis.max(state_age_millis);
+    }
+    for stream in &mut streams {
+        if stream.state == StreamState::Active {
+            stream.active_forward_age_millis =
+                stream.active_forward_age_millis.max(state_age_millis);
+        }
+    }
+    let mut resources = sample_host_resources();
+    if let Some(rss) = resources.resident_set_bytes() {
+        max_sampled_rss_bytes.fetch_max(rss.get(), Ordering::AcqRel);
+    }
+    resources.set_max_sampled_resident_set_bytes(NonZeroU64::new(
+        max_sampled_rss_bytes.load(Ordering::Acquire),
+    ));
+    let event = HeartbeatEvent::new(run_id, status, work, eta, resources)
+        .with_event_kind(kind)
+        .with_phase(phase)
+        .with_phase_elapsed(phase_elapsed)
+        .with_elapsed(elapsed)
+        .with_metadata(metadata)
+        .with_queue(queue)
+        .with_streams(streams)
+        .with_rates(rates);
+    eprintln!("{}", event.human_summary());
+    log.append(event)?;
+    timing.prior_sample = now;
+    timing.prior_forwards = work.logical_forwards;
+    timing.prior_tokens = tokens;
+    timing.prior_worker_tasks = work.worker_tasks;
+    timing.prior_scalar_terms = work.scalar_terms;
+    timing.prior_progress_unit = progress_unit;
+    timing.prior_progress_completed = progress_completed;
+    Ok(())
+}
+
+fn positive_rate(count: u64, seconds: f64) -> Option<f64> {
+    if count == 0 || !seconds.is_finite() || seconds <= 0.0 {
+        return None;
+    }
+    let rate = count as f64 / seconds;
+    rate.is_finite().then_some(rate)
+}
+
+/// Derive seconds per forward only when the measured forward rate has a
+/// finite, strictly positive reciprocal. A completed zero-work refusal has a
+/// valid `0.0` cumulative rate but no meaningful seconds-per-forward value;
+/// emitting `+inf` would serialize as JSON `null` and fail semantic readback.
+pub fn seconds_per_forward_from_rate(rate: Option<f64>) -> Option<f64> {
+    let rate = rate.filter(|rate| rate.is_finite() && *rate > 0.0)?;
+    let seconds = 1.0 / rate;
+    (seconds.is_finite() && seconds > 0.0).then_some(seconds)
+}
+
+#[derive(Debug)]
+pub enum HeartbeatWorkerError {
+    InvalidCadence,
+    Progress(ProgressError),
+    Report(ReportError),
+    WorkerStopped,
+    Writer(String),
+    Panicked,
+}
+
+impl fmt::Display for HeartbeatWorkerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCadence => write!(formatter, "heartbeat cadence must be nonzero"),
+            Self::Progress(error) => write!(formatter, "heartbeat progress: {error}"),
+            Self::Report(error) => write!(formatter, "heartbeat report: {error}"),
+            Self::WorkerStopped => write!(formatter, "heartbeat worker stopped unexpectedly"),
+            Self::Writer(reason) => write!(formatter, "heartbeat writer: {reason}"),
+            Self::Panicked => write!(formatter, "heartbeat worker panicked"),
+        }
+    }
+}
+
+impl std::error::Error for HeartbeatWorkerError {}
+
+impl From<ProgressError> for HeartbeatWorkerError {
+    fn from(error: ProgressError) -> Self {
+        Self::Progress(error)
+    }
+}
+
+impl From<ReportError> for HeartbeatWorkerError {
+    fn from(error: ReportError) -> Self {
+        Self::Report(error)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeterministicEvidence {
+    pub schema: String,
+    pub status: RunStatus,
+    pub identity: BTreeMap<String, String>,
+    /// Caller-owned exact observations. Observability never transforms this.
+    pub output: Value,
+}
+
+impl DeterministicEvidence {
+    pub fn new(status: RunStatus, identity: BTreeMap<String, String>, output: Value) -> Self {
+        Self {
+            schema: EVIDENCE_SCHEMA.to_owned(),
+            status,
+            identity,
+            output,
+        }
+    }
+}
+
+/// Project empirical run identities into the timing- and path-free companion.
+/// The standalone preflight CID covers absolute operator paths, while the
+/// selected executor configuration is timing-derived; both remain in the
+/// RunReport. The deterministic sidecar replaces the former with the CID of
+/// its already-scrubbed S0 projection and omits the latter.
+pub fn deterministic_evidence_identities(
+    metadata: &RunMetadata,
+    output: &Value,
+) -> Result<BTreeMap<String, String>, ReportError> {
+    let mut identities = metadata.identities.clone();
+    identities.remove("teacher_free_s4_preflight");
+    identities.remove("probe_selected_execution");
+    if let Some(preflight) = output.get("S0_teacher_free_preflight") {
+        let bytes = serde_json::to_vec(preflight)?;
+        identities.insert(
+            "teacher_free_s4_preflight".to_owned(),
+            format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+        );
+    }
+    Ok(identities)
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunReport {
+    pub schema: String,
+    pub run_id: String,
+    pub mode: ObservabilityMode,
+    pub status: RunStatus,
+    pub started_unix_millis: u64,
+    pub elapsed_millis: u64,
+    pub metadata: Option<RunMetadata>,
+    pub work: WorkSnapshot,
+    pub queue: QueueSnapshot,
+    pub streams: Vec<StreamProgress>,
+    pub rates: RateSnapshot,
+    pub eta: EtaSnapshot,
+    pub resources: ResourceAvailability,
+    /// Empirical, run-variant measurements such as per-wave wall times and
+    /// throughput. These bytes are deliberately excluded from deterministic
+    /// evidence.
+    pub measurements: BTreeMap<String, Value>,
+    pub detail: Option<String>,
+}
+
+impl RunReport {
+    pub fn new(
+        run_id: impl Into<String>,
+        mode: ObservabilityMode,
+        status: RunStatus,
+        work: WorkSnapshot,
+        eta: EtaSnapshot,
+        resources: ResourceAvailability,
+    ) -> Self {
+        let started_unix_millis = unix_millis_now();
+        Self {
+            schema: RUN_REPORT_SCHEMA.to_owned(),
+            run_id: run_id.into(),
+            mode,
+            status,
+            started_unix_millis,
+            elapsed_millis: eta.elapsed_seconds.saturating_mul(1000),
+            metadata: None,
+            work,
+            queue: QueueSnapshot::default(),
+            streams: Vec::new(),
+            rates: RateSnapshot::default(),
+            eta,
+            resources,
+            measurements: BTreeMap::new(),
+            detail: None,
+        }
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: RunMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    pub fn with_queue(mut self, queue: QueueSnapshot) -> Self {
+        self.queue = queue;
+        self
+    }
+
+    pub fn with_streams(mut self, streams: Vec<StreamProgress>) -> Self {
+        self.streams = streams;
+        self
+    }
+
+    pub fn with_rates(mut self, rates: RateSnapshot) -> Self {
+        self.rates = rates;
+        self
+    }
+
+    pub fn with_measurements(mut self, measurements: BTreeMap<String, Value>) -> Self {
+        self.measurements = measurements;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportPaths {
+    pub run: PathBuf,
+    pub evidence: PathBuf,
+}
+
+/// Fully serialized, synced, and read-back-validated final companions. The
+/// caller may prepare this value while the heartbeat writer is still alive,
+/// then emit and stop the terminal event, and finally perform only the two
+/// atomic renames in [`PreparedReports::commit`].
+pub struct PreparedReports {
+    paths: ReportPaths,
+    run_temp: PathBuf,
+    evidence_temp: PathBuf,
+}
+
+impl PreparedReports {
+    pub fn commit(self) -> Result<ReportPaths, ReportError> {
+        let publish = (|| -> Result<(), ReportError> {
+            // Evidence is published first; the run report is the commit
+            // marker and therefore always lands last.
+            std::fs::rename(&self.evidence_temp, &self.paths.evidence)?;
+            std::fs::rename(&self.run_temp, &self.paths.run)?;
+            Ok(())
+        })();
+        if let Err(error) = publish {
+            if let Err(invalidation) = invalidate_final_reports_checked(&self.paths.run) {
+                return Err(ReportError::InvalidCompanion(format!(
+                    "publish failed ({error}); canonical companion invalidation also failed ({invalidation})"
+                )));
+            }
+            return Err(error);
+        }
+        Ok(self.paths.clone())
+    }
+}
+
+impl Drop for PreparedReports {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.run_temp);
+        let _ = std::fs::remove_file(&self.evidence_temp);
+    }
+}
+
+/// Serialize, sync, and read back both final companions without publishing
+/// either canonical path.
+pub fn prepare_final_reports(
+    report_path: impl AsRef<Path>,
+    run: &RunReport,
+    evidence: &DeterministicEvidence,
+) -> Result<PreparedReports, ReportError> {
+    let report_path = report_path.as_ref();
+    // This run owns the configured canonical paths from this point onward.
+    // Remove any prior pair before staging so a later terminal/preparation
+    // failure cannot leave a stale PASS masquerading as the current run.
+    invalidate_final_reports_checked(report_path)?;
+    let result = (|| -> Result<PreparedReports, ReportError> {
+        if run.schema != RUN_REPORT_SCHEMA {
+            return Err(ReportError::InvalidCompanion(format!(
+                "run schema {:?} does not match {RUN_REPORT_SCHEMA}",
+                run.schema
+            )));
+        }
+        if evidence.schema != EVIDENCE_SCHEMA {
+            return Err(ReportError::InvalidCompanion(format!(
+                "evidence schema {:?} does not match {EVIDENCE_SCHEMA}",
+                evidence.schema
+            )));
+        }
+        if run.status != evidence.status {
+            return Err(ReportError::InvalidCompanion(format!(
+                "run status {} does not match evidence status {}",
+                run.status.as_str(),
+                evidence.status.as_str()
+            )));
+        }
+        let paths = ReportPaths {
+            run: report_path.to_owned(),
+            evidence: evidence_path_for_report(report_path)?,
+        };
+        if let Some(directory) = report_path.parent() {
+            std::fs::create_dir_all(directory)?;
+        }
+        let mut run_bytes = serde_json::to_vec_pretty(run)?;
+        run_bytes.push(b'\n');
+        let mut evidence_bytes = serde_json::to_vec(evidence)?;
+        evidence_bytes.push(b'\n');
+        let prepared = PreparedReports {
+            run_temp: temporary_sibling(&paths.run, "run")?,
+            evidence_temp: temporary_sibling(&paths.evidence, "evidence")?,
+            paths,
+        };
+        write_synced_new(&prepared.run_temp, &run_bytes)?;
+        write_synced_new(&prepared.evidence_temp, &evidence_bytes)?;
+        let decoded_run: RunReport = serde_json::from_slice(&std::fs::read(&prepared.run_temp)?)?;
+        let decoded_evidence: DeterministicEvidence =
+            serde_json::from_slice(&std::fs::read(&prepared.evidence_temp)?)?;
+        if decoded_run != *run || decoded_evidence != *evidence {
+            return Err(ReportError::InvalidCompanion(
+                "temporary report readback changed serialized content".to_owned(),
+            ));
+        }
+        Ok(prepared)
+    })();
+    match result {
+        Ok(prepared) => Ok(prepared),
+        Err(error) => match invalidate_final_reports_checked(report_path) {
+            Ok(()) => Err(error),
+            Err(invalidation) => Err(ReportError::InvalidCompanion(format!(
+                "preparation failed ({error}); canonical companion invalidation also failed ({invalidation})"
+            ))),
+        },
+    }
+}
+
+pub fn write_final_reports(
+    report_path: impl AsRef<Path>,
+    run: &RunReport,
+    evidence: &DeterministicEvidence,
+) -> Result<ReportPaths, ReportError> {
+    prepare_final_reports(report_path, run, evidence)?.commit()
+}
+
+/// Remove both canonical companions after any failed preparation or commit.
+/// A stale report or evidence sidecar must not masquerade as the current run.
+/// Missing paths are already invalidated; every other removal failure is
+/// surfaced so callers cannot continue beside a prior canonical PASS.
+pub fn invalidate_final_reports_checked(report_path: impl AsRef<Path>) -> Result<(), ReportError> {
+    let report_path = report_path.as_ref();
+    let evidence_path = evidence_path_for_report(report_path)?;
+    // Evidence is published first and the run report is the commit marker, so
+    // invalidate in the same order. A non-removable run path must not prevent
+    // cleanup of a partially published evidence companion.
+    let mut removal_failure = None;
+    for path in [evidence_path.as_path(), report_path] {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                if removal_failure.is_none() {
+                    removal_failure = Some(error);
+                }
+            }
+        }
+    }
+    removal_failure.map_or(Ok(()), |error| Err(ReportError::Io(error)))
+}
+
+/// Resolve and invalidate the canonical report companions before any other
+/// fallible harness configuration. A later probe or fixture rejection cannot
+/// then leave a prior PASS visible under this invocation's selected path.
+pub fn take_run_report_ownership(
+    current_dir: impl AsRef<Path>,
+    configured: Option<String>,
+) -> Result<PathBuf, ReportError> {
+    let selected = match configured {
+        Some(path) if path.trim().is_empty() => {
+            return Err(ReportError::InvalidReportPath(PathBuf::from(path)));
+        }
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from("target/teacher-parity/parity-report.json"),
+    };
+    let report_path = if selected.is_absolute() {
+        selected
+    } else {
+        current_dir.as_ref().join(selected)
+    };
+    invalidate_final_reports_checked(&report_path)?;
+    Ok(report_path)
+}
+
+pub fn events_path_for_report(report_path: impl AsRef<Path>) -> Result<PathBuf, ReportError> {
+    sibling_path(report_path.as_ref(), "events.jsonl")
+}
+
+pub fn evidence_path_for_report(report_path: impl AsRef<Path>) -> Result<PathBuf, ReportError> {
+    sibling_path(report_path.as_ref(), "evidence.json")
+}
+
+fn sibling_path(report_path: &Path, suffix: &str) -> Result<PathBuf, ReportError> {
+    let stem = report_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| ReportError::InvalidReportPath(report_path.to_owned()))?;
+    Ok(report_path.with_file_name(format!("{stem}.{suffix}")))
+}
+
+fn temporary_sibling(path: &Path, label: &str) -> Result<PathBuf, ReportError> {
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| ReportError::InvalidReportPath(path.to_owned()))?;
+    Ok(path.with_file_name(format!(
+        ".{filename}.{label}-{}-{}",
+        std::process::id(),
+        NEXT_TEMP.fetch_add(1, Ordering::Relaxed)
+    )))
+}
+
+fn write_synced_new(path: &Path, bytes: &[u8]) -> Result<(), ReportError> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// Atomically publish one standalone JSON artifact after synced temporary
+/// write and semantic readback. This is used by cheap preflight-only entry
+/// points that deliberately do not initialize the heartbeat/run machinery.
+pub fn write_atomic_json(path: impl AsRef<Path>, value: &Value) -> Result<PathBuf, ReportError> {
+    let path = path.as_ref();
+    if let Some(directory) = path.parent() {
+        std::fs::create_dir_all(directory)?;
+    }
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    let temporary = temporary_sibling(path, "standalone")?;
+    let result = (|| -> Result<(), ReportError> {
+        write_synced_new(&temporary, &bytes)?;
+        let decoded: Value = serde_json::from_slice(&std::fs::read(&temporary)?)?;
+        if decoded != *value {
+            return Err(ReportError::InvalidCompanion(
+                "standalone JSON readback changed serialized content".to_owned(),
+            ));
+        }
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result.map(|()| path.to_owned())
+}
+
+/// Publish a standalone teacher-free preflight outcome before returning it.
+/// A non-PASS outcome receives a caller-built evidence object so the exact
+/// refusal survives process failure. If publication itself fails, the write
+/// failure and the original refusal are both retained in the returned reason.
+pub fn publish_atomic_preflight_outcome(
+    path: impl AsRef<Path>,
+    outcome: Result<Value, String>,
+    failure_report: impl FnOnce(&str) -> Value,
+) -> Result<Value, String> {
+    let path = path.as_ref();
+    // A preflight artifact is an admission token for expensive teacher work.
+    // Once a new attempt owns this path, an older AVAILABLE token must not
+    // survive a later publication failure and masquerade as the current run.
+    if let Err(error) = std::fs::remove_file(path) {
+        if error.kind() != io::ErrorKind::NotFound {
+            return Err(match &outcome {
+                Ok(_) => format!(
+                    "FAILED: invalidate stale teacher-free preflight report {}: {error}",
+                    path.display()
+                ),
+                Err(reason) => format!(
+                    "FAILED: teacher-free preflight refused ({reason}); invalidate stale report {}: {error}",
+                    path.display()
+                ),
+            });
+        }
+    }
+    match outcome {
+        Ok(report) => {
+            write_atomic_json(path, &report).map_err(|error| {
+                format!(
+                    "FAILED: write teacher-free preflight report {}: {error}",
+                    path.display()
+                )
+            })?;
+            Ok(report)
+        }
+        Err(reason) => {
+            let report = failure_report(&reason);
+            write_atomic_json(path, &report).map_err(|error| {
+                format!(
+                    "FAILED: teacher-free preflight refused ({reason}); write durable refusal report {}: {error}",
+                    path.display()
+                )
+            })?;
+            Err(reason)
+        }
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+pub fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(duration_millis)
+        .unwrap_or(0)
+}
+
+#[derive(Debug)]
+pub enum ReportError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    InvalidReportPath(PathBuf),
+    InvalidCompanion(String),
+}
+
+impl fmt::Display for ReportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "telemetry I/O: {error}"),
+            Self::Json(error) => write!(formatter, "telemetry JSON: {error}"),
+            Self::InvalidReportPath(path) => {
+                write!(formatter, "invalid report path {}", path.display())
+            }
+            Self::InvalidCompanion(reason) => {
+                write!(formatter, "invalid report companion: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReportError {}
+
+impl From<io::Error> for ReportError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for ReportError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}

--- a/xtask/src/audit.rs
+++ b/xtask/src/audit.rs
@@ -109,7 +109,7 @@ fn effective_lines(text: &str) -> Vec<(usize, &str)> {
         }
         let opens = raw.matches('{').count() as i32;
         let closes = raw.matches('}').count() as i32;
-        if line.starts_with("#[cfg(test)]") {
+        if line.starts_with("#[cfg(test)]") || line.starts_with("#[cfg(all(test,") {
             in_test = true;
             test_depth = depth;
         }
@@ -190,11 +190,17 @@ pub fn audit_limits(root: &Path) -> Result<(), Fail> {
     // could not be ingested into a valid teacher at construction. It is the
     // host-side counterpart of `NotAProduct`, not a runtime limitation, so it is
     // sanctioned here alongside the graph substrate's three.
+    // The three #932 exact-harness errors are also construction/admission
+    // boundaries, not deployed-runtime limitations: they reject an invalid
+    // caller-declared shape, bounded state, or evidence view before use.
     let sanctioned = [
         "NotAProduct",
         "ObservedBound",
         "KappaError",
         "SourceUnavailable",
+        "ExactForwardPlanError",
+        "TeacherStateCapacityError",
+        "ExactMulticoreProbeValidationError",
     ];
 
     let mut violations = Vec::new();
@@ -456,7 +462,21 @@ fn gather_all(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Fail> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_std_io_trait_result;
+    use super::{effective_lines, is_std_io_trait_result};
+
+    #[test]
+    fn cfg_all_test_modules_are_excluded_from_shipped_source_audits() {
+        let source = r#"
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    fn test_only() -> Result<(), String> { Ok(()) }
+}
+fn shipped() -> Result<(), SourceUnavailable> { Ok(()) }
+"#;
+        let lines = effective_lines(source);
+        assert!(!lines.iter().any(|(_, line)| line.contains("test_only")));
+        assert!(lines.iter().any(|(_, line)| line.contains("shipped")));
+    }
 
     #[test]
     fn std_io_result_carve_out_requires_adjacent_fully_qualified_trait_impl() {


### PR DESCRIPTION
Closes #932

## Outcome

Replaces the open-ended serial live-teacher parity path with bounded exact multicore execution, shared immutable weights, private stream state, canonical reductions, durable heartbeats/events, hard deadlines, and fail-closed fixture and report validation.

The current canonical local bundle is truthfully `UNAVAILABLE`, so the live tuner and full parity run remain `NOT_RUN`; no threshold was relaxed and no production-performance claim is made.

## Scope

- exact row-partition executor and adaptive W=4/W=8 tuner
- shared S2/S3/S7 transcript and bounded adaptive S4 continuation
- content-bound production-envelope and tokenizer validation
- durable JSONL progress plus machine-readable report/evidence schemas
- deterministic, negative-control, observability, and BDD coverage
- configuration, roadmap, research, baseline, and conformance documentation

No deployed serving behavior, runtime artifact format, multiplication-free kernel, or parity floor changes.

## Local verification

- `cargo test -p uor-r4-model-source --lib --offline`: 155 passed, 4 fixture-gated ignored
- `cargo test --test parity_determinism_932 --offline`: 4 passed
- `cargo test --test parity_observability_932 --offline`: 49 passed
- `cargo fmt --all -- --check`
- `python3 scripts/check_claim_wording.py`
- `cargo run -p xtask --offline -- check-model`: 33 ids
- graph-format no-std and alloc ladders
- wasm32 library check
- strict workspace clippy passed on the final source state

The protected merge queue is the binding full-workspace verification. The expensive local workspace rerun was intentionally not repeated after the focused gates because CI runs the complete speculative-merge ladder.

## Evidence

Current teacher-free preflight: `UNAVAILABLE`; missing canonical `release-bundle.json`; teacher source unopened; zero teacher forwards. Ordinary BDD evidence is structurally complete and records zero work rather than treating absent prerequisites as PASS. Exact CIDs and the superseding run contract are recorded in `docs/teacher_parity_parallelism_932.md`.
