### PR TITLE
runtime(#942): carry the generated-prefix signature in production

### DIFF
--- a/crates/uor-r4-router/src/lib.rs
+++ b/crates/uor-r4-router/src/lib.rs
@@ -17,7 +17,7 @@ pub mod session_signature;
 
 pub use session_signature::{
     fixture_session_signatures, from_state as session_signature_from_state,
-    from_tokens as session_signature_from_tokens, MULTI_TURN_FIXTURE,
+    from_tokens as session_signature_from_tokens, TokenHistorySignature, MULTI_TURN_FIXTURE,
 };
 
 // #790 item 4: only the live cascade surface is exported — the dead

--- a/crates/uor-r4-router/src/session_signature.rs
+++ b/crates/uor-r4-router/src/session_signature.rs
@@ -7,6 +7,64 @@
 pub const SESSION_SIGNATURE_BITS: usize = 288;
 pub const SESSION_SIGNATURE_BYTES: usize = SESSION_SIGNATURE_BITS / 8;
 
+/// Fixed-size incremental form of [`from_tokens`].
+///
+/// The state can be seeded once from an admitted prompt and extended after
+/// each committed generated token. [`Self::signature`] is byte-identical to
+/// calling [`from_tokens`] over the complete prefix, without retaining or
+/// rescanning that prefix. This construction lives on the serving side; the
+/// graph runtime still consumes only the resulting 288-bit value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenHistorySignature {
+    lanes: [u64; 5],
+    next_position: usize,
+}
+
+impl Default for TokenHistorySignature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenHistorySignature {
+    pub const fn new() -> Self {
+        Self {
+            lanes: [0; 5],
+            next_position: 0,
+        }
+    }
+
+    pub fn from_tokens(tokens: &[u32]) -> Self {
+        let mut state = Self::new();
+        for &token in tokens {
+            state.push(token);
+        }
+        state
+    }
+
+    /// Commit one token to the trajectory.
+    pub fn push(&mut self, token: u32) {
+        let position = self.next_position;
+        let mut value =
+            u64::from(token).wrapping_add((position as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15));
+        for (lane, slot) in self.lanes.iter_mut().enumerate() {
+            value = splitmix64(value.wrapping_add(lane as u64));
+            *slot = slot.rotate_left((lane * 11 + position % 17) as u32) ^ value;
+        }
+        self.next_position = self.next_position.saturating_add(1);
+    }
+
+    pub fn signature(&self) -> [u8; SESSION_SIGNATURE_BYTES] {
+        let mut signature = [0u8; SESSION_SIGNATURE_BYTES];
+        for (index, byte) in signature.iter_mut().enumerate() {
+            let lane = index % self.lanes.len();
+            let shift = (index / self.lanes.len()) * 8;
+            *byte = (self.lanes[lane] >> shift) as u8;
+        }
+        signature
+    }
+}
+
 /// Quantize a centered session-manifold state into the graph's 288-bit
 /// signature space.
 ///
@@ -37,23 +95,7 @@ pub fn from_state(state: &[f64]) -> [u8; SESSION_SIGNATURE_BYTES] {
 /// the direct chat client session-sensitive; the HTTP server uses [`from_state`]
 /// from its persistent manifold instead.
 pub fn from_tokens(tokens: &[u32]) -> [u8; SESSION_SIGNATURE_BYTES] {
-    let mut lanes = [0u64; 5];
-    for (position, &token) in tokens.iter().enumerate() {
-        let mut value =
-            u64::from(token).wrapping_add((position as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15));
-        for (lane, slot) in lanes.iter_mut().enumerate() {
-            value = splitmix64(value.wrapping_add(lane as u64));
-            *slot = slot.rotate_left((lane * 11 + position % 17) as u32) ^ value;
-        }
-    }
-
-    let mut signature = [0u8; SESSION_SIGNATURE_BYTES];
-    for (index, byte) in signature.iter_mut().enumerate() {
-        let lane = index % lanes.len();
-        let shift = (index / lanes.len()) * 8;
-        *byte = (lanes[lane] >> shift) as u8;
-    }
-    signature
+    TokenHistorySignature::from_tokens(tokens).signature()
 }
 
 fn splitmix64(mut value: u64) -> u64 {
@@ -81,6 +123,34 @@ mod tests {
     fn token_history_projection_is_order_sensitive() {
         assert_ne!(from_tokens(&[1, 2, 3]), from_tokens(&[3, 2, 1]));
         assert_eq!(from_tokens(&[]), [0; SESSION_SIGNATURE_BYTES]);
+    }
+
+    #[test]
+    fn incremental_token_history_matches_every_batch_prefix() {
+        let tokens = [1, 89, 21, 34, 55, 8, 13, 144, 233, 3, 5, 377];
+        let mut incremental = TokenHistorySignature::new();
+        assert_eq!(incremental.signature(), from_tokens(&[]));
+        for (index, &token) in tokens.iter().enumerate() {
+            incremental.push(token);
+            assert_eq!(
+                incremental.signature(),
+                from_tokens(&tokens[..=index]),
+                "incremental signature diverged at prefix {}",
+                index + 1
+            );
+        }
+    }
+
+    #[test]
+    fn token_history_retains_information_beyond_shared_window() {
+        let shared_window = [10, 11, 12, 13, 14, 15, 16, 17];
+        let mut first = TokenHistorySignature::from_tokens(&[1, 2, 3, 4]);
+        let mut second = TokenHistorySignature::from_tokens(&[91, 92, 93, 94]);
+        for &token in &shared_window {
+            first.push(token);
+            second.push(token);
+        }
+        assert_ne!(first.signature(), second.signature());
     }
 }
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -654,8 +654,12 @@ therefore **`NOT TRIGGERED`** (no runtime/format/compiler change) and, for the s
 falsifier (no bounded correction or state reduces the frozen free-running gap → the
 deployed artifact is a teacher-forced continuation/retrieval system, not a generative
 engine at this scope). Re-entry requires a representation with cross-step free-running
-memory and must re-enter under the frozen #841 §6 bar. The S3 tracker #824 now records its
-stage verdict against its three completed children (a separate tracker action).
+memory and must re-enter under the frozen #841 §6 bar. The S3 tracker #824 records its
+historical `LIMIT` verdict against its three completed children. **#942 (2026-08-25)
+reopens S3 for a bounded implementation-first slice:** strict production decoding carries a
+fixed-size incremental signature of the complete admitted prompt plus committed generated prefix
+alongside the existing short scoring window. This is deployed memory reachability, not a
+coherence result; the frozen #841 bar is unchanged.
 
 **S4 — bounded typed planning is LIMITED; geometry adds no advantage; untouched final-partition
 reasoning is not established (#843/#845/#846, 2026-08-22).**

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -431,6 +431,15 @@ generation claim into any downstream stage. This entry mirrors the tracker verdi
   memory, re-measured under the unchanged #841 §6 bar and the frozen #838
   selective-prediction gates (the #887 discipline).
 
+### S3 bounded representation re-entry — ACTIVE (#942, 2026-08-25)
+
+The tracker is reopened for one implementation-first slice without revising the historical
+`LIMIT` verdict. The strict production generator now carries a fixed-size incremental
+signature of the complete admitted prompt plus committed generated prefix alongside its
+bounded scoring window. This establishes cross-step memory reachability through the existing
+normative session-signature lane; it does **not** establish coherent generation or change the
+frozen #841 §6 bar. Broader measurement remains gated on the focused product-path canary.
+
 ### S4 entry reconciliation — AMEND + PROCEED (2026-08-22)
 
 S3 (#824) closed `LIMIT` and S2 (#823) stands at `REVISE`, so #826's written entry

--- a/src/tless_uor.rs
+++ b/src/tless_uor.rs
@@ -28,7 +28,7 @@ use uor_foundation::pipeline::{
 use uor_r4_core::transformerless::compiler::{self, Compiled, WINDOW};
 use uor_r4_core::transformerless::runtime::{self, Store};
 
-use uor_r4_router::{R4HostBounds, R4_FP_MAX, R4_INLINE_BYTES};
+use uor_r4_router::{R4HostBounds, TokenHistorySignature, R4_FP_MAX, R4_INLINE_BYTES};
 
 // =====================================================================
 // State: compiled artifact + graded store, per-thread
@@ -495,15 +495,14 @@ fn generate_production_r4g1_response(
             }
         };
 
-    let mut window = [0u32; WINDOW];
-    let tail = &seed[seed.len().saturating_sub(WINDOW)..];
-    let mut window_len = tail.len();
-    window[..window_len].copy_from_slice(tail);
-    let mut generated = Vec::with_capacity(max_tokens.min(128));
+    let steps = max_tokens.min(128);
+    let mut trajectory = ProductionTrajectory::from_seed(&seed);
+    let mut generated = Vec::with_capacity(steps);
     let mut last_coverage = None;
 
-    for _ in 0..max_tokens.min(128) {
-        match engine.predict(&window[..window_len]) {
+    for _ in 0..steps {
+        let session_signature = trajectory.session_signature();
+        match engine.predict_with_session_signature(trajectory.window(), Some(&session_signature)) {
             Ok(uor_r4_api::NormativeServingDecision::Serve(served)) => {
                 last_coverage = Some(match served.status {
                     uor_r4_api::ScoreStatus::Novel => {
@@ -517,13 +516,7 @@ fn generate_production_r4g1_response(
                     break;
                 }
                 generated.push(served.token);
-                if window_len < WINDOW {
-                    window[window_len] = served.token;
-                    window_len += 1;
-                } else {
-                    window.copy_within(1.., 0);
-                    window[WINDOW - 1] = served.token;
-                }
+                trajectory.commit(served.token);
             }
             Ok(uor_r4_api::NormativeServingDecision::Abstain(_)) => {
                 return R4g1Generation::Abstained;
@@ -550,6 +543,49 @@ fn generate_production_r4g1_response(
         None => R4g1Generation::HardIncompatibility(
             "production tokenizer cannot decode the runtime continuation".into(),
         ),
+    }
+}
+
+/// Fixed-size production decode state. The scorer retains its existing
+/// bounded window while the secondary signature lane carries the complete
+/// admitted prompt plus committed generated prefix. EOS, abstention, and
+/// decline never call [`Self::commit`], so speculative output cannot enter
+/// trajectory memory.
+struct ProductionTrajectory {
+    window: [u32; WINDOW],
+    window_len: usize,
+    history_signature: TokenHistorySignature,
+}
+
+impl ProductionTrajectory {
+    fn from_seed(seed: &[u32]) -> Self {
+        let mut window = [0u32; WINDOW];
+        let tail = &seed[seed.len().saturating_sub(WINDOW)..];
+        window[..tail.len()].copy_from_slice(tail);
+        Self {
+            window,
+            window_len: tail.len(),
+            history_signature: TokenHistorySignature::from_tokens(seed),
+        }
+    }
+
+    fn window(&self) -> &[u32] {
+        &self.window[..self.window_len]
+    }
+
+    fn session_signature(&self) -> [u8; uor_r4_router::session_signature::SESSION_SIGNATURE_BYTES] {
+        self.history_signature.signature()
+    }
+
+    fn commit(&mut self, token: u32) {
+        self.history_signature.push(token);
+        if self.window_len < WINDOW {
+            self.window[self.window_len] = token;
+            self.window_len += 1;
+        } else {
+            self.window.copy_within(1.., 0);
+            self.window[WINDOW - 1] = token;
+        }
     }
 }
 
@@ -1397,6 +1433,25 @@ mod tests {
     };
 
     static R4G1_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn production_trajectory_keeps_prefix_memory_beyond_runtime_window() {
+        let shared_window: Vec<u32> = (100..100 + WINDOW as u32).collect();
+        let mut first_seed = vec![1, 2, 3, 4];
+        first_seed.extend_from_slice(&shared_window);
+        let mut second_seed = vec![91, 92, 93, 94];
+        second_seed.extend_from_slice(&shared_window);
+
+        let mut first = ProductionTrajectory::from_seed(&first_seed);
+        let mut second = ProductionTrajectory::from_seed(&second_seed);
+        assert_eq!(first.window(), second.window());
+        assert_ne!(first.session_signature(), second.session_signature());
+
+        first.commit(777);
+        second.commit(777);
+        assert_eq!(first.window(), second.window());
+        assert_ne!(first.session_signature(), second.session_signature());
+    }
 
     fn fixture_state() {
         let dir = concat!(


### PR DESCRIPTION
## Outcome

Strict schema-2 production decoding now carries a fixed-size incremental signature over the complete admitted prompt plus every committed generated token while retaining the existing bounded scoring window. The incremental state is byte-identical to the prior batch token-history signature at every prefix and performs no per-step allocation.

EOS, abstention, decline, and speculative output do not enter the trajectory state. Existing admission and old-artifact behavior are unchanged.

## Focused verification

- `cargo fmt --check`
- `python3 scripts/check_claim_wording.py`
- `cargo test -p uor-r4-router session_signature --offline` — 5 passed
- `cargo test --lib production_trajectory_keeps_prefix_memory_beyond_runtime_window --offline` — passed
- `cargo test -p uor-r4-graph-runtime --test r4g1_runtime_test session_signature_enters_rout_fallback_as_secondary_probe --offline` — passed
- `cargo test --lib complete_production_envelope_installs_and_corpus_tamper_is_atomic --offline` — passed
- `cargo check -p uor-r4-wasm-router --all-targets --offline`

## Claim boundary

This establishes deployed full-prefix signature reachability. It does not establish coherent generation or revise the historical S3 `LIMIT`; the frozen #841 generation bar remains unchanged.

Closes #942