### PR TITLE
Compile and compose full-prefix trajectory routing regions (#946)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "uor-r4-core",
  "uor-r4-graph-format",
  "uor-r4-model-source",
+ "uor-r4-router",
 ]
 
 [[package]]

--- a/crates/uor-r4-api/tests/production_prefix_memory_canary_944.rs
+++ b/crates/uor-r4-api/tests/production_prefix_memory_canary_944.rs
@@ -24,6 +24,8 @@ use uor_r4_router::TokenHistorySignature;
 
 const MAX_CASES: usize = 512;
 const RESULT_SCHEMA: &str = "uor-r4-production-prefix-memory-canary/1";
+const DEFAULT_ISSUE: u32 = 944;
+const DEFAULT_REPORT: &str = "docs/production_prefix_memory_canary_944_result.json";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -150,7 +152,6 @@ struct EffectRecord {
 
 fn is_effect(record: &EffectRecord) -> bool {
     record.full_routing.context_probe_attempted
-        && record.full_routing.context_admitted_nodes == 0
         && record.full_routing.session_probe_attempted
         && record.full_routing.session_admitted_nodes > 0
         && matches!(
@@ -223,7 +224,7 @@ fn select(
         .map_err(|error| format!("normative selection rejected canary input: {error:?}"))
 }
 
-fn run_canary(root: &Path) -> Result<CanaryReport, String> {
+fn run_canary(root: &Path, issue: u32) -> Result<CanaryReport, String> {
     let graph = read(root, "graph/score.r4g1")?;
     let sections_absent_graph = read(root, "graph/score_sections_absent.r4g1")?;
     let label_shuffled_graph = read(root, "graph/score_label_shuffled.r4g1")?;
@@ -353,7 +354,7 @@ fn run_canary(root: &Path) -> Result<CanaryReport, String> {
         .collect();
     Ok(CanaryReport {
         schema: RESULT_SCHEMA,
-        issue: 944,
+        issue,
         verdict: if first_effect.is_some() {
             "EFFECT_ESTABLISHED"
         } else {
@@ -365,8 +366,7 @@ fn run_canary(root: &Path) -> Result<CanaryReport, String> {
         release_manifest_cid: cid(&release_manifest),
         corpus_meta_cid: cid(&corpus_meta),
         corpus_records_cid: cid(&corpus_records),
-        selection_rule:
-            "first held-out corpus positions with a complete in-story prefix longer than the newest eight-token window",
+        selection_rule: "first held-out corpus positions with a complete in-story prefix longer than the newest eight-token window",
         tested_count: tested_positions.len(),
         first_tested_position: tested_positions[0],
         last_tested_position: *tested_positions.last().expect("non-empty positions"),
@@ -381,7 +381,9 @@ fn write_report(report: &CanaryReport) -> Result<PathBuf, String> {
     let mut bytes = serde_json::to_vec_pretty(report)
         .map_err(|error| format!("serialize canary report: {error}"))?;
     bytes.push(b'\n');
-    let output = repo_root().join("docs/production_prefix_memory_canary_944_result.json");
+    let output = std::env::var_os("R4_S3_CANARY_REPORT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root().join(DEFAULT_REPORT));
     std::fs::write(&output, bytes)
         .map_err(|error| format!("write {}: {error}", output.display()))?;
     Ok(output)
@@ -440,6 +442,12 @@ fn canary_verdict_requires_behavior_and_session_admission() {
         is_effect(&record),
         "admitted session routing plus a changed token qualifies"
     );
+    record.full_routing.context_admitted_nodes = 4;
+    record.full_routing.selected_source = "composed-signatures";
+    assert!(
+        is_effect(&record),
+        "composed context and trajectory admissions qualify"
+    );
     record.full_routing.session_admitted_nodes = 0;
     assert!(
         !is_effect(&record),
@@ -451,7 +459,13 @@ fn canary_verdict_requires_behavior_and_session_admission() {
 #[ignore = "bounded local evidence run: requires the exact schema-2 #933 envelope"]
 fn production_prefix_memory_canary_944() {
     let root = bundle_root().unwrap_or_else(|reason| panic!("UNAVAILABLE: {reason}"));
-    let report = run_canary(&root).unwrap_or_else(|reason| panic!("UNAVAILABLE: {reason}"));
+    let issue = std::env::var("R4_S3_CANARY_ISSUE")
+        .ok()
+        .map(|value| value.parse::<u32>())
+        .transpose()
+        .unwrap_or_else(|error| panic!("UNAVAILABLE: invalid R4_S3_CANARY_ISSUE: {error}"))
+        .unwrap_or(DEFAULT_ISSUE);
+    let report = run_canary(&root, issue).unwrap_or_else(|reason| panic!("UNAVAILABLE: {reason}"));
     let output = write_report(&report).expect("retain deterministic canary report");
     println!("verdict                 : {}", report.verdict);
     println!("inspected               : {}", report.counts.inspected);

--- a/crates/uor-r4-api/tests/production_prefix_memory_canary_944.rs
+++ b/crates/uor-r4-api/tests/production_prefix_memory_canary_944.rs
@@ -123,6 +123,7 @@ fn routing_record(trace: SignatureRoutingTrace) -> RoutingRecord {
             SignatureRoutingSource::SuffixDfa => "suffix-dfa",
             SignatureRoutingSource::ContextSignature => "context-signature",
             SignatureRoutingSource::SessionSignature => "session-signature",
+            SignatureRoutingSource::ComposedSignatures => "composed-signatures",
             SignatureRoutingSource::NearestContextSignature => "nearest-context-signature",
             SignatureRoutingSource::NearestSessionSignature => "nearest-session-signature",
             SignatureRoutingSource::DefaultNode => "default-node",
@@ -152,7 +153,10 @@ fn is_effect(record: &EffectRecord) -> bool {
         && record.full_routing.context_admitted_nodes == 0
         && record.full_routing.session_probe_attempted
         && record.full_routing.session_admitted_nodes > 0
-        && record.full_routing.selected_source == "session-signature"
+        && matches!(
+            record.full_routing.selected_source,
+            "session-signature" | "composed-signatures"
+        )
         && (record.candidate_list_changed || record.served_token_changed)
 }
 

--- a/crates/uor-r4-api/tests/trajectory_routing_preflight_946.rs
+++ b/crates/uor-r4-api/tests/trajectory_routing_preflight_946.rs
@@ -1,0 +1,260 @@
+//! Issue #946 binding cheap instrument.
+//!
+//! This ignored, teacher-free harness compiles at most 4,096 recorded train
+//! positions and inspects at most 4,096 recorded held-out positions. The
+//! treatment and context-only control have identical region, edge, ROUT,
+//! EMIT, candidate, and active-node ceilings. A negative verdict is a valid
+//! terminal measurement and deliberately does not fail the test process.
+
+use std::path::Path;
+use std::time::Instant;
+
+use serde_json::json;
+use uor_r4_core::transformerless::compiler::{self, STAGES};
+use uor_r4_graph_compiler::induction as cover;
+use uor_r4_graph_format::{GraphView, ScoreQ, SectionId};
+use uor_r4_graph_runtime::R4G1Runtime;
+
+const MAX_TRAIN_POSITIONS: usize = 4_096;
+const MAX_HELD_OUT_POSITIONS: usize = 4_096;
+
+fn cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn read(path: &Path, name: &str) -> Vec<u8> {
+    std::fs::read(path.join(name))
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.join(name).display()))
+}
+
+fn candidates(
+    runtime: &R4G1Runtime<'_>,
+    context: &[u32],
+    context_signature: &[u8],
+    trajectory_signature: Option<&[u8]>,
+) -> Vec<(u32, i32)> {
+    let mut scores = vec![ScoreQ::MIN; runtime.node_count() as usize];
+    let mut output = [(0u32, ScoreQ::MIN); 8];
+    let count = runtime.predict_candidates_with_signature_lanes(
+        context,
+        Some(context_signature),
+        trajectory_signature,
+        &mut scores,
+        &mut output,
+    );
+    output[..count]
+        .iter()
+        .map(|(token, score)| (*token, score.raw()))
+        .collect()
+}
+
+#[test]
+#[ignore = "teacher-free exact-input instrument; set R4_TRAJECTORY_PREFLIGHT_BUNDLE"]
+fn exact_recorded_corpus_preflight() {
+    let started = Instant::now();
+    let bundle = std::env::var("R4_TRAJECTORY_PREFLIGHT_BUNDLE")
+        .expect("R4_TRAJECTORY_PREFLIGHT_BUNDLE must name the exact #933 full bundle");
+    let bundle = Path::new(&bundle);
+    let artifact_bytes = read(bundle, "tless_artifacts.bin");
+    let corpus_meta = read(bundle, "corpus.meta");
+    let corpus_records = read(bundle, "corpus.records");
+    let artifacts = compiler::parse_artifacts(&artifact_bytes).expect("TLA parses");
+    let corpus = compiler::load_corpus_bytes(&corpus_meta, &corpus_records, None)
+        .expect("recorded corpus parses");
+    let (mut train_positions, mut held_out_positions) = cover::split_positions(&corpus);
+    train_positions.truncate(MAX_TRAIN_POSITIONS);
+    held_out_positions.truncate(MAX_HELD_OUT_POSITIONS);
+    assert!(
+        !train_positions.is_empty(),
+        "preflight needs train positions"
+    );
+    assert!(
+        !held_out_positions.is_empty(),
+        "preflight needs held-out positions"
+    );
+
+    let extraction_started = Instant::now();
+    let train = cover::build_observations_with_threads(&artifacts, &corpus, &train_positions, 1);
+    let held_out =
+        cover::build_observations_with_threads(&artifacts, &corpus, &held_out_positions, 1);
+    let extraction_ms = extraction_started.elapsed().as_millis();
+
+    let config = cover::CoverConfig {
+        depths: 2,
+        k0: 32,
+        regions_budget: 64,
+        memory_budget_bytes: 256 * 1024 * 1024,
+        threads: 1,
+        min_support: 16,
+        entropy_gain_bits: 0.25,
+        radius_quantile_numerator: 95,
+        radius_quantile_denominator: 100,
+        ..cover::CoverConfig::default()
+    };
+    let artifact_kappa = cid(&artifact_bytes);
+    let mut corpus_hasher = blake3::Hasher::new();
+    corpus_hasher.update(&corpus_meta);
+    corpus_hasher.update(&corpus_records);
+    let corpus_kappa = format!("blake3:{}", corpus_hasher.finalize().to_hex());
+
+    let induction_started = Instant::now();
+    let mut induced = cover::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)
+        .expect("bounded cover induction succeeds");
+    assert_eq!(
+        cover::attach_trajectory_routing(
+            &mut induced.cover,
+            &train,
+            config.radius_quantile_numerator,
+            config.radius_quantile_denominator,
+        ),
+        induced.cover.regions.len(),
+        "every fixed-budget region receives one trajectory prototype"
+    );
+    let induction_ms = induction_started.elapsed().as_millis();
+
+    let mut control = induced.cover.clone();
+    for region in &mut control.regions {
+        region.trajectory_sig = Some(region.sig);
+        region.trajectory_radius = Some(region.radius);
+    }
+    let reference = cover::ReferenceClassifier::freeze(&induced.cover);
+    let edges = cover::build_edges(&induced.cover, &reference, &train, &corpus.story);
+    let prior = cover::root_prior(&train);
+    let vocab = (artifacts.token_codes.len() / STAGES) as u32;
+    let emit = |graph: &cover::Cover| {
+        cover::emit_r4g1(
+            &artifact_bytes,
+            (&corpus_meta, &corpus_records),
+            vocab,
+            graph,
+            &edges,
+            &prior,
+            &train,
+        )
+        .expect("bounded in-memory artifact emits")
+        .0
+    };
+    let emission_started = Instant::now();
+    let treatment_bytes = emit(&induced.cover);
+    let treatment_repeat = emit(&induced.cover);
+    let control_bytes = emit(&control);
+    let emission_ms = emission_started.elapsed().as_millis();
+    assert_eq!(
+        treatment_bytes, treatment_repeat,
+        "double compilation identity"
+    );
+    assert_eq!(
+        treatment_bytes.len(),
+        control_bytes.len(),
+        "equal byte budget"
+    );
+    let treatment_view = GraphView::parse(&treatment_bytes).expect("treatment admits");
+    let control_view = GraphView::parse(&control_bytes).expect("control admits");
+    assert_eq!(treatment_view.node_count(), control_view.node_count());
+    assert_eq!(treatment_view.edge_count(), control_view.edge_count());
+    assert_eq!(
+        treatment_view.section(SectionId::ROUT).map(<[u8]>::len),
+        control_view.section(SectionId::ROUT).map(<[u8]>::len)
+    );
+    assert_eq!(
+        treatment_view.section(SectionId::EMIT),
+        control_view.section(SectionId::EMIT)
+    );
+    let treatment = R4G1Runtime::parse(&treatment_bytes).expect("treatment runtime admission");
+    let control = R4G1Runtime::parse(&control_bytes).expect("control runtime admission");
+
+    let mut inspected = 0usize;
+    let mut fallback_positions = 0usize;
+    let mut trajectory_admissions = 0usize;
+    let mut effects = 0usize;
+    let mut first_effect = None;
+    for observation in &held_out {
+        inspected += 1;
+        let context = cover::context_window(&corpus, observation.position as usize);
+        let mut scores = vec![ScoreQ::MIN; treatment.node_count() as usize];
+        let (_, trace) = treatment.predict_distribution_with_signature_lanes_traced(
+            &context,
+            Some(&observation.sig),
+            Some(&observation.trajectory_sig),
+            &mut scores,
+        );
+        if !trace.context_probe_attempted {
+            continue;
+        }
+        fallback_positions += 1;
+        if trace.session_admitted_nodes == 0 {
+            continue;
+        }
+        trajectory_admissions += 1;
+        let treatment_candidates = candidates(
+            &treatment,
+            &context,
+            &observation.sig,
+            Some(&observation.trajectory_sig),
+        );
+        let control_candidates =
+            candidates(&control, &context, &observation.sig, Some(&observation.sig));
+        if treatment_candidates != control_candidates {
+            effects += 1;
+            if first_effect.is_none() {
+                first_effect = Some(json!({
+                    "position": observation.position,
+                    "context_admitted_nodes": trace.context_admitted_nodes,
+                    "trajectory_admitted_nodes": trace.session_admitted_nodes,
+                    "treatment_candidates": treatment_candidates,
+                    "control_candidates": control_candidates,
+                }));
+            }
+        }
+    }
+
+    let verdict = if effects > 0 {
+        "PREFLIGHT_POSITIVE"
+    } else {
+        "REPRESENTATION_NOT_ESTABLISHED"
+    };
+    let report = json!({
+        "schema": "uor-r4.trajectory-routing-preflight/1",
+        "issue": 946,
+        "verdict": verdict,
+        "teacher_loaded": false,
+        "limits": {
+            "train_positions": MAX_TRAIN_POSITIONS,
+            "held_out_positions": MAX_HELD_OUT_POSITIONS,
+            "context_active_nodes": 4,
+            "trajectory_active_nodes": 4,
+            "total_active_nodes": 8,
+        },
+        "inputs": {
+            "artifact_kappa": artifact_kappa,
+            "corpus_kappa": corpus_kappa,
+        },
+        "budgets": {
+            "regions": induced.cover.regions.len(),
+            "nodes": treatment_view.node_count(),
+            "edges": treatment_view.edge_count(),
+            "treatment_bytes": treatment_bytes.len(),
+            "control_bytes": control_bytes.len(),
+            "rout_bytes": treatment_view.section(SectionId::ROUT).map(<[u8]>::len),
+            "emit_bytes": treatment_view.section(SectionId::EMIT).map(<[u8]>::len),
+        },
+        "counts": {
+            "inspected": inspected,
+            "fallback_positions": fallback_positions,
+            "trajectory_admissions": trajectory_admissions,
+            "candidate_effects": effects,
+        },
+        "first_effect": first_effect,
+        "outputs": {
+            "treatment_cid": cid(&treatment_bytes),
+            "control_cid": cid(&control_bytes),
+        },
+        "timing_ms": {
+            "observation_extraction": extraction_ms,
+            "induction": induction_ms,
+            "emission": emission_ms,
+            "total": started.elapsed().as_millis(),
+        },
+    });
+    println!("ISSUE_946_PREFLIGHT_REPORT={report}");
+}

--- a/crates/uor-r4-core/src/transformerless/mod.rs
+++ b/crates/uor-r4-core/src/transformerless/mod.rs
@@ -218,13 +218,13 @@ mod witnesses {
         // shifts for the same conversion) and the median split. The query
         // path is division- and multiplication-free.
         let expected_allowed = vec![
-            "vp_tree.rs: line 59: let proto_start = \
-             (node.prototype_word_start as usize).checked_mul(8)?; "
+            "vp_tree.rs: line 79: let proto_start = \
+             (prototype_word_start as usize).checked_mul(8)?; "
                 .to_string(),
-            "vp_tree.rs: line 60: let mask_start = \
+            "vp_tree.rs: line 80: let mask_start = \
              (node.mask_word_start as usize).checked_mul(8)?; "
                 .to_string(),
-            "vp_tree.rs: line 142: let split = distances.len() / 2; ".to_string(),
+            "vp_tree.rs: line 170: let split = distances.len() / 2; ".to_string(),
         ];
         assert_eq!(
             allowed, expected_allowed,

--- a/crates/uor-r4-graph-certify/src/fmm.rs
+++ b/crates/uor-r4-graph-certify/src/fmm.rs
@@ -663,6 +663,8 @@ mod tests {
             depth: 1,
             radius: 8,
             sig,
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         }
     }

--- a/crates/uor-r4-graph-certify/src/score.rs
+++ b/crates/uor-r4-graph-certify/src/score.rs
@@ -1711,22 +1711,63 @@ pub fn emit_scored_r4g1_with_bound_partition_cids(
     let max_emission_entries = DEFAULT_MAX_EMISSION_ENTRIES
         .max(emission_len[1..].iter().copied().max().unwrap_or(0) as u32);
 
-    // ROUT: [HALT + padding][(1 + R) × W prototype words][same masks].
-    let sig_words = SIG_WORDS as u32;
+    // ROUT: legacy artifacts retain the historical banked context layout.
+    // A #946 artifact uses equal-budget self-contained region blocks:
+    // context prototype, context mask, trajectory prototype, radius metadata.
     let mut rout = Vec::with_capacity(8 + node_total * SIG_WORDS * 8 * 2);
     rout.push(0x00); // HALT
     rout.extend_from_slice(&[0u8; 7]); // program padding to 8-byte alignment
-    rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root prototype: zeros
-    for region in regions {
-        let mut words = [0u8; SIG_WORDS * 8];
-        words[..SIG_BYTES].copy_from_slice(&region.sig);
-        rout.extend_from_slice(&words);
-    }
-    rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root mask: zeros
-    for _ in regions {
-        let mut words = [0u8; SIG_WORDS * 8];
-        words[..SIG_BYTES].fill(0xFF); // all-ones mask (v1)
-        rout.extend_from_slice(&words);
+    let mut prototype_word_starts = Vec::with_capacity(regions.len());
+    let mut mask_word_starts = Vec::with_capacity(regions.len());
+    let mut node_flags = Vec::with_capacity(regions.len());
+    let has_trajectory_routes = regions
+        .iter()
+        .any(|region| region.trajectory_sig.is_some() || region.trajectory_radius.is_some());
+    if !has_trajectory_routes {
+        let prototype_words_start = (rout.len() / 8) as u32;
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root prototype: zeros
+        for region in regions {
+            let mut words = [0u8; SIG_WORDS * 8];
+            words[..SIG_BYTES].copy_from_slice(&region.sig);
+            rout.extend_from_slice(&words);
+        }
+        let mask_words_start = (rout.len() / 8) as u32;
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root mask: zeros
+        for _ in regions {
+            let mut words = [0u8; SIG_WORDS * 8];
+            words[..SIG_BYTES].fill(0xFF); // all-ones mask (v1)
+            rout.extend_from_slice(&words);
+        }
+        for index in 0..regions.len() {
+            prototype_word_starts
+                .push(prototype_words_start + (index as u32 + 1) * SIG_WORDS as u32);
+            mask_word_starts.push(mask_words_start + (index as u32 + 1) * SIG_WORDS as u32);
+            node_flags.push(0u8);
+        }
+    } else {
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root prototype
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root mask
+        for region in regions {
+            prototype_word_starts.push((rout.len() / 8) as u32);
+            let mut context = [0u8; SIG_WORDS * 8];
+            context[..SIG_BYTES].copy_from_slice(&region.sig);
+            rout.extend_from_slice(&context);
+            mask_word_starts.push((rout.len() / 8) as u32);
+            let mut mask = [0u8; SIG_WORDS * 8];
+            mask[..SIG_BYTES].fill(0xFF);
+            rout.extend_from_slice(&mask);
+            let (Some(signature), Some(radius)) = (region.trajectory_sig, region.trajectory_radius)
+            else {
+                panic!("trajectory-enabled scored graphs require both fields on every region")
+            };
+            let mut trajectory = [0u8; SIG_WORDS * 8];
+            trajectory[..SIG_BYTES].copy_from_slice(&signature);
+            rout.extend_from_slice(&trajectory);
+            let mut metadata = [0u8; 8];
+            metadata[..2].copy_from_slice(&radius.to_le_bytes());
+            rout.extend_from_slice(&metadata);
+            node_flags.push(uor_r4_graph_format::NODE_FLAG_TRAJECTORY_ROUTE);
+        }
     }
 
     // NODE: the root record is all zeros; regions follow ascending id.
@@ -1740,11 +1781,11 @@ pub fn emit_scored_r4g1_with_bound_partition_cids(
         node_section.extend_from_slice(&forward_len[i].to_le_bytes());
         node_section.extend_from_slice(&emission_start[i].to_le_bytes());
         node_section.extend_from_slice(&emission_len[i].to_le_bytes());
-        node_section.extend_from_slice(&(1 + (i as u32) * sig_words).to_le_bytes());
-        node_section.extend_from_slice(&(1 + (node_count + i as u32) * sig_words).to_le_bytes());
+        node_section.extend_from_slice(&prototype_word_starts[index].to_le_bytes());
+        node_section.extend_from_slice(&mask_word_starts[index].to_le_bytes());
         node_section.extend_from_slice(&region.radius.to_le_bytes());
         node_section.push(region.depth);
-        node_section.push(0); // flags
+        node_section.push(node_flags[index]);
     }
 
     // EDGE: canonical records followed by the reverse index.
@@ -1944,6 +1985,8 @@ pub fn regions_from_cover(cover: &cover::Cover) -> Vec<RegionParams> {
             depth: region.depth,
             radius: region.radius,
             sig: region.sig,
+            trajectory_sig: region.trajectory_sig,
+            trajectory_radius: region.trajectory_radius,
             parent: region.parent,
         })
         .collect()
@@ -6613,6 +6656,7 @@ mod context_rows_tests {
                 sample: [0; 32],
                 vector: Vec::new(),
                 sig: [0; SIG_BYTES],
+                trajectory_sig: [0; SIG_BYTES],
                 prev: corpus.input[position],
                 next: corpus.next[position],
             })
@@ -6640,6 +6684,7 @@ mod context_rows_tests {
                 sample: [0; 32],
                 vector: Vec::new(),
                 sig: [0; SIG_BYTES],
+                trajectory_sig: [0; SIG_BYTES],
                 prev: corpus.input[position],
                 next: corpus.next[position],
             })

--- a/crates/uor-r4-graph-certify/src/score_runtime.rs
+++ b/crates/uor-r4-graph-certify/src/score_runtime.rs
@@ -141,7 +141,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
-use uor_r4_graph_format::{GraphView, ScoreQ, SectionId};
+use uor_r4_graph_format::{
+    trajectory_metadata_word_start, trajectory_prototype_word_start, GraphView, ScoreQ, SectionId,
+    NODE_FLAG_TRAJECTORY_ROUTE,
+};
 
 use uor_r4_core::transformerless::compiler::{self, Compiled, SIG_BYTES, STAGES};
 use uor_r4_core::transformerless::runtime::{self, OpKernel, Store};
@@ -198,6 +201,10 @@ pub struct RegionParams {
     pub radius: u16,
     /// Binarized prototype signature.
     pub sig: [u8; SIG_BYTES],
+    /// Optional full-prefix trajectory prototype carried by #946 artifacts.
+    pub trajectory_sig: Option<[u8; SIG_BYTES]>,
+    /// Calibrated radius for [`Self::trajectory_sig`].
+    pub trajectory_radius: Option<u16>,
     /// Parent region id (`None` at depth 1 — the parent is the root).
     pub parent: Option<u32>,
 }
@@ -243,6 +250,22 @@ pub fn regions_from_view(view: &GraphView) -> Option<Vec<RegionParams>> {
         let window = rout.get(start..start + signature_bytes)?;
         let mut sig = [0u8; SIG_BYTES];
         sig.copy_from_slice(window);
+        let (trajectory_sig, trajectory_radius) = if node.flags & NODE_FLAG_TRAJECTORY_ROUTE != 0 {
+            let prototype_word = trajectory_prototype_word_start(node, head.signature_words())?;
+            let prototype_start = (prototype_word as usize) << 3;
+            let prototype = rout.get(prototype_start..prototype_start + signature_bytes)?;
+            let mut signature = [0u8; SIG_BYTES];
+            signature.copy_from_slice(prototype);
+            let metadata_word = trajectory_metadata_word_start(node, head.signature_words())?;
+            let metadata_start = (metadata_word as usize) << 3;
+            let metadata = rout.get(metadata_start..metadata_start + 2)?;
+            (
+                Some(signature),
+                Some(u16::from_le_bytes([metadata[0], metadata[1]])),
+            )
+        } else {
+            (None, None)
+        };
         let parent =
             parent_of
                 .get(&node_index)
@@ -252,6 +275,8 @@ pub fn regions_from_view(view: &GraphView) -> Option<Vec<RegionParams>> {
             depth: node.depth.0,
             radius: node.radius.0,
             sig,
+            trajectory_sig,
+            trajectory_radius,
             parent,
         });
         node_index += 1;

--- a/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
+++ b/crates/uor-r4-graph-certify/tests/fwda_roundtrip.rs
@@ -35,6 +35,7 @@ fn observation(position: usize, corpus: &Corpus) -> Observation {
         sample: [0; 32],
         vector: Vec::new(),
         sig: [0; SIG_BYTES],
+        trajectory_sig: [0; SIG_BYTES],
         prev: corpus.input[position],
         next: corpus.next[position],
     }
@@ -150,6 +151,8 @@ fn tiny_artifact_emitted(
         depth: 1,
         radius: 0,
         sig: [0; SIG_BYTES],
+        trajectory_sig: None,
+        trajectory_radius: None,
         parent: None,
     }];
     let context_rows = vec![

--- a/crates/uor-r4-graph-certify/tests/skipmix_roundtrip.rs
+++ b/crates/uor-r4-graph-certify/tests/skipmix_roundtrip.rs
@@ -44,6 +44,8 @@ fn tiny_artifact(
         depth: 1,
         radius: 0,
         sig: [0; SIG_BYTES],
+        trajectory_sig: None,
+        trajectory_radius: None,
         parent: None,
     }];
     let context_rows = vec![ContextRow {

--- a/crates/uor-r4-graph-certify/tests/two_sided_context.rs
+++ b/crates/uor-r4-graph-certify/tests/two_sided_context.rs
@@ -558,6 +558,7 @@ fn two_sided_context_keying() {
             sample: [0; 32],
             vector: Vec::new(),
             sig: [0; SIG_BYTES],
+            trajectory_sig: [0; SIG_BYTES],
             prev: c.input[i],
             next: truth,
         });

--- a/crates/uor-r4-graph-cli/src/lib.rs
+++ b/crates/uor-r4-graph-cli/src/lib.rs
@@ -4670,6 +4670,7 @@ struct CoverOptions {
     min_support: usize,
     entropy_gain_bits: f64,
     radius_quantile: u32,
+    trajectory_routing: bool,
     output: PathBuf,
     /// Explicit stable mutation authority for a managed/canonical bundle.
     /// Without this flag, `--out` is always an arbitrary standalone root,
@@ -4711,6 +4712,7 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
         min_support: cover::DEFAULT_MIN_SUPPORT,
         entropy_gain_bits: cover::DEFAULT_SPLIT_ENTROPY_GAIN_BITS,
         radius_quantile: cover::RADIUS_QUANTILE_NUMERATOR,
+        trajectory_routing: false,
         output: PathBuf::from("cover"),
         bundle_root: None,
         source_manifest_kappa: None,
@@ -4726,6 +4728,11 @@ fn parse_cover_options(args: &[String]) -> Result<CoverOptions, SourceUnavailabl
             // the `emit_r4g1_with_provenance` call below), so this flag
             // is a no-op kept only for backward CLI compatibility with
             // phase 2a callers/scripts that already pass it.
+            index += 1;
+            continue;
+        }
+        if flag == "--trajectory-routing" {
+            options.trajectory_routing = true;
             index += 1;
             continue;
         }
@@ -5030,10 +5037,27 @@ fn cover_command_with_authority(
         &held_out_positions,
         config.threads as usize,
     );
-    let induced =
-        cover::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa).ok_or_else(|| {
+    let mut induced = cover::induce_cover(&train, &config, &artifact_kappa, &corpus_kappa)
+        .ok_or_else(|| {
             SourceUnavailable::new("cover induction needs at least one train observation")
         })?;
+    if options.trajectory_routing {
+        let attached = cover::attach_trajectory_routing(
+            &mut induced.cover,
+            &train,
+            config.radius_quantile_numerator,
+            config.radius_quantile_denominator,
+        );
+        if attached != induced.cover.regions.len() {
+            return Err(SourceUnavailable::new(format!(
+                "trajectory routing attached {attached} of {} regions",
+                induced.cover.regions.len()
+            )));
+        }
+        eprintln!(
+            "cover: attached calibrated full-trajectory prototypes to {attached} fixed-budget regions"
+        );
+    }
     let reference = cover::ReferenceClassifier::freeze(&induced.cover);
     eprintln!(
         "cover: {} regions across {} depth(s); evaluating held-out routing recall...",
@@ -10553,7 +10577,7 @@ fn transformerless_usage() -> &'static str {
                  markerless legacy attention copy (dense-present derivations are refused): copy-recorded-attention --corpus-meta <META> --corpus-recs <RECS> --out <attention_operator.json>\n\
                  guarded streaming corpus derivation (N <= source; complete runs may undershoot): subsample-recorded-corpus --src-meta <META> --src-recs <RECS> --out-meta <corpus.meta> --out-recs <corpus.records> --records <N>\n\
                  transformer-free refresh: runtime-corpus --artifacts <TLA> --store <TLS1> --seed-meta <META> --seed-recs <RECS> --out <DIR> --target N [--threads N]\n\
-                 graph cover: cover --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>]\n\
+                 graph cover: cover --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>] [--trajectory-routing]\n\
                  graph score: score --corpus-meta <META> --corpus-recs <RECS> --artifacts <TLA> --out <DIR> [--bundle-root <ROOT>] [--jobs N] [--quality-controls on|off]\n\
                    --bundle-root explicitly declares one managed/canonical bundle authority; without it, --out is an exact standalone root fixed at transaction start\n\
                  observation pipeline: observe [--source DIR [--tokenizer-family FAMILY --tokenizer-version N] | --checkpoint BIN] [--seconds N] [--target N] [--shards N] [--out DIR] [--sequence-length N]\n\

--- a/crates/uor-r4-graph-cli/tests/graph_infill_cli.rs
+++ b/crates/uor-r4-graph-cli/tests/graph_infill_cli.rs
@@ -24,6 +24,8 @@ fn tiny_artifact_bytes() -> Vec<u8> {
         depth: 1,
         radius: 0,
         sig: [0; SIG_BYTES],
+        trajectory_sig: None,
+        trajectory_radius: None,
         parent: None,
     }];
     let context_rows = vec![

--- a/crates/uor-r4-graph-compiler/Cargo.toml
+++ b/crates/uor-r4-graph-compiler/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 uor-r4-model-source = { version = "0.1.0", path = "../uor-r4-model-source" }
 uor-r4-graph-format = { version = "0.1.0", path = "../uor-r4-graph-format" }
 uor-r4-core = { version = "0.1.0", path = "../uor-r4-core" }
+uor-r4-router = { version = "0.1.0", path = "../uor-r4-router" }
 rayon = "1.10.0"
 libm = "0.2"
 blake3 = "1.5.0"

--- a/crates/uor-r4-graph-compiler/src/induction.rs
+++ b/crates/uor-r4-graph-compiler/src/induction.rs
@@ -127,6 +127,7 @@ use uor_r4_core::transformerless::compiler::{
     self, Corpus, D, SIG_BYTES, SIG_WORDS, STAGES, quantile_radius,
 };
 use uor_r4_core::transformerless::runtime;
+use uor_r4_router::TokenHistorySignature;
 
 #[inline]
 fn canonical_math_enabled() -> bool {
@@ -635,6 +636,9 @@ pub struct Observation {
     pub vector: Vec<f32>,
     /// `H(x)`: sign bits of the centered bundle (`runtime::sig_plain`).
     pub sig: [u8; SIG_BYTES],
+    /// Full in-story token trajectory through this position, encoded by the
+    /// exact fixed-size incremental signature production serving carries.
+    pub trajectory_sig: [u8; SIG_BYTES],
     /// Preceding token of this corpus position.
     pub prev: u32,
     /// Sampled next token of this corpus position.
@@ -658,7 +662,27 @@ pub fn build_observations(
     corpus: &Corpus,
     positions: &[usize],
 ) -> Vec<Observation> {
-    build_observations_serial(art, corpus, positions, None)
+    let trajectory = trajectory_signatures(corpus);
+    build_observations_serial(art, corpus, positions, &trajectory, None)
+}
+
+/// Full-prefix signatures for every corpus position in one ordered pass.
+/// State resets exactly when the recorded story id changes, matching the
+/// production seed/commit contract without rescanning any prefix.
+pub fn trajectory_signatures(corpus: &Corpus) -> Vec<[u8; SIG_BYTES]> {
+    let n = corpus.n.min(corpus.story.len()).min(corpus.input.len());
+    let mut signatures = Vec::with_capacity(n);
+    let mut current_story = None;
+    let mut state = TokenHistorySignature::new();
+    for position in 0..n {
+        if current_story != Some(corpus.story[position]) {
+            current_story = Some(corpus.story[position]);
+            state = TokenHistorySignature::new();
+        }
+        state.push(corpus.input[position]);
+        signatures.push(state.signature());
+    }
+    signatures
 }
 
 /// Build observations with bounded parallel extraction.
@@ -708,9 +732,11 @@ fn build_observations_with_threads_impl(
     if positions.is_empty() {
         return Vec::new();
     }
+    let trajectory = trajectory_signatures(corpus);
+    let trajectory = trajectory.as_slice();
     let worker_count = threads.max(1).min(positions.len());
     if worker_count == 1 {
-        return build_observations_serial(art, corpus, positions, completed);
+        return build_observations_serial(art, corpus, positions, trajectory, completed);
     }
     let chunk_size = positions.len().div_ceil(worker_count);
     let mut chunks = Vec::with_capacity(worker_count);
@@ -719,7 +745,9 @@ fn build_observations_with_threads_impl(
         for (chunk_id, shard) in positions.chunks(chunk_size).enumerate() {
             handles.push((
                 chunk_id,
-                scope.spawn(move || build_observations_serial(art, corpus, shard, completed)),
+                scope.spawn(move || {
+                    build_observations_serial(art, corpus, shard, trajectory, completed)
+                }),
             ));
         }
         for (chunk_id, handle) in handles {
@@ -744,6 +772,7 @@ fn build_observations_serial(
     art: &compiler::Compiled,
     corpus: &Corpus,
     positions: &[usize],
+    trajectory: &[[u8; SIG_BYTES]],
     completed: Option<&AtomicUsize>,
 ) -> Vec<Observation> {
     let rot = compiler::derive_rotations();
@@ -791,6 +820,7 @@ fn build_observations_serial(
             sample: sample_id(&context_window(corpus, i)),
             vector,
             sig,
+            trajectory_sig: trajectory.get(i).copied().unwrap_or([0; SIG_BYTES]),
             prev: corpus.input[i],
             next: corpus.next[i],
         });
@@ -1524,6 +1554,11 @@ pub struct CoverRegion {
     /// Calibrated acceptance radius: the configured percentile of member
     /// masked-Hamming distances (all-ones mask in v1).
     pub radius: u16,
+    /// Optional full-trajectory prototype for this same semantic region.
+    /// `None` preserves the legacy context-only wire layout exactly.
+    pub trajectory_sig: Option<[u8; SIG_BYTES]>,
+    /// Calibrated masked-Hamming radius for [`Self::trajectory_sig`].
+    pub trajectory_radius: Option<u16>,
     /// Train members assigned to this region (top-1).
     pub support: u32,
     /// Within-region next-token entropy in bits (train members).
@@ -1569,6 +1604,13 @@ impl Cover {
             }
             hasher.update(&region.sig);
             hasher.update(&region.radius.to_le_bytes());
+            if let (Some(signature), Some(radius)) =
+                (region.trajectory_sig, region.trajectory_radius)
+            {
+                hasher.update(b"trajectory-route-v1");
+                hasher.update(&signature);
+                hasher.update(&radius.to_le_bytes());
+            }
         }
         format!("blake3:{}", hasher.finalize().to_hex())
     }
@@ -1740,6 +1782,8 @@ pub fn induce_cover(
             sig: binarize_prototype(centroid),
             prototype: centroid.clone(),
             radius: 0, // calibrated below
+            trajectory_sig: None,
+            trajectory_radius: None,
             support: members.len() as u32,
             entropy_bits: entropy,
             split_gain_bits: 0.0,
@@ -1874,6 +1918,8 @@ pub fn induce_cover(
                 sig: binarize_prototype(centroid),
                 prototype: centroid.clone(),
                 radius: 0,
+                trajectory_sig: None,
+                trajectory_radius: None,
                 support: members.len() as u32,
                 entropy_bits: entropy,
                 split_gain_bits: 0.0,
@@ -1913,6 +1959,60 @@ pub fn induce_cover(
         batch_size,
         decision_trace,
     })
+}
+
+/// Attach one calibrated full-trajectory prototype to every non-empty cover
+/// region without changing region membership, node count, edges, or emission
+/// budgets. The prototype is the deterministic per-bit majority of member
+/// trajectory signatures (ties remain zero); the radius uses the identical
+/// configured quantile contract as context routing.
+pub fn attach_trajectory_routing(
+    cover: &mut Cover,
+    observations: &[Observation],
+    radius_quantile_numerator: u32,
+    radius_quantile_denominator: u32,
+) -> usize {
+    let mut attached = 0usize;
+    for (region_index, region) in cover.regions.iter_mut().enumerate() {
+        let Some(members) = cover.members.get(region_index) else {
+            continue;
+        };
+        if members.is_empty() {
+            continue;
+        }
+        let mut ones = [0u32; D];
+        let mut member_signatures = Vec::with_capacity(members.len());
+        for &member in members {
+            let Some(observation) = observations.get(member) else {
+                continue;
+            };
+            let signature = observation.trajectory_sig;
+            for bit in 0..D {
+                ones[bit] += u32::from(signature[bit / 8] & (1 << (bit % 8)) != 0);
+            }
+            member_signatures.push(signature);
+        }
+        if member_signatures.is_empty() {
+            continue;
+        }
+        let mut prototype = [0u8; SIG_BYTES];
+        let member_count = member_signatures.len() as u32;
+        for (bit, &count) in ones.iter().enumerate() {
+            if count.saturating_mul(2) > member_count {
+                prototype[bit / 8] |= 1 << (bit % 8);
+            }
+        }
+        let radius = calibrate_region_radius_with_quantile(
+            &member_signatures,
+            &prototype,
+            radius_quantile_numerator,
+            radius_quantile_denominator,
+        );
+        region.trajectory_sig = Some(prototype);
+        region.trajectory_radius = Some(radius);
+        attached += 1;
+    }
+    attached
 }
 
 /// One canonical edge of the cover graph.
@@ -2423,22 +2523,68 @@ fn emit_r4g1_inner(
         rout.push(0x00);
     }
 
-    let prototype_words_start = (rout.len() / 8) as u32;
-    let sig_words = SIG_WORDS as u32;
+    let mut prototype_word_starts = Vec::with_capacity(node_total);
+    let mut mask_word_starts = Vec::with_capacity(node_total);
+    let mut node_flags = Vec::with_capacity(node_total);
+    let has_trajectory_routes = cover
+        .regions
+        .iter()
+        .any(|region| region.trajectory_sig.is_some() || region.trajectory_radius.is_some());
 
-    rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root prototype
-    for region in &cover.regions {
-        let mut words = [0u8; SIG_WORDS * 8];
-        words[..SIG_BYTES].copy_from_slice(&region.sig);
-        rout.extend_from_slice(&words);
-    }
+    if !has_trajectory_routes {
+        // Preserve the historical banked v0 layout byte-for-byte.
+        let prototype_words_start = (rout.len() / 8) as u32;
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]);
+        for region in &cover.regions {
+            let mut words = [0u8; SIG_WORDS * 8];
+            words[..SIG_BYTES].copy_from_slice(&region.sig);
+            rout.extend_from_slice(&words);
+        }
+        let mask_words_start = (rout.len() / 8) as u32;
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]);
+        for _ in &cover.regions {
+            let mut words = [0u8; SIG_WORDS * 8];
+            words[..SIG_BYTES].fill(0xFF);
+            rout.extend_from_slice(&words);
+        }
+        for index in 0..node_total {
+            prototype_word_starts.push(prototype_words_start + index as u32 * SIG_WORDS as u32);
+            mask_word_starts.push(mask_words_start + index as u32 * SIG_WORDS as u32);
+            node_flags.push(0);
+        }
+    } else {
+        // Root retains the context-only v0 fields. Region records use
+        // self-contained blocks so the trajectory prototype and metadata are
+        // derivable from the existing mask pointer without widening NODE.
+        prototype_word_starts.push((rout.len() / 8) as u32);
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]);
+        mask_word_starts.push((rout.len() / 8) as u32);
+        rout.extend_from_slice(&[0u8; SIG_WORDS * 8]);
+        node_flags.push(0u8);
 
-    let mask_words_start = (rout.len() / 8) as u32;
-    rout.extend_from_slice(&[0u8; SIG_WORDS * 8]); // root mask
-    for _ in &cover.regions {
-        let mut words = [0u8; SIG_WORDS * 8];
-        words[..SIG_BYTES].fill(0xFF);
-        rout.extend_from_slice(&words);
+        for region in &cover.regions {
+            prototype_word_starts.push((rout.len() / 8) as u32);
+            let mut context_words = [0u8; SIG_WORDS * 8];
+            context_words[..SIG_BYTES].copy_from_slice(&region.sig);
+            rout.extend_from_slice(&context_words);
+
+            mask_word_starts.push((rout.len() / 8) as u32);
+            let mut mask_words = [0u8; SIG_WORDS * 8];
+            mask_words[..SIG_BYTES].fill(0xFF);
+            rout.extend_from_slice(&mask_words);
+
+            let (Some(signature), Some(radius)) = (region.trajectory_sig, region.trajectory_radius)
+            else {
+                panic!("trajectory-enabled covers require every region to carry both fields")
+            };
+            let mut trajectory_words = [0u8; SIG_WORDS * 8];
+            trajectory_words[..SIG_BYTES].copy_from_slice(&signature);
+            rout.extend_from_slice(&trajectory_words);
+            let mut metadata = [0u8; 8];
+            metadata[..2].copy_from_slice(&radius.to_le_bytes());
+            rout.extend_from_slice(&metadata);
+            node_flags.push(uor_r4_graph_format::NODE_FLAG_TRAJECTORY_ROUTE);
+        }
     }
 
     // EMIT: descriptor + the v0 linear-count root prior block + region token residuals.
@@ -2529,11 +2675,11 @@ fn emit_r4g1_inner(
     node_section.extend_from_slice(&0u16.to_le_bytes()); // forward_len
     node_section.extend_from_slice(&emission_starts[0].to_le_bytes());
     node_section.extend_from_slice(&emission_lens[0].to_le_bytes());
-    node_section.extend_from_slice(&0u32.to_le_bytes()); // prototype_words_start
-    node_section.extend_from_slice(&0u32.to_le_bytes()); // mask_words_start
+    node_section.extend_from_slice(&prototype_word_starts[0].to_le_bytes());
+    node_section.extend_from_slice(&mask_word_starts[0].to_le_bytes());
     node_section.extend_from_slice(&0u16.to_le_bytes()); // radius
     node_section.push(0); // depth
-    node_section.push(0); // flags
+    node_section.push(node_flags[0]);
     for (index, region) in cover.regions.iter().enumerate() {
         let i = 1 + index;
         node_section.extend_from_slice(&child_start[i].to_le_bytes());
@@ -2542,12 +2688,11 @@ fn emit_r4g1_inner(
         node_section.extend_from_slice(&forward_len[i].to_le_bytes());
         node_section.extend_from_slice(&emission_starts[i].to_le_bytes());
         node_section.extend_from_slice(&emission_lens[i].to_le_bytes());
-        node_section
-            .extend_from_slice(&(prototype_words_start + (i as u32) * sig_words).to_le_bytes());
-        node_section.extend_from_slice(&(mask_words_start + (i as u32) * sig_words).to_le_bytes());
+        node_section.extend_from_slice(&prototype_word_starts[i].to_le_bytes());
+        node_section.extend_from_slice(&mask_word_starts[i].to_le_bytes());
         node_section.extend_from_slice(&region.radius.to_le_bytes());
         node_section.push(region.depth);
-        node_section.push(0); // flags
+        node_section.push(node_flags[i]);
     }
 
     // EDGE: canonical records (score_q 0 — v1 carries no log-domain edge

--- a/crates/uor-r4-graph-compiler/src/quantum_cover.rs
+++ b/crates/uor-r4-graph-compiler/src/quantum_cover.rs
@@ -238,6 +238,7 @@ mod tests {
                 sample: [0u8; 32],
                 vector: Vec::new(),
                 sig: [0u8; SIG_BYTES],
+                trajectory_sig: [0u8; SIG_BYTES],
                 prev: 0,
                 next: if i < 50 { 1 } else { 2 },
             })

--- a/crates/uor-r4-graph-compiler/src/routing.rs
+++ b/crates/uor-r4-graph-compiler/src/routing.rs
@@ -390,6 +390,8 @@ mod tests {
                 prototype: vec![0.0; D],
                 sig,
                 radius,
+                trajectory_sig: None,
+                trajectory_radius: None,
                 support: 64 + id,
                 entropy_bits: 0.0,
                 split_gain_bits: 0.0,
@@ -420,6 +422,7 @@ mod tests {
                     sample: [i as u8; 32],
                     vector: vec![0.0; D],
                     sig,
+                    trajectory_sig: sig,
                     prev: i % 7,
                     next: (i * 3) % 11,
                 }

--- a/crates/uor-r4-graph-compiler/tests/induction.rs
+++ b/crates/uor-r4-graph-compiler/tests/induction.rs
@@ -17,7 +17,11 @@ use uor_r4_graph_compiler::induction::{
     EDGE_KIND_TRANSITION, Observation,
 };
 use uor_r4_graph_compiler::observation as observe;
-use uor_r4_graph_format::{GraphView, SectionId};
+use uor_r4_graph_format::{
+    GraphView, NODE_FLAG_TRAJECTORY_ROUTE, SectionId, trajectory_metadata_word_start,
+    trajectory_prototype_word_start,
+};
+use uor_r4_router::TokenHistorySignature;
 
 // ------------------------------------------------------- synthetic data --
 
@@ -119,6 +123,7 @@ fn synthetic_observations() -> (Vec<Observation>, Vec<usize>) {
                 sample: blake3::hash(&position.to_le_bytes()).into(),
                 vector,
                 sig,
+                trajectory_sig: sig,
                 prev: 0,
                 next,
             });
@@ -181,6 +186,8 @@ fn hand_region(id: u32, depth: u8, sig: [u8; SIG_BYTES], radius: u16) -> CoverRe
         prototype: vec![0.0; D],
         sig,
         radius,
+        trajectory_sig: None,
+        trajectory_radius: None,
         support: 0,
         entropy_bits: 0.0,
         split_gain_bits: 0.0,
@@ -940,6 +947,91 @@ fn r4g1_artifact_validates_and_reproduces() {
     assert!(view.section(SectionId::EXCT).is_none());
 }
 
+#[test]
+fn trajectory_routes_pack_deterministically_under_an_equal_control_budget() {
+    let (observations, _) = synthetic_observations();
+    let mut treatment = induce_synthetic(&observations, &synthetic_config()).cover;
+    assert_eq!(
+        cover::attach_trajectory_routing(&mut treatment, &observations, 95, 100),
+        treatment.regions.len()
+    );
+    let mut control = treatment.clone();
+    for region in &mut control.regions {
+        region.trajectory_sig = Some(region.sig);
+        region.trajectory_radius = Some(region.radius);
+    }
+    let edges = cover::build_edges(
+        &treatment,
+        &cover::ReferenceClassifier::freeze(&treatment),
+        &observations,
+        &vec![0; 10_000],
+    );
+    let prior = cover::root_prior(&observations);
+    let emit = |candidate: &Cover| {
+        cover::emit_r4g1(
+            b"trajectory-routing-test-artifact",
+            (b"synthetic-meta", b"synthetic-recs"),
+            64,
+            candidate,
+            &edges,
+            &prior,
+            &observations,
+        )
+        .expect("trajectory artifact emits")
+    };
+    let (treatment_bytes, treatment_info) = emit(&treatment);
+    let (treatment_again, _) = emit(&treatment);
+    let (control_bytes, control_info) = emit(&control);
+    assert_eq!(
+        treatment_bytes, treatment_again,
+        "double compilation identity"
+    );
+    assert_eq!(treatment_info.node_count, control_info.node_count);
+    assert_eq!(treatment_info.edge_count, control_info.edge_count);
+    assert_eq!(treatment_info.artifact_bytes, control_info.artifact_bytes);
+
+    let treatment_view = GraphView::parse(&treatment_bytes).expect("treatment validates");
+    let control_view = GraphView::parse(&control_bytes).expect("control validates");
+    assert_eq!(
+        treatment_view.section(SectionId::EMIT),
+        control_view.section(SectionId::EMIT),
+        "trajectory treatment cannot buy an effect with a larger emission budget"
+    );
+    assert_eq!(
+        treatment_view.section(SectionId::ROUT).map(<[u8]>::len),
+        control_view.section(SectionId::ROUT).map(<[u8]>::len),
+        "the treatment and control use the same ROUT ceiling"
+    );
+    let head = treatment_view.head().expect("HEAD");
+    let rout = treatment_view.section(SectionId::ROUT).expect("ROUT");
+    for region in &treatment.regions {
+        let node = treatment_view
+            .node(cover::region_node_id(region.id))
+            .expect("region node");
+        assert_eq!(
+            node.flags & NODE_FLAG_TRAJECTORY_ROUTE,
+            NODE_FLAG_TRAJECTORY_ROUTE
+        );
+        let prototype_word = trajectory_prototype_word_start(node, head.signature_words())
+            .expect("trajectory prototype pointer");
+        let prototype_start = prototype_word as usize * 8;
+        assert_eq!(
+            &rout[prototype_start..prototype_start + SIG_BYTES],
+            region
+                .trajectory_sig
+                .as_ref()
+                .expect("trajectory prototype")
+        );
+        let metadata_word = trajectory_metadata_word_start(node, head.signature_words())
+            .expect("trajectory metadata pointer");
+        let metadata_start = metadata_word as usize * 8;
+        assert_eq!(
+            u16::from_le_bytes([rout[metadata_start], rout[metadata_start + 1]]),
+            region.trajectory_radius.expect("trajectory radius")
+        );
+    }
+}
+
 /// #637 phase 2: `emit_r4g1_with_provenance` is additive-only. Its `None`
 /// sibling ([`cover::emit_r4g1_with_tokenizer_cid`]) stays byte-identical
 /// (no PROV section, no pinned κ fixture affected); a caller that opts in
@@ -1087,6 +1179,7 @@ fn entropy_reduction_matches_hand_computation() {
         sample: [0u8; 32],
         vector: vec![0.0; D],
         sig: [0u8; SIG_BYTES],
+        trajectory_sig: [0u8; SIG_BYTES],
         prev: 0,
         next,
     };
@@ -1124,6 +1217,7 @@ fn objective_decomposition_and_tie_breaking_are_deterministic() {
             sample: [position as u8; 32],
             vector,
             sig,
+            trajectory_sig: sig,
             prev: position.saturating_sub(1),
             next,
         }
@@ -1325,6 +1419,43 @@ fn context_window_respects_story_boundaries_and_width() {
     assert_eq!(
         observe::sample_id(&cover::context_window(&corpus, 9)),
         observe::sample_id(&(2..=9).collect::<Vec<u32>>())
+    );
+}
+
+#[test]
+fn trajectory_signatures_match_production_prefixes_and_reset_per_story() {
+    let corpus = Corpus {
+        n: 7,
+        stories: 2,
+        story: vec![0, 0, 0, 0, 1, 1, 1],
+        input: vec![11, 12, 13, 14, 91, 92, 93],
+        next: vec![0; 7],
+        t_argmax: vec![0; 7],
+        top_tokens: vec![[0; 8]; 7],
+        top_weights: vec![[0; 8]; 7],
+        span_start: vec![0; 7],
+        span_end: vec![0; 7],
+        byte_start: vec![0; 7],
+        byte_end: vec![0; 7],
+        hidden: None,
+    };
+    let signatures = cover::trajectory_signatures(&corpus);
+    for position in 0..4 {
+        assert_eq!(
+            signatures[position],
+            TokenHistorySignature::from_tokens(&corpus.input[..=position]).signature()
+        );
+    }
+    for position in 4..7 {
+        assert_eq!(
+            signatures[position],
+            TokenHistorySignature::from_tokens(&corpus.input[4..=position]).signature()
+        );
+    }
+    assert_eq!(
+        signatures[4],
+        TokenHistorySignature::from_tokens(&[91]).signature(),
+        "the second story must not inherit the first story's trajectory"
     );
 }
 

--- a/crates/uor-r4-graph-format/src/error.rs
+++ b/crates/uor-r4-graph-format/src/error.rs
@@ -22,6 +22,10 @@ pub enum RangeField {
     Prototype,
     /// `mask_word_start` into the ROUT section (u64 words).
     Mask,
+    /// Flagged full-trajectory prototype in the ROUT section.
+    TrajectoryPrototype,
+    /// Flagged full-trajectory metadata word in the ROUT section.
+    TrajectoryMetadata,
 }
 
 impl fmt::Display for RangeField {
@@ -32,6 +36,8 @@ impl fmt::Display for RangeField {
             RangeField::Emission => "emission",
             RangeField::Prototype => "prototype",
             RangeField::Mask => "mask",
+            RangeField::TrajectoryPrototype => "trajectory prototype",
+            RangeField::TrajectoryMetadata => "trajectory metadata",
         };
         write!(f, "{name}")
     }
@@ -178,6 +184,11 @@ pub enum FormatError {
         /// Actual NODE section length in bytes.
         section_len: u64,
     },
+    /// A NODE record sets flag bits unknown to this format version.
+    UnknownNodeFlags { node: u32, flags: u8 },
+    /// A trajectory-route metadata word has non-zero reserved bytes or a
+    /// radius wider than the declared signature.
+    InvalidTrajectoryRouteMetadata { node: u32 },
     /// HEAD declares `edge_count > 0` but the EDGE section is absent.
     MissingEdgeSection,
     /// EDGE section byte length ≠ `edge_count × (16 + 4)` — canonical
@@ -763,6 +774,14 @@ impl fmt::Display for FormatError {
             } => write!(
                 f,
                 "NODE section holds {section_len} bytes, not node_count {declared} x 30"
+            ),
+            FormatError::UnknownNodeFlags { node, flags } => write!(
+                f,
+                "NODE record {node} sets unknown flag bits 0x{flags:02x}"
+            ),
+            FormatError::InvalidTrajectoryRouteMetadata { node } => write!(
+                f,
+                "NODE record {node} has invalid trajectory-route metadata"
             ),
             FormatError::MissingEdgeSection => {
                 write!(f, "HEAD declares edge_count > 0 but the EDGE section is absent")

--- a/crates/uor-r4-graph-format/src/lib.rs
+++ b/crates/uor-r4-graph-format/src/lib.rs
@@ -146,8 +146,9 @@ pub use pstate::{
     PSTATE_HEADER_LEN, PSTATE_MAGIC, PSTATE_ROW_LEN, PSTATE_VERSION,
 };
 pub use records::{
-    EdgeKind, PackedEdge, PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, PACKED_EDGE_LEN,
-    PACKED_NODE_LEN, STORAGE_DESCRIPTOR_LEN,
+    trajectory_metadata_word_start, trajectory_prototype_word_start, EdgeKind, PackedEdge,
+    PackedNode, StorageDescriptor, EDGE_KIND_OPTIONAL_BIT, NODE_FLAGS_KNOWN,
+    NODE_FLAG_TRAJECTORY_ROUTE, PACKED_EDGE_LEN, PACKED_NODE_LEN, STORAGE_DESCRIPTOR_LEN,
 };
 pub use rout::{OP_HALT, OP_JMP_FWD, OP_LEAF, OP_TEST_POPCOUNT_LE};
 #[cfg(feature = "alloc")]

--- a/crates/uor-r4-graph-format/src/records.rs
+++ b/crates/uor-r4-graph-format/src/records.rs
@@ -94,6 +94,17 @@ pub const fn is_optional_edge_kind(kind: u8) -> bool {
 
 /// Packed node record size in bytes.
 pub const PACKED_NODE_LEN: usize = 30;
+/// NODE flag: this region carries a second, full-trajectory prototype and
+/// calibrated radius immediately after its context mask in ROUT.
+///
+/// Layout for a flagged node, in u64 words, is:
+/// `context prototype[W] | context mask[W] | trajectory prototype[W] |
+/// trajectory metadata[1]`. The metadata word stores a little-endian `u16`
+/// radius followed by six zero reserved bytes. Legacy flag-zero nodes retain
+/// the original v0 layout and semantics.
+pub const NODE_FLAG_TRAJECTORY_ROUTE: u8 = 0x01;
+/// Every NODE flag bit understood by this format version.
+pub const NODE_FLAGS_KNOWN: u8 = NODE_FLAG_TRAJECTORY_ROUTE;
 /// Packed canonical edge record size in bytes.
 pub const PACKED_EDGE_LEN: usize = 16;
 /// Reverse-index entry size: one u32 edge ID per canonical edge.
@@ -148,8 +159,29 @@ pub struct PackedNode {
     pub radius: Radius,
     /// Multiresolution depth; must be < HEAD `depth_count`.
     pub depth: Depth,
-    /// Per-node flags (no bits defined in v0).
+    /// Per-node flags. [`NODE_FLAG_TRAJECTORY_ROUTE`] declares the optional
+    /// full-trajectory ROUT prototype/radius extension.
     pub flags: u8,
+}
+
+/// First u64 word of a flagged node's trajectory prototype.
+pub const fn trajectory_prototype_word_start(
+    node: PackedNode,
+    signature_words: u16,
+) -> Option<u32> {
+    if node.flags & NODE_FLAG_TRAJECTORY_ROUTE == 0 {
+        return None;
+    }
+    node.mask_word_start.checked_add(signature_words as u32)
+}
+
+/// u64 word containing a flagged node's trajectory radius metadata.
+pub const fn trajectory_metadata_word_start(node: PackedNode, signature_words: u16) -> Option<u32> {
+    let prototype = match trajectory_prototype_word_start(node, signature_words) {
+        Some(value) => value,
+        None => return None,
+    };
+    prototype.checked_add(signature_words as u32)
 }
 
 /// One packed canonical edge (16 bytes little-endian):

--- a/crates/uor-r4-graph-format/src/stage2.rs
+++ b/crates/uor-r4-graph-format/src/stage2.rs
@@ -29,8 +29,9 @@ use crate::error::{BoundKind, EdgePayloadField, FormatError, RangeField};
 use crate::head::{Head, FEATURE_EDGE_ALGEBRA_V1, KNOWN_FEATURE_BITS_REQUIRED};
 use crate::header::read_u32_le;
 use crate::records::{
-    self, is_optional_edge_kind, EdgeKind, StorageDescriptor, PACKED_EDGE_LEN, PACKED_NODE_LEN,
-    REVERSE_INDEX_ENTRY_LEN, STORAGE_DESCRIPTOR_LEN,
+    self, is_optional_edge_kind, trajectory_metadata_word_start, trajectory_prototype_word_start,
+    EdgeKind, StorageDescriptor, NODE_FLAGS_KNOWN, NODE_FLAG_TRAJECTORY_ROUTE, PACKED_EDGE_LEN,
+    PACKED_NODE_LEN, REVERSE_INDEX_ENTRY_LEN, STORAGE_DESCRIPTOR_LEN,
 };
 use crate::rout;
 use crate::types::SectionId;
@@ -152,6 +153,13 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, crate::NotAProd
             // The section size was validated above, so the record is
             // in bounds.
             let node = records::decode_node(&bytes[i as usize * PACKED_NODE_LEN..]);
+            if node.flags & !NODE_FLAGS_KNOWN != 0 {
+                return Err((FormatError::UnknownNodeFlags {
+                    node: i,
+                    flags: node.flags & !NODE_FLAGS_KNOWN,
+                })
+                .into());
+            }
             let child_end = u64::from(node.child_start) + u64::from(node.child_len);
             if child_end > u64::from(head.edge_count()) {
                 return Err((FormatError::RangeOutOfBounds {
@@ -193,6 +201,52 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, crate::NotAProd
                 })
                 .into());
             }
+            if node.flags & NODE_FLAG_TRAJECTORY_ROUTE != 0 {
+                let Some(trajectory_start) =
+                    trajectory_prototype_word_start(node, head.signature_words())
+                else {
+                    return Err((FormatError::RangeOutOfBounds {
+                        node: i,
+                        field: RangeField::TrajectoryPrototype,
+                    })
+                    .into());
+                };
+                let Some(metadata_start) =
+                    trajectory_metadata_word_start(node, head.signature_words())
+                else {
+                    return Err((FormatError::RangeOutOfBounds {
+                        node: i,
+                        field: RangeField::TrajectoryMetadata,
+                    })
+                    .into());
+                };
+                if u64::from(trajectory_start) + signature_words > rout_words {
+                    return Err((FormatError::RangeOutOfBounds {
+                        node: i,
+                        field: RangeField::TrajectoryPrototype,
+                    })
+                    .into());
+                }
+                if u64::from(metadata_start) + 1 > rout_words {
+                    return Err((FormatError::RangeOutOfBounds {
+                        node: i,
+                        field: RangeField::TrajectoryMetadata,
+                    })
+                    .into());
+                }
+                let rout = rout_bytes.ok_or(FormatError::RangeOutOfBounds {
+                    node: i,
+                    field: RangeField::TrajectoryMetadata,
+                })?;
+                let metadata_begin = metadata_start as usize * 8;
+                let metadata = &rout[metadata_begin..metadata_begin + 8];
+                let trajectory_radius = u16::from_le_bytes([metadata[0], metadata[1]]);
+                if metadata[2..].iter().any(|&byte| byte != 0)
+                    || u32::from(trajectory_radius) > u32::from(head.signature_bytes()) * 8
+                {
+                    return Err((FormatError::InvalidTrajectoryRouteMetadata { node: i }).into());
+                }
+            }
             // Zero-padding rule (RFC §4.1): with word-aligned storage of
             // a byte-exact signature, the bytes between the signature
             // and the end of every validated prototype/mask window must
@@ -214,6 +268,26 @@ pub(crate) fn validate(view: &GraphView) -> Result<Option<Head>, crate::NotAProd
                             return Err(
                                 (FormatError::NonZeroSignaturePadding { node: i, field }).into()
                             );
+                        }
+                    }
+                    if let Some(word_start) =
+                        trajectory_prototype_word_start(node, head.signature_words())
+                    {
+                        let begin = word_start as usize * 8 + signature_bytes;
+                        let end = word_start as usize * 8 + storage_bytes;
+                        let Some(padding) = rout.get(begin..end) else {
+                            return Err((FormatError::RangeOutOfBounds {
+                                node: i,
+                                field: RangeField::TrajectoryPrototype,
+                            })
+                            .into());
+                        };
+                        if padding.iter().any(|&byte| byte != 0) {
+                            return Err((FormatError::NonZeroSignaturePadding {
+                                node: i,
+                                field: RangeField::TrajectoryPrototype,
+                            })
+                            .into());
                         }
                     }
                 }

--- a/crates/uor-r4-graph-format/tests/stage2.rs
+++ b/crates/uor-r4-graph-format/tests/stage2.rs
@@ -13,6 +13,7 @@ use common::{
 use uor_r4_graph_format::{
     ArtifactBuilder, BoundKind, Depth, EdgeKind, EdgePayloadField, FormatError, GraphView,
     KappaError, NodeId, Radius, RangeField, ScoreQ, SectionId, FEATURE_EDGE_ALGEBRA_V1, HEADER_LEN,
+    NODE_FLAG_TRAJECTORY_ROUTE,
 };
 
 /// The happy-path packed node records: two nodes whose ranges resolve
@@ -892,10 +893,87 @@ fn word_aligned_fixture() -> Fixture {
     }
 }
 
+fn trajectory_route_fixture() -> Fixture {
+    let mut fixture = word_aligned_fixture();
+    let nodes = [NodeFields {
+        prototype_word_start: 1,
+        mask_word_start: 6,
+        radius: 9,
+        depth: 1,
+        flags: NODE_FLAG_TRAJECTORY_ROUTE,
+        ..NodeFields::default()
+    }];
+    fixture.nodes = Some(node_section(&nodes));
+    let mut rout = fixture.rout.take().expect("ROUT fixture");
+    let mut trajectory = [0u8; 40];
+    trajectory[..36].fill(0xA5);
+    rout.extend_from_slice(&trajectory);
+    let mut metadata = [0u8; 8];
+    metadata[..2].copy_from_slice(&17u16.to_le_bytes());
+    rout.extend_from_slice(&metadata);
+    fixture.rout = Some(rout);
+    fixture
+}
+
 #[test]
 fn word_aligned_signature_storage_parses() {
     let bytes = word_aligned_fixture().build();
     GraphView::parse(&bytes).expect("36-byte signature in 5 words must parse");
+}
+
+#[test]
+fn trajectory_route_extension_parses() {
+    GraphView::parse(&trajectory_route_fixture().build())
+        .expect("flagged trajectory prototype and metadata must parse");
+}
+
+#[test]
+fn reject_unknown_node_lane_flag() {
+    let mut fixture = word_aligned_fixture();
+    let nodes = [NodeFields {
+        prototype_word_start: 1,
+        mask_word_start: 6,
+        depth: 1,
+        flags: 0x80,
+        ..NodeFields::default()
+    }];
+    fixture.nodes = Some(node_section(&nodes));
+    assert_eq!(
+        err_of(&fixture.build()),
+        FormatError::UnknownNodeFlags {
+            node: 0,
+            flags: 0x80,
+        }
+    );
+}
+
+#[test]
+fn reject_invalid_trajectory_route_metadata() {
+    let mut fixture = trajectory_route_fixture();
+    let mut rout = fixture.rout.take().expect("ROUT fixture");
+    let metadata_start = rout.len() - 8;
+    rout[metadata_start + 2] = 1;
+    fixture.rout = Some(rout);
+    assert_eq!(
+        err_of(&fixture.build()),
+        FormatError::InvalidTrajectoryRouteMetadata { node: 0 }
+    );
+}
+
+#[test]
+fn reject_nonzero_trajectory_prototype_padding() {
+    let mut fixture = trajectory_route_fixture();
+    let mut rout = fixture.rout.take().expect("ROUT fixture");
+    // word 11 starts the 40-byte trajectory prototype; byte 36 is padding.
+    rout[11 * 8 + 36] = 1;
+    fixture.rout = Some(rout);
+    assert_eq!(
+        err_of(&fixture.build()),
+        FormatError::NonZeroSignaturePadding {
+            node: 0,
+            field: RangeField::TrajectoryPrototype,
+        }
+    );
 }
 
 #[test]

--- a/crates/uor-r4-graph-runtime/src/engine.rs
+++ b/crates/uor-r4-graph-runtime/src/engine.rs
@@ -4,7 +4,10 @@ use crate::status::ResolutionStatus;
 use crate::vp_tree::{MIN_ROUTE_INDEX_NODES, VpTree};
 use uor_r4_graph_format::{CODE_OP_HALT, OP_CLEAR_SLOT, OP_SHIFT_SLOTS, OP_UPDATE_SLOT};
 use uor_r4_graph_format::{FormatError, PsiBagTable, ScoreQ, SkipmixTable};
-use uor_r4_graph_format::{GraphView, NotAProduct, SectionId};
+use uor_r4_graph_format::{
+    GraphView, NODE_FLAG_TRAJECTORY_ROUTE, NotAProduct, SectionId, trajectory_metadata_word_start,
+    trajectory_prototype_word_start,
+};
 
 /// Fixed width of the normative served-candidate shortlist.
 pub const SERVED_CANDIDATE_CAPACITY: usize = 8;
@@ -112,9 +115,17 @@ pub enum SignatureRoutingSource {
     SuffixDfa,
     ContextSignature,
     SessionSignature,
+    /// Context and full-trajectory probes both supplied bounded active nodes.
+    ComposedSignatures,
     NearestContextSignature,
     NearestSessionSignature,
     DefaultNode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteProbeLane {
+    Context,
+    Trajectory,
 }
 
 impl ServedCandidates {
@@ -163,6 +174,8 @@ impl Default for ServedCandidates {
 pub struct R4G1Runtime<'a> {
     chain: crate::patch_chain::PatchChain<'a>,
     route_index: Option<VpTree>,
+    trajectory_route_index: Option<VpTree>,
+    has_trajectory_routes: bool,
     skipmix: Option<SkipmixTable<'a>>,
     psi_bag: Option<PsiBagTable<'a>>,
 }
@@ -265,9 +278,18 @@ impl<'a> R4G1Runtime<'a> {
         let route_index = (view.node_count().unwrap_or(0) >= MIN_ROUTE_INDEX_NODES)
             .then(|| VpTree::from_graph(&view))
             .flatten();
+        let has_trajectory_routes = view
+            .nodes()
+            .any(|node| node.flags & NODE_FLAG_TRAJECTORY_ROUTE != 0);
+        let trajectory_route_index = (has_trajectory_routes
+            && view.node_count().unwrap_or(0) >= MIN_ROUTE_INDEX_NODES)
+            .then(|| VpTree::from_trajectory_graph(&view))
+            .flatten();
         Ok(Self {
             chain: crate::patch_chain::PatchChain::new(view),
             route_index,
+            trajectory_route_index,
+            has_trajectory_routes,
             skipmix,
             psi_bag,
         })
@@ -313,9 +335,14 @@ impl<'a> R4G1Runtime<'a> {
         &self,
         base_graph: &uor_r4_graph_format::GraphView<'_>,
         sig: &[u8],
+        lane: RouteProbeLane,
         active_nodes: &mut [u32],
     ) -> (u32, usize) {
-        if let Some(index) = self.route_index.as_ref() {
+        let index = match lane {
+            RouteProbeLane::Context => self.route_index.as_ref(),
+            RouteProbeLane::Trajectory => self.trajectory_route_index.as_ref(),
+        };
+        if let Some(index) = index {
             let mut matched_nodes = [0u32; 8];
             let (best_node, _best_dist, active_count) = index.query(sig, &mut matched_nodes);
             active_nodes[..active_count].copy_from_slice(&matched_nodes[..active_count]);
@@ -325,11 +352,30 @@ impl<'a> R4G1Runtime<'a> {
             let mut best_node = 0;
             let mut best_dist = u32::MAX;
             let mut active_count = 0usize;
+            let mut active_distances = [u32::MAX; 8];
             let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
+            let signature_words = base_graph
+                .head()
+                .map(|head| head.signature_words())
+                .unwrap_or(0);
 
             for n in 1..num_nodes {
                 if let Some(node) = base_graph.node(n) {
-                    let proto_offset = (node.prototype_word_start as usize) << 3;
+                    if lane == RouteProbeLane::Trajectory
+                        && node.flags & NODE_FLAG_TRAJECTORY_ROUTE == 0
+                    {
+                        continue;
+                    }
+                    let prototype_word = match lane {
+                        RouteProbeLane::Context => Some(node.prototype_word_start),
+                        RouteProbeLane::Trajectory => {
+                            trajectory_prototype_word_start(node, signature_words)
+                        }
+                    };
+                    let Some(prototype_word) = prototype_word else {
+                        continue;
+                    };
+                    let proto_offset = (prototype_word as usize) << 3;
                     let mask_offset = (node.mask_word_start as usize) << 3;
 
                     if proto_offset + sig.len() <= rout_bytes.len()
@@ -348,13 +394,40 @@ impl<'a> R4G1Runtime<'a> {
                         }
 
                         // Collect Quantum MoE ensemble nodes matching distance threshold
-                        let rad = u32::from(node.radius.0).max(120);
-                        if dist <= rad
-                            && active_count < 8
-                            && !active_nodes[..active_count].contains(&n)
-                        {
-                            active_nodes[active_count] = n;
-                            active_count += 1;
+                        let rad = match lane {
+                            RouteProbeLane::Context => u32::from(node.radius.0).max(120),
+                            RouteProbeLane::Trajectory => {
+                                let Some(metadata_word) =
+                                    trajectory_metadata_word_start(node, signature_words)
+                                else {
+                                    continue;
+                                };
+                                let metadata_offset = (metadata_word as usize) << 3;
+                                let Some(bytes) =
+                                    rout_bytes.get(metadata_offset..metadata_offset + 2)
+                                else {
+                                    continue;
+                                };
+                                u32::from(u16::from_le_bytes([bytes[0], bytes[1]]))
+                            }
+                        };
+                        if dist <= rad {
+                            let limit = active_nodes.len().min(8);
+                            let position = (0..active_count)
+                                .position(|index| {
+                                    (dist, n) < (active_distances[index], active_nodes[index])
+                                })
+                                .unwrap_or(active_count);
+                            if position < limit {
+                                let next_count = (active_count + 1).min(limit);
+                                for index in (position + 1..next_count).rev() {
+                                    active_nodes[index] = active_nodes[index - 1];
+                                    active_distances[index] = active_distances[index - 1];
+                                }
+                                active_nodes[position] = n;
+                                active_distances[position] = dist;
+                                active_count = next_count;
+                            }
                         }
                     }
                 }
@@ -1005,55 +1078,122 @@ impl<'a> R4G1Runtime<'a> {
         // If the suffix DFA fell off the manifold, use the continuous 288-bit VSA signature
         // to find the top-M semantic regions N_best (N_best <= 8) to jump back onto the graph!
         //
-        // #247 admission (calibration recorded on the issue: fixture session
-        // signatures land 24/24 within ROUT radii through the shipped
-        // quantizer): the context signature keeps primacy, and the SESSION
-        // signature is consulted as the secondary probe only when the context
-        // probe admits nothing within any calibrated radius (previously such
-        // positions routed via the nearest out-of-radius prototype or fell
-        // through to Novel). Within-radius session routing beats
-        // outside-radius context routing by the radius rule's own semantics.
+        // Legacy artifacts retain #247 context primacy exactly. A #946
+        // trajectory-enabled artifact explicitly calibrates a second prototype
+        // per semantic region; only those artifacts probe both lanes and
+        // compose at most four context plus four trajectory matches.
         if active_len == 0 || (active_len == 1 && active_nodes[0] == 0) {
-            let mut best_node = 0u32;
-            let mut active_count = 0usize;
-            if let Some(sig) = context_signature {
-                routing.context_probe_attempted = true;
-                (best_node, active_count) = self.rout_probe(base_graph, sig, &mut active_nodes);
-                routing.context_admitted_nodes = active_count.min(usize::from(u8::MAX)) as u8;
-                if active_count > 0 {
-                    routing.selected_source = SignatureRoutingSource::ContextSignature;
+            active_len = 0;
+            if self.has_trajectory_routes {
+                let mut context_nodes = [0u32; 8];
+                let mut trajectory_nodes = [0u32; 8];
+                let mut context_best = 0u32;
+                let mut trajectory_best = 0u32;
+                let mut context_count = 0usize;
+                let mut trajectory_count = 0usize;
+                if let Some(sig) = context_signature {
+                    routing.context_probe_attempted = true;
+                    (context_best, context_count) = self.rout_probe(
+                        base_graph,
+                        sig,
+                        RouteProbeLane::Context,
+                        &mut context_nodes,
+                    );
+                    routing.context_admitted_nodes = context_count.min(usize::from(u8::MAX)) as u8;
                 }
-            }
-            if active_count == 0
-                && let Some(sig) = session_signature
-            {
-                routing.session_probe_attempted = true;
-                let mut session_nodes = [0u32; 64];
-                let (session_best, session_count) =
-                    self.rout_probe(base_graph, sig, &mut session_nodes);
-                routing.session_admitted_nodes = session_count.min(usize::from(u8::MAX)) as u8;
-                if session_count > 0 {
-                    active_nodes[..session_count].copy_from_slice(&session_nodes[..session_count]);
-                    best_node = session_best;
-                    active_count = session_count;
-                    routing.selected_source = SignatureRoutingSource::SessionSignature;
-                } else if best_node == 0 {
-                    best_node = session_best;
-                    if best_node != 0 {
-                        routing.selected_source = SignatureRoutingSource::NearestSessionSignature;
+                if let Some(sig) = session_signature {
+                    routing.session_probe_attempted = true;
+                    (trajectory_best, trajectory_count) = self.rout_probe(
+                        base_graph,
+                        sig,
+                        RouteProbeLane::Trajectory,
+                        &mut trajectory_nodes,
+                    );
+                    routing.session_admitted_nodes =
+                        trajectory_count.min(usize::from(u8::MAX)) as u8;
+                }
+
+                for &node in context_nodes[..context_count.min(4)].iter() {
+                    active_nodes[active_len] = node;
+                    active_len += 1;
+                }
+                for &node in trajectory_nodes[..trajectory_count.min(4)].iter() {
+                    if active_len < 8 && !active_nodes[..active_len].contains(&node) {
+                        active_nodes[active_len] = node;
+                        active_len += 1;
                     }
                 }
-            }
-
-            if active_count > 0 {
-                active_len = active_count;
-            } else if best_node != 0 {
-                active_nodes[0] = best_node;
-                active_len = 1;
-                if routing.selected_source == SignatureRoutingSource::SuffixDfa
-                    || routing.selected_source == SignatureRoutingSource::None
+                routing.selected_source = match (context_count > 0, trajectory_count > 0) {
+                    (true, true) => SignatureRoutingSource::ComposedSignatures,
+                    (true, false) => SignatureRoutingSource::ContextSignature,
+                    (false, true) => SignatureRoutingSource::SessionSignature,
+                    (false, false) if context_best != 0 => {
+                        active_nodes[0] = context_best;
+                        active_len = 1;
+                        SignatureRoutingSource::NearestContextSignature
+                    }
+                    (false, false) if trajectory_best != 0 => {
+                        active_nodes[0] = trajectory_best;
+                        active_len = 1;
+                        SignatureRoutingSource::NearestSessionSignature
+                    }
+                    _ => SignatureRoutingSource::None,
+                };
+            } else {
+                // Legacy #247 behavior: the session signature probes the
+                // context prototype bank only after the primary probe admits
+                // no node.
+                let mut best_node = 0u32;
+                let mut active_count = 0usize;
+                if let Some(sig) = context_signature {
+                    routing.context_probe_attempted = true;
+                    (best_node, active_count) = self.rout_probe(
+                        base_graph,
+                        sig,
+                        RouteProbeLane::Context,
+                        &mut active_nodes,
+                    );
+                    routing.context_admitted_nodes = active_count.min(usize::from(u8::MAX)) as u8;
+                    if active_count > 0 {
+                        routing.selected_source = SignatureRoutingSource::ContextSignature;
+                    }
+                }
+                if active_count == 0
+                    && let Some(sig) = session_signature
                 {
-                    routing.selected_source = SignatureRoutingSource::NearestContextSignature;
+                    routing.session_probe_attempted = true;
+                    let mut session_nodes = [0u32; 8];
+                    let (session_best, session_count) = self.rout_probe(
+                        base_graph,
+                        sig,
+                        RouteProbeLane::Context,
+                        &mut session_nodes,
+                    );
+                    routing.session_admitted_nodes = session_count.min(usize::from(u8::MAX)) as u8;
+                    if session_count > 0 {
+                        active_nodes[..session_count]
+                            .copy_from_slice(&session_nodes[..session_count]);
+                        best_node = session_best;
+                        active_count = session_count;
+                        routing.selected_source = SignatureRoutingSource::SessionSignature;
+                    } else if best_node == 0 {
+                        best_node = session_best;
+                        if best_node != 0 {
+                            routing.selected_source =
+                                SignatureRoutingSource::NearestSessionSignature;
+                        }
+                    }
+                }
+                if active_count > 0 {
+                    active_len = active_count;
+                } else if best_node != 0 {
+                    active_nodes[0] = best_node;
+                    active_len = 1;
+                    if routing.selected_source == SignatureRoutingSource::SuffixDfa
+                        || routing.selected_source == SignatureRoutingSource::None
+                    {
+                        routing.selected_source = SignatureRoutingSource::NearestContextSignature;
+                    }
                 }
             }
         }
@@ -1158,9 +1298,34 @@ impl<'a> R4G1Runtime<'a> {
                             ScoreQ::from_raw(1)
                         };
 
-                        let sig_bonus = if let Some(sig) = session_signature.or(context_signature) {
+                        let trajectory_lane = self.has_trajectory_routes
+                            && target_node.flags & NODE_FLAG_TRAJECTORY_ROUTE != 0
+                            && session_signature.is_some();
+                        let affinity_signature = if trajectory_lane {
+                            session_signature
+                        } else if self.has_trajectory_routes {
+                            context_signature
+                        } else {
+                            // Legacy #247 affinity order is part of old-artifact
+                            // serving identity.
+                            session_signature.or(context_signature)
+                        };
+                        let sig_bonus = if let Some(sig) = affinity_signature {
                             let rout_bytes = base_graph.section(SectionId::ROUT).unwrap_or(&[]);
-                            let proto_offset = (target_node.prototype_word_start as usize) << 3;
+                            let prototype_word = if trajectory_lane {
+                                base_graph.head().and_then(|head| {
+                                    trajectory_prototype_word_start(
+                                        target_node,
+                                        head.signature_words(),
+                                    )
+                                })
+                            } else {
+                                Some(target_node.prototype_word_start)
+                            };
+                            let Some(prototype_word) = prototype_word else {
+                                continue;
+                            };
+                            let proto_offset = (prototype_word as usize) << 3;
                             let mask_offset = (target_node.mask_word_start as usize) << 3;
                             if proto_offset + sig.len() <= rout_bytes.len()
                                 && mask_offset + sig.len() <= rout_bytes.len()

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -7,7 +7,10 @@
 
 use alloc::vec::Vec;
 
-use uor_r4_graph_format::{GraphView, SectionId};
+use uor_r4_graph_format::{
+    GraphView, NODE_FLAG_TRAJECTORY_ROUTE, SectionId, trajectory_metadata_word_start,
+    trajectory_prototype_word_start,
+};
 
 const NONE: u32 = u32::MAX;
 
@@ -42,6 +45,15 @@ pub(crate) struct VpTree {
 impl VpTree {
     /// Build an index when ROUT contains a single shared mask.
     pub(crate) fn from_graph(view: &GraphView<'_>) -> Option<Self> {
+        Self::from_graph_lane(view, false)
+    }
+
+    /// Build the independent full-trajectory index for flagged regions.
+    pub(crate) fn from_trajectory_graph(view: &GraphView<'_>) -> Option<Self> {
+        Self::from_graph_lane(view, true)
+    }
+
+    fn from_graph_lane(view: &GraphView<'_>, trajectory: bool) -> Option<Self> {
         let head = view.head()?;
         let signature_bytes = usize::from(head.signature_bytes());
         if signature_bytes == 0 {
@@ -56,7 +68,15 @@ impl VpTree {
             if node_id == 0 {
                 continue;
             }
-            let proto_start = (node.prototype_word_start as usize).checked_mul(8)?; // p4-allow(load-time): overflow-checked word-to-byte conversion during VP-tree construction; the query path uses shifts
+            if trajectory && node.flags & NODE_FLAG_TRAJECTORY_ROUTE == 0 {
+                continue;
+            }
+            let prototype_word_start = if trajectory {
+                trajectory_prototype_word_start(node, head.signature_words())?
+            } else {
+                node.prototype_word_start
+            };
+            let proto_start = (prototype_word_start as usize).checked_mul(8)?; // p4-allow(load-time): overflow-checked word-to-byte conversion during VP-tree construction; the query path uses shifts
             let mask_start = (node.mask_word_start as usize).checked_mul(8)?; // p4-allow(load-time): same load-time conversion as above
             let proto_end = proto_start.checked_add(signature_bytes)?;
             let mask_end = mask_start.checked_add(signature_bytes)?;
@@ -78,7 +98,14 @@ impl VpTree {
             points.push(Point {
                 node_id,
                 prototype: masked_prototype,
-                radius: u32::from(node.radius.0).max(120),
+                radius: if trajectory {
+                    let metadata =
+                        trajectory_metadata_word_start(node, head.signature_words())? as usize * 8;
+                    let bytes = rout.get(metadata..metadata + 2)?;
+                    u32::from(u16::from_le_bytes([bytes[0], bytes[1]]))
+                } else {
+                    u32::from(node.radius.0).max(120)
+                },
             });
         }
 
@@ -172,13 +199,18 @@ impl VpTree {
             .sum()
     }
 
-    fn insert_active(active: &mut [u32; 8], active_len: &mut usize, node_id: u32) {
+    fn insert_active(
+        active: &mut [u32; 8],
+        distances: &mut [u32; 8],
+        active_len: &mut usize,
+        node_id: u32,
+        distance: u32,
+    ) {
         if active[..*active_len].contains(&node_id) {
             return;
         }
-        let position = active[..*active_len]
-            .iter()
-            .position(|&existing| existing > node_id)
+        let position = (0..*active_len)
+            .position(|index| (distance, node_id) < (distances[index], active[index]))
             .unwrap_or(*active_len);
         if position >= active.len() {
             return;
@@ -188,8 +220,10 @@ impl VpTree {
         }
         for index in (position + 1..*active_len).rev() {
             active[index] = active[index - 1];
+            distances[index] = distances[index - 1];
         }
         active[position] = node_id;
+        distances[position] = distance;
     }
 
     fn search_node(
@@ -199,6 +233,7 @@ impl VpTree {
         best_node: &mut u32,
         best_distance: &mut u32,
         active: &mut [u32; 8],
+        active_distances: &mut [u32; 8],
         active_len: &mut usize,
     ) {
         if tree_index == NONE {
@@ -212,7 +247,13 @@ impl VpTree {
             *best_node = point.node_id;
         }
         if distance <= point.radius {
-            Self::insert_active(active, active_len, point.node_id);
+            Self::insert_active(
+                active,
+                active_distances,
+                active_len,
+                point.node_id,
+                distance,
+            );
         }
 
         let bound = (*best_distance).max(self.max_radius);
@@ -223,6 +264,7 @@ impl VpTree {
                 best_node,
                 best_distance,
                 active,
+                active_distances,
                 active_len,
             );
             if distance.saturating_add(bound) >= tree_node.threshold {
@@ -232,6 +274,7 @@ impl VpTree {
                     best_node,
                     best_distance,
                     active,
+                    active_distances,
                     active_len,
                 );
             }
@@ -242,6 +285,7 @@ impl VpTree {
                 best_node,
                 best_distance,
                 active,
+                active_distances,
                 active_len,
             );
             if distance.saturating_sub(bound) <= tree_node.threshold {
@@ -251,6 +295,7 @@ impl VpTree {
                     best_node,
                     best_distance,
                     active,
+                    active_distances,
                     active_len,
                 );
             }
@@ -267,12 +312,14 @@ impl VpTree {
         let mut best_node = 0;
         let mut best_distance = u32::MAX;
         let mut active_len = 0;
+        let mut active_distances = [u32::MAX; 8];
         self.search_node(
             0,
             signature,
             &mut best_node,
             &mut best_distance,
             active,
+            &mut active_distances,
             &mut active_len,
         );
         (best_node, best_distance, active_len)

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -99,8 +99,9 @@ impl VpTree {
                 node_id,
                 prototype: masked_prototype,
                 radius: if trajectory {
-                    let metadata =
-                        trajectory_metadata_word_start(node, head.signature_words())? as usize << 3;
+                    let metadata = (trajectory_metadata_word_start(node, head.signature_words())?
+                        as usize)
+                        << 3;
                     let bytes = rout.get(metadata..metadata + 2)?;
                     u32::from(u16::from_le_bytes([bytes[0], bytes[1]]))
                 } else {

--- a/crates/uor-r4-graph-runtime/src/vp_tree.rs
+++ b/crates/uor-r4-graph-runtime/src/vp_tree.rs
@@ -100,7 +100,7 @@ impl VpTree {
                 prototype: masked_prototype,
                 radius: if trajectory {
                     let metadata =
-                        trajectory_metadata_word_start(node, head.signature_words())? as usize * 8;
+                        trajectory_metadata_word_start(node, head.signature_words())? as usize << 3;
                     let bytes = rout.get(metadata..metadata + 2)?;
                     u32::from(u16::from_le_bytes([bytes[0], bytes[1]]))
                 } else {

--- a/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
+++ b/crates/uor-r4-graph-runtime/tests/r4g1_runtime_test.rs
@@ -3,9 +3,10 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::collections::BTreeMap;
-use uor_r4_core::transformerless::compiler::{self, STAGES};
+use uor_r4_core::transformerless::compiler::{self, D, SIG_BYTES, STAGES};
 use uor_r4_core::transformerless::convert_r4g1;
 use uor_r4_core::transformerless::runtime::{self, Store};
+use uor_r4_graph_compiler::induction::{self as cover, Cover, CoverRegion, Observation};
 use uor_r4_graph_format::{
     ArtifactBuilder, FormatError, GraphView, ScoreQ, SectionId, build_psi_bag_table,
     build_skipmix_table,
@@ -148,6 +149,59 @@ fn artifact_with_serving_sections(skmx: Option<&[u8]>, psib: Option<&[u8]>) -> V
         .expect("artifact with serving sections builds")
 }
 
+fn trajectory_route_artifact(treatment: bool) -> Vec<u8> {
+    let context_signatures = [[0xAA; SIG_BYTES], [0x55; SIG_BYTES]];
+    let trajectory_signatures = if treatment {
+        [[0x00; SIG_BYTES], [0xFF; SIG_BYTES]]
+    } else {
+        context_signatures
+    };
+    let observations: Vec<Observation> = (0..2)
+        .map(|index| Observation {
+            position: index as u32,
+            sample: [index as u8; 32],
+            vector: vec![0.0; D],
+            sig: context_signatures[index],
+            trajectory_sig: trajectory_signatures[index],
+            prev: 0,
+            next: 41 + index as u32,
+        })
+        .collect();
+    let regions: Vec<CoverRegion> = (0..2)
+        .map(|index| CoverRegion {
+            id: index as u32,
+            depth: 1,
+            parent: None,
+            children: Vec::new(),
+            prototype: vec![0.0; D],
+            sig: context_signatures[index],
+            radius: 0,
+            trajectory_sig: Some(trajectory_signatures[index]),
+            trajectory_radius: Some(0),
+            support: 1,
+            entropy_bits: 0.0,
+            split_gain_bits: 0.0,
+        })
+        .collect();
+    let graph = Cover {
+        regions,
+        max_depth: 1,
+        paths: vec![vec![0], vec![1]],
+        members: vec![vec![0], vec![1]],
+    };
+    cover::emit_r4g1(
+        b"trajectory-route-runtime-test",
+        (b"meta", b"records"),
+        1024,
+        &graph,
+        &[],
+        &cover::root_prior(&observations),
+        &observations,
+    )
+    .expect("trajectory route fixture emits")
+    .0
+}
+
 #[test]
 fn r4g1_runtime_parses_and_predicts() {
     let (art_bytes, artifacts) = fixture_artifacts();
@@ -277,6 +331,84 @@ fn session_signature_enters_rout_fallback_as_secondary_probe() {
         context_trace.selected_source,
         SignatureRoutingSource::ContextSignature
     );
+}
+
+#[test]
+fn trajectory_lane_is_isolated_composed_deterministic_and_allocation_free() {
+    let treatment_bytes = trajectory_route_artifact(true);
+    let control_bytes = trajectory_route_artifact(false);
+    assert_eq!(
+        treatment_bytes.len(),
+        control_bytes.len(),
+        "planted treatment and inert control share one byte budget"
+    );
+    let treatment = R4G1Runtime::parse(&treatment_bytes).expect("treatment parses");
+    let control = R4G1Runtime::parse(&control_bytes).expect("control parses");
+    let context_signature = [0u8; SIG_BYTES];
+    let full_trajectory = [0xFFu8; SIG_BYTES];
+    let mut treatment_scores = vec![ScoreQ::MIN; treatment.node_count() as usize];
+    let mut control_scores = vec![ScoreQ::MIN; control.node_count() as usize];
+
+    let (treatment_decision, treatment_trace) = treatment
+        .predict_distribution_with_signature_lanes_traced(
+            &[999],
+            Some(&context_signature),
+            Some(&full_trajectory),
+            &mut treatment_scores,
+        );
+    let (control_decision, control_trace) = control
+        .predict_distribution_with_signature_lanes_traced(
+            &[999],
+            Some(&context_signature),
+            Some(&full_trajectory),
+            &mut control_scores,
+        );
+    assert!(treatment_trace.context_probe_attempted);
+    assert!(treatment_trace.session_probe_attempted);
+    assert_eq!(treatment_trace.context_admitted_nodes, 0);
+    assert_eq!(treatment_trace.session_admitted_nodes, 1);
+    assert_eq!(
+        treatment_trace.selected_source,
+        SignatureRoutingSource::SessionSignature
+    );
+    assert_eq!(control_trace.session_admitted_nodes, 0, "inert control");
+    assert_ne!(
+        treatment_decision, control_decision,
+        "the planted full-prefix lane must change the normative decision"
+    );
+
+    let no_session_treatment = treatment.predict_distribution_with_signature_lanes(
+        &[999],
+        Some(&context_signature),
+        None,
+        &mut treatment_scores,
+    );
+    let no_session_control = control.predict_distribution_with_signature_lanes(
+        &[999],
+        Some(&context_signature),
+        None,
+        &mut control_scores,
+    );
+    assert_eq!(
+        no_session_treatment, no_session_control,
+        "trajectory prototypes are invisible to context-only calls"
+    );
+
+    let allocations = counted_allocations(|| {
+        for _ in 0..64 {
+            treatment_scores.fill(ScoreQ::MIN);
+            assert_eq!(
+                treatment.predict_distribution_with_signature_lanes(
+                    &[999],
+                    Some(&context_signature),
+                    Some(&full_trajectory),
+                    &mut treatment_scores,
+                ),
+                treatment_decision
+            );
+        }
+    });
+    assert_eq!(allocations, 0, "trajectory composition must not allocate");
 }
 
 #[test]

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -668,6 +668,19 @@ by contract. See [`docs/production_prefix_memory_canary_944.md`](production_pref
 and the CID-bound result JSON. A further S3 re-entry must first make complete-prefix information
 behaviorally reachable in the compiled representation.
 
+**S3 compiler re-entry — explicit trajectory regions are production-reachable but remain
+behaviorally `INERT` (#946, 2026-08-25).** Compiler observations now use the production
+`TokenHistorySignature` over each complete in-story prefix, R4G1 flag `0x01` carries a
+validated trajectory prototype/radius, and the normative fallback composes a fixed four
+context plus four trajectory nodes. A 4,096-position teacher-free equal-budget preflight was
+positive (1,549 trajectory admissions and candidate differences), authorizing one exact
+#933-bound candidate. The schema-2 product canary then admitted trajectory routes in all 20 of
+its reachable fallback cases, but different earlier prefixes changed **0/512** candidate lists
+and **0/512** served tokens. Verdict: **`INERT`**. The frozen #841 evaluation remains
+**NOT_RUN**, and no coherence, semantic relevance, planning, or generative-engine claim is
+promoted. See [`docs/trajectory_routing_946.md`](trajectory_routing_946.md) and its bound
+result JSON.
+
 **S4 — bounded typed planning is LIMITED; geometry adds no advantage; untouched final-partition
 reasoning is not established (#843/#845/#846, 2026-08-22).**
 [`docs/bounded_semantic_transitions_843.md`](bounded_semantic_transitions_843.md) establishes

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -446,6 +446,19 @@ token changes. Verdict: **`INERT`** for this artifact. The broader #841 rerun is
 the next re-entry must make complete-prefix information behaviorally reachable in the compiled
 representation before repeating the same canary.
 
+### S3 compiled trajectory-region re-entry — REACHABLE + INERT (#946, 2026-08-25)
+
+The compiler now records the production full-prefix token-history signature and emits explicit
+trajectory prototypes/radii in R4G1. The normative runtime validates and indexes the context and
+trajectory lanes separately, then composes a deterministic allocation-free 4+4 active set under
+the existing ceiling of eight. The binding teacher-free equal-budget preflight was positive and
+authorized one #933-bound schema-2 candidate. In the exact 512-case product canary, all 20 graph-
+fallback cases admitted trajectory nodes, but earlier-prefix changes produced 0 candidate-list
+changes and 0 served-token changes. Verdict: **`INERT`**. The implementation closes the
+representation/reachability defect but does not change the historical S3 `LIMIT`, the frozen
+#841 bar, or downstream claim status; #841 remains `NOT_RUN`. Record:
+`docs/trajectory_routing_946.md`.
+
 ### S4 entry reconciliation — AMEND + PROCEED (2026-08-22)
 
 S3 (#824) closed `LIMIT` and S2 (#823) stands at `REVISE`, so #826's written entry

--- a/docs/trajectory_routing_946.md
+++ b/docs/trajectory_routing_946.md
@@ -1,0 +1,79 @@
+# Full-prefix trajectory routing regions (#946)
+
+- **Implementation status:** complete for compiler, R4G1 admission, and normative runtime.
+- **Product verdict:** `INERT` on the exact #933-bound schema-2 candidate.
+- **Scope:** teacher-free one-step production selection. This does not establish coherence,
+  semantic relevance, planning, or clearance of the frozen #841 generation bar.
+- **Result:** [`trajectory_routing_946_product_result.json`](trajectory_routing_946_product_result.json).
+
+## Implemented mechanism
+
+Compiler observations now carry a 288-bit full-prefix `TokenHistorySignature`, updated once
+per recorded token and reset at story boundaries with the same algorithm production uses.
+`cover --trajectory-routing` attaches a deterministic prototype and calibrated radius to each
+induced region without increasing the region ceiling. R4G1 node flag `0x01` declares that ROUT
+extension; stage-2 admission rejects unknown flags, invalid extents, invalid radii, nonzero
+reserved bytes, and nonzero signature padding.
+
+The normative runtime builds separate context and trajectory route indexes at admission.
+Fallback probes both lanes, composes at most four context plus four trajectory nodes in stable
+distance/node-ID order, removes duplicates, and scores each node with its declared signature
+lane. The active-set ceiling remains eight. Legacy flag-zero artifacts and calls without a
+trajectory signature retain their previous behavior. The hot path uses fixed arrays and remains
+allocation-free; runtime admission remains `no_std` compatible.
+
+## Binding cheap instrument
+
+The teacher-free preflight used 4,096 training and 4,096 held-out positions from the exact
+#933 input. Treatment and context-only control had identical ceilings and sizes: 64 regions,
+65 nodes, 1,232 edges, 8,280 ROUT bytes, 30,796 EMIT bytes, 66,508 total bytes, and a 4+4
+active-node split. It observed 1,549 fallback positions, 1,549 trajectory admissions, and
+1,549 candidate-list differences. Repeated treatment emission was byte-identical.
+
+The treatment CID was
+`blake3:53ab5e4098bd06db1c7183d4e529059f160209f906a52101c359cbb1e16e2353`;
+the control CID was
+`blake3:a30c9beed023b53ce8f008498e77986cce8c4f616f7ac38759d4567e3401dc07`.
+Total preflight wall time was 8.386 seconds. No teacher was loaded. The measured-stage
+projection and 15-minute hard wall were posted before the candidate build; the actual cover
+build completed in 17 seconds.
+
+## Exact candidate and admission
+
+The candidate reused the #933-bound teacher artifact
+`blake3:6324aabec22fca5af371333cefc206f9b6762bfb52dccfb8efa0dc8fe5a1efaa`
+and corpus stream
+`blake3:7db27ffb488ad996f2317c99f3eb627ca964b28c3e730d050d1e51136c7a335e`.
+It contains 34 induced regions, 35 scored nodes, and 439 scored edges. The scored graph is
+77,672,656 bytes, 1,664 bytes larger than the historical #933 context-only graph while keeping
+the same node, edge, emission-entry, candidate, and active-node ceilings. This byte delta is
+reported explicitly; the full artifact is not described as byte-equal to the historical
+control.
+
+The graph CID is
+`blake3:b97b5834799968d34c319a03df9a9dd217bf89a3ec2fd0b53f06abd2e03c38ba`.
+The schema-2 instruction-chat release manifest CID is
+`blake3:987b60167c6f1b1a57a646e8f5685051062680113b202fdcd6c4559b5b8d77d0`.
+Its compiler authority is implementation commit
+`45d293181c0db35ea343a761d3fb1a19425c5ad7`.
+
+Production admission's full 72,130-position census passed: selector top-1 was 21,293/72,130
+(29.5203%) versus the same-position TLA comparator at 20,284/72,130 (28.1214%). Witness replay
+passed 64/64; internal and cross-surface mismatches were zero. This repeats the #933 quality
+scope and is admission evidence, not a new quality claim.
+
+## Product canary
+
+The bounded product canary admitted the complete schema-2 envelope before inspecting the same
+first 512 eligible held-out positions used by #944. Of those, 492 resolved through exact context
+rows. All remaining 20 attempted both route lanes and admitted trajectory nodes, establishing
+that the new representation is reachable in production. However, changing the earlier prefix
+changed zero normative candidate lists and zero served tokens. Tested-position CID:
+`blake3:f108e9caab5edc0b7b4d312cf5ae187608d9653ea3d4e24bfa00ef68a07507b7`;
+ordered-observation CID:
+`blake3:f87a37bf1888371c6822236abb558f9d34b8b41485cd1870dd6915fb33416dda`.
+
+**Empirical Criterion. Status: Empirical. Verdict: `INERT`.** Trajectory routing is compiled,
+admitted, and reached, but the exact bounded product comparison found no earlier-prefix-caused
+normative behavior change. Per the predeclared contract, #841 is **NOT_RUN** and no later
+production-scope slice is authorized from this result.

--- a/docs/trajectory_routing_946_product_result.json
+++ b/docs/trajectory_routing_946_product_result.json
@@ -1,0 +1,29 @@
+{
+  "schema": "uor-r4-production-prefix-memory-canary/1",
+  "issue": 946,
+  "verdict": "INERT",
+  "claim_scope": "one-step normative R4G1 production selection on the exact admitted artifact; no coherence claim",
+  "max_cases": 512,
+  "graph_cid": "blake3:b97b5834799968d34c319a03df9a9dd217bf89a3ec2fd0b53f06abd2e03c38ba",
+  "release_manifest_cid": "blake3:987b60167c6f1b1a57a646e8f5685051062680113b202fdcd6c4559b5b8d77d0",
+  "corpus_meta_cid": "blake3:aa9d176779c1d2411e872c49c95ed585ee805ded5fa1b808ddf2f517a245b0ce",
+  "corpus_records_cid": "blake3:4692307368fecce481a4aac452fd8df4e63d2f1bd07ee0f2932108f8595f8f62",
+  "selection_rule": "first held-out corpus positions with a complete in-story prefix longer than the newest eight-token window",
+  "tested_count": 512,
+  "first_tested_position": 288802,
+  "last_tested_position": 289345,
+  "tested_positions_cid": "blake3:f108e9caab5edc0b7b4d312cf5ae187608d9653ea3d4e24bfa00ef68a07507b7",
+  "observations_cid": "blake3:f87a37bf1888371c6822236abb558f9d34b8b41485cd1870dd6915fb33416dda",
+  "counts": {
+    "inspected": 512,
+    "context_row_hits": 492,
+    "suffix_dfa_routes": 0,
+    "context_probe_attempts": 20,
+    "context_probe_misses": 0,
+    "session_probe_attempts": 20,
+    "session_probe_admissions": 20,
+    "candidate_list_changes": 0,
+    "served_token_changes": 0
+  },
+  "first_effect": null
+}

--- a/docs/transformerless/R4G1.md
+++ b/docs/transformerless/R4G1.md
@@ -178,6 +178,14 @@ unassigned in v0 (PTCH-era, Phase 9); the draft line carries only the fixed pref
   28      u8    depth                (< HEAD depth_count)
   29      u8    flags
   ```
+  Node flag `0x01` (`NODE_FLAG_TRAJECTORY_ROUTE`) declares a second, full-trajectory
+  routing prototype. Unknown flag bits are rejected. Flag-zero nodes retain the historical
+  context-only interpretation and byte layout. For a flagged node, ROUT contains the
+  self-contained word sequence `context prototype[W] | context mask[W] | trajectory
+  prototype[W] | trajectory metadata[1]`; the metadata word is a little-endian `u16`
+  trajectory radius followed by six required-zero bytes. The trajectory prototype starts
+  at `mask_word_start + W`, so NODE remains 30 bytes. Stage 2 validates the extra prototype,
+  metadata extent, radius bound, reserved bytes, and signature padding.
 - **EDGE**: v0 draft-line layout, implemented: the canonical edge array — 16-byte records
   `(u32 src, u32 dst, i32 score_q, u8 kind, u8 flags, u16 reserved)` — with stable edge IDs =
   array index, immediately followed by the reverse index: `edge_count` × u32 edge IDs, ranges
@@ -208,6 +216,12 @@ unassigned in v0 (PTCH-era, Phase 9); the draft line carries only the fixed pref
   `shortlist_len` must be 0); the program ends at the first HALT, or at section end with a
   final LEAF; jumps are forward-only by construction (unsigned forward delta ⇒ acyclic) and
   in-bounds; static op count ≤ HEAD.D (bounds every execution path under forward-only jumps).
+  Admitted trajectory-route nodes are indexed separately from context nodes. Context and
+  trajectory queries use their declared prototype lane; graph fallback composes at most four
+  context and four trajectory matches in stable `(distance, node_id)` order, deduplicated,
+  within the existing eight-node active-set ceiling. Index construction occurs during graph
+  admission, outside steady-state prediction. Artifacts with no `0x01` node retain the legacy
+  context-only probe and serving behavior.
 - **EMIT**: root prior block B(v) + residual lists keyed by region (sparse, bounded ≤ HEAD.E per
   region), shared emission blocks by reference. Each table carries a dyadic **storage
   descriptor** — v0 draft-line layout, implemented: a 4-byte prefix `{width u8 (0=i8, 1=i16,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4412,6 +4412,8 @@ pub(crate) mod tests {
                     depth: 1,
                     radius: 4,
                     sig: covered_sig,
+                    trajectory_sig: None,
+                    trajectory_radius: None,
                     parent: None,
                 },
                 RegionParams {
@@ -4419,6 +4421,8 @@ pub(crate) mod tests {
                     depth: 1,
                     radius: 4,
                     sig: [0xFF; SIG_BYTES],
+                    trajectory_sig: None,
+                    trajectory_radius: None,
                     parent: None,
                 },
             ];

--- a/src/server.rs
+++ b/src/server.rs
@@ -18934,6 +18934,8 @@ mod tests {
             depth: 1,
             radius: 0,
             sig: [0; compiler::SIG_BYTES],
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         }];
         let mut root_prior = BTreeMap::new();

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -1430,6 +1430,7 @@ fn disjoint_halves_observations(w: &mut R4g1World) {
             sample: [0u8; 32],
             vector: Vec::new(),
             sig: [0u8; SIG_BYTES],
+            trajectory_sig: [0u8; SIG_BYTES],
             prev: 0u32,
             next: if i < 50 { 1 } else { 2 },
         })

--- a/tests/status_policy_common/mod.rs
+++ b/tests/status_policy_common/mod.rs
@@ -229,6 +229,8 @@ pub fn signature_fixture(status_policy_override: Option<serde_json::Value>) -> P
             depth: 1,
             radius: 4,
             sig: covered_sig,
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         },
         RegionParams {
@@ -236,6 +238,8 @@ pub fn signature_fixture(status_policy_override: Option<serde_json::Value>) -> P
             depth: 1,
             radius: 4,
             sig: graph_sig,
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         },
     ];
@@ -287,6 +291,8 @@ fn window_fixture_with_rows(skipmix_rows: &[SkipmixRowInput]) -> ProbeFixture {
             depth: 1,
             radius: 4,
             sig: covered_sig,
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         },
         RegionParams {
@@ -294,6 +300,8 @@ fn window_fixture_with_rows(skipmix_rows: &[SkipmixRowInput]) -> ProbeFixture {
             depth: 1,
             radius: 4,
             sig: graph_sig,
+            trajectory_sig: None,
+            trajectory_radius: None,
             parent: None,
         },
     ];


### PR DESCRIPTION
References #946

## Outcome

- compiles production-identical full-prefix TokenHistorySignature observations and explicit trajectory ROUT regions
- validates node lane flags and builds separate context/trajectory indexes at admission
- composes a deterministic allocation-free 4+4 active set under the existing ceiling of eight
- preserves legacy flag-zero and no-session behavior
- records the bounded exact #933 product result: trajectory routes reached all 20 fallback cases, but changed 0/512 candidate lists and 0/512 served tokens, so the truthful verdict is INERT and #841 remains NOT_RUN

## Focused verification

- cargo fmt --check
- cargo check for every touched package with all targets, offline
- focused graph compiler, format, runtime, certifier, CLI, and API tests
- graph runtime no-default-features check
- WASM boundary check
- teacher-free 4,096-position equal-budget preflight: PREFLIGHT_POSITIVE
- exact schema-2 production admission and 72,130-position deployed-quality census: PASS
- exact 512-case product canary: INERT
- python3 scripts/check_claim_wording.py

BDD, teacher parity, frozen #841, fuzz, audit, Kani, and other certification suites were intentionally NOT_RUN locally per #946 and the repository fast-gate policy.